### PR TITLE
feat(store): append-only resolution events — supersede-not-delete lifecycle (#102)

### DIFF
--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -64,13 +64,23 @@ def _same_item(a_text: str, b_text: str, generic=frozenset()) -> bool:
 
 
 def merge(new_cp: dict, prev_cp: dict | None, now: float,
-          floor: float = 0.05, cap: int = 8) -> dict:
+          floor: float = 0.05, cap: int = 8,
+          resolved: frozenset = frozenset()) -> dict:
     """Fold prev_cp's carry-eligible items into a COPY of new_cp.
 
     Native items are never dropped or reordered — carry only appends, and (on
     a dedup hit) copies the older first_seen onto the native twin so decay age
     survives rewording. Anachronism guard: healing an old session must not
     swallow a newer checkpoint's state.
+
+    `resolved` (#102): a set of item_ref/id strings the CALLER has already
+    determined are closed (via store.resolutions/is_resolved) — merge does no
+    I/O itself (module invariant, see the module docstring). A resolved prev
+    item with NO native twin is not carried. A resolved prev item WITH a
+    native twin still runs the twin block: id inheritance still lands on the
+    twin (that's what lets #103 suppress the re-extraction at render time),
+    and the native item itself is never dropped — only the render layer, not
+    carry, decides what to do with a resolved-but-still-mentioned item.
 
     No-op paths (non-dict inputs, anachronism guard) return new_cp UNCHANGED,
     not a copy — callers reassign the result immediately, so a defensive
@@ -135,7 +145,14 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                     cur = store._created_epoch(twin["first_seen"])
                     if old is not None and (cur is None or old < cur):
                         twin["first_seen"] = item["first_seen"]
+                # Identity rides the same rail as first_seen (#102): the prev
+                # item's id lands on the reworded native twin, so a resolution
+                # recorded against the old id still binds after re-extraction.
+                if item.get("id"):
+                    twin.setdefault("id", item["id"])
                 continue
+            if item.get("id") in resolved:
+                continue  # world closed this loop (#102) — stop carrying it
             if scoring.effective_weight(item, item_type, now) < floor:
                 continue  # expired — deterministic exit (noise budget)
             # Carry-once covers REWORDED twins too (#31 item 9): a prev item

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -445,6 +445,63 @@ def _cmd_recall(args) -> int:
     return 0
 
 
+# ---- resolve/log: zero-LLM append-only event writers (#102) ----
+
+
+def _cmd_resolve(args) -> int:
+    """Append a resolution event for ONE checkpoint item (#102). Exact id
+    first; else a fuzzy query that must match uniquely — an ambiguous bind
+    is refused with candidates listed, because a wrong bind silently
+    suppresses a live memory (the false-merge lesson, #13)."""
+    project = _resolve_project(args.project)
+    checkpoint = store.read_latest(project_dir=project, fallback=False)
+    if not isinstance(checkpoint, dict):
+        print("no checkpoint for this project yet — nothing to resolve")
+        return 1
+    items = []
+    for section, key in store._ITEM_LISTS:
+        for item in ((checkpoint.get(section) or {}).get(key) or []):
+            if isinstance(item, dict) and item.get("id"):
+                items.append((key, item))
+    target = next((it for _, it in items if it["id"] == args.target), None)
+    if target is None:
+        texts = [str(it.get("text") or "") for _, it in items]
+        generic = carry._generic_terms(texts)
+        hits = [(key, it) for key, it in items
+                if carry._same_item(args.target, str(it.get("text") or ""), generic)]
+        if len(hits) == 1:
+            target = hits[0][1]
+        else:
+            label = "no item matches" if not hits else "ambiguous — matches"
+            print(f"{label} {args.target!r}; candidates:")
+            listing = hits or items
+            for key, it in listing:
+                print(f"  {it['id']}  [{key}] {it.get('text', '')}")
+            print("resolve by exact id: daimon resolve <id>")
+            return 1
+    ok = store.append_event(target["id"], args.status, note=args.note or "",
+                            project_dir=project)
+    if not ok:
+        print("event not written (daimon disabled or project unknown)")
+        return 1
+    print(f"resolved {target['id']}: {target.get('text', '')} [{args.status}]")
+    return 0
+
+
+def _cmd_log(args) -> int:
+    """Freeform zero-LLM event append (#102): a timeline fact worth keeping
+    that is not tied to one item. The fold ignores ref-less lines; readers
+    of the raw log get the audit trail."""
+    project = _resolve_project(args.project)
+    ok = store.append_event("", args.status, note=args.text,
+                            kind=args.kind, project_dir=project)
+    if not ok:
+        print("event not written (daimon disabled or project unknown)")
+        return 1
+    print(f"logged [{args.kind}] {args.text}")
+    return 0
+
+
 # ---- recall-inject: the UserPromptSubmit hook backend (#125) ----
 
 _SEEN_PRUNE_SECONDS = 7 * 86400  # cooldown files for week-old sessions are dead
@@ -1591,6 +1648,29 @@ def main(argv=None) -> int:
         "--limit", type=int, default=20, help="max results (default: 20)"
     )
     p_recall.set_defaults(func=_cmd_recall)
+
+    p_resolve = sub.add_parser(
+        "resolve", help="mark a checkpoint item resolved — append-only event, "
+        "folds at read so the item stops carrying (#102)",
+        epilog="Examples:\n  daimon resolve o-3f8a2c\n"
+               "  daimon resolve \"release pipeline approval\" --note \"shipped in 0.9\"\n",
+    )
+    p_resolve.add_argument("target", help="item id (exact) or a query that must match exactly one item")
+    p_resolve.add_argument("--status", default="resolved",
+                           help="free-form lifecycle status (default: resolved; "
+                                "a status starting with 'reopen' revives the item)")
+    p_resolve.add_argument("--note", help="optional context recorded on the event")
+    p_resolve.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    p_resolve.set_defaults(func=_cmd_resolve)
+
+    p_log = sub.add_parser(
+        "log", help="append a freeform timeline event (zero-LLM) to this project's event log (#102)",
+    )
+    p_log.add_argument("--text", required=True, help="what happened")
+    p_log.add_argument("--kind", default="note", help="event kind (default: note)")
+    p_log.add_argument("--status", default="", help="optional free-form status")
+    p_log.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    p_log.set_defaults(func=_cmd_log)
 
     p_inject = sub.add_parser(
         "recall-inject",

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -212,9 +212,13 @@ def _run_serialize(transcript_path: Path, project: str | None) -> int:
             # this project's bucket permanently. No prev -> no carry.
             prev = store.read_latest(project, fallback=False)
             now = store._created_epoch(checkpoint.get("created")) or time.time()
+            events = store.resolutions(project_dir=project)
+            resolved = frozenset(ref for ref, evt in events.items()
+                                 if store.is_resolved(evt))
             checkpoint = carry.merge(checkpoint, prev, now,
                                      floor=config.carry_floor(),
-                                     cap=config.carry_max())
+                                     cap=config.carry_max(),
+                                     resolved=resolved)
         except Exception:  # keep the unmerged checkpoint, proceed to write
             pass
     out = store.write_checkpoint(session_id, checkpoint, project_dir=project)

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -24,6 +24,7 @@ one a live pointer still references. The default is generous on purpose so #33's
 merged checkpoint history keeps a deep well of files to reconstruct from.
 """
 
+import hashlib
 import json
 import os
 import re
@@ -350,6 +351,50 @@ def _gc_checkpoints(d: Path, keep: int) -> None:
             pass
 
 
+# The five list sections that hold checkpoint items. active_topic is a single
+# per-session dict and never needs an id (it does not carry, #33).
+_ITEM_LISTS = (
+    ("working_context", "open_questions"),
+    ("working_context", "recent_decisions"),
+    ("epistemic_snapshot", "strong_beliefs"),
+    ("epistemic_snapshot", "uncertainties"),
+    ("epistemic_snapshot", "contradictions_flagged"),
+)
+
+
+def _stamp_item_ids(checkpoint: dict) -> None:
+    """Stable per-item ids (#102): sha1 of kind:text, 6 hex chars, prefixed
+    with the kind's initial. setdefault semantics — an item that already
+    carries an id (a carried twin, a re-write) is never re-stamped, so
+    identity survives rotation and re-serialization. Collisions within one
+    checkpoint widen the slice; identical-text twins fall through to a
+    counter suffix (same text, same kind, still two loops)."""
+    seen: set = set()
+    for section, key in _ITEM_LISTS:
+        items = (checkpoint.get(section) or {}).get(key)
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict) or not str(item.get("text") or "").strip():
+                continue
+            if item.get("id"):
+                seen.add(item["id"])
+                continue
+            digest = hashlib.sha1(
+                f"{key}:{item['text']}".encode("utf-8")).hexdigest()
+            cand = ""
+            for width in (6, 8, 12, 40):
+                cand = f"{key[0]}-{digest[:width]}"
+                if cand not in seen:
+                    break
+            n = 2
+            while cand in seen:
+                cand = f"{key[0]}-{digest[:6]}-{n}"
+                n += 1
+            item["id"] = cand
+            seen.add(cand)
+
+
 def write_checkpoint(session_id: str, checkpoint: dict, project_dir=None) -> Path:
     """Write the session checkpoint + the global latest pointer, and — when the
     project is known — the per-project latest pointer too. The global pointer is
@@ -372,6 +417,7 @@ def write_checkpoint(session_id: str, checkpoint: dict, project_dir=None) -> Pat
     # store stays free of the git/subprocess dependency (scar 0). Present on every
     # checkpoint so read_team can attribute it later, even when team-write is off.
     checkpoint.setdefault("author", config.author())
+    _stamp_item_ids(checkpoint)
     # Stamp project attribution the same idempotent way. Bucket pointers rotate
     # away after `history` writes, so pointer-derived attribution EXPIRES — a
     # session older than the pointer window would lose its project forever and

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -663,3 +663,81 @@ def read_team(project_dir=None) -> list[tuple[str, dict]]:
                     best[key] = (rec, cp.get("author") or adir.name, cp)
     ordered = sorted(best.values(), key=lambda t: t[0], reverse=True)
     return [(author, cp) for _rec, author, cp in ordered]
+
+
+# ---- #102: append-only resolution events ----
+
+
+def _events_path(project_dir=None):
+    slug = project_slug(project_dir)
+    if not slug:
+        return None
+    return config.checkpoint_dir() / slug / "events.jsonl"
+
+
+def append_event(item_ref: str, status: str, note: str = "",
+                 kind: str = "resolution", source: str = "cli",
+                 project_dir=None) -> bool:
+    """One appended JSON line per lifecycle fact (#102). Append-only: the
+    file is never rewritten — resolution is a derivation at read, so the
+    audit trail must stay byte-stable. Silent no-op under the kill switch
+    and when the project is unknown (an event without a bucket has no
+    reader)."""
+    if config.is_disabled():
+        return False
+    path = _events_path(project_dir)
+    if path is None:
+        return False
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        evt = {"ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+               "kind": kind, "item_ref": item_ref, "status": status,
+               "source": source}
+        if note:
+            evt["note"] = note
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(evt, ensure_ascii=False) + "\n")
+        return True
+    except OSError:
+        return False
+
+
+def resolutions(project_dir=None) -> dict:
+    """events.jsonl -> {item_ref: latest event} — latest by ts, NEVER line
+    order (concurrent writers may interleave). Unknown kinds and extra
+    fields ride along untouched; unparseable lines are skipped best-effort:
+    a reader must never drop the log over one bad line."""
+    out: dict = {}
+    path = _events_path(project_dir)
+    if path is None:
+        return out
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return out
+    for line in lines:
+        try:
+            evt = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(evt, dict):
+            continue
+        ref = str(evt.get("item_ref") or "")
+        if not ref:
+            continue
+        cur = out.get(ref)
+        new_e = _created_epoch(evt.get("ts"))
+        cur_e = _created_epoch(cur.get("ts")) if cur else None
+        if cur is None or (new_e is not None and (cur_e is None or new_e >= cur_e)):
+            out[ref] = evt
+    return out
+
+
+def is_resolved(event) -> bool:
+    """Liveness rule (#102): latest event wins; a status starting with
+    'reopen' returns the item to live; anything else means resolved. Status
+    is free-form text by design — never an enum, so unknown statuses resolve
+    (the writer bothered to record a lifecycle fact) rather than vanish."""
+    if not isinstance(event, dict):
+        return False
+    return not str(event.get("status") or "").lower().startswith("reopen")

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -318,3 +318,49 @@ def test_in_call_reworded_prev_twins_carry_once():
     out = carry.merge(_cp("S-new"), prev, NOW)
     qs = out["working_context"]["open_questions"]
     assert len(qs) == 1
+
+
+# --- id inheritance + resolved-skip (#102): merge stays pure, caller injects
+# the resolved set as a frozenset of item_ref strings. -----------------------
+
+def test_twin_inherits_prev_id():
+    prev = _cp("S-prev", 1, questions=[
+        _item("cache guard holds", id="o-aaa111")])
+    new = _cp("S-new", 0, questions=[
+        _item("the cache guard is holding", days=0)])
+    out = carry.merge(new, prev, NOW)
+    qs = out["working_context"]["open_questions"]
+    assert len(qs) == 1
+    assert qs[0]["id"] == "o-aaa111"
+
+
+def test_resolved_prev_item_does_not_carry():
+    prev = _cp("S-prev", 1, questions=[
+        _item("dead loop no longer relevant", id="o-dead01"),
+        _item("control sibling loop still open", id="o-alive1")])
+    out = carry.merge(_cp("S-new"), prev, NOW, resolved=frozenset({"o-dead01"}))
+    qs = out["working_context"]["open_questions"]
+    texts = [q["text"] for q in qs]
+    assert "dead loop no longer relevant" not in texts
+    assert "control sibling loop still open" in texts
+
+
+def test_resolved_prev_with_native_twin_still_inherits_id_and_native_survives():
+    prev = _cp("S-prev", 1, questions=[
+        _item("dead loop no longer relevant", id="o-dead01")])
+    new = _cp("S-new", 0, questions=[
+        _item("dead loop is no longer relevant now", days=0)])
+    out = carry.merge(new, prev, NOW, resolved=frozenset({"o-dead01"}))
+    qs = out["working_context"]["open_questions"]
+    assert len(qs) == 1  # native twin never dropped
+    assert qs[0]["id"] == "o-dead01"
+
+
+def test_merge_without_resolved_kwarg_unchanged():
+    prev = _cp("S-prev", 1, questions=[_item("zephyr ledger drop unresolved")])
+    new = _cp("S-new")
+    out = carry.merge(new, prev, NOW)
+    qs = out["working_context"]["open_questions"]
+    assert len(qs) == 1
+    assert qs[0]["text"] == "zephyr ledger drop unresolved"
+    assert qs[0]["carried_from"] == "S-prev"

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3176,3 +3176,71 @@ def test_main_installs_crash_excepthook(monkeypatch):
     with pytest.raises(SystemExit):
         cli.main(["--version"])
     assert sys.excepthook is cli._crash_stamp_excepthook
+
+
+# ---- #102: daimon resolve / daimon log ----
+
+
+def _write_cp_with_ids(store, project="/p/A"):
+    cp = {"working_context": {"open_questions": [
+        {"text": "release pipeline awaiting manual approval step", "trust": "inferred"},
+        {"text": "serializer chunk retry budget unclear", "trust": "inferred"},
+    ]}}
+    store.write_checkpoint("S1", cp, project_dir=project)
+    return cp
+
+
+def test_resolve_by_exact_id_appends_event(tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    assert cli.main(["resolve", iid]) == 0
+    r = store.resolutions(project_dir="/p/A")
+    assert store.is_resolved(r[iid])
+
+
+def test_resolve_by_unique_fuzzy_query(tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    assert cli.main(["resolve", "release pipeline manual approval",
+                     "--status", "resolved", "--note", "approved and shipped"]) == 0
+    r = store.resolutions(project_dir="/p/A")
+    assert r[iid]["note"] == "approved and shipped"
+
+
+def test_resolve_ambiguous_refuses_and_lists_candidates(tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = {"working_context": {"open_questions": [
+        {"text": "gateway retry budget for serializer chunks"},
+        {"text": "serializer chunk retry budget unclear"},
+    ]}}
+    store.write_checkpoint("S1", cp, project_dir="/p/A")
+    assert cli.main(["resolve", "serializer chunk retry budget"]) == 1
+    out = capsys.readouterr().out
+    for item in cp["working_context"]["open_questions"]:
+        assert item["id"] in out  # both candidates listed with ids
+    assert store.resolutions(project_dir="/p/A") == {}  # nothing appended
+
+
+def test_resolve_no_match_exits_1(tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    _write_cp_with_ids(store)
+    assert cli.main(["resolve", "completely unrelated nonsense query"]) == 1
+    assert store.resolutions(project_dir="/p/A") == {}
+
+
+def test_log_appends_freeform_event(tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    _write_cp_with_ids(store)
+    assert cli.main(["log", "--text", "midnight deploy went clean"]) == 0
+    slug = store.project_slug("/p/A")
+    line = json.loads((tmp_checkpoint_dir / slug / "events.jsonl").read_text().splitlines()[0])
+    assert line["kind"] == "note"
+    assert line["note"] == "midnight deploy went clean"
+    assert line["item_ref"] == ""

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -909,3 +909,60 @@ def test_non_dict_and_empty_items_are_skipped(tmp_checkpoint_dir):
     cp = {"working_context": {"open_questions": ["bare string", {"text": ""}, {"no": "text"}]}}
     store.write_checkpoint("S1", cp)  # must not raise
     assert "id" not in cp["working_context"]["open_questions"][1]
+
+
+# ---- #102: append-only event log + fold ----
+
+
+def test_append_event_writes_jsonl_line(tmp_checkpoint_dir, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    assert store.append_event("o-abc123", "resolved", note="shipped",
+                              project_dir="/p/A") is True
+    slug = store.project_slug("/p/A")
+    lines = (tmp_checkpoint_dir / slug / "events.jsonl").read_text().splitlines()
+    evt = json.loads(lines[0])
+    assert evt["item_ref"] == "o-abc123"
+    assert evt["status"] == "resolved"
+    assert evt["note"] == "shipped"
+    assert evt["kind"] == "resolution"
+    assert evt["ts"].endswith("Z")
+
+
+def test_append_event_respects_kill_switch(tmp_checkpoint_dir, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_DISABLE", "1")
+    assert store.append_event("o-abc123", "resolved", project_dir="/p/A") is False
+    slug = store.project_slug("/p/A")
+    assert not (tmp_checkpoint_dir / slug / "events.jsonl").exists()
+
+
+def test_resolutions_latest_wins_by_timestamp_not_line_order(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    d = tmp_checkpoint_dir / slug
+    d.mkdir(parents=True, exist_ok=True)
+    # NEWER event written FIRST in the file — fold must still prefer it
+    (d / "events.jsonl").write_text(
+        '{"ts": "2026-07-07T10:00:00Z", "kind": "resolution", "item_ref": "o-a", "status": "reopened"}\n'
+        '{"ts": "2026-07-06T10:00:00Z", "kind": "resolution", "item_ref": "o-a", "status": "resolved"}\n'
+        'not json at all\n'
+        '{"ts": "2026-07-07T09:00:00Z", "kind": "future-kind", "item_ref": "o-b", "status": "done", "extra": 1}\n'
+    )
+    r = store.resolutions(project_dir="/p/A")
+    assert r["o-a"]["status"] == "reopened"
+    assert r["o-b"]["extra"] == 1  # unknown kind + field preserved
+
+
+def test_is_resolved_semantics():
+    from daimon_briefing import store
+    assert store.is_resolved(None) is False
+    assert store.is_resolved({"status": "resolved"}) is True
+    assert store.is_resolved({"status": "superseded-by:o-x"}) is True
+    assert store.is_resolved({"status": "REOPENED — regression"}) is False
+
+
+def test_resolutions_missing_file_or_project_is_empty(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    assert store.resolutions(project_dir="/p/NOPE") == {}
+    assert store.resolutions(project_dir=None) == {}

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -852,3 +852,60 @@ def test_pointer_lock_excludes_second_holder(tmp_checkpoint_dir):
                 fcntl.flock(probe.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
         finally:
             probe.close()
+
+
+# ---- #102: stable item ids stamped at write ----
+
+
+def _cp_with_items():
+    return {
+        "working_context": {
+            "open_questions": [{"text": "will the cache hold", "trust": "inferred"}],
+            "recent_decisions": [{"text": "ship the guard", "trust": "verbatim"}],
+        },
+        "epistemic_snapshot": {
+            "strong_beliefs": [{"text": "carry must stay pure"}],
+            "uncertainties": [{"text": "is the window right"}],
+            "contradictions_flagged": [{"text": "doc says X code says Y"}],
+        },
+    }
+
+
+def test_write_stamps_id_on_every_list_item(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    cp = _cp_with_items()
+    store.write_checkpoint("S1", cp)
+    assert cp["working_context"]["open_questions"][0]["id"].startswith("o-")
+    assert cp["working_context"]["recent_decisions"][0]["id"].startswith("r-")
+    assert cp["epistemic_snapshot"]["strong_beliefs"][0]["id"].startswith("s-")
+    assert cp["epistemic_snapshot"]["uncertainties"][0]["id"].startswith("u-")
+    assert cp["epistemic_snapshot"]["contradictions_flagged"][0]["id"].startswith("c-")
+
+
+def test_id_stamping_is_idempotent_and_deterministic(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    cp = _cp_with_items()
+    store.write_checkpoint("S1", cp)
+    first = cp["working_context"]["open_questions"][0]["id"]
+    store.write_checkpoint("S1b", cp)
+    assert cp["working_context"]["open_questions"][0]["id"] == first
+    cp2 = _cp_with_items()
+    store.write_checkpoint("S2", cp2)
+    assert cp2["working_context"]["open_questions"][0]["id"] == first  # same kind+text -> same id
+
+
+def test_identical_text_twins_get_distinct_ids(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    cp = _cp_with_items()
+    cp["working_context"]["open_questions"].append(
+        {"text": "will the cache hold"})  # exact duplicate text
+    store.write_checkpoint("S1", cp)
+    ids = [i["id"] for i in cp["working_context"]["open_questions"]]
+    assert len(set(ids)) == 2
+
+
+def test_non_dict_and_empty_items_are_skipped(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    cp = {"working_context": {"open_questions": ["bare string", {"text": ""}, {"no": "text"}]}}
+    store.write_checkpoint("S1", cp)  # must not raise
+    assert "id" not in cp["working_context"]["open_questions"][1]


### PR DESCRIPTION
Closes #102.

Checkpoint items had no stable identity and no lifecycle: a resolved item kept carrying forward because collapse was an LLM merge judgment (the #14 leak).

- every list item gets a stable `id` stamped at write (setdefault — carried twins keep their identity; sha1 of kind:text, collision-widened)
- `carry.merge` inherits the prev twin's id onto reworded natives (the first_seen rail) and skips prev items whose id folds to resolved — merge stays pure, the caller injects the fold
- `events.jsonl` per project bucket: append-only, free-form status, latest-wins by timestamp (never line order), unknown kinds/fields preserved
- `daimon resolve <id-or-query>`: exact id or unique fuzzy match; ambiguous binds are refused with candidates listed (a wrong bind would suppress a live memory)
- `daimon log`: freeform zero-LLM timeline events
- render-time suppression of natively re-extracted twins of resolved items is #103 (this PR gives them the inherited id #103 needs)
