### PR TITLE
fix(version): derive __version__ from installed metadata

### DIFF
--- a/plugin/daimon_briefing/__init__.py
+++ b/plugin/daimon_briefing/__init__.py
@@ -1,10 +1,16 @@
 """Daimon dream-briefing — hermes plugin entrypoint (Slice 1, local-file, no Honcho)."""
 
+from importlib import metadata
 from pathlib import Path
 
 from . import hooks
 
-__version__ = "0.2.0"
+try:
+    # Single source of truth: the installed distribution (pyproject version).
+    # A hardcoded string here shipped a 0.3.0 wheel that reported 0.2.0 (#10).
+    __version__ = metadata.version("daimon-briefing")
+except metadata.PackageNotFoundError:  # imported from a raw source tree
+    __version__ = "0.0.0+unknown"
 
 
 def register(ctx):

--- a/plugin/tests/test_version.py
+++ b/plugin/tests/test_version.py
@@ -1,0 +1,21 @@
+"""#10: the reported version must track the packaged version — the 0.3.0 wheel
+shipped introducing itself as 0.2.0 because __version__ was a hardcoded string
+outside release-please's lock-step surface."""
+
+import re
+from pathlib import Path
+
+import daimon_briefing
+
+
+def _pyproject_version() -> str:
+    # regex, not tomllib — the suite's floor is py3.10 which lacks tomllib.
+    text = (Path(daimon_briefing.__file__).parent.parent / "pyproject.toml").read_text(
+        encoding="utf-8")
+    m = re.search(r'^version = "([^"]+)"', text, re.M)
+    assert m, "pyproject.toml lost its version line"
+    return m.group(1)
+
+
+def test_dunder_version_matches_packaged_version():
+    assert daimon_briefing.__version__ == _pyproject_version()

--- a/plugin/uv.lock
+++ b/plugin/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "daimon-briefing"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #10

The 0.3.0 wheel introduces itself as 0.2.0: `__init__.py` hardcoded `__version__` outside release-please's extra-files lock-step. Fix derives it from `importlib.metadata.version("daimon-briefing")` — pyproject becomes the single source of truth, the sync-list failure class disappears. Raw-source imports (no installed dist) fall back to `0.0.0+unknown`.

Regression test pins `__version__` == pyproject version.

Merging this produces a `fix:` commit → release-please proposes 0.3.1; PyPI 0.3.0 stays as-is (immutable), 0.3.1 reports correctly.