### PR TITLE
fix(skill): install the Windsurf global skill into the skills directory, not memories

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ items as immutable quotes, verify stale-looking claims before repeating them.
 ```sh
 daimon skill install claude      # ~/.claude/skills/daimon/SKILL.md
 daimon skill install codex       # managed block in ~/.codex/AGENTS.md
-daimon skill install windsurf    # global rules (or --project for .windsurf/rules/)
+daimon skill install windsurf    # ~/.codeium/windsurf/skills/daimon/SKILL.md (or --project for .windsurf/rules/)
 daimon skill install cursor --project   # .cursor/rules/daimon.mdc (Cursor has no global rules file)
 daimon skill install gemini      # managed block in ~/.gemini/GEMINI.md
 ```
@@ -114,7 +114,7 @@ daimon skill install gemini      # managed block in ~/.gemini/GEMINI.md
 `daimon skill show` prints the skill content (hosts add a thin format
 wrapper — version markers or frontmatter — around it; add `--compact` for
 the rules-host variant). `daimon skill list` shows which scopes each host
-supports. On shared files (`AGENTS.md`, `GEMINI.md`, Windsurf global rules)
+supports. On shared files (`AGENTS.md`, `GEMINI.md`)
 daimon only ever touches its own marker block — `daimon skill uninstall
 <host>` removes exactly that block, or the whole file for hosts where the
 skill owns it outright. Re-run install after upgrading to refresh the content.

--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -1,13 +1,13 @@
 """Canonical agent-skill content, two densities (#66).
 
-FULL renders Claude Code's lazily-loaded SKILL.md — description-gated, so the
-frontmatter description carries triggering conditions ONLY (a workflow summary
-there makes agents skip the body). COMPACT renders the always-injected rules
-block for Codex/Gemini/Windsurf/Cursor — those hosts concatenate the whole
-file into every prompt, so triggers live in the rule text, the budget is
-brutal (Windsurf global rules cap the FILE at 6,000 chars, shared with the
-user's own rules), and the must-win rule repeats at the end because every
-vendor resolves instruction conflicts later-wins.
+FULL renders the lazily-loaded SKILL.md (Claude Code; Windsurf global since
+#88) — description-gated, so the frontmatter description carries triggering
+conditions ONLY (a workflow summary there makes agents skip the body).
+COMPACT renders the always-injected rules block for Codex/Gemini/Cursor and
+Windsurf --project — those hosts concatenate the whole file into every
+prompt, so triggers live in the rule text, the budget is brutal (Windsurf
+rules files cap at 6,000 chars each), and the must-win rule repeats at the
+end because every vendor resolves instruction conflicts later-wins.
 """
 
 SKILL_NAME = "using-daimon-memory"

--- a/plugin/daimon_briefing/skill_install.py
+++ b/plugin/daimon_briefing/skill_install.py
@@ -3,7 +3,7 @@
 Two writer families. Owned-file: the destination is daimon's own file
 (SKILL.md, daimon.mdc, daimon.md) — overwrite is safe and idempotent by
 construction. Marker-block: the destination is a file the USER owns
-(AGENTS.md, GEMINI.md, Windsurf global rules) — daimon may only replace the
+(AGENTS.md, GEMINI.md) — daimon may only replace the
 region between its own version-stamped markers, appends the block at the END
 of the file (every vendor resolves instruction conflicts later-wins), and
 refuses on half-broken marker state rather than guess.
