### PR TITLE
fix(teamsync): guard git timeouts into offline degradation + non-interactive credential handling

### DIFF
--- a/plugin/daimon_briefing/teamsync.py
+++ b/plugin/daimon_briefing/teamsync.py
@@ -35,6 +35,7 @@ sidecar directory.
 """
 
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -60,12 +61,34 @@ class TeamError(Exception):
     failure. Everything else in sync degrades gracefully to rc 0."""
 
 
+def _run_git(argv, timeout) -> subprocess.CompletedProcess:
+    """Run a git argv NON-INTERACTIVELY and never raise, whatever git does.
+
+    - GIT_TERMINAL_PROMPT=0 + stdin=DEVNULL turn a missing-credential remote
+      into a fast rc != 0 instead of a blocked interactive credential prompt
+      that hangs until the timeout fires.
+    - A TimeoutExpired (a SubprocessError, NOT an OSError — so it would slip
+      past every caller's OSError catch) is converted into a synthetic FAILED
+      CompletedProcess (rc 124, the shell timeout convention). Every caller
+      already maps rc != 0 to the right outcome (offline for sync, TeamError
+      for init/clone), so the documented "never raises" contract holds
+      uniformly under a hung remote, not just under a clean rc != 0."""
+    try:
+        return subprocess.run(
+            argv,
+            capture_output=True, text=True, timeout=timeout,
+            env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+            stdin=subprocess.DEVNULL,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            argv, 124, stdout="", stderr=f"git timed out after {timeout}s",
+        )
+
+
 def _git(cwd, *args, timeout=GIT_TIMEOUT) -> subprocess.CompletedProcess:
-    """One git call, cwd pinned to the sidecar, never raises on rc != 0."""
-    return subprocess.run(
-        ["git", "-C", str(cwd), *args],
-        capture_output=True, text=True, timeout=timeout,
-    )
+    """One git call, cwd pinned to the sidecar, never raises (rc != 0 or timeout)."""
+    return _run_git(["git", "-C", str(cwd), *args], timeout)
 
 
 def _last_line(text: str) -> str:
@@ -132,9 +155,9 @@ def _identity_extra(sidecar) -> list[str]:
 
 
 def _commit(sidecar, message) -> subprocess.CompletedProcess:
-    return subprocess.run(
+    return _run_git(
         ["git", "-C", str(sidecar), *_identity_extra(sidecar), "commit", "-m", message],
-        capture_output=True, text=True, timeout=GIT_TIMEOUT,
+        GIT_TIMEOUT,
     )
 
 
@@ -172,10 +195,7 @@ def init(url: str) -> Path:
             "run `daimon team sync`, or remove the directory to re-clone"
         )
     root.mkdir(parents=True, exist_ok=True)
-    proc = subprocess.run(
-        ["git", "clone", "--", url, str(dest)],
-        capture_output=True, text=True, timeout=NET_TIMEOUT,
-    )
+    proc = _run_git(["git", "clone", "--", url, str(dest)], NET_TIMEOUT)
     if proc.returncode != 0:
         raise TeamError(f"git clone failed: {_last_line(proc.stderr)}")
     if _head(dest) is None:  # unborn branch: the remote was empty

--- a/plugin/tests/test_teamsync.py
+++ b/plugin/tests/test_teamsync.py
@@ -445,6 +445,85 @@ def test_sync_removes_stale_index_lock_keeps_fresh(bare_remote, tmp_path):
     assert isinstance(report, dict)  # degraded, never raised
 
 
