### PR TITLE
fix(release): reach through release-please's tagged TOML values in the uv.lock jsonpath

### DIFF
--- a/plugin/uv.lock
+++ b/plugin/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "daimon-briefing"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,7 @@
         {
           "type": "toml",
           "path": "plugin/uv.lock",
-          "jsonpath": "$.package[?(@.name=='daimon-briefing')].version"
+          "jsonpath": "$.package[?(@.name.value=='daimon-briefing')].version"
         },
         {
           "type": "json",


### PR DESCRIPTION
Closes #85

One character class of bug, two lines of diff:

- `release-please-config.json`: `@.name` → `@.name.value` — release-please's `GenericToml` parses with `TaggedTOMLParser` (byte-position wrappers `{start, end, value}` around every scalar), so the filter must compare through the wrapper. Proven locally against the exact bundled stack (jsonpath-plus@10, @iarna/toml@3): current path → `[]`, fixed path → `/package/1/version`. The 0.8.1 run's `⚠ No entries modified` warning is the in-CI witness.
- `plugin/uv.lock`: the one-time 0.8.0 → 0.8.1 relock the miss left behind.

Proof, next release: the release PR diff includes the `uv.lock` pin bump. If release-please ever changes its internal TaggedValue shape, this fails open (warning + untouched file) and the same release-diff check catches it.