### PR TITLE
fix(cli): UX-contract batch — surface messages match behavior (7 repairs)

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -17,6 +17,7 @@
 """
 
 import argparse
+import getpass
 import json
 import os
 import re
@@ -296,6 +297,13 @@ def _cmd_brief(args) -> int:
     # read_latest still falls back to the global pointer if the project has none.
     project = _resolve_project(args.project)
     checkpoint = store.read_latest(project_dir=project)
+    # Label the global-pointer fallback (#29): status calls the same situation
+    # "global checkpoint (fallback)"; brief must not present another project's
+    # state as this project's without saying so.
+    proj_path = store.project_latest_path(project)
+    if checkpoint and proj_path is not None and not proj_path.exists():
+        print("⚠ no checkpoint for this project — showing the global "
+              "checkpoint (fallback), possibly another project's.")
     # NOTE: drift is checked against the resolved project root. If read_latest fell
     # back to the GLOBAL pointer (another project's checkpoint), its anchor file paths
     # are relative to a different root and may report spurious "hard" drift. Acceptable
@@ -316,6 +324,9 @@ def _cmd_recall(args) -> int:
     recall.search auto-(re)builds it — so the only hard failure surfaced here is
     an FTS5-less sqlite3 (rc 1, named); everything else degrades to no matches."""
     query = " ".join(args.query)
