### PR TITLE
ci: pre-commit hook + lint-gate hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
           fail_ci_if_error: false
 
   lint:
+    # Intended state: this job is a required status check in branch
+    # protection (repo settings — maintainer action, not configurable here).
     name: lint (ruff + mypy)
     runs-on: ubuntu-latest
     defaults:
@@ -77,8 +79,10 @@ jobs:
 
       # Blocking: ruff and mypy are version-pinned in the dev extra so the
       # gate is reproducible.
+      # Same paths as .pre-commit-config.yaml — keep the two in sync so the
+      # local hook and CI can never disagree about what is lint-clean.
       - name: ruff check
-        run: uv run --extra dev ruff check daimon_briefing
+        run: uv run --extra dev ruff check daimon_briefing tests ../scripts
 
       # Non-blocking: mypy currently reports pre-existing errors that are a
       # deliberate follow-up. continue-on-error keeps them visible in the log

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ dist/
 build/
 .pytest_cache/
 .coverage
+coverage.xml
+junit.xml
 htmlcov/
 .ruff_cache/
 .mypy_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# Local commit-time mirror of the CI lint gate. Install once after cloning:
+#
+#     uvx pre-commit install
+#
+# Check-only by design: no autofix hook — surprising rewrites at commit time
+# are worse than a red hook that tells you what to fix.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Pinned to the exact ruff version in plugin/pyproject.toml's dev extra
+    # (ruff==0.15.20) — a version skew between this hook and CI would produce
+    # contradictory verdicts. Bump both together.
+    rev: v0.15.20
+    hooks:
+      - id: ruff-check
+        # Same paths the CI lint job checks (.github/workflows/ci.yml) —
+        # keep the two in sync.
+        files: ^(plugin/(daimon_briefing|tests)|scripts)/
+  - repo: local
+    hooks:
+      - id: hook-mirror-drift
+        name: hook mirror drift (scripts/sync_hooks.py --check)
+        # Some hook files are deliberate byte-for-byte copies of a canonical
+        # source; this fails the commit when a copy has drifted. Fix with:
+        #     uv run python scripts/sync_hooks.py
+        entry: uv run python scripts/sync_hooks.py --check
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+The Python package lives in `plugin/`; [uv](https://docs.astral.sh/uv/) drives
+everything — no pip, no manual venvs.
+
+## Setup
+
+```bash
+git clone https://github.com/Daily-Nerd/daimon.git
+cd daimon
+uvx pre-commit install
+```
+
+`uvx pre-commit install` is a one-time step: it wires the commit-time hooks
+(`.pre-commit-config.yaml`), which run **ruff** (check only, no autofix) over
+the same paths CI lints, plus the **hook-mirror drift check**
+(`scripts/sync_hooks.py --check`). Some hook files are deliberate
+byte-for-byte copies of a canonical source; if the drift check goes red, edit
+the canonical file and run `uv run python scripts/sync_hooks.py` to propagate.
+
+## Tests
+
+```bash
+cd plugin
+uv run --extra dev --extra pretty pytest
+```
+
+`--extra pretty` matters: the rich-path tests import `rich` unconditionally,
+so a bare `uv run pytest` produces false failures.
+
+## Lint
+
+```bash
+cd plugin
+uv run --extra dev ruff check daimon_briefing tests ../scripts
+```
+
+ruff is version-pinned in the dev extra and the pre-commit hook pins the same
+version, so the commit-time verdict always matches CI.
+
+## CI gates
+
+Every PR runs pytest on Python 3.10 and 3.13, `lint (ruff + mypy)` (ruff
+blocking, mypy advisory for now), scar lint, and the PR convention check.
+The `lint (ruff + mypy)` job is intended to be a required status check in
+branch protection — flipping that switch is a repo-settings action for the
+maintainer, not something the tree controls.

--- a/README.md
+++ b/README.md
@@ -163,4 +163,5 @@ Daimon is self-contained at runtime — no external memory backend, no server. T
 - [Codex hooks](./hook/CODEX.md) — Codex adapter setup
 - [The Problem](./docs/PROBLEM.md) — the context-loss thesis
 - [Research Logbook](./research/README.md) — findings, decisions, evidence trail
+- [Contributing](./CONTRIBUTING.md) — dev setup, tests, lint, pre-commit hooks
 - Historical docs ([RFC](./docs/RFC.md), [Architecture](./docs/ARCHITECTURE.md), [Pitch](./docs/PITCH.md), [Validation Plan](./docs/VALIDATION.md)) are preserved with status banners — superseded ≠ deleted.

--- a/plugin/tests/conftest.py
+++ b/plugin/tests/conftest.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 
 import pytest

--- a/plugin/tests/test_briefing.py
+++ b/plugin/tests/test_briefing.py
@@ -1,3 +1,5 @@
+import time as _time
+
 from daimon_briefing import briefing
 
 
@@ -298,8 +300,6 @@ def test_render_plain_handles_missing_overflow_key():
 
 
 # ---- #78: decay/recency ordering inside briefing sections ----
-
-import time as _time
 
 _NOW78 = 1_800_000_000.0
 

--- a/plugin/tests/test_claude_hooks.py
+++ b/plugin/tests/test_claude_hooks.py
@@ -228,7 +228,7 @@ def test_brief_hook_no_team_sync_without_remote(tmp_path, tmp_checkpoint_dir):
         extra_env={"PATH": str(fake_bin), "DAIMON_TEAM_DIR": str(empty_team)},
     )
     assert proc.returncode == 0
