### PR TITLE
fix(briefing): validate active_topic quotes in the LLM-render gate

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -19,7 +19,7 @@ import time
 # store/carry import graph checked (#103): neither store, carry, recall, nor
 # scoring imports briefing — no cycle, so this stays a normal module-level
 # import (contrast carry.py's own local-import notes, which don't apply here).
-from . import carry, config, llm, scoring, store
+from . import carry, config, llm, schema, scoring, store
 
 log = logging.getLogger("daimon.briefing")
 
@@ -407,13 +407,13 @@ def _render_parts(b: dict, trimmed: dict) -> str:
 
 
 def _iter_trusted_quotes(checkpoint):
-    """Yield every verbatim item's quote across the cognitive sections."""
-    wc = checkpoint.get("working_context") or {}
-    es = checkpoint.get("epistemic_snapshot") or {}
-    for items in (wc.get("open_questions"), wc.get("recent_decisions"),
-                  es.get("strong_beliefs"), es.get("uncertainties"),
-                  es.get("contradictions_flagged")):
-        for item in items or []:
+    """Yield every verbatim item's quote across the cognitive sections.
+    Sections come from schema.ITEM_FIELDS so a field added there is validated
+    here without another hand-kept list (#146 drift class; #161 added the
+    active_topic singleton this way)."""
+    for field in schema.ITEM_FIELDS:
+        value = (checkpoint.get(field.section) or {}).get(field.key)
+        for item in (value,) if field.singleton else (value or []):
             if (isinstance(item, dict) and item.get("trust") == "verbatim"
                     and str(item.get("quote") or "").strip()):
                 yield str(item["quote"]).strip()

--- a/plugin/tests/test_briefing.py
+++ b/plugin/tests/test_briefing.py
@@ -518,6 +518,46 @@ def test_llm_render_accepted_when_quotes_survive(sample_checkpoint, monkeypatch)
     assert briefing.render(sample_checkpoint) == faithful
 
 
+def test_llm_render_rejected_when_topic_quote_missing(sample_checkpoint, monkeypatch):
+    # active_topic is a singleton item, not a list, so it used to skip the
+    # quote gate entirely — a dropped or reworded topic quote sailed through
+    # while every list-section quote was checked (#161).
+    _llm_briefing_env(monkeypatch)
+    from daimon_briefing import llm
+    sample_checkpoint["working_context"]["active_topic"] = {
+        "text": "Wiring the on_session_end hook",
+        "trust": "verbatim",
+        "quote": "let's wire the on_session_end hook next",
+    }
+    unfaithful = (  # every LIST quote survives; only the topic quote is lost
+        'Verify: "I\'ll merge it myself later from the GitHub UI". '
+        'Open: "do we chunk below 1200 lines or single-pass?". '
+        'Decided: "we adopt the D-007 prompt for the serializer".'
+    )
+    monkeypatch.setattr(llm, "chat", lambda *a, **k: unfaithful)
+    out = briefing.render(sample_checkpoint)
+    assert out != unfaithful  # rejected — deterministic fallback took over
+    assert "Wiring the on_session_end hook" in out
+
+
+def test_llm_render_accepted_when_topic_quote_survives(sample_checkpoint, monkeypatch):
+    _llm_briefing_env(monkeypatch)
+    from daimon_briefing import llm
+    sample_checkpoint["working_context"]["active_topic"] = {
+        "text": "Wiring the on_session_end hook",
+        "trust": "verbatim",
+        "quote": "let's wire the on_session_end hook next",
+    }
+    faithful = (
+        'Topic: "let\'s wire the on_session_end hook next". '
+        'Verify: "I\'ll merge it myself later from the GitHub UI". '
+        'Open: "do we chunk below 1200 lines or single-pass?". '
+        'Decided: "we adopt the D-007 prompt for the serializer".'
+    )
+    monkeypatch.setattr(llm, "chat", lambda *a, **k: faithful)
+    assert briefing.render(sample_checkpoint) == faithful
+
+
 def test_llm_render_tolerates_rewrapped_whitespace(sample_checkpoint, monkeypatch):
     # LLMs re-wrap lines; a quote split across a newline is still intact.
     _llm_briefing_env(monkeypatch)


### PR DESCRIPTION
Closes #161

### Problem

`_iter_trusted_quotes` yielded verbatim quotes from the five list sections but never `active_topic` — a fabricated or reworded verbatim topic quote in an LLM render passed validation, the one class of verbatim quote the gate ignored.

### Fix

Iteration derives from `schema.ITEM_FIELDS` (singleton-aware: `(value,)` vs `(value or [])`; `None` topic short-circuits on the existing `isinstance` guard) — no sixth hand-written section list, the #146 drift class stays dead. The per-item check is byte-identical for the five lists; `_validate_llm_render`'s short-circuit and whitespace normalization untouched; sole caller is order-insensitive.

Behavior change is the point: an unfaithful topic quote now drops the render to the plain fallback (logged warning, no crash, no data loss) — the same degrade every other broken verbatim quote already triggers. Verbatim promise > pretty prose.

### Tests

TDD red first: a render keeping all five list quotes but dropping the verbatim topic quote was **accepted** pre-fix. Both new tests run the real path (`render()` → `_render_llm` → validation), not units. Full suite: **1111 passed**. Ruff clean on the production file (one pre-existing E402 in the test file predates this change, verified via stash against HEAD; outside CI's lint scope — #151 territory). Commit signed.