### PR TITLE
fix(anchor): derive the drift-scan item walk from the shared schema

### DIFF
--- a/plugin/daimon_briefing/anchor.py
+++ b/plugin/daimon_briefing/anchor.py
@@ -1,9 +1,12 @@
-"""Anchor cognitive items to code symbols and detect drift — stdlib only.
+"""Anchor cognitive items to code symbols and detect drift.
 
 A symbol is identified by (file, symbol) where symbol is `name` or `Class.method`.
 The fingerprint is a structural hash (`ast.dump` of the def node), so it is stable
 to formatting/comments/line-shift and changes only on real structural edits. No MCP,
 no LLM, no network — resolution and drift checks read the project's own source.
+Dependencies stay minimal for the same reason: stdlib plus the import-free
+`schema` leaf, from which `_all_items` derives its field walk so drift coverage
+cannot lag behind the checkpoint shape (#146/#160).
 
 Caveat: `ast.dump` output is stable only WITHIN a Python version. A checkpoint anchored
 under one interpreter and checked under another may report a spurious "soft" drift — it
@@ -14,6 +17,8 @@ resolved and checked by the same interpreter.
 import ast
 import hashlib
 from pathlib import Path
+
+from . import schema
 
 _DEF = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
 
@@ -79,15 +84,17 @@ def check(anchor: dict, project_root) -> str:
 
 
 def _all_items(checkpoint: dict):
-    wc = checkpoint.get("working_context") or {}
-    es = checkpoint.get("epistemic_snapshot") or {}
-    for key in ("open_questions", "recent_decisions"):
-        yield from (wc.get(key) or [])
-    for key in ("strong_beliefs", "uncertainties"):
-        yield from (es.get(key) or [])
-    active = wc.get("active_topic")
-    if isinstance(active, dict):
-        yield active
+    """Yield every item schema.ITEM_FIELDS declares (#146) — singletons
+    (active_topic) only when they are dicts, list entries as-is (drifted()
+    tolerates non-dict entries per item)."""
+    for field in schema.ITEM_FIELDS:
+        block = checkpoint.get(field.section) or {}
+        if field.singleton:
+            item = block.get(field.key)
+            if isinstance(item, dict):
+                yield item
+        else:
+            yield from (block.get(field.key) or [])
 
 
 def drifted(checkpoint: dict, project_root) -> list[dict]:

--- a/plugin/tests/test_anchor.py
+++ b/plugin/tests/test_anchor.py
@@ -180,6 +180,48 @@ def test_brief_render_survives_syntax_error_in_anchored_file(tmp_path, capsys):
     assert "[GONE] q-broken-file" in out
 
 
+def test_drifted_collects_anchored_contradiction(tmp_path):
+    # Regression (#160): contradictions_flagged was the fifth hand-rolled
+    # item-list copy and was omitted from the drift scan — an anchored
+    # contradiction whose target symbol drifted never surfaced.
+    _write(tmp_path, "m.py", _SRC)
+    a = anchor.resolve(tmp_path, "m.py", "foo")
+    _write(tmp_path, "m.py", _SRC.replace("return x + 1", "return x + 99"))
+    checkpoint = {
+        "working_context": {
+            "active_topic": {"text": "t", "trust": "inferred"},
+            "open_questions": [],
+            "recent_decisions": [],
+        },
+        "epistemic_snapshot": {
+            "strong_beliefs": [],
+            "uncertainties": [],
+            "contradictions_flagged": [
+                {"text": "c-drifted", "trust": "inferred", "anchored_to": a}
+            ],
+        },
+    }
+    out = anchor.drifted(checkpoint, tmp_path)
+    assert [(d["item"]["text"], d["kind"]) for d in out] == [("c-drifted", "soft")]
+
+
+def test_all_items_covers_every_schema_item_field():
+    # Field-coverage pin against the descriptor (#146/#160): a field added to
+    # schema.ITEM_FIELDS must be walked by the drift scan — no sixth copy.
+    from daimon_briefing import schema
+
+    checkpoint = {}
+    expected = set()
+    for field in schema.ITEM_FIELDS:
+        text = f"{field.section}.{field.key}"
+        item = {"text": text, "trust": "inferred"}
+        section = checkpoint.setdefault(field.section, {})
+        section[field.key] = item if field.singleton else [item]
+        expected.add(text)
+    got = {item["text"] for item in anchor._all_items(checkpoint)}
+    assert got == expected
+
+
 def test_drifted_collects_soft_drift(tmp_path):
     _write(tmp_path, "m.py", _SRC)
     a = anchor.resolve(tmp_path, "m.py", "foo")


### PR DESCRIPTION
Closes #160

### Problem

`anchor._all_items` was a **fifth** hand-rolled item-list copy (after #146 unified four) and omitted `contradictions_flagged` — anchored contradiction items never produced drift warnings.

### Fix

The walk derives from `schema.ITEM_FIELDS`. Shape decision per the issue: checked the stdlib-only rationale first — the docstring's constraint is about external dependencies ('No MCP, no LLM, no network'), not intra-package imports, and `anchor.py` is not one of the hook-mirrored files, so importing the import-free `schema` leaf preserves the real intent (docstring amended to say exactly that). Yield semantics preserved: dict-only singleton (`active_topic`), non-dict list entries pass through as before (`drifted()` guards per item — review-verified identical).

Walk order now starts with `active_topic` (descriptor order) — `drifted()`'s only consumer asserts set-wise; drift-item relative order for the four anchored lists unchanged.

### Tests

TDD red first: coverage test reported exactly `epistemic_snapshot.contradictions_flagged` missing; regression test (real source file, real soft drift — no mocks) got `[]`. Green after the derive. The coverage test walks the descriptor, so a future field can't silently fall out of drift scanning.

Full suite: **1111 passed** (+2). Ruff clean. Commit signed.