### PR TITLE
docs(readme): PyPI-first quickstart, sample briefing, Windsurf setup, plain-language status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,103 +2,137 @@
 
 > A **dream-briefing** for your AI agent: a skimmable "while you were away / here's where we left off" artifact, shown when you resume a session.
 
----
+Your agent forgets everything between sessions. Daimon writes a small cognitive checkpoint when a session ends and turns it into a briefing when the next one starts — so the agent resumes from a faithful prior state instead of a confident guess:
 
-## What is Daimon?
+```
+While you were away — here's where we left off.
 
-Daimon is a **dream-briefing** for AI coding agents — **Claude Code, Codex, and [hermes-agent](https://github.com/NousResearch/hermes-agent)-style hosts**. At the end of a session it writes a small cognitive checkpoint; at the start of the next one it reconstructs that checkpoint into a short briefing the agent shows you — so it resumes from a faithful prior state instead of a confident guess.
+VERIFY BEFORE TRUSTING (state may have changed outside this session):
+- [✓ verbatim] PR #212 state — you said you'd merge it yourself from the UI  — "I'll merge it after the demo"
 
-It is **self-contained and host-agnostic**: a hooks + CLI tool with its own lean memory substrate — a per-project checkpoint store and a prose serializer that pins decisions, beliefs, and open questions with trust class, quote provenance, and supersession. **stdlib-first, offline-first, no server.** It needs only a transcript and an LLM endpoint (pluggable: a local CLI like `claude`, or any OpenAI-compatible gateway). It does **not** depend on [Honcho](https://github.com/plastic-labs/honcho), [Graphiti](https://github.com/getzep/graphiti), or hermes at runtime — those were evaluated as a substrate and deliberately not adopted (see **[D-009](./research/DECISIONS.md)** and `research/memory-backend/`).
+Open loops:
+- [✓ verbatim] Retry policy for the payments webhook — exponential or fixed?  — "don't ship the retry loop until we pick a policy"
+- [~ inferred] The staging config drift needs an owner [carried]
+
+Decisions made:
+- [✓ verbatim] Postgres advisory locks over Redis locks for the scheduler  — "let's not add a Redis dependency for this"
+- [~ inferred] Feature-flag the new invoice path; default off until QA signs off
+
+Active topic: Migrating the scheduler off cron to the new worker pool
+```
+
+Every item carries its **trust class**: `✓ verbatim` items are pinned to an exact quote from the transcript and are never reworded — not by carry-over between sessions, not by rendering, not by budget truncation. `~ inferred` items are the agent's own conclusions and are allowed to evolve. Items carried from older sessions say so. That distinction — knowing which memories are quotes and which are guesses — is the point.
 
 The name comes from the Greek *δαίμων* — a guiding spirit (distinct from "demon") believed to accompany a person, offering counsel and warnings.
 
 ---
 
-## Quickstart
+## Install
 
-### Claude Code — plugin install (recommended)
+The `daimon` CLI ships on PyPI:
 
