### PR TITLE
docs: split per-host setup guides into docs/hosts/

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Config lives in `~/.daimon/env` (hooks run with the host's inherited env, not yo
 
 ### Hook up your host
 
+See [docs/hosts/](./docs/hosts/) for per-host setup guides (Claude Code,
+Codex, Gemini CLI, Windsurf). Quick version:
+
 **Claude Code (plugin — recommended):**
 
 ```
@@ -154,6 +157,7 @@ Daimon is self-contained at runtime — no external memory backend, no server. T
 ## Docs
 
 - [MVP — Dream-Briefing](./docs/MVP-DREAM-BRIEFING.md) — authoritative architecture
+- [docs/hosts/](./docs/hosts/) — per-host setup guides (Claude Code, Codex, Gemini CLI, Windsurf)
 - [Codex hooks](./hook/CODEX.md) — Codex adapter setup
 - [The Problem](./docs/PROBLEM.md) — the context-loss thesis
 - [Research Logbook](./research/README.md) — findings, decisions, evidence trail

--- a/docs/hosts/README.md
+++ b/docs/hosts/README.md
@@ -1,0 +1,33 @@
+# Host setup guides
+
+Daimon closes a capture -> inject loop around whatever agent host you use: a
+session-end hook writes a checkpoint, a session-start (or per-prompt) hook
+turns the latest checkpoint into a briefing. Support depth varies by what
+hook events each host actually exposes.
+
+| Host | Install | Capture | Briefing injection | Status |
+|---|---|---|---|---|
+| [Claude Code](./claude-code.md) | Plugin (`/plugin install daimon@daimon`) or manual `hook/daimon-hooks.py install` | `SessionEnd` hook spawns `daimon serialize` detached | `SessionStart` hook injects the briefing; `UserPromptSubmit` hook adds proactive recall | live-validated daily |
+| [Codex](./codex.md) | Manual `hook/codex-hooks.py install` (from a clone) | Throttled `Stop` hook (Codex has no session-end event) | `SessionStart` hook injects via `additionalContext` | shipped, awaiting first live run |
+| [Gemini CLI](./gemini.md) | Manual `hook/gemini-hooks.py install` (from a clone) | Blocked upstream (`gemini-cli#14715` — `transcript_path` is an empty stub) | `SessionStart` hook injects via `additionalContext` | blocked upstream (`gemini-cli#14715`) |
+| [Windsurf (Cascade)](./windsurf.md) | `daimon hooks install windsurf` | Throttled serialize on `pre_user_prompt` / `post_cascade_response(_with_transcript)` | None — Cascade has no session-start-equivalent event; read via `daimon brief` in a terminal | shipped, in live validation |
+
+## Three moving parts
+
+Every host setup combines up to three pieces, installed independently:
+
+- **Hooks** capture your sessions and (where the host supports it) inject the
+  briefing as context. Claude Code gets a packaged plugin; other hosts install
+  standalone hook scripts via `daimon hooks install <host>` (currently
+  Windsurf) or the manual lifecycle scripts under `hook/` (Codex, Gemini, and
+  Claude Code without the plugin).
+- **The skill** (`daimon skill install <host>`) teaches the agent on the other
+  side of the hook how to use what the hooks capture — read the briefing at
+  session start, treat `verbatim` items as immutable quotes, verify
+  stale-looking claims before repeating them.
+- **The `daimon` CLI** is the single source of truth every hook shells out to
+  for serialization, rendering, and storage — install it once
+  (`uv tool install 'daimon-briefing[pretty]'`) and every host's hooks share
+  the same checkpoint store.
+
+Pick your host above for the full setup walkthrough.

--- a/docs/hosts/claude-code.md
+++ b/docs/hosts/claude-code.md
@@ -1,0 +1,112 @@
+# Claude Code
+
+Claude Code is the live-validated host: daily dogfood, full loop (serialize
+-> carry -> brief -> recall), field incidents recorded in
+[research/LOGBOOK.md](../../research/README.md).
+
+## Install (plugin — recommended)
+
+```
+/plugin marketplace add Daily-Nerd/daimon
+/plugin install daimon@daimon
+```
+
+The plugin registers the `SessionStart` / `UserPromptSubmit` / `SessionEnd`
+hooks itself via `.claude-plugin/plugin.json` + `hooks/hooks.json`. Order
+doesn't matter relative to installing the `daimon` CLI: if the hooks land
+before the CLI, sessions start normally and the hook prints a one-line install
+hint instead of a briefing.
+
+> **Don't mix install paths.** Plugin users must **not** also run the manual
+> hook installer below — both paths coexisting registers the hooks twice
+> (double briefings, double serialize LLM calls). Switching from manual to
+> plugin: run `python3 hook/daimon-hooks.py uninstall` first.
+
+## Install (manual / dogfood hooks)
+
+For a repo clone without the plugin system, `hook/daimon-hooks.py` is a
+lifecycle manager (same shape as SCAR's `scar-hooks.py`):
+
+```sh
+python3 hook/daimon-hooks.py install   [--dry-run]
+python3 hook/daimon-hooks.py uninstall [--dry-run]
+python3 hook/daimon-hooks.py status
+```
+
+Install copies the hook scripts to `~/.claude/hooks/` and registers them
+under `SessionStart` / `SessionEnd` in `~/.claude/settings.json` (idempotent;
+settings backed up before every mutation). Requires the plugin CLI on PATH:
+`uv tool install ./plugin` (or equivalent) so `daimon` resolves (the hooks
+also accept the deprecated `daimon-briefing` alias as a fallback) — reinstall
+after updating `plugin/` so the CLI picks up `.jsonl` transcript support,
+which `SessionEnd` depends on.
+
+## What each script does
+
+Three scripts close the capture -> inject loop, whichever install path
+registers them:
+
+- **`daimon-session-brief.py`** — `SessionStart` hook. Reads the payload from
+  stdin and shells out to the installed `daimon brief` CLI (single source of
+  truth for rendering); prints the briefing to stdout, which Claude Code
+  injects as session context. **Per-project routing:** the payload `cwd` is
+  slugged (Claude Code style: `/Users/x/proj` -> `-Users-x-proj`) and this
+  project's `<checkpoint-dir>/<slug>/latest.json` is preferred; if the
+  project has no checkpoint of its own, the global `latest.json` is used and
+  the briefing header is labeled `(global fallback — checkpoint may be from
+  another project)`. The cwd is forwarded to the CLI via `DAIMON_PROJECT_DIR`
+  so both route identically. No `cwd` in the payload -> global behavior,
+  unlabeled. Fail-open: always exits 0, prints a one-line diagnostic on
+  failure instead of dying silently. Respects `DAIMON_DISABLE` and
+  `DAIMON_CHECKPOINT_DIR`.
+- **`daimon-session-end.py`** — `SessionEnd` hook. Reads the payload from
+  stdin and spawns `daimon serialize <transcript_path>` as a detached
+  background process — serialization is an LLM call (30s+ on long sessions)
+  and must never block `/exit`. The payload `cwd` is passed to the child as
+  `DAIMON_PROJECT_DIR`, so the serializer writes this project's
+  `<slug>/latest.json` in addition to the global `latest.json` (kept for
+  backward compatibility and the fallback path). No `cwd` -> child env
+  untouched, global-only as before. Diagnostics and serializer output land in
+  `~/.daimon/logs/serialize.log` — both the `wrote checkpoint: <path> (took
+  Ns)` success line and named-error lines (`... after Ns`) carry elapsed
+  seconds. Fail-open, respects `DAIMON_DISABLE`. Not fired on hard kills
+  (terminal closed, SIGKILL) — briefings can still be stale, which is why the
+  `SessionStart` header shows checkpoint age.
+
+  LLM credentials come from `~/.daimon/env` (see the
+  [plugin README](../../plugin/README.md) Connect an LLM section) — hooks
+  inherit the host process environment, not your shell profile, so
+  `DAIMON_LLM_API_KEY` / `DAIMON_LLM_MODEL` / `DAIMON_LLM_BASE_URL` belong in
+  that file (chmod 600). Without it, serialize fails fast with a named error
+  in `~/.daimon/logs/serialize.log`.
+- **`daimon-prompt-recall.py`** — `UserPromptSubmit` hook (proactive "you
+  worked on this before" recall). Fires on every prompt, pipes the prompt to
+  `daimon recall-inject` on stdin, and injects a one-line pointer when the
+  prompt overlaps a prior open loop. Because it fires per-prompt, failures
+  are silent (exit 0, no output) — the only thing it ever prints is a real
+  suggestion — and slash commands (host directives, not work statements)
+  never match.
+
+These two capture/inject scripts are wired in one of two mutually exclusive
+ways — pick ONE (both at once double-fires every session: two briefing
+injections, two serialize LLM calls). See the install sections above.
+
+## Teach the agent the protocol
+
+```sh
+daimon skill install claude      # ~/.claude/skills/daimon/SKILL.md
+```
+
+`daimon skill show` prints the skill content; `daimon skill list` shows which
+scopes each host supports. Re-run install after upgrading `daimon` to refresh
+the content.
+
+## Verify
+
+```sh
+daimon status
+```
+
+`daimon status` reports capture health honestly, including failures, skips,
+and crashes; a failed capture self-heals on the next start. End a session ->
+a checkpoint is written; start the next -> the briefing appears.

--- a/docs/hosts/codex.md
+++ b/docs/hosts/codex.md
@@ -1,0 +1,64 @@
+# Codex
+
+Codex is code-verified and unit-tested (`test_codex_hooks.py`), but has zero
+recorded live sessions — the adapter and installer ship, but no logbook entry
+documents a real Codex session completing the capture -> inject loop yet.
+Treat "runs on Codex" as inferred until one is on record.
+
+## Install (manual, from a clone)
+
+Adds Daimon's capture -> inject loop to Codex:
+
+```sh
+python3 hook/codex-hooks.py install   [--dry-run]
+python3 hook/codex-hooks.py uninstall [--dry-run]
+python3 hook/codex-hooks.py status
+```
+
+Install copies both hook scripts to `~/.codex/hooks/` and registers them in
+`~/.codex/hooks.json`. After installing, open `/hooks` in Codex to review and
+trust the hook definitions — Codex skips untrusted hook definitions until you
+do.
+
+Requires the `daimon` CLI on `PATH` (the deprecated `daimon-briefing` alias
+also works as a fallback):
+
+```sh
+uv tool install ./plugin
+```
+
+## What each script does
+
+- **`daimon-codex-session-start.py`** — `SessionStart` hook. Reads the latest
+  project checkpoint and returns Codex `additionalContext` JSON, so the
+  briefing is injected as developer context.
+- **`daimon-codex-stop.py`** — `Stop` hook. Codex exposes `Stop` at turn
+  scope, not as a clean session-end event, so this hook serializes
+  opportunistically and is throttled by `DAIMON_CODEX_MIN_SERIALIZE_INTERVAL`
+  (default `300` seconds per session). Set it to `0` to serialize every turn,
+  or set `DAIMON_CODEX_SERIALIZE_ON_STOP=0` to disable Codex capture while
+  leaving briefing injection installed.
+
+Codex docs note that `transcript_path` is provided for convenience but its
+format is not a stable interface. Daimon's JSONL parser is intentionally
+best-effort and ignores unknown rows rather than treating raw JSON as
+transcript text.
+
+## Teach the agent the protocol
+
+```sh
+daimon skill install codex       # managed block in ~/.codex/AGENTS.md
+```
+
+On the shared `AGENTS.md` file, daimon only ever touches its own marker
+block — `daimon skill uninstall codex` removes exactly that block. Re-run
+install after upgrading `daimon` to refresh the content.
+
+## Verify
+
+```sh
+daimon status
+```
+
+`daimon status` reports capture health honestly, including failures, skips,
+and crashes.

--- a/docs/hosts/gemini.md
+++ b/docs/hosts/gemini.md
@@ -1,0 +1,56 @@
+# Gemini CLI
+
+Gemini support mirrors the Claude Code shape, split across two scripts. The
+briefing hook is shipped, but serialize **cannot run end-to-end today**:
+capture is staged behind upstream `gemini-cli#14715` (`transcript_path`
+stub) — half a loop, by upstream constraint, not a daimon bug.
+
+## What each script does
+
+- **`daimon-gemini-session-start.py`** — `SessionStart` hook. Shells out to
+  `daimon brief` and injects the result via Gemini's
+  `{"hookSpecificOutput": {"additionalContext": ...}}` envelope. Gemini
+  requires **pure-JSON stdout** ("Silence is Mandatory") — unlike the Claude
+  Code hook, nothing is ever printed raw; operator-facing diagnostics ride
+  `{"systemMessage": ...}` instead. `SessionStart` is advisory-only: exit 0
+  always, startup is never blocked.
+- **`daimon-gemini-session-end.py`** — `SessionEnd` hook. Mirrors the Claude
+  Code `SessionEnd` hook (spawns `daimon serialize <transcript_path>`
+  detached), but Gemini CLI currently sends `transcript_path` as an **empty
+  stub** (`gemini-cli#14715`, upstream limitation as of 2026-07-01), so this
+  hook's primary behavior today is a graceful, logged skip. The spawn path is
+  ready for when upstream populates the field.
+
+## Install (manual, from a clone)
+
+`gemini-hooks.py` is the lifecycle manager (same shape as `codex-hooks.py`):
+
+```sh
+python3 hook/gemini-hooks.py install   [--dry-run]
+python3 hook/gemini-hooks.py uninstall [--dry-run]
+python3 hook/gemini-hooks.py status
+```
+
+Install copies both scripts (plus `_daimon_hook_lib.py`) to `~/.gemini/hooks/`
+and registers them in `~/.gemini/settings.json` (user layer). Requires the
+`daimon` CLI on `PATH` (`uv tool install ./plugin` or equivalent).
+
+## Teach the agent the protocol
+
+```sh
+daimon skill install gemini      # managed block in ~/.gemini/GEMINI.md
+```
+
+On the shared `GEMINI.md` file, daimon only ever touches its own marker
+block — `daimon skill uninstall gemini` removes exactly that block. Re-run
+install after upgrading `daimon` to refresh the content.
+
+## Verify
+
+```sh
+daimon status
+```
+
+Until `gemini-cli#14715` is resolved upstream, expect `daimon status` to show
+capture as skipped rather than written — briefing injection on `SessionStart`
+still works independently of capture.

--- a/docs/hosts/windsurf.md
+++ b/docs/hosts/windsurf.md
@@ -1,0 +1,82 @@
+# Windsurf (Cascade)
+
+Windsurf's adapter is shipped and code-verified (native-transcript serialize,
+probe-hardened), live validation in progress. No logbook entry yet documents
+a complete dogfooded loop the way Claude Code's does — treat end-to-end "runs
+on Windsurf" as inferred from code + unit tests until one is on record.
+
+## Install
+
+```sh
+daimon hooks install windsurf   # copies daimon-windsurf-hooks.py, _daimon_hook_lib.py,
+                                 # and redact.py to ~/.daimon/hooks/, then prints the
+                                 # registration snippet for Cascade's hooks config
+daimon hooks list                # hosts with packaged hook scripts
+```
+
+`daimon hooks install <host>` ships `redact.py` alongside the hook script(s)
+so a standalone host adapter can scrub secrets at its own write sites
+(transcript accumulation, checkpoint, event log) without importing the
+venv-only `daimon_briefing` package — a test keeps this copy byte-identical
+to the canonical `plugin/daimon_briefing/redact.py`. Re-run `daimon hooks
+install windsurf` after every `daimon` upgrade so the installed scripts (and
+the bundled `redact.py`) stay in sync with the installed CLI.
+
+Point Windsurf's Cascade hooks config (user-level JSON — see
+[the Cascade hooks docs](https://docs.windsurf.com/windsurf/cascade/hooks))
+at the installed script for all **three** events: `pre_user_prompt`,
+`post_cascade_response`, and `post_cascade_response_with_transcript`.
+
+## How the one script covers three events
+
+One script, `daimon-windsurf-hooks.py`, is registered for three Cascade hook
+events:
+
+- **Native transcript preferred:** when `post_cascade_response_with_transcript`
+  is registered and Cascade's native `.jsonl` transcript
+  (`~/.windsurf/transcripts/<trajectory_id>.jsonl`) exists for the trajectory,
+  it is serialized directly — no accumulation needed.
+- **Accumulation fallback:** `pre_user_prompt` / `post_cascade_response`
+  carry no transcript path, so the adapter appends each turn to its own
+  `~/.daimon/windsurf/transcripts/<trajectory_id>.md` in the same
+  `**role**:`-marked shape `daimon serialize` already parses.
+- **Throttled serialize:** both serialize-capable events fire every turn;
+  `DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL` (default 300s, `0` = every turn)
+  gates the spawn per trajectory, sharing one marker so registering both
+  events never double-spawns.
+- **Self-probing:** any payload shape the adapter can't handle is dumped to
+  `~/.daimon/windsurf/unparsed-<event>-<stamp>.json` (at most one dump per
+  event name), so the next adapter iteration has real evidence to work from
+  instead of another manual probe round.
+- **No briefing injection:** Cascade's hook set has no session-start-equivalent
+  event, so unlike Claude Code/Codex/Gemini the briefing is not injected as
+  context — it's read via the terminal (`daimon brief`). This is a permanent
+  host constraint, not a bug.
+- Fail-open everywhere; kill switch `DAIMON_DISABLE=1`.
+
+Windsurf has no session-end event, so serialization runs on the throttle
+above. Two knobs worth setting for your first week:
+
+```sh
+echo 'DAIMON_MIN_MESSAGES=4' >> ~/.daimon/env                      # don't skip short first sessions
+echo 'DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL=0' >> ~/.daimon/env   # no tail loss while you evaluate
+```
+
+## Teach the agent the protocol
+
+```sh
+daimon skill install windsurf             # ~/.codeium/windsurf/skills/daimon/SKILL.md
+daimon skill install windsurf --project   # .windsurf/rules/daimon.md
+```
+
+Re-run install after upgrading `daimon` to refresh the content.
+
+## Verify
+
+```sh
+daimon status
+```
+
+Briefings are read with `daimon brief` in a terminal — not injected — so
+`daimon status` (rather than a session-start prompt) is the way to confirm a
+checkpoint was written after your last session.

--- a/hook/README.md
+++ b/hook/README.md
@@ -1,159 +1,84 @@
 # Agent hook adapters
 
-## Codex
+> Setting up daimon for your agent? See [docs/hosts/](../docs/hosts/) for
+> per-host install and setup guides. This file is contributor-facing
+> reference for the adapter internals.
 
-Codex support lives in [CODEX.md](./CODEX.md). It installs a `SessionStart`
-hook for briefing injection and a throttled `Stop` hook for transcript capture.
+## What an adapter is
 
-## Gemini CLI
+Each host adapter is a **standalone, stdlib-only** script (or script pair)
+that a host invokes at its own session boundaries. It cannot import the
+`daimon_briefing` package — that lives in an isolated `uv tool` venv — so it
+locates and shells out to the installed `daimon` CLI, which owns all
+serialization, rendering, and storage. The CLI is the single source of truth:
+no host re-renders a checkpoint or re-implements parsing, so hosts never
+drift from each other.
 
-Gemini support mirrors the Claude Code shape, split across two scripts:
+## Script-pair shape
 
-- `daimon-gemini-session-start.py` — `SessionStart` hook. Shells out to
-  `daimon brief` and injects the result via Gemini's
-  `{"hookSpecificOutput": {"additionalContext": ...}}` envelope. Gemini
-  requires **pure-JSON stdout** ("Silence is Mandatory") — unlike the Claude
-  Code hook, nothing is ever printed raw; operator-facing diagnostics ride
-  `{"systemMessage": ...}` instead. SessionStart is advisory-only: exit 0
-  always, startup is never blocked.
-- `daimon-gemini-session-end.py` — `SessionEnd` hook. Mirrors the Claude Code
-  SessionEnd hook (spawns `daimon serialize <transcript_path>` detached), but
-  Gemini CLI currently sends `transcript_path` as an **empty stub**
-  (`gemini-cli#14715`, upstream limitation as of 2026-07-01), so this hook's
-  primary behavior today is a graceful, logged skip. The spawn path is ready
-  for when upstream populates the field.
-- `gemini-hooks.py` — lifecycle manager (same shape as `codex-hooks.py`):
+A host adapter is one or two scripts against the same host-boundary events:
 
-```sh
-python3 hook/gemini-hooks.py install   [--dry-run]
-python3 hook/gemini-hooks.py uninstall [--dry-run]
-python3 hook/gemini-hooks.py status
-```
+- A **read-path** script fires on a session/turn-start-shaped event, shells
+  out to `daimon brief` (or `daimon recall-inject` for per-prompt recall),
+  and returns the result in whatever envelope the host expects (raw stdout
+  for Claude Code, `additionalContext` JSON for Codex/Gemini). Always
+  fail-open: exit 0 even on failure, with a one-line diagnostic instead of a
+  silent death (except per-prompt recall hooks, which stay silent on failure
+  by design — see `daimon-prompt-recall.py`).
+- A **write-path** script fires on a session/turn-end-shaped event and spawns
+  `daimon serialize <transcript>` as a **detached** background process
+  (`start_new_session=True`) — serialization is an LLM call (30s+), so the
+  hook must return immediately rather than block the host's exit.
 
-Install copies both scripts (plus `_daimon_hook_lib.py`) to `~/.gemini/hooks/`
-and registers them in `~/.gemini/settings.json` (user layer). Requires the
-`daimon` CLI on `PATH` (`uv tool install ./plugin` or equivalent).
+Hosts without a clean session-end event (Codex, Windsurf) serialize
+opportunistically on a throttled turn-scoped event instead
+(`DAIMON_CODEX_MIN_SERIALIZE_INTERVAL`,
+`DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL`).
 
-## Windsurf (Cascade)
+Per-host lifecycle managers (`daimon-hooks.py`, `codex-hooks.py`,
+`gemini-hooks.py`) install/uninstall/status their host's script(s) into the
+host's own config location, idempotently, with a settings backup before every
+mutation.
 
-One script, `daimon-windsurf-hooks.py`, is registered for three Cascade hook
-events (`pre_user_prompt`, `post_cascade_response`,
-`post_cascade_response_with_transcript` — see
-[docs.windsurf.com](https://docs.windsurf.com/windsurf/cascade/hooks)):
+## `_daimon_hook_lib.py`
 
-- **Native transcript preferred:** when `post_cascade_response_with_transcript`
-  is registered and Cascade's native `.jsonl` transcript
-  (`~/.windsurf/transcripts/<trajectory_id>.jsonl`) exists for the trajectory,
-  it is serialized directly — no accumulation needed (#71).
-- **Accumulation fallback (#35):** `pre_user_prompt` / `post_cascade_response`
-  carry no transcript path, so the adapter appends each turn to its own
-  `~/.daimon/windsurf/transcripts/<trajectory_id>.md` in the same
-  `**role**:`-marked shape `daimon serialize` already parses.
-- **Throttled serialize:** both serialize-capable events fire every turn;
-  `DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL` (default 300s, `0` = every turn)
-  gates the spawn per trajectory, sharing one marker so registering both
-  events never double-spawns.
-- **Self-probing (#62):** any payload shape the adapter can't handle is
-  dumped to `~/.daimon/windsurf/unparsed-<event>-<stamp>.json` (at most one
-  dump per event name), so the next adapter iteration has real evidence to
-  work from instead of another manual probe round.
-- **No briefing injection:** Cascade's hook set has no session-start-equivalent
-  event, so unlike Claude Code/Codex/Gemini the briefing is not injected as
-  context — it's read via the terminal (`daimon brief`). This is a permanent
-  host constraint, not a bug (0.8.1 #82).
-- Fail-open everywhere; kill switch `DAIMON_DISABLE=1`.
+Everything the adapters would otherwise duplicate lives in the shared
+`hook/_daimon_hook_lib.py`: kill-switch check (`DAIMON_DISABLE`), `daimon`
+CLI resolution (with the deprecated `daimon-briefing` alias as fallback),
+per-project env (`DAIMON_PROJECT_DIR`), detached-spawn helpers, and
+checkpoint-age formatting. Host-specific behavior — Gemini's pure-JSON
+stdout, Codex's `additionalContext` envelope, Windsurf's three-event script —
+stays in each script. A new host becomes first-class by adding a script pair
+against this same shared lib.
 
-`daimon-windsurf-probe.py` is a separate, standalone dev tool (not installed
-by end users) used to capture raw Cascade hook payloads and scan Windsurf's
-sqlite state (`--scan-vscdb`) — the ground-truth-gathering step that the
-adapter above was built from (#37, #38).
+## Probe conventions
 
-Install via the packaged CLI installer rather than a manual lifecycle script:
+When an adapter meets a payload shape it can't handle, it self-probes instead
+of silently dropping data: dump the raw payload to
+`~/.daimon/<host>/unparsed-<event>-<stamp>.json` (at most one dump per event
+name), so the next iteration has real evidence instead of another manual
+probe round. `daimon-windsurf-probe.py` is a separate, standalone dev tool
+(not installed for end users) that captures raw Cascade hook payloads and
+scans Windsurf's sqlite state (`--scan-vscdb`) — the ground-truth-gathering
+step the Windsurf adapter was built from.
 
-```sh
-daimon hooks install windsurf   # copies daimon-windsurf-hooks.py, _daimon_hook_lib.py,
-                                 # and redact.py to ~/.daimon/hooks/, then prints the
-                                 # registration snippet for Cascade's hooks config
-daimon hooks list                # hosts with packaged hook scripts
-```
+## `redact.py` ships alongside the hooks
 
-`daimon hooks install <host>` (currently: `windsurf` — `daimon hooks list`
-shows every host with a packaged installer; Claude Code is intentionally
-excluded because the plugin marketplace owns that path, and Codex/Gemini
-still use the manual lifecycle scripts above) ships `redact.py` alongside
-the hook script(s) so a standalone host adapter can scrub secrets at its own
-write sites (transcript accumulation, checkpoint, event log) without
-importing the venv-only `daimon_briefing` package — a test keeps this copy
-byte-identical to the canonical `plugin/daimon_briefing/redact.py`. Re-run
-`daimon hooks install <host>` after every `daimon` upgrade so the installed
-scripts (and the bundled `redact.py`) stay in sync with the installed CLI.
+`daimon hooks install <host>` copies `redact.py` next to the hook script(s)
+so a standalone host adapter can scrub secrets at its own write sites
+(transcript accumulation, checkpoint, event log) without importing the
+venv-only `daimon_briefing` package. Re-run `daimon hooks install <host>`
+after every `daimon` upgrade so the installed scripts (and the bundled
+`redact.py`) stay in sync with the installed CLI.
 
-## Claude Code dogfood hooks
+## Drift guard
 
-Closes the full capture→inject loop in Claude Code (which does not load hermes
-plugins; the hermes path in `plugin/` is unaffected):
-
-- `SessionEnd` writes a checkpoint from the ending session's transcript
-- `SessionStart` injects the latest checkpoint as a briefing
-
-- `daimon-session-brief.py` — SessionStart hook. Reads the payload from stdin
-  and shells out to the installed `daimon brief` CLI (single source of
-  truth for rendering); prints the briefing to stdout, which Claude Code injects
-  as session context. **Per-project routing:** the payload `cwd` is slugged
-  (Claude Code style: `/Users/x/proj` → `-Users-x-proj`) and this project's
-  `<checkpoint-dir>/<slug>/latest.json` is preferred; if the project has no
-  checkpoint of its own, the global `latest.json` is used and the briefing
-  header is labeled `(global fallback — checkpoint may be from another
-  project)`. The cwd is forwarded to the CLI via `DAIMON_PROJECT_DIR` so both
-  route identically. No `cwd` in the payload → global behavior, unlabeled.
-  Fail-open: always exits 0, prints a one-line diagnostic on failure instead of
-  dying silently. Respects `DAIMON_DISABLE` and `DAIMON_CHECKPOINT_DIR`.
-- `daimon-session-end.py` — SessionEnd hook. Reads the payload from stdin and
-  spawns `daimon serialize <transcript_path>` as a detached background
-  process — serialization is an LLM call (30s+ on long sessions) and must never
-  block `/exit`. The payload `cwd` is passed to the child as
-  `DAIMON_PROJECT_DIR`, so the serializer writes this project's
-  `<slug>/latest.json` in addition to the global `latest.json` (kept for
-  backward compatibility and the fallback path). No `cwd` → child env untouched,
-  global-only as before. Diagnostics and serializer output land in
-  `~/.daimon/logs/serialize.log` — both the `wrote checkpoint: <path> (took
-  Ns)` success line and named-error lines (`... after Ns`) carry elapsed
-  seconds, so checkpoint generation time is visible in production. Fail-open,
-  respects `DAIMON_DISABLE`.
-  Not fired on hard kills (terminal closed, SIGKILL) — briefings can still be
-  stale, which is why the SessionStart header shows checkpoint age.
-
-  Note: this fires for EVERY Claude Code session in every project, and each
-  fire costs one LLM serialize call. The briefing slot is per-project: each
-  project's last session wins its own `latest.json`; sessions in other projects
-  can no longer hijack it. Kill switch: `DAIMON_DISABLE=1`.
-
-  LLM credentials come from `~/.daimon/env` (see `plugin/README.md`
-  Configuration) — hooks inherit the host process environment, not your shell
-  profile, so `DAIMON_LLM_API_KEY` / `DAIMON_LLM_MODEL` / `DAIMON_LLM_BASE_URL`
-  belong in that file (chmod 600). Without it, serialize fails fast with a
-  named error in `~/.daimon/logs/serialize.log`.
-These two scripts are wired in one of two mutually exclusive ways — pick ONE
-(both at once double-fires every session: two briefing injections, two
-serialize LLM calls):
-
-- **Plugin (recommended):** the repo is a Claude Code plugin
-  (`.claude-plugin/plugin.json` + `hooks/hooks.json` reference these scripts
-  via `${CLAUDE_PLUGIN_ROOT}`). Install: `/plugin marketplace add
-  Daily-Nerd/daimon` then `/plugin install daimon@daimon`.
-- **Manual (Codex / non-plugin hosts):** `daimon-hooks.py` — lifecycle manager
-  (same shape as SCAR's `scar-hooks.py`):
-
-```sh
-python3 hook/daimon-hooks.py install   [--dry-run]
-python3 hook/daimon-hooks.py uninstall [--dry-run]
-python3 hook/daimon-hooks.py status
-```
-
-Install copies both hooks to `~/.claude/hooks/` and registers them under
-`SessionStart` / `SessionEnd` in `~/.claude/settings.json` (idempotent;
-settings backed up before every mutation). Requires the plugin CLI on PATH:
-`uv tool install ./plugin` (or equivalent) so `daimon` resolves (the hooks also
-accept the deprecated `daimon-briefing` alias as a fallback) — reinstall after
-updating `plugin/` so the CLI picks up `.jsonl` transcript support, which
-SessionEnd depends on.
+Canonical adapter sources live here in `hook/`; the Claude Code plugin and
+the manual installers read them directly from this directory. Packaged
+copies also ship inside the PyPI wheel at
+`plugin/daimon_briefing/_hooks/` (so `daimon hooks install <host>` works
+without a repo clone) and at `plugin/daimon_briefing/_hooks/redact.py` (the
+copy of `plugin/daimon_briefing/redact.py` that installs alongside standalone
+hosts). A byte-equality test (`plugin/tests/test_hooks_install.py`) guards
+both copies against drift — when you edit a script or `redact.py` here, copy
+the change into `plugin/daimon_briefing/_hooks/` in the same change.


### PR DESCRIPTION
Closes #123

## Summary
- New `docs/hosts/` directory: an index with a host support matrix (install, capture, briefing injection, status) plus one setup guide per host (Claude Code, Codex, Gemini CLI, Windsurf). Content moved from `hook/README.md` and `README.md` — all behavior claims unchanged from #121.
- `hook/README.md` slimmed from mixed-audience walkthroughs to a contributor-facing adapter reference (script-pair shape, `_daimon_hook_lib.py`, probe conventions, `redact.py` shipping, drift guard) with a pointer to `docs/hosts/` for setup.
- `README.md` links `docs/hosts/` from the quickstart and the docs list — two-line change.

## Changes
| File | Change |
|------|--------|
| `docs/hosts/README.md` | New — support matrix + hooks/skill/CLI orientation |
| `docs/hosts/claude-code.md` | New — plugin + manual hooks + skill + verification |
| `docs/hosts/codex.md` | New — from hook/README Codex section + hook/CODEX.md |
| `docs/hosts/gemini.md` | New — keeps upstream-blocker caveat (`gemini-cli#14715`) verbatim |
| `docs/hosts/windsurf.md` | New — native-transcript capture, throttling, terminal briefing, `hooks install` |
| `hook/README.md` | Slimmed to contributor adapter reference (−71 net lines) |
| `README.md` | Two links to `docs/hosts/` |

## Test Plan
- [x] All relative links resolve from each file's location
- [x] Host status claims cross-checked against `docs/MVP-DREAM-BRIEFING.md` §2 and the README status table — no contradictions
- [x] No new behavior claims introduced — content traced to #121-verified sources
- [x] Docs-only change — no code, no scripts touched

## Contributor Checklist
- [x] Linked an approved issue (#123, `status:approved`)
- [x] Exactly one `type:*` label (`type:docs`)
- [x] Shellcheck N/A — no scripts modified
- [x] Docs updated — this PR is the docs update
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers