### PR TITLE
feat(carry): freeze verbatim items on re-discovery to stop rewording erosion

### DIFF
--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -107,9 +107,27 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                          and _same_item(text, str(n.get("text") or ""), generic)),
                         None)
             if twin is not None:
-                # Session re-discussed it: the new wording wins, but the item's
-                # AGE does not reset (run-01: 8-12 resets/20 cycles killed the
-                # #128 overdue boost). Keep the older birth stamp.
+                # Session re-discussed it. Split by the PREV item's trust class
+                # (#22, two-path recall):
+                #   - verbatim -> FREEZE. A verbatim item carries an immutable
+                #     pinned quote (D-006); recall must not re-write it
+                #     (reconsolidation, Nader/Schafe/LeDoux 2000). The prev's
+                #     frozen original text+quote+trust overwrite the reworded
+                #     native twin. prev is the older by construction and holds
+                #     the canonical pin, so it wins even when the native twin is
+                #     itself verbatim with a DIFFERENT quote (don't-erode; the
+                #     asymmetric bias in _same_item — false-merge worse than
+                #     false-non-merge — favors the original). external_state and
+                #     other native fields are left untouched.
+                #   - inferred/untagged -> new wording wins (beliefs are allowed
+                #     to reconsolidate; that is correct).
+                # AGE never resets either way (run-01: 8-12 resets/20 cycles
+                # killed the #128 overdue boost) — keep the older birth stamp.
+                if item.get("trust") == "verbatim":
+                    twin["text"] = item["text"]
+                    if item.get("quote"):
+                        twin["quote"] = item["quote"]
+                    twin["trust"] = "verbatim"
                 if item.get("first_seen") and not twin.get("first_seen"):
                     twin["first_seen"] = item["first_seen"]
                 elif item.get("first_seen") and twin.get("first_seen"):

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -215,3 +215,93 @@ def test_in_call_duplicate_prev_items_carry_once():
     out = carry.merge(_cp("S-new"), prev, NOW)
     qs = out["working_context"]["open_questions"]
     assert len(qs) == 1
+
+
+# --- verbatim-freeze on re-discovery (#22): reconsolidation defense ----------
+# A [✓ verbatim] item carries an immutable pinned quote (D-006). When a later
+# session re-discusses it and the serializer emits a reworded native twin, the
+# prev's frozen original text+quote+trust must win — recall must NOT re-write a
+# verbatim item (Nader/Schafe/LeDoux reconsolidation; daimon has a verbatim
+# store the brain lacks). Inferred beliefs still evolve, unchanged.
+
+_VERB_ORIG = ("quorint-ledger reconciliation drops entries when upstream "
+              "feed pauses")
+_VERB_QUOTE = "drops entries when upstream feed pauses"
+_VERB_TWIN = ("quorint-ledger reconciliation still dropping entries on "
+              "feed pauses")
+
+
+def test_verbatim_prev_freezes_reworded_native_twin():
+    # CORE: prev verbatim + reworded (here inferred) native twin -> the merged
+    # item is the frozen original text+quote, trust stays verbatim. RED today:
+    # "new wording wins" keeps the reworded native text and drops the quote.
+    prev = _cp("S-prev", 1, questions=[_item(
+        _VERB_ORIG, trust="verbatim", quote=_VERB_QUOTE, days=45)])
+    new = _cp("S-new", 0, questions=[_item(_VERB_TWIN, days=0)])
+    out = carry.merge(new, prev, NOW)
+    qs = out["working_context"]["open_questions"]
+    assert len(qs) == 1
+    assert qs[0]["text"] == _VERB_ORIG          # frozen original, not reworded
+    assert qs[0]["quote"] == _VERB_QUOTE        # pinned quote survived recall
+    assert qs[0]["trust"] == "verbatim"         # not downgraded to inferred
+    assert qs[0]["first_seen"] == _iso(45)      # older birth stamp preserved
+
+
+def test_inferred_prev_still_reconsolidates_new_wording_wins():
+    # GUARD against over-freezing: an inferred prev item is ALLOWED to evolve.
+    # New wording wins exactly as before the #22 fix; nothing is frozen.
+    prev = _cp("S-prev", 1, questions=[_item(_VERB_ORIG, days=45)])
+    new = _cp("S-new", 0, questions=[_item(_VERB_TWIN, days=0)])
+    out = carry.merge(new, prev, NOW)
+    qs = out["working_context"]["open_questions"]
+    assert len(qs) == 1
+    assert "still dropping" in qs[0]["text"]    # NEW wording won
+    assert qs[0]["trust"] == "inferred"         # NOT frozen to verbatim
+    assert qs[0]["first_seen"] == _iso(45)      # age still inherited
+
+
+def test_verbatim_identical_twin_survives_byte_identical():
+    # No-op path: native item already byte-identical to the prev verbatim. Exact
+    # text is caught by the idempotency guard before freeze; assert nothing is
+    # corrupted (text+quote+trust intact, still one item).
+    prev = _cp("S-prev", 1, questions=[_item(
+        _VERB_ORIG, trust="verbatim", quote=_VERB_QUOTE, days=45)])
+    new = _cp("S-new", 0, questions=[_item(
+        _VERB_ORIG, trust="verbatim", quote=_VERB_QUOTE, days=0)])
+    out = carry.merge(new, prev, NOW)
+    qs = out["working_context"]["open_questions"]
+    assert len(qs) == 1
+    assert qs[0]["text"] == _VERB_ORIG
+    assert qs[0]["quote"] == _VERB_QUOTE
+    assert qs[0]["trust"] == "verbatim"
+
+
+def test_verbatim_freeze_inherits_older_first_seen():
+    # first_seen birth-stamp inheritance still works on the freeze path: the
+    # native twin has a NEWER stamp; the older prev original stamp must win,
+    # AND the payload is frozen to verbatim.
+    prev = _cp("S-prev", 1, questions=[_item(
+        _VERB_ORIG, trust="verbatim", quote=_VERB_QUOTE, days=45)])
+    new = _cp("S-new", 0, questions=[_item(_VERB_TWIN, days=0)])
+    out = carry.merge(new, prev, NOW)
+    qs = out["working_context"]["open_questions"]
+    assert qs[0]["first_seen"] == _iso(45)      # older birth stamp inherited
+    assert qs[0]["trust"] == "verbatim"         # payload frozen alongside
+
+
+def test_two_verbatim_twins_different_quotes_older_original_wins():
+    # DESIGN CHOICE: a re-discovered item that is ALSO verbatim but carries a
+    # DIFFERENT quote -> freeze to the OLDER pinned original (prev). The thesis
+    # is don't-erode; _same_item's asymmetric bias (a false merge is worse than
+    # a false non-merge) favors keeping the original over the reworded requote.
+    prev = _cp("S-prev", 1, questions=[_item(
+        _VERB_ORIG, trust="verbatim", quote=_VERB_QUOTE, days=45)])
+    new = _cp("S-new", 0, questions=[_item(
+        _VERB_TWIN, trust="verbatim",
+        quote="still dropping entries on feed pauses", days=0)])
+    out = carry.merge(new, prev, NOW)
+    qs = out["working_context"]["open_questions"]
+    assert len(qs) == 1
+    assert qs[0]["text"] == _VERB_ORIG                    # older original text
+    assert qs[0]["quote"] == _VERB_QUOTE                  # older pinned quote
+    assert qs[0]["trust"] == "verbatim"


### PR DESCRIPTION
## What

Move 1 of the two-path recall arc (#13 umbrella): freeze verbatim items so re-discovery stops eroding them.

In `carry.merge()`, when a previous checkpoint's item is a salient-term **twin** of a freshly serialized native item, the old twin branch let "the new wording win" — it kept the reworded native text and only inherited the older `first_seen`. For a `trust="verbatim"` item that carries an immutable pinned `quote` (D-006), that discards the pinned original on every recall.

## Why — reconsolidation

That is exactly **reconsolidation** (Nader, Schafe & LeDoux 2000): a consolidated memory, when reactivated, returns to a labile state and is re-stored — potentially altered — each time it is recalled. The brain does this because it has *no verbatim store* and can only reconstruct from gist. Daimon replicated the failure mode structurally (measured quote integrity 0.24 under load, #13 v2). But daimon **has** a verbatim store and can replay the tape exactly — it inherited a brain limitation it does not share.

## The fix (deterministic, no LLM)

On the twin branch, split by the **previous** item's trust class:

- **`trust="verbatim"`** → **FREEZE**: the prev's frozen original `text` + `quote` + `trust` overwrite the reworded native twin. `prev` is older by construction and holds the canonical pin, so it wins even when the native twin is itself verbatim with a *different* quote (don't-erode; `_same_item`'s asymmetric bias — a false merge is worse than a false non-merge — favors the original).
- **`inferred`/untagged** → unchanged: new wording wins (inferred beliefs are allowed to reconsolidate; that is correct).

`first_seen` birth-stamp inheritance and `external_state` are preserved. Twin-detection and the DF floors (`_same_item`, `_MIN_SHARED`, `_MIN_RATIO`, `_GENERIC_DF`) are untouched — this changes only what happens *after* a twin is found.

## Tests (TDD, RED→GREEN)

Five tests in `test_carry.py`: verbatim prev freezes a reworded native twin; inferred prev still reconsolidates; identical verbatim survives byte-identical; `first_seen` inheritance holds on the freeze path; two verbatim twins with different quotes → older pinned original wins (documented design choice). Full suite: **711 passed**.

## Scope

`carry.py` + `test_carry.py` only. No version bump (release-please owns it). No serializer/recall/floor changes.

Closes #22