### PR TITLE
feat(brief): withhold event-resolved items — evidence-gated reverify (#103)

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -151,7 +151,7 @@ def withhold(checkpoint, resolutions: dict) -> tuple[dict, list]:
     # Dry run over the ORIGINAL checkpoint — decide what would be withheld
     # before paying for a deepcopy (most briefs resolve nothing).
     to_drop = []  # [(section, key, index, item, event)]
-    for section, key, _item_type in carry._CARRIED_KINDS:
+    for section, key in store._ITEM_LISTS:
         items = (checkpoint.get(section) or {}).get(key)
         if not isinstance(items, list):
             continue
@@ -160,9 +160,12 @@ def withhold(checkpoint, resolutions: dict) -> tuple[dict, list]:
                 continue
             item_id = item.get("id")
             if item_id:
-                evt = resolutions.get(item_id)
-                if evt is not None and item_id in resolved_refs:
-                    to_drop.append((section, key, idx, item, evt))
+                # resolved_refs is built from resolutions.items(), so membership
+                # here already guarantees resolutions[item_id] exists (M1: the
+                # old `evt is not None and ...` check was redundant — a subset
+                # check never needs the superset's own membership re-verified).
+                if item_id in resolved_refs:
+                    to_drop.append((section, key, idx, item, resolutions[item_id]))
                 continue  # id-bearing: bound exactly or not at all, never fuzzy
             text = str(item.get("text") or "").strip()
             if not text or not resolved_texts:

--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -11,11 +11,15 @@ beliefs, then uncertainties, then contradictions flagged. Verbatim items are mar
 distinctly from inferred ones.
 """
 
+import copy
 import logging
 import re
 import time
 
-from . import config, llm, scoring
+# store/carry import graph checked (#103): neither store, carry, recall, nor
+# scoring imports briefing — no cycle, so this stays a normal module-level
+# import (contrast carry.py's own local-import notes, which don't apply here).
+from . import carry, config, llm, scoring, store
 
 log = logging.getLogger("daimon.briefing")
 
@@ -112,6 +116,80 @@ def build(checkpoint, now=None) -> dict | None:
         "uncertainties": uncertainties,
         "contradictions": contradictions,
     }
+
+
+# ---- #103: withhold event-resolved items at render time ----
+
+
+def withhold(checkpoint, resolutions: dict) -> tuple[dict, list]:
+    """Drop items the world has already resolved, at RENDER time only — the
+    checkpoint on disk (and carry's copy of it) is never touched. `resolutions`
+    is `{item_ref: latest_event}`, exactly store.resolutions()'s shape; pure,
+    no I/O — the caller does the read (fail-open lives there, not here).
+
+    Binding is exact for id-bearing items: an item withholds only if ITS OWN
+    id is a resolved ref. id-LESS (legacy) items fall back to a fuzzy match on
+    item_text via carry._same_item/_generic_terms — but that fuzzy path is
+    id-bearing items' one guardrail: they NEVER take it, even on an exact text
+    coincidence (test_id_bearing_item_never_fuzzy_withheld). A fuzzy withhold
+    of an id-bearing item would silently suppress a live memory that merely
+    resembles a closed one — the worst failure mode this feature can have.
+
+    No resolved events, or a non-dict checkpoint -> (checkpoint, []) UNCHANGED,
+    same no-op idiom as carry.merge: no copy is made unless something actually
+    withholds, so the common case (nothing resolved yet) costs nothing."""
+    if not isinstance(checkpoint, dict) or not resolutions:
+        return checkpoint, []
+
+    resolved_refs = {ref for ref, evt in resolutions.items() if store.is_resolved(evt)}
+    if not resolved_refs:
+        return checkpoint, []
+    resolved_texts = [str(resolutions[ref].get("item_text") or "").strip()
+                       for ref in resolved_refs]
+    resolved_texts = [t for t in resolved_texts if t]
+
+    # Dry run over the ORIGINAL checkpoint — decide what would be withheld
+    # before paying for a deepcopy (most briefs resolve nothing).
+    to_drop = []  # [(section, key, index, item, event)]
+    for section, key, _item_type in carry._CARRIED_KINDS:
+        items = (checkpoint.get(section) or {}).get(key)
+        if not isinstance(items, list):
+            continue
+        for idx, item in enumerate(items):
+            if not isinstance(item, dict):
+                continue
+            item_id = item.get("id")
+            if item_id:
+                evt = resolutions.get(item_id)
+                if evt is not None and item_id in resolved_refs:
+                    to_drop.append((section, key, idx, item, evt))
+                continue  # id-bearing: bound exactly or not at all, never fuzzy
+            text = str(item.get("text") or "").strip()
+            if not text or not resolved_texts:
+                continue
+            generic = carry._generic_terms(resolved_texts + [text])
+            for ref in resolved_refs:
+                evt = resolutions[ref]
+                cand_text = str(evt.get("item_text") or "").strip()
+                if cand_text and carry._same_item(text, cand_text, generic):
+                    to_drop.append((section, key, idx, item, evt))
+                    break
+
+    if not to_drop:
+        return checkpoint, []
+
+    out = copy.deepcopy(checkpoint)
+    withheld = []
+    drop_idx_by_list: dict[tuple[str, str], set] = {}
+    for section, key, idx, item, evt in to_drop:
+        drop_idx_by_list.setdefault((section, key), set()).add(idx)
+        withheld.append((key, item, evt))
+    for (section, key), idxs in drop_idx_by_list.items():
+        items = out[section][key]
+        kept = [it for i, it in enumerate(items) if i not in idxs]
+        items[:] = kept
+
+    return out, withheld
 
 
 # ---- #79: token budget — section-preserving truncation ----

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -501,6 +501,51 @@ def _cmd_resolve(args) -> int:
     return 0
 
 
+def _cmd_reverify(args) -> int:
+    """Evidence-gated reopen (#103): re-stamping a resolved item without
+    evidence would mark an unchecked claim verified — the one thing this
+    tool must never do to its own audit trail. Reopen is allowed only when
+    the original anchor still checks out live (the code proved itself) or
+    the caller supplies --evidence (a human vouches for it); otherwise the
+    refusal appends nothing. Exact id only — no fuzzy match, because
+    reopening is a deliberate act; find ids via `daimon status --suppressed`."""
+    project = _resolve_project(args.project)
+    checkpoint = store.read_latest(project_dir=project, fallback=False)
+    if not isinstance(checkpoint, dict):
+        print("no checkpoint for this project yet — nothing to reverify")
+        return 1
+    item = None
+    for section, key in store._ITEM_LISTS:
+        for it in ((checkpoint.get(section) or {}).get(key) or []):
+            if isinstance(it, dict) and it.get("id") == args.target:
+                item = it
+                break
+        if item is not None:
+            break
+    if item is None:
+        print(f"no item found with id {args.target!r}")
+        return 1
+    evidence = args.evidence or ""
+    a = item.get("anchored_to")
+    if isinstance(a, dict) and anchor.check(a, project) == "live":
+        note = "reverified: anchor live"
+        if evidence:
+            note += "; " + evidence
+    elif evidence:
+        note = f"evidence: {evidence}"
+    else:
+        print("re-stamping without evidence would mark an unchecked claim "
+              "verified — supply --evidence, or fix the anchored code and retry")
+        return 1
+    ok = store.append_event(item["id"], "reopened", note=note,
+                            item_text=item.get("text", ""), project_dir=project)
+    if not ok:
+        print("event not written (daimon disabled or project unknown)")
+        return 1
+    print(f"reopened {item['id']}: {item.get('text', '')}")
+    return 0
+
+
 def _cmd_log(args) -> int:
     """Freeform zero-LLM event append (#102): a timeline fact worth keeping
     that is not tied to one item. The fold ignores ref-less lines; readers
@@ -1712,6 +1757,18 @@ def main(argv=None) -> int:
     p_resolve.add_argument("--note", help="optional context recorded on the event")
     p_resolve.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
     p_resolve.set_defaults(func=_cmd_resolve)
+
+    p_reverify = sub.add_parser(
+        "reverify", help="evidence-gated reopen of a resolved item (#103) — "
+        "refuses without proof, so a claim can't get re-verified for free",
+        epilog="Examples:\n"
+               "  daimon reverify o-3f8a2c --evidence \"checked release page\"\n"
+               "  daimon reverify o-3f8a2c   # reopens only if the anchor still checks live\n",
+    )
+    p_reverify.add_argument("target", help="item id (exact only — reverify is deliberate, no fuzzy match)")
+    p_reverify.add_argument("--evidence", help="why this claim can be trusted again")
+    p_reverify.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    p_reverify.set_defaults(func=_cmd_reverify)
 
     p_log = sub.add_parser(
         "log", help="append a freeform timeline event (zero-LLM) to this project's event log (#102)",

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -787,10 +787,47 @@ def _crash_log_info(path: Path, now: float) -> dict | None:
             "age": _format_age(age), "path": str(path)}
 
 
+def _print_suppressed(project) -> int:
+    """`daimon status --suppressed` (#103): the visibility answer to brief's
+    silent-suppression note ("N resolved item(s) withheld — `daimon status
+    --suppressed` to list"). Reuses briefing.withhold for the classification
+    rather than reimplementing it — the resolved/live split must stay in
+    exactly one place. Reads ONLY this project's own latest checkpoint
+    (fallback=False, same rule as carry #94): listing another project's
+    withheld items under this project's status would be worse than listing
+    none. Fails open like brief's withhold call — a broken events.jsonl
+    must not crash `status`, it should just report nothing suppressed."""
+    checkpoint = store.read_latest(project_dir=project, fallback=False)
+    withheld = []
+    if checkpoint:
+        try:
+            events = store.resolutions(project_dir=project)
+            _, withheld = briefing.withhold(checkpoint, events)
+        except Exception:
+            withheld = []
+    if not withheld:
+        print("no suppressed items")
+        return 0
+    print(f"suppressed items ({len(withheld)}):")
+    for key, item, evt in withheld:
+        item_id = item.get("id") or "-"
+        text = str(item.get("text") or "").strip()
+        status = str(evt.get("status") or "")
+        ts = str(evt.get("ts") or "")
+        note = str(evt.get("note") or "").strip()
+        paren = f"{status} {ts}"
+        if note:
+            paren += f", {note}"
+        print(f"  {item_id}  [{key}] {text}  ({paren})")
+    return 0
+
+
 def _cmd_status(args) -> int:
     _note_usage("status")
-    now = time.time()
     project = _resolve_project(args.project)
+    if getattr(args, "suppressed", False):
+        return _print_suppressed(project)
+    now = time.time()
     proj = _checkpoint_info(store.project_latest_path(project), now)
     glob = _checkpoint_info(store.global_latest_path(), now)
     same = bool(
@@ -1708,6 +1745,10 @@ def main(argv=None) -> int:
     )
     p_status.add_argument(
         "--json", action="store_true", help="machine-readable output"
+    )
+    p_status.add_argument(
+        "--suppressed", action="store_true",
+        help="list items withheld from the briefing as resolved (#103)",
     )
     p_status.set_defaults(func=_cmd_status)
 

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -396,6 +396,15 @@ def _cmd_brief(args) -> int:
     if fallback_used:
         render.render_brief_note(["⚠ no checkpoint for this project — showing the global "
                                   "checkpoint (fallback), possibly another project's."])
+    withheld = []
+    if checkpoint:
+        # Withhold (#103): render-time derivation, fail-open — a briefing
+        # must never die over suppression machinery.
+        try:
+            events = store.resolutions(project_dir=project)
+            checkpoint, withheld = briefing.withhold(checkpoint, events)
+        except Exception:
+            withheld = []
     # NOTE: drift is checked against the resolved project root. If read_latest fell
     # back to the GLOBAL pointer (another project's checkpoint), its anchor file paths
     # are relative to a different root and may report spurious "hard" drift. Acceptable
@@ -405,6 +414,10 @@ def _cmd_brief(args) -> int:
     # renderer emits no Teammates section, byte-identical to a non-team briefing.
     teammates = _team_briefings(project) if getattr(args, "team", False) else None
     render.render_brief(checkpoint, drift=drift, teammates=teammates)
+    if withheld:
+        render.render_brief_note([
+            f"{len(withheld)} resolved item(s) withheld — "
+            "`daimon status --suppressed` to list"])
     return 0
 
 

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -480,7 +480,7 @@ def _cmd_resolve(args) -> int:
             print("resolve by exact id: daimon resolve <id>")
             return 1
     ok = store.append_event(target["id"], args.status, note=args.note or "",
-                            project_dir=project)
+                            project_dir=project, item_text=str(target.get("text") or ""))
     if not ok:
         print("event not written (daimon disabled or project unknown)")
         return 1

--- a/plugin/daimon_briefing/hooks.py
+++ b/plugin/daimon_briefing/hooks.py
@@ -64,11 +64,22 @@ def pre_llm_call(session_id=None, user_message=None, conversation_history=None,
             return None
         if not is_first_turn:
             return None
-        checkpoint = store.read_latest(
-            project_dir=config.resolve_project_root(config.project_dir())
-        )
+        project = config.resolve_project_root(config.project_dir())
+        checkpoint = store.read_latest(project_dir=project)
         if checkpoint is None:
             return None
+        # Withhold (#103 I1): this in-process injection path used to render the
+        # RAW checkpoint, so a resolved item still auto-injected into every new
+        # session's context — `daimon brief` already suppressed it, this hook
+        # didn't. Same fail-open rule as _cmd_brief: any resolutions() failure
+        # falls back to the unfiltered checkpoint, never blocks injection. No
+        # withheld-count note here — this is context injection, not a human-
+        # facing brief, so suppression stays clean (no note to render).
+        try:
+            events = store.resolutions(project_dir=project)
+            checkpoint, _withheld = briefing.withhold(checkpoint, events)
+        except Exception:
+            pass
         text = briefing.render(checkpoint)
         if not text:
             return None

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -677,7 +677,7 @@ def _events_path(project_dir=None):
 
 def append_event(item_ref: str, status: str, note: str = "",
                  kind: str = "resolution", source: str = "cli",
-                 project_dir=None) -> bool:
+                 project_dir=None, item_text: str = "") -> bool:
     """One appended JSON line per lifecycle fact (#102). Append-only: the
     file is never rewritten — resolution is a derivation at read, so the
     audit trail must stay byte-stable. Silent no-op under the kill switch
@@ -695,6 +695,8 @@ def append_event(item_ref: str, status: str, note: str = "",
                "source": source}
         if note:
             evt["note"] = note
+        if item_text:
+            evt["item_text"] = item_text
         with path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(evt, ensure_ascii=False) + "\n")
         return True

--- a/plugin/tests/test_briefing.py
+++ b/plugin/tests/test_briefing.py
@@ -547,3 +547,56 @@ def test_mark_untagged_trust_is_not_inferred():
     assert briefing._mark({"text": "x", "trust": ""}) == "? untagged"
     assert briefing._mark({"text": "x", "trust": "inferred"}) == "~ inferred"
     assert briefing._mark({"text": "x", "trust": "verbatim"}) == "✓ verbatim"
+
+
+# ---- #103: withhold event-resolved items at render time ----
+
+
+def _res_evt(ref, status="resolved", text=""):
+    e = {"ts": "2026-07-07T00:00:00Z", "kind": "resolution",
+         "item_ref": ref, "status": status}
+    if text:
+        e["item_text"] = text
+    return e
+
+
+def test_withhold_by_exact_id():
+    cp = {"working_context": {"open_questions": [
+        {"text": "is the gateway stable", "id": "o-aaa"},
+        {"text": "does carry hold", "id": "o-bbb"}]}}
+    filtered, withheld = briefing.withhold(cp, {"o-aaa": _res_evt("o-aaa")})
+    texts = [i["text"] for i in filtered["working_context"]["open_questions"]]
+    assert texts == ["does carry hold"]
+    assert withheld[0][1]["id"] == "o-aaa"
+    assert len(cp["working_context"]["open_questions"]) == 2  # input untouched
+
+
+def test_reopen_event_does_not_withhold():
+    cp = {"working_context": {"open_questions": [{"text": "x y z", "id": "o-aaa"}]}}
+    filtered, withheld = briefing.withhold(
+        cp, {"o-aaa": _res_evt("o-aaa", status="reopened")})
+    assert withheld == []
+    assert filtered["working_context"]["open_questions"]
+
+
+def test_legacy_idless_item_withheld_by_item_text_fuzzy():
+    cp = {"working_context": {"open_questions": [
+        {"text": "release pipeline approval step still awaiting manual gate"}]}}  # no id
+    ev = _res_evt("o-old01", text="release pipeline manual approval gate awaiting")
+    filtered, withheld = briefing.withhold(cp, {"o-old01": ev})
+    assert filtered["working_context"]["open_questions"] == []
+    assert len(withheld) == 1
+
+
+def test_id_bearing_item_never_fuzzy_withheld():
+    cp = {"working_context": {"open_questions": [
+        {"text": "release pipeline manual approval gate awaiting", "id": "o-live1"}]}}
+    ev = _res_evt("o-old01", text="release pipeline manual approval gate awaiting")
+    filtered, withheld = briefing.withhold(cp, {"o-old01": ev})
+    assert withheld == []  # exact text match but id-bearing: never fuzzy-bound
+
+
+def test_no_resolved_events_returns_input_unchanged():
+    cp = {"working_context": {"open_questions": [{"text": "x", "id": "o-a"}]}}
+    filtered, withheld = briefing.withhold(cp, {})
+    assert filtered is cp and withheld == []

--- a/plugin/tests/test_briefing.py
+++ b/plugin/tests/test_briefing.py
@@ -600,3 +600,23 @@ def test_no_resolved_events_returns_input_unchanged():
     cp = {"working_context": {"open_questions": [{"text": "x", "id": "o-a"}]}}
     filtered, withheld = briefing.withhold(cp, {})
     assert filtered is cp and withheld == []
+
+
+def test_withhold_covers_strong_beliefs():
+    # #103 I2: withhold used to iterate only carry._CARRIED_KINDS (3 of 5
+    # item kinds), so a resolved strong_beliefs id never suppressed — even
+    # though `daimon resolve` accepts it. withhold must cover all five
+    # store._ITEM_LISTS kinds; carry's own 3-kind carry policy is untouched.
+    cp = {"epistemic_snapshot": {"strong_beliefs": [
+        {"text": "extractive pinning prevents silent fact loss", "id": "b-aaa"}]}}
+    filtered, withheld = briefing.withhold(cp, {"b-aaa": _res_evt("b-aaa")})
+    assert filtered["epistemic_snapshot"]["strong_beliefs"] == []
+    assert withheld[0][1]["id"] == "b-aaa"
+
+
+def test_withhold_covers_contradictions_flagged():
+    cp = {"epistemic_snapshot": {"contradictions_flagged": [
+        {"text": "conflicting claims about the gateway", "id": "c-aaa"}]}}
+    filtered, withheld = briefing.withhold(cp, {"c-aaa": _res_evt("c-aaa")})
+    assert filtered["epistemic_snapshot"]["contradictions_flagged"] == []
+    assert withheld[0][1]["id"] == "c-aaa"

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2550,6 +2550,36 @@ def test_brief_fails_open_when_resolutions_raises(
     assert "Chunk threshold for the serializer" in out
 
 
+def test_status_suppressed_lists_withheld_item(tmp_checkpoint_dir, sample_checkpoint, capsys):
+    # #103: `daimon status --suppressed` answers the brief's "N resolved
+    # item(s) withheld" note with the actual listing, reusing briefing.withhold
+    # rather than reimplementing the classification.
+    from daimon_briefing import store
+    store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+    written = store.read_latest(project_dir="/repo/x")
+    item = written["working_context"]["open_questions"][1]
+    item_id = item["id"]
+    store.append_event(item_id, "resolved", project_dir="/repo/x")
+    rc = cli.main(["status", "--suppressed", "--project", "/repo/x"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "suppressed items (1):" in out
+    assert item_id in out
+    assert "Chunk threshold for the serializer" in out
+    assert "resolved" in out
+    # the live item must never show up in the suppressed listing
+    assert "PR #6 state" not in out
+
+
+def test_status_suppressed_none_prints_message(tmp_checkpoint_dir, sample_checkpoint, capsys):
+    from daimon_briefing import store
+    store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+    rc = cli.main(["status", "--suppressed", "--project", "/repo/x"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert out.strip() == "no suppressed items"
+
+
 def test_recall_rejects_nonpositive_limit(tmp_checkpoint_dir, capsys):
     # --limit 0 / -N used to clamp silently to 1 result. Reject loudly.
     rc = cli.main(["recall", "anything", "--limit", "0"])

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3198,6 +3198,7 @@ def test_resolve_by_exact_id_appends_event(tmp_checkpoint_dir, capsys, monkeypat
     assert cli.main(["resolve", iid]) == 0
     r = store.resolutions(project_dir="/p/A")
     assert store.is_resolved(r[iid])
+    assert r[iid]["item_text"] == "release pipeline awaiting manual approval step"
 
 
 def test_resolve_by_unique_fuzzy_query(tmp_checkpoint_dir, capsys, monkeypatch):

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2511,6 +2511,45 @@ def test_brief_fallback_full_via_env(
     assert "fallback" in out.lower()
 
 
+def test_brief_withholds_resolved_item_and_notes_suppression(
+        tmp_checkpoint_dir, sample_checkpoint, capsys):
+    # #103: a resolved item must not print in the brief, and the withheld
+    # count must be announced so the suppression is never silent.
+    from daimon_briefing import store
+    store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+    # write_checkpoint stamps a stable per-item id (#102) on every item, so a
+    # real checkpoint's items are id-bearing by the time brief reads them —
+    # resolve that exact id (the id-less fuzzy path is for legacy checkpoints
+    # predating id-stamping, covered by the pure-function tests).
+    written = store.read_latest(project_dir="/repo/x")
+    item_id = written["working_context"]["open_questions"][1]["id"]
+    store.append_event(item_id, "resolved", project_dir="/repo/x")
+    rc = cli.main(["brief", "--project", "/repo/x"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Chunk threshold for the serializer" not in out
+    assert "1 resolved item(s) withheld" in out
+    assert "--suppressed" in out
+
+
+def test_brief_fails_open_when_resolutions_raises(
+        tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
+    # #103: withhold machinery must never take the briefing down with it —
+    # a broken events.jsonl (or any resolutions() failure) still renders the
+    # full, unfiltered brief and exits clean.
+    from daimon_briefing import store
+    store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(store, "resolutions", _boom)
+    rc = cli.main(["brief", "--project", "/repo/x"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Chunk threshold for the serializer" in out
+
+
 def test_recall_rejects_nonpositive_limit(tmp_checkpoint_dir, capsys):
     # --limit 0 / -N used to clamp silently to 1 result. Reject loudly.
     rc = cli.main(["recall", "anything", "--limit", "0"])

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2571,6 +2571,28 @@ def test_status_suppressed_lists_withheld_item(tmp_checkpoint_dir, sample_checkp
     assert "PR #6 state" not in out
 
 
+def test_status_suppressed_lists_withheld_strong_belief(tmp_checkpoint_dir, sample_checkpoint, capsys):
+    # #103 I2: `daimon resolve` accepts all five item kinds (store._ITEM_LISTS),
+    # but withhold used to iterate only carry._CARRIED_KINDS (3 of 5) — a
+    # resolved strong_beliefs id never suppressed. Cover the gap end-to-end.
+    from daimon_briefing import store
+    store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+    written = store.read_latest(project_dir="/repo/x")
+    item = written["epistemic_snapshot"]["strong_beliefs"][0]
+    item_id = item["id"]
+    store.append_event(item_id, "resolved", project_dir="/repo/x")
+    rc = cli.main(["brief", "--project", "/repo/x"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Extractive pinning prevents silent fact loss" not in out
+    assert "1 resolved item(s) withheld" in out
+    rc = cli.main(["status", "--suppressed", "--project", "/repo/x"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "suppressed items (1):" in out
+    assert item_id in out
+
+
 def test_status_suppressed_none_prints_message(tmp_checkpoint_dir, sample_checkpoint, capsys):
     from daimon_briefing import store
     store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
@@ -3367,6 +3389,25 @@ def test_reverify_anchor_live_reopens_without_evidence(tmp_checkpoint_dir, tmp_p
     r = store.resolutions(project_dir="/p/A")
     assert not store.is_resolved(r[iid])
     assert "anchor live" in r[iid]["note"]
+
+
+def test_reverify_anchor_live_and_evidence_combined_note(tmp_checkpoint_dir, capsys, monkeypatch):
+    # M4: when the anchor is live AND --evidence is supplied, the note
+    # concatenates both — "reverified: anchor live; <evidence>".
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = {"working_context": {"open_questions": [
+        {"text": "anchored claim about foo()", "trust": "inferred",
+         "anchored_to": {"file": "foo.py", "symbol": "foo", "body_hash": "deadbeef"}},
+    ]}}
+    store.write_checkpoint("S1", cp, project_dir="/p/A")
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    store.append_event(iid, "resolved", project_dir="/p/A")
+    monkeypatch.setattr(cli.anchor, "check", lambda a, p: "live")
+    assert cli.main(["reverify", iid, "--evidence", "saw it work"]) == 0
+    r = store.resolutions(project_dir="/p/A")
+    assert not store.is_resolved(r[iid])
+    assert r[iid]["note"] == "reverified: anchor live; saw it work"
 
 
 def test_reverify_anchor_drifted_still_refused_without_evidence(tmp_checkpoint_dir, capsys, monkeypatch):

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3314,3 +3314,72 @@ def test_log_appends_freeform_event(tmp_checkpoint_dir, capsys, monkeypatch):
     assert line["kind"] == "note"
     assert line["note"] == "midnight deploy went clean"
     assert line["item_ref"] == ""
+
+
+# ---- #103: daimon reverify — evidence-gated reopen ----
+
+
+def test_reverify_not_found_exits_1(tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    _write_cp_with_ids(store)
+    assert cli.main(["reverify", "no-such-id"]) == 1
+    assert store.resolutions(project_dir="/p/A") == {}
+
+
+def test_reverify_refuses_without_evidence_when_no_anchor(tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    store.append_event(iid, "resolved", project_dir="/p/A")
+    assert cli.main(["reverify", iid]) == 1
+    out = capsys.readouterr().out
+    assert "without evidence" in out
+    r = store.resolutions(project_dir="/p/A")
+    assert store.is_resolved(r[iid])  # unchanged — still resolved, nothing appended
+
+
+def test_reverify_with_evidence_reopens(tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    store.append_event(iid, "resolved", project_dir="/p/A")
+    assert cli.main(["reverify", iid, "--evidence", "checked release page"]) == 0
+    r = store.resolutions(project_dir="/p/A")
+    assert not store.is_resolved(r[iid])
+    assert "checked release page" in r[iid]["note"]
+
+
+def test_reverify_anchor_live_reopens_without_evidence(tmp_checkpoint_dir, tmp_path, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = {"working_context": {"open_questions": [
+        {"text": "anchored claim about foo()", "trust": "inferred",
+         "anchored_to": {"file": "foo.py", "symbol": "foo", "body_hash": "deadbeef"}},
+    ]}}
+    store.write_checkpoint("S1", cp, project_dir="/p/A")
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    store.append_event(iid, "resolved", project_dir="/p/A")
+    monkeypatch.setattr(cli.anchor, "check", lambda a, p: "live")
+    assert cli.main(["reverify", iid]) == 0
+    r = store.resolutions(project_dir="/p/A")
+    assert not store.is_resolved(r[iid])
+    assert "anchor live" in r[iid]["note"]
+
+
+def test_reverify_anchor_drifted_still_refused_without_evidence(tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = {"working_context": {"open_questions": [
+        {"text": "anchored claim about bar()", "trust": "inferred",
+         "anchored_to": {"file": "bar.py", "symbol": "bar", "body_hash": "deadbeef"}},
+    ]}}
+    store.write_checkpoint("S1", cp, project_dir="/p/A")
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    store.append_event(iid, "resolved", project_dir="/p/A")
+    monkeypatch.setattr(cli.anchor, "check", lambda a, p: "hard")
+    assert cli.main(["reverify", iid]) == 1
+    r = store.resolutions(project_dir="/p/A")
+    assert store.is_resolved(r[iid])  # unchanged — still resolved, nothing appended

--- a/plugin/tests/test_hooks.py
+++ b/plugin/tests/test_hooks.py
@@ -271,6 +271,55 @@ def test_pre_llm_call_routes_project_through_resolve_project_root(
     assert captured["project_dir"] == "/git/top"
 
 
+# ---- #103 I1: pre_llm_call must withhold resolved items before injecting ----
+
+
+def test_pre_llm_call_withholds_resolved_item(tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
+    # hermes' pre_llm_call rendered the RAW checkpoint — a resolved item still
+    # auto-injected into every new session's context. Fix mirrors _cmd_brief:
+    # read this project's resolutions, apply briefing.withhold, then render.
+    # A project_dir is required: resolutions() no-ops (empty dict) for the
+    # unrouted/global bucket (project_slug(None) is None), so the fixture
+    # must route through a real project like the CLI-level #103 tests do.
+    from daimon_briefing import store
+
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/repo/x")
+    store.write_checkpoint("S-prev", sample_checkpoint, project_dir="/repo/x")
+    written = store.read_latest(project_dir="/repo/x")
+    item_id = written["working_context"]["open_questions"][1]["id"]
+    store.append_event(item_id, "resolved", project_dir="/repo/x")
+    out = hooks.pre_llm_call(
+        session_id="S2", user_message="hi", conversation_history=[], is_first_turn=True,
+        model="m", platform="cli",
+    )
+    assert isinstance(out, dict)
+    assert "Chunk threshold for the serializer" not in out["context"]
+    # PR #6 item is untouched — only the resolved item is withheld.
+    assert "PR #6" in out["context"]
+
+
+def test_pre_llm_call_fails_open_when_resolutions_raises(
+    tmp_checkpoint_dir, sample_checkpoint, monkeypatch
+):
+    # Withhold machinery must never suppress the injection path either — a
+    # broken events.jsonl still injects the full, unfiltered briefing.
+    from daimon_briefing import store
+
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/repo/x")
+    store.write_checkpoint("S-prev", sample_checkpoint, project_dir="/repo/x")
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(hooks.store, "resolutions", _boom)
+    out = hooks.pre_llm_call(
+        session_id="S2", user_message="hi", conversation_history=[], is_first_turn=True,
+        model="m", platform="cli",
+    )
+    assert isinstance(out, dict)
+    assert "Chunk threshold for the serializer" in out["context"]
+
+
 # ---- register(ctx) ----
 
 

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -966,3 +966,20 @@ def test_resolutions_missing_file_or_project_is_empty(tmp_checkpoint_dir):
     from daimon_briefing import store
     assert store.resolutions(project_dir="/p/NOPE") == {}
     assert store.resolutions(project_dir=None) == {}
+
+
+def test_append_event_stores_item_text_when_given(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    store.append_event("o-abc", "resolved", project_dir="/p/A",
+                       item_text="the exact loop wording")
+    slug = store.project_slug("/p/A")
+    evt = json.loads((tmp_checkpoint_dir / slug / "events.jsonl").read_text().splitlines()[0])
+    assert evt["item_text"] == "the exact loop wording"
+
+
+def test_append_event_omits_empty_item_text(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    store.append_event("o-abc", "resolved", project_dir="/p/A")
+    slug = store.project_slug("/p/A")
+    evt = json.loads((tmp_checkpoint_dir / slug / "events.jsonl").read_text().splitlines()[0])
+    assert "item_text" not in evt


### PR DESCRIPTION
Closes #103.

A drift/resolution flag rendered above a confidently-worded stale item does not read as a warning (#96 lesson) — resolved items must stop rendering, auditable, never guessed.

- `briefing.withhold` (pure, carry-pattern): filters event-resolved items from a render-time copy; the checkpoint file is never mutated. Id-bearing items bind exactly; id-less legacy items match resolved events' recorded `item_text` fuzzily; an id-bearing item is never fuzzy-withheld.
- brief prints one line when items were withheld; `daimon status --suppressed` lists them (id, kind, text, event).
- `daimon reverify <id>`: reopen gated on a live anchor check or explicit `--evidence` — re-stamping without evidence would mark an unchecked claim verified; refusal appends nothing.
- resolution events now record the item's text (enables the legacy match; readers already preserve unknown fields).
- fail-open: a resolutions read failure renders the brief unfiltered.
- scope note: anchor-hard drift does NOT withhold in v1 — fallback-root checkpoints can report spurious hard drift (cli.py:399-402), and suppression must never fire on a guess. Anchor-based withhold graduates with root-confidence gating (follow-up).