### PR TITLE
chore(hooks): add sync script for hook-shipped file mirrors

### DIFF
--- a/hook/README.md
+++ b/hook/README.md
@@ -82,3 +82,18 @@ copy of `plugin/daimon_briefing/redact.py` that installs alongside standalone
 hosts). A byte-equality test (`plugin/tests/test_hooks_install.py`) guards
 both copies against drift — when you edit a script or `redact.py` here, copy
 the change into `plugin/daimon_briefing/_hooks/` in the same change.
+
+### Editing hook-shipped files
+
+Don't copy the duplicates by hand. Edit the canonical source, then run the
+sync script, then commit both:
+
+1. Edit the canonical file (`plugin/daimon_briefing/redact.py`, or the
+   adapter source here in `hook/`).
+2. `uv run python scripts/sync_hooks.py` — copies each canonical file to its
+   mirrors byte-for-byte.
+3. Commit the canonical file and its synced copies together.
+
+Run `uv run python scripts/sync_hooks.py --check` to see which copies (if any)
+have drifted without writing anything; it drives the same manifest the
+byte-equality test reads.

--- a/plugin/tests/test_hooks_install.py
+++ b/plugin/tests/test_hooks_install.py
@@ -1,8 +1,8 @@
 """#43: hook scripts ship in the package; `daimon hooks install <host>` puts
 them at a stable path so registration survives every upgrade."""
 
-import os
 import stat
+import sys
 from pathlib import Path
 
 import pytest
@@ -12,7 +12,17 @@ from daimon_briefing import cli
 REPO_HOOK_DIR = Path(__file__).parents[2] / "hook"
 PKG_HOOKS_DIR = Path(__file__).parents[1] / "daimon_briefing" / "_hooks"
 
-_SHIPPED = ("daimon-windsurf-hooks.py", "_daimon_hook_lib.py", "redact.py")
+_SCRIPTS_DIR = Path(__file__).parents[2] / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+from sync_hooks import SYNC_PAIRS  # noqa: E402
+
+# Derived from the one shared manifest — the names copied into the packaged
+# _hooks/ dir — so this list can never drift from what the sync script ships.
+_PKG_HOOKS_REL = "plugin/daimon_briefing/_hooks/"
+_SHIPPED = tuple(
+    Path(dst).name for _, dst in SYNC_PAIRS if dst.startswith(_PKG_HOOKS_REL)
+)
 
 
 @pytest.mark.parametrize("name", _SHIPPED)

--- a/plugin/tests/test_sync_hooks.py
+++ b/plugin/tests/test_sync_hooks.py
@@ -1,0 +1,70 @@
+"""#149: scripts/sync_hooks.py copies the intentionally-duplicated hook-shipped
+files from their canonical sources, driven by the same manifest the drift guard
+in test_hooks_install.py reads. --check reports drift and writes nothing."""
+
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).parents[2] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import sync_hooks  # noqa: E402
+
+
+def _build_tree(root, edits=None):
+    # Materialize an in-sync copy of the mirror topology under `root`: each
+    # canonical source gets deterministic content, each copy starts identical.
+    srcs = {src: f"# canonical {src}\n".encode() for src, _ in sync_hooks.SYNC_PAIRS}
+    for src, dst in sync_hooks.SYNC_PAIRS:
+        (root / src).parent.mkdir(parents=True, exist_ok=True)
+        (root / src).write_bytes(srcs[src])
+        (root / dst).parent.mkdir(parents=True, exist_ok=True)
+        (root / dst).write_bytes(srcs[src])
+    if edits:
+        for rel, data in edits.items():
+            (root / rel).write_bytes(data)
+    return root
+
+
+def test_check_clean_tree_exits_zero(tmp_path):
+    root = _build_tree(tmp_path)
+    assert sync_hooks.check(root) == 0
+
+
+def test_check_detects_introduced_drift(tmp_path):
+    src, _ = sync_hooks.SYNC_PAIRS[0]
+    root = _build_tree(tmp_path, edits={src: b"# edited canonical\n"})
+    assert sync_hooks.check(root) == 1
+
+
+def test_sync_repairs_drift_to_byte_identity(tmp_path):
+    src, _ = sync_hooks.SYNC_PAIRS[0]
+    root = _build_tree(tmp_path, edits={src: b"# edited canonical\n"})
+    assert sync_hooks.sync(root) == 0
+    for s, d in sync_hooks.SYNC_PAIRS:
+        assert (root / d).read_bytes() == (root / s).read_bytes()
+    assert sync_hooks.check(root) == 0
+
+
+def test_sync_clean_tree_writes_nothing(tmp_path):
+    root = _build_tree(tmp_path)
+    before = {d: (root / d).stat().st_mtime_ns for _, d in sync_hooks.SYNC_PAIRS}
+    assert sync_hooks.sync(root) == 0
+    after = {d: (root / d).stat().st_mtime_ns for _, d in sync_hooks.SYNC_PAIRS}
+    assert before == after
+
+
+def test_main_check_flag_reads_module_repo_root(tmp_path, monkeypatch):
+    root = _build_tree(tmp_path)
+    monkeypatch.setattr(sync_hooks, "REPO_ROOT", root)
+    assert sync_hooks.main(["--check"]) == 0
+    src, _ = sync_hooks.SYNC_PAIRS[0]
+    (root / src).write_bytes(b"# drift\n")
+    assert sync_hooks.main(["--check"]) == 1
+
+
+def test_check_against_real_repo_is_clean():
+    # Ties the manifest's relative paths to the real tree: a wrong path raises
+    # here, and any live drift fails just like the byte-identity guards.
+    assert sync_hooks.check(sync_hooks.REPO_ROOT) == 0

--- a/scripts/sync_hooks.py
+++ b/scripts/sync_hooks.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Sync the intentionally-duplicated hook-shipped files from their canonical
+sources.
+
+Some hook files are deliberately duplicated: standalone host adapters cannot
+import the venv-only ``daimon_briefing`` package, so a copy of ``redact.py``
+(and the packaged adapter scripts) has to sit next to them. Edit the canonical
+source, then run this script to propagate the change byte-for-byte:
+
+    uv run python scripts/sync_hooks.py
+
+``--check`` reports drift and exits non-zero without writing anything (CI use).
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Single source of truth for the hook-file mirror topology: (canonical source,
+# copy that must stay byte-identical), both repo-root-relative. The drift guard
+# in plugin/tests/test_hooks_install.py imports this — do not keep a second list.
+SYNC_PAIRS = (
+    ("plugin/daimon_briefing/redact.py", "plugin/daimon_briefing/_hooks/redact.py"),
+    ("plugin/daimon_briefing/redact.py", "hook/redact.py"),
+    ("hook/daimon-windsurf-hooks.py", "plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py"),
+    ("hook/_daimon_hook_lib.py", "plugin/daimon_briefing/_hooks/_daimon_hook_lib.py"),
+)
+
+
+def _drifted(root):
+    """Return the (src, dst) pairs whose copy differs from its canonical source."""
+    out = []
+    for src, dst in SYNC_PAIRS:
+        source_path = root / src
+        if not source_path.exists():
+            sys.exit(f"manifest error: canonical source missing: {src}")
+        source = source_path.read_bytes()
+        copy = root / dst
+        if not copy.exists() or copy.read_bytes() != source:
+            out.append((src, dst))
+    return out
+
+
+def check(root=REPO_ROOT):
+    drifted = _drifted(root)
+    if drifted:
+        print("hook copies out of sync (run: uv run python scripts/sync_hooks.py):")
+        for src, dst in drifted:
+            print(f"  {dst}  <-  {src}")
+        return 1
+    print("hook copies in sync")
+    return 0
+
+
+def sync(root=REPO_ROOT):
+    drifted = _drifted(root)
+    for src, dst in drifted:
+        (root / dst).write_bytes((root / src).read_bytes())
+        print(f"synced {dst}  <-  {src}")
+    if not drifted:
+        print("hook copies already in sync")
+    return 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Sync hook-shipped duplicate files.")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="report drift and exit non-zero; write nothing",
+    )
+    args = parser.parse_args(argv)
+    return check(REPO_ROOT) if args.check else sync(REPO_ROOT)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #149

### What

Adds `scripts/sync_hooks.py` — one command to propagate the intentionally-duplicated hook-shipped files from their canonical sources, byte-for-byte:

- `plugin/daimon_briefing/redact.py` → `plugin/daimon_briefing/_hooks/redact.py` + `hook/redact.py`
- `hook/daimon-windsurf-hooks.py`, `hook/_daimon_hook_lib.py` → `plugin/daimon_briefing/_hooks/`

`--check` reports drift and exits non-zero without writing anything.

### Why

The duplication is deliberate (host adapters run under the host's Python and cannot import the venv-only package) and the drift tests already gate byte-identity in CI — but the copy step itself was manual. Recent redaction pattern work meant applying the same edit three times by hand.

### How

- Mirror topology lives in one place: `SYNC_PAIRS` in the script. `test_hooks_install.py` now derives its `_SHIPPED` list from that manifest — no second hand-maintained list; a new mirrored file joins the sync and the drift tests together.
- Missing canonical source = clear error, not a traceback.
- `hook/README.md` documents the workflow: edit canonical → run sync → commit.
- New `plugin/tests/test_sync_hooks.py` (7 tests): --check detects drift / writes nothing, sync repairs to byte-identity, clean tree is a no-op (mtime-guarded), real-repo check stays clean.

### Notes

- No packaging or runtime change: wheel ships only `daimon_briefing`; `daimon hooks install` untouched. Existing drift tests unchanged in meaning.
- TDD: tests written first (red: `ModuleNotFoundError: No module named 'sync_hooks'`), then implementation to green.
- Full suite: 1080 passed. Ruff clean on changed files.
- Pre-existing dead `import os` in `test_hooks_install.py` removed (CI lints only `daimon_briefing`, so it had never been flagged).