### PR TITLE
fix(store): stop cross-project first_seen bleed and tolerate corrupt checkpoint pointers

### DIFF
--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -485,8 +485,14 @@ def write_checkpoint(session_id: str, checkpoint: dict, project_dir=None) -> Pat
     if slug:
         checkpoint.setdefault("project_slug", slug)
     # Birth stamps (#126) need the previous latest BEFORE this write moves it.
-    # read_latest never raises (returns None on absent/torn pointers).
-    _stamp_first_seen(checkpoint, read_latest(project_dir))
+    # read_latest never raises (returns None on absent/torn pointers). When the
+    # project is KNOWN, suppress the global fallback (#139): _stamp_first_seen
+    # PERSISTS what it reads, and the global pointer holds the most recent
+    # checkpoint of ANY project — a known project's first write must inherit
+    # nothing (None → all items fresh), never a foreign first_seen. When the
+    # project is UNKNOWN, the global pointer IS this stream's own prior
+    # checkpoint, so the fallback stays on (same-stream carry, #126 legacy).
+    _stamp_first_seen(checkpoint, read_latest(project_dir, fallback=not slug))
     blob = json.dumps(checkpoint, indent=2, ensure_ascii=False)
     history = config.checkpoint_history()
     _atomic_write(path, blob)
@@ -573,7 +579,12 @@ def read_checkpoint(session_id: str) -> dict | None:
         return None
     if not path.exists():
         return None
-    return json.loads(path.read_text(encoding="utf-8"))
+    # Torn/corrupt file is treated as absent, matching the module's tolerant
+    # readers (_pointer_regresses, _file_recency, sibling_buckets) (#139).
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
 
 
 def read_latest(project_dir=None, fallback: bool = True) -> dict | None:
@@ -589,13 +600,21 @@ def read_latest(project_dir=None, fallback: bool = True) -> dict | None:
     if slug:
         path = d / slug / _LATEST
         if path.exists():
-            return json.loads(path.read_text(encoding="utf-8"))
+            # A torn project pointer is treated as absent and falls through to the
+            # global fallback below (#139) — not the same as "no data".
+            try:
+                return json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                pass
     if not fallback:
         return None
     path = d / _LATEST
     if not path.exists():
         return None
-    return json.loads(path.read_text(encoding="utf-8"))
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
 
 
 # ---- team memory (#111): opt-in shared mirror, derive-never-write shared state ----

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1122,3 +1122,60 @@ def test_redact_tolerates_malformed_links(tmp_checkpoint_dir):
     cp = {"working_context": {"recent_decisions": [
         {"text": "x", "links": ["bare", {"no": "target"}, {"target": 7}]}]}}
     store.write_checkpoint("S1", cp)  # must not raise
