### PR TITLE
feat(brief): reject path for supersede candidates — hint in annotation, evidence-free reject

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -55,7 +55,8 @@ def _line(item) -> str:
         # withheld, just flagged with a one-command confirm path.
         item_id = item.get("id") or "?"
         base += (f"\n  ⚠ likely superseded by {candidate} — confirm: "
-                 f"daimon resolve {item_id} --status superseded-by:{candidate}")
+                 f"daimon resolve {item_id} --status superseded-by:{candidate}"
+                 f"\n    reject: daimon reverify {item_id}")
     return base
 
 

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -562,6 +562,26 @@ def _cmd_resolve(args) -> int:
     return 0
 
 
+def _is_supersede_candidate(item_id: str, project) -> bool:
+    """True when the item's LATEST lifecycle event is a serializer-authored
+    supersede-candidate — an unconfirmed machine SUGGESTION (#14) that has
+    never withheld anything. This is the one reopen target that needs no
+    evidence: rejecting a guess is not vouching for a claim (#111). The
+    source gate mirrors `_emit_supersede_candidates` — only the serializer
+    ever writes candidates, so a human verdict already latest reads as
+    not-a-candidate and keeps the evidence gate. Fails closed: a broken
+    events fold means 'not a candidate', so the evidence gate still applies."""
+    try:
+        prior = store.resolutions(project_dir=project).get(item_id)
+    except Exception:
+        return False
+    if not isinstance(prior, dict):
+        return False
+    status = str(prior.get("status") or "").lower()
+    source = str(prior.get("source") or "")
+    return status.startswith("supersede-candidate") and source == "serializer"
+
+
 def _cmd_reverify(args) -> int:
     """Evidence-gated reopen (#103): re-stamping a resolved item without
     evidence would mark an unchecked claim verified — the one thing this
@@ -569,7 +589,12 @@ def _cmd_reverify(args) -> int:
     the original anchor still checks out live (the code proved itself) or
     the caller supplies --evidence (a human vouches for it); otherwise the
     refusal appends nothing. Exact id only — no fuzzy match, because
-    reopening is a deliberate act; find ids via `daimon status --suppressed`."""
+    reopening is a deliberate act; find ids via `daimon status --suppressed`.
+
+    #111 exception: when the target is an unconfirmed supersede CANDIDATE
+    (a machine guess that has never withheld anything), reopen is allowed
+    with no evidence — rejecting a suggestion is not vouching for a claim.
+    The reopened event is a human verdict, so re-detection stays silent."""
     project = _resolve_project(args.project)
     checkpoint = store.read_latest(project_dir=project, fallback=False)
     if not isinstance(checkpoint, dict):
@@ -594,6 +619,12 @@ def _cmd_reverify(args) -> int:
             note += "; " + evidence
     elif evidence:
         note = f"evidence: {evidence}"
+    elif _is_supersede_candidate(item["id"], project):
+        # #111: the target is an unconfirmed machine SUGGESTION, never a
+        # withheld/suppressed item — rejecting a guess needs no proof. The
+        # reopened event below is a human verdict, so the human-speaks-once
+        # gate (#14) silences re-detection of this candidate permanently.
+        note = "candidate rejected"
     else:
         print("re-stamping without evidence would mark an unchecked claim "
               "verified — supply --evidence, or fix the anchored code and retry")
@@ -937,6 +968,10 @@ def _print_suppressed(project) -> int:
             text = str(item.get("text") or "").strip()
             new_id = item.get("_supersede_candidate") or "-"
             print(f"  {item_id}  [{key}] {text}  -> {new_id}")
+            # #111: both a confirm and a reject path — a human who disagrees
+            # with the guess must not have to reach for evidence machinery.
+            print(f"    confirm: daimon resolve {item_id} --status superseded-by:{new_id}")
+            print(f"    reject: daimon reverify {item_id}")
     return 0
 
 
@@ -1836,7 +1871,8 @@ def main(argv=None) -> int:
         "refuses without proof, so a claim can't get re-verified for free",
         epilog="Examples:\n"
                "  daimon reverify o-3f8a2c --evidence \"checked release page\"\n"
-               "  daimon reverify o-3f8a2c   # reopens only if the anchor still checks live\n",
+               "  daimon reverify o-3f8a2c   # reopens only if the anchor still checks live\n"
+               "  daimon reverify o-3f8a2c   # rejects an unconfirmed supersede candidate — no evidence needed\n",
     )
     p_reverify.add_argument("target", help="item id (exact only — reverify is deliberate, no fuzzy match)")
     p_reverify.add_argument("--evidence", help="why this claim can be trusted again")

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -149,7 +149,8 @@ def _rich_brief(b: dict) -> None:
                 item_id = i.get("id") or "?"
                 body.append(
                     f"    ⚠ likely superseded by {candidate} — confirm: "
-                    f"daimon resolve {item_id} --status superseded-by:{candidate}\n",
+                    f"daimon resolve {item_id} --status superseded-by:{candidate}\n"
+                    f"    reject: daimon reverify {item_id}\n",
                     style="yellow")
         if key == "decisions":
             note = briefing._overflow_note(b.get("decisions_overflow", 0))

--- a/plugin/tests/test_briefing.py
+++ b/plugin/tests/test_briefing.py
@@ -705,6 +705,15 @@ def test_line_renders_candidate_annotation():
     assert "daimon resolve r-old --status superseded-by:r-new" in line
 
 
+def test_line_renders_candidate_reject_hint():
+    # #111: a human who disagrees with the machine's guess needs a printed
+    # path too — the reject command rides alongside the confirm command.
+    item = {"text": "use the old gateway timeout", "id": "r-old",
+            "_supersede_candidate": "r-new"}
+    line = briefing._line(item)
+    assert "reject: daimon reverify r-old" in line
+
+
 def test_reopen_clears_candidate_flag():
     # A reopen event as the LATEST event means the item is neither resolved
     # nor a candidate — no drop, no stamp, no annotation.

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2743,6 +2743,10 @@ def test_brief_shows_annotation_and_status_lists_subsection(
     assert "likely superseded (unconfirmed):" in out
     assert item_id in out
     assert "r-9f3a2b" in out
+    # #111: the subsection prints both the confirm and the reject command,
+    # so a human who disagrees with the guess has a printed path.
+    assert f"daimon resolve {item_id} --status superseded-by:r-9f3a2b" in out
+    assert f"daimon reverify {item_id}" in out
 
 
 def test_transient_field_never_persisted(tmp_checkpoint_dir, sample_checkpoint, capsys):
@@ -3586,3 +3590,53 @@ def test_reverify_anchor_drifted_still_refused_without_evidence(tmp_checkpoint_d
     assert cli.main(["reverify", iid]) == 1
     r = store.resolutions(project_dir="/p/A")
     assert store.is_resolved(r[iid])  # unchanged — still resolved, nothing appended
+
+
+# ---- #111: candidate reject — evidence-free, silences re-detection ----
+
+
+def test_reverify_rejects_candidate_without_evidence(tmp_checkpoint_dir, capsys, monkeypatch):
+    # A supersede-candidate is an unconfirmed machine SUGGESTION, never a
+    # withheld item — rejecting a guess needs no proof. reverify with no
+    # --evidence must succeed and write a reopened (human) event.
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    store.append_event(iid, "supersede-candidate:o-9f3a2b",
+                       source="serializer", project_dir="/p/A")
+    assert cli.main(["reverify", iid]) == 0
+    r = store.resolutions(project_dir="/p/A")
+    # latest event is now a human reopen — the item stays live (not resolved)
+    # and is no longer a candidate.
+    assert not store.is_resolved(r[iid])
+    assert str(r[iid].get("source")) != "serializer"
+
+
+def test_reverify_candidate_reject_silences_re_detection(tmp_checkpoint_dir, capsys, monkeypatch):
+    # After an evidence-free reject, the human-speaks-once gate (#14) keeps
+    # the machine silent forever — re-serialize offers nothing.
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    store.append_event(iid, "supersede-candidate:o-9f3a2b",
+                       source="serializer", project_dir="/p/A")
+    assert cli.main(["reverify", iid]) == 0
+    events = store.resolutions(project_dir="/p/A")
+    pairs = [(iid, "o-9f3a2b", "release pipeline awaiting manual approval step")]
+    assert cli._emit_supersede_candidates(pairs, events, "/p/A") == 0
+
+
+def test_reverify_still_refuses_resolved_item_without_evidence(tmp_checkpoint_dir, capsys, monkeypatch):
+    # Guard: the evidence-free path is candidate-only. A genuinely RESOLVED
+    # item (not a machine candidate) still demands evidence — #103 semantics
+    # are untouched.
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    store.append_event(iid, "resolved", project_dir="/p/A")
+    assert cli.main(["reverify", iid]) == 1
+    out = capsys.readouterr().out
+    assert "without evidence" in out


### PR DESCRIPTION
Closes #111.

## What

The `#110` supersede-candidate annotation printed only the CONFIRM command. A human who disagreed with the machine's supersession guess had no printed path, and the only silencing mechanism — `daimon reverify --evidence` — demanded evidence for an item that was never withheld. Requiring proof to reject a suggestion is semantically backwards.

This adds the missing reject half:

- **Reject hint in the annotation.** Beside the existing `confirm: daimon resolve <id> --status superseded-by:<new>`, the brief now prints `reject: daimon reverify <id>` on an adjacent line. Both the plain path (`briefing._line`) and the rich panel (`render.py`) carry it, keeping parity.
- **Reject hints in `status --suppressed`.** The `likely superseded (unconfirmed)` subsection now prints an explicit confirm command and a reject command under each candidate, instead of only the `-> <new-id>` arrow.
- **Evidence-free candidate reject in `reverify`.** When the target's latest event is a serializer-authored `supersede-candidate:*` — an unconfirmed machine guess that has never withheld anything — `reverify` skips the evidence gate. It writes a `reopened` (human) event, which the existing human-speaks-once gate from `#110` treats as a verdict, so re-detection stays silent permanently. No parallel silencing mechanism is introduced.

## Why it's safe

- Candidates still never suppress items; suppression semantics are untouched.
- The evidence-free path is candidate-only: a genuinely resolved item still demands `--evidence` (the `#103` guarantee that an unchecked claim can't be re-verified for free is preserved). The candidate check gates on both status prefix and `source == "serializer"`, and fails closed on a broken events fold.

## Tests

Full suite green (997 passed). New coverage:

- annotation prints the reject command
- `status --suppressed` prints confirm + reject commands
- `reverify` rejects a candidate with no `--evidence` and writes a human `reopened` event
- an evidence-free reject silences re-detection (`_emit_supersede_candidates` offers nothing after)
- a resolved (non-candidate) item still refuses reopen without evidence

## Note on scope

The issue names the annotation and `status --suppressed`. In `status --suppressed` the pre-existing "confirm hint" was only the `-> <new-id>` arrow, not a runnable command; to place the reject hint alongside a real confirm hint, this promotes both to full commands. This is a small superset of the literal ask, chosen for symmetry with the annotation.