### PR TITLE
feat(observability): silent failures leave traces — crash log surfaced, hung serializes healable, fallback stamped

### DIFF
--- a/hook/daimon-codex-stop.py
+++ b/hook/daimon-codex-stop.py
@@ -125,7 +125,8 @@ def main() -> int:
     try:
         lib.spawn_serialize(cli, transcript_path, child_env)
         _mark_spawned(session_id)
-        lib.log(f"codex-stop: spawned serialize for {session_id} (project: {cwd or '?'})")
+        lib.log(f"codex-stop: spawned serialize for {session_id} "
+                f"(project: {cwd or '?'}) (transcript: {transcript_path})")
     except OSError as exc:
         lib.log(f"codex-stop: spawn failed ({type(exc).__name__}: {exc})")
     return 0

--- a/hook/daimon-gemini-session-end.py
+++ b/hook/daimon-gemini-session-end.py
@@ -89,7 +89,8 @@ def main() -> int:
         lib.spawn_serialize(cli, transcript_path, child_env)
         lib.log(
             f"gemini-session-end: spawned serialize for {session_id} "
-            f"(reason: {reason}, project: {cwd or '?'})"
+            f"(reason: {reason}, project: {cwd or '?'}) "
+            f"(transcript: {transcript_path})"
         )
     except OSError as exc:
         lib.log(f"gemini-session-end: spawn failed ({type(exc).__name__}: {exc})")

--- a/hook/daimon-session-end.py
+++ b/hook/daimon-session-end.py
@@ -77,9 +77,13 @@ def main() -> int:
     child_env = lib.project_env(cwd)
     try:
         lib.spawn_serialize(cli, transcript_path, child_env)
+        # Trailing (transcript: ...) group (#28): if the child crashes before
+        # writing any result line, this is the only surviving pointer to the
+        # transcript — it makes the hung session healable instead of lost.
         lib.log(
             f"session-end: spawned serialize for {session_id} "
-            f"(reason: {reason}, project: {cwd or '?'})"
+            f"(reason: {reason}, project: {cwd or '?'}) "
+            f"(transcript: {transcript_path})"
         )
     except OSError as exc:
         lib.log(f"session-end: spawn failed ({type(exc).__name__}: {exc})")

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -119,6 +119,7 @@ def _run_serialize(transcript_path: Path, project: str | None) -> int:
     session_id = path.stem
     # Elapsed time lands in serialize.log — checkpoint generation runs 4-25 min
     # in production and was invisible before this.
+    llm.reset_fallback()  # #28: detect a silent backend downgrade during THIS run
     start = time.monotonic()
     try:
         checkpoint = serializer.serialize_strict(session_id, messages, chat=_chat)
@@ -157,6 +158,11 @@ def _run_serialize(transcript_path: Path, project: str | None) -> int:
     out = store.write_checkpoint(session_id, checkpoint, project_dir=project)
     elapsed = int(time.monotonic() - start)
     msg = f"wrote checkpoint: {out} (took {elapsed}s)"
+    if llm.fallback_used():
+        # Trailing marker (#28): the configured backend failed and the weaker
+        # command fallback produced this checkpoint — success, but downgraded.
+        # Suffix-safe: _RESULT_OK_RE/_LEDGER_OK_RE are prefix-anchored.
+        msg += " [fallback backend]"
     print(msg)
     _append_serialize_log(msg)
     # Opt-in scar-candidate harvest (#100), mirroring the hermes host wiring
@@ -495,11 +501,21 @@ def _checkpoint_info(path, now) -> dict:
     }
 
 