+
+
+# ---- #139: cross-project first_seen bleed + corrupt-pointer tolerance ----
+
+
+def _independent(sample_checkpoint, sid, days_ago):
+    # Deep copy so two checkpoints with matching item TEXT never share item dicts
+    # (a shallow copy would let one write's in-place first_seen stamp bleed into
+    # the other and mask what the pointer path actually returns).
+    return json.loads(json.dumps(_stamped(sample_checkpoint, sid, days_ago)))
+
+
+def test_first_seen_does_not_bleed_across_projects(tmp_checkpoint_dir, sample_checkpoint):
+    # Project A has an older checkpoint whose item text coincides with project B's.
+    # B's FIRST write has no per-project pointer yet; the birth stamp must NOT fall
+    # back to the global pointer (A's checkpoint) and inherit A's older first_seen.
+    store.write_checkpoint("S-a", _independent(sample_checkpoint, "S-a", 5), project_dir="/p/A")
+    store.write_checkpoint("S-b", _independent(sample_checkpoint, "S-b", 0), project_dir="/p/B")
+    back = store.read_checkpoint("S-b")
+    carried_text = sample_checkpoint["working_context"]["open_questions"][0]["text"]
+    assert _first_seens(back)[carried_text] == back["created"]  # fresh, not A's
+
+
+def test_first_seen_still_inherits_within_same_project(tmp_checkpoint_dir, sample_checkpoint):
+    # Guard against over-fixing: a second write to the SAME project still inherits
+    # first_seen from that project's own prior checkpoint (the project pointer path,
+    # which fallback=False does not touch).
+    store.write_checkpoint("S-1", _independent(sample_checkpoint, "S-1", 5), project_dir="/p/A")
+    t1 = store.read_checkpoint("S-1")["created"]
+    store.write_checkpoint("S-2", _independent(sample_checkpoint, "S-2", 0), project_dir="/p/A")
+    back = store.read_checkpoint("S-2")
+    carried_text = sample_checkpoint["working_context"]["open_questions"][0]["text"]
+    assert _first_seens(back)[carried_text] == t1  # inherited from A's own prior
+
+
+def test_read_checkpoint_corrupt_file_returns_none(tmp_checkpoint_dir, sample_checkpoint):
+    store.write_checkpoint("S-torn", sample_checkpoint)
+    (tmp_checkpoint_dir / "S-torn.json").write_text('{"created": "2026', encoding="utf-8")
+    assert store.read_checkpoint("S-torn") is None  # tolerant, no raise
+
+
+def test_read_latest_corrupt_project_pointer_falls_through_to_global(
+    tmp_checkpoint_dir, sample_checkpoint
+):
+    store.write_checkpoint("S-g", {**sample_checkpoint, "session_id": "S-g"})  # global
+    slug = store.project_slug("/p/torn")
+    pdir = tmp_checkpoint_dir / slug
+    pdir.mkdir(parents=True, exist_ok=True)
+    (pdir / "latest.json").write_text("{not json", encoding="utf-8")  # torn project pointer
+    got = store.read_latest(project_dir="/p/torn", fallback=True)
+    assert got is not None and got["session_id"] == "S-g"  # fell through, no raise
+
+
+def test_read_latest_corrupt_global_pointer_returns_none(tmp_checkpoint_dir):
+    tmp_checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_checkpoint_dir / "latest.json").write_text("{not json", encoding="utf-8")
+    assert store.read_latest() is None  # tolerant, no raise


### PR DESCRIPTION
Closes #139

## What
Fixes two checkpoint-read robustness bugs in `store.py`, both confirmed on current main.

1. **Cross-project `first_seen` bleed (correctness).** The write path stamped birth dates with `read_latest`'s default `fallback=True`, so a known project's first write fell through to the global pointer (the most recent checkpoint of ANY project) and, on an exact-text match, inherited a foreign, older `first_seen`. The stamp persists, so those items decayed faster and sorted wrong from birth (same class as #94, on this field).
2. **Corrupt pointer crashed reads (robustness).** `read_checkpoint` and `read_latest` did bare `json.loads(path.read_text(...))` with no guard, so a torn/truncated `latest.json` tracebacked `daimon brief` and the carry path — and, because `read_latest` runs in the write path before pointers rotate, a corrupt global pointer could throw after the per-session file was written = a half-applied write.

## Why
The global pointer holds the most recent checkpoint of any project, and `_stamp_first_seen` persists what it reads; `read_latest`'s own docstring already says persist-callers must not see the global pointer. Every other reader in the module already tolerates a torn file — these two did not.

## How
- Suppress the global fallback **only when a project slug is known** (`fallback=not slug`). A known project's first write inherits nothing (`None` → all items stamped fresh). When the project is **unknown**, the global pointer legitimately IS this stream's own prior checkpoint, so same-stream carry (#126 legacy) is preserved — an unconditional `fallback=False` would have regressed that.
- Wrap the `json.loads` calls to treat a torn file as absent, matching the module's existing idiom (`except (OSError, json.JSONDecodeError)`): `read_checkpoint` → `None`; corrupt **project** pointer → fall through to the global fallback; corrupt **global** pointer → `None`.

## Tests
Red-first, then green. Added to `tests/test_store.py`:
- `first_seen` does not bleed across projects; still inherits within the same project (over-fix guard).
- `read_checkpoint` on invalid JSON returns `None`.
- `read_latest` corrupt project pointer falls through to a valid global; corrupt global pointer returns `None`.

Full suite: 1074 passed. `ruff` clean. `mypy` unchanged at 44 pre-existing errors (none in the changed lines).