### PR TITLE
feat(hosts): serialize Windsurf sessions from the native Cascade transcript

### DIFF
--- a/hook/daimon-windsurf-hooks.py
+++ b/hook/daimon-windsurf-hooks.py
@@ -1,33 +1,52 @@
 #!/usr/bin/env python3
-"""Windsurf Cascade adapter: accumulate a transcript per trajectory, serialize
-on a throttle (#35).
+"""Windsurf Cascade adapter: serialize from the native transcript when
+Cascade provides one, accumulate a daimon-side transcript otherwise (#35, #70).
 
-Register this ONE script for BOTH Cascade hook events (docs:
+Register this ONE script for THREE Cascade hook events (docs:
 https://docs.windsurf.com/windsurf/cascade/hooks):
 
-    pre_user_prompt          -> records the user side of the turn
-    post_cascade_response    -> records the assistant side + (throttled)
-                                spawns `daimon serialize`
+    pre_user_prompt                        -> records the user side of the
+                                               turn (legacy accumulation path)
+    post_cascade_response                   -> records the assistant side +
+                                               (throttled) spawns
+                                               `daimon serialize` on the
+                                               ACCUMULATED transcript
+    post_cascade_response_with_transcript   -> (throttled) spawns
+                                               `daimon serialize` directly on
+                                               Cascade's NATIVE transcript —
+                                               preferred when available; no
+                                               accumulation write for this
+                                               event
 
-Why accumulation: the real `post_cascade_response` payload carries NO
-transcript path, `~/.windsurf/transcripts/` does not exist, and state.vscdb
-holds UI state only (probe rounds 1-2, live machine). Windsurf keeps its
-conversations out of reach, so daimon keeps its own: each hook call appends a
-`**role**:`-marked turn to ~/.daimon/windsurf/transcripts/<trajectory_id>.md —
-the exact markdown shape `daimon serialize` already parses.
+Native transcript preferred: issue #70 field evidence showed Windsurf DOES
+write a native `.jsonl` transcript (~/.windsurf/transcripts/<trajectory_id>.jsonl)
+when `post_cascade_response_with_transcript` is registered, carrying both
+conversation sides. When that path is registered and its file exists, it is
+the source of truth and accumulation becomes redundant for that trajectory.
+
+Why accumulation still exists (legacy path, #35): the plain
+`post_cascade_response` payload carries NO transcript path, and hosts that
+only register the two legacy events never get one. Windsurf otherwise keeps
+its conversations out of reach, so daimon keeps its own: each hook call
+appends a `**role**:`-marked turn to
+~/.daimon/windsurf/transcripts/<trajectory_id>.md — the exact markdown shape
+`daimon serialize` already parses.
 
 Self-probing (#62): any payload this adapter cannot handle — unextractable
-`pre_user_prompt` text, a missing trajectory_id, or an event it does not
-know (the docs list 12; `post_cascade_response_with_transcript` is the one
-worth catching) — is dumped to ~/.daimon/windsurf/unparsed-<event>-<stamp>.json
-so the next adapter iteration can be built from evidence instead of another
-probe round. At most ONE dump per event name: a script registered for all
-12 Cascade events must not flood the state dir.
+`pre_user_prompt` text, a missing trajectory_id, a
+`post_cascade_response_with_transcript` whose transcript_path is missing or
+does not exist, or an event it does not know — is dumped to
+~/.daimon/windsurf/unparsed-<event>-<stamp>.json so the next adapter
+iteration can be built from evidence instead of another probe round. At most
+ONE dump per event name: a script registered for all 12 Cascade events must
+not flood the state dir.
 
-Throttle: `post_cascade_response` fires EVERY turn; serializing each one is
-an LLM call per turn. DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL seconds
-(default 300, 0 = every turn) gate the spawn per trajectory — the codex-stop
-pattern. Accumulation itself is never throttled.
+Throttle: `post_cascade_response` and `post_cascade_response_with_transcript`
+both fire EVERY turn; serializing each one is an LLM call per turn.
+DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL seconds (default 300, 0 = every turn)
+gate the spawn per trajectory — the codex-stop pattern. Both events share the
+SAME per-trajectory marker, so registering both never double-spawns.
+Accumulation itself is never throttled.
 
 Fail-open everywhere: always exit 0; a broken daimon must never break
 Cascade. Kill switch: DAIMON_DISABLE=1.
@@ -192,9 +211,22 @@ def main() -> int:
         _append_turn(trajectory_id, "user", text)
         return 0
 
+    if event == "post_cascade_response_with_transcript":
+        tool_info = payload.get("tool_info")
+        raw_path = tool_info.get("transcript_path") if isinstance(tool_info, dict) else None
+        native_path = Path(raw_path) if isinstance(raw_path, str) and raw_path.strip() else None
+        if native_path is None or not native_path.exists():
+            if _dump_probe(event, payload):
+                lib.log("windsurf-cascade: post_cascade_response_with_transcript "
+                        "transcript_path missing or absent — dumped for the next "
+                        "adapter iteration")
+            return 0
+        _spawn_serialize_for(trajectory_id, native_path,
+                             f"native transcript: {native_path}")
+        return 0
+
     if event != "post_cascade_response":
-        # Unknown events dump instead of vanishing (#62) —
-        # post_cascade_response_with_transcript lands here until adopted.
+        # Unknown events dump instead of vanishing (#62).
         if _dump_probe(event, payload):
             lib.log(f"windsurf-cascade: unhandled event {event} — payload dumped "
                     "for the next adapter iteration")
@@ -207,22 +239,30 @@ def main() -> int:
         return 0
     transcript_path = _append_turn(trajectory_id, "assistant", response)
 
+    _spawn_serialize_for(trajectory_id, transcript_path,
+                         f"transcript: {transcript_path}")
+    return 0
+
+
+def _spawn_serialize_for(trajectory_id: str, transcript_path, detail: str) -> None:
+    """Throttled spawn of `daimon serialize` shared by BOTH post events — same
+    per-trajectory marker, so registering post_cascade_response AND
+    post_cascade_response_with_transcript together never double-spawns (#70)."""
     if not _should_spawn(trajectory_id):
         lib.log(f"windsurf-cascade: skipped serialize for {trajectory_id} (throttled)")
-        return 0
+        return
     cli = lib.resolve_cli()
     if cli is None:
         lib.log("windsurf-cascade: `daimon` CLI not found — checkpoint skipped")
-        return 0
+        return
     cwd = _project_cwd()
     try:
         lib.spawn_serialize(cli, str(transcript_path), lib.project_env(cwd))
         _mark_spawned(trajectory_id)
         lib.log(f"windsurf-cascade: spawned serialize for {trajectory_id} "
-                f"(project: {cwd or '?'}) (transcript: {transcript_path})")
+                f"(project: {cwd or '?'}) ({detail})")
     except OSError as exc:
         lib.log(f"windsurf-cascade: spawn failed ({type(exc).__name__}: {exc})")
-    return 0
 
 
 if __name__ == "__main__":

--- a/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
+++ b/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
@@ -1,33 +1,52 @@
 #!/usr/bin/env python3
-"""Windsurf Cascade adapter: accumulate a transcript per trajectory, serialize
-on a throttle (#35).
+"""Windsurf Cascade adapter: serialize from the native transcript when
+Cascade provides one, accumulate a daimon-side transcript otherwise (#35, #70).
 
-Register this ONE script for BOTH Cascade hook events (docs:
+Register this ONE script for THREE Cascade hook events (docs:
 https://docs.windsurf.com/windsurf/cascade/hooks):
 
-    pre_user_prompt          -> records the user side of the turn
-    post_cascade_response    -> records the assistant side + (throttled)
-                                spawns `daimon serialize`
+    pre_user_prompt                        -> records the user side of the
+                                               turn (legacy accumulation path)
+    post_cascade_response                   -> records the assistant side +
+                                               (throttled) spawns
+                                               `daimon serialize` on the
+                                               ACCUMULATED transcript
+    post_cascade_response_with_transcript   -> (throttled) spawns
+                                               `daimon serialize` directly on
+                                               Cascade's NATIVE transcript —
+                                               preferred when available; no
+                                               accumulation write for this
+                                               event
 
-Why accumulation: the real `post_cascade_response` payload carries NO
-transcript path, `~/.windsurf/transcripts/` does not exist, and state.vscdb
-holds UI state only (probe rounds 1-2, live machine). Windsurf keeps its
-conversations out of reach, so daimon keeps its own: each hook call appends a
-`**role**:`-marked turn to ~/.daimon/windsurf/transcripts/<trajectory_id>.md —
-the exact markdown shape `daimon serialize` already parses.
+Native transcript preferred: issue #70 field evidence showed Windsurf DOES
+write a native `.jsonl` transcript (~/.windsurf/transcripts/<trajectory_id>.jsonl)
+when `post_cascade_response_with_transcript` is registered, carrying both
+conversation sides. When that path is registered and its file exists, it is
+the source of truth and accumulation becomes redundant for that trajectory.
+
+Why accumulation still exists (legacy path, #35): the plain
+`post_cascade_response` payload carries NO transcript path, and hosts that
+only register the two legacy events never get one. Windsurf otherwise keeps
+its conversations out of reach, so daimon keeps its own: each hook call
+appends a `**role**:`-marked turn to
+~/.daimon/windsurf/transcripts/<trajectory_id>.md — the exact markdown shape
+`daimon serialize` already parses.
 
 Self-probing (#62): any payload this adapter cannot handle — unextractable
-`pre_user_prompt` text, a missing trajectory_id, or an event it does not
-know (the docs list 12; `post_cascade_response_with_transcript` is the one
-worth catching) — is dumped to ~/.daimon/windsurf/unparsed-<event>-<stamp>.json
-so the next adapter iteration can be built from evidence instead of another
-probe round. At most ONE dump per event name: a script registered for all
-12 Cascade events must not flood the state dir.
+`pre_user_prompt` text, a missing trajectory_id, a
+`post_cascade_response_with_transcript` whose transcript_path is missing or
+does not exist, or an event it does not know — is dumped to
+~/.daimon/windsurf/unparsed-<event>-<stamp>.json so the next adapter
+iteration can be built from evidence instead of another probe round. At most
+ONE dump per event name: a script registered for all 12 Cascade events must
+not flood the state dir.
 
-Throttle: `post_cascade_response` fires EVERY turn; serializing each one is
-an LLM call per turn. DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL seconds
-(default 300, 0 = every turn) gate the spawn per trajectory — the codex-stop
-pattern. Accumulation itself is never throttled.
+Throttle: `post_cascade_response` and `post_cascade_response_with_transcript`
+both fire EVERY turn; serializing each one is an LLM call per turn.
+DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL seconds (default 300, 0 = every turn)
+gate the spawn per trajectory — the codex-stop pattern. Both events share the
+SAME per-trajectory marker, so registering both never double-spawns.
+Accumulation itself is never throttled.
 
 Fail-open everywhere: always exit 0; a broken daimon must never break
 Cascade. Kill switch: DAIMON_DISABLE=1.
@@ -192,9 +211,22 @@ def main() -> int:
         _append_turn(trajectory_id, "user", text)
         return 0
 
+    if event == "post_cascade_response_with_transcript":
+        tool_info = payload.get("tool_info")
+        raw_path = tool_info.get("transcript_path") if isinstance(tool_info, dict) else None
+        native_path = Path(raw_path) if isinstance(raw_path, str) and raw_path.strip() else None
+        if native_path is None or not native_path.exists():
+            if _dump_probe(event, payload):
+                lib.log("windsurf-cascade: post_cascade_response_with_transcript "
+                        "transcript_path missing or absent — dumped for the next "
+                        "adapter iteration")
+            return 0
+        _spawn_serialize_for(trajectory_id, native_path,
+                             f"native transcript: {native_path}")
+        return 0
+
     if event != "post_cascade_response":
-        # Unknown events dump instead of vanishing (#62) —
-        # post_cascade_response_with_transcript lands here until adopted.
+        # Unknown events dump instead of vanishing (#62).
         if _dump_probe(event, payload):
             lib.log(f"windsurf-cascade: unhandled event {event} — payload dumped "
                     "for the next adapter iteration")
@@ -207,22 +239,30 @@ def main() -> int:
         return 0
     transcript_path = _append_turn(trajectory_id, "assistant", response)
 
+    _spawn_serialize_for(trajectory_id, transcript_path,
+                         f"transcript: {transcript_path}")
+    return 0
+
+
+def _spawn_serialize_for(trajectory_id: str, transcript_path, detail: str) -> None:
+    """Throttled spawn of `daimon serialize` shared by BOTH post events — same
+    per-trajectory marker, so registering post_cascade_response AND
+    post_cascade_response_with_transcript together never double-spawns (#70)."""
     if not _should_spawn(trajectory_id):
         lib.log(f"windsurf-cascade: skipped serialize for {trajectory_id} (throttled)")
-        return 0
+        return
     cli = lib.resolve_cli()
     if cli is None:
         lib.log("windsurf-cascade: `daimon` CLI not found — checkpoint skipped")
-        return 0
+        return
     cwd = _project_cwd()
     try:
         lib.spawn_serialize(cli, str(transcript_path), lib.project_env(cwd))
         _mark_spawned(trajectory_id)
         lib.log(f"windsurf-cascade: spawned serialize for {trajectory_id} "
-                f"(project: {cwd or '?'}) (transcript: {transcript_path})")
+                f"(project: {cwd or '?'}) ({detail})")
     except OSError as exc:
         lib.log(f"windsurf-cascade: spawn failed ({type(exc).__name__}: {exc})")
-    return 0
 
 
 if __name__ == "__main__":

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1250,7 +1250,8 @@ _HOOK_HOSTS = {
     "windsurf": {
         "files": ("daimon-windsurf-hooks.py", "_daimon_hook_lib.py"),
         "entry": "daimon-windsurf-hooks.py",
-        "events": ("pre_user_prompt", "post_cascade_response"),
+        "events": ("pre_user_prompt", "post_cascade_response",
+                   "post_cascade_response_with_transcript"),
     },
 }
 

--- a/plugin/daimon_briefing/transcript.py
+++ b/plugin/daimon_briefing/transcript.py
@@ -3,7 +3,8 @@
 1. from_session(session_id) — reads hermes session history via SessionDB. The hermes
    import is guarded (hermes only available in-hermes); unavailable -> [] not raise.
 2. from_file(path) — CLI/dogfood fallback. `.jsonl` parses as an agent session
-   transcript; anything else as plain text/markdown.
+   transcript; anything else as plain text/markdown. Includes a dedicated
+   branch for Windsurf Cascade's native transcript (#70).
 
 All messages normalize to OpenAI-format dicts: {"role": str, "content": str}.
 """
@@ -101,6 +102,34 @@ def _from_jsonl(text: str) -> list[dict]:
             codex_messages.append({"role": role, "content": content.strip()})
     if codex_messages:
         return codex_messages
+
+    # Windsurf Cascade's native transcript (#70): rows are exactly
+    # {type, status, <payload-key>} and the payload key does NOT always equal
+    # the type (grep_search_v2 keeps payload key grep_search) — so text
+    # carriers are matched by type, never derived from it. The exact-3-key
+    # shape (not just the type name) is what distinguishes a genuine Cascade
+    # row from other hosts' JSONL that happens to reuse a `user_input` key.
+    # canceled lines are dropped; done AND error both serialize (a
+    # failed-but-emitted response is still context).
+    windsurf_messages: list[dict] = []
+    for obj in objects:
+        obj_type = obj.get("type")
+        if obj_type not in ("user_input", "planner_response"):
+            continue
+        if len(obj) != 3 or "status" not in obj:
+            continue
+        if obj.get("status") == "canceled":
+            continue
+        role = "user" if obj_type == "user_input" else "assistant"
+        payload = obj.get(obj_type)
+        if not isinstance(payload, dict):
+            continue
+        text_key = "user_response" if obj_type == "user_input" else "response"
+        text = payload.get(text_key)
+        if isinstance(text, str) and text.strip():
+            windsurf_messages.append({"role": role, "content": text.strip()})
+    if windsurf_messages:
+        return windsurf_messages
 
     messages: list[dict] = []
     for obj in objects:

--- a/plugin/daimon_briefing/transcript.py
+++ b/plugin/daimon_briefing/transcript.py
@@ -103,12 +103,14 @@ def _from_jsonl(text: str) -> list[dict]:
     if codex_messages:
         return codex_messages
 
-    # Windsurf Cascade's native transcript (#70): rows are exactly
+    # Windsurf Cascade's native transcript (#70): rows carry
     # {type, status, <payload-key>} and the payload key does NOT always equal
     # the type (grep_search_v2 keeps payload key grep_search) — so text
-    # carriers are matched by type, never derived from it. The exact-3-key
-    # shape (not just the type name) is what distinguishes a genuine Cascade
-    # row from other hosts' JSONL that happens to reuse a `user_input` key.
+    # carriers are matched by type, never derived from it. The `status` key
+    # (deliberately NOT a key count: a schema-widened row must still parse,
+    # or the whole branch silently disables and the role-less fallback drops
+    # every planner_response) is what distinguishes a genuine Cascade row
+    # from other hosts' JSONL that happens to reuse a `user_input` key.
     # canceled lines are dropped; done AND error both serialize (a
     # failed-but-emitted response is still context).
     windsurf_messages: list[dict] = []
@@ -116,7 +118,7 @@ def _from_jsonl(text: str) -> list[dict]:
         obj_type = obj.get("type")
         if obj_type not in ("user_input", "planner_response"):
             continue
-        if len(obj) != 3 or "status" not in obj:
+        if "status" not in obj:
             continue
         if obj.get("status") == "canceled":
             continue

--- a/plugin/tests/test_transcript.py
+++ b/plugin/tests/test_transcript.py
@@ -145,6 +145,38 @@ def test_from_file_parses_current_codex_event_stream_without_duplicates(tmp_path
     ]
 
 
+def test_from_file_windsurf_cascade_jsonl_parses_user_and_assistant(tmp_path):
+    # Field-confirmed (#70): native Cascade transcript rows are exactly
+    # {type, status, <payload-key>}. canceled is dropped, error is kept
+    # (a failed-but-emitted response is still context), tool lines skipped.
+    p = _write_jsonl(tmp_path / "cascade.jsonl", [
+        {"type": "user_input", "status": "done",
+         "user_input": {"user_response": "arreglá el bug de auth"}},
+        {"type": "run_command", "status": "done",
+         "run_command": {"command": "pytest"}},
+        {"type": "planner_response", "status": "canceled",
+         "planner_response": {"response": "should not appear"}},
+        {"type": "planner_response", "status": "done",
+         "planner_response": {"response": "Ya lo arreglé."}},
+        {"type": "user_input", "status": "error",
+         "user_input": {"user_response": "seguí, dale"}},
+    ])
+    msgs = transcript.from_file(p)
+    assert msgs == [
+        {"role": "user", "content": "arreglá el bug de auth"},
+        {"role": "assistant", "content": "Ya lo arreglé."},
+        {"role": "user", "content": "seguí, dale"},
+    ]
+
+
+def test_from_file_windsurf_cascade_noise_only_returns_empty(tmp_path):
+    p = _write_jsonl(tmp_path / "cascade.jsonl", [
+        {"type": "grep_search_v2", "status": "done", "grep_search": {"query": "foo"}},
+        {"type": "list_directory", "status": "done", "list_directory": {"path": "/x"}},
+    ])
+    assert transcript.from_file(p) == []
+
+
 def test_from_session_returns_empty_when_hermes_unavailable(monkeypatch):
     # Force the hermes import seam to fail; must degrade to [] not raise.
     monkeypatch.setattr(transcript, "_load_session_db", lambda: None)

--- a/plugin/tests/test_transcript.py
+++ b/plugin/tests/test_transcript.py
@@ -160,12 +160,36 @@ def test_from_file_windsurf_cascade_jsonl_parses_user_and_assistant(tmp_path):
          "planner_response": {"response": "Ya lo arreglé."}},
         {"type": "user_input", "status": "error",
          "user_input": {"user_response": "seguí, dale"}},
+        {"type": "planner_response", "status": "error",
+         "planner_response": {"response": "falló a mitad, pero esto salió"}},
     ])
     msgs = transcript.from_file(p)
     assert msgs == [
         {"role": "user", "content": "arreglá el bug de auth"},
         {"role": "assistant", "content": "Ya lo arreglé."},
         {"role": "user", "content": "seguí, dale"},
+        {"role": "assistant", "content": "falló a mitad, pero esto salió"},
+    ]
+
+
+def test_from_file_windsurf_cascade_tolerates_schema_widened_rows(tmp_path):
+    # Forward-compat: a Cascade row that grows a 4th key (e.g. timestamp)
+    # must still parse as a turn — a strict key-count gate would silently
+    # disable the whole branch and the best-effort fallback would drop every
+    # planner_response (no role mapping) → user-only transcripts. The
+    # `status` key is the discriminator, not the key count.
+    p = _write_jsonl(tmp_path / "cascade.jsonl", [
+        {"type": "user_input", "status": "done",
+         "timestamp": "2026-07-04T10:00:00Z",
+         "user_input": {"user_response": "hola"}},
+        {"type": "planner_response", "status": "done",
+         "timestamp": "2026-07-04T10:00:05Z",
+         "planner_response": {"response": "hola, ¿qué hacemos?"}},
+    ])
+    msgs = transcript.from_file(p)
+    assert msgs == [
+        {"role": "user", "content": "hola"},
+        {"role": "assistant", "content": "hola, ¿qué hacemos?"},
     ]
 
 

--- a/plugin/tests/test_windsurf_hooks.py
+++ b/plugin/tests/test_windsurf_hooks.py
@@ -191,6 +191,66 @@ def test_unparsed_pre_prompt_dump_bounded_once(tmp_path):
     assert len(dumps) == 1
 
 
+def _with_transcript_payload(transcript_path):
+    return {
+        "agent_action_name": "post_cascade_response_with_transcript",
+        "trajectory_id": TRAJ,
+        "timestamp": "2026-07-03T16:45:48.476887-06:00",
+        "execution_id": "exec-1",
+        "model_name": "Claude Sonnet 4.5",
+        "tool_info": {"transcript_path": str(transcript_path)},
+    }
+
+
+def test_with_transcript_existing_path_spawns_native_serialize(tmp_path):
+    # #70: the native Cascade transcript, when present, is what gets
+    # serialized — NOT the daimon-side accumulation file, and no probe dump.
+    native = tmp_path / "native-transcript.jsonl"
+    native.write_text('{"type": "user_input", "status": "done", '
+                      '"user_input": {"user_response": "hola"}}\n',
+                      encoding="utf-8")
+    payload = _with_transcript_payload(native)
+    proc, capture = _run(payload, tmp_path,
+                         extra_env={"DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL": "0"})
+    assert proc.returncode == 0
+    calls = _wait_for_capture(capture)
+    assert str(native) in calls
+    assert not _transcript(tmp_path).exists()
+    dumps = list((tmp_path / ".daimon" / "windsurf").glob("unparsed-*.json"))
+    assert dumps == []
+
+
+def test_with_transcript_missing_path_dumps_probe_no_spawn(tmp_path):
+    missing = tmp_path / "does-not-exist.jsonl"
+    payload = _with_transcript_payload(missing)
+    proc, capture = _run(payload, tmp_path,
+                         extra_env={"DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL": "0"})
+    assert proc.returncode == 0
+    time.sleep(0.3)
+    assert not capture.exists() or "serialize" not in capture.read_text()
+    dumps = list((tmp_path / ".daimon" / "windsurf").glob("unparsed-*.json"))
+    assert dumps and str(missing) in dumps[0].read_text(encoding="utf-8")
+
+
+def test_with_transcript_shares_throttle_marker_with_accumulation(tmp_path):
+    # Both post events share the SAME per-trajectory marker — registering
+    # both must never double-spawn inside one throttle interval.
+    extra = {"DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL": "3600"}
+    proc, capture = _run(_post_payload("first"), tmp_path, extra_env=extra)
+    assert proc.returncode == 0
+    _wait_for_capture(capture)
+
+    native = tmp_path / "native-transcript.jsonl"
+    native.write_text('{"type": "planner_response", "status": "done", '
+                      '"planner_response": {"response": "listo"}}\n',
+                      encoding="utf-8")
+    payload = _with_transcript_payload(native)
+    proc, capture2 = _run(payload, tmp_path, extra_env=extra)
+    assert proc.returncode == 0
+    time.sleep(0.5)
+    assert capture2.read_text().count("serialize") == 1  # unchanged: no new spawn
+
+
 def test_pre_user_prompt_docs_shape_appends_user_turn(tmp_path):
     # Documented shape (docs.devin.ai/desktop/cascade/hooks): text lives in
     # tool_info.user_prompt. Regression guard — passes on the current


### PR DESCRIPTION
Closes #70

## What

The adapter now handles `post_cascade_response_with_transcript`: when Windsurf hands over its native transcript path (`~/.windsurf/transcripts/{trajectory_id}.jsonl`), daimon serializes from that file directly — both sides of the conversation included — instead of relying on its own accumulated markdown. Accumulation stays as the legacy path for installs registered only for the older events; the per-trajectory throttle marker is shared, so registering both events never double-spawns. `daimon hooks install windsurf` now lists the third event.

`transcript.py` gains a dedicated Cascade branch (same precedence pattern as the Codex block): `user_input.user_response` → user turn, `planner_response.response` → assistant turn, `canceled` rows skipped (`done` and `error` both serialize — a failed response is still context), tool-event rows ignored. Detection keys on the `status` field rather than exact row shape, so a future Windsurf field addition degrades to a no-op instead of silently dropping assistant turns.

## Why

Live field evidence (#70): the native transcript materializes once the hook is registered, and it carries the user turns the accumulation design could never reliably capture (`pre_user_prompt` remains unconfirmed in the field). This deletes the user-side capture problem instead of solving it.

## Evidence chain

Schema confirmed from three structure-only field samples (payload shape, row shape `{type, status, <payload-key>}`, text-carrier keys, status domain) — documented in #70. The probe dumps that produced this evidence shipped in #63.

## Tests

TDD: transcript fixtures for turn extraction/status filtering/schema-widened rows (the widened-row test failed RED against an earlier strict shape guard, proving the data-loss mode it prevents), adapter subprocess tests for native-path spawn, missing-file probe dump, and shared-throttle single-spawn. Suite: 862 passed.