-def _status_health(proj, glob, outstanding, siblings, *, now) -> dict:
+def _status_health(proj, glob, outstanding, siblings, *, now,
+                   disabled: bool = False) -> dict:
     """Objective health verdict for `status`. Pure — `now` is injected. Warns only
     on data-driven signals: a NEWER phantom-child bucket (the #74 split), a missing
-    project checkpoint, or outstanding serialize failures. No age thresholds."""
+    project checkpoint, outstanding serialize failures, or the kill switch being
+    set. No age thresholds."""
     warnings: list[str] = []
+
+    # #28: a stuck DAIMON_DISABLE=1 silently stops all capture — the single
+    # most important thing status can say, so it leads the verdict.
+    if disabled:
+        warnings.append(
+            "DAIMON_DISABLE is set — capture is OFF (no checkpoints are "
+            "being written)"
+        )
 
     proj_mtime = (now - proj["age_seconds"]) if proj.get("exists") else None
     newer = [
@@ -587,6 +603,29 @@ def _parse_serialize_log(path, now) -> dict | None:
     return {"spawn": spawn, "result": result}
 
 
+def _crash_log_info(path: Path, now: float) -> dict | None:
+    """Tail of serialize-crash.log — the file spawn_serialize points child
+    stderr at. It was a write-only dead-drop: tracebacks landed there and no
+    command ever read it (#28). Returns None when absent/empty/unreadable;
+    else the last non-empty line (a traceback's final line names the
+    exception) plus the file's age."""
+    try:
+        st = path.stat()
+        if st.st_size == 0:
+            return None
+        with path.open("rb") as f:
+            f.seek(max(0, st.st_size - 4096))
+            tail = f.read().decode("utf-8", errors="replace")
+    except OSError:
+        return None
+    lines = [ln.strip() for ln in tail.splitlines() if ln.strip()]
+    if not lines:
+        return None
+    age = int(now - st.st_mtime)
+    return {"last_line": lines[-1], "age_seconds": age,
+            "age": _format_age(age), "path": str(path)}
+
+
 def _cmd_status(args) -> int:
     now = time.time()
     project = _resolve_project(args.project)
@@ -602,8 +641,18 @@ def _cmd_status(args) -> int:
     except OSError:
         _ledger_text = ""
     outstanding = _compute_outstanding(_ledger_text, now)
+    crash = _crash_log_info(config.log_dir() / "serialize-crash.log", now)
+    recall_error = _crash_log_info(config.log_dir() / "recall-error.log", now)
+    disabled = config.is_disabled()
+    # Skips are terminal by design (too-short sessions), but invisible skips
+    # read as captured sessions (#28) — count them for display.
+    skipped_recent = sum(
+        1 for e in _session_ledger(_ledger_text, now).values()
+        if e["result_kind"] == "skipped"
+    )
     siblings = store.sibling_buckets(project)
-    health = _status_health(proj, glob, outstanding, siblings, now=now)
+    health = _status_health(proj, glob, outstanding, siblings, now=now,
+                            disabled=disabled)
     # ONE objective team line (#113), only when a team remote exists — the #84
     # health-line rule: no line, no false alarms when the team feature is unused.
     team = teamsync.status_line()
@@ -621,7 +670,8 @@ def _cmd_status(args) -> int:
         print(json.dumps(
             {"project": proj, "global": glob, "last_serialize": last,
              "outstanding": outstanding, "siblings": siblings, "health": health,
-             "team": team},
+             "team": team, "crash": crash, "disabled": disabled,
+             "skipped_recent": skipped_recent, "recall_error": recall_error},
             indent=2,
         ))
         return rc
@@ -629,7 +679,8 @@ def _cmd_status(args) -> int:
     render.render_status({
         "project": project, "proj": proj, "glob": glob, "same": same, "last": last,
         "outstanding": outstanding, "identity": identity, "health": health,
-        "team": team,
+        "team": team, "crash": crash, "skipped_recent": skipped_recent,
+        "recall_error": recall_error,
     })
     return rc
 
@@ -647,6 +698,11 @@ _HEAL_TRANSCRIPT_RE = re.compile(r"\(transcript: (.+?)\) after \d+s")
 _LEDGER_OK_RE = re.compile(r"^wrote checkpoint: (.+?) \(took \d+s\)")
 _LEDGER_SKIP_RE = re.compile(r"^skipped serialize for (\S+):")
 _LEDGER_PROJECT_RE = re.compile(r"project: (.*?)\)")
+# #28: hooks stamp the transcript path on the spawn line as a TRAILING group —
+# `... (reason: r, project: p) (transcript: <path>)` — so a child that crashes
+# before writing any result line still leaves a healable trail. Trailing-only
+# match keeps it disjoint from _HEAL_TRANSCRIPT_RE (error lines, `after Ns`).
+_LEDGER_SPAWN_TRANSCRIPT_RE = re.compile(r"\(transcript: (.+?)\)\s*$")
 
 
 def _session_ledger(text: str, now: float) -> dict:
@@ -680,6 +736,9 @@ def _session_ledger(text: str, now: float) -> dict:
             if pm:
                 raw = pm.group(1).strip()
                 e["project"] = raw if (raw and raw != "?") else None
+            tm = _LEDGER_SPAWN_TRANSCRIPT_RE.search(line)
+            if tm:
+                e["transcript"] = tm.group(1)
             if "retry serialize for" in line:
                 e["retried"] = True
             continue
@@ -733,8 +792,16 @@ def _outstanding_failures(ledger, now, has_checkpoint, ceiling, transcript_exist
                         "transcript": e["transcript"], "project": e["project"],
                         "spawned": e["spawned"], "line": e["result_line"]})
         elif e["result_kind"] is None and e["spawned"] and age is not None and age > ceiling:
