### PR TITLE
feat(heal): add --force to override the one-retry-ever cap

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -115,7 +115,7 @@ daimon skill list              # which scopes each host supports
 | `daimon recall <terms>` | Full-text search over your whole checkpoint history |
 | `daimon resolve <item>` | Mark a checkpoint item resolved so it stops carrying forward |
 | `daimon reverify <item>` | Evidence-gated reopen of a resolved item |
-| `daimon heal` | Re-serialize the most recent failed session, if it can be done safely |
+| `daimon heal [--force]` | Re-serialize the most recent failed session, if it can be done safely; `--force` ignores a prior retry marker to re-heal a retry-exhausted session |
 | `daimon stats` | Local usage + capture aggregates (nothing is transmitted) |
 | `daimon configure` | Detect/repair the LLM backend |
 | `daimon hooks install <host>` | Install packaged host hook scripts |

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -7,8 +7,10 @@
     daimon status [--project DIR] [--json]
                                          checkpoint presence/age + last
                                          serialize outcome from the log
-    daimon heal                          re-serialize the most recent
-                                         FAILED session if safe (#26)
+    daimon heal [--force]                 re-serialize the most recent
+                                         FAILED session if safe (#26);
+                                         --force ignores a prior retry
+                                         marker (#15)
     daimon configure [--backend ...]     detect the resolved LLM backend
                                          and fill gaps in ~/.daimon/env
     daimon write-checkpoint [--project DIR] [--source S]
@@ -1079,15 +1081,18 @@ def _cmd_audit_quotes(args) -> int:
 def _cmd_heal(args) -> int:
     """Explain the heal decision, then repair the newest healable session if safe.
     Every no-op returns 0 (a no-op heal is never an error). `--dry-run` explains
-    without serializing."""
+    without serializing. `--force` (#15) ignores a prior retry marker so a
+    retry-exhausted session becomes healable again — the default one-retry-ever
+    policy is unchanged when --force is absent."""
     dry_run = getattr(args, "dry_run", False)
+    force = getattr(args, "force", False)
     try:
         text = (config.log_dir() / "serialize.log").read_text(encoding="utf-8")
     except OSError:
         text = ""
     now = time.time()
-    plan = _heal_plan(text, now)
-    render.render_heal(plan, dry_run=dry_run)
+    plan = _heal_plan(text, now, force=force)
+    render.render_heal(plan, dry_run=dry_run, force=force)
     if dry_run or plan["target"] is None:
         return 0
     t = plan["target"]
@@ -1780,6 +1785,10 @@ def main(argv=None) -> int:
     p_heal.add_argument(
         "--dry-run", action="store_true",
         help="explain what heal would repair (and why not) without serializing",
+    )
+    p_heal.add_argument(
+        "--force", action="store_true",
+        help="ignore a prior retry marker and re-heal a retry-exhausted session (#15)",
     )
     p_heal.set_defaults(func=_cmd_heal)
 

--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -39,7 +39,16 @@ def _append_retry_log(session_id: str, prior: str) -> None:
     """Mark a #26 heal retry in serialize.log BEFORE re-serializing. The line is
     a TIMESTAMPED spawn-style marker (matching the hook spawn-line stamp format)
     so `status` surfaces it AND the dedup check can find it later — one retry per
-    session, ever. Best-effort: never break a heal."""
+    session, ever, BY DEFAULT. That cap deliberately survived the cache-buster
+    era (#15): retries used to be pointless byte-identical replays against a
+    caching gateway, so capping at one was strictly correct; the serializer now
+    cache-busts both failure layers, so a second heal is no longer guaranteed
+    to reproduce the first failure. The cap stays anyway — it bounds token burn
+    on a permanently-bad transcript — but `daimon heal --force` is the explicit
+    operator override past it (`_outstanding_failures`'s `force` param). This
+    writer's format is unchanged either way: a forced retry appends the SAME
+    marker shape, so a forced heal re-classifies as retry-exhausted again until
+    the next --force. Best-effort: never break a heal."""
     try:
         log_dir = config.log_dir()
         log_dir.mkdir(parents=True, exist_ok=True)
@@ -201,13 +210,20 @@ def _session_ledger(text: str, now: float) -> dict:
     return sessions
 
 
-def _outstanding_failures(ledger, now, has_checkpoint, ceiling, transcript_exists) -> list:
+def _outstanding_failures(ledger, now, has_checkpoint, ceiling, transcript_exists, force=False) -> list:
     """Sessions still LOST — no checkpoint AND latest state != success.
     `has_checkpoint(sid)` and `transcript_exists(path)` are injected so this
     stays pure/testable. error+spawn+transcript-on-disk+not-retried -> healable
     (exactly what heal will repair); error but retried -> retry-exhausted; error
     but no spawn record or transcript gone -> unrecoverable (lost, heal can't
-    retry it); spawn with no result older than `ceiling` -> hung."""
+    retry it); spawn with no result older than `ceiling` -> hung.
+
+    `force` (#15) is the `daimon heal --force` escape hatch: it ignores the
+    `retried` gate on both the error and hung paths, so a retry-exhausted (or
+    retried-hung) session reclassifies as `healable` again PROVIDED its
+    transcript still exists — force can't repair what's genuinely gone, so
+    those stay `unrecoverable`/`hung`. Callers that don't pass `force` (e.g.
+    `status`, and default `heal`) see classification exactly as before."""
     out = []
     for sid, e in ledger.items():
         if e["result_kind"] in ("success", "skipped"):
@@ -216,7 +232,7 @@ def _outstanding_failures(ledger, now, has_checkpoint, ceiling, transcript_exist
             continue
         age = e["spawn_age"]
         if e["result_kind"] == "error":
-            if e["retried"]:
+            if e["retried"] and not force:
                 cls = "retry-exhausted"
             elif e["spawned"] and e["transcript"] and transcript_exists(e["transcript"]):
                 cls = "healable"
@@ -230,10 +246,11 @@ def _outstanding_failures(ledger, now, has_checkpoint, ceiling, transcript_exist
             # #28: a spawn line that recorded its transcript makes a hung
             # (crashed/killed) serialize healable — the checkpoint is
             # recoverable as long as the transcript is still on disk. The
-            # one-retry-ever policy (#26) applies unchanged via `retried`.
+            # one-retry-ever policy (#26) applies unchanged via `retried`,
+            # unless `force` (#15) overrides it.
             t = e["transcript"]
             cls = ("healable"
-                   if t and transcript_exists(t) and not e["retried"]
+                   if t and transcript_exists(t) and (not e["retried"] or force)
                    else "hung")
             out.append({"sid": sid, "kind": "hung", "class": cls, "age": age,
                         "age_str": _format_age(age), "transcript": t,
@@ -242,32 +259,37 @@ def _outstanding_failures(ledger, now, has_checkpoint, ceiling, transcript_exist
     return out
 
 
-def _compute_outstanding(text: str, now: float) -> list:
+def _compute_outstanding(text: str, now: float, force: bool = False) -> list:
     """Wire the pure ledger/classifier to the live store + filesystem. Single
     source for both `status` (display) and `heal` (repair) so their notion of
-    'outstanding' can never drift."""
+    'outstanding' can never drift. `force` (#15) is forwarded to
+    `_outstanding_failures`; callers that don't pass it get unchanged default
+    classification."""
     return _outstanding_failures(
         _session_ledger(text, now), now,
         lambda sid: store.read_checkpoint(sid) is not None,
         config.hung_after_seconds(),
         lambda p: bool(p) and Path(p).exists(),
+        force=force,
     )
 
 
 _HEAL_SKIP_REASON = {
-    "retry-exhausted": "retry already attempted, still failing",
+    "retry-exhausted": "retry already attempted, still failing (re-run with --force)",
     "unrecoverable": "no spawn record or transcript gone — cannot auto-heal",
     "hung": "spawned, no result (hung/killed) — transcript unavailable",
 }
 
 
-def _heal_plan(text, now) -> dict:
+def _heal_plan(text, now, force=False) -> dict:
     """Decide what `heal` will repair and why. Pure — `now` injected. Reuses the
     SAME _compute_outstanding source as status, so their notion of healable agrees.
     target = the newest `healable` (already gauntlet-vetted); every other outstanding
     failure lands in `skipped` with a reason; `note` is the headline when there is no
-    target."""
-    outstanding = _compute_outstanding(text, now)
+    target. `force` (#15) is forwarded to _compute_outstanding — the classifier does
+    the actual retry-exhausted-to-healable promotion, so this layer needs no
+    special-casing beyond passing the flag through."""
+    outstanding = _compute_outstanding(text, now, force=force)
     healable = [f for f in outstanding if f["class"] == "healable"]
     target = None
     if healable:

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -302,14 +302,17 @@ def render_status(data: dict) -> None:
         _plain_status(data)
 
 
-def render_heal(plan: dict, *, dry_run: bool) -> None:
-    """Plain explanation of a heal decision. No rich — heal output is procedural."""
+def render_heal(plan: dict, *, dry_run: bool, force: bool = False) -> None:
+    """Plain explanation of a heal decision. No rich — heal output is procedural.
+    `force` (#15) gets its own wording ("force-heal") so the operator can tell
+    a --force run apart from an ordinary heal at a glance."""
     t = plan["target"]
     if t:
+        verb = "force-heal" if force else "heal"
         if dry_run:
-            print(f"would heal {t['sid']} (failed {t['age_str']} ago, transcript {t['transcript']})")
+            print(f"would {verb} {t['sid']} (failed {t['age_str']} ago, transcript {t['transcript']})")
         else:
-            print(f"healing {t['sid']} (failed {t['age_str']} ago)…")
+            print(f"{verb}ing {t['sid']} (failed {t['age_str']} ago)…")
     elif plan["note"]:
         print(plan["note"])
     for s in plan["skipped"]:
@@ -359,7 +362,13 @@ def _outstanding_lines(outstanding) -> list:
                     f"(hung/killed; transcript unavailable)"
                 )
         elif f["class"] == "retry-exhausted":
-            lines.append(f"  - {f['sid']}  error {age} ago — retry attempted, still failing")
+            # #15: name the escape hatch here — this is the one place an
+            # operator sees "retry-exhausted" without already reading heal's
+            # own skip reason.
+            lines.append(
+                f"  - {f['sid']}  error {age} ago — retry attempted, still failing "
+                f"(re-run with `daimon heal --force`)"
+            )
         elif f["class"] == "unrecoverable":
             lines.append(f"  - {f['sid']}  error {age} ago — transcript unavailable, cannot auto-heal")
         else:

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -982,6 +982,87 @@ def test_cli_heal_noop_when_no_log(tmp_checkpoint_dir, tmp_log_dir, fake_chat_fa
     assert chat.calls == []
 
 
+# ---- #15: `heal --force` — explicit escape hatch past the one-retry-ever cap ----
+
+
+def test_cli_heal_force_reheals_retry_exhausted_session(
+    tmp_checkpoint_dir, tmp_log_dir, fake_chat_factory, monkeypatch
+):
+    # A retry marker already exists for the stem (default heal refuses, see
+    # test_cli_heal_dedup_one_retry_per_session) -> --force ignores the marker
+    # and repairs it anyway, appending a SECOND retry marker in the same
+    # parseable format (so the session re-classifies as retry-exhausted again
+    # until the next --force).
+    from daimon_briefing import config, store
+
+    stem = "sample_transcript"
+    transcript = FIXTURES / "sample_transcript.md"
+    _write_log(
+        tmp_log_dir,
+        [
+            f"2026-06-10T12:00:00Z session-end: spawned serialize for {stem} (reason: exit, project: /p/A)",
+            f"error: boom (transcript: {transcript}) after 1s",
+            f"2026-06-10T12:05:00Z session-start: retry serialize for {stem} (prior: error: boom)",
+            f"error: boom again (transcript: {transcript}) after 1s",
+        ],
+    )
+    chat = fake_chat_factory(_valid_json())
+    monkeypatch.setattr(cli, "_chat", chat)
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+
+    rc = cli.main(["heal", "--force"])
+    assert rc == 0
+    assert store.read_checkpoint(stem) is not None
+    log = (config.log_dir() / "serialize.log").read_text()
+    assert log.count(f"session-start: retry serialize for {stem}") == 2
+    # the new marker is still parseable by the ledger's spawn regex
+    outstanding = cli._compute_outstanding(log, time.time())
+    assert outstanding == []  # healed -> checkpoint now exists, nothing outstanding
+
+
+def test_cli_heal_default_still_refuses_after_force(
+    tmp_checkpoint_dir, tmp_log_dir, fake_chat_factory, monkeypatch
+):
+    # Default policy is unchanged: a session already retried (even via
+    # --force) is retry-exhausted again for a plain `daimon heal`.
+    from daimon_briefing import store
+
+    stem = "sample_transcript"
+    transcript = FIXTURES / "sample_transcript.md"
+    _write_log(
+        tmp_log_dir,
+        [
+            f"2026-06-10T12:00:00Z session-end: spawned serialize for {stem} (reason: exit, project: /p/A)",
+            f"error: boom (transcript: {transcript}) after 1s",
+            f"2026-06-10T12:05:00Z session-start: retry serialize for {stem} (prior: error: boom)",
+            f"error: boom again (transcript: {transcript}) after 1s",
+        ],
+    )
+    chat = fake_chat_factory(_valid_json())
+    monkeypatch.setattr(cli, "_chat", chat)
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+
+    rc = cli.main(["heal"])
+    assert rc == 0
+    assert chat.calls == []
+    assert store.read_checkpoint(stem) is None
+
+
+def test_heal_argparser_has_force(monkeypatch):
+    # Mirrors test_heal_argparser_has_dry_run: stub _cmd_heal to capture the
+    # parsed namespace without running a real heal.
+    from daimon_briefing import cli
+    seen = {}
+    monkeypatch.setattr(cli, "_cmd_heal", lambda args: seen.setdefault("force", args.force) or 0)
+
+    cli.main(["heal", "--force"])
+    assert seen["force"] is True
+
+    seen.clear()
+    cli.main(["heal"])
+    assert seen["force"] is False
+
+
 # ---- #48: `configure` — detect/report backend + fill gaps in ~/.daimon/env ----
 
 
@@ -1556,6 +1637,30 @@ def test_outstanding_retry_marker_is_exhausted_not_healable():
     assert out[0]["class"] == "retry-exhausted"
 
 
+def test_outstanding_force_promotes_retry_exhausted_to_healable():
+    # #15: --force ignores the retry marker when the transcript is still on
+    # disk — the session is repairable again, not permanently retry-exhausted.
+    ledger = {"X": _led(retried=True)}
+    out = cli._outstanding_failures(ledger, 0.0, lambda sid: False, 1800, lambda p: True, force=True)
+    assert out[0]["class"] == "healable"
+
+
+def test_outstanding_force_does_not_resurrect_missing_transcript():
+    # --force can't repair what genuinely can't be repaired: transcript gone
+    # is still unrecoverable even when forced.
+    ledger = {"X": _led(retried=True, transcript="/gone/X.jsonl")}
+    out = cli._outstanding_failures(ledger, 0.0, lambda sid: False, 1800, lambda p: False, force=True)
+    assert out[0]["class"] == "unrecoverable"
+
+
+def test_outstanding_without_force_retry_exhausted_stays_exhausted():
+    # force defaults False — status's own call (no force) must keep classifying
+    # a retried session as retry-exhausted, matching default heal's refusal.
+    ledger = {"X": _led(retried=True)}
+    out = cli._outstanding_failures(ledger, 0.0, lambda sid: False, 1800, lambda p: True)
+    assert out[0]["class"] == "retry-exhausted"
+
+
 def test_outstanding_hung_only_past_ceiling():
     young = {"X": _led(result_kind=None, result_line=None, transcript=None, spawn_age=100)}
     assert cli._outstanding_failures(young, 0.0, lambda sid: False, 1800, lambda p: True) == []
@@ -1698,7 +1803,7 @@ def test_heal_plan_targets_newest_healable(monkeypatch):
         {"sid": "S-old", "class": "retry-exhausted", "transcript": "/t/old.jsonl", "project": "/p",
          "age_str": "9m", "line": "error: boom (transcript: /t/old.jsonl) after 3s"},
     ]
-    monkeypatch.setattr(ledger, "_compute_outstanding", lambda text, now: items)
+    monkeypatch.setattr(ledger, "_compute_outstanding", lambda text, now, force=False: items)
     plan = cli._heal_plan("logtext", 1000.0)
     assert plan["target"]["sid"] == "S-new"
     assert plan["target"]["transcript"] == "/t/new.jsonl"
@@ -1716,7 +1821,7 @@ def test_heal_plan_second_healable_says_rerun(monkeypatch):
         {"sid": "S2", "class": "healable", "transcript": "/t/2", "project": "/p", "age_str": "2m",
          "line": "error: x (transcript: /t/2) after 1s"},
     ]
-    monkeypatch.setattr(ledger, "_compute_outstanding", lambda text, now: items)
+    monkeypatch.setattr(ledger, "_compute_outstanding", lambda text, now, force=False: items)
     plan = cli._heal_plan("x", 1000.0)
     assert plan["target"]["sid"] == "S1"
     assert plan["skipped"][0]["sid"] == "S2"
@@ -1725,7 +1830,7 @@ def test_heal_plan_second_healable_says_rerun(monkeypatch):
 
 def test_heal_plan_no_log(monkeypatch):
     from daimon_briefing import cli, ledger
-    monkeypatch.setattr(ledger, "_compute_outstanding", lambda text, now: [])
+    monkeypatch.setattr(ledger, "_compute_outstanding", lambda text, now, force=False: [])
     plan = cli._heal_plan("", 1000.0)
     assert plan["target"] is None and plan["skipped"] == []
     assert "no serialize activity logged" in plan["note"]
@@ -1733,7 +1838,7 @@ def test_heal_plan_no_log(monkeypatch):
 
 def test_heal_plan_no_outstanding(monkeypatch):
     from daimon_briefing import cli, ledger
-    monkeypatch.setattr(ledger, "_compute_outstanding", lambda text, now: [])
+    monkeypatch.setattr(ledger, "_compute_outstanding", lambda text, now, force=False: [])
     plan = cli._heal_plan("some log with only successes", 1000.0)
     assert plan["target"] is None
     assert "no outstanding failures" in plan["note"]
@@ -1743,11 +1848,32 @@ def test_heal_plan_only_unrepairable(monkeypatch):
     from daimon_briefing import cli, ledger
     items = [{"sid": "H1", "class": "hung", "transcript": None, "project": None,
               "age_str": "40m", "line": None}]
-    monkeypatch.setattr(ledger, "_compute_outstanding", lambda text, now: items)
+    monkeypatch.setattr(ledger, "_compute_outstanding", lambda text, now, force=False: items)
     plan = cli._heal_plan("x", 1000.0)
     assert plan["target"] is None
     assert "can't be auto-repaired" in plan["note"]
     assert plan["skipped"][0]["sid"] == "H1" and "hung" in plan["skipped"][0]["reason"]
+
+
+def test_heal_plan_force_targets_retry_exhausted(monkeypatch):
+    # #15: force=True forwards to _compute_outstanding, which itself
+    # promotes retry-exhausted -> healable; _heal_plan just picks it up like
+    # any other healable target — no special-casing needed at this layer.
+    from daimon_briefing import cli, ledger
+    items = [
+        {"sid": "S-old", "class": "healable", "transcript": "/t/old.jsonl", "project": "/p",
+         "age_str": "9m", "line": "error: boom (transcript: /t/old.jsonl) after 3s"},
+    ]
+    seen = {}
+
+    def fake_compute_outstanding(text, now, force=False):
+        seen["force"] = force
+        return items
+
+    monkeypatch.setattr(ledger, "_compute_outstanding", fake_compute_outstanding)
+    plan = cli._heal_plan("x", 1000.0, force=True)
+    assert seen["force"] is True
+    assert plan["target"]["sid"] == "S-old"
 
 
 # ---- #86: _cmd_heal — render always, gate the serialize, --dry-run ----
@@ -1758,7 +1884,7 @@ def test_cmd_heal_dry_run_does_not_serialize(monkeypatch, capsys):
     plan = {"target": {"sid": "S-A", "transcript": "/t/a.jsonl", "project": "/p",
                        "age_str": "3m", "line": "error: x (transcript: /t/a.jsonl) after 1s"},
             "skipped": [], "note": ""}
-    monkeypatch.setattr(cli, "_heal_plan", lambda text, now: plan)
+    monkeypatch.setattr(cli, "_heal_plan", lambda text, now, force=False: plan)
     called = {"n": 0}
     monkeypatch.setattr(cli, "_run_serialize", lambda *a, **k: called.__setitem__("n", called["n"] + 1) or 0)
     monkeypatch.setattr(cli, "_append_retry_log", lambda *a, **k: called.__setitem__("retry", True))
@@ -1778,7 +1904,7 @@ def test_cmd_heal_real_serializes_target(monkeypatch, tmp_path):
     plan = {"target": {"sid": "S-A", "transcript": str(tp), "project": "/p",
                        "age_str": "3m", "line": "error: x (transcript: %s) after 1s" % tp},
             "skipped": [], "note": ""}
-    monkeypatch.setattr(cli, "_heal_plan", lambda text, now: plan)
+    monkeypatch.setattr(cli, "_heal_plan", lambda text, now, force=False: plan)
     monkeypatch.setattr(cli, "_append_retry_log", lambda *a, **k: None)
     seen = {}
     monkeypatch.setattr(cli, "_run_serialize", lambda path, proj: seen.update(path=path, proj=proj) or 0)
@@ -1792,13 +1918,30 @@ def test_cmd_heal_real_serializes_target(monkeypatch, tmp_path):
 
 def test_cmd_heal_no_target_returns_zero(monkeypatch, capsys):
     from daimon_briefing import cli
-    monkeypatch.setattr(cli, "_heal_plan", lambda text, now: {"target": None, "skipped": [], "note": "nothing to heal — no outstanding failures"})
+    monkeypatch.setattr(cli, "_heal_plan", lambda text, now, force=False: {"target": None, "skipped": [], "note": "nothing to heal — no outstanding failures"})
     monkeypatch.setattr(cli, "_run_serialize", lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not serialize")))
 
     class A:
         dry_run = False
     assert cli._cmd_heal(A()) == 0
     assert "no outstanding failures" in capsys.readouterr().out
+
+
+def test_cmd_heal_forwards_force_to_heal_plan(monkeypatch):
+    from daimon_briefing import cli
+    seen = {}
+
+    def fake_heal_plan(text, now, force=False):
+        seen["force"] = force
+        return {"target": None, "skipped": [], "note": "nothing to heal — no outstanding failures"}
+
+    monkeypatch.setattr(cli, "_heal_plan", fake_heal_plan)
+
+    class A:
+        dry_run = False
+        force = True
+    assert cli._cmd_heal(A()) == 0
+    assert seen["force"] is True
 
 
 def test_heal_argparser_has_dry_run(monkeypatch):

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -214,13 +214,18 @@ def test_render_status_outstanding_block_plain_exact(capsys):
 
 
 def test_render_status_outstanding_retry_exhausted_hint(capsys):
+    # #15: the escape hatch is discoverable from `status` itself, not just
+    # from reading the heal skip reason.
     data = _status_data()
     data["outstanding"] = [{"sid": "S-A", "kind": "error", "class": "retry-exhausted",
                             "age": 180, "age_str": "3m", "transcript": "/t/S-A.jsonl",
                             "project": "/p/A", "spawned": True, "line": "error: boom"}]
     render.render_status(data)
     out = capsys.readouterr().out
-    assert "  - S-A  error 3m ago — retry attempted, still failing\n" in out
+    assert (
+        "  - S-A  error 3m ago — retry attempted, still failing "
+        "(re-run with `daimon heal --force`)\n"
+    ) in out
 
 
 def test_render_status_unrecoverable_hint(capsys):
@@ -503,6 +508,37 @@ def test_render_heal_note_and_skipped(capsys):
     out = capsys.readouterr().out
     assert "nothing to heal — 1 failure can't be auto-repaired:" in out
     assert "H1" in out and "hung/killed" in out
+
+
+def test_render_heal_force_target_dry_run(capsys):
+    # #15: --force gets its own narration so a dry-run makes clear the retry
+    # marker is being ignored, not that this is an ordinary heal.
+    from daimon_briefing import render
+    plan = {"target": {"sid": "S-A", "transcript": "/t/a.jsonl", "project": "/p",
+                       "age_str": "9m", "line": "x"}, "skipped": [], "note": ""}
+    render.render_heal(plan, dry_run=True, force=True)
+    out = capsys.readouterr().out
+    assert "would force-heal S-A" in out and "/t/a.jsonl" in out
+
+
+def test_render_heal_force_target_real(capsys):
+    from daimon_briefing import render
+    plan = {"target": {"sid": "S-A", "transcript": "/t/a.jsonl", "project": "/p",
+                       "age_str": "9m", "line": "x"}, "skipped": [], "note": ""}
+    render.render_heal(plan, dry_run=False, force=True)
+    out = capsys.readouterr().out
+    assert "force-healing S-A" in out
+
+
+def test_render_heal_not_forced_omits_force_wording(capsys):
+    # force=False (the default) must not accidentally regress ordinary heal
+    # output to the forced wording.
+    from daimon_briefing import render
+    plan = {"target": {"sid": "S-A", "transcript": "/t/a.jsonl", "project": "/p",
+                       "age_str": "3m", "line": "x"}, "skipped": [], "note": ""}
+    render.render_heal(plan, dry_run=False)
+    out = capsys.readouterr().out
+    assert "healing S-A" in out and "force" not in out
 
 
 # ---- Teammates section (#111): attributed, never merged, empty = no-op ----


### PR DESCRIPTION
Closes #15

## What

Adds `daimon heal --force`, an explicit escape hatch that ignores the retry-exhausted classification and re-heals the most recent failed capture even when a retry marker already exists. The default `daimon heal` (no `--force`) policy is unchanged — the one-retry-ever cap still applies.

## Why

`_append_retry_log`'s one-retry-ever cap was calibrated when a heal retry replayed the exact same request body against a caching gateway — a second attempt was guaranteed to reproduce the first failure. The serializer now cache-busts both in-call failure layers (parse retries via a per-attempt prompt marker, validation retries via `_RETRY_NOTE`), so a heal retry is no longer a deterministic replay. A first heal that fails during a transient outage now leaves the session permanently unrecoverable under the default policy, even though a later attempt would likely succeed. Per issue #15, option 3 was ratified: keep the default conservative, add an explicit override.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/ledger.py` | `_outstanding_failures`/`_compute_outstanding`/`_heal_plan` gain a `force` param; under force, a retry-exhausted (or retried-hung) session reclassifies as `healable` when its transcript still exists. `_HEAL_SKIP_REASON` and the `_append_retry_log` docstring updated. |
| `plugin/daimon_briefing/cli.py` | `heal` subcommand gains `--force`; `_cmd_heal` forwards it to `_heal_plan`/`render_heal`. |
| `plugin/daimon_briefing/render.py` | `render_heal` narrates "force-heal(ing)" when forced; `status`'s retry-exhausted line now points at `daimon heal --force`. |
| `plugin/README.md` | `daimon heal` command table row documents `--force`. |
| `plugin/tests/test_cli.py`, `plugin/tests/test_render.py` | New coverage for the force path (classifier, plan, cmd, argparser, full `cli.main(["heal", "--force"])` round trip) plus signature updates to existing stubs for the new `force` kwarg. |

The retry-marker log line format is byte-identical either way — a forced retry appends the same shape, still parseable by `_SPAWN_RE`, so a forced heal re-classifies as retry-exhausted again until the next `--force`.

## Tests

- [x] `uv run pytest -q` from `plugin/`: 1225 passed (baseline 1214 + 11 net new)
- [x] `uv run ruff check .`: all checks passed
- [x] `uv run mypy daimon_briefing`: 45 errors, identical count and set to main baseline — zero new
- [x] Manual: `heal --help` shows `--force`; direct classifier check confirms a retry-exhausted session flips to `healable` under `force=True` and stays `retry-exhausted` without it
- [x] New integration test drives the full round trip: `cli.main(["heal", "--force"])` re-heals a session with an existing retry marker and appends a second, still-parseable marker; a companion test confirms plain `daimon heal` still refuses the same session