### PR TITLE
feat(team): architect-authored project layout for the team sidecar

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,6 +80,7 @@ Opt-in shared-memory mirror. See [docs/team.md](./team.md) for the full workflow
 | `DAIMON_TEAM` | off | When truthy, mirror each checkpoint into the shared team dir so `brief --team` can surface teammates. Gates **writes** only — reads of the team dir are always allowed. |
 | `DAIMON_AUTHOR` | git `user.name`, then OS user | Team author identity used to namespace your checkpoints. Falls back to `git config user.name`, then the OS username, then `unknown`. |
 | `DAIMON_TEAM_DIR` | `~/.daimon/team` | Root of the shared team-memory mirror. |
+| `DAIMON_TEAM_PROJECT` | unset | Explicit logical project path for this machine's sessions (relative, e.g. `core/api-gateway`). Overrides the sidecar's `daimon-team.toml` mapping and the origin-derived fallback when routing checkpoints under `projects/`. |
 | `DAIMON_TEAM_RETENTION_DAYS` | `365` | Read-time age window: teammates' checkpoints older than this many days are skipped when reading. `0` = keep all. Never physically deletes from the shared append-only branch. |
 
 ## Host hooks

--- a/docs/team.md
+++ b/docs/team.md
@@ -88,17 +88,78 @@ A sync pass does three things, in order:
   mismatch, so a no-op sync costs one lightweight network round-trip.
 - Leaves everything else alone.
 
-Only immutable per-author checkpoint files ever sync. On disk they live at
-`~/.daimon/team/<remote-slug>/authors/<author-slug>/<session_id>.json`; inside
-the shared repo the path is `authors/<author-slug>/<session_id>.json`. No mutable
-pointers are ever written to the sidecar — because every author appends to a
-disjoint path and nothing is ever rewritten, merges are conflict-free by
-construction. Your local "latest checkpoint" pointers stay private on your
-machine and never sync.
+Only immutable per-author checkpoint files ever sync. On disk they live under
+`~/.daimon/team/<remote-slug>/`; inside the shared repo the path is
+`projects/<logical/path>/authors/<author-slug>/<session_id>.json` (see the
+project layout section below), or `authors/<author-slug>/<session_id>.json`
+when no project identity resolves. No mutable pointers are ever written to the
+sidecar — because every author appends to a disjoint path and nothing is ever
+rewritten, merges are conflict-free by construction. Your local "latest
+checkpoint" pointers stay private on your machine and never sync.
 
 `DAIMON_TEAM=1` gates **writes only**. With it unset, your checkpoints are not
 mirrored into the sidecar — but reads of the team directory are always on, so you
 can still see teammates' memory even before you start contributing your own.
+
+## Project layout: the architect-authored squad tree
+
+Checkpoints in the sidecar are grouped by **logical project**, so several repos
+can share one memory pool and the same repo maps to the same pool on every
+teammate's machine. The hierarchy is organizational, not forge-derived: a team
+architect authors `daimon-team.toml` at the sidecar root — the squad tree with
+repos mapped into it — and commits it like any other file. **Daimon only reads
+this file; humans write and commit it.**
+
+```toml
+# daimon-team.toml — at the sidecar repo root, written by your team architect.
+#
+# One table per logical project. The key is the project's path in the squad
+# tree (any depth); `repos` lists every repo that feeds that project's pool.
+# ssh/https/scp spellings of the same repo are equivalent — the origin URL is
+# normalized (scheme, credentials, `.git`, case) before matching.
+
+[projects."core/cosmo/dusters/finance-1"]
+repos = [
+  "git@github.com:org/finance-svc.git",    # several repos → ONE shared pool
+  "https://github.com/org/finance-web",
+]
+
+[projects."core/api-gateway"]
+repos = ["git@github.com:org/gateway.git"]
+```
+
+On disk, a mapped repo's checkpoints land at
+`projects/core/cosmo/dusters/finance-1/authors/<author-slug>/<session_id>.json`
+— every path segment is munged filesystem-safe, so a config key can never
+escape the sidecar.
+
+A session's logical project is resolved in this order:
+
+1. **`DAIMON_TEAM_PROJECT`** — a relative path like `core/api-gateway`, set
+   per machine. Explicit local intent; beats the config file.
+2. **The `daimon-team.toml` mapping** — the session repo's `origin` URL is
+   normalized and matched against every project's `repos`.
+3. **Origin-derived fallback** — the origin URL's path without the host
+   (`git@github.com:org/repo.git` → `projects/org/repo/…`). Unmapped repos
+   still get portable identity, so the config file is optional and
+   incremental — add mappings as the squad tree takes shape.
+4. **No origin at all** (no git, no remote) — the checkpoint files directly
+   under `authors/<author-slug>/`, exactly as before this layout existed.
+
+The config file is optional and can be added or changed at any time — unmapped
+repos sync under their origin-derived path from day one. Remapping a repo never
+orphans its earlier history: reads cover the previous location too, so
+checkpoints already sitting under the old path stay visible after the move.
+
+A broken or unparseable `daimon-team.toml` never blocks a write: the mapping
+is treated as absent (resolution falls through to the origin-derived
+fallback) and the parse error is surfaced as a warning in `daimon team
+status`.
+
+**Legacy note:** sidecars written before this layout keep their flat
+`authors/<author-slug>/` files. That era stays readable forever — reads fan in
+across both layouts and there is no migration; new checkpoints simply start
+landing under `projects/` once a project identity resolves.
 
 ## Reading teammates
 
@@ -122,6 +183,7 @@ shared branch.
 | `DAIMON_TEAM` | unset (off) | Set to `1` to mirror your checkpoints into the team dir. Gates writes only; reads are always on. |
 | `DAIMON_AUTHOR` | `git config user.name` → OS username → `unknown` | The author name your checkpoints are filed under. |
 | `DAIMON_TEAM_DIR` | `~/.daimon/team` | Root of the local team mirror (one subdirectory per sidecar clone). |
+| `DAIMON_TEAM_PROJECT` | unset | Explicit logical project path (e.g. `core/api-gateway`) for this machine's sessions. Beats the `daimon-team.toml` mapping and the origin-derived fallback. |
 | `DAIMON_TEAM_RETENTION_DAYS` | `365` | Read-time age window for teammates' checkpoints; `0` = keep all. |
 
 See [docs/configuration.md](./configuration.md) for the full environment

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1273,6 +1273,10 @@ def _cmd_team_status(args) -> int:
         authors = ", ".join(row["authors"]) or "none yet"
         lines.append(f"{row['slug']}: {row['freshness']} — "
                      f"{row['unpushed']} unpushed checkpoint(s), authors: {authors}")
+        # #200: a broken daimon-team.toml fails open (mapping ignored) on the
+        # write path — status is the one place the parse error surfaces.
+        if row.get("config_warning"):
+            lines.append(f"  warning: {row['config_warning']}")
     render.render_team_status(lines)
     return 0
 

--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -205,6 +205,15 @@ def recall_seen_dir() -> Path:
     return Path.home() / ".daimon" / "recall_seen"
 
 
