### PR TITLE
fix(carry): filter document-frequent terms from dedup identity

### DIFF
--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -9,6 +9,7 @@ caller injects clock and knobs (scar: a default wall-clock anywhere silently
 freezes time math under simulation)."""
 
 import copy
+from collections import Counter
 
 from . import recall, scoring, store
 
@@ -22,16 +23,41 @@ _CARRIED_KINDS = (
 
 _MIN_SHARED = 3     # shared salient terms for same-item
 _MIN_RATIO = 0.6    # or this fraction of the shorter term list
+_GENERIC_DF = 3     # a term shared by >=3 items of one kind is that kind's
+                    # vocabulary, not an item's identity. Filtering it out of
+                    # dedup stops generic overlap (data/field/validation, the
+                    # #13 live specimen) from forging a false merge. Computed
+                    # per kind per merge — no static stoplist, so carry stays
+                    # language-neutral (es i18n just shipped).
 
 
-def _same_item(a_text: str, b_text: str) -> bool:
+def _generic_terms(texts, k: int = _GENERIC_DF) -> frozenset:
+    """Salient terms appearing in >= k DISTINCT texts of one kind — that kind's
+    shared vocabulary, which dedup must ignore. Document frequency counts a term
+    once per text (set per text), so repetition inside one item can't inflate
+    it."""
+    df: Counter = Counter()
+    for t in texts:
+        df.update(set(recall.salient_terms(t)))
+    return frozenset(term for term, n in df.items() if n >= k)
+
+
+def _same_item(a_text: str, b_text: str, generic=frozenset()) -> bool:
     """Term-overlap identity: the serializer rewords constantly (run-01), so
     exact text misses twins. Shared >=3 salient terms, or >=60% of the shorter
-    list, means same item. Short texts (<2 salient terms) never fuzzy-match —
-    the exact-text guard still catches identical ones."""
-    a = set(recall.salient_terms(a_text))
-    b = set(recall.salient_terms(b_text))
-    if not a or not b:
+    list, means same item — but only AFTER subtracting `generic` (the kind's
+    document-frequent vocabulary), so overlap on common words can't merge
+    unrelated items.
+
+    Floor: if either filtered set has <2 terms, never fuzzy-match. This blocks a
+    single surviving shared term from passing the ratio path (1/1 = 1.0). The
+    bias is deliberate and asymmetric: a false merge erases a loop and forges
+    its birth stamp, while a false non-merge only costs a duplicate item — so
+    tie-break toward NOT merging. The exact-text guard still catches identical
+    items regardless."""
+    a = set(recall.salient_terms(a_text)) - generic
+    b = set(recall.salient_terms(b_text)) - generic
+    if len(a) < 2 or len(b) < 2:
         return False
     shared = len(a & b)
     return shared >= _MIN_SHARED or shared / min(len(a), len(b)) >= _MIN_RATIO
@@ -64,6 +90,12 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
             continue
         prev_items = (prev_cp.get(section) or {}).get(key) or []
         native_texts = {i.get("text") for i in native if isinstance(i, dict)}
+        # Generic vocabulary for THIS kind, from the same universe merge iterates
+        # (native + prev): terms this common are not identity, so dedup ignores
+        # them (#13). Computed once per kind, passed to every _same_item below.
+        generic = _generic_terms(
+            [str(i.get("text") or "") for i in native if isinstance(i, dict)]
+            + [str(i.get("text") or "") for i in prev_items if isinstance(i, dict)])
         carried = []
         for item in prev_items:
             if not isinstance(item, dict) or not str(item.get("text") or "").strip():
@@ -72,7 +104,8 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
             if text in native_texts:
                 continue  # exact twin already present (idempotency)
             twin = next((n for n in native if isinstance(n, dict)
-                         and _same_item(text, str(n.get("text") or ""))), None)
+                         and _same_item(text, str(n.get("text") or ""), generic)),
+                        None)
             if twin is not None:
                 # Session re-discussed it: the new wording wins, but the item's
                 # AGE does not reset (run-01: 8-12 resets/20 cycles killed the

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -7,6 +7,18 @@ from daimon_briefing import carry
 
 NOW = 1_760_000_000.0  # arbitrary fixed epoch
 
+# Live false-merge specimen (2026-07-02): two UNRELATED items that matched on
+# exactly the generic terms {data, field, validation}. See #13.
+_SPEC_A = ("First external user validation — the core adoption-arc objective "
+           "that unblocks _MIN_OVERLAP field data, DAIMON_TEAM validation, and "
+           "teammate-noise research questions")
+_SPEC_B = ("Q-STALE + multi-cycle degradation validation — parked on LLM "
+           "budget. Need field data: what do 20 serialize cycles do to a "
+           "long-lived open loop, and how does that inform decay tuning?")
+# Sibling native item carrying the same generic vocabulary, so {data, field,
+# validation} each reach document-frequency 3 across the kind (A, sibling, B).
+_SPEC_SIB = "extra validation of the data field mapping"
+
 
 def _iso(days_before_now):
     import datetime as dt
