### PR TITLE
fix(briefing): verbatim integrity on every render surface — LLM render post-validated, truncation exemption, untagged trust

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -11,17 +11,28 @@ beliefs, then uncertainties, then contradictions flagged. Verbatim items are mar
 distinctly from inferred ones.
 """
 
+import logging
 import re
 import time
 
 from . import config, llm, scoring
 
+log = logging.getLogger("daimon.briefing")
+
 _VERBATIM_MARK = "✓ verbatim"
 _INFERRED_MARK = "~ inferred"
+_UNTAGGED_MARK = "? untagged"
 
 
 def _mark(item) -> str:
-    return _VERBATIM_MARK if item.get("trust") == "verbatim" else _INFERRED_MARK
+    # A missing/empty trust class renders as "untagged", never as a confident
+    # "inferred" the item never earned (#30) — the recall CLI already agrees.
+    trust = item.get("trust")
+    if trust == "verbatim":
+        return _VERBATIM_MARK
+    if trust:
+        return _INFERRED_MARK
+    return _UNTAGGED_MARK
 
 
 def _line(item) -> str:
@@ -163,11 +174,16 @@ def render_plain(b: dict) -> str:
     if not budget or estimate_tokens(text) <= budget:
         return text
 
-    # Stage 1: shorten monster items in place of dropping them.
+    # Stage 1: shorten monster items in place of dropping them. Verbatim text
+    # is exempt (#30) — the #23 freeze made it immutable in carry, and a
+    # render that rewrites it under budget pressure breaks the same guarantee.
+    # An oversized verbatim item can still be DROPPED whole in stage 2
+    # (announced by the trim note); it is never rewritten.
     b = dict(b)
     for key, _end in _DROP_ORDER:
         b[key] = [
-            {**i, "text": truncate_preserving_sections(
+            i if i.get("trust") == "verbatim"
+            else {**i, "text": truncate_preserving_sections(
                 i.get("text", ""), _ITEM_TRUNCATE_CHARS)}
             for i in (b.get(key) or [])
         ]
@@ -231,16 +247,46 @@ def _render_parts(b: dict, trimmed: dict) -> str:
     return "\n".join(parts)
 
 
+def _iter_trusted_quotes(checkpoint):
+    """Yield every verbatim item's quote across the cognitive sections."""
+    wc = checkpoint.get("working_context") or {}
+    es = checkpoint.get("epistemic_snapshot") or {}
+    for items in (wc.get("open_questions"), wc.get("recent_decisions"),
+                  es.get("strong_beliefs"), es.get("uncertainties"),
+                  es.get("contradictions_flagged")):
+        for item in items or []:
+            if (isinstance(item, dict) and item.get("trust") == "verbatim"
+                    and str(item.get("quote") or "").strip()):
+                yield str(item["quote"]).strip()
+
+
+def _validate_llm_render(rendered: str, checkpoint) -> bool:
+    """The mechanical check the deterministic render gets for free (#30): every
+    verbatim quote must survive the LLM's prose INTACT. Whitespace-normalized
+    on both sides — LLMs re-wrap lines, and a re-wrapped quote is still the
+    exact wording. Any lost or mutated quote fails the whole render; the
+    verbatim/inferred distinction is a guarantee, not a request."""
+    haystack = re.sub(r"\s+", " ", rendered)
+    for quote in _iter_trusted_quotes(checkpoint):
+        if re.sub(r"\s+", " ", quote) not in haystack:
+            return False
+    return True
+
+
 def render(checkpoint) -> str | None:
     """Render the briefing, or None if there is nothing worth surfacing.
-    LLM rendering is opt-in (DAIMON_LLM_BRIEFING) and falls back to deterministic."""
+    LLM rendering is opt-in (DAIMON_LLM_BRIEFING), post-validated for verbatim
+    quote integrity, and falls back to deterministic on any doubt."""
     b = build(checkpoint)
     if b is None:
         return None
     if config.llm_briefing():
         rendered = _render_llm(checkpoint)
         if rendered:
-            return rendered
+            if _validate_llm_render(rendered, checkpoint):
+                return rendered
+            log.warning("llm briefing dropped a verbatim quote — "
+                        "falling back to the deterministic render")
     return render_plain(b)
 
 

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -35,7 +35,16 @@ def supports_rich() -> bool:
     return True
 
 
-_TRUST_STYLE = {"verbatim": "bold green", "inferred": "yellow"}
+_TRUST_STYLE = {"verbatim": "bold green", "inferred": "yellow", "untagged": "dim"}
+
+
+def _trust_key(item) -> str:
+    """Three-way trust class for styling (#30): missing/empty trust is
+    "untagged", never presented as a confident "inferred"."""
+    trust = item.get("trust")
+    if trust == "verbatim":
+        return "verbatim"
+    return "inferred" if trust else "untagged"
 
 _SECTIONS = [
     ("external", "⚠ VERIFY BEFORE TRUSTING", "red"),
@@ -127,7 +136,7 @@ def _rich_brief(b: dict) -> None:
             continue
         body = Text()
         for i in items:
-            trust = "verbatim" if i.get("trust") == "verbatim" else "inferred"
+            trust = _trust_key(i)
             body.append(f"• {i.get('text', '').strip()}\n", style=_TRUST_STYLE[trust])
             quote = i.get("quote", "").strip()
             if quote:
@@ -193,7 +202,7 @@ def _rich_teammates(teammates) -> None:
         if decisions:
             body.append("Decisions made:\n", style="bold")
             for i in decisions:
-                trust = "verbatim" if i.get("trust") == "verbatim" else "inferred"
+                trust = _trust_key(i)
                 body.append(f"• {i.get('text', '').strip()}\n", style=_TRUST_STYLE[trust])
             note = briefing._overflow_note(b.get("decisions_overflow", 0))
             if note:

--- a/plugin/tests/test_briefing.py
+++ b/plugin/tests/test_briefing.py
@@ -115,13 +115,20 @@ def test_llm_briefing_sends_configured_temperature(sample_checkpoint, monkeypatc
     monkeypatch.setenv("DAIMON_LLM_TEMPERATURE", "1")
     captured = {}
 
+    # The fake response must carry every verbatim quote — #30 post-validation
+    # rejects an LLM render that loses one, and this test is about the
+    # request body, not the validation gate.
+    faithful = ('llm-rendered briefing: "I\'ll merge it myself later from the '
+                'GitHub UI" / "do we chunk below 1200 lines or single-pass?" / '
+                '"we adopt the D-007 prompt for the serializer"')
+
     def fake_urlopen(req, timeout=None):
         captured["body"] = json.loads(req.data)
-        payload = {"choices": [{"message": {"content": "llm-rendered briefing"}}]}
+        payload = {"choices": [{"message": {"content": faithful}}]}
         return io.BytesIO(json.dumps(payload).encode())
 
     monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
-    assert briefing.render(sample_checkpoint) == "llm-rendered briefing"
+    assert briefing.render(sample_checkpoint) == faithful
     assert captured["body"]["temperature"] == 1.0
 
 
@@ -446,3 +453,97 @@ def test_line_carried_marker_precedes_quote():
             "quote": "the exact words", "carried_from": "S-0"}
     line = briefing._line(item)
     assert line.index("[carried]") < line.index("the exact words")
+
+
+# ---- #30: trust-class integrity — the differentiator's own guarantees ----
+
+
+def _llm_briefing_env(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BRIEFING", "1")
+    monkeypatch.setenv("DAIMON_LLM_BASE_URL", "http://127.0.0.1:9")
+    monkeypatch.setenv("DAIMON_LLM_API_KEY", "sk-test")
+    monkeypatch.setenv("DAIMON_LLM_MODEL", "test-model")
+
+
+def test_llm_render_rejected_when_verbatim_quote_missing(sample_checkpoint, monkeypatch):
+    # The LLM path used to print whatever came back — a verbatim pin could be
+    # silently dropped or reworded. A render that loses any verbatim quote is
+    # rejected and the deterministic render takes over (#30).
+    _llm_briefing_env(monkeypatch)
+    from daimon_briefing import llm
+    monkeypatch.setattr(llm, "chat",
+                        lambda *a, **k: "a fluent briefing that quotes nothing")
+    out = briefing.render(sample_checkpoint)
+    # deterministic fallback: every verbatim quote is present, mechanically
+    assert "I'll merge it myself later from the GitHub UI" in out
+    assert "do we chunk below 1200 lines or single-pass?" in out
+
+
+def test_llm_render_accepted_when_quotes_survive(sample_checkpoint, monkeypatch):
+    _llm_briefing_env(monkeypatch)
+    from daimon_briefing import llm
+    faithful = (
+        "While you were away: verify PR #6 first — "
+        '"I\'ll merge it myself later from the GitHub UI". '
+        'Open: "do we chunk below 1200 lines or single-pass?". '
+        'Decided: "we adopt the D-007 prompt for the serializer".'
+    )
+    monkeypatch.setattr(llm, "chat", lambda *a, **k: faithful)
+    assert briefing.render(sample_checkpoint) == faithful
+
+
+def test_llm_render_tolerates_rewrapped_whitespace(sample_checkpoint, monkeypatch):
+    # LLMs re-wrap lines; a quote split across a newline is still intact.
+    _llm_briefing_env(monkeypatch)
+    from daimon_briefing import llm
+    rewrapped = (
+        'Verify: "I\'ll merge it myself\nlater from the GitHub UI".\n'
+        'Open: "do we chunk below 1200\nlines or single-pass?".\n'
+        'Decided: "we adopt the D-007\nprompt for the serializer".'
+    )
+    monkeypatch.setattr(llm, "chat", lambda *a, **k: rewrapped)
+    assert briefing.render(sample_checkpoint) == rewrapped
+
+
+def test_budget_truncation_never_rewrites_verbatim_text(monkeypatch):
+    # #23 froze verbatim text in carry; render must honor the same rule —
+    # budget pressure truncates INFERRED items first, verbatim text stays
+    # byte-intact (#30).
+    monkeypatch.setenv("DAIMON_BRIEF_MAX_TOKENS", "400")
+    long_verbatim = "the exact verbatim wording " + "alpha bravo " * 60
+    long_inferred = "an inferred summary " + "charlie delta " * 60
+    cp = {
+        "session_id": "S-v",
+        "working_context": {
+            "active_topic": {"text": "topic", "trust": "inferred"},
+            "open_questions": [
+                {"text": long_verbatim, "trust": "verbatim", "importance": 9,
+                 "first_seen": "2026-07-01T00:00:00Z"},
+                {"text": long_inferred, "trust": "inferred", "importance": 9,
+                 "first_seen": "2026-07-01T00:00:00Z"},
+            ],
+            "recent_decisions": [],
+        },
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": [],
+                               "contradictions_flagged": []},
+    }
+    b = briefing.build(cp, now=1_800_000_000.0)
+    out = briefing.render_plain(b)
+    # Verbatim: either byte-intact (render strips trailing whitespace) or
+    # dropped whole — a rewritten-in-place verbatim text is the violation.
+    assert (long_verbatim.strip() in out
+            or "the exact verbatim wording" not in out), \
+        "verbatim text was truncated in place — rewritten, not dropped"
+    # Budget pressure DID land on the inferred item (proves the exemption is
+    # doing work, not that the budget never fired).
+    assert long_inferred.strip() not in out
+
+
+def test_mark_untagged_trust_is_not_inferred():
+    # An item with no trust class must not be presented as a confident
+    # "~ inferred" — that is a classification it never earned (#30). The
+    # recall CLI already says "untagged"; the briefing must agree.
+    assert briefing._mark({"text": "x"}) == "? untagged"
+    assert briefing._mark({"text": "x", "trust": ""}) == "? untagged"
+    assert briefing._mark({"text": "x", "trust": "inferred"}) == "~ inferred"
+    assert briefing._mark({"text": "x", "trust": "verbatim"}) == "✓ verbatim"

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -323,7 +323,12 @@ def test_render_brief_honors_llm_briefing_when_present(monkeypatch, sample_check
     # narrative (same source of truth as the hermes hook), not the deterministic text.
     from daimon_briefing import briefing
     monkeypatch.setattr(briefing.config, "llm_briefing", lambda: True)
-    monkeypatch.setattr(briefing, "_render_llm", lambda cp: "LLM-NARRATIVE-SENTINEL")
+    # #30 post-validation: the fake LLM narrative must keep every verbatim
+    # quote intact or the render path (correctly) rejects it.
+    sentinel = ('LLM-NARRATIVE-SENTINEL — "I\'ll merge it myself later from '
+                'the GitHub UI" / "do we chunk below 1200 lines or '
+                'single-pass?" / "we adopt the D-007 prompt for the serializer"')
+    monkeypatch.setattr(briefing, "_render_llm", lambda cp: sentinel)
     # plain path (autouse DAIMON_PLAIN=1 keeps supports_rich False)
     render.render_brief(sample_checkpoint)
     out = capsys.readouterr().out

--- a/research/DECISIONS.md
+++ b/research/DECISIONS.md
@@ -133,3 +133,15 @@ ADR-lite. Each decision: what, alternatives, rationale, reversal cost, date, sta
 **Reversal cost:** Medium — changes the serialize prompt and likely the checkpoint schema.
 
 **Status:** ✅ **Resolved (probe, 2026-06-09 — `findings/03`).** Three-arm probe on S2 (the worst long session): D-007 prompt alone lifts RR 37.9%→58.6% (helps, insufficient); D-007 prompt + **chunked multi-pass extraction** (800-line chunks + merge) reaches **RR 89.7% / FMR 6.7%** — clears both bars. The richer prompt is adopted AND the architecture is chunked: serialization for long transcripts is chunk→extract→merge (`docs/MVP-DREAM-BRIEFING.md §4`). Merge pass showed no fabrication (FMR under bar). Caveats: n=1, LLM-judged. See also `.scars/0001` (judge grounding must reference transcript, not answer key).
+
+## D-013 — Verbatim expiry stays; verbatim immutability extended to every render surface
+
+**What (2026-07-03):** Two rules pinned after the four-lens audit (issue #30). (1) **Verbatim items are NOT exempt from carry's weight-floor expiry** — rational forgetting (Anderson & Schooler; the #78/#123 decay model) applies to every trust class. Verbatim means *exact wording*, not *immortal*: an unresolved verbatim item nobody has touched decays past the floor and drops from carry like any other item. (2) **Verbatim text is immutable on every surface, not just carry (#23):** render-time budget truncation (stage 1, `briefing.render_plain`) skips verbatim items' text — an oversized verbatim item may be *dropped whole* (announced by the trim note) but never rewritten in place — and the opt-in LLM briefing render is post-validated (`_validate_llm_render`): a render that loses or mutates any verbatim quote is rejected and the deterministic render takes over.
+
+**Alternatives:** Full expiry exemption for verbatim (risk: the cap-8/kind budget fills with stale verbatim items and crowds out fresh carries); a longer decay horizon for verbatim (adds a tuning knob with no field data — violates don't-tune-on-n=1); leaving the LLM render unvalidated but documented as experimental (keeps the differentiator broken on an opt-in path).
+
+**Rationale:** The verbatim/inferred distinction is the product's central guarantee; it must mean exactly one thing everywhere. Immutability governs *wording* (reconsolidation fix, #22/#23); expiry governs *retention* (rational forgetting). Keeping the two orthogonal preserves both cognitive-science groundings without inventing an unfounded knob.
+
+**Reversal cost:** Low — an expiry exemption or horizon knob can be added in carry.merge if field data ever shows load-bearing verbatim items dying at the floor.
+
+**Status:** ✅ **Active (2026-07-03).** Implemented with issue #30: truncation exemption + LLM-render post-validation + untagged trust rendering. Related: #22/#23 (freeze on re-discovery), D-006 (extractive pinning).


### PR DESCRIPTION
Closes #30

## Summary

The audit found the differentiator's own guarantees leaking at the edges. Three code repairs + one recorded design decision (D-013):

- **LLM render post-validation** — `_validate_llm_render` requires every verbatim quote to survive the LLM's prose intact (whitespace-normalized). Lost/mutated quote → log.warning + deterministic fallback. The safe direction: worst case is the render you'd have gotten with the flag off.
- **Truncation exemption** — stage-1 budget truncation skips verbatim items' text; inferred items absorb the pressure. Oversized verbatim can be dropped whole (announced by the trim note), never rewritten. One immutability rule everywhere (#23 parity).
- **Untagged trust** — missing/empty trust renders `? untagged` (plain `_mark`, rich `_trust_key`), never a confident `~ inferred`. Matches the recall CLI's existing behavior.
- **D-013 recorded** — verbatim expiry in carry stays (rational forgetting is universal; verbatim = exact wording, not immortal). Full rationale + reversal triggers in `research/DECISIONS.md`.

## Test plan

- [x] TDD: 6 new tests, behavior changes watched red first (rejection, whitespace-rewrap acceptance, truncation exemption + pressure-proof, untagged marks)
- [x] 2 existing tests updated to the validated contract (their fake LLM responses now carry the quotes — they tested request wiring, not the gate)
- [x] `uv run pytest` — 759 passed (plugin), 961 (repo root)

## Scars

#6 (decision-cap chronology) and #16 (simulated clocks) both fired — neither contract touched; test passes `now=` explicitly.

## Non-goals

Carry expiry knobs (D-013 explicitly rejects tuning without field data); #31 tail items.