### PR TITLE
docs: propagate D-009 pivot to install-facing artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Daimon's surface, honestly scoped:
 
 - **The briefing UX** — a session-*start* artifact (`research/findings/07`).
 - **The cognitive-checkpoint serializer** — extractive trust/provenance/supersession over a real transcript (D-006/D-007), self-contained, no graph DB.
-- **Host-agnostic hooks** — Claude Code + Codex today, hermes optional; other hosts (Odysseus, openclawd, …) reachable via a thin adapter.
+- **Host-agnostic hooks** — Claude Code (live-validated daily) + Codex (adapter ships, not yet live-dogfooded), hermes optional; other hosts (Odysseus, openclawd, …) reachable via a thin adapter.
 - **The initiative taxonomy** — attention-gated proactive interruption (MVP ships Level 0 only: pull at session start, nothing pings you).
 
 Honcho and Graphiti were evaluated as a memory substrate and **not adopted** — they conflict with Daimon's lean / offline / no-gateway constraints (the lexical-first verdict is in `research/memory-backend/`; rationale in **[D-009](./research/DECISIONS.md)**). A Claimify-style extraction gate, if built, is a natural upstream PR to Graphiti — not a runtime dependency.
@@ -79,7 +79,7 @@ Honcho and Graphiti were evaluated as a memory substrate and **not adopted** —
 
 This project was previously framed as a standalone "persistent AI companion" with an epistemic-graph differentiator. That framing was **retired** per **[D-008](./research/DECISIONS.md)** (user-approved 2026-06-09): Track B (`findings/07`) found ~7/9 of the proposed epistemic-graph features already shipped by Honcho + Graphiti. The differentiator was a dependency, not a moat.
 
-**Update ([D-009](./research/DECISIONS.md), 2026-06-27):** D-008's "build on Honcho + Graphiti" half **never shipped** and was inverted by later evidence — the gateway outages this cycle plus the memory-backend scale-test (see [research/memory-backend/](./research/memory-backend/) and D-009 in [research/DECISIONS.md](./research/DECISIONS.md)). The runtime is **self-contained and host-agnostic** (Claude Code + Codex today; hermes optional); Honcho/Graphiti are not runtime dependencies.
+**Update ([D-009](./research/DECISIONS.md), 2026-06-27):** D-008's "build on Honcho + Graphiti" half **never shipped** and was inverted by later evidence — the gateway outages this cycle plus the memory-backend scale-test (see [research/memory-backend/](./research/memory-backend/) and D-009 in [research/DECISIONS.md](./research/DECISIONS.md)). The runtime is **self-contained and host-agnostic** (Claude Code live-validated; Codex adapter shipped, awaiting first live run; hermes optional); Honcho/Graphiti are not runtime dependencies.
 
 **Authoritative architecture:** [docs/MVP-DREAM-BRIEFING.md](./docs/MVP-DREAM-BRIEFING.md)
 **Evidence trail:** [research/](./research/README.md) — algorithms, findings, decisions, open questions

--- a/docs/MVP-DREAM-BRIEFING.md
+++ b/docs/MVP-DREAM-BRIEFING.md
@@ -39,9 +39,16 @@ The **primary integration is native host hooks.** Daimon ships standalone hook s
 1. **The native SessionEnd payload carries the transcript path.** The serializer reads the transcript directly from the file the host names — there is no separate session-database read and no dependency on host-internal storage.
 2. **The briefing is injected at session start, not deferred.** SessionStart stdout becomes session context, so the "while you were away" artifact lands before the first model turn. (Hosts whose start hook cannot inject — see Appendix A for the hermes case — defer to the first model call instead.)
 
-### Host adapters — Codex and Gemini (VERIFIED — `hook/_daimon_hook_lib.py`, `hook/daimon-codex-*.py`, `hook/daimon-gemini-*.py`)
+### Host adapters — Codex and Gemini (code VERIFIED, not yet live-dogfooded — `hook/_daimon_hook_lib.py`, `hook/daimon-codex-*.py`, `hook/daimon-gemini-*.py`)
 
 The hook scripts are standalone and **stdlib-only**: they run inside whatever interpreter the host invokes and **cannot import the `daimon_briefing` package** (it lives in an isolated uv-tool venv), so they locate and shell out to the installed `daimon` CLI. Everything the adapters would otherwise duplicate — kill-switch check, CLI resolution, per-project env, detached spawn helpers, checkpoint-age formatting — lives in the shared `hook/_daimon_hook_lib.py`. Host-specific behavior stays in each script: Gemini's pure-JSON stdout, Codex's `additionalContext` envelope and throttled `Stop` hook (Codex has no SessionEnd, so it serializes on a throttled Stop). This is the "thin host adapter" D-009 calls for — new hosts (Odysseus, openclawd, …) become first-class by adding a script pair against the same shared lib.
+
+**Live-validation status per host (honest ladder — trust class applies to hosts too):**
+
+- **Claude Code — LIVE.** The only field-tested host: daily dogfood, full loop (serialize → carry → brief → recall), field incidents recorded in `research/LOGBOOK.md`.
+- **Codex — code-verified + unit-tested (`test_codex_hooks.py`), zero recorded live sessions.** The adapter and installer ship, but no LOGBOOK entry documents a real Codex session completing the capture → inject loop. Treat "runs on Codex" as INFERRED until one is on record.
+- **Gemini — briefing hook shipped; serialize CANNOT run end-to-end today.** Capture is staged behind upstream `gemini-cli#14715` (`transcript_path` stub). Half a loop, by upstream constraint.
+- **hermes — secondary path (Appendix A), unit-tested against a fake host context only.** Never run under a real hermes-agent.
 
 ### Diagram (ASCII — native-hook path)
 
@@ -144,7 +151,7 @@ SCAR (git-native negative-knowledge graph: deadends/fences/landmines, `.scars/`)
 
 What ships today, behind `daimon`:
 
-- **Checkpoint → briefing loop** — SessionEnd serialize, SessionStart briefing, per-project checkpoint store. Runs on Claude Code and Codex via native hooks; a host-free dogfood CLI (`daimon serialize` / `daimon brief`) needs no host at all.
+- **Checkpoint → briefing loop** — SessionEnd serialize, SessionStart briefing, per-project checkpoint store. Live-validated on Claude Code; the Codex adapter ships code-verified but has no recorded live session (see the host-status ladder in §2). A host-free dogfood CLI (`daimon serialize` / `daimon brief`) needs no host at all.
 - **Recall fix (D-007)** — chunked multi-pass extraction + merge for long transcripts, gated against the §3 regression harness (RR ≥70%, FMR ≤10%). Serializer failures are surfaced by cause (ChatError vs JSON-parse vs schema-validation) to the CLI/log rather than swallowed.
 - **Deterministic carry** — unresolved open loops carried forward by exact term overlap, marked `[carried]`.
 - **Proactive recall** — `daimon recall-inject` behind the UserPromptSubmit hook.
