### PR TITLE
chore(release): release-please updates the daimon-briefing pin in uv.lock

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,11 @@
           "jsonpath": "$.project.version"
         },
         {
+          "type": "toml",
+          "path": "plugin/uv.lock",
+          "jsonpath": "$.package[?(@.name=='daimon-briefing')].version"
+        },
+        {
           "type": "json",
           "path": ".claude-plugin/plugin.json",
           "jsonpath": "$.version"


### PR DESCRIPTION
Closes #80

release-please bumps `plugin/pyproject.toml` every release but nothing relocks, so `plugin/uv.lock`'s own-package pin drifts (the #78 relock was two releases behind) and the next `uv` invocation dirties the tree.

One config line: `plugin/uv.lock` becomes a `toml` extra-file with jsonpath `$.package[?(@.name=='daimon-briefing')].version` — selecting exactly the one line `uv lock` changes on a version bump (verified: the 0.6.0→0.7.0 and 0.7.0→0.8.0 relocks were single-line diffs).

Safety:
- `GenericToml` resolves paths with `jsonpath-plus` (filter expressions supported) and does a pointer-targeted value replacement — same machinery already updating `pyproject.toml` here surgically every release.
- Verified against the actual lock: the filter hits exactly one entry, and the top-level lockfile-format `version = 1` is not on the path.
- Fail-open: if the path resolves nothing, release-please warns and leaves the file unchanged — worst case is today's status quo.

Proof lands with the next release PR: its diff should include the `uv.lock` pin bump alongside `pyproject.toml`.