### PR TITLE
fix(hooks): close the claude --resume capture gap

### DIFF
--- a/hook/_daimon_hook_lib.py
+++ b/hook/_daimon_hook_lib.py
@@ -289,7 +289,20 @@ def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
         if best_path is None:
             return
         spawn_serialize(cli, str(best_path), project_env(cwd))
-        log(f"session-start: catch-up serialize spawned for {best_path.stem} (orphaned transcript)")
+        # Ledger-shaped spawn line: ledger._SPAWN_RE already lists the
+        # `session-start:` prefix (for the #26 retry marker), and the `spawned`
+        # verb keeps this distinct from that one-retry-ever marker. Being a
+        # first-class ledger citizen means a catch-up child that hangs or
+        # crashes past the ceiling surfaces in `daimon status`, and — thanks
+        # to the trailing (transcript: ...) group (#28), same shape as
+        # daimon-session-end.py's spawn line — stays healable instead of
+        # invisible. The child's own result line (wrote checkpoint / skipped /
+        # error) resolves the pair exactly like a session-end spawn.
+        log(
+            f"session-start: spawned serialize for {best_path.stem} "
+            f"(reason: catch-up-orphan, project: {cwd or '?'}) "
+            f"(transcript: {best_path})"
+        )
     except Exception as exc:  # noqa: BLE001 — the sweep must never break the briefing
         log(f"session-start: catch-up sweep failed ({type(exc).__name__}: {exc})")
 

--- a/hook/_daimon_hook_lib.py
+++ b/hook/_daimon_hook_lib.py
@@ -234,6 +234,66 @@ def spawn_team_sync(cli, cwd) -> None:
         pass
 
 
