### PR TITLE
fix(carry): add quantity-conflict guard to stop unlinked twin false merge

### DIFF
--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -35,30 +35,55 @@ _GENERIC_DF = 3     # a term shared by >=3 items of one kind is that kind's
                     # language-neutral (es i18n just shipped).
 
 # Quantity-conflict guard (#173): spelled number-words, normalized to the
-# digit they name. `salient_terms` drops bare digits (<3 chars) and never
+# value they name. `salient_terms` drops bare digits (<3 chars) and never
 # stems, so "ten" and "10" would otherwise never be recognized as the same
 # value — this table is what makes them equivalent.
+_UNITS = {"one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6,
+          "seven": 7, "eight": 8, "nine": 9}
+_TENS = {"twenty": 20, "thirty": 30, "forty": 40, "fifty": 50, "sixty": 60,
+         "seventy": 70, "eighty": 80, "ninety": 90}
 _NUMBER_WORDS = {
-    "one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6,
-    "seven": 7, "eight": 8, "nine": 9, "ten": 10, "eleven": 11,
-    "twelve": 12, "thirteen": 13, "fourteen": 14, "fifteen": 15,
-    "sixteen": 16, "seventeen": 17, "eighteen": 18, "nineteen": 19,
-    "twenty": 20, "thirty": 30, "forty": 40, "fifty": 50, "sixty": 60,
-    "seventy": 70, "eighty": 80, "ninety": 90, "hundred": 100,
+    "zero": 0, **_UNITS, "ten": 10, "eleven": 11, "twelve": 12,
+    "thirteen": 13, "fourteen": 14, "fifteen": 15, "sixteen": 16,
+    "seventeen": 17, "eighteen": 18, "nineteen": 19, **_TENS, "hundred": 100,
 }
+# Compound tens+unit ("twenty-five", "twenty five") must combine into ONE
+# value (25), not two ({20, 5}) — matched and consumed before the single-word
+# pass below so the tens/unit words aren't ALSO counted individually.
+_COMPOUND_RE = re.compile(
+    r"\b(" + "|".join(_TENS) + r")[\s-]+(" + "|".join(_UNITS) + r")\b",
+    re.IGNORECASE)
 _NUMBER_WORD_RE = re.compile(
     r"\b(" + "|".join(_NUMBER_WORDS) + r")\b", re.IGNORECASE)
-_DIGIT_RE = re.compile(r"\b\d+\b")
+# Optional decimal point: "2.5" is ONE value (2.5), not two ({2, 5}).
+_DIGIT_RE = re.compile(r"\b\d+(?:\.\d+)?\b")
+# Thousands separator: "1,000" and "1000" must normalize to the same value.
+# Lookaround-only substitution (no capture groups) so it composes as a
+# pre-pass without disturbing match offsets used elsewhere.
+_THOUSANDS_COMMA_RE = re.compile(r"(?<=\d),(?=\d{3}\b)")
 
 
 def _quantity_tokens(text: str) -> frozenset:
-    """Digit and spelled-number tokens in `text`, normalized to int values.
-    A hyphenated compound like "ten-week" still yields {10}: `\\b` sits on
-    the letter/hyphen boundary same as on whitespace, so the word inside
-    survives untouched by the tokenizer split `salient_terms` would apply."""
-    values = {int(m.group(0)) for m in _DIGIT_RE.finditer(text)}
-    values.update(_NUMBER_WORDS[m.group(0).lower()]
-                  for m in _NUMBER_WORD_RE.finditer(text))
+    """Digit and spelled-number tokens in `text`, normalized to int/float
+    values. A hyphenated compound like "ten-week" still yields {10}: `\\b`
+    sits on the letter/hyphen boundary same as on whitespace, so the word
+    inside survives untouched by the tokenizer split `salient_terms` would
+    apply. Thousands separators are stripped first ("1,000" == "1000"), and
+    a compound tens+unit word pair ("twenty-five") combines into one value
+    (25) instead of being read as two ({20, 5})."""
+    text = _THOUSANDS_COMMA_RE.sub("", text)
+    values: set = set()
+    consumed: list[tuple[int, int]] = []
+    for m in _COMPOUND_RE.finditer(text):
+        values.add(_TENS[m.group(1).lower()] + _UNITS[m.group(2).lower()])
+        consumed.append(m.span())
+    for m in _DIGIT_RE.finditer(text):
+        raw = m.group(0)
+        values.add(float(raw) if "." in raw else int(raw))
+    for m in _NUMBER_WORD_RE.finditer(text):
+        if any(start <= m.start() < end for start, end in consumed):
+            continue  # already folded into a compound match above
+        values.add(_NUMBER_WORDS[m.group(0).lower()])
     return frozenset(values)
 
 
