### PR TITLE
chore(github): issue and PR templates — lean, enforcement-aligned

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: Bug report
+description: Something broke — capture, serialization, briefing, CLI, or a host hook
+title: "fix: "
+labels: ["bug", "type:fix"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Everything daimon knows about itself is local. The diagnostics below answer most
+        questions in one round-trip — paste them and skip the back-and-forth.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you did and what broke. Quote error text exactly.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. daimon hooks install windsurf
+        2. ...
+    validations:
+      required: false
+
+  - type: dropdown
+    id: host
+    attributes:
+      label: Host
+      options:
+        - Claude Code
+        - Codex
+        - Windsurf / Devin
+        - No host (daimon CLI directly)
+        - Other (say which in "What happened")
+    validations:
+      required: true
+
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Serializer backend
+      description: The backend `daimon configure` set up, if you know it.
+      options:
+        - anthropic
+        - openai-compatible (Gemini, etc.)
+        - claude-cli
+        - command
+        - don't know
+    validations:
+      required: false
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: |
+        Paste the output of these three (all local, nothing is transmitted — redact
+        anything you consider sensitive):
+
+            daimon --version
+            daimon status
+            daimon stats
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log lines
+      description: "`tail -50 ~/.daimon/logs/serialize.log` around the failure."
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: A capability daimon should have, or a pain it should remove
+title: "feat: "
+labels: ["enhancement", "type:feat"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: The pain point, as concretely as you can. What happens today that shouldn't, or can't happen that should?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How it would work from your side — commands, output, behavior. Rough is fine.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you use today, or other shapes this could take.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: host
+    attributes:
+      label: Where would you use it?
+      options:
+        - Claude Code
+        - Codex
+        - Windsurf / Devin
+        - daimon CLI directly
+        - Everywhere / host-independent
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+Closes #
+
+<!--
+CI gates on this PR (pr-validation.yml):
+- body links an issue labeled status:approved (Closes/Fixes/Resolves #N)
+- exactly one type:* label on the PR
+- conventional title — squash-merge makes it the commit subject on main
+- branch named type/description (lowercase)
+-->
+
+## What
+
+## Why
+
+## Tests
+
+<!-- What you ran and what it proves. New behavior needs a test that failed before the change. -->


### PR DESCRIPTION
Closes #64

## What

- `.github/ISSUE_TEMPLATE/bug_report.yml` — what happened / expected / repro, host + backend dropdowns, **required diagnostics paste** (`daimon --version`, `daimon status`, `daimon stats`), optional `serialize.log` tail. Auto-labels `bug` + `type:fix`.
- `.github/ISSUE_TEMPLATE/feature_request.yml` — problem / proposed solution / alternatives / target host. Auto-labels `enhancement` + `type:feat`.
- `.github/ISSUE_TEMPLATE/config.yml` — blank issues off.
- `.github/PULL_REQUEST_TEMPLATE.md` — `Closes #N` slot, What/Why/Tests, one HTML comment stating the four CI gates from `pr-validation.yml` so authors stop discovering them on a red check.

## Why

External bug reports currently arrive without the diagnostics that answer most questions, costing a round-trip each. Everything the templates ask for is local-only output; the copy says so and reminds reporters to redact.

## Tests

YAML parses clean (`yaml.safe_load` on all three). Template rendering is GitHub-side — verify visually on the New Issue page after merge.