-    content = _wait_for_text(capture, "invoked heal")  # hook ran to completion
+    _wait_for_text(capture, "invoked heal")  # hook ran to completion
     time.sleep(0.3)  # give a (wrongly) spawned sync a chance to record
     assert "invoked team" not in capture.read_text()
 
@@ -642,7 +642,7 @@ def test_windsurf_probe_scan_vscdb_finds_trajectory_key(tmp_path):
     # ItemTable). The scan mode must report which key holds a given trajectory
     # WITHOUT shipping whole conversation blobs — key names, sizes, and a
     # small head of the matching value only.
-    import sqlite3, subprocess
+    import sqlite3
     probe = Path(__file__).resolve().parents[2] / "hook" / "daimon-windsurf-probe.py"
     db = tmp_path / "state.vscdb"
     conn = sqlite3.connect(str(db))

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -1593,7 +1594,7 @@ def test_cmd_status_json_has_health_and_siblings(tmp_checkpoint_dir, capsys, mon
     class A:
         project = root
         json = True
-    rc = cli._cmd_status(A())
+    cli._cmd_status(A())
     out = json.loads(capsys.readouterr().out)
     assert "health" in out and "siblings" in out
     assert out["project"]["slug"] == slug
@@ -2049,7 +2050,7 @@ def test_cli_recall_flags_superseded(tmp_checkpoint_dir, capsys, monkeypatch, tm
         project_dir=proj)
     rc = cli.main(["recall", "meerkat", "--project", proj])
     assert rc == 0
-    lines = [l for l in capsys.readouterr().out.splitlines() if "meerkat" in l]
+    lines = [ln for ln in capsys.readouterr().out.splitlines() if "meerkat" in ln]
     assert len(lines) == 2
     assert "superseded" not in lines[0]  # live item first
     assert "superseded by S-new" in lines[1]
@@ -2982,7 +2983,7 @@ def test_status_json_reports_disabled(tmp_checkpoint_dir, sample_checkpoint, cap
     from daimon_briefing import store
     store.write_checkpoint("S1", sample_checkpoint)
     monkeypatch.setenv("DAIMON_DISABLE", "1")
-    rc = cli.main(["status", "--json"])
+    cli.main(["status", "--json"])
     data = json.loads(capsys.readouterr().out)
     assert data["disabled"] is True
 
@@ -3010,7 +3011,7 @@ def test_status_counts_recent_skipped_sessions(
 def test_status_no_skip_line_when_none(tmp_checkpoint_dir, sample_checkpoint, capsys):
     from daimon_briefing import store
     store.write_checkpoint("S1", sample_checkpoint)
-    rc = cli.main(["status"])
+    cli.main(["status"])
     assert "skipped" not in capsys.readouterr().out
 
 
@@ -3316,8 +3317,6 @@ def test_stats_events_scoped_to_current_project(
 
 
 # ---- retention: hook briefings vs deliberate re-reads ----
-
-from datetime import datetime, timedelta, timezone
 
 
 def _usage_line(days_ago, cmd, now):

--- a/plugin/tests/test_config.py
+++ b/plugin/tests/test_config.py
@@ -1,4 +1,8 @@
-from daimon_briefing import config
+import getpass
+import subprocess
+from pathlib import Path
+
+from daimon_briefing import config, store
 
 
 def test_checkpoint_dir_from_env(monkeypatch, tmp_path):
@@ -191,12 +195,6 @@ def test_hung_after_seconds_malformed_falls_back(monkeypatch):
 
 # ---- resolve_project_root: normalize a subdir session to its git toplevel (#74) ----
 
-import subprocess
-
-from pathlib import Path
-
-from daimon_briefing import store
-
 
 def _init_git_repo(path: Path) -> None:
     """Init a bare-minimum git repo. `rev-parse --show-toplevel` works right after
@@ -316,8 +314,6 @@ def test_checkpoint_keep_noninteger_falls_back(monkeypatch):
 
 
 # ---- team memory (#111): opt-in dual-write, team dir, author identity ----
-
-import getpass
 
 
 def test_team_enabled_opt_in(monkeypatch):

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -765,7 +765,6 @@ def test_suggest_db_error_writes_breadcrumb(tmp_checkpoint_dir, monkeypatch):
                                  "trust": "inferred"}]),
         project_dir="/repo/x",
     )
-    real_connect = sq.connect
     def bad_connect(*a, **k):
         raise sq.OperationalError("database is locked")
     monkeypatch.setattr(recall.sqlite3, "connect", bad_connect)

--- a/plugin/tests/test_transcript.py
+++ b/plugin/tests/test_transcript.py
@@ -1,3 +1,4 @@
+import json as _json
 from pathlib import Path
 
 from daimon_briefing import transcript
@@ -220,8 +221,6 @@ def test_from_session_uses_db_when_available(monkeypatch):
 
 
 # ---- last_timestamp: session-end stamp for heal/serialize routing (#123) ----
-
-import json as _json
 
 
 def _jsonl(tmp_path, rows, name="s.jsonl"):


### PR DESCRIPTION
Closes #151

### What

1. **`.pre-commit-config.yaml`**: ruff check-only (no autofix), pinned `v0.15.20` — the exact version CI uses (tag + hook id verified against the upstream repo); plus a local `scripts/sync_hooks.py --check` hook (`always_run`, <100ms stdlib) so hook-mirror drift dies at commit time. Path scope identical to CI, bump-both-together comment on both sides.
2. **CI lint scope**: `ruff check daimon_briefing tests ../scripts` (from the job's `plugin/` working dir). The extension surfaced **15 pre-existing findings** (issue predicted 5) — F401/F841/E401/E402/E741 across 7 test files, each fixed mechanically; review verified every dropped binding was dead and every import move order-safe. Zero test-behavior change.
3. **`.gitignore`**: `coverage.xml` + `junit.xml` (CI generates the latter since the test-results upload).
4. **`CONTRIBUTING.md`** (new — none existed): setup, `uvx pre-commit install`, the test-runner incantation including the `--extra pretty` gotcha, lint commands, linked from README.
5. **Maintainer step documented as intended state** (here, in CONTRIBUTING, and on the lint job): add "lint (ruff + mypy)" to branch-protection required status checks — repo settings, only the maintainer can flip it. Suggest recording the flip in a comment on #151.

Rule tightening (beyond default E4/E7/E9/F, the E501 decision) deliberately untouched — the issue defers it until the broadened scope's noise level is visible. It now is: 15 findings, all trivial.

### Proof

- `pre-commit run --all-files` clean on the tree; **demonstrably fails** on a planted lint error (F401/E402 reported, exit 1) and a planted mirror drift (names the drifted pair, exit 1); sabotage reverted, clean re-run captured.
- Full suite **1114 passed**. Extended ruff clean, exactly as CI will run it. Commit signed.