@@ -73,7 +98,14 @@ def _quantity_conflict(a_text: str, b_text: str) -> bool:
         drop every number; that must stay mergeable.
       - one set is a SUBSET of the other ({6} vs {3, 6}) -> no conflict. A
         restatement that drops SOME numbers but introduces no new, differing
-        one is still the same item reworded, not an update."""
+        one is still the same item reworded, not an update.
+
+    Also runs inside `_is_reversal_of` and `bind_links` (both call
+    `_same_item` on a supersedes link's free-text TARGET against a prev
+    item's text). That's normally inert: a target names the OLD item, so its
+    quantities equal or are a subset of the prev item's — conflict needs a
+    genuinely NEW, differing number, which a same-subject target citation
+    doesn't introduce."""
     a = _quantity_tokens(a_text)
     b = _quantity_tokens(b_text)
     if not a or not b:

--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -34,6 +34,52 @@ _GENERIC_DF = 3     # a term shared by >=3 items of one kind is that kind's
                     # per kind per merge — no static stoplist, so carry stays
                     # language-neutral (es i18n just shipped).
 
+# Quantity-conflict guard (#173): spelled number-words, normalized to the
+# digit they name. `salient_terms` drops bare digits (<3 chars) and never
+# stems, so "ten" and "10" would otherwise never be recognized as the same
+# value — this table is what makes them equivalent.
+_NUMBER_WORDS = {
+    "one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6,
+    "seven": 7, "eight": 8, "nine": 9, "ten": 10, "eleven": 11,
+    "twelve": 12, "thirteen": 13, "fourteen": 14, "fifteen": 15,
+    "sixteen": 16, "seventeen": 17, "eighteen": 18, "nineteen": 19,
+    "twenty": 20, "thirty": 30, "forty": 40, "fifty": 50, "sixty": 60,
+    "seventy": 70, "eighty": 80, "ninety": 90, "hundred": 100,
+}
+_NUMBER_WORD_RE = re.compile(
+    r"\b(" + "|".join(_NUMBER_WORDS) + r")\b", re.IGNORECASE)
+_DIGIT_RE = re.compile(r"\b\d+\b")
+
+
+def _quantity_tokens(text: str) -> frozenset:
+    """Digit and spelled-number tokens in `text`, normalized to int values.
+    A hyphenated compound like "ten-week" still yields {10}: `\\b` sits on
+    the letter/hyphen boundary same as on whitespace, so the word inside
+    survives untouched by the tokenizer split `salient_terms` would apply."""
+    values = {int(m.group(0)) for m in _DIGIT_RE.finditer(text)}
+    values.update(_NUMBER_WORDS[m.group(0).lower()]
+                  for m in _NUMBER_WORD_RE.finditer(text))
+    return frozenset(values)
+
+
+def _quantity_conflict(a_text: str, b_text: str) -> bool:
+    """Structural evidence two texts are DISTINCT items regardless of term
+    overlap (#173): both carry quantity tokens, and neither's value set is a
+    subset of the other's — a two-sided numeric mismatch (the live specimen:
+    {10, 6} vs {6, 3}, "10" and "3" each appear on only one side).
+
+    Two deliberate non-fires, both to avoid re-breaking #22:
+      - either text has NO quantity tokens -> no conflict. A restatement can
+        drop every number; that must stay mergeable.
+      - one set is a SUBSET of the other ({6} vs {3, 6}) -> no conflict. A
+        restatement that drops SOME numbers but introduces no new, differing
+        one is still the same item reworded, not an update."""
+    a = _quantity_tokens(a_text)
+    b = _quantity_tokens(b_text)
+    if not a or not b:
+        return False
+    return not (a <= b or b <= a)
+
 
 def _generic_terms(texts, k: int = _GENERIC_DF) -> frozenset:
     """Salient terms appearing in >= k DISTINCT texts of one kind — that kind's
@@ -58,7 +104,14 @@ def _same_item(a_text: str, b_text: str, generic=frozenset()) -> bool:
     bias is deliberate and asymmetric: a false merge erases a loop and forges
     its birth stamp, while a false non-merge only costs a duplicate item — so
     tie-break toward NOT merging. The exact-text guard still catches identical
-    items regardless."""
+    items regardless.
+
+    Quantity-conflict guard (#173) runs FIRST and short-circuits term overlap
+    entirely: two texts stating different numbers are structurally distinct
+    even when they share enough subject vocabulary to clear the thresholds
+    below (an UPDATE's shared frame, not a reworded twin)."""
+    if _quantity_conflict(a_text, b_text):
+        return False
     a = set(recall.salient_terms(a_text)) - generic
     b = set(recall.salient_terms(b_text)) - generic
     if len(a) < 2 or len(b) < 2:

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -752,3 +752,87 @@ def test_freeze_copies_prev_quote_verified_with_quote():
     q = out["working_context"]["open_questions"][0]
     assert q["quote"] == _VERB_QUOTE
     assert q["quote_verified"] is True
+
+
+# --- quantity-conflict guard on unlinked twin false merge (#173) ------------
+# A native item that UPDATES a prior verbatim decision (not a re-statement,
+# not an explicit #167 reversal) can share enough subject vocabulary to
+# twin-match under _same_item's term-overlap rule alone. When the two texts
+# state DIFFERENT numbers, that is structural evidence they are distinct
+# items, not a reworded twin — the guard must block the match regardless of
+# term overlap, so the #22 freeze never fires and the update survives.
+
+_QTY_PREV = ("Study commitment: target exam X with a ten-week plan at 6 "
+             "hours per week")
+_QTY_PREV_QUOTE = "ten-week plan at 6 hours per week"
+_QTY_NATIVE = ("Maintain 6 hours per week study commitment, compressed "
+               "into 3 weeks")
+
+
+def test_quantity_conflict_blocks_twin_merge_native_update_survives():
+    # #173 live specimen: {ten, 6} vs {6, 3} — neither is a subset of the
+    # other, a genuine two-sided numeric mismatch. RED today: term overlap
+    # ({study, commitment, week, hours}) alone twin-matches them and the #22
+    # freeze overwrites the native update's text+quote with the prev
+    # decision's, silently losing the "compressed into 3 weeks" change.
+    prev = _cp("S-prev", 1, decisions=[_item(
+        _QTY_PREV, trust="verbatim", quote=_QTY_PREV_QUOTE, days=10)])
+    new = _cp("S-new", 0, decisions=[_item(_QTY_NATIVE, days=0)])
+    out = carry.merge(new, prev, NOW)
+    ds = out["working_context"]["recent_decisions"]
+    native = next(d for d in ds if not d.get("carried_from"))
+    assert native["text"] == _QTY_NATIVE          # update text intact
+    assert native.get("trust") != "verbatim"       # never frozen
+    assert "carried_from" not in native
+    carried = next(d for d in ds if d.get("carried_from"))
+    assert carried["text"] == _QTY_PREV            # prev survives separately
+    assert carried["quote"] == _QTY_PREV_QUOTE
+    assert carried["trust"] == "verbatim"
+    assert len(ds) == 2
+
+
+def test_quantity_equivalence_number_word_and_digit_still_freezes():
+    # GUARD against over-firing: "ten"/"six" and "10"/"6" normalize to the
+    # SAME value set -> no conflict -> the #22 freeze still applies exactly
+    # as before the guard existed.
+    prev = _cp("S-prev", 1, decisions=[_item(
+        "Study commitment: target exam Y with a ten week plan at six hours "
+        "per week", trust="verbatim",
+        quote="ten week plan at six hours per week", days=45)])
+    new = _cp("S-new", 0, decisions=[_item(
+        "Study commitment: maintaining a 10 week plan at 6 hours per week",
+        days=0)])
+    out = carry.merge(new, prev, NOW)
+    ds = out["working_context"]["recent_decisions"]
+    assert len(ds) == 1
+    assert ds[0]["trust"] == "verbatim"
+    assert "ten week plan" in ds[0]["text"]         # frozen original won
+
+
+def test_quantity_subset_drop_still_freezes_restatement():
+    # DESIGN CHOICE: a restatement that DROPS one number but keeps the other
+    # ({10, 6} -> {6}) is a subset, not a conflict — #22's "restatement drops
+    # detail" behavior must still freeze it. Only a two-sided mismatch (#173
+    # specimen above) counts as conflict.
+    prev = _cp("S-prev", 1, decisions=[_item(
+        _QTY_PREV, trust="verbatim", quote=_QTY_PREV_QUOTE, days=45)])
+    new = _cp("S-new", 0, decisions=[_item(
+        "Study commitment still on at 6 hours per week", days=0)])
+    out = carry.merge(new, prev, NOW)
+    ds = out["working_context"]["recent_decisions"]
+    assert len(ds) == 1
+    assert ds[0]["trust"] == "verbatim"
+    assert ds[0]["text"] == _QTY_PREV               # frozen original won
+
+
+def test_quantity_conflict_dedup_path_prev_items_carry_separately():
+    # Same guard on the plain dedup path (#31 item 9's carry-once): two PREV
+    # items reworded-twins of each other on term overlap alone, but stating
+    # CONFLICTING quantities, must both carry rather than collapsing into one.
+    prev = _cp("S-prev", 1, decisions=[
+        _item("study commitment ten week plan six hours weekly", days=5),
+        _item("study commitment three week plan six hours weekly", days=3),
+    ])
+    out = carry.merge(_cp("S-new"), prev, NOW)
+    ds = out["working_context"]["recent_decisions"]
+    assert len(ds) == 2

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -836,3 +836,115 @@ def test_quantity_conflict_dedup_path_prev_items_carry_separately():
     out = carry.merge(_cp("S-new"), prev, NOW)
     ds = out["working_context"]["recent_decisions"]
     assert len(ds) == 2
+
+
+# --- quantity extraction hardening (#173 review round 2) --------------------
+# Adversarial review found the naive extractor false-conflicts on ordinary
+# reformatting of the SAME number: "1,000" tokenized digit-by-digit around
+# the comma, "twenty-five" read as two separate words instead of one
+# compound, and "2.5" split into {2, 5} at the decimal point. All three bugs
+# point the same direction — over-blocking a legitimate freeze/merge — so
+# each gets a direct unit test on `_quantity_tokens` plus a merge-level
+# regression proving the freeze still fires end to end.
+
+def test_quantity_tokens_strips_thousand_separators():
+    assert carry._quantity_tokens("1,000 users churned") == frozenset({1000})
+    assert carry._quantity_tokens("1000 users churned") == frozenset({1000})
+
+
+def test_quantity_tokens_combines_compound_number_words():
+    assert carry._quantity_tokens("twenty-five students enrolled") == \
+        frozenset({25})
+    assert carry._quantity_tokens("twenty five students enrolled") == \
+        frozenset({25})
+    assert carry._quantity_tokens("25 students enrolled") == frozenset({25})
+
+
+def test_quantity_tokens_decimal_is_one_value():
+    assert carry._quantity_tokens("throughput at 2.5 times baseline") == \
+        frozenset({2.5})
+
+
+def test_quantity_tokens_zero():
+    assert carry._quantity_tokens("zero regressions found") == frozenset({0})
+
+
+def test_quantity_comma_thousands_restatement_still_freezes():
+    # "1,000" vs "1000" must normalize to the same value -> no conflict ->
+    # the #22 freeze fires exactly as it would with no comma at all.
+    prev = _cp("S-prev", 1, decisions=[_item(
+        "Budget approved: 1,000 seats for the rollout", trust="verbatim",
+        quote="1,000 seats for the rollout", days=45)])
+    new = _cp("S-new", 0, decisions=[_item(
+        "Budget approved: 1000 seats confirmed for the rollout", days=0)])
+    out = carry.merge(new, prev, NOW)
+    ds = out["working_context"]["recent_decisions"]
+    assert len(ds) == 1
+    assert ds[0]["trust"] == "verbatim"
+    assert "1,000 seats" in ds[0]["text"]           # frozen original won
+
+
+def test_quantity_compound_word_restatement_still_freezes():
+    # "twenty-five" vs "25" must normalize to the same value -> no conflict.
+    prev = _cp("S-prev", 1, decisions=[_item(
+        "Team target: twenty-five signups this month", trust="verbatim",
+        quote="twenty-five signups this month", days=45)])
+    new = _cp("S-new", 0, decisions=[_item(
+        "Team target: 25 signups confirmed this month", days=0)])
+    out = carry.merge(new, prev, NOW)
+    ds = out["working_context"]["recent_decisions"]
+    assert len(ds) == 1
+    assert ds[0]["trust"] == "verbatim"
+    assert "twenty-five signups" in ds[0]["text"]   # frozen original won
+
+
+# --- quantity guard interaction with the #167 reversal pipeline (#173 round
+# 2 pinning test) -------------------------------------------------------------
+# A reversal's native text can legitimately state a DIFFERENT quantity than
+# the prev item it reverses (that's the whole point of a reversal). The
+# guard already produces the correct outcome here on its own (no twin, so no
+# freeze — the same result #167's carve-out targets), but nothing pinned
+# that the REST of the pipeline (prev still carries alongside, bind_links
+# still resolves the supersedes link) keeps working when the guard is the
+# thing blocking the twin match instead of `_is_reversal_of`.
+
+_REV_QTY_PREV = ("Study commitment: target the quorint solutions architect "
+                  "exam with a 10-week plan at 6 hours per week")
+_REV_QTY_PREV_QUOTE = "10-week plan at 6 hours per week"
+_REV_QTY_NATIVE = ("Drop the 10-week quorint architect plan entirely; "
+                    "committing to a 3-week sprint instead")
+_REV_QTY_NATIVE_QUOTE = "committing to a 3-week sprint instead"
+_REV_QTY_TARGET = "quorint solutions architect exam 10-week plan"
+
+
+def _qty_reversal_cps():
+    prev = _cp("S-prev", 1, decisions=[_item(
+        _REV_QTY_PREV, trust="verbatim", quote=_REV_QTY_PREV_QUOTE,
+        quote_verified=True, id="r-qty001", days=10)])
+    new = _cp("S-new", 0, decisions=[_item(
+        _REV_QTY_NATIVE, trust="verbatim", quote=_REV_QTY_NATIVE_QUOTE,
+        quote_verified=True, days=0,
+        links=[{"type": "supersedes", "target": _REV_QTY_TARGET}])])
+    return prev, new
+
+
+def test_quantity_conflict_guard_does_not_defeat_reversal_pipeline():
+    # prev {10, 6} vs native {10, 3} conflict on quantity alone (guard blocks
+    # the twin before _is_reversal_of even runs) -> same outcome #167 already
+    # guarantees: reversal text+quote survive untouched, prev carries
+    # alongside, and bind_links still resolves the supersedes link (whose
+    # target text cites only the OLD, non-conflicting "10-week" wording)
+    # into a supersede-candidate pair.
+    prev, new = _qty_reversal_cps()
+    out = carry.merge(new, prev, NOW)
+    ds = out["working_context"]["recent_decisions"]
+    native = next(d for d in ds if not d.get("carried_from"))
+    assert native["text"] == _REV_QTY_NATIVE
+    assert native["quote"] == _REV_QTY_NATIVE_QUOTE
+    assert len(ds) == 2
+    carried = next(d for d in ds if d.get("carried_from"))
+    assert carried["text"] == _REV_QTY_PREV
+    assert carried["id"] == "r-qty001"
+    native["id"] = "r-qty-new"  # what store._stamp_item_ids does pre-bind
+    pairs = carry.bind_links(out, prev)
+    assert pairs == [("r-qty001", "r-qty-new", _REV_QTY_PREV)]


### PR DESCRIPTION
## Summary
- `_same_item` twin-matched a native decision that UPDATES a prior verbatim decision purely on shared subject vocabulary (e.g. {study, commitment, week, hours}), with no supersedes link for the #167 reversal carve-out to catch.
- The #22 verbatim freeze then overwrote the update's text and quote with the old decision's, silently losing the change.
- Adds a structural quantity-conflict guard inside `_same_item`: extract quantity tokens (digits and spelled number-words one..twenty plus tens/hundred, normalized to int/float) from both texts. Two texts that both carry quantities whose value sets are neither equal, subset, nor superset of each other are never treated as the same item, regardless of term overlap.

## Conflict rule chosen and why
Given two quantity-token sets A and B:
- If either is empty, no conflict (a restatement can legitimately drop every number — must stay mergeable, preserves existing #22 behavior).
- If one is a subset of the other (e.g. `{6}` vs `{3, 6}`), no conflict. A restatement that drops *some* numbers but introduces no new, differing one is still the same item reworded, not an update.
- Otherwise (neither side is a subset of the other — a genuine two-sided mismatch, e.g. `{10, 6}` vs `{6, 3}`), conflict: block the twin match.

The subset carve-out was chosen over "any set difference = conflict" because a strict any-difference rule would misfire on ordinary restatements that drop one of several numbers (a real pattern #22 already has to tolerate), re-breaking that freeze path. The live #173 specimen (`{10, 6}` vs `{6, 3}`) conflicts under either rule since `10` and `3` each appear on only one side, so the subset carve-out doesn't weaken the fix for the reported case — it only avoids over-firing on partial-drop restatements.

Placement is inside `_same_item` itself (not a narrower freeze-only guard) — no existing fixture forced a fallback; every existing digit/number-word-bearing fixture in `test_carry.py` either has quantities on only one side (guard stays inert) or none at all.

## Extraction hardening (round 2, adversarial review)
The naive extractor false-conflicted on ordinary reformatting of the *same* number — all three bugs over-block a legitimate freeze/merge, same failure direction as the guard's own asymmetric bias, so they had to be closed before merge:

- **Thousands separators**: `"1,000"` tokenized digit-by-digit around the comma as `{1, 0}`, vs `"1000"` as `{1000}` — false conflict on a trivial restatement. Fixed by stripping `(?<=\d),(?=\d{3}\b)` before extraction.
- **Compound number-words**: `"twenty-five"` was read as two independent words `{20, 5}`, vs `"25"` as `{25}` — false conflict on a digit/word restatement. Fixed with a compound pass that matches an adjacent tens+unit pair (hyphen or space separated) and consumes it as one value (25) *before* the single-word pass runs, so the tens/unit words aren't also counted individually.
- **Decimals**: `"2.5"` split at the decimal point into `{2, 5}` instead of one value. Fixed by extending the digit regex to an optional decimal tail (`\d+(?:\.\d+)?`) and normalizing to float when a decimal point is present.
- Added `"zero": 0` to the number-word table.

## Reversal-pipeline interaction (pinning test)
`_is_reversal_of` and `bind_links` also call `_same_item` — on a supersedes link's free-text target against a prev item's text — so the guard now runs inside those comparisons too. That's normally inert (a target names the OLD item, so its quantities equal or are a subset of the prev item's), but nothing pinned it. Added `test_quantity_conflict_guard_does_not_defeat_reversal_pipeline`: a reversal whose native text states a genuinely different quantity than the prev item it reverses (`{10, 6}` vs `{10, 3}`) still gets the correct outcome — the guard blocks the twin match before `_is_reversal_of` even runs (same end result the #167 carve-out targets), the reversal's own text+quote survive untouched, the prev item still carries alongside as its own item, and `bind_links` still resolves the supersedes link (whose target text cites only the old, non-conflicting wording) into a supersede-candidate pair.

## Test plan
- [x] `uv run pytest -q` from `plugin/`: 1180 passed (1169 baseline + 11 new across both rounds)
- [x] `uv run --extra dev ruff check daimon_briefing tests ../scripts`: clean
- [x] `uv run --extra dev mypy daimon_briefing`: only the pre-existing untyped-`carried` note remains (confirmed unchanged via diff against origin/main), nothing new introduced; job is non-blocking in CI
- [x] New tests: #173 specimen (conflict blocks twin merge, native update survives), number-word/digit equivalence still freezes, subset drop still freezes (documents the chosen rule), dedup path keeps conflicting prev items separate, comma-thousands restatement still freezes, compound-word restatement still freezes, decimal/zero/comma/compound unit tests on the extractor itself, and the reversal-pipeline pinning test above

Closes #173