### PR TITLE
feat(redact): extend redaction to remaining transcript-persistence seams

### DIFF
--- a/hook/_daimon_hook_lib.py
+++ b/hook/_daimon_hook_lib.py
@@ -14,6 +14,7 @@ pure-JSON stdout, Codex's additionalContext envelope + Stop throttling, and
 Codex's mtime-only age line. Only what is genuinely identical lives here.
 """
 
+import importlib.util
 import json
 import os
 import re
@@ -32,6 +33,47 @@ FALLBACKS = [
 ]
 
 LOG_DIR = Path.home() / ".daimon" / "logs"
+
+
+def _load_redact():
+    """Load the shipped redaction module (#104) from THIS file's own directory,
+    where `daimon hooks install` places redact.py. File-location import (never
+    `import redact`) so it never depends on sys.path state and never collides
+    with an unrelated top-level module. None when absent — a stale install
+    missing redact.py; the hook write sites then SKIP rather than persist raw
+    text (#109). Patterns live ONLY in redact.py (scar 0022) — never copied
+    here, and a test keeps the shipped copy byte-identical to the package's."""
+    path = Path(__file__).resolve().parent / "redact.py"
+    if not path.exists():
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location("_daimon_hooks_redact", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    except Exception:  # noqa: BLE001 — a broken module must never crash a hook
+        return None
+
+
+_REDACT = _load_redact()
+
+
+def redaction_available() -> bool:
+    """True when the shipped redaction module loaded. A hook MUST gate its
+    write sites on this and skip when False: #104's disk guarantee (a quoted
+    secret never persists) outranks accumulation/probe availability (#109)."""
+    return _REDACT is not None
+
+
+def redact_text(text: str) -> str:
+    """Best-effort capture-time secret scrub, delegating to the shipped redact
+    module (#104). Returns text UNCHANGED when the module is unavailable — the
+    caller gates on redaction_available() first, so that path never persists.
+    The module's own per-pattern fail-open guarantees a scrub, never a raise."""
+    if _REDACT is None:
+        return text
+    scrubbed, _counts = _REDACT.redact_text(text)
+    return scrubbed
 
 
 def disabled() -> bool:

--- a/hook/daimon-windsurf-hooks.py
+++ b/hook/daimon-windsurf-hooks.py
@@ -125,11 +125,14 @@ def _mark_spawned(trajectory_id: str) -> None:
 def _append_turn(trajectory_id: str, role: str, text: str) -> Path:
     """Append one `**role**:`-marked turn — the markdown shape
     transcript.from_file's role regex parses (marker starts a turn, following
-    lines are its continuation)."""
+    lines are its continuation). Turn text is secret-scrubbed at this write
+    site (#109): the accumulation file is a disk artifact `daimon serialize`
+    reads later, so a quoted secret must not land here raw. main() has already
+    gated on lib.redaction_available(), so the scrub is guaranteed real."""
     TRANSCRIPT_DIR.mkdir(parents=True, exist_ok=True)
     path = TRANSCRIPT_DIR / f"{_safe_name(trajectory_id)}.md"
     with path.open("a", encoding="utf-8") as f:
-        f.write(f"**{role}**: {text.strip()}\n\n")
+        f.write(f"**{role}**: {lib.redact_text(text).strip()}\n\n")
     return path
 
 
@@ -150,10 +153,26 @@ def _extract_prompt(payload: dict) -> str | None:
     return None
 
 
+def _redact_payload(obj):
+    """Deep copy of `obj` with every string leaf secret-scrubbed (#109). Keys,
+    structure, and non-string scalars are preserved so the probe dump stays a
+    faithful, usable diagnostic — only secret-shaped substrings inside string
+    values are masked. main() has gated on lib.redaction_available()."""
+    if isinstance(obj, str):
+        return lib.redact_text(obj)
+    if isinstance(obj, dict):
+        return {k: _redact_payload(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_redact_payload(v) for v in obj]
+    return obj
+
+
 def _dump_probe(event: str, payload: dict) -> bool:
     """Bounded self-probe dump (#62): at most one unparsed-*.json per event
     name. Returns True when a dump was written (callers log only then, so a
-    hook registered for every Cascade event stays quiet after the first)."""
+    hook registered for every Cascade event stays quiet after the first).
+    Payload string leaves are secret-scrubbed at this write site (#109) so no
+    quoted secret reaches unparsed-*.json, while structure stays usable."""
     try:
         STATE_DIR.mkdir(parents=True, exist_ok=True)
         tag = _safe_name(event or "unknown")
@@ -161,7 +180,8 @@ def _dump_probe(event: str, payload: dict) -> bool:
             return False
         stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
         (STATE_DIR / f"unparsed-{tag}-{stamp}.json").write_text(
-            json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+            json.dumps(_redact_payload(payload), indent=2, ensure_ascii=False),
+            encoding="utf-8")
         return True
     except OSError:
         return False
@@ -181,6 +201,14 @@ def main() -> int:
         _fallback_log("windsurf-cascade: hook library missing (_daimon_hook_lib.py) — skipped")
         return 0
     if lib.disabled():
+        return 0
+    if not lib.redaction_available():
+        # #109: every write site below (accumulation, probe dumps) persists
+        # transcript-derived text. Without the redaction module we cannot
+        # guarantee a quoted secret is scrubbed, so skip rather than write raw —
+        # #104's disk guarantee outranks accumulation. Fail-open: still exit 0.
+        lib.log("windsurf-cascade: redaction module unavailable — skipped "
+                "(no raw transcript persisted)")
         return 0
 
     try:

--- a/hook/daimon-windsurf-hooks.py
+++ b/hook/daimon-windsurf-hooks.py
@@ -157,14 +157,21 @@ def _redact_payload(obj):
     """Deep copy of `obj` with every string leaf secret-scrubbed (#109). Keys,
     structure, and non-string scalars are preserved so the probe dump stays a
     faithful, usable diagnostic — only secret-shaped substrings inside string
-    values are masked. main() has gated on lib.redaction_available()."""
+    values are masked. main() has gated on lib.redaction_available().
+
+    JSON payloads only ever yield dict/list/str/scalar, but the helper is
+    fail-safe against reuse: tuples are scrubbed like lists, and ANY other
+    unrecognized type is rendered via str() and scrubbed rather than passed
+    through raw — a silent skip would contradict the disk-wide guarantee."""
     if isinstance(obj, str):
         return lib.redact_text(obj)
     if isinstance(obj, dict):
         return {k: _redact_payload(v) for k, v in obj.items()}
-    if isinstance(obj, list):
+    if isinstance(obj, (list, tuple)):
         return [_redact_payload(v) for v in obj]
-    return obj
+    if obj is None or isinstance(obj, (bool, int, float)):
+        return obj
+    return lib.redact_text(str(obj))
 
 
 def _dump_probe(event: str, payload: dict) -> bool:

--- a/hook/redact.py
+++ b/hook/redact.py
@@ -1,0 +1,56 @@
+"""Deterministic capture-time secret redaction (#104) — stdlib only, zero LLM.
+
+Checkpoints persist outside the session and the team mirror replicates them
+to a shared remote, so a quoted secret must never reach disk. Patterns are
+precision-first: each requires a concrete shape (assignment operator, URL
+scheme, key prefix, header keyword) — never bare entropy — so prose
+("the token budget", "password rotation policy") survives untouched.
+Replacement is a stable visible marker, [redacted:<kind>]: auditable,
+never silent."""
+
+import re
+
+# (kind, compiled pattern). Order matters only for overlap (pem first: a key
+# block may contain assignment-looking lines that must not double-count).
+_PATTERNS = (
+    ("pem", re.compile(
+        r"-----BEGIN [A-Z0-9 ]*(?:KEY|CERTIFICATE)[A-Z0-9 ]*-----"
+        r"(?:.*?-----END [A-Z0-9 ]*(?:KEY|CERTIFICATE)[A-Z0-9 ]*-----|.*)",
+        re.DOTALL)),
+    ("aws-key", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
+    ("stripe-key", re.compile(r"\b[rsp]k_live_[0-9A-Za-z]{8,}\b")),
+    ("bearer", re.compile(
+        r"(?i)\b(?:bearer|authorization:\s*\w+)\s+[A-Za-z0-9._~+/=-]{16,}")),
+    ("api-key", re.compile(
+        r"(?i)\b([\w-]{0,32}?(?:api[_-]?key|secret|token|password|passwd))"
+        r"(\s*[=:]\s*)['\"]?(?!\[redacted:)[^\s'\"]{8,}")),
+    ("credential-url", re.compile(
+        r"\b([a-z][a-z0-9+.-]{0,15}://[^/\s:@]+):(?!\[redacted:)[^/\s@]+@")),
+)
+
+
+def redact_text(s):
+    """(redacted, {kind: count}). Non-string / empty input passes through
+    unchanged — callers scrub optional fields without type checks. A regex
+    failure skips that pattern (fail-open: redaction must never cost the
+    write; unreachable with these static patterns, cheap insurance)."""
+    counts: dict = {}
+    if not isinstance(s, str) or not s:
+        return s, counts
+
+    def _mark(kind):
+        counts[kind] = counts.get(kind, 0) + 1
+
+    for kind, rx in _PATTERNS:
+        def _sub(m, kind=kind):
+            _mark(kind)
+            if kind == "api-key":
+                return m.group(1) + m.group(2) + "[redacted:api-key]"
+            if kind == "credential-url":
+                return m.group(1) + ":[redacted:credential-url]@"
+            return f"[redacted:{kind}]"
+        try:
+            s = rx.sub(_sub, s)
+        except re.error:  # pragma: no cover — static patterns
+            continue
+    return s, counts

--- a/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
+++ b/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
@@ -14,6 +14,7 @@ pure-JSON stdout, Codex's additionalContext envelope + Stop throttling, and
 Codex's mtime-only age line. Only what is genuinely identical lives here.
 """
 
+import importlib.util
 import json
 import os
 import re
@@ -32,6 +33,47 @@ FALLBACKS = [
 ]
 
 LOG_DIR = Path.home() / ".daimon" / "logs"
+
+
+def _load_redact():
+    """Load the shipped redaction module (#104) from THIS file's own directory,
+    where `daimon hooks install` places redact.py. File-location import (never
+    `import redact`) so it never depends on sys.path state and never collides
+    with an unrelated top-level module. None when absent — a stale install
+    missing redact.py; the hook write sites then SKIP rather than persist raw
+    text (#109). Patterns live ONLY in redact.py (scar 0022) — never copied
+    here, and a test keeps the shipped copy byte-identical to the package's."""
+    path = Path(__file__).resolve().parent / "redact.py"
+    if not path.exists():
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location("_daimon_hooks_redact", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    except Exception:  # noqa: BLE001 — a broken module must never crash a hook
+        return None
+
+
+_REDACT = _load_redact()
+
+
+def redaction_available() -> bool:
+    """True when the shipped redaction module loaded. A hook MUST gate its
+    write sites on this and skip when False: #104's disk guarantee (a quoted
+    secret never persists) outranks accumulation/probe availability (#109)."""
+    return _REDACT is not None
+
+
+def redact_text(text: str) -> str:
+    """Best-effort capture-time secret scrub, delegating to the shipped redact
+    module (#104). Returns text UNCHANGED when the module is unavailable — the
+    caller gates on redaction_available() first, so that path never persists.
+    The module's own per-pattern fail-open guarantees a scrub, never a raise."""
+    if _REDACT is None:
+        return text
+    scrubbed, _counts = _REDACT.redact_text(text)
+    return scrubbed
 
 
 def disabled() -> bool:

--- a/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
+++ b/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
@@ -125,11 +125,14 @@ def _mark_spawned(trajectory_id: str) -> None:
 def _append_turn(trajectory_id: str, role: str, text: str) -> Path:
     """Append one `**role**:`-marked turn — the markdown shape
     transcript.from_file's role regex parses (marker starts a turn, following
-    lines are its continuation)."""
+    lines are its continuation). Turn text is secret-scrubbed at this write
+    site (#109): the accumulation file is a disk artifact `daimon serialize`
+    reads later, so a quoted secret must not land here raw. main() has already
+    gated on lib.redaction_available(), so the scrub is guaranteed real."""
     TRANSCRIPT_DIR.mkdir(parents=True, exist_ok=True)
     path = TRANSCRIPT_DIR / f"{_safe_name(trajectory_id)}.md"
     with path.open("a", encoding="utf-8") as f:
-        f.write(f"**{role}**: {text.strip()}\n\n")
+        f.write(f"**{role}**: {lib.redact_text(text).strip()}\n\n")
     return path
 
 
@@ -150,10 +153,26 @@ def _extract_prompt(payload: dict) -> str | None:
     return None
 
 
+def _redact_payload(obj):
+    """Deep copy of `obj` with every string leaf secret-scrubbed (#109). Keys,
+    structure, and non-string scalars are preserved so the probe dump stays a
+    faithful, usable diagnostic — only secret-shaped substrings inside string
+    values are masked. main() has gated on lib.redaction_available()."""
+    if isinstance(obj, str):
+        return lib.redact_text(obj)
+    if isinstance(obj, dict):
+        return {k: _redact_payload(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_redact_payload(v) for v in obj]
+    return obj
+
+
 def _dump_probe(event: str, payload: dict) -> bool:
     """Bounded self-probe dump (#62): at most one unparsed-*.json per event
     name. Returns True when a dump was written (callers log only then, so a
-    hook registered for every Cascade event stays quiet after the first)."""
+    hook registered for every Cascade event stays quiet after the first).
+    Payload string leaves are secret-scrubbed at this write site (#109) so no
+    quoted secret reaches unparsed-*.json, while structure stays usable."""
     try:
         STATE_DIR.mkdir(parents=True, exist_ok=True)
         tag = _safe_name(event or "unknown")
@@ -161,7 +180,8 @@ def _dump_probe(event: str, payload: dict) -> bool:
             return False
         stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
         (STATE_DIR / f"unparsed-{tag}-{stamp}.json").write_text(
-            json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+            json.dumps(_redact_payload(payload), indent=2, ensure_ascii=False),
+            encoding="utf-8")
         return True
     except OSError:
         return False
@@ -181,6 +201,14 @@ def main() -> int:
         _fallback_log("windsurf-cascade: hook library missing (_daimon_hook_lib.py) — skipped")
         return 0
     if lib.disabled():
+        return 0
+    if not lib.redaction_available():
+        # #109: every write site below (accumulation, probe dumps) persists
+        # transcript-derived text. Without the redaction module we cannot
+        # guarantee a quoted secret is scrubbed, so skip rather than write raw —
+        # #104's disk guarantee outranks accumulation. Fail-open: still exit 0.
+        lib.log("windsurf-cascade: redaction module unavailable — skipped "
+                "(no raw transcript persisted)")
         return 0
 
     try:

--- a/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
+++ b/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
@@ -157,14 +157,21 @@ def _redact_payload(obj):
     """Deep copy of `obj` with every string leaf secret-scrubbed (#109). Keys,
     structure, and non-string scalars are preserved so the probe dump stays a
     faithful, usable diagnostic — only secret-shaped substrings inside string
-    values are masked. main() has gated on lib.redaction_available()."""
+    values are masked. main() has gated on lib.redaction_available().
+
+    JSON payloads only ever yield dict/list/str/scalar, but the helper is
+    fail-safe against reuse: tuples are scrubbed like lists, and ANY other
+    unrecognized type is rendered via str() and scrubbed rather than passed
+    through raw — a silent skip would contradict the disk-wide guarantee."""
     if isinstance(obj, str):
         return lib.redact_text(obj)
     if isinstance(obj, dict):
         return {k: _redact_payload(v) for k, v in obj.items()}
-    if isinstance(obj, list):
+    if isinstance(obj, (list, tuple)):
         return [_redact_payload(v) for v in obj]
-    return obj
+    if obj is None or isinstance(obj, (bool, int, float)):
+        return obj
+    return lib.redact_text(str(obj))
 
 
 def _dump_probe(event: str, payload: dict) -> bool:

--- a/plugin/daimon_briefing/_hooks/redact.py
+++ b/plugin/daimon_briefing/_hooks/redact.py
@@ -1,0 +1,56 @@
+"""Deterministic capture-time secret redaction (#104) — stdlib only, zero LLM.
+
+Checkpoints persist outside the session and the team mirror replicates them
+to a shared remote, so a quoted secret must never reach disk. Patterns are
+precision-first: each requires a concrete shape (assignment operator, URL
+scheme, key prefix, header keyword) — never bare entropy — so prose
+("the token budget", "password rotation policy") survives untouched.
+Replacement is a stable visible marker, [redacted:<kind>]: auditable,
+never silent."""
+
+import re
+
+# (kind, compiled pattern). Order matters only for overlap (pem first: a key
+# block may contain assignment-looking lines that must not double-count).
+_PATTERNS = (
+    ("pem", re.compile(
+        r"-----BEGIN [A-Z0-9 ]*(?:KEY|CERTIFICATE)[A-Z0-9 ]*-----"
+        r"(?:.*?-----END [A-Z0-9 ]*(?:KEY|CERTIFICATE)[A-Z0-9 ]*-----|.*)",
+        re.DOTALL)),
+    ("aws-key", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
+    ("stripe-key", re.compile(r"\b[rsp]k_live_[0-9A-Za-z]{8,}\b")),
+    ("bearer", re.compile(
+        r"(?i)\b(?:bearer|authorization:\s*\w+)\s+[A-Za-z0-9._~+/=-]{16,}")),
+    ("api-key", re.compile(
+        r"(?i)\b([\w-]{0,32}?(?:api[_-]?key|secret|token|password|passwd))"
+        r"(\s*[=:]\s*)['\"]?(?!\[redacted:)[^\s'\"]{8,}")),
+    ("credential-url", re.compile(
+        r"\b([a-z][a-z0-9+.-]{0,15}://[^/\s:@]+):(?!\[redacted:)[^/\s@]+@")),
+)
+
+
+def redact_text(s):
+    """(redacted, {kind: count}). Non-string / empty input passes through
+    unchanged — callers scrub optional fields without type checks. A regex
+    failure skips that pattern (fail-open: redaction must never cost the
+    write; unreachable with these static patterns, cheap insurance)."""
+    counts: dict = {}
+    if not isinstance(s, str) or not s:
+        return s, counts
+
+    def _mark(kind):
+        counts[kind] = counts.get(kind, 0) + 1
+
+    for kind, rx in _PATTERNS:
+        def _sub(m, kind=kind):
+            _mark(kind)
+            if kind == "api-key":
+                return m.group(1) + m.group(2) + "[redacted:api-key]"
+            if kind == "credential-url":
+                return m.group(1) + ":[redacted:credential-url]@"
+            return f"[redacted:{kind}]"
+        try:
+            s = rx.sub(_sub, s)
+        except re.error:  # pragma: no cover — static patterns
+            continue
+    return s, counts

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1634,7 +1634,11 @@ def _cmd_stats(args) -> int:
 # purpose: the plugin marketplace owns that path.
 _HOOK_HOSTS = {
     "windsurf": {
-        "files": ("daimon-windsurf-hooks.py", "_daimon_hook_lib.py"),
+        # redact.py ships alongside the scripts so the standalone hooks can
+        # scrub secrets at their write sites (#109) without importing the
+        # venv-only package. A test keeps it byte-identical to the canonical
+        # daimon_briefing/redact.py.
+        "files": ("daimon-windsurf-hooks.py", "_daimon_hook_lib.py", "redact.py"),
         "entry": "daimon-windsurf-hooks.py",
         "events": ("pre_user_prompt", "post_cascade_response",
                    "post_cascade_response_with_transcript"),

--- a/plugin/daimon_briefing/harvest.py
+++ b/plugin/daimon_briefing/harvest.py
@@ -14,7 +14,7 @@ import re
 from pathlib import Path
 from typing import NamedTuple
 
-from . import transcript
+from . import redact, transcript
 
 log = logging.getLogger("daimon_briefing")
 
@@ -113,9 +113,15 @@ def to_candidate(hit, anchor, session_id, today):
 
     `title` is emitted via json.dumps → a valid double-quoted YAML scalar even when
     the sentence contains ':' or quotes (the #1 hand-written-scar YAML footgun).
+
+    The verbatim sentence is secret-scrubbed here (#109) before it becomes the
+    candidate's title, slug, and body — candidate files are committable, so a
+    quoted secret must never persist to .scars/candidates/*.md. Classification
+    (_scar_type) reads the raw hit: its markers are prose, untouched by redaction.
     """
     typ = _scar_type(hit)
-    title = " ".join(hit.sentence.split())[:80].rstrip()
+    sentence, _ = redact.redact_text(hit.sentence)
+    title = " ".join(sentence.split())[:80].rstrip()
     slug = _slug(title)
     review = (
         datetime.date.fromisoformat(today) + datetime.timedelta(days=365)
@@ -138,7 +144,7 @@ def to_candidate(hit, anchor, session_id, today):
         f"  review_after: {review}\n"
         "status: candidate\n"
         "---\n\n"
-        f"{hit.sentence.strip()}\n\n"
+        f"{sentence.strip()}\n\n"
         "Auto-harvested from the session transcript — a human must verify the claim "
         "and confirm the anchor before promotion.\n"
     )

--- a/plugin/tests/test_harvest.py
+++ b/plugin/tests/test_harvest.py
@@ -179,6 +179,21 @@ def test_to_candidate_title_with_colon_is_yaml_safe():
     assert fm["title"].startswith('"')  # json.dumps quoting keeps YAML valid
 
 
+def test_to_candidate_redacts_secret_in_body_and_title():
+    # #109: candidate files are committable — a verbatim assistant sentence
+    # carrying a secret must be scrubbed before it becomes the candidate's
+    # title, slug, and body.
+    hit = harvest.Hit(
+        "avoidance",
+        "Never hardcode sk_live_a1B2c3D4e5F6g7H8 in config.py.",
+        "", 0,
+    )
+    slug, md = harvest.to_candidate(hit, "config.py", "S1", "2026-06-30")
+    assert "sk_live_a1B2c3D4e5F6g7H8" not in md
+    assert "[redacted:stripe-key]" in md
+    assert "sk_live" not in slug
+
+
 def _assistant(text):
     return {"role": "assistant", "content": text}
 

--- a/plugin/tests/test_hooks_install.py
+++ b/plugin/tests/test_hooks_install.py
@@ -12,7 +12,7 @@ from daimon_briefing import cli
 REPO_HOOK_DIR = Path(__file__).parents[2] / "hook"
 PKG_HOOKS_DIR = Path(__file__).parents[1] / "daimon_briefing" / "_hooks"
 
-_SHIPPED = ("daimon-windsurf-hooks.py", "_daimon_hook_lib.py")
+_SHIPPED = ("daimon-windsurf-hooks.py", "_daimon_hook_lib.py", "redact.py")
 
 
 @pytest.mark.parametrize("name", _SHIPPED)
@@ -22,6 +22,16 @@ def test_packaged_hook_matches_repo_copy(name):
     repo = (REPO_HOOK_DIR / name).read_bytes()
     packaged = (PKG_HOOKS_DIR / name).read_bytes()
     assert repo == packaged, f"{name}: repo hook/ and packaged _hooks/ differ"
+
+
+def test_shipped_redact_matches_canonical_module():
+    # #109: the standalone hooks scrub secrets with a redact.py shipped next to
+    # them (they cannot import the venv-only package). It MUST stay byte-
+    # identical to the canonical module, so patterns — and scar 0022's long-
+    # input backtracking guarantee — live in ONE place and never drift.
+    canonical = (Path(__file__).parents[1] / "daimon_briefing" / "redact.py").read_bytes()
+    shipped = (PKG_HOOKS_DIR / "redact.py").read_bytes()
+    assert shipped == canonical, "hook-shipped redact.py drifted from the canonical module"
 
 
 def test_hooks_install_windsurf_writes_stable_executable_copies(tmp_path, monkeypatch, capsys):

--- a/plugin/tests/test_windsurf_hooks.py
+++ b/plugin/tests/test_windsurf_hooks.py
@@ -251,6 +251,37 @@ def test_with_transcript_shares_throttle_marker_with_accumulation(tmp_path):
     assert capture2.read_text().count("serialize") == 1  # unchanged: no new spawn
 
 
+_STRIPE = "sk_live_a1B2c3D4e5F6g7H8"
+
+
+def test_post_response_redacts_secret_in_accumulated_transcript(tmp_path):
+    # #109: the accumulation .md is a disk artifact `daimon serialize` reads
+    # later — a quoted secret in a turn must be scrubbed at the append write
+    # site so it never reaches disk raw (mirrors the #104 checkpoint seam).
+    proc, _ = _run(_post_payload(f"deploy with {_STRIPE} now"), tmp_path)
+    assert proc.returncode == 0
+    text = _transcript(tmp_path).read_text(encoding="utf-8")
+    assert _STRIPE not in text
+    assert "[redacted:stripe-key]" in text
+
+
+def test_probe_dump_redacts_secret_but_keeps_structure(tmp_path):
+    # #109: probe dumps persist raw event payloads. Secret-shaped values must
+    # be scrubbed while keys / structure survive, so the dump stays a usable
+    # diagnostic for the next adapter iteration.
+    payload = {"agent_action_name": "pre_user_prompt", "trajectory_id": TRAJ,
+               "tool_info": {"weird_field": {"note": f"key is {_STRIPE}"}}}
+    proc, _ = _run(payload, tmp_path)
+    assert proc.returncode == 0
+    dumps = list((tmp_path / ".daimon" / "windsurf").glob("unparsed-*.json"))
+    assert dumps
+    body = dumps[0].read_text(encoding="utf-8")
+    assert _STRIPE not in body
+    assert "[redacted:stripe-key]" in body
+    parsed = json.loads(body)  # still valid JSON, structure intact
+    assert parsed["tool_info"]["weird_field"]["note"]  # key + leaf preserved
+
+
 def test_pre_user_prompt_docs_shape_appends_user_turn(tmp_path):
     # Documented shape (docs.devin.ai/desktop/cascade/hooks): text lives in
     # tool_info.user_prompt. Regression guard — passes on the current

--- a/plugin/tests/test_windsurf_hooks.py
+++ b/plugin/tests/test_windsurf_hooks.py
@@ -7,6 +7,7 @@ state only. The adapter therefore ACCUMULATES its own transcript per
 trajectory and serializes it on a throttle.
 """
 
+import importlib.util
 import json
 import os
 import stat
@@ -18,6 +19,17 @@ from pathlib import Path
 HOOK_DIR = Path(__file__).parents[2] / "hook"
 HOOK = HOOK_DIR / "daimon-windsurf-hooks.py"
 VENV_BIN = Path(sys.executable).parent
+
+
+def _load_hook_module():
+    """Import the hyphenated hook script as a module so its internal helpers
+    (e.g. _redact_payload) can be unit-tested directly — the subprocess path
+    only exercises JSON-shaped payloads, which can never carry tuples or
+    unknown-type objects."""
+    spec = importlib.util.spec_from_file_location("daimon_windsurf_hook_under_test", HOOK)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
 
 TRAJ = "b0ba5494-dce6-47a2-8da0-a7c11b18d392"
 
@@ -280,6 +292,33 @@ def test_probe_dump_redacts_secret_but_keeps_structure(tmp_path):
     assert "[redacted:stripe-key]" in body
     parsed = json.loads(body)  # still valid JSON, structure intact
     assert parsed["tool_info"]["weird_field"]["note"]  # key + leaf preserved
+
+
+def test_redact_payload_handles_tuple_and_unknown_type():
+    # #109 hardening: dict/list/str is not the whole space. A tuple's strings
+    # and any unrecognized container/object must NOT slip through unredacted —
+    # a silent skip contradicts the disk-wide guarantee if the helper is reused.
+    mod = _load_hook_module()
+
+    class _Weird:
+        def __str__(self):
+            return "leaked sk_live_a1B2c3D4e5F6g7H8 here"
+
+    out = mod._redact_payload(("plain", _STRIPE, _Weird()))
+    assert isinstance(out, list)  # tuple normalized to a json-dumpable list
+    assert out[0] == "plain"
+    assert _STRIPE not in out[1] and "[redacted:stripe-key]" in out[1]
+    # unknown type: fail-safe str() rendering, scrubbed — never passed through raw
+    assert isinstance(out[2], str)
+    assert _STRIPE not in out[2] and "[redacted:stripe-key]" in out[2]
+
+
+def test_redact_payload_preserves_scalars():
+    # Non-string scalars are structural, not secret carriers — they pass through
+    # untouched so the dump stays faithful.
+    mod = _load_hook_module()
+    assert mod._redact_payload({"n": 42, "f": 1.5, "b": True, "z": None}) == {
+        "n": 42, "f": 1.5, "b": True, "z": None}
 
 
 def test_pre_user_prompt_docs_shape_appends_user_turn(tmp_path):


### PR DESCRIPTION
## What

#104 shipped capture-time secret redaction at the checkpoint/event write seam. Three other paths still persisted transcript-derived text to disk unredacted:

- **Windsurf accumulator** — raw turn text appended to `~/.daimon/windsurf/transcripts/<trajectory>.md` before serialization ever runs
- **Windsurf probe dumps** — raw event payloads written to `unparsed-*.json`
- **harvest** — verbatim assistant sentences written into committable `.scars/candidates/*.md`

Each now runs the same `redact.redact_text` pass at its write site, so the disk-wide guarantee (a quoted secret never persists) actually holds. Zero-LLM; no new patterns.

## Per-seam wiring

- **Accumulator** (`_append_turn`): the appended turn text is scrubbed before the write.
- **Probe dumps** (`_dump_probe`): a recursive `_redact_payload` scrubs every string leaf while preserving keys, structure, and non-string scalars — the dump stays a usable diagnostic.
- **harvest** (`to_candidate`): the verbatim sentence is scrubbed before it becomes the candidate's title, slug, and body. Classification reads the raw hit (its markers are prose, untouched by redaction).

## How the standalone hooks reach the module

The Windsurf hooks run under the host's `python3` and cannot import the venv-only `daimon_briefing` package (same reason `_daimon_hook_lib` already duplicates `slug`/`created_epoch`). Since `redact.py` is pure-stdlib and self-contained, it now **ships alongside the hooks** (`daimon hooks install` copies it to `~/.daimon/hooks/`) and is loaded by a same-dir file-location import. Patterns live in **one** file — a byte-identity test keeps the shipped copy from drifting from the canonical `daimon_briefing/redact.py`, so scar 0022's long-input backtracking guarantee still covers it. `harvest` runs in-venv and imports `redact` directly.

## Redaction-failure handling

Mirrors #104: `redact_text` is fail-open per-pattern and always returns a best-effort-scrubbed string, never raises. The only new failure mode is the shipped module being absent (a stale install). For that, `main()` gates on `redaction_available()` and **skips the hook entirely** (still exits 0) rather than persist raw text — the disk guarantee outranks accumulation availability, exactly as #104 fails closed at the module import. In-venv `harvest` always has the module.

## Tests

Failing-first, then green. Full suite: **1009 passed**.

- accumulator + probe-dump redaction (secret scrubbed, structure/keys preserved)
- harvest candidate body/title/slug redaction
- drift guard extended to `redact.py`; new single-source guard asserts the shipped copy is byte-identical to the canonical module

No dependency changes (stdlib only).

Closes #109