### PR TITLE
feat(serializer): D-012 — preserve transcript language in item text

### DIFF
--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
 # Checkpoints are only comparable across runs sharing this version (scar
 # landmine #4); pre-bump checkpoints firing the #93 format_version mismatch
 # warning is desired, not a bug.
-PROMPT_VERSION = "D-011"
+PROMPT_VERSION = "D-012"
 
 
 class SerializeError(Exception):
@@ -114,6 +114,10 @@ RULES — follow every one exactly; this is the point of the exercise:
     what the next session does; 9-10 = architectural or hard to reverse. Score by CONSEQUENCE,
     not by how recently it was said.
 
+15. TRANSCRIPT LANGUAGE: write every item's `text` in the same language as the transcript
+    (a Spanish session produces Spanish items). Never translate quotes — a `quote` is always
+    the exact original wording. Schema keys and structure stay in English as shown.
+
 Schema shape:
 {
   "session_id": "<id>",
@@ -181,6 +185,10 @@ MERGE RULES — follow every one exactly:
 11. IMPORTANCE: carry each item's integer `importance` (1-10) into the merged output. When
     deduplicating, keep the canonical item's score; if the duplicates' scores differ, keep the
     HIGHEST — under-weighting a load-bearing item costs more than over-weighting a minor one.
+
+12. TRANSCRIPT LANGUAGE: keep every item's `text` in the same language as the transcript —
+    merging must not translate items (a Spanish session stays Spanish). Never translate quotes;
+    a `quote` is always the exact original wording. Schema keys and structure stay in English.
 
 Schema shape:
 {

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -615,12 +615,23 @@ def test_serialize_prompt_has_d008_fidelity_rules():
     assert "Omission is safer than fabrication" in sys
 
 
-def test_prompt_version_is_d011():
+def test_prompt_version_is_d012():
     # D-008 -> D-010 (#101: emotional_valence dropped from the schema).
     # D-009 is taken by the host-adapter decision. D-010 -> D-011 (#126:
-    # per-item importance added to the emitted schema). Pre-bump checkpoints
-    # firing the format_version mismatch warning (#93) is DESIRED behavior.
-    assert serializer.PROMPT_VERSION == "D-011"
+    # per-item importance added to the emitted schema). D-011 -> D-012 (#5:
+    # transcript-language preservation rule). Pre-bump checkpoints firing the
+    # format_version mismatch warning (#93) is DESIRED behavior.
+    assert serializer.PROMPT_VERSION == "D-012"
+
+
+def test_prompts_preserve_transcript_language():
+    # #5: item text must stay in the transcript's language (Spanish sessions
+    # produced English paraphrases while quotes stayed Spanish -> mixed-language
+    # checkpoints break recall term-overlap and carry twin-dedup). Rule must be
+    # in BOTH prompts — merge re-emits items and can translate-drift too.
+    for sys in (serializer.SERIALIZE_SYS, serializer.MERGE_SYS):
+        assert "same language as the transcript" in sys
+        assert "Never translate quotes" in sys
 
 
 def test_emotional_valence_absent_from_prompts():


### PR DESCRIPTION
Closes #5

Adds the transcript-language rule to BOTH prompts (serialize rule 15, merge rule 12 — merge re-emits items and can translate-drift independently):

- item `text` stays in the transcript's language
- quotes are NEVER translated (extends the verbatim contract)
- schema keys/structure stay English

PROMPT_VERSION bumped D-011 → D-012 per house convention; old checkpoints will fire the format_version mismatch warning, which is desired.

Live behavior is LLM-dependent and can't be asserted in the mocked CI suite — the Spanish-cohort field round is the real validation (that's the point of the cohort). Prompt-contract tests pin the rule text in both prompts.

TDD: 2 red watched failing; 700 green.