### PR TITLE
fix(heal): survive hung targets; attribute pre-flight errors to their session

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -105,13 +105,19 @@ def _run_serialize(transcript_path: Path, project: str | None) -> int:
 
     # Pre-flight missing credentials so the error names them before any LLM work
     # (a conflated message cost a live debugging round-trip — see PR #12 fallout).
+    # Pre-flight error lines carry the transcript suffix (#49): without it the
+    # ledger cannot attribute the failure to its session, and a config gap
+    # (no key) reads as "hung/killed" in status instead of its real cause.
+    # With it, the session is attributable AND healable once config is fixed.
     if _chat is llm.chat and not config.llm_api_key():
-        msg = "error: no LLM API key — set DAIMON_LLM_API_KEY (env or ~/.daimon/env)"
+        msg = ("error: no LLM API key — set DAIMON_LLM_API_KEY "
+               f"(env or ~/.daimon/env) (transcript: {path})")
         print(msg, file=sys.stderr)
         _append_serialize_log(msg)
         return 1
     if _chat is llm.chat and not config.llm_model():
-        msg = "error: no LLM model — set DAIMON_LLM_MODEL (env or ~/.daimon/env)"
+        msg = ("error: no LLM model — set DAIMON_LLM_MODEL "
+               f"(env or ~/.daimon/env) (transcript: {path})")
         print(msg, file=sys.stderr)
         _append_serialize_log(msg)
         return 1
@@ -688,10 +694,13 @@ def _cmd_status(args) -> int:
 
 # ---- heal: opportunistic ONE-shot repair of the most recent FAILED serialize ----
 
-# The transcript carried by a SerializeError result line (see _run_serialize):
-# `error: <exc> (transcript: <path>) after <N>s`. Pre-flight errors (no API key,
-# transcript-not-found) carry no `(transcript:...)` and so are not healable.
-_HEAL_TRANSCRIPT_RE = re.compile(r"\(transcript: (.+?)\) after \d+s")
+# The transcript carried by an error result line (see _run_serialize):
+# `error: <exc> (transcript: <path>) after <N>s` for serialize failures, or
+# `error: <preflight msg> (transcript: <path>)` for pre-flight errors (#49) —
+# the `after Ns` clause is optional so both attribute to their session. A
+# pre-flight-failed session with its transcript on disk is healable: fixing
+# the config (e.g. adding the API key) makes the retry succeed.
+_HEAL_TRANSCRIPT_RE = re.compile(r"\(transcript: (.+?)\)(?: after \d+s|$)")
 
 # Per-session ledger regexes (kept SEPARATE from _RESULT_OK_RE/_RESULT_ERR_RE,
 # which _parse_serialize_log depends on). Success lines embed the session id in
@@ -881,7 +890,9 @@ def _cmd_heal(args) -> int:
     if not transcript_path.exists():
         print(f"heal aborted: transcript for {t['sid']} vanished")
         return 0
-    prior = t["line"].split(" (transcript:")[0]
+    # A hung target has no result line (#34 made spawn-with-transcript hung
+    # sessions healable) — the retry marker still needs a prior (#49).
+    prior = (t["line"] or "hung: spawned, no result").split(" (transcript:")[0]
     _append_retry_log(t["sid"], prior)
     return _run_serialize(transcript_path, t["project"])
 

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2671,3 +2671,62 @@ def test_spawn_re_recognizes_windsurf_cascade_prefix():
     assert led["T-1"]["spawned"] is True
     assert led["T-1"]["transcript"] == "/t/T-1.md"
     assert led["T-1"]["project"] == "/p/A"
