### PR TITLE
fix(store): make same-second resolution ties content-deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,15 @@ jobs:
         # fails loudly instead of silently touching a real ~/.daimon.
         run: |
           mkdir -p "$RUNNER_TEMP/fake-home"
-          HOME="$RUNNER_TEMP/fake-home" uv run --extra dev --extra pretty pytest -q --cov=daimon_briefing --cov-report=xml
+          HOME="$RUNNER_TEMP/fake-home" uv run --extra dev --extra pretty pytest -q --cov=daimon_briefing --cov-report=xml --junitxml=junit.xml
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./plugin/junit.xml
+          flags: py${{ matrix.python-version }}
 
       - name: Upload coverage to Codecov
         # Reporting only — no coverage threshold gates the build yet. The

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -781,11 +781,41 @@ def append_event(item_ref: str, status: str, note: str = "",
         return False
 
 
+def _tie_rank(evt: dict) -> int:
+    """Same-second precedence (#143), from event content only. reopen beats
+    resolving: when order is unknowable the item stays visible — hiding a
+    live item costs more than showing a resolved one. supersede-candidate
+    loses to everything: a machine SUGGESTION must never shadow a same-second
+    definitive statement (mirrors is_resolved's no-suppression rule)."""
+    status = str(evt.get("status") or "").lower()
+    if status.startswith("supersede-candidate"):
+        return 0
+    if status.startswith("reopen"):
+        return 2
+    return 1
+
+
+def _tie_wins(new_evt: dict, cur_evt: dict) -> bool:
+    """Same-second tie rule (#143), derived from event CONTENT only so the
+    fold is identical under any line order (concurrent writers interleave;
+    a future log rewrite may reorder). Higher _tie_rank wins; equal ranks
+    fall to canonical-JSON comparison: arbitrary, but deterministic."""
+    new_r, cur_r = _tie_rank(new_evt), _tie_rank(cur_evt)
+    if new_r != cur_r:
+        return new_r > cur_r
+    return (json.dumps(new_evt, sort_keys=True, ensure_ascii=False)
+            > json.dumps(cur_evt, sort_keys=True, ensure_ascii=False))
+
+
 def resolutions(project_dir=None) -> dict:
     """events.jsonl -> {item_ref: latest event} — latest by ts, NEVER line
-    order (concurrent writers may interleave). Unknown kinds and extra
-    fields ride along untouched; unparseable lines are skipped best-effort:
-    a reader must never drop the log over one bad line."""
+    order (concurrent writers may interleave, and a rewritten/reordered log
+    must fold identically). Equal-ts ties break on content via _tie_wins
+    (#143): reopen > resolving > supersede-candidate, then canonical-JSON
+    order — never the line's position in the file. Unknown
+    kinds and extra fields ride along untouched; unparseable lines are
+    skipped best-effort: a reader must never drop the log over one bad
+    line."""
     out: dict = {}
     path = _events_path(project_dir)
     if path is None:
@@ -805,9 +835,15 @@ def resolutions(project_dir=None) -> dict:
         if not ref:
             continue
         cur = out.get(ref)
+        if cur is None:
+            out[ref] = evt
+            continue
         new_e = _created_epoch(evt.get("ts"))
-        cur_e = _created_epoch(cur.get("ts")) if cur else None
-        if cur is None or (new_e is not None and (cur_e is None or new_e >= cur_e)):
+        if new_e is None:
+            continue  # an unstamped event never displaces a stamped one
+        cur_e = _created_epoch(cur.get("ts"))
+        if (cur_e is None or new_e > cur_e
+                or (new_e == cur_e and _tie_wins(evt, cur))):
             out[ref] = evt
     return out
 

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1,8 +1,9 @@
 import json
 import re
+import time as _time
 from pathlib import Path
 
-from daimon_briefing import serializer, store
+from daimon_briefing import config, serializer, store
 
 _ISO_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 
@@ -460,8 +461,6 @@ def test_gc_orders_by_created_stamp_with_mtime_fallback(tmp_checkpoint_dir, monk
 
 # ---- team memory (#111): author stamping, dual-write, read_team ----
 
-from daimon_briefing import config
-
 
 def _team_author_dir(author_slug: str) -> Path:
     return config.team_dir() / "local" / "authors" / author_slug
@@ -610,9 +609,6 @@ def test_read_team_never_raises_on_garbage(tmp_checkpoint_dir, monkeypatch):
 
 
 # ---- team retention (#113): read-time age filter, NO physical deletes ----
-
-
-import time as _time
 
 
 def _stamped(sample_checkpoint, sid, days_ago):
@@ -968,22 +964,71 @@ def test_resolutions_missing_file_or_project_is_empty(tmp_checkpoint_dir):
     assert store.resolutions(project_dir=None) == {}
 
 
-def test_resolutions_equal_timestamp_tie_break_last_line_wins(tmp_checkpoint_dir):
-    # CONTRACT (pinned, not a preference): when two events for the SAME
-    # item_ref share a timestamp, the fold keeps the one appearing LATER in
-    # file order. The fold replaces on `new_e >= cur_e`, so an equal ts lets
-    # each subsequent line overwrite — the last write to the log wins the tie.
+def test_resolutions_equal_timestamp_live_wins_both_orders(tmp_checkpoint_dir):
+    # CONTRACT (pinned, #143): when two events for the SAME item_ref share a
+    # timestamp, the tie-break derives from event CONTENT, never file order —
+    # a live-making event (reopen) beats a resolving one in BOTH append
+    # orders. Line order must not matter: concurrent writers interleave and
+    # a future log rewrite/compaction may reorder lines.
     from daimon_briefing import store
     slug = store.project_slug("/p/A")
     d = tmp_checkpoint_dir / slug
     d.mkdir(parents=True, exist_ok=True)
-    (d / "events.jsonl").write_text(
-        '{"ts": "2026-07-07T10:00:00Z", "item_ref": "o-a", "status": "resolved", "note": "first"}\n'
-        '{"ts": "2026-07-07T10:00:00Z", "item_ref": "o-a", "status": "reopened", "note": "second"}\n'
-    )
+    reopen = '{"ts": "2026-07-07T10:00:00Z", "item_ref": "o-a", "status": "reopened", "note": "back"}\n'
+    resolve = '{"ts": "2026-07-07T10:00:00Z", "item_ref": "o-a", "status": "resolved", "note": "done"}\n'
+
+    (d / "events.jsonl").write_text(reopen + resolve)
     r = store.resolutions(project_dir="/p/A")
     assert r["o-a"]["status"] == "reopened"
-    assert r["o-a"]["note"] == "second"
+    assert store.is_resolved(r["o-a"]) is False
+
+    (d / "events.jsonl").write_text(resolve + reopen)
+    r = store.resolutions(project_dir="/p/A")
+    assert r["o-a"]["status"] == "reopened"
+    assert store.is_resolved(r["o-a"]) is False
+
+
+def test_resolutions_equal_timestamp_candidate_loses_both_orders(tmp_checkpoint_dir):
+    # A supersede-candidate is a machine SUGGESTION — at an equal timestamp
+    # it loses to ANY definitive statement (reopen or resolve), in both
+    # append orders. Otherwise a same-second suggestion could shadow a human
+    # verdict whenever the two land in the same second (e.g. reverify right
+    # after serialize).
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    d = tmp_checkpoint_dir / slug
+    d.mkdir(parents=True, exist_ok=True)
+    cand = ('{"ts": "2026-07-07T10:00:00Z", "item_ref": "o-a",'
+            ' "status": "supersede-candidate:o-x", "source": "serializer"}\n')
+    reopen = ('{"ts": "2026-07-07T10:00:00Z", "item_ref": "o-a",'
+              ' "status": "reopened", "source": "cli"}\n')
+    resolve = ('{"ts": "2026-07-07T10:00:00Z", "item_ref": "o-a",'
+               ' "status": "resolved", "source": "cli"}\n')
+
+    for log in (cand + reopen, reopen + cand):
+        (d / "events.jsonl").write_text(log)
+        assert store.resolutions(project_dir="/p/A")["o-a"]["status"] == "reopened"
+    for log in (cand + resolve, resolve + cand):
+        (d / "events.jsonl").write_text(log)
+        assert store.resolutions(project_dir="/p/A")["o-a"]["status"] == "resolved"
+
+
+def test_resolutions_equal_timestamp_same_class_tie_is_order_independent(tmp_checkpoint_dir):
+    # Two events of the SAME liveness class at the same second must fold to
+    # the same winner regardless of append order (content-derived tie-break,
+    # not line order) — so a reordered log yields an identical fold.
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    d = tmp_checkpoint_dir / slug
+    d.mkdir(parents=True, exist_ok=True)
+    a = '{"ts": "2026-07-07T10:00:00Z", "item_ref": "o-a", "status": "resolved", "note": "alpha"}\n'
+    b = '{"ts": "2026-07-07T10:00:00Z", "item_ref": "o-a", "status": "resolved", "note": "beta"}\n'
+
+    (d / "events.jsonl").write_text(a + b)
+    winner_ab = store.resolutions(project_dir="/p/A")["o-a"]
+    (d / "events.jsonl").write_text(b + a)
+    winner_ba = store.resolutions(project_dir="/p/A")["o-a"]
+    assert winner_ab == winner_ba
 
 
 def test_resolutions_invalid_utf8_bytes_return_empty(tmp_checkpoint_dir):

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1031,6 +1031,25 @@ def test_resolutions_equal_timestamp_same_class_tie_is_order_independent(tmp_che
     assert winner_ab == winner_ba
 
 
+def test_resolutions_skips_unstamped_nondict_and_refless_events(tmp_checkpoint_dir):
+    # An unstamped event must never displace a stamped one, and non-dict or
+    # item_ref-less lines ride through without poisoning the fold.
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    d = tmp_checkpoint_dir / slug
+    d.mkdir(parents=True, exist_ok=True)
+    lines = (
+        '{"ts": "2026-07-07T10:00:00Z", "item_ref": "o-a", "status": "resolved"}\n'
+        '{"ts": "not-a-timestamp", "item_ref": "o-a", "status": "reopened"}\n'
+        '"just a string"\n'
+        '{"ts": "2026-07-07T11:00:00Z", "status": "reopened"}\n'
+    )
+    (d / "events.jsonl").write_text(lines)
+    out = store.resolutions(project_dir="/p/A")
+    assert out["o-a"]["status"] == "resolved"  # unstamped reopen didn't displace
+    assert list(out) == ["o-a"]
+
+
 def test_resolutions_invalid_utf8_bytes_return_empty(tmp_checkpoint_dir):
     # A corrupt log (invalid UTF-8) must fail open like a missing file, never
     # raise UnicodeDecodeError out of the read path — a reader can never let


### PR DESCRIPTION
Closes #143

### Problem

`resolutions()` folded same-second events by file order (`>=` over line iteration) while its own docstring forbids relying on line order. A same-second reopen+resolve was decided by append order, and anything that rewrites `events.jsonl` (the planned #106 compaction) could silently flip resolution outcomes.

### Fix

Explicit precedence derived purely from event content — no positional dependence:

1. `reopen` beats resolving statuses: when order is unknowable, hiding a live item costs more than showing a resolved one.
2. `supersede-candidate` loses to everything: a machine suggestion must never shadow a same-second human verdict — the same asymmetry `is_resolved()` already encodes.
3. Equal-rank ties fall to canonical-JSON comparison (`sort_keys=True`): arbitrary but deterministic.

Because the rule depends on nothing positional, the fold is identical under any line reordering — #106 can compact/reorder `events.jsonl` freely. Unstamped events no longer displace stamped ones (tightens a hole in the old fold). Docstring aligned with the new contract.

Why not a per-line seq number: global monotonicity needs read-before-append (races the concurrent interleaving the docstring already anticipates), and legacy lines without `seq` would need a precedence fallback anyway — option (a) buys schema evolution plus the same rule.

### Tests

Replaces the test that pinned last-line-wins (the contract this issue overturns) with three both-orders tests: live-wins, candidate-loses, same-class-order-independent. Rank prefixes match `is_resolved()` exactly. Side effect: an intermittent same-second flake in `test_cli.py` reverify tests becomes deterministic. Full suite: **1082 passed**, ruff clean.

### Also

Second commit adds JUnit test-results upload to Codecov (`--junitxml` + `codecov/test-results-action@v1`), mirroring the existing coverage upload — token-gated, never turns CI red.