### PR TITLE
feat(schema): typed supersedes links with candidate events — detect, offer, human confirms

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -49,6 +49,13 @@ def _line(item) -> str:
         base += " [carried]"
     if quote:
         base += f'  — "{quote}"'
+    candidate = item.get("_supersede_candidate")
+    if candidate:
+        # #14: a machine-suggested (unconfirmed) supersession — never
+        # withheld, just flagged with a one-command confirm path.
+        item_id = item.get("id") or "?"
+        base += (f"\n  ⚠ likely superseded by {candidate} — confirm: "
+                 f"daimon resolve {item_id} --status superseded-by:{candidate}")
     return base
 
 
@@ -120,8 +127,15 @@ def build(checkpoint, now=None) -> dict | None:
 
 # ---- #103: withhold event-resolved items at render time ----
 
+# #14 shape gate for a supersede-candidate's new-id payload: kind initial +
+# hex slice (+ optional collision counter), same shape store._stamp_item_ids
+# emits and carry._ID_SHAPE recognizes — duplicated rather than imported
+# because carry's copy is unbounded ({6,}) and this one fullmatches
+# attacker-adjacent event text, where bounded quantifiers are the rule.
+_CANDIDATE_ID_SHAPE = re.compile(r"[a-z]-[0-9a-f]{6,40}(-\d+)?")
 
-def withhold(checkpoint, resolutions: dict) -> tuple[dict, list]:
+
+def withhold(checkpoint, resolutions: dict) -> tuple[dict, list, list]:
     """Drop items the world has already resolved, at RENDER time only — the
     checkpoint on disk (and carry's copy of it) is never touched. `resolutions`
     is `{item_ref: latest_event}`, exactly store.resolutions()'s shape; pure,
@@ -135,22 +149,49 @@ def withhold(checkpoint, resolutions: dict) -> tuple[dict, list]:
     of an id-bearing item would silently suppress a live memory that merely
     resembles a closed one — the worst failure mode this feature can have.
 
-    No resolved events, or a non-dict checkpoint -> (checkpoint, []) UNCHANGED,
-    same no-op idiom as carry.merge: no copy is made unless something actually
-    withholds, so the common case (nothing resolved yet) costs nothing."""
+    #14: a THIRD outcome — a "supersede-candidate:<new-id>" latest event is a
+    machine SUGGESTION, not a resolution (store.is_resolved says so: it stays
+    live). Candidates are never dropped; instead the RETURNED COPY's item gets
+    a transient `_supersede_candidate = "<new-id>"` stamp so render/CLI layers
+    can flag it — id-bearing only, by construction (candidates are only ever
+    emitted against ids).
+
+    No resolved/candidate events, or a non-dict checkpoint ->
+    (checkpoint, [], []) UNCHANGED, same no-op idiom as carry.merge: no copy
+    is made unless something actually withholds or is stamped, so the common
+    case (nothing resolved yet) costs nothing."""
     if not isinstance(checkpoint, dict) or not resolutions:
-        return checkpoint, []
+        return checkpoint, [], []
 
     resolved_refs = {ref for ref, evt in resolutions.items() if store.is_resolved(evt)}
-    if not resolved_refs:
-        return checkpoint, []
+    candidate_refs: dict[str, str] = {}
+    for ref, evt in resolutions.items():
+        if not isinstance(evt, dict):
+            continue
+        status = str(evt.get("status") or "")
+        if status.lower().startswith("supersede-candidate") and ":" in status:
+            new_id = status.split(":", 1)[1].strip()
+            # Shape gate: the status field is free-form by design, so the
+            # payload after the colon can be ANY text — and it rides verbatim
+            # into the rendered confirm-command suggestion and the hook-
+            # injected LLM context (an injection surface). Only an id-shaped
+            # payload earns a stamp; a malformed machine claim earns no
+            # surface at all (unannotated, unlisted — still never withheld).
+            # Mirrors carry._ID_SHAPE, with the hex run bounded (fullmatch on
+            # attacker-adjacent input wants bounded quantifiers).
+            if new_id and _CANDIDATE_ID_SHAPE.fullmatch(new_id):
+                candidate_refs[ref] = new_id
+
+    if not resolved_refs and not candidate_refs:
+        return checkpoint, [], []
     resolved_texts = [str(resolutions[ref].get("item_text") or "").strip()
                        for ref in resolved_refs]
     resolved_texts = [t for t in resolved_texts if t]
 
-    # Dry run over the ORIGINAL checkpoint — decide what would be withheld
-    # before paying for a deepcopy (most briefs resolve nothing).
+    # Dry run over the ORIGINAL checkpoint — decide what would be withheld/
+    # stamped before paying for a deepcopy (most briefs resolve nothing).
     to_drop = []  # [(section, key, index, item, event)]
+    to_stamp = []  # [(section, key, index, event, new_id)]
     for section, key in store._ITEM_LISTS:
         items = (checkpoint.get(section) or {}).get(key)
         if not isinstance(items, list):
@@ -166,6 +207,9 @@ def withhold(checkpoint, resolutions: dict) -> tuple[dict, list]:
                 # check never needs the superset's own membership re-verified).
                 if item_id in resolved_refs:
                     to_drop.append((section, key, idx, item, resolutions[item_id]))
+                elif item_id in candidate_refs:
+                    to_stamp.append((section, key, idx, resolutions[item_id],
+                                      candidate_refs[item_id]))
                 continue  # id-bearing: bound exactly or not at all, never fuzzy
             text = str(item.get("text") or "").strip()
             if not text or not resolved_texts:
@@ -178,10 +222,22 @@ def withhold(checkpoint, resolutions: dict) -> tuple[dict, list]:
                     to_drop.append((section, key, idx, item, evt))
                     break
 
-    if not to_drop:
-        return checkpoint, []
+    if not to_drop and not to_stamp:
+        return checkpoint, [], []
 
     out = copy.deepcopy(checkpoint)
+
+    # Stamp BEFORE dropping: to_stamp/to_drop indices both refer to the
+    # ORIGINAL (pre-removal) list positions, and stamping never changes list
+    # length — so stamping first keeps every index valid for the drop pass
+    # that follows, regardless of whether a stamped and a dropped item share
+    # a section/key list.
+    candidates = []
+    for section, key, idx, evt, new_id in to_stamp:
+        item = out[section][key][idx]
+        item["_supersede_candidate"] = new_id
+        candidates.append((key, item, evt))
+
     withheld = []
     drop_idx_by_list: dict[tuple[str, str], set] = {}
     for section, key, idx, item, evt in to_drop:
@@ -192,7 +248,7 @@ def withhold(checkpoint, resolutions: dict) -> tuple[dict, list]:
         kept = [it for i, it in enumerate(items) if i not in idxs]
         items[:] = kept
 
-    return out, withheld
+    return out, withheld, candidates
 
 
 # ---- #79: token budget — section-preserving truncation ----

--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -9,9 +9,16 @@ caller injects clock and knobs (scar: a default wall-clock anywhere silently
 freezes time math under simulation)."""
 
 import copy