+_ORPHAN_MAX_AGE_SECONDS = 14 * 24 * 3600  # 14 days — bounds the sweep's directory scan
+
+
+def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
+    """Catch-up sweep (#185) for a `claude --resume` fork's never-captured
+    transcript: resuming a dead session forks it into a NEW session id with its
+    own transcript file, but the host can fail to fire SessionEnd for that fork
+    (e.g. the IDE window is killed again before a clean exit) — there is then
+    nothing daimon can hook at ITS end, so recovery has to happen here, at the
+    NEXT session's start instead.
+
+    Scans the directory the CURRENT session's own transcript lives in (its
+    siblings are every other session ever run against this project) for the
+    most recently modified transcript that looks uncaptured: no checkpoint on
+    disk for it at all, or a checkpoint OLDER than the transcript (written
+    before the session actually ended). Spawns AT MOST ONE detached serialize
+    per session start — the newest candidate — the exact same way
+    `daimon-session-end.py` does.
+
+    Idempotent by construction, so the mtime heuristic alone is enough: the
+    spawned serialize hits the #185 identical-bytes guard and no-ops if the
+    transcript actually WAS captured, and the existing too-short skip handles
+    noise/tiny files. Fail-open — this must run AFTER briefing emission and
+    never affect it, so every error here is swallowed, at most logged."""
+    if cli is None or not transcript_path:
+        return
+    try:
+        current = Path(transcript_path)
+        directory = current.parent
+        if not directory.is_dir():
+            return
+        cutoff = time.time() - _ORPHAN_MAX_AGE_SECONDS
+        ckpt_dir = checkpoint_dir()
+        best_path = None
+        best_mtime = None
+        for candidate in directory.glob("*.jsonl"):
+            if candidate.stem == session_id or candidate == current:
+                continue  # never sweep the session that is starting right now
+            try:
+                mtime = candidate.stat().st_mtime
+            except OSError:
+                continue
+            if mtime < cutoff:
+                continue  # outside the bounded scan window
+            ckpt_path = ckpt_dir / f"{candidate.stem}.json"
+            try:
+                if ckpt_path.stat().st_mtime >= mtime:
+                    continue  # already captured at/after this transcript's mtime
+            except OSError:
+                pass  # no checkpoint on disk at all -> orphan candidate
+            if best_mtime is None or mtime > best_mtime:
+                best_path, best_mtime = candidate, mtime
+        if best_path is None:
+            return
+        spawn_serialize(cli, str(best_path), project_env(cwd))
+        log(f"session-start: catch-up serialize spawned for {best_path.stem} (orphaned transcript)")
+    except Exception as exc:  # noqa: BLE001 — the sweep must never break the briefing
+        log(f"session-start: catch-up sweep failed ({type(exc).__name__}: {exc})")
+
+
 def spawn_serialize(cli, transcript_path, env) -> None:
     """Spawn `daimon serialize <transcript>` DETACHED so the hook returns
     immediately (serialization is a 30s+ LLM call). Raises OSError on spawn

--- a/hook/daimon-session-brief.py
+++ b/hook/daimon-session-brief.py
@@ -91,7 +91,10 @@ def main() -> int:
     if lib.disabled():
         return 0
 
-    cwd = str(lib.payload().get("cwd") or "").strip()
+    data = lib.payload()
+    cwd = str(data.get("cwd") or "").strip()
+    session_id = str(data.get("session_id") or "").strip()
+    transcript_path = str(data.get("transcript_path") or "").strip()
     cli = lib.resolve_cli()
     try:
         _emit_briefing(cwd, cli)
@@ -103,6 +106,12 @@ def main() -> int:
     # Opportunistic team sync (#113): detached, gated on a real sidecar remote
     # existing (cheap dir scan inside) — never blocks or delays the briefing.
     lib.spawn_team_sync(cli, cwd)
+    # Orphan catch-up sweep (#185): recovers a `claude --resume` fork whose
+    # SessionEnd never fired (app-quit kills hooks) by scanning this project's
+    # transcript directory at the NEXT session's start instead. Runs LAST, after
+    # the briefing is already on stdout — its own fail-open guarantee (see
+    # lib.sweep_orphans) means it can never affect what the user already saw.
+    lib.sweep_orphans(cli, cwd, session_id, transcript_path)
     return 0
 
 

--- a/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
+++ b/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
@@ -289,7 +289,20 @@ def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
         if best_path is None:
             return
         spawn_serialize(cli, str(best_path), project_env(cwd))
-        log(f"session-start: catch-up serialize spawned for {best_path.stem} (orphaned transcript)")
+        # Ledger-shaped spawn line: ledger._SPAWN_RE already lists the
+        # `session-start:` prefix (for the #26 retry marker), and the `spawned`
+        # verb keeps this distinct from that one-retry-ever marker. Being a
+        # first-class ledger citizen means a catch-up child that hangs or
+        # crashes past the ceiling surfaces in `daimon status`, and — thanks
+        # to the trailing (transcript: ...) group (#28), same shape as
+        # daimon-session-end.py's spawn line — stays healable instead of
+        # invisible. The child's own result line (wrote checkpoint / skipped /
+        # error) resolves the pair exactly like a session-end spawn.
+        log(
+            f"session-start: spawned serialize for {best_path.stem} "
+            f"(reason: catch-up-orphan, project: {cwd or '?'}) "
+            f"(transcript: {best_path})"
+        )
     except Exception as exc:  # noqa: BLE001 — the sweep must never break the briefing
         log(f"session-start: catch-up sweep failed ({type(exc).__name__}: {exc})")
 

--- a/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
+++ b/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
@@ -234,6 +234,66 @@ def spawn_team_sync(cli, cwd) -> None:
         pass
 
 
+_ORPHAN_MAX_AGE_SECONDS = 14 * 24 * 3600  # 14 days — bounds the sweep's directory scan
+
+
+def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
+    """Catch-up sweep (#185) for a `claude --resume` fork's never-captured
+    transcript: resuming a dead session forks it into a NEW session id with its
+    own transcript file, but the host can fail to fire SessionEnd for that fork
+    (e.g. the IDE window is killed again before a clean exit) — there is then
+    nothing daimon can hook at ITS end, so recovery has to happen here, at the
+    NEXT session's start instead.
+
+    Scans the directory the CURRENT session's own transcript lives in (its
+    siblings are every other session ever run against this project) for the
+    most recently modified transcript that looks uncaptured: no checkpoint on
+    disk for it at all, or a checkpoint OLDER than the transcript (written
+    before the session actually ended). Spawns AT MOST ONE detached serialize
+    per session start — the newest candidate — the exact same way
+    `daimon-session-end.py` does.
+
+    Idempotent by construction, so the mtime heuristic alone is enough: the
+    spawned serialize hits the #185 identical-bytes guard and no-ops if the
+    transcript actually WAS captured, and the existing too-short skip handles
+    noise/tiny files. Fail-open — this must run AFTER briefing emission and
+    never affect it, so every error here is swallowed, at most logged."""
+    if cli is None or not transcript_path:
+        return
+    try:
+        current = Path(transcript_path)
+        directory = current.parent
+        if not directory.is_dir():
+            return
+        cutoff = time.time() - _ORPHAN_MAX_AGE_SECONDS
+        ckpt_dir = checkpoint_dir()
+        best_path = None
+        best_mtime = None
+        for candidate in directory.glob("*.jsonl"):
+            if candidate.stem == session_id or candidate == current:
+                continue  # never sweep the session that is starting right now
+            try:
+                mtime = candidate.stat().st_mtime
+            except OSError:
+                continue
+            if mtime < cutoff:
+                continue  # outside the bounded scan window
+            ckpt_path = ckpt_dir / f"{candidate.stem}.json"
+            try:
+                if ckpt_path.stat().st_mtime >= mtime:
+                    continue  # already captured at/after this transcript's mtime
+            except OSError:
+                pass  # no checkpoint on disk at all -> orphan candidate
+            if best_mtime is None or mtime > best_mtime:
+                best_path, best_mtime = candidate, mtime
+        if best_path is None:
+            return
+        spawn_serialize(cli, str(best_path), project_env(cwd))
+        log(f"session-start: catch-up serialize spawned for {best_path.stem} (orphaned transcript)")
+    except Exception as exc:  # noqa: BLE001 — the sweep must never break the briefing
+        log(f"session-start: catch-up sweep failed ({type(exc).__name__}: {exc})")
+
+
 def spawn_serialize(cli, transcript_path, env) -> None:
     """Spawn `daimon serialize <transcript>` DETACHED so the hook returns
     immediately (serialization is a 30s+ LLM call). Raises OSError on spawn

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -161,6 +161,21 @@ def _run_serialize(transcript_path: Path, project: str | None) -> int:
     # the checkpoint can bind to its exact source content. None when unreadable —
     # stamped only when present; readers tolerate its absence (old checkpoints).
     transcript_sha = transcript.file_sha256(path)
+    session_id = path.stem
+
+    # Identical-bytes guard (#185): a `claude --resume` fork leaves the ORIGINAL
+    # session's transcript on disk unchanged, but a SessionEnd can still fire for
+    # it later (host quirk, retry, manual re-run) — without this, that re-run
+    # burns a full LLM call reproducing a byte-identical checkpoint and reports
+    # a misleading fresh "success" while the real (forked) session's work never
+    # gets captured. Checked BEFORE parsing/preflight/LLM so a hash match short-
+    # circuits all of it, even with no LLM backend configured at all.
+    if store.transcript_unchanged(session_id, transcript_sha):
+        msg = f"skipped serialize for {session_id}: transcript unchanged since checkpoint (hash match)"
+        print(msg)
+        _append_serialize_log(msg)
+        return 0
+
     try:
         messages = transcript.from_file(path)
     except FileNotFoundError:
@@ -178,7 +193,6 @@ def _run_serialize(transcript_path: Path, project: str | None) -> int:
             _append_serialize_log(preflight)
             return 1
 
-    session_id = path.stem
     # Elapsed time lands in serialize.log — checkpoint generation runs 4-25 min
     # in production and was invisible before this.
     llm.reset_fallback()  # #28: detect a silent backend downgrade during THIS run

