### PR TITLE
chore(scars): repair evidence after the fresh-history cut

### DIFF
--- a/.scars/0001-llm-judge-grounding-reference.deadend.md
+++ b/.scars/0001-llm-judge-grounding-reference.deadend.md
@@ -11,7 +11,7 @@ anchors:
   - pattern: "GROUNDING_JUDGE_SYS"
   - path: research/experiments/track-a/scoring/score.py
 evidence:
-  - commit: e665a43
+  - note: "lab commit e665a43 (pre-public-history archive)"
 expires:
   condition: "FMR scoring no longer uses LLM-as-judge"
   review_after: 2027-06-09

--- a/.scars/0002-probe-concurrent-runs.landmine.md
+++ b/.scars/0002-probe-concurrent-runs.landmine.md
@@ -10,7 +10,7 @@ anchors:
   - path: research/experiments/track-a/probe_d007.py
   - pattern: "score.json"
 evidence:
-  - "2026-06-09: background run + user foreground run started ~3min apart; idempotency check (score.json exists?) raced, both re-serialized arms B/C, ~116k duplicate kimi tokens, interleaved artifacts in runs/S2/probe-d007/"
+  - note: "2026-06-09: background run + user foreground run started ~3min apart; idempotency check (score.json exists?) raced, both re-serialized arms B/C, ~116k duplicate kimi tokens, interleaved artifacts in runs/S2/probe-d007/"
 expires:
   condition: "probe gains a lockfile or unique run-id dirs"
   review_after: 2027-06-09

--- a/.scars/0003-uv-tool-install-cached-wheel.landmine.md
+++ b/.scars/0003-uv-tool-install-cached-wheel.landmine.md
@@ -10,7 +10,7 @@ anchors:
   - path: plugin/pyproject.toml
   - pattern: "uv tool install"
 evidence:
-  - "2026-06-10: after editing plugin source, `uv tool install --force ./plugin` reported success but the installed daimon-briefing still printed the OLD conflated error message; `--force --reinstall` picked up the edits. Version stayed 0.1.0 both times."
+  - note: "2026-06-10: after editing plugin source, `uv tool install --force ./plugin` reported success but the installed daimon-briefing still printed the OLD conflated error message; `--force --reinstall` picked up the edits. Version stayed 0.1.0 both times."
 expires:
   condition: "plugin adopts per-change version bumps, or install docs/scripts always pass --reinstall"
   review_after: 2027-06-10

--- a/.scars/0005-uv-run-daimon-resolves-stale-global-tool.landmine.md
+++ b/.scars/0005-uv-run-daimon-resolves-stale-global-tool.landmine.md
@@ -10,8 +10,8 @@ anchors:
   - path: plugin/pyproject.toml
   - pattern: "uv run daimon"
 evidence:
-  - "2026-07-02: live verification of D-011 importance emission ran a 320s chunked serialize that silently produced a D-010 checkpoint — `uv run daimon serialize` from repo root had executed ~/.local/share/uv/tools/daimon-briefing (last `uv tool install` snapshot), not the branch code"
-  - "2026-07-02, same day, second bite: bare `uv run pytest` resolved a leaked foreign VIRTUAL_ENV (fabcap/.venv), so the hook-subprocess e2e tests exercised the stale global tool via PATH — the new recall-inject hook test failed until rerun as `uv run --project plugin pytest`"
+  - note: "2026-07-02: live verification of D-011 importance emission ran a 320s chunked serialize that silently produced a D-010 checkpoint — `uv run daimon serialize` from repo root had executed ~/.local/share/uv/tools/daimon-briefing (last `uv tool install` snapshot), not the branch code"
+  - note: "2026-07-02, same day, second bite: bare `uv run pytest` resolved a leaked foreign VIRTUAL_ENV (fabcap/.venv), so the hook-subprocess e2e tests exercised the stale global tool via PATH — the new recall-inject hook test failed until rerun as `uv run --project plugin pytest`"
 expires:
   condition: "pyproject.toml moves to the repo root, or the global `daimon` uv tool is installed --editable"
   review_after: 2027-01-01

--- a/.scars/0008-merge-call-count-is-hierarchical.landmine.md
+++ b/.scars/0008-merge-call-count-is-hierarchical.landmine.md
@@ -10,7 +10,7 @@ anchors:
   - path: plugin/daimon_briefing/serializer.py
   - pattern: "MERGE_SYS"
 evidence:
-  - commit: 6aa7844  # squash-merge of PR #70
+  - note: "lab commit 6aa7844 (pre-public-history archive; squash-merge of lab PR #70)"
   - pr: 70
 expires:
   condition: "merge_partials stops folding hierarchically (single-pass merge restored)"

--- a/.scars/0009-serialize-log-last-of-kind-masks-failures.landmine.md
+++ b/.scars/0009-serialize-log-last-of-kind-masks-failures.landmine.md
@@ -11,7 +11,7 @@ anchors:
   - pattern: "_parse_serialize_log|last[_ ]?result"
 evidence:
   - pr: 0
-  - commit: 5dbee88  # squash-merge of PR #73
+  - note: "lab commit 5dbee88 (pre-public-history archive; squash-merge of lab PR #73)"
 expires:
   condition: "serialize.log becomes per-session (one file per session) instead of a single global append-only ledger"
   review_after: 2027-06-30

