### PR TITLE
feat(cli): rich-parity for remaining human-facing output

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -286,7 +286,7 @@ def _cmd_write_checkpoint(args) -> int:
     checkpoint["source"] = args.source  # provenance: introspection vs reconstruction
     session_id = str(checkpoint["session_id"])
     out = store.write_checkpoint(session_id, checkpoint, project_dir=_resolve_project(args.project))
-    print(f"wrote checkpoint: {out} (source: {args.source})")
+    render.render_write_checkpoint([f"wrote checkpoint: {out} (source: {args.source})"])
     return 0
 
 
@@ -332,7 +332,7 @@ def _cmd_anchor(args) -> int:
     item = matches[0]
     item["anchored_to"] = a
     store.write_checkpoint(session_id, checkpoint, project_dir=project)
-    print(f"attached {a['qualified_name']} to: {item.get('text')}")
+    render.render_anchor_attach([f"attached {a['qualified_name']} to: {item.get('text')}"])
     return 0
 
 
@@ -367,8 +367,8 @@ def _cmd_brief(args) -> int:
     # state as this project's without saying so.
     proj_path = store.project_latest_path(project)
     if checkpoint and proj_path is not None and not proj_path.exists():
-        print("⚠ no checkpoint for this project — showing the global "
-              "checkpoint (fallback), possibly another project's.")
+        render.render_brief_note(["⚠ no checkpoint for this project — showing the global "
+                                  "checkpoint (fallback), possibly another project's."])
     # NOTE: drift is checked against the resolved project root. If read_latest fell
     # back to the GLOBAL pointer (another project's checkpoint), its anchor file paths
     # are relative to a different root and may report spurious "hard" drift. Acceptable
@@ -946,7 +946,7 @@ def _cmd_heal(args) -> int:
     t = plan["target"]
     transcript_path = Path(t["transcript"])
     if not transcript_path.exists():
-        print(f"heal aborted: transcript for {t['sid']} vanished")
+        render.render_heal_abort([f"heal aborted: transcript for {t['sid']} vanished"])
         return 0
     # A hung target has no result line (#34 made spawn-with-transcript hung
     # sessions healable) — the retry marker still needs a prior (#49).
@@ -1067,7 +1067,7 @@ def _cmd_configure(args) -> int:
                   file=sys.stderr)
             return 1
         elapsed = time.monotonic() - start
-        print(f"backend test: ok ({elapsed:.1f}s round trip)")
+        render.render_configure_lines([f"backend test: ok ({elapsed:.1f}s round trip)"])
         return 0
 
     st = configure.status()
@@ -1089,7 +1089,7 @@ def _cmd_configure(args) -> int:
                 updates["DAIMON_LLM_COMMAND_OUTPUT"] = args.output
         # claude-cli: just pin the backend, no credentials needed.
         path = configure.write_env(updates)
-        print(f"wrote {path}")
+        render.render_configure_lines([f"wrote {path}"])
         render.render_configure(configure.status())  # reprint the new resolved state
         return 0
 
@@ -1097,8 +1097,8 @@ def _cmd_configure(args) -> int:
         return 0  # nothing to do
     if not sys.stdin.isatty():
         # Non-interactive and not ready: guide, never block.
-        print("not ready — re-run with --backend {litellm,command,claude-cli} "
-              "and the matching value flags, or run interactively in a terminal.")
+        render.render_configure_lines(["not ready — re-run with --backend {litellm,command,claude-cli} "
+                                       "and the matching value flags, or run interactively in a terminal."])
         return 0
 
     # Interactive: prompt for a backend and its values.
@@ -1125,7 +1125,7 @@ def _cmd_configure(args) -> int:
             updates["DAIMON_LLM_COMMAND_OUTPUT"] = output
     # claude-cli: nothing more to ask.
     path = configure.write_env(updates)
-    print(f"wrote {path}")
+    render.render_configure_lines([f"wrote {path}"])
     render.render_configure(configure.status())
     return 0
 

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -499,8 +499,8 @@ def _render_lines(lines, *, footer=None) -> None:
     """Shared "print a list of pre-formatted lines" primitive behind
     render_skill_lines/render_recall_lines/render_hooks_*/render_team_*: the
     plain path is a bare print loop (byte-identical to each command's
-    pre-#68 output); the rich path upgrades "warning:"-prefixed lines to
-    yellow. `markup=False` is load-bearing — recall lines contain literal
+    pre-#68 output); the rich path upgrades "warning:"- and "⚠"-prefixed
+    lines to yellow. `markup=False` is load-bearing — recall lines contain literal
     "[author]"/"[trust]"/"[kind]" brackets, which rich's Console would
     otherwise parse as (invalid, silently-dropped) style tags, eating the
     content. `footer`, if given, prints after a blank-line separator."""
@@ -516,7 +516,7 @@ def _render_lines(lines, *, footer=None) -> None:
 
     console = Console()
     for ln in lines:
