### PR TITLE
fix(redact): close plaintext log seams outside the redaction choke point

### DIFF
--- a/hook/README.md
+++ b/hook/README.md
@@ -71,6 +71,12 @@ venv-only `daimon_briefing` package. Re-run `daimon hooks install <host>`
 after every `daimon` upgrade so the installed scripts (and the bundled
 `redact.py`) stay in sync with the installed CLI.
 
+Redaction scope is **disk-only** by design: every artifact that persists
+(checkpoints, event log, transcript accumulation, probe dumps, diagnostic
+logs) is scrubbed at its write site, while the serializer's LLM backend still
+receives the raw transcript text — that backend is the egress point the user
+configures, not a disk artifact.
+
 ## Drift guard
 
 Canonical adapter sources live here in `hook/`; the Claude Code plugin and

--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -13,7 +13,7 @@ import time
 import urllib.error
 import urllib.request
 
-from . import config
+from . import config, redact
 
 log = logging.getLogger(__name__)
 
@@ -254,8 +254,11 @@ def _chat_command(messages, deadline):
                 d = config.log_dir()
                 d.mkdir(parents=True, exist_ok=True)
                 p = d / "backend-stderr.log"
+                # CLI backends can echo prompt fragments (transcript text)
+                # into stderr — scrub before it persists (#141).
+                err_logged, _ = redact.redact_text(err or "")
                 p.write_text(
-                    f"command backend exit {rc} (argv0: {argv[0]})\n{err or ''}\n",
+                    f"command backend exit {rc} (argv0: {argv[0]})\n{err_logged}\n",
                     encoding="utf-8")
                 hint = f"stderr: {p}"
             except OSError:

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -18,7 +18,7 @@ import re
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-from . import config, llm
+from . import config, llm, redact
 
 # No handlers/basicConfig here — the library stays silent unless the caller
 # configures logging. Multi-hour serialize runs need this heartbeat to be killable.