--- a/.scars/0011-grounding-skeptic-strictness-is-correct.fence.md
+++ b/.scars/0011-grounding-skeptic-strictness-is-correct.fence.md
@@ -12,7 +12,7 @@ anchors:
   - pattern: "verify_negative|GROUNDED IS STRICT|skeptic"
 evidence:
   - pr: 59
-  - commit: fcaaffd  # squash-merge of PR #59
+  - note: "lab commit fcaaffd (pre-public-history archive; squash-merge of lab PR #59)"
   - note: See .scars landmine #4 (per-claim judge deltas are noise-dominated without forced verification).
 expires:
   condition: "The fixture is re-labeled against full transcripts and the skeptic still misses >25% of TRUE judge_errors that are single-sentence (not multi-turn) assertions."

--- a/.scars/0012-scale-grading-penalizes-verbose-history.landmine.md
+++ b/.scars/0012-scale-grading-penalizes-verbose-history.landmine.md
@@ -10,7 +10,7 @@ anchors:
   - path: research/memory-backend/benchmark/state/grade.py
   - pattern: "ANSWER_PROMPT|asserts_stale|is_override"
 evidence:
-  - commit: bc1114b  # fix squashed into PR #41
+  - note: "lab commit bc1114b (pre-public-history archive; fix squashed into lab PR #41)"
   - note: First 2K scale smoke: prose override 0.167 / staleness 0.833 vs CSL 1.000 — looked like prose collapses under noise.
 expires:
   condition: "grading scores semantic current-state instead of substring-matching stale tokens"

--- a/.scars/0013-two-llm-clients-share-hang-shape.landmine.md
+++ b/.scars/0013-two-llm-clients-share-hang-shape.landmine.md
@@ -10,8 +10,8 @@ anchors:
   - path: research/experiments/lib/llm.py
   - path: research/memory-backend/benchmark/evaluate.py
 evidence:
-  - commit: d8d0fb9  # squash-merge of PR #69
-  - commit: 162e49c  # squash-merge of PR #71
+  - note: "lab commit d8d0fb9 (pre-public-history archive; squash-merge of lab PR #69)"
+  - note: "lab commit 162e49c (pre-public-history archive; squash-merge of lab PR #71)"
   - pr: 69
   - pr: 71
 expires:

--- a/.scars/0015-gateway-response-cache-pins-bad-responses.landmine.md
+++ b/.scars/0015-gateway-response-cache-pins-bad-responses.landmine.md
@@ -12,7 +12,7 @@ anchors:
   - pattern: "DAIMON_LLM_NO_CACHE"
 evidence:
   - note: H1 attempts 5-6 (2026-06-12): chunk 2 returned empty after 344s once; every later identical request replayed the cached empty in <1s, including the pre-cache-buster retry
-  - commit: 26d6253
+  - note: "lab commit 26d6253 (pre-public-history archive)"
 expires:
   condition: "gateway response caching disabled for the daimon key, or all daimon calls send no-cache"
   review_after: 2026-09-12

--- a/.scars/0016-simulated-clock-must-thread-into-every-now-consumer.landmine.md
+++ b/.scars/0016-simulated-clock-must-thread-into-every-now-consumer.landmine.md
@@ -10,7 +10,7 @@ anchors:
   - path: research/experiments/multicycle/
   - pattern: "briefing\.build\b"
 evidence:
-  - commit: 510787d  # fix squashed into PR #134
+  - note: "lab commit 510787d (pre-public-history archive; fix squashed into lab PR #134)"
   - note: live run-01 killed 2026-07-02 — 6 cycles of spend invalidated
 expires:
   condition: "briefing.build / scoring.effective_weight require an explicit now (no wall-clock default)"

--- a/.scars/0018-grounding-screen-droplist-safety.landmine.md
+++ b/.scars/0018-grounding-screen-droplist-safety.landmine.md
@@ -10,7 +10,7 @@ anchors:
   - path: research/experiments/track-a/scoring/grounding_screen.py
   - pattern: "STOPWORDS|salient_tokens|screen_negative"
 evidence:
-  - commit: fef27b5  # squash-merge of PR #51
+  - note: "lab commit fef27b5 (pre-public-history archive; squash-merge of lab PR #51)"
 expires:
   condition: "the screen stops auto-confirming the absent bucket (e.g. a skeptic re-judge is added over the ABSENT bucket — present-bucket adjudication alone does NOT expire this)"
   review_after: 2027-06-29


### PR DESCRIPTION
Scars-only change (issue-first gate exempt per pr-validation).

## What

- 10 `commit:` evidence refs pointed at squash-merges from the private pre-public archive — unreachable SHAs, and their inline comments cited LAB PR numbers that now collide with public numbering (lab PR #70 ≠ public #70). Converted to `note:` entries naming the archive and disambiguating the PR references.
- 3 scars (#2, #3, #5) carried real evidence as bare YAML strings the linter can't recognize as receipts — converted to typed `note:` entries, text unchanged.

## Result

`scar lint`: 0 errors, 0 unreachable-evidence, 0 no-evidence warnings (was 10 + 3). The 3 remaining partial-rot hints are scanner false positives — deep-match truncation and armed-tripwire misreads — tracked in #72; the anchors themselves are correct and untouched here.

## Verification

Diff is frontmatter-evidence-only: 12 files, 14 lines, no body or anchor changes.