### PR TITLE
chore(deps): relock daimon-briefing at the released 0.8.0

### DIFF
--- a/plugin/uv.lock
+++ b/plugin/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "daimon-briefing"
-version = "0.6.0"
+version = "0.8.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #78 — the one-time relock. `uv lock --project plugin` after the 0.8.0 release: `daimon-briefing 0.6.0 → 0.8.0`, one line.

Structural fix (release pipeline owns the relock so drift stops recurring): #80.