### PR TITLE
chore(scars): promote deadend 0022 — unbounded prefix backtracking

### DIFF
--- a/.scars/0022-unbounded-prefix-class-before-keyword-alternation-backtracks.deadend.md
+++ b/.scars/0022-unbounded-prefix-class-before-keyword-alternation-backtracks.deadend.md
@@ -1,21 +1,21 @@
 ---
-id: 0
+id: 22
 type: deadend
 title: Unbounded [\w-]* prefix before a keyword alternation backtracks quadratically — bound it ({0,32}?) or the write path hangs
 severity: high
 confidence: 0.9
 created: 2026-07-07
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/redact.py
-violation: "\[\\w-\]\*\(\?:"
 evidence:
   - pr: 108
-  - note: "adjudicated fix in 964dfbb widened api-key to [\\w-]*(?:api[_-]?key|...) so env-var names match; passed unit tests AND task review; final-review adversarial probe measured O(N²): 16KB no-separator run = 7s, 32KB ≈ 28s — a checkpoint write freeze fail-open cannot catch (slowness is not an exception). Fixed in aa966df: [\\w-]{0,32}? lazy bounded prefix -> 0.40ms at 32KB"
+  - note: adjudicated fix in 964dfbb widened api-key to [\\w-]*(?:api[_-]?key|...) so env-var names match; passed unit tests AND task review; final-review adversarial probe measured O(N²): 16KB no-separator run = 7s, 32KB ≈ 28s — a checkpoint write freeze fail-open cannot catch (slowness is not an exception). Fixed in aa966df: [\\w-]{0,32}? lazy bounded prefix -> 0.40ms at 32KB
 expires:
   condition: "redaction moves off Python re (e.g. re2/hyperscan) or gains a timeout wrapper"
   review_after: 2027-07-07
-status: candidate
+violation: "\[\\w-\]\*\(\?:"
+status: active
 ---
 
 Tried in #104: widening the api-key pattern with an unbounded `[\w-]*` prefix


### PR DESCRIPTION
Promotes reviewed candidate to active scar 0022 (deadend, severity high).

## What it records

PR #108's redaction module briefly widened the api-key pattern with an unbounded `[\w-]*` prefix so env-var-style names match the keyword alternation. The prefix class overlaps the keyword characters, so a long separator-free `[\w-]` run makes the engine retry every split point — quadratic time on a regex that runs on every checkpoint write. Unit tests and per-task review both passed; only an adversarial length probe surfaced it (16KB = 7s, 32KB ≈ 28s). Fixed in aa966df with a bounded lazy prefix (`[\w-]{0,32}?` → 0.40ms at 32KB).

Rule the scar enforces: prefix classes before keyword alternations must be bounded and lazy, and every capture-path regex gets a long-input completion test. Python `re` has no timeout; fail-open except-clauses cannot catch slow matches.

## Review evidence

- `scar lint` clean: 22 files, 0 errors, 0 partial-rot, 0 unreachable-evidence
- Evidence commits verified: 964dfbb (introduced), aa966df (fixed)
- Violation tripwire proven both directions: fires on `[\w-]*(?:`, silent on the bounded shape and on current `redact.py`
- Long-input completion tests already in `plugin/tests/test_redact.py` (50k-char runs)

Scars-only change — issue-first gate skipped per pr-validation.yml.