### PR TITLE
fix(carry): full-vocabulary fallback for link targets that generic subtraction strips

### DIFF
--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -67,6 +67,40 @@ def _same_item(a_text: str, b_text: str, generic=frozenset()) -> bool:
     return shared >= _MIN_SHARED or shared / min(len(a), len(b)) >= _MIN_RATIO
 
 
+def _is_reversal_of(native_item: dict, prev_text: str, prev_id,
+                    generic=frozenset()) -> bool:
+    """Reversal signature (#167): a native item that carries its OWN verified
+    quote AND a `supersedes` link aimed at the prev item is a REVERSAL of that
+    item, not a re-statement — merge's twin block must not treat it as a twin
+    (the #22 freeze would overwrite the reversal with the very decision it
+    reverses, and twin id-inheritance would make bind_links suppress the
+    supersede-candidate event as a self-link).
+
+    Both legs are required: the verified quote pins the reversal to THIS
+    session's transcript (an unverified quote could be fabricated re-extraction
+    — freeze stays the safe default), and the link must aim at the prev item
+    (id-equal when already bound, `_same_item` on free text otherwise) so an
+    unrelated supersedes link can't defeat the freeze."""
+    if native_item.get("quote_verified") is not True:
+        return False
+    links = native_item.get("links")
+    if not isinstance(links, list):
+        return False
+    for link in links:
+        if not isinstance(link, dict) or link.get("type") != "supersedes":
+            continue
+        target = link.get("target")
+        if not isinstance(target, str) or not target.strip():
+            continue
+        if _ID_SHAPE.fullmatch(target):
+            if prev_id and target == prev_id:
+                return True
+            continue
+        if _same_item(target, prev_text, generic):
+            return True
+    return False
+
+
 def merge(new_cp: dict, prev_cp: dict | None, now: float,
           floor: float = 0.05, cap: int = 8,
           resolved: frozenset = frozenset()) -> dict:
@@ -117,8 +151,15 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
             text = item["text"]
             if text in native_texts:
                 continue  # exact twin already present (idempotency)
+            # Reversal guard (#167): a native that supersedes THIS prev item
+            # (own verified quote + aimed link) is excluded from twin candidacy
+            # — no freeze, no id inheritance, and the prev item falls through
+            # to the normal carry path below so the render layer can flag it
+            # once bind_links emits the supersede-candidate event.
             twin = next((n for n in native if isinstance(n, dict)
-                         and _same_item(text, str(n.get("text") or ""), generic)),
+                         and _same_item(text, str(n.get("text") or ""), generic)
+                         and not _is_reversal_of(n, text, item.get("id"),
+                                                 generic)),
                         None)
             if twin is not None:
                 # Session re-discussed it. Split by the PREV item's trust class
@@ -141,6 +182,15 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                     twin["text"] = item["text"]
                     if item.get("quote"):
                         twin["quote"] = item["quote"]
+                        # quote_verified travels WITH the quote (#167): the
+                        # native's verdict attested its own (now replaced)
+                        # quote — keeping it would stamp "verified" on a quote
+                        # this session never checked. Prev's verdict rides
+                        # along; absent (pre-#125 checkpoint) means unknown.
+                        if "quote_verified" in item:
+                            twin["quote_verified"] = item["quote_verified"]
+                        else:
+                            twin.pop("quote_verified", None)
                     twin["trust"] = "verbatim"
                 if item.get("first_seen") and not twin.get("first_seen"):
                     twin["first_seen"] = item["first_seen"]

