### PR TITLE
chore: fsync env writes + pin anchor syntax-error degrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,18 @@ jobs:
         # fails loudly instead of silently touching a real ~/.daimon.
         run: |
           mkdir -p "$RUNNER_TEMP/fake-home"
-          HOME="$RUNNER_TEMP/fake-home" uv run --extra dev --extra pretty pytest -q --cov=daimon_briefing --cov-report=xml
+          HOME="$RUNNER_TEMP/fake-home" uv run --extra dev --extra pretty pytest -q --cov=daimon_briefing --cov-report=xml --junitxml=junit.xml
+
+      - name: Upload test results to Codecov
+        if: ${{ matrix.python-version == '3.13' && !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./plugin/junit.xml
+          flags: py${{ matrix.python-version }}
 
       - name: Upload coverage to Codecov
+        if: ${{ matrix.python-version == '3.13' && !cancelled() }}
         # Reporting only — no coverage threshold gates the build yet. The
         # upload no-ops gracefully when CODECOV_TOKEN is unset, so a missing
         # secret never turns CI red.

--- a/plugin/daimon_briefing/configure.py
+++ b/plugin/daimon_briefing/configure.py
@@ -56,7 +56,7 @@ def write_env(updates: dict) -> Path:
     sorted KEY=VALUE lines, preserving unrelated pre-existing keys.
 
     The file is machine-managed: comments/order are NOT preserved (normalized).
-    Written atomically (temp + os.replace) and chmod 600 — it holds API keys.
+    Written atomically (temp + fsync + os.replace) and chmod 600 — it holds API keys.
     Empty merge result -> no file is created (the claude zero-config case writes
     nothing). Returns the target path either way.
     """
@@ -70,6 +70,9 @@ def write_env(updates: dict) -> Path:
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(body)
+            f.flush()
+            os.fsync(f.fileno())  # durable before replace: a power cut must
+            # never leave a truncated env file (it holds the backend config)
         os.replace(tmp, path)
     except BaseException:
         try:

--- a/plugin/tests/test_anchor.py
+++ b/plugin/tests/test_anchor.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from daimon_briefing import anchor
 
 _SRC = '''
@@ -119,6 +117,67 @@ def test_drifted_does_not_raise_on_malformed_anchor(tmp_path):
     out = anchor.drifted(checkpoint, tmp_path)  # must not raise
     assert [d["item"]["text"] for d in out] == ["broken"]
     assert out[0]["kind"] == "hard"
+
+
+# ---- target file with syntax errors (hot path: drift scan runs on every brief) ----
+
+_BROKEN_SRC = "def foo(:\n    return x + 1\n"  # unparseable on any Python version
+
+
+def test_check_hard_when_target_file_has_syntax_error(tmp_path):
+    # An anchored file that no longer parses is unverifiable — degrade to "hard"
+    # (fail toward verify-before-trusting), never raise.
+    _write(tmp_path, "m.py", _SRC)
+    a = anchor.resolve(tmp_path, "m.py", "foo")
+    _write(tmp_path, "m.py", _BROKEN_SRC)
+    assert anchor.check(a, tmp_path) == "hard"
+
+
+def test_body_hash_of_returns_none_on_syntax_error():
+    assert anchor.body_hash_of(_BROKEN_SRC, "foo") is None
+
+
+def test_drifted_degrades_on_syntax_error_file(tmp_path):
+    _write(tmp_path, "m.py", _SRC)
+    a = anchor.resolve(tmp_path, "m.py", "foo")
+    _write(tmp_path, "m.py", _BROKEN_SRC)
+    checkpoint = {
+        "working_context": {
+            "active_topic": {"text": "t", "trust": "inferred"},
+            "open_questions": [
+                {"text": "q-broken-file", "trust": "inferred", "anchored_to": a}
+            ],
+            "recent_decisions": [],
+        },
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []},
+    }
+    out = anchor.drifted(checkpoint, tmp_path)  # must not raise
+    assert [(d["item"]["text"], d["kind"]) for d in out] == [("q-broken-file", "hard")]
+
+
+def test_brief_render_survives_syntax_error_in_anchored_file(tmp_path, capsys):
+    # End-to-end pin: brief render over a drift scan that hit an unparseable
+    # file must not traceback — the item surfaces as GONE drift.
+    from daimon_briefing import render
+
+    _write(tmp_path, "m.py", _SRC)
+    a = anchor.resolve(tmp_path, "m.py", "foo")
+    _write(tmp_path, "m.py", _BROKEN_SRC)
+    checkpoint = {
+        "working_context": {
+            "active_topic": {"text": "t", "trust": "inferred"},
+            "open_questions": [
+                {"text": "q-broken-file", "trust": "inferred", "anchored_to": a}
+            ],
+            "recent_decisions": [],
+        },
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []},
+    }
+    drift = anchor.drifted(checkpoint, tmp_path)
+    render.render_brief(checkpoint, drift=drift)  # must not raise
+    out = capsys.readouterr().out
+    assert "CODE DRIFT" in out
+    assert "[GONE] q-broken-file" in out
 
 
 def test_drifted_collects_soft_drift(tmp_path):

--- a/plugin/tests/test_configure.py
+++ b/plugin/tests/test_configure.py
@@ -1,4 +1,4 @@
-import stat
+import os
 
 import pytest
 
@@ -143,6 +143,34 @@ def test_write_env_empty_updates_no_file(tmp_path, monkeypatch):
     out = configure.write_env({})
     assert not env_file.exists()  # nothing to persist -> no empty file created
     assert out == env_file
+
+
+def test_write_env_fsyncs_temp_file_before_replace(tmp_path, monkeypatch):
+    # Durability: without an fsync before os.replace, a power cut can leave a
+    # truncated/empty env file — silently unconfiguring the backend on next boot.
+    env_file = tmp_path / "env"
+    monkeypatch.setenv("DAIMON_ENV_FILE", str(env_file))
+
+    events = []
+    real_fsync, real_replace = os.fsync, os.replace
+
+    def spy_fsync(fd):
+        events.append("fsync")
+        return real_fsync(fd)
+
+    def spy_replace(src, dst):
+        events.append("replace")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(configure.os, "fsync", spy_fsync)
+    monkeypatch.setattr(configure.os, "replace", spy_replace)
+
+    configure.write_env({"DAIMON_LLM_API_KEY": "sk-1"})
+
+    assert "fsync" in events, "temp file must be fsynced before it replaces the env file"
+    assert "replace" in events
+    assert events.index("fsync") < events.index("replace")
+    assert env_file.read_text(encoding="utf-8") == "DAIMON_LLM_API_KEY=sk-1\n"
 
 
 def test_write_env_sorted_lines(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #148

### What

1. **Env write durability**: `write_env` wrote the temp file and `os.replace`d it with no sync — a power cut at the wrong moment could truncate `.env`, leaving daimon silently unconfigured on next boot. Now `flush` + `os.fsync` precede the replace. Directory-entry fsync deliberately **not** added: the store's atomic checkpoint write accepts the same rename-durability window; diverging here would fork the idiom (if we ever want dir-fsync, it belongs in both places as its own change).
2. **Anchor syntax-error degrade pinned**: the scan's unparseable-file path (`ast.parse` → `None` hash → `hard` → renders `[GONE]`) was already graceful but had zero tests on a path every brief render hits. Four tests now hold it, including one true end-to-end (`anchor.drifted` on a syntax-error file → `render.render_brief` → no traceback, `[GONE]` in output).

TDD: fsync test red first (`assert 'fsync' in ['replace']`); anchor tests green on first run — that's the pin confirming existing degrade, the red cycle was demonstrated where the gap was real.

### Also

Second commit: codecov uploads (coverage + test results) restricted to the py3.13 matrix leg. Coverage is identical across legs — no version-conditional code in the package — so the second upload added only flag noise and double patch-status reporting.

### Verification

Full suite: **1085 passed** (+5). Ruff clean on changed files. Both commits signed.