-            out.append({"sid": sid, "kind": "hung", "class": "hung", "age": age,
-                        "age_str": _format_age(age), "transcript": None,
+            # #28: a spawn line that recorded its transcript makes a hung
+            # (crashed/killed) serialize healable — the checkpoint is
+            # recoverable as long as the transcript is still on disk. The
+            # one-retry-ever policy (#26) applies unchanged via `retried`.
+            t = e["transcript"]
+            cls = ("healable"
+                   if t and transcript_exists(t) and not e["retried"]
+                   else "hung")
+            out.append({"sid": sid, "kind": "hung", "class": cls, "age": age,
+                        "age_str": _format_age(age), "transcript": t,
                         "project": e["project"], "spawned": True, "line": None})
     out.sort(key=lambda f: (f["age"] is None, f["age"] or 0))
     return out

--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -114,9 +114,26 @@ def _chat_litellm(messages, model=None, temperature=None, timeout=None, retries=
     raise ChatError(f"LLM failed after {retries} tries: {last}")
 
 
+# #28: the silent-fallback flag. Sticky across chat() calls within one process
+# (a serialize is one child process, possibly several chat calls) so the caller
+# can stamp "this checkpoint used the weaker fallback backend" on its result
+# line. reset_fallback() at the start of a unit of work; fallback_used() after.
+_fallback_used = False
+
+
+def fallback_used() -> bool:
+    return _fallback_used
+
+
+def reset_fallback() -> None:
+    global _fallback_used
+    _fallback_used = False
+
+
 def chat(messages, model=None, temperature=None, timeout=None, retries=3, deadline=None):
     """Dispatch to the configured backend. litellm (default) falls back to a
     command backend on ChatError when fallback is enabled and one resolves."""
+    global _fallback_used
     backend = config.llm_backend()
     if backend == "auto":
         if config.llm_api_key():
@@ -133,6 +150,7 @@ def chat(messages, model=None, temperature=None, timeout=None, retries=3, deadli
     except ChatError:
         if config.llm_fallback() and _resolve_command() is not None:
             log.warning("llm.fallback backend=command (litellm failed)")
+            _fallback_used = True
             return _chat_command(messages, deadline)
         raise
 

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -32,14 +32,35 @@ another project's scoped recall (same philosophy as store's pointer routing).
 
 import hashlib
 import json
+import logging
 import os
 import re
 import sqlite3
 import time
 import unicodedata
+from datetime import datetime, timezone
 from pathlib import Path
 
 from . import config, scoring, store
+
+log = logging.getLogger("daimon.recall")
+
+
+def _note_error(where: str, exc: BaseException) -> None:
+    """Breadcrumb for a swallowed index error (#28). Recall is fail-open by
+    design — a broken index degrades to [] — but silently, a broken recall is
+    indistinguishable from \"no prior work\". One line to recall-error.log
+    (read back by `daimon status`) plus a log.warning. Best-effort: the
+    breadcrumb itself must never break the swallow."""
+    log.warning("recall.%s swallowed %s: %s", where, type(exc).__name__, exc)
+    try:
+        d = config.log_dir()
+        d.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with (d / "recall-error.log").open("a", encoding="utf-8") as f:
+            f.write(f"{stamp} {where}: {type(exc).__name__}: {exc}\n")
+    except OSError:
+        pass
 
 # v2 (#125): items grew importance + first_seen for suggest()'s ranking; the
 # version bump makes _ensure_fresh discard any v1 db and rebuild.
@@ -373,8 +394,8 @@ def search(query: str, project_dir=None, all_projects: bool = False,
         return []
     try:
         _ensure_fresh()
-    except (OSError, sqlite3.Error):
-        pass  # disk trouble on a DERIVED index: try the query on what exists
+    except (OSError, sqlite3.Error) as exc:
+        _note_error("search.refresh", exc)  # then try the query on what exists
     want = None if all_projects else store.project_slug(project_dir)
 
     sql = (
@@ -426,7 +447,8 @@ def search(query: str, project_dir=None, all_projects: bool = False,
         try:
             rebuild()
             return _query()
-        except (OSError, sqlite3.DatabaseError):
+        except (OSError, sqlite3.DatabaseError) as exc:
+            _note_error("search", exc)
             return []
 
 
@@ -544,8 +566,8 @@ def suggest(prompt: str, project_dir=None, current_session=None,
     expr = " OR ".join('"' + t.replace('"', '""') + '"' for t in terms)
     try:
         _ensure_fresh()
-    except (OSError, sqlite3.Error):
-        pass
+    except (OSError, sqlite3.Error) as exc:
+        _note_error("suggest.refresh", exc)
     sql = (
         "SELECT i.text, i.quote, i.trust, i.kind, i.author, i.project_slug,"
         " i.session_id, i.created, i.importance, i.first_seen, i.superseded_by,"
@@ -561,7 +583,8 @@ def suggest(prompt: str, project_dir=None, current_session=None,
             rows = [dict(zip(cols, row)) for row in cur.fetchall()]
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        _note_error("suggest", exc)
         return []  # suggestion is opportunistic — any db trouble means silence
 
     # Pass 1: per-session distinct-term coverage. The overlap gate below is

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -271,16 +271,48 @@ def render_heal(plan: dict, *, dry_run: bool) -> None:
         print(f"  - {s['sid']}  ({s['age_str']} ago) — {s['reason']}")
 
 
+def _print_skips_plain(n) -> None:
+    """Informational, not a warning (#28): a skip is by-design (too-short
+    session), but an invisible skip reads as a captured session."""
+    if n:
+        print(f"recent sessions skipped (too short to serialize): {n}")
+
+
+def _print_crash_plain(crash) -> None:
+    """One line for the newest child-process crash (#28). serialize-crash.log
+    is where spawn_serialize points child stderr; before this, nothing ever
+    read it back. No-op when the log is absent/empty."""
+    if not crash:
+        return
+    print(f"last serialize crash: {crash['age']} ago — {crash['last_line']}")
+    print(f"  full traceback: {crash['path']}")
+
+
+def _print_recall_error_plain(err) -> None:
+    """Newest swallowed recall-index error (#28) — without it, a broken index
+    reads as \"no prior work\"."""
+    if not err:
+        return
+    print(f"last recall error: {err['age']} ago — {err['last_line']}")
+
+
 def _outstanding_lines(outstanding) -> list:
     """Human lines for lost sessions; empty list when nothing is outstanding."""
     lines = []
     for f in outstanding:
         age = f["age_str"]
         if f["kind"] == "hung":
-            lines.append(
-                f"  - {f['sid']}  spawned {age} ago, no result "
-                f"(hung/killed; transcript unavailable)"
-            )
+            # #28: a hung spawn whose transcript survived is healable now.
+            if f["class"] == "healable":
+                lines.append(
+                    f"  - {f['sid']}  spawned {age} ago, no result "
+                    f"(hung/killed) — run `daimon heal`"
+                )
+            else:
+                lines.append(
+                    f"  - {f['sid']}  spawned {age} ago, no result "
+                    f"(hung/killed; transcript unavailable)"
+                )
         elif f["class"] == "retry-exhausted":
             lines.append(f"  - {f['sid']}  error {age} ago — retry attempted, still failing")
         elif f["class"] == "unrecoverable":
@@ -320,6 +352,9 @@ def _plain_status(data: dict) -> None:
         print("global checkpoint (fallback): none")
     if last is None:
         print("last serialize: no serialize history")
+        _print_crash_plain(data.get("crash"))
+        _print_recall_error_plain(data.get("recall_error"))
+        _print_skips_plain(data.get("skipped_recent"))
         return
     if last["result"]:
         print(f"last serialize result: {last['result']['outcome']} — {last['result']['line']}")
@@ -331,6 +366,9 @@ def _plain_status(data: dict) -> None:
         print(f"last serialize spawn: session {s['session_id']}{ago}")
     else:
         print("last serialize spawn: none logged yet")
+    _print_crash_plain(data.get("crash"))
+    _print_recall_error_plain(data.get("recall_error"))
+    _print_skips_plain(data.get("skipped_recent"))
 
     outstanding = data.get("outstanding") or []
     if outstanding:
@@ -391,6 +429,18 @@ def _rich_status(data: dict) -> None:
             console.print(f"last serialize spawn: session {s['session_id']}{ago}")
         else:
             console.print("last serialize spawn: none logged yet")
+    crash = data.get("crash")
+    if crash:
+        console.print(f"[red]last serialize crash:[/red] {crash['age']} ago — "
+                      f"{crash['last_line']}")
+        console.print(f"  [dim]full traceback: {crash['path']}[/dim]")
+    recall_err = data.get("recall_error")
+    if recall_err:
+        console.print(f"[red]last recall error:[/red] {recall_err['age']} ago — "
+                      f"{recall_err['last_line']}")
+    if data.get("skipped_recent"):
+        console.print(f"[dim]recent sessions skipped (too short to serialize): "
+                      f"{data['skipped_recent']}[/dim]")
 
     outstanding = data.get("outstanding") or []
     if outstanding:

--- a/plugin/tests/test_claude_hooks.py
+++ b/plugin/tests/test_claude_hooks.py
@@ -504,3 +504,23 @@ def test_prompt_hook_silent_when_lib_missing(tmp_checkpoint_dir, tmp_path):
                         "prompt": "debugging the litellm gateway cache again"},
                 tmp_path)
     assert proc.returncode == 0 and proc.stdout.strip() == ""
+
+
+def test_session_end_spawn_line_records_transcript(tmp_path, tmp_checkpoint_dir):
+    # #28: the spawn line must carry the transcript path — a child that
+    # crashes before writing a result line leaves no other pointer to it,
+    # and heal needs it to classify the hung session as healable.
+    fake_bin, _capture = _fake_cli(tmp_path)
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("{}\n")
+    payload = {
+        "session_id": "S-tr",
+        "transcript_path": str(transcript),
+        "cwd": "/Users/x/projA",
+        "reason": "exit",
+    }
+    proc = _run(END_HOOK, payload, tmp_path, extra_env={"PATH": str(fake_bin)})
+    assert proc.returncode == 0
+    log = tmp_path / ".daimon" / "logs" / "serialize.log"
+    content = _wait_for_text(log, "spawned serialize for S-tr")
+    assert f"(transcript: {transcript})" in content

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -657,7 +657,9 @@ def test_cli_status_json_shape(
     rc = cli.main(["status", "--json"])
     assert rc == 0
     data = json.loads(capsys.readouterr().out)
-    assert set(data) == {"project", "global", "last_serialize", "outstanding", "siblings", "health", "team"}
+    assert set(data) == {"project", "global", "last_serialize", "outstanding",
+                         "siblings", "health", "team", "crash", "disabled",
+                         "skipped_recent", "recall_error"}
     assert data["team"] is None  # no team remote configured -> explicit null (#113)
     assert data["project"]["exists"] is True
     assert data["project"]["session_id"] == "S-prev"
@@ -2419,3 +2421,242 @@ def test_team_sync_project_flag_warns_ignored(monkeypatch, capsys):
     rc = cli.main(["team", "sync", "--project", "/repo/x"])
     assert rc == 0
     assert "project" in capsys.readouterr().err.lower()
+
+
+# ---- #28 S1: transcript path on spawn lines — hung sessions become healable ----
+
+
+def test_session_ledger_reads_transcript_from_spawn_line():
+    # A crashed/killed child never writes an error line, so the spawn line is
+    # the only place the transcript path can survive. The ledger must pick it
+    # up from there (#28).
+    text = ("2026-06-10T12:00:00Z session-end: spawned serialize for A "
+            "(reason: exit, project: /p/A) (transcript: /t/A.jsonl)")
+    led = cli._session_ledger(text, now=0.0)
+    assert led["A"]["transcript"] == "/t/A.jsonl"
+    assert led["A"]["project"] == "/p/A"  # project parse unaffected by the suffix
+    assert led["A"]["result_kind"] is None
+
+
+def test_outstanding_hung_with_live_transcript_is_healable():
+    # F1 (audit): kill -9 mid-serialize lost the checkpoint AND heal declared
+    # it unrepairable even though the transcript was still on disk. With the
+    # transcript recorded at spawn time, a hung session becomes healable.
+    ledger = {"X": _led(result_kind=None, result_line=None, spawn_age=3600)}
+    out = cli._outstanding_failures(ledger, 0.0, lambda sid: False, 1800, lambda p: True)
+    assert out[0]["kind"] == "hung"
+    assert out[0]["class"] == "healable"
+    assert out[0]["transcript"] == "/t/X.jsonl"
+
+
+def test_outstanding_hung_without_transcript_stays_hung():
+    ledger = {"X": _led(result_kind=None, result_line=None, spawn_age=3600,
+                        transcript=None)}
+    out = cli._outstanding_failures(ledger, 0.0, lambda sid: False, 1800, lambda p: True)
+    assert out[0]["class"] == "hung"
+
+
+def test_outstanding_hung_transcript_gone_stays_hung():
+    ledger = {"X": _led(result_kind=None, result_line=None, spawn_age=3600)}
+    out = cli._outstanding_failures(ledger, 0.0, lambda sid: False, 1800, lambda p: False)
+    assert out[0]["class"] == "hung"
+
+
+def test_outstanding_hung_already_retried_stays_hung():
+    # One-retry-ever policy (#26) applies to hung heals too: a healed-hung
+    # session that hangs again must not loop.
+    ledger = {"X": _led(result_kind=None, result_line=None, spawn_age=3600,
+                        retried=True)}
+    out = cli._outstanding_failures(ledger, 0.0, lambda sid: False, 1800, lambda p: True)
+    assert out[0]["class"] == "hung"
+
+
+def test_heal_plan_targets_hung_healable(tmp_checkpoint_dir, tmp_path):
+    # End-to-end through the pure plan: a hung spawn whose transcript is still
+    # on disk becomes the heal target instead of an unrepairable skip.
+    from datetime import datetime, timezone
+    transcript = tmp_path / "H.jsonl"
+    transcript.write_text("{}\n")
+    text = ("2026-06-10T12:00:00Z session-end: spawned serialize for H "
+            f"(reason: exit, project: /p/H) (transcript: {transcript})")
+    now = datetime(2026, 6, 10, 13, 0, 0, tzinfo=timezone.utc).timestamp()
+    plan = cli._heal_plan(text, now)
+    assert plan["target"] is not None
+    assert plan["target"]["sid"] == "H"
+    assert plan["target"]["transcript"] == str(transcript)
+
+
+# ---- #28 S2: serialize-crash.log stops being a write-only dead-drop ----
+
+
+def test_crash_log_info_missing_file_is_none(tmp_path):
+    assert cli._crash_log_info(tmp_path / "nope.log", now=0.0) is None
+
+
+def test_crash_log_info_empty_file_is_none(tmp_path):
+    p = tmp_path / "serialize-crash.log"
+    p.write_text("")
+    assert cli._crash_log_info(p, now=0.0) is None
+
+
+def test_crash_log_info_reports_last_line_and_age(tmp_path):
+    p = tmp_path / "serialize-crash.log"
+    p.write_text(
+        "Traceback (most recent call last):\n"
+        '  File "x.py", line 1, in <module>\n'
+        "OSError: [Errno 28] No space left on device\n"
+    )
+    import os
+    os.utime(p, (1000.0, 1000.0))
+    info = cli._crash_log_info(p, now=1300.0)
+    assert info["last_line"] == "OSError: [Errno 28] No space left on device"
+    assert info["age_seconds"] == 300
+    assert info["age"] == "5m"
+    assert info["path"] == str(p)
+
+
+def test_status_json_includes_crash_info(tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
+    from daimon_briefing import config, store
+    store.write_checkpoint("S1", sample_checkpoint)
+    crash = config.log_dir() / "serialize-crash.log"
+    crash.parent.mkdir(parents=True, exist_ok=True)
+    crash.write_text("RuntimeError: child exploded\n")
+    rc = cli.main(["status", "--json"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["crash"]["last_line"] == "RuntimeError: child exploded"
+
+
+def test_status_plain_shows_crash_line(tmp_checkpoint_dir, sample_checkpoint, capsys):
+    from daimon_briefing import config, store
+    store.write_checkpoint("S1", sample_checkpoint)
+    crash = config.log_dir() / "serialize-crash.log"
+    crash.parent.mkdir(parents=True, exist_ok=True)
+    crash.write_text("RuntimeError: child exploded\n")
+    rc = cli.main(["status"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "last serialize crash" in out.lower()
+    assert "RuntimeError: child exploded" in out
+
+
+def test_status_plain_no_crash_line_when_log_absent(tmp_checkpoint_dir, sample_checkpoint, capsys):
+    from daimon_briefing import store
+    store.write_checkpoint("S1", sample_checkpoint)
+    rc = cli.main(["status"])
+    assert rc == 0
+    assert "last serialize crash" not in capsys.readouterr().out.lower()
+
+
+# ---- #28 S3+S4: disabled banner + skipped-session visibility ----
+
+
+def test_status_health_disabled_is_top_warning():
+    # F4 (audit): DAIMON_DISABLE=1 silently stops capture; status never said so.
+    h = cli._status_health(_proj(), {"exists": True, "same_session_as_project": True},
+                           [], [], now=1000.0, disabled=True)
+    assert h["ok"] is False
+    assert "DAIMON_DISABLE" in h["verdict"]
+    assert "capture is OFF" in h["verdict"]
+
+
+def test_status_health_not_disabled_unchanged():
+    h = cli._status_health(_proj(), {"exists": True, "same_session_as_project": True},
+                           [], [], now=1000.0, disabled=False)
+    assert h["ok"] is True
+
+
+def test_status_shows_disabled_banner(tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
+    from daimon_briefing import store
+    store.write_checkpoint("S1", sample_checkpoint)
+    monkeypatch.setenv("DAIMON_DISABLE", "1")
+    rc = cli.main(["status"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "DAIMON_DISABLE" in out and "capture is OFF" in out
+
+
+def test_status_json_reports_disabled(tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
+    from daimon_briefing import store
+    store.write_checkpoint("S1", sample_checkpoint)
+    monkeypatch.setenv("DAIMON_DISABLE", "1")
+    rc = cli.main(["status", "--json"])
+    data = json.loads(capsys.readouterr().out)
+    assert data["disabled"] is True
+
+
+def test_status_counts_recent_skipped_sessions(
+        tmp_checkpoint_dir, tmp_log_dir, sample_checkpoint, capsys, monkeypatch):
+    # F5 (audit): a too-short session skips serialize by design, but status
+    # implied the session was captured. Surface the count.
+    from daimon_briefing import store
+    store.write_checkpoint("S-prev", sample_checkpoint, project_dir="/p/A")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    _write_log(tmp_log_dir, [
+        "2026-06-10T12:00:00Z session-end: spawned serialize for S-tiny (reason: exit, project: /p/A)",
+        "skipped serialize for S-tiny: too short (3 < 10 messages)",
+    ])
+    rc = cli.main(["status", "--json"])
+    data = json.loads(capsys.readouterr().out)
+    assert data["skipped_recent"] == 1
+    rc = cli.main(["status"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "skipped" in out and "too short" in out
+
+
+def test_status_no_skip_line_when_none(tmp_checkpoint_dir, sample_checkpoint, capsys):
+    from daimon_briefing import store
+    store.write_checkpoint("S1", sample_checkpoint)
+    rc = cli.main(["status"])
+    assert "skipped" not in capsys.readouterr().out
+
+
+def test_status_surfaces_recall_error(tmp_checkpoint_dir, sample_checkpoint, capsys):
+    # #28 S5: the recall breadcrumb must reach status, or it's a second
+    # dead-drop.
+    from daimon_briefing import config, store
+    store.write_checkpoint("S1", sample_checkpoint)
+    p = config.log_dir() / "recall-error.log"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("2026-07-03T10:00:00Z search: OSError: disk full\n")
+    rc = cli.main(["status", "--json"])
+    data = json.loads(capsys.readouterr().out)
+    assert "disk full" in data["recall_error"]["last_line"]
+    rc = cli.main(["status"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "last recall error" in out
+
+
+def test_serialize_result_line_marks_llm_fallback(
+        tmp_checkpoint_dir, tmp_log_dir, fake_chat_factory, capsys, monkeypatch):
+    # #28 S6 (F2): a gateway outage silently swapped in the weaker command
+    # backend and stamped plain success. The result line — which status shows
+    # verbatim — must carry the downgrade.
+    from daimon_briefing import llm
+
+    def chat_with_fallback(*a, **k):
+        llm._fallback_used = True  # simulate llm.chat falling back mid-serialize
+        return fake_chat_factory(_valid_json("S-fb"))(*a, **k)
+
+    monkeypatch.setattr(cli, "_chat", chat_with_fallback)
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    rc = cli.main(["serialize", str(FIXTURES / "sample_transcript.md")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "[fallback backend]" in out
+    log_text = (tmp_log_dir / "serialize.log").read_text(encoding="utf-8")
+    assert "[fallback backend]" in log_text
+    # the marked line still parses as a success for status/ledger
+    led = cli._session_ledger(log_text, now=0.0)
+    assert led["sample_transcript"]["result_kind"] == "success"
+
+
+def test_serialize_result_line_clean_without_fallback(
+        tmp_checkpoint_dir, fake_chat_factory, capsys, monkeypatch):
+    monkeypatch.setattr(cli, "_chat", fake_chat_factory(_valid_json("S-nf")))
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    rc = cli.main(["serialize", str(FIXTURES / "sample_transcript.md")])
+    assert rc == 0
+    assert "[fallback backend]" not in capsys.readouterr().out

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -359,3 +359,28 @@ def test_chat_auto_falls_to_litellm_when_nothing(monkeypatch):
                         lambda *a, **k: (_ for _ in ()).throw(llm.ChatError("No LLM API key")))
     with pytest.raises(llm.ChatError):
         llm.chat([{"role": "user", "content": "x"}])
+
+
+# ---- #28 S6: fallback must be observable, not just logged to a dead-drop ----
+
+
+def test_chat_fallback_sets_flag(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    def boom(*a, **k):
+        raise llm.ChatError("gateway down")
+    monkeypatch.setattr(llm, "_chat_litellm", boom)
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text"))
+    monkeypatch.setattr(llm, "_chat_command", lambda m, deadline: "FALLBACK")
+    llm.reset_fallback()
+    assert llm.fallback_used() is False
+    llm.chat([{"role": "user", "content": "x"}])
+    assert llm.fallback_used() is True
+
+
+def test_chat_direct_success_leaves_flag_clear(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setattr(llm, "_chat_litellm", lambda *a, **k: "OK")
+    llm.reset_fallback()
+    llm.chat([{"role": "user", "content": "x"}])
+    assert llm.fallback_used() is False

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -733,3 +733,54 @@ def test_suggest_caps_at_two_distinct_sessions(tmp_checkpoint_dir, monkeypatch):
                          project_dir="/repo/x", current_session="S-now")
     assert 0 < len(out) <= 2
     assert len({o["session_id"] for o in out}) == len(out)
+
+
+# ---- #28 S5: index errors leave a breadcrumb instead of failing to silence ----
+
+
+def test_search_index_error_writes_breadcrumb(tmp_checkpoint_dir, monkeypatch):
+    # A broken index degrades to [] (fail-open) — but silently, a broken
+    # recall is indistinguishable from "no prior work". The swallow must
+    # leave a trace status can surface (#28).
+    from daimon_briefing import config, store
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S1", _cp("S1"), project_dir="/repo/x")
+
+    def boom():
+        raise OSError("disk full")
+    monkeypatch.setattr(recall, "rebuild", boom)
+    monkeypatch.setattr(recall, "_ensure_fresh", boom)
+    assert recall.search("something", all_projects=True) == []
+    breadcrumb = config.log_dir() / "recall-error.log"
+    assert breadcrumb.exists()
+    assert "disk full" in breadcrumb.read_text(encoding="utf-8")
+
+
+def test_suggest_db_error_writes_breadcrumb(tmp_checkpoint_dir, monkeypatch):
+    from daimon_briefing import config, store
+    import sqlite3 as sq
+    store.write_checkpoint(
+        "S-old",
+        _cp("S-old", decisions=[{"text": "litellm gateway cache pinning",
+                                 "trust": "inferred"}]),
+        project_dir="/repo/x",
+    )
+    real_connect = sq.connect
+    def bad_connect(*a, **k):
+        raise sq.OperationalError("database is locked")
+    monkeypatch.setattr(recall.sqlite3, "connect", bad_connect)
+    out = recall.suggest("debugging the litellm gateway cache pinning",
+                         project_dir="/repo/x", current_session="S-now")
+    assert out == []
+    breadcrumb = config.log_dir() / "recall-error.log"
+    assert breadcrumb.exists()
+    assert "database is locked" in breadcrumb.read_text(encoding="utf-8")
+
+
+def test_search_happy_path_writes_no_breadcrumb(tmp_checkpoint_dir, monkeypatch):
+    from daimon_briefing import config, store
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S1", _cp("S1", decisions=[
+        {"text": "pelican decision", "trust": "inferred"}]), project_dir="/repo/x")
+    assert recall.search("pelican", all_projects=True)
+    assert not (config.log_dir() / "recall-error.log").exists()


### PR DESCRIPTION
Closes #28

## Summary

Six repairs for the audit's silent-failure cluster (F1-F5 + recall swallow). Daimon stays fail-open; every failure now leaves a trace `daimon status` shows. This answers the audit question "will anyone notice when the hook fails silently?" with mechanism instead of hope.

## Changes

| Slice | What | Where |
|-------|------|-------|
| S1 | Spawn lines carry `(transcript: …)` as a trailing group; hung (crashed/killed) serializes with a live transcript classify **healable** — heal recovers them instead of declaring "transcript unavailable". One-retry-ever (#26) preserved via the retry marker. | `hook/daimon-{session-end,codex-stop,gemini-session-end}.py`, `cli.py` ledger/classifier, `render.py` |
| S2 | `status` reads `serialize-crash.log` (child stderr dead-drop): last crash line + age, plain/rich/json. | `cli._crash_log_info`, `render.py` |
| S3 | `DAIMON_DISABLE` set → status verdict leads with "capture is OFF"; `disabled` json field. | `cli._status_health` |
| S4 | Recent too-short skips counted and shown; `skipped_recent` json field. | `cli.py`, `render.py` |
| S5 | recall's swallowed index errors append one line to `recall-error.log` + `log.warning`; status surfaces the newest. | `recall._note_error`, `cli.py`, `render.py` |
| S6 | LLM fallback sets a sticky per-process flag; the `wrote checkpoint:` result line gains `[fallback backend]` (suffix-safe for all prefix-anchored regexes). | `llm.py`, `cli._run_serialize` |

## Scar compliance

- Scar #9 (last-of-kind over serialize.log): all new classification flows through the per-session ledger; crash/recall-error surfacing is display-only and labeled "last".
- Scar #15 (gateway cache pins bad responses): llm.py change is an observability flag only — no retry/body logic touched.

## Test plan

- [x] TDD throughout: 20 new tests, every behavior change watched red first
- [x] `uv run pytest` — 754 passed
- [x] Live verify on this machine: status now shows **10 skipped sessions** that were invisible before; `DAIMON_DISABLE=1 daimon status` leads with the OFF banner; crash/recall breadcrumbs correctly absent (no crashes)

## Non-goals

Heal retry-policy changes (#15); a general logging framework (explicitly out per issue); trust-integrity items (#30).