### PR TITLE
feat(cli): rich-parity for stats, recall, hooks, team, and --help

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,9 @@ jobs:
 
       - name: Run tests
         # --extra pretty: the rich-path smoke tests in test_render.py import
-        # rich unconditionally, so the suite requires it even though runtime
-        # deps are stdlib-only.
+        # rich unconditionally, and the --help formatter tests in test_cli.py
+        # exercise rich-argparse the same way, so the suite requires both even
+        # though runtime deps are stdlib-only.
         # HOME is redirected so any test that escapes the isolation fixtures
         # fails loudly instead of silently touching a real ~/.daimon.
         run: |

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -37,12 +37,17 @@ _chat = llm.chat
 def _formatter_class():
     """argparse help formatter: RichHelpFormatter-family when rich-argparse
     (daimon[pretty]) is importable, else the stock formatter everywhere
-    already used it. Unlike render.supports_rich(), this needs no separate
-    TTY/NO_COLOR/DAIMON_PLAIN gate of its own — rich's Console auto-detects a
-    non-terminal stream and honors NO_COLOR itself, so `--help` degrades to
-    plain text automatically when piped or redirected; a bare import guard is
-    the whole contract, and it keeps `--help` byte-identical to before #68
-    whenever rich-argparse is absent."""
+    already used it. Unlike render.supports_rich(), this needs no TTY gate of
+    its own — rich's Console auto-detects a non-terminal stream, so `--help`
+    degrades to plain text automatically when piped or redirected. It DOES
+    need to honor the same DAIMON_PLAIN/NO_COLOR opt-outs supports_rich checks
+    (same truthiness semantics), because rich-argparse's own Console has no
+    idea what DAIMON_PLAIN means — left ungated, `--help` would ignore a
+    user's explicit plain-mode request while every other command honors it."""
+    if os.environ.get("DAIMON_PLAIN", "").strip().lower() in render._TRUTHY:
+        return argparse.RawDescriptionHelpFormatter
+    if os.environ.get("NO_COLOR") is not None:
+        return argparse.RawDescriptionHelpFormatter
     try:
         from rich_argparse import RawDescriptionRichHelpFormatter
         return RawDescriptionRichHelpFormatter
@@ -986,7 +991,6 @@ def _cmd_team_sync(args) -> int:
             "(run `daimon team init <remote-url>`)",
         ])
         return 0
-    lines = []
     for r in reports:
         parts = [f"{r['committed']} committed", "pushed" if r["pushed"] else "no push"]
         if r["fetched"]:
@@ -994,10 +998,13 @@ def _cmd_team_sync(args) -> int:
         line = f"{r['slug']}: " + ", ".join(parts)
         if r["notes"]:
             line += " (" + "; ".join(r["notes"]) + ")"
-        lines.append(line)
+        # Rendered per-report (not collected and rendered once after the loop):
+        # this keeps a report's stdout line interleaved with ITS OWN stderr
+        # warnings below, matching the ordering the pre-#68 print()-per-report
+        # loop had.
+        render.render_team_sync([line])
         for w in r["warnings"]:
             print(f"warning: {w}", file=sys.stderr)
