### PR TITLE
fix(cli): stamp uncaught crashes with a timestamp header before the traceback

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1361,7 +1361,21 @@ def _cmd_skill_uninstall(args) -> int:
     return 0
 
 
+def _crash_stamp_excepthook(exc_type, exc, tb) -> None:
+    """Uncaught-crash header (#92): serialize-crash.log is the detached
+    child's RAW stderr fd — no logger sits in the write path, so the only
+    process that can timestamp a crash is the crashing one. One ISO-stamped
+    line, then the stock traceback. Covers uncaught Python exceptions (the
+    dominant case); interpreter-level deaths still write nothing."""
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    cmd = next((a for a in sys.argv[1:] if not a.startswith("-")), "?")
+    print(f"--- crash {stamp} pid={os.getpid()} cmd={cmd} ---",
+          file=sys.stderr, flush=True)
+    sys.__excepthook__(exc_type, exc, tb)
+
+
 def main(argv=None) -> int:
+    sys.excepthook = _crash_stamp_excepthook  # #92: stamp uncaught crashes
     # #68: one formatter selection for the WHOLE parser tree. argparse does not
     # propagate formatter_class from parent to subparser, so every add_parser
     # call below must receive it — done here by patching add_parser on each

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2927,3 +2927,31 @@ def test_stats_empty_world_is_calm(tmp_checkpoint_dir, capsys):
     assert data["usage"] == {}
     assert data["capture"]["success"] == 0
     assert data["store"]["checkpoints"] == 0
+
+
+# ---- crash stamping (#92): timestamp header before uncaught tracebacks ------
+
+
+def test_crash_excepthook_stamps_before_traceback(capsys, monkeypatch):
+    # serialize-crash.log is the detached child's raw stderr — the only place
+    # a timestamp can come from is the crashing process itself. The hook must
+    # print one ISO-stamped header line, then the normal traceback.
+    monkeypatch.setattr(sys, "argv", ["daimon", "serialize", "/tmp/t.md"])
+    try:
+        raise RuntimeError("boom for the stamp test")
+    except RuntimeError:
+        exc_type, exc, tb = sys.exc_info()
+    cli._crash_stamp_excepthook(exc_type, exc, tb)
+    err = capsys.readouterr().err
+    first = err.splitlines()[0]
+    assert re.fullmatch(
+        r"--- crash \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z pid=\d+ "
+        r"cmd=serialize ---", first)
+    assert "RuntimeError: boom for the stamp test" in err
+
+
+def test_main_installs_crash_excepthook(monkeypatch):
+    monkeypatch.setattr(sys, "excepthook", sys.__excepthook__)
+    with pytest.raises(SystemExit):
+        cli.main(["--version"])
+    assert sys.excepthook is cli._crash_stamp_excepthook


### PR DESCRIPTION
Closes #92

`serialize-crash.log` is the detached child's **raw stderr fd** (`spawn_serialize` hands the open file straight to `Popen`), so the only process that can timestamp a crash is the crashing one. The CLI entrypoint now installs a `sys.excepthook` that prints one header line before the stock traceback:

```
--- crash 2026-07-06T22:14:22Z pid=332 cmd=serialize ---
Traceback (most recent call last):
  ...
```

(That block is the actual output of an end-to-end run through the working tree.)

- Stamps only on real crashes — the log keeps its only-grows-on-trouble property (rejected alternative: per-spawn headers, which would drown the log in headers-without-crashes)
- Every host adapter spawning through the shared lib benefits
- TDD red-first: header-format-before-traceback + main-installs-hook. Suite: 888 passed.
- Known limit (in the docstring): uncaught Python exceptions only; interpreter-level deaths write nothing anyway