@@ -133,6 +145,64 @@ def test_cap_keeps_heaviest_carried_only():
 
 def test_same_item_short_texts_never_fuzzy_match():
     assert carry._same_item("ok", "ok go") is False
+
+
+def test_generic_overlap_does_not_false_merge_specimen():
+    # Live #13 specimen: fresh native A and unrelated carried B share only the
+    # generic terms {data, field, validation}. B must survive as its OWN item;
+    # A must NOT inherit B's older birth stamp.
+    new = _cp("S-new", 0, questions=[
+        _item(_SPEC_A, days=0), _item(_SPEC_SIB, days=1)])
+    prev = _cp("S-prev", 1, questions=[_item(_SPEC_B, imp=7, days=45)])
+    out = carry.merge(new, prev, NOW)
+    qs = out["working_context"]["open_questions"]
+    texts = [q["text"] for q in qs]
+    assert _SPEC_B in texts                       # B kept, not erased
+    b_item = next(q for q in qs if q["text"] == _SPEC_B)
+    assert b_item["carried_from"] == "S-prev"
+    a_item = next(q for q in qs if q["text"] == _SPEC_A)
+    assert a_item["first_seen"] == _iso(0)        # A did NOT inherit B's stamp
+    assert "carried_from" not in a_item
+    assert len(qs) == 3
+
+
+def test_same_item_generic_filter_is_the_fix_not_a_threshold():
+    generic = frozenset({"data", "field", "validation"})
+    assert carry._same_item(_SPEC_A, _SPEC_B, generic) is False
+    assert carry._same_item(_SPEC_A, _SPEC_B) is True   # unfiltered: the bug
+
+
+def test_specific_twin_still_merges_and_inherits_age():
+    # Two rewordings sharing SPECIFIC low-DF terms must still match (run-02
+    # behavior): the guard filters vocabulary, not identity.
+    old = _item("quorint-ledger reconciliation drops entries when upstream "
+                "feed pauses", days=45)
+    new_twin = _item("quorint-ledger reconciliation still dropping entries on "
+                     "feed pauses", days=0)
+    prev = _cp("S-prev", 1, questions=[
+        old, _item("unrelated gavotte pipeline flaking noise", days=3)])
+    new = _cp("S-new", 0, questions=[
+        new_twin, _item("tervane cache eviction unclear noise", days=1)])
+    out = carry.merge(new, prev, NOW)
+    qs = out["working_context"]["open_questions"]
+    twin = next(q for q in qs if "still dropping" in q["text"])
+    assert twin["first_seen"] == _iso(45)               # matched -> age inherited
+    assert not any("drops entries" in q["text"] for q in qs)  # not duplicated
+
+
+def test_post_filter_floor_blocks_single_shared_term():
+    generic = frozenset({"data", "field", "validation"})
+    a = "data field validation alpha"          # filtered -> {alpha}
+    b = "data field validation alpha bravo"    # filtered -> {alpha, bravo}
+    # ratio would be 1/1 = 1.0 >= _MIN_RATIO without the floor; floor blocks it
+    assert carry._same_item(a, b, generic) is False
+
+
+def test_generic_terms_df_boundary():
+    texts = ["zeta omega alpha", "zeta omega beta", "omega gamma delta"]
+    generic = carry._generic_terms(texts)   # k defaults to _GENERIC_DF (3)
+    assert "omega" in generic       # 3 distinct texts -> generic
+    assert "zeta" not in generic    # exactly 2 distinct texts -> not generic
 
 
 def test_in_call_duplicate_prev_items_carry_once():

--- a/plugin/uv.lock
+++ b/plugin/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "daimon-briefing"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #13 (false-merge guard slice — rewording erosion and belief carry remain tracked there)

## What

Dedup identity in `carry.merge()` now filters document-frequent terms before comparing items. A salient term appearing in ≥3 distinct item texts within the kind being merged (`_GENERIC_DF = 3`) is treated as shared vocabulary, not identity evidence. After filtering, either side with fewer than 2 remaining terms never fuzzy-matches.

`_MIN_SHARED` / `_MIN_RATIO` values are unchanged — this changes the term set, not the thresholds.

## Why

First live firing of the dedup path (2026-07-02) was a false merge: a fresh adoption-arc item matched an unrelated carried research item on exactly three shared generic terms — `{data, field, validation}` — at the `_MIN_SHARED = 3` floor. The unrelated loop was erased as a separate item and the fresh item inherited its birth stamp.

The cost asymmetry drives the design: a false merge erases a loop and forges its `first_seen`; a false non-merge only costs a duplicate item one cap slot. The guard biases toward not merging.

DF-based filtering over a static stoplist: language-neutral (Spanish checkpoints work unchanged post-i18n) and self-tuning per project — each repo's own noise vocabulary gets filtered without curation.

## Tests

- Live-specimen regression (the exact false-merge pair, embedded at realistic DF)
- Legit rewording twins with specific shared terms still merge and inherit `first_seen` (run-02 behavior preserved)
- Post-filter floor: single surviving shared term cannot pass the ratio path
- DF boundary: 2 texts → not generic, 3 texts → generic