-    render.render_team_sync(lines)
     return 0
 
 

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -17,6 +17,7 @@
 """
 
 import argparse
+import functools
 import getpass
 import json
 import os
@@ -31,6 +32,22 @@ from . import __version__
 
 # Module-level seam so tests can inject a fake LLM client.
 _chat = llm.chat
+
+
+def _formatter_class():
+    """argparse help formatter: RichHelpFormatter-family when rich-argparse
+    (daimon[pretty]) is importable, else the stock formatter everywhere
+    already used it. Unlike render.supports_rich(), this needs no separate
+    TTY/NO_COLOR/DAIMON_PLAIN gate of its own — rich's Console auto-detects a
+    non-terminal stream and honors NO_COLOR itself, so `--help` degrades to
+    plain text automatically when piped or redirected; a bare import guard is
+    the whole contract, and it keeps `--help` byte-identical to before #68
+    whenever rich-argparse is absent."""
+    try:
+        from rich_argparse import RawDescriptionRichHelpFormatter
+        return RawDescriptionRichHelpFormatter
+    except ImportError:
+        return argparse.RawDescriptionHelpFormatter
 
 
 def _prompt(question: str) -> str:
@@ -382,15 +399,17 @@ def _cmd_recall(args) -> int:
         print(json.dumps(results, indent=2, ensure_ascii=False))
         return 0
     if not results:
-        print("no matches")
+        render.render_recall_lines(["no matches"])
         return 0
     now = time.time()
+    lines = []
     for r in results:
         age = _format_age(now - r["created"]) if r.get("created") else "?"
         superseded = f" [superseded by {r['superseded_by']}]" if r.get("superseded_by") else ""
         trust = r.get("trust") or "untagged"
-        print(f"[{r['author']}] [{trust}] [{r['kind']}] {r['text']} "
-              f"({r['session_id']}, {age} ago){superseded}")
+        lines.append(f"[{r['author']}] [{trust}] [{r['kind']}] {r['text']} "
+                     f"({r['session_id']}, {age} ago){superseded}")
+    render.render_recall_lines(lines)
     return 0
 
 
@@ -940,9 +959,11 @@ def _cmd_team_init(args) -> int:
     except teamsync.TeamError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
-    print(f"initialized team sidecar: {dest}")
-    print("checkpoints now sync there — `daimon team sync` runs opportunistically "
-          "at session start")
+    render.render_team_init([
+        f"initialized team sidecar: {dest}",
+        "checkpoints now sync there — `daimon team sync` runs opportunistically "
+        "at session start",
+    ])
     return 0
 
 
@@ -956,13 +977,16 @@ def _cmd_team_sync(args) -> int:
         print("daimon team: --project is ignored — sync is project-agnostic "
               "(all own checkpoints sync)", file=sys.stderr)
     if not teamsync.git_available():
-        print("daimon team: git not found on PATH — sync skipped")
+        render.render_team_sync(["daimon team: git not found on PATH — sync skipped"])
         return 0
     reports = teamsync.sync()
     if not reports:
-        print("daimon team: no team remote configured — nothing to sync "
-              "(run `daimon team init <remote-url>`)")
+        render.render_team_sync([
+            "daimon team: no team remote configured — nothing to sync "
+            "(run `daimon team init <remote-url>`)",
+        ])
         return 0
+    lines = []
     for r in reports:
         parts = [f"{r['committed']} committed", "pushed" if r["pushed"] else "no push"]
         if r["fetched"]:
@@ -970,27 +994,32 @@ def _cmd_team_sync(args) -> int:
         line = f"{r['slug']}: " + ", ".join(parts)
         if r["notes"]:
             line += " (" + "; ".join(r["notes"]) + ")"
-        print(line)
+        lines.append(line)
         for w in r["warnings"]:
             print(f"warning: {w}", file=sys.stderr)
+    render.render_team_sync(lines)
     return 0
 
 
 def _cmd_team_status(args) -> int:
     if not teamsync.git_available():
-        print("daimon team: git not found on PATH")
+        render.render_team_status(["daimon team: git not found on PATH"])
         return 0
     rows = teamsync.team_status()
     if not rows:
-        print("no team remote configured — run `daimon team init <remote-url>`")
+        render.render_team_status([
+            "no team remote configured — run `daimon team init <remote-url>`",
+        ])
         return 0
     if args.json:
         print(json.dumps(rows, indent=2))
         return 0
+    lines = []
     for row in rows:
         authors = ", ".join(row["authors"]) or "none yet"
-        print(f"{row['slug']}: {row['freshness']} — "
-              f"{row['unpushed']} unpushed checkpoint(s), authors: {authors}")
+        lines.append(f"{row['slug']}: {row['freshness']} — "
+                     f"{row['unpushed']} unpushed checkpoint(s), authors: {authors}")
+    render.render_team_status(lines)
     return 0
 
 
@@ -1200,29 +1229,7 @@ def _cmd_stats(args) -> int:
     if args.json:
         print(json.dumps(data, indent=2))
         return 0
-    u, c, s = data["usage"], data["capture"], data["store"]
-    print("usage (local, never transmitted):")
-    if u:
-        for cmd_name, n in sorted(u.items(), key=lambda kv: -kv[1]):
-            print(f"  {cmd_name}: {n}")
-    else:
-        print("  none recorded yet")
-    print("capture:")
-    print(f"  serialized: {c['success']}  skipped: {c['skipped']}  "
-          f"errors: {c['errors']}  via fallback backend: {c['fallback_serializes']}")
-    if c["hosts"]:
-        print("  spawns by host: " + ", ".join(
-            f"{h}: {n}" for h, n in sorted(c["hosts"].items())))
-    if c["success"]:
-        print(f"  serialize seconds: max {c['max_serialize_seconds']}, "
-              f"avg {c['total_serialize_seconds'] // c['success']}")
-    print("store:")
-    print(f"  checkpoints: {s['checkpoints']}  project buckets: {s['project_buckets']}")
-    if s["items_by_kind"]:
-        print("  items by kind: " + ", ".join(
-            f"{k}: {n}" for k, n in sorted(s["items_by_kind"].items())))
-    print(f"  trust: verbatim {s['items_verbatim']}, inferred {s['items_inferred']}, "
-          f"untagged {s['items_untagged']}  (carried: {s['items_carried']})")
+    render.render_stats(data)
     return 0
 
 
@@ -1246,8 +1253,9 @@ def _hooks_target_dir() -> Path:
 
 
 def _cmd_hooks_list(args) -> int:
-    for host, spec in sorted(_HOOK_HOSTS.items()):
-        print(f"{host}  ({spec['entry']}; events: {', '.join(spec['events'])})")
+    lines = [f"{host}  ({spec['entry']}; events: {', '.join(spec['events'])})"
+             for host, spec in sorted(_HOOK_HOSTS.items())]
+    render.render_hooks_list(lines)
     return 0
 
 
@@ -1272,16 +1280,19 @@ def _cmd_hooks_install(args) -> int:
         dest.write_bytes(data)
         dest.chmod(dest.stat().st_mode | 0o100)  # u+x
     entry = target / spec["entry"]
-    print(f"installed {len(spec['files'])} file(s) to {target}")
-    print("")
-    print(f"Register this command for the events below "
-          f"(host hooks config — see the host's hooks documentation):")
-    print(f"  command: python3 {entry}")
+    lines = [
+        f"installed {len(spec['files'])} file(s) to {target}",
+        "",
+        "Register this command for the events below "
+        "(host hooks config — see the host's hooks documentation):",
+        f"  command: python3 {entry}",
+    ]
     for ev in spec["events"]:
-        print(f"  event:   {ev}")
-    print("")
-    print("Re-run `daimon hooks install " + args.host +
-          "` after every `uv tool upgrade daimon-briefing`.")
+        lines.append(f"  event:   {ev}")
+    lines.append("")
+    lines.append("Re-run `daimon hooks install " + args.host +
+                 "` after every `uv tool upgrade daimon-briefing`.")
+    render.render_hooks_install(lines)
     return 0
 
 
@@ -1343,6 +1354,12 @@ def _cmd_skill_uninstall(args) -> int:
 
 
 def main(argv=None) -> int:
+    # #68: one formatter selection for the WHOLE parser tree. argparse does not
+    # propagate formatter_class from parent to subparser, so every add_parser
+    # call below must receive it — done here by patching add_parser on each
+    # subparsers action into a partial pre-bound with `fmt`, rather than
+    # threading formatter_class= through 20+ individual call sites.
+    fmt = _formatter_class()
     parser = argparse.ArgumentParser(
         prog="daimon",
         description="Cognitive checkpoints — serialize sessions, brief on resume.",
@@ -1350,12 +1367,13 @@ def main(argv=None) -> int:
                "  daimon brief                 render the latest briefing\n"
                "  daimon status                checkpoint presence + last serialize\n"
                "  daimon configure             detect/repair the LLM backend\n",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=fmt,
     )
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s {__version__}"
     )
     sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser = functools.partial(sub.add_parser, formatter_class=fmt)
 
     p_ser = sub.add_parser("serialize", help="serialize a transcript file into a checkpoint")
     p_ser.add_argument("transcript", help="path to a text/markdown transcript")
@@ -1384,7 +1402,6 @@ def main(argv=None) -> int:
     p_brief = sub.add_parser(
         "brief", help="render the briefing from the latest checkpoint",
         epilog="Examples:\n  daimon brief\n  daimon brief --project .\n  DAIMON_PLAIN=1 daimon brief\n",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p_brief.add_argument(
         "--project",
@@ -1402,7 +1419,6 @@ def main(argv=None) -> int:
         epilog="Examples:\n  daimon anchor daimon_briefing/cli.py _cmd_brief\n"
                "  daimon anchor pkg/mod.py MyClass.method --project .\n"
                "  daimon anchor pkg/mod.py fn --attach 'auth decision'\n",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p_anchor.add_argument("file", help="repo-relative path to the source file")
     p_anchor.add_argument("symbol", help="symbol name or Class.method")
@@ -1421,7 +1437,6 @@ def main(argv=None) -> int:
         epilog="Examples:\n"
                "  daimon recall auth caching\n"
                "  daimon recall gateway --all-projects --json\n",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p_recall.add_argument(
         "query", nargs="+",
@@ -1459,7 +1474,6 @@ def main(argv=None) -> int:
         epilog="Examples:\n"
                "  daimon status\n"
                "  daimon status --project . --json\n",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p_status.add_argument(
         "--project",
@@ -1486,9 +1500,9 @@ def main(argv=None) -> int:
                "  daimon team init git@github.com:org/team-memory.git\n"
                "  daimon team sync\n"
                "  daimon team status\n",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     team_sub = p_team.add_subparsers(dest="team_cmd", required=True)
+    team_sub.add_parser = functools.partial(team_sub.add_parser, formatter_class=fmt)
     pt_init = team_sub.add_parser(
         "init", help="clone the private team sidecar repo (empty remote OK)"
     )
@@ -1543,6 +1557,7 @@ def main(argv=None) -> int:
         help="ship host hook scripts from the package (#43): list, install",
     )
     hooks_sub = p_hooks.add_subparsers(dest="hooks_cmd", required=True)
+    hooks_sub.add_parser = functools.partial(hooks_sub.add_parser, formatter_class=fmt)
     ph_list = hooks_sub.add_parser("list", help="hosts with packaged hook scripts")
     ph_list.set_defaults(func=_cmd_hooks_list)
     ph_install = hooks_sub.add_parser(
@@ -1557,6 +1572,7 @@ def main(argv=None) -> int:
         "skill",
         help="install the daimon agent skill into a host's rules/skills file (#66)")
     skill_sub = p_skill.add_subparsers(dest="skill_cmd", required=True)
+    skill_sub.add_parser = functools.partial(skill_sub.add_parser, formatter_class=fmt)
     ps_list = skill_sub.add_parser("list", help="hosts with a skill renderer")
     ps_list.set_defaults(func=_cmd_skill_list)
     ps_show = skill_sub.add_parser(

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -492,6 +492,18 @@ def render_skill_lines(lines, *, footer=None) -> None:
     char-cap truncation notice) that gets yellow styling on the rich path.
     `footer`, if given, is trailing line(s) printed after a blank line — the
     upgrade-reminder `skill install` prints after its result lines."""
