### PR TITLE
chore(store): events.jsonl stats instrumentation + fold hardening (#106)

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1589,11 +1589,36 @@ def _stats_retention(now=None) -> dict:
     return out
 
 
+def _stats_events(project_dir) -> dict:
+    """events.jsonl (current project) -> raw line count + fold cost. The
+    measure-first instrument for #106: compaction of the append-only log stays
+    deferred until these numbers show a real cost. `lines` counts EVERY
+    appended line (the growth signal), `resolved_refs` the folded item count,
+    and `fold_ms` times a full store.resolutions() — read + parse + latest-by-ts
+    fold over the whole log, measured at stats time. Fails open to zeroes when
+    the project is unknown or the log is missing/corrupt (same as the fold)."""
+    out = {"lines": 0, "fold_ms": 0.0, "resolved_refs": 0}
+    path = store._events_path(project_dir)
+    if path is None:
+        return out
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return out
+    out["lines"] = len(text.splitlines())
+    start = time.perf_counter()
+    folded = store.resolutions(project_dir=project_dir)
+    out["fold_ms"] = round((time.perf_counter() - start) * 1000, 2)
+    out["resolved_refs"] = len(folded)
+    return out
+
+
 def _cmd_stats(args) -> int:
     """Aggregate what is already on disk. Nothing is transmitted anywhere —
     sharing the output is a deliberate act (the user pastes it)."""
     data = {"usage": _stats_usage(), "capture": _stats_capture(),
-            "store": _stats_store(), "retention": _stats_retention()}
+            "store": _stats_store(), "retention": _stats_retention(),
+            "events": _stats_events(_resolve_project(None))}
     if args.json:
         print(json.dumps(data, indent=2))
         return 0

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -653,6 +653,11 @@ def _plain_stats(data: dict) -> None:
             f"{k}: {n}" for k, n in sorted(s["items_by_kind"].items())))
     print(f"  trust: verbatim {s['items_verbatim']}, inferred {s['items_inferred']}, "
           f"untagged {s['items_untagged']}  (carried: {s['items_carried']})")
+    e = data.get("events")
+    if e:
+        print("events (this project):")
+        print(f"  log lines: {e['lines']}  resolved refs: {e['resolved_refs']}  "
+              f"fold: {e['fold_ms']}ms")
 
 
 def _rich_stats(data: dict) -> None:
@@ -731,3 +736,14 @@ def _rich_stats(data: dict) -> None:
         f"untagged {s['items_untagged']}  (carried: {s['items_carried']})",
     )
     console.print(store_table)
+
+    e = data.get("events")
+    if e:
+        events_table = Table(title="events (this project)", title_justify="left",
+                             show_header=True, header_style="bold")
+        events_table.add_column("metric")
+        events_table.add_column("value")
+        events_table.add_row("log lines", str(e["lines"]))
+        events_table.add_row("resolved refs", str(e["resolved_refs"]))
+        events_table.add_row("fold", f"{e['fold_ms']}ms")
+        console.print(events_table)

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -766,7 +766,7 @@ def resolutions(project_dir=None) -> dict:
         return out
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return out
     for line in lines:
         try:

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3280,6 +3280,39 @@ def test_stats_empty_world_is_calm(tmp_checkpoint_dir, capsys):
     assert data["usage"] == {}
     assert data["capture"]["success"] == 0
     assert data["store"]["checkpoints"] == 0
