### PR TITLE
fix(teamsync): scope sync commit to the author's own directory

### DIFF
--- a/plugin/daimon_briefing/teamsync.py
+++ b/plugin/daimon_briefing/teamsync.py
@@ -154,9 +154,15 @@ def _identity_extra(sidecar) -> list[str]:
             "-c", f"user.email={store.project_slug(author)}@daimon.invalid"]
 
 
-def _commit(sidecar, message) -> subprocess.CompletedProcess:
+def _commit(sidecar, message, pathspec) -> subprocess.CompletedProcess:
+    """Pathspec-scoped commit (#144). A bare `git commit` snapshots the WHOLE
+    index — anything the user happened to have pre-staged in the sidecar would
+    be swept into the append-only team branch. The pathspec limits the commit
+    to the caller's own paths and leaves every other index entry exactly as it
+    was (git's partial-commit semantics)."""
     return _run_git(
-        ["git", "-C", str(sidecar), *_identity_extra(sidecar), "commit", "-m", message],
+        ["git", "-C", str(sidecar), *_identity_extra(sidecar),
+         "commit", "-m", message, "--", pathspec],
         GIT_TIMEOUT,
     )
 
@@ -201,7 +207,7 @@ def init(url: str) -> Path:
     if _head(dest) is None:  # unborn branch: the remote was empty
         (dest / "README.md").write_text(_STUB_README, encoding="utf-8")
         _git(dest, "add", "--", "README.md")
-        cp = _commit(dest, "sync: initialize team memory sidecar")
+        cp = _commit(dest, "sync: initialize team memory sidecar", "README.md")
         if cp.returncode != 0:
             raise TeamError(f"could not seed root commit: {_last_line(cp.stderr or cp.stdout)}")
         push = _git(dest, "push", "-u", "origin", _branch(dest), timeout=NET_TIMEOUT)
@@ -240,12 +246,15 @@ def _commit_own(sidecar, report) -> None:
     status = _git(sidecar, "status", "--porcelain", "--", own_dir)
     if status.returncode != 0 or not status.stdout.strip():
         return
-    _git(sidecar, "add", "--", own_dir)
-    staged = _git(sidecar, "diff", "--cached", "--name-only")
+    if _git(sidecar, "add", "--", own_dir).returncode != 0:
+        return
+    # Count scoped to the own dir (#144): the index may carry unrelated
+    # pre-staged entries, and the commit below deliberately excludes them.
+    staged = _git(sidecar, "diff", "--cached", "--name-only", "--", own_dir)
     n = len([ln for ln in staged.stdout.splitlines() if ln.strip()])
     if not n:
         return
-    cp = _commit(sidecar, f"sync: {config.author()} {n} checkpoint(s)")
+    cp = _commit(sidecar, f"sync: {config.author()} {n} checkpoint(s)", own_dir)
     if cp.returncode == 0:
         report["committed"] = n
     else:

--- a/plugin/tests/test_teamsync.py
+++ b/plugin/tests/test_teamsync.py
@@ -151,6 +151,27 @@ def test_sync_never_touches_other_authors_paths(bare_remote, monkeypatch):
     assert "authors/Bob/S9.json" not in _bare_files(bare_remote)
 
 
+def test_sync_commit_excludes_prestaged_unrelated_paths(bare_remote, monkeypatch):
+    # #144: a bare `git commit` sweeps EVERYTHING in the index. If anything
+    # unrelated was pre-staged in the sidecar when a sync fires, it must NOT be
+    # published to the team branch, must NOT inflate the reported count, and
+    # must still be staged (exactly as the user left it) after the sync.
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    sidecar = teamsync.init(str(bare_remote))
+    (sidecar / "notes.txt").write_text("not for the team\n", encoding="utf-8")
+    _git(sidecar, "add", "--", "notes.txt")
+    _write_team_file(sidecar, "Ada", "S1.json")
+    r = teamsync.sync_remote(sidecar)
+    assert r["committed"] == 1        # own-dir count, not index-wide
+    committed = set(
+        _git(sidecar, "diff", "--name-only", "HEAD~1", "HEAD").stdout.split()
+    )
+    assert committed == {"authors/Ada/S1.json"}
+    assert "notes.txt" not in _bare_files(bare_remote)
+    staged = _git(sidecar, "diff", "--cached", "--name-only").stdout.split()
+    assert staged == ["notes.txt"]    # pre-staged entry survives untouched
+
+
 def test_sync_nothing_to_do_is_clean_noop(bare_remote, monkeypatch):
     monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
     sidecar = teamsync.init(str(bare_remote))

--- a/plugin/tests/test_teamsync.py
+++ b/plugin/tests/test_teamsync.py
@@ -172,6 +172,24 @@ def test_sync_commit_excludes_prestaged_unrelated_paths(bare_remote, monkeypatch
     assert staged == ["notes.txt"]    # pre-staged entry survives untouched
 
 
+def test_sync_failed_add_aborts_commit(bare_remote, monkeypatch):
+    # #144: if staging the own dir fails, committing would publish whatever
+    # stale state the index happens to hold — abort instead.
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    sidecar = teamsync.init(str(bare_remote))
+    _write_team_file(sidecar, "Ada", "S1.json")
+    real_git = teamsync._git
+
+    def failing_add(cwd, *args, **kwargs):
+        if args and args[0] == "add":
+            return subprocess.CompletedProcess(args, 1, stdout="", stderr="add failed")
+        return real_git(cwd, *args, **kwargs)
+
+    monkeypatch.setattr(teamsync, "_git", failing_add)
+    r = teamsync.sync_remote(sidecar)
+    assert r["committed"] == 0
+
+
 def test_sync_nothing_to_do_is_clean_noop(bare_remote, monkeypatch):
     monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
     sidecar = teamsync.init(str(bare_remote))


### PR DESCRIPTION
Closes #144

### Problem

`_commit()` ran a bare `git commit` while `_commit_own()` staged only the member's own directory. Anything the user had pre-staged in the sidecar index was swept into the append-only team branch — breaking the disjoint-paths invariant that makes team sync conflict-free — and the reported item count was index-wide.

### Fix

- `_commit()` takes a required pathspec and commits `-- authors/<own>` through the existing `_run_git` choke point (#137 timeout/rc=124 degradation contract untouched; verified partial commit works on unborn HEAD for the `init()` seed path, and `_recover_wedge`'s merge-abort ordering keeps the no-partial-commit-during-merge failure out of reach).
- Reported count derives from `git diff --cached --name-only -- <own_dir>` — own-directory changes only.
- A failed `git add` now aborts the commit instead of proceeding to commit stale index state (review finding).

Rejected alternatives: temporary index (`GIT_INDEX_FILE`) and `commit-tree` plumbing — both bypass the `_run_git`/identity choke points and add multi-call raciness against the sidecar's index serialization, solving nothing the pathspec doesn't.

### Tests

New regression: pre-stage an unrelated file in the sidecar → sync → team-branch commit tree contains exactly the own-author checkpoint, count == 1, the unrelated file is absent from the remote and still the sole staged entry afterward. TDD red first (`assert 2 == 1` — count was index-wide, commit swept the file).

Full suite: 1081 passed. Teamsync suite 38/38 including all #136/#137 timeout tests. Ruff clean on changed files.