@@ -165,7 +172,7 @@ Not shipped / not planned as a runtime dependency: any external memory server or
 
 **ASSUMED / UNVERIFIED (verify before relying):**
 - **Q-model — serializer model + latency budget in-hook.** Which model the detached serializer calls (the host's configured model? a separate cheap model? the `claude` CLI backend?) and its latency budget at session end depend on the user's `daimon configure` result. Single-model confound (`findings/03`) still applies — don't reuse old kimi-k2.6 numbers as a floor.
-- **Q-host — new host adapters.** The Codex/Gemini adapters are VERIFIED; Odysseus/openclawd/other hosts are ASSUMED reachable via the same `_daimon_hook_lib.py` shape until an adapter is actually written and dogfooded.
+- **Q-host — host adapters beyond Claude Code.** The Codex/Gemini adapter *code* is verified and unit-tested, but no host other than Claude Code has a recorded live session — Codex awaits its first dogfooded loop, Gemini serialize is blocked upstream (`gemini-cli#14715`), hermes has only fake-context unit tests. Odysseus/openclawd/other hosts are ASSUMED reachable via the same `_daimon_hook_lib.py` shape until an adapter is actually written and dogfooded.
 - **Q-carry — carry tuning.** The salient-term overlap thresholds and generic-term filtering in `carry.py` are tuned on limited live data; re-tune as more sessions accumulate.
 
 ---

--- a/docs/MVP-DREAM-BRIEFING.md
+++ b/docs/MVP-DREAM-BRIEFING.md
@@ -1,107 +1,101 @@
-# MVP — Dream-Briefing Skill (on hermes-agent + Honcho)
+# MVP — Dream-Briefing (self-contained, host-agnostic)
 
-**Status:** Scoping. Supersedes the standalone-product framing in `docs/RFC.md` / `docs/ARCHITECTURE.md` per **D-008** (user-approved 2026-06-09).
+**Status:** Shipped MVP. This is the authoritative architecture. It describes the **self-contained, host-agnostic** runtime per **[D-009](../research/DECISIONS.md)** (2026-06-27), which supersedes the standalone-product framing in `docs/RFC.md` / `docs/ARCHITECTURE.md` (D-008) *and* D-008's "build on Honcho + Graphiti" substrate framing. Honcho and Graphiti were evaluated as a memory backend and **not adopted as runtime dependencies** — the shipped core is its own lean stack (checkpoint store + prose serializer + deterministic render + pluggable LLM backend).
 
-**Provenance rule for this doc:** every claim about hermes-agent or Honcho internals is tagged **VERIFIED** (read in their code/docs, with path) or **ASSUMED** (inference, unread). This project was burned by overclaiming once (`findings/03`, `findings/07`); do not repeat it.
+**Provenance rule for this doc:** every claim about the runtime or a host's hook contract is tagged **VERIFIED** (read in this repo's code or the host's docs, with path) or **ASSUMED** (inference, unread). This project was burned by overclaiming once (`findings/03`, `findings/07`); do not repeat it.
 
 ---
 
 ## 1. What it is
 
-A **dream-briefing** is a session-*start* artifact: a skimmable "while you were away / here's where we left off" briefing the agent shows you when you resume work, reconstructed from a cognitive checkpoint written at the end of the prior session. It is the one piece of the original Daimon kernel that neither Honcho nor Graphiti ships (`findings/07` delta map) and that was demonstrated valuable live.
+A **dream-briefing** is a session-*start* artifact: a skimmable "while you were away / here's where we left off" briefing the agent shows you when you resume work, reconstructed from a cognitive checkpoint written at the end of the prior session. It is the one piece of the original Daimon kernel that the memory backends evaluated in D-009 did not ship, and that was demonstrated valuable live.
 
-**Motivating failure (the gap it closes):** the agent confidently asserted a PR was still open when the user had already merged it *outside the AI ecosystem*. The agent had no record of the state change because nothing carried the prior session's open loops forward. The briefing exists to surface exactly those carried-over facts ("last session you were waiting on PR #6 — verify its state before acting") so the model resumes from a faithful prior state instead of a confident guess. The briefing's job is **recall fidelity, not fluency** — `findings/03` proved reconstruction is faithful (FMR ~1%); the weakness is omission (RR 67.3%).
+**Motivating failure (the gap it closes):** the agent confidently asserted a PR was still open when the user had already merged it *outside the AI ecosystem*. The agent had no record of the state change because nothing carried the prior session's open loops forward. The briefing exists to surface exactly those carried-over facts ("last session you were waiting on PR #6 — verify its state before acting") so the model resumes from a faithful prior state instead of a confident guess. The briefing's job is **recall fidelity, not fluency** — `findings/03` proved reconstruction is faithful (FMR ~1%); the weakness is omission (RR 67.3%), which §4 addresses.
 
 ---
 
 ## 2. Architecture
 
-### Extension points (hermes-agent) — VERIFIED
+The **primary integration is native host hooks.** Daimon ships standalone hook scripts that a host (Claude Code, Codex, Gemini) invokes at its own session boundaries; the scripts shell out to an installed `daimon` CLI which owns all serialization, rendering, and storage. There is **no server and no external memory backend** — the runtime is stdlib-only and offline-first. A hermes-agent plugin is an *optional secondary* surface (Appendix A).
 
-hermes-agent has an **event-hooks system** (not just SKILL.md skills). Two hook flavors share the same event names:
-- **Shell hooks** — declared in `cli-config.yaml`, run as subprocesses; Hermes pipes a JSON payload to stdin and reads JSON from stdout. *VERIFIED — `website/docs/user-guide/features/hooks.md`.*
-- **Plugin hooks** — Python, registered via `ctx.register_hook("<event>", callback)` from a `register(ctx)` entrypoint in `plugin.yaml`. *VERIFIED — `website/docs/user-guide/features/hooks.md`.*
+### Native hooks — Claude Code (VERIFIED — `hooks/hooks.json`, `hook/`)
 
-Relevant events (plugin-hook names) — *VERIFIED, same source:*
+`hooks/hooks.json` declares three hooks; the plugin registers them with the host:
 
-| Event | Fires | Signature (args the callback receives) |
+| Host event | Script | Role |
 |---|---|---|
-| `on_session_start` | session begins | `(session_id: str, model: str, platform: str, **kwargs)` — **return value ignored** (cannot inject) |
-| `on_session_end` | end of every `run_conversation()` | `(session_id, completed, interrupted, model, platform, **kwargs)` |
-| `on_session_finalize` | session identity torn down ("last chance to flush state") | `(session_id, platform, **kwargs)` |
-| `pre_llm_call` | before each model call | receives `conversation_history: list` (OpenAI format); **can inject** — returning `{"context": "..."}` (or a non-empty string) appends text to the **current turn's user message** [*Slice-1 build correction: full signature is `(session_id, user_message, conversation_history, is_first_turn, model, platform, **kwargs)` — extra `user_message` param vs. the table originally claimed; VERIFIED at code level during build*] |
-| `post_llm_call` | after each model call | receives `conversation_history` |
+| `SessionEnd` | `hook/daimon-session-end.py` | Serialize the ending session into a checkpoint |
+| `SessionStart` | `hook/daimon-session-brief.py` | Inject the briefing as session context |
+| `UserPromptSubmit` | `hook/daimon-prompt-recall.py` | Proactive "you worked on this before" recall |
 
-**Two architectural constraints this forces (both VERIFIED, both load-bearing):**
+**Write path (SessionEnd) — VERIFIED `hook/daimon-session-end.py`.** The hook reads the SessionEnd payload from stdin (`{session_id, transcript_path, cwd, reason, ...}`) and spawns `daimon serialize <transcript_path>` as a **detached** background process (`start_new_session=True`, so it survives `/exit`). Serialization is a 30s+ LLM call; blocking session exit on it is unacceptable, so the hook returns immediately and the child finishes on its own. Fail-open: always exit 0; diagnostics go to `~/.daimon/logs/serialize.log`. Per-project routing hands the session's `cwd` to the child so the checkpoint lands under the right project.
 
-1. **Session-lifecycle hooks do NOT receive the transcript.** `on_session_start` / `on_session_end` / `on_session_finalize` get only session metadata. The serializer therefore cannot get the transcript *from the hook payload* — it must read it from storage by `session_id` (see below).
-2. **`on_session_start` cannot inject context.** Its return value is ignored. The briefing therefore cannot be injected at the start hook. It must be injected at the **first `pre_llm_call`** of the new session (which both receives history *and* can append to the user message). Injection lands in the **user message, not system prompt** (deliberate, to preserve prompt caching) — *VERIFIED.*
+**Read path (SessionStart) — VERIFIED `hook/daimon-session-brief.py`.** The hook shells out to `daimon brief`; whatever the CLI prints to stdout is injected as additional session context. The CLI is the *single source of truth* for briefing rendering, so no host re-renders the checkpoint and the hosts never drift. Fail-open (exit 0); a missing CLI prints a one-line install hint instead of a briefing.
 
-### Transcript access — VERIFIED
+**Proactive recall (UserPromptSubmit) — VERIFIED `hook/daimon-prompt-recall.py`.** Fires on every prompt, pipes the prompt to `daimon recall-inject` on stdin, and injects a one-line pointer when the prompt overlaps a prior open loop. Because it fires per-prompt, failures are **silent** (exit 0, no output) — the only thing it ever prints is a real suggestion — and it never re-suggests what the SessionStart briefing already carried.
 
-hermes persists session message history in **`~/.hermes/state.db`** (SQLite, `messages` table keyed by `session_id`). Programmatic read: instantiate first — `db = SessionDB(); db.get_messages_as_conversation(session_id)` (OpenAI-format array), from `hermes_state.py`. *VERIFIED — `website/docs/developer-guide/session-storage.md`; corrected during Slice-1 build: `SessionDB` is instantiated, not called statically as this doc originally wrote.* So the session-end serializer reads the full transcript by `session_id` even though the hook payload omits it. (Legacy `~/.hermes/sessions/*.jsonl` may exist for old sessions — *VERIFIED, same source.*)
+**Two architectural facts this shape gives us (both VERIFIED, both load-bearing):**
 
-### Checkpoint store
+1. **The native SessionEnd payload carries the transcript path.** The serializer reads the transcript directly from the file the host names — there is no separate session-database read and no dependency on host-internal storage.
+2. **The briefing is injected at session start, not deferred.** SessionStart stdout becomes session context, so the "while you were away" artifact lands before the first model turn. (Hosts whose start hook cannot inject — see Appendix A for the hermes case — defer to the first model call instead.)
 
-- **MVP / Slice 1: local file.** `~/.daimon/checkpoints/<session_id>.json` (the Track-A `cognitive-state.schema.json`). No Honcho dependency. Lets the user dogfood immediately.
-- **Slice 2+: Honcho.** Write the checkpoint as a message from a dedicated analysis peer via `session.add_messages(...)`; Honcho's deriver enqueues representation derivation async. Read at session start via `session.context(summary=True, tokens=N)` (prompt-ready bundle, `.to_anthropic()` / `.to_openai()`) and/or `peer.chat(query)` for targeted recall. *VERIFIED method names — Honcho docs/PyPI `honcho-ai` (`session.add_messages`, `session.context(tokens=...)`, `context.to_openai/to_anthropic`, `peer.chat(query)`, `peer.representation()`).* Which Honcho call best fits the briefing (static `context` vs. reasoned `peer.chat`) is **ASSUMED** until probed — see §9.
+### Host adapters — Codex and Gemini (VERIFIED — `hook/_daimon_hook_lib.py`, `hook/daimon-codex-*.py`, `hook/daimon-gemini-*.py`)
 
-### Diagram (ASCII)
+The hook scripts are standalone and **stdlib-only**: they run inside whatever interpreter the host invokes and **cannot import the `daimon_briefing` package** (it lives in an isolated uv-tool venv), so they locate and shell out to the installed `daimon` CLI. Everything the adapters would otherwise duplicate — kill-switch check, CLI resolution, per-project env, detached spawn helpers, checkpoint-age formatting — lives in the shared `hook/_daimon_hook_lib.py`. Host-specific behavior stays in each script: Gemini's pure-JSON stdout, Codex's `additionalContext` envelope and throttled `Stop` hook (Codex has no SessionEnd, so it serializes on a throttled Stop). This is the "thin host adapter" D-009 calls for — new hosts (Odysseus, openclawd, …) become first-class by adding a script pair against the same shared lib.
+
+### Diagram (ASCII — native-hook path)
 
 ```
   SESSION N (work happens)
   ─────────────────────────────────────────────────────────────────
         │ user merges PR #6 OUTSIDE the AI ecosystem (no record yet)
         ▼
-  [ session ends ] ──fires──► on_session_end(session_id, …)        ← VERIFIED hook
-        │                          │
-        │            (1) SessionDB.get_messages(session_id)         ← VERIFIED read path
-        │                          ▼
+  [ session ends ] ──host fires──► SessionEnd hook (daimon-session-end.py)
+        │                                │  reads {transcript_path, cwd} from stdin
+        │                    spawn DETACHED: `daimon serialize <transcript>`
+        │                                ▼
         │                 ┌─────────────────────┐
-        │                 │   SERIALIZER         │  Track-A serialize prompt
-        │                 │  transcript → CHKPT  │  + cognitive-state.schema.json
+        │                 │   SERIALIZER         │  D-010 serialize prompt
+        │                 │  transcript → CHKPT  │  + cognitive-state schema
         │                 │  (extractive-pinned, │  (D-006 trust classes)
-        │                 │   chunked if >~1200ln)│  (D-007 recall fix)
+        │                 │   chunked if long)   │  (D-007 recall fix)
         │                 └─────────┬───────────┘
         │                           ▼
-        │         Slice 1: ~/.daimon/checkpoints/<id>.json   (local file)
-        │         Slice 2+: session.add_messages(...)         (Honcho)   ← VERIFIED
+        │            ~/.daimon/checkpoints/<project>/<id>.json   (per-project store)
+        │            deterministic carry: unresolved loops → next checkpoint, [carried]
   ─────────────────────────────────────────────────────────────────
   SESSION N+1 (resume)
   ─────────────────────────────────────────────────────────────────
-   on_session_start(session_id, …)   ← VERIFIED; CANNOT inject (return ignored)
-        │ (load latest checkpoint into skill state)
+   SessionStart hook (daimon-session-brief.py)   ← shells out to `daimon brief`
+        │   RECONSTRUCT checkpoint → briefing (deterministic render)
         ▼
-   first pre_llm_call(conversation_history)   ← VERIFIED; CAN inject
-        │   RECONSTRUCT checkpoint → briefing (Track-A reconstruct prompt)
-        │   Slice 2+: blend with session.context(summary=True) / peer.chat()  ← VERIFIED
-        ▼
-   return {"context": "<dream briefing>"}  → appended to user message  ← VERIFIED
+   stdout → injected as session context           ← briefing lands before first turn
         ▼
    model resumes with carried-over state ("you merged PR #6 — verify before acting")
+        │
+        ▼   … and on each later prompt:
+   UserPromptSubmit hook (daimon-prompt-recall.py) → `daimon recall-inject`
+        │   prompt overlaps a prior open loop? inject a one-line pointer (else silent)
 ```
 
-**Why a hybrid skill+hooks shape, not a pure SKILL.md skill:** a pure agentskills.io SKILL.md is invoked by slash command or conversation — it has **no automatic session-start/session-end trigger** (*VERIFIED — skills docs describe no lifecycle activation*). The briefing must fire *automatically* at boundaries, so the serialize/inject mechanism lives in **hooks**; the SKILL.md is the user-facing surface (`/daimon-briefing`, config, docs) that ships the hook registration.
-
-**Packaging verdict (VERIFIED — see §9 Q-A):** a SKILL.md dir and a plugin are **two separate, incompatible installation surfaces**. There is no field in the agentskills.io frontmatter that registers a plugin hook. Single-bundle UX is possible only via **a plugin that also calls `ctx.register_skill(name, path)`** — the plugin ships the hook logic AND exposes the skill via a namespaced name. [*Slice-1 build correction: the namespace is DERIVED as `<plugin-name>:<skill-dir>` — ours is `daimon-briefing:daimon-briefing`, not the freely-chosen `daimon:briefing` this doc originally assumed.*] Distribution: `hermes plugins install owner/daimon-plugin --enable`. One `hermes` command, zero manual config edits. *VERIFIED — `website/docs/user-guide/features/plugins.md` (ctx.register_skill table row), `website/docs/guides/build-a-hermes-plugin.md` (Bundle skills section, lines 383–424).* The plugin-first shape also allows a pip distribution path (`hermes_agent.plugins` entry-point group — *VERIFIED `hermes_cli/plugins.py` `ENTRY_POINTS_GROUP`*), meaning `pip install daimon-agent` could be a one-command install story for Slice 3+.
+**Why hooks + a CLI, not a pure SKILL.md skill:** a SKILL.md skill is invoked by slash command or conversation — it has **no automatic session-start/session-end trigger**. The briefing must fire *automatically* at boundaries, so the serialize/inject/recall mechanism lives in **host hooks**, and the bundled `skills/daimon-briefing/SKILL.md` is only the user-facing surface (what a stranger's agent reads to explain the tool).
 
 ---
 
 ## 3. What we reuse from Track A
 
-The Track-A rig (`research/experiments/track-a/`) is the serializer seed — reuse, don't rewrite:
+The Track-A rig (`research/experiments/track-a/`) was the serializer seed — its prompts and schema ship, hardened, in `plugin/daimon_briefing/`:
 
-- **`schema/cognitive-state.schema.json`** — the checkpoint format, already carries per-item **trust classes** (`verbatim` + required `quote` / `inferred`) implementing **D-006** (extractive pinning). This is the MVP checkpoint schema.
-- **`prompts/01-serialize.md`** (= `runner.py:SERIALIZE_SYS`) — the session-end serialize prompt with the anti-confabulation constraint. Becomes the serializer the `on_session_end` hook runs. D-007 revisions land here.
-- **`prompts/02-reconstruct.md`** (= `runner.py:RECONSTRUCT_SYS`) — the checkpoint→briefing prompt. Becomes what the `pre_llm_call` injection runs (PART 2 "dream sequence" *is* the briefing).
-- **`scoring/score.py` + the 5 ground-truthed sessions** — keep as a **regression harness**. Any prompt/schema/chunking change re-runs against the held answer keys; gate = RR ≥70%, FMR ≤10% (`findings/03`). This is the guardrail that stops a recall fix from reintroducing fabrication.
-- **`runner.py`** — the serialize→reconstruct automation; adapt into the hook's serializer entrypoint.
+- **`schema/cognitive-state.schema.json`** — the checkpoint format, carrying per-item **trust classes** (`verbatim` + required `quote` / `inferred`) implementing **D-006** (extractive pinning). This is the shipped checkpoint schema.
+- **`prompts/01-serialize.md`** (now `serializer.py`, D-010 prompt) — the session-end serialize prompt with the anti-confabulation constraint. Runs behind `daimon serialize`; D-007 revisions landed here.
+- **`prompts/02-reconstruct.md`** — the checkpoint→briefing prompt, now the deterministic render behind `daimon brief`.
+- **`scoring/score.py` + the 5 ground-truthed sessions** — kept as a **regression harness**. Any prompt/schema/chunking change re-runs against the held answer keys; gate = RR ≥70%, FMR ≤10% (`findings/03`). This is the guardrail that stops a recall fix from reintroducing fabrication.
 
 ---
 
-## 4. The recall problem and the plan (D-007) — **PROBE RUN, FORK RESOLVED: CHUNKING**
+## 4. The recall problem and the fix (D-007) — **SHIPPED: CHUNKING**
 
-`findings/03`: recall is **length-driven**, sharp cliff at **~1,400 transcript lines**. The D-007 fork (prompt vs architecture) **was probed on 2026-06-09** (`experiments/track-a/probe_d007.py`, S2, three arms, transcript-grounded LLM judge):
+`findings/03`: recall is **length-driven**, with a sharp cliff at **~1,400 transcript lines**. The D-007 fork (prompt vs architecture) was probed on 2026-06-09 (`experiments/track-a/probe_d007.py`, S2, three arms, transcript-grounded LLM judge):
 
 | Arm | RR | FMR | Bars (≥70% / ≤10%) |
 |---|---|---|---|
@@ -109,82 +103,84 @@ The Track-A rig (`research/experiments/track-a/`) is the serializer seed — reu
 | D-007 prompt, single-pass | 58.6% | 4.2% | ❌ recall |
 | D-007 prompt + chunked (800 ln / 100 overlap) + merge | **89.7%** | **6.7%** | ✅ |
 
-**Resolved: the Slice 1 serializer is chunk→extract→merge for long transcripts; the D-007 prompt is adopted in both regimes.** Prompt alone helps (+21pp) but cannot clear the bar on a 2,187-line transcript — context/attention degradation, as `findings/03` predicted. The merge pass did not fabricate (FMR 6.7% under bar) — D-006 verbatim `quote` pinning held.
+**Shipped: the serializer is chunk→extract→merge for long transcripts; the D-007 prompt is adopted in both regimes** (`serializer.py` — single-pass below the chunk threshold, chunked multi-pass above, with a merge pass). Prompt alone helps (+21pp) but cannot clear the bar on a 2,187-line transcript — context/attention degradation, as `findings/03` predicted. The merge pass did not fabricate (FMR 6.7% under bar) — D-006 verbatim `quote` pinning held.
 
-**Remaining plan:**
-1. **Single-pass below ~1,200 lines, chunked above** (margin under the 1,400 cliff; threshold from n=5 + this probe, one model — re-tune with more sessions).
-2. **Re-score on all 5 sessions** with the chunked serializer (probe was S2-only). Add the pieces `findings/03` still names as owed: un-annotated **holdout** (contamination confound), **2-cycle** degradation test before any "no confabulation" claim.
-3. Judge caveat: probe scored by LLM-as-judge (transcript-grounded — see `.scars/0001`), not human-verified. Same-judge cross-arm deltas are sound; absolute RR is judge-dependent (judge is harsher than the human Round-1 scoring).
-4. **Staleness (Q-STALE, from first live dogfood — `findings/03`):** facts that evolve within a session get pinned to their earliest strong quote (observed live: the briefing cited the superseded broken-judge probe numbers as verbatim evidence). Slice 2 serializer/merge MUST prefer the latest state of an evolving fact — pin the final quote, optionally noting the evolution — and the regression harness gains a **staleness-rate** metric alongside RR/FMR. FMR cannot catch this (the stale quote is genuinely in the transcript).
+**Staleness (Q-STALE, from live dogfood — `findings/03`):** facts that evolve within a session can be pinned to their earliest strong quote (observed live: the briefing cited superseded probe numbers as verbatim evidence). The merge prompt now prefers the **latest state** of an evolving fact (see the final-state reconciliation rules in `serializer.py:MERGE_SYS`), and unresolved loops that survive a session are moved forward by **deterministic carry** (`carry.py`) — exact salient-term overlap, no LLM — and labelled `[carried]` in the briefing so a survived loop is visibly distinct from a freshly observed one. FMR cannot catch staleness on its own (the stale quote is genuinely in the transcript), so the regression harness tracks it separately.
 
 ---
 
 ## 5. Initiative taxonomy (v0)
 
-MVP ships **Level 0 only — pull, at session start.** The briefing appears when you resume; nothing pings you proactively. This is the silent-by-default posture `findings/05` recommends ("the danger isn't *can we decide when to interrupt* — it's *will users tolerate any proactive AI*"). Level 0 sidesteps the entire interruptibility/attention-model problem.
+MVP ships **Level 0 only — pull, at session start** (plus the lightweight per-prompt recall pointer, which is still pull-shaped: it answers the prompt you just typed, it does not ping you unprompted). The briefing appears when you resume; nothing interrupts you. This is the silent-by-default posture `findings/05` recommends ("the danger isn't *can we decide when to interrupt* — it's *will users tolerate any proactive AI*"). Level 0 sidesteps the entire interruptibility/attention-model problem.
 
-**Deferred (Level 1–3):** confidence×relevance×attention EV gate, the four-channel escalation (dream-log → chat → Slack DM → DM+mention), the attention model (calendar/activity/`/dnd`), and the contextual-bandit upgrade. All designed in `findings/05`; none in MVP. Rationale: each needs proactive-interrupt infrastructure and an attention signal hermes does not obviously expose (ASSUMED — not verified), and adoption risk dominates algorithm risk here.
+**Deferred (Level 1–3):** confidence×relevance×attention EV gate, the four-channel escalation (dream-log → chat → Slack DM → DM+mention), the attention model (calendar/activity/`/dnd`), and the contextual-bandit upgrade. All designed in `findings/05`; none in MVP. Rationale: each needs proactive-interrupt infrastructure and an attention signal, and adoption risk dominates algorithm risk here.
 
 ---
 
 ## 6. Out of scope for MVP
 
-- **Epistemic graph / belief store / contradiction detection.** Use Honcho (reconciliation) + Graphiti (temporal validity intervals). `findings/07` / D-005-retracted: building it is reimplementing shipped, funded products. The briefing *consumes* their output; it does not replace it.
+- **Epistemic graph / belief store / contradiction detection.** D-009 evaluated the temporal-KG memory backends (Honcho for reconciliation, Graphiti for temporal validity intervals) as a runtime substrate and **rejected them** — a server + graph DB + embeddings reintroduce the gateway/embedding fragility that offline-first is meant to avoid, and Graphiti's one load-bearing idea (temporal-validity supersession) the serializer schema already does cheaply. The briefing does not build an epistemic graph; it carries load-bearing facts forward extractively.
 - **Proactive interruption** (Level 1–3) — §5.
-- **Multi-platform** — target the hermes CLI/gateway path only; no Slack/web/mobile surfaces.
-- **Checkpoint versioning / rollback** — `findings/03`: rollback to a checkpoint made by the same lossy process is a weak defense against confabulation; it guards crashes, not drift. Honcho/Graphiti carry temporal history if needed later.
+- **Multi-platform surfaces** — target the host-hook path only; no Slack/web/mobile.
+- **Checkpoint versioning / rollback** — `findings/03`: rollback to a checkpoint made by the same lossy process is a weak defense against confabulation; it guards crashes, not drift.
 - **Semantic evolution-vs-contradiction classification** — hard, unproven (`findings/07`); research follow-up, not MVP.
 
 ---
 
-## 7. Upstream contribution track
+## 7. Upstream contribution track (optional, not a runtime dependency)
 
-Two net-new pieces from `findings/07` whose natural home is a PR, not a standalone build:
+One net-new piece from `findings/07` whose natural home is a PR to an existing project rather than a Daimon runtime dependency:
 
-1. **Claimify-style extraction gate → PR to Graphiti.** Confirmed absent from Graphiti's `node_operations.py` (no confidence / verification / decontextualization gate before a fact enters the graph) — `findings/07`. The Track-A serializer's `verbatim`+`quote` extractive pinning is a working seed of this gate. Contribution = a high-confidence, decontextualized extraction pass in front of edge/node creation. **Verify line-level against current Graphiti before claiming the gap** (`findings/07` caveat: quotes were WebFetch @ v0.29.1).
-2. **Evolution-vs-contradiction classification → research follow-up, not a PR yet.** Graphiti distinguishes the two only by interval overlap; classifying the *kind* of change (corrected misconception vs. real-world state change vs. refinement) is reasoning neither Graphiti nor Honcho does. Hardest, narrowest, unproven — keep as a research note until there's evidence it works.
+- **Claimify-style extraction gate → optional PR to Graphiti.** `findings/07` found Graphiti's `node_operations.py` has no confidence / verification / decontextualization gate before a fact enters the graph. The serializer's `verbatim`+`quote` extractive pinning is a working seed of such a gate. This is a *contribution*, not a dependency — Daimon does not run on Graphiti. **Verify line-level against current Graphiti before claiming the gap** (`findings/07` caveat: quotes were WebFetch @ v0.29.1).
+- **Evolution-vs-contradiction classification → research follow-up.** Classifying the *kind* of change (corrected misconception vs. real-world state change vs. refinement) is reasoning the evaluated backends do not do. Hardest, narrowest, unproven — a research note until there's evidence it works.
 
-### Adjacent: SCAR convergence (not MVP scope)
+### Adjacent: SCAR convergence
 
-SCAR (sibling project — git-native negative-knowledge graph: deadends/fences/landmines, `.scars/`) runs a session-end candidate-drafter that LLM-reads the transcript for *abandonment* signals; Daimon's serializer LLM-reads the same transcript for *state* (decisions/open-loops/fixes). Same hook point, same input, opposite polarity. Running both naively doubles per-session extraction cost. Future merge: **one session-end extraction pass emitting two artifacts** — the cognitive checkpoint AND scar candidates. The D-007 serializer prompt already extracts assistant-side fixes/diagnoses with root cause, which is most of a `deadend` draft. Deliberately NOT coupled during MVP (two concept-stage projects, independent validation gates); revisit after SCAR's gate 0.4 and Daimon Slice 1 both conclude.
+SCAR (git-native negative-knowledge graph: deadends/fences/landmines, `.scars/`) runs a session-end candidate-drafter that LLM-reads the transcript for *abandonment* signals; Daimon's serializer LLM-reads the same transcript for *state* (decisions/open-loops/fixes). Same hook point, same input, opposite polarity. Daimon already ships an optional session-end scar-harvest pass (`harvest.run`, gated by config) that emits scar candidates alongside the checkpoint — so a single session-end extraction can feed both artifacts.
 
 ---
 
-## 8. Milestones (thin vertical slices)
+## 8. Delivery status
 
-Each slice is independently shippable and testable. **Slice 1 runs without Honcho** so the user dogfoods on day one.
+What ships today, behind `daimon`:
 
-**Slice 1 — Local-file briefing, no Honcho.**
-`on_session_end` hook → read transcript via `SessionDB.get_messages(session_id)` → run Track-A serializer → write `~/.daimon/checkpoints/<id>.json`. First `pre_llm_call` of next session (`is_first_turn: bool` flag in hook signature — *VERIFIED `website/docs/user-guide/features/hooks.md` `pre_llm_call` parameter table*) → reconstruct → return `{"context": briefing}`. **Ship as a hermes plugin** (`plugin.yaml` + `__init__.py` with `ctx.register_hook()` + `ctx.register_skill()` + bundled `skills/daimon-briefing/SKILL.md`). Install: `hermes plugins install owner/daimon-plugin --enable`. *Dogfoodable in hermes/Claude Code immediately; zero external deps; single install command.* [*Packaging shape changed from "skill bundle" to "plugin with bundled skill" — VERIFIED as the only single-command install path — see §9 Q-A.*] Test: does the next session's briefing surface the prior session's open loops (the PR-merge gap)?
+- **Checkpoint → briefing loop** — SessionEnd serialize, SessionStart briefing, per-project checkpoint store. Runs on Claude Code and Codex via native hooks; a host-free dogfood CLI (`daimon serialize` / `daimon brief`) needs no host at all.
+- **Recall fix (D-007)** — chunked multi-pass extraction + merge for long transcripts, gated against the §3 regression harness (RR ≥70%, FMR ≤10%). Serializer failures are surfaced by cause (ChatError vs JSON-parse vs schema-validation) to the CLI/log rather than swallowed.
+- **Deterministic carry** — unresolved open loops carried forward by exact term overlap, marked `[carried]`.
+- **Proactive recall** — `daimon recall-inject` behind the UserPromptSubmit hook.
+- **Code-drift detection** — `daimon anchor <file> <symbol>` binds a checkpoint item to a code symbol; the briefing flags it under **CODE DRIFT** when the symbol's body changes (offline, stdlib `ast`).
+- **Operability** — `daimon status` (health), `daimon heal` (one-shot recovery of a failed serialize, also fired detached at SessionStart), `daimon configure` (backend detection + `~/.daimon/env`).
 
-**Slice 2 — Recall fix (D-007).**
-Add chunked multi-pass extraction for transcripts >~1,200 ln + edit-style merge. Gate against the §3 regression harness (RR ≥70%, FMR ≤10%). Run the S2 probe, the holdout, and the 2-cycle test. No new surface — same Slice-1 UX, better checkpoints.
-Also: **named serializer failures** (from second live dogfood, 2026-06-10) — `serializer.serialize()` swallows all failure causes into `None` (`except Exception: return None`); the 120s-timeout root cause took instrumented reproduction to find instead of one log line. Distinguish ChatError vs JSON-parse vs schema-validation failures and surface the reason to the CLI/log (same class of fix as the PR #13 CLI error split, one layer deeper).
-
-**Slice 3 — Honcho-backed checkpoint + recall.**
-Swap the local-file store for `session.add_messages()` (write) and blend `session.context(summary=True)` / `peer.chat()` into the briefing (read). Checkpoint store becomes pluggable (`file` | `honcho`). Gives cross-session user modeling + reconciliation for free. Behind a config flag; local-file remains the default fallback.
-
-**Slice 4 (optional) — Claimify gate PR to Graphiti.**
-Extract the extraction-gate logic, verify the gap against current Graphiti, open the PR. Independent of Slices 1–3.
+Not shipped / not planned as a runtime dependency: any external memory server or graph backend (D-009).
 
 ---
 
 ## 9. Open questions (VERIFIED vs ASSUMED)
 
-**VERIFIED (read in their docs/code):**
-- hermes has an event-hooks system with `on_session_start` / `on_session_end` / `on_session_finalize` / `pre_llm_call` / `post_llm_call` — `website/docs/user-guide/features/hooks.md`.
-- Session-lifecycle hooks do **not** carry the transcript; only `pre_llm_call`/`post_llm_call` carry `conversation_history` — same source.
-- `on_session_start` **cannot** inject context (return ignored); `pre_llm_call` **can** (`{"context": ...}` → appended to the user message, not system prompt) — same source.
-- Transcript is readable by `session_id` from `~/.hermes/state.db` via `SessionDB.get_messages()` (`hermes_state.py`) — `website/docs/developer-guide/session-storage.md`.
-- hermes skills follow the agentskills.io SKILL.md standard and have **no** automatic session-lifecycle activation (slash/conversation only) — skills docs.
-- Honcho SDK (`honcho-ai`): `session.add_messages()`, `session.context(tokens=N)` → `.to_openai()`/`.to_anthropic()`, `peer.chat(query)`, `peer.representation()` — Honcho docs / PyPI.
-- Honcho is **AGPL-3.0**; hermes is **MIT**; Daimon is **Apache-2.0** (D-001) — repo license files.
+**VERIFIED (read in this repo's code):**
+- Native Claude Code hooks are declared in `hooks/hooks.json` (`SessionStart` / `UserPromptSubmit` / `SessionEnd`) and implemented under `hook/`; the SessionEnd payload carries `transcript_path` and `cwd`.
+- The hook scripts are stdlib-only and shell out to the installed `daimon` CLI; they cannot import `daimon_briefing` (isolated uv-tool venv). Shared helpers live in `hook/_daimon_hook_lib.py`.
+- The serializer chunks long transcripts and merges, preferring latest-state on evolving facts (`serializer.py`); deterministic carry is LLM-free (`carry.py`).
+- hermes is an **optional** host, not a requirement: `transcript.py` guards the hermes import and the CLI works without hermes (Appendix A).
 
-**VERIFIED (added this session):**
-- **Q-A — Single-install UX: VERIFIED. Answer: YES, via plugin-with-bundled-skill.** A SKILL.md directory alone **cannot** register a hook — there is no frontmatter field for that in the agentskills.io SKILL.md schema. The correct shape is a **hermes plugin** that (a) calls `ctx.register_hook("on_session_end", ...)` and `ctx.register_hook("pre_llm_call", ...)` in its `register(ctx)` entrypoint, and (b) calls `ctx.register_skill("briefing", skill_md_path)` to expose the SKILL.md as `daimon:briefing`. Both hooks and the skill ship in one plugin directory. Install: `hermes plugins install owner/daimon-plugin --enable` — one command, zero manual config edits. Also distributable as a pip package via the `hermes_agent.plugins` entry-point group (`ENTRY_POINTS_GROUP` constant — `hermes_cli/plugins.py`). *VERIFIED — `website/docs/user-guide/features/plugins.md` (capability table: "Bundle skills → `ctx.register_skill()`"); `website/docs/guides/build-a-hermes-plugin.md` ("Bundle skills" section, complete working example); `website/docs/developer-guide/creating-skills.md` (SKILL.md frontmatter schema — no hook field exists); `hermes_cli/plugins.py` (`ENTRY_POINTS_GROUP = "hermes_agent.plugins"`).*
-- **Q-B — Briefing injection timing: VERIFIED.** `pre_llm_call` receives `is_first_turn: bool` as a named parameter — **no flag state needs to persist across the session-start → first-llm boundary**. The hook can gate injection with `if not is_first_turn: return None` directly. *VERIFIED — `website/docs/user-guide/features/hooks.md` (`pre_llm_call` parameter table: `is_first_turn | bool | True if this is the first turn of a new session, False on subsequent turns`); `website/docs/guides/build-a-hermes-plugin.md` (same parameter listed in hook reference table).*
+**ASSUMED / UNVERIFIED (verify before relying):**
+- **Q-model — serializer model + latency budget in-hook.** Which model the detached serializer calls (the host's configured model? a separate cheap model? the `claude` CLI backend?) and its latency budget at session end depend on the user's `daimon configure` result. Single-model confound (`findings/03`) still applies — don't reuse old kimi-k2.6 numbers as a floor.
+- **Q-host — new host adapters.** The Codex/Gemini adapters are VERIFIED; Odysseus/openclawd/other hosts are ASSUMED reachable via the same `_daimon_hook_lib.py` shape until an adapter is actually written and dogfooded.
+- **Q-carry — carry tuning.** The salient-term overlap thresholds and generic-term filtering in `carry.py` are tuned on limited live data; re-tune as more sessions accumulate.
 
-**ASSUMED / UNVERIFIED (could not confirm in code — verify before relying):**
-- **Q-C — Honcho call choice for the briefing.** Static `session.context(summary=True)` vs. reasoned `peer.chat()` vs. both. Untested; decide empirically in Slice 3. Also: Honcho's *queryable belief-revision history* (vs. silent reconciliation) was the one under-documented Honcho seam (`findings/07` caveat) — probe before depending on it.
-- **Q-D — Serializer model in-hook.** Track-A used a LiteLLM gateway; which model the hook serializer calls (hermes's configured model? a separate cheap model?) and its latency budget at session end are unspecified. Single-model confound (`findings/03`) still applies — don't reuse kimi-k2.6 numbers as a floor.
-- **Q-E — AGPL-3.0 posture.** Calling Honcho over its API/SDK from an Apache-2.0 plugin is **not** a derivative work under FSF's own position (mere API/network communication does not create a combined work; AGPL's §13 copyleft triggers on *conveying or running a modified Honcho*, not on a separate client calling it). **Verified at the principle level; NOT verified for our exact deployment** — if we ever *bundle/self-host a modified* Honcho, or statically link the SDK in a way that forms one program, re-check. hermes already integrates Honcho, which is corroborating but not a legal clearance. Get a license read before shipping Slice 3. *(FSF AGPL-3.0 text; not legal advice.)*
+---
+
+## Appendix A — Secondary integration: hermes-agent plugin (optional)
+
+hermes-agent is **one optional host**, not a requirement. When Daimon runs under hermes, the same serialize→brief loop is wired through hermes's in-process plugin-hook system instead of standalone host scripts. This path still exists in code (`plugin/daimon_briefing/__init__.py`, `plugin/daimon_briefing/hooks.py`) and is guarded so a missing hermes never breaks the standalone CLI.
+
+**Registration — VERIFIED `plugin/daimon_briefing/__init__.py`.** A `register(ctx)` entrypoint wires two hooks and bundles the skill:
+- `ctx.register_hook("on_session_end", hooks.on_session_end)`
+- `ctx.register_hook("pre_llm_call", hooks.pre_llm_call)`
+- `ctx.register_skill(name, skill_md_path)` for each bundled skill dir.
+
+**Two constraints specific to the hermes path (VERIFIED — `plugin/daimon_briefing/hooks.py`, hermes hook docs):**
+1. **Session-lifecycle hooks do not receive the transcript.** `on_session_end` gets only session metadata, so the serializer reads the transcript from hermes session storage by `session_id` (`transcript.from_session`) — unlike the native path, which is handed `transcript_path` directly.
+2. **The session-start hook cannot inject context** (its return value is ignored). The briefing is therefore injected at the **first `pre_llm_call`** of the next session, gated on the `is_first_turn` flag, and appended to the user message (not the system prompt, to preserve prompt caching).
+
+The hermes callbacks run in-process (not a detached subprocess), but delegate to the same `serializer`, `store`, `briefing`, and `carry` modules the CLI uses, so both integration paths produce identical checkpoints and briefings.

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "daimon-briefing"
 version = "0.3.2"
-description = "Dream-briefing hermes plugin: cognitive checkpoint at session end, 'while you were away' briefing at session start. Slice 1 (local-file, no Honcho)."
+description = "Dream-briefing for AI coding agents: writes a cognitive checkpoint at session end and shows a 'while you were away' briefing at session start. Self-contained, stdlib-only."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }

--- a/plugin/skills/daimon-briefing/SKILL.md
+++ b/plugin/skills/daimon-briefing/SKILL.md
@@ -25,9 +25,13 @@ Each item is marked `✓ verbatim` (pinned to an exact quote — trust it) or
 
 ## Automatic behavior
 
-You do not need to invoke anything. The briefing appears automatically on the first
-turn of a new session if a prior checkpoint exists. Checkpoints are written
-automatically when a session ends.
+You do not need to invoke anything. The plugin wires the host's native session
+hooks: a checkpoint is written automatically when a session **ends**, and the
+briefing appears automatically at the **start** of the next session if a prior
+checkpoint exists. Between those, a lightweight **proactive recall** watches your
+prompts and surfaces a one-line "you worked on this before" pointer when the
+current prompt overlaps a prior open loop — without re-suggesting anything the
+start-of-session briefing already carried.
 
 ## Manual trigger
 
@@ -43,7 +47,29 @@ See the plugin README. Key knobs: `DAIMON_DISABLE=1` (kill switch),
 `DAIMON_CHECKPOINT_DIR`, `DAIMON_MIN_MESSAGES`, `DAIMON_LLM_*` (falling back to
 `LITELLM_*`), `DAIMON_LLM_BACKEND=command` + `DAIMON_LLM_COMMAND` (headless-CLI fallback).
 
-## Scope (Slice 1)
+## What ships today
 
-Local-file checkpoints, single-pass serialization, no Honcho. Long-transcript recall
-(chunking) is Slice 2; Honcho-backed cross-session recall is Slice 3.
+Daimon is self-contained and host-agnostic — no server, no external memory
+backend, stdlib-only at runtime. The capabilities behind the briefing:
+
+- **Checkpoint → briefing loop.** Session end serializes the transcript into a
+  per-project JSON checkpoint; session start reconstructs it into the briefing.
+- **Chunked extraction.** Long transcripts are split into overlapping chunks,
+  serialized pass-by-pass, then merged — so recall holds up on long sessions
+  instead of degrading as the transcript grows.
+- **Deterministic carry.** Unresolved open loops that still matter are carried
+  forward into the next checkpoint by exact term overlap (no LLM in the carry
+  step) and marked `[carried]` so you can see a loop survived from an earlier
+  session rather than being freshly observed.
+- **Proactive recall.** A per-prompt pointer to prior work when your current
+  prompt overlaps an open loop (see *Automatic behavior*).
+- **Trust classing.** Every item is `✓ verbatim` (pinned to an exact quote) or
+  `~ inferred` (paraphrased), so you know what to trust literally.
+- **Code-drift detection.** `daimon anchor <file> <symbol>` binds a checkpoint
+  item to a code symbol; the briefing flags it under **CODE DRIFT — verify
+  before trusting** when that symbol's body changes or disappears (offline,
+  stdlib `ast`).
+- **Scars.** An optional session-end pass harvests negative-knowledge signals
+  (abandoned approaches, landmines) into the repo's `.scars/` directory.
+- **Status & self-heal.** `daimon status` reports checkpoint/briefing health;
+  a failed capture self-heals on the next session start.


### PR DESCRIPTION
## What

Propagates the **D-009** architecture pivot (self-contained, host-agnostic runtime; Honcho/Graphiti evaluated and *not* adopted; native host hooks are the primary integration) into the three install-facing artifacts a stranger — and their agent — reads at install time, so they stop contradicting the decision ledger and the shipped code.

## Changes

- **`docs/MVP-DREAM-BRIEFING.md`** — status banner now references D-009 (was "Scoping … per D-008"). §2 rewritten around the native host-hook mechanism as primary: `SessionEnd` → detached `daimon serialize`, `SessionStart` → `daimon brief` injection, `UserPromptSubmit` → `daimon recall-inject`, with Codex/Gemini adapters sharing `hook/_daimon_hook_lib.py`. The hermes plugin-hook path is demoted to a clearly-labeled secondary **Appendix A**. Honcho/Slice forward promises removed from scope (§6), upstream track (§7), delivery status (§8, was the Slice 1–4 milestones), and open questions (§9). Structure, voice, and provenance-tag discipline preserved.
- **`plugin/skills/daimon-briefing/SKILL.md`** — deleted the Slice 1/2/3 framing and the "Honcho-backed cross-session recall" promise. Now describes what ships today: checkpoint→briefing loop, chunked extraction, deterministic carry with `[carried]` provenance, proactive recall, verbatim/inferred trust classing, `daimon anchor` drift detection, scars, status/heal.
- **`plugin/pyproject.toml`** — `description` rewritten to one accurate line (no "hermes plugin", no "Slice 1"). Nothing else in the file touched; release-please still owns versions.

Docs-only: no code, no behavior, no version bump.

## Verification

`rg -n "Honcho|Slice" README.md docs/MVP-DREAM-BRIEFING.md plugin/skills/daimon-briefing/SKILL.md plugin/pyproject.toml` → zero `Slice` hits; every remaining `Honcho` hit is intentional historical/rejection context (evaluated-and-rejected per D-009), no forward-looking promises. `hermes` survives only where it labels the secondary integration path (or accurate entry-point config comments in pyproject).

Every architecture claim is backed by code read for this change: `hooks/hooks.json`, `hook/daimon-session-end.py`, `hook/daimon-session-brief.py`, `hook/daimon-prompt-recall.py`, `hook/_daimon_hook_lib.py`, `plugin/daimon_briefing/{__init__,hooks,serializer,carry,briefing}.py`.

Note: `README.md` needed no edits. Its "authoritative architecture" pointer was inaccurate only because the *target* doc's banner still said D-008/Scoping; fixing that banner makes the existing README wording correct. The README already reflects D-009.

Closes #19