### PR TITLE
fix(hooks): ledger in-process capture failures so status and heal see them

### DIFF
--- a/plugin/daimon_briefing/hooks.py
+++ b/plugin/daimon_briefing/hooks.py
@@ -1,7 +1,8 @@
-"""Hermes hook callbacks. Both hooks are defensive: a broken hook must NEVER break
-the user's session, so everything is wrapped — failures log and give up silently.
+"""Host hook callbacks for in-process capture. Both hooks are defensive: a
+broken hook must NEVER break the user's session, so everything is wrapped —
+failures log, leave a ledger entry in serialize.log, and give up.
 
-# VERIFIED website/docs/guides/build-a-hermes-plugin.md (hook callback signatures):
+# VERIFIED host plugin guide (hook callback signatures):
 #   on_session_end(session_id, completed, interrupted, model, platform, **kwargs)
 #   pre_llm_call(session_id, user_message, conversation_history, is_first_turn,
 #                model, platform, **kwargs) -> {"context": str} | str | None
@@ -9,6 +10,8 @@ the user's session, so everything is wrapped — failures log and give up silent
 
 import logging
 import time
+from datetime import datetime, timezone
+from pathlib import Path
 
 from . import briefing, config, harvest, llm, serializer, store, transcript
 
@@ -18,23 +21,67 @@ log = logging.getLogger("daimon_briefing")
 _chat = llm.chat
 
 
+def _ledger_failure(session_id, exc, elapsed, transcript_path=None):
+    """Append a failed capture to serialize.log — the ledger `daimon status`
+    and `daimon heal` parse. log.exception alone reaches nothing the CLI reads,
+    so a failed in-process capture used to be silent, uncounted, non-healable.
+
+    Two lines, byte-shaped like the spawn + result pair every spawned-CLI
+    capture leaves (cli._SPAWN_RE / cli._RESULT_ERR_RE round-trip), so the
+    per-session ledger attributes the failure and heal classifies it under its
+    NORMAL rules: transcript file on disk -> healable (one retry ever, #26);
+    none -> counted but not auto-repairable. The parser derives the session id
+    from the transcript token's stem, so a host-provided path is used only when
+    its stem IS the session id — otherwise the spawn and error lines would
+    split across two ledger entries. Best-effort: must never raise into the
+    hook's own never-raise contract."""
+    try:
+        path = str(transcript_path or "").strip()
+        if not path or Path(path).stem != session_id:
+            path = session_id
+        try:
+            project = config.resolve_project_root(config.project_dir())
+        except Exception:
+            project = None
+        reason = " ".join(str(exc).split()) or type(exc).__name__
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        log_dir = config.log_dir()
+        log_dir.mkdir(parents=True, exist_ok=True)
+        with (log_dir / "serialize.log").open("a", encoding="utf-8") as f:
+            f.write(
+                f"{stamp} session-end: spawned serialize for {session_id} "
+                f"(reason: in-process capture, project: {project or '?'}) "
+                f"(transcript: {path})\n"
+            )
+            f.write(f"error: {reason} (transcript: {path}) after {max(0, int(elapsed))}s\n")
+    except Exception:
+        log.exception("daimon: could not ledger capture failure for session %s", session_id)
+
+
 def on_session_end(session_id, completed=None, interrupted=None, model=None, platform=None, **kwargs):
     """End-of-session: read transcript -> serialize -> validate -> store. Never raises.
 
     DAIMON_TIMEOUT is the TOTAL budget for the serialize LLM work: the deadline is
     computed here at hook start and forwarded so retries cannot stack past it.
-    Everything — including config access — lives inside the try; nothing may escape.
+    Everything — including config access — lives inside the try; nothing may
+    escape, and any failure lands in serialize.log so status/heal see it (#142).
     """
+    start = time.monotonic()
     try:
         if config.is_disabled():
             return
-        start = time.monotonic()
         deadline = start + config.timeout_seconds()
         messages = transcript.from_session(session_id)
         if not messages or len(messages) < config.min_messages():
             return
-        checkpoint = serializer.serialize(session_id, messages, chat=_chat, deadline=deadline)
-        if checkpoint is None:
+        try:
+            # serialize_strict, NOT the never-raise serialize(): a swallowed
+            # LLM/schema failure would exit through the old "skip" branch and
+            # never reach the ledger — only a too-short session is a true skip.
+            checkpoint = serializer.serialize_strict(
+                session_id, messages, chat=_chat, deadline=deadline
+            )
+        except serializer.TooShortError:
             log.info("daimon: no checkpoint produced for session %s (skip)", session_id)
             return
         root = config.resolve_project_root(config.project_dir())
@@ -49,8 +96,10 @@ def on_session_end(session_id, completed=None, interrupted=None, model=None, pla
                 harvest.run(messages, project_root=root, session_id=session_id)
             except Exception:
                 log.exception("daimon: scar harvest failed (checkpoint unaffected)")
-    except Exception:  # a broken hook must not break the session
+    except Exception as exc:  # a broken hook must not break the session
         log.exception("daimon: on_session_end failed for session %s (giving up)", session_id)
+        _ledger_failure(session_id, exc, time.monotonic() - start,
+                        kwargs.get("transcript_path"))
 
 
 def pre_llm_call(session_id=None, user_message=None, conversation_history=None,

--- a/plugin/tests/test_hooks.py
+++ b/plugin/tests/test_hooks.py
@@ -231,7 +231,7 @@ def test_on_session_end_passes_deadline_to_chat(tmp_checkpoint_dir, fake_chat_fa
 def test_on_session_end_routes_project_through_resolve_project_root(
     tmp_checkpoint_dir, fake_chat_factory, monkeypatch
 ):
-    from daimon_briefing import store, transcript
+    from daimon_briefing import transcript
 
     chat = fake_chat_factory(_valid_json("S-end"))
     monkeypatch.setattr(transcript, "from_session", lambda sid: make_messages(20))
@@ -391,3 +391,172 @@ def test_on_session_end_checkpoint_survives_harvest_explosion(tmp_checkpoint_dir
 
     hooks.on_session_end(session_id="S-h", completed=True, interrupted=False, model="m", platform="cli")
     assert store.read_checkpoint("S-h") is not None  # checkpoint written despite harvest crash
+
+
+# ---- #142: a failed in-process capture must land in serialize.log (the ledger) ----
+
+
+def _ledger_text():
+    from daimon_briefing import config
+
+    return (config.log_dir() / "serialize.log").read_text(encoding="utf-8")
+
+
+def _fail_session(fake_chat_factory, monkeypatch, session_id="S-fail", **kwargs):
+    """Drive on_session_end into a real capture failure: the LLM explodes."""
+    from daimon_briefing import transcript
+
+    chat = fake_chat_factory(RuntimeError("kaboom"))
+    monkeypatch.setattr(transcript, "from_session", lambda sid: make_messages(20))
+    monkeypatch.setattr(hooks, "_chat", chat)
+    hooks.on_session_end(
+        session_id=session_id, completed=True, interrupted=False, model="m",
+        platform="cli", **kwargs,
+    )
+
+
+def test_on_session_end_failure_writes_attributed_ledger_entry(
+    tmp_checkpoint_dir, fake_chat_factory, monkeypatch
+):
+    # log.exception alone reaches nothing `status`/`heal` parse — the failure
+    # must land in serialize.log in the CLI writer's exact shape, attributed
+    # to its session by the per-session ledger fold.
+    import time
+
+    from daimon_briefing import cli
+
+    _fail_session(fake_chat_factory, monkeypatch, session_id="S-fail")
+
+    text = _ledger_text()
+    entry = cli._session_ledger(text, time.time()).get("S-fail")
+    assert entry is not None
+    assert entry["result_kind"] == "error"
+    assert entry["spawned"] is True  # classified by the normal heal rules
+    assert "kaboom" in (entry["result_line"] or "")
+
+
+def test_status_counts_failed_in_process_capture(
+    tmp_checkpoint_dir, fake_chat_factory, capsys, monkeypatch
+):
+    import json
+
+    from daimon_briefing import cli
+
+    _fail_session(fake_chat_factory, monkeypatch, session_id="S-fail")
+
+    cli.main(["status", "--json"])
+    data = json.loads(capsys.readouterr().out)
+    assert "S-fail" in [f["sid"] for f in data["outstanding"]]
+
+
+def test_heal_plan_includes_failed_in_process_capture(
+    tmp_checkpoint_dir, fake_chat_factory, monkeypatch
+):
+    # No transcript file on disk -> not auto-repairable, but the plan must
+    # still surface the failed session instead of pretending nothing happened.
+    import time
+
+    from daimon_briefing import cli
+
+    _fail_session(fake_chat_factory, monkeypatch, session_id="S-fail")
+
+    plan = cli._heal_plan(_ledger_text(), time.time())
+    listed = [s["sid"] for s in plan["skipped"]]
+    if plan["target"] is not None:
+        listed.append(plan["target"]["sid"])
+    assert "S-fail" in listed
+
+
+def test_heal_retries_failed_in_process_capture_with_transcript(
+    tmp_checkpoint_dir, fake_chat_factory, capsys, monkeypatch
+):
+    # When the host hands the hook a real transcript file, the failure is
+    # healable like any spawned-CLI failure: heal targets it, marks the ONE
+    # retry (#26), and the retry writes the checkpoint.
+    import time
+    from pathlib import Path
+
+    from daimon_briefing import cli, store
+
+    tpath = Path(__file__).parent / "fixtures" / "sample_transcript.md"
+    sid = tpath.stem  # ledger attribution: session id == transcript stem
+
+    _fail_session(fake_chat_factory, monkeypatch, session_id=sid,
+                  transcript_path=str(tpath))
+
+    plan = cli._heal_plan(_ledger_text(), time.time())
+    assert plan["target"] is not None
+    assert plan["target"]["sid"] == sid
+
+    good_chat = fake_chat_factory(_valid_json(sid))
+    monkeypatch.setattr(cli, "_chat", good_chat)
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    assert cli.main(["heal"]) == 0
+    assert store.read_checkpoint(sid) is not None
+    assert f"session-start: retry serialize for {sid}" in _ledger_text()
+
+
+def test_on_session_end_failure_ignores_mismatched_transcript_path(
+    tmp_checkpoint_dir, fake_chat_factory, monkeypatch
+):
+    # A host transcript path whose stem is NOT the session id would split the
+    # failure across two ledger entries (spawn under one id, error under
+    # another) — fall back to the session id token instead.
+    import time
+
+    from daimon_briefing import cli
+
+    _fail_session(fake_chat_factory, monkeypatch, session_id="S-fail",
+                  transcript_path="/somewhere/else.jsonl")
+
+    entry = cli._session_ledger(_ledger_text(), time.time()).get("S-fail")
+    assert entry is not None
+    assert entry["result_kind"] == "error"
+    assert entry["spawned"] is True
+
+
+def test_on_session_end_success_leaves_no_ledger_entry(
+    tmp_checkpoint_dir, fake_chat_factory, monkeypatch
+):
+    from daimon_briefing import config, transcript
+
+    chat = fake_chat_factory(_valid_json("S-ok"))
+    monkeypatch.setattr(transcript, "from_session", lambda sid: make_messages(20))
+    monkeypatch.setattr(hooks, "_chat", chat)
+    hooks.on_session_end(
+        session_id="S-ok", completed=True, interrupted=False, model="m", platform="cli"
+    )
+    assert not (config.log_dir() / "serialize.log").exists()
+
+
+def test_on_session_end_too_short_serialize_leaves_no_failure_entry(
+    tmp_checkpoint_dir, fake_chat_factory, monkeypatch
+):
+    # A too-short session is a legitimate skip, not a loss — it must never be
+    # ledgered as a failure heal would try to repair.
+    from daimon_briefing import config, serializer, transcript
+
+    monkeypatch.setattr(transcript, "from_session", lambda sid: make_messages(20))
+    monkeypatch.setattr(hooks, "_chat", fake_chat_factory(_valid_json("S-tiny")))
+
+    def _too_short(*_a, **_k):
+        raise serializer.TooShortError("too short")
+
+    monkeypatch.setattr(hooks.serializer, "serialize_strict", _too_short, raising=False)
+    monkeypatch.setattr(hooks.serializer, "serialize", lambda *a, **k: None)
+    hooks.on_session_end(
+        session_id="S-tiny", completed=True, interrupted=False, model="m", platform="cli"
+    )
+    log_file = config.log_dir() / "serialize.log"
+    assert not log_file.exists() or "error:" not in log_file.read_text(encoding="utf-8")
+
+
+def test_on_session_end_never_raises_when_ledger_write_fails(
+    tmp_checkpoint_dir, fake_chat_factory, monkeypatch
+):
+    monkeypatch.setattr(hooks.config, "log_dir", _raiser)
+    _fail_session(fake_chat_factory, monkeypatch, session_id="S-fail")  # must not raise
+
+
+def test_hooks_docstring_no_stale_project_name():
+    assert "hermes" not in (hooks.__doc__ or "").lower()

--- a/plugin/tests/test_hooks.py
+++ b/plugin/tests/test_hooks.py
@@ -435,6 +435,28 @@ def test_on_session_end_failure_writes_attributed_ledger_entry(
     assert "kaboom" in (entry["result_line"] or "")
 
 
+def test_failure_ledgered_even_when_project_resolution_raises(
+    tmp_checkpoint_dir, fake_chat_factory, monkeypatch
+):
+    # Project attribution is best-effort decoration: if resolving the project
+    # root itself blows up, the failure must still reach the ledger as '?'.
+    import time
+
+    from daimon_briefing import cli, config
+
+    def _boom(_dir):
+        raise RuntimeError("no project root")
+
+    monkeypatch.setattr(config, "resolve_project_root", _boom)
+    _fail_session(fake_chat_factory, monkeypatch, session_id="S-noproj")
+
+    text = _ledger_text()
+    assert "project: ?" in text
+    entry = cli._session_ledger(text, time.time()).get("S-noproj")
+    assert entry is not None
+    assert entry["result_kind"] == "error"
+
+
 def test_status_counts_failed_in_process_capture(
     tmp_checkpoint_dir, fake_chat_factory, capsys, monkeypatch
 ):


### PR DESCRIPTION
Closes #142

### Problem — deeper than filed

The issue said failures were caught by `log.exception()` and never reached `serialize.log`. Implementation found the failure mode never even got that far: the hook called `serializer.serialize()`, a **never-raise wrapper** that returns `None` on LLM/schema failures — the guarding `except` was dead code for the production failure path. A failed in-process capture was silent, uncounted, non-healable.

### Fix

- Hook calls `serialize_strict`; `TooShortError` remains the one legitimate skip, everything else lands in the failure handler.
- Failures write to `serialize.log` as the same **spawn + error line pair** every spawned-CLI capture leaves — round-trips the existing ledger regexes (`_SPAWN_RE`, `_RESULT_ERR_RE`, heal/stats/project patterns) with zero parser changes.
- Attribution keys on the transcript token stem; a host-supplied `transcript_path` is used only when its stem equals the session id (otherwise spawn/error would split across two ledger entries — pinned by test).
- With a real transcript file, the failure classifies **healable**: `daimon heal` plans it, writes the retry marker (one-retry policy intact), retry writes the checkpoint. Without one it's counted honestly as cannot-auto-heal — same rule as any spawned failure whose transcript vanished.
- Ledger writing is itself fail-open — recording failure never breaks the hook. Success path writes nothing.
- Stale pre-rename docstring fixed.

### Timeout check (issue item b)

Not applicable, no change: the 420s figure exists only as operational guidance in research docs — both paths already resolve the same `config.timeout_seconds()` (default 120). The hook's total-deadline semantics are deliberate (pinned by existing test + scar fence). What changes: a deadline blowout is no longer silent — it ledgers as a failure status can show.

### Verification

TDD red first (`FileNotFoundError: .../serialize.log` — nothing ever written). 8 new tests parse via the real `cli._session_ledger()` / `cli._heal_plan()` and run full `cli.main([\"status\"])` — live proof: `⚠ 1 session failed to serialize` surfaced, heal dry-run planned the retry. Full suite post-rebase onto current main: **1106 passed**. Ruff clean.