### PR TITLE
feat(cli): header-only brief fallback by default, full body opt-in

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -122,7 +122,10 @@ daimon serialize path/to/transcript.md
 daimon brief
 #   → prints the briefing to stdout
 #   → with DAIMON_PROJECT_DIR set, prefers that project's latest.json
-#     (global latest.json is the fallback)
+#   → no checkpoint for the project yet: prints a header-only note saying
+#     where the most recent activity lives, instead of rendering another
+#     project's checkpoint; opt in to the full global-fallback body with
+#     --global-fallback or DAIMON_BRIEF_GLOBAL_FALLBACK=full
 
 # 3. Check whether a checkpoint actually got written (no log grepping):
 daimon status [--project DIR] [--json]

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -366,11 +366,30 @@ def _cmd_brief(args) -> int:
     # read_latest still falls back to the global pointer if the project has none.
     project = _resolve_project(args.project)
     checkpoint = store.read_latest(project_dir=project)
+    proj_path = store.project_latest_path(project)
+    fallback_used = (checkpoint is not None and proj_path is not None
+                     and not proj_path.exists())
+    if fallback_used and not (getattr(args, "global_fallback", False)
+                              or config.brief_global_fallback()):
+        # Header-only fallback (#96): the foreign body is suppressed — one
+        # warning line above a hundred foreign lines does not read as a
+        # warning. Orient (where the activity actually is) and exit clean;
+        # `daimon status` still shows the full pointer table.
+        slug = str(checkpoint.get("project_slug") or "").strip() or "another project"
+        epoch = store._created_epoch(checkpoint.get("created"))
+        age = f"{_format_age(time.time() - epoch)} ago" if epoch else "age unknown"
+        render.render_brief_note([
+            "No briefing for this project yet — the first serialized session "
+            "will create one.",
+            f"(Most recent activity elsewhere: {slug}, {age}.)",
+            "Use --global-fallback or DAIMON_BRIEF_GLOBAL_FALLBACK=full to "
+            "view that checkpoint here.",
+        ])
+        return 0
     # Label the global-pointer fallback (#29): status calls the same situation
     # "global checkpoint (fallback)"; brief must not present another project's
     # state as this project's without saying so.
-    proj_path = store.project_latest_path(project)
-    if checkpoint and proj_path is not None and not proj_path.exists():
+    if fallback_used:
         render.render_brief_note(["⚠ no checkpoint for this project — showing the global "
                                   "checkpoint (fallback), possibly another project's."])
     # NOTE: drift is checked against the resolved project root. If read_latest fell
@@ -1437,6 +1456,12 @@ def main(argv=None) -> int:
         "--team", action="store_true",
         help="also show a 'Teammates' section: each teammate's active topic + "
              "recent decisions from the shared team memory (#111)",
+    )
+    p_brief.add_argument(
+        "--global-fallback", action="store_true",
+        help="when this project has no checkpoint, render the full global "
+             "checkpoint (possibly another project's) instead of the "
+             "header-only note (#96)",
     )
     p_brief.set_defaults(func=_cmd_brief)
 

--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -77,6 +77,15 @@ def checkpoint_history() -> int:
         return 3
 
 
+def brief_global_fallback() -> bool:
+    """#96: brief's cross-project global-pointer fallback is header-only by
+    default — a fresh project's briefing that is 100% another project's
+    content reads as contamination no matter how it is labeled (two field
+    reports on the #94 arc). Opt in to the full foreign body with
+    DAIMON_BRIEF_GLOBAL_FALLBACK=full (or 1)."""
+    return (_get("DAIMON_BRIEF_GLOBAL_FALLBACK") or "") in ("full", "1")
+
+
 def carry_enabled() -> bool:
     """Deterministic cross-session carry (#33 Phase 2). Default ON — it fixes a
     measured defect (multicycle run-01: whole-item loss under LLM-mediated

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -51,10 +51,14 @@ def test_cli_serialize_writes_checkpoint(tmp_checkpoint_dir, fake_chat_factory, 
     assert store.read_latest()["session_id"] == "sample_transcript"
 
 
-def test_cli_brief_prints_briefing(tmp_checkpoint_dir, sample_checkpoint, capsys):
+def test_cli_brief_prints_briefing(tmp_checkpoint_dir, sample_checkpoint, capsys,
+                                   monkeypatch):
     from daimon_briefing import store
 
-    store.write_checkpoint("S-prev", sample_checkpoint)
+    # Route to the checkpoint's own project — a slugless global-only write
+    # would hit the #96 header-only fallback instead of rendering.
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    store.write_checkpoint("S-prev", sample_checkpoint, project_dir="/p/A")
     rc = cli.main(["brief"])
     assert rc == 0
     out = capsys.readouterr().out
@@ -307,6 +311,8 @@ def test_cli_brief_prefers_project_latest(tmp_checkpoint_dir, sample_checkpoint,
 
 
 def test_cli_brief_falls_back_to_global(tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
+    # #96: the global fallback is header-only by default — the foreign body
+    # renders only on explicit opt-in (covered by test_brief_fallback_full_*).
     from daimon_briefing import store
 
     store.write_checkpoint("S-global", sample_checkpoint)
@@ -314,7 +320,8 @@ def test_cli_brief_falls_back_to_global(tmp_checkpoint_dir, sample_checkpoint, c
     rc = cli.main(["brief"])
     assert rc == 0
     out = capsys.readouterr().out
-    assert "PR #6" in out
+    assert "no briefing for this project yet" in out.lower()
+    assert "PR #6" not in out
 
 
 def test_cli_brief_routes_to_cwd_when_no_env(
@@ -2461,6 +2468,47 @@ def test_brief_no_fallback_label_for_own_project(
     rc = cli.main(["brief", "--project", "/repo/x"])
     assert rc == 0
     assert "fallback" not in capsys.readouterr().out.lower()
+
+
+def test_brief_fallback_header_only_by_default(
+        tmp_checkpoint_dir, sample_checkpoint, capsys):
+    # #96: a fresh project's fallback briefing was 100% another project's
+    # content under one warning line — two field reports read it as
+    # contamination. Default is now an orientation header; the foreign body
+    # renders only on explicit opt-in.
+    from daimon_briefing import store
+    store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+    rc = cli.main(["brief", "--project", "/repo/some-other-project"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "no briefing for this project yet" in out.lower()
+    assert "-repo-x" in out  # says WHERE the recent activity actually lives
+    # none of the foreign checkpoint's items may render
+    assert "PR #6 state" not in out
+    assert "D-007" not in out
+
+
+def test_brief_fallback_full_via_flag(
+        tmp_checkpoint_dir, sample_checkpoint, capsys):
+    from daimon_briefing import store
+    store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+    rc = cli.main(["brief", "--project", "/repo/other", "--global-fallback"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "PR #6 state" in out          # full foreign body on opt-in
+    assert "fallback" in out.lower()     # #29 warning label retained
+
+
+def test_brief_fallback_full_via_env(
+        tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_BRIEF_GLOBAL_FALLBACK", "full")
+    store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+    rc = cli.main(["brief", "--project", "/repo/other"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "PR #6 state" in out
+    assert "fallback" in out.lower()
 
 
 def test_recall_rejects_nonpositive_limit(tmp_checkpoint_dir, capsys):


### PR DESCRIPTION
Closes #96

## What

- `daimon brief` in a project with no checkpoint now prints a three-line orientation note — no briefing yet, where the most recent activity lives (foreign project's slug + age), and how to opt in — instead of rendering the global checkpoint's full body.
- Opt-in to the old full render: `daimon brief --global-fallback` or `DAIMON_BRIEF_GLOBAL_FALLBACK=full` (or `1`). Opt-in keeps the #29 warning label.
- `daimon status` unchanged — pointer table still shows project/global rows. Carry guard from #95 untouched (display path only). README updated.

## Why

Two users in one week on the #94 arc read the labeled fallback as cross-project contamination: one warning line above ~100 lines of foreign items scrolls away instantly, and what remains on screen looks like the current project's briefing. Now that #95 guarantees fallback content can never persist into the project, the display-time value of the full foreign dump is low and the confusion cost is field-proven. See #96 for alternatives considered.

## Tests

- `test_brief_fallback_header_only_by_default` — watched fail (rendered foreign body), now header-only: orientation text present, foreign slug named, zero foreign items.
- `test_brief_fallback_full_via_flag` — watched fail (`unrecognized arguments: --global-fallback`), now full body + label.
- `test_brief_fallback_full_via_env` — env opt-in path.
- Two pre-existing tests updated because they encoded the old default (`test_cli_brief_falls_back_to_global` now asserts header-only; `test_cli_brief_prints_briefing` routes to its own project).
- Full suite: 894 passed.
- Live verify from the working tree: fresh project → header note with real slug + age; `--global-fallback` → full render with warning label; own-project brief byte-identical.