-        style = "yellow" if ln.startswith("warning:") else None
+        style = "yellow" if ln.startswith(("warning:", "⚠")) else None
         console.print(ln, style=style, markup=False)
     if footer:
         console.print("")
@@ -557,6 +557,38 @@ def render_team_sync(lines) -> None:
 
 
 def render_team_status(lines) -> None:
+    _render_lines(lines)
+
+
+# ---- residual command results (#75) ------------------------------------------
+
+
+def render_write_checkpoint(lines) -> None:
+    """`daimon write-checkpoint` success line. Validation errors stay plain on
+    stderr and never route through here."""
+    _render_lines(lines)
+
+
+def render_anchor_attach(lines) -> None:
+    """`daimon anchor --attach` success line. The no-attach JSON dump and all
+    error paths stay plain unconditionally."""
+    _render_lines(lines)
+
+
+def render_configure_lines(lines) -> None:
+    """`daimon configure` result lines: backend-test ok, "wrote <env path>",
+    and the non-interactive not-ready guidance. The resolved-state block
+    renders via render_configure; FAILED paths stay plain on stderr."""
+    _render_lines(lines)
+
+
+def render_brief_note(lines) -> None:
+    """`daimon brief` advisory notes — the ⚠ global-fallback warning."""
+    _render_lines(lines)
+
+
+def render_heal_abort(lines) -> None:
+    """`daimon heal` abort notice (target transcript vanished)."""
     _render_lines(lines)
 
 

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -774,3 +774,66 @@ def test_render_team_status_rich_smoke(monkeypatch, capsys):
     monkeypatch.setattr(render, "supports_rich", lambda: True)
     render.render_team_status(["x: fresh — 0 unpushed checkpoint(s), authors: Ada"])
     assert "fresh" in capsys.readouterr().out
+
+
+# ---- #75: residual rich-parity — write-checkpoint, anchor --attach,
+# configure results, brief note, heal abort
+
+
+def test_render_write_checkpoint_plain_exact_format(capsys):
+    render.render_write_checkpoint(["wrote checkpoint: /tmp/x.json (source: introspection)"])
+    assert capsys.readouterr().out == "wrote checkpoint: /tmp/x.json (source: introspection)\n"
+
+
+def test_render_write_checkpoint_rich_smoke(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_write_checkpoint(["wrote checkpoint: /tmp/x.json (source: introspection)"])
+    assert "wrote checkpoint" in capsys.readouterr().out
+
+
+def test_render_anchor_attach_plain_exact_format(capsys):
+    render.render_anchor_attach(["attached store.py::Store.save to: the save item"])
+    assert capsys.readouterr().out == "attached store.py::Store.save to: the save item\n"
+
+
+def test_render_anchor_attach_rich_smoke(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_anchor_attach(["attached store.py::Store.save to: the save item"])
+    assert "attached" in capsys.readouterr().out
+
+
+def test_render_configure_lines_plain_exact_format(capsys):
+    render.render_configure_lines(["backend test: ok (1.2s round trip)", "wrote /tmp/env"])
+    assert capsys.readouterr().out == "backend test: ok (1.2s round trip)\nwrote /tmp/env\n"
+
+
+def test_render_configure_lines_rich_smoke(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_configure_lines(["backend test: ok (1.2s round trip)"])
+    assert "round trip" in capsys.readouterr().out
+
+
+def test_render_brief_note_plain_exact_format(capsys):
+    line = ("⚠ no checkpoint for this project — showing the global "
+            "checkpoint (fallback), possibly another project's.")
+    render.render_brief_note([line])
+    assert capsys.readouterr().out == line + "\n"
+
+
+def test_render_brief_note_rich_smoke(monkeypatch, capsys):
+    # ⚠-prefixed lines take the warning styling on the rich path; content-only
+    # assertion per the house rule (format is covered plain).
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_brief_note(["⚠ no checkpoint for this project"])
+    assert "no checkpoint for this project" in capsys.readouterr().out
+
+
+def test_render_heal_abort_plain_exact_format(capsys):
+    render.render_heal_abort(["heal aborted: transcript for S-1 vanished"])
+    assert capsys.readouterr().out == "heal aborted: transcript for S-1 vanished\n"
+
+
+def test_render_heal_abort_rich_smoke(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_heal_abort(["heal aborted: transcript for S-1 vanished"])
+    assert "heal aborted" in capsys.readouterr().out


### PR DESCRIPTION
Closes #75

Routes the five remaining bare-print() human outputs through render.py's rich pipeline: write-checkpoint success, anchor --attach confirmation, configure results, brief ⚠ fallback warning, heal abort. Per-command wrappers over `_render_lines`; plain path byte-identical; ⚠-prefixed lines join warning: in yellow styling.

Explicitly untouched (machine contracts): serialize, recall-inject, skill show, all --json branches, stderr errors.

TDD: 10 render tests (plain exact-format + rich content smoke per wrapper). Suite: 872 passed.


