### PR TITLE
docs: add Codecov coverage badge to root and plugin READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Daimon
 
+[![codecov](https://codecov.io/gh/Daily-Nerd/daimon/graph/badge.svg?token=gYJmnMwAue)](https://codecov.io/gh/Daily-Nerd/daimon)
+
 > A **dream-briefing** for your AI agent: a skimmable "while you were away / here's where we left off" artifact, shown when you resume a session.
 
 Your agent forgets everything between sessions. Daimon writes a small cognitive checkpoint when a session ends and turns it into a briefing when the next one starts — so the agent resumes from a faithful prior state instead of a confident guess:

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,5 +1,7 @@
 # Daimon
 
+[![codecov](https://codecov.io/gh/Daily-Nerd/daimon/graph/badge.svg?token=gYJmnMwAue)](https://codecov.io/gh/Daily-Nerd/daimon)
+
 Your AI coding agent forgets everything between sessions. **Daimon** writes a small
 cognitive checkpoint when a session ends, then renders a "while you were away"
 briefing when the next one starts — so the agent resumes from a faithful record of


### PR DESCRIPTION
Closes #130

## What

Adds the Codecov coverage badge under the `# Daimon` title in both `README.md` (GitHub) and `plugin/README.md` (PyPI).

## Why

Coverage uploads to Codecov as of #129 but the signal wasn't surfaced anywhere a reader lands. Both READMEs so the badge shows on GitHub and on the PyPI package page.

## Tests

Docs-only, 4 insertions across two files, no code touched. Badge URL uses Codecov's public graph-badge token (read-only, meant for public READMEs), not the secret upload token.