+    _render_lines(lines, footer=footer)
+
+
+def _render_lines(lines, *, footer=None) -> None:
+    """Shared "print a list of pre-formatted lines" primitive behind
+    render_skill_lines/render_recall_lines/render_hooks_*/render_team_*: the
+    plain path is a bare print loop (byte-identical to each command's
+    pre-#68 output); the rich path upgrades "warning:"-prefixed lines to
+    yellow. `markup=False` is load-bearing — recall lines contain literal
+    "[author]"/"[trust]"/"[kind]" brackets, which rich's Console would
+    otherwise parse as (invalid, silently-dropped) style tags, eating the
+    content. `footer`, if given, prints after a blank-line separator."""
     if not supports_rich():
         for ln in lines:
             print(ln)
@@ -504,11 +516,135 @@ def render_skill_lines(lines, *, footer=None) -> None:
 
     console = Console()
     for ln in lines:
-        if ln.startswith("warning:"):
-            console.print(ln, style="yellow")
-        else:
-            console.print(ln)
+        style = "yellow" if ln.startswith("warning:") else None
+        console.print(ln, style=style, markup=False)
     if footer:
         console.print("")
         for ln in footer:
-            console.print(ln)
+            console.print(ln, markup=False)
+
+
+# ---- recall: `daimon recall` (#68) ------------------------------------------
+
+
+def render_recall_lines(lines) -> None:
+    """`daimon recall` human-facing matches, or the single "no matches" line.
+    `--json` and `recall-inject` (machine-consumed) never route through here —
+    they stay plain unconditionally."""
+    _render_lines(lines)
+
+
+# ---- hooks: `daimon hooks list|install` (#68) -------------------------------
+
+
+def render_hooks_list(lines) -> None:
+    _render_lines(lines)
+
+
+def render_hooks_install(lines) -> None:
+    _render_lines(lines)
+
+
+# ---- team: `daimon team init|sync|status` (#68) -----------------------------
+
+
+def render_team_init(lines) -> None:
+    _render_lines(lines)
+
+
+def render_team_sync(lines) -> None:
+    _render_lines(lines)
+
+
+def render_team_status(lines) -> None:
+    _render_lines(lines)
+
+
+# ---- stats: `daimon stats` (#68) --------------------------------------------
+
+
+def render_stats(data: dict) -> None:
+    if supports_rich():
+        _rich_stats(data)
+    else:
+        _plain_stats(data)
+
+
+def _plain_stats(data: dict) -> None:
+    u, c, s = data["usage"], data["capture"], data["store"]
+    print("usage (local, never transmitted):")
+    if u:
+        for cmd_name, n in sorted(u.items(), key=lambda kv: -kv[1]):
+            print(f"  {cmd_name}: {n}")
+    else:
+        print("  none recorded yet")
+    print("capture:")
+    print(f"  serialized: {c['success']}  skipped: {c['skipped']}  "
+          f"errors: {c['errors']}  via fallback backend: {c['fallback_serializes']}")
+    if c["hosts"]:
+        print("  spawns by host: " + ", ".join(
+            f"{h}: {n}" for h, n in sorted(c["hosts"].items())))
+    if c["success"]:
+        print(f"  serialize seconds: max {c['max_serialize_seconds']}, "
+              f"avg {c['total_serialize_seconds'] // c['success']}")
+    print("store:")
+    print(f"  checkpoints: {s['checkpoints']}  project buckets: {s['project_buckets']}")
+    if s["items_by_kind"]:
+        print("  items by kind: " + ", ".join(
+            f"{k}: {n}" for k, n in sorted(s["items_by_kind"].items())))
+    print(f"  trust: verbatim {s['items_verbatim']}, inferred {s['items_inferred']}, "
+          f"untagged {s['items_untagged']}  (carried: {s['items_carried']})")
+
+
+def _rich_stats(data: dict) -> None:
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+    u, c, s = data["usage"], data["capture"], data["store"]
+
+    usage_table = Table(title="usage (local, never transmitted)", title_justify="left",
+                        show_header=True, header_style="bold")
+    usage_table.add_column("command")
+    usage_table.add_column("count", justify="right")
+    if u:
+        for cmd_name, n in sorted(u.items(), key=lambda kv: -kv[1]):
+            usage_table.add_row(cmd_name, str(n))
+    else:
+        usage_table.add_row("[dim]none recorded yet[/dim]", "")
+    console.print(usage_table)
+
+    capture_table = Table(title="capture", title_justify="left",
+                          show_header=True, header_style="bold")
+    capture_table.add_column("metric")
+    capture_table.add_column("value")
+    capture_table.add_row("serialized", str(c["success"]))
+    capture_table.add_row("skipped", str(c["skipped"]))
+    capture_table.add_row("errors", str(c["errors"]))
+    capture_table.add_row("via fallback backend", str(c["fallback_serializes"]))
+    if c["hosts"]:
+        capture_table.add_row("spawns by host", ", ".join(
+            f"{h}: {n}" for h, n in sorted(c["hosts"].items())))
+    if c["success"]:
+        capture_table.add_row(
+            "serialize seconds",
+            f"max {c['max_serialize_seconds']}, "
+            f"avg {c['total_serialize_seconds'] // c['success']}",
+        )
+    console.print(capture_table)
+
+    store_table = Table(title="store", title_justify="left",
+                        show_header=True, header_style="bold")
+    store_table.add_column("metric")
+    store_table.add_column("value")
+    store_table.add_row("checkpoints", str(s["checkpoints"]))
+    store_table.add_row("project buckets", str(s["project_buckets"]))
+    if s["items_by_kind"]:
+        store_table.add_row("items by kind", ", ".join(
+            f"{k}: {n}" for k, n in sorted(s["items_by_kind"].items())))
+    store_table.add_row(
+        "trust",
+        f"verbatim {s['items_verbatim']}, inferred {s['items_inferred']}, "
+        f"untagged {s['items_untagged']}  (carried: {s['items_carried']})",
+    )
+    console.print(store_table)

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -11,7 +11,10 @@ dependencies = []
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0"]
-pretty = ["rich>=13"]
+pretty = [
+    "rich>=13",
+    "rich-argparse>=1.8.0",
+]
 
 # pip-distributable hermes plugin: auto-discovered via the entry-point group.
 # VERIFIED — website/docs/guides/build-a-hermes-plugin.md (Entry-Point Group: "hermes_agent.plugins")

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import sys
 import time
 from pathlib import Path
 
@@ -1167,6 +1168,53 @@ def test_status_help_has_example(capsys):
     assert exc.value.code == 0
     out = capsys.readouterr().out
     assert "Examples:" in out
+
+
+# ---- #68: --help formatter — rich-argparse when present, stock when absent -
+
+
+def test_help_falls_back_to_stock_formatter_when_rich_argparse_absent(monkeypatch, capsys):
+    # Same seam test_render.py uses to force an ImportError (_force_rich_absent):
+    # a None entry in sys.modules makes `import rich_argparse` raise, so this
+    # exercises _formatter_class()'s except-ImportError branch even though the
+    # dev venv has rich-argparse installed for the rich-path tests below.
+    monkeypatch.setitem(sys.modules, "rich_argparse", None)
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "Examples:" in out
+    assert "daimon brief" in out
+
+
+def test_help_uses_rich_formatter_when_rich_argparse_present(capsys):
+    pytest.importorskip("rich_argparse")
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    # content-only smoke: rich-argparse's formatter still carries the epilog
+    # and subcommand descriptions through, just with different chrome.
+    assert "Examples:" in out
+    assert "daimon brief" in out
+
+
+def test_help_propagates_to_nested_subparsers(capsys):
+    # #68: argparse does NOT propagate formatter_class from parent to child —
+    # a nested subcommand (team sync, hooks install, skill install) must still
+    # get a working --help regardless of which formatter is selected.
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["team", "sync", "--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "--project" in out
+
+    capsys.readouterr()
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["hooks", "install", "--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "host" in out
 
 
 def test_cli_anchor_prints_resolved_block(tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1187,8 +1187,12 @@ def test_help_falls_back_to_stock_formatter_when_rich_argparse_absent(monkeypatc
     assert "daimon brief" in out
 
 
-def test_help_uses_rich_formatter_when_rich_argparse_present(capsys):
+def test_help_uses_rich_formatter_when_rich_argparse_present(capsys, monkeypatch):
     pytest.importorskip("rich_argparse")
+    # The autouse fixture sets DAIMON_PLAIN=1 for test determinism; that would
+    # now (correctly) force the stock formatter regardless of rich-argparse's
+    # presence, so unset it here to actually exercise the rich path.
+    monkeypatch.delenv("DAIMON_PLAIN", raising=False)
     with pytest.raises(SystemExit) as exc:
         cli.main(["--help"])
     assert exc.value.code == 0
@@ -1197,6 +1201,18 @@ def test_help_uses_rich_formatter_when_rich_argparse_present(capsys):
     # and subcommand descriptions through, just with different chrome.
     assert "Examples:" in out
     assert "daimon brief" in out
+
+
+def test_formatter_class_honors_daimon_plain_even_with_rich_argparse(monkeypatch):
+    # DAIMON_PLAIN must win over an importable rich_argparse — _formatter_class
+    # has to mirror render.supports_rich()'s ENV-VAR gate (DAIMON_PLAIN checked
+    # first, then NO_COLOR), not just the bare import guard. Regression for a
+    # review finding: --help used to ignore plain-mode opt-outs entirely.
+    pytest.importorskip("rich_argparse")
+    import argparse
+
+    monkeypatch.setenv("DAIMON_PLAIN", "1")
+    assert cli._formatter_class() is argparse.RawDescriptionHelpFormatter
 
 
 def test_help_propagates_to_nested_subparsers(capsys):

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -574,3 +574,203 @@ def test_render_skill_lines_rich_smoke(monkeypatch, capsys):
     assert "truncates this file" in out
     assert "installed daimon skill" in out
     assert "Re-run `daimon skill install cursor`" in out
+
+
+# ---- stats: `daimon stats` (#68 rich parity) --------------------------------
+
+
+def _stats_sample():
+    return {
+        "usage": {"brief": 2},
+        "capture": {
+            "success": 2, "skipped": 1, "errors": 1, "fallback_serializes": 1,
+            "hosts": {"session-end": 1, "windsurf-cascade": 1},
+            "max_serialize_seconds": 42, "total_serialize_seconds": 50,
+        },
+        "store": {
+            "checkpoints": 3, "project_buckets": 2,
+            "items_by_kind": {"decision": 2, "belief": 1},
+            "items_verbatim": 2, "items_inferred": 1, "items_untagged": 0,
+            "items_carried": 1,
+        },
+    }
+
+
+def _stats_empty():
+    return {
+        "usage": {},
+        "capture": {"success": 0, "skipped": 0, "errors": 0,
+                    "fallback_serializes": 0, "hosts": {},
+                    "max_serialize_seconds": 0, "total_serialize_seconds": 0},
+        "store": {"checkpoints": 0, "project_buckets": 0, "items_by_kind": {},
+                  "items_verbatim": 0, "items_inferred": 0, "items_untagged": 0,
+                  "items_carried": 0},
+    }
+
+
+def test_render_stats_plain_exact_format(capsys):
+    render.render_stats(_stats_sample())
+    out = capsys.readouterr().out
+    assert out == (
+        "usage (local, never transmitted):\n"
+        "  brief: 2\n"
+        "capture:\n"
+        "  serialized: 2  skipped: 1  errors: 1  via fallback backend: 1\n"
+        "  spawns by host: session-end: 1, windsurf-cascade: 1\n"
+        "  serialize seconds: max 42, avg 25\n"
+        "store:\n"
+        "  checkpoints: 3  project buckets: 2\n"
+        "  items by kind: belief: 1, decision: 2\n"
+        "  trust: verbatim 2, inferred 1, untagged 0  (carried: 1)\n"
+    )
+
+
+def test_render_stats_plain_empty_world(capsys):
+    render.render_stats(_stats_empty())
+    out = capsys.readouterr().out
+    assert out == (
+        "usage (local, never transmitted):\n"
+        "  none recorded yet\n"
+        "capture:\n"
+        "  serialized: 0  skipped: 0  errors: 0  via fallback backend: 0\n"
+        "store:\n"
+        "  checkpoints: 0  project buckets: 0\n"
+        "  trust: verbatim 0, inferred 0, untagged 0  (carried: 0)\n"
+    )
+
+
+def test_render_stats_rich_smoke(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_stats(_stats_sample())
+    out = capsys.readouterr().out
+    assert "usage" in out.lower()
+    assert "brief" in out
+    assert "verbatim" in out
+
+
+# ---- recall: `daimon recall` (#68 rich parity) ------------------------------
+
+
+def test_render_recall_lines_plain_no_matches(capsys):
+    render.render_recall_lines(["no matches"])
+    assert capsys.readouterr().out == "no matches\n"
+
+
+def test_render_recall_lines_plain_exact_format(capsys):
+    render.render_recall_lines(
+        ["[alice] [verbatim] [decision] did the thing (S1, 2h ago)"]
+    )
+    out = capsys.readouterr().out
+    assert out == "[alice] [verbatim] [decision] did the thing (S1, 2h ago)\n"
+
+
+def test_render_recall_lines_rich_smoke_preserves_brackets(monkeypatch, capsys):
+    # Bracketed content ([author], [trust], [kind]) must survive rich markup
+    # parsing untouched — rich would otherwise silently eat "[alice]" as an
+    # (invalid) style tag. Regression guard for that data-loss failure mode.
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_recall_lines(
+        ["[alice] [verbatim] [decision] did the thing (S1, 2h ago)"]
+    )
+    out = capsys.readouterr().out
+    assert "[alice]" in out
+    assert "[verbatim]" in out
+    assert "[decision]" in out
+
+
+# ---- hooks: `daimon hooks list|install` (#68 rich parity) -------------------
+
+
+def test_render_hooks_list_plain_exact_format(capsys):
+    render.render_hooks_list(
+        ["windsurf  (daimon-windsurf-hooks.py; events: pre_user_prompt, post_cascade_response)"]
+    )
+    out = capsys.readouterr().out
+    assert out == "windsurf  (daimon-windsurf-hooks.py; events: pre_user_prompt, post_cascade_response)\n"
+
+
+def test_render_hooks_list_rich_smoke(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_hooks_list(["windsurf  (entry.py; events: a, b)"])
+    out = capsys.readouterr().out
+    assert "windsurf" in out
+
+
+def test_render_hooks_install_plain_exact_format(capsys):
+    render.render_hooks_install([
+        "installed 2 file(s) to /h/.daimon/hooks",
+        "",
+        "Register this command for the events below "
+        "(host hooks config — see the host's hooks documentation):",
+        "  command: python3 /h/.daimon/hooks/daimon-windsurf-hooks.py",
+        "  event:   pre_user_prompt",
+        "  event:   post_cascade_response",
+        "",
+        "Re-run `daimon hooks install windsurf` after every "
+        "`uv tool upgrade daimon-briefing`.",
+    ])
+    out = capsys.readouterr().out
+    assert out == (
+        "installed 2 file(s) to /h/.daimon/hooks\n"
+        "\n"
+        "Register this command for the events below "
+        "(host hooks config — see the host's hooks documentation):\n"
+        "  command: python3 /h/.daimon/hooks/daimon-windsurf-hooks.py\n"
+        "  event:   pre_user_prompt\n"
+        "  event:   post_cascade_response\n"
+        "\n"
+        "Re-run `daimon hooks install windsurf` after every "
+        "`uv tool upgrade daimon-briefing`.\n"
+    )
+
+
+def test_render_hooks_install_rich_smoke(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_hooks_install(["installed 1 file(s) to /h/.daimon/hooks"])
+    out = capsys.readouterr().out
+    assert "installed" in out
+
+
+# ---- team: `daimon team init|sync|status` (#68 rich parity) ----------------
+
+
+def test_render_team_init_plain_exact_format(capsys):
+    render.render_team_init([
+        "initialized team sidecar: /h/.daimon/team/x",
+        "checkpoints now sync there — `daimon team sync` runs opportunistically "
+        "at session start",
+    ])
+    out = capsys.readouterr().out
+    assert out == (
+        "initialized team sidecar: /h/.daimon/team/x\n"
+        "checkpoints now sync there — `daimon team sync` runs opportunistically "
+        "at session start\n"
+    )
+
+
+def test_render_team_init_rich_smoke(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_team_init(["initialized team sidecar: /x"])
+    assert "initialized" in capsys.readouterr().out
+
+
+def test_render_team_sync_plain_exact_format(capsys):
+    render.render_team_sync(["x: 1 committed, pushed"])
+    assert capsys.readouterr().out == "x: 1 committed, pushed\n"
+
+
+def test_render_team_sync_rich_smoke(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_team_sync(["x: 1 committed, pushed"])
+    assert "committed" in capsys.readouterr().out
+
+
+def test_render_team_status_plain_exact_format(capsys):
+    render.render_team_status(["x: fresh — 0 unpushed checkpoint(s), authors: Ada"])
+    assert capsys.readouterr().out == "x: fresh — 0 unpushed checkpoint(s), authors: Ada\n"
+
+
+def test_render_team_status_rich_smoke(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_team_status(["x: fresh — 0 unpushed checkpoint(s), authors: Ada"])
+    assert "fresh" in capsys.readouterr().out

--- a/plugin/uv.lock
+++ b/plugin/uv.lock
@@ -22,12 +22,14 @@ dev = [
 ]
 pretty = [
     { name = "rich" },
+    { name = "rich-argparse" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "rich", marker = "extra == 'pretty'", specifier = ">=13" },
+    { name = "rich-argparse", marker = "extra == 'pretty'", specifier = ">=1.8.0" },
 ]
 provides-extras = ["dev", "pretty"]
 
@@ -129,6 +131,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rich-argparse"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/e5/1064c43203a357d668cd42435f7a15fe6af51512d85b2104fecb937aa861/rich_argparse-1.8.0.tar.gz", hash = "sha256:679df3d832fa94ad6e4bdb07ded088cd7ea2dddc58ae9b2b46346a40b06cbc0c", size = 38940, upload-time = "2026-05-01T15:18:43.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/35/1cceccc5fcb50fa2ed53e2aa278cd032f3902682a73e763fb1ac3be8e6fa/rich_argparse-1.8.0-py3-none-any.whl", hash = "sha256:d2a3ce7854654e2253c578763ab0a32f05016f23a55fadba7b9a91b6c0e92142", size = 25616, upload-time = "2026-05-01T15:18:42.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #68

## What

Routes the remaining plain-print commands through `render.py`'s `supports_rich()` dual path: `stats` (three titled tables, matching `status`'s table style), `recall`, `hooks list/install`, and `team init/sync/status`. `--help` across all 22 subcommands renders via `rich-argparse` when the `[pretty]` extra is installed — stock argparse otherwise, byte-identical.

## Behavior guarantees

- Plain fallback output is byte-identical to before (hand-verified against the removed code; all pre-existing exact-string tests pass unchanged)
- `--json`, `recall --inject`, and stderr error paths stay plain — machine-consumed surfaces never grow markup
- `DAIMON_PLAIN` / `NO_COLOR` force the stock help formatter too, mirroring `supports_rich()`'s env gating exactly (incl. truthiness semantics)
- `team sync` keeps per-report stdout/stderr interleaving
- `rich-argparse` lives only in the `[pretty]` extra — zero new hard dependencies; `uv.lock` updated accordingly

## Tests

TDD per helper (16 RED→GREEN), focused env-gating regression test for the help formatter (including un-neutering the autouse `DAIMON_PLAIN=1` conftest fixture for the rich-path test), `--help` diffed across all subcommands with rich-argparse absent vs present. Suite: 856 passed under both CI extras configurations.