### PR TITLE
fix(configure): `--test` proves JSON-extraction fitness, not just transport

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1011,10 +1011,24 @@ def _cmd_configure(args) -> int:
     if getattr(args, "test", False):
         start = time.monotonic()
         try:
-            llm.chat([{"role": "user", "content": "Reply with exactly: ok"}],
-                     retries=1)
+            reply = llm.chat(
+                [{"role": "user", "content":
+                  'Reply with exactly this JSON and nothing else: {"ok": true}'}],
+                retries=1)
         except llm.ChatError as exc:
             print(f"backend test: FAILED — {exc}", file=sys.stderr)
+            return 1
+        # Same extraction path serialization uses (#59): a transport that
+        # answers but cannot return extractable JSON — agent-style CLIs often
+        # can't — must fail HERE, not on the first real serialize.
+        try:
+            llm.extract_json(reply)
+        except json.JSONDecodeError:
+            print("backend test: FAILED — transport works, but the backend did "
+                  "not return extractable JSON; serialization will fail. "
+                  "Agent-style CLIs often can't do this — use an "
+                  "OpenAI-compatible endpoint or a raw-completion CLI.",
+                  file=sys.stderr)
             return 1
         elapsed = time.monotonic() - start
         print(f"backend test: ok ({elapsed:.1f}s round trip)")

--- a/plugin/tests/test_configure.py
+++ b/plugin/tests/test_configure.py
@@ -160,7 +160,8 @@ def test_configure_test_passes_with_working_backend(monkeypatch, capsys, tmp_pat
     from daimon_briefing import cli, llm
     monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
     monkeypatch.setenv("DAIMON_LLM_COMMAND", "fake-cli")
-    monkeypatch.setattr(llm, "_run_command", lambda *a, **k: (0, "ok", ""))
+    # #59: --test now requires extractable JSON, same bar as serialization.
+    monkeypatch.setattr(llm, "_run_command", lambda *a, **k: (0, '{"ok": true}', ""))
     rc = cli.main(["configure", "--test"])
     out = capsys.readouterr().out
     assert rc == 0
@@ -179,3 +180,32 @@ def test_configure_test_fails_loud_with_broken_backend(monkeypatch, capsys, tmp_
     assert rc == 1
     assert "backend test: FAILED" in err
     assert "backend-stderr.log" in err
+
+
+# ---- #59: --test proves JSON-extraction fitness, not just transport ----
+
+
+def test_configure_test_fails_when_backend_cannot_produce_json(monkeypatch, capsys):
+    # Field case: an agent-harness CLI chats politely but never emits JSON —
+    # transport-only smoke test said ok while every serialize failed.
+    from daimon_briefing import cli, llm
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "chatty-agent")
+    monkeypatch.setattr(llm, "_run_command",
+                        lambda *a, **k: (0, "Sure! Let me think about that...", ""))
+    rc = cli.main(["configure", "--test"])
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "extractable JSON" in err
+
+
+def test_configure_test_passes_with_json_capable_backend(monkeypatch, capsys):
+    from daimon_briefing import cli, llm
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "good-cli")
+    monkeypatch.setattr(llm, "_run_command",
+                        lambda *a, **k: (0, 'Here you go: {"ok": true}', ""))
+    rc = cli.main(["configure", "--test"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "backend test: ok" in out


### PR DESCRIPTION
Closes #59

## Field case (same evening, same live user)

`configure --test` → `ok (4.3s)`; every real serialize → `no JSON object/array found in response`. The smoke test proved transport; serialization needs extractable JSON. The user's backend was an agent-harness CLI that chats but never emits JSON.

## Change

`--test` requests `{"ok": true}` and validates the reply through the same `llm.extract_json` path the serializer uses. Transport-works-but-no-JSON fails at setup, loudly, with guidance (OpenAI-compatible endpoint or raw-completion CLI).

## Test plan

- [x] TDD: chatty-agent reply watched fail red (rc 0 → asserted 1), JSON-capable pin
- [x] #56's transport test updated to the new bar (fake now replies JSON — deliberate contract change)
- [x] `uv run pytest` — 801 passed
- [x] Live: `daimon configure --test` against a real backend → `ok (3.0s round trip)` (real backends pass the stricter bar)