### PR TITLE
fix(redact): close secret-leak gaps for quoted keys, token prefixes, and password-only URLs

### DIFF
--- a/hook/redact.py
+++ b/hook/redact.py
@@ -19,13 +19,32 @@ _PATTERNS = (
         re.DOTALL)),
     ("aws-key", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
     ("stripe-key", re.compile(r"\b[rsp]k_live_[0-9A-Za-z]{8,}\b")),
+    # Fixed-prefix vendor tokens: anchored on a documented literal prefix +
+    # charset (same "concrete shape, never bare entropy" precision as aws/
+    # stripe). A literal prefix before a single char class has no ambiguous
+    # backtracking, so an open-ended body ({N,}) is linear and safe — and
+    # redacts the whole token (a capped upper bound would leak the tail).
+    ("github-token", re.compile(
+        r"\b(?:gh[oprsu]_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{40,})\b")),
+    ("gitlab-token", re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}")),
+    ("slack-token", re.compile(r"\bxox[abprs]-[A-Za-z0-9-]{10,}")),
+    ("google-key", re.compile(r"\bAIza[0-9A-Za-z_-]{35}")),
+    ("openai-key", re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}")),
+    ("jwt", re.compile(
+        r"\beyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+")),
     ("bearer", re.compile(
         r"(?i)\b(?:bearer|authorization:\s*\w+)\s+[A-Za-z0-9._~+/=-]{16,}")),
+    # Separator tolerates an optional quote before the operator ("api_key":)
+    # and the value may itself be quote-wrapped, so JSON/pasted-config bodies
+    # redact. The bounded lazy prefix [\w-]{0,32}? stays per scar-0022 — no
+    # unbounded class before the keyword alternation.
     ("api-key", re.compile(
         r"(?i)\b([\w-]{0,32}?(?:api[_-]?key|secret|token|password|passwd))"
-        r"(\s*[=:]\s*)['\"]?(?!\[redacted:)[^\s'\"]{8,}")),
+        r"(['\"]?\s*[=:]\s*)['\"]?(?!\[redacted:)[^\s'\"]{8,}")),
+    # User portion optional ([^/\s:@]*) so password-only URLs (redis://:pw@h)
+    # match; the group(1)+":[redacted…]@" reconstruction stays valid empty.
     ("credential-url", re.compile(
-        r"\b([a-z][a-z0-9+.-]{0,15}://[^/\s:@]+):(?!\[redacted:)[^/\s@]+@")),
+        r"\b([a-z][a-z0-9+.-]{0,15}://[^/\s:@]*):(?!\[redacted:)[^/\s@]+@")),
 )
 
 

--- a/hook/redact.py
+++ b/hook/redact.py
@@ -25,7 +25,7 @@ _PATTERNS = (
     # backtracking, so an open-ended body ({N,}) is linear and safe — and
     # redacts the whole token (a capped upper bound would leak the tail).
     ("github-token", re.compile(
-        r"\b(?:gh[oprsu]_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{40,})\b")),
+        r"\b(?:gh[oprsu]_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{40,})\b")),
     ("gitlab-token", re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}")),
     ("slack-token", re.compile(r"\bxox[abprs]-[A-Za-z0-9-]{10,}")),
     ("google-key", re.compile(r"\bAIza[0-9A-Za-z_-]{35}")),

--- a/plugin/daimon_briefing/_hooks/redact.py
+++ b/plugin/daimon_briefing/_hooks/redact.py
@@ -19,13 +19,32 @@ _PATTERNS = (
         re.DOTALL)),
     ("aws-key", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
     ("stripe-key", re.compile(r"\b[rsp]k_live_[0-9A-Za-z]{8,}\b")),
+    # Fixed-prefix vendor tokens: anchored on a documented literal prefix +
+    # charset (same "concrete shape, never bare entropy" precision as aws/
+    # stripe). A literal prefix before a single char class has no ambiguous
+    # backtracking, so an open-ended body ({N,}) is linear and safe — and
+    # redacts the whole token (a capped upper bound would leak the tail).
+    ("github-token", re.compile(
+        r"\b(?:gh[oprsu]_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{40,})\b")),
+    ("gitlab-token", re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}")),
+    ("slack-token", re.compile(r"\bxox[abprs]-[A-Za-z0-9-]{10,}")),
+    ("google-key", re.compile(r"\bAIza[0-9A-Za-z_-]{35}")),
+    ("openai-key", re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}")),
+    ("jwt", re.compile(
+        r"\beyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+")),
     ("bearer", re.compile(
         r"(?i)\b(?:bearer|authorization:\s*\w+)\s+[A-Za-z0-9._~+/=-]{16,}")),
+    # Separator tolerates an optional quote before the operator ("api_key":)
+    # and the value may itself be quote-wrapped, so JSON/pasted-config bodies
+    # redact. The bounded lazy prefix [\w-]{0,32}? stays per scar-0022 — no
+    # unbounded class before the keyword alternation.
     ("api-key", re.compile(
         r"(?i)\b([\w-]{0,32}?(?:api[_-]?key|secret|token|password|passwd))"
-        r"(\s*[=:]\s*)['\"]?(?!\[redacted:)[^\s'\"]{8,}")),
+        r"(['\"]?\s*[=:]\s*)['\"]?(?!\[redacted:)[^\s'\"]{8,}")),
+    # User portion optional ([^/\s:@]*) so password-only URLs (redis://:pw@h)
+    # match; the group(1)+":[redacted…]@" reconstruction stays valid empty.
     ("credential-url", re.compile(
-        r"\b([a-z][a-z0-9+.-]{0,15}://[^/\s:@]+):(?!\[redacted:)[^/\s@]+@")),
+        r"\b([a-z][a-z0-9+.-]{0,15}://[^/\s:@]*):(?!\[redacted:)[^/\s@]+@")),
 )
 
 

