### PR TITLE
feat(hosts): port the orphan catch-up sweep to Codex session-start

### DIFF
--- a/hook/_daimon_hook_lib.py
+++ b/hook/_daimon_hook_lib.py
@@ -238,12 +238,22 @@ _ORPHAN_MAX_AGE_SECONDS = 14 * 24 * 3600  # 14 days — bounds the sweep's direc
 
 
 def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
-    """Catch-up sweep (#185) for a `claude --resume` fork's never-captured
-    transcript: resuming a dead session forks it into a NEW session id with its
-    own transcript file, but the host can fail to fire SessionEnd for that fork
-    (e.g. the IDE window is killed again before a clean exit) — there is then
-    nothing daimon can hook at ITS end, so recovery has to happen here, at the
-    NEXT session's start instead.
+    """Catch-up sweep for a transcript that was never captured because the
+    host's own end-of-session capture path silently missed it. Two callers,
+    same shared logic (host-agnostic by design — nothing below is Claude- or
+    Codex-specific):
+
+    - Claude Code (#185): resuming a dead session forks it into a NEW session
+      id with its own transcript file, but the host can fail to fire
+      SessionEnd for that fork (e.g. the IDE window is killed again before a
+      clean exit) — there is then nothing daimon can hook at ITS end.
+    - Codex (#188): the Stop hook throttles serialize per session
+      (`DAIMON_CODEX_MIN_SERIALIZE_INTERVAL`), so a session whose final
+      activity lands inside the throttle window and never resumes is never
+      serialized again.
+
+    Either way, recovery has to happen here, at the NEXT session's start,
+    instead of at the missed end-of-session event.
 
     Scans the directory the CURRENT session's own transcript lives in (its
     siblings are every other session ever run against this project) for the

--- a/hook/daimon-codex-session-start.py
+++ b/hook/daimon-codex-session-start.py
@@ -100,7 +100,10 @@ def main() -> int:
     if lib.disabled():
         return 0
 
-    cwd = str(lib.payload().get("cwd") or "").strip()
+    data = lib.payload()
+    cwd = str(data.get("cwd") or "").strip()
+    session_id = str(data.get("session_id") or "").strip()
+    transcript_path = str(data.get("transcript_path") or "").strip()
     cli = lib.resolve_cli()
     try:
         _emit_briefing(cwd, cli)
@@ -109,6 +112,14 @@ def main() -> int:
     # Opportunistic self-heal runs regardless of whether a briefing emitted: a
     # failed serialize leaves NO checkpoint, exactly the case where heal matters.
     lib.spawn_heal(cli, cwd)
+    # Orphan catch-up sweep (#188), porting Claude Code's #185 mechanism as-is:
+    # Codex's Stop hook throttles serialize per session, so a session whose
+    # final activity lands inside the throttle window and never resumes is
+    # never captured again. Scanning this session's transcript-sibling
+    # directory at the NEXT session's start recovers it. Runs LAST, after the
+    # briefing is already emitted — lib.sweep_orphans' own fail-open guarantee
+    # means it can never affect what Codex already saw.
+    lib.sweep_orphans(cli, cwd, session_id, transcript_path)
     return 0
 
 

--- a/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
+++ b/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
@@ -238,12 +238,22 @@ _ORPHAN_MAX_AGE_SECONDS = 14 * 24 * 3600  # 14 days — bounds the sweep's direc
 
 
 def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
-    """Catch-up sweep (#185) for a `claude --resume` fork's never-captured
-    transcript: resuming a dead session forks it into a NEW session id with its
-    own transcript file, but the host can fail to fire SessionEnd for that fork
-    (e.g. the IDE window is killed again before a clean exit) — there is then
-    nothing daimon can hook at ITS end, so recovery has to happen here, at the
-    NEXT session's start instead.
+    """Catch-up sweep for a transcript that was never captured because the
+    host's own end-of-session capture path silently missed it. Two callers,
+    same shared logic (host-agnostic by design — nothing below is Claude- or
+    Codex-specific):
+
+    - Claude Code (#185): resuming a dead session forks it into a NEW session
+      id with its own transcript file, but the host can fail to fire
+      SessionEnd for that fork (e.g. the IDE window is killed again before a
+      clean exit) — there is then nothing daimon can hook at ITS end.
+    - Codex (#188): the Stop hook throttles serialize per session
+      (`DAIMON_CODEX_MIN_SERIALIZE_INTERVAL`), so a session whose final
+      activity lands inside the throttle window and never resumes is never
+      serialized again.
+
+    Either way, recovery has to happen here, at the NEXT session's start,
+    instead of at the missed end-of-session event.
 
     Scans the directory the CURRENT session's own transcript lives in (its
     siblings are every other session ever run against this project) for the

--- a/plugin/tests/test_codex_hooks.py
+++ b/plugin/tests/test_codex_hooks.py
@@ -166,6 +166,149 @@ def _fake_cli(tmp_path) -> tuple[Path, Path]:
     return fake_bin, capture
 
 
+# ---- orphan catch-up sweep (#188): SessionStart wiring to lib.sweep_orphans ----
+#
+# lib.sweep_orphans itself (newest-only, 14-day cutoff, checkpoint-freshness
+# skip, directory-missing no-op, spawn-failure fail-open) is already
+# exhaustively unit-tested in test_claude_hooks.py against the exact same
+# shared function — it is reused here unmodified, not copied. These tests
+# only cover what is specific to the Codex hook: that SessionStart actually
+# wires session_id/transcript_path through to the sweep, runs it after heal,
+# and never lets it disturb the briefing.
+
+
+def _age(path: Path, seconds: float) -> None:
+    past = time.time() - seconds
+    os.utime(path, (past, past))
+
+
+def _fake_cli_argv_recording(tmp_path) -> tuple[Path, Path]:
+    """A fake `daimon` that appends each invocation's full argv to a capture
+    file (one line per call), so a test can distinguish the `heal` call from
+    a `serialize <path>` call spawned later by the same hook run."""
+    fake_bin = tmp_path / "fakebin"
+    fake_bin.mkdir()
+    capture = tmp_path / "argv.txt"
+    script = fake_bin / "daimon"
+    script.write_text(
+        "#!/bin/sh\n"
+        f'printf "%s\\n" "$*" >> "{capture}"\n'
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    return fake_bin, capture
+
+
+def test_codex_session_start_spawns_catch_up_serialize_for_orphaned_transcript(
+    tmp_path, tmp_checkpoint_dir
+):
+    fake_bin, capture = _fake_cli_argv_recording(tmp_path)
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+    orphan = transcripts / "S-orphan.jsonl"
+    orphan.write_text("{}\n")
+    _age(orphan, 3600)  # 1h old, no checkpoint anywhere -> orphan
+
+    proc = _run(
+        START_HOOK,
+        {"cwd": "/Users/x/projA", "session_id": "S-new", "transcript_path": str(current)},
+        tmp_path,
+        extra_env={"PATH": str(fake_bin)},
+    )
+    assert proc.returncode == 0
+    content = _wait_for_text(capture, "serialize")
+    serialize_calls = [
+        line for line in content.splitlines() if line.split()[:1] == ["serialize"]
+    ]
+    assert len(serialize_calls) == 1
+    assert str(orphan) in serialize_calls[0]
+
+
+def test_codex_session_start_no_catch_up_spawn_without_orphan(tmp_path, tmp_checkpoint_dir):
+    fake_bin, capture = _fake_cli_argv_recording(tmp_path)
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+
+    proc = _run(
+        START_HOOK,
+        {"cwd": "/Users/x/projA", "session_id": "S-new", "transcript_path": str(current)},
+        tmp_path,
+        extra_env={"PATH": str(fake_bin)},
+    )
+    assert proc.returncode == 0
+    _wait_for_text(capture, "heal")  # heal always fires — confirms the child had time to run
+    content = capture.read_text()
+    serialize_calls = [
+        line for line in content.splitlines() if line.split()[:1] == ["serialize"]
+    ]
+    assert serialize_calls == []
+
+
+def test_codex_session_start_excludes_current_session_via_session_id(
+    tmp_path, tmp_checkpoint_dir
+):
+    # The current session's OWN transcript must never be swept, even aged and
+    # uncaptured — proves the hook actually threads session_id through to
+    # lib.sweep_orphans rather than relying on path identity alone.
+    fake_bin, capture = _fake_cli_argv_recording(tmp_path)
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+    _age(current, 3600)
+
+    proc = _run(
+        START_HOOK,
+        {"cwd": "/Users/x/projA", "session_id": "S-new", "transcript_path": str(current)},
+        tmp_path,
+        extra_env={"PATH": str(fake_bin)},
+    )
+    assert proc.returncode == 0
+    _wait_for_text(capture, "heal")
+    content = capture.read_text()
+    serialize_calls = [
+        line for line in content.splitlines() if line.split()[:1] == ["serialize"]
+    ]
+    assert serialize_calls == []
+
+
+def test_codex_session_start_sweep_noop_when_transcript_dir_missing(tmp_path, tmp_checkpoint_dir):
+    # Codex's transcript_path layout is documented as not a stable interface
+    # (hook/CODEX.md) — a sibling directory that doesn't exist must be a silent
+    # no-op, never a crash.
+    fake_bin, capture = _fake_cli_argv_recording(tmp_path)
+    missing = tmp_path / "gone" / "S-new.jsonl"
+
+    proc = _run(
+        START_HOOK,
+        {"cwd": "/Users/x/projA", "session_id": "S-new", "transcript_path": str(missing)},
+        tmp_path,
+        extra_env={"PATH": str(fake_bin)},
+    )
+    assert proc.returncode == 0
+    _wait_for_text(capture, "heal")
+    content = capture.read_text()
+    serialize_calls = [
+        line for line in content.splitlines() if line.split()[:1] == ["serialize"]
+    ]
+    assert serialize_calls == []
+
+
+def test_codex_session_start_sweep_never_breaks_briefing_output(
+    tmp_path, tmp_checkpoint_dir, sample_checkpoint
+):
+    # No transcript_path in the payload at all -> sweep can't act, briefing is
+    # unaffected (matches every pre-#188 session-start test's payload shape).
+    store.write_checkpoint("S-global", {**sample_checkpoint, "session_id": "S-global"})
+    proc = _run(START_HOOK, {"cwd": "/p/never-seen", "session_id": "S-new"}, tmp_path)
+    assert proc.returncode == 0
+    ctx = _additional_context(proc.stdout)
+    assert "checkpoint: S-global" in ctx
+
+
 def _wait_for(path: Path, timeout=10.0) -> str:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:


### PR DESCRIPTION
Closes #188

## Summary

- Ports the orphan catch-up sweep (`lib.sweep_orphans`, #186/#185) to Codex's `SessionStart` hook, closing the tail-loss gap #42 identified for Codex: a session whose final activity lands inside the `DAIMON_CODEX_MIN_SERIALIZE_INTERVAL` throttle window and never resumes was never captured again.
- Wires `session_id` and `transcript_path` from the hook payload into the existing shared sweep function, run last (after briefing emission and `spawn_heal`), fail-open, same placement contract as Claude Code's brief hook.
- Generalizes the `sweep_orphans` docstring to note both callers, since the function is reused as-is with no host-specific changes.

## Design decision: direct reuse, no wrapper or parameterization

`lib.sweep_orphans(cli, cwd, session_id, transcript_path)` already has zero Claude-specific logic in its implementation (the pre-existing docstring described the Claude `--resume` fork scenario, but the code itself just scans `Path(transcript_path).parent` for sibling `*.jsonl` files against checkpoint freshness). Its existing defensive guards — directory-missing no-op, broad fail-open except, 14-day cutoff, current-session exclusion by both `session_id` and path identity — already satisfy Codex's documented constraint that `transcript_path`'s layout is "not a stable interface" (`hook/CODEX.md`). Wrapping or parameterizing it would add complexity with no behavioral gain, so the Codex hook calls it directly, exactly like `daimon-session-brief.py` does for Claude Code.

This narrows the loss class described in #42 (which proposed a debounced finalizer requiring a persistent watcher — contrary to this codebase's one-shot detached-child design, and remains separately deferred) without introducing any daemon or timer.

## Changes

| File | Change |
|------|--------|
| `hook/daimon-codex-session-start.py` | Extract `session_id`/`transcript_path` from the payload; call `lib.sweep_orphans(...)` last, after `spawn_heal`, fail-open |
| `hook/_daimon_hook_lib.py` | Generalize `sweep_orphans` docstring to describe both the Claude Code (#185) and Codex (#188) callers — no behavior change |
| `plugin/daimon_briefing/_hooks/_daimon_hook_lib.py` | Synced mirror copy via `scripts/sync_hooks.py` |
| `plugin/tests/test_codex_hooks.py` | 5 new subprocess-level wiring tests |

## Scope note: Windsurf excluded

Windsurf is deliberately out of scope. Cascade has no session-start-equivalent event (`docs/hosts/windsurf.md`), so there is no hook point to sweep from, and a time-based debounced finalizer would require a persistent watcher contrary to the codebase's one-shot-child design. This PR closes the actual data-loss gap for the host where a catch-up sweep is possible; the Windsurf/debounced-finalizer idea stays deferred under #42 on its own terms.

## Test plan

- [x] `uv run pytest` — 1185 passed (1180 baseline + 5 new)
- [x] `uv run ruff check .` — clean
- [x] `uv run python scripts/sync_hooks.py --check` — hook copies in sync
- [x] New tests cover: orphan present → exactly one `serialize` spawn; no orphan → no spawn (heal still fires); current session excluded via `session_id` wiring (not just path identity); missing/non-existent transcript sibling dir → no crash, no spawn; no `transcript_path` in payload at all → briefing output unaffected
- [x] Newest-only, 14-day cutoff, and checkpoint-freshness branches are NOT re-tested here — `lib.sweep_orphans` is reused unmodified and those branches are already exhaustively unit-tested against the same function in `test_claude_hooks.py`; re-asserting them at the Codex subprocess layer would test already-covered implementation, not new behavior

## Contributor checklist

- [x] Linked an approved issue (#188, `status:approved`)
- [x] Will add exactly one `type:feat` label
- [x] Conventional commit format, GPG-signed
- [x] No `Co-Authored-By` trailers
