### PR TITLE
feat(receipts): signed provenance receipts for checkpoints via vitni (opt-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ skill owns it outright. Re-run install after upgrading to refresh the content.
 - **Proactive recall** — when a new prompt overlaps prior work from an older session, the briefing surfaces it ("you worked on this before"), in English or Spanish — accented text is a first-class citizen.
 - **Code anchors** — `daimon anchor <file> <symbol>` pins a belief to a code symbol; if that code changes or disappears, the next briefing flags the item under **CODE DRIFT — verify before trusting**. Offline, stdlib `ast`.
 - **Team memory (opt-in)** — `daimon team init <remote>` mirrors checkpoints through a git remote; teammates' active topics and decisions appear in your briefing, clearly attributed, never merged into your own sections. See the [team memory setup guide](./docs/team.md) — start with its privacy boundary, because the shared repo must be private.
+- **Signed receipts (opt-in)** — with `DAIMON_RECEIPTS=1`, each checkpoint is paired with an offline [vitni](https://github.com/Daily-Nerd/vitni) signature binding its exact bytes to its source transcript, so a post-hoc edit is detectable; verify any checkpoint with `daimon verify-receipt`.
 
 ## What's net-new here
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,6 +83,28 @@ Opt-in shared-memory mirror. See [docs/team.md](./team.md) for the full workflow
 | `DAIMON_TEAM_PROJECT` | unset | Explicit logical project path for this machine's sessions (relative, e.g. `core/api-gateway`). Overrides the sidecar's `daimon-team.toml` mapping and the origin-derived fallback when routing checkpoints under `projects/`. |
 | `DAIMON_TEAM_RETENTION_DAYS` | `365` | Read-time age window: teammates' checkpoints older than this many days are skipped when reading. `0` = keep all. Never physically deletes from the shared append-only branch. |
 
+## Receipts
+
+Opt-in signed provenance receipts (#204). When enabled, each checkpoint is
+paired with a [vitni](https://github.com/Daily-Nerd/vitni) `local`-binding
+receipt: an Ed25519-signed statement that binds the checkpoint's exact on-disk
+bytes (`outputs_hash`) to its source transcript (`inputs_hash`), written to a
+`<session>.receipt` sidecar. This makes a post-hoc edit to a checkpoint file
+detectable. Receipts are fully valid offline — nothing leaves the machine.
+
+Every step is **fail-open**: a missing CLI, missing openssl, timeout, or bad
+output logs one line to `serialize.log` and proceeds without a receipt — a
+receipts failure never blocks or fails a serialize or a briefing. Verify a
+checkpoint on demand with `daimon verify-receipt [session]`; at briefing time a
+receipt-era checkpoint whose receipt is missing or no longer matches its bytes
+has its `✓ verbatim` labels degraded with a visible note.
+
+| Variable | Default | What it does |
+|---|---|---|
+| `DAIMON_RECEIPTS` | off | When truthy, mint a signed receipt beside each checkpoint. Default off — a new subprocess per serialize is opt-in. |
+| `DAIMON_VITNI_CLI` | `vitni-verify` (on PATH) | The vitni verifier CLI used to sign/verify. A path or a name resolved on PATH. Contract: `<cli> <command>` with one JSON object on stdin and one JSON line on stdout. |
+| `DAIMON_KEYS_DIR` | `~/.daimon/keys` | Where the Ed25519 signing seed (`signing.seed`, mode 0600, auto-created on first mint) and cached public key (`signing.pub.json`) live. |
+
 ## Host hooks
 
 Serialize-throttle knobs for hosts that lack a clean session-end event. See

--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -19,34 +19,53 @@ import time
 # store/carry import graph checked (#103): neither store, carry, recall, nor
 # scoring imports briefing — no cycle, so this stays a normal module-level
 # import (contrast carry.py's own local-import notes, which don't apply here).
-from . import carry, config, llm, schema, scoring, store
+from . import carry, config, llm, receipts, schema, scoring, store
 
 log = logging.getLogger("daimon.briefing")
 
 _VERBATIM_MARK = "✓ verbatim"
 _INFERRED_MARK = "~ inferred"
 _UNTAGGED_MARK = "? untagged"
+# #204: when a receipt-era checkpoint's provenance can't be locally confirmed at
+# brief time, a `verbatim` label has NOT earned its checkmark — the stored bytes
+# may have been edited. Degrade it visibly rather than assert integrity we can't
+# prove. Inferred/untagged never claimed integrity, so they never degrade.
+_DEGRADED_MARK = "⚠ unverified (verbatim)"
+DEGRADE_NOTE = (
+    "⚠ RECEIPT UNVERIFIED — this checkpoint claims signed provenance, but its "
+    "receipt is missing or no longer matches the stored bytes. The 'verbatim' "
+    "quotes below are shown UNVERIFIED (run `daimon verify-receipt`).")
 
 
-def _mark(item) -> str:
+def receipt_degraded(checkpoint) -> bool:
+    """Cheap brief-time provenance check (#204), fail-open. Delegates to
+    receipts.verbatim_degraded — sidecar presence + outputs_hash byte match only,
+    never the vitni CLI (full crypto is `daimon verify-receipt`)."""
+    try:
+        return receipts.verbatim_degraded(checkpoint)
+    except Exception:
+        return False
+
+
+def _mark(item, degraded: bool = False) -> str:
     # A missing/empty trust class renders as "untagged", never as a confident
     # "inferred" the item never earned (#30) — the recall CLI already agrees.
     trust = item.get("trust")
     if trust == "verbatim":
-        return _VERBATIM_MARK
+        return _DEGRADED_MARK if degraded else _VERBATIM_MARK
     if trust:
         return _INFERRED_MARK
     return _UNTAGGED_MARK
 
 
-def _line(item) -> str:
+def _line(item, degraded: bool = False) -> str:
     # #134: dict.get returns the stored None for a present-but-null key (the
     # default only fires for an ABSENT key), so a torn/legacy checkpoint could
     # crash the whole render here. Use the codebase's str(x or "") idiom
     # (store.py, carry.py) — tolerant of null, same as iter_items' stance.
     text = str(item.get("text") or "").strip()
     quote = str(item.get("quote") or "").strip()
-    base = f'- [{_mark(item)}] {text}'
+    base = f'- [{_mark(item, degraded)}] {text}'
     if item.get("carried_from"):
         # Epistemic honesty, same philosophy as trust marks: a loop carried
         # from an older session must not read as fresh context (#33 Phase 2).
@@ -323,13 +342,14 @@ _DROP_ORDER = (("beliefs", "tail"), ("uncertainties", "tail"),
                ("decisions", "head"), ("open_loops", "tail"))
 
 
-def render_plain(b: dict) -> str:
+def render_plain(b: dict, degraded: bool = False) -> str:
     """The deterministic briefing text. Under the #79 budget this is
     BYTE-IDENTICAL to the legacy render(); over it, long items truncate
     (sections preserved) and then whole items drop, lowest value first,
-    each cut announced with a trim note."""
+    each cut announced with a trim note. `degraded` (#204) downgrades every
+    verbatim label and adds one header note when the receipt is unverifiable."""
     budget = config.brief_max_tokens()
-    text = _render_parts(b, {})
+    text = _render_parts(b, {}, degraded)
     if not budget or estimate_tokens(text) <= budget:
         return text
 
@@ -347,7 +367,7 @@ def render_plain(b: dict) -> str:
             for i in (b.get(key) or [])
         ]
     trimmed = {key: 0 for key, _ in _DROP_ORDER}
-    text = _render_parts(b, trimmed)
+    text = _render_parts(b, trimmed, degraded)
 
     # Stage 2: drop whole items, least valuable first, until the budget holds
     # or only the skeleton remains.
@@ -357,14 +377,19 @@ def render_plain(b: dict) -> str:
             items.pop(-1 if end == "tail" else 0)
             b[key] = items
             trimmed[key] += 1
-            text = _render_parts(b, trimmed)
+            text = _render_parts(b, trimmed, degraded)
         if estimate_tokens(text) <= budget:
             break
     return text
 
 
-def _render_parts(b: dict, trimmed: dict) -> str:
+def _render_parts(b: dict, trimmed: dict, degraded: bool = False) -> str:
     parts = ["While you were away — here's where we left off."]
+    if degraded:
+        # One header note (#204), embedded in the text so the hook-injected
+        # briefing carries it too — not just the human-facing CLI render.
+        parts.append("")
+        parts.append(DEGRADE_NOTE)
 
     def _section(header: str, key: str) -> None:
         items = b.get(key) or []
@@ -373,7 +398,7 @@ def _render_parts(b: dict, trimmed: dict) -> str:
             return
         parts.append("")
         parts.append(header)
-        parts.extend(_line(i) for i in items)
+        parts.extend(_line(i, degraded) for i in items)
         if key == "decisions":
             overflow = _overflow_note(b.get("decisions_overflow", 0))
             if overflow:
@@ -384,7 +409,7 @@ def _render_parts(b: dict, trimmed: dict) -> str:
     if b["external"]:
         parts.append("")
         parts.append("VERIFY BEFORE TRUSTING (state may have changed outside this session):")
-        parts.extend(_line(i) for i in b["external"])
+        parts.extend(_line(i, degraded) for i in b["external"])
 
     _section("Open loops:", "open_loops")
     _section("Decisions made:", "decisions")
@@ -401,7 +426,7 @@ def _render_parts(b: dict, trimmed: dict) -> str:
     if b.get("contradictions"):
         parts.append("")
         parts.append("Contradictions flagged:")
-        parts.extend(_line(i) for i in b["contradictions"])
+        parts.extend(_line(i, degraded) for i in b["contradictions"])
 
     return "\n".join(parts)
 
@@ -439,14 +464,17 @@ def render(checkpoint) -> str | None:
     b = build(checkpoint)
     if b is None:
         return None
+    degraded = receipt_degraded(checkpoint)
     if config.llm_briefing():
         rendered = _render_llm(checkpoint)
         if rendered:
             if _validate_llm_render(rendered, checkpoint):
-                return rendered
+                # The LLM render carries no per-item marks to degrade; prepend the
+                # one header note so an unverifiable receipt still fails loud (#204).
+                return f"{DEGRADE_NOTE}\n\n{rendered}" if degraded else rendered
             log.warning("llm briefing dropped a verbatim quote — "
                         "falling back to the deterministic render")
-    return render_plain(b)
+    return render_plain(b, degraded)
 
 
 # Seeded from research/experiments/track-a/prompts/02-reconstruct.md, tuned for a

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -29,7 +29,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from . import anchor, briefing, carry, config, configure, harvest, llm, recall, render, serializer, store, teamsync, transcript
+from . import anchor, briefing, carry, config, configure, harvest, llm, recall, receipts, render, serializer, store, teamsync, transcript
 from . import __version__
 
 # The serialize.log ledger subsystem lives in ledger.py (#147 + #162, pure
@@ -1025,6 +1025,25 @@ def _print_suppressed(project) -> int:
     return 0
 
 
+def _cmd_verify_receipt(args) -> int:
+    """Verify a checkpoint's signed provenance receipt (#204). Default target is
+    the current project's latest checkpoint; a session id can be passed
+    explicitly. rc 0 verified / 1 failed / 2 unable (see receipts.verify_receipt)."""
+    _note_usage("verify-receipt")
+    session_id = getattr(args, "session_id", None)
+    if not session_id:
+        project = _resolve_project(args.project)
+        checkpoint = store.read_latest(project_dir=project)
+        if not isinstance(checkpoint, dict) or not checkpoint.get("session_id"):
+            print("no checkpoint for this project yet — nothing to verify")
+            return 2
+        session_id = checkpoint["session_id"]
+    rc, lines = receipts.verify_receipt(str(session_id))
+    for line in lines:
+        print(line)
+    return rc
+
+
 def _cmd_status(args) -> int:
     _note_usage("status")
     project = _resolve_project(args.project)
@@ -1058,6 +1077,9 @@ def _cmd_status(args) -> int:
     # ONE objective team line (#113), only when a team remote exists — the #84
     # health-line rule: no line, no false alarms when the team feature is unused.
     team = teamsync.status_line()
+    # One receipts line, only when the feature is on (#204) — mirrors the team
+    # line's "no line when unused" rule so status stays quiet by default.
+    receipts_line = receipts.status_line(project)
     identity = {
         "cwd": str(Path(args.project or ".").expanduser().resolve()),
         "git_root": project,
@@ -1073,7 +1095,8 @@ def _cmd_status(args) -> int:
             {"project": proj, "global": glob, "last_serialize": last,
              "outstanding": outstanding, "siblings": siblings, "health": health,
              "team": team, "crash": crash, "disabled": disabled,
-             "skipped_recent": skipped_recent, "recall_error": recall_error},
+             "skipped_recent": skipped_recent, "recall_error": recall_error,
+             "receipts": receipts_line},
             indent=2,
         ))
         return rc
@@ -1082,7 +1105,7 @@ def _cmd_status(args) -> int:
         "project": project, "proj": proj, "glob": glob, "same": same, "last": last,
         "outstanding": outstanding, "identity": identity, "health": health,
         "team": team, "crash": crash, "skipped_recent": skipped_recent,
-        "recall_error": recall_error,
+        "recall_error": recall_error, "receipts": receipts_line,
     })
     return rc
 
@@ -1858,6 +1881,20 @@ def main(argv=None) -> int:
         help="list items withheld from the briefing as resolved (#103)",
     )
     p_status.set_defaults(func=_cmd_status)
+
+    p_vr = sub.add_parser(
+        "verify-receipt",
+        help="verify a checkpoint's signed provenance receipt via the vitni CLI (#204)",
+        epilog="Examples:\n"
+               "  daimon verify-receipt\n"
+               "  daimon verify-receipt <session-id>\n",
+    )
+    p_vr.add_argument(
+        "session_id", nargs="?",
+        help="session id to verify (default: this project's latest checkpoint)")
+    p_vr.add_argument(
+        "--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    p_vr.set_defaults(func=_cmd_verify_receipt)
 
     p_audit = sub.add_parser(
         "audit-quotes",

--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -261,6 +261,34 @@ def author() -> str:
     return name or "unknown"
 
 
+# ---- signed provenance receipts (#204): opt-in vitni local-binding receipts ----
+
+
+def receipts_enabled() -> bool:
+    """Opt-in (DAIMON_RECEIPTS=1, default OFF): mint a vitni `local`-binding
+    receipt beside each checkpoint so a post-hoc edit to the artifact is
+    detectable. Gates the mint path only; every step is fail-open — a receipts
+    failure must never block or fail a serialize/brief (#204)."""
+    return _flag("DAIMON_RECEIPTS")
+
+
+def vitni_cli() -> str:
+    """The vitni verifier CLI (#204). DAIMON_VITNI_CLI overrides; default
+    'vitni-verify' resolved on PATH. Contract: `<cli> <command>` with one JSON
+    object on stdin and one JSON line on stdout."""
+    return (_get("DAIMON_VITNI_CLI") or "").strip() or "vitni-verify"
+
+
+def keys_dir() -> Path:
+    """Where the #204 Ed25519 signing seed (signing.seed, 0600) and cached
+    public key (signing.pub.json) live. Default ~/.daimon/keys; DAIMON_KEYS_DIR
+    overrides (tests point it under tmp so no test can touch real keys)."""
+    raw = _get("DAIMON_KEYS_DIR")
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".daimon" / "keys"
+
+
 def log_dir() -> Path:
     """Where the session-end hook writes serialize.log. The hook hardcodes
     ~/.daimon/logs; this override exists so the CLI (and tests) can point

--- a/plugin/daimon_briefing/receipts.py
+++ b/plugin/daimon_briefing/receipts.py
@@ -1,0 +1,448 @@
+"""Signed provenance receipts for checkpoints via vitni (#204).
+
+Everything that touches vitni lives here. A checkpoint's `transcript_hash` (#125)
+binds it to its source bytes, but nothing proved the checkpoint ON DISK was the
+one the serializer wrote — a post-hoc edit was undetectable. An opt-in
+`vitni/0.2` `local`-binding receipt closes that: `outputs_hash` covers the exact
+final checkpoint blob, `inputs_hash` the raw transcript, the whole thing signed
+Ed25519 via the vitni CLI and dropped in a sidecar.
+
+FAIL-OPEN IS THE CONTRACT. Any failure — gate off, no seed, no openssl, no CLI,
+timeout, nonzero rc, garbage output — logs one line (this package's logger
+reaches serialize.log via #194's handler) and proceeds WITHOUT a receipt. A
+receipts failure must never fail or block a serialize or a briefing.
+
+Split of concerns at brief time (documented so it stays deliberate): the
+briefing does a CHEAP tamper check only (sidecar present + outputs_hash byte
+match, no subprocess) — enough to catch an edited or removed artifact. The FULL
+cryptographic verification (signature, structure, policy binding) lives in the
+on-demand `daimon verify-receipt`, which shells out to the vitni CLI.
+"""
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from . import config
+
+log = logging.getLogger(__name__)  # child of `daimon_briefing` → serialize.log
+
+# --- protocol constants (§2/§10/§15, validated against the conformance vectors) ---
+_PROTOCOL = "vitni/0.2"
+_BINDING = "local"
+METHOD = "local:daimon.serialize"
+KID = "daimon-1"                     # fixed key id for v1
+_MULTIHASH_SHA256 = bytes([0x12, 0x20])  # multicodec sha2-256 + 32-byte length
+
+# The fixed 16-byte ASN.1/PKCS8 prefix for a raw Ed25519 seed (RFC 8410) — the
+# same trick vitni's sign.ts documents: prepend it to the 32-byte seed to get a
+# DER PKCS8 private key openssl/node can import.
+_PKCS8_ED25519_PREFIX = bytes.fromhex("302e020100300506032b657004220420")
+
+_SEED_FILE = "signing.seed"
+_PUB_FILE = "signing.pub.json"
+_CLI_TIMEOUT = 10                   # seconds; a signer that hangs must not hang us
+_SIDECAR_SUFFIX = ".receipt"        # NOT .json — see _sidecar_path
+
+
+# ---- hashes (pure stdlib) --------------------------------------------------
+
+
+def _multibase_wrap(raw32: bytes) -> str:
+    """vitni hash/nonce encoding: multibase base64url (`u`) of a multihash
+    sha2-256 wrapper (0x12 0x20) around 32 bytes. Confirmed byte-for-byte
+    against the receipt-id-local conformance vector."""
+    return "u" + base64.urlsafe_b64encode(
+        _MULTIHASH_SHA256 + raw32).decode("ascii").rstrip("=")
+
+
+def _multibase_sha256(data: bytes) -> str:
+    return _multibase_wrap(hashlib.sha256(data).digest())
+
+
+def _wrap_hex_sha256(hex_digest) -> str | None:
+    """Wrap an already-computed hex sha256 (transcript_hash is stored this way,
+    #125) into the vitni multihash string WITHOUT re-hashing. None on anything
+    that is not a 32-byte hex digest."""
+    if not isinstance(hex_digest, str):
+        return None
+    try:
+        raw = bytes.fromhex(hex_digest)
+    except ValueError:
+        return None
+    return _multibase_wrap(raw) if len(raw) == 32 else None
+
+
+def _nonce() -> str:
+    """A fresh per-mint nonce: 32 CSPRNG bytes in the same multihash wrapper the
+    conformance vectors show for the receipt `nonce` field."""
+    return _multibase_wrap(os.urandom(32))
+
+
+# ---- key material ----------------------------------------------------------
+
+
+def _read_seed(seed_path: Path) -> bytes | None:
+    try:
+        raw = base64.b64decode(seed_path.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return None
+    return raw if len(raw) == 32 else None
+
+
+def _ensure_seed(keys_dir: Path) -> bytes | None:
+    """Load the Ed25519 seed, creating it (32 CSPRNG bytes, base64, mode 0600) on
+    first mint. O_EXCL so two racing first-mints can never write divergent seeds
+    — the loser reads the winner's. None on any failure (fail-open)."""
+    seed_path = keys_dir / _SEED_FILE
+    raw = _read_seed(seed_path)
+    if raw is not None:
+        return raw
+    try:
+        keys_dir.mkdir(parents=True, exist_ok=True)
+        raw = os.urandom(32)
+        fd = os.open(str(seed_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            os.write(fd, base64.b64encode(raw))
+        finally:
+            os.close(fd)
+        os.chmod(seed_path, 0o600)  # umask-independent guarantee
+        return raw
+    except FileExistsError:
+        return _read_seed(seed_path)  # lost the create race — use the winner's
+    except OSError as exc:
+        log.warning("daimon receipts: cannot create signing seed (%s); no receipt", exc)
+        return None
+
+
+def _derive_pubkey_x(seed: bytes) -> str | None:
+    """Raw Ed25519 public key (base64url, no pad) for `seed`, via openssl. The
+    seed is wrapped into a PKCS8 DER, `openssl pkey -pubout` emits the 44-byte
+    SPKI DER whose last 32 bytes ARE the raw public key. None on any failure —
+    e.g. macOS LibreSSL lacks Ed25519 in `openssl pkey` (fail-open to no receipt)."""
+    der = _PKCS8_ED25519_PREFIX + seed
+    try:
+        proc = subprocess.run(
+            ["openssl", "pkey", "-inform", "DER", "-pubout", "-outform", "DER"],
+            input=der, capture_output=True, timeout=_CLI_TIMEOUT,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        log.warning("daimon receipts: openssl unavailable (%s); no receipt", exc)
+        return None
+    if proc.returncode != 0 or len(proc.stdout) < 32:
+        log.warning("daimon receipts: openssl pubkey derivation failed (rc=%s); no receipt",
+                    proc.returncode)
+        return None
+    return base64.urlsafe_b64encode(proc.stdout[-32:]).decode("ascii").rstrip("=")
+
+
+def _pubkey_jwk(x: str) -> dict:
+    return {"kty": "OKP", "crv": "Ed25519", "x": x, "alg": "EdDSA", "status": "active"}
+
+
+def _ensure_pubkey(keys_dir: Path, seed: bytes) -> dict | None:
+    """Load the cached public JWK, deriving + caching it once on first mint.
+    None when derivation is impossible (no openssl) — no receipt this run."""
+    pub_path = keys_dir / _PUB_FILE
+    try:
+        jwk = json.loads(pub_path.read_text(encoding="utf-8"))
+        if isinstance(jwk, dict) and jwk.get("x"):
+            return jwk
+    except (OSError, json.JSONDecodeError):
+        pass
+    x = _derive_pubkey_x(seed)
+    if not x:
+        return None
+    jwk = _pubkey_jwk(x)
+    try:
+        keys_dir.mkdir(parents=True, exist_ok=True)
+        _atomic_write_text(pub_path, json.dumps(jwk))
+    except OSError:
+        pass  # derivation succeeded; a cache-write failure is non-fatal
+    return jwk
+
+
+def _load_pubkey(keys_dir: Path) -> dict | None:
+    try:
+        jwk = json.loads((keys_dir / _PUB_FILE).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return jwk if isinstance(jwk, dict) and jwk.get("x") else None
+
+
+# ---- CLI plumbing ----------------------------------------------------------
+
+
+def _resolve_cli() -> str | None:
+    """Absolute path to the vitni CLI, or None when it is not resolvable —
+    DAIMON_VITNI_CLI (a path or a name) then PATH. shutil.which handles both."""
+    return shutil.which(config.vitni_cli())
+
+
+def _run_cli(cli: str, command: str, stdin_json: str) -> dict | None:
+    """Run `<cli> <command>` with JSON on stdin; parse the one JSON line back.
+    None on any failure (spawn error, timeout, nonzero rc, non-JSON, {"error"})."""
+    try:
+        proc = subprocess.run(
+            [cli, command], input=stdin_json.encode("utf-8"),
+            capture_output=True, timeout=_CLI_TIMEOUT,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        log.warning("daimon receipts: vitni %s failed to run (%s)", command, exc)
+        return None
+    if proc.returncode != 0:
+        log.warning("daimon receipts: vitni %s exited rc=%s: %s", command,
+                    proc.returncode, proc.stderr.decode("utf-8", "replace")[:200])
+        return None
+    try:
+        out = json.loads(proc.stdout.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        log.warning("daimon receipts: vitni %s produced non-JSON output", command)
+        return None
+    if not isinstance(out, dict) or "error" in out:
+        log.warning("daimon receipts: vitni %s returned %r", command, out)
+        return None
+    return out
+
+
+# ---- atomic sidecar write --------------------------------------------------
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    tmp = path.with_name(path.name + f".{os.getpid()}.tmp")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _sidecar_path(checkpoint_path: Path) -> Path:
+    """`<session>.receipt` beside the checkpoint. Deliberately NOT `.json`: the
+    sidecar lives in the flat store dir, and every GC / session-file / recall /
+    pointer scan filters on `suffix == ".json"` or the pointer regex — a
+    `.receipt` file is invisible to all of them, so GC never eats it and it never
+    counts toward DAIMON_CHECKPOINT_KEEP (#204)."""
+    return checkpoint_path.with_suffix(_SIDECAR_SUFFIX)
+
+
+def _checkpoint_file(session_id: str) -> Path:
+    """The per-session checkpoint file the receipt binds. Lazy store import
+    avoids a store<->receipts cycle (store imports this module at top)."""
+    from . import store
+    return config.checkpoint_dir() / f"{store._safe_name(session_id)}.json"
+
+
+# ---- mint (called from store.write_checkpoint) -----------------------------
+
+
+def plan_mint(checkpoint: dict) -> dict | None:
+    """Decide whether to mint for `checkpoint` and prepare key material, WITHOUT
+    touching the checkpoint or writing anything. Returns a context dict when a
+    mint should proceed (caller then stamps the era marker before serializing the
+    blob), else None: gate off, no/invalid transcript_hash (a receipt binding
+    nothing is noise), no CLI, no openssl, or no seed. Fail-open — None means
+    'serialize proceeds receiptless', never an error."""
+    if not config.receipts_enabled():
+        return None
+    inputs_hash = _wrap_hex_sha256(checkpoint.get("transcript_hash"))
+    if inputs_hash is None:
+        log.info("daimon receipts: no usable transcript_hash; skipping receipt mint")
+        return None
+    cli = _resolve_cli()
+    if cli is None:
+        log.info("daimon receipts: vitni CLI %r not found; skipping receipt mint",
+                 config.vitni_cli())
+        return None
+    keys_dir = config.keys_dir()
+    seed = _ensure_seed(keys_dir)
+    if seed is None:
+        return None
+    if _ensure_pubkey(keys_dir, seed) is None:
+        return None
+    return {
+        "cli": cli,
+        "seed_b64": base64.b64encode(seed).decode("ascii"),
+        "inputs_hash": inputs_hash,
+        "performer_id": str(checkpoint.get("author") or "unknown"),
+    }
+
+
+def mint(plan: dict, checkpoint: dict, blob: str, checkpoint_path: Path) -> bool:
+    """Sign a local-binding receipt over the final checkpoint `blob` and write the
+    sidecar. Called AFTER the checkpoint file is written, so outputs_hash covers
+    the exact bytes on disk. Fail-open: returns False + logs on any failure, never
+    raises. (A sign failure here leaves the era marker without a sidecar, which a
+    later brief/verify surfaces loudly — the correct direction for a signer that
+    was present at plan time but then broke.)"""
+    try:
+        receipt = {
+            "v": _PROTOCOL,
+            "binding": _BINDING,
+            "action_ref": None,
+            "performer_id": plan["performer_id"],
+            "requester_id": None,
+            "method": METHOD,
+            "inputs_hash": plan["inputs_hash"],
+            "outputs_hash": _multibase_sha256(blob.encode("utf-8")),
+            "cost": {"tokens": "0", "usd_micros": "0", "wall_ms": "0",
+                     "rail_ref": None},
+            "status": "OK",
+            "reason": None,
+            "parent_receipt_hash": None,
+            "log_policy": "best_effort",
+            "ts": checkpoint.get("created"),
+            "nonce": _nonce(),
+        }
+        out = _run_cli(plan["cli"], "sign", json.dumps(
+            {"receipt": receipt, "kid": KID, "private_key_b64": plan["seed_b64"]}))
+        jws = out.get("signed_receipt") if out else None
+        if not isinstance(jws, str) or jws.count(".") != 2:
+            log.warning("daimon receipts: sign produced no usable JWS; no sidecar")
+            return False
+        _atomic_write_text(_sidecar_path(checkpoint_path), json.dumps(
+            {"jws": jws, "receipt": receipt, "kid": KID,
+             "performer_id": plan["performer_id"]}, indent=2, ensure_ascii=False))
+        return True
+    except Exception as exc:  # noqa: BLE001 — a receipts failure must never fail a write
+        # Type+message only, no traceback: the signing seed is in scope in this
+        # frame, and a locals-capturing log handler must never see it (#204).
+        log.warning("daimon receipts: mint failed; checkpoint written without "
+                    "receipt (%s: %s)", type(exc).__name__, exc)
+        return False
+
+
+# ---- verify (daimon verify-receipt) ----------------------------------------
+
+
+def verify_receipt(session_id: str) -> tuple[int, list[str]]:
+    """Full verification for one session's receipt. Returns (rc, lines):
+      0 verified — signature valid, structure canonical, binding=local, AND the
+                   checkpoint bytes still match the signed outputs_hash;
+      1 failed   — file edited after signing, receipt removed from a receipt-era
+                   checkpoint, corrupt sidecar, or the vitni CLI rejected it;
+      2 unable   — pre-receipt checkpoint (nothing to verify), no vitni CLI, or no
+                   local public key.
+    Never raises."""
+    try:
+        return _verify_receipt(session_id)
+    except Exception:  # noqa: BLE001 — a user command, but still never crash
+        log.warning("daimon receipts: verify-receipt crashed", exc_info=True)
+        return 2, ["unable to verify: an unexpected error occurred (see serialize.log)"]
+
+
+def _verify_receipt(session_id: str) -> tuple[int, list[str]]:
+    cp_file = _checkpoint_file(session_id)
+    if not cp_file.exists():
+        return 2, [f"no checkpoint on disk for session {session_id}"]
+    try:
+        checkpoint = json.loads(cp_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        checkpoint = {}
+    marked = isinstance(checkpoint, dict) and checkpoint.get("receipts") is True
+    sidecar_path = _sidecar_path(cp_file)
+    if not sidecar_path.exists():
+        if marked:
+            return 1, [
+                f"FAILED: session {session_id} is marked receipt-era but its receipt is missing",
+                "  the receipt was removed or lost — provenance cannot be confirmed"]
+        return 2, [f"pre-receipt checkpoint (session {session_id}) — nothing to verify"]
+    try:
+        sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        receipt = sidecar["receipt"]
+        jws = sidecar["jws"]
+    except (OSError, json.JSONDecodeError, KeyError, TypeError):
+        return 1, [f"FAILED: receipt sidecar for {session_id} is unreadable or corrupt"]
+
+    # 1) byte match — proves THIS file is the one that was signed. The CLI proves
+    # the signature/structure; only this proves the artifact wasn't edited after.
+    expected = receipt.get("outputs_hash")
+    if not expected or _multibase_sha256(cp_file.read_bytes()) != expected:
+        return 1, [
+            f"FAILED: session {session_id} bytes do not match the receipt's outputs_hash",
+            "  the checkpoint was edited after it was signed"]
+
+    # 2) full crypto via the vitni CLI.
+    cli = _resolve_cli()
+    if cli is None:
+        return 2, [
+            f"unable to verify: vitni CLI {config.vitni_cli()!r} not found",
+            "  (checkpoint bytes DO match the receipt; run again with the CLI on PATH)"]
+    pubkey = _load_pubkey(config.keys_dir())
+    if pubkey is None:
+        return 2, ["unable to verify: no local public key (signing.pub.json missing)"]
+    performer = sidecar.get("performer_id") or receipt.get("performer_id")
+    kid = sidecar.get("kid") or KID
+    if not jws or not performer:
+        return 1, [f"FAILED: receipt for {session_id} is missing its signature or performer"]
+    out = _run_cli(cli, "verify", json.dumps({
+        "signed_receipt": jws,
+        "keys": {performer: {kid: pubkey}},
+        "policy": {"expected_binding": _BINDING, "expected_method": METHOD},
+    }))
+    if out is None:
+        return 2, ["unable to verify: the vitni CLI did not return a usable result"]
+    if out.get("valid") is True:
+        return 0, [
+            f"verified: session {session_id} — signature valid, bytes match, binding=local",
+            f"  performer={performer} kid={kid}"]
+    return 1, [f"FAILED: vitni rejected the receipt ({out.get('reason')})"]
+
+
+# ---- brief-time tamper check (cheap, no subprocess) ------------------------
+
+
+def verbatim_degraded(checkpoint) -> bool:
+    """True when a receipt-era checkpoint's provenance can't be locally confirmed
+    at brief time — the sidecar is missing (removed/lost) or the checkpoint file's
+    bytes no longer match the signed outputs_hash (edited). CHEAP by design: only
+    a file read + a sha256, NEVER the vitni CLI (full crypto is verify-receipt).
+
+    Pre-receipt checkpoints (no `receipts` marker) never degrade — no retroactive
+    downgrades. A missing CLI is irrelevant here, so it never degrades. Fail-open:
+    any error returns False (don't punish labels over our own bug)."""
+    try:
+        if not isinstance(checkpoint, dict) or checkpoint.get("receipts") is not True:
+            return False
+        session_id = checkpoint.get("session_id")
+        if not session_id:
+            return False
+        cp_file = _checkpoint_file(str(session_id))
+        sidecar_path = _sidecar_path(cp_file)
+        if not sidecar_path.exists():
+            return True  # receipt-era but the receipt is gone — degrade loudly
+        try:
+            expected = json.loads(sidecar_path.read_text(encoding="utf-8")) \
+                .get("receipt", {}).get("outputs_hash")
+            blob = cp_file.read_bytes()
+        except (OSError, json.JSONDecodeError, AttributeError):
+            return False  # can't read one side — fail-open, don't degrade
+        if not expected:
+            return False
+        return _multibase_sha256(blob) != expected
+    except Exception:  # noqa: BLE001
+        return False
+
+
+# ---- status line (daimon status) -------------------------------------------
+
+
+def status_line(project_dir=None) -> str | None:
+    """One `daimon status` line about receipts, or None when the feature is off.
+    Reflects the latest checkpoint's mint result via the sidecar's existence."""
+    if not config.receipts_enabled():
+        return None
+    from . import store
+    checkpoint = store.read_latest(project_dir=project_dir)
+    if not isinstance(checkpoint, dict) or not checkpoint.get("session_id"):
+        return "receipts: on — no checkpoint to sign yet"
+    sid = str(checkpoint["session_id"])
+    sidecar = _sidecar_path(_checkpoint_file(sid))
+    if sidecar.exists():
+        return f"receipts: on — latest checkpoint {sid} is signed"
+    if checkpoint.get("receipts") is True:
+        return (f"receipts: on — latest checkpoint {sid} is marked receipt-era but "
+                "its receipt is MISSING (see serialize.log)")
+    return f"receipts: on — latest checkpoint {sid} predates receipts (unsigned)"

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -106,10 +106,13 @@ def render_brief(checkpoint, drift=None, teammates=None) -> None:
             _print_drift(drift)
             _print_teammates(teammates)
             return
+    # #204: degrade verbatim labels when the receipt can't be locally confirmed.
+    # Cheap check (sidecar + byte match), computed once for both render paths.
+    degraded = briefing.receipt_degraded(checkpoint)
     if not supports_rich():
-        print(briefing.render_plain(b))
+        print(briefing.render_plain(b, degraded))
     else:
-        _rich_brief(b)
+        _rich_brief(b, degraded)
     _print_drift(drift)
     _print_teammates(teammates)
 
@@ -142,13 +145,16 @@ def _print_drift(drift) -> None:
     )
 
 
-def _rich_brief(b: dict) -> None:
+def _rich_brief(b: dict, degraded: bool = False) -> None:
     from rich.console import Console
     from rich.panel import Panel
     from rich.text import Text
 
     console = Console()
     console.print(Text("While you were away — here's where we left off.", style="bold"))
+    if degraded:
+        # One header note (#204), parity with the plain path's embedded note.
+        console.print(Text(briefing.DEGRADE_NOTE, style="bold red"))
     for key, title, style in _SECTIONS:
         items = b.get(key) or []
         if not items:
@@ -156,7 +162,11 @@ def _rich_brief(b: dict) -> None:
         body = Text()
         for i in items:
             trust = _trust_key(i)
-            body.append(f"• {i.get('text', '').strip()}\n", style=_TRUST_STYLE[trust])
+            # Degrade a verbatim item's confident green — its integrity is
+            # unverified (#204). Inferred/untagged never claimed it, so untouched.
+            item_style = "bold red" if (degraded and trust == "verbatim") \
+                else _TRUST_STYLE[trust]
+            body.append(f"• {i.get('text', '').strip()}\n", style=item_style)
             quote = i.get("quote", "").strip()
             if quote:
                 body.append(f'    "{quote}"\n', style="dim italic")
@@ -387,6 +397,8 @@ def _plain_status(data: dict) -> None:
             print(f"  ⚠ {w}")
     if data.get("team"):
         print(data["team"])  # one objective line; absent when team unused (#113)
+    if data.get("receipts"):
+        print(data["receipts"])  # #204: one line, only when receipts are on
     proj, glob, last = data["proj"], data["glob"], data["last"]
     print(f"project: {data['project']}")
     if proj["exists"]:
@@ -449,6 +461,8 @@ def _rich_status(data: dict) -> None:
             console.print(f"  ⚠ {w}")
     if data.get("team"):
         console.print(data["team"])  # one objective line; absent when team unused (#113)
+    if data.get("receipts"):
+        console.print(data["receipts"])  # #204: one line, only when receipts are on
     proj, glob, last = data["proj"], data["glob"], data["last"]
     table = Table(title=f"daimon status — {data['project']}", title_justify="left",
                   show_header=True, header_style="bold")

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -33,7 +33,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
-from . import config, redact, schema, serializer, teamproject
+from . import config, receipts, redact, schema, serializer, teamproject
 
 _LATEST = "latest.json"
 # Rotation pointers, not per-session checkpoints. Anything else ending in .json in
@@ -490,6 +490,16 @@ def write_checkpoint(session_id: str, checkpoint: dict, project_dir=None) -> Pat
     # project is UNKNOWN, the global pointer IS this stream's own prior
     # checkpoint, so the fallback stays on (same-stream carry, #126 legacy).
     _stamp_first_seen(checkpoint, read_latest(project_dir, fallback=not slug))
+    # Signed provenance receipt (#204): decide + prep key material BEFORE the blob
+    # is serialized, so the `receipts` era marker rides INSIDE the signed bytes
+    # (outputs_hash covers the exact blob). plan_mint returns None (and stamps
+    # nothing) when the feature is off or a receipt can't be produced — gate off,
+    # no transcript_hash, no CLI/openssl/seed — so serialize proceeds receiptless.
+    # The sidecar itself is written AFTER the checkpoint file succeeds (below).
+    # setdefault: a re-write of an already-marked checkpoint keeps its marker.
+    receipt_plan = receipts.plan_mint(checkpoint)
+    if receipt_plan is not None:
+        checkpoint.setdefault("receipts", True)
     blob = json.dumps(checkpoint, indent=2, ensure_ascii=False)
     history = config.checkpoint_history()
     _atomic_write(path, blob)
@@ -514,6 +524,12 @@ def write_checkpoint(session_id: str, checkpoint: dict, project_dir=None) -> Pat
             if not _pointer_regresses(pdir, new_epoch):
                 _rotate_pointers(pdir, history)
                 _atomic_write(pdir / _LATEST, blob)
+    # Mint the receipt now that the checkpoint file is durably on disk (#204):
+    # outputs_hash covers those exact bytes. Best-effort and self-contained —
+    # receipts.mint swallows every failure — so it can never affect the write /
+    # pointers / GC above, nor this function's rc.
+    if receipt_plan is not None:
+        receipts.mint(receipt_plan, checkpoint, blob, path)
     # Opportunistic retention: serialize already succeeded, so pruning old
     # per-session files here never touches the read/briefing hot path (#92).
     _gc_checkpoints(d, config.checkpoint_keep())

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -673,8 +673,9 @@ def test_cli_status_json_shape(
     data = json.loads(capsys.readouterr().out)
     assert set(data) == {"project", "global", "last_serialize", "outstanding",
                          "siblings", "health", "team", "crash", "disabled",
-                         "skipped_recent", "recall_error"}
+                         "skipped_recent", "recall_error", "receipts"}
     assert data["team"] is None  # no team remote configured -> explicit null (#113)
+    assert data["receipts"] is None  # #204 feature off -> explicit null
     assert data["project"]["exists"] is True
     assert data["project"]["session_id"] == "S-prev"
     assert data["project"]["dir"] == "/p/A"

--- a/plugin/tests/test_receipts.py
+++ b/plugin/tests/test_receipts.py
@@ -1,0 +1,560 @@
+"""Signed provenance receipts (#204).
+
+CI has NO node and NO vitni CLI, so every test that needs the signer stubs it
+with a fake executable (a python script echoing canned JSON, capturing the
+stdin it received so the input contract can be asserted). openssl-dependent key
+derivation is exercised in one real test (skipped where openssl lacks Ed25519,
+e.g. macOS LibreSSL) plus a subprocess-monkeypatched test that proves the SPKI
+byte-slice logic without any real openssl.
+
+Ground-truth fixtures (validated end-to-end against the real vitni CLI):
+  seed  = bytes(range(32))
+  pub x = "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+  SPKI  = 302a300506032b657003210003a107bff3ce10be1d70dd18e74bc09967e4d6309ba50d5f1ddc8664125531b8
+The multihash wrapper is checked against the receipt-id-local conformance vector.
+"""
+
+import base64
+import hashlib
+import json
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from daimon_briefing import briefing, cli, config, receipts, store
+
+_SEED = bytes(range(32))
+_SEED_B64 = base64.b64encode(_SEED).decode("ascii")
+_PUB_X = "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+_SPKI_HEX = ("302a300506032b657003210003a107bff3ce10be1d70dd18e74bc09967"
+             "e4d6309ba50d5f1ddc8664125531b8")
+
+# A real sha256 hex digest (of b"") for transcript_hash wiring.
+_TSCRIPT_HEX = hashlib.sha256(b"hello transcript").hexdigest()
+
+
+# ---- fake vitni CLI --------------------------------------------------------
+
+_FAKE_CLI_SRC = r'''#!/usr/bin/env python3
+import sys, json, os
+cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+raw = sys.stdin.read()
+cap = os.environ.get("FAKE_VITNI_CAPTURE")
+if cap:
+    with open(cap, "a") as f:
+        f.write(json.dumps({"cmd": cmd, "stdin": raw}) + "\n")
+mode = os.environ.get("FAKE_VITNI_MODE", "ok")
+if mode == "garbage":
+    sys.stdout.write("not json at all")
+    sys.exit(0)
+if mode == "rc1":
+    sys.stderr.write("boom")
+    sys.exit(1)
+if mode == "hang":
+    import time
+    time.sleep(30)
+try:
+    data = json.loads(raw)
+except ValueError:
+    print(json.dumps({"error": "invalid_json"})); sys.exit(0)
+if cmd == "sign":
+    print(json.dumps({"signed_receipt": os.environ.get("FAKE_VITNI_JWS", "aaa.bbb.ccc")}))
+elif cmd == "verify":
+    verdict = os.environ.get("FAKE_VITNI_VERDICT", "ok")
+    if verdict == "ok":
+        print(json.dumps({"valid": True, "reason": "ok"}))
+    else:
+        print(json.dumps({"valid": False, "reason": verdict}))
+else:
+    print(json.dumps({"error": "unknown_command"}))
+sys.exit(0)
+'''
+
+
+@pytest.fixture
+def fake_cli(tmp_path, monkeypatch):
+    """Install a fake vitni CLI on DAIMON_VITNI_CLI + capture file. Returns the
+    capture-path so a test can assert what daimon actually sent on stdin."""
+    script = tmp_path / "fake-vitni"
+    script.write_text(_FAKE_CLI_SRC)
+    script.chmod(0o755)
+    capture = tmp_path / "vitni-capture.jsonl"
+    monkeypatch.setenv("DAIMON_VITNI_CLI", str(script))
+    monkeypatch.setenv("FAKE_VITNI_CAPTURE", str(capture))
+    return capture
+
+
+@pytest.fixture
+def keys_ready(tmp_path, monkeypatch):
+    """Pre-seed the keys dir with the ground-truth seed + pubkey so mint/verify
+    tests never touch real openssl (macOS LibreSSL lacks Ed25519)."""
+    kdir = tmp_path / "keys"
+    kdir.mkdir()
+    (kdir / "signing.seed").write_text(_SEED_B64)
+    (kdir / "signing.seed").chmod(0o600)
+    (kdir / "signing.pub.json").write_text(json.dumps(
+        {"kty": "OKP", "crv": "Ed25519", "x": _PUB_X, "alg": "EdDSA",
+         "status": "active"}))
+    monkeypatch.setenv("DAIMON_KEYS_DIR", str(kdir))
+    return kdir
+
+
+def _capture_lines(capture: Path):
+    return [json.loads(x) for x in capture.read_text().splitlines() if x.strip()]
+
+
+# ---- hash wrappers ---------------------------------------------------------
+
+def test_multibase_wrapper_matches_conformance_vector():
+    # receipt-id/local-binding vector: sha256 over the canonical bytes, wrapped.
+    canon_hex = (
+        "7b22616374696f6e5f726566223a6e756c6c2c2262696e64696e67223a226c6f63"
+        "616c222c22636f7374223a7b227261696c5f726566223a6e756c6c2c22746f6b656e"
+        "73223a223130222c227573645f6d6963726f73223a2230222c2277616c6c5f6d7322"
+        "3a2233227d2c22696e707574735f68617368223a227545694173386b32365837436a"
+        "4469626f4f79724675654b654778596558422d6e516c357a42444e696b3475594a41"
+        "222c226c6f675f706f6c696379223a22626573745f6566666f7274222c226d657468"
+        "6f64223a226c6f63616c3a6461696d6f6e2e73657269616c697a65222c226e6f6e63"
+        "65223a22754569446a734d52436d507763464a7237394d695a62376b6b4a36354235"
+        "4753626b30796b6c5a6b6265464b345651222c226f7574707574735f68617368223a"
+        "227545694173386b32365837436a4469626f4f79724675654b654778596558422d6e"
+        "516c357a42444e696b3475594a41222c22706172656e745f726563656970745f6861"
+        "7368223a6e756c6c2c22706572666f726d65725f6964223a227372762d64656d6f22"
+        "2c22726561736f6e223a6e756c6c2c227265717565737465725f6964223a6e756c6c"
+        "2c22737461747573223a224f4b222c227473223a22323032362d30352d3238543030"
+        "3a30303a30305a222c2276223a227669746e692f302e32227d")
+    canon = bytes.fromhex(canon_hex)
+    assert receipts._multibase_sha256(canon) == (
+        "uEiAYMKB9HXrG3NWrXdWzPAFmwDQrVKxjAczQzFVi_DdWJw")
+
+
+def test_wrap_hex_sha256_roundtrip():
+    hexd = hashlib.sha256(b"x").hexdigest()
+    wrapped = receipts._wrap_hex_sha256(hexd)
+    assert wrapped == receipts._multibase_sha256(b"x")
+    assert wrapped.startswith("uEi")
+
+
+def test_wrap_hex_sha256_rejects_non_digest():
+    assert receipts._wrap_hex_sha256("not-hex") is None
+    assert receipts._wrap_hex_sha256("ab") is None  # too short
+    assert receipts._wrap_hex_sha256(None) is None
+
+
+def test_nonce_is_wrapped_32_random_bytes():
+    n1, n2 = receipts._nonce(), receipts._nonce()
+    assert n1 != n2
+    assert n1.startswith("uEi")
+    # decode and confirm 0x12 0x20 multihash prefix + 32 bytes
+    raw = base64.urlsafe_b64decode(n1[1:] + "=" * (-len(n1[1:]) % 4))
+    assert raw[:2] == bytes([0x12, 0x20]) and len(raw) == 34
+
+
+# ---- key derivation --------------------------------------------------------
+
+def test_derive_pubkey_slice_logic(monkeypatch):
+    """SPKI byte-slice + b64url encoding is correct, proven WITHOUT real openssl
+    by feeding the known SPKI DER back as openssl's stdout."""
+    def fake_run(cmd, **kw):
+        assert cmd[0] == "openssl"
+        return subprocess.CompletedProcess(cmd, 0, stdout=bytes.fromhex(_SPKI_HEX),
+                                           stderr=b"")
+    monkeypatch.setattr(receipts.subprocess, "run", fake_run)
+    assert receipts._derive_pubkey_x(_SEED) == _PUB_X
+
+
+def test_derive_pubkey_real_openssl():
+    """Real openssl round-trip when available (skips on Ed25519-less LibreSSL)."""
+    x = receipts._derive_pubkey_x(_SEED)
+    if x is None:
+        pytest.skip("openssl lacks Ed25519 (e.g. macOS LibreSSL)")
+    assert x == _PUB_X
+
+
+def test_derive_pubkey_openssl_absent_returns_none(monkeypatch):
+    def boom(*a, **k):
+        raise FileNotFoundError("openssl")
+    monkeypatch.setattr(receipts.subprocess, "run", boom)
+    assert receipts._derive_pubkey_x(_SEED) is None
+
+
+def test_ensure_seed_creates_0600(tmp_path, monkeypatch):
+    kdir = tmp_path / "keys"
+    monkeypatch.setenv("DAIMON_KEYS_DIR", str(kdir))
+    seed = receipts._ensure_seed(config.keys_dir())
+    assert isinstance(seed, bytes) and len(seed) == 32
+    seed_file = kdir / "signing.seed"
+    assert seed_file.exists()
+    assert stat.S_IMODE(seed_file.stat().st_mode) == 0o600
+    # idempotent — a second call returns the same seed, no regen
+    assert receipts._ensure_seed(config.keys_dir()) == seed
+
+
+# ---- plan_mint gating ------------------------------------------------------
+
+def test_plan_mint_none_when_gate_off(keys_ready, fake_cli):
+    cp = {"transcript_hash": _TSCRIPT_HEX, "author": "alice"}
+    assert receipts.plan_mint(cp) is None  # DAIMON_RECEIPTS not set
+
+
+def test_plan_mint_none_without_transcript_hash(keys_ready, fake_cli, monkeypatch):
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    assert receipts.plan_mint({"author": "alice"}) is None
+
+
+def test_plan_mint_none_when_cli_missing(keys_ready, monkeypatch):
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    monkeypatch.setenv("DAIMON_VITNI_CLI", "definitely-not-on-path-xyz")
+    cp = {"transcript_hash": _TSCRIPT_HEX, "author": "alice"}
+    assert receipts.plan_mint(cp) is None
+
+
+def test_plan_mint_ok(keys_ready, fake_cli, monkeypatch):
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    cp = {"transcript_hash": _TSCRIPT_HEX, "author": "alice"}
+    plan = receipts.plan_mint(cp)
+    assert plan is not None
+    assert plan["performer_id"] == "alice"
+    assert plan["inputs_hash"] == receipts._wrap_hex_sha256(_TSCRIPT_HEX)
+
+
+# ---- mint ------------------------------------------------------------------
+
+def _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                    session="S-r", extra=None):
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    cp = {"session_id": session, "transcript_hash": _TSCRIPT_HEX,
+          "created": "2026-07-09T00:00:00Z",
+          "working_context": {"recent_decisions": [
+              {"text": "d1", "trust": "verbatim", "quote": "q1"}]}}
+    if extra:
+        cp.update(extra)
+    path = store.write_checkpoint(session, cp)
+    return path
+
+
+def test_mint_writes_sidecar_and_era_marker(tmp_checkpoint_dir, monkeypatch,
+                                             keys_ready, fake_cli):
+    monkeypatch.setenv("FAKE_VITNI_JWS", "hdr.pay.sig")
+    path = _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli)
+    # era marker is inside the written checkpoint (signed bytes)
+    written = json.loads(path.read_text())
+    assert written["receipts"] is True
+    # sidecar exists, NO .json suffix
+    sidecar = path.with_suffix(".receipt")
+    assert sidecar.exists()
+    sc = json.loads(sidecar.read_text())
+    assert sc["jws"] == "hdr.pay.sig"
+    assert sc["kid"] == "daimon-1"
+    assert sc["performer_id"]
+    # receipt fields
+    r = sc["receipt"]
+    assert r["v"] == "vitni/0.2"
+    assert r["binding"] == "local"
+    assert r["method"] == "local:daimon.serialize"
+    assert r["inputs_hash"] == receipts._wrap_hex_sha256(_TSCRIPT_HEX)
+    assert r["outputs_hash"] == receipts._multibase_sha256(path.read_bytes())
+    assert r["ts"] == "2026-07-09T00:00:00Z"
+    assert r["cost"]["tokens"] == "0"
+    assert r["status"] == "OK"
+
+
+def test_mint_sign_stdin_contract(tmp_checkpoint_dir, monkeypatch, keys_ready,
+                                  fake_cli):
+    _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli)
+    lines = _capture_lines(fake_cli)
+    signs = [x for x in lines if x["cmd"] == "sign"]
+    assert len(signs) == 1
+    payload = json.loads(signs[0]["stdin"])
+    assert set(payload) == {"receipt", "kid", "private_key_b64"}
+    assert payload["kid"] == "daimon-1"
+    assert payload["private_key_b64"] == _SEED_B64
+    assert payload["receipt"]["binding"] == "local"
+
+
+def test_gate_off_no_side_effects(tmp_checkpoint_dir, keys_ready, fake_cli):
+    # DAIMON_RECEIPTS unset — no marker, no sidecar, no CLI call
+    cp = {"session_id": "S-off", "transcript_hash": _TSCRIPT_HEX,
+          "created": "2026-07-09T00:00:00Z"}
+    path = store.write_checkpoint("S-off", cp)
+    assert "receipts" not in json.loads(path.read_text())
+    assert not path.with_suffix(".receipt").exists()
+    assert not fake_cli.exists()  # capture file never created -> CLI never ran
+
+
+def test_absent_transcript_hash_skips_mint(tmp_checkpoint_dir, monkeypatch,
+                                           keys_ready, fake_cli):
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    cp = {"session_id": "S-noh", "created": "2026-07-09T00:00:00Z"}
+    path = store.write_checkpoint("S-noh", cp)
+    assert "receipts" not in json.loads(path.read_text())
+    assert not path.with_suffix(".receipt").exists()
+
+
+def test_cli_garbage_is_fail_open(tmp_checkpoint_dir, monkeypatch, keys_ready,
+                                  fake_cli):
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    monkeypatch.setenv("FAKE_VITNI_MODE", "garbage")
+    cp = {"session_id": "S-g", "transcript_hash": _TSCRIPT_HEX,
+          "created": "2026-07-09T00:00:00Z"}
+    path = store.write_checkpoint("S-g", cp)  # must NOT raise
+    assert path.exists()  # serialize/write still succeeded
+    assert not path.with_suffix(".receipt").exists()  # no sidecar minted
+
+
+def test_cli_rc1_is_fail_open(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli):
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    monkeypatch.setenv("FAKE_VITNI_MODE", "rc1")
+    cp = {"session_id": "S-e", "transcript_hash": _TSCRIPT_HEX,
+          "created": "2026-07-09T00:00:00Z"}
+    path = store.write_checkpoint("S-e", cp)
+    assert path.exists()
+    assert not path.with_suffix(".receipt").exists()
+
+
+def test_openssl_absent_no_mint_write_succeeds(tmp_checkpoint_dir, monkeypatch,
+                                               fake_cli, tmp_path):
+    # Fresh keys dir (no pre-seed) + openssl broken -> no pubkey -> no mint.
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    monkeypatch.setenv("DAIMON_KEYS_DIR", str(tmp_path / "freshkeys"))
+    monkeypatch.setattr(receipts.subprocess, "run",
+                        lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()))
+    cp = {"session_id": "S-noss", "transcript_hash": _TSCRIPT_HEX,
+          "created": "2026-07-09T00:00:00Z"}
+    path = store.write_checkpoint("S-noss", cp)
+    assert path.exists()
+    assert "receipts" not in json.loads(path.read_text())
+    assert not path.with_suffix(".receipt").exists()
+
+
+# ---- GC interaction --------------------------------------------------------
+
+def test_gc_never_eats_receipts_and_they_dont_count(tmp_checkpoint_dir,
+                                                    monkeypatch, keys_ready,
+                                                    fake_cli):
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    monkeypatch.setenv("DAIMON_CHECKPOINT_KEEP", "1")
+    # Two checkpoints; KEEP=1 GCs the older per-session .json but must keep BOTH
+    # .receipt sidecars invisible to GC, and the sidecars must not count as
+    # checkpoint files toward the window.
+    for i, sid in enumerate(("S-a", "S-b")):
+        cp = {"session_id": sid, "transcript_hash": _TSCRIPT_HEX,
+              "created": f"2026-07-0{i + 1}T00:00:00Z"}
+        store.write_checkpoint(sid, cp)
+    d = config.checkpoint_dir()
+    # _session_files must exclude .receipt entirely
+    names = {p.name for p in store._session_files(d)}
+    assert not any(n.endswith(".receipt") for n in names)
+    # both receipt sidecars survive GC
+    assert (d / "S-a.receipt").exists()
+    assert (d / "S-b.receipt").exists()
+
+
+# ---- verify-receipt --------------------------------------------------------
+
+def test_verify_receipt_verified(tmp_checkpoint_dir, monkeypatch, keys_ready,
+                                 fake_cli):
+    _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                    session="S-v")
+    rc, lines = receipts.verify_receipt("S-v")
+    assert rc == 0, lines
+    assert any("verified" in x for x in lines)
+    # verify stdin contract
+    verifies = [x for x in _capture_lines(fake_cli) if x["cmd"] == "verify"]
+    assert verifies
+    vin = json.loads(verifies[-1]["stdin"])
+    assert vin["policy"]["expected_binding"] == "local"
+    assert vin["policy"]["expected_method"] == "local:daimon.serialize"
+    performer = list(vin["keys"])[0]
+    assert "daimon-1" in vin["keys"][performer]
+
+
+def test_verify_receipt_tampered_file(tmp_checkpoint_dir, monkeypatch, keys_ready,
+                                      fake_cli):
+    path = _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                           session="S-t")
+    # edit the checkpoint file after signing
+    data = json.loads(path.read_text())
+    data["tampered"] = True
+    path.write_text(json.dumps(data, indent=2))
+    rc, lines = receipts.verify_receipt("S-t")
+    assert rc == 1
+    assert any("outputs_hash" in x or "edited" in x for x in lines)
+
+
+def test_verify_receipt_missing_sidecar_pre_receipt(tmp_checkpoint_dir):
+    # ordinary checkpoint, no marker, no sidecar -> unable, calm (rc 2)
+    store.write_checkpoint("S-pre", {"session_id": "S-pre"})
+    rc, lines = receipts.verify_receipt("S-pre")
+    assert rc == 2
+    assert any("pre-receipt" in x for x in lines)
+
+
+def test_verify_receipt_marked_but_sidecar_gone(tmp_checkpoint_dir, monkeypatch,
+                                                 keys_ready, fake_cli):
+    path = _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                           session="S-del")
+    path.with_suffix(".receipt").unlink()  # someone removed the receipt
+    rc, lines = receipts.verify_receipt("S-del")
+    assert rc == 1
+    assert any("missing" in x.lower() for x in lines)
+
+
+def test_verify_receipt_no_cli(tmp_checkpoint_dir, monkeypatch, keys_ready,
+                               fake_cli):
+    _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                    session="S-nocli")
+    monkeypatch.setenv("DAIMON_VITNI_CLI", "definitely-not-on-path-xyz")
+    rc, lines = receipts.verify_receipt("S-nocli")
+    assert rc == 2  # unable — bytes match but no CLI for full crypto
+
+
+def test_verify_receipt_signature_rejected(tmp_checkpoint_dir, monkeypatch,
+                                            keys_ready, fake_cli):
+    _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                    session="S-badsig")
+    monkeypatch.setenv("FAKE_VITNI_VERDICT", "bad_signature")
+    rc, lines = receipts.verify_receipt("S-badsig")
+    assert rc == 1
+    assert any("bad_signature" in x for x in lines)
+
+
+# ---- brief-time degrade ----------------------------------------------------
+
+def test_verbatim_degraded_false_pre_receipt(tmp_checkpoint_dir):
+    store.write_checkpoint("S-p", {"session_id": "S-p"})
+    cp = store.read_checkpoint("S-p")
+    assert receipts.verbatim_degraded(cp) is False
+
+
+def test_verbatim_degraded_false_when_intact(tmp_checkpoint_dir, monkeypatch,
+                                             keys_ready, fake_cli):
+    _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                    session="S-ok")
+    cp = store.read_checkpoint("S-ok")
+    assert receipts.verbatim_degraded(cp) is False
+
+
+def test_verbatim_degraded_true_sidecar_gone(tmp_checkpoint_dir, monkeypatch,
+                                             keys_ready, fake_cli):
+    path = _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                           session="S-gone")
+    path.with_suffix(".receipt").unlink()
+    cp = store.read_checkpoint("S-gone")
+    assert receipts.verbatim_degraded(cp) is True
+
+
+def test_verbatim_degraded_true_on_hash_mismatch(tmp_checkpoint_dir, monkeypatch,
+                                                 keys_ready, fake_cli):
+    path = _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                           session="S-mm")
+    data = json.loads(path.read_text())
+    data["x"] = "edited"
+    path.write_text(json.dumps(data, indent=2))
+    cp = store.read_checkpoint("S-mm")
+    assert receipts.verbatim_degraded(cp) is True
+
+
+def test_verbatim_degraded_never_subprocesses(tmp_checkpoint_dir, monkeypatch,
+                                              keys_ready, fake_cli):
+    _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                    session="S-ns")
+    # Missing CLI must NOT matter to the brief-time check.
+    monkeypatch.setenv("DAIMON_VITNI_CLI", "definitely-not-on-path-xyz")
+    calls = []
+    monkeypatch.setattr(receipts.subprocess, "run",
+                        lambda *a, **k: calls.append(a) or None)
+    cp = store.read_checkpoint("S-ns")
+    assert receipts.verbatim_degraded(cp) is False
+    assert calls == []
+
+
+# ---- status line -----------------------------------------------------------
+
+def test_status_line_none_when_off(tmp_checkpoint_dir):
+    assert receipts.status_line() is None
+
+
+def test_status_line_signed(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli):
+    _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                    session="S-sl")
+    line = receipts.status_line()
+    assert line and "signed" in line
+
+
+# ---- briefing render integration -------------------------------------------
+
+
+def test_briefing_intact_keeps_verbatim_mark(tmp_checkpoint_dir, monkeypatch,
+                                              keys_ready, fake_cli):
+    _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                    session="S-bi")
+    cp = store.read_checkpoint("S-bi")
+    text = briefing.render(cp)
+    assert "✓ verbatim" in text
+    assert briefing.DEGRADE_NOTE not in text
+
+
+def test_briefing_degrades_when_receipt_gone(tmp_checkpoint_dir, monkeypatch,
+                                             keys_ready, fake_cli):
+    path = _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                           session="S-bd")
+    path.with_suffix(".receipt").unlink()
+    cp = store.read_checkpoint("S-bd")
+    text = briefing.render(cp)
+    assert briefing.DEGRADE_NOTE in text
+    assert "✓ verbatim" not in text  # every verbatim label degraded
+    assert "unverified" in text
+
+
+def test_briefing_pre_receipt_never_degrades(tmp_checkpoint_dir):
+    cp = {"session_id": "S-bp", "working_context": {"recent_decisions": [
+        {"text": "d", "trust": "verbatim", "quote": "q"}]}}
+    store.write_checkpoint("S-bp", cp)
+    loaded = store.read_checkpoint("S-bp")
+    text = briefing.render(loaded)
+    assert briefing.DEGRADE_NOTE not in text
+    assert "✓ verbatim" in text
+
+
+def test_briefing_missing_cli_never_degrades(tmp_checkpoint_dir, monkeypatch,
+                                             keys_ready, fake_cli):
+    _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                    session="S-bc")
+    cp = store.read_checkpoint("S-bc")
+    monkeypatch.setenv("DAIMON_VITNI_CLI", "definitely-not-on-path-xyz")
+    text = briefing.render(cp)
+    assert briefing.DEGRADE_NOTE not in text  # intact sidecar + bytes match
+    assert "✓ verbatim" in text
+
+
+# ---- CLI verify-receipt / status -------------------------------------------
+
+
+def test_cli_verify_receipt_verified(tmp_checkpoint_dir, monkeypatch, keys_ready,
+                                     fake_cli, capsys):
+    _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                    session="S-cv")
+    rc = cli.main(["verify-receipt", "S-cv"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "verified" in out
+
+
+def test_cli_verify_receipt_no_checkpoint(tmp_checkpoint_dir, capsys):
+    rc = cli.main(["verify-receipt", "does-not-exist"])
+    out = capsys.readouterr().out
+    assert rc == 2
+    assert "no checkpoint" in out or "nothing to verify" in out
+
+
+def test_cli_status_shows_receipts_line(tmp_checkpoint_dir, monkeypatch,
+                                        keys_ready, fake_cli, capsys):
+    _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                    session="S-cs")
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    cli.main(["status"])
+    out = capsys.readouterr().out
+    assert "receipts: on" in out

--- a/plugin/tests/test_receipts.py
+++ b/plugin/tests/test_receipts.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 import pytest
 
-from daimon_briefing import briefing, cli, config, receipts, store
+from daimon_briefing import briefing, cli, config, receipts, render, store
 
 _SEED = bytes(range(32))
 _SEED_B64 = base64.b64encode(_SEED).decode("ascii")
@@ -558,3 +558,273 @@ def test_cli_status_shows_receipts_line(tmp_checkpoint_dir, monkeypatch,
     cli.main(["status"])
     out = capsys.readouterr().out
     assert "receipts: on" in out
+
+
+def test_cli_verify_receipt_default_no_checkpoint(tmp_checkpoint_dir, capsys):
+    # No positional session id + empty store -> the default-latest branch.
+    rc = cli.main(["verify-receipt"])
+    out = capsys.readouterr().out
+    assert rc == 2
+    assert "nothing to verify" in out
+
+
+def test_cli_verify_receipt_default_uses_latest(tmp_checkpoint_dir, monkeypatch,
+                                                keys_ready, fake_cli, capsys):
+    _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                    session="S-cdef")
+    rc = cli.main(["verify-receipt"])  # no session -> resolves latest checkpoint
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "verified" in out
+
+
+# ---- fail-open seams: keys, CLI plumbing, mint --------------------------------
+
+
+def test_ensure_seed_race_reads_winner(tmp_path, monkeypatch):
+    # O_EXCL create loses the race (FileExistsError) -> re-read the winner's seed.
+    kdir = tmp_path / "k"
+    kdir.mkdir()
+    winner = bytes(range(32))
+    calls = {"n": 0}
+
+    def fake_read(path):
+        calls["n"] += 1
+        return None if calls["n"] == 1 else winner  # miss fast-path, then win
+
+    monkeypatch.setattr(receipts, "_read_seed", fake_read)
+    monkeypatch.setattr(receipts.os, "open",
+                        lambda *a, **k: (_ for _ in ()).throw(FileExistsError()))
+    assert receipts._ensure_seed(kdir) == winner
+
+
+def test_ensure_seed_oserror_returns_none(tmp_path, monkeypatch):
+    kdir = tmp_path / "k"
+    monkeypatch.setattr(receipts.os, "open",
+                        lambda *a, **k: (_ for _ in ()).throw(PermissionError()))
+    assert receipts._ensure_seed(kdir) is None
+
+
+def test_ensure_pubkey_derives_and_caches(tmp_path, monkeypatch):
+    kdir = tmp_path / "k"
+    kdir.mkdir()
+
+    def fake_run(cmd, **kw):
+        assert cmd[0] == "openssl"
+        return subprocess.CompletedProcess(cmd, 0, stdout=bytes.fromhex(_SPKI_HEX),
+                                           stderr=b"")
+
+    monkeypatch.setattr(receipts.subprocess, "run", fake_run)
+    jwk = receipts._ensure_pubkey(kdir, _SEED)
+    assert jwk == {"kty": "OKP", "crv": "Ed25519", "x": _PUB_X, "alg": "EdDSA",
+                   "status": "active"}
+    assert (kdir / "signing.pub.json").exists()  # cached for next time
+
+
+def test_ensure_pubkey_cache_write_failure_still_returns_jwk(tmp_path, monkeypatch):
+    # Derivation succeeds but the cache write fails -> non-fatal, jwk still returned.
+    kdir = tmp_path / "k"
+    kdir.mkdir()
+    monkeypatch.setattr(receipts.subprocess, "run",
+                        lambda cmd, **kw: subprocess.CompletedProcess(
+                            cmd, 0, stdout=bytes.fromhex(_SPKI_HEX), stderr=b""))
+    monkeypatch.setattr(receipts, "_atomic_write_text",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("readonly")))
+    jwk = receipts._ensure_pubkey(kdir, _SEED)
+    assert jwk["x"] == _PUB_X
+    assert not (kdir / "signing.pub.json").exists()  # cache write was swallowed
+
+
+def test_load_pubkey_missing_returns_none(tmp_path):
+    assert receipts._load_pubkey(tmp_path / "nope") is None
+
+
+def test_load_pubkey_corrupt_returns_none(tmp_path):
+    (tmp_path / "signing.pub.json").write_text("not json{")
+    assert receipts._load_pubkey(tmp_path) is None
+
+
+def test_run_cli_spawn_error_returns_none(monkeypatch):
+    monkeypatch.setattr(receipts.subprocess, "run",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("spawn")))
+    assert receipts._run_cli("x", "sign", "{}") is None
+
+
+def test_run_cli_error_output_returns_none(fake_cli):
+    # The fake CLI emits {"error":"unknown_command"} for an unknown command.
+    cli_path = receipts._resolve_cli()
+    assert receipts._run_cli(cli_path, "bogus-cmd", "{}") is None
+
+
+def test_plan_mint_none_when_seed_unavailable(keys_ready, fake_cli, monkeypatch):
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    monkeypatch.setattr(receipts, "_ensure_seed", lambda kd: None)
+    cp = {"transcript_hash": _TSCRIPT_HEX, "author": "alice"}
+    assert receipts.plan_mint(cp) is None
+
+
+def test_mint_internal_exception_is_fail_open(tmp_path, monkeypatch):
+    # An exception INSIDE mint (here: the sign call) -> logged, False, no sidecar,
+    # never raised. Also walks the receipt-build lines (outputs_hash/nonce).
+    monkeypatch.setattr(receipts, "_run_cli",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    plan = {"cli": "x", "seed_b64": _SEED_B64,
+            "inputs_hash": receipts._wrap_hex_sha256(_TSCRIPT_HEX),
+            "performer_id": "alice"}
+    cp_path = tmp_path / "S.json"
+    cp_path.write_text("{}")
+    assert receipts.mint(plan, {"created": "2026-07-09T00:00:00Z"}, "{}", cp_path) is False
+    assert not cp_path.with_suffix(".receipt").exists()
+
+
+# ---- verify_receipt edge verdicts ---------------------------------------------
+
+
+def test_verify_receipt_outer_crash_returns_unable(tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setattr(receipts, "_verify_receipt",
+                        lambda sid: (_ for _ in ()).throw(RuntimeError("boom")))
+    rc, lines = receipts.verify_receipt("S-x")
+    assert rc == 2
+    assert any("unexpected error" in x for x in lines)
+
+
+def test_verify_receipt_corrupt_checkpoint_json(tmp_checkpoint_dir):
+    # Unparseable checkpoint file (torn) + no sidecar -> treated as {} -> pre-receipt.
+    d = config.checkpoint_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "S-torn.json").write_text("{not json")
+    rc, lines = receipts.verify_receipt("S-torn")
+    assert rc == 2
+    assert any("pre-receipt" in x for x in lines)
+
+
+def test_verify_receipt_corrupt_sidecar(tmp_checkpoint_dir):
+    store.write_checkpoint("S-badsc", {"session_id": "S-badsc"})
+    d = config.checkpoint_dir()
+    (d / "S-badsc.receipt").write_text("garbage{")
+    rc, lines = receipts.verify_receipt("S-badsc")
+    assert rc == 1
+    assert any("unreadable or corrupt" in x for x in lines)
+
+
+def test_verify_receipt_no_pubkey(tmp_checkpoint_dir, monkeypatch, keys_ready,
+                                  fake_cli):
+    _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                    session="S-nopub")
+    (keys_ready / "signing.pub.json").unlink()  # bytes match, CLI ok, no key
+    rc, lines = receipts.verify_receipt("S-nopub")
+    assert rc == 2
+    assert any("no local public key" in x for x in lines)
+
+
+def test_verify_receipt_missing_jws(tmp_checkpoint_dir, monkeypatch, keys_ready,
+                                    fake_cli):
+    path = _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                           session="S-nojws")
+    sidecar = path.with_suffix(".receipt")
+    sc = json.loads(sidecar.read_text())
+    sc["jws"] = ""  # keep receipt/outputs_hash so byte-match still passes
+    sidecar.write_text(json.dumps(sc))
+    rc, lines = receipts.verify_receipt("S-nojws")
+    assert rc == 1
+    assert any("missing its signature" in x for x in lines)
+
+
+def test_verify_receipt_cli_garbage_is_unable(tmp_checkpoint_dir, monkeypatch,
+                                              keys_ready, fake_cli):
+    _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                    session="S-vg")
+    monkeypatch.setenv("FAKE_VITNI_MODE", "garbage")  # verify -> non-JSON -> None
+    rc, lines = receipts.verify_receipt("S-vg")
+    assert rc == 2
+    assert any("did not return a usable result" in x for x in lines)
+
+
+# ---- verbatim_degraded edge branches ------------------------------------------
+
+
+def test_verbatim_degraded_false_without_session_id():
+    assert receipts.verbatim_degraded({"receipts": True}) is False
+
+
+def test_verbatim_degraded_false_on_corrupt_sidecar(tmp_checkpoint_dir, monkeypatch,
+                                                    keys_ready, fake_cli):
+    path = _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                           session="S-dc")
+    path.with_suffix(".receipt").write_text("garbage{")  # unreadable -> fail-open
+    cp = store.read_checkpoint("S-dc")
+    assert receipts.verbatim_degraded(cp) is False
+
+
+def test_verbatim_degraded_false_when_no_outputs_hash(tmp_checkpoint_dir, monkeypatch,
+                                                      keys_ready, fake_cli):
+    path = _mint_via_store(tmp_checkpoint_dir, monkeypatch, keys_ready, fake_cli,
+                           session="S-noh2")
+    sidecar = path.with_suffix(".receipt")
+    sidecar.write_text(json.dumps({"jws": "a.b.c", "receipt": {}}))  # no outputs_hash
+    cp = store.read_checkpoint("S-noh2")
+    assert receipts.verbatim_degraded(cp) is False
+
+
+def test_verbatim_degraded_outer_exception_is_false(monkeypatch):
+    monkeypatch.setattr(receipts, "_checkpoint_file",
+                        lambda sid: (_ for _ in ()).throw(RuntimeError("boom")))
+    assert receipts.verbatim_degraded({"receipts": True, "session_id": "S"}) is False
+
+
+# ---- status_line variants -----------------------------------------------------
+
+
+def test_status_line_no_checkpoint(tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    assert receipts.status_line() == "receipts: on — no checkpoint to sign yet"
+
+
+def test_status_line_marked_but_missing(tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    # A receipt-era marker but no sidecar (mint failed) -> MISSING line.
+    store.write_checkpoint("S-sm", {"session_id": "S-sm", "receipts": True})
+    line = receipts.status_line()
+    assert "MISSING" in line
+
+
+def test_status_line_predates_receipts(tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    store.write_checkpoint("S-pre2", {"session_id": "S-pre2"})  # no marker, no sidecar
+    line = receipts.status_line()
+    assert "predates receipts" in line
+
+
+# ---- cross-module #204 seams (briefing / render / config) ---------------------
+
+
+def test_briefing_receipt_degraded_swallows_exception(monkeypatch):
+    monkeypatch.setattr(receipts, "verbatim_degraded",
+                        lambda cp: (_ for _ in ()).throw(RuntimeError("boom")))
+    assert briefing.receipt_degraded({"x": 1}) is False
+
+
+def test_rich_brief_prints_degrade_note(monkeypatch, sample_checkpoint, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    monkeypatch.setattr(briefing, "receipt_degraded", lambda cp: True)
+    render.render_brief(sample_checkpoint)
+    out = capsys.readouterr().out
+    assert "RECEIPT UNVERIFIED" in out
+
+
+def test_rich_status_prints_receipts_line(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    data = {
+        "project": "/p", "proj": {"exists": False}, "glob": {"exists": False},
+        "same": False, "last": None, "outstanding": [], "identity": None,
+        "health": None, "team": None,
+        "receipts": "receipts: on — latest checkpoint S is signed",
+    }
+    render.render_status(data)
+    out = capsys.readouterr().out
+    assert "receipts: on" in out
+
+
+def test_keys_dir_default_when_unset(monkeypatch):
+    monkeypatch.delenv("DAIMON_KEYS_DIR", raising=False)
+    assert config.keys_dir() == Path.home() / ".daimon" / "keys"

--- a/plugin/tests/test_receipts.py
+++ b/plugin/tests/test_receipts.py
@@ -180,6 +180,18 @@ def test_derive_pubkey_openssl_absent_returns_none(monkeypatch):
     assert receipts._derive_pubkey_x(_SEED) is None
 
 
+@pytest.mark.parametrize("rc,stdout", [(1, b""), (0, b"short")])
+def test_derive_pubkey_openssl_rejects_returns_none(monkeypatch, rc, stdout):
+    # The LibreSSL-shaped failure (rc!=0 "unable to load key") and a
+    # truncated-SPKI output both fail open. Monkeypatched so the branch is
+    # walked deterministically — real openssl only enters it on Ed25519-less
+    # builds, which CI's OpenSSL 3.x is not.
+    def fake_run(cmd, **kw):
+        return subprocess.CompletedProcess(cmd, rc, stdout=stdout, stderr=b"err")
+    monkeypatch.setattr(receipts.subprocess, "run", fake_run)
+    assert receipts._derive_pubkey_x(_SEED) is None
+
+
 def test_ensure_seed_creates_0600(tmp_path, monkeypatch):
     kdir = tmp_path / "keys"
     monkeypatch.setenv("DAIMON_KEYS_DIR", str(kdir))


### PR DESCRIPTION
Closes #204

## What

`DAIMON_RECEIPTS=1` (default OFF) mints a signed provenance receipt at every checkpoint write, using [vitni](https://github.com/Daily-Nerd/vitni) (`vitni/0.2`, `local` binding, method `local:daimon.serialize` — the spec's own example). Receipts are fully valid offline (vitni L1); nothing leaves the machine.

- **Mint** (last step of `write_checkpoint`, after the checkpoint file is durably written): `inputs_hash` = the #125 raw-transcript hash, `outputs_hash` = the exact blob on disk, Ed25519-signed via the `vitni-verify` CLI (stdin JSON, bounded timeout), sidecar `<session_id>.receipt`. The sidecar deliberately drops `.json` — every scan that could eat or miscount it (GC, pointer stems, recall's index, audit-quotes) filters on that suffix, locked in by a test that GC never prunes receipts and they never count toward `DAIMON_CHECKPOINT_KEEP`.
- **Era marker**: minted checkpoints carry `receipts: true` inside the signed bytes — self-describing, no retroactive judgment of the ~2k pre-receipt checkpoints, ever.
- **Verify**: `daimon verify-receipt [session]` = full check (CLI signature verification + local byte-match proving THIS file is the signed one); rc 0 verified / 1 failed / 2 unable. Briefings run only the cheap half (sidecar presence + hash match, zero subprocess): a receipt-era checkpoint failing it gets its `✓ verbatim` labels visibly degraded with one header note — fail loud, never block. Missing CLI never degrades.
- **Fail-open mint**: no seed, no openssl, no CLI, timeout, garbage output — one log line (lands in serialize.log via #194's handler), serialize succeeds receipt-less. A receipts failure can never fail a write.
- **Keys**: 32-byte Ed25519 seed at `~/.daimon/keys/signing.seed` (0600, auto-created); public key derived once via openssl DER slicing. The seed travels only on subprocess stdin, and the mint-failure log line carries exception type+message only — no traceback, since the seed is in scope in that frame.

## Known limitation (deliberate, v1)

macOS ships LibreSSL, which cannot derive Ed25519 public keys — key setup fail-opens there (receipts stay off, one log line). CI's OpenSSL 3.x works, and the real crypto was validated end-to-end against the built vitni CLI locally: mint → verify rc 0 → one-byte tamper → rc 1. A vitni `keygen` command has been requested and will replace the openssl path.

## Config

`DAIMON_RECEIPTS`, `DAIMON_VITNI_CLI`, `DAIMON_KEYS_DIR` — documented in `docs/configuration.md` (new Receipts section) + one README bullet.

## Tests

Suite 1297 → **1336 passed, 1 skipped** (40 new, red-first; the skip is the real-openssl derivation test on LibreSSL boxes). CI needs no node: the vitni CLI is stubbed by fake executables that assert the stdin contract; the multihash wrapper is pinned against a vitni conformance-vector fixture. Independent adversarial review: one hardening finding (traceback logging in a seed-scoped frame), fixed.