### PR TITLE
chore(ci): add codecov components for per-subsystem coverage tracking

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,62 @@
+# Codecov components (#192): per-subsystem coverage visibility.
+#
+# Components are pure report filtering (https://docs.codecov.com/docs/components):
+# they slice the existing single upload (--cov=daimon_briefing) by path, so this
+# file changes no uploads and adds no CI jobs. Phase 1 deliberately defines NO
+# per-component status gates — the repo-wide codecov/patch check remains the only
+# blocking signal; tighten per-component targets once baselines are visible.
+#
+# hook/ adapter scripts are exercised via subprocess in tests and never appear in
+# coverage reports, so they cannot be a component under the current collection.
+
+comment:
+  layout: "header, diff, flags, components, files"
+
+component_management:
+  individual_components:
+    - component_id: serializer-capture
+      name: serializer-capture
+      paths:
+        - plugin/daimon_briefing/serializer.py
+        - plugin/daimon_briefing/transcript.py
+        - plugin/daimon_briefing/llm.py
+        - plugin/daimon_briefing/harvest.py
+    - component_id: memory-core
+      name: memory-core
+      paths:
+        - plugin/daimon_briefing/carry.py
+        - plugin/daimon_briefing/scoring.py
+        - plugin/daimon_briefing/recall.py
+        - plugin/daimon_briefing/schema.py
+        - plugin/daimon_briefing/anchor.py
+    - component_id: briefing-render
+      name: briefing-render
+      paths:
+        - plugin/daimon_briefing/briefing.py
+        - plugin/daimon_briefing/render.py
+    - component_id: storage-ledger
+      name: storage-ledger
+      paths:
+        - plugin/daimon_briefing/store.py
+        - plugin/daimon_briefing/ledger.py
+    - component_id: cli
+      name: cli
+      paths:
+        - plugin/daimon_briefing/cli.py
+        - plugin/daimon_briefing/configure.py
+        - plugin/daimon_briefing/config.py
+    - component_id: host-hooks
+      name: host-hooks
+      paths:
+        - plugin/daimon_briefing/hooks.py
+        - plugin/daimon_briefing/_hooks/**
+    - component_id: redaction
+      name: redaction
+      paths:
+        - plugin/daimon_briefing/redact.py
+    - component_id: integrations
+      name: integrations
+      paths:
+        - plugin/daimon_briefing/teamsync.py
+        - plugin/daimon_briefing/skill_content.py
+        - plugin/daimon_briefing/skill_install.py


### PR DESCRIPTION
## What

Adds a root `codecov.yml` defining eight path-filtered components over the existing single coverage upload, plus `components` in the PR-comment layout.

| component | scope |
| --- | --- |
| serializer-capture | serializer, transcript, llm, harvest |
| memory-core | carry, scoring, recall, schema, anchor |
| briefing-render | briefing, render |
| storage-ledger | store, ledger |
| cli | cli, configure, config |
| host-hooks | hooks, _hooks/** |
| redaction | redact |
| integrations | teamsync, skill_content, skill_install |

## Why

One repo-wide number lets a coverage drop in a high-stakes module (redaction, carry, serializer) hide behind gains elsewhere. Components give per-subsystem numbers on every PR and filterable coverage-over-time in the Codecov UI — pure report filtering, defined entirely in `codecov.yml` (https://docs.codecov.com/docs/components).

## Notes

- No upload or CI-job changes; the single `--cov=daimon_briefing` upload is sliced by path.
- Phase 1 defines no per-component status gates — the repo-wide `codecov/patch` check stays the only blocking signal. Targets can be tightened per component once baselines are visible.
- `hook/` adapter scripts are subprocess-tested and absent from coverage reports, so they can't be a component under current collection (noted in the file header).
- YAML validated: `curl --data-binary @codecov.yml https://codecov.io/validate` → Valid.

Closes #192