### PR TITLE
feat(hosts): probe --scan-vscdb — locate Cascade conversations in Windsurf's sqlite state

### DIFF
--- a/hook/daimon-windsurf-probe.py
+++ b/hook/daimon-windsurf-probe.py
@@ -21,6 +21,17 @@ HOW TO RUN (takes ~5 minutes):
    beyond your one test prompt).
 
 The probe is fail-open: it always exits 0 and never blocks Cascade.
+
+SECOND MODE — state.vscdb scan (run directly in a terminal, no hook needed):
+
+    python3 daimon-windsurf-probe.py --scan-vscdb [TRAJECTORY_ID] [--db PATH]...
+
+Windsurf/Devin stores Cascade state in VS Code-style sqlite databases
+(`state.vscdb`, table ItemTable). This mode reports which keys hold
+conversation data — key names, value sizes, and (when TRAJECTORY_ID is given)
+a small head of the matching value so the adapter's parser can be built
+against the real turn structure. Whole conversation blobs are NEVER copied.
+Without --db it scans the default Devin/Windsurf storage roots.
 """
 
 import json
@@ -30,9 +41,78 @@ from pathlib import Path
 
 OUT_DIR = Path.home() / "daimon-windsurf-probe"
 TRANSCRIPT_SAMPLE_LINES = 10
+_MATCH_HEAD_CHARS = 400
+_KEY_HINT = ("cascade", "chat", "trajector", "conversation", "memor")
+
+
+def _default_dbs():
+    """Known state.vscdb locations across the rebrand (Devin) and the legacy
+    name (Windsurf), macOS + Linux layouts. Globs are cheap; absent roots
+    yield nothing."""
+    roots = []
+    for app in ("Devin", "Windsurf"):
+        roots.append(Path.home() / "Library" / "Application Support" / app / "User")
+        roots.append(Path.home() / ".config" / app / "User")
+    dbs = []
+    for root in roots:
+        dbs.extend(root.glob("globalStorage/state.vscdb"))
+        dbs.extend(root.glob("workspaceStorage/*/state.vscdb"))
+    return dbs
+
+
+def _read_item_table(db_path: Path):
+    """Yield (key, value-bytes) rows, read-only. A locked/foreign db yields
+    nothing — the probe never writes and never raises."""
+    import sqlite3
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro&immutable=1", uri=True)
+        try:
+            yield from conn.execute("SELECT key, value FROM ItemTable")
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return
+
+
+def _scan_vscdb(trajectory_id: str | None, db_paths) -> int:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    lines = [f"vscdb scan {stamp}  trajectory_id={trajectory_id or '-'}"]
+    dbs = [Path(p).expanduser() for p in db_paths] if db_paths else _default_dbs()
+    for db in dbs:
+        lines.append(f"\n=== {db}  (exists={db.is_file()})")
+        if not db.is_file():
+            continue
+        for key, value in _read_item_table(db):
+            raw = value if isinstance(value, (bytes, bytearray)) else str(value).encode()
+            text = raw.decode("utf-8", errors="replace")
+            interesting = any(h in key.lower() for h in _KEY_HINT)
+            hit = bool(trajectory_id) and trajectory_id in text
+            if hit:
+                idx = text.find(trajectory_id)
+                head = text[max(0, idx - 100):idx + _MATCH_HEAD_CHARS]
+                lines.append(f"MATCH {key}  ({len(raw)} bytes)")
+                lines.append(f"  …{head}…")
+            elif interesting:
+                lines.append(f"key {key}  ({len(raw)} bytes)")
+    report = OUT_DIR / f"vscdb-scan-{stamp}.txt"
+    report.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"daimon probe: scan written to {report}")
+    return 0
 
 
 def main() -> int:
+    if "--scan-vscdb" in sys.argv[1:]:
+        args = sys.argv[1:]
+        args.remove("--scan-vscdb")
+        dbs = []
+        while "--db" in args:
+            i = args.index("--db")
+            dbs.append(args[i + 1])
+            del args[i:i + 2]
+        trajectory_id = args[0] if args else None
+        return _scan_vscdb(trajectory_id, dbs)
+
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 

--- a/plugin/tests/test_claude_hooks.py
+++ b/plugin/tests/test_claude_hooks.py
@@ -557,3 +557,51 @@ def test_windsurf_probe_non_json_stdin_still_exits_zero(tmp_path):
     )
     assert proc.returncode == 0
     assert list((tmp_path / "daimon-windsurf-probe").glob("payload-*.raw"))
+
+
+def test_windsurf_probe_scan_vscdb_finds_trajectory_key(tmp_path):
+    # #35: Windsurf stores Cascade state in VS Code-style sqlite (state.vscdb,
+    # ItemTable). The scan mode must report which key holds a given trajectory
+    # WITHOUT shipping whole conversation blobs — key names, sizes, and a
+    # small head of the matching value only.
+    import sqlite3, subprocess
+    probe = Path(__file__).resolve().parents[2] / "hook" / "daimon-windsurf-probe.py"
+    db = tmp_path / "state.vscdb"
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value BLOB)")
+    traj = "b0ba5494-dce6-47a2-8da0-a7c11b18d392"
+    blob = json.dumps({"trajectories": [{"id": traj, "turns": [
+        {"role": "user", "text": "hola"},
+        {"role": "assistant", "text": "### Planner Response\n\nHola!"}]}]})
+    conn.execute("INSERT INTO ItemTable VALUES (?, ?)",
+                 ("windsurf.cascadeState", blob.encode()))
+    conn.execute("INSERT INTO ItemTable VALUES (?, ?)",
+                 ("editor.fontSize", b"14"))
+    conn.commit()
+    conn.close()
+
+    proc = subprocess.run(
+        [sys.executable, str(probe), "--scan-vscdb", traj, "--db", str(db)],
+        capture_output=True, text=True,
+        env={**os.environ, "HOME": str(tmp_path)},
+    )
+    assert proc.returncode == 0
+    reports = list((tmp_path / "daimon-windsurf-probe").glob("vscdb-scan-*.txt"))
+    assert reports, "scan report not written"
+    report = reports[0].read_text()
+    assert "windsurf.cascadeState" in report          # the key that matched
+    assert traj in report
+    assert "hola" in report                            # head sample present
+    assert "editor.fontSize" not in report or "MATCH" not in report.split("editor.fontSize")[1][:40]
+
+
+def test_windsurf_probe_scan_vscdb_missing_db_exits_zero(tmp_path):
+    import subprocess
+    probe = Path(__file__).resolve().parents[2] / "hook" / "daimon-windsurf-probe.py"
+    proc = subprocess.run(
+        [sys.executable, str(probe), "--scan-vscdb", "whatever",
+         "--db", str(tmp_path / "absent.vscdb")],
+        capture_output=True, text=True,
+        env={**os.environ, "HOME": str(tmp_path)},
+    )
+    assert proc.returncode == 0


### PR DESCRIPTION
Closes #39 (slice of #35 — the adapter PR closes that one)

## Field findings that motivated this (round-1 probe, real machine)

- `post_cascade_response` payload: `trajectory_id`, `execution_id`, `timestamp`, `model_name`, `tool_info.response` — **no transcript_path** (draft docs overstated)
- `~/.windsurf/transcripts/` does not exist
- Conversations live in VS Code-fork sqlite: `state.vscdb` (ItemTable) under `globalStorage` / `workspaceStorage`

## What this adds

`--scan-vscdb [TRAJECTORY_ID] [--db PATH]...` — standalone terminal mode (no hook, no Cascade turn). Opens the dbs `mode=ro&immutable=1`, reports conversation-ish key names + sizes, and for a known trajectory_id a ~400-char head of the matching value (parser needs the turn structure, not the conversation). Defaults scan Devin + legacy Windsurf roots, macOS + Linux. Fail-open, always rc 0.

## Decision this feeds

If the scan shows clean per-trajectory turn data → adapter reads state.vscdb (full-fidelity transcript). If blobs are opaque/unstable → fall back to hook-accumulated transcript (daimon-owned markdown). Either way the serialize trigger stays `post_cascade_response` + codex-style throttle.

## Test plan

- [x] TDD: scan test watched red (no report) before implementation; synthetic ItemTable with match + noise key
- [x] Missing-db path exits 0
- [x] `uv run pytest` — 763 passed