@@ -41,10 +41,14 @@ HOSTS = {
         "char_cap": 32768,  # Codex project_doc_max_bytes default — stops reading past it
     },
     "windsurf": {
-        "global": (".codeium/windsurf/memories/global_rules.md", "block", "compact"),
+        # Global skills live at ~/.codeium/windsurf/skills/<name>/SKILL.md
+        # (#88 field report) — memories/global_rules.md is Windsurf's MEMORIES
+        # store, which pre-#88 versions polluted with a compact block; install
+        # and uninstall both clean that legacy block (see _WINDSURF_LEGACY).
+        # Project scope stays a rules file: the project-level skills path is
+        # unverified on a live machine.
+        "global": (".codeium/windsurf/skills/daimon/SKILL.md", "owned", "full"),
         "project": (".windsurf/rules/daimon.md", "owned", "compact"),
-        "char_cap": 6000,  # documented cap is chars; compared as bytes below
-                           # (conservative — fires earlier, never later)
     },
     "cursor": {
         "global": None,
@@ -69,6 +73,28 @@ _OWNED_WRAPPERS = {
 
 class SkillInstallError(Exception):
     pass
+
+
+# Pre-#88 Windsurf global installs wrote a marker block into the MEMORIES
+# file. Both install and uninstall strip that stale block so an upgrade (or
+# removal) never leaves skill content squatting in the memories channel.
+_WINDSURF_LEGACY = ".codeium/windsurf/memories/global_rules.md"
+
+
+def _clean_windsurf_legacy(home: Path) -> str | None:
+    """Remove the daimon marker block from the legacy memories file if present.
+    Returns a report line, or None when there is nothing to clean. Same
+    lossless-boundary contract as the block uninstall path."""
+    legacy = home / _WINDSURF_LEGACY
+    try:
+        text = legacy.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    if not _BLOCK_RE.search(text):
+        return None
+    new = _BLOCK_RE.sub("", text, count=1).rstrip("\n")
+    legacy.write_text((new + "\n") if new else "", encoding="utf-8")
+    return f"removed legacy daimon:skill block from {legacy} (memories, pre-#88)"
 
 
 def _render(variant: str) -> str:
@@ -133,15 +159,19 @@ def install(host: str, *, project: bool, home: Path, cwd: Path) -> list[str]:
         new = _replace_block(old, _block(variant))
         dest.write_text(new, encoding="utf-8")
         cap = spec.get("char_cap")
-        # Codex's documented cap is bytes; Windsurf's is chars. Comparing
-        # UTF-8 byte length against both is the conservative choice — bytes
-        # >= chars for any text with non-ASCII content, so a byte-based
-        # warning can only fire earlier than a char-based one, never later.
+        # Codex's documented cap is bytes (project_doc_max_bytes). Byte length
+        # is also the conservative comparison if a chars-capped host ever
+        # returns here — bytes >= chars for any non-ASCII text, so a byte
+        # warning can only fire earlier, never later.
         new_size = len(new.encode("utf-8"))
         if cap and new_size > cap:
             lines.append(
                 f"warning: {dest} is {new_size:,} bytes — {host} truncates "
                 f"this file at {cap:,} bytes; trim your own rules or use --project")
+    if host == "windsurf" and not project:
+        cleaned = _clean_windsurf_legacy(home)
+        if cleaned:
+            lines.append(cleaned)
     lines.insert(0, f"installed daimon skill ({variant}) -> {dest}")
     return lines
 
@@ -149,11 +179,16 @@ def install(host: str, *, project: bool, home: Path, cwd: Path) -> list[str]:
 def uninstall(host: str, *, project: bool, home: Path, cwd: Path) -> list[str]:
     _spec_dict, (rel, kind, _variant) = _spec(host, project)
     dest = (cwd if project else home) / rel
+    legacy_lines = []
+    if host == "windsurf" and not project:
+        cleaned = _clean_windsurf_legacy(home)
+        if cleaned:
+            legacy_lines.append(cleaned)
     if not dest.exists():
-        return [f"nothing installed at {dest}"]
+        return legacy_lines + [f"nothing installed at {dest}"]
     if kind == "owned":
         dest.unlink()
-        return [f"removed {dest}"]
+        return legacy_lines + [f"removed {dest}"]
     text = dest.read_text(encoding="utf-8")
     if not _BLOCK_RE.search(text):
         return [f"no daimon:skill block in {dest} — left untouched"]

--- a/plugin/tests/test_skill_install.py
+++ b/plugin/tests/test_skill_install.py
@@ -100,13 +100,58 @@ def test_half_broken_markers_refuse(tmp_path):
         install("codex", project=False, home=home, cwd=tmp_path)
 
 
-def test_windsurf_global_warns_over_char_cap(tmp_path):
+def test_codex_global_warns_over_char_cap(tmp_path):
     home = tmp_path / "home"
-    rules = home / ".codeium" / "windsurf" / "memories"
-    rules.mkdir(parents=True)
-    (rules / "global_rules.md").write_text("x" * 5000, encoding="utf-8")
-    result_lines = install("windsurf", project=False, home=home, cwd=tmp_path)
-    assert any("6,000" in ln or "6000" in ln for ln in result_lines)
+    (home / ".codex").mkdir(parents=True)
+    (home / ".codex" / "AGENTS.md").write_text("x" * 32000, encoding="utf-8")
+    result_lines = install("codex", project=False, home=home, cwd=tmp_path)
+    assert any("32,768" in ln or "32768" in ln for ln in result_lines)
+
+
+# ---- windsurf global: real skills dir + memories migration (#88) ----
+
+
+def test_windsurf_global_writes_full_skill(tmp_path):
+    # #88 field report: global skills live at
+    # ~/.codeium/windsurf/skills/<name>/SKILL.md — memories/global_rules.md is
+    # Windsurf's MEMORIES store, not a skills registry.
+    _, home, _ = _run("windsurf", tmp_path)
+    dest = home / ".codeium" / "windsurf" / "skills" / "daimon" / "SKILL.md"
+    text = dest.read_text(encoding="utf-8")
+    assert text.startswith("---\nname: using-daimon-memory")
+    assert "daimon brief" in text
+
+
+def test_windsurf_global_install_migrates_legacy_memories_block(tmp_path):
+    # Pre-#88 installs left a marker block in memories/global_rules.md.
+    # Reinstall must relocate the skill AND strip the stale block, leaving
+    # the user's own memories byte-identical.
+    home = tmp_path / "home"
+    mem = home / ".codeium" / "windsurf" / "memories"
+    mem.mkdir(parents=True)
+    user = "# my real memories\n\nprefers tabs.\n"
+    legacy = (f"{user}\n<!-- daimon:skill v0.7.0 start -->\nold skill\n"
+              "<!-- daimon:skill v0.7.0 end -->\n")
+    (mem / "global_rules.md").write_text(legacy, encoding="utf-8")
+    install("windsurf", project=False, home=home, cwd=tmp_path)
+    assert (home / ".codeium" / "windsurf" / "skills" / "daimon"
+            / "SKILL.md").exists()
+    assert (mem / "global_rules.md").read_text(encoding="utf-8") == user
+
+
+def test_windsurf_global_uninstall_cleans_legacy_block_too(tmp_path):
+    home = tmp_path / "home"
+    mem = home / ".codeium" / "windsurf" / "memories"
+    mem.mkdir(parents=True)
+    user = "# my real memories\n"
+    (mem / "global_rules.md").write_text(
+        f"{user}\n<!-- daimon:skill v0.7.0 start -->\nold\n"
+        "<!-- daimon:skill v0.7.0 end -->\n", encoding="utf-8")
+    install("windsurf", project=False, home=home, cwd=tmp_path)
+    uninstall("windsurf", project=False, home=home, cwd=tmp_path)
+    assert not (home / ".codeium" / "windsurf" / "skills" / "daimon"
+                / "SKILL.md").exists()
+    assert (mem / "global_rules.md").read_text(encoding="utf-8") == user
 
 
 # ---- uninstall ----


### PR DESCRIPTION
Closes #88

Field-reported: Windsurf global skills live at `~/.codeium/windsurf/skills/<name>/SKILL.md` — the installer was writing a compact marker block into `memories/global_rules.md`, which is the MEMORIES store.

- Global → owned **full** `SKILL.md` at the real path (frontmatter-gated, on-demand; `render_full` already emits the Agent-Skills frontmatter). The 6,000-char always-injected budget stops applying — the cap test moves to codex, the cap machinery's remaining user.
- **Migration built in**: install and uninstall both strip the stale pre-#88 block from the memories file (lossless — same boundary contract the block-uninstall tests pin). Upgrading testers relocate the skill with one `daimon skill install windsurf`; uninstall never leaves skill content squatting in memories.
- Project scope unchanged (`.windsurf/rules/daimon.md`): the project-level skills path is unverified on a live machine — noted in the HOSTS comment for the next field report.
- README + module docs updated to match.

TDD: 3 red-first tests (real path + full variant, install-time migration, uninstall legacy cleanup). Suite: 886 passed.