--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -279,6 +279,22 @@ def bind_links(merged_cp: dict, prev_cp: dict | None) -> list[tuple[str, str, st
                     continue  # already bound
                 matches = [p for p in prev_items
                            if _same_item(target, str(p["text"]), generic)]
+                if not matches:
+                    # Loose-target fallback (#168): supersession pairs share
+                    # their subject vocabulary BY NATURE — when it reaches
+                    # DF>=3 across the kind (reversal + restatement + prev
+                    # original), generic subtraction strips exactly the terms
+                    # that identify the target and pass 1 finds nothing.
+                    # Retry on FULL vocabulary, strict >=3 shared floor only
+                    # (no ratio path — terse targets over-fire it); the
+                    # unique-match gate below still refuses ambiguity, so a
+                    # generic-vocab target matching several items stays text.
+                    # Zero matches only: pass 1 finding SEVERAL is a verdict
+                    # (ambiguous), not a miss.
+                    matches = [p for p in prev_items
+                               if len(set(recall.salient_terms(target))
+                                      & set(recall.salient_terms(str(p["text"]))))
+                               >= _MIN_SHARED]
                 if len(matches) != 1:
                     continue  # unbound or ambiguous — leave as text
                 prev_id, old_text = matches[0]["id"], matches[0]["text"]

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -121,10 +121,15 @@ RULES — follow every one exactly; this is the point of the exercise:
 
 16. SUPERSESSION LINKS (conservative): when a recent_decision explicitly REPLACES a prior
     decision — signaled by explicit replacement language such as "instead of", "replaces", or
-    "we changed from X to Y" — attach `"links": [{"type": "supersedes", "target": "<short
-    description of the OLD decision>"}]` to that item. NEVER attach a supersedes link from
-    topic overlap or similarity alone; the replacement must be stated explicitly, not guessed.
-    Omit `links` entirely when no such replacement applies — do not emit an empty array.
+    "we changed from X to Y" — attach `"links": [{"type": "supersedes", "target": "<the OLD
+    decision, named as specifically as this transcript allows>"}]` to that item. The target is
+    matched against the old decision's stored text by word overlap, so name it with the exact
+    nouns the transcript uses for it (subject + object + qualifiers, e.g. "use Tutorials Dojo
+    practice exam sets for week 9", not "Tutorials Dojo purchase plan") — never invent summary
+    words the transcript does not contain, and never compress it below the words needed to pick
+    it out. NEVER attach a supersedes link from topic overlap or similarity alone; the
+    replacement must be stated explicitly, not guessed. Omit `links` entirely when no such
+    replacement applies — do not emit an empty array.
 
 Schema shape:
 {

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -603,6 +603,38 @@ def test_reversal_id_shaped_target_matches_prev_id():
     assert len(ds) == 2
 
 
+def test_reversal_detected_past_malformed_and_empty_link_entries():
+    # The link walk must skip junk entries (non-dict, wrong type, missing or
+    # blank target) and still find the aimed supersedes link after them.
+    prev, new = _reversal_cps()
+    native = new["working_context"]["recent_decisions"][0]
+    native["links"] = [
+        "bare-string",
+        {"type": "related", "target": _REV_TARGET},
+        {"type": "supersedes"},
+        {"type": "supersedes", "target": "   "},
+        {"type": "supersedes", "target": 42},
+        {"type": "supersedes", "target": _REV_TARGET},
+    ]
+    out = carry.merge(new, prev, NOW)
+    ds = out["working_context"]["recent_decisions"]
+    assert len(ds) == 2                            # reversal + carried prev
+    native_out = next(d for d in ds if not d.get("carried_from"))
+    assert native_out["text"] == _REV_NATIVE       # freeze did not fire
+
+
+def test_id_shaped_target_for_other_item_does_not_defeat_freeze():
+    # An already-bound target aimed at a DIFFERENT item's id is not a reversal
+    # of THIS prev item — the freeze must still apply to the twin.
+    prev, new = _reversal_cps()
+    new["working_context"]["recent_decisions"][0]["links"][0]["target"] = \
+        "r-fff999"  # id-shaped, but not the prev item's id
+    out = carry.merge(new, prev, NOW)
+    ds = out["working_context"]["recent_decisions"]
+    assert len(ds) == 1
+    assert ds[0]["text"] == _REV_PREV              # frozen original won
+
+
 # --- quote_verified must travel with the quote on the freeze path (#167) -----
 
 def test_freeze_pops_stale_quote_verified_when_prev_has_none():

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -652,6 +652,96 @@ def test_freeze_pops_stale_quote_verified_when_prev_has_none():
     assert "quote_verified" not in q
 
 
+# --- loose-target fallback in bind_links (#168) ------------------------------
+# Supersession pairs share their subject vocabulary BY NATURE — the subject is
+# the identity. When that vocabulary reaches document-frequency 3 across the
+# kind (reversal + restatement + prev original), generic subtraction strips it
+# and the link target can no longer reach the _same_item floors, so the
+# supersession silently never binds. Fallback: when the generic-subtracted pass
+# finds ZERO matches, retry without subtraction under the strict >=3 shared
+# floor only (no ratio path — terse targets over-fire it), still requiring a
+# UNIQUE match (never-guess: ambiguity stays unbound).
+
+def _loose_target_cps():
+    prev = _cp("S-prev", 1, decisions=[
+        _item("commit to the aws solutions architect exam ten week plan",
+              id="d-old001"),
+        _item("zephyr gateway rollout ordering unrelated", id="d-old002"),
+    ])
+    merged = _cp("S-new", 0, decisions=[
+        _item("drop the aws solutions architect prep entirely",
+              id="d-new001",
+              links=[{"type": "supersedes",
+                      "target": "aws solutions architect advanced preparation"}]),
+        _item("aws solutions architect course refund requested",
+              id="d-new002"),
+    ])
+    return prev, merged
+
+
+def test_bind_links_generic_stripped_target_falls_back_to_unique_bind():
+    # RED today: {aws, solutions, architect} hit DF>=3 across the kind ->
+    # generic -> the target's residue {advanced, preparation} shares nothing
+    # with the prev item -> pass 1 finds zero -> link stays free text. The
+    # fallback must bind it: full-vocabulary overlap is 3 shared terms and the
+    # match is unique.
+    prev, merged = _loose_target_cps()
+    pairs = carry.bind_links(merged, prev)
+    assert pairs == [("d-old001", "d-new001",
+                      "commit to the aws solutions architect exam ten week "
+                      "plan")]
+    link = merged["working_context"]["recent_decisions"][0]["links"][0]
+    assert link["target"] == "d-old001"
+
+
+def test_bind_links_fallback_refuses_ambiguous_full_vocab():
+    # Two prev items both reach >=3 shared full-vocabulary terms with the
+    # target -> fallback must stay unbound (a wrong bind fabricates
+    # provenance).
+    prev, merged = _loose_target_cps()
+    prev["working_context"]["recent_decisions"][1] = _item(
+        "retake the aws solutions architect exam next quarter", id="d-old002")
+    pairs = carry.bind_links(merged, prev)
+    assert pairs == []
+    link = merged["working_context"]["recent_decisions"][0]["links"][0]
+    assert link["target"] == "aws solutions architect advanced preparation"
+
+
+def test_bind_links_fallback_requires_three_full_shared_terms():
+    # Documented limit (the terse-target class, live specimen): "Tutorials
+    # Dojo purchase plan" shares only {tutorials, dojo} with the prev item —
+    # 2 < 3 shared and ratio 2/4 = 0.5 < 0.6, so pass 1 misses; the fallback
+    # (>=3 full-vocabulary shared, no ratio path) must ALSO refuse. Two terms
+    # is not identity — the prompt-side fix (name the old decision
+    # specifically) is the answer for this class, not looser matching.
+    prev = _cp("S-prev", 1, decisions=[
+        _item("use tutorials dojo practice exam sets for week nine",
+              id="d-old001")])
+    merged = _cp("S-new", 0, decisions=[
+        _item("switch to the plimsol skills program instead",
+              id="d-new001",
+              links=[{"type": "supersedes",
+                      "target": "tutorials dojo purchase plan"}])])
+    pairs = carry.bind_links(merged, prev)
+    assert pairs == []
+
+
+def test_bind_links_pass1_ambiguity_never_falls_back():
+    # Pass 1 finding MULTIPLE matches is a verdict (ambiguous), not a miss —
+    # the fallback only runs on zero matches. Mirrors
+    # test_bind_links_ambiguous_stays_text_no_pair with the fallback present.
+    prev = _cp("S-prev", 1, decisions=[
+        _item("old zulu rollout plan alpha version one", id="r-old010"),
+        _item("old zulu rollout plan beta version two", id="r-old020"),
+    ])
+    merged = _cp("S-new", 0, decisions=[
+        _item("switch to plan omega", id="r-new002",
+              links=[{"type": "supersedes",
+                      "target": "legacy zulu rollout plan alpha beta"}])])
+    pairs = carry.bind_links(merged, prev)
+    assert pairs == []
+
+
 def test_freeze_copies_prev_quote_verified_with_quote():
     # Prev carries its own verdict — it rides along with the pinned quote.
     prev = _cp("S-prev", 1, questions=[_item(

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -481,3 +481,152 @@ def test_bind_links_same_kind_only():
     assert pairs == []
     link = merged["working_context"]["recent_decisions"][0]["links"][0]
     assert link["target"] == text
+
+
+# --- reversal guard on the verbatim freeze (#167) ----------------------------
+# A native item that REVERSES a prev verbatim decision shares its vocabulary
+# (both name the same subject), so _same_item twin-matches them — and the #22
+# freeze then overwrites the reversal with the decision it was reversing. The
+# reversal signature (the native carries its OWN verified quote AND a
+# `supersedes` link aimed at the prev item) must exclude it from twin
+# candidacy entirely: no freeze, no id inheritance, prev carried as its own
+# item so bind_links can emit the supersede-candidate event.
+
+_REV_PREV = ("Study commitment: target the quorint solutions architect exam "
+             "with a ten week plan")
+_REV_PREV_QUOTE = "committing to the quorint solutions architect exam"
+_REV_NATIVE = ("Drop the quorint solutions architect exam prep entirely; new "
+               "target is the plimsol cloud engineer exam")
+_REV_NATIVE_QUOTE = "dropping the quorint solutions architect prep entirely"
+_REV_TARGET = "quorint solutions architect exam preparation plan"
+
+
+def _reversal_cps():
+    prev = _cp("S-prev", 1, decisions=[_item(
+        _REV_PREV, trust="verbatim", quote=_REV_PREV_QUOTE,
+        quote_verified=True, id="r-old001", days=10)])
+    new = _cp("S-new", 0, decisions=[_item(
+        _REV_NATIVE, trust="verbatim", quote=_REV_NATIVE_QUOTE,
+        quote_verified=True, days=0,
+        links=[{"type": "supersedes", "target": _REV_TARGET}])])
+    return prev, new
+
+
+def test_reversal_native_survives_prev_verbatim_freeze():
+    # RED today: the freeze overwrites the reversal's text+quote with the prev
+    # decision's, and the reversal is lost from the record.
+    prev, new = _reversal_cps()
+    out = carry.merge(new, prev, NOW)
+    ds = out["working_context"]["recent_decisions"]
+    native = next(d for d in ds if not d.get("carried_from"))
+    assert native["text"] == _REV_NATIVE          # reversal text intact
+    assert native["quote"] == _REV_NATIVE_QUOTE   # its own verified quote intact
+    assert native.get("quote_verified") is True
+    assert native.get("id") != "r-old001"         # no twin id-inheritance
+
+
+def test_reversal_prev_item_still_carries_alongside():
+    # The reversed decision is NOT silently dropped: it carries as its own item
+    # (distinct id) so the render layer can flag it as a supersede-candidate.
+    prev, new = _reversal_cps()
+    out = carry.merge(new, prev, NOW)
+    ds = out["working_context"]["recent_decisions"]
+    assert len(ds) == 2
+    carried = next(d for d in ds if d.get("carried_from"))
+    assert carried["text"] == _REV_PREV
+    assert carried["id"] == "r-old001"
+    assert carried["carried_from"] == "S-prev"
+
+
+def test_reversal_then_bind_links_emits_candidate_pair():
+    # End of the pipeline the bug suppressed: after merge, the (stamped) native
+    # reversal binds its text target to the prev id and bind_links returns the
+    # pair — distinct ids, so the self/twin guard no longer eats the event.
+    prev, new = _reversal_cps()
+    out = carry.merge(new, prev, NOW)
+    native = next(d for d in out["working_context"]["recent_decisions"]
+                  if not d.get("carried_from"))
+    native["id"] = "r-new001"  # what store._stamp_item_ids does pre-bind
+    pairs = carry.bind_links(out, prev)
+    assert pairs == [("r-old001", "r-new001", _REV_PREV)]
+
+
+def test_unrelated_supersedes_link_does_not_defeat_freeze():
+    # GUARD against over-loosening: a native twin whose supersedes link points
+    # somewhere ELSE is a re-statement carrying an unrelated link — the #22
+    # freeze must still apply.
+    prev = _cp("S-prev", 1, decisions=[_item(
+        _REV_PREV, trust="verbatim", quote=_REV_PREV_QUOTE,
+        id="r-old001", days=10)])
+    new = _cp("S-new", 0, decisions=[_item(
+        "the quorint solutions architect exam commitment still stands",
+        trust="verbatim", quote="commitment still stands",
+        quote_verified=True, days=0,
+        links=[{"type": "supersedes",
+                "target": "zephyr gateway rollout ordering choice"}])])
+    out = carry.merge(new, prev, NOW)
+    ds = out["working_context"]["recent_decisions"]
+    assert len(ds) == 1
+    assert ds[0]["text"] == _REV_PREV             # frozen original won
+    assert ds[0]["quote"] == _REV_PREV_QUOTE
+
+
+def test_reversal_signature_requires_verified_quote():
+    # An UNVERIFIED native with a supersedes link is not trusted as a reversal
+    # (the quote could be fabricated) — freeze applies as before.
+    prev = _cp("S-prev", 1, decisions=[_item(
+        _REV_PREV, trust="verbatim", quote=_REV_PREV_QUOTE,
+        id="r-old001", days=10)])
+    new = _cp("S-new", 0, decisions=[_item(
+        _REV_NATIVE, trust="verbatim", quote=_REV_NATIVE_QUOTE,
+        quote_verified=False, days=0,
+        links=[{"type": "supersedes", "target": _REV_TARGET}])])
+    out = carry.merge(new, prev, NOW)
+    ds = out["working_context"]["recent_decisions"]
+    assert len(ds) == 1
+    assert ds[0]["text"] == _REV_PREV             # frozen original won
+
+
+def test_reversal_id_shaped_target_matches_prev_id():
+    # The serializer may emit an already-bound id target; the reversal guard
+    # must recognize it against the prev item's id, not just free text. The
+    # target must be _ID_SHAPE-valid (hex tail), so this fixture re-ids the
+    # prev item — "r-old001" has a non-hex tail and would take the text path.
+    prev, new = _reversal_cps()
+    prev["working_context"]["recent_decisions"][0]["id"] = "r-abc123"
+    new["working_context"]["recent_decisions"][0]["links"][0]["target"] = \
+        "r-abc123"
+    out = carry.merge(new, prev, NOW)
+    ds = out["working_context"]["recent_decisions"]
+    native = next(d for d in ds if not d.get("carried_from"))
+    assert native["text"] == _REV_NATIVE
+    assert len(ds) == 2
+
+
+# --- quote_verified must travel with the quote on the freeze path (#167) -----
+
+def test_freeze_pops_stale_quote_verified_when_prev_has_none():
+    # Prev verbatim from a pre-#125 checkpoint (no quote_verified key). The
+    # freeze swaps in prev's quote; the native's quote_verified=True must NOT
+    # survive attached to a quote it never verified.
+    prev = _cp("S-prev", 1, questions=[_item(
+        _VERB_ORIG, trust="verbatim", quote=_VERB_QUOTE, days=45)])
+    new = _cp("S-new", 0, questions=[_item(
+        _VERB_TWIN, trust="verbatim", quote="still dropping on pauses",
+        quote_verified=True, days=0)])
+    out = carry.merge(new, prev, NOW)
+    q = out["working_context"]["open_questions"][0]
+    assert q["quote"] == _VERB_QUOTE
+    assert "quote_verified" not in q
+
+
+def test_freeze_copies_prev_quote_verified_with_quote():
+    # Prev carries its own verdict — it rides along with the pinned quote.
+    prev = _cp("S-prev", 1, questions=[_item(
+        _VERB_ORIG, trust="verbatim", quote=_VERB_QUOTE,
+        quote_verified=True, days=45)])
+    new = _cp("S-new", 0, questions=[_item(_VERB_TWIN, days=0)])
+    out = carry.merge(new, prev, NOW)
+    q = out["working_context"]["open_questions"][0]
+    assert q["quote"] == _VERB_QUOTE
+    assert q["quote_verified"] is True


### PR DESCRIPTION
## Summary

Stacked on #169 (base branch: `fix/167-freeze-eats-reversal` — retarget to main after #169 merges).

Supersession pairs share their subject vocabulary by nature — the subject IS the identity. When that vocabulary reaches document frequency 3 across the kind (reversal + restatement + prev original), generic subtraction strips exactly the terms that identify the link target, pass 1 of `bind_links` finds zero matches, and the supersession silently never binds: no candidate event, no briefing flag.

## Fix

- `bind_links`: on a ZERO-match pass 1, retry on full vocabulary under the strict >=3 shared-terms floor (no ratio path — terse targets over-fire it). The unique-match gate still refuses ambiguity, and a multi-match pass 1 is a verdict (ambiguous), not a miss — the fallback never runs on it. Never-guess bias preserved: a generic-vocab target matching several items stays free text.
- Serializer prompt rule 16: the model must name the old decision with the exact nouns the transcript uses (subject + object + qualifiers), never an invented compressed summary. The terse-target class (2 shared terms, e.g. "Tutorials Dojo purchase plan") is unbindable by design at match time and is fixed at the source.

## Tests

4 new tests (red-first on the core case): generic-stripped target falls back to a unique bind, fallback refuses ambiguous full-vocab matches, the 2-shared-terms limit stays refused (documented live specimen), and pass-1 ambiguity never triggers the fallback.

Full suite: 1126 passed.

Closes #168