-Inside Claude Code, add this repo as a marketplace and install the plugin (it wires the `SessionStart`/`SessionEnd` hooks for you):
+```sh
+uv tool install 'daimon-briefing[pretty]'
+#   pipx works identically: pipx install 'daimon-briefing[pretty]'
+#   [pretty] adds rich tables/panels for status/brief; plain text without it
+```
+
+**Upgrading:**
+
+```sh
+uv tool upgrade daimon-briefing
+daimon hooks install <host>     # refresh installed hook scripts to match (non-plugin hosts)
+```
+
+### Connect an LLM (one time)
+
+Serialization needs an LLM endpoint. If the `claude` CLI is on your PATH you are **zero-config** — `daimon configure` prints `✓ ready` and you're done. Otherwise, any **OpenAI-compatible endpoint** works — for example a free-tier Gemini key:
+
+```sh
+daimon configure --backend litellm \
+  --base-url https://generativelanguage.googleapis.com/v1beta/openai \
+  --api-key <YOUR-KEY> --model gemini-2.5-flash
+```
+
+Or any headless CLI that reads a prompt on stdin and prints the response:
+
+```sh
+daimon configure --backend command --command '<your-llm-cli>' --output text
+```
+
+Config lives in `~/.daimon/env` (hooks run with the host's inherited env, not your shell profile). Kill switch: `DAIMON_DISABLE=1`.
+
+### Hook up your host
+
+**Claude Code (plugin — recommended):**
 
 ```
 /plugin marketplace add Daily-Nerd/daimon
 /plugin install daimon@daimon
 ```
 
-Then, in a terminal, install the `daimon` CLI the hooks shell out to, and configure an LLM backend:
+The plugin registers the `SessionStart`/`SessionEnd` hooks itself. Order doesn't matter: if the hooks land before the CLI, sessions start normally and the hook prints a one-line install hint instead of a briefing.
+
+> **Don't mix install paths.** Plugin users must **not** also run the manual hook installer below — both paths coexisting registers the hooks twice (double briefings, double serialize LLM calls). Switching from manual to plugin: run `python3 hook/daimon-hooks.py uninstall` first.
+
+**Windsurf:**
 
 ```sh
-# 1. Install the daimon CLI (no clone needed)
-uv tool install 'git+https://github.com/Daily-Nerd/daimon#subdirectory=plugin'
-#   From a clone instead: uv tool install ./plugin
-#   Optional pretty output: uv tool install './plugin[pretty]'
-#   (rich tables/panels for `status`/`brief`/`configure`; auto-falls back to plain text when
-#    rich is absent, output is piped, NO_COLOR is set, or DAIMON_PLAIN=1)
-
-# 2. Detect/choose an LLM backend and write ~/.daimon/env
-daimon configure                    # ✓ already? prints "ready". Gaps? fills them (chmod 600)
+daimon hooks install windsurf
 ```
 
-`daimon configure` resolves the backend the same way the hooks do: if the **`claude` CLI** is on your PATH and no API key is set, you're **zero-config** — it prints `✓ ready` and writes nothing. Otherwise it writes the right `DAIMON_LLM_*` keys (litellm/OpenAI-compatible, or a custom command). Hooks run with the host's inherited env (no shell profile), which is why config lives in `~/.daimon/env`, not your shell.
+This copies the hook script to the stable path `~/.daimon/hooks/` and prints the registration snippet: point Windsurf's Cascade hooks config (user-level JSON — see [Windsurf's hooks docs](https://docs.windsurf.com/windsurf/cascade/hooks)) at that script for **both** the `pre_user_prompt` and `post_cascade_response` events. Windsurf has no session-end event, so daimon accumulates its own transcript per conversation and serializes on a throttle (`DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL`, default 300s; `0` serializes every turn). Briefings are read with `daimon brief` in a terminal. Two knobs worth setting for your first week:
 
-Order doesn't matter: if the hooks land before the CLI, sessions start normally and the hook prints a one-line install hint instead of a briefing.
+```sh
+echo 'DAIMON_MIN_MESSAGES=4' >> ~/.daimon/env                      # don't skip short first sessions
+echo 'DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL=0' >> ~/.daimon/env   # no tail loss while you evaluate
+```
 
-> **Don't mix install paths.** The plugin registers the hooks itself — plugin users must **not** also run `hook/daimon-hooks.py install` (the manual path below). Both paths coexisting registers the hooks twice: every session would inject the briefing twice and spawn two checkpoint serializes (two LLM calls). If you're switching to the plugin from a manual install, run `python3 hook/daimon-hooks.py uninstall` first.
-
-### Manual hooks — Codex and non-plugin hosts (fallback)
-
-From a clone, after steps 1–2 above:
+**Codex and other hosts (manual, from a clone):**
 
 ```sh
 python3 hook/daimon-hooks.py install   # Claude Code without the plugin system
 #   Codex: see hook/CODEX.md
 ```
 
-This copies the hook scripts to `~/.claude/hooks/` and registers them in `~/.claude/settings.json` directly — same hooks, no marketplace required.
-
-That's it. End a session → a checkpoint is written; start the next → a *"while you were away"* briefing appears. Check state anytime with `daimon status`; a failed capture self-heals on the next start. Kill switch: `DAIMON_DISABLE=1`.
-
-Anchor a belief to code: `daimon anchor <file> <symbol>` prints an `anchored_to` block — put it on a checkpoint item, and `daimon brief` flags that item under **CODE DRIFT — verify before trusting** when the symbol's body changes or disappears. Offline, stdlib `ast`, no MCP.
+That's it. End a session → a checkpoint is written; start the next → the briefing appears. Check state anytime with `daimon status` — it reports capture health honestly, including failures, skips, and crashes; a failed capture self-heals on the next start.
 
 ---
 
-## What's net-new
+## What you get beyond the briefing
 
-Daimon's surface, honestly scoped:
+- **`daimon recall <terms>`** — full-text search over your whole checkpoint history (and your team's, if enabled). Multi-term queries degrade to ranked partial matches instead of returning nothing.
+- **Proactive recall** — when a new prompt overlaps prior work from an older session, the briefing surfaces it ("you worked on this before"), in English or Spanish — accented text is a first-class citizen.
+- **Code anchors** — `daimon anchor <file> <symbol>` pins a belief to a code symbol; if that code changes or disappears, the next briefing flags the item under **CODE DRIFT — verify before trusting**. Offline, stdlib `ast`.
+- **Team memory (opt-in)** — `daimon team init <remote>` mirrors checkpoints through a git remote; teammates' active topics and decisions appear in your briefing, clearly attributed, never merged into your own sections.
 
-- **The briefing UX** — a session-*start* artifact (`research/findings/07`).
-- **The cognitive-checkpoint serializer** — extractive trust/provenance/supersession over a real transcript (D-006/D-007), self-contained, no graph DB.
-- **Host-agnostic hooks** — Claude Code (live-validated daily) + Codex (adapter ships, not yet live-dogfooded), hermes optional; other hosts (Odysseus, openclawd, …) reachable via a thin adapter.
-- **The initiative taxonomy** — attention-gated proactive interruption (MVP ships Level 0 only: pull at session start, nothing pings you).
+## What's net-new here
 
-Honcho and Graphiti were evaluated as a memory substrate and **not adopted** — they conflict with Daimon's lean / offline / no-gateway constraints (the lexical-first verdict is in `research/memory-backend/`; rationale in **[D-009](./research/DECISIONS.md)**). A Claimify-style extraction gate, if built, is a natural upstream PR to Graphiti — not a runtime dependency.
-
----
+- **Trust-classed, quote-pinned memory** — every briefing item is marked verbatim (exact quote, immutable everywhere) or inferred (allowed to evolve), with provenance and supersession tracked extractively. No embeddings, no graph database, no server: the store is per-project JSON plus a derived SQLite FTS5 index, stdlib-first and offline-first.
+- **The briefing UX** — memory that arrives as a session-*start* artifact you can skim in 30 seconds, ordered by what to verify first.
+- **Host-agnostic hooks** — Claude Code (live-validated daily), Windsurf (adapter shipped, in live validation), Codex (adapter shipped, awaiting first live run); other hosts are reachable via the same thin adapter shape.
 
 ## Status
 
-This project was previously framed as a standalone "persistent AI companion" with an epistemic-graph differentiator. That framing was **retired** per **[D-008](./research/DECISIONS.md)** (user-approved 2026-06-09): Track B (`findings/07`) found ~7/9 of the proposed epistemic-graph features already shipped by Honcho + Graphiti. The differentiator was a dependency, not a moat.
+| Surface | State |
+|---------|-------|
+| Claude Code plugin + hooks | live-validated daily |
+| CLI (`brief`, `status`, `recall`, `heal`, `anchor`, `configure`, `hooks`) | stable, on PyPI |
+| Windsurf adapter | shipped, in live validation |
+| Codex adapter | shipped, awaiting first live run |
+| Gemini host hooks | blocked upstream (`gemini-cli#14715`) |
+| Team memory | shipped, opt-in, early |
 
-**Update ([D-009](./research/DECISIONS.md), 2026-06-27):** D-008's "build on Honcho + Graphiti" half **never shipped** and was inverted by later evidence — the gateway outages this cycle plus the memory-backend scale-test (see [research/memory-backend/](./research/memory-backend/) and D-009 in [research/DECISIONS.md](./research/DECISIONS.md)). The runtime is **self-contained and host-agnostic** (Claude Code live-validated; Codex adapter shipped, awaiting first live run; hermes optional); Honcho/Graphiti are not runtime dependencies.
+Daimon is self-contained at runtime — no external memory backend, no server. The full evidence trail behind every design decision (algorithms, findings, decision records, rejected alternatives) lives in [research/](./research/README.md); the architecture is documented in [docs/MVP-DREAM-BRIEFING.md](./docs/MVP-DREAM-BRIEFING.md).
 
-**Authoritative architecture:** [docs/MVP-DREAM-BRIEFING.md](./docs/MVP-DREAM-BRIEFING.md)
-**Evidence trail:** [research/](./research/README.md) — algorithms, findings, decisions, open questions
-
-The older `docs/` (RFC, Architecture, Pitch, Problem) are preserved with status banners — superseded ≠ deleted — because the research docs reference them by section.
-
-**License:** Apache-2.0 (D-001) · **Org:** [Daily-Nerd](https://github.com/Daily-Nerd)
-
-Daimon was developed in a private lab repo; this repository starts at v0.2.0. The full evidence trail — algorithms, findings, decisions, logbook — ships in [research/](./research/README.md).
+**License:** Apache-2.0 · **Org:** [Daily-Nerd](https://github.com/Daily-Nerd) · This repository starts at v0.2.0 (earlier development happened in a private lab repo; the research trail ships in [research/](./research/README.md)).
 
 ---
 
 ## Docs
 
-- [MVP — Dream-Briefing Skill](./docs/MVP-DREAM-BRIEFING.md) — current authoritative architecture (provenance-tagged)
-- [Codex hooks](./hook/CODEX.md) — Codex `SessionStart` / throttled `Stop` adapter
-- [The Pitch](./docs/PITCH.md) — earlier positioning (depends-on-Honcho/Graphiti framing; superseded by [D-009](./research/DECISIONS.md))
-- [The Problem](./docs/PROBLEM.md) — the context-loss thesis (still valid; demonstrated live)
-- [Validation Plan](./docs/VALIDATION.md) — the pre-build gate, with its outcome banner
-- [Technical RFC](./docs/RFC.md) — superseded; CRP checkpoint sections still live (the MVP reuses them)
-- [Architecture](./docs/ARCHITECTURE.md) — superseded by MVP-DREAM-BRIEFING.md
-- [Research Logbook](./research/README.md) — the evidence trail
+- [MVP — Dream-Briefing](./docs/MVP-DREAM-BRIEFING.md) — authoritative architecture
+- [Codex hooks](./hook/CODEX.md) — Codex adapter setup
+- [The Problem](./docs/PROBLEM.md) — the context-loss thesis
+- [Research Logbook](./research/README.md) — findings, decisions, evidence trail
+- Historical docs ([RFC](./docs/RFC.md), [Architecture](./docs/ARCHITECTURE.md), [Pitch](./docs/PITCH.md), [Validation Plan](./docs/VALIDATION.md)) are preserved with status banners — superseded ≠ deleted.


### PR DESCRIPTION
Closes #46

## Summary

- **Show the product first**: a realistic sample briefing in the first screen — trust marks, pinned quotes, carried items — plus a plain-words explanation of why verbatim/inferred matters
- **Install leads with PyPI** (`uv tool install 'daimon-briefing[pretty]'`), with an explicit upgrade flow (`uv tool upgrade` + `daimon hooks install <host>`); git clone demoted to the manual-hooks path
- **Backend section for users without the claude CLI**: any OpenAI-compatible endpoint (free-tier key example) or any stdin→stdout CLI via the command backend
- **Windsurf section**: `daimon hooks install windsurf`, both registration events, the no-session-end throttle tradeoff, and the two first-week knobs
- **Status = what-works-today table**; decision archaeology moved out (linked to research/, not inlined)
- Features section: recall (ranked partial matches), proactive recall (Spanish accents first-class), code anchors / drift flags, opt-in team memory

## ⚠ Merge ordering

`daimon hooks install` shipped in #44 — **not in PyPI 0.5.0** (verified: `uv tool run --from 'daimon-briefing==0.5.0' daimon hooks list` → invalid choice). Merge the release PR (#45, 0.6.0) first and let it publish; then this README documents commands every PyPI user actually has.

## Test plan

- [x] No repo files link to removed README anchors
- [x] Every command in the quickstart verified against current main (`hooks install` live-tested in #44; configure flags checked against argparse)
- [x] Docs-only — no runtime surface