### PR TITLE
feat(hosts): Windsurf Cascade payload probe — ground truth before the adapter

### DIFF
--- a/hook/daimon-windsurf-probe.py
+++ b/hook/daimon-windsurf-probe.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Windsurf Cascade hook probe — capture the REAL hook payload before we build.
+
+The Windsurf adapter (#35) needs ground truth: the Cascade Hooks docs
+(https://docs.windsurf.com/windsurf/cascade/hooks) are marked draft, so before
+writing `daimon-windsurf-hooks.py` we capture what a real `post_cascade_response`
+event actually delivers — payload shape, transcript_path location, and a sample
+of the transcript's JSONL step format.
+
+HOW TO RUN (takes ~5 minutes):
+
+1. Save this file anywhere, e.g. `~/daimon-windsurf-probe.py`.
+2. Register it as a Cascade hook (user-level hooks JSON — see the docs page
+   above for the exact file location on your platform), for the
+   `post_cascade_response` event, command: `python3 ~/daimon-windsurf-probe.py`.
+   If your Windsurf build offers `post_cascade_response_with_transcript`,
+   register that variant instead (richer payload).
+3. Open Windsurf, run ONE short Cascade turn (any prompt).
+4. Send back the folder `~/daimon-windsurf-probe/` (it contains the captured
+   payload and a small transcript sample — a few lines, nothing sensitive
+   beyond your one test prompt).
+
+The probe is fail-open: it always exits 0 and never blocks Cascade.
+"""
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+OUT_DIR = Path.home() / "daimon-windsurf-probe"
+TRANSCRIPT_SAMPLE_LINES = 10
+
+
+def main() -> int:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    raw = sys.stdin.read()
+    (OUT_DIR / f"payload-{stamp}.raw").write_text(raw, encoding="utf-8")
+
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        (OUT_DIR / f"payload-{stamp}.note").write_text(
+            "stdin was not JSON — raw capture only\n", encoding="utf-8")
+        return 0
+
+    (OUT_DIR / f"payload-{stamp}.json").write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    # Any *path* field that exists on disk gets a head sample — the adapter
+    # needs the transcript's per-line step schema, not the whole conversation.
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            if not (isinstance(value, str) and "path" in key.lower()):
+                continue
+            p = Path(value).expanduser()
+            if not p.is_file():
+                continue
+            try:
+                with p.open("r", encoding="utf-8", errors="replace") as f:
+                    head = [next(f) for _ in range(TRANSCRIPT_SAMPLE_LINES)]
+            except StopIteration:
+                head = p.read_text(encoding="utf-8",
+                                   errors="replace").splitlines(keepends=True)
+            except OSError:
+                continue
+            (OUT_DIR / f"sample-{key}-{stamp}.txt").write_text(
+                "".join(head), encoding="utf-8")
+
+    print(f"daimon probe: captured to {OUT_DIR}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:  # noqa: BLE001 — a probe must never break the host
+        sys.exit(0)

--- a/plugin/tests/test_claude_hooks.py
+++ b/plugin/tests/test_claude_hooks.py
@@ -524,3 +524,36 @@ def test_session_end_spawn_line_records_transcript(tmp_path, tmp_checkpoint_dir)
     log = tmp_path / ".daimon" / "logs" / "serialize.log"
     content = _wait_for_text(log, "spawned serialize for S-tr")
     assert f"(transcript: {transcript})" in content
+
+
+def test_windsurf_probe_captures_payload_and_transcript_sample(tmp_path):
+    # #35: the probe must dump the raw payload, parsed JSON, and a head sample
+    # of any on-disk *path* field — and always exit 0.
+    import subprocess
+    probe = Path(__file__).resolve().parents[2] / "hook" / "daimon-windsurf-probe.py"
+    transcript = tmp_path / "trajectory.jsonl"
+    transcript.write_text('{"type":"user_prompt","status":"done"}\n' * 3)
+    payload = {"trajectory_id": "T1", "transcript_path": str(transcript)}
+    proc = subprocess.run(
+        [sys.executable, str(probe)], input=json.dumps(payload),
+        capture_output=True, text=True,
+        env={**os.environ, "HOME": str(tmp_path)},
+    )
+    assert proc.returncode == 0
+    out_dir = tmp_path / "daimon-windsurf-probe"
+    files = {p.name.split("-", 1)[0] + Path(p.name).suffix for p in out_dir.iterdir()}
+    assert any(f.startswith("payload") and f.endswith(".json") for f in files)
+    samples = list(out_dir.glob("sample-transcript_path-*.txt"))
+    assert samples and "user_prompt" in samples[0].read_text()
+
+
+def test_windsurf_probe_non_json_stdin_still_exits_zero(tmp_path):
+    import subprocess
+    probe = Path(__file__).resolve().parents[2] / "hook" / "daimon-windsurf-probe.py"
+    proc = subprocess.run(
+        [sys.executable, str(probe)], input="not json at all",
+        capture_output=True, text=True,
+        env={**os.environ, "HOME": str(tmp_path)},
+    )
+    assert proc.returncode == 0
+    assert list((tmp_path / "daimon-windsurf-probe").glob("payload-*.raw"))


### PR DESCRIPTION
Refs #35 (first slice — the adapter PR closes it)

## Summary

- A Windsurf user wants to run daimon — #35's revisit trigger fired, so the Windsurf half is un-deferred (see issue comment with corrected feasibility: Cascade Hooks DO ship `post_cascade_response` + `transcript_path`).
- Cascade Hooks docs are **draft**; building the adapter against them risks shipping to a payload that doesn't exist. This probe captures ground truth from a real install: raw + parsed payload, plus a 10-line head sample of any on-disk `*path*` field (the transcript JSONL step schema the parser needs).
- Fail-open: always exit 0, never blocks Cascade. Instructions for the tester are in the module docstring (5-minute task).

## Changes

| File | Change |
|------|--------|
| `hook/daimon-windsurf-probe.py` | standalone probe, no imports from the package |
| `plugin/tests/test_claude_hooks.py` | 2 subprocess tests: payload+sample capture, non-JSON stdin exits 0 |

## Test plan

- [x] `uv run pytest` — 761 passed (plugin)
- [x] Probe exercised via subprocess in tests with fake payload + transcript
- Note: probe is diagnostic tooling written before its tests (tests passed on first run — not watched red). Flagging rather than hiding it.

## Next (adapter PR, closes #35)

`hook/daimon-windsurf-hooks.py` (throttled per-turn serialize) + Windsurf JSONL parser in `transcript.py` + `_SPAWN_RE` host prefix + README install section — built against the captured payload.