+    if args.limit < 1:
+        print(f"error: --limit must be >= 1 (got {args.limit})", file=sys.stderr)
+        return 2
     project = _resolve_project(args.project)
     try:
         results = recall.search(query, project_dir=project,
@@ -523,9 +534,14 @@ def _status_health(proj, glob, outstanding, siblings, *, now) -> dict:
 
     if outstanding:
         n = len(outstanding)
-        warnings.append(
-            f"{n} session{'s' if n != 1 else ''} failed to serialize — run 'daimon heal'"
-        )
+        msg = f"{n} session{'s' if n != 1 else ''} failed to serialize"
+        # Only point at heal when it can actually repair something (#29) —
+        # "run 'daimon heal'" followed by "nothing to heal" is a contradiction.
+        if any(f.get("class") == "healable" for f in outstanding):
+            msg += " — run 'daimon heal'"
+        else:
+            msg += " (not auto-repairable)"
+        warnings.append(msg)
 
     if not warnings:
         verdict = "✓ fresh"
@@ -821,6 +837,11 @@ def _cmd_team_sync(args) -> int:
     """rc 0 for every sync-nothing-to-do shape (no git, no remotes, offline);
     warnings go to stderr but never change the rc — a degraded sync is not a
     user error."""
+    if getattr(args, "project", None):
+        # Accepted for CLI symmetry only — say so instead of silently running
+        # a global sync the user thought was scoped (#29).
+        print("daimon team: --project is ignored — sync is project-agnostic "
+              "(all own checkpoints sync)", file=sys.stderr)
     if not teamsync.git_available():
         print("daimon team: git not found on PATH — sync skipped")
         return 0
@@ -908,7 +929,9 @@ def _cmd_configure(args) -> int:
         base_url = _prompt("base_url (blank for default): ").strip()
         if base_url:
             updates["DAIMON_LLM_BASE_URL"] = base_url
-        api_key = _prompt("api_key: ").strip()
+        # getpass, not _prompt (#29): the secret must not echo to the
+        # terminal or land in scrollback.
+        api_key = getpass.getpass("api_key: ").strip()
         if api_key:
             updates["DAIMON_LLM_API_KEY"] = api_key
         model = _prompt("model: ").strip()

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -60,7 +60,11 @@ def _print_version_note(checkpoint) -> None:
 def render_brief(checkpoint, drift=None, teammates=None) -> None:
     b = briefing.build(checkpoint)
     if b is None:
-        print("No checkpoint yet — nothing to brief. Run `serialize` first.")
+        # Point at the real flow (#29): checkpoints come from the hooks; bare
+        # `serialize` dead-ends (it needs a transcript path).
+        print("No checkpoint yet — nothing to brief. Checkpoints are written "
+              "automatically at session end; to backfill one manually, run "
+              "`daimon serialize <transcript>`.")
         _print_teammates(teammates)
         return
     _print_version_note(checkpoint)
@@ -369,12 +373,24 @@ def _rich_status(data: dict) -> None:
     else:
         table.add_row("global (fallback)", "[dim]none[/dim]", "—")
     console.print(table)
-    if last and last["result"]:
-        style = "green" if last["result"]["outcome"] == "success" else "red"
-        console.print(f"last serialize: [{style}]{last['result']['outcome']}[/{style}] — "
-                      f"{last['result']['line']}")
-    elif last is None:
+    # Mirror _plain_status fact-for-fact (#29): same command, same statements,
+    # regardless of whether `rich` is installed. In particular a spawn with no
+    # result yet (in-progress or hung serialize) must be visible here too.
+    if last is None:
         console.print("[dim]no serialize history[/dim]")
+    else:
+        if last["result"]:
+            style = "green" if last["result"]["outcome"] == "success" else "red"
+            console.print(f"last serialize result: [{style}]{last['result']['outcome']}[/{style}] — "
+                          f"{last['result']['line']}")
+        else:
+            console.print("last serialize result: none logged yet")
+        if last["spawn"]:
+            s = last["spawn"]
+            ago = f", {s['age']} ago" if "age" in s else ""
+            console.print(f"last serialize spawn: session {s['session_id']}{ago}")
+        else:
+            console.print("last serialize spawn: none logged yet")
 
     outstanding = data.get("outstanding") or []
     if outstanding:

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1077,8 +1077,9 @@ def test_cli_configure_interactive_litellm(capsys, monkeypatch, tmp_path):
     _set_claude(monkeypatch, False)
     monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
 
-    answers = iter(["litellm", "U", "K", "M"])
+    answers = iter(["litellm", "U", "M"])  # api_key goes through getpass (#29)
     monkeypatch.setattr(cli, "_prompt", lambda q: next(answers))
+    monkeypatch.setattr(cli.getpass, "getpass", lambda prompt="": "K")
 
     rc = cli.main(["configure"])
     assert rc == 0
@@ -2319,3 +2320,102 @@ def test_serialize_carry_failure_still_writes_checkpoint(
 
     written = store.read_latest(project_dir=project)
     assert written["session_id"] == "S-new"
+
+
+# ---- #29: UX-contract batch — surface messages must match what the code does ----
+
+
+def test_status_health_heal_hint_gated_on_healable():
+    # status must only say "run 'daimon heal'" when heal can actually repair
+    # something — a healable failure is present.
+    h = cli._status_health(_proj(), {"exists": True},
+                           [{"sid": "S", "class": "healable"}], [], now=1000.0)
+    assert any("daimon heal" in w for w in h["warnings"])
+
+
+def test_status_health_no_heal_hint_when_unrepairable():
+    # Live contradiction (audit): status said "run 'daimon heal'"; heal
+    # answered "nothing to heal". No healable failure -> no heal hint.
+    h = cli._status_health(_proj(), {"exists": True},
+                           [{"sid": "S", "class": "unrecoverable"},
+                            {"sid": "T", "class": "hung"}], [], now=1000.0)
+    assert any("failed to serialize" in w for w in h["warnings"])
+    assert not any("daimon heal" in w for w in h["warnings"])
+
+
+def test_brief_labels_global_fallback_for_other_project(
+        tmp_checkpoint_dir, sample_checkpoint, capsys):
+    # brief --project X with no checkpoint for X silently rendered ANOTHER
+    # project's briefing. status labels the same fallback; brief must too.
+    from daimon_briefing import store
+    store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+    rc = cli.main(["brief", "--project", "/repo/some-other-project"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "fallback" in out.lower()
+
+
+def test_brief_no_fallback_label_for_own_project(
+        tmp_checkpoint_dir, sample_checkpoint, capsys):
+    from daimon_briefing import store
+    store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+    rc = cli.main(["brief", "--project", "/repo/x"])
+    assert rc == 0
+    assert "fallback" not in capsys.readouterr().out.lower()
+
+
+def test_recall_rejects_nonpositive_limit(tmp_checkpoint_dir, capsys):
+    # --limit 0 / -N used to clamp silently to 1 result. Reject loudly.
+    rc = cli.main(["recall", "anything", "--limit", "0"])
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "limit" in err.lower()
+    rc = cli.main(["recall", "anything", "--limit", "-3"])
+    assert rc == 2
+
+
+def test_configure_interactive_api_key_uses_getpass(monkeypatch, capsys):
+    # The api_key prompt must not echo the secret to the terminal: it goes
+    # through getpass, never through the plain input() _prompt.
+    import getpass as getpass_mod
+    from daimon_briefing import configure as configure_mod, render as render_mod
+
+    monkeypatch.setattr(configure_mod, "status", lambda: {"ready": False})
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True, raising=False)
+
+    asked = []
+    answers = {"backend": "litellm", "base_url": "", "model": ""}
+
+    def fake_prompt(q):
+        asked.append(q)
+        for key, val in answers.items():
+            if key in q:
+                return val
+        return ""
+
+    monkeypatch.setattr(cli, "_prompt", fake_prompt)
+    monkeypatch.setattr(getpass_mod, "getpass", lambda prompt="": "sk-secret")
+
+    written = {}
+
+    def fake_write_env(updates):
+        written.update(updates)
+        return Path("/dev/null")
+
+    monkeypatch.setattr(configure_mod, "write_env", fake_write_env)
+    monkeypatch.setattr(render_mod, "render_configure", lambda st: None)
+
+    rc = cli.main(["configure"])
+    assert rc == 0
+    assert written.get("DAIMON_LLM_API_KEY") == "sk-secret"
+    assert not any("api_key" in q for q in asked)
+
+
+def test_team_sync_project_flag_warns_ignored(monkeypatch, capsys):
+    # `team sync --project` is accepted "for CLI symmetry" but does nothing —
+    # a scoped sync must say it's ignored, not silently sync everything.
+    from daimon_briefing import teamsync
+    monkeypatch.setattr(teamsync, "git_available", lambda: False)
+    rc = cli.main(["team", "sync", "--project", "/repo/x"])
+    assert rc == 0
+    assert "project" in capsys.readouterr().err.lower()

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -75,9 +75,52 @@ def test_render_brief_rich_smoke(monkeypatch, sample_checkpoint, capsys):
 
 
 def test_render_brief_no_content(capsys):
+    # #29: the old hint said "Run `serialize` first" — a dead end (serialize
+    # needs a transcript path and is hook-internal). Point at the real flow.
     render.render_brief({})
     out = capsys.readouterr().out
-    assert out == "No checkpoint yet — nothing to brief. Run `serialize` first.\n"
+    assert "No checkpoint yet" in out
+    assert "Run `serialize` first" not in out
+    assert "session end" in out  # checkpoints come from hooks automatically
+
+
+def _serialize_status_data(last):
+    return {
+        "project": "/repo/x",
+        "proj": {"exists": False},
+        "glob": {"exists": False},
+        "same": False,
+        "last": last,
+        "outstanding": [],
+        "identity": None,
+        "health": None,
+        "team": None,
+    }
+
+
+def test_render_status_rich_reports_spawn_without_result(monkeypatch, capsys):
+    # #29: plain status always prints spawn + result lines; the rich branch
+    # rendered NOTHING for a spawn-with-no-result (in-progress/hung serialize).
+    # Same command must state the same facts regardless of `rich`.
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_status(_serialize_status_data(
+        {"spawn": {"session_id": "S-hung", "age": "5m"}, "result": None}))
+    out = capsys.readouterr().out
+    assert "S-hung" in out          # the spawn is visible
+    assert "none logged yet" in out  # and the missing result is stated
+
+
+def test_render_status_rich_and_plain_state_same_serialize_facts(monkeypatch, capsys):
+    data = _serialize_status_data(
+        {"spawn": {"session_id": "S-1", "age": "2m"},
+         "result": {"outcome": "success", "line": "ok S-1"}})
+    render.render_status(data)
+    plain = capsys.readouterr().out
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_status(data)
+    rich_out = capsys.readouterr().out
+    for fact in ("S-1", "success"):
+        assert fact in plain and fact in rich_out
 
 
 def test_render_brief_notes_version_mismatch(sample_checkpoint, capsys):


### PR DESCRIPTION
Closes #29

## Summary

Seven repairs from the audit, one defect class: the surface message contradicts the code. Top two were reproduced live pre-fix and re-verified fixed post-fix.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/cli.py` | heal hint gated on a `healable` failure existing; `brief --project` fallback label; `recall --limit` < 1 rejected (rc 2); api_key via `getpass`; `team sync --project` ignored-flag warning |
| `plugin/daimon_briefing/render.py` | rich status mirrors plain fact-for-fact (spawn-without-result now visible); empty-store hint points at the hook flow, not dead-end `serialize` |
| `plugin/tests/test_cli.py` | 7 new tests (gated hint both directions, fallback label both directions, limit guard, getpass, sync warning); 1 existing configure test updated to the new getpass contract |
| `plugin/tests/test_render.py` | rich spawn-parity test + fact-parity pin; no-content hint test updated |

## Scar compliance

Scar #9 (last-of-kind reasoning over serialize.log masks buried failures) fired on the status edit: the heal-hint gate reasons over the per-session `outstanding` ledger — the scar-compliant structure — not last-of-kind. The rich parity change displays last-of-kind facts already shown by plain; it adds no reasoning.

## Test plan

- [x] TDD: all 7 behavior changes watched failing red first (feature-missing failures verified individually)
- [x] `uv run pytest` — 727 passed
- [x] Live verify: `recall --limit 0` → rc 2 with error; `brief --project /tmp/nonexistent` → fallback warning line; `team sync --project` → ignored warning; `daimon status` on the real hung session → "(not auto-repairable)", no false heal hint

## Non-goals

Cross-project drift flags on fallback (deferred in-code to a follow-up); observability cluster is #28; trust-integrity items are #30.