+
+
+# ---- #49: heal crash on hung targets + preflight-error attribution ----
+
+
+def test_heal_hung_target_does_not_crash(tmp_checkpoint_dir, tmp_log_dir, tmp_path, monkeypatch):
+    # Live crash (first Windsurf field run): a hung-healable target has
+    # line=None and _cmd_heal's retry-marker builder split() it.
+    from datetime import datetime, timezone
+    transcript = tmp_path / "H1.md"
+    transcript.write_text("**user**: hola\n")
+    _write_log(tmp_log_dir, [
+        "2026-07-03T22:00:00Z windsurf-cascade: spawned serialize for H1 "
+        f"(project: /p/H) (transcript: {transcript})",
+    ])
+    ran = {}
+    monkeypatch.setattr(cli, "_run_serialize", lambda p, proj: ran.update(p=p) or 0)
+    monkeypatch.setattr(cli.time, "time",
+                        lambda: datetime(2026, 7, 3, 23, 0, 0, tzinfo=timezone.utc).timestamp())
+    rc = cli.main(["heal"])
+    assert rc == 0
+    assert ran.get("p") == transcript  # the hung session actually got healed
+    # the retry marker landed with a non-crashy prior
+    log_text = (tmp_log_dir / "serialize.log").read_text()
+    assert "retry serialize for H1" in log_text
+
+
+def test_preflight_error_line_attributes_to_session(tmp_checkpoint_dir):
+    # A child that dies pre-flight (no API key) must not read as hung/killed:
+    # the error line carries the transcript so the ledger attributes it.
+    text = "\n".join([
+        "2026-07-03T22:00:00Z windsurf-cascade: spawned serialize for P1 "
+        "(project: /p/A) (transcript: /t/P1.md)",
+        "error: no LLM API key — set DAIMON_LLM_API_KEY (env or ~/.daimon/env) "
+        "(transcript: /t/P1.md)",
+    ])
+    led = cli._session_ledger(text, now=0.0)
+    assert led["P1"]["result_kind"] == "error"
+    assert led["P1"]["transcript"] == "/t/P1.md"
+
+
+def test_preflight_error_session_is_healable_when_transcript_exists():
+    ledger = {"P1": _led(result_line="error: no LLM API key — set DAIMON_LLM_API_KEY "
+                                     "(env or ~/.daimon/env) (transcript: /t/P1.md)")}
+    out = cli._outstanding_failures(ledger, 0.0, lambda sid: False, 1800, lambda p: True)
+    assert out[0]["class"] == "healable"
+
+
+def test_serialize_preflight_errors_carry_transcript_suffix(
+        tmp_checkpoint_dir, tmp_log_dir, monkeypatch, tmp_path):
+    # End-to-end: _run_serialize's own pre-flight error lines carry the suffix.
+    monkeypatch.delenv("DAIMON_LLM_API_KEY", raising=False)
+    monkeypatch.setattr(cli.config, "llm_api_key", lambda: None)
+    p = tmp_path / "S-pre.md"
+    p.write_text("**user**: hola\n")
+    rc = cli.main(["serialize", str(p)])
+    assert rc == 1
+    log_text = (tmp_log_dir / "serialize.log").read_text()
+    assert f"(transcript: {p})" in log_text


### PR DESCRIPTION
Closes #49

## Field-found (first live run of the Windsurf adapter)

1. **Crash reproduced + fixed**: `daimon heal` on a hung-healable target → `AttributeError: 'NoneType' object has no attribute 'split'` — #34 introduced `line: None` hung targets; the retry-marker builder assumed a result line. TDD: the exact field traceback reproduced red first.
2. **Misclassification fixed**: children dying pre-flight (`no LLM API key`) showed as `hung/killed` because pre-flight error lines carried no transcript suffix — unattributable to their session (exactly the buried-failure class scar #9 warns about). Pre-flight lines now carry `(transcript: <path>)`; `_HEAL_TRANSCRIPT_RE` makes `after Ns` optional. The failure shows its real cause, and the session becomes healable — correct, since fixing the config makes the retry succeed.

## Test plan

- [x] TDD: 4 new tests, 3 watched red (crash repro, ledger attribution, end-to-end pre-flight suffix)
- [x] `uv run pytest` — 784 passed
- [x] Scar #9 honored: changes move failures INTO per-session attribution