--- a/plugin/daimon_briefing/_hooks/redact.py
+++ b/plugin/daimon_briefing/_hooks/redact.py
@@ -25,7 +25,7 @@ _PATTERNS = (
     # backtracking, so an open-ended body ({N,}) is linear and safe — and
     # redacts the whole token (a capped upper bound would leak the tail).
     ("github-token", re.compile(
-        r"\b(?:gh[oprsu]_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{40,})\b")),
+        r"\b(?:gh[oprsu]_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{40,})\b")),
     ("gitlab-token", re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}")),
     ("slack-token", re.compile(r"\bxox[abprs]-[A-Za-z0-9-]{10,}")),
     ("google-key", re.compile(r"\bAIza[0-9A-Za-z_-]{35}")),

--- a/plugin/daimon_briefing/redact.py
+++ b/plugin/daimon_briefing/redact.py
@@ -19,13 +19,32 @@ _PATTERNS = (
         re.DOTALL)),
     ("aws-key", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
     ("stripe-key", re.compile(r"\b[rsp]k_live_[0-9A-Za-z]{8,}\b")),
+    # Fixed-prefix vendor tokens: anchored on a documented literal prefix +
+    # charset (same "concrete shape, never bare entropy" precision as aws/
+    # stripe). A literal prefix before a single char class has no ambiguous
+    # backtracking, so an open-ended body ({N,}) is linear and safe — and
+    # redacts the whole token (a capped upper bound would leak the tail).
+    ("github-token", re.compile(
+        r"\b(?:gh[oprsu]_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{40,})\b")),
+    ("gitlab-token", re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}")),
+    ("slack-token", re.compile(r"\bxox[abprs]-[A-Za-z0-9-]{10,}")),
+    ("google-key", re.compile(r"\bAIza[0-9A-Za-z_-]{35}")),
+    ("openai-key", re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}")),
+    ("jwt", re.compile(
+        r"\beyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+")),
     ("bearer", re.compile(
         r"(?i)\b(?:bearer|authorization:\s*\w+)\s+[A-Za-z0-9._~+/=-]{16,}")),
+    # Separator tolerates an optional quote before the operator ("api_key":)
+    # and the value may itself be quote-wrapped, so JSON/pasted-config bodies
+    # redact. The bounded lazy prefix [\w-]{0,32}? stays per scar-0022 — no
+    # unbounded class before the keyword alternation.
     ("api-key", re.compile(
         r"(?i)\b([\w-]{0,32}?(?:api[_-]?key|secret|token|password|passwd))"
-        r"(\s*[=:]\s*)['\"]?(?!\[redacted:)[^\s'\"]{8,}")),
+        r"(['\"]?\s*[=:]\s*)['\"]?(?!\[redacted:)[^\s'\"]{8,}")),
+    # User portion optional ([^/\s:@]*) so password-only URLs (redis://:pw@h)
+    # match; the group(1)+":[redacted…]@" reconstruction stays valid empty.
     ("credential-url", re.compile(
-        r"\b([a-z][a-z0-9+.-]{0,15}://[^/\s:@]+):(?!\[redacted:)[^/\s@]+@")),
+        r"\b([a-z][a-z0-9+.-]{0,15}://[^/\s:@]*):(?!\[redacted:)[^/\s@]+@")),
 )
 
 

