### PR TITLE
refactor(schema): single-source the item-list schema across consumers

### DIFF
--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -12,7 +12,7 @@ import copy
 import re
 from collections import Counter
 
-from . import recall, scoring, store
+from . import recall, schema, scoring, store
 
 # An item id already looks like this (store._stamp_item_ids: kind-initial +
 # >=6 hex chars, optional -N collision suffix) — never treat it as free text
@@ -20,13 +20,10 @@ from . import recall, scoring, store
 # alternation froze the write path under quadratic backtracking).
 _ID_SHAPE = re.compile(r"[a-z]-[0-9a-f]{6,}(-\d+)?")
 
-# (section, key, scoring TYPE_RULES type). Beliefs regenerate cheaply and
-# active_topic is per-session by definition — neither carries (v1).
-_CARRIED_KINDS = (
-    ("working_context", "open_questions", "open_question"),
-    ("working_context", "recent_decisions", "recent_decision"),
-    ("epistemic_snapshot", "uncertainties", "uncertainty"),
-)
+# (section, key, scoring TYPE_RULES type), from the shared schema (#146).
+# Beliefs regenerate cheaply and active_topic is per-session by definition —
+# neither carries (v1); the carries flag in schema.ITEM_FIELDS records that.
+_CARRIED_KINDS = schema.CARRIED_KINDS
 
 _MIN_SHARED = 3     # shared salient terms for same-item
 _MIN_RATIO = 0.6    # or this fraction of the shorter term list

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -41,7 +41,7 @@ import unicodedata
 from datetime import datetime, timezone
 from pathlib import Path
 
-from . import config, scoring, store
+from . import config, schema, scoring, store
 
 log = logging.getLogger("daimon.recall")
 
@@ -73,15 +73,9 @@ _FTS5_MISSING_MSG = (
 )
 
 # (checkpoint section, key, indexed kind). Every trust-tagged cognitive list in
-# the serializer schema, including contradictions_flagged (item shape varies).
-_KIND_SOURCES = (
-    ("working_context", "active_topic", "topic"),
-    ("working_context", "open_questions", "question"),
-    ("working_context", "recent_decisions", "decision"),
-    ("epistemic_snapshot", "strong_beliefs", "belief"),
-    ("epistemic_snapshot", "uncertainties", "uncertainty"),
-    ("epistemic_snapshot", "contradictions_flagged", "contradiction"),
-)
+# the serializer schema, including contradictions_flagged (item shape varies) —
+# derived from the shared item-field table (#146).
+_KIND_SOURCES = schema.KIND_SOURCES
 
 
 class RecallError(RuntimeError):
@@ -500,14 +494,10 @@ _MIN_OVERLAP = 2        # matched SESSION must share >=2 distinct salient terms
                         # — a multi-topic prompt splits its terms across items
                         # (first field miss, 2026-07-02)
 
-# recall index `kind` -> scoring TYPE_RULES key (#78 composition).
-_KIND_TO_TYPE = {
-    "question": "open_question",
-    "decision": "recent_decision",
-    "belief": "strong_belief",
-    "uncertainty": "uncertainty",
-    "topic": "active_topic",
-}
+# recall index `kind` -> scoring TYPE_RULES key (#78 composition), from the
+# shared schema (#146). `contradiction` has no dedicated rules and is absent —
+# the .get() below keeps its default fallback.
+_KIND_TO_TYPE = schema.KIND_TO_TYPE
 
 
 def _fold(tok: str) -> str:

--- a/plugin/daimon_briefing/schema.py
+++ b/plugin/daimon_briefing/schema.py
@@ -1,0 +1,65 @@
+"""Checkpoint item-field schema — the single source of truth (#146).
+
+store, serializer, recall, and carry each hand-maintained their own copy of
+"the item-bearing fields of a checkpoint", and the copies drifted:
+serializer.iter_items omitted contradictions_flagged, so those items skipped
+first_seen stamping and importance sanitization while still receiving ids,
+redaction, recall indexing, and withhold treatment. Every consumer now derives
+its view from ITEM_FIELDS below; a field added here propagates to all of them
+(and to the serialize→brief E2E test, which iterates this table).
+
+Deliberately import-free: store imports serializer, recall imports store,
+carry imports recall — this module sits below the whole chain so any of them
+can import it without a cycle.
+"""
+
+from typing import NamedTuple
+
+
+class ItemField(NamedTuple):
+    """One item-bearing checkpoint field, with the facts each consumer needs."""
+
+    section: str    # top-level checkpoint key (working_context / epistemic_snapshot)
+    key: str        # field name under the section
+    singleton: bool  # True: one item dict (active_topic); False: list of item dicts
+    kind: str       # recall index kind — the singular per-item label
+    scoring_type: str | None  # scoring.TYPE_RULES key; None -> consumers fall
+    #                           back to their own default (recall's .get)
+    carries: bool   # carry.merge folds unresolved items forward (#33 Phase 2)
+
+
+# Order is load-bearing: consumers iterate this tuple directly, so it feeds
+# ordering-sensitive paths (iter_items walks, recall indexing, carry).
+#
+# carries: beliefs regenerate cheaply and active_topic is per-session by
+# definition — neither carries (v1). contradictions_flagged has no dedicated
+# scoring rules and never carries; its item shape varies (may be bare strings),
+# which every consumer already tolerates per item.
+ITEM_FIELDS: tuple[ItemField, ...] = (
+    ItemField("working_context", "active_topic", True, "topic", "active_topic", False),
+    ItemField("working_context", "open_questions", False, "question", "open_question", True),
+    ItemField("working_context", "recent_decisions", False, "decision", "recent_decision", True),
+    ItemField("epistemic_snapshot", "strong_beliefs", False, "belief", "strong_belief", False),
+    ItemField("epistemic_snapshot", "uncertainties", False, "uncertainty", "uncertainty", True),
+    ItemField("epistemic_snapshot", "contradictions_flagged", False, "contradiction", None, False),
+)
+
+# (section, key) for the list sections that hold checkpoint items — store's
+# redaction/id-stamping view. active_topic is a single per-session dict and
+# never needs an id (it does not carry, #33).
+ITEM_LISTS: tuple[tuple[str, str], ...] = tuple(
+    (f.section, f.key) for f in ITEM_FIELDS if not f.singleton)
+
+# (section, key, indexed kind) — recall's index view: every trust-tagged
+# cognitive field, active_topic included.
+KIND_SOURCES: tuple[tuple[str, str, str], ...] = tuple(
+    (f.section, f.key, f.kind) for f in ITEM_FIELDS)
+
+# (section, key, scoring TYPE_RULES type) — carry's view: carried fields only.
+CARRIED_KINDS: tuple[tuple[str, str, str], ...] = tuple(
+    (f.section, f.key, f.scoring_type) for f in ITEM_FIELDS if f.carries)
+
+# recall index kind -> scoring.TYPE_RULES key (#78 composition). Kinds without
+# dedicated rules (contradiction) are absent; lookups .get their own default.
+KIND_TO_TYPE: dict[str, str] = {
+    f.kind: f.scoring_type for f in ITEM_FIELDS if f.scoring_type}

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -18,7 +18,7 @@ import re
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-from . import config, llm, redact
+from . import config, llm, redact, schema
 
 # No handlers/basicConfig here — the library stays silent unless the caller
 # configures logging. Multi-hour serialize runs need this heartbeat to be killable.
@@ -286,25 +286,24 @@ def _valid_item(item) -> bool:
 
 
 def iter_items(checkpoint):
-    """Yield every schema item dict in a checkpoint: active_topic plus the four
-    item lists. Single source for cross-cutting per-item passes (#126) — store's
-    first_seen stamping and sanitize_importance both walk exactly this set.
-    Tolerant of absent keys and non-dict entries (torn/legacy checkpoints)."""
-    wc = checkpoint.get("working_context")
-    es = checkpoint.get("epistemic_snapshot")
-    if isinstance(wc, dict):
-        topic = wc.get("active_topic")
-        if isinstance(topic, dict):
-            yield topic
-        for key in ("open_questions", "recent_decisions"):
-            for item in wc.get(key) or []:
-                if isinstance(item, dict):
-                    yield item
-    if isinstance(es, dict):
-        for key in ("strong_beliefs", "uncertainties"):
-            for item in es.get(key) or []:
-                if isinstance(item, dict):
-                    yield item
+    """Yield every schema item dict in a checkpoint: active_topic plus the five
+    item lists, exactly the fields schema.ITEM_FIELDS declares (#146). Single
+    source for cross-cutting per-item passes (#126) — store's first_seen
+    stamping and sanitize_importance both walk exactly this set. Tolerant of
+    absent keys and non-dict entries (torn/legacy checkpoints, and
+    contradictions_flagged whose item shape varies)."""
+    for field in schema.ITEM_FIELDS:
+        block = checkpoint.get(field.section)
+        if not isinstance(block, dict):
+            continue
+        if field.singleton:
+            item = block.get(field.key)
+            if isinstance(item, dict):
+                yield item
+            continue
+        for item in block.get(field.key) or []:
+            if isinstance(item, dict):
+                yield item
 
 
 def sanitize_importance(checkpoint) -> None:

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -33,7 +33,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
-from . import config, redact, serializer
+from . import config, redact, schema, serializer
 
 _LATEST = "latest.json"
 # Rotation pointers, not per-session checkpoints. Anything else ending in .json in
