### PR TITLE
feat(configure): live progress indicator while --test runs the backend roundtrip

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1180,10 +1180,15 @@ def _cmd_configure(args) -> int:
     if getattr(args, "test", False):
         start = time.monotonic()
         try:
-            reply = llm.chat(
-                [{"role": "user", "content":
-                  'Reply with exactly this JSON and nothing else: {"ok": true}'}],
-                retries=1)
+            # working() (#182): the roundtrip is ~15s of otherwise-dead
+            # terminal at the exact moment a new user decides whether the
+            # tool works — spinner on rich/TTY, one plain line elsewhere.
+            with render.working("testing backend — one tiny prompt through "
+                                "the resolved backend"):
+                reply = llm.chat(
+                    [{"role": "user", "content":
+                      'Reply with exactly this JSON and nothing else: {"ok": true}'}],
+                    retries=1)
         except llm.ChatError as exc:
             print(f"backend test: FAILED — {exc}", file=sys.stderr)
             return 1

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -8,6 +8,7 @@ which is non-TTY — always renders plain.
 
 import os
 import sys
+from contextlib import contextmanager
 
 from . import briefing, config, serializer
 
@@ -36,6 +37,24 @@ def supports_rich() -> bool:
 
 
 _TRUST_STYLE = {"verbatim": "bold green", "inferred": "yellow", "untagged": "dim"}
+
+
+@contextmanager
+def working(message: str):
+    """Live 'this is running' indicator around a slow call (#182).
+
+    Rich + TTY: an animated status spinner for the duration of the body —
+    the first thing a new user runs (`configure --test`) is a ~15s silent
+    LLM roundtrip, and dead terminal at that moment reads as hung. Plain
+    path prints the message once and returns (hook/log-safe, exact-format
+    testable). Body exceptions propagate untouched either way."""
+    if not supports_rich():
+        print(f"{message}...", flush=True)
+        yield
+        return
+    from rich.console import Console
+    with Console().status(f"{message}..."):
+        yield
 
 
 def _trust_key(item) -> str:

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -864,3 +864,36 @@ def test_render_heal_abort_rich_smoke(monkeypatch, capsys):
     monkeypatch.setattr(render, "supports_rich", lambda: True)
     render.render_heal_abort(["heal aborted: transcript for S-1 vanished"])
     assert "heal aborted" in capsys.readouterr().out
+
+
+# ---- working(): live progress indicator around a slow call (#182) ----------
+
+
+def test_working_plain_prints_message_once_and_runs_body(capsys):
+    ran = []
+    with render.working("testing backend"):
+        ran.append(True)
+    assert ran == [True]
+    assert capsys.readouterr().out == "testing backend...\n"
+
+
+def test_working_rich_smoke_runs_body(monkeypatch, capsys):
+    # rich Status animates on a live console; content-only smoke per house
+    # rule — body must run and nothing may raise with the spinner active.
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    ran = []
+    with render.working("testing backend"):
+        ran.append(True)
+    assert ran == [True]
+
+
+def test_working_plain_body_exception_propagates(capsys):
+    class Boom(RuntimeError):
+        pass
+    try:
+        with render.working("testing backend"):
+            raise Boom()
+    except Boom:
+        pass
+    else:  # pragma: no cover - the assert below documents intent
+        raise AssertionError("working() swallowed the body's exception")


### PR DESCRIPTION
## Summary

`daimon configure --backend claude-cli --test` sat completely silent for the LLM roundtrip (~15s observed live) and then printed the verdict — the FIRST command a new user runs after install, indistinguishable from a hang while it works.

## Changes

- `render.working(message)` — context manager on the existing `supports_rich()` gate: animated `Console.status` spinner on rich+TTY; a single plain `message...` line on the plain/non-TTY path (hook- and log-safe, exact-format testable). Body exceptions propagate untouched.
- `--test` branch wraps the `llm.chat` roundtrip in it. Verdict line unchanged.

Plain path, live:

```
testing backend — one tiny prompt through the resolved backend...
backend test: ok (3.7s round trip)
```

## Tests

3 red-first: plain path prints the message exactly once and runs the body, rich smoke (body runs, nothing raises with the spinner active), body exceptions propagate. Existing configure --test trio untouched and green.

Full suite: 1133 passed.

Closes #182