--- a/plugin/daimon_briefing/hooks.py
+++ b/plugin/daimon_briefing/hooks.py
@@ -71,6 +71,23 @@ def on_session_end(session_id, completed=None, interrupted=None, model=None, pla
         if config.is_disabled():
             return
         deadline = start + config.timeout_seconds()
+        # Identical-bytes guard (#185), same helper cli._run_serialize uses: when
+        # the host hands us a real transcript file (optional — this host reads
+        # messages via transcript.from_session, not a file, so a path is not
+        # always available) and its bytes are unchanged since the checkpoint
+        # already on disk for this session, skip rather than burn an LLM call
+        # reproducing a byte-identical checkpoint. No transcript_path -> can't
+        # hash -> proceeds exactly as before #185 (fail-open).
+        transcript_path = kwargs.get("transcript_path")
+        if transcript_path:
+            transcript_sha = transcript.file_sha256(transcript_path)
+            if store.transcript_unchanged(session_id, transcript_sha):
+                log.info(
+                    "daimon: skipped serialize for session %s: transcript "
+                    "unchanged since checkpoint (hash match)",
+                    session_id,
+                )
+                return
         messages = transcript.from_session(session_id)
         if not messages or len(messages) < config.min_messages():
             return

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -569,6 +569,28 @@ def sibling_buckets(project_dir) -> list[dict]:
     return out
 
 
+def transcript_unchanged(session_id: str, transcript_hash: str | None) -> bool:
+    """True when `transcript_hash` matches the `transcript_hash` already stamped
+    on the PER-SESSION checkpoint for `session_id` (#185): the identical-bytes
+    guard both serialize entry points (cli._run_serialize, hooks.on_session_end)
+    call BEFORE any LLM work, so a duplicate/late SessionEnd on an unchanged
+    transcript (e.g. a `claude --resume` fork's dead original session) is
+    skipped instead of burning a full LLM call to reproduce a byte-identical
+    checkpoint. Fail-open on every edge — no fresh hash, no existing checkpoint,
+    or a missing/malformed stored hash all return False (proceed with a normal
+    serialize); only an exact hex-digest match, computed the same way
+    (transcript.file_sha256, over raw pre-render bytes — #125), justifies a skip."""
+    if not transcript_hash:
+        return False
+    existing = read_checkpoint(session_id)
+    if not existing:
+        return False
+    stored = existing.get("transcript_hash")
+    if not isinstance(stored, str) or not stored:
+        return False
+    return stored == transcript_hash
+
+
 def read_checkpoint(session_id: str) -> dict | None:
     try:
         path = _contained_path(config.checkpoint_dir(), session_id)

--- a/plugin/tests/test_claude_hooks.py
+++ b/plugin/tests/test_claude_hooks.py
@@ -544,7 +544,121 @@ def test_sweep_orphans_logs_breadcrumb_on_spawn(tmp_path, monkeypatch):
     monkeypatch.setattr(lib, "spawn_serialize", lambda cli, path, env: None)
     lib.sweep_orphans("daimon", "/p/A", "S-new", str(current))
     log_text = (tmp_path / "logs" / "serialize.log").read_text(encoding="utf-8")
-    assert "session-start: catch-up serialize spawned for S-orphan (orphaned transcript)" in log_text
+    # Ledger-shaped spawn line (ledger._SPAWN_RE), same shape as the session-end
+    # adapter's, with the trailing (transcript: ...) group (#28) so a crashed
+    # catch-up child stays healable rather than invisible.
+    assert (
+        "session-start: spawned serialize for S-orphan "
+        f"(reason: catch-up-orphan, project: /p/A) (transcript: {orphan})"
+    ) in log_text
+
+
+def test_sweep_orphans_spawn_line_project_unknown_placeholder(tmp_path, monkeypatch):
+    # No cwd known -> the project group logs '?' exactly like daimon-session-end.py.
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
+    monkeypatch.setattr(lib, "LOG_DIR", tmp_path / "logs")
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+    orphan = transcripts / "S-orphan.jsonl"
+    orphan.write_text("{}\n")
+    _age(orphan, 3600)
+
+    monkeypatch.setattr(lib, "spawn_serialize", lambda cli, path, env: None)
+    lib.sweep_orphans("daimon", "", "S-new", str(current))
+    log_text = (tmp_path / "logs" / "serialize.log").read_text(encoding="utf-8")
+    assert "(reason: catch-up-orphan, project: ?)" in log_text
+
+
+# ---- #185: the catch-up spawn line is a first-class ledger citizen ----
+
+_CATCH_UP_SPAWN = (
+    "2026-07-09T18:00:00Z session-start: spawned serialize for S-orphan "
+    "(reason: catch-up-orphan, project: /p/A) (transcript: /tmp/S-orphan.jsonl)"
+)
+_CATCH_UP_NOW = time.mktime((2026, 7, 9, 18, 0, 30, 0, 0, 0))  # ~30s after the stamp
+
+
+def test_catch_up_spawn_line_registers_in_session_ledger():
+    from daimon_briefing import ledger
+
+    entry = ledger._session_ledger(_CATCH_UP_SPAWN + "\n", _CATCH_UP_NOW).get("S-orphan")
+    assert entry is not None
+    assert entry["spawned"] is True
+    assert entry["project"] == "/p/A"
+    assert entry["transcript"] == "/tmp/S-orphan.jsonl"
+    assert entry["retried"] is False  # 'spawned', not the #26 one-retry marker
+
+
+def test_catch_up_spawn_without_result_is_outstanding_and_healable():
+    # Heal coverage: a catch-up child that hangs/crashes past the ceiling must
+    # surface as outstanding — and be healable while its transcript survives.
+    from daimon_briefing import ledger
+
+    led = ledger._session_ledger(_CATCH_UP_SPAWN + "\n", _CATCH_UP_NOW)
+    out = ledger._outstanding_failures(
+        led, _CATCH_UP_NOW,
+        has_checkpoint=lambda sid: False,
+        ceiling=10,  # spawn is ~30s old -> past the hung ceiling
+        transcript_exists=lambda p: True,
+    )
+    assert [f["sid"] for f in out] == ["S-orphan"]
+    assert out[0]["class"] == "healable"
+
+
+def test_catch_up_spawn_resolved_by_hash_match_skip():
+    # spawn -> hash-match skip: the pair must resolve, never stuck outstanding.
+    from daimon_briefing import ledger
+
+    text = (_CATCH_UP_SPAWN + "\n"
+            "skipped serialize for S-orphan: transcript unchanged since checkpoint (hash match)\n")
+    led = ledger._session_ledger(text, _CATCH_UP_NOW)
+    assert led["S-orphan"]["result_kind"] == "skipped"
+    out = ledger._outstanding_failures(
+        led, _CATCH_UP_NOW,
+        has_checkpoint=lambda sid: False,
+        ceiling=10,
+        transcript_exists=lambda p: True,
+    )
+    assert out == []
+
+
+def test_catch_up_spawn_resolved_by_success():
+    # spawn -> wrote checkpoint: resolves the same way a session-end spawn does.
+    from daimon_briefing import ledger
+
+    text = (_CATCH_UP_SPAWN + "\n"
+            "wrote checkpoint: /home/u/.daimon/checkpoints/S-orphan.json (took 42s)\n")
+    led = ledger._session_ledger(text, _CATCH_UP_NOW)
+    assert led["S-orphan"]["result_kind"] == "success"
+    out = ledger._outstanding_failures(
+        led, _CATCH_UP_NOW,
+        has_checkpoint=lambda sid: False,
+        ceiling=10,
+        transcript_exists=lambda p: True,
+    )
+    assert out == []
+
+
+def test_catch_up_spawn_not_counted_in_host_capture_stats(tmp_path, monkeypatch):
+    # _STATS_HOST_RE deliberately excludes session-start spawns (they also carry
+    # the #26 retry marker) — a catch-up spawn must not inflate per-host counts,
+    # and its child's single result line is what stats tally (no double count).
+    from daimon_briefing import ledger
+
+    log_dir = tmp_path / "stats-logs"
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(log_dir))
+    log_dir.mkdir(parents=True)
+    (log_dir / "serialize.log").write_text(
+        _CATCH_UP_SPAWN + "\n"
+        "skipped serialize for S-orphan: transcript unchanged since checkpoint (hash match)\n",
+        encoding="utf-8",
+    )
+    stats = ledger._stats_capture()
+    assert stats["hosts"] == {}
+    assert stats["skipped"] == 1
+    assert stats["errors"] == 0
 
 
 def test_sweep_orphans_noop_without_cli(tmp_path, monkeypatch):

