### PR TITLE
fix(skill): frontmatter name matches the skill directory name

### DIFF
--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -10,7 +10,10 @@ rules files cap at 6,000 chars each), and the must-win rule repeats at the
 end because every vendor resolves instruction conflicts later-wins.
 """
 
-SKILL_NAME = "using-daimon-memory"
+# Agent Skills contract (#90): the frontmatter name MUST equal the skill's
+# directory name — every install path writes into a `daimon/` dir. Triggering
+# guidance lives in the description; the name is an identifier, not prose.
+SKILL_NAME = "daimon"
 
 _DESCRIPTION = (
     "Use when a daimon briefing appears in context, when the user references "

--- a/plugin/tests/test_skill_cli.py
+++ b/plugin/tests/test_skill_cli.py
@@ -8,7 +8,7 @@ from daimon_briefing import cli
 def test_skill_show_prints_full(capsys):
     assert cli.main(["skill", "show"]) == 0
     out = capsys.readouterr().out
-    assert "name: using-daimon-memory" in out
+    assert "name: daimon" in out
 
 
 def test_skill_show_compact(capsys):

--- a/plugin/tests/test_skill_content.py
+++ b/plugin/tests/test_skill_content.py
@@ -24,7 +24,7 @@ def test_full_has_trigger_only_frontmatter():
     full = skill_content.render_full()
     assert full.startswith("---\n")
     header = full.split("---\n")[1]
-    assert "name: using-daimon-memory" in header
+    assert "name: daimon" in header
     assert "description: Use when" in header
     for leak in ("run daimon brief", "then", "first,"):
         assert leak not in header.split("description:")[1].split("\n")[0].lower()

--- a/plugin/tests/test_skill_install.py
+++ b/plugin/tests/test_skill_install.py
@@ -25,7 +25,7 @@ def test_claude_global_writes_full_skill(tmp_path):
     _, home, _ = _run("claude", tmp_path)
     dest = home / ".claude" / "skills" / "daimon" / "SKILL.md"
     text = dest.read_text(encoding="utf-8")
-    assert text.startswith("---\nname: using-daimon-memory")
+    assert text.startswith("---\nname: daimon")
     assert "daimon brief" in text
 
 
@@ -118,7 +118,7 @@ def test_windsurf_global_writes_full_skill(tmp_path):
     _, home, _ = _run("windsurf", tmp_path)
     dest = home / ".codeium" / "windsurf" / "skills" / "daimon" / "SKILL.md"
     text = dest.read_text(encoding="utf-8")
-    assert text.startswith("---\nname: using-daimon-memory")
+    assert text.startswith("---\nname: daimon")
     assert "daimon brief" in text
 
 


### PR DESCRIPTION
Closes #90

Field report: hosts validate that SKILL.md's `name` equals its directory name; all install paths use `daimon/` but the frontmatter said `using-daimon-memory`. One constant (`SKILL_NAME = "daimon"`), four test assertions flipped red-first. Description field — the only part read for triggering — unchanged. 886 pass.

Existing installs pick up the corrected name on the next `daimon skill install <host>` (owned-file overwrite, no migration needed).