### PR TITLE
feat(harvest): Spanish scar markers — detector no longer silent on Spanish replies

### DIFF
--- a/plugin/daimon_briefing/harvest.py
+++ b/plugin/daimon_briefing/harvest.py
@@ -27,11 +27,18 @@ class Hit(NamedTuple):
 
 
 _AVOID_RE = re.compile(
-    r"\b(avoid|don't|do not|never|gotcha|pitfall|footgun|broke|breaks|mistake|dead[ -]?end)\b",
+    r"\b(avoid|don't|do not|never|gotcha|pitfall|footgun|broke|breaks|mistake|dead[ -]?end"
+    # Spanish band mirrors the English markers (#4). Bare "no" is far more
+    # frequent than "don't", so only specific imperative constructions fire —
+    # never plain negation ("no devuelve" stays silent).
+    r"|evit(?:a|á|ar|es|en)|nunca|jam[áa]s|trampa|romp(?:e|i[óo]|en)"
+    r"|callej[óo]n sin salida|punto muerto|no (?:hagas|toques|uses|llames))\b",
     re.IGNORECASE,
 )
 _INTENT_RE = re.compile(
-    r"\b(on purpose|intentional(?:ly)?|deliberately|looks wrong but|must stay|keep this)\b",
+    r"\b(on purpose|intentional(?:ly)?|deliberately|looks wrong but|must stay|keep this"
+    r"|a prop[óo]sito|intencional(?:mente)?|adrede|deliberadamente"
+    r"|parece (?:mal|incorrecto) pero|debe quedar(?:se)?)\b",
     re.IGNORECASE,
 )
 

--- a/plugin/tests/test_harvest.py
+++ b/plugin/tests/test_harvest.py
@@ -59,6 +59,43 @@ def test_detect_intentional_wins_within_a_sentence():
     assert hits[0].kind == "intentional"
 
 
+def test_detect_flags_spanish_avoidance():
+    # Assistants reply in Spanish to Spanish-speaking users; the detector must
+    # not go silent on them (#4).
+    msgs = [{"role": "assistant",
+             "content": "Evitá llamar resolve() dos veces en config.py. "
+                        "Nunca toques config.py durante el flush."}]
+    hits = harvest.detect(msgs)
+    assert len(hits) == 2
+    assert all(h.kind == "avoidance" for h in hits)
+
+
+def test_detect_flags_spanish_breakage_and_deadend():
+    msgs = [{"role": "assistant",
+             "content": "Ese enfoque se rompió con sesiones reales. "
+                        "Resultó ser un callejón sin salida."}]
+    hits = harvest.detect(msgs)
+    assert len(hits) == 2
+    assert all(h.kind == "avoidance" for h in hits)
+
+
+def test_detect_flags_spanish_intentional():
+    msgs = [{"role": "assistant",
+             "content": "Este cast parece incorrecto pero es intencional, debe quedarse."}]
+    hits = harvest.detect(msgs)
+    assert len(hits) == 1
+    assert hits[0].kind == "intentional"
+
+
+def test_detect_spanish_plain_prose_stays_silent():
+    # "no" is far more frequent in Spanish than "don't" in English — plain
+    # negation must not fire the avoidance class.
+    msgs = [{"role": "assistant",
+             "content": "La función no devuelve rutas absolutas. "
+                        "El resultado no incluye duplicados."}]
+    assert harvest.detect(msgs) == []
+
+
 def test_anchor_of_returns_existing_path(tmp_path):
     (tmp_path / "config.py").write_text("x = 1\n")
     hit = harvest.Hit("avoidance", "Avoid calling resolve() twice in config.py.", "", 0)


### PR DESCRIPTION
Closes #4

The zero-LLM scar harvester's marker regexes were English-only — assistants replying in Spanish produced zero candidates, silently. Adds the Spanish band to both classes:

- **Avoidance**: evita(r), nunca, jamás, trampa, rompió/rompe, callejón sin salida, punto muerto, and only SPECIFIC `no <imperative>` constructions (no hagas/toques/uses/llames) — bare negation ('la función no devuelve...') stays silent, since Spanish 'no' is far more frequent than English 'don't' (FP-rate guard flagged in the issue, encoded as a test).
- **Intentional**: a propósito, intencional(mente), adrede, deliberadamente, parece mal/incorrecto pero, debe quedar(se).

Native-speaker review welcome on the marker vocabulary — first-cohort feedback shapes v2.

TDD: 3 red tests watched failing + plain-prose silence guard; 699 plugin tests green.