### PR TITLE
fix(plugin): remove duplicate hooks declaration from the plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -17,6 +17,5 @@
     "session",
     "context",
     "hooks"
-  ],
-  "hooks": "./hooks/hooks.json"
+  ]
 }


### PR DESCRIPTION
## Summary

Marketplace installs (`/plugin install daimon@daimon`) failed to load any hooks:

```
Duplicate hooks file detected: ./hooks/hooks.json resolves to already-loaded file ...
The standard hooks/hooks.json is loaded automatically, so manifest.hooks should only
reference additional hook files.
```

Claude Code auto-loads the conventional `hooks/hooks.json` from the plugin root; `.claude-plugin/plugin.json` declared that same file in its `hooks` field (which is reserved for ADDITIONAL hook files), so the loader rejected it as a duplicate and the plugin shipped with zero working hooks — the briefing never fired for marketplace users.

One-line fix: drop the `hooks` key; the conventional file keeps loading automatically.

Not related to coexisting manual installs — this failed on every marketplace install. Needs the next release cut to reach marketplace users (installs resolve versioned artifacts).

Closes #179