### PR TITLE
feat(configure): `--test` smoke-tests the backend; command stderr lands in a local log

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1004,6 +1004,22 @@ def _cmd_configure(args) -> int:
     With no flags it is SAFE everywhere: it only prompts on a TTY when daimon is
     not ready, and otherwise just prints guidance — it never blocks.
     """
+    # --test (#56): prove the RESOLVED backend works, interactively, at setup
+    # time — the alternative is a real serialize failing minutes later inside
+    # a detached hook child. One tiny prompt through the same llm.chat path
+    # serialization uses; failure prints the cause and where stderr landed.
+    if getattr(args, "test", False):
+        start = time.monotonic()
+        try:
+            llm.chat([{"role": "user", "content": "Reply with exactly: ok"}],
+                     retries=1)
+        except llm.ChatError as exc:
+            print(f"backend test: FAILED — {exc}", file=sys.stderr)
+            return 1
+        elapsed = time.monotonic() - start
+        print(f"backend test: ok ({elapsed:.1f}s round trip)")
+        return 0
+
     st = configure.status()
     render.render_configure(st)
 
@@ -1436,6 +1452,11 @@ def main(argv=None) -> int:
     p_cfg.add_argument("--base-url", help="litellm: DAIMON_LLM_BASE_URL")
     p_cfg.add_argument("--command", help="command: DAIMON_LLM_COMMAND")
     p_cfg.add_argument("--output", help="command: DAIMON_LLM_COMMAND_OUTPUT (text|json:<key>)")
+    p_cfg.add_argument(
+        "--test", action="store_true",
+        help="send one tiny prompt through the resolved backend and report "
+             "pass/fail — run this right after configuring (#56)",
+    )
     p_cfg.set_defaults(func=_cmd_configure)
 
     p_stats = sub.add_parser(

--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -244,7 +244,23 @@ def _chat_command(messages, deadline):
         except subprocess.TimeoutExpired:
             raise ChatError("command backend timed out")
         if rc != 0:
-            raise ChatError(f"command backend exited {rc} (stderr suppressed)")
+            # stderr stays OFF every wire, but the user's own disk is the same
+            # trust domain as the transcript being serialized — discarding it
+            # locally turned every backend failure into guesswork (#56, exit
+            # 101 in the field with zero diagnostics). Truncate-per-run: the
+            # log is "the last failure", not an archive.
+            hint = "stderr suppressed"
+            try:
+                d = config.log_dir()
+                d.mkdir(parents=True, exist_ok=True)
+                p = d / "backend-stderr.log"
+                p.write_text(
+                    f"command backend exit {rc} (argv0: {argv[0]})\n{err or ''}\n",
+                    encoding="utf-8")
+                hint = f"stderr: {p}"
+            except OSError:
+                pass
+            raise ChatError(f"command backend exited {rc} ({hint})")
         try:
             text = _extract_output(out, output_spec)
         except (json.JSONDecodeError, KeyError, TypeError):

--- a/plugin/tests/test_configure.py
+++ b/plugin/tests/test_configure.py
@@ -151,3 +151,31 @@ def test_write_env_sorted_lines(tmp_path, monkeypatch):
     configure.write_env({"B_KEY": "2", "A_KEY": "1"})
     lines = [ln for ln in env_file.read_text().splitlines() if ln]
     assert lines == ["A_KEY=1", "B_KEY=2"]
+
+
+# ---- #56: configure --test — prove the backend works AT SETUP ----
+
+
+def test_configure_test_passes_with_working_backend(monkeypatch, capsys, tmp_path):
+    from daimon_briefing import cli, llm
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "fake-cli")
+    monkeypatch.setattr(llm, "_run_command", lambda *a, **k: (0, "ok", ""))
+    rc = cli.main(["configure", "--test"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "backend test: ok" in out
+
+
+def test_configure_test_fails_loud_with_broken_backend(monkeypatch, capsys, tmp_path):
+    from daimon_briefing import cli, llm
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "failing-cli")
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setattr(llm, "_run_command",
+                        lambda *a, **k: (101, "", "panic: no prompt"))
+    rc = cli.main(["configure", "--test"])
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "backend test: FAILED" in err
+    assert "backend-stderr.log" in err

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -384,3 +384,35 @@ def test_chat_direct_success_leaves_flag_clear(monkeypatch):
     llm.reset_fallback()
     llm.chat([{"role": "user", "content": "x"}])
     assert llm.fallback_used() is False
+
+
+# ---- #56: command-backend stderr lands locally; never guessed at again ----
+
+
+def test_command_backend_failure_writes_stderr_log(monkeypatch, tmp_path):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "failing-cli")
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setattr(llm, "_run_command",
+                        lambda *a, **k: (101, "", "panic: no prompt provided"))
+    with pytest.raises(llm.ChatError) as exc:
+        llm.chat([{"role": "user", "content": "hola"}])
+    assert "backend-stderr.log" in str(exc.value)
+    assert "suppressed" not in str(exc.value)
+    log = tmp_path / "logs" / "backend-stderr.log"
+    assert "panic: no prompt provided" in log.read_text()
+    assert "exit 101" in log.read_text()
+
+
+def test_command_backend_stderr_log_truncates_per_run(monkeypatch, tmp_path):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "failing-cli")
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setattr(llm, "_run_command", lambda *a, **k: (1, "", "first"))
+    with pytest.raises(llm.ChatError):
+        llm.chat([{"role": "user", "content": "x"}])
+    monkeypatch.setattr(llm, "_run_command", lambda *a, **k: (1, "", "second"))
+    with pytest.raises(llm.ChatError):
+        llm.chat([{"role": "user", "content": "x"}])
+    text = (tmp_path / "logs" / "backend-stderr.log").read_text()
+    assert "second" in text and "first" not in text


### PR DESCRIPTION
Closes #56

## Field-found (fourth live finding of the day)

A command backend exited 101 in 1s; the only diagnostic anywhere was `(stderr suppressed)`. Root gaps: stderr discarded even locally, and `configure` proves config *parses*, never that the backend *works*.

## Changes

| Piece | What |
|-------|------|
| `llm._chat_command` | non-zero exit writes stderr + exit code to `~/.daimon/logs/backend-stderr.log` (truncate-per-run); ChatError points at the file. Never transmitted — local disk = same trust domain as the transcript itself |
| `daimon configure --test` | one tiny prompt through the resolved backend via the same `llm.chat` path serialization uses; pass prints round-trip time, failure prints the cause + stderr location, rc 1 |

## Test plan

- [x] TDD: 4 tests watched red first (stderr file + message pointer, truncate-per-run, --test pass, --test loud failure)
- [x] `uv run pytest` — 798 passed
- [x] Live: `daimon configure --test` against a real backend → `backend test: ok (3.1s round trip)`
- [x] Scars #15 (no retry-body changes) and #9 (no serialize.log reasoning) honored