### PR TITLE
chore(scars): move reintroduction guards from pattern anchors to violation fields

### DIFF
--- a/.scars/0005-uv-run-daimon-resolves-stale-global-tool.landmine.md
+++ b/.scars/0005-uv-run-daimon-resolves-stale-global-tool.landmine.md
@@ -7,8 +7,10 @@ confidence: 0.95
 created: 2026-07-02
 authors: [claude, kibukx]
 anchors:
-  - path: plugin/pyproject.toml
-  - pattern: "uv run daimon"
+  - path: plugin/
+  - path: README.md
+  - path: docs/
+violation: "uv run daimon"
 evidence:
   - note: "2026-07-02: live verification of D-011 importance emission ran a 320s chunked serialize that silently produced a D-010 checkpoint — `uv run daimon serialize` from repo root had executed ~/.local/share/uv/tools/daimon-briefing (last `uv tool install` snapshot), not the branch code"
   - note: "2026-07-02, same day, second bite: bare `uv run pytest` resolved a leaked foreign VIRTUAL_ENV (fabcap/.venv), so the hook-subprocess e2e tests exercised the stale global tool via PATH — the new recall-inject hook test failed until rerun as `uv run --project plugin pytest`"

--- a/.scars/0019-scar-pattern-anchors-are-a-three-layer-escape-trap.landmine.md
+++ b/.scars/0019-scar-pattern-anchors-are-a-three-layer-escape-trap.landmine.md
@@ -8,7 +8,7 @@ created: 2026-07-02
 authors: ["claude-code", "kibukx"]
 anchors:
   - path: .scars/
-  - pattern: "pattern:.*\\\\"
+violation: "pattern:.*\\\\"
 evidence:
   - note: 2026-07-02, promote refusal: \"briefing\\\\.build\\\\(\" (reflexive YAML double-backslash) reaches the regex engine RAW — '\\\\(' = literal backslash + bare group-open: 'missing ), unterminated subpattern'. scar promote refused.
   - note: 2026-07-02, rot round-trip on scar #16: double-backslash form reported dead (raw '\\\\.' never matches a plain dot); single-QUOTED form kept the quotes as pattern chars (echoed /'briefing\\.build\\b'/) — still dead; double-quoted single-backslash \"briefing\\.build\\b\" went live. Parser strips double quotes only, processes NO escapes.


### PR DESCRIPTION
Refs #72 — daimon-side half. The scanner-side half (scan-head truncation + lint migration hint) is Daily-Nerd/Scar#157.

Scars #5 and #19 encoded healthy-if-absent reintroduction guards as pattern anchors, which liveness reads as dead — 2 of #72's 3 false partial-rot advisories. Pattern anchors keep strict rot-if-gone semantics (a zero-match pattern that guards *existing* code shape is real rot; reclassifying zero-match as healthy would bless ghost patterns — the landmine #6 class). The forbidden shapes move to `violation:`, the post-edit tripwire that feeds the fired→violated log.

Scar #5's path anchors widen to `plugin/`, `README.md`, `docs/`: violations gate on path-anchor proximity, and the measured reintroduction surface (evidence note 2: hook-subprocess e2e tests; run instructions in docs) is not `pyproject.toml`.

Verification (synthetic `scar check --diff`, both directions per scar):
- #5 fires on `uv run daimon` added in a plugin test and in docs; silent on `uv run --project plugin daimon`
- #19 fires on an over-escaped `\\\\`-form pattern added to a candidate scar; silent on the correct double-quoted single-backslash form
- `scar lint`: 3 partial-rot advisories → 1 (remaining: scar #1 deep-match, fixed by the scanner PR)

Post-merge note: scar #19's `expires.condition` is half-satisfied by the scanner PR (full-content liveness) — review #19 for retirement once that ships in a Scar release and the local tool upgrades. #72 itself stays open until the scanner fix lands and lint runs fully clean here.