### PR TITLE
feat(cli): ship host hook scripts in the package — `daimon hooks install <host>`

### DIFF
--- a/plugin/daimon_briefing/_hooks/__init__.py
+++ b/plugin/daimon_briefing/_hooks/__init__.py
@@ -1,0 +1,8 @@
+"""Packaged copies of the standalone host hook scripts (#43).
+
+Canonical sources live in the repo's hook/ directory (the Claude Code plugin
+and manual installs read them there); these copies ship in the PyPI wheel so
+`daimon hooks install <host>` works without a repo clone. A byte-equality
+test (tests/test_hooks_install.py) guards against drift — edit hook/<name>
+and copy it here in the same change.
+"""

--- a/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
+++ b/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
@@ -1,0 +1,213 @@
+"""Shared stdlib-only helpers for the daimon host-adapter hooks.
+
+The hook scripts (Claude Code / Codex / Gemini SessionStart + SessionEnd) run
+as standalone scripts from their own install dir, inside whatever interpreter
+the host invokes — they CANNOT import the daimon_briefing package, which lives
+in an isolated uv-tool venv. This module holds the helpers all three adapters
+would otherwise duplicate verbatim. It is loaded by same-dir lookup:
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import _daimon_hook_lib as lib
+
+Host-specific behavior deliberately stays in the individual hooks — Gemini's
+pure-JSON stdout, Codex's additionalContext envelope + Stop throttling, and
+Codex's mtime-only age line. Only what is genuinely identical lives here.
+"""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Prefer the `daimon` command; fall back to the deprecated `daimon-briefing`
+# alias so a stale hook meeting a renamed binary (or vice-versa) still resolves.
+FALLBACKS = [
+    Path.home() / ".local" / "bin" / "daimon",
+    Path.home() / ".local" / "bin" / "daimon-briefing",
+]
+
+LOG_DIR = Path.home() / ".daimon" / "logs"
+
+
+def disabled() -> bool:
+    """True when the DAIMON_DISABLE kill switch is set (1/true/yes/on)."""
+    return os.environ.get("DAIMON_DISABLE", "").strip() in ("1", "true", "yes", "on")
+
+
+def resolve_cli():
+    """Locate the daimon CLI: `daimon`, then the deprecated `daimon-briefing`
+    alias, then the well-known ~/.local/bin fallbacks. None when nothing resolves."""
+    return (
+        shutil.which("daimon")
+        or shutil.which("daimon-briefing")
+        or next((str(p) for p in FALLBACKS if p.exists()), None)
+    )
+
+
+def payload() -> dict:
+    """Hook payload from stdin ({session_id, transcript_path, cwd, ...}).
+
+    Unparseable/empty stdin degrades to {} — the caller then behaves exactly as
+    it did before per-project routing (global latest), instead of dying."""
+    try:
+        raw = sys.stdin.read()
+        data = json.loads(raw) if raw.strip() else {}
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def checkpoint_dir() -> Path:
+    raw = os.environ.get("DAIMON_CHECKPOINT_DIR")
+    return Path(raw).expanduser() if raw else Path.home() / ".daimon" / "checkpoints"
+
+
+def slug(project_dir: str) -> str | None:
+    """cwd -> filesystem-safe slug, same scheme as daimon_briefing.store.project_slug.
+
+    Duplicated here because the hooks are standalone stdlib-only scripts that
+    cannot import the package (isolated uv-tool venv). Keep in sync with
+    daimon_briefing.store.project_slug."""
+    s = (project_dir or "").strip()
+    if not s:
+        return None
+    return re.sub(r"[^\w-]", "-", s) or None
+
+
+def created_epoch(created) -> float | None:
+    """Epoch for a checkpoint's ISO-8601 `created` stamp, or None if absent/bad.
+
+    Duplicated here because the hooks are stdlib-only and cannot import the
+    package. Keep in sync with daimon_briefing.store._created_epoch."""
+    if not isinstance(created, str):
+        return None
+    try:
+        ts = datetime.strptime(created, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        return None
+    return ts.replace(tzinfo=timezone.utc).timestamp()
+
+
+def age_line(latest: Path) -> str:
+    """Human age of the checkpoint, so a stale briefing is visibly stale. Age
+    prefers the written `created` stamp (which survives pointer rotation) and
+    falls back to file mtime for legacy checkpoints (#93)."""
+    try:
+        data = json.loads(latest.read_text(encoding="utf-8"))
+    except Exception:
+        data = {}
+    epoch = created_epoch(data.get("created"))
+    ref = epoch if epoch is not None else latest.stat().st_mtime
+    secs = max(0, time.time() - ref)
+    if secs < 3600:
+        age = f"{int(secs // 60)}m"
+    elif secs < 86400:
+        age = f"{secs / 3600:.1f}h"
+    else:
+        age = f"{secs / 86400:.1f}d"
+    session_id = data.get("session_id", "?")
+    return f"(checkpoint: {session_id}, written {age} ago)"
+
+
+def project_env(cwd):
+    """Child env with DAIMON_PROJECT_DIR set to `cwd`, or None to inherit the
+    parent env unchanged (pre-routing behavior when no cwd is known)."""
+    return {**os.environ, "DAIMON_PROJECT_DIR": cwd} if cwd else None
+
+
+def log(line: str) -> None:
+    """Append a UTC-timestamped line to serialize.log. Never raises — logging
+    must not break a hook. The caller supplies the host tag as part of `line`."""
+    try:
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with (LOG_DIR / "serialize.log").open("a", encoding="utf-8") as f:
+            f.write(f"{stamp} {line}\n")
+    except OSError:
+        pass
+
+
+def spawn_heal(cli, cwd) -> None:
+    """Fire a one-shot self-heal of the most recent FAILED serialize, DETACHED so
+    it adds ~0 latency and never blocks the session (#26). Fail-open: a heal that
+    can't start must not disturb the briefing. The child routes by the failed
+    session's OWN project (recovered from serialize.log), NOT this cwd —
+    DAIMON_PROJECT_DIR is forwarded only so heal honors log/checkpoint overrides."""
+    if cli is None:
+        return
+    try:
+        subprocess.Popen(
+            [cli, "heal"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,  # survive the exiting parent
+            env=project_env(cwd),
+        )
+    except OSError:
+        pass
+
+
+def team_dir() -> Path:
+    raw = os.environ.get("DAIMON_TEAM_DIR")
+    return Path(raw).expanduser() if raw else Path.home() / ".daimon" / "team"
+
+
+def has_team_remote() -> bool:
+    """Cheap gate for the opportunistic team sync (#113): any team-dir entry
+    that looks like a sidecar clone (has a .git). Pure dir scan — no git, no
+    package import — so the check costs ~nothing when the team feature is
+    unused. Never raises."""
+    try:
+        return any(
+            p.is_dir() and p.name != "local" and (p / ".git").exists()
+            for p in team_dir().iterdir()
+        )
+    except OSError:
+        return False
+
+
+def spawn_team_sync(cli, cwd) -> None:
+    """Fire `daimon team sync` DETACHED at SessionStart (#113), mirroring
+    spawn_heal: ~0 latency, NEVER blocks the briefing, fail-open. Gated on
+    has_team_remote() so machines that never ran `daimon team init` pay only
+    a directory scan."""
+    if cli is None or not has_team_remote():
+        return
+    try:
+        subprocess.Popen(
+            [cli, "team", "sync"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,  # survive the exiting parent
+            env=project_env(cwd),
+        )
+    except OSError:
+        pass
+
+
+def spawn_serialize(cli, transcript_path, env) -> None:
+    """Spawn `daimon serialize <transcript>` DETACHED so the hook returns
+    immediately (serialization is a 30s+ LLM call). Raises OSError on spawn
+    failure so the caller can log its own host-tagged diagnostic.
+
+    The CLI logs its result lines to serialize.log first-class (FR #27), so we
+    DON'T capture the child's stdout here — that double-logged results. stderr
+    goes to a SEPARATE crash log to preserve uncaught tracebacks without
+    duplicating the CLI's `error:` result lines in serialize.log."""
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    with (LOG_DIR / "serialize-crash.log").open("a", encoding="utf-8") as crashf:
+        subprocess.Popen(
+            [cli, "serialize", transcript_path],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=crashf,
+            start_new_session=True,  # survive the exiting parent
+            env=env,
+        )

--- a/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
+++ b/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Windsurf Cascade adapter: accumulate a transcript per trajectory, serialize
+on a throttle (#35).
+
+Register this ONE script for BOTH Cascade hook events (docs:
+https://docs.windsurf.com/windsurf/cascade/hooks):
+
+    pre_user_prompt          -> records the user side of the turn
+    post_cascade_response    -> records the assistant side + (throttled)
+                                spawns `daimon serialize`
+
+Why accumulation: the real `post_cascade_response` payload carries NO
+transcript path, `~/.windsurf/transcripts/` does not exist, and state.vscdb
+holds UI state only (probe rounds 1-2, live machine). Windsurf keeps its
+conversations out of reach, so daimon keeps its own: each hook call appends a
+`**role**:`-marked turn to ~/.daimon/windsurf/transcripts/<trajectory_id>.md —
+the exact markdown shape `daimon serialize` already parses.
+
+Self-probing: a `pre_user_prompt` payload this adapter cannot extract text
+from is dumped to ~/.daimon/windsurf/unparsed-<stamp>.json (payload only,
+fail-open) so the next adapter iteration can be built from evidence instead
+of another probe round.
+
+Throttle: `post_cascade_response` fires EVERY turn; serializing each one is
+an LLM call per turn. DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL seconds
+(default 300, 0 = every turn) gate the spawn per trajectory — the codex-stop
+pattern. Accumulation itself is never throttled.
+
+Fail-open everywhere: always exit 0; a broken daimon must never break
+Cascade. Kill switch: DAIMON_DISABLE=1.
+"""
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    import _daimon_hook_lib as lib
+except Exception:  # noqa: BLE001 — missing/corrupt lib must never crash the hook
+    lib = None
+
+STATE_DIR = Path.home() / ".daimon" / "windsurf"
+TRANSCRIPT_DIR = STATE_DIR / "transcripts"
+
+# Keys tried, in order, for the user-prompt text — the pre_user_prompt payload
+# shape is not yet field-confirmed (post_cascade_response is), so the
+# extractor is tolerant and everything else lands in an unparsed-*.json dump.
+_PROMPT_KEYS = ("prompt", "user_prompt", "text", "message", "content", "input")
+
+
+def _fallback_log(line: str) -> None:
+    try:
+        log_dir = Path.home() / ".daimon" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with (log_dir / "serialize.log").open("a", encoding="utf-8") as f:
+            f.write(f"{stamp} {line}\n")
+    except OSError:
+        pass
+
+
+def _interval_seconds() -> int:
+    raw = os.environ.get("DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL", "300").strip()
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return 300
+
+
+def _safe_name(trajectory_id: str) -> str:
+    return trajectory_id.replace("/", "_").replace("\\", "_").replace("..", "_")
+
+
+def _should_spawn(trajectory_id: str) -> bool:
+    interval = _interval_seconds()
+    if interval <= 0:
+        return True
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        marker = STATE_DIR / f"{_safe_name(trajectory_id)}.last-serialize"
+        if marker.exists() and time.time() - marker.stat().st_mtime < interval:
+            return False
+        return True
+    except OSError:
+        return True
+
+
+def _mark_spawned(trajectory_id: str) -> None:
+    if _interval_seconds() <= 0:
+        return
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        (STATE_DIR / f"{_safe_name(trajectory_id)}.last-serialize").write_text(
+            str(int(time.time())), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _append_turn(trajectory_id: str, role: str, text: str) -> Path:
+    """Append one `**role**:`-marked turn — the markdown shape
+    transcript.from_file's role regex parses (marker starts a turn, following
+    lines are its continuation)."""
+    TRANSCRIPT_DIR.mkdir(parents=True, exist_ok=True)
+    path = TRANSCRIPT_DIR / f"{_safe_name(trajectory_id)}.md"
+    with path.open("a", encoding="utf-8") as f:
+        f.write(f"**{role}**: {text.strip()}\n\n")
+    return path
+
+
+def _extract_prompt(payload: dict) -> str | None:
+    """Tolerant text extraction for the not-yet-confirmed pre_user_prompt
+    shape: try tool_info first (where post_cascade_response keeps its data),
+    then the payload root."""
+    sources = []
+    tool_info = payload.get("tool_info")
+    if isinstance(tool_info, dict):
+        sources.append(tool_info)
+    sources.append(payload)
+    for src in sources:
+        for key in _PROMPT_KEYS:
+            val = src.get(key)
+            if isinstance(val, str) and val.strip():
+                return val
+    return None
+
+
+def _dump_unparsed(payload: dict) -> None:
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+        (STATE_DIR / f"unparsed-{stamp}.json").write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _project_cwd() -> str:
+    """Best-effort project dir: the hook process cwd, unless it is somewhere
+    meaningless (home, root). The payload carries no workspace path."""
+    cwd = os.getcwd()
+    if cwd in (str(Path.home()), "/", ""):
+        return ""
+    return cwd
+
+
+def main() -> int:
+    if lib is None:
+        _fallback_log("windsurf-cascade: hook library missing (_daimon_hook_lib.py) — skipped")
+        return 0
+    if lib.disabled():
+        return 0
+
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        lib.log("windsurf-cascade: unparseable stdin payload — skipped")
+        return 0
+    if not isinstance(payload, dict):
+        lib.log("windsurf-cascade: non-object payload — skipped")
+        return 0
+
+    event = str(payload.get("agent_action_name") or "")
+    trajectory_id = str(payload.get("trajectory_id") or "").strip()
+    if not trajectory_id:
+        lib.log(f"windsurf-cascade: no trajectory_id on {event or '?'} — skipped")
+        return 0
+
+    if event == "pre_user_prompt":
+        text = _extract_prompt(payload)
+        if text is None:
+            _dump_unparsed(payload)
+            lib.log("windsurf-cascade: pre_user_prompt shape unknown — dumped for "
+                    "the next adapter iteration (transcript stays assistant-only)")
+            return 0
+        _append_turn(trajectory_id, "user", text)
+        return 0
+
+    if event != "post_cascade_response":
+        return 0  # future events: ignore quietly, fail-open
+
+    tool_info = payload.get("tool_info")
+    response = tool_info.get("response") if isinstance(tool_info, dict) else None
+    if not (isinstance(response, str) and response.strip()):
+        lib.log(f"windsurf-cascade: empty response for {trajectory_id} — skipped")
+        return 0
+    transcript_path = _append_turn(trajectory_id, "assistant", response)
+
+    if not _should_spawn(trajectory_id):
+        lib.log(f"windsurf-cascade: skipped serialize for {trajectory_id} (throttled)")
+        return 0
+    cli = lib.resolve_cli()
+    if cli is None:
+        lib.log("windsurf-cascade: `daimon` CLI not found — checkpoint skipped")
+        return 0
+    cwd = _project_cwd()
+    try:
+        lib.spawn_serialize(cli, str(transcript_path), lib.project_env(cwd))
+        _mark_spawned(trajectory_id)
+        lib.log(f"windsurf-cascade: spawned serialize for {trajectory_id} "
+                f"(project: {cwd or '?'}) (transcript: {transcript_path})")
+    except OSError as exc:
+        lib.log(f"windsurf-cascade: spawn failed ({type(exc).__name__}: {exc})")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:  # fail-open, but leave a trace
+        if lib is not None:
+            lib.log(f"windsurf-cascade: hook error ({type(exc).__name__}: {exc})")
+        else:
+            _fallback_log(f"windsurf-cascade: hook error ({type(exc).__name__}: {exc})")
+        sys.exit(0)

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1019,6 +1019,65 @@ def _cmd_configure(args) -> int:
     return 0
 
 
+# ---- hooks: ship host hook scripts from the package (#43) ----
+
+# host -> (files to install, entry script, events to register). The packaged
+# copies live in daimon_briefing/_hooks/ and are drift-guarded against the
+# repo's hook/ dir by tests/test_hooks_install.py. Claude Code is absent on
+# purpose: the plugin marketplace owns that path.
+_HOOK_HOSTS = {
+    "windsurf": {
+        "files": ("daimon-windsurf-hooks.py", "_daimon_hook_lib.py"),
+        "entry": "daimon-windsurf-hooks.py",
+        "events": ("pre_user_prompt", "post_cascade_response"),
+    },
+}
+
+
+def _hooks_target_dir() -> Path:
+    return Path.home() / ".daimon" / "hooks"
+
+
+def _cmd_hooks_list(args) -> int:
+    for host, spec in sorted(_HOOK_HOSTS.items()):
+        print(f"{host}  ({spec['entry']}; events: {', '.join(spec['events'])})")
+    return 0
+
+
+def _cmd_hooks_install(args) -> int:
+    """Copy the host's packaged hook script(s) to ~/.daimon/hooks/ — a STABLE
+    path the host's hooks config points at once. Idempotent: re-running after
+    `uv tool upgrade daimon-briefing` refreshes the scripts to match the
+    installed CLI, which is the whole point (#43: a curl'd script drifts)."""
+    from importlib import resources
+
+    spec = _HOOK_HOSTS.get(args.host)
+    if spec is None:
+        known = ", ".join(sorted(_HOOK_HOSTS))
+        print(f"error: unknown host '{args.host}' (known: {known})", file=sys.stderr)
+        return 2
+    target = _hooks_target_dir()
+    target.mkdir(parents=True, exist_ok=True)
+    pkg = resources.files("daimon_briefing._hooks")
+    for name in spec["files"]:
+        data = (pkg / name).read_bytes()
+        dest = target / name
+        dest.write_bytes(data)
+        dest.chmod(dest.stat().st_mode | 0o100)  # u+x
+    entry = target / spec["entry"]
+    print(f"installed {len(spec['files'])} file(s) to {target}")
+    print("")
+    print(f"Register this command for the events below "
+          f"(host hooks config — see the host's hooks documentation):")
+    print(f"  command: python3 {entry}")
+    for ev in spec["events"]:
+        print(f"  event:   {ev}")
+    print("")
+    print("Re-run `daimon hooks install " + args.host +
+          "` after every `uv tool upgrade daimon-briefing`.")
+    return 0
+
+
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(
         prog="daimon",
@@ -1201,6 +1260,21 @@ def main(argv=None) -> int:
     p_cfg.add_argument("--command", help="command: DAIMON_LLM_COMMAND")
     p_cfg.add_argument("--output", help="command: DAIMON_LLM_COMMAND_OUTPUT (text|json:<key>)")
     p_cfg.set_defaults(func=_cmd_configure)
+
+    p_hooks = sub.add_parser(
+        "hooks",
+        help="ship host hook scripts from the package (#43): list, install",
+    )
+    hooks_sub = p_hooks.add_subparsers(dest="hooks_cmd", required=True)
+    ph_list = hooks_sub.add_parser("list", help="hosts with packaged hook scripts")
+    ph_list.set_defaults(func=_cmd_hooks_list)
+    ph_install = hooks_sub.add_parser(
+        "install",
+        help="copy a host's hook script(s) to the stable path ~/.daimon/hooks/ "
+             "and print the registration snippet — re-run after every upgrade",
+    )
+    ph_install.add_argument("host", help="host to install (see `daimon hooks list`)")
+    ph_install.set_defaults(func=_cmd_hooks_install)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/plugin/tests/test_hooks_install.py
+++ b/plugin/tests/test_hooks_install.py
@@ -1,0 +1,62 @@
+"""#43: hook scripts ship in the package; `daimon hooks install <host>` puts
+them at a stable path so registration survives every upgrade."""
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from daimon_briefing import cli
+
+REPO_HOOK_DIR = Path(__file__).parents[2] / "hook"
+PKG_HOOKS_DIR = Path(__file__).parents[1] / "daimon_briefing" / "_hooks"
+
+_SHIPPED = ("daimon-windsurf-hooks.py", "_daimon_hook_lib.py")
+
+
+@pytest.mark.parametrize("name", _SHIPPED)
+def test_packaged_hook_matches_repo_copy(name):
+    # Drift guard: the packaged copy IS the repo script, byte for byte. If
+    # you edited hook/<name>, copy it into daimon_briefing/_hooks/ too.
+    repo = (REPO_HOOK_DIR / name).read_bytes()
+    packaged = (PKG_HOOKS_DIR / name).read_bytes()
+    assert repo == packaged, f"{name}: repo hook/ and packaged _hooks/ differ"
+
+
+def test_hooks_install_windsurf_writes_stable_executable_copies(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    rc = cli.main(["hooks", "install", "windsurf"])
+    assert rc == 0
+    target = tmp_path / ".daimon" / "hooks"
+    for name in _SHIPPED:
+        p = target / name
+        assert p.is_file(), f"{name} not installed"
+        assert p.stat().st_mode & stat.S_IXUSR, f"{name} not executable"
+        assert p.read_bytes() == (PKG_HOOKS_DIR / name).read_bytes()
+    out = capsys.readouterr().out
+    # the registration snippet points at the STABLE installed path
+    assert str(target / "daimon-windsurf-hooks.py") in out
+    assert "pre_user_prompt" in out and "post_cascade_response" in out
+
+
+def test_hooks_install_is_idempotent_refresh(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "windsurf"]) == 0
+    stale = tmp_path / ".daimon" / "hooks" / "daimon-windsurf-hooks.py"
+    stale.write_text("# stale old version")
+    assert cli.main(["hooks", "install", "windsurf"]) == 0
+    assert stale.read_bytes() == (PKG_HOOKS_DIR / "daimon-windsurf-hooks.py").read_bytes()
+
+
+def test_hooks_install_unknown_host_errors(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    rc = cli.main(["hooks", "install", "emacs"])
+    assert rc == 2
+    assert "emacs" in capsys.readouterr().err
+
+
+def test_hooks_list_names_windsurf(capsys):
+    rc = cli.main(["hooks", "list"])
+    assert rc == 0
+    assert "windsurf" in capsys.readouterr().out


### PR DESCRIPTION
Closes #43

## Problem (live-confirmed)

Fresh PyPI install of 0.5.0 → no hook scripts anywhere. The wheel packages only `daimon_briefing/`; `hook/` exists only in the repo. Non-Claude-Code hosts depended on a curl'd raw file that (a) nobody refreshes on upgrade and (b) tracks `main`, not the installed version.

## Fix

| Piece | What |
|-------|------|
| `daimon_briefing/_hooks/` | checked-in copies of `daimon-windsurf-hooks.py` + `_daimon_hook_lib.py`; byte-equality tests guard repo↔package drift |
| `daimon hooks list` | enumerate packaged hosts |
| `daimon hooks install windsurf` | copy to stable `~/.daimon/hooks/` (executable, idempotent) + print registration snippet with events |

Upgrade flow: `uv tool upgrade daimon-briefing && daimon hooks install windsurf` — script and CLI in version lockstep, registration path never changes.

Deliberate scope: no auto-registration in the host's hooks JSON (schema still being confirmed on a live install); Claude Code stays on the marketplace path.

## Test plan

- [x] TDD: 6 tests watched red first (drift guard ×2, install+executable+snippet, idempotent refresh, unknown-host rc 2, list)
- [x] Wheel built and inspected: `_hooks/` files present
- [x] Live: `daimon hooks install windsurf` against a scratch HOME — files executable, snippet correct
- [x] `uv run pytest` — 780 passed