### PR TITLE
fix(hosts): Windsurf adapter probe-dumps payloads it previously dropped silently

### DIFF
--- a/hook/daimon-windsurf-hooks.py
+++ b/hook/daimon-windsurf-hooks.py
@@ -16,10 +16,13 @@ conversations out of reach, so daimon keeps its own: each hook call appends a
 `**role**:`-marked turn to ~/.daimon/windsurf/transcripts/<trajectory_id>.md —
 the exact markdown shape `daimon serialize` already parses.
 
-Self-probing: a `pre_user_prompt` payload this adapter cannot extract text
-from is dumped to ~/.daimon/windsurf/unparsed-<stamp>.json (payload only,
-fail-open) so the next adapter iteration can be built from evidence instead
-of another probe round.
+Self-probing (#62): any payload this adapter cannot handle — unextractable
+`pre_user_prompt` text, a missing trajectory_id, or an event it does not
+know (the docs list 12; `post_cascade_response_with_transcript` is the one
+worth catching) — is dumped to ~/.daimon/windsurf/unparsed-<event>-<stamp>.json
+so the next adapter iteration can be built from evidence instead of another
+probe round. At most ONE dump per event name: a script registered for all
+12 Cascade events must not flood the state dir.
 
 Throttle: `post_cascade_response` fires EVERY turn; serializing each one is
 an LLM call per turn. DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL seconds
@@ -128,14 +131,21 @@ def _extract_prompt(payload: dict) -> str | None:
     return None
 
 
-def _dump_unparsed(payload: dict) -> None:
+def _dump_probe(event: str, payload: dict) -> bool:
+    """Bounded self-probe dump (#62): at most one unparsed-*.json per event
+    name. Returns True when a dump was written (callers log only then, so a
+    hook registered for every Cascade event stays quiet after the first)."""
     try:
         STATE_DIR.mkdir(parents=True, exist_ok=True)
+        tag = _safe_name(event or "unknown")
+        if any(STATE_DIR.glob(f"unparsed-{tag}-*.json")):
+            return False
         stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
-        (STATE_DIR / f"unparsed-{stamp}.json").write_text(
+        (STATE_DIR / f"unparsed-{tag}-{stamp}.json").write_text(
             json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+        return True
     except OSError:
-        pass
+        return False
 
 
 def _project_cwd() -> str:
@@ -166,21 +176,29 @@ def main() -> int:
     event = str(payload.get("agent_action_name") or "")
     trajectory_id = str(payload.get("trajectory_id") or "").strip()
     if not trajectory_id:
-        lib.log(f"windsurf-cascade: no trajectory_id on {event or '?'} — skipped")
+        if _dump_probe(f"{event or 'unknown'}-no-trajectory-id", payload):
+            lib.log(f"windsurf-cascade: no trajectory_id on {event or '?'} — "
+                    "payload dumped, skipped")
         return 0
 
     if event == "pre_user_prompt":
         text = _extract_prompt(payload)
         if text is None:
-            _dump_unparsed(payload)
-            lib.log("windsurf-cascade: pre_user_prompt shape unknown — dumped for "
-                    "the next adapter iteration (transcript stays assistant-only)")
+            if _dump_probe(event, payload):
+                lib.log("windsurf-cascade: pre_user_prompt shape unknown — dumped "
+                        "for the next adapter iteration (transcript stays "
+                        "assistant-only)")
             return 0
         _append_turn(trajectory_id, "user", text)
         return 0
 
     if event != "post_cascade_response":
-        return 0  # future events: ignore quietly, fail-open
+        # Unknown events dump instead of vanishing (#62) —
+        # post_cascade_response_with_transcript lands here until adopted.
+        if _dump_probe(event, payload):
+            lib.log(f"windsurf-cascade: unhandled event {event} — payload dumped "
+                    "for the next adapter iteration")
+        return 0
 
     tool_info = payload.get("tool_info")
     response = tool_info.get("response") if isinstance(tool_info, dict) else None

--- a/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
+++ b/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
@@ -16,10 +16,13 @@ conversations out of reach, so daimon keeps its own: each hook call appends a
 `**role**:`-marked turn to ~/.daimon/windsurf/transcripts/<trajectory_id>.md —
 the exact markdown shape `daimon serialize` already parses.
 
-Self-probing: a `pre_user_prompt` payload this adapter cannot extract text
-from is dumped to ~/.daimon/windsurf/unparsed-<stamp>.json (payload only,
-fail-open) so the next adapter iteration can be built from evidence instead
-of another probe round.
+Self-probing (#62): any payload this adapter cannot handle — unextractable
+`pre_user_prompt` text, a missing trajectory_id, or an event it does not
+know (the docs list 12; `post_cascade_response_with_transcript` is the one
+worth catching) — is dumped to ~/.daimon/windsurf/unparsed-<event>-<stamp>.json
+so the next adapter iteration can be built from evidence instead of another
+probe round. At most ONE dump per event name: a script registered for all
+12 Cascade events must not flood the state dir.
 
 Throttle: `post_cascade_response` fires EVERY turn; serializing each one is
 an LLM call per turn. DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL seconds
@@ -128,14 +131,21 @@ def _extract_prompt(payload: dict) -> str | None:
     return None
 
 
-def _dump_unparsed(payload: dict) -> None:
+def _dump_probe(event: str, payload: dict) -> bool:
+    """Bounded self-probe dump (#62): at most one unparsed-*.json per event
+    name. Returns True when a dump was written (callers log only then, so a
+    hook registered for every Cascade event stays quiet after the first)."""
     try:
         STATE_DIR.mkdir(parents=True, exist_ok=True)
+        tag = _safe_name(event or "unknown")
+        if any(STATE_DIR.glob(f"unparsed-{tag}-*.json")):
+            return False
         stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
-        (STATE_DIR / f"unparsed-{stamp}.json").write_text(
+        (STATE_DIR / f"unparsed-{tag}-{stamp}.json").write_text(
             json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+        return True
     except OSError:
-        pass
+        return False
 
 
 def _project_cwd() -> str:
@@ -166,21 +176,29 @@ def main() -> int:
     event = str(payload.get("agent_action_name") or "")
     trajectory_id = str(payload.get("trajectory_id") or "").strip()
     if not trajectory_id:
-        lib.log(f"windsurf-cascade: no trajectory_id on {event or '?'} — skipped")
+        if _dump_probe(f"{event or 'unknown'}-no-trajectory-id", payload):
+            lib.log(f"windsurf-cascade: no trajectory_id on {event or '?'} — "
+                    "payload dumped, skipped")
         return 0
 
     if event == "pre_user_prompt":
         text = _extract_prompt(payload)
         if text is None:
-            _dump_unparsed(payload)
-            lib.log("windsurf-cascade: pre_user_prompt shape unknown — dumped for "
-                    "the next adapter iteration (transcript stays assistant-only)")
+            if _dump_probe(event, payload):
+                lib.log("windsurf-cascade: pre_user_prompt shape unknown — dumped "
+                        "for the next adapter iteration (transcript stays "
+                        "assistant-only)")
             return 0
         _append_turn(trajectory_id, "user", text)
         return 0
 
     if event != "post_cascade_response":
-        return 0  # future events: ignore quietly, fail-open
+        # Unknown events dump instead of vanishing (#62) —
+        # post_cascade_response_with_transcript lands here until adopted.
+        if _dump_probe(event, payload):
+            lib.log(f"windsurf-cascade: unhandled event {event} — payload dumped "
+                    "for the next adapter iteration")
+        return 0
 
     tool_info = payload.get("tool_info")
     response = tool_info.get("response") if isinstance(tool_info, dict) else None

--- a/plugin/tests/test_windsurf_hooks.py
+++ b/plugin/tests/test_windsurf_hooks.py
@@ -154,8 +154,51 @@ def test_unparseable_stdin_exits_zero(tmp_path):
     assert proc.returncode == 0
 
 
-def test_missing_trajectory_id_skips_quietly(tmp_path):
-    proc, _ = _run({"agent_action_name": "post_cascade_response",
-                    "tool_info": {"response": "x"}}, tmp_path)
+def test_missing_trajectory_id_dumps_probe_payload(tmp_path):
+    # #62: a payload without trajectory_id must still land in a probe dump —
+    # the field showed this path swallowing pre_user_prompt invisibly.
+    proc, _ = _run({"agent_action_name": "pre_user_prompt",
+                    "tool_info": {"user_prompt": "hola"}}, tmp_path)
     assert proc.returncode == 0
     assert not (tmp_path / ".daimon" / "windsurf" / "transcripts").exists()
+    dumps = list((tmp_path / ".daimon" / "windsurf").glob("unparsed-*.json"))
+    assert dumps and "hola" in dumps[0].read_text(encoding="utf-8")
+
+
+def test_unhandled_event_dumps_once(tmp_path):
+    # #62: unknown agent_action_name must probe-dump instead of vanishing —
+    # and repeated payloads for the same event must not flood the state dir.
+    payload = {"agent_action_name": "post_cascade_response_with_transcript",
+               "trajectory_id": TRAJ,
+               "tool_info": {"transcript_path": "/x/y.jsonl"}}
+    proc, _ = _run(payload, tmp_path)
+    assert proc.returncode == 0
+    proc, _ = _run(payload, tmp_path)
+    assert proc.returncode == 0
+    dumps = list((tmp_path / ".daimon" / "windsurf").glob("unparsed-*.json"))
+    assert len(dumps) == 1
+    assert "transcript_path" in dumps[0].read_text(encoding="utf-8")
+
+
+def test_unparsed_pre_prompt_dump_bounded_once(tmp_path):
+    # #62: the existing pre_user_prompt shape dump joins the same
+    # one-dump-per-event bound.
+    payload = {"agent_action_name": "pre_user_prompt", "trajectory_id": TRAJ,
+               "tool_info": {"weird_field": {"nested": True}}}
+    _run(payload, tmp_path)
+    _run(payload, tmp_path)
+    dumps = list((tmp_path / ".daimon" / "windsurf").glob("unparsed-*.json"))
+    assert len(dumps) == 1
+
+
+def test_pre_user_prompt_docs_shape_appends_user_turn(tmp_path):
+    # Documented shape (docs.devin.ai/desktop/cascade/hooks): text lives in
+    # tool_info.user_prompt. Regression guard — passes on the current
+    # extractor by design.
+    payload = {"agent_action_name": "pre_user_prompt", "trajectory_id": TRAJ,
+               "tool_info": {"user_prompt": "can you run the echo hello command"}}
+    proc, _ = _run(payload, tmp_path)
+    assert proc.returncode == 0
+    text = _transcript(tmp_path).read_text(encoding="utf-8")
+    assert "**user**:" in text
+    assert "can you run the echo hello command" in text


### PR DESCRIPTION
Closes #62

## What

The adapter's self-probing contract promised any unhandled payload lands in `~/.daimon/windsurf/unparsed-*.json`. Two paths broke it:

1. Missing `trajectory_id` → skipped before the dump could fire (the guard ran before event dispatch)
2. Unknown `agent_action_name` → silently ignored, no log, no dump

Both now probe-dump, **bounded to one dump per event name** (`unparsed-<event>-<stamp>.json`) so a script registered for all 12 documented Cascade events cannot flood the state dir. Callers log only when a dump is actually written — the log stays quiet after the first occurrence. The pre-existing unbounded `pre_user_prompt` dump joins the same mechanism.

## Why now

Live field data: assistant turns accumulate, spawns fire, yet zero dumps and no user turns — the exact failure the self-probe existed to diagnose, invisible because both silent paths bypass it. Hook docs (now redirected to docs.devin.ai/desktop/cascade/hooks) also document `post_cascade_response_with_transcript`, which today vanishes at the unknown-event path; with this change it produces its first payload sample, feeding the adapter-v2 evaluation.

## Tests

TDD: 3 new failing tests (missing-trajectory dump, unhandled-event dump-once, pre_user_prompt dump bound) + 1 regression guard for the documented `tool_info.user_prompt` shape. Full suite: 803 passed.