### PR TITLE
feat(store): capture-time secret redaction on checkpoint and event writes

### DIFF
--- a/.scars/candidates/unbounded-prefix-class-before-keyword-alternation-backtracks.md
+++ b/.scars/candidates/unbounded-prefix-class-before-keyword-alternation-backtracks.md
@@ -1,0 +1,31 @@
+---
+id: 0
+type: deadend
+title: Unbounded [\w-]* prefix before a keyword alternation backtracks quadratically — bound it ({0,32}?) or the write path hangs
+severity: high
+confidence: 0.9
+created: 2026-07-07
+authors: ["claude-code"]
+anchors:
+  - path: plugin/daimon_briefing/redact.py
+violation: "\[\\w-\]\*\(\?:"
+evidence:
+  - pr: 108
+  - note: "adjudicated fix in 964dfbb widened api-key to [\\w-]*(?:api[_-]?key|...) so env-var names match; passed unit tests AND task review; final-review adversarial probe measured O(N²): 16KB no-separator run = 7s, 32KB ≈ 28s — a checkpoint write freeze fail-open cannot catch (slowness is not an exception). Fixed in aa966df: [\\w-]{0,32}? lazy bounded prefix -> 0.40ms at 32KB"
+expires:
+  condition: "redaction moves off Python re (e.g. re2/hyperscan) or gains a timeout wrapper"
+  review_after: 2027-07-07
+status: candidate
+---
+
+Tried in #104: widening the api-key pattern with an unbounded `[\w-]*` prefix
+so env-var-style names (DAIMON_LLM_API_KEY=) match the keyword alternation.
+Failure mode: the prefix class overlaps the keyword characters, so on a long
+`[\w-]` run with NO separator (pasted base64url blob, concatenated hashes)
+the engine retries every split point — quadratic time, and this regex runs on
+every text/quote of every item on every checkpoint write. Unit tests and
+per-task review both passed; only an adversarial LENGTH probe surfaced it.
+Rule: any prefix class before a keyword alternation must be BOUNDED and lazy
+(`[\w-]{0,32}?`), and every capture-path regex gets a long-input completion
+test (50k chars, no timing assert — completion IS the signal). Python `re`
+has no timeout; fail-open except-clauses do not protect against slow matches.

--- a/plugin/daimon_briefing/redact.py
+++ b/plugin/daimon_briefing/redact.py
@@ -22,10 +22,10 @@ _PATTERNS = (
     ("bearer", re.compile(
         r"(?i)\b(?:bearer|authorization:\s*\w+)\s+[A-Za-z0-9._~+/=-]{16,}")),
     ("api-key", re.compile(
-        r"(?i)([\w-]*(?:api[_-]?key|secret|token|password|passwd))(\s*[=:]\s*)"
-        r"['\"]?[^\s'\"]{8,}")),
+        r"(?i)\b([\w-]{0,32}?(?:api[_-]?key|secret|token|password|passwd))"
+        r"(\s*[=:]\s*)['\"]?(?!\[redacted:)[^\s'\"]{8,}")),
     ("credential-url", re.compile(
-        r"\b([a-z][a-z0-9+.-]*://[^/\s:@]+):[^/\s@]+@")),
+        r"\b([a-z][a-z0-9+.-]{0,15}://[^/\s:@]+):(?!\[redacted:)[^/\s@]+@")),
 )
 
 

