### PR TITLE
fix(briefing): stop fuzzy-withholding live items against id-bearing closed loops

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -138,6 +138,8 @@ def build(checkpoint, now=None) -> dict | None:
 # emits and carry._ID_SHAPE recognizes — duplicated rather than imported
 # because carry's copy is unbounded ({6,}) and this one fullmatches
 # attacker-adjacent event text, where bounded quantifiers are the rule.
+# Also gates the fuzzy pool (#145): a resolution ref of this shape belongs
+# to a stamped item, whose suppression is exact-id-only.
 _CANDIDATE_ID_SHAPE = re.compile(r"[a-z]-[0-9a-f]{6,40}(-\d+)?")
 
 
@@ -154,6 +156,9 @@ def withhold(checkpoint, resolutions: dict) -> tuple[dict, list, list]:
     coincidence (test_id_bearing_item_never_fuzzy_withheld). A fuzzy withhold
     of an id-bearing item would silently suppress a live memory that merely
     resembles a closed one — the worst failure mode this feature can have.
+    The pool is guarded symmetrically (#145): only resolutions whose OWN ref
+    is not id-shaped feed the fuzzy match, so a resolved id-bearing loop's
+    text can't fuzzy-suppress a live id-less item that merely resembles it.
 
     #14: a THIRD outcome — a "supersede-candidate:<new-id>" latest event is a
     machine SUGGESTION, not a resolution (store.is_resolved says so: it stays
@@ -190,8 +195,19 @@ def withhold(checkpoint, resolutions: dict) -> tuple[dict, list, list]:
 
     if not resolved_refs and not candidate_refs:
         return checkpoint, [], []
+    # #145: the fuzzy pool holds ONLY resolutions whose own ref is not
+    # id-shaped (legacy, pre-id-stamping events). An id-bearing resolution is
+    # fully handled by the exact id branch below — its text in this pool
+    # contributes nothing to correct suppression and only creates the false-
+    # positive surface where a live id-less item that merely RESEMBLES an
+    # unrelated closed loop gets silently withheld. Ref shape decides:
+    # store._stamp_item_ids only ever emits ids of this shape, so a
+    # non-matching ref cannot belong to a stamped item. When the shape read
+    # is wrong the item is shown, not withheld — fail-open.
+    fuzzy_refs = [ref for ref in resolved_refs
+                  if not _CANDIDATE_ID_SHAPE.fullmatch(str(ref))]
     resolved_texts = [str(resolutions[ref].get("item_text") or "").strip()
-                       for ref in resolved_refs]
+                       for ref in fuzzy_refs]
     resolved_texts = [t for t in resolved_texts if t]
 
     # Dry run over the ORIGINAL checkpoint — decide what would be withheld/
@@ -221,7 +237,7 @@ def withhold(checkpoint, resolutions: dict) -> tuple[dict, list, list]:
             if not text or not resolved_texts:
                 continue
             generic = carry._generic_terms(resolved_texts + [text])
-            for ref in resolved_refs:
+            for ref in fuzzy_refs:
                 evt = resolutions[ref]
                 cand_text = str(evt.get("item_text") or "").strip()
                 if cand_text and carry._same_item(text, cand_text, generic):

--- a/plugin/tests/test_briefing.py
+++ b/plugin/tests/test_briefing.py
@@ -626,6 +626,51 @@ def test_id_bearing_item_never_fuzzy_withheld():
     assert candidates == []
 
 
+def test_live_idless_item_survives_id_bearing_resolved_overlap():
+    # #145: the resolved loop carries a REAL stamped id (kind initial + hex,
+    # store._stamp_item_ids shape) — exact id match already covers it fully,
+    # so its text must not sit in the fuzzy pool where a live id-less legacy
+    # item that merely resembles it would be silently withheld.
+    cp = {"working_context": {"open_questions": [
+        {"text": "release pipeline approval step still awaiting manual gate"}]}}  # no id
+    ev = _res_evt("o-3f2a9c", text="release pipeline manual approval gate awaiting")
+    filtered, withheld, candidates = briefing.withhold(cp, {"o-3f2a9c": ev})
+    assert withheld == []
+    assert candidates == []
+    assert filtered["working_context"]["open_questions"] == \
+        cp["working_context"]["open_questions"]
+
+
+def test_idless_resolution_still_fuzzy_suppresses_among_id_bearing_ones():
+    # #145 pin: restricting the fuzzy pool to id-less resolutions must not
+    # break genuine legacy suppression — a resolved item whose OWN ref is not
+    # id-shaped still fuzzy-binds its id-less live twin, even when id-bearing
+    # resolutions sit alongside it in the same resolutions fold.
+    cp = {"working_context": {"open_questions": [
+        {"text": "release pipeline approval step still awaiting manual gate"}]}}  # no id
+    legacy_ev = _res_evt("pipeline gate loop",  # legacy ref: not id-shaped
+                         text="release pipeline manual approval gate awaiting")
+    id_ev = _res_evt("o-9bd41e", text="gateway retry budget confirmed stable")
+    filtered, withheld, candidates = briefing.withhold(
+        cp, {"pipeline gate loop": legacy_ev, "o-9bd41e": id_ev})
+    assert filtered["working_context"]["open_questions"] == []
+    assert len(withheld) == 1
+    assert withheld[0][2] is legacy_ev  # bound to the legacy event, not the id one
+    assert candidates == []
+
+
+def test_exact_id_suppression_unchanged_by_fuzzy_pool_restriction():
+    # #145 pin: excluding an id-bearing resolution from the FUZZY pool must
+    # not weaken its EXACT suppression — the item carrying that id still drops.
+    cp = {"working_context": {"open_questions": [
+        {"text": "release pipeline manual approval gate awaiting", "id": "o-3f2a9c"}]}}
+    ev = _res_evt("o-3f2a9c", text="release pipeline manual approval gate awaiting")
+    filtered, withheld, candidates = briefing.withhold(cp, {"o-3f2a9c": ev})
+    assert filtered["working_context"]["open_questions"] == []
+    assert len(withheld) == 1
+    assert candidates == []
+
+
 def test_no_resolved_events_returns_input_unchanged():
     cp = {"working_context": {"open_questions": [{"text": "x", "id": "o-a"}]}}
     filtered, withheld, candidates = briefing.withhold(cp, {})


### PR DESCRIPTION
Closes #145

### Problem

Withhold's fuzzy pool included every resolved loop's text. A live **id-less legacy item** (pre-id-stamping checkpoints) whose wording merely resembled an unrelated id-bearing CLOSED loop could be silently suppressed — a live memory hidden, the feature's documented worst case.

### Fix

Id-bearing resolutions are already suppressed by exact id match — their text bought no correct suppression, only false-positive surface. The fuzzy pool is now restricted to resolutions whose own ref is **not id-shaped**, applied to both the candidate text list and the iterated refs (restricting the text list alone would have been a no-op — the match loop pulled `item_text` from the refs directly; red test proved it).

Soundness: stamped ids are `{kind-initial}-{hex6..40}[-n]` by construction and `resolve` writes `item_ref` from the item id, so id-shaped ⇔ id-bearing. A misread shape errs toward showing the item — fail-open contract intact. Exact-id suppression checks the original unfiltered set (untouched, pinned). The pool shrinks naturally as pre-id checkpoints age out.

### Tests

TDD red first: live id-less item overlapping an id-bearing closed loop was withheld → now survives. Plus pins: legacy id-less resolution still fuzzy-suppresses its twin (even alongside id-bearing resolutions); exact-id suppression unchanged. Full suite: **1083 passed**, ruff clean.