### PR TITLE
feat(hosts): Windsurf Cascade adapter — accumulated transcript, throttled serialize

### DIFF
--- a/hook/daimon-windsurf-hooks.py
+++ b/hook/daimon-windsurf-hooks.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Windsurf Cascade adapter: accumulate a transcript per trajectory, serialize
+on a throttle (#35).
+
+Register this ONE script for BOTH Cascade hook events (docs:
+https://docs.windsurf.com/windsurf/cascade/hooks):
+
+    pre_user_prompt          -> records the user side of the turn
+    post_cascade_response    -> records the assistant side + (throttled)
+                                spawns `daimon serialize`
+
+Why accumulation: the real `post_cascade_response` payload carries NO
+transcript path, `~/.windsurf/transcripts/` does not exist, and state.vscdb
+holds UI state only (probe rounds 1-2, live machine). Windsurf keeps its
+conversations out of reach, so daimon keeps its own: each hook call appends a
+`**role**:`-marked turn to ~/.daimon/windsurf/transcripts/<trajectory_id>.md —
+the exact markdown shape `daimon serialize` already parses.
+
+Self-probing: a `pre_user_prompt` payload this adapter cannot extract text
+from is dumped to ~/.daimon/windsurf/unparsed-<stamp>.json (payload only,
+fail-open) so the next adapter iteration can be built from evidence instead
+of another probe round.
+
+Throttle: `post_cascade_response` fires EVERY turn; serializing each one is
+an LLM call per turn. DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL seconds
+(default 300, 0 = every turn) gate the spawn per trajectory — the codex-stop
+pattern. Accumulation itself is never throttled.
+
+Fail-open everywhere: always exit 0; a broken daimon must never break
+Cascade. Kill switch: DAIMON_DISABLE=1.
+"""
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    import _daimon_hook_lib as lib
+except Exception:  # noqa: BLE001 — missing/corrupt lib must never crash the hook
+    lib = None
+
+STATE_DIR = Path.home() / ".daimon" / "windsurf"
+TRANSCRIPT_DIR = STATE_DIR / "transcripts"
+
+# Keys tried, in order, for the user-prompt text — the pre_user_prompt payload
+# shape is not yet field-confirmed (post_cascade_response is), so the
+# extractor is tolerant and everything else lands in an unparsed-*.json dump.
+_PROMPT_KEYS = ("prompt", "user_prompt", "text", "message", "content", "input")
+
+
+def _fallback_log(line: str) -> None:
+    try:
+        log_dir = Path.home() / ".daimon" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with (log_dir / "serialize.log").open("a", encoding="utf-8") as f:
+            f.write(f"{stamp} {line}\n")
+    except OSError:
+        pass
+
+
+def _interval_seconds() -> int:
+    raw = os.environ.get("DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL", "300").strip()
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return 300
+
+
+def _safe_name(trajectory_id: str) -> str:
+    return trajectory_id.replace("/", "_").replace("\\", "_").replace("..", "_")
+
+
+def _should_spawn(trajectory_id: str) -> bool:
+    interval = _interval_seconds()
+    if interval <= 0:
+        return True
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        marker = STATE_DIR / f"{_safe_name(trajectory_id)}.last-serialize"
+        if marker.exists() and time.time() - marker.stat().st_mtime < interval:
+            return False
+        return True
+    except OSError:
+        return True
+
+
+def _mark_spawned(trajectory_id: str) -> None:
+    if _interval_seconds() <= 0:
+        return
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        (STATE_DIR / f"{_safe_name(trajectory_id)}.last-serialize").write_text(
+            str(int(time.time())), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _append_turn(trajectory_id: str, role: str, text: str) -> Path:
+    """Append one `**role**:`-marked turn — the markdown shape
+    transcript.from_file's role regex parses (marker starts a turn, following
+    lines are its continuation)."""
+    TRANSCRIPT_DIR.mkdir(parents=True, exist_ok=True)
+    path = TRANSCRIPT_DIR / f"{_safe_name(trajectory_id)}.md"
+    with path.open("a", encoding="utf-8") as f:
+        f.write(f"**{role}**: {text.strip()}\n\n")
+    return path
+
+
+def _extract_prompt(payload: dict) -> str | None:
+    """Tolerant text extraction for the not-yet-confirmed pre_user_prompt
+    shape: try tool_info first (where post_cascade_response keeps its data),
+    then the payload root."""
+    sources = []
+    tool_info = payload.get("tool_info")
+    if isinstance(tool_info, dict):
+        sources.append(tool_info)
+    sources.append(payload)
+    for src in sources:
+        for key in _PROMPT_KEYS:
+            val = src.get(key)
+            if isinstance(val, str) and val.strip():
+                return val
+    return None
+
+
+def _dump_unparsed(payload: dict) -> None:
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+        (STATE_DIR / f"unparsed-{stamp}.json").write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _project_cwd() -> str:
+    """Best-effort project dir: the hook process cwd, unless it is somewhere
+    meaningless (home, root). The payload carries no workspace path."""
+    cwd = os.getcwd()
+    if cwd in (str(Path.home()), "/", ""):
+        return ""
+    return cwd
+
+
+def main() -> int:
+    if lib is None:
+        _fallback_log("windsurf-cascade: hook library missing (_daimon_hook_lib.py) — skipped")
+        return 0
+    if lib.disabled():
+        return 0
+
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        lib.log("windsurf-cascade: unparseable stdin payload — skipped")
+        return 0
+    if not isinstance(payload, dict):
+        lib.log("windsurf-cascade: non-object payload — skipped")
+        return 0
+
+    event = str(payload.get("agent_action_name") or "")
+    trajectory_id = str(payload.get("trajectory_id") or "").strip()
+    if not trajectory_id:
+        lib.log(f"windsurf-cascade: no trajectory_id on {event or '?'} — skipped")
+        return 0
+
+    if event == "pre_user_prompt":
+        text = _extract_prompt(payload)
+        if text is None:
+            _dump_unparsed(payload)
+            lib.log("windsurf-cascade: pre_user_prompt shape unknown — dumped for "
+                    "the next adapter iteration (transcript stays assistant-only)")
+            return 0
+        _append_turn(trajectory_id, "user", text)
+        return 0
+
+    if event != "post_cascade_response":
+        return 0  # future events: ignore quietly, fail-open
+
+    tool_info = payload.get("tool_info")
+    response = tool_info.get("response") if isinstance(tool_info, dict) else None
+    if not (isinstance(response, str) and response.strip()):
+        lib.log(f"windsurf-cascade: empty response for {trajectory_id} — skipped")
+        return 0
+    transcript_path = _append_turn(trajectory_id, "assistant", response)
+
+    if not _should_spawn(trajectory_id):
+        lib.log(f"windsurf-cascade: skipped serialize for {trajectory_id} (throttled)")
+        return 0
+    cli = lib.resolve_cli()
+    if cli is None:
+        lib.log("windsurf-cascade: `daimon` CLI not found — checkpoint skipped")
+        return 0
+    cwd = _project_cwd()
+    try:
+        lib.spawn_serialize(cli, str(transcript_path), lib.project_env(cwd))
+        _mark_spawned(trajectory_id)
+        lib.log(f"windsurf-cascade: spawned serialize for {trajectory_id} "
+                f"(project: {cwd or '?'}) (transcript: {transcript_path})")
+    except OSError as exc:
+        lib.log(f"windsurf-cascade: spawn failed ({type(exc).__name__}: {exc})")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:  # fail-open, but leave a trace
+        if lib is not None:
+            lib.log(f"windsurf-cascade: hook error ({type(exc).__name__}: {exc})")
+        else:
+            _fallback_log(f"windsurf-cascade: hook error ({type(exc).__name__}: {exc})")
+        sys.exit(0)

--- a/hook/daimon-windsurf-probe.py
+++ b/hook/daimon-windsurf-probe.py
@@ -101,7 +101,63 @@ def _scan_vscdb(trajectory_id: str | None, db_paths) -> int:
     return 0
 
 
+_HUNT_MAX_FILE_BYTES = 64 * 1024 * 1024
+_HUNT_DEFAULT_ROOTS = (
+    "~/Library/Application Support/Devin",
+    "~/Library/Application Support/Windsurf",
+    "~/.codeium", "~/.windsurf", "~/.devin",
+    "~/.config/Devin", "~/.config/Windsurf",
+)
+
+
+def _hunt(trajectory_id: str, roots) -> int:
+    """Walk bounded roots and report every file whose bytes contain the
+    trajectory id — paths + sizes + a small context head, never whole files.
+    Settles WHERE the conversation store lives when the documented locations
+    come up empty (state.vscdb held UI state only)."""
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    needle = trajectory_id.encode()
+    lines = [f"hunt {stamp}  trajectory_id={trajectory_id}"]
+    root_paths = ([Path(r).expanduser() for r in roots] if roots
+                  else [Path(r).expanduser() for r in _HUNT_DEFAULT_ROOTS])
+    for root in root_paths:
+        lines.append(f"\n=== {root}  (exists={root.is_dir()})")
+        if not root.is_dir():
+            continue
+        for p in root.rglob("*"):
+            try:
+                if not p.is_file() or p.stat().st_size > _HUNT_MAX_FILE_BYTES:
+                    continue
+                data = p.read_bytes()
+            except OSError:
+                continue
+            idx = data.find(needle)
+            if idx == -1:
+                continue
+            head = data[max(0, idx - 100):idx + 400].decode("utf-8", errors="replace")
+            lines.append(f"MATCH {p}  ({len(data)} bytes)")
+            lines.append(f"  …{head}…")
+    report = OUT_DIR / f"hunt-{stamp}.txt"
+    report.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"daimon probe: hunt written to {report}")
+    return 0
+
+
 def main() -> int:
+    if "--hunt" in sys.argv[1:]:
+        args = sys.argv[1:]
+        args.remove("--hunt")
+        roots = []
+        while "--root" in args:
+            i = args.index("--root")
+            roots.append(args[i + 1])
+            del args[i:i + 2]
+        if not args:
+            print("usage: --hunt TRAJECTORY_ID [--root DIR]...")
+            return 0
+        return _hunt(args[0], roots)
+
     if "--scan-vscdb" in sys.argv[1:]:
         args = sys.argv[1:]
         args.remove("--scan-vscdb")

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -449,7 +449,8 @@ def _cmd_recall_inject(args) -> int:
 # host and the verb are alternations. A new host adapter MUST add its prefix
 # here or its serializes are invisible to status/hung detection/heal.
 _SPAWN_RE = re.compile(
-    r"^(\S+) (?:gemini-session-end|session-end|codex-stop|session-start): "
+    r"^(\S+) (?:gemini-session-end|session-end|codex-stop|windsurf-cascade|"
+    r"session-start): "
     r"(?:spawned|retry) serialize for (\S+)"
 )
 # Child stdout/stderr land in the log RAW (no timestamp): the serialize

--- a/plugin/tests/test_claude_hooks.py
+++ b/plugin/tests/test_claude_hooks.py
@@ -605,3 +605,29 @@ def test_windsurf_probe_scan_vscdb_missing_db_exits_zero(tmp_path):
         env={**os.environ, "HOME": str(tmp_path)},
     )
     assert proc.returncode == 0
+
+
+def test_windsurf_probe_hunt_finds_id_in_arbitrary_files(tmp_path):
+    # #35: state.vscdb turned out to hold UI state only — the hunt walks
+    # bounded roots and reports every file containing the trajectory id
+    # (paths + sizes + small context head, never whole files).
+    import subprocess
+    probe = Path(__file__).resolve().parents[2] / "hook" / "daimon-windsurf-probe.py"
+    traj = "b0ba5494-dce6-47a2-8da0-a7c11b18d392"
+    root = tmp_path / "store"
+    (root / "deep" / "nested").mkdir(parents=True)
+    hit = root / "deep" / "nested" / "conv.leveldb-log"
+    hit.write_bytes(b"\x00binary\x01" + f'{{"trajectory_id":"{traj}","turns":["hola"]}}'.encode() + b"\x02")
+    (root / "noise.txt").write_text("nothing here")
+    proc = subprocess.run(
+        [sys.executable, str(probe), "--hunt", traj, "--root", str(root)],
+        capture_output=True, text=True,
+        env={**os.environ, "HOME": str(tmp_path)},
+    )
+    assert proc.returncode == 0
+    reports = list((tmp_path / "daimon-windsurf-probe").glob("hunt-*.txt"))
+    assert reports, "hunt report not written"
+    report = reports[0].read_text()
+    assert "conv.leveldb-log" in report
+    assert "hola" in report          # context head around the match
+    assert "noise.txt" not in report

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2660,3 +2660,14 @@ def test_serialize_result_line_clean_without_fallback(
     rc = cli.main(["serialize", str(FIXTURES / "sample_transcript.md")])
     assert rc == 0
     assert "[fallback backend]" not in capsys.readouterr().out
+
+
+def test_spawn_re_recognizes_windsurf_cascade_prefix():
+    # cli.py hard rule: a new host adapter MUST add its prefix to _SPAWN_RE or
+    # its serializes are invisible to status/hung detection/heal (#35).
+    text = ("2026-07-03T23:00:00Z windsurf-cascade: spawned serialize for T-1 "
+            "(project: /p/A) (transcript: /t/T-1.md)")
+    led = cli._session_ledger(text, now=0.0)
+    assert led["T-1"]["spawned"] is True
+    assert led["T-1"]["transcript"] == "/t/T-1.md"
+    assert led["T-1"]["project"] == "/p/A"

--- a/plugin/tests/test_windsurf_hooks.py
+++ b/plugin/tests/test_windsurf_hooks.py
@@ -1,0 +1,161 @@
+"""Subprocess-level tests for the Windsurf Cascade adapter (#35).
+
+Ground truth (probe rounds 1-2, real machine): `post_cascade_response`
+delivers {agent_action_name, trajectory_id, execution_id, timestamp,
+model_name, tool_info.response} — no transcript_path; state.vscdb holds UI
+state only. The adapter therefore ACCUMULATES its own transcript per
+trajectory and serializes it on a throttle.
+"""
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+HOOK_DIR = Path(__file__).parents[2] / "hook"
+HOOK = HOOK_DIR / "daimon-windsurf-hooks.py"
+VENV_BIN = Path(sys.executable).parent
+
+TRAJ = "b0ba5494-dce6-47a2-8da0-a7c11b18d392"
+
+
+def _post_payload(response="### Planner Response\n\nDone."):
+    return {
+        "agent_action_name": "post_cascade_response",
+        "trajectory_id": TRAJ,
+        "timestamp": "2026-07-03T16:45:48.476887-06:00",
+        "execution_id": "exec-1",
+        "model_name": "Claude Sonnet 4.5",
+        "tool_info": {"response": response},
+    }
+
+
+def _fake_cli(tmp_path):
+    """A fake `daimon` on PATH that records its argv."""
+    fake_bin = tmp_path / "fakebin"
+    fake_bin.mkdir(exist_ok=True)
+    capture = tmp_path / "cli-calls.txt"
+    script = fake_bin / "daimon"
+    script.write_text(f"#!/bin/sh\necho \"$@\" >> {capture}\n")
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    return fake_bin, capture
+
+
+def _run(payload, tmp_path, extra_env=None, cwd=None):
+    fake_bin, capture = _fake_cli(tmp_path)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{VENV_BIN}{os.pathsep}{os.environ.get('PATH', '')}",
+        "HOME": str(tmp_path),
+    }
+    if extra_env:
+        env.update(extra_env)
+    stdin = json.dumps(payload) if isinstance(payload, dict) else (payload or "")
+    proc = subprocess.run(
+        [sys.executable, str(HOOK)], input=stdin, capture_output=True,
+        text=True, env=env, timeout=30, cwd=cwd or str(tmp_path),
+    )
+    return proc, capture
+
+
+def _transcript(tmp_path):
+    return tmp_path / ".daimon" / "windsurf" / "transcripts" / f"{TRAJ}.md"
+
+
+def test_post_response_appends_assistant_turn(tmp_path):
+    proc, _ = _run(_post_payload("Hola, aquí va la respuesta."), tmp_path)
+    assert proc.returncode == 0
+    text = _transcript(tmp_path).read_text(encoding="utf-8")
+    assert "**assistant**:" in text
+    assert "Hola, aquí va la respuesta." in text
+
+
+def test_pre_user_prompt_appends_user_turn(tmp_path):
+    payload = {"agent_action_name": "pre_user_prompt",
+               "trajectory_id": TRAJ,
+               "tool_info": {"prompt": "arreglá el bug de auth"}}
+    proc, _ = _run(payload, tmp_path)
+    assert proc.returncode == 0
+    text = _transcript(tmp_path).read_text(encoding="utf-8")
+    assert "**user**:" in text
+    assert "arreglá el bug de auth" in text
+
+
+def test_turns_accumulate_in_order(tmp_path):
+    _run({"agent_action_name": "pre_user_prompt", "trajectory_id": TRAJ,
+          "tool_info": {"prompt": "pregunta uno"}}, tmp_path)
+    _run(_post_payload("respuesta uno"), tmp_path)
+    text = _transcript(tmp_path).read_text(encoding="utf-8")
+    assert text.index("pregunta uno") < text.index("respuesta uno")
+
+
+def test_unknown_pre_prompt_shape_dumps_debug_and_exits_zero(tmp_path):
+    # Self-probing (#35): a payload the adapter can't extract text from must
+    # not be lost — it lands in a debug dump for the next adapter iteration.
+    payload = {"agent_action_name": "pre_user_prompt", "trajectory_id": TRAJ,
+               "tool_info": {"weird_field": {"nested": True}}}
+    proc, _ = _run(payload, tmp_path)
+    assert proc.returncode == 0
+    dumps = list((tmp_path / ".daimon" / "windsurf").glob("unparsed-*.json"))
+    assert dumps and "weird_field" in dumps[0].read_text()
+
+
+def _wait_for_capture(capture: Path, timeout=10.0) -> str:
+    """The serialize child is detached — poll for its argv capture."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if capture.exists() and capture.read_text().strip():
+            return capture.read_text()
+        time.sleep(0.05)
+    raise AssertionError(f"fake daimon was never invoked ({capture})")
+
+
+def test_post_response_spawns_throttled_serialize(tmp_path):
+    extra = {"DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL": "3600"}
+    proc, capture = _run(_post_payload("first"), tmp_path, extra_env=extra)
+    assert proc.returncode == 0
+    calls = _wait_for_capture(capture)
+    assert "serialize" in calls
+    assert TRAJ in calls
+    # second post inside the interval: accumulates but does NOT spawn again.
+    # (The throttle decision is synchronous — the hook has exited by the time
+    # _run returns, so a short settle covers only a straggler child echo.)
+    proc, capture2 = _run(_post_payload("second"), tmp_path, extra_env=extra)
+    assert proc.returncode == 0
+    time.sleep(0.5)
+    assert capture2.read_text().count("serialize") == 1
+    text = _transcript(tmp_path).read_text(encoding="utf-8")
+    assert "second" in text  # accumulation never throttles
+
+
+def test_spawn_line_carries_host_prefix_and_transcript(tmp_path):
+    proc, _ = _run(_post_payload(), tmp_path,
+                   extra_env={"DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL": "0"})
+    assert proc.returncode == 0
+    log = tmp_path / ".daimon" / "logs" / "serialize.log"
+    content = log.read_text(encoding="utf-8")
+    assert f"windsurf-cascade: spawned serialize for {TRAJ}" in content
+    assert "(transcript:" in content
+
+
+def test_disabled_kill_switch_is_silent(tmp_path):
+    proc, capture = _run(_post_payload(), tmp_path,
+                         extra_env={"DAIMON_DISABLE": "1"})
+    assert proc.returncode == 0
+    assert not _transcript(tmp_path).exists()
+    assert not capture.exists() or "serialize" not in capture.read_text()
+
+
+def test_unparseable_stdin_exits_zero(tmp_path):
+    proc, _ = _run("not json", tmp_path)
+    assert proc.returncode == 0
+
+
+def test_missing_trajectory_id_skips_quietly(tmp_path):
+    proc, _ = _run({"agent_action_name": "post_cascade_response",
+                    "tool_info": {"response": "x"}}, tmp_path)
+    assert proc.returncode == 0
+    assert not (tmp_path / ".daimon" / "windsurf" / "transcripts").exists()

--- a/plugin/uv.lock
+++ b/plugin/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "daimon-briefing"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #35

## Design, grounded in live-machine probe rounds

The documented `transcript_path` does not exist in the real `post_cascade_response` payload; `~/.windsurf/transcripts/` is absent; `state.vscdb` (60+ databases scanned) holds UI state only. So the adapter accumulates a daimon-owned transcript per trajectory — zero dependency on the host's internal storage:

| Event | Action |
|-------|--------|
| `pre_user_prompt` | append `**user**:` turn (tolerant key extraction — unknown shapes dump to `unparsed-*.json`, making the adapter self-probing) |
| `post_cascade_response` | append `**assistant**:` turn (field-confirmed shape) + throttled `daimon serialize` spawn |

- Throttle: `DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL` (default 300s, 0 = every turn), codex-stop pattern; accumulation itself never throttles
- `windsurf-cascade` added to `_SPAWN_RE` (the cli.py hard rule) with transcript path stamped on the spawn line — hung/crashed serializes stay healable (#28)
- Session id = `trajectory_id`; project routing = hook process cwd (payload carries no workspace path) with home/root guarded
- Fail-open everywhere; `DAIMON_DISABLE` honored
- Probe gains `--hunt TRAJECTORY_ID [--root DIR]` — bounded byte-search to settle where a host hides conversations

## Registration (user-level Cascade hooks JSON)

Both events, same command: `python3 <path>/daimon-windsurf-hooks.py` — see module docstring.

## Known limitations (v1, documented in the script)

- No briefing injection into Cascade — briefings are read via `daimon brief` in the terminal
- `pre_user_prompt` payload shape is not yet field-confirmed; until then transcripts may be assistant-only (still serializable; unknown shapes are captured for iteration)

## Test plan

- [x] TDD: 10 adapter tests + hunt test + `_SPAWN_RE` ledger test, all watched red first (adapter absent)
- [x] `uv run pytest` — 774 passed
- [x] Manual: real captured payload through the hook end-to-end (transcript written, spawn line logged, fake CLI invoked)
- Note: one loaded full-suite run flaked 2 pre-existing timing-sensitive hook tests (3-min run under machine load); green on two consecutive re-runs, unrelated to this diff