--- a/plugin/tests/test_claude_hooks.py
+++ b/plugin/tests/test_claude_hooks.py
@@ -24,6 +24,15 @@ MANAGER = HOOK_DIR / "daimon-hooks.py"
 LIB_NAME = "_daimon_hook_lib.py"
 VENV_BIN = Path(sys.executable).parent  # holds the `daimon` console script
 
+# Direct import of the (non-hyphenated) shared lib for unit-level sweep tests
+# (#185) — same technique test_windsurf_hooks.py uses for its hyphenated
+# sibling: the subprocess-level tests below exercise the real JSON-in/exit-0
+# contract, this covers sweep_orphans' internal branches without spawning a
+# real child process for every case.
+if str(HOOK_DIR) not in sys.path:
+    sys.path.insert(0, str(HOOK_DIR))
+import _daimon_hook_lib as lib  # noqa: E402
+
 
 def _manager(tmp_path, *args) -> subprocess.CompletedProcess:
     env = {
@@ -422,6 +431,233 @@ def test_session_end_no_cwd_no_project_env(tmp_path, tmp_checkpoint_dir):
     assert proc.returncode == 0
     captured = _wait_for(capture)
     assert "DAIMON_PROJECT_DIR=\n" in captured  # unset for the child, exactly as today
+
+
+# ---- sweep_orphans (#185): session-start catch-up sweep, unit-level ----
+
+
+def _age(path: Path, seconds: float) -> None:
+    past = time.time() - seconds
+    os.utime(path, (past, past))
+
+
+def test_sweep_orphans_spawns_for_uncaptured_transcript(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
+    monkeypatch.setattr(lib, "LOG_DIR", tmp_path / "logs")  # a spawn also logs a breadcrumb
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+    orphan = transcripts / "S-orphan.jsonl"
+    orphan.write_text("{}\n")
+    _age(orphan, 3600)  # 1h old, no checkpoint anywhere -> orphan
+
+    calls = []
+    monkeypatch.setattr(lib, "spawn_serialize", lambda cli, path, env: calls.append(path))
+    lib.sweep_orphans("daimon", "/p/A", "S-new", str(current))
+    assert calls == [str(orphan)]
+
+
+def test_sweep_orphans_spawns_only_the_newest_candidate(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
+    monkeypatch.setattr(lib, "LOG_DIR", tmp_path / "logs")  # a spawn also logs a breadcrumb
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+    older = transcripts / "S-old.jsonl"
+    older.write_text("{}\n")
+    _age(older, 7200)
+    newer = transcripts / "S-newer.jsonl"
+    newer.write_text("{}\n")
+    _age(newer, 60)
+
+    calls = []
+    monkeypatch.setattr(lib, "spawn_serialize", lambda cli, path, env: calls.append(path))
+    lib.sweep_orphans("daimon", "/p/A", "S-new", str(current))
+    assert calls == [str(newer)]
+
+
+def test_sweep_orphans_excludes_current_session(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+    _age(current, 3600)  # old + no checkpoint, but IS the current session
+
+    calls = []
+    monkeypatch.setattr(lib, "spawn_serialize", lambda cli, path, env: calls.append(path))
+    lib.sweep_orphans("daimon", "/p/A", "S-new", str(current))
+    assert calls == []
+
+
+def test_sweep_orphans_skips_when_checkpoint_is_newer_than_transcript(tmp_path, monkeypatch):
+    ckpt_dir = tmp_path / "checkpoints"
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(ckpt_dir))
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+    captured = transcripts / "S-captured.jsonl"
+    captured.write_text("{}\n")
+    _age(captured, 3600)  # 1h old transcript
+    ckpt_dir.mkdir(parents=True)
+    (ckpt_dir / "S-captured.json").write_text("{}\n")  # checkpoint written NOW -> newer
+
+    calls = []
+    monkeypatch.setattr(lib, "spawn_serialize", lambda cli, path, env: calls.append(path))
+    lib.sweep_orphans("daimon", "/p/A", "S-new", str(current))
+    assert calls == []
+
+
+def test_sweep_orphans_ignores_transcripts_older_than_14_days(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+    stale = transcripts / "S-ancient.jsonl"
+    stale.write_text("{}\n")
+    _age(stale, 15 * 24 * 3600)  # 15 days old, no checkpoint -> still ignored
+
+    calls = []
+    monkeypatch.setattr(lib, "spawn_serialize", lambda cli, path, env: calls.append(path))
+    lib.sweep_orphans("daimon", "/p/A", "S-new", str(current))
+    assert calls == []
+
+
+def test_sweep_orphans_logs_breadcrumb_on_spawn(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
+    # _daimon_hook_lib.LOG_DIR is a module-level constant (Path.home()-derived,
+    # not env-driven — these are standalone scripts, no DAIMON_LOG_DIR seam),
+    # so it's monkeypatched directly rather than via env var.
+    monkeypatch.setattr(lib, "LOG_DIR", tmp_path / "logs")
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+    orphan = transcripts / "S-orphan.jsonl"
+    orphan.write_text("{}\n")
+    _age(orphan, 3600)
+
+    monkeypatch.setattr(lib, "spawn_serialize", lambda cli, path, env: None)
+    lib.sweep_orphans("daimon", "/p/A", "S-new", str(current))
+    log_text = (tmp_path / "logs" / "serialize.log").read_text(encoding="utf-8")
+    assert "session-start: catch-up serialize spawned for S-orphan (orphaned transcript)" in log_text
+
+
+def test_sweep_orphans_noop_without_cli(tmp_path, monkeypatch):
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+    orphan = transcripts / "S-orphan.jsonl"
+    orphan.write_text("{}\n")
+    _age(orphan, 3600)
+
+    calls = []
+    monkeypatch.setattr(lib, "spawn_serialize", lambda cli, path, env: calls.append(path))
+    lib.sweep_orphans(None, "/p/A", "S-new", str(current))
+    assert calls == []
+
+
+def test_sweep_orphans_noop_without_transcript_path(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(lib, "spawn_serialize", lambda cli, path, env: calls.append(path))
+    lib.sweep_orphans("daimon", "/p/A", "S-new", "")
+    assert calls == []
+
+
+def test_sweep_orphans_never_raises_when_spawn_serialize_explodes(tmp_path, monkeypatch):
+    # Fail-open (#185): a sweep error must never propagate into the hook —
+    # the briefing has already printed by the time this runs.
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
+    monkeypatch.setattr(lib, "LOG_DIR", tmp_path / "logs")
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+    orphan = transcripts / "S-orphan.jsonl"
+    orphan.write_text("{}\n")
+    _age(orphan, 3600)
+
+    def _boom(*_a, **_k):
+        raise OSError("spawn failed")
+
+    monkeypatch.setattr(lib, "spawn_serialize", _boom)
+    lib.sweep_orphans("daimon", "/p/A", "S-new", str(current))  # must not raise
+    log_text = (tmp_path / "logs" / "serialize.log").read_text(encoding="utf-8")
+    assert "session-start: catch-up sweep failed" in log_text
+
+
+def test_sweep_orphans_never_raises_when_directory_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
+    calls = []
+    monkeypatch.setattr(lib, "spawn_serialize", lambda cli, path, env: calls.append(path))
+    lib.sweep_orphans("daimon", "/p/A", "S-new", str(tmp_path / "gone" / "S-new.jsonl"))
+    assert calls == []
+
+
+# ---- daimon-session-brief.py: orphan sweep wired end-to-end (#185) ----
+
+
+def test_brief_hook_spawns_catch_up_serialize_for_orphaned_transcript(tmp_path, tmp_checkpoint_dir):
+    fake_bin, capture = _fake_cli_argv_recording(tmp_path)
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+    orphan = transcripts / "S-orphan.jsonl"
+    orphan.write_text("{}\n")
+    _age(orphan, 3600)
+
+    proc = _run(
+        BRIEF_HOOK,
+        {"cwd": "/Users/x/projA", "session_id": "S-new", "transcript_path": str(current)},
+        tmp_path,
+        extra_env={"PATH": str(fake_bin)},
+    )
+    assert proc.returncode == 0
+    content = _wait_for_text(capture, "serialize")
+    serialize_calls = [
+        line for line in content.splitlines() if line.split()[:1] == ["serialize"]
+    ]
+    assert len(serialize_calls) == 1
+    assert str(orphan) in serialize_calls[0]
+
+
+def test_brief_hook_no_catch_up_spawn_without_orphan(tmp_path, tmp_checkpoint_dir):
+    fake_bin, capture = _fake_cli_argv_recording(tmp_path)
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+
+    proc = _run(
+        BRIEF_HOOK,
+        {"cwd": "/Users/x/projA", "session_id": "S-new", "transcript_path": str(current)},
+        tmp_path,
+        extra_env={"PATH": str(fake_bin)},
+    )
+    assert proc.returncode == 0
+    _wait_for_text(capture, "heal")  # heal always fires — confirms the child had time to run
+    content = capture.read_text()
+    serialize_calls = [
+        line for line in content.splitlines() if line.split()[:1] == ["serialize"]
+    ]
+    assert serialize_calls == []
+
+
+def test_brief_hook_sweep_never_breaks_briefing_output(
+    tmp_path, tmp_checkpoint_dir, sample_checkpoint
+):
+    # No transcript_path in the payload at all -> sweep can't act, briefing is
+    # unaffected (matches every pre-#185 brief-hook test's payload shape).
+    store.write_checkpoint("S-global", {**sample_checkpoint, "session_id": "S-global"})
+    proc = _run(BRIEF_HOOK, {"cwd": "/p/never-seen", "session_id": "S-new"}, tmp_path)
+    assert proc.returncode == 0
+    assert "checkpoint: S-global" in proc.stdout
 
 
 # ---- lib-missing fail-open (#108) ----

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1748,6 +1748,103 @@ def test_run_serialize_too_short_is_skipped(tmp_path, tmp_log_dir, fake_chat_fac
     assert "error:" not in log            # NOT an error line
 
 
+# ---- #185: identical-bytes guard skips a re-serialize of an unchanged transcript ----
+
+
+def test_run_serialize_skips_when_transcript_hash_matches_checkpoint(
+    tmp_checkpoint_dir, tmp_log_dir, fake_chat_factory, monkeypatch, capsys
+):
+    from daimon_briefing import store, transcript
+
+    tp = FIXTURES / "sample_transcript.md"
+    sid = tp.stem
+    sha = transcript.file_sha256(tp)
+    store.write_checkpoint(sid, {**json.loads(_valid_json(sid)), "transcript_hash": sha})
+
+    monkeypatch.setattr(cli, "_chat", fake_chat_factory("must not be called"))
+    rc = cli._run_serialize(tp, "/p")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert f"skipped serialize for {sid}: transcript unchanged since checkpoint (hash match)" in out
+    log = (tmp_log_dir / "serialize.log").read_text()
+    assert f"skipped serialize for {sid}: transcript unchanged since checkpoint (hash match)" in log
+    assert "error:" not in log
+
+
+def test_run_serialize_proceeds_when_transcript_hash_differs(
+    tmp_checkpoint_dir, tmp_log_dir, fake_chat_factory, monkeypatch, capsys
+):
+    from daimon_briefing import store
+
+    tp = FIXTURES / "sample_transcript.md"
+    sid = tp.stem
+    store.write_checkpoint(sid, {**json.loads(_valid_json(sid)), "transcript_hash": "stale-hash"})
+
+    monkeypatch.setattr(cli, "_chat", fake_chat_factory(_valid_json(sid)))
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    rc = cli._run_serialize(tp, "/p")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "wrote checkpoint" in out
+    assert "skipped" not in out
+
+
+def test_run_serialize_proceeds_when_no_existing_checkpoint(
+    tmp_checkpoint_dir, tmp_log_dir, fake_chat_factory, monkeypatch, capsys
+):
+    tp = FIXTURES / "sample_transcript.md"
+    monkeypatch.setattr(cli, "_chat", fake_chat_factory(_valid_json(tp.stem)))
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    rc = cli._run_serialize(tp, "/p")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "wrote checkpoint" in out
+
+
+def test_run_serialize_proceeds_when_existing_checkpoint_has_no_hash(
+    tmp_checkpoint_dir, tmp_log_dir, fake_chat_factory, monkeypatch, capsys
+):
+    from daimon_briefing import store
+
+    tp = FIXTURES / "sample_transcript.md"
+    sid = tp.stem
+    ck = json.loads(_valid_json(sid))
+    ck.pop("transcript_hash", None)
+    store.write_checkpoint(sid, ck)
+
+    monkeypatch.setattr(cli, "_chat", fake_chat_factory(_valid_json(sid)))
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    rc = cli._run_serialize(tp, "/p")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "wrote checkpoint" in out
+
+
+def test_run_serialize_skip_is_classified_skipped_by_ledger(
+    tmp_checkpoint_dir, tmp_log_dir, fake_chat_factory, monkeypatch, capsys
+):
+    # #185: the new skip reason must classify identically to the existing
+    # too-short skip — never "error", never outstanding/healable.
+    import time
+
+    from daimon_briefing import store, transcript
+
+    tp = FIXTURES / "sample_transcript.md"
+    sid = tp.stem
+    sha = transcript.file_sha256(tp)
+    store.write_checkpoint(sid, {**json.loads(_valid_json(sid)), "transcript_hash": sha})
+    monkeypatch.setattr(cli, "_chat", fake_chat_factory("must not be called"))
+    cli._run_serialize(tp, "/p")
+    capsys.readouterr()
+
+    log = (tmp_log_dir / "serialize.log").read_text()
+    entry = cli._session_ledger(log, time.time()).get(sid)
+    assert entry is not None
+    assert entry["result_kind"] == "skipped"
+    outstanding = cli._compute_outstanding(log, time.time())
+    assert sid not in [f["sid"] for f in outstanding]
+
+
 def test_session_ledger_recognizes_skipped():
     from daimon_briefing import cli
     text = "skipped serialize for S1: transcript too short (1 < 10 messages)\n"

--- a/plugin/tests/test_hooks.py
+++ b/plugin/tests/test_hooks.py
@@ -1,3 +1,5 @@
+import json
+
 import daimon_briefing as plugin
 from daimon_briefing import hooks
 from tests.conftest import make_messages
@@ -142,6 +144,127 @@ def test_on_session_end_never_raises_when_chat_explodes(tmp_checkpoint_dir, fake
         session_id="S-end", completed=True, interrupted=False, model="m", platform="cli"
     )
     assert store.read_checkpoint("S-end") is None
+
+
+# ---- #185: identical-bytes guard (shared with cli._run_serialize) ----
+
+
+def test_on_session_end_skips_when_transcript_hash_matches_checkpoint(
+    tmp_checkpoint_dir, fake_chat_factory, monkeypatch, tmp_path
+):
+    from daimon_briefing import store, transcript as transcript_mod
+
+    tpath = tmp_path / "S-end.jsonl"
+    tpath.write_text('{"role": "user", "content": "hi"}\n')
+    sha = transcript_mod.file_sha256(tpath)
+    store.write_checkpoint("S-end", {**json.loads(_valid_json("S-end")), "transcript_hash": sha})
+
+    chat = fake_chat_factory(_valid_json("S-end"))
+    monkeypatch.setattr(transcript_mod, "from_session", lambda sid: make_messages(20))
+    monkeypatch.setattr(hooks, "_chat", chat)
+
+    hooks.on_session_end(
+        session_id="S-end", completed=True, interrupted=False, model="m", platform="cli",
+        transcript_path=str(tpath),
+    )
+    assert chat.calls == []  # never invoked — the guard short-circuited before the LLM
+
+
+def test_on_session_end_proceeds_when_transcript_hash_differs(
+    tmp_checkpoint_dir, fake_chat_factory, monkeypatch, tmp_path
+):
+    from daimon_briefing import store, transcript as transcript_mod
+
+    tpath = tmp_path / "S-end.jsonl"
+    tpath.write_text('{"role": "user", "content": "hi"}\n')
+    store.write_checkpoint("S-end", {**json.loads(_valid_json("S-end")), "transcript_hash": "stale"})
+
+    chat = fake_chat_factory(_valid_json("S-end"))
+    monkeypatch.setattr(transcript_mod, "from_session", lambda sid: make_messages(20))
+    monkeypatch.setattr(hooks, "_chat", chat)
+
+    hooks.on_session_end(
+        session_id="S-end", completed=True, interrupted=False, model="m", platform="cli",
+        transcript_path=str(tpath),
+    )
+    assert len(chat.calls) == 1
+    assert store.read_checkpoint("S-end") is not None
+
+
+def test_on_session_end_proceeds_when_no_transcript_path_given(
+    tmp_checkpoint_dir, fake_chat_factory, monkeypatch
+):
+    # No file-based transcript to hash — the guard can't act, so behavior stays
+    # exactly as before #185 (fail-open, never blocks a legitimate capture).
+    from daimon_briefing import transcript as transcript_mod
+
+    chat = fake_chat_factory(_valid_json("S-end"))
+    monkeypatch.setattr(transcript_mod, "from_session", lambda sid: make_messages(20))
+    monkeypatch.setattr(hooks, "_chat", chat)
+
+    hooks.on_session_end(
+        session_id="S-end", completed=True, interrupted=False, model="m", platform="cli"
+    )
+    assert len(chat.calls) == 1
+
+
+def test_on_session_end_proceeds_when_no_existing_checkpoint(
+    tmp_checkpoint_dir, fake_chat_factory, monkeypatch, tmp_path
+):
+    from daimon_briefing import transcript as transcript_mod
+
+    tpath = tmp_path / "S-end.jsonl"
+    tpath.write_text('{"role": "user", "content": "hi"}\n')
+    chat = fake_chat_factory(_valid_json("S-end"))
+    monkeypatch.setattr(transcript_mod, "from_session", lambda sid: make_messages(20))
+    monkeypatch.setattr(hooks, "_chat", chat)
+
+    hooks.on_session_end(
+        session_id="S-end", completed=True, interrupted=False, model="m", platform="cli",
+        transcript_path=str(tpath),
+    )
+    assert len(chat.calls) == 1
+
+
+def test_on_session_end_skip_leaves_no_ledger_entry(
+    tmp_checkpoint_dir, fake_chat_factory, monkeypatch, tmp_path
+):
+    # Mirrors the too-short skip: a hash-match skip is a benign no-op, never
+    # written to serialize.log (only in-process FAILURES are ledgered — #142).
+    from daimon_briefing import config, store, transcript as transcript_mod
+
+    tpath = tmp_path / "S-end.jsonl"
+    tpath.write_text('{"role": "user", "content": "hi"}\n')
+    sha = transcript_mod.file_sha256(tpath)
+    store.write_checkpoint("S-end", {**json.loads(_valid_json("S-end")), "transcript_hash": sha})
+
+    chat = fake_chat_factory(_valid_json("S-end"))
+    monkeypatch.setattr(transcript_mod, "from_session", lambda sid: make_messages(20))
+    monkeypatch.setattr(hooks, "_chat", chat)
+
+    hooks.on_session_end(
+        session_id="S-end", completed=True, interrupted=False, model="m", platform="cli",
+        transcript_path=str(tpath),
+    )
+    assert not (config.log_dir() / "serialize.log").exists()
+
+
+def test_on_session_end_guard_never_raises_when_transcript_unchanged_raises(
+    tmp_checkpoint_dir, fake_chat_factory, monkeypatch, tmp_path
+):
+    from daimon_briefing import transcript as transcript_mod
+
+    tpath = tmp_path / "S-end.jsonl"
+    tpath.write_text('{"role": "user", "content": "hi"}\n')
+    chat = fake_chat_factory(_valid_json("S-end"))
+    monkeypatch.setattr(transcript_mod, "from_session", lambda sid: make_messages(20))
+    monkeypatch.setattr(hooks, "_chat", chat)
+    monkeypatch.setattr(hooks.store, "transcript_unchanged", _raiser)
+
+    hooks.on_session_end(
+        session_id="S-end", completed=True, interrupted=False, model="m", platform="cli",
+        transcript_path=str(tpath),
+    )  # must not raise — swallowed by the outer never-raise contract
 
 
 # ---- never-raise: failure injection at every dependency seam ----

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1258,3 +1258,43 @@ def test_read_latest_corrupt_global_pointer_returns_none(tmp_checkpoint_dir):
     tmp_checkpoint_dir.mkdir(parents=True, exist_ok=True)
     (tmp_checkpoint_dir / "latest.json").write_text("{not json", encoding="utf-8")
     assert store.read_latest() is None  # tolerant, no raise
+
+
+# ---- transcript_unchanged (#185): identical-bytes guard ----
+
+
+def test_transcript_unchanged_true_on_hash_match(tmp_checkpoint_dir, sample_checkpoint):
+    ck = {**sample_checkpoint, "session_id": "S-hash", "transcript_hash": "abc123"}
+    store.write_checkpoint("S-hash", ck)
+    assert store.transcript_unchanged("S-hash", "abc123") is True
+
+
+def test_transcript_unchanged_false_on_hash_mismatch(tmp_checkpoint_dir, sample_checkpoint):
+    ck = {**sample_checkpoint, "session_id": "S-hash", "transcript_hash": "abc123"}
+    store.write_checkpoint("S-hash", ck)
+    assert store.transcript_unchanged("S-hash", "different-hash") is False
+
+
+def test_transcript_unchanged_false_when_no_existing_checkpoint(tmp_checkpoint_dir):
+    assert store.transcript_unchanged("S-never-seen", "abc123") is False
+
+
+def test_transcript_unchanged_false_when_stored_hash_missing(tmp_checkpoint_dir, sample_checkpoint):
+    # Pre-#125 checkpoints carry no transcript_hash at all — fail open, never skip.
+    ck = {**sample_checkpoint, "session_id": "S-nohash"}
+    ck.pop("transcript_hash", None)
+    store.write_checkpoint("S-nohash", ck)
+    assert store.transcript_unchanged("S-nohash", "abc123") is False
+
+
+def test_transcript_unchanged_false_when_stored_hash_malformed(tmp_checkpoint_dir, sample_checkpoint):
+    ck = {**sample_checkpoint, "session_id": "S-badhash", "transcript_hash": 12345}
+    store.write_checkpoint("S-badhash", ck)
+    assert store.transcript_unchanged("S-badhash", "abc123") is False
+
+
+def test_transcript_unchanged_false_when_new_hash_is_none(tmp_checkpoint_dir, sample_checkpoint):
+    # An unreadable/missing transcript hashes to None — never treated as a match.
+    ck = {**sample_checkpoint, "session_id": "S-hash2", "transcript_hash": "abc123"}
+    store.write_checkpoint("S-hash2", ck)
+    assert store.transcript_unchanged("S-hash2", None) is False


### PR DESCRIPTION
## Summary

A resumed session (`claude --resume`) forks into a new session id with its
own transcript, but the host can fail to fire `SessionEnd` for the fork
(app-quit kills hooks) — nothing daimon can hook at that session's end.
Meanwhile a later `SessionEnd` for the dead *original* session re-serializes
its byte-identical transcript: a full LLM call reproduces the same
checkpoint and the run logs as a fresh success, masking that the resumed
work was never captured (`daimon status` shows a recent successful
serialize while the project checkpoint stays stale).

## Changes

Two-pronged fix:

- **Identical-bytes guard** — `store.transcript_unchanged(session_id,
  transcript_hash)` compares the fresh transcript sha256 against the
  `transcript_hash` already stamped on that session's checkpoint. Both
  serialize entry points check it before any LLM work:
  - `cli._run_serialize` (the `daimon serialize <transcript>` CLI path,
    what `daimon-session-end.py` spawns)
  - `hooks.on_session_end` (the in-process host path, when a
    `transcript_path` is available)
  A hash match logs `skipped serialize for <id>: transcript unchanged since
  checkpoint (hash match)` instead of a fresh "wrote checkpoint" line.
  Fail-open on every edge: no fresh hash, no existing checkpoint, or a
  missing/malformed stored hash all proceed with a normal serialize. The
  new skip line reuses the existing `skipped serialize for X:` shape, so
  `daimon status`/heal classify it exactly like the existing too-short
  skip (never as an error, never outstanding).

- **Orphan catch-up sweep** — the Claude Code `SessionStart` hook
  (`daimon-session-brief.py`, via a new `_daimon_hook_lib.sweep_orphans`
  helper) scans the current project's transcript directory, *after*
  briefing emission, for a transcript with no checkpoint at all or a
  checkpoint older than itself, bounded to the last 14 days, and spawns
  ONE detached serialize for the newest such candidate — the same
  fire-and-forget path `SessionEnd` uses. The spawned serialize hits the
  identical-bytes guard above and no-ops if the transcript was actually
  already captured, so the sweep only needs the cheap mtime heuristic —
  no extra bookkeeping. Fail-open: any sweep error is swallowed and at
  most logged, never affecting the briefing already printed.

  The spawn logs a ledger-shaped line — `session-start: spawned serialize
  for <stem> (reason: catch-up-orphan, project: <cwd or ?>) (transcript:
  <path>)` — matching `ledger._SPAWN_RE` with the trailing transcript
  group, so a hung/crashed catch-up child surfaces in `daimon status` and
  stays healable, and the child's own result line resolves the pair like
  any session-end spawn. `session-start` spawns stay excluded from
  `_STATS_HOST_RE`, so per-host capture counts are not inflated.

`hook/_daimon_hook_lib.py` is a canonical source mirrored into
`plugin/daimon_briefing/_hooks/`; the copy was resynced with
`scripts/sync_hooks.py` and the drift guard stays green.

## Tests

Red-first for both prongs:
- `store.transcript_unchanged`: hash match/mismatch, no checkpoint,
  missing/malformed stored hash, no fresh hash.
- `cli._run_serialize`: skip on hash match (with the exact log line),
  proceed on mismatch/no-checkpoint/no-stored-hash, and ledger
  classification (`skipped`, never outstanding).
- `hooks.on_session_end`: skip when a transcript_path is given and hashes
  match, proceed otherwise (including no transcript_path at all), never
  raises when the guard itself explodes.
- `_daimon_hook_lib.sweep_orphans` (direct import, unit-level): spawns for
  an uncaptured transcript, only the newest of several candidates, excludes
  the current session, no spawn when the checkpoint is newer, ignores
  transcripts older than 14 days, logs the ledger-shaped spawn line (incl.
  the `project: ?` placeholder), no-ops without a CLI or transcript_path,
  never raises on a missing directory or a `spawn_serialize` explosion.
- Ledger integration for the catch-up spawn line: registers in
  `_session_ledger` with project + transcript attribution (and
  `retried=False`); an unresolved spawn past the hung ceiling is
  outstanding and healable; spawn→hash-match-skip and spawn→success both
  resolve to no outstanding entries; catch-up spawns don't inflate
  per-host capture stats.
- `daimon-session-brief.py` (subprocess, end-to-end): spawns the catch-up
  serialize for an orphan, no spawn without one, briefing output unaffected
  when no `transcript_path` is in the payload at all.

Full suite: 1169 passed (up from 1041 on `main`). `ruff check daimon_briefing
tests ../scripts` clean.

Closes #185