+    # events instrument reports zeroes when there is no log to fold
+    assert data["events"] == {"lines": 0, "fold_ms": 0.0, "resolved_refs": 0}
+
+
+def test_stats_events_reports_line_count_and_fold_time(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # measure-first instrument (#106): the events section counts every appended
+    # line for the CURRENT project and times a full read+fold at stats time.
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    store.append_event("o-a", "resolved", project_dir="/p/A")
+    store.append_event("o-a", "reopened", project_dir="/p/A")  # same ref, later line
+    store.append_event("o-b", "resolved", project_dir="/p/A")
+    rc = cli.main(["stats", "--json"])
+    assert rc == 0
+    ev = json.loads(capsys.readouterr().out)["events"]
+    assert ev["lines"] == 3          # every appended line, not folded refs
+    assert ev["resolved_refs"] == 2  # o-a and o-b after fold
+    assert isinstance(ev["fold_ms"], float)
+    assert ev["fold_ms"] >= 0.0
+
+
+def test_stats_events_scoped_to_current_project(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # the section reports ONLY the current project's log — another project's
+    # events must not leak into the count.
+    from daimon_briefing import store
+    store.append_event("o-a", "resolved", project_dir="/p/A")
+    store.append_event("o-b", "resolved", project_dir="/p/OTHER")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    rc = cli.main(["stats", "--json"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["events"]["lines"] == 1
 
 
 # ---- retention: hook briefings vs deliberate re-reads ----

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -648,6 +648,33 @@ def test_render_stats_rich_smoke(monkeypatch, capsys):
     assert "verbatim" in out
 
 
+def test_render_stats_plain_events_section(capsys):
+    data = _stats_sample()
+    data["events"] = {"lines": 12, "fold_ms": 0.34, "resolved_refs": 7}
+    render.render_stats(data)
+    out = capsys.readouterr().out
+    assert "events (this project):" in out
+    assert "log lines: 12" in out
+    assert "resolved refs: 7" in out
+    assert "fold: 0.34ms" in out
+
+
+def test_render_stats_plain_omits_events_when_absent(capsys):
+    # optional section, mirrors retention — no events key, no section
+    render.render_stats(_stats_sample())
+    assert "events (this project):" not in capsys.readouterr().out
+
+
+def test_render_stats_rich_events_section(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    data = _stats_sample()
+    data["events"] = {"lines": 12, "fold_ms": 0.34, "resolved_refs": 7}
+    render.render_stats(data)
+    out = capsys.readouterr().out
+    assert "events" in out.lower()
+    assert "12" in out
+
+
 # ---- recall: `daimon recall` (#68 rich parity) ------------------------------
 
 

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -968,6 +968,36 @@ def test_resolutions_missing_file_or_project_is_empty(tmp_checkpoint_dir):
     assert store.resolutions(project_dir=None) == {}
 
 
+def test_resolutions_equal_timestamp_tie_break_last_line_wins(tmp_checkpoint_dir):
+    # CONTRACT (pinned, not a preference): when two events for the SAME
+    # item_ref share a timestamp, the fold keeps the one appearing LATER in
+    # file order. The fold replaces on `new_e >= cur_e`, so an equal ts lets
+    # each subsequent line overwrite — the last write to the log wins the tie.
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    d = tmp_checkpoint_dir / slug
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "events.jsonl").write_text(
+        '{"ts": "2026-07-07T10:00:00Z", "item_ref": "o-a", "status": "resolved", "note": "first"}\n'
+        '{"ts": "2026-07-07T10:00:00Z", "item_ref": "o-a", "status": "reopened", "note": "second"}\n'
+    )
+    r = store.resolutions(project_dir="/p/A")
+    assert r["o-a"]["status"] == "reopened"
+    assert r["o-a"]["note"] == "second"
+
+
+def test_resolutions_invalid_utf8_bytes_return_empty(tmp_checkpoint_dir):
+    # A corrupt log (invalid UTF-8) must fail open like a missing file, never
+    # raise UnicodeDecodeError out of the read path — a reader can never let
+    # one bad byte take down the whole fold.
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    d = tmp_checkpoint_dir / slug
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "events.jsonl").write_bytes(b'{"item_ref": "o-a", "status": "resolved"}\n\xff\xfe bad bytes\n')
+    assert store.resolutions(project_dir="/p/A") == {}
+
+
 def test_append_event_stores_item_text_when_given(tmp_checkpoint_dir):
     from daimon_briefing import store
     store.append_event("o-abc", "resolved", project_dir="/p/A",


### PR DESCRIPTION
Closes #115. Part of #106 (compaction remains deferred there pending the measurements this adds).

Measure-first slice. This does **not** build compaction of the append-only
resolution event log — that stays deferred until field evidence justifies it.
The issue prescribes measuring first (line count + fold time in stats); this
adds exactly that instrument, plus one adjacent hardening fix, so the deferral
decision can rest on real numbers rather than a guess.

## What changed

- **Stats instrumentation** — `daimon stats` gains a per-project `events`
  section reporting the current project's `events.jsonl` total line count and
  fold time (a full read + latest-by-ts fold, timed at stats time), plus the
  resolved-ref count after folding. Rendered in both plain and rich output,
  optional like the existing retention section.
- **Tie-break test** — pins equal-timestamp tie-break in the events fold: when
  two events for the same `item_ref` share a timestamp, the later line in file
  order wins. Documents the current contract; **no behavior change**.
- **Error hardening** — `store.resolutions` now catches `UnicodeDecodeError`
  alongside `OSError` in the read path, so a corrupt log fails open to an empty
  fold instead of raising.

## Sample output

```
events (this project):
  log lines: 9  resolved refs: 4  fold: 1.87ms
```

JSON shape:

```json
"events": { "lines": 9, "fold_ms": 1.21, "resolved_refs": 4 }
```

## Tests

Full suite green (1004 passed). New tests: fold tie-break + invalid-UTF-8
fail-open in `test_store.py`; events line-count/fold-time and project-scoping
in `test_cli.py`; plain + rich events-section rendering in `test_render.py`.