--- a/plugin/daimon_briefing/redact.py
+++ b/plugin/daimon_briefing/redact.py
@@ -25,7 +25,7 @@ _PATTERNS = (
     # backtracking, so an open-ended body ({N,}) is linear and safe — and
     # redacts the whole token (a capped upper bound would leak the tail).
     ("github-token", re.compile(
-        r"\b(?:gh[oprsu]_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{40,})\b")),
+        r"\b(?:gh[oprsu]_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{40,})\b")),
     ("gitlab-token", re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}")),
     ("slack-token", re.compile(r"\bxox[abprs]-[A-Za-z0-9-]{10,}")),
     ("google-key", re.compile(r"\bAIza[0-9A-Za-z_-]{35}")),

--- a/plugin/tests/test_redact_leak_gaps.py
+++ b/plugin/tests/test_redact_leak_gaps.py
@@ -45,6 +45,14 @@ def test_github_fine_grained_pat_redacted():
     assert "B" * 40 not in out and c.get("github-token") == 1
 
 
+def test_github_token_over_36_chars_redacted():
+    # #132 hardening: an exact-length {36} pattern leaks any token that is not
+    # precisely 36 chars — a longer or future-format ghp_ token walks to disk.
+    # {36,N} keeps the leak closed for realistic length growth.
+    out, c = _one("token ghp_" + "A" * 40 + " committed")
+    assert "ghp_" + "A" * 40 not in out and c.get("github-token") == 1
+
+
 def test_gitlab_token_redacted():
     out, c = _one("glpat-" + "C" * 20 + " leaked")
     assert "C" * 20 not in out and c.get("gitlab-token") == 1

--- a/plugin/tests/test_redact_leak_gaps.py
+++ b/plugin/tests/test_redact_leak_gaps.py
@@ -1,0 +1,141 @@
+"""#132: close secret-leak gaps — quoted/JSON keys, common token prefixes,
+password-only credential URLs. Each leak case is asserted red-first; a
+precision block guards prose from over-redaction; a completion/timing block
+guards scar-0022's ReDoS bound on the new/changed patterns."""
+
+import time
+from pathlib import Path
+
+from daimon_briefing import redact
+
+
+def _one(s):
+    out, counts = redact.redact_text(s)
+    return out, counts
+
+
+# ---- gap 1: quoted / JSON key-value ----------------------------------------
+
+
+def test_json_api_key_value_redacted():
+    out, c = _one('{"api_key": "sk-liveAbC123456789"}')
+    assert "sk-liveAbC123456789" not in out and c.get("api-key") == 1
+
+
+def test_json_password_value_redacted():
+    out, c = _one('{"password": "supersecret123"}')
+    assert "supersecret123" not in out and c.get("api-key") == 1
+
+
+def test_single_quoted_json_key_redacted():
+    out, c = _one("'secret' = 'topsecretvalue1'")
+    assert "topsecretvalue1" not in out and c.get("api-key") == 1
+
+
+# ---- gap 2: common fixed-prefix tokens -------------------------------------
+
+
+def test_github_personal_token_redacted():
+    out, c = _one("token ghp_" + "A" * 36 + " committed")
+    assert "ghp_" + "A" * 36 not in out and c.get("github-token") == 1
+
+
+def test_github_fine_grained_pat_redacted():
+    out, c = _one("use github_pat_" + "B" * 40 + " here")
+    assert "B" * 40 not in out and c.get("github-token") == 1
+
+
+def test_gitlab_token_redacted():
+    out, c = _one("glpat-" + "C" * 20 + " leaked")
+    assert "C" * 20 not in out and c.get("gitlab-token") == 1
+
+
+def test_slack_bot_token_redacted():
+    out, c = _one("xoxb-123456789012-abcdefghijkl in config")
+    assert "abcdefghijkl" not in out and c.get("slack-token") == 1
+
+
+def test_google_api_key_redacted():
+    out, c = _one("key AIza" + "D" * 35 + " loaded")
+    assert "AIza" + "D" * 35 not in out and c.get("google-key") == 1
+
+
+def test_openai_key_redacted():
+    out, c = _one("sk-proj-" + "E" * 40 + " set")
+    assert "E" * 40 not in out and c.get("openai-key") == 1
+
+
+def test_bare_jwt_redacted():
+    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NSJ9.abcDEF123_-xyz"
+    out, c = _one("session " + jwt + " expired")
+    assert jwt not in out and c.get("jwt") == 1
+
+
+# ---- gap 3: password-only credential URLs ----------------------------------
+
+
+def test_password_only_redis_url_redacted():
+    out, c = _one("redis://:mypassword123@localhost:6379/0")
+    assert "mypassword123" not in out
+    assert "redis://:[redacted:credential-url]@localhost" in out
+    assert c.get("credential-url") == 1
+
+
+def test_password_only_amqp_url_redacted():
+    out, c = _one("amqp://:secretpass@rabbit:5672")
+    assert "secretpass" not in out
+    assert "amqp://:[redacted:credential-url]@rabbit" in out
+    assert c.get("credential-url") == 1
+
+
+def test_user_and_password_credential_url_still_redacted():
+    out, c = _one("postgres://admin:hunter2secret@db.example.com:5432/x")
+    assert "hunter2secret" not in out
+    assert "postgres://admin:[redacted:credential-url]@db.example.com" in out
+
+
+# ---- precision: prose must survive untouched -------------------------------
+
+
+def test_prose_not_over_redacted():
+    for s in (
+        "the token budget was blown",
+        "password rotation policy is quarterly",
+        "see the api key rotation notes",
+        "the deploy secret is documented elsewhere",
+        "https://docs.example.com/path and http://localhost:8080/x",
+    ):
+        out, c = _one(s)
+        assert c == {}, f"over-redacted: {s!r} -> {c}"
+        assert out == s
+
+
+# ---- scar-0022: no catastrophic backtracking on the new/changed patterns ---
+
+
+def test_no_backtracking_on_adversarial_inputs():
+    # Completion IS the signal (scar-0022 convention: python re has no timeout,
+    # a quadratic blowup hangs rather than raises). The documented bad case ran
+    # 7-28s; a generous 2s ceiling cleanly separates linear from quadratic
+    # without the CI flakiness of a tight bound.
+    adversarial = (
+        ("a-" * 5000) + "password=" + "x" * 8,   # bounded-prefix keyword run
+        ("password" + " " * 20000 + "= " + "y" * 8),  # keyword + whitespace run
+        "eyJ" + "a" * 50000,                     # near-JWT, no dots
+        "eyJ" + "a" * 20000 + ".eyJ" + "a" * 20000,  # two segments, no 3rd dot
+        "sk-" + "z" * 50000,                     # long token body
+        "a." * 25000,                            # long scheme run, no ://
+    )
+    start = time.perf_counter()
+    for s in adversarial:
+        _one(s)
+    assert time.perf_counter() - start < 2.0
+
+
+# ---- twin: canonical module and shipped hook copy stay byte-identical ------
+
+
+def test_redact_twin_byte_identical():
+    canonical = (Path(redact.__file__)).read_bytes()
+    twin = (Path(redact.__file__).parent / "_hooks" / "redact.py").read_bytes()
+    assert twin == canonical, "redact.py and _hooks/redact.py drifted"


