### PR TITLE
feat(stats): distinguish hook-driven briefings from deliberate re-reads

### DIFF
--- a/hook/daimon-session-brief.py
+++ b/hook/daimon-session-brief.py
@@ -29,6 +29,12 @@ except Exception:  # noqa: BLE001 — missing/corrupt lib must never crash the h
 TIMEOUT = 8  # seconds; hook budget is 10
 
 
+def _run_brief(cli, cwd: str, auto: bool):
+    argv = [cli, "brief", "--auto"] if auto else [cli, "brief"]
+    return subprocess.run(argv, capture_output=True, text=True, timeout=TIMEOUT,
+                          env=lib.project_env(cwd))
+
+
 def _emit_briefing(cwd: str, cli) -> None:
     # No binary at all is the plugin-install onboarding state (#91): the plugin
     # ships the hooks, the CLI arrives separately. One actionable line, exit 0.
@@ -55,10 +61,12 @@ def _emit_briefing(cwd: str, cli) -> None:
 
     # The CLI must route the same way this hook did: hand it the project cwd.
     try:
-        proc = subprocess.run(
-            [cli, "brief"], capture_output=True, text=True, timeout=TIMEOUT,
-            env=lib.project_env(cwd),
-        )
+        proc = _run_brief(cli, cwd, auto=True)
+        if proc.returncode == 2:
+            # argparse exit 2: a pre-flag `daimon` on PATH rejected --auto
+            # (the plugin updates independently of the CLI). A briefing must
+            # never die over instrumentation — retry plain.
+            proc = _run_brief(cli, cwd, auto=False)
     except subprocess.TimeoutExpired:
         print(f"daimon: `daimon brief` timed out after {TIMEOUT}s — briefing skipped")
         return

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -361,7 +361,7 @@ def _team_briefings(project) -> list:
 
 
 def _cmd_brief(args) -> int:
-    _note_usage("brief")
+    _note_usage("brief:auto" if getattr(args, "auto", False) else "brief")
     # Route like status/serialize: --project, else DAIMON_PROJECT_DIR, else cwd.
     # read_latest still falls back to the global pointer if the project has none.
     project = _resolve_project(args.project)
@@ -1462,6 +1462,11 @@ def main(argv=None) -> int:
         help="when this project has no checkpoint, render the full global "
              "checkpoint (possibly another project's) instead of the "
              "header-only note (#96)",
+    )
+    p_brief.add_argument(
+        "--auto", action="store_true",
+        help="mark this render as hook-driven (SessionStart) so `daimon stats` "
+             "can separate automatic briefings from deliberate re-reads (#54)",
     )
     p_brief.set_defaults(func=_cmd_brief)
 

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -24,7 +24,7 @@ import os
 import re
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from . import anchor, briefing, carry, config, configure, harvest, llm, recall, render, serializer, store, teamsync, transcript
@@ -1251,11 +1251,85 @@ def _stats_store() -> dict:
     return out
 
 