+import re
 from collections import Counter
 
 from . import recall, scoring, store
+
+# An item id already looks like this (store._stamp_item_ids: kind-initial +
+# >=6 hex chars, optional -N collision suffix) — never treat it as free text
+# to rebind. Bounded quantifiers only (scar: unbounded prefix before an
+# alternation froze the write path under quadratic backtracking).
+_ID_SHAPE = re.compile(r"[a-z]-[0-9a-f]{6,}(-\d+)?")
 
 # (section, key, scoring TYPE_RULES type). Beliefs regenerate cheaply and
 # active_topic is per-session by definition — neither carries (v1).
@@ -169,3 +176,70 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                      reverse=True)
         native.extend(carried[:cap])
     return out
+
+
+def bind_links(merged_cp: dict, prev_cp: dict | None) -> list[tuple[str, str, str]]:
+    """Pure text-target -> prev-id binding (#14). For every `supersedes` link
+    on merged_cp's carried-kind items whose `target` is still free text (not
+    already an item-id shape), find the SAME-KIND prev item it refers to by
+    `_same_item` and rewrite `link["target"]` to that item's id — IN PLACE on
+    merged_cp (caller owns the copy, mirrors `merge`'s contract).
+
+    Never-guess: only a UNIQUE prev match rewrites; zero or multiple matches
+    leave the text target untouched (same don't-merge bias as `_same_item` —
+    a wrong bind fabricates provenance, a missed bind just stays text).
+    Self/twin guard: skip when the matched prev id equals the item's own id
+    (twin id-inheritance in `merge` makes a decision supersede itself
+    reachable). Malformed links (non-dict, missing/non-str target) are
+    skipped, never raised on.
+
+    Returns (old_id, new_id, old_text) triples for the caller to turn into
+    events — no I/O here, same as `merge`. Deduped by (old_id, new_id): two
+    links resolving to the same prev item are one supersession event."""
+    if not isinstance(merged_cp, dict) or not isinstance(prev_cp, dict):
+        return []
+    pairs: list[tuple[str, str, str]] = []
+    seen: set[tuple[str, str]] = set()  # dedupe triples by (old_id, new_id) —
+    # two links resolving to the same prev item are one supersession event
+    for section, key, _item_type in _CARRIED_KINDS:
+        native = (merged_cp.get(section) or {}).get(key)
+        if not isinstance(native, list):
+            continue
+        prev_items = [p for p in ((prev_cp.get(section) or {}).get(key) or [])
+                      if isinstance(p, dict) and p.get("id")
+                      and str(p.get("text") or "").strip()]
+        if not prev_items:
+            continue
+        # DF universe: natives + prev, but SKIP carried natives — merge()
+        # copied those verbatim from prev, so counting them again doubles
+        # their vocabulary's document frequency, forges generic status for
+        # terms two prev candidates legitimately share, and collapses an
+        # ambiguous target into a false-unique bind.
+        generic = _generic_terms(
+            [str(i.get("text") or "") for i in native
+             if isinstance(i, dict) and not i.get("carried_from")]
+            + [str(p["text"]) for p in prev_items])
+        for item in native:
+            if not isinstance(item, dict) or not isinstance(item.get("links"), list):
+                continue
+            for link in item["links"]:
+                if not isinstance(link, dict) or link.get("type") != "supersedes":
+                    continue
+                target = link.get("target")
+                if not isinstance(target, str) or not target.strip():
+                    continue
+                if _ID_SHAPE.fullmatch(target):
+                    continue  # already bound
+                matches = [p for p in prev_items
+                           if _same_item(target, str(p["text"]), generic)]
+                if len(matches) != 1:
+                    continue  # unbound or ambiguous — leave as text
+                prev_id, old_text = matches[0]["id"], matches[0]["text"]
+                if prev_id == item.get("id"):
+                    continue  # self/twin supersession — no-op, not a link
+                link["target"] = prev_id  # every matched link rebinds,
+                new_id = item.get("id") or ""
+                if (prev_id, new_id) not in seen:  # but one event per pair
+                    seen.add((prev_id, new_id))
+                    pairs.append((prev_id, new_id, old_text))
+    return pairs

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -219,6 +219,17 @@ def _run_serialize(transcript_path: Path, project: str | None) -> int:
                                      floor=config.carry_floor(),
                                      cap=config.carry_max(),
                                      resolved=resolved)
+            # #14: text-target supersession links bound to prev-item ids ->
+            # candidate events, gated so a human verdict is never overridden
+            # (see _emit_supersede_candidates). Same fail-open try as merge
+            # itself — a broken emission must never cost the checkpoint.
+            # Stamp ids BEFORE binding: fresh natives are only stamped inside
+            # write_checkpoint (after this block), so without this every new
+            # item binds with new_id="" and the event carries no target.
+            # Setdefault-idempotent — write_checkpoint's re-stamp no-ops.
+            store._stamp_item_ids(checkpoint)
+            pairs = carry.bind_links(checkpoint, prev)
+            _emit_supersede_candidates(pairs, events, project)
         except Exception:  # keep the unmerged checkpoint, proceed to write
             pass
     out = store.write_checkpoint(session_id, checkpoint, project_dir=project)
@@ -244,6 +255,52 @@ def _run_serialize(transcript_path: Path, project: str | None) -> int:
         except Exception:  # a broken harvest must not fail the serialize
             pass
     return 0
