### PR TITLE
docs: add team memory setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ skill owns it outright. Re-run install after upgrading to refresh the content.
 - **`daimon recall <terms>`** — full-text search over your whole checkpoint history (and your team's, if enabled). Multi-term queries degrade to ranked partial matches instead of returning nothing.
 - **Proactive recall** — when a new prompt overlaps prior work from an older session, the briefing surfaces it ("you worked on this before"), in English or Spanish — accented text is a first-class citizen.
 - **Code anchors** — `daimon anchor <file> <symbol>` pins a belief to a code symbol; if that code changes or disappears, the next briefing flags the item under **CODE DRIFT — verify before trusting**. Offline, stdlib `ast`.
-- **Team memory (opt-in)** — `daimon team init <remote>` mirrors checkpoints through a git remote; teammates' active topics and decisions appear in your briefing, clearly attributed, never merged into your own sections.
+- **Team memory (opt-in)** — `daimon team init <remote>` mirrors checkpoints through a git remote; teammates' active topics and decisions appear in your briefing, clearly attributed, never merged into your own sections. See the [team memory setup guide](./docs/team.md) — start with its privacy boundary, because the shared repo must be private.
 
 ## What's net-new here
 

--- a/docs/team.md
+++ b/docs/team.md
@@ -1,0 +1,149 @@
+# Team memory
+
+Team memory mirrors each of your session checkpoints — immutable, one file per
+author — through a shared git sidecar repo, so a whole team's memory converges
+without merging anyone's notes into anyone else's. Once it's enabled, teammates'
+active topics and decisions show up attributed (never blended into your own) in
+`daimon brief --team`, and their history is searchable alongside yours in
+`daimon recall`.
+
+## The shared repo is the privacy boundary — read this first
+
+**The sidecar's access control IS the membership and privacy boundary. Whoever
+can read that git repo can read everything every member's sessions produced, so
+the remote MUST be a private repository.** There is no second gate. When team
+memory is on, whatever a session discussed is mirrored to the shared repo
+*verbatim*, after one pass of shape-based secret redaction.
+
+That redaction is deliberately narrow. It catches secrets with a concrete,
+recognizable shape — assignment-style `api_key=…` / `token:…` pairs, PEM key and
+certificate blocks, `Bearer` headers, `credential://user:pass@host` URLs, and
+fixed-prefix vendor tokens (AWS `AKIA…`, Stripe `sk_live_…`, GitHub `ghp_…`,
+GitLab, Slack, Google, OpenAI keys, JWTs). Each match is replaced with a visible
+`[redacted:<kind>]` marker. It does **not** understand meaning: free-text
+confidential prose — a customer name, an unreleased plan, an internal URL written
+as ordinary words — is not a secret shape and syncs through untouched. Treat the
+shared repo as if every member can read every word, because they can.
+
+Author identity is declared, not authenticated. Any member of the repo can write
+under any author name; daimon cross-checks the name stamped in each arriving file
+against the git author who committed it and surfaces a mismatch as a warning, but
+it never blocks the write. The repo's access control is what keeps outsiders out
+— the author label only tells you who a file *claims* to be from.
+
+## Setup (two people)
+
+Do this once per shared repo, then once on each machine.
+
+**1. Create an empty private git repo** on your host of choice (GitHub, GitLab,
+self-hosted — anything git can clone over SSH or HTTPS). Leave it empty; the
+first `daimon team init` seeds it. Make sure it is **private** and that every
+teammate has push access.
+
+**2. On each machine**, enable team memory and set your author name. Put these in
+`~/.daimon/env` (loaded by daimon) or export them in your shell:
+
+```sh
+DAIMON_TEAM=1
+DAIMON_AUTHOR="Ada Lovelace"   # optional — see below
+```
+
+`DAIMON_AUTHOR` is optional. When it's unset, daimon falls back to
+`git config user.name`, then to your OS username, and finally to `unknown`. Set
+it explicitly if your git identity isn't the name you want teammates to see.
+
+**3. On each machine**, clone the sidecar:
+
+```sh
+daimon team init git@github.com:your-org/team-memory.git
+```
+
+An empty remote is fine — the first machine to init seeds a root commit and
+pushes it. Running init a second time against a directory that already exists is
+an error, not a re-clone.
+
+**4. Verify** on each machine:
+
+```sh
+daimon team status
+```
+
+You should see the remote listed with its freshness and the authors seen so far.
+
+## What happens, and when
+
+At the start of every session, daimon fires `daimon team sync` detached in the
+background. It never blocks your briefing and never fails your session — if
+anything goes wrong the session proceeds exactly as if team memory were off. The
+spawn is gated on a team remote actually existing, so machines that never ran
+`daimon team init` pay only a directory scan.
+
+A sync pass does three things, in order:
+
+- **Commits and pushes your own author directory only.** It stages and commits
+  new files under `authors/<your-author-slug>/`, nothing else — never another
+  author's files, never anything you happened to leave staged in the sidecar.
+- **Fetches teammates' updates**, but only when the remote actually changed. A
+  refs-only `ls-remote` probe compares hashes first; objects transfer only on a
+  mismatch, so a no-op sync costs one lightweight network round-trip.
+- Leaves everything else alone.
+
+Only immutable per-author checkpoint files ever sync. On disk they live at
+`~/.daimon/team/<remote-slug>/authors/<author-slug>/<session_id>.json`; inside
+the shared repo the path is `authors/<author-slug>/<session_id>.json`. No mutable
+pointers are ever written to the sidecar — because every author appends to a
+disjoint path and nothing is ever rewritten, merges are conflict-free by
+construction. Your local "latest checkpoint" pointers stay private on your
+machine and never sync.
+
+`DAIMON_TEAM=1` gates **writes only**. With it unset, your checkpoints are not
+mirrored into the sidecar — but reads of the team directory are always on, so you
+can still see teammates' memory even before you start contributing your own.
+
+## Reading teammates
+
+- **`daimon brief --team`** — your normal briefing, plus a Teammates section: one
+  attributed block per teammate (excluding yourself), newest first. With no team
+  data the section simply doesn't appear.
+- **`daimon recall <query>`** — full-text (SQLite FTS5) search over your local
+  history *and* the team's.
+- **`daimon team status`** — per-remote freshness, your own unpushed checkpoint
+  count, and the authors seen in the sidecar.
+
+Teammates' checkpoints are shown within a read-time age window controlled by
+`DAIMON_TEAM_RETENTION_DAYS` (default 365; `0` means keep everything). Aging out
+is a read filter only — no file is ever physically deleted from the append-only
+shared branch.
+
+## Environment reference
+
+| Variable | Default | What it does |
+|---|---|---|
+| `DAIMON_TEAM` | unset (off) | Set to `1` to mirror your checkpoints into the team dir. Gates writes only; reads are always on. |
+| `DAIMON_AUTHOR` | `git config user.name` → OS username → `unknown` | The author name your checkpoints are filed under. |
+| `DAIMON_TEAM_DIR` | `~/.daimon/team` | Root of the local team mirror (one subdirectory per sidecar clone). |
+| `DAIMON_TEAM_RETENTION_DAYS` | `365` | Read-time age window for teammates' checkpoints; `0` = keep all. |
+
+See [docs/configuration.md](./configuration.md) for the full environment
+reference.
+
+## When things go wrong
+
+Sync is fail-open by design: any degraded outcome leaves you on the last synced
+state and never breaks the session.
+
+| Situation | What happens |
+|---|---|
+| Offline | Sync defers; you keep the last synced team state. Your own new checkpoints commit locally and queue for the next push. |
+| Missing git credentials | Git runs non-interactively (`GIT_TERMINAL_PROMPT=0`) — it fails fast instead of hanging on a credential prompt, and sync degrades to offline. |
+| Concurrent pushes | A rejected push is benign (a teammate won the race). Daimon integrates their change and retries, bounded to 3 attempts, then warns if still rejected. |
+| Rewritten shared history | Loud warning; daimon leaves your local copy untouched and refuses to auto-repair. Daimon never force-pushes — resolve it manually with git and your team. |
+| Git not installed | Sync is skipped and returns success (rc 0) — team memory is simply inactive. |
+
+## Status
+
+Team memory is early. It is designed for and validated at 1–2 person scale, where
+the git sidecar's conflict-free append model and the private-repo boundary hold
+up cleanly. It is **not** a defended multi-tenant boundary: the security model is
+"everyone in the private repo trusts everyone else in the private repo." Size the
+repo's membership accordingly.


### PR DESCRIPTION
Closes #197

## What

New `docs/team.md` — the setup and operations guide for the opt-in team-memory subsystem, which shipped with CLI help as its only documentation. Contents, in order:

- **The privacy boundary first**: the shared repo's access control is the only membership/privacy gate; the remote must be private; shape-based secret redaction (`[redacted:<kind>]` markers for key/token/PEM/credential-URL shapes) does not catch free-text confidential prose; author identity is declared, not authenticated (mismatch warns, never blocks).
- Two-person setup walkthrough: private repo → `DAIMON_TEAM=1` + optional `DAIMON_AUTHOR` per machine → `daimon team init <url>` → verify with `daimon team status`.
- Sync semantics: SessionStart spawns `daimon team sync` detached and fail-open; commits/pushes own author dir only; refs-only change probe before fetch; immutable per-author files, conflict-free by construction; local pointers never sync; `DAIMON_TEAM` gates writes only.
- Reading teammates: `brief --team`, `recall`, `team status`, and the `DAIMON_TEAM_RETENTION_DAYS` read-time window.
- Failure-mode table: offline, missing credentials, concurrent pushes, rewritten history (warn-and-refuse), git absent.
- Honest status: validated at 1–2 person scale; not a defended multi-tenant boundary.

README team bullet links to the guide. Companion to #198 (`docs/configuration.md`), which the env table links to — merge both (order doesn't matter beyond a brief dead link).