### PR TITLE
test(team): cover the defensive seams codecov flagged on #201

### DIFF
--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -591,13 +591,36 @@ def test_read_team_newest_per_author_for_project(tmp_checkpoint_dir, sample_chec
 def test_read_team_filters_by_project(tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
     monkeypatch.setenv("DAIMON_TEAM", "1")
     monkeypatch.setenv("DAIMON_AUTHOR", "ada")
-    store.write_checkpoint("a-x", sample_checkpoint, project_dir="/repo/x")
-    store.write_checkpoint("a-y", sample_checkpoint, project_dir="/repo/y")
+    # Fresh dict per write (#202): write_checkpoint stamps project_slug on the
+    # caller's dict via setdefault, so a REUSED dict carries the first write's
+    # slug into the second — both blobs stamped /repo/x and the filter below
+    # never exercised. Production builds a fresh dict per serialize.
+    store.write_checkpoint("a-x", {**sample_checkpoint}, project_dir="/repo/x")
+    store.write_checkpoint("a-y", {**sample_checkpoint}, project_dir="/repo/y")
     team = store.read_team(project_dir="/repo/x")
     authors = [a for a, _ in team]
     assert authors == ["ada"]
     # only the /repo/x checkpoint is returned for ada
     assert team[0][1]["project_slug"] == store.project_slug("/repo/x")
+    assert team[0][1]["session_id"] == sample_checkpoint["session_id"]
+
+
+def test_read_team_skips_unlistable_author_entry(tmp_checkpoint_dir):
+    # A stray FILE where an author dir belongs (half-synced sidecar, foreign
+    # junk) makes iterdir raise — the fan-in must skip it, not crash (#202).
+    authors = _team_author_dir("ada").parent
+    authors.mkdir(parents=True, exist_ok=True)
+    (authors / "not-a-dir").write_text("junk", encoding="utf-8")
+    assert store.read_team(project_dir="/repo/x") == []
+
+
+def test_read_team_skips_non_dict_checkpoint(tmp_checkpoint_dir):
+    # Valid JSON that isn't an object (a list, a string) is foreign data,
+    # skipped like a torn file (#202).
+    d = _team_author_dir("ada")
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "weird.json").write_text('[1, 2]', encoding="utf-8")
+    assert store.read_team(project_dir="/repo/x") == []
 
 
 def test_read_team_never_raises_on_garbage(tmp_checkpoint_dir, monkeypatch):

--- a/plugin/tests/test_teamproject.py
+++ b/plugin/tests/test_teamproject.py
@@ -415,3 +415,80 @@ def test_mapped_repos_share_one_team_pool(tmp_path, monkeypatch):
     team = store.read_team(project_dir=web)
     assert [a for a, _ in team] == ["ada"]
     assert team[0][1]["session_id"] == "S-svc"
+
+
+# ---- #202: the defensive seams codecov flagged unexercised on #201 ----
+
+
+def test_tomli_import_fallback():
+    # py3.10 has no stdlib tomllib; the module must fall back to the tomli
+    # runtime dep (#202). Simulated on every version: block tomllib, stub
+    # tomli, reload — manual restore so the module is ALWAYS reloaded clean
+    # even when the assertion fails.
+    import builtins
+    import importlib
+    import sys
+    import types
+
+    real_import = builtins.__import__
+    stub = types.ModuleType("tomli")
+    stub.loads = lambda s: {}
+
+    def blocking(name, *args, **kwargs):
+        if name == "tomllib":
+            raise ModuleNotFoundError("No module named 'tomllib'")
+        if name == "tomli":
+            return stub
+        return real_import(name, *args, **kwargs)
+
+    saved_tomllib = sys.modules.pop("tomllib", None)
+    saved_tomli = sys.modules.pop("tomli", None)
+    builtins.__import__ = blocking
+    try:
+        importlib.reload(teamproject)
+        assert teamproject.tomllib is stub
+    finally:
+        builtins.__import__ = real_import
+        if saved_tomllib is not None:
+            sys.modules["tomllib"] = saved_tomllib
+        if saved_tomli is not None:
+            sys.modules["tomli"] = saved_tomli
+        importlib.reload(teamproject)
+
+
+def test_logical_segments_empty_inputs():
+    assert teamproject.logical_segments(None) == ()
+    assert teamproject.logical_segments("") == ()
+
+
+def test_config_entry_with_non_list_repos_is_skipped(tmp_path):
+    # A malformed entry (repos = string, not list) is dropped, so resolution
+    # falls through to the tier-3 origin-derived path.
+    _write_config(
+        '[projects."core/x"]\n'
+        'repos = "git@github.com:org/a.git"\n'
+    )
+    repo = _repo(tmp_path, "a", "git@github.com:org/a.git")
+    assert teamproject.read_candidates(repo)[0] == ("org", "a")
+
+
+def test_git_probe_failure_resolves_to_flat_era(tmp_path, monkeypatch):
+    # The origin probe raising (timeout, git missing) must degrade to tier 4
+    # (legacy flat era), never propagate into a write.
+    repo = _repo(tmp_path, "a", "git@github.com:org/a.git")
+
+    def boom(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="git", timeout=5)
+
+    monkeypatch.setattr(teamproject.subprocess, "run", boom)
+    assert teamproject.read_candidates(repo) == []
+
+
+def test_read_candidates_swallows_resolver_bugs(tmp_path, monkeypatch):
+    # Belt-and-braces: an unexpected resolver exception yields [] (flat era),
+    # never a broken serialize.
+    def buggy(project_dir):
+        raise RuntimeError("resolver bug")
+
+    monkeypatch.setattr(teamproject, "_candidates", buggy)
+    assert teamproject.read_candidates(tmp_path) == []


### PR DESCRIPTION
Closes #202

## What

Covers the 12 patch lines codecov flagged on the merged #201 — all defensive seams:

- `teamproject.py`: py3.10 tomli import fallback (tested version-independently: block `tomllib` at import machinery level, stub `tomli`, reload, restore in `finally`), `logical_segments` empty inputs, config entry with non-list `repos` (falls through to origin-derived tier), git origin probe raising → flat era, `read_candidates` belt-and-braces swallow.
- `store.py` `read_team` fan-in: stray file where an author dir belongs (iterdir OSError skipped), valid-JSON-but-not-an-object checkpoint skipped, legacy-era `project_slug` stamp mismatch filtered.

## The interesting find

The stamp-filter line being uncovered exposed `test_read_team_filters_by_project` as **vacuous**: `write_checkpoint` stamps `project_slug` idempotently on the caller's dict (`store.py:483`, by design — re-writes must not re-stamp), so the test's reused `sample_checkpoint` dict carried `/repo/x`'s slug into the `/repo/y` write; both blobs matched the filter and the assertion passed without the filter ever firing. Fixed with a fresh dict per write plus a session-id assertion that fails if filtering breaks. Production is unaffected — every serialize builds a fresh checkpoint dict.

## Tests

Suite 1290 → **1297** (6 new + 1 rewritten). Verified locally via coverage JSON: zero remaining missing lines among the 12 targets.