### PR TITLE
fix(serialize): backend-aware pre-flight — command/claude-cli backends need no API key

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -82,6 +82,28 @@ def _append_retry_log(session_id: str, prior: str) -> None:
         pass
 
 
+def _preflight_error(path: Path) -> str | None:
+    """Credential pre-flight, mirroring llm.chat's routing (#52): an API key
+    and model are required only when the resolved transport is llm-bound.
+    The command / claude-cli backends need neither — pre-flight used to demand
+    them anyway, so a command-backend user could never serialize (and the
+    zero-config claude path only worked when a stray gateway key happened to
+    be in env). Error lines carry the transcript suffix (#49) so the ledger
+    attributes the failure to its session and heal can retry once fixed."""
+    backend = config.llm_backend()
+    if backend in ("command", "claude-cli"):
+        return None
+    if backend == "auto" and llm._resolve_command() is not None:
+        return None  # llm.chat will route to the command CLI, key-free
+    if not config.llm_api_key():
+        return ("error: no LLM API key — set DAIMON_LLM_API_KEY "
+                f"(env or ~/.daimon/env) (transcript: {path})")
+    if not config.llm_model():
+        return ("error: no LLM model — set DAIMON_LLM_MODEL "
+                f"(env or ~/.daimon/env) (transcript: {path})")
+    return None
+
+
 def _run_serialize(transcript_path: Path, project: str | None) -> int:
     """Serialize one transcript to a checkpoint routed to `project` (used AS-IS;
     None => global pointer only, NO cwd fallback). The caller decides routing —
@@ -105,22 +127,12 @@ def _run_serialize(transcript_path: Path, project: str | None) -> int:
 
     # Pre-flight missing credentials so the error names them before any LLM work
     # (a conflated message cost a live debugging round-trip — see PR #12 fallout).
-    # Pre-flight error lines carry the transcript suffix (#49): without it the
-    # ledger cannot attribute the failure to its session, and a config gap
-    # (no key) reads as "hung/killed" in status instead of its real cause.
-    # With it, the session is attributable AND healable once config is fixed.
-    if _chat is llm.chat and not config.llm_api_key():
-        msg = ("error: no LLM API key — set DAIMON_LLM_API_KEY "
-               f"(env or ~/.daimon/env) (transcript: {path})")
-        print(msg, file=sys.stderr)
-        _append_serialize_log(msg)
-        return 1
-    if _chat is llm.chat and not config.llm_model():
-        msg = ("error: no LLM model — set DAIMON_LLM_MODEL "
-               f"(env or ~/.daimon/env) (transcript: {path})")
-        print(msg, file=sys.stderr)
-        _append_serialize_log(msg)
-        return 1
+    if _chat is llm.chat:
+        preflight = _preflight_error(path)
+        if preflight is not None:
+            print(preflight, file=sys.stderr)
+            _append_serialize_log(preflight)
+            return 1
 
     session_id = path.stem
     # Elapsed time lands in serialize.log — checkpoint generation runs 4-25 min

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -102,8 +102,12 @@ def test_cli_serialize_no_api_key_names_the_cause(
     # The live failure mode: hook fired but no LLM credentials configured.
     # Must fail fast BEFORE the LLM call, naming the missing key — not the
     # conflated "too short, LLM error, or invalid output".
+    # Backend pinned litellm: since #52 pre-flight only requires a key on
+    # litellm-bound transports (a dev machine's `claude` on PATH would
+    # otherwise legitimately pass).
     for var in ("DAIMON_LLM_API_KEY", "LITELLM_API_KEY"):
         monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
     monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
     rc = cli.main(["serialize", str(FIXTURES / "sample_transcript.md")])
     assert rc != 0
@@ -2722,7 +2726,9 @@ def test_preflight_error_session_is_healable_when_transcript_exists():
 def test_serialize_preflight_errors_carry_transcript_suffix(
         tmp_checkpoint_dir, tmp_log_dir, monkeypatch, tmp_path):
     # End-to-end: _run_serialize's own pre-flight error lines carry the suffix.
+    # Backend pinned litellm — pre-flight is backend-aware since #52.
     monkeypatch.delenv("DAIMON_LLM_API_KEY", raising=False)
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
     monkeypatch.setattr(cli.config, "llm_api_key", lambda: None)
     p = tmp_path / "S-pre.md"
     p.write_text("**user**: hola\n")
@@ -2730,3 +2736,52 @@ def test_serialize_preflight_errors_carry_transcript_suffix(
     assert rc == 1
     log_text = (tmp_log_dir / "serialize.log").read_text()
     assert f"(transcript: {p})" in log_text
+
+
+# ---- #52: pre-flight must mirror llm.chat's backend routing ----
+
+
+def _clear_llm_env_52(monkeypatch):
+    for var in ("DAIMON_LLM_API_KEY", "LITELLM_API_KEY", "DAIMON_LLM_MODEL",
+                "LITELLM_MODEL", "DAIMON_LLM_BACKEND", "DAIMON_LLM_COMMAND"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_preflight_passes_for_command_backend_without_key(monkeypatch, tmp_path):
+    # A `command` backend needs no API key and no model — pre-flight killed
+    # it anyway (field-found: a command-backend user could never serialize).
+    _clear_llm_env_52(monkeypatch)
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "some-llm-cli")
+    assert cli._preflight_error(Path("/t/x.md")) is None
+
+
+def test_preflight_passes_for_claude_cli_backend_without_key(monkeypatch):
+    _clear_llm_env_52(monkeypatch)
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "claude-cli")
+    assert cli._preflight_error(Path("/t/x.md")) is None
+
+
+def test_preflight_passes_for_auto_when_command_resolves(monkeypatch):
+    # The advertised zero-config path: auto backend, claude on PATH, no key.
+    from daimon_briefing import llm
+    _clear_llm_env_52(monkeypatch)
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("claude -p", "text"))
+    assert cli._preflight_error(Path("/t/x.md")) is None
+
+
+def test_preflight_names_missing_key_when_litellm_bound(monkeypatch):
+    from daimon_briefing import llm
+    _clear_llm_env_52(monkeypatch)
+    monkeypatch.setattr(llm, "_resolve_command", lambda: None)  # nothing on PATH
+    err = cli._preflight_error(Path("/t/x.md"))
+    assert err is not None and "DAIMON_LLM_API_KEY" in err
+    assert "(transcript: /t/x.md)" in err  # #49 attribution survives
+
+
+def test_preflight_names_missing_model_when_key_present(monkeypatch):
+    _clear_llm_env_52(monkeypatch)
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_API_KEY", "sk-x")
+    err = cli._preflight_error(Path("/t/x.md"))
+    assert err is not None and "DAIMON_LLM_MODEL" in err


### PR DESCRIPTION
Closes #52

## Field-found (second finding from the first live Windsurf run)

The pre-flight in `_run_serialize` demanded `DAIMON_LLM_API_KEY` + model unconditionally. But `llm.chat` routes `command`/`claude-cli` backends to a CLI needing neither:

- a **command-backend user could never serialize** — pre-flight returned `error: no LLM API key` before chat ever ran
- the **advertised zero-config claude path was broken by the same check** — it only ever worked when a gateway key happened to be in env (which is why dogfooding never caught it; pre-flight predates the command backend, PR #12 era)

## Fix

`_preflight_error(path)` mirrors `llm.chat`'s routing: key/model required only when the transport is litellm-bound (`backend == litellm`, or `auto` with no command CLI resolving). Pure helper, unit-tested per backend. #49's transcript suffix preserved on the error lines.

## Test plan

- [x] TDD: 5 helper tests watched red (command / claude-cli / auto-with-CLI pass key-free; litellm-bound paths name the missing key/model with the transcript suffix)
- [x] 2 existing tests pinned to `DAIMON_LLM_BACKEND=litellm` — they assert the missing-key error, which now correctly can't fire when a command CLI resolves on the machine running the tests
- [x] `uv run pytest` — 789 passed