### PR TITLE
fix(recall): fold suggest() haystack — accented Spanish prior work was silenced by the overlap gate

### DIFF
--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -572,7 +572,10 @@ def suggest(prompt: str, project_dir=None, current_session=None,
     for r in rows:
         if r["session_id"] in excluded:
             continue
-        haystack = f"{r['text']} {r['quote'] or ''}".lower()
+        # Fold the haystack like the terms (#27): salient_terms folds
+        # "sesión"->"sesion", so an unfolded haystack silences accented
+        # content that FTS5 (remove_diacritics) already matched.
+        haystack = _fold(f"{r['text']} {r['quote'] or ''}".lower())
         hit = {t for t in terms if t in haystack}
         if not hit:
             continue

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -666,6 +666,58 @@ def test_suggest_includes_superseded_flagged_not_hidden(tmp_checkpoint_dir, monk
     assert out[0]["superseded_by"] == "S-newer"
 
 
+def test_suggest_matches_accented_spanish_content(tmp_checkpoint_dir, monkeypatch):
+    # #27: salient_terms folds diacritics (sesión -> sesion) but the overlap
+    # gate substring-tested folded terms against an UNFOLDED haystack, so a
+    # session whose only shared terms are accented was silenced even though
+    # FTS5 matched the row. Spanish-first content must surface like ASCII.
+    store.write_checkpoint(
+        "S-es",
+        _cp125("S-es", decisions=[{
+            "text": "Definimos la sesión de autenticación con tokens",
+            "trust": "verbatim", "importance": 8,
+            "first_seen": "2026-06-20T00:00:00Z",
+        }], created="2026-06-20T00:00:00Z"),
+        project_dir="/repo/x",
+    )
+    out = recall.suggest("quiero revisar la sesión de autenticación otra vez",
+                         project_dir="/repo/x", current_session="S-now")
+    assert out and out[0]["session_id"] == "S-es"
+
+
+def test_suggest_ascii_prompt_matches_accented_item(tmp_checkpoint_dir, monkeypatch):
+    # Users drop accents when typing fast: "sesion" must still hit "sesión".
+    store.write_checkpoint(
+        "S-es",
+        _cp125("S-es", decisions=[{
+            "text": "Definimos la sesión de autenticación con tokens",
+            "trust": "verbatim", "importance": 8,
+            "first_seen": "2026-06-20T00:00:00Z",
+        }], created="2026-06-20T00:00:00Z"),
+        project_dir="/repo/x",
+    )
+    out = recall.suggest("revisar la sesion de autenticacion otra vez",
+                         project_dir="/repo/x", current_session="S-now")
+    assert out and out[0]["session_id"] == "S-es"
+
+
+def test_suggest_accented_prompt_matches_ascii_item(tmp_checkpoint_dir, monkeypatch):
+    # Opposite direction: accented prompt, ASCII-stored item (folding already
+    # handled this via salient_terms — pin it so it never regresses).
+    store.write_checkpoint(
+        "S-ascii",
+        _cp125("S-ascii", decisions=[{
+            "text": "Definimos la sesion de autenticacion con tokens",
+            "trust": "verbatim", "importance": 8,
+            "first_seen": "2026-06-20T00:00:00Z",
+        }], created="2026-06-20T00:00:00Z"),
+        project_dir="/repo/x",
+    )
+    out = recall.suggest("quiero revisar la sesión de autenticación otra vez",
+                         project_dir="/repo/x", current_session="S-now")
+    assert out and out[0]["session_id"] == "S-ascii"
+
+
 def test_suggest_caps_at_two_distinct_sessions(tmp_checkpoint_dir, monkeypatch):
     for i, sid in enumerate(["S-a", "S-b", "S-c"]):
         _write_team_file(


### PR DESCRIPTION
Closes #27

## Summary

- `suggest()` folds query terms but substring-tested them against an unfolded haystack: FTS5 matched accented rows, then the Python overlap gate dropped them. Spanish content with accented shared terms (`sesión`, `autenticación`) never surfaced; identical ASCII content did.
- Fix: fold the haystack with the existing `_fold()` before the membership test. One line. No gate/threshold changes (`_MIN_OVERLAP` untouched); `search()` unaffected (no Python-side re-check).
- Found by the 4-lens audit (correctness lens, reproduced end-to-end); critical — this is the proactive-recall path Spanish-speaking users exercise.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/recall.py` | Fold haystack in `suggest()` overlap gate |
| `plugin/tests/test_recall.py` | 3 tests: accented×accented, ASCII prompt×accented item, accented prompt×ASCII item (regression pin) |

## Test plan

- [x] TDD: both accented-item tests watched failing red (`[]`) before the fix; ASCII-item direction passed pre-fix and is pinned
- [x] `uv run pytest` — 718 passed
- [x] Existing `test_suggest_*` gates unchanged and green