+# ---- #136: git timeouts degrade offline, non-interactive credentials ----
+
+
+def test_git_timeout_returns_failed_completedprocess_not_raise(tmp_path, monkeypatch):
+    # TimeoutExpired subclasses SubprocessError (NOT OSError), so it would slip
+    # past every caller's OSError catch. _git must convert it into the same
+    # rc != 0 shape the offline/TeamError paths already handle — never raise.
+    def boom(argv, *a, **k):
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=k.get("timeout", 1))
+    monkeypatch.setattr(teamsync.subprocess, "run", boom)
+    proc = teamsync._git(tmp_path, "ls-remote", "origin")
+    assert isinstance(proc, subprocess.CompletedProcess)
+    assert proc.returncode != 0
+    assert "timed out" in (proc.stderr or "")
+
+
+def test_git_calls_are_non_interactive(tmp_path, monkeypatch):
+    # A private remote with no cached creds must fail fast, not block on git's
+    # interactive credential prompt until the timeout fires.
+    captured = {}
+    real_run = subprocess.run
+
+    def spy(argv, *a, **k):
+        captured.update(k)
+        captured["argv"] = argv
+        return real_run(argv, *a, **k)
+
+    monkeypatch.setattr(teamsync.subprocess, "run", spy)
+    teamsync._git(tmp_path, "rev-parse", "HEAD")
+    assert captured["env"]["GIT_TERMINAL_PROMPT"] == "0"
+    assert captured["stdin"] is subprocess.DEVNULL
+    assert captured["capture_output"] is True  # existing kwargs preserved, not clobbered
+    assert captured["text"] is True
+
+
+def test_sync_remote_offline_on_timeout_never_raises(bare_remote, monkeypatch):
+    # The "never raises / lands offline" contract must hold under a hung remote,
+    # not just under a clean rc != 0 (which the offline test already covers).
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    sidecar = teamsync.init(str(bare_remote))
+    _write_team_file(sidecar, "Ada", "S1.json")
+
+    def timeout_run(argv, *a, **k):
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=k.get("timeout", 1))
+
+    monkeypatch.setattr(teamsync.subprocess, "run", timeout_run)
+    r = teamsync.sync_remote(sidecar)  # must NOT raise
+    assert isinstance(r, dict)
+    assert any("offline" in n for n in r["notes"])
+    assert r["pushed"] is False
+
+
+def test_cli_team_sync_rc0_on_timeout(bare_remote, monkeypatch):
+    # End-to-end: a hung remote degrades to rc 0, never a traceback + crash.
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    teamsync.init(str(bare_remote))
+
+    def timeout_run(argv, *a, **k):
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=k.get("timeout", 1))
+
+    monkeypatch.setattr(teamsync.subprocess, "run", timeout_run)
+    assert cli.main(["team", "sync"]) == 0
+
+
+def test_init_clone_timeout_surfaces_teamerror(tmp_path, monkeypatch):
+    # init's contract is a clean TeamError on failure — a clone timeout must
+    # surface there, not as a raw TimeoutExpired traceback.
+    real_run = subprocess.run
+
+    def maybe_timeout(argv, *a, **k):
+        if "clone" in argv:
+            raise subprocess.TimeoutExpired(cmd=argv, timeout=k.get("timeout", 1))
+        return real_run(argv, *a, **k)
+
+    monkeypatch.setattr(teamsync.subprocess, "run", maybe_timeout)
+    with pytest.raises(teamsync.TeamError, match="clone failed"):
+        teamsync.init(str(tmp_path / "some-remote.git"))
+
+
 def test_merge_works_without_any_git_identity(bare_remote, tmp_path, monkeypatch):
     # CI runners have NO git identity and auto-detect fails ("(none)" hostname);
     # macOS auto-detects, which masked this locally. Reproduce CI exactly:


### PR DESCRIPTION
Closes #136

## What
Guard every git subprocess call in `teamsync` against `subprocess.TimeoutExpired` and run them non-interactively. `_git`, `_commit`, and the `init` clone now funnel through one `_run_git` helper that:

1. **Converts a timeout into a synthetic failed `CompletedProcess` (rc 124)** instead of letting `TimeoutExpired` propagate. Every caller already maps `rc != 0` to the right outcome — `offline` for `sync_remote`, `TeamError` for `init` — so the documented "never raises" contract now holds under a hung remote, not just under a clean `rc != 0`.
2. **Runs non-interactively** via `env GIT_TERMINAL_PROMPT=0` + `stdin=subprocess.DEVNULL`, so a private remote with no cached credentials fails fast rather than blocking on git's interactive credential prompt until the timeout fires.

## Why
`subprocess.TimeoutExpired` subclasses `SubprocessError`, **not** `OSError`. The callers (`_ls_remote`, `_integrate`, `sync_remote`, `_cmd_team_sync`) only catch `OSError`/`TeamError`/`ValueError`, so a network stall crashed with a traceback and a non-zero exit instead of degrading to "offline — using last-synced team state". The `rc != 0` offline-detection path never ran because the exception fired first. A single choke point (`_git`/`_run_git`) matches how `rc != 0` is already handled and can't be missed across the call sites.

Honors scar 0002: the git-index concurrency model is untouched — this only adds timeout + non-interactive guards.

## Tests
Red-first, then green (all in `tests/test_teamsync.py`):
- `_git` on a `TimeoutExpired` returns a nonzero `CompletedProcess` and does **not** raise.
- git calls are invoked with `GIT_TERMINAL_PROMPT=0` and `stdin=DEVNULL` (and existing `capture_output`/`text` kwargs preserved).
- `sync_remote` on a timing-out remote reports `offline` in its notes and never raises.
- `daimon team sync` returns rc 0 on a hung remote (no traceback/crash).
- `init` clone timeout surfaces a clean `TeamError`, not a raw `TimeoutExpired`.

Full suite: **1069 passed** (was 1064 + 5 new). `ruff check` clean. `mypy` unchanged at 44 pre-existing errors (none introduced; the two `teamsync.py` reports are the pre-existing untyped-`report`-dict pattern, not touched here).