+def team_project() -> str | None:
+    """Explicit logical team-project path for this machine's sessions (#200):
+    a relative path like 'core/api-gateway'. Tier-1 override in teamproject's
+    resolution — explicit local intent beats the daimon-team.toml mapping and
+    the origin-derived fallback. Unset = resolve from git origin as usual."""
+    val = (_get("DAIMON_TEAM_PROJECT") or "").strip()
+    return val or None
+
+
 def team_retention_days() -> int:
     """Read-time age window for teammates' checkpoints (#113): read_team skips
     files older than this many days. 0 = keep all. Default 365 — deliberately

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -5,6 +5,7 @@ by scanning the same files everything else reads:
 
     local flat store   <checkpoint_dir>/<session_id>.json   (pointers excluded)
     team dir           <team_dir>/*/authors/<author>/*.json (all remotes, #111)
+                       <team_dir>/*/projects/**/authors/<author>/*.json (#200)
 
 Any doubt about the db — missing, corrupt, foreign schema, stale fingerprint —
 resolves to a full rebuild. Rebuild is a linear scan of at most a few hundred
@@ -166,10 +167,9 @@ def _scan_sources():
     except OSError:
         remotes = []
     for remote in remotes:
-        try:
-            author_dirs = list((remote / "authors").iterdir())
-        except OSError:
-            continue  # not a remote-shaped dir
+        # Both layout eras (#200): legacy flat authors/* plus nested
+        # projects/**/authors/* — same walker read_team's fan-in rests on.
+        author_dirs = store._team_author_dirs(remote)
         for adir in author_dirs:
             try:
                 files = [p for p in adir.iterdir()

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -33,7 +33,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
-from . import config, redact, schema, serializer
+from . import config, redact, schema, serializer, teamproject
 
 _LATEST = "latest.json"
 # Rotation pointers, not per-session checkpoints. Anything else ending in .json in
@@ -663,7 +663,9 @@ def _team_write_slug() -> str:
 
 def _dual_write_team(session_id: str, checkpoint: dict, project_dir) -> None:
     """Mirror a just-written checkpoint into the shared team dir (opt-in, #111):
-        <team_dir>/<remote-slug>/authors/<author-slug>/<session_id>.json
+        <team_dir>/<remote-slug>/projects/<seg…>/authors/<author-slug>/<sid>.json
+    under the #200 logical project path when one resolves, else the legacy flat
+        <team_dir>/<remote-slug>/authors/<author-slug>/<sid>.json
     where <remote-slug> is the single synced remote when one exists, else
     'local' (see _team_write_slug). Immutable append — NO pointers are EVER
     written here (the multi-writer git spike verdict: mutable pointers don't
@@ -672,7 +674,8 @@ def _dual_write_team(session_id: str, checkpoint: dict, project_dir) -> None:
     succeeded.
 
     Stamps `project_slug` onto a COPY of the checkpoint so read_team can filter by
-    project without a pointer; the local blob is left clean (no project routing of
+    project without a pointer, plus `team_project` (the "/"-joined logical path,
+    #200) on nested writes; the local blob is left clean (no project routing of
     its own)."""
     try:
         # Full project_slug munging, NOT _safe_name: _safe_name maps "a/b" and
@@ -681,12 +684,21 @@ def _dual_write_team(session_id: str, checkpoint: dict, project_dir) -> None:
         # non-word char to '-'. Post-munge collisions ("a b" vs "a-b") remain a
         # documented edge — distinct humans colliding there is unrealistic.
         author_slug = project_slug(config.author()) or "unknown"
-        d = config.team_dir() / _team_write_slug() / "authors" / author_slug
+        base = config.team_dir() / _team_write_slug()
+        # #200: env/config/origin-derived logical path (segments are munged in
+        # teamproject and can never escape the sidecar); None = flat era.
+        segs = teamproject.resolve(project_dir)
+        if segs:
+            d = base.joinpath("projects", *segs, "authors", author_slug)
+        else:
+            d = base / "authors" / author_slug
         d.mkdir(parents=True, exist_ok=True)
         # Shallow copy is deliberate and sufficient: only top-level keys are
         # stamped below; nested structures are never mutated on this path.
         blob = dict(checkpoint)
         blob.setdefault("project_slug", project_slug(project_dir))
+        if segs:
+            blob.setdefault("team_project", "/".join(segs))
         _atomic_write(d / f"{_safe_name(session_id)}.json",
                       json.dumps(blob, indent=2, ensure_ascii=False))
     except OSError:
@@ -702,17 +714,47 @@ def team_retention_cutoff() -> float | None:
     return (time.time() - days * 86400) if days > 0 else None
 
 
+def _team_author_dirs(remote: Path) -> list[Path]:
+    """Every authors/<author-slug> dir under one remote, BOTH eras (#200):
+    legacy flat authors/* plus nested projects/**/authors/* at any depth.
+    Descent stops at each authors/ dir — author dirs hold only checkpoint
+    files, never further layout. Pure file-ops, never raises."""
+    out: list[Path] = []
+    try:
+        out.extend(p for p in (remote / "authors").iterdir() if p.is_dir())
+    except OSError:
+        pass
+    for cur, dirnames, _files in os.walk(remote / "projects"):
+        if Path(cur).name == "authors":
+            out.extend(Path(cur) / name for name in sorted(dirnames))
+            dirnames[:] = []
+    return out
+
+
 def read_team(project_dir=None) -> list[tuple[str, dict]]:
     """Newest checkpoint per author in the shared team dir, for the given project.
 
-    Fan-in across every remote-slug: <team_dir>/*/authors/<author-slug>/*.json.
+    Fan-in across every remote-slug, BOTH layout eras (#200) combined:
+      - projects/<candidate…>/authors/* — the logical-path era, for EVERY
+        candidate path (teamproject.read_candidates: the winning tier PLUS the
+        lower tiers' paths when they differ — a repo mapped or env-overridden
+        AFTER it synced keeps its earlier nested history readable, never
+        orphaned). The path IS the project filter, so no stamp check is needed
+        (and several repos mapped to one logical project share one read pool
+        by construction).
+      - authors/*                       — the legacy flat era, filtered by the
+        stamped `project_slug` as always ("old flat sidecars stay readable
+        forever; no migration")
+    When no logical path resolves (teamproject tier 4), only the legacy era is
+    read — exactly the pre-#200 behavior.
+
     Derive-at-read — there are no pointers to trust: the newest checkpoint per
     author is chosen by the #93 `created` stamp (file mtime fallback, via
     _file_recency), exactly as the local GC ranks files. Returns
     [(author, checkpoint), ...] newest-first by each author's newest checkpoint.
 
-    Project filter: only checkpoints whose stamped `project_slug` matches this
-    project's slug. When the project is unknown (slug None) no filter is applied.
+    Legacy project filter: only checkpoints whose stamped `project_slug` matches
+    this project's slug. When the project is unknown (slug None) no filter applies.
 
     Retention (#113): checkpoints older than DAIMON_TEAM_RETENTION_DAYS (by the
     same _file_recency the ranking uses; 0 = keep all) are skipped AT READ TIME
@@ -723,38 +765,54 @@ def read_team(project_dir=None) -> list[tuple[str, dict]]:
     root = config.team_dir()
     want_slug = project_slug(project_dir)
     cutoff = team_retention_cutoff()
+    candidates = teamproject.read_candidates(project_dir)
     # author-slug (dir identity, one per author) -> (recency, author, checkpoint)
     best: dict[str, tuple[float, str, dict]] = {}
+
+    def _consider(adir: Path, check_stamp: bool) -> None:
+        try:
+            files = [p for p in adir.iterdir()
+                     if p.is_file() and p.suffix == ".json"]
+        except OSError:
+            return
+        for p in files:
+            try:
+                cp = json.loads(p.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue  # torn/foreign file — skip, never crash the fan-in
+            if not isinstance(cp, dict):
+                continue
+            if check_stamp and want_slug is not None \
+                    and cp.get("project_slug") != want_slug:
+                continue
+            rec = _file_recency(p)
+            if cutoff is not None and rec < cutoff:
+                continue  # aged out of the read window; file stays on disk
+            key = adir.name
+            if key not in best or rec > best[key][0]:
+                best[key] = (rec, cp.get("author") or adir.name, cp)
+
     try:
         remotes = list(root.iterdir())
     except OSError:
         return []
     for remote in remotes:
+        # Nested era (#200): only THIS project's subtrees — every candidate
+        # path (winner + prior-tier locations); the paths filter.
+        for segs in candidates:
+            nested = remote.joinpath("projects", *segs, "authors")
+            try:
+                for adir in nested.iterdir():
+                    _consider(adir, check_stamp=False)
+            except OSError:
+                pass  # no such subtree in this remote (yet)
+        # Legacy flat era: stamp-filtered, readable forever.
         try:
             author_dirs = list((remote / "authors").iterdir())
         except OSError:
             continue  # not a remote-shaped dir; skip
         for adir in author_dirs:
-            try:
-                files = [p for p in adir.iterdir()
-                         if p.is_file() and p.suffix == ".json"]
-            except OSError:
-                continue
-            for p in files:
-                try:
-                    cp = json.loads(p.read_text(encoding="utf-8"))
-                except (OSError, json.JSONDecodeError):
-                    continue  # torn/foreign file — skip, never crash the fan-in
-                if not isinstance(cp, dict):
-                    continue
-                if want_slug is not None and cp.get("project_slug") != want_slug:
-                    continue
-                rec = _file_recency(p)
-                if cutoff is not None and rec < cutoff:
-                    continue  # aged out of the read window; file stays on disk
-                key = adir.name
-                if key not in best or rec > best[key][0]:
-                    best[key] = (rec, cp.get("author") or adir.name, cp)
+            _consider(adir, check_stamp=True)
     ordered = sorted(best.values(), key=lambda t: t[0], reverse=True)
     return [(author, cp) for _rec, author, cp in ordered]
 

--- a/plugin/daimon_briefing/teamproject.py
+++ b/plugin/daimon_briefing/teamproject.py
@@ -1,0 +1,209 @@
+"""Logical team-project resolution (#200): which projects/<path…> a session's
+checkpoints belong to in the shared team sidecar.
+
+The hierarchy is ORGANIZATIONAL, not forge-derived: the team architect authors
+`daimon-team.toml` at the sidecar root — the logical squad tree with repos
+mapped INTO it. Daimon only READS that file; humans write and commit it, so
+the no-daimon-written-mutable-shared-state invariant survives (sync still
+commits own author dirs only; the config arrives through normal fetch).
+
+    [projects."core/cosmo/dusters/finance-1"]
+    repos = ["git@github.com:org/finance-svc.git",
+             "https://github.com/org/finance-web"]
+
+Resolution order for a project working dir:
+    1. DAIMON_TEAM_PROJECT env — explicit per-machine intent, beats everything
+    2. config mapping — normalized `git remote get-url origin` match
+    3. origin-derived fallback — the origin's path portion (zero-config default)
+    4. no origin resolvable → None → the legacy flat era exactly
+
+Writes go to the WINNING tier only (resolve). Reads fan across the full
+candidate set (read_candidates: winner first, then the lower tiers' paths
+when they differ) — mapping or env-overriding a repo AFTER it already synced
+must never orphan the history sitting under its earlier path.
+
+Every segment is munged with the store.project_slug char rules (non-word,
+non-dash → '-'), so a resolved path can never contain a separator or `..` and
+cannot escape the sidecar. Broken/unreadable TOML is treated as absent (fail
+open to tier 3); the parse error surfaces in `daimon team status`.
+
+The git dependency lives HERE (the resolution/policy layer, mirroring
+config.resolve_project_root) — store stays pure file-ops. Results are cached
+per process per project dir: one bounded git probe per write/read path.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+try:
+    import tomllib  # py3.11+ stdlib
+except ModuleNotFoundError:  # py3.10: tomli is the conditional runtime dep
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from . import config
+
+CONFIG_NAME = "daimon-team.toml"
+GIT_TIMEOUT = 5  # seconds — bounded; resolution must never block a write
+
+# (project_dir, team_dir, DAIMON_TEAM_PROJECT) -> ordered candidate list,
+# winner first (see read_candidates). The extra key parts keep test isolation
+# honest; in a real (short-lived) process they are constant and this is the
+# per-project cache the docstring promises.
+_cache: dict[tuple, list[tuple[str, ...]]] = {}
+
+
+def _munge_segment(seg: str) -> str:
+    # Same char rules as store.project_slug (kept local — store imports this
+    # module, so importing store back would cycle): every char that is not a
+    # word char or '-' becomes '-'. The result can never contain a path
+    # separator or a '.', so `..` and friends cannot escape the sidecar.
+    return re.sub(r"[^\w-]", "-", seg)
+
+
+def logical_segments(path_str) -> tuple[str, ...]:
+    """Munged segments of a "/"-separated logical path; empties dropped."""
+    if not path_str:
+        return ()
+    return tuple(
+        s for s in (_munge_segment(p.strip()) for p in str(path_str).split("/")) if s
+    )
+
+
+def normalize_repo_url(url) -> str | None:
+    """Canonical host/path form for a repo URL, so ssh/https/scp spellings of
+    the same repo compare equal: scheme stripped, credentials stripped, scp
+    ':' → '/', trailing '.git' and slashes stripped, lowercased."""
+    s = str(url or "").strip()
+    if not s:
+        return None
+    s = re.sub(r"^[A-Za-z][A-Za-z0-9+.-]*://", "", s)  # scheme
+    s = re.sub(r"^[^/@]+@", "", s)                      # user[:pass]@
+    s = s.replace(":", "/", 1)                          # scp-form host:path
+    s = s.strip("/")
+    if s.lower().endswith(".git"):
+        s = s[: -len(".git")]
+    return s.strip("/").lower() or None
+
+
+def _parse_config(path: Path) -> tuple[list[tuple[tuple[str, ...], set[str]]], str | None]:
+    """One config file -> ([(logical segments, normalized repo urls)], error).
+
+    Absent file = ([], None). Broken TOML or an unreadable file = ([], message)
+    — the config is treated as absent (fail open) but the error is surfaced.
+    Junk shapes inside valid TOML are skipped entry-by-entry, never fatal."""
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return [], None
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+        return [], f"{CONFIG_NAME} unreadable ({exc}) — mapping ignored"
+    entries: list[tuple[tuple[str, ...], set[str]]] = []
+    projects = data.get("projects")
+    if not isinstance(projects, dict):
+        return [], None
+    for logical, table in projects.items():
+        segs = logical_segments(logical)
+        repos = table.get("repos") if isinstance(table, dict) else None
+        if not segs or not isinstance(repos, list):
+            continue
+        normalized = {n for n in (normalize_repo_url(r) for r in repos) if n}
+        if normalized:
+            entries.append((segs, normalized))
+    return entries, None
+
+
+def config_error(sidecar: Path) -> str | None:
+    """Parse error for a sidecar's daimon-team.toml, or None (missing/valid).
+    `daimon team status` surfaces this — a broken mapping fails open silently
+    on the write path and must not stay invisible."""
+    _entries, err = _parse_config(Path(sidecar) / CONFIG_NAME)
+    return err
+
+
+def _config_entries() -> list[tuple[tuple[str, ...], set[str]]]:
+    """Mappings from every sidecar's config, fanned in across <team_dir>/*/
+    (the same every-remote fan-in read_team uses). Sorted dir order so a
+    (pathological) duplicate repo mapping resolves deterministically."""
+    entries: list[tuple[tuple[str, ...], set[str]]] = []
+    try:
+        subdirs = sorted(p for p in config.team_dir().iterdir() if p.is_dir())
+    except OSError:
+        return []
+    for d in subdirs:
+        rows, _err = _parse_config(d / CONFIG_NAME)
+        entries.extend(rows)
+    return entries
+
+
+def _origin_url(project_dir) -> str | None:
+    """`git remote get-url origin` for a working dir, or None on ANY failure
+    (no git, not a repo, no remote, timeout). Bounded, never raises."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(project_dir), "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=GIT_TIMEOUT,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def resolve(project_dir) -> tuple[str, ...] | None:
+    """Logical-path segments for a project working dir — the WRITE target —
+    or None (legacy flat era). The winning tier only; readers use
+    read_candidates so a later remap never strands what this wrote."""
+    cands = read_candidates(project_dir)
+    return cands[0] if cands else None
+
+
+def read_candidates(project_dir) -> list[tuple[str, ...]]:
+    """Every logical path this project's nested history may live under,
+    winner first, deduped. Writes use only the winner (resolve); reads fan
+    across the whole set — a repo mapped (or env-overridden) AFTER it synced
+    under a lower tier's path must keep that earlier history readable, not
+    orphan it. [] = nothing resolves (legacy flat era only).
+
+    Cached per process; never raises — resolution failure must degrade to
+    the flat era, not fail the write/read that asked."""
+    key = (str(project_dir or ""), str(config.team_dir()),
+           config.team_project() or "")
+    if key in _cache:
+        return _cache[key]
+    try:
+        result = _candidates(project_dir)
+    except Exception:  # belt-and-braces: a resolver bug must not break writes
+        result = []
+    _cache[key] = result
+    return result
+
+
+def _candidates(project_dir) -> list[tuple[str, ...]]:
+    out: list[tuple[str, ...]] = []
+    # Tier 1: explicit local intent — needs no git, wins over central config.
+    env = config.team_project()
+    if env:
+        segs = logical_segments(env)
+        if segs:
+            out.append(segs)
+    if project_dir:
+        origin = normalize_repo_url(_origin_url(project_dir))
+        if origin:
+            # Tier 2: the architect's mapping. Several repos may map to ONE
+            # logical project — the squad-level shared pool.
+            for segs, repos in _config_entries():
+                if origin in repos:
+                    out.append(segs)
+                    break
+            # Tier 3: origin-derived fallback — path portion WITHOUT the
+            # host, so unmapped repos still get portable identity. Kept as a
+            # read candidate even when a higher tier wins: pre-mapping
+            # history lives here.
+            derived = logical_segments("/".join(origin.split("/")[1:]))
+            if derived:
+                out.append(derived)
+    # Tier 4: nothing resolved → [] → flat era. Dedupe preserves tier order.
+    seen: set[tuple[str, ...]] = set()
+    return [s for s in out if not (s in seen or seen.add(s))]

--- a/plugin/daimon_briefing/teamsync.py
+++ b/plugin/daimon_briefing/teamsync.py
@@ -3,7 +3,11 @@
 Layout (extends the #111 team dir):
     <team_dir>/local/                    Phase 1 local-only mirror (no git)
     <team_dir>/<remote-slug>/            one git CLONE per team remote (sidecar)
-        authors/<author-slug>/*.json     immutable per-author checkpoint files
+        authors/<author-slug>/*.json     legacy flat era — readable forever
+        projects/<seg…>/authors/<author-slug>/*.json
+                                         #200 logical-project era (teamproject)
+        daimon-team.toml                 architect-authored mapping — humans
+                                         write and commit it; daimon only reads
 
 The multi-writer git spike verdict is LAW here:
   1. Only immutable per-author files are synced — NO mutable pointers ever land
@@ -42,7 +46,7 @@ import subprocess
 import time
 from pathlib import Path
 
-from . import config, store
+from . import config, store, teamproject
 
 GIT_TIMEOUT = 15        # seconds — local plumbing calls
 NET_TIMEOUT = 60        # seconds — ls-remote / fetch / push / clone touch the network
@@ -154,15 +158,15 @@ def _identity_extra(sidecar) -> list[str]:
             "-c", f"user.email={store.project_slug(author)}@daimon.invalid"]
 
 
-def _commit(sidecar, message, pathspec) -> subprocess.CompletedProcess:
+def _commit(sidecar, message, pathspecs) -> subprocess.CompletedProcess:
     """Pathspec-scoped commit (#144). A bare `git commit` snapshots the WHOLE
     index — anything the user happened to have pre-staged in the sidecar would
-    be swept into the append-only team branch. The pathspec limits the commit
-    to the caller's own paths and leaves every other index entry exactly as it
+    be swept into the append-only team branch. The pathspecs limit the commit
+    to the caller's own paths and leave every other index entry exactly as it
     was (git's partial-commit semantics)."""
     return _run_git(
         ["git", "-C", str(sidecar), *_identity_extra(sidecar),
-         "commit", "-m", message, "--", pathspec],
+         "commit", "-m", message, "--", *pathspecs],
         GIT_TIMEOUT,
     )
 
@@ -207,7 +211,7 @@ def init(url: str) -> Path:
     if _head(dest) is None:  # unborn branch: the remote was empty
         (dest / "README.md").write_text(_STUB_README, encoding="utf-8")
         _git(dest, "add", "--", "README.md")
-        cp = _commit(dest, "sync: initialize team memory sidecar", "README.md")
+        cp = _commit(dest, "sync: initialize team memory sidecar", ["README.md"])
         if cp.returncode != 0:
             raise TeamError(f"could not seed root commit: {_last_line(cp.stderr or cp.stdout)}")
         push = _git(dest, "push", "-u", "origin", _branch(dest), timeout=NET_TIMEOUT)
@@ -236,25 +240,51 @@ def _ls_remote(sidecar, branch) -> tuple[str, str | None]:
     return ("ok", out.split()[0])
 
 
+def _own_pathspecs(sidecar: Path, own: str) -> list[str]:
+    """Own-author dirs in BOTH layout eras (#200): the legacy flat
+    authors/<own>/ plus every projects/**/authors/<own>/ at any depth. Found
+    by an explicit walk yielding explicit relative paths — exact by
+    construction, where a `projects/**/authors/<own>` glob pathspec would ride
+    on git's glob semantics. Descent stops at each authors/ dir (author dirs
+    hold only checkpoint files). Never raises (os.walk swallows errors)."""
+    specs = []
+    # Existence-gated: `git add` FAILS outright on a pathspec that matches
+    # nothing, so a nested-only sidecar must not carry a phantom flat spec
+    # (and vice versa). The nested specs come off the disk walk, so they
+    # exist by construction.
+    if (sidecar / "authors" / own).is_dir():
+        specs.append(f"authors/{own}")
+    for cur, dirnames, _files in os.walk(sidecar / "projects"):
+        cur_p = Path(cur)
+        if cur_p.name == "authors":
+            if own in dirnames:
+                specs.append((cur_p / own).relative_to(sidecar).as_posix())
+            dirnames[:] = []
+    return specs
+
+
 def _commit_own(sidecar, report) -> None:
-    """Stage + commit NEW files under authors/<own-author-slug>/ ONLY. The add
-    is path-scoped to the own-author dir, so other authors' paths (and any
-    stray junk in the sidecar) are never touched — disjoint append-only paths
-    are what make the whole scheme conflict-free."""
+    """Stage + commit NEW files under the own-author dirs ONLY — both eras
+    (#200): authors/<own>/ and projects/**/authors/<own>/. The add is
+    path-scoped to those dirs, so other authors' paths (and any stray junk in
+    the sidecar) are never touched — disjoint append-only paths are what make
+    the whole scheme conflict-free."""
     own = store.project_slug(config.author()) or "unknown"
-    own_dir = f"authors/{own}"
-    status = _git(sidecar, "status", "--porcelain", "--", own_dir)
+    own_dirs = _own_pathspecs(sidecar, own)
+    if not own_dirs:
+        return  # no own dir in either era: nothing of ours to stage
+    status = _git(sidecar, "status", "--porcelain", "--", *own_dirs)
     if status.returncode != 0 or not status.stdout.strip():
         return
-    if _git(sidecar, "add", "--", own_dir).returncode != 0:
+    if _git(sidecar, "add", "--", *own_dirs).returncode != 0:
         return
-    # Count scoped to the own dir (#144): the index may carry unrelated
+    # Count scoped to the own dirs (#144): the index may carry unrelated
     # pre-staged entries, and the commit below deliberately excludes them.
-    staged = _git(sidecar, "diff", "--cached", "--name-only", "--", own_dir)
+    staged = _git(sidecar, "diff", "--cached", "--name-only", "--", *own_dirs)
     n = len([ln for ln in staged.stdout.splitlines() if ln.strip()])
     if not n:
         return
-    cp = _commit(sidecar, f"sync: {config.author()} {n} checkpoint(s)", own_dir)
+    cp = _commit(sidecar, f"sync: {config.author()} {n} checkpoint(s)", own_dirs)
     if cp.returncode == 0:
         report["committed"] = n
     else:
@@ -280,7 +310,9 @@ def _check_author_mismatch(sidecar, old, new, report) -> None:
         return
     for path in diff.stdout.splitlines():
         path = path.strip()
-        if not re.fullmatch(r"authors/[^/]+/[^/]+\.json", path):
+        # Both layout eras (#200): flat authors/… and nested projects/**/authors/…
+        if not re.fullmatch(
+                r"(?:projects/(?:[^/]+/)+)?authors/[^/]+/[^/]+\.json", path):
             continue
         show = _git(sidecar, "show", f"{new}:{path}")
         if show.returncode != 0:
@@ -449,12 +481,9 @@ def git_available() -> bool:
 
 
 def _authors_seen(sidecar) -> list[str]:
-    try:
-        return sorted(
-            p.name for p in (sidecar / "authors").iterdir() if p.is_dir()
-        )
-    except OSError:
-        return []
+    # Both layout eras (#200): store's walker already fans in flat authors/*
+    # and nested projects/**/authors/*; one author in both counts once.
+    return sorted({p.name for p in store._team_author_dirs(sidecar)})
 
 
 def _unpushed_count(sidecar, branch) -> int:
@@ -491,6 +520,9 @@ def team_status() -> list[dict]:
             "freshness": freshness,
             "unpushed": _unpushed_count(sidecar, branch),
             "authors": _authors_seen(sidecar),
+            # #200: a broken daimon-team.toml fails open on the write path
+            # (mapping ignored) — status is where the parse error surfaces.
+            "config_warning": teamproject.config_error(sidecar),
         })
     return rows
 

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -26,8 +26,11 @@ classifiers = [
     "Topic :: Software Development",
     "Environment :: Console",
 ]
-# Runtime: stdlib only. hermes is provided by the host at runtime, never a hard dep.
-dependencies = []
+# Runtime: stdlib only, except the py3.10 TOML backport — teamproject reads the
+# architect-authored daimon-team.toml (#200) and tomllib is stdlib only from 3.11.
+dependencies = [
+    "tomli>=2.0; python_version < '3.11'",
+]
 
 [project.optional-dependencies]
 # Versions are pinned so the CI lint gate is reproducible: a ruff/mypy
@@ -37,8 +40,6 @@ dev = [
     "pytest-cov==7.1.0",
     "ruff==0.15.20",
     "mypy==2.2.0",
-    # tomllib is stdlib only from 3.11; tests parse pyproject.toml on 3.10 too
-    "tomli>=2.0; python_version < '3.11'",
 ]
 pretty = [
     "rich>=13",

--- a/plugin/tests/conftest.py
+++ b/plugin/tests/conftest.py
@@ -28,6 +28,12 @@ def _isolate_daimon_home(tmp_path, monkeypatch):
     monkeypatch.setenv("DAIMON_RECALL_SEEN_DIR", str(home / "recall_seen"))
     monkeypatch.delenv("DAIMON_TEAM", raising=False)
     monkeypatch.delenv("DAIMON_AUTHOR", raising=False)
+    # #200: a host DAIMON_TEAM_PROJECT would nest every team write; and the
+    # resolver caches per (project_dir, team_dir, env) — clear it so no test
+    # can see another test's resolution.
+    monkeypatch.delenv("DAIMON_TEAM_PROJECT", raising=False)
+    from daimon_briefing import teamproject
+    teamproject._cache.clear()
     # Clear kill switch / overrides that may leak from the host env.
     monkeypatch.delenv("DAIMON_DISABLE", raising=False)
     monkeypatch.delenv("DAIMON_MIN_MESSAGES", raising=False)

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -80,6 +80,38 @@ def test_rebuild_indexes_team_items(tmp_checkpoint_dir, monkeypatch):
     assert hits[0]["kind"] == "belief"
 
 
+def _write_nested_team_file(logical, author_slug, sid, cp, project_dir=None):
+    """A #200 nested-era teammate blob: projects/<logical…>/authors/<slug>/."""
+    d = (config.team_dir() / "local" / "projects").joinpath(
+        *logical.split("/")) / "authors" / author_slug
+    d.mkdir(parents=True, exist_ok=True)
+    blob = dict(cp)
+    blob.setdefault("author", author_slug)
+    blob.setdefault("team_project", logical)
+    if project_dir is not None:
+        blob["project_slug"] = store.project_slug(project_dir)
+    (d / f"{sid}.json").write_text(
+        json.dumps(blob, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+def test_rebuild_indexes_nested_team_items(tmp_checkpoint_dir, monkeypatch):
+    # #200: blobs under projects/**/authors/* feed the index too.
+    _write_nested_team_file(
+        "core/cosmo/dusters/finance-1", "grace", "S-n",
+        _cp("S-n", beliefs=[{"text": "Nested capybara ledgers reconcile",
+                             "trust": "inferred"}]),
+        project_dir="/repo/x",
+    )
+    recall.rebuild()
+    hits = recall.search("capybara", all_projects=True)
+    assert len(hits) == 1
+    assert hits[0]["author"] == "grace"
+    # The project_slug stamp still scopes nested blobs to their project.
+    scoped = recall.search("capybara", project_dir="/repo/x")
+    assert len(scoped) == 1
+
+
 def test_search_matches_quote_text(tmp_checkpoint_dir, monkeypatch):
     monkeypatch.setenv("DAIMON_AUTHOR", "ada")
     store.write_checkpoint(

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -649,6 +649,109 @@ def test_read_team_retention_default_is_generous(tmp_checkpoint_dir, sample_chec
     assert [a for a, _ in store.read_team(project_dir="/repo/x")] == ["ada"]
 
 
+# ---- project-first team layout (#200): nested writes + both-era reads ----
+# DAIMON_TEAM_PROJECT (tier 1) drives resolution here — no git repos needed;
+# the git-backed tiers are exercised in test_teamproject.py.
+
+
+def _nested_author_dir(logical: str, author_slug: str) -> Path:
+    return (config.team_dir() / "local" / "projects"
+            ).joinpath(*logical.split("/")) / "authors" / author_slug
+
+
+def test_dual_write_nested_under_resolved_project(tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/api gateway")
+    store.write_checkpoint("S-a", sample_checkpoint, project_dir="/repo/x")
+    path = _nested_author_dir("core/api-gateway", "ada") / "S-a.json"
+    assert path.exists()
+    blob = json.loads(path.read_text(encoding="utf-8"))
+    # `team_project` = the "/"-joined logical path, ALONGSIDE the legacy stamp.
+    assert blob["team_project"] == "core/api-gateway"
+    assert blob["project_slug"] == store.project_slug("/repo/x")
+    # No flat-era copy: the nested path replaced it, not duplicated it.
+    assert not (_team_author_dir("ada") / "S-a.json").exists()
+
+
+def test_dual_write_flat_when_unresolved(tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
+    # No env, /repo/x is not a git repo → tier 4 → TODAY'S flat behavior exactly.
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-a", sample_checkpoint, project_dir="/repo/x")
+    path = _team_author_dir("ada") / "S-a.json"
+    assert path.exists()
+    blob = json.loads(path.read_text(encoding="utf-8"))
+    assert "team_project" not in blob
+    assert not (config.team_dir() / "local" / "projects").exists()
+
+
+def test_read_team_merges_both_eras_newest_wins(tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    # Legacy flat era: ada's OLD checkpoint (stamp filter must admit it).
+    store.write_checkpoint("a-flat", _stamped(sample_checkpoint, "a-flat", 100),
+                           project_dir="/repo/x")
+    # Nested era: ada's NEWER checkpoint under the resolved project.
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/api")
+    store.write_checkpoint("a-nested", _stamped(sample_checkpoint, "a-nested", 10),
+                           project_dir="/repo/x")
+    # grace only ever wrote in the flat era.
+    monkeypatch.delenv("DAIMON_TEAM_PROJECT")
+    monkeypatch.setenv("DAIMON_AUTHOR", "grace")
+    store.write_checkpoint("g-flat", _stamped(sample_checkpoint, "g-flat", 50),
+                           project_dir="/repo/x")
+
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/api")
+    team = store.read_team(project_dir="/repo/x")
+    by_author = {author: cp for author, cp in team}
+    assert set(by_author) == {"ada", "grace"}  # both eras fan in
+    assert by_author["ada"]["session_id"] == "a-nested"  # newest across eras
+
+
+def test_read_team_none_resolution_reads_legacy_only(tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/api")
+    store.write_checkpoint("a-nested", _stamped(sample_checkpoint, "a-nested", 10),
+                           project_dir="/repo/x")
+    monkeypatch.delenv("DAIMON_TEAM_PROJECT")
+    monkeypatch.setenv("DAIMON_AUTHOR", "grace")
+    store.write_checkpoint("g-flat", _stamped(sample_checkpoint, "g-flat", 5),
+                           project_dir="/repo/x")
+    # Resolution now yields None (/repo/x is not a repo, no env) → legacy only.
+    team = store.read_team(project_dir="/repo/x")
+    assert [a for a, _ in team] == ["grace"]
+
+
+def test_read_team_nested_needs_no_stamp_filter(tmp_checkpoint_dir, monkeypatch):
+    # In the nested era the PATH is the project filter — a blob without any
+    # project_slug stamp still belongs to the pool it physically lives in.
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/api")
+    d = _nested_author_dir("core/api", "grace")
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "S-g.json").write_text(
+        json.dumps({"session_id": "S-g", "author": "grace"}), encoding="utf-8")
+    team = store.read_team(project_dir="/repo/x")
+    assert [a for a, _ in team] == ["grace"]
+
+
+def test_read_team_nested_retention_applies(tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_TEAM_RETENTION_DAYS", "30")
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/api")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("a-old", _stamped(sample_checkpoint, "a-old", 40),
+                           project_dir="/repo/x")
+    monkeypatch.setenv("DAIMON_AUTHOR", "grace")
+    store.write_checkpoint("g-new", _stamped(sample_checkpoint, "g-new", 1),
+                           project_dir="/repo/x")
+    team = store.read_team(project_dir="/repo/x")
+    assert [a for a, _ in team] == ["grace"]  # ada aged out of the READ window
+    # NO physical deletes — the nested era is append-only too.
+    assert (_nested_author_dir("core/api", "ada") / "a-old.json").exists()
+
+
 # ---- latest-pointer regression guard: heal of an old session must not steal
 # ---- "latest" from a newer one (#123) ----
 

--- a/plugin/tests/test_teamproject.py
+++ b/plugin/tests/test_teamproject.py
@@ -1,0 +1,417 @@
+"""Logical team-project resolution (#200): architect-authored daimon-team.toml
+mapping, DAIMON_TEAM_PROJECT override, origin-derived fallback.
+
+Git-dependent tests build REAL local repos under tmp (the test_teamsync
+pattern) — no test ever talks to a network remote. The autouse conftest
+fixture already points DAIMON_TEAM_DIR under tmp.
+"""
+
+import json
+import os
+import subprocess
+
+import pytest
+
+from daimon_briefing import config, store, teamproject
+
+
+@pytest.fixture(autouse=True)
+def _git_isolation(monkeypatch):
+    """Keep the host's git config out of every repo these tests create."""
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+    monkeypatch.setenv("GIT_TERMINAL_PROMPT", "0")
+
+
+def _repo(tmp_path, name, origin=None):
+    """A real local git repo, optionally with an `origin` remote configured."""
+    d = tmp_path / name
+    d.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", str(d)],
+                   check=True, capture_output=True, timeout=30)
+    if origin:
+        subprocess.run(["git", "-C", str(d), "remote", "add", "origin", origin],
+                       check=True, capture_output=True, timeout=30)
+    return d
+
+
+def _write_config(text, remote="local"):
+    """Author a daimon-team.toml under <team_dir>/<remote>/ (the local read path)."""
+    root = config.team_dir() / remote
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / teamproject.CONFIG_NAME
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+# ---- origin-URL normalization: ssh/https/scp forms must compare equal ----
+
+
+def test_normalize_scp_and_https_forms_are_equal():
+    assert (teamproject.normalize_repo_url("git@github.com:org/finance-svc.git")
+            == teamproject.normalize_repo_url("https://github.com/org/finance-svc"))
+
+
+def test_normalize_strips_git_suffix_and_trailing_slashes():
+    assert (teamproject.normalize_repo_url("https://github.com/org/x.git/")
+            == "github.com/org/x")
+
+
+def test_normalize_lowercases():
+    assert teamproject.normalize_repo_url("HTTPS://GitHub.COM/Org/Repo") == \
+        "github.com/org/repo"
+
+
+def test_normalize_strips_credentials():
+    assert teamproject.normalize_repo_url("https://user:pass@github.com/org/x") == \
+        "github.com/org/x"
+    assert teamproject.normalize_repo_url("ssh://git@gitlab.com/grp/sub/x.git") == \
+        "gitlab.com/grp/sub/x"
+
+
+def test_normalize_empty_is_none():
+    assert teamproject.normalize_repo_url("") is None
+    assert teamproject.normalize_repo_url(None) is None
+
+
+# ---- tier 1: DAIMON_TEAM_PROJECT — explicit local intent, no git needed ----
+
+
+def test_env_project_resolves_without_git(monkeypatch):
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/api-gateway")
+    assert teamproject.resolve(None) == ("core", "api-gateway")
+
+
+def test_env_segments_munged_and_empties_dropped(monkeypatch):
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core//api gateway/")
+    assert teamproject.resolve(None) == ("core", "api-gateway")
+
+
+@pytest.mark.parametrize("hostile", [
+    "../../etc",
+    "..%2F..%2Fetc",
+    "a\\..\\b",
+    "/abs/path",
+    "C:\\windows\\system32",
+    "core/../../etc/passwd",
+    "././.",
+    "//",
+    "  ",
+])
+def test_hostile_env_inputs_never_escape(monkeypatch, tmp_path, hostile):
+    # Munged segments can never contain separators or `..` — a resolved path
+    # joined under a base dir must stay inside that base dir.
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", hostile)
+    segs = teamproject.resolve(None)
+    if segs is None:
+        return  # all-empty inputs resolve to nothing — flat era, safe
+    base = tmp_path / "base"
+    for seg in segs:
+        assert "/" not in seg
+        assert "\\" not in seg
+        assert seg not in ("", ".", "..")
+    joined = base.joinpath(*segs)
+    assert joined.resolve().is_relative_to(base.resolve())
+
+
+def test_env_all_empty_falls_through_to_none(monkeypatch):
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "///")
+    assert teamproject.resolve(None) is None
+
+
+# ---- tier 2: architect config mapping (normalized-origin match) ----
+
+
+def test_config_mapping_matches_normalized_origin(tmp_path):
+    repo = _repo(tmp_path, "finance-svc", "git@github.com:Org/Finance-Svc.git")
+    _write_config(
+        '[projects."core/cosmo/dusters/finance-1"]\n'
+        'repos = ["https://github.com/org/finance-svc"]\n'
+    )
+    assert teamproject.resolve(repo) == ("core", "cosmo", "dusters", "finance-1")
+
+
+def test_env_beats_config(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, "finance-svc", "git@github.com:org/finance-svc.git")
+    _write_config(
+        '[projects."core/finance"]\n'
+        'repos = ["https://github.com/org/finance-svc"]\n'
+    )
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "overridden/here")
+    assert teamproject.resolve(repo) == ("overridden", "here")
+
+
+def test_config_project_key_segments_are_munged(tmp_path):
+    repo = _repo(tmp_path, "x", "https://github.com/org/x")
+    _write_config(
+        '[projects."core/../etc/api gateway"]\n'
+        'repos = ["https://github.com/org/x"]\n'
+    )
+    segs = teamproject.resolve(repo)
+    assert segs == ("core", "--", "etc", "api-gateway")
+    for seg in segs:
+        assert "/" not in seg and seg != ".."
+
+
+def test_multiple_repos_map_to_one_project(tmp_path):
+    # Several repos → ONE logical project: the squad-level shared pool.
+    svc = _repo(tmp_path, "svc", "git@github.com:org/finance-svc.git")
+    web = _repo(tmp_path, "web", "https://github.com/org/finance-web")
+    _write_config(
+        '[projects."core/finance"]\n'
+        'repos = [\n'
+        '  "git@github.com:org/finance-svc.git",\n'
+        '  "https://github.com/org/finance-web",\n'
+        ']\n'
+    )
+    assert teamproject.resolve(svc) == ("core", "finance")
+    assert teamproject.resolve(web) == ("core", "finance")
+
+
+# ---- tier 3: origin-derived fallback (zero-config portable identity) ----
+
+
+def test_derived_fallback_strips_host_and_munges(tmp_path):
+    repo = _repo(tmp_path, "x", "git@gitlab.com:platform/devops/infra.git")
+    assert teamproject.resolve(repo) == ("platform", "devops", "infra")
+
+
+def test_derived_fallback_when_config_does_not_match(tmp_path):
+    repo = _repo(tmp_path, "x", "https://github.com/org/unmapped")
+    _write_config(
+        '[projects."core/finance"]\n'
+        'repos = ["https://github.com/org/other-repo"]\n'
+    )
+    assert teamproject.resolve(repo) == ("org", "unmapped")
+
+
+# ---- tier 4: no origin at all → None → legacy flat era ----
+
+
+def test_no_remote_returns_none(tmp_path):
+    repo = _repo(tmp_path, "x")  # git repo, no origin remote
+    assert teamproject.resolve(repo) is None
+
+
+def test_non_repo_dir_returns_none(tmp_path):
+    d = tmp_path / "not-a-repo"
+    d.mkdir()
+    assert teamproject.resolve(d) is None
+
+
+def test_none_project_dir_returns_none():
+    assert teamproject.resolve(None) is None
+
+
+# ---- broken/missing config: fail open, surface the parse error ----
+
+
+def test_broken_toml_fails_open_to_derived(tmp_path):
+    repo = _repo(tmp_path, "x", "https://github.com/org/x")
+    _write_config("[projects.\nthis is not toml")
+    assert teamproject.resolve(repo) == ("org", "x")
+
+
+def test_config_error_surfaces_parse_failure():
+    _write_config("not = valid = toml [")
+    err = teamproject.config_error(config.team_dir() / "local")
+    assert err is not None
+    assert teamproject.CONFIG_NAME in err
+
+
+def test_config_error_none_when_missing():
+    root = config.team_dir() / "local"
+    root.mkdir(parents=True, exist_ok=True)
+    assert teamproject.config_error(root) is None
+
+
+def test_config_error_none_when_valid():
+    _write_config('[projects."core/x"]\nrepos = ["https://github.com/org/x"]\n')
+    assert teamproject.config_error(config.team_dir() / "local") is None
+
+
+def test_unreadable_config_treated_absent(tmp_path):
+    # A daimon-team.toml that cannot be READ (here: it is a directory) is the
+    # same fail-open shape as broken TOML: config absent + error surfaced.
+    repo = _repo(tmp_path, "x", "https://github.com/org/x")
+    root = config.team_dir() / "local"
+    (root / teamproject.CONFIG_NAME).mkdir(parents=True)
+    assert teamproject.resolve(repo) == ("org", "x")
+    assert teamproject.config_error(root) is not None
+
+
+def test_config_with_wrong_shapes_is_tolerated(tmp_path):
+    # Valid TOML, junk shapes: no crash, junk entries ignored, good ones work.
+    repo = _repo(tmp_path, "x", "https://github.com/org/x")
+    _write_config(
+        'projects = 7\n'  # not even a table
+    )
+    assert teamproject.resolve(repo) == ("org", "x")
+    assert teamproject.config_error(config.team_dir() / "local") is None
+
+
+# ---- remap resilience: reads cover every candidate path, writes only the
+# ---- winner — mapping (or env-overriding) a repo AFTER it synced must never
+# ---- orphan the history already sitting under the earlier path ----
+
+
+def _ago(days):
+    import time as _t
+    return _t.strftime("%Y-%m-%dT%H:%M:%SZ", _t.gmtime(_t.time() - days * 86400))
+
+
+def _mini_cp(sid, days_ago):
+    return {"session_id": sid, "created": _ago(days_ago)}
+
+
+def test_read_candidates_winner_first_then_derived(tmp_path):
+    repo = _repo(tmp_path, "x", "git@github.com:org/finance-svc.git")
+    _write_config(
+        '[projects."core/finance"]\n'
+        'repos = ["https://github.com/org/finance-svc"]\n'
+    )
+    assert teamproject.read_candidates(repo) == [
+        ("core", "finance"),        # tier 2 wins…
+        ("org", "finance-svc"),     # …but the tier-3 path stays readable
+    ]
+    assert teamproject.resolve(repo) == ("core", "finance")  # writes: winner only
+
+
+def test_read_candidates_env_includes_lower_tiers(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, "x", "git@github.com:org/finance-svc.git")
+    _write_config(
+        '[projects."core/finance"]\n'
+        'repos = ["https://github.com/org/finance-svc"]\n'
+    )
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "squad/special")
+    assert teamproject.read_candidates(repo) == [
+        ("squad", "special"),
+        ("core", "finance"),
+        ("org", "finance-svc"),
+    ]
+    assert teamproject.resolve(repo) == ("squad", "special")
+
+
+def test_read_candidates_dedupe_when_tiers_agree(tmp_path, monkeypatch):
+    # env naming exactly the derived path must not produce a duplicate scan.
+    repo = _repo(tmp_path, "x", "https://github.com/org/x")
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "org/x")
+    assert teamproject.read_candidates(repo) == [("org", "x")]
+
+
+def test_read_candidates_empty_when_nothing_resolves(tmp_path):
+    d = tmp_path / "not-a-repo"
+    d.mkdir()
+    assert teamproject.read_candidates(d) == []
+
+
+def test_remap_keeps_prior_history_readable(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    repo = _repo(tmp_path, "svc", "git@github.com:org/finance-svc.git")
+    # Day one, unmapped: ada syncs under the tier-3 origin-derived path.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-early", _mini_cp("S-early", 30), project_dir=repo)
+    derived = (config.team_dir() / "local" / "projects" / "org" / "finance-svc"
+               / "authors" / "ada" / "S-early.json")
+    assert derived.exists()
+    # The architect maps the repo AFTER that history exists. A real remap is
+    # seen by a fresh process; the per-process cache is cleared to model that.
+    _write_config(
+        '[projects."core/finance"]\n'
+        'repos = ["https://github.com/org/finance-svc"]\n'
+    )
+    teamproject._cache.clear()
+    monkeypatch.setenv("DAIMON_AUTHOR", "grace")
+    store.write_checkpoint("S-late", _mini_cp("S-late", 1), project_dir=repo)
+    mapped = (config.team_dir() / "local" / "projects" / "core" / "finance"
+              / "authors" / "grace" / "S-late.json")
+    assert mapped.exists()  # new writes land at the mapped path only
+    # Reads fan across BOTH paths: pre-map history is not orphaned.
+    team = store.read_team(project_dir=repo)
+    by_author = {a: cp for a, cp in team}
+    assert set(by_author) == {"ada", "grace"}
+    assert by_author["ada"]["session_id"] == "S-early"
+
+
+def test_env_override_remap_keeps_prior_history_readable(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    repo = _repo(tmp_path, "svc", "git@github.com:org/finance-svc.git")
+    _write_config(
+        '[projects."core/finance"]\n'
+        'repos = ["https://github.com/org/finance-svc"]\n'
+    )
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-early", _mini_cp("S-early", 30), project_dir=repo)
+    # This machine later imposes an explicit override (tier 1).
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "squad/special")
+    monkeypatch.setenv("DAIMON_AUTHOR", "grace")
+    store.write_checkpoint("S-late", _mini_cp("S-late", 1), project_dir=repo)
+    assert (config.team_dir() / "local" / "projects" / "squad" / "special"
+            / "authors" / "grace" / "S-late.json").exists()
+    team = store.read_team(project_dir=repo)
+    by_author = {a: cp for a, cp in team}
+    assert set(by_author) == {"ada", "grace"}  # config-era history still read
+
+
+def test_same_author_across_candidates_newest_wins_once(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    repo = _repo(tmp_path, "svc", "git@github.com:org/finance-svc.git")
+    store.write_checkpoint("S-early", _mini_cp("S-early", 30), project_dir=repo)
+    _write_config(
+        '[projects."core/finance"]\n'
+        'repos = ["https://github.com/org/finance-svc"]\n'
+    )
+    teamproject._cache.clear()
+    store.write_checkpoint("S-late", _mini_cp("S-late", 1), project_dir=repo)
+    team = store.read_team(project_dir=repo)
+    assert [a for a, _ in team] == ["ada"]  # one entry, no duplicates
+    assert team[0][1]["session_id"] == "S-late"  # newest across candidates
+
+
+# ---- caching: one git probe per process per project dir ----
+
+
+def test_resolution_cached_per_project_dir(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, "x", "https://github.com/org/x")
+    calls = []
+    real = teamproject._origin_url
+
+    def counting(project_dir):
+        calls.append(project_dir)
+        return real(project_dir)
+
+    monkeypatch.setattr(teamproject, "_origin_url", counting)
+    assert teamproject.resolve(repo) == ("org", "x")
+    assert teamproject.resolve(repo) == ("org", "x")
+    assert len(calls) == 1
+
+
+# ---- end to end: two mapped repos share one team read pool ----
+
+
+def test_mapped_repos_share_one_team_pool(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    svc = _repo(tmp_path, "svc", "git@github.com:org/finance-svc.git")
+    web = _repo(tmp_path, "web", "https://github.com/org/finance-web")
+    _write_config(
+        '[projects."core/finance"]\n'
+        'repos = [\n'
+        '  "git@github.com:org/finance-svc.git",\n'
+        '  "https://github.com/org/finance-web",\n'
+        ']\n'
+    )
+    cp = {"session_id": "S-svc",
+          "working_context": {"recent_decisions": [
+              {"text": "Adopt the shared pool", "trust": "inferred"}]}}
+    store.write_checkpoint("S-svc", cp, project_dir=svc)
+    nested = (config.team_dir() / "local" / "projects" / "core" / "finance"
+              / "authors" / "ada" / "S-svc.json")
+    assert nested.exists()
+    blob = json.loads(nested.read_text(encoding="utf-8"))
+    assert blob["team_project"] == "core/finance"
+    # A session in the OTHER mapped repo reads the same pool by construction.
+    team = store.read_team(project_dir=web)
+    assert [a for a, _ in team] == ["ada"]
+    assert team[0][1]["session_id"] == "S-svc"

--- a/plugin/tests/test_teamsync.py
+++ b/plugin/tests/test_teamsync.py
@@ -172,6 +172,47 @@ def test_sync_commit_excludes_prestaged_unrelated_paths(bare_remote, monkeypatch
     assert staged == ["notes.txt"]    # pre-staged entry survives untouched
 
 
+def _write_nested_team_file(sidecar, logical, author_slug, name, payload=None):
+    """Lay down a #200 nested-era file: projects/<logical…>/authors/<slug>/<name>."""
+    d = sidecar.joinpath("projects", *logical.split("/"), "authors", author_slug)
+    d.mkdir(parents=True, exist_ok=True)
+    (d / name).write_text(
+        json.dumps(payload or {"session_id": name, "author": author_slug}),
+        encoding="utf-8",
+    )
+
+
+def test_sync_stages_own_files_in_both_eras(bare_remote, monkeypatch):
+    # #200: own files land flat (legacy era) AND nested at any depth under
+    # projects/ — sync must commit both, and never another author's files.
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    sidecar = teamsync.init(str(bare_remote))
+    _write_team_file(sidecar, "Ada", "S1.json")
+    _write_nested_team_file(sidecar, "core/api", "Ada", "S2.json")
+    _write_nested_team_file(sidecar, "core/cosmo/dusters/finance-1", "Ada", "S3.json")
+    _write_nested_team_file(sidecar, "core/api", "Bob", "S9.json")
+    r = teamsync.sync_remote(sidecar)
+    assert r["committed"] == 3
+    published = _bare_files(bare_remote)
+    assert "authors/Ada/S1.json" in published
+    assert "projects/core/api/authors/Ada/S2.json" in published
+    assert "projects/core/cosmo/dusters/finance-1/authors/Ada/S3.json" in published
+    # Bob's nested file was neither committed nor pushed — still untracked.
+    status = _git(sidecar, "status", "--porcelain").stdout
+    assert "?? projects/core/api/authors/Bob/" in status
+    assert "projects/core/api/authors/Bob/S9.json" not in published
+
+
+def test_sync_nested_only_no_flat_dir(bare_remote, monkeypatch):
+    # A sidecar born after #200 may have NO flat authors/ dir at all.
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    sidecar = teamsync.init(str(bare_remote))
+    _write_nested_team_file(sidecar, "core/api", "Ada", "S1.json")
+    r = teamsync.sync_remote(sidecar)
+    assert r["committed"] == 1
+    assert "projects/core/api/authors/Ada/S1.json" in _bare_files(bare_remote)
+
+
 def test_sync_failed_add_aborts_commit(bare_remote, monkeypatch):
     # #144: if staging the own dir fails, committing would publish whatever
     # stale state the index happens to hold — abort instead.
@@ -403,6 +444,41 @@ def test_cli_team_status_freshness_unpushed_authors(bare_remote, monkeypatch, ca
     assert "fresh" in out              # ls-remote hash matches tracking ref
     assert "1 unpushed" in out
     assert "Ada" in out
+
+
+def test_status_authors_seen_includes_nested(bare_remote, monkeypatch):
+    # #200: authors who only ever wrote in the nested era must still count.
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    sidecar = teamsync.init(str(bare_remote))
+    _write_team_file(sidecar, "Ada", "S1.json")
+    _write_nested_team_file(sidecar, "core/api", "Bob", "S2.json")
+    rows = teamsync.team_status()
+    assert rows[0]["authors"] == ["Ada", "Bob"]
+
+
+def test_team_status_warns_on_broken_config(bare_remote, monkeypatch, capsys):
+    # #200: a broken daimon-team.toml fails open (config treated as absent),
+    # but the parse error must surface in `daimon team status`.
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    sidecar = teamsync.init(str(bare_remote))
+    (sidecar / "daimon-team.toml").write_text("[projects.\nbroken", encoding="utf-8")
+    rows = teamsync.team_status()
+    assert rows[0]["config_warning"]
+    assert cli.main(["team", "status"]) == 0
+    assert "daimon-team.toml" in capsys.readouterr().out
+
+
+def test_team_status_no_warning_on_valid_or_missing_config(bare_remote, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    sidecar = teamsync.init(str(bare_remote))
+    rows = teamsync.team_status()
+    assert rows[0]["config_warning"] is None  # missing file: no false alarm
+    (sidecar / "daimon-team.toml").write_text(
+        '[projects."core/x"]\nrepos = ["https://github.com/org/x"]\n',
+        encoding="utf-8",
+    )
+    rows = teamsync.team_status()
+    assert rows[0]["config_warning"] is None
 
 
 def test_cli_team_status_no_remote(capsys):

--- a/plugin/uv.lock
+++ b/plugin/uv.lock
@@ -163,6 +163,9 @@ toml = [
 name = "daimon-briefing"
 version = "0.12.3"
 source = { editable = "." }
+dependencies = [
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
 
 [package.optional-dependencies]
 dev = [
@@ -170,7 +173,6 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 pretty = [
     { name = "rich" },
@@ -185,7 +187,7 @@ requires-dist = [
     { name = "rich", marker = "extra == 'pretty'", specifier = ">=13" },
     { name = "rich-argparse", marker = "extra == 'pretty'", specifier = ">=1.8.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.20" },
-    { name = "tomli", marker = "python_full_version < '3.11' and extra == 'dev'", specifier = ">=2.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
 ]
 provides-extras = ["dev", "pretty"]
 


### PR DESCRIPTION
Closes #200

## What

One shared memory repo can now house every project a team works on, organized by a squad tree the team's architect defines in `daimon-team.toml` at the sidecar root:

```toml
[projects."core/cosmo/dusters/finance-1"]
repos = [
  "git@github.com:org/finance-svc.git",
  "https://github.com/org/finance-web",
]
```

Checkpoints land at `projects/<logical/path>/authors/<author-slug>/<session_id>.json` — browsable by squad/project in the repo UI, arbitrary nesting depth, logical names decoupled from repo names. Several repos may map to one logical project and share its memory pool.

## Why the old model failed teams

`project_slug` is a munged absolute checkout path — it embeds `$HOME`, so two teammates cloning the same repo could never produce the same slug, and `brief --team`'s project filter showed them each other's nothing. The sidecar was also author-flat and unbrowsable by project.

## Design invariants held

- **Daimon only reads the config; humans write and commit it.** Sync still commits per-author dirs only — no daimon-written mutable shared state, no new merge surface.
- **Resolution is tiered and fail-open**: `DAIMON_TEAM_PROJECT` env → config mapping (origin URLs normalized so scp/https/`.git`/case variants match) → origin-derived portable path (zero-config default) → no origin = legacy flat era, unchanged.
- **Remap-resilient reads**: reads fan across every candidate tier plus the flat era, newest-per-author — mapping a repo after it already synced never orphans its history. Old sidecars stay readable forever; no migration.
- **Fail-open everywhere**: broken TOML falls through to the fallback tier and surfaces as a warning in `daimon team status`; the git origin probe is bounded (5s) and never blocks or fails a serialize.
- **Path safety**: config keys and env values are munged per segment (no separators, no `..`) and cannot escape the sidecar — property-tested with hostile inputs.
- teamsync own-dir staging is depth-agnostic and existence-gated (`git add` hard-fails on no-match pathspecs); it can never stage another author's files or the config.
- Recall index walks both eras.

## Docs

`docs/team.md` gains the layout section (schema, commented example, resolution order, remap/no-migration notes); `docs/configuration.md` gains `DAIMON_TEAM_PROJECT`.

## Dependencies

`tomli>=2.0` becomes a conditional runtime dependency on py<3.11 (stdlib `tomllib` elsewhere) — first runtime dep, py3.10-only, parser-only.

## Tests

Suite 1237 → **1290** (53 new, red-first): TOML parse/broken/missing, URL-normalization matrix, tier precedence, hostile-segment safety, nested dual-write + stamps, both-era reads + retention + newest-wins dedupe, multi-repo shared pool, remap scenarios (config and env variants), staging isolation, recall coverage. Independent adversarial review: no findings.