+
+
+def _emit_supersede_candidates(pairs, events: dict, project) -> int:
+    """Turn `carry.bind_links` triples into `supersede-candidate:*` events,
+    gated so a machine SUGGESTION never overrides a human verdict (#14,
+    human-speaks-once).
+
+    `events` is the SAME `store.resolutions` fold the serialize block already
+    fetched for `resolved` — reused, not re-read, so this stays consistent
+    with the resolved set computed moments earlier in the same call.
+
+    Gate per (old_id, new_id, old_text) triple:
+    (a) prior = events.get(old_id) — the latest lifecycle fact for old_id.
+    (b) prior exists and its source isn't "serializer" -> a HUMAN spoke
+        (confirmed via superseded-by, rejected via reopened, or anything
+        else typed by a person) -> skip, forever. The gate itself is why a
+        latest-event check is enough for permanence: machine events only
+        ever land through this function, and this function refuses to
+        write over a non-serializer prior, so once a human event is latest
+        no future serialize run can dethrone it — there is no path back to
+        a machine-authored latest.
+    (c) prior exists, is a serializer-authored candidate, and already points
+        at this same new_id -> idempotent, skip (re-running serialize on an
+        unchanged pair must not spam the log).
+    (d) otherwise -> append. Covers both the fresh case (no prior) and the
+        candidate-changed case (prior candidate names a DIFFERENT new_id —
+        the carry target moved, so a fresh candidate replaces it as latest).
+
+    Returns the number of events actually appended."""
+    appended = 0
+    for old_id, new_id, old_text in pairs:
+        if not new_id:
+            continue  # defense-in-depth: never write a candidate with no
+                      # target ("supersede-candidate:") — the wiring stamps
+                      # ids before binding, but a caller that skips that
+                      # step must not corrupt the event log
+        prior = events.get(old_id)
+        if prior and str(prior.get("source") or "") != "serializer":
+            continue  # human spoke — machine stays silent forever
+        if prior and prior.get("status") == f"supersede-candidate:{new_id}":
+            continue  # idempotent — same candidate already latest
+        if store.append_event(old_id, f"supersede-candidate:{new_id}",
+                              source="serializer", item_text=old_text,
+                              project_dir=project):
+            appended += 1
+    return appended
 
 
 def _session_end_stamp(path) -> str:

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -456,10 +456,14 @@ def _cmd_brief(args) -> int:
     withheld = []
     if checkpoint:
         # Withhold (#103): render-time derivation, fail-open — a briefing
-        # must never die over suppression machinery.
+        # must never die over suppression machinery. #14: candidates ride
+        # along stamped on `checkpoint` itself — the deterministic path
+        # (render_plain via briefing._line) picks up the annotation; the
+        # opt-in LLM briefing path does not surface it (same pre-existing
+        # scope as [carried]), so nothing further is done with them here.
         try:
             events = store.resolutions(project_dir=project)
-            checkpoint, withheld = briefing.withhold(checkpoint, events)
+            checkpoint, withheld, _candidates = briefing.withhold(checkpoint, events)
         except Exception:
             withheld = []
     # NOTE: drift is checked against the resolved project root. If read_latest fell
