### PR TITLE
chore(plugin): close the store/recall audit correctness tail

### DIFF
--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -138,6 +138,12 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                 continue
             if scoring.effective_weight(item, item_type, now) < floor:
                 continue  # expired — deterministic exit (noise budget)
+            # Carry-once covers REWORDED twins too (#31 item 9): a prev item
+            # that fuzzy-matches something already carried this call is the
+            # same loop reworded — first (prev-order) wording wins.
+            if any(_same_item(text, str(c.get("text") or ""), generic)
+                   for c in carried):
+                continue
             kept = copy.deepcopy(item)
             kept.setdefault("carried_from", prev_sid)
             carried.append(kept)

--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -114,6 +114,18 @@ def checkpoint_keep() -> int:
         return 100
 
 
+def gc_pin_importance() -> int:
+    """Item-importance threshold that pins a checkpoint file against GC (#31):
+    a file whose max item importance reaches this survives outside the newest-N
+    window — an importance-10 decision must not die to 100 newer trivia
+    (rational forgetting weighs NEED, not just recency). Default 9; 0 disables
+    pinning (pure recency window, the pre-#31 behavior)."""
+    try:
+        return min(10, max(0, int(_get("DAIMON_GC_PIN_IMPORTANCE") or "9")))
+    except ValueError:
+        return 9
+
+
 def max_briefing_decisions() -> int:
     """Cap on decisions shown in the briefing (render-time view). Default 10; 0 =
     unbounded. The checkpoint keeps ALL decisions — this bounds only the injected

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -307,12 +307,19 @@ def rebuild() -> int:
     try:
         _init_schema(conn)
         count = 0
-        # (author, project_slug) -> (recency, session_id) of the newest checkpoint
+        # (author, project_slug) -> (recency, session_id) of the newest checkpoint.
+        # session_id is the same-second tie-break (#31 item 7): scan order is
+        # readdir order, which is unspecified — without a stable secondary key
+        # the superseded flags flip across rebuilds. Tuple compare gives it.
         newest: dict[tuple, tuple[float, str]] = {}
         for sid, author, slug, recency, cp in _scan_sources():
-            key = (author, slug)
-            if key not in newest or recency > newest[key][0]:
-                newest[key] = (recency, sid)
+            # Unattributed sessions never supersede each other (#31 item 6):
+            # NULL slugs are UNRELATED projects sharing a non-identity, not
+            # one project's history — they stay out of the newest map entirely.
+            if slug is not None:
+                key = (author, slug)
+                if key not in newest or (recency, sid) > newest[key]:
+                    newest[key] = (recency, sid)
             for kind, text, trust, quote, importance, first_seen in _items(cp):
                 cur = conn.execute(
                     "INSERT INTO items"
@@ -484,7 +491,8 @@ tratando todavia entonces ahora gracias quizas intenta intentar
 # imperative/filler band (favor/ayuda/necesito = please/help/need); scar #18
 # rule — do not drop beyond the frequency band the English list established.
 
-_TERM_CAP = 12          # enough signal for OR-matching, bounded query cost
+_TERM_CAP = 24          # bounded query cost; 12 dropped real cue terms on long
+                        # prompts (#31 item 5, encoding-specificity inversion)
 _MIN_TERMS = 2          # a one-word prompt is never a retrieval request
 _MIN_OVERLAP = 2        # matched SESSION must share >=2 distinct salient terms
                         # across its items: one shared word is coincidence, not
@@ -573,7 +581,11 @@ def suggest(prompt: str, project_dir=None, current_session=None,
         " i.session_id, i.created, i.importance, i.first_seen, i.superseded_by,"
         " bm25(items_fts) AS rank"
         " FROM items_fts JOIN items i ON i.id = items_fts.rowid"
-        " WHERE items_fts MATCH ? AND i.project_slug = ? LIMIT 64"
+        # Best-ranked candidates first (#31 item 4): without ORDER BY the LIMIT
+        # window is arbitrary — on a busy project (>N matching rows) the
+        # strongest rows could be truncated away, silencing prior work.
+        " WHERE items_fts MATCH ? AND i.project_slug = ?"
+        " ORDER BY rank ASC LIMIT 256"
     )
     try:
         conn = sqlite3.connect(str(config.recall_db()))

--- a/plugin/daimon_briefing/scoring.py
+++ b/plugin/daimon_briefing/scoring.py
@@ -54,9 +54,19 @@ def _overdue_boost(overdue_days: float) -> float:
     return min(_ESCALATION_CAP, 1.0 + overdue_days ** 1.5 / 100.0)
 
 
+_SKEW_TOLERANCE = 300.0   # seconds a stamp may sit in the future (normal
+                          # machine-to-machine clock skew) and still count as
+                          # fresh; beyond it the stamp is a lie (#31 item 8)
+
+
 def _age_days(item, now: float) -> float | None:
     epoch = store._created_epoch(item.get("first_seen"))
     if epoch is None:
+        return None
+    # A stamp further in the future than clock skew explains gets NEUTRAL
+    # recency (None), never max: a future-stamped teammate item must not
+    # outrank genuinely fresh local work (#31 item 8).
+    if epoch - now > _SKEW_TOLERANCE:
         return None
     return max(0.0, (now - epoch) / 86400.0)
 

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -28,6 +28,7 @@ import json
 import os
 import re
 import time
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -76,6 +77,54 @@ def _atomic_write(path: Path, blob: str) -> None:
     tmp = path.with_name(path.name + f".{os.getpid()}.tmp")
     tmp.write_text(blob, encoding="utf-8")
     os.replace(tmp, path)  # atomic on POSIX
+
+
+_LOCK_NAME = ".pointer.lock"   # dotfile: invisible to _session_files (.json
+                               # filter) and _pointer_stems (_POINTER_RE)
+_LOCK_TRIES = 50               # x 20ms = ~1s bounded wait, then fail open
+_LOCK_INTERVAL = 0.02
+
+try:
+    import fcntl as _fcntl
+except ImportError:            # non-POSIX: lock degrades to a no-op
+    _fcntl = None
+
+
+@contextmanager
+def _pointer_lock(d: Path):
+    """Serialize the check-rotate-write pointer sequence in dir `d` (#31):
+    two sessions ending together interleave _pointer_regresses / rotation /
+    the latest write (multi-step TOCTOU) — one can clobber the prev-N chain
+    or let an older checkpoint win `latest`. flock on a sidecar dotfile with
+    a bounded wait; yields whether the lock was actually acquired. Fail-open
+    everywhere (no fcntl, unwritable dir, contention past the wait): the
+    caller proceeds unguarded, which is exactly the pre-lock behavior."""
+    if _fcntl is None:
+        yield False
+        return
+    fh = None
+    held = False
+    try:
+        fh = open(d / _LOCK_NAME, "a+")
+        for _ in range(_LOCK_TRIES):
+            try:
+                _fcntl.flock(fh.fileno(), _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+                held = True
+                break
+            except OSError:
+                time.sleep(_LOCK_INTERVAL)
+    except OSError:
+        pass
+    try:
+        yield held
+    finally:
+        if fh is not None:
+            try:
+                if held:
+                    _fcntl.flock(fh.fileno(), _fcntl.LOCK_UN)
+                fh.close()
+            except OSError:
+                pass
 
 
 def _rotate_pointers(d: Path, history: int) -> None:
@@ -219,16 +268,63 @@ def _pointer_stems(d: Path) -> set[str] | None:
     return stems
 
 
+_TMP_REAP_SECONDS = 3600   # a *.tmp older than this is a kill-9 orphan, not an
+                           # in-flight _atomic_write (#31 item 3)
+
+
+def _reap_stale_tmps(d: Path) -> None:
+    """Unlink orphaned *.tmp files (kill-9 mid-_atomic_write) in the flat dir
+    and every bucket subdir. Age-gated so a write in flight right now is never
+    touched. Best-effort: never raises (#31 item 3 — GC only pruned .json, so
+    these accumulated forever)."""
+    cutoff = time.time() - _TMP_REAP_SECONDS
+    try:
+        dirs = [d] + [e for e in d.iterdir() if e.is_dir()]
+    except OSError:
+        return
+    for sub in dirs:
+        try:
+            tmps = [p for p in sub.iterdir()
+                    if p.is_file() and p.name.endswith(".tmp")]
+        except OSError:
+            continue
+        for p in tmps:
+            try:
+                if p.stat().st_mtime < cutoff:
+                    p.unlink()
+            except OSError:
+                pass
+
+
+def _max_importance(path: Path) -> int:
+    """Max item importance in a checkpoint file, 0 when unreadable/unstamped.
+    Torn or legacy files pin nothing — recency retention handles them as
+    before; pinning is a best-effort bonus, never a gate."""
+    try:
+        cp = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return 0
+    best = 0
+    for item in serializer.iter_items(cp):
+        imp = item.get("importance")
+        if isinstance(imp, int) and not isinstance(imp, bool) and imp > best:
+            best = imp
+    return best
+
+
 def _gc_checkpoints(d: Path, keep: int) -> None:
     """Prune old per-session checkpoint files, retaining the newest `keep` plus any
-    a live pointer references. keep <= 0 disables GC (keep forever). Best-effort:
-    never raises — a GC failure must not fail the serialize that triggered it
-    (mirrors _rotate_pointers / cli._append_serialize_log's try/except OSError).
+    a live pointer references, plus any pinned by importance (#31 item 1: max
+    item importance >= config.gc_pin_importance(); 0 disables). keep <= 0
+    disables GC (keep forever). Best-effort: never raises — a GC failure must
+    not fail the serialize that triggered it (mirrors _rotate_pointers /
+    cli._append_serialize_log's try/except OSError).
 
     Known race, accepted: the pointer scan is a snapshot, so a bucket + pointer
     written by a concurrent serialize between scan and unlink is invisible here.
     Harmless in practice — that pointer references a just-written file, which the
     newest-`keep` window already retains (default 100 is generous for this too)."""
+    _reap_stale_tmps(d)  # independent of `keep`: orphaned tmps are never data
     if keep <= 0:
         return
     try:
@@ -240,11 +336,14 @@ def _gc_checkpoints(d: Path, keep: int) -> None:
             return  # protection set unknowable — fail-safe, prune nothing
         files.sort(key=_file_recency, reverse=True)
         stale = files[keep:]
+        pin = config.gc_pin_importance()
     except OSError:
         return
     for p in stale:
         if p.stem in protected:
             continue
+        if pin and _max_importance(p) >= pin:
+            continue  # pinned: high-importance memory outlives the window
         try:
             p.unlink()
         except OSError:
@@ -294,15 +393,22 @@ def write_checkpoint(session_id: str, checkpoint: dict, project_dir=None) -> Pat
     # session. Rotation is skipped together with the write so prev-N history
     # doesn't churn on a blocked update.
     new_epoch = _created_epoch(checkpoint.get("created"))
-    if not _pointer_regresses(d, new_epoch):
-        _rotate_pointers(d, history)
-        _atomic_write(d / _LATEST, blob)
+    # The regress check + rotation + latest write is one critical section per
+    # pointer dir (#31 item 2): unguarded, two sessions ending together can
+    # interleave the steps — clobbering the prev-N chain or letting an older
+    # write win latest. _pointer_lock serializes it; on lock failure the
+    # sequence proceeds unguarded (pre-lock behavior, fail-open).
+    with _pointer_lock(d):
+        if not _pointer_regresses(d, new_epoch):
+            _rotate_pointers(d, history)
+            _atomic_write(d / _LATEST, blob)
     if slug:
         pdir = d / slug
         pdir.mkdir(parents=True, exist_ok=True)
-        if not _pointer_regresses(pdir, new_epoch):
-            _rotate_pointers(pdir, history)
-            _atomic_write(pdir / _LATEST, blob)
+        with _pointer_lock(pdir):
+            if not _pointer_regresses(pdir, new_epoch):
+                _rotate_pointers(pdir, history)
+                _atomic_write(pdir / _LATEST, blob)
     # Opportunistic retention: serialize already succeeded, so pruning old
     # per-session files here never touches the read/briefing hot path (#92).
     _gc_checkpoints(d, config.checkpoint_keep())

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -305,3 +305,16 @@ def test_two_verbatim_twins_different_quotes_older_original_wins():
     assert qs[0]["text"] == _VERB_ORIG                    # older original text
     assert qs[0]["quote"] == _VERB_QUOTE                  # older pinned quote
     assert qs[0]["trust"] == "verbatim"
+
+
+def test_in_call_reworded_prev_twins_carry_once():
+    # #31 item 9: two prev items that are REWORDED twins of each other (fuzzy
+    # _same_item hit, no exact-text match, no native twin) must not both
+    # carry — the carry-once intent covers fuzzy twins, not just byte-exact.
+    prev = _cp("S-prev", 1, questions=[
+        _item("quorint ledger reconciliation loop drops entries"),
+        _item("quorint ledger reconciliation loop dropping entries nightly"),
+    ])
+    out = carry.merge(_cp("S-new"), prev, NOW)
+    qs = out["working_context"]["open_questions"]
+    assert len(qs) == 1

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -784,3 +784,103 @@ def test_search_happy_path_writes_no_breadcrumb(tmp_checkpoint_dir, monkeypatch)
         {"text": "pelican decision", "trust": "inferred"}]), project_dir="/repo/x")
     assert recall.search("pelican", all_projects=True)
     assert not (config.log_dir() / "recall-error.log").exists()
+
+
+# ---- #31 audit tail: suggest truncation, term cap, supersession edges -------
+
+
+def test_suggest_survives_busy_project_candidate_overflow(tmp_checkpoint_dir, monkeypatch):
+    # #31 item 4: the candidate query was LIMIT 64 with no ORDER BY — on a
+    # busy project (>64 matching rows) the strongest rows could be arbitrarily
+    # truncated away, silencing prior work. Best-ranked rows must survive.
+    filler = [{"text": f"quorint filler ledger entry number {i} alpha",
+               "trust": "inferred", "importance": 5,
+               "first_seen": "2026-06-20T00:00:00Z"} for i in range(68)]
+    strong = [{"text": "quorint zephyr reconciliation drops entries on pause",
+               "trust": "verbatim", "importance": 8,
+               "first_seen": "2026-06-20T00:00:00Z"},
+              {"text": "zephyr quorint retry loop confirmed unresolved",
+               "trust": "inferred", "importance": 7,
+               "first_seen": "2026-06-20T00:00:00Z"}]
+    store.write_checkpoint(
+        "S-busy", _cp125("S-busy", questions=filler + strong,
+                         created="2026-06-20T00:00:00Z"),
+        project_dir="/repo/x")
+    recall.rebuild()
+    out = recall.suggest("quorint zephyr reconciliation status",
+                         project_dir="/repo/x", current_session="S-now")
+    assert out, "strong rows were truncated out of the candidate window"
+    assert "zephyr" in out[0]["text"]
+
+
+def test_suggest_rich_prompt_terms_beyond_twelve_still_match(tmp_checkpoint_dir, monkeypatch):
+    # #31 item 5: _TERM_CAP dropped prompt terms 13+ — a richer cue silenced
+    # a match (encoding-specificity inversion). Terms past the old cap must
+    # still retrieve.
+    store.write_checkpoint(
+        "S-old", _cp125("S-old", questions=[{
+            "text": "quorint zephyr reconciliation pipeline unresolved",
+            "trust": "inferred", "importance": 7,
+            "first_seen": "2026-06-20T00:00:00Z"}],
+            created="2026-06-20T00:00:00Z"),
+        project_dir="/repo/x")
+    recall.rebuild()
+    junk = ("alpine bravado charlemagne dolomite ellipse foxglove gargoyle "
+            "hyacinth ignition jamboree kaleidoscope labyrinth")  # 12 salient
+    out = recall.suggest(f"{junk} quorint zephyr",
+                         project_dir="/repo/x", current_session="S-now")
+    assert out and out[0]["session_id"] == "S-old"
+
+
+def test_unattributed_sessions_never_supersede_each_other(tmp_checkpoint_dir, monkeypatch):
+    # #31 item 6: all NULL-slug (unattributed) sessions shared one supersession
+    # bucket — the newest unattributed session superseded unrelated
+    # unattributed projects. Unattributed sessions must not supersede at all.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint(
+        "S-un-old", _cp125("S-un-old", questions=[{
+            "text": "gargantuan refactor of the flotilla parser pending",
+            "trust": "inferred"}], created="2026-06-01T00:00:00Z"))
+    store.write_checkpoint(
+        "S-un-new", _cp125("S-un-new", questions=[{
+            "text": "totally unrelated kraken deployment question open",
+            "trust": "inferred"}], created="2026-06-20T00:00:00Z"))
+    recall.rebuild()
+    conn = sqlite3.connect(str(config.recall_db()))
+    try:
+        rows = conn.execute(
+            "SELECT DISTINCT superseded_by FROM items"
+            " WHERE session_id = 'S-un-old'").fetchall()
+    finally:
+        conn.close()
+    assert rows == [(None,)], f"unattributed session was superseded: {rows}"
+
+
+def test_supersession_same_second_tie_breaks_deterministically(tmp_checkpoint_dir, monkeypatch):
+    # #31 item 7: newest-per-(author, slug) tie-broke by arbitrary scan order
+    # on same-second recency — nondeterministic superseded flags across
+    # rebuilds. Ties must break on session_id (greater wins), stable always.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    same = "2026-06-20T00:00:00Z"
+    # S-aaa written FIRST: pre-fix, the first-scanned session won ties, so
+    # this ordering makes the old nondeterminism pick the wrong winner.
+    store.write_checkpoint(
+        "S-aaa", _cp125("S-aaa", questions=[{
+            "text": "aardvark index rebuild question", "trust": "inferred"}],
+            created=same), project_dir="/repo/x")
+    store.write_checkpoint(
+        "S-zzz", _cp125("S-zzz", questions=[{
+            "text": "zeppelin cache warmup question", "trust": "inferred"}],
+            created=same), project_dir="/repo/x")
+    for _ in range(2):  # stable across rebuilds
+        recall.rebuild()
+        conn = sqlite3.connect(str(config.recall_db()))
+        try:
+            old = conn.execute("SELECT DISTINCT superseded_by FROM items"
+                               " WHERE session_id = 'S-aaa'").fetchall()
+            new = conn.execute("SELECT DISTINCT superseded_by FROM items"
+                               " WHERE session_id = 'S-zzz'").fetchall()
+        finally:
+            conn.close()
+        assert old == [("S-zzz",)]
+        assert new == [(None,)]

--- a/plugin/tests/test_scoring.py
+++ b/plugin/tests/test_scoring.py
@@ -77,3 +77,22 @@ def test_deterministic():
     a = scoring.effective_weight(_item(12, 7), "uncertainty", _NOW)
     b = scoring.effective_weight(_item(12, 7), "uncertainty", _NOW)
     assert a == b
+
+
+def test_future_stamp_does_not_outrank_fresh():
+    # Teammate clock skew (#31 item 8): a stamp hours in the future must not
+    # take max recency — it gets NEUTRAL weight, below a genuinely fresh item.
+    future = scoring.effective_weight(_item(-2, 5), "recent_decision", _NOW)
+    fresh = scoring.effective_weight(_item(0, 5), "recent_decision", _NOW)
+    neutral = scoring.effective_weight(_item(None, 5), "recent_decision", _NOW)
+    assert future < fresh
+    assert future == neutral
+
+
+def test_small_clock_skew_tolerated_as_fresh():
+    # Seconds-level skew between machines is normal — treat as age 0, not lies.
+    skewed = _item(None, 5)
+    skewed["first_seen"] = _time.strftime(
+        "%Y-%m-%dT%H:%M:%SZ", _time.gmtime(_NOW + 60))  # 60s in the future
+    w = scoring.effective_weight(skewed, "recent_decision", _NOW)
+    assert w == scoring.effective_weight(_item(0, 5), "recent_decision", _NOW)

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -55,7 +55,10 @@ def test_latest_pointer_is_separate_file(tmp_checkpoint_dir, sample_checkpoint):
 def test_write_leaves_no_temp_files(tmp_checkpoint_dir, sample_checkpoint):
     store.write_checkpoint("S-prev", sample_checkpoint)
     files = {p.name for p in tmp_checkpoint_dir.iterdir()}
-    assert files == {"S-prev.json", "latest.json"}
+    # .pointer.lock is deliberate infrastructure (#31 item 2), not a leak —
+    # unlinking a flock file after release reintroduces the ABA race it
+    # exists to prevent, so it stays. This guards against leaked *.tmp only.
+    assert files == {"S-prev.json", "latest.json", store._LOCK_NAME}
 
 
 # ---- schema stamping: format_version + created at write time (#93) ----
@@ -749,3 +752,89 @@ def test_first_seen_idempotent_on_rewrite(tmp_checkpoint_dir, sample_checkpoint)
     back = store.read_checkpoint("S-1")
     carried_text = sample_checkpoint["working_context"]["open_questions"][0]["text"]
     assert _first_seens(back)[carried_text] == "2026-01-01T00:00:00Z"
+
+
+# ---- #31 audit tail: importance-pinned GC, tmp reaping, pointer lock --------
+
+
+def _imp_cp(sample, sid, created, importance):
+    return {**sample, "session_id": sid, "created": created,
+            "working_context": {
+                "active_topic": {"text": f"topic {sid}", "trust": "inferred"},
+                "open_questions": [{"text": f"question of {sid}",
+                                    "trust": "inferred",
+                                    "importance": importance}],
+                "recent_decisions": [],
+            }}
+
+
+def test_gc_pins_high_importance_beyond_keep(tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
+    # #31 item 1: recency-only GC killed an importance-10 decision when newer
+    # low-importance checkpoints filled the window. Max item importance >= the
+    # pin threshold (default 9) exempts the file from pruning.
+    monkeypatch.setenv("DAIMON_CHECKPOINT_HISTORY", "1")
+    monkeypatch.setenv("DAIMON_CHECKPOINT_KEEP", "2")
+    store.write_checkpoint("S1", _imp_cp(sample_checkpoint, "S1",
+                                         "2021-01-01T00:00:00Z", 10))
+    for i, sid in enumerate(("S2", "S3", "S4")):
+        store.write_checkpoint(sid, _imp_cp(sample_checkpoint, sid,
+                                            f"202{i + 2}-01-01T00:00:00Z", 3))
+    present = _session_files_present(tmp_checkpoint_dir)
+    assert "S1.json" in present            # pinned by importance
+    assert "S2.json" not in present        # normal prune
+    assert {"S3.json", "S4.json"} <= present
+
+
+def test_gc_pin_disabled_at_zero(tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
+    monkeypatch.setenv("DAIMON_CHECKPOINT_HISTORY", "1")
+    monkeypatch.setenv("DAIMON_CHECKPOINT_KEEP", "2")
+    monkeypatch.setenv("DAIMON_GC_PIN_IMPORTANCE", "0")
+    store.write_checkpoint("S1", _imp_cp(sample_checkpoint, "S1",
+                                         "2021-01-01T00:00:00Z", 10))
+    for i, sid in enumerate(("S2", "S3", "S4")):
+        store.write_checkpoint(sid, _imp_cp(sample_checkpoint, sid,
+                                            f"202{i + 2}-01-01T00:00:00Z", 3))
+    present = _session_files_present(tmp_checkpoint_dir)
+    assert "S1.json" not in present        # pinning off -> pure recency window
+
+
+def test_gc_reaps_stale_tmp_files(tmp_checkpoint_dir, sample_checkpoint):
+    # #31 item 3: kill-9 mid-write orphans *.tmp forever (GC only touched
+    # .json). Stale tmp (>1h) is reaped, in the flat dir AND buckets; a fresh
+    # tmp (a write possibly in flight right now) is left alone.
+    import os as _os
+    import time as _time
+    store.write_checkpoint("S1", {**sample_checkpoint, "session_id": "S1"},
+                           project_dir="/p/A")
+    d = tmp_checkpoint_dir
+    bucket = next(p for p in d.iterdir() if p.is_dir())
+    stale_flat = d / "dead.json.999.tmp"
+    stale_bucket = bucket / "dead.json.999.tmp"
+    fresh = d / "live.json.888.tmp"
+    for p in (stale_flat, stale_bucket, fresh):
+        p.write_text("{}", encoding="utf-8")
+    old = _time.time() - 2 * 3600
+    _os.utime(stale_flat, (old, old))
+    _os.utime(stale_bucket, (old, old))
+    store._gc_checkpoints(d, keep=100)
+    assert not stale_flat.exists()
+    assert not stale_bucket.exists()
+    assert fresh.exists()
+
+
+def test_pointer_lock_excludes_second_holder(tmp_checkpoint_dir):
+    # #31 item 2: rotate-then-write latest is a multi-step TOCTOU when two
+    # sessions end together. The critical section is now flock-guarded; a
+    # second would-be holder cannot acquire while the first holds it.
+    import pytest
+    fcntl = pytest.importorskip("fcntl")
+    d = tmp_checkpoint_dir
+    d.mkdir(parents=True, exist_ok=True)
+    with store._pointer_lock(d) as held:
+        assert held
+        probe = open(d / store._LOCK_NAME, "a+")
+        try:
+            with pytest.raises(OSError):
+                fcntl.flock(probe.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        finally:
+            probe.close()


### PR DESCRIPTION
Closes #31 — all nine findings, TDD red-first (883 pass, 872 baseline + 11 new).

| # | finding | fix |
|---|---|---|
| 1 | GC importance-blind | pin tier: max item importance ≥ `DAIMON_GC_PIN_IMPORTANCE` (default 9, 0 = off) survives the recency window |
| 2 | pointer rotation TOCTOU | `.pointer.lock` flock around regress-check/rotate/write per dir; bounded 1s wait; fail-open to pre-lock behavior |
| 3 | orphaned `*.tmp` never reaped | age-gated reap (>1h) in flat dir + buckets, independent of `keep` |
| 4 | `suggest` LIMIT 64, no ORDER BY | `ORDER BY rank ASC LIMIT 256` — strongest rows can no longer be arbitrarily truncated |
| 5 | `_TERM_CAP=12` drops cue terms 13+ | cap 24 |
| 6 | NULL-slug supersession bucket | unattributed sessions never supersede each other |
| 7 | same-second supersession nondeterminism | tie-break on session_id (tuple compare), stable across rebuilds |
| 8 | future stamps get max recency | >5-min-future `first_seen` → neutral recency (clock-skew tolerance below that) |
| 9 | reworded prev twins both carry | carry-once extends to fuzzy twins via the existing `_same_item` + generic filter |

Notes for review:
- Item 7's red was not observable (readdir order is opaque on the test filesystem) — its test asserts the determinism contract across two rebuilds instead of a witnessed failure.
- Item 2 keeps the lock file in place after release (standard flock pattern; unlink reintroduces the ABA race). The existing no-temp-files test learned the distinction.
- Item 8 also has a small tolerance test documenting that seconds-level skew still counts as fresh.