### PR TITLE
fix(briefing): reject and tolerate null text/quote instead of crashing the render

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -40,8 +40,12 @@ def _mark(item) -> str:
 
 
 def _line(item) -> str:
-    text = item.get("text", "").strip()
-    quote = item.get("quote", "").strip()
+    # #134: dict.get returns the stored None for a present-but-null key (the
+    # default only fires for an ABSENT key), so a torn/legacy checkpoint could
+    # crash the whole render here. Use the codebase's str(x or "") idiom
+    # (store.py, carry.py) — tolerant of null, same as iter_items' stance.
+    text = str(item.get("text") or "").strip()
+    quote = str(item.get("quote") or "").strip()
     base = f'- [{_mark(item)}] {text}'
     if item.get("carried_from"):
         # Epistemic honesty, same philosophy as trust marks: a loop carried
@@ -61,7 +65,8 @@ def _line(item) -> str:
 
 
 def _nonempty(item) -> bool:
-    return bool(item and isinstance(item, dict) and item.get("text", "").strip())
+    # #134: null-safe — a present-but-null text must read as empty, not crash.
+    return bool(item and isinstance(item, dict) and str(item.get("text") or "").strip())
 
 
 def _overflow_note(dropped: int) -> str | None:

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -260,6 +260,12 @@ def _valid_item(item) -> bool:
         return False
     if "text" not in item or "trust" not in item:
         return False
+    # #134: presence != a usable value. A present-but-null (or non-str) text
+    # passed this check, reached disk, then crashed briefing.render on the next
+    # session. Reject at the boundary. Empty str stays valid — active_topic MAY
+    # carry empty text (test_validate_allows_empty_active_topic_text).
+    if not isinstance(item["text"], str):
+        return False
     if item["trust"] not in _TRUST_CLASSES:
         return False
     if item["trust"] == "verbatim":

--- a/plugin/tests/test_briefing.py
+++ b/plugin/tests/test_briefing.py
@@ -455,6 +455,32 @@ def test_line_carried_marker_precedes_quote():
     assert line.index("[carried]") < line.index("the exact words")
 
 
+# ---- #134: null text/quote must render, not crash (torn/legacy checkpoint) ----
+
+
+def test_line_tolerates_null_text_and_quote():
+    # dict.get returns the stored None for a present-but-null key, so the old
+    # .get("text", "").strip() raised AttributeError. Must not raise now.
+    assert isinstance(briefing._line({"text": None, "trust": "inferred"}), str)
+    assert isinstance(
+        briefing._line({"text": None, "trust": "verbatim", "quote": None}), str)
+
+
+def test_nonempty_tolerates_null_text():
+    assert briefing._nonempty({"text": None, "trust": "inferred"}) is False
+
+
+def test_build_drops_null_text_item_and_renders_good_ones():
+    # End-to-end: one null-text item among good items must not take down the
+    # whole render — the bad item drops, the good items still show.
+    cp = {"working_context": {"recent_decisions": [
+              {"text": None, "trust": "inferred"},
+              {"text": "shipped the fix", "trust": "inferred"}]},
+          "epistemic_snapshot": {}}
+    out = briefing.render_plain(briefing.build(cp))
+    assert "shipped the fix" in out
+
+
 # ---- #30: trust-class integrity — the differentiator's own guarantees ----
 
 

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -721,6 +721,24 @@ def test_valid_item_rejects_malformed_anchor():
     assert serializer._valid_item(item) is False
 
 
+# ---- #134: a present-but-null (or non-str) text passed validation, reached
+# disk, then crashed the briefing render on the next session ----
+
+
+def test_valid_item_rejects_null_text():
+    assert serializer._valid_item({"text": None, "trust": "inferred"}) is False
+
+
+def test_valid_item_rejects_nonstr_text():
+    assert serializer._valid_item({"text": 123, "trust": "inferred"}) is False
+
+
+def test_valid_item_still_accepts_empty_text():
+    # active_topic MAY have empty text (test_validate_allows_empty_active_topic_text)
+    # — a str-but-empty text stays valid; only a non-str text is rejected.
+    assert serializer._valid_item({"text": "", "trust": "inferred"}) is True
+
+
 # ---- #118: validation-failure retry with attempt nonce ----
 
 


### PR DESCRIPTION
Closes #134

## What
A present-but-null `text` passed `serializer._valid_item`, reached disk, then crashed the entire briefing render on the next session — silently, because the hook swallows the exception and the user simply gets no briefing.

Fix in both layers (defense in depth):
- **Validator (`serializer._valid_item`)**: now requires `text` to be a `str`, rejecting `None`/non-str at the boundary so bad items never reach disk. Empty `str` stays valid, preserving the empty-`active_topic` contract (`test_validate_allows_empty_active_topic_text`).
- **Briefing (`_line`, `_nonempty`)**: switched to the codebase's existing `str(item.get("text") or "")` idiom (matches `store.py`/`carry.py`), so a torn/legacy checkpoint that already holds a null renders instead of crashing.

## Why
`_valid_item` only checked key *presence*, and `dict.get(k, default)` returns the stored `None` when the key is present-but-null (the default only applies to an absent key). So `None.strip()` raised `AttributeError` and took down the core user-visible feature. A single malformed extractor emission — or a legacy checkpoint on disk — was enough.

## Tests
Red-first (all failed before the fix, pass after):
- `_valid_item` rejects `text: None` and `text: 123`; still accepts `text: ""` (no over-rejection).
- `briefing._line` / `_nonempty` on null `text`/`quote` no longer raise.
- End-to-end: a checkpoint with one null-text item among good decisions renders — the bad item drops, the good items still show.

Full suite: `1064 passed` (1058 baseline + 6 new). `ruff check daimon_briefing` clean.