@@ -901,26 +905,38 @@ def _print_suppressed(project) -> int:
     must not crash `status`, it should just report nothing suppressed."""
     checkpoint = store.read_latest(project_dir=project, fallback=False)
     withheld = []
+    candidates = []
     if checkpoint:
         try:
             events = store.resolutions(project_dir=project)
-            _, withheld = briefing.withhold(checkpoint, events)
+            _, withheld, candidates = briefing.withhold(checkpoint, events)
         except Exception:
             withheld = []
-    if not withheld:
+            candidates = []
+    if not withheld and not candidates:
         print("no suppressed items")
         return 0
-    print(f"suppressed items ({len(withheld)}):")
-    for key, item, evt in withheld:
-        item_id = item.get("id") or "-"
-        text = str(item.get("text") or "").strip()
-        status = str(evt.get("status") or "")
-        ts = str(evt.get("ts") or "")
-        note = str(evt.get("note") or "").strip()
-        paren = f"{status} {ts}"
-        if note:
-            paren += f", {note}"
-        print(f"  {item_id}  [{key}] {text}  ({paren})")
+    if withheld:
+        print(f"suppressed items ({len(withheld)}):")
+        for key, item, evt in withheld:
+            item_id = item.get("id") or "-"
+            text = str(item.get("text") or "").strip()
+            status = str(evt.get("status") or "")
+            ts = str(evt.get("ts") or "")
+            note = str(evt.get("note") or "").strip()
+            paren = f"{status} {ts}"
+            if note:
+                paren += f", {note}"
+            print(f"  {item_id}  [{key}] {text}  ({paren})")
+    if candidates:
+        # #14: machine SUGGESTIONS, not resolutions — a separate subsection
+        # so they never read as confirmed suppressions.
+        print("likely superseded (unconfirmed):")
+        for key, item, evt in candidates:
+            item_id = item.get("id") or "-"
+            text = str(item.get("text") or "").strip()
+            new_id = item.get("_supersede_candidate") or "-"
+            print(f"  {item_id}  [{key}] {text}  -> {new_id}")
     return 0
 
 

--- a/plugin/daimon_briefing/hooks.py
+++ b/plugin/daimon_briefing/hooks.py
@@ -77,7 +77,7 @@ def pre_llm_call(session_id=None, user_message=None, conversation_history=None,
         # facing brief, so suppression stays clean (no note to render).
         try:
             events = store.resolutions(project_dir=project)
-            checkpoint, _withheld = briefing.withhold(checkpoint, events)
+            checkpoint, _withheld, _candidates = briefing.withhold(checkpoint, events)
         except Exception:
             pass
         text = briefing.render(checkpoint)

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -141,6 +141,16 @@ def _rich_brief(b: dict) -> None:
             quote = i.get("quote", "").strip()
             if quote:
                 body.append(f'    "{quote}"\n', style="dim italic")
+            candidate = i.get("_supersede_candidate")
+            if candidate:
+                # #14: parity with briefing._line's plain-path annotation —
+                # this panel builds its own Text body rather than routing
+                # through _line, so the flag has to be repeated here.
+                item_id = i.get("id") or "?"
+                body.append(
+                    f"    ⚠ likely superseded by {candidate} — confirm: "
+                    f"daimon resolve {item_id} --status superseded-by:{candidate}\n",
+                    style="yellow")
         if key == "decisions":
             note = briefing._overflow_note(b.get("decisions_overflow", 0))
             if note:

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -118,13 +118,20 @@ RULES — follow every one exactly; this is the point of the exercise:
     (a Spanish session produces Spanish items). Never translate quotes — a `quote` is always
     the exact original wording. Schema keys and structure stay in English as shown.
 
+16. SUPERSESSION LINKS (conservative): when a recent_decision explicitly REPLACES a prior
+    decision — signaled by explicit replacement language such as "instead of", "replaces", or
+    "we changed from X to Y" — attach `"links": [{"type": "supersedes", "target": "<short
+    description of the OLD decision>"}]` to that item. NEVER attach a supersedes link from
+    topic overlap or similarity alone; the replacement must be stated explicitly, not guessed.
+    Omit `links` entirely when no such replacement applies — do not emit an empty array.
+
 Schema shape:
 {
   "session_id": "<id>",
   "working_context": {
     "active_topic": {"text": "", "trust": "", "quote": "", "importance": 0},
     "open_questions": [{"text": "", "trust": "", "quote": "", "external_state": false, "importance": 0}],
-    "recent_decisions": [{"text": "", "trust": "", "quote": "", "importance": 0}]
+    "recent_decisions": [{"text": "", "trust": "", "quote": "", "importance": 0, "links": [{"type": "", "target": ""}]}]
   },
   "epistemic_snapshot": {
     "strong_beliefs": [{"text": "", "trust": "", "quote": "", "importance": 0}],
@@ -190,13 +197,18 @@ MERGE RULES — follow every one exactly:
     merging must not translate items (a Spanish session stays Spanish). Never translate quotes;
     a `quote` is always the exact original wording. Schema keys and structure stay in English.
 
+13. LINKS PRESERVATION: preserve every item's `links` array verbatim — never drop, alter, or
+    invent a link entry. When deduplicating two items into one canonical item, the merged
+    item's `links` is the union of both items' links (dedupe identical {type, target} pairs)
+    so neither side's links are lost.
+
 Schema shape:
 {
   "session_id": "<id>",
   "working_context": {
     "active_topic": {"text": "", "trust": "", "quote": "", "importance": 0},
     "open_questions": [{"text": "", "trust": "", "quote": "", "external_state": false, "importance": 0}],
-    "recent_decisions": [{"text": "", "trust": "", "quote": "", "importance": 0}]
+    "recent_decisions": [{"text": "", "trust": "", "quote": "", "importance": 0, "links": [{"type": "", "target": ""}]}]
   },
   "epistemic_snapshot": {
     "strong_beliefs": [{"text": "", "trust": "", "quote": "", "importance": 0}],

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -363,8 +363,12 @@ _ITEM_LISTS = (
 
 
 def _redact_checkpoint(checkpoint: dict) -> None:
-    """Capture-time secret redaction (#104): runs BEFORE _stamp_item_ids so
-    ids hash the redacted text (identity stays stable across re-writes).
+    """Capture-time secret redaction (#104): runs before this module's own
+    _stamp_item_ids call below, so ids stamped HERE hash redacted text. On
+    the serialize path the cli stamps ids earlier (before bind_links, #14),
+    so ids there hash pre-redaction text — no leak (sha1 slices are not
+    reversible) and no consumer recomputes ids from text, but identity for
+    secret-bearing items differs between the two paths.
     Covers text AND quote on every list item plus active_topic — verbatim
     quotes are the likeliest secret carriers. Stamps a visible
     checkpoint["redactions"] counter only when something was scrubbed."""
@@ -783,10 +787,12 @@ def resolutions(project_dir=None) -> dict:
 
 
 def is_resolved(event) -> bool:
-    """Liveness rule (#102): latest event wins; a status starting with
-    'reopen' returns the item to live; anything else means resolved. Status
-    is free-form text by design — never an enum, so unknown statuses resolve
-    (the writer bothered to record a lifecycle fact) rather than vanish."""
+    """Liveness rule (#102, #14): latest event wins; three states — a status
+    starting with 'reopen' returns the item to live; 'supersede-candidate'
+    is a machine SUGGESTION and stays live by construction (a guess must
+    never suppress); anything else means resolved. Status is free-form text
+    by design — never an enum, so unknown statuses resolve (the writer
+    bothered to record a lifecycle fact) rather than vanish."""
     if not isinstance(event, dict):
         return False
     status = str(event.get("status") or "").lower()

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -386,6 +386,11 @@ def _redact_checkpoint(checkpoint: dict) -> None:
             if isinstance(item, dict):
                 _scrub(item, "text")
                 _scrub(item, "quote")
+                links = item.get("links")
+                if isinstance(links, list):
+                    for link in links:
+                        if isinstance(link, dict) and isinstance(link.get("target"), str):
+                            _scrub(link, "target")
     topic = (checkpoint.get("working_context") or {}).get("active_topic")
     if isinstance(topic, dict):
         _scrub(topic, "text")
@@ -784,4 +789,9 @@ def is_resolved(event) -> bool:
     (the writer bothered to record a lifecycle fact) rather than vanish."""
     if not isinstance(event, dict):
         return False
-    return not str(event.get("status") or "").lower().startswith("reopen")
+    status = str(event.get("status") or "").lower()
+    if status.startswith("supersede-candidate"):
+        return False  # a machine SUGGESTION is live by construction (#14):
+                      # every consumer (carry, withhold, future) inherits
+                      # no-suppression without knowing candidates exist.
+    return not status.startswith("reopen")

--- a/plugin/tests/test_briefing.py
+++ b/plugin/tests/test_briefing.py
@@ -564,18 +564,20 @@ def test_withhold_by_exact_id():
     cp = {"working_context": {"open_questions": [
         {"text": "is the gateway stable", "id": "o-aaa"},
         {"text": "does carry hold", "id": "o-bbb"}]}}
-    filtered, withheld = briefing.withhold(cp, {"o-aaa": _res_evt("o-aaa")})
+    filtered, withheld, candidates = briefing.withhold(cp, {"o-aaa": _res_evt("o-aaa")})
     texts = [i["text"] for i in filtered["working_context"]["open_questions"]]
     assert texts == ["does carry hold"]
     assert withheld[0][1]["id"] == "o-aaa"
+    assert candidates == []
     assert len(cp["working_context"]["open_questions"]) == 2  # input untouched
 
 
 def test_reopen_event_does_not_withhold():
     cp = {"working_context": {"open_questions": [{"text": "x y z", "id": "o-aaa"}]}}
-    filtered, withheld = briefing.withhold(
+    filtered, withheld, candidates = briefing.withhold(
         cp, {"o-aaa": _res_evt("o-aaa", status="reopened")})
     assert withheld == []
+    assert candidates == []
     assert filtered["working_context"]["open_questions"]
 
 
@@ -583,23 +585,25 @@ def test_legacy_idless_item_withheld_by_item_text_fuzzy():
     cp = {"working_context": {"open_questions": [
         {"text": "release pipeline approval step still awaiting manual gate"}]}}  # no id
     ev = _res_evt("o-old01", text="release pipeline manual approval gate awaiting")
-    filtered, withheld = briefing.withhold(cp, {"o-old01": ev})
+    filtered, withheld, candidates = briefing.withhold(cp, {"o-old01": ev})
     assert filtered["working_context"]["open_questions"] == []
     assert len(withheld) == 1
+    assert candidates == []
 
 
 def test_id_bearing_item_never_fuzzy_withheld():
     cp = {"working_context": {"open_questions": [
         {"text": "release pipeline manual approval gate awaiting", "id": "o-live1"}]}}
     ev = _res_evt("o-old01", text="release pipeline manual approval gate awaiting")
-    filtered, withheld = briefing.withhold(cp, {"o-old01": ev})
+    filtered, withheld, candidates = briefing.withhold(cp, {"o-old01": ev})
     assert withheld == []  # exact text match but id-bearing: never fuzzy-bound
+    assert candidates == []
 
 
 def test_no_resolved_events_returns_input_unchanged():
     cp = {"working_context": {"open_questions": [{"text": "x", "id": "o-a"}]}}
-    filtered, withheld = briefing.withhold(cp, {})
-    assert filtered is cp and withheld == []
+    filtered, withheld, candidates = briefing.withhold(cp, {})
+    assert filtered is cp and withheld == [] and candidates == []
 
 
 def test_withhold_covers_strong_beliefs():
@@ -609,14 +613,106 @@ def test_withhold_covers_strong_beliefs():
     # store._ITEM_LISTS kinds; carry's own 3-kind carry policy is untouched.
     cp = {"epistemic_snapshot": {"strong_beliefs": [
         {"text": "extractive pinning prevents silent fact loss", "id": "b-aaa"}]}}
-    filtered, withheld = briefing.withhold(cp, {"b-aaa": _res_evt("b-aaa")})
+    filtered, withheld, candidates = briefing.withhold(cp, {"b-aaa": _res_evt("b-aaa")})
     assert filtered["epistemic_snapshot"]["strong_beliefs"] == []
     assert withheld[0][1]["id"] == "b-aaa"
+    assert candidates == []
 
 
 def test_withhold_covers_contradictions_flagged():
     cp = {"epistemic_snapshot": {"contradictions_flagged": [
         {"text": "conflicting claims about the gateway", "id": "c-aaa"}]}}
-    filtered, withheld = briefing.withhold(cp, {"c-aaa": _res_evt("c-aaa")})
+    filtered, withheld, candidates = briefing.withhold(cp, {"c-aaa": _res_evt("c-aaa")})
     assert filtered["epistemic_snapshot"]["contradictions_flagged"] == []
     assert withheld[0][1]["id"] == "c-aaa"
+    assert candidates == []
+
+
+# ---- #14: withhold's third outcome — supersede-candidate is a live SUGGESTION ----
+
+
+def test_withhold_candidate_kept_and_stamped():
+    cp = {"working_context": {"recent_decisions": [
+        {"text": "use the old gateway timeout", "id": "r-old"}]}}
+    resolutions = {"r-old": _res_evt("r-old", status="supersede-candidate:r-9f3a2b")}
+    filtered, withheld, candidates = briefing.withhold(cp, resolutions)
+    # item PRESENT in filtered, and stamped on the returned copy only.
+    kept = filtered["working_context"]["recent_decisions"]
+    assert len(kept) == 1
+    assert kept[0]["id"] == "r-old"
+    assert kept[0]["_supersede_candidate"] == "r-9f3a2b"
+    assert withheld == []
+    assert len(candidates) == 1
+    assert candidates[0][0] == "recent_decisions"
+    assert candidates[0][1]["id"] == "r-old"
+    assert candidates[0][1]["_supersede_candidate"] == "r-9f3a2b"
+    assert candidates[0][2]["status"] == "supersede-candidate:r-9f3a2b"
+    # input checkpoint is never mutated — no transient field, ever.
+    assert "_supersede_candidate" not in cp["working_context"]["recent_decisions"][0]
+
+
+def test_withhold_candidate_malformed_new_id_never_stamped():
+    # The status field is free-form by design, so a candidate's payload can
+    # carry arbitrary text ("supersede-candidate:o-new1a; echo pwned"). That
+    # text would ride verbatim into the rendered confirm-command suggestion
+    # AND the hook-injected LLM context — an injection surface. Only an
+    # id-shaped payload earns a stamp; a malformed machine claim earns no
+    # surface at all: no stamp, no candidates entry, item stays live and
+    # renders normally.
+    cp = {"working_context": {"open_questions": [
+        {"text": "is the gateway stable", "id": "o-aaa"}]}}
+    filtered, withheld, candidates = briefing.withhold(
+        cp, {"o-aaa": _res_evt(
+            "o-aaa", status="supersede-candidate:o-new1a; echo pwned")})
+    assert withheld == []
+    assert candidates == []
+    kept = filtered["working_context"]["open_questions"]
+    assert len(kept) == 1
+    assert "_supersede_candidate" not in kept[0]
+    assert "pwned" not in briefing._line(kept[0])
+
+
+def test_withhold_candidate_conforming_id_still_stamps():
+    # Regression pair for the shape gate: a real serializer-shaped id
+    # (kind initial + hex slice, optional counter suffix) must still stamp.
+    cp = {"working_context": {"open_questions": [
+        {"text": "is the gateway stable", "id": "o-aaa"}]}}
+    filtered, withheld, candidates = briefing.withhold(
+        cp, {"o-aaa": _res_evt("o-aaa", status="supersede-candidate:o-1a2b3c-2")})
+    assert withheld == []
+    assert len(candidates) == 1
+    assert filtered["working_context"]["open_questions"][0][
+        "_supersede_candidate"] == "o-1a2b3c-2"
+
+
+def test_withhold_hard_still_drops():
+    # Regression: a hard "superseded-by" (cli) resolution still drops the
+    # item exactly as before, and candidates comes back empty.
+    cp = {"working_context": {"open_questions": [
+        {"text": "is the gateway stable", "id": "o-aaa"}]}}
+    filtered, withheld, candidates = briefing.withhold(
+        cp, {"o-aaa": _res_evt("o-aaa", status="superseded-by:o-new")})
+    assert filtered["working_context"]["open_questions"] == []
+    assert len(withheld) == 1
+    assert candidates == []
+
+
+def test_line_renders_candidate_annotation():
+    item = {"text": "use the old gateway timeout", "id": "r-old",
+            "_supersede_candidate": "r-new"}
+    line = briefing._line(item)
+    assert "likely superseded by r-new" in line
+    assert "daimon resolve r-old --status superseded-by:r-new" in line
+
+
+def test_reopen_clears_candidate_flag():
+    # A reopen event as the LATEST event means the item is neither resolved
+    # nor a candidate — no drop, no stamp, no annotation.
+    cp = {"working_context": {"recent_decisions": [
+        {"text": "use the old gateway timeout", "id": "r-old"}]}}
+    filtered, withheld, candidates = briefing.withhold(
+        cp, {"r-old": _res_evt("r-old", status="reopened")})
+    assert withheld == []
+    assert candidates == []
+    kept = filtered["working_context"]["recent_decisions"]
+    assert "_supersede_candidate" not in kept[0]

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -364,3 +364,120 @@ def test_merge_without_resolved_kwarg_unchanged():
     assert len(qs) == 1
     assert qs[0]["text"] == "zephyr ledger drop unresolved"
     assert qs[0]["carried_from"] == "S-prev"
+
+
+# --- bind_links (#14): pure text-target -> prev-id binding for supersedes
+# links. Never-guess: only a UNIQUE same-kind prev match rewrites. -----------
+
+def test_bind_links_unique_match_rewrites_and_returns_pair():
+    prev = _cp("S-prev", 1, decisions=[
+        _item("use gateway A for serialize", id="r-old001")])
+    merged = _cp("S-new", 0, decisions=[
+        _item("use gateway B", id="r-new001",
+              links=[{"type": "supersedes",
+                      "target": "gateway A serialize choice"}])])
+    pairs = carry.bind_links(merged, prev)
+    assert pairs == [("r-old001", "r-new001", "use gateway A for serialize")]
+    link = merged["working_context"]["recent_decisions"][0]["links"][0]
+    assert link["target"] == "r-old001"
+
+
+def test_bind_links_ambiguous_stays_text_no_pair():
+    prev = _cp("S-prev", 1, decisions=[
+        _item("old zulu rollout plan alpha version one", id="r-old010"),
+        _item("old zulu rollout plan beta version two", id="r-old020"),
+    ])
+    target = "legacy zulu rollout plan alpha beta"
+    merged = _cp("S-new", 0, decisions=[
+        _item("switch to plan omega", id="r-new002",
+              links=[{"type": "supersedes", "target": target}])])
+    pairs = carry.bind_links(merged, prev)
+    assert pairs == []
+    link = merged["working_context"]["recent_decisions"][0]["links"][0]
+    assert link["target"] == target
+
+
+def test_bind_links_skips_self_and_twin():
+    # Native item INHERITED the prev item's id (twin id-inheritance, carry.py
+    # ~151-152) and its link target text-matches that SAME prev item.
+    orig = "gateway A serialize choice locked"
+    prev = _cp("S-prev", 1, decisions=[_item(orig, id="r-old001")])
+    merged = _cp("S-new", 0, decisions=[
+        _item("gateway A serialize choice still locked", id="r-old001",
+              links=[{"type": "supersedes", "target": orig}])])
+    pairs = carry.bind_links(merged, prev)
+    assert pairs == []
+    link = merged["working_context"]["recent_decisions"][0]["links"][0]
+    assert link["target"] == orig
+
+
+def test_bind_links_ignores_id_shaped_targets_and_malformed():
+    prev = _cp("S-prev", 1, decisions=[
+        _item("some other decision entirely", id="r-abc123")])
+    merged = _cp("S-new", 0, decisions=[
+        _item("native decision one", id="r-new003",
+              links=[{"type": "supersedes", "target": "r-abc123"}]),
+        _item("native decision two", id="r-new004",
+              links=["bare", {"type": "supersedes"}]),
+    ])
+    pairs = carry.bind_links(merged, prev)  # no raise
+    assert pairs == []
+    decisions = merged["working_context"]["recent_decisions"]
+    assert decisions[0]["links"][0]["target"] == "r-abc123"
+
+
+def test_bind_links_carried_native_does_not_double_count_generic():
+    # Reviewer repro: merge() carries prev items verbatim into merged natives
+    # (stamped carried_from), so counting them AGAIN in the DF universe pushes
+    # shared vocabulary over _GENERIC_DF=3, strips it as generic, and collapses
+    # a genuinely AMBIGUOUS target into a false-unique bind. Carried natives
+    # must be excluded from the universe — their vocabulary is already
+    # represented via prev_items. Ambiguous must stay unbound.
+    prev = _cp("S-prev", 1, decisions=[
+        _item("alpha bravo charlie delta echo", id="d-old001"),
+        _item("alpha bravo charlie foxtrot golf", id="d-old002"),
+    ])
+    target = "alpha bravo charlie delta echo"
+    merged = _cp("S-new", 0, decisions=[
+        _item("alpha bravo charlie delta echo", id="d-old001",
+              carried_from="S-prev"),  # carried verbatim by merge()
+        _item("switch to the new gateway plan", id="d-new001",
+              links=[{"type": "supersedes", "target": target}]),
+    ])
+    pairs = carry.bind_links(merged, prev)
+    assert pairs == []  # target matches BOTH prev decisions -> ambiguous
+    link = merged["working_context"]["recent_decisions"][1]["links"][0]
+    assert link["target"] == target  # unchanged
+
+
+def test_bind_links_dedupes_triples_but_rewrites_both_links():
+    # Two supersedes links on ONE item both resolving to the same prev item:
+    # both targets are rewritten, but the returned list carries ONE triple
+    # (dedupe by (old_id, new_id), keep first).
+    prev = _cp("S-prev", 1, decisions=[
+        _item("use gateway A for serialize", id="d-old001")])
+    merged = _cp("S-new", 0, decisions=[
+        _item("use gateway B", id="d-new001",
+              links=[{"type": "supersedes",
+                      "target": "gateway A serialize choice"},
+                     {"type": "supersedes",
+                      "target": "serialize via gateway A"}])])
+    pairs = carry.bind_links(merged, prev)
+    assert pairs == [("d-old001", "d-new001", "use gateway A for serialize")]
+    links = merged["working_context"]["recent_decisions"][0]["links"]
+    assert links[0]["target"] == "d-old001"
+    assert links[1]["target"] == "d-old001"
+
+
+def test_bind_links_same_kind_only():
+    # Target text matches an OPEN QUESTION in prev, not a decision -> the
+    # decisions-kind walk never looks at prev open_questions, so no bind.
+    text = "gateway A serialize choice locked"
+    prev = _cp("S-prev", 1, questions=[_item(text, id="q-old001")])
+    merged = _cp("S-new", 0, decisions=[
+        _item("switch decision", id="r-new005",
+              links=[{"type": "supersedes", "target": text}])])
+    pairs = carry.bind_links(merged, prev)
+    assert pairs == []
+    link = merged["working_context"]["recent_decisions"][0]["links"][0]
+    assert link["target"] == text

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2428,6 +2428,121 @@ def test_serialize_carry_failure_still_writes_checkpoint(
     assert written["session_id"] == "S-new"
 
 
+# ---- #14 Task 4: candidate emission behind the human-speaks-once gate ----
+
+
+def test_candidate_emitted_when_no_prior_event(tmp_checkpoint_dir, monkeypatch):
+    from daimon_briefing import store
+
+    project = "/p/candidate-emit"
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", project)
+    pairs = [("r-old", "r-new", "old text")]
+    count = cli._emit_supersede_candidates(pairs, {}, project)
+    assert count == 1
+
+    slug = store.project_slug(project)
+    lines = (tmp_checkpoint_dir / slug / "events.jsonl").read_text().splitlines()
+    evt = json.loads(lines[0])
+    assert evt["item_ref"] == "r-old"
+    assert evt["status"] == "supersede-candidate:r-new"
+    assert evt["source"] == "serializer"
+    assert evt["item_text"] == "old text"
+
+
+def test_candidate_skipped_after_human_confirm_and_reject(tmp_checkpoint_dir, monkeypatch):
+    project = "/p/candidate-human"
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", project)
+    pairs = [("r-old", "r-new", "old text")]
+
+    events_confirmed = {"r-old": {"status": "superseded-by:r-new", "source": "cli"}}
+    assert cli._emit_supersede_candidates(pairs, events_confirmed, project) == 0
+
+    events_rejected = {"r-old": {"status": "reopened", "source": "cli"}}
+    assert cli._emit_supersede_candidates(pairs, events_rejected, project) == 0
+
+
+def test_candidate_idempotent_and_new_id_reemits(tmp_checkpoint_dir, monkeypatch):
+    project = "/p/candidate-idem"
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", project)
+    pairs = [("r-old", "r-new", "old text")]
+
+    events_same = {"r-old": {"status": "supersede-candidate:r-new", "source": "serializer"}}
+    assert cli._emit_supersede_candidates(pairs, events_same, project) == 0
+
+    events_diff = {"r-old": {"status": "supersede-candidate:r-other", "source": "serializer"}}
+    assert cli._emit_supersede_candidates(pairs, events_diff, project) == 1
+
+
+def test_stamp_before_bind_gives_fresh_native_a_real_new_id(tmp_checkpoint_dir):
+    # Sequence pin: fresh native items only get ids inside write_checkpoint,
+    # which runs AFTER the carry block — so the serialize wiring must stamp
+    # ids itself before binding, or every fresh decision binds with
+    # new_id="" and gate (c) collapses all such pairs into one.
+    from daimon_briefing import carry, store
+
+    prev = {
+        "session_id": "S-prev",
+        "working_context": {
+            "open_questions": [],
+            "recent_decisions": [
+                {"text": "use gateway A for serialize", "id": "r-old001"},
+            ],
+        },
+        "epistemic_snapshot": {"uncertainties": []},
+    }
+    cp = {
+        "session_id": "S-new",
+        "working_context": {
+            "open_questions": [],
+            "recent_decisions": [
+                # FRESH native decision — no id yet, exactly as the serializer
+                # emits it before write_checkpoint stamps.
+                {"text": "use gateway B",
+                 "links": [{"type": "supersedes",
+                            "target": "gateway A serialize choice"}]},
+            ],
+        },
+        "epistemic_snapshot": {"uncertainties": []},
+    }
+    store._stamp_item_ids(cp)
+    pairs = carry.bind_links(cp, prev)
+    assert len(pairs) == 1
+    old_id, new_id, old_text = pairs[0]
+    assert old_id == "r-old001"
+    assert new_id  # non-empty — the stamped id, not ""
+    assert new_id == cp["working_context"]["recent_decisions"][0]["id"]
+    assert old_text == "use gateway A for serialize"
+
+
+def test_candidate_skips_falsy_new_id(tmp_checkpoint_dir, monkeypatch):
+    # Defense-in-depth: never write "supersede-candidate:" with no target.
+    from daimon_briefing import store
+
+    project = "/p/candidate-falsy"
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", project)
+    pairs = [("r-old", "", "old text")]
+    assert cli._emit_supersede_candidates(pairs, {}, project) == 0
+    slug = store.project_slug(project)
+    assert not (tmp_checkpoint_dir / slug / "events.jsonl").exists()
+
+
+def test_carry_still_carries_candidate_ref(tmp_checkpoint_dir, monkeypatch):
+    # B1 pin: a supersede-candidate event must NOT resolve the item — the
+    # serialize path's `resolved` set (resolutions + is_resolved) must not
+    # contain it, or carry would silently drop the candidate item.
+    from daimon_briefing import store
+
+    project = "/p/candidate-carry-pin"
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", project)
+    store.append_event("X", "supersede-candidate:r-new", source="serializer",
+                       project_dir=project)
+
+    events = store.resolutions(project_dir=project)
+    resolved = frozenset(ref for ref, evt in events.items()
+                         if store.is_resolved(evt))
+    assert "X" not in resolved
+
+
 # ---- #29: UX-contract batch — surface messages must match what the code does ----
 
 

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2717,6 +2717,53 @@ def test_status_suppressed_none_prints_message(tmp_checkpoint_dir, sample_checkp
     assert out.strip() == "no suppressed items"
 
 
+# ---- #14: withhold's third outcome, end-to-end (brief annotation + status subsection) ----
+
+
+def test_brief_shows_annotation_and_status_lists_subsection(
+        tmp_checkpoint_dir, sample_checkpoint, capsys):
+    from daimon_briefing import store
+    store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+    written = store.read_latest(project_dir="/repo/x")
+    item = written["working_context"]["recent_decisions"][0]
+    item_id = item["id"]
+    # new-id must be serializer-shaped (kind initial + hex slice) — withhold's
+    # #14 shape gate refuses anything else, so the fixture uses a real shape.
+    store.append_event(item_id, "supersede-candidate:r-9f3a2b", project_dir="/repo/x")
+
+    rc = cli.main(["brief", "--project", "/repo/x"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "likely superseded by r-9f3a2b" in out
+    assert f"daimon resolve {item_id} --status superseded-by:r-9f3a2b" in out
+
+    rc = cli.main(["status", "--suppressed", "--project", "/repo/x"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "likely superseded (unconfirmed):" in out
+    assert item_id in out
+    assert "r-9f3a2b" in out
+
+
+def test_transient_field_never_persisted(tmp_checkpoint_dir, sample_checkpoint, capsys):
+    # The `_supersede_candidate` stamp lives ONLY on withhold's returned copy —
+    # no writer ever persists it. Run a brief (which triggers withhold), then
+    # re-read the checkpoint straight off disk and confirm it never appears.
+    from daimon_briefing import store
+    store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+    written = store.read_latest(project_dir="/repo/x")
+    item_id = written["working_context"]["recent_decisions"][0]["id"]
+    store.append_event(item_id, "supersede-candidate:r-9f3a2b", project_dir="/repo/x")
+
+    rc = cli.main(["brief", "--project", "/repo/x"])
+    assert rc == 0
+    capsys.readouterr()
+
+    path = store.project_latest_path("/repo/x")
+    on_disk = json.loads(path.read_text(encoding="utf-8"))
+    assert "_supersede_candidate" not in json.dumps(on_disk)
+
+
 def test_recall_rejects_nonpositive_limit(tmp_checkpoint_dir, capsys):
     # --limit 0 / -N used to clamp silently to 1 result. Reject loudly.
     rc = cli.main(["recall", "anything", "--limit", "0"])

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -864,3 +864,30 @@ def test_serialize_strict_sanitizes_importance_never_fails_on_junk(fake_chat_fac
 def test_validate_tolerates_importance_field():
     ckpt = _ckpt_with_importances([3])
     assert serializer.validate(ckpt)
+
+
+def test_recent_decisions_schema_carries_links_shape():
+    # #14: recent_decisions items gain an optional links shape for typed
+    # cross-references (v1 scope: supersedes only). Both prompts render the
+    # same schema block, so both must show the new item shape.
+    links_shape = '"links": [{"type": "", "target": ""}]'
+    assert links_shape in serializer.SERIALIZE_SYS
+    assert links_shape in serializer.MERGE_SYS
+
+
+def test_extraction_rule_mentions_supersedes_conservatively():
+    # Conservative extraction: only explicit replacement language earns a
+    # supersedes link — never mere topic overlap between two decisions.
+    sys_prompt = serializer.SERIALIZE_SYS
+    assert "supersedes" in sys_prompt
+    assert "instead of" in sys_prompt  # explicit-replacement language required
+    assert "topic overlap" in sys_prompt  # anti-overreach guard
+
+
+def test_merge_sys_preserves_links():
+    # Merge must carry links through untouched, and union them (never drop
+    # either side's) when two items collapse into one canonical item.
+    sys_prompt = serializer.MERGE_SYS
+    assert "LINKS PRESERVATION" in sys_prompt
+    assert "verbatim" in sys_prompt
+    assert "union" in sys_prompt.lower()

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1066,3 +1066,29 @@ def test_append_event_redacts_note_and_item_text(tmp_checkpoint_dir):
     raw = (tmp_checkpoint_dir / slug / "events.jsonl").read_text()
     assert "AKIAIOSFODNN7EXAMPLE" not in raw and "eyJhbGci" not in raw
     assert "[redacted:aws-key]" in raw
+
+
+def test_is_resolved_supersede_candidate_is_live():
+    from daimon_briefing import store
+    assert store.is_resolved({"status": "supersede-candidate:r-9f2c1a"}) is False
+    assert store.is_resolved({"status": "superseded-by:r-9f2c1a"}) is True   # regression
+    assert store.is_resolved({"status": "REOPENED"}) is False                 # regression
+
+
+def test_redact_scrubs_link_targets(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    cp = {"working_context": {"recent_decisions": [
+        {"text": "use gateway B",
+         "links": [{"type": "supersedes",
+                    "target": "use gateway A with DAIMON_LLM_API_KEY=sk-abcdef1234567890"}]}]}}
+    store.write_checkpoint("S1", cp)
+    tgt = cp["working_context"]["recent_decisions"][0]["links"][0]["target"]
+    assert "sk-abcdef1234567890" not in tgt and "[redacted:api-key]" in tgt
+    assert cp["redactions"]["api-key"] == 1
+
+
+def test_redact_tolerates_malformed_links(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    cp = {"working_context": {"recent_decisions": [
+        {"text": "x", "links": ["bare", {"no": "target"}, {"target": 7}]}]}}
+    store.write_checkpoint("S1", cp)  # must not raise


### PR DESCRIPTION
Closes #14.

Checkpoint items were flat: a new decision replacing an old one left both occupying carry cap slots until someone noticed. This ships the issue's typed-links schema with its concrete consumer: automatic supersession DETECTION that offers a one-command collapse — and can never collapse anything by itself.

- optional `links: [{type, target}]` on items; enum documented (implements/fixes/informs/blocks/supersedes), v1 extracts `supersedes` only, on decisions, and only from explicit replacement language; unknown types tolerated on read; old checkpoints load unchanged
- the serializer emits text targets (it cannot know prior ids); `carry.bind_links` binds them to prev same-kind items at carry time — unique match or stays unbound; self/twin supersession guarded
- a bound link appends a `supersede-candidate:<new-id>` event — NON-RESOLVING by construction (`is_resolved` returns live), so carry, withhold, and every future consumer inherit no-suppression without knowing candidates exist; a machine claim can never hide a memory
- human-speaks-once gate: once any human event exists for a ref (confirm or reject), machine emission is silent forever; re-serialization is idempotent (no event spam)
- brief annotates the old item: `⚠ likely superseded by <id> — confirm: daimon resolve ...`; `daimon status --suppressed` lists unconfirmed candidates; confirming frees the cap slot through the existing resolution machinery
- link targets pass capture-time redaction; no DB, no embeddings, no graph traversal — plain typed edges in checkpoint JSON, per the issue's own fence