@@ -421,10 +421,12 @@ def verify_quotes(checkpoint, transcript_text: str) -> int:
     """Verify every verbatim item's quote against the rendered transcript, in
     place (#125). On a hit the item gets `quote_verified: true`; on a miss it is
     downgraded to trust="inferred" with `quote_verified: false` and the downgrade
-    is logged (count + item-text prefix). Items already trust="inferred" are left
-    untouched — no stamp. Runs ONCE at serialize, PRE-redaction, so the quote is
-    still the raw text (a quote whose secret redaction will later mask still
-    verifies here against the raw rendered text). Returns the downgrade count."""
+    is logged (count + redacted item-text prefix — this runs pre-redaction, so
+    the raw text must not reach a log sink; #141). Items already trust="inferred"
+    are left untouched — no stamp. Runs ONCE at serialize, PRE-redaction, so the
+    quote is still the raw text (a quote whose secret redaction will later mask
+    still verifies here against the raw rendered text). Returns the downgrade
+    count."""
     downgraded = 0
     for item in iter_items(checkpoint):
         if item.get("trust") != "verbatim":
@@ -438,8 +440,12 @@ def verify_quotes(checkpoint, transcript_text: str) -> int:
             item["trust"] = "inferred"
             item["quote_verified"] = False
             downgraded += 1
+            # Log-line-only scrub: item ids are not stamped until store-save,
+            # so the text prefix is the only diagnostic handle here. The item
+            # itself stays raw (store redacts it; ids hash redacted text).
+            logged, _ = redact.redact_text(item.get("text") or "")
             log.warning("quote verification: downgraded verbatim->inferred: %.80s",
-                        item.get("text") or "")
+                        logged)
     if downgraded:
         log.info("quote verification: %d verbatim item(s) downgraded to inferred",
                  downgraded)

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -766,6 +766,9 @@ def append_event(item_ref: str, status: str, note: str = "",
     try:
         note, _ = redact.redact_text(note)
         item_text, _ = redact.redact_text(item_text)
+        # status is free-form by design (readers prefix-match, never enum) —
+        # so it can carry a secret-shaped value and must be scrubbed too (#141).
+        status, _ = redact.redact_text(status)
         path.parent.mkdir(parents=True, exist_ok=True)
         evt = {"ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                "kind": kind, "item_ref": item_ref, "status": status,

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -404,6 +404,23 @@ def test_command_backend_failure_writes_stderr_log(monkeypatch, tmp_path):
     assert "exit 101" in log.read_text()
 
 
+def test_command_backend_stderr_log_redacts_secret(monkeypatch, tmp_path):
+    # #141: CLI backends can echo prompt fragments (transcript text) into
+    # stderr on failure — the local stderr log is a disk artifact and must be
+    # scrubbed like every other write site.
+    secret = "AKIAIOSFODNN7EXAMPLE"
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "failing-cli")
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setattr(llm, "_run_command",
+                        lambda *a, **k: (1, "", f"prompt was: key {secret}"))
+    with pytest.raises(llm.ChatError):
+        llm.chat([{"role": "user", "content": "hola"}])
+    text = (tmp_path / "logs" / "backend-stderr.log").read_text()
+    assert secret not in text
+    assert "[redacted:aws-key]" in text
+
+
 def test_command_backend_stderr_log_truncates_per_run(monkeypatch, tmp_path):
     monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
     monkeypatch.setenv("DAIMON_LLM_COMMAND", "failing-cli")

--- a/plugin/tests/test_quote_verification.py
+++ b/plugin/tests/test_quote_verification.py
@@ -134,6 +134,24 @@ def test_verify_quotes_downgrades_on_miss(caplog):
     assert any("fabricated decision" in r.getMessage() for r in caplog.records)
 
 
+def test_verify_quotes_downgrade_log_redacts_secret(caplog):
+    # #141: the downgrade warning is the one verify_quotes line that carries
+    # item text, and it fires PRE-redaction — a secret inside a downgraded
+    # item must be scrubbed in the log line while the checkpoint item itself
+    # stays raw (store redacts it at write time, ids must hash redacted text).
+    secret = "AKIAIOSFODNN7EXAMPLE"
+    cp = _cp_with({("working_context", "recent_decisions"): [
+        {"text": f"rotate key {secret} next", "trust": "verbatim",
+         "quote": "this exact sentence is nowhere in the transcript at all"}]})
+    with caplog.at_level(logging.WARNING, logger="daimon_briefing.serializer"):
+        serializer.verify_quotes(cp, "assistant: something entirely unrelated")
+    msgs = [r.getMessage() for r in caplog.records]
+    assert not any(secret in m for m in msgs)
+    assert any("[redacted:aws-key]" in m for m in msgs)
+    item = cp["working_context"]["recent_decisions"][0]
+    assert item["text"] == f"rotate key {secret} next"  # log-only scrub
+
+
 def test_verify_quotes_leaves_inferred_items_unstamped():
     cp = _cp_with({("working_context", "recent_decisions"): [
         {"text": "d", "trust": "inferred", "quote": ""}]})

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1098,6 +1098,21 @@ def test_append_event_redacts_note_and_item_text(tmp_checkpoint_dir):
     assert "[redacted:aws-key]" in raw
 
 
+def test_append_event_redacts_status(tmp_checkpoint_dir):
+    # #141: note and item_text were scrubbed but status was written raw —
+    # status is free-form by design, so a secret-shaped value carried in it
+    # must not escape to events.jsonl.
+    from daimon_briefing import store
+    store.append_event("o-a", "blocked-on:AKIAIOSFODNN7EXAMPLE",
+                       project_dir="/p/A")
+    slug = store.project_slug("/p/A")
+    raw = (tmp_checkpoint_dir / slug / "events.jsonl").read_text()
+    assert "AKIAIOSFODNN7EXAMPLE" not in raw
+    # Resolution readers prefix-match status (resolved/reopen/...): redaction
+    # must scrub the payload without disturbing the prefix.
+    assert '"blocked-on:[redacted:aws-key]"' in raw
+
+
 def test_is_resolved_supersede_candidate_is_live():
     from daimon_briefing import store
     assert store.is_resolved({"status": "supersede-candidate:r-9f2c1a"}) is False

--- a/plugin/tests/test_windsurf_hooks.py
+++ b/plugin/tests/test_windsurf_hooks.py
@@ -321,6 +321,38 @@ def test_redact_payload_preserves_scalars():
         "n": 42, "f": 1.5, "b": True, "z": None}
 
 
+def test_redaction_unavailable_skips_and_persists_no_raw_text(tmp_path):
+    # #141 (pins the #109 skip branch): with redact.py missing at hook runtime
+    # — a stale install — the hook must skip instead of writing raw: exit 0,
+    # a skip line in serialize.log, and NO transcript-derived text on disk.
+    bare = tmp_path / "barehooks"
+    bare.mkdir()
+    for name in ("daimon-windsurf-hooks.py", "_daimon_hook_lib.py"):
+        (bare / name).write_bytes((HOOK_DIR / name).read_bytes())
+    fake_bin, capture = _fake_cli(tmp_path)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{VENV_BIN}{os.pathsep}{os.environ.get('PATH', '')}",
+        "HOME": str(tmp_path),
+        "DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL": "0",
+    }
+    payload = _post_payload(f"deploy with {_STRIPE} now")
+    proc = subprocess.run(
+        [sys.executable, str(bare / "daimon-windsurf-hooks.py")],
+        input=json.dumps(payload), capture_output=True, text=True,
+        env=env, timeout=30, cwd=str(tmp_path),
+    )
+    assert proc.returncode == 0  # fail-open: skip, never break Cascade
+    log = (tmp_path / ".daimon" / "logs" / "serialize.log").read_text(encoding="utf-8")
+    assert "redaction module unavailable" in log and "skipped" in log
+    assert not _transcript(tmp_path).exists()
+    assert not capture.exists() or "serialize" not in capture.read_text()
+    # the secret from the payload reached NO file under this HOME
+    for p in tmp_path.rglob("*"):
+        if p.is_file():
+            assert _STRIPE not in p.read_text(encoding="utf-8", errors="replace")
+
+
 def test_pre_user_prompt_docs_shape_appends_user_turn(tmp_path):
     # Documented shape (docs.devin.ai/desktop/cascade/hooks): text lives in
     # tool_info.user_prompt. Regression guard — passes on the current


### PR DESCRIPTION
Closes #141

### Problem

The disk redaction guarantee (#109) covers checkpoint writes, but three log seams wrote text to disk raw:

1. Quote-downgrade warning logged the item text to `serialize.log` **before** redaction (serializer.py)
2. Command-backend subprocess stderr written to `backend-stderr.log` unscrubbed (llm.py) — CLI backends can echo prompt fragments on failure
3. `append_event` redacted `note` and `item_text` but wrote the free-form `status` field raw to `events.jsonl` (store.py)

### Fix

All three seams now pass through `redact.redact_text` before touching disk. `redact.py` itself is untouched (mirror drift check clean).

Design notes:
- **Downgrade log redacts rather than drops the text prefix**: item ids are stamped at store-write time, so no id exists at verify time — the 80-char prefix is the only diagnostic handle. The checkpoint item itself stays raw at that point by design (store redacts at write; ids hash redacted text).
- **Status redaction can't break resolution semantics**: readers prefix-match `resolved`/`reopen`/`supersede-candidate`, which no pattern rewrites — a test pins the prefix surviving redaction of a payload (`blocked-on:[redacted:aws-key]`).
- `redact_text` is fail-open by contract (non-str passthrough, per-pattern guard — 'redaction must never cost the write'), so bare calls match every existing call site.

Also:
- Pins the windsurf hook's redaction-unavailable branch (last untested secret-to-disk path): subprocess test stages the hook files **without** `redact.py` in a sandboxed `HOME` — asserts exit 0, the skip is logged, and a recursive scan finds the payload secret in no file.
- Documents the disk-only scope of the guarantee (the serializer's LLM backend sees raw text by design) in `hook/README.md`.

### Tests

Four new tests, TDD red first (raw `AKIAIOSFODNN7EXAMPLE` asserted present in each target log before the fix). Full suite: **1084 passed**. Ruff clean on changed files. `scripts/sync_hooks.py --check`: in sync.