@@ -358,15 +358,12 @@ def _gc_checkpoints(d: Path, keep: int) -> None:
 # deepcopy) and redaction/id-stamping below only ever touch named fields — so no
 # code here needs to name it; this note is the reservation.
 
-# The five list sections that hold checkpoint items. active_topic is a single
-# per-session dict and never needs an id (it does not carry, #33).
-_ITEM_LISTS = (
-    ("working_context", "open_questions"),
-    ("working_context", "recent_decisions"),
-    ("epistemic_snapshot", "strong_beliefs"),
-    ("epistemic_snapshot", "uncertainties"),
-    ("epistemic_snapshot", "contradictions_flagged"),
-)
+# The five list sections that hold checkpoint items, from the shared schema
+# (#146 — one definition; serializer/recall/carry derive theirs from the same
+# table). active_topic is a single per-session dict and never needs an id (it
+# does not carry, #33). Aliased because briefing.withhold and cli iterate
+# store._ITEM_LISTS.
+_ITEM_LISTS = schema.ITEM_LISTS
 
 
 def _redact_checkpoint(checkpoint: dict) -> None:

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -64,3 +64,8 @@ ignore_missing_imports = true
 
 [tool.coverage.run]
 source = ["daimon_briefing"]
+# _hooks/ ships byte-identical mirrors of files whose canonical sources are
+# tested (drift-guarded by test_hooks_install.py), and the adapter scripts
+# execute only as subprocesses under the host's Python — in-process line
+# coverage can never see them, so counting them only distorts the total.
+omit = ["daimon_briefing/_hooks/*"]

--- a/plugin/tests/test_serialize_brief_e2e.py
+++ b/plugin/tests/test_serialize_brief_e2e.py
@@ -1,0 +1,85 @@
+"""Serialize→brief E2E over the shared item-field schema (#146).
+
+Builds a checkpoint populating EVERY item-bearing field schema.ITEM_FIELDS
+declares, runs it through the real post-extraction pipeline
+(serializer.sanitize_importance -> store.write_checkpoint -> store.read_latest
+-> briefing.render), and asserts each item comes out whole: first_seen stamped,
+importance sanitized, id present (list items), text + trust tag in the brief.
+
+Descriptor-driven on purpose: a field added to schema.ITEM_FIELDS is covered
+here with no test edit — and a consumer that drops a declared list fails this
+test instead of shipping the drift silently."""
+
+import re
+
+from daimon_briefing import briefing, schema, serializer, store
+
+_CREATED = "2026-07-08T00:00:00Z"
+_PROJECT = "/tmp/daimon-e2e-project"
+
+
+def _probe_text(field: schema.ItemField) -> str:
+    return f"probe item for {field.key}"
+
+
+def _item(field: schema.ItemField) -> dict:
+    return {
+        "text": _probe_text(field),
+        "trust": "inferred",
+        # Out of range on purpose: sanitize_importance must clamp it to 10.
+        # A consumer that skips this field leaves 99 behind — the assertion
+        # below catches exactly that.
+        "importance": 99,
+    }
+
+
+def _full_checkpoint() -> dict:
+    cp = {"session_id": "S-e2e", "created": _CREATED}
+    for f in schema.ITEM_FIELDS:
+        block = cp.setdefault(f.section, {})
+        block[f.key] = _item(f) if f.singleton else [_item(f)]
+    return cp
+
+
+def test_descriptor_covers_known_drift_field():
+    # The field whose omission from iter_items motivated #146 must be declared.
+    assert ("epistemic_snapshot", "contradictions_flagged") in schema.ITEM_LISTS
+
+
+def test_every_schema_field_survives_serialize_to_brief(tmp_checkpoint_dir):
+    cp = _full_checkpoint()
+    assert serializer.validate(cp), "fixture must pass the serializer gate"
+
+    # The real pipeline order: sanitize (serialize step), then the store write
+    # (redaction, id stamping, first_seen stamping), then read + render.
+    serializer.sanitize_importance(cp)
+    store.write_checkpoint("S-e2e", cp, project_dir=_PROJECT)
+
+    stored = store.read_latest(project_dir=_PROJECT)
+    assert stored is not None
+
+    for f in schema.ITEM_FIELDS:
+        block = stored.get(f.section) or {}
+        items = [block.get(f.key)] if f.singleton else block.get(f.key)
+        assert items, f"{f.key}: dropped between write and read"
+        for item in items:
+            assert isinstance(item, dict), f"{f.key}: item shape mangled"
+            assert item.get("first_seen") == _CREATED, (
+                f"{f.key}: first_seen missing or wrong ({item.get('first_seen')!r})")
+            assert item.get("importance") == 10, (
+                f"{f.key}: importance not sanitized ({item.get('importance')!r})")
+            if not f.singleton:
+                assert item.get("id"), f"{f.key}: id not stamped"
+
+    brief = briefing.render(stored)
+    assert brief is not None
+
+    lines = brief.splitlines()
+    for f in schema.ITEM_FIELDS:
+        text = _probe_text(f)
+        assert text in brief, f"{f.key}: item missing from the brief"
+        if f.singleton:
+            continue  # active_topic renders as a header line, no trust tag
+        line = next(ln for ln in lines if text in ln)
+        assert re.match(r"- \[~ inferred\]", line), (
+            f"{f.key}: item rendered without its trust tag: {line!r}")


### PR DESCRIPTION
Closes #146

### Problem

The item-bearing checkpoint lists were hand-defined **four** times (store.`_ITEM_LISTS`, serializer.`iter_items`, recall's kind maps, carry's carried kinds) and had drifted: `iter_items` omitted `contradictions_flagged` — those items got ids and redaction but skipped `first_seen` inheritance, importance sanitization, quote verification, and GC importance pinning.

### Fix

New leaf module `schema.py` owns the descriptor (`ItemField`: section, key, singleton, kind, scoring_type, carries). Import-free by design — the chain runs serializer ← store ← recall ← carry, so a leaf is the only cycle-safe host. All four consumers now derive their views from it.

Review verified the derived views **element-by-element against the old literals — value-identical including ordering**. `recall`'s contradiction→`recent_decision` scoring fallback preserved exactly (`scoring_type=None` omits the key, `.get` default intact). `store._ITEM_LISTS` stays as an alias — briefing/cli iterate it unchanged.

Behavior change is exactly the issue's intent, contradictions-scoped: they now flow through `first_seen`, sanitize, `verify_quotes`, `_max_importance`, and the quote audit like every other list. No load-time downgrade risk: `verify_quotes` runs only at serialize time for new checkpoints.

### E2E test

`test_serialize_brief_e2e.py` populates one item per descriptor field, writes through real disk I/O (`write_checkpoint` → `read_latest`), renders a brief, asserts id + trust tag + first_seen per item. Driven by `ITEM_FIELDS`, so a future field is auto-covered and a consumer dropping it fails the test. TDD red first — the red output was the issue's exact claim (`first_seen missing`, `importance: 99` unsanitized on contradictions).

### Found while here (not touched, follow-up material)

- `anchor.py:81 _all_items` is a **fifth** hand-rolled copy, also missing `contradictions_flagged` — left alone (module is deliberately stdlib-only/import-free).
- `briefing._iter_trusted_quotes` covers the five lists but excludes `active_topic` from LLM-render quote validation.

### Also

Second commit: coverage now omits `daimon_briefing/_hooks/` — byte-identical mirrors of drift-guarded tested sources, executed only as subprocesses under the host's Python; in-process line coverage can never see them (they showed as 299 permanently-0% lines distorting the total).

### Verification

Full suite **1099 passed** (+2). Ruff clean on all changed files. Both commits signed.