### PR TITLE
feat(recall): AND-then-OR fallback — multi-term queries degrade to ranked partials instead of zeroing out

### DIFF
--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -344,15 +344,16 @@ def _ensure_fresh() -> None:
         rebuild()
 
 
-def _match_expr(query: str) -> str | None:
+def _match_expr(query: str, join: str = " ") -> str | None:
     """User text -> a safe FTS5 MATCH expression: every whitespace token becomes
-    a quoted phrase (internal quotes doubled), joined by implicit AND. Bare
-    quotes/AND/OR/NEAR/parens/'*' thus match as words instead of erroring as
-    syntax. None when nothing searchable remains."""
+    a quoted phrase (internal quotes doubled), joined by implicit AND (or the
+    given operator, e.g. " OR " for the #25 fallback). Bare quotes/AND/OR/NEAR/
+    parens/'*' thus match as words instead of erroring as syntax. None when
+    nothing searchable remains."""
     parts = []
     for token in query.split():
         parts.append('"' + token.replace('"', '""') + '"')
-    return " ".join(parts) or None
+    return join.join(parts) or None
 
 
 def search(query: str, project_dir=None, all_projects: bool = False,
@@ -361,7 +362,12 @@ def search(query: str, project_dir=None, all_projects: bool = False,
     bm25 rank, newest checkpoint first within equal rank. Scope: project_dir's
     slug unless all_projects (or the project is unknown — no filter then,
     matching read_team's semantics). Never raises on hostile query text;
-    raises RecallError only when FTS5 itself is unavailable."""
+    raises RecallError only when FTS5 itself is unavailable.
+
+    AND is primary; when a multi-term query matches nothing, the same quoted
+    tokens retry joined by OR (#25) — bm25 ranks items covering more terms
+    first, so a richer cue degrades to partial matches instead of zeroing out
+    (encoding specificity: more cue must never mean less recall)."""
     expr = _match_expr(query)
     if expr is None:
         return []
@@ -379,15 +385,16 @@ def search(query: str, project_dir=None, all_projects: bool = False,
         " FROM items_fts JOIN items i ON i.id = items_fts.rowid"
         " WHERE items_fts MATCH ?"
     )
-    params: list = [expr]
     if want is not None:
         sql += " AND i.project_slug = ?"
-        params.append(want)
     sql += (" ORDER BY (i.superseded_by IS NOT NULL) ASC, rank ASC,"
             " i.created DESC LIMIT ?")
-    params.append(max(1, int(limit)))
 
-    def _run() -> list[dict]:
+    def _run(match_expr: str) -> list[dict]:
+        params: list = [match_expr]
+        if want is not None:
+            params.append(want)
+        params.append(max(1, int(limit)))
         conn = sqlite3.connect(str(config.recall_db()))
         try:
             cur = conn.execute(sql, params)
@@ -396,8 +403,16 @@ def search(query: str, project_dir=None, all_projects: bool = False,
         finally:
             conn.close()
 
+    def _query() -> list[dict]:
+        rows = _run(expr)
+        if not rows:
+            or_expr = _match_expr(query, " OR ")
+            if or_expr != expr:  # differs only when there are >=2 tokens
+                rows = _run(or_expr)
+        return rows
+
     try:
-        return _run()
+        return _query()
     except sqlite3.OperationalError as exc:
         if "fts5" in str(exc).lower() and "no such module" in str(exc).lower():
             raise RecallError(_FTS5_MISSING_MSG) from exc
@@ -410,7 +425,7 @@ def search(query: str, project_dir=None, all_projects: bool = False,
         # OSError here too: disk-full mid-rebuild must not escape search().
         try:
             rebuild()
-            return _run()
+            return _query()
         except (OSError, sqlite3.DatabaseError):
             return []
 

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -285,6 +285,64 @@ def test_empty_query_returns_empty(tmp_checkpoint_dir):
     assert recall.search("", all_projects=True) == []
 
 
+# ---- #25: AND-then-OR fallback — a richer cue must never zero out recall ----
+
+
+def test_multi_term_query_falls_back_to_or_when_and_matches_nothing(
+        tmp_checkpoint_dir, monkeypatch):
+    # Field find (2026-07-03): "science" hit, "ACB" hit, "science ACB" -> no
+    # matches. Strict AND punishes cue enrichment (encoding specificity says
+    # more cue should IMPROVE retrieval). When AND yields nothing, retry the
+    # same quoted tokens with OR and return ranked partial matches.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S1", _cp("S1", decisions=[
+        {"text": "vulture research arc closed", "trust": "inferred"}]),
+        project_dir="/repo/x")
+    store.write_checkpoint("S2", _cp("S2", decisions=[
+        {"text": "condor migration shipped", "trust": "inferred"}]),
+        project_dir="/repo/x")
+    hits = recall.search("vulture condor", all_projects=True)
+    texts = " ".join(h["text"] for h in hits)
+    assert "vulture" in texts and "condor" in texts
+
+
+def test_and_semantics_stay_primary_when_terms_cooccur(
+        tmp_checkpoint_dir, monkeypatch):
+    # The fallback fires ONLY on an empty AND result: when one item holds all
+    # terms, precision wins and the single-term item must NOT dilute results.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S1", _cp("S1", decisions=[
+        {"text": "osprey harrier combined rework", "trust": "inferred"}]),
+        project_dir="/repo/x")
+    store.write_checkpoint("S2", _cp("S2", decisions=[
+        {"text": "osprey solo note", "trust": "inferred"}]),
+        project_dir="/repo/x")
+    hits = recall.search("osprey harrier", all_projects=True)
+    assert [h["text"] for h in hits] == ["osprey harrier combined rework"]
+
+
+def test_or_fallback_respects_project_scope(tmp_checkpoint_dir, monkeypatch):
+    # Partial matches must not leak across projects: the fallback query keeps
+    # the same slug filter as the AND pass.
+    _write_team_file("grace", "S-x", _cp("S-x", decisions=[
+        {"text": "vulture decision in x", "trust": "inferred"}]),
+        project_dir="/repo/x")
+    _write_team_file("grace", "S-y", _cp("S-y", decisions=[
+        {"text": "condor decision in y", "trust": "inferred"}]),
+        project_dir="/repo/y")
+    hits = recall.search("vulture condor", project_dir="/repo/x")
+    assert [h["text"] for h in hits] == ["vulture decision in x"]
+
+
+def test_single_term_miss_stays_empty(tmp_checkpoint_dir, monkeypatch):
+    # One token has no OR variant — a genuine miss stays a miss.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S1", _cp("S1", decisions=[
+        {"text": "vulture research arc closed", "trust": "inferred"}]),
+        project_dir="/repo/x")
+    assert recall.search("homework", all_projects=True) == []
+
+
 def test_search_empty_world_returns_empty(tmp_checkpoint_dir):
     # No checkpoints anywhere, no db — search must not invent or crash.
     assert recall.search("anything", all_projects=True) == []

--- a/plugin/uv.lock
+++ b/plugin/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "daimon-briefing"
-version = "0.3.1"
+version = "0.3.3"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #25

## Summary

- `daimon recall "science ACB"` returned **no matches** while each term alone hit — `_match_expr` joins tokens with implicit AND, so every added cue term raised the odds of an empty result. Inverts encoding specificity (Tulving 1973): a richer cue must improve recall, never punish it.
- AND stays primary. Only when the AND pass returns zero rows **and** the query has ≥2 tokens, the same quoted-phrase tokens retry joined by `OR`. bm25 ranks items covering more terms first, so results degrade to ranked partial matches.
- Same token quoting on both passes (hostile-syntax safety unchanged); project-slug scoping applies identically to the fallback.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/recall.py` | `_match_expr` gains a `join` operator param; `search()` runs AND then falls back to OR on empty result (both passes share the rebuild-retry error handling) |
| `plugin/tests/test_recall.py` | 4 tests: OR fallback returns union, AND precision preserved when terms co-occur, fallback respects project scope, single-term miss stays empty |

## Test plan

- [x] TDD: both fallback tests watched failing red (empty results) before implementation
- [x] `uv run pytest` — 715 passed
- [x] Live field repro: `uv run daimon recall "science ACB"` now returns ranked union; `daimon recall "science"` output unchanged
- [x] Hostile-query parametrized suite unchanged and green

## Non-goals

- No change to `suggest()` gates (`_MIN_OVERLAP`, `_MIN_TERMS` untouched)
- No renderer hint for partial matches (deferred, noted optional in #25)