+_USAGE_STAMP_FMT = "%Y-%m-%dT%H:%M:%SZ"
+_RETENTION_WINDOW_DAYS = 14
+
+
+def _parse_stamp(token: str):
+    try:
+        return datetime.strptime(token, _USAGE_STAMP_FMT).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def _spawns_in_window(cutoff) -> bool:
+    """True when serialize.log shows any hook-spawned capture inside the
+    window — i.e. sessions ARE happening on this machine."""
+    try:
+        text = (config.log_dir() / "serialize.log").read_text(encoding="utf-8")
+    except OSError:
+        return False
+    for line in text.splitlines():
+        line = line.strip()
+        if not _STATS_HOST_RE.match(line):
+            continue
+        stamp = _parse_stamp(line.split()[0])
+        if stamp is not None and stamp >= cutoff:
+            return True
+    return False
+
+
+def _stats_retention(now=None) -> dict:
+    """usage.log -> hook-driven briefings (`brief:auto`) vs deliberate
+    re-reads, over the last _RETENTION_WINDOW_DAYS. Plain `brief` lines
+    stamped before the first `brief:auto` ever logged predate the flag and
+    are reported as untagged — ambiguous, never guessed (#54 honesty rule).
+    stale_hook_warning: sessions were captured in the window but zero
+    auto-briefings were logged — the SessionStart hook likely predates
+    --auto."""
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=_RETENTION_WINDOW_DAYS)
+    out = {"window_days": _RETENTION_WINDOW_DAYS, "hook_briefs": 0,
+           "rereads": {"brief": 0, "status": 0, "recall": 0},
+           "rereads_total": 0, "rereads_per_hook_brief": None,
+           "untagged_briefs": 0, "stale_hook_warning": False}
+    try:
+        lines = (config.log_dir() / "usage.log").read_text(encoding="utf-8").splitlines()
+    except OSError:
+        lines = []
+    events = []
+    for line in lines:
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        stamp = _parse_stamp(parts[0])
+        if stamp is not None:
+            events.append((stamp, parts[1]))
+    first_auto = min((s for s, cmd in events if cmd == "brief:auto"), default=None)
+    for stamp, cmd in events:
+        if cmd == "brief" and (first_auto is None or stamp < first_auto):
+            out["untagged_briefs"] += 1
+            continue
+        if stamp < cutoff:
+            continue
+        if cmd == "brief:auto":
+            out["hook_briefs"] += 1
+        elif cmd in out["rereads"]:
+            out["rereads"][cmd] += 1
+    out["rereads_total"] = sum(out["rereads"].values())
+    if out["hook_briefs"]:
+        out["rereads_per_hook_brief"] = round(
+            out["rereads_total"] / out["hook_briefs"], 2)
+    if out["hook_briefs"] == 0 and _spawns_in_window(cutoff):
+        out["stale_hook_warning"] = True
+    return out
+
+
 def _cmd_stats(args) -> int:
     """Aggregate what is already on disk. Nothing is transmitted anywhere —
     sharing the output is a deliberate act (the user pastes it)."""
     data = {"usage": _stats_usage(), "capture": _stats_capture(),
-            "store": _stats_store()}
+            "store": _stats_store(), "retention": _stats_retention()}
     if args.json:
         print(json.dumps(data, indent=2))
         return 0

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -610,6 +610,22 @@ def _plain_stats(data: dict) -> None:
             print(f"  {cmd_name}: {n}")
     else:
         print("  none recorded yet")
+    r = data.get("retention")
+    if r:
+        print(f"retention (last {r['window_days']}d):")
+        print(f"  hook briefings: {r['hook_briefs']}")
+        rr = r["rereads"]
+        print(f"  deliberate re-reads: brief {rr['brief']}, status {rr['status']}, "
+              f"recall {rr['recall']}  (total {r['rereads_total']})")
+        ratio = r["rereads_per_hook_brief"]
+        print(f"  re-reads per hook briefing: "
+              f"{ratio if ratio is not None else 'n/a'}")
+        if r["untagged_briefs"]:
+            print(f"  untagged brief lines (pre --auto): {r['untagged_briefs']}")
+        if r["stale_hook_warning"]:
+            print("  ⚠ sessions captured but no hook briefings logged — the "
+                  "SessionStart hook may predate --auto; re-run `daimon hooks "
+                  "install` (or update the plugin)")
     print("capture:")
     print(f"  serialized: {c['success']}  skipped: {c['skipped']}  "
           f"errors: {c['errors']}  via fallback backend: {c['fallback_serializes']}")
@@ -645,6 +661,30 @@ def _rich_stats(data: dict) -> None:
     else:
         usage_table.add_row("[dim]none recorded yet[/dim]", "")
     console.print(usage_table)
+
+    r = data.get("retention")
+    if r:
+        ret_table = Table(title=f"retention (last {r['window_days']}d)",
+                          title_justify="left", show_header=True,
+                          header_style="bold")
+        ret_table.add_column("metric")
+        ret_table.add_column("value", justify="right")
+        ret_table.add_row("hook briefings", str(r["hook_briefs"]))
+        rr = r["rereads"]
+        ret_table.add_row("deliberate re-reads",
+                          f"brief {rr['brief']}, status {rr['status']}, "
+                          f"recall {rr['recall']} (total {r['rereads_total']})")
+        ratio = r["rereads_per_hook_brief"]
+        ret_table.add_row("re-reads per hook briefing",
+                          "n/a" if ratio is None else str(ratio))
+        if r["untagged_briefs"]:
+            ret_table.add_row("untagged brief lines (pre --auto)",
+                              str(r["untagged_briefs"]))
+        console.print(ret_table)
+        if r["stale_hook_warning"]:
+            console.print("[yellow]⚠ sessions captured but no hook briefings "
+                          "logged — re-run `daimon hooks install` (or update "
+                          "the plugin)[/yellow]")
 
     capture_table = Table(title="capture", title_justify="left",
                           show_header=True, header_style="bold")

--- a/plugin/tests/test_claude_hooks.py
+++ b/plugin/tests/test_claude_hooks.py
@@ -246,6 +246,84 @@ def test_brief_hook_disable_suppresses_heal(tmp_path, tmp_checkpoint_dir):
     assert not capture.exists()
 
 
+def _fake_cli_argv_recording(tmp_path) -> tuple[Path, Path]:
+    """A fake `daimon` that appends each invocation's full argv to a capture
+    file (one line per call) and prints a briefing body — lets a test observe
+    exactly which flags `_emit_briefing` passed and how many times it retried."""
+    fake_bin = tmp_path / "fakebin"
+    fake_bin.mkdir()
+    capture = tmp_path / "argv.txt"
+    script = fake_bin / "daimon"
+    script.write_text(
+        "#!/bin/sh\n"
+        f'printf "%s\\n" "$*" >> "{capture}"\n'
+        "echo briefing-body\n"
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    return fake_bin, capture
+
+
+def test_brief_hook_passes_auto_flag(tmp_path, tmp_checkpoint_dir, sample_checkpoint):
+    # #100: `daimon brief --auto` (Task 1) is only useful if the hook sends it.
+    store.write_checkpoint("S-global", {**sample_checkpoint, "session_id": "S-global"})
+    fake_bin, capture = _fake_cli_argv_recording(tmp_path)
+    proc = _run(
+        BRIEF_HOOK,
+        {"cwd": "/Users/x/projA", "session_id": "S-new"},
+        tmp_path,
+        extra_env={"PATH": str(fake_bin)},
+    )
+    assert proc.returncode == 0
+    recorded = capture.read_text()
+    assert "--auto" in recorded
+
+
+def _fake_cli_preflag(tmp_path) -> tuple[Path, Path]:
+    """A fake `daimon` shaped like a CLI installed before the --auto flag
+    shipped: the plugin (and this hook) update independently of the CLI via
+    uv/pip, so a newer hook meeting an older CLI on PATH is a real field
+    scenario. It rejects --auto with argparse's exit code 2 but briefs fine
+    without it. Records each invocation to let a test count the retry."""
+    fake_bin = tmp_path / "fakebin"
+    fake_bin.mkdir()
+    capture = tmp_path / "argv.txt"
+    script = fake_bin / "daimon"
+    script.write_text(
+        "#!/bin/sh\n"
+        f'printf "%s\\n" "$*" >> "{capture}"\n'
+        'case "$*" in *--auto*) exit 2;; esac\n'
+        "echo briefing-body\n"
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    return fake_bin, capture
+
+
+def test_brief_hook_retries_without_auto_on_preflag_cli(tmp_path, tmp_checkpoint_dir, sample_checkpoint):
+    # #100: exit 2 (argparse rejection) from a pre-flag CLI must degrade to a
+    # plain retry, never a lost briefing.
+    store.write_checkpoint("S-global", {**sample_checkpoint, "session_id": "S-global"})
+    fake_bin, capture = _fake_cli_preflag(tmp_path)
+    proc = _run(
+        BRIEF_HOOK,
+        {"cwd": "/Users/x/projA", "session_id": "S-new"},
+        tmp_path,
+        extra_env={"PATH": str(fake_bin)},
+    )
+    assert proc.returncode == 0
+    assert "briefing-body" in proc.stdout  # briefing survived the mismatch
+
+    # Filter to `brief` invocations only: main() also opportunistically spawns
+    # `daimon heal` detached against this same fake CLI, and that line must not
+    # be mistaken for the retry.
+    brief_calls = [
+        line for line in capture.read_text().splitlines()
+        if line.split()[:1] == ["brief"]
+    ]
+    assert len(brief_calls) == 2  # --auto attempted first, then the plain retry
+    assert "--auto" in brief_calls[0]
+    assert "--auto" not in brief_calls[1]
+
+
 # ---- daimon-session-end.py ----
 
 

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3120,6 +3120,23 @@ def test_stats_plain_renders_retention_section(tmp_checkpoint_dir, tmp_log_dir,
     assert "re-reads per hook briefing: 1.0" in out
 
 
+def test_stats_rich_renders_retention_section(tmp_checkpoint_dir, tmp_log_dir,
+                                              sample_checkpoint, capsys, monkeypatch):
+    pytest.importorskip("rich")
+    from daimon_briefing import render, store
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    store.write_checkpoint("S1", sample_checkpoint)
+    now = datetime.now(timezone.utc)
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "usage.log").write_text(_usage_line(1, "brief:auto", now)
+                                           + _usage_line(0, "status", now))
+    assert cli.main(["stats"]) == 0
+    out = capsys.readouterr().out
+    assert "retention (last 14d)" in out
+    assert "hook briefings" in out
+    assert "1.0" in out  # re-reads per hook briefing ratio
+
+
 def test_stats_plain_warns_on_stale_hook(tmp_checkpoint_dir, tmp_log_dir,
                                          sample_checkpoint, capsys, monkeypatch):
     from daimon_briefing import store

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3025,6 +3025,85 @@ def test_stats_empty_world_is_calm(tmp_checkpoint_dir, capsys):
     assert data["store"]["checkpoints"] == 0
 
 
+# ---- retention: hook briefings vs deliberate re-reads ----
+
+from datetime import datetime, timedelta, timezone
+
+
+def _usage_line(days_ago, cmd, now):
+    stamp = (now - timedelta(days=days_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return f"{stamp} {cmd}\n"
+
+
+def test_retention_counts_hook_briefs_and_rereads_in_window(tmp_log_dir):
+    now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "usage.log").write_text(
+        _usage_line(20, "brief", now)          # before first auto -> untagged
+        + _usage_line(10, "brief:auto", now)   # first auto = upgrade marker
+        + _usage_line(5, "brief:auto", now)
+        + _usage_line(4, "brief", now)         # after marker -> deliberate re-read
+        + _usage_line(3, "status", now)
+        + _usage_line(2, "recall", now)
+        + _usage_line(16, "status", now)       # outside the 14d window -> ignored
+    )
+    r = cli._stats_retention(now=now)
+    assert r["window_days"] == 14
+    assert r["hook_briefs"] == 2
+    assert r["rereads"] == {"brief": 1, "status": 1, "recall": 1}
+    assert r["rereads_total"] == 3
+    assert r["rereads_per_hook_brief"] == 1.5
+    assert r["untagged_briefs"] == 1
+    assert r["stale_hook_warning"] is False
+
+
+def test_retention_zero_hook_briefs_ratio_is_none(tmp_log_dir):
+    now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "usage.log").write_text(_usage_line(1, "status", now))
+    r = cli._stats_retention(now=now)
+    assert r["hook_briefs"] == 0
+    assert r["rereads_per_hook_brief"] is None
+
+
+def test_retention_all_briefs_untagged_when_no_auto_ever(tmp_log_dir):
+    now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "usage.log").write_text(
+        _usage_line(3, "brief", now) + _usage_line(1, "brief", now))
+    r = cli._stats_retention(now=now)
+    assert r["untagged_briefs"] == 2
+    assert r["rereads"]["brief"] == 0  # never guessed
+
+
+def test_retention_stale_hook_warning_fires_on_spawns_without_auto(tmp_log_dir):
+    now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+    stamp = (now - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "serialize.log").write_text(
+        f"{stamp} session-end: spawned serialize for S9 (pid 1)\n")
+    r = cli._stats_retention(now=now)
+    assert r["stale_hook_warning"] is True
+
+
+def test_retention_no_warning_without_spawns(tmp_log_dir):
+    now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+    r = cli._stats_retention(now=now)
+    assert r["stale_hook_warning"] is False
+
+
+def test_stats_json_includes_retention(tmp_checkpoint_dir, tmp_log_dir,
+                                       sample_checkpoint, capsys):
+    from daimon_briefing import store
+    store.write_checkpoint("S1", sample_checkpoint)
+    assert cli.main(["stats", "--json"]) == 0
+    data = json.loads(capsys.readouterr().out)
+    assert "retention" in data
+    assert set(data["retention"]) >= {"window_days", "hook_briefs", "rereads",
+                                      "rereads_total", "rereads_per_hook_brief",
+                                      "untagged_briefs", "stale_hook_warning"}
+
+
 # ---- crash stamping (#92): timestamp header before uncaught tracebacks ------
 
 

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2948,6 +2948,25 @@ def test_usage_logging_respects_kill_switch(tmp_checkpoint_dir, tmp_log_dir,
     assert not (tmp_log_dir / "usage.log").exists()
 
 
+def test_brief_auto_logs_distinct_single_token(tmp_checkpoint_dir, tmp_log_dir,
+                                               sample_checkpoint, capsys):
+    from daimon_briefing import store
+    store.write_checkpoint("S1", sample_checkpoint)
+    assert cli.main(["brief", "--auto"]) == 0
+    lines = (tmp_log_dir / "usage.log").read_text().splitlines()
+    assert len(lines) == 1
+    assert lines[0].split()[1] == "brief:auto"  # single token: len(parts)==2 filter survives
+
+
+def test_brief_without_auto_logs_plain_token(tmp_checkpoint_dir, tmp_log_dir,
+                                             sample_checkpoint, capsys):
+    from daimon_briefing import store
+    store.write_checkpoint("S1", sample_checkpoint)
+    assert cli.main(["brief"]) == 0
+    lines = (tmp_log_dir / "usage.log").read_text().splitlines()
+    assert lines[0].split()[1] == "brief"
+
+
 def test_stats_json_reports_usage_capture_and_store(
         tmp_checkpoint_dir, tmp_log_dir, sample_checkpoint, capsys):
     from daimon_briefing import store

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3104,6 +3104,35 @@ def test_stats_json_includes_retention(tmp_checkpoint_dir, tmp_log_dir,
                                       "untagged_briefs", "stale_hook_warning"}
 
 
+def test_stats_plain_renders_retention_section(tmp_checkpoint_dir, tmp_log_dir,
+                                               sample_checkpoint, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PLAIN", "1")
+    store.write_checkpoint("S1", sample_checkpoint)
+    now = datetime.now(timezone.utc)
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "usage.log").write_text(_usage_line(1, "brief:auto", now)
+                                           + _usage_line(0, "status", now))
+    assert cli.main(["stats"]) == 0
+    out = capsys.readouterr().out
+    assert "retention (last 14d):" in out
+    assert "hook briefings: 1" in out
+    assert "re-reads per hook briefing: 1.0" in out
+
+
+def test_stats_plain_warns_on_stale_hook(tmp_checkpoint_dir, tmp_log_dir,
+                                         sample_checkpoint, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PLAIN", "1")
+    store.write_checkpoint("S1", sample_checkpoint)
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "serialize.log").write_text(
+        f"{stamp} session-end: spawned serialize for S9 (pid 1)\n")
+    assert cli.main(["stats"]) == 0
+    assert "re-run `daimon hooks install`" in capsys.readouterr().out
+
+
 # ---- crash stamping (#92): timestamp header before uncaught tracebacks ------
 
 


### PR DESCRIPTION
Closes #100.

SessionStart hooks shell out to `daimon brief`, landing in the same usage counter as a manual run — stats could not answer 'do I actually re-read briefings?' (#54).

- `daimon brief --auto` logs `brief:auto` (single token; the len==2 usage.log filter is untouched)
- `daimon stats` gains a 14-day retention section: hook briefings vs deliberate re-reads, ratio, untagged pre-flag lines (classified by the first `brief:auto` ever logged — ambiguous lines are reported, never guessed), plain+rich parity
- stale-hook warning when sessions were captured in-window but zero auto-briefings were logged
- the Claude Code SessionStart hook passes `--auto` and retries without it on exit 2, so a pre-flag CLI never loses its briefing (plugin and CLI update independently)