### PR DESCRIPTION
Closes #132

## What

Extends `redact.py` `_PATTERNS` (stdlib-only, precision-first) to close three secret-leak shapes an audit reproduced against the live `redact_text()`:

1. **Quoted/JSON key-value** — `"api_key": "sk-live…"` and `"password": "supersecret123"` now redact. The `api-key` separator accepts an optional quote before the `:`/`=` operator, and the value may be quote-wrapped; the group-1/group-2 reconstruction (`keyword + separator + [redacted:api-key]`) is preserved, leaving the closing quote intact.
2. **Fixed-prefix vendor tokens** — added patterns anchored on documented prefixes: `github-token` (`ghp_`/`gho_`/`ghs_`/`ghu_`/`ghr_` + `github_pat_`), `gitlab-token` (`glpat-`), `slack-token` (`xox[abprs]-`), `google-key` (`AIza…`), `openai-key` (`sk-`/`sk-proj-`), and bare `jwt` (`eyJ….eyJ….sig`).
3. **Password-only credential URLs** — the user portion is now optional, so `redis://:pass@host` and `amqp://:pass@host` match while `scheme://user:pass@host` keeps working. Empty-user reconstruction yields valid `redis://:[redacted:credential-url]@host`.

## Why

`redact.py` is the guarantee that a quoted secret never reaches disk (checkpoint, git-shared team sidecar, SQLite FTS index). Each gap let a real-world secret persist — the core local-first promise failing.

## Tests

New `plugin/tests/test_redact_leak_gaps.py`, driven red-first:

- One assertion per leak class (JSON api_key/password, github `ghp_`/`github_pat_`, gitlab, slack, google, openai, JWT, redis/amqp password-only URLs).
- **Precision guard** — prose (`the token budget`, `password rotation policy`, `api key rotation notes`, a bare `secret` sentence, plain https/http URLs) is asserted unchanged; over-redaction is a regression.
- **ReDoS guard** — adversarial inputs (scar-0022 shapes: long bounded-prefix keyword run, keyword + huge whitespace, near-JWTs, long token bodies, long scheme runs) complete well under a generous ceiling. Honors scar-0022: the `api-key` prefix stays bounded lazy `[\w-]{0,32}?`, and every new token pattern anchors a literal prefix before a single char class — no unbounded prefix before an alternation.
- **Twin sync** — all three `redact.py` copies (module, packaged `_hooks/`, repo `hook/`) stay byte-identical; existing drift tests pass.

Full suite: **1057 passed** (was 1041). `ruff check daimon_briefing`: clean.