### PR TITLE
fix(store): carry reads only the project's own latest pointer

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -206,7 +206,11 @@ def _run_serialize(transcript_path: Path, project: str | None) -> int:
         # itself (a briefing missing carried items is strictly better than
         # no briefing at all; same idiom as harvest.run's swallow below).
         try:
-            prev = store.read_latest(project)
+            # fallback=False (#94): on a project's first serialize there is no
+            # per-project pointer, and the global pointer is another project's
+            # checkpoint — carrying from it would write foreign items into
+            # this project's bucket permanently. No prev -> no carry.
+            prev = store.read_latest(project, fallback=False)
             now = store._created_epoch(checkpoint.get("created")) or time.time()
             checkpoint = carry.merge(checkpoint, prev, now,
                                      floor=config.carry_floor(),

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -474,15 +474,22 @@ def read_checkpoint(session_id: str) -> dict | None:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def read_latest(project_dir=None) -> dict | None:
+def read_latest(project_dir=None, fallback: bool = True) -> dict | None:
     """Latest checkpoint, preferring the project's own pointer when known;
-    falls back to the global pointer (pre-routing checkpoints, fresh projects)."""
+    falls back to the global pointer (pre-routing checkpoints, fresh projects).
+
+    fallback=False reads ONLY the project's own pointer (#94): the global
+    pointer holds the most recent checkpoint of ANY project, so callers that
+    PERSIST what they read (carry) must never see it — display callers (brief)
+    keep the fallback and label it."""
     d = config.checkpoint_dir()
     slug = project_slug(project_dir)
     if slug:
         path = d / slug / _LATEST
         if path.exists():
             return json.loads(path.read_text(encoding="utf-8"))
+    if not fallback:
+        return None
     path = d / _LATEST
     if not path.exists():
         return None

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2362,6 +2362,35 @@ def test_serialize_carry_kill_switch(
     assert "quorint reconciliation loop unresolved" not in texts
 
 
+def test_serialize_carry_ignores_other_projects_checkpoint(
+    tmp_checkpoint_dir, fake_chat_factory, monkeypatch, tmp_path
+):
+    """#94: a fresh project's FIRST serialize has no per-project pointer, so
+    carry's read_latest used to fall back to the global pointer — the most
+    recent checkpoint of ANY project — and permanently fold a foreign
+    project's items into this project's bucket. Carry must read only the
+    project's own pointer."""
+    from daimon_briefing import store
+
+    _prev_with_open_question("/p/other-project", "2026-06-25T08:00:00Z",
+                             "2026-06-28T00:00:00Z")
+
+    chat = fake_chat_factory(_valid_json("S-new"))
+    monkeypatch.setattr(cli, "_chat", chat)
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/fresh-project")
+
+    p = _timed_jsonl(tmp_path, "S-new.jsonl", [
+        "2026-07-01T10:00:00Z", "2026-07-01T10:01:00Z", "2026-07-01T10:02:00Z",
+    ])
+    rc = cli.main(["serialize", str(p)])
+    assert rc == 0
+
+    written = store.read_latest(project_dir="/p/fresh-project")
+    texts = {q.get("text") for q in written["working_context"]["open_questions"]}
+    assert "quorint reconciliation loop unresolved" not in texts
+
+
 def test_serialize_carry_failure_still_writes_checkpoint(
     tmp_checkpoint_dir, fake_chat_factory, monkeypatch, tmp_path
 ):

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -222,6 +222,20 @@ def test_read_latest_none_when_both_absent(tmp_checkpoint_dir):
     assert store.read_latest(project_dir="/p/never-seen") is None
 
 
+def test_read_latest_no_fallback_skips_global(tmp_checkpoint_dir, sample_checkpoint):
+    # #94: carry's read path must not see another project's checkpoint through
+    # the global pointer — a fresh project reads None, not a foreign session.
+    store.write_checkpoint("S-other", {**sample_checkpoint, "session_id": "S-other"},
+                           project_dir="/p/other")
+    assert store.read_latest(project_dir="/p/fresh", fallback=False) is None
+
+
+def test_read_latest_no_fallback_still_reads_own_project(tmp_checkpoint_dir, sample_checkpoint):
+    store.write_checkpoint("S-a", {**sample_checkpoint, "session_id": "S-a"},
+                           project_dir="/p/A")
+    assert store.read_latest(project_dir="/p/A", fallback=False)["session_id"] == "S-a"
+
+
 # ---- checkpoint rotation: keep last N pointers per dir (#33 Phase 1) ----
 
 


### PR DESCRIPTION
Closes #94

## What

- `store.read_latest()` grows a `fallback` flag (default `True`, unchanged behavior). With `fallback=False` it reads ONLY the project's own `<slug>/latest.json` and returns `None` instead of falling back to the global pointer.
- The carry call site in `_run_serialize` passes `fallback=False`: a fresh project's first serialize gets `prev=None` (no carry) instead of another project's checkpoint.
- Brief's display path is untouched — the labeled global-fallback warning from #29 still works.

## Why

The global `latest.json` holds the most recent checkpoint of ANY project. On a project's first serialize there is no per-project pointer yet, so carry read the global pointer and `carry.merge` (which has no project identity guard, by design — it is pure and caller-fed) folded a foreign project's open questions/decisions/uncertainties into the new project's bucket permanently. Every later brief re-read the poisoned checkpoint, so briefings kept mixing projects even in fresh sessions. Field-reported in #94.

Guarding at the read call site (rather than inside `carry.merge`) keeps merge's no-I/O contract intact and blocks the leak at its source.

## Tests

- `test_read_latest_no_fallback_skips_global` — failed before (`TypeError`, then would return the foreign checkpoint); passes now.
- `test_read_latest_no_fallback_still_reads_own_project` — the flag must not break same-project reads.
- `test_serialize_carry_ignores_other_projects_checkpoint` — end-to-end repro of #94: prev checkpoint written under `/p/other-project`, serialize under fresh `/p/fresh-project`; before the fix the foreign open question was carried in (watched it fail), now it is not.
- Full suite: 891 passed.