--- a/plugin/daimon_briefing/redact.py
+++ b/plugin/daimon_briefing/redact.py
@@ -1,0 +1,56 @@
+"""Deterministic capture-time secret redaction (#104) — stdlib only, zero LLM.
+
+Checkpoints persist outside the session and the team mirror replicates them
+to a shared remote, so a quoted secret must never reach disk. Patterns are
+precision-first: each requires a concrete shape (assignment operator, URL
+scheme, key prefix, header keyword) — never bare entropy — so prose
+("the token budget", "password rotation policy") survives untouched.
+Replacement is a stable visible marker, [redacted:<kind>]: auditable,
+never silent."""
+
+import re
+
+# (kind, compiled pattern). Order matters only for overlap (pem first: a key
+# block may contain assignment-looking lines that must not double-count).
+_PATTERNS = (
+    ("pem", re.compile(
+        r"-----BEGIN [A-Z0-9 ]*(?:KEY|CERTIFICATE)[A-Z0-9 ]*-----"
+        r"(?:.*?-----END [A-Z0-9 ]*(?:KEY|CERTIFICATE)[A-Z0-9 ]*-----|.*)",
+        re.DOTALL)),
+    ("aws-key", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
+    ("stripe-key", re.compile(r"\b[rsp]k_live_[0-9A-Za-z]{8,}\b")),
+    ("bearer", re.compile(
+        r"(?i)\b(?:bearer|authorization:\s*\w+)\s+[A-Za-z0-9._~+/=-]{16,}")),
+    ("api-key", re.compile(
+        r"(?i)([\w-]*(?:api[_-]?key|secret|token|password|passwd))(\s*[=:]\s*)"
+        r"['\"]?[^\s'\"]{8,}")),
+    ("credential-url", re.compile(
+        r"\b([a-z][a-z0-9+.-]*://[^/\s:@]+):[^/\s@]+@")),
+)
+
+
+def redact_text(s):
+    """(redacted, {kind: count}). Non-string / empty input passes through
+    unchanged — callers scrub optional fields without type checks. A regex
+    failure skips that pattern (fail-open: redaction must never cost the
+    write; unreachable with these static patterns, cheap insurance)."""
+    counts: dict = {}
+    if not isinstance(s, str) or not s:
+        return s, counts
+
+    def _mark(kind):
+        counts[kind] = counts.get(kind, 0) + 1
+
+    for kind, rx in _PATTERNS:
+        def _sub(m, kind=kind):
+            _mark(kind)
+            if kind == "api-key":
+                return m.group(1) + m.group(2) + "[redacted:api-key]"
+            if kind == "credential-url":
+                return m.group(1) + ":[redacted:credential-url]@"
+            return f"[redacted:{kind}]"
+        try:
+            s = rx.sub(_sub, s)
+        except re.error:  # pragma: no cover — static patterns
+            continue
+    return s, counts

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -33,7 +33,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
-from . import config, serializer
+from . import config, redact, serializer
 
 _LATEST = "latest.json"
 # Rotation pointers, not per-session checkpoints. Anything else ending in .json in
@@ -362,6 +362,45 @@ _ITEM_LISTS = (
 )
 
 
+def _redact_checkpoint(checkpoint: dict) -> None:
+    """Capture-time secret redaction (#104): runs BEFORE _stamp_item_ids so
+    ids hash the redacted text (identity stays stable across re-writes).
+    Covers text AND quote on every list item plus active_topic — verbatim
+    quotes are the likeliest secret carriers. Stamps a visible
+    checkpoint["redactions"] counter only when something was scrubbed."""
+    counts: dict = {}
+
+    def _scrub(d: dict, field: str) -> None:
+        val = d.get(field)
+        red, c = redact.redact_text(val)
+        if c:
+            d[field] = red
+            for k, n in c.items():
+                counts[k] = counts.get(k, 0) + n
+
+    for section, key in _ITEM_LISTS:
+        items = (checkpoint.get(section) or {}).get(key)
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if isinstance(item, dict):
+                _scrub(item, "text")
+                _scrub(item, "quote")
+    topic = (checkpoint.get("working_context") or {}).get("active_topic")
+    if isinstance(topic, dict):
+        _scrub(topic, "text")
+        _scrub(topic, "quote")
+    if counts:
+        # MERGE, never overwrite: a re-write (anchor --attach reads, mutates,
+        # writes the same dict) only re-matches NEW secrets — old markers don't
+        # match the patterns again, so overwriting would drop kinds still
+        # physically present in the checkpoint.
+        merged = dict(checkpoint.get("redactions") or {})
+        for k, n in counts.items():
+            merged[k] = merged.get(k, 0) + n
+        checkpoint["redactions"] = merged
+
+
 def _stamp_item_ids(checkpoint: dict) -> None:
     """Stable per-item ids (#102): sha1 of kind:text, 6 hex chars, prefixed
     with the kind's initial. setdefault semantics — an item that already
@@ -417,6 +456,7 @@ def write_checkpoint(session_id: str, checkpoint: dict, project_dir=None) -> Pat
     # store stays free of the git/subprocess dependency (scar 0). Present on every
     # checkpoint so read_team can attribute it later, even when team-write is off.
     checkpoint.setdefault("author", config.author())
+    _redact_checkpoint(checkpoint)
     _stamp_item_ids(checkpoint)
     # Stamp project attribution the same idempotent way. Bucket pointers rotate
     # away after `history` writes, so pointer-derived attribution EXPIRES — a
@@ -689,6 +729,8 @@ def append_event(item_ref: str, status: str, note: str = "",
     if path is None:
         return False
     try:
+        note, _ = redact.redact_text(note)
+        item_text, _ = redact.redact_text(item_text)
         path.parent.mkdir(parents=True, exist_ok=True)
         evt = {"ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                "kind": kind, "item_ref": item_ref, "status": status,

--- a/plugin/tests/test_redact.py
+++ b/plugin/tests/test_redact.py
@@ -65,3 +65,39 @@ def test_non_string_and_empty_passthrough():
     assert redact.redact_text("") == ("", {})
     assert redact.redact_text(None) == (None, {})
     assert redact.redact_text(7) == (7, {})
+
+
+# ---- #104 final-review fixes: backtracking bounds + marker idempotency ----
+
+
+def test_redaction_markers_never_rematch_on_second_pass():
+    # I3: [redacted:api-key] / [redacted:credential-url] markers satisfy the
+    # patterns' own value class, so re-running redact_text over already-
+    # redacted text (the anchor --attach rewrite path) must not re-count.
+    s = ("set DAIMON_LLM_API_KEY=sk-abcdef1234567890 in env and "
+         "postgres://admin:hunter2secret@db.example.com:5432/x")
+    out, counts = _one(s)
+    assert counts.get("api-key") == 1
+    assert counts.get("credential-url") == 1
+    out2, counts2 = _one(out)
+    assert out2 == out
+    assert counts2 == {}
+
+
+def test_api_key_pattern_no_quadratic_blowup_on_long_word_run():
+    # C1: unbounded prefix quantifier overlapping the keyword alternation
+    # caused O(N^2) backtracking on long separator-free [\w-] runs.
+    out, counts = _one("a" * 50000)
+    assert counts == {}
+
+
+def test_api_key_pattern_no_quadratic_blowup_on_long_hyphenated_run():
+    out, counts = _one("a-" * 25000)
+    assert counts == {}
+
+
+def test_credential_url_pattern_no_quadratic_blowup_on_long_scheme_run():
+    # I2: unbounded scheme span caused O(N^2) backtracking on long
+    # lowercase-dotted runs that never resolve to "://".
+    out, counts = _one("a." * 25000)
+    assert counts == {}

--- a/plugin/tests/test_redact.py
+++ b/plugin/tests/test_redact.py
@@ -1,0 +1,67 @@
+"""#104: capture-time secret redaction — per-pattern positive + negative."""
+
+from daimon_briefing import redact
+
+
+def _one(s):
+    out, counts = redact.redact_text(s)
+    return out, counts
+
+
+def test_pem_block_redacted_terminated_and_unterminated():
+    out, c = _one("key follows\n-----BEGIN RSA PRIVATE KEY-----\nabc\n"
+                  "-----END RSA PRIVATE KEY-----\ndone")
+    assert "[redacted:pem]" in out and "abc" not in out and c["pem"] == 1
+    out2, c2 = _one("-----BEGIN PRIVATE KEY-----\nabc def")
+    assert "[redacted:pem]" in out2 and "abc" not in out2
+
+
+def test_aws_key_redacted_prose_survives():
+    out, c = _one("creds AKIAIOSFODNN7EXAMPLE were used")
+    assert "AKIAIOSFODNN7EXAMPLE" not in out and c["aws-key"] == 1
+    out2, c2 = _one("the AKIA prefix identifies aws keys")
+    assert c2 == {} and "AKIA prefix" in out2
+
+
+def test_stripe_key_redacted_docs_mention_survives():
+    out, c = _one("use sk_live_a1B2c3D4e5F6g7H8 in prod")
+    assert "sk_live_a1B2c3D4e5F6g7H8" not in out and c["stripe-key"] == 1
+    out2, c2 = _one("rotate the sk_live key monthly")
+    assert c2 == {}
+
+
+def test_bearer_token_redacted_prose_survives():
+    out, c = _one("header was Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x")
+    assert "eyJhbGci" not in out and c["bearer"] == 1
+    out2, c2 = _one("the bearer of good news arrived")
+    assert c2 == {}
+
+
+def test_api_key_assignment_redacted_keeps_name_and_separator():
+    out, c = _one("set DAIMON_LLM_API_KEY=sk-abcdef1234567890 in env")
+    assert "sk-abcdef1234567890" not in out
+    assert "API_KEY=[redacted:api-key]" in out and c["api-key"] == 1
+    out2, c2 = _one("api_key: 'x9y8z7w6v5u4t3s2'")
+    assert "x9y8z7" not in out2 and c2["api-key"] == 1
+    out3, c3 = _one("the token budget and password rotation policy")
+    assert c3 == {}
+
+
+def test_credential_url_redacts_password_keeps_host():
+    out, c = _one("postgres://admin:hunter2secret@db.example.com:5432/x")
+    assert "hunter2secret" not in out
+    assert "postgres://admin:[redacted:credential-url]@db.example.com" in out
+    assert c["credential-url"] == 1
+    out2, c2 = _one("see https://docs.example.com/path and http://localhost:8080/x")
+    assert c2 == {}
+
+
+def test_multiple_hits_counted():
+    out, c = _one("AKIAIOSFODNN7EXAMPLE and AKIAI44QH8DHBEXAMPLE")
+    assert c["aws-key"] == 2
+
+
+def test_non_string_and_empty_passthrough():
+    assert redact.redact_text("") == ("", {})
+    assert redact.redact_text(None) == (None, {})
+    assert redact.redact_text(7) == (7, {})

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1044,6 +1044,19 @@ def test_rewrite_merges_redaction_counts(tmp_checkpoint_dir):
     assert cp["redactions"] == {"aws-key": 1, "stripe-key": 1}
 
 
+def test_rewrite_same_secret_keeps_redaction_count_stable(tmp_checkpoint_dir):
+    # I3: api-key/credential-url markers satisfy their own patterns' value
+    # class, so re-writing the SAME already-redacted dict (anchor --attach
+    # path) must not inflate the count on every re-write.
+    from daimon_briefing import store
+    cp = {"working_context": {"open_questions": [
+        {"text": "set DAIMON_LLM_API_KEY=sk-abcdef1234567890 in env"}]}}
+    store.write_checkpoint("S1", cp)
+    assert cp["redactions"] == {"api-key": 1}
+    store.write_checkpoint("S1", cp)
+    assert cp["redactions"] == {"api-key": 1}
+
+
 def test_append_event_redacts_note_and_item_text(tmp_checkpoint_dir):
     from daimon_briefing import store
     store.append_event("o-a", "resolved", note="key was AKIAIOSFODNN7EXAMPLE",

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -983,3 +983,73 @@ def test_append_event_omits_empty_item_text(tmp_checkpoint_dir):
     slug = store.project_slug("/p/A")
     evt = json.loads((tmp_checkpoint_dir / slug / "events.jsonl").read_text().splitlines()[0])
     assert "item_text" not in evt
+
+
+# ---- #104: capture-time redaction wiring ----
+
+
+def test_write_checkpoint_redacts_text_and_quote(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    cp = {"working_context": {"open_questions": [
+        {"text": "creds AKIAIOSFODNN7EXAMPLE leaked?",
+         "quote": "he pasted DAIMON_LLM_API_KEY=sk-abcdef1234567890"}]}}
+    store.write_checkpoint("S1", cp)
+    item = cp["working_context"]["open_questions"][0]
+    assert "AKIAIOSFODNN7EXAMPLE" not in item["text"]
+    assert "sk-abcdef1234567890" not in item["quote"]
+    assert cp["redactions"] == {"aws-key": 1, "api-key": 1}
+    on_disk = (tmp_checkpoint_dir / "S1.json").read_text()
+    assert "AKIAIOSFODNN7EXAMPLE" not in on_disk and "sk-abcdef" not in on_disk
+
+
+def test_write_checkpoint_redacts_active_topic(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    cp = {"working_context": {"active_topic": {
+        "text": "rotating postgres://admin:hunter2secret@db/x"}}}
+    store.write_checkpoint("S1", cp)
+    assert "hunter2secret" not in cp["working_context"]["active_topic"]["text"]
+
+
+def test_no_redactions_key_when_clean(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    cp = {"working_context": {"open_questions": [{"text": "all clean here"}]}}
+    store.write_checkpoint("S1", cp)
+    assert "redactions" not in cp
+
+
+def test_item_id_hashes_redacted_text(tmp_checkpoint_dir):
+    import hashlib
+    from daimon_briefing import store
+    cp = {"working_context": {"open_questions": [
+        {"text": "creds AKIAIOSFODNN7EXAMPLE leaked?"}]}}
+    store.write_checkpoint("S1", cp)
+    item = cp["working_context"]["open_questions"][0]
+    digest = hashlib.sha1(
+        f"open_questions:{item['text']}".encode("utf-8")).hexdigest()
+    assert item["id"] == f"o-{digest[:6]}"  # id derived from REDACTED text
+
+
+def test_rewrite_merges_redaction_counts(tmp_checkpoint_dir):
+    # The anchor --attach path: read_latest -> mutate -> write_checkpoint on the
+    # SAME dict. Old markers don't re-match patterns, so a naive overwrite of
+    # checkpoint["redactions"] would drop kinds still physically present.
+    from daimon_briefing import store
+    cp = {"working_context": {"open_questions": [
+        {"text": "creds AKIAIOSFODNN7EXAMPLE leaked?"}]}}
+    store.write_checkpoint("S1", cp)
+    assert cp["redactions"] == {"aws-key": 1}
+    cp["working_context"]["open_questions"].append(
+        {"text": "charge key sk_live_abcdef1234567890 exposed"})
+    store.write_checkpoint("S1", cp)
+    assert cp["redactions"] == {"aws-key": 1, "stripe-key": 1}
+
+
+def test_append_event_redacts_note_and_item_text(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    store.append_event("o-a", "resolved", note="key was AKIAIOSFODNN7EXAMPLE",
+                       item_text="Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x",
+                       project_dir="/p/A")
+    slug = store.project_slug("/p/A")
+    raw = (tmp_checkpoint_dir / slug / "events.jsonl").read_text()
+    assert "AKIAIOSFODNN7EXAMPLE" not in raw and "eyJhbGci" not in raw
+    assert "[redacted:aws-key]" in raw


### PR DESCRIPTION
Closes #104.

Checkpoints serialize raw transcripts to disk, and team sync mirrors whatever is written — a quoted API key would persist and replicate. This adds a deterministic, zero-LLM redaction pass at the write seam.

- new `redact` module: precision-first patterns (PEM, AWS key ids, Stripe live keys, bearer/authorization tokens, key=value assignments, credential URLs — password only, host stays readable); every pattern has a prose-look-alike negative test
- `write_checkpoint` scrubs `text` and `quote` on every item plus active_topic BEFORE id stamping, so ids hash the redacted text; a visible `redactions` counter is stamped on the checkpoint only when something was scrubbed
- `append_event` scrubs `note`/`item_text` through the same module
- markers are visible (`[redacted:<kind>]`), never silent; the team mirror inherits automatically since it copies what's on disk