### PR TITLE
feat(receipts): prefer vitni keygen for public-key derivation, openssl fallback

### DIFF
--- a/.scars/candidates/local-coverage-lies-across-crypto-libs.md
+++ b/.scars/candidates/local-coverage-lies-across-crypto-libs.md
@@ -1,0 +1,33 @@
+---
+id: 0
+type: landmine
+title: Local patch-coverage green does NOT mean codecov green when a branch depends on LibreSSL-vs-OpenSSL behavior
+severity: medium
+confidence: 0.9
+created: 2026-07-10
+authors: ["claude-code"]
+anchors:
+  - path: plugin/daimon_briefing/receipts.py
+evidence:
+  - pr: 205
+  - pr: 207
+  - note: "three catch-up commits across two PRs: 71feff7/efa57aa (#205), post-review sweep (#207) — each time local intersect said 0 missing, codecov said otherwise"
+expires:
+  condition: "openssl subprocess path removed from receipts.py (vitni keygen becomes the only derivation), or CI adds a macOS/LibreSSL coverage job"
+  review_after: 2026-10-01
+status: candidate
+---
+
+receipts.py's key derivation branches on what the host crypto CLI can do:
+macOS LibreSSL fails Ed25519 (`openssl pkey` → rc≠0), CI's OpenSSL 3.x
+succeeds. Any test that exercises the REAL subprocess therefore covers
+DIFFERENT lines locally than on CI — the failure branch is green on the dev
+Mac and missing on ubuntu, and vice versa for the success body. Verifying
+patch coverage locally before push (coverage-json ∩ diff-hunks) reads 0
+missing while codecov still flags lines; it took three catch-up commits
+across PR #205 and PR #207 to learn this. Rule: for any change touching a
+platform-conditional subprocess branch here, either (a) add a
+monkeypatched-subprocess twin that walks BOTH branches deterministically on
+any box, or (b) pull codecov's per-line report for the pushed sha
+(api.codecov.io /report/?path=...&sha=...) instead of trusting the local
+intersect. Local green is necessary, never sufficient, on this file.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,6 +99,11 @@ checkpoint on demand with `daimon verify-receipt [session]`; at briefing time a
 receipt-era checkpoint whose receipt is missing or no longer matches its bytes
 has its `✓ verbatim` labels degraded with a visible note.
 
+Public-key derivation prefers the vitni CLI's `keygen` command (vitni 0.5.0+) and
+falls back to openssl on older CLIs or a failed probe — so on macOS, where Apple's
+LibreSSL has no Ed25519 in `openssl pkey`, receipts work once vitni ≥ 0.5.0 is
+installed, with no openssl-with-Ed25519 required.
+
 | Variable | Default | What it does |
 |---|---|---|
 | `DAIMON_RECEIPTS` | off | When truthy, mint a signed receipt beside each checkpoint. Default off — a new subprocess per serialize is opt-in. |

--- a/plugin/daimon_briefing/receipts.py
+++ b/plugin/daimon_briefing/receipts.py
@@ -49,6 +49,16 @@ _PUB_FILE = "signing.pub.json"
 _CLI_TIMEOUT = 10                   # seconds; a signer that hangs must not hang us
 _SIDECAR_SUFFIX = ".receipt"        # NOT .json — see _sidecar_path
 
+# vitni keygen (0.5.0+) derive-only probe (#206): the RFC 8032 TEST 1 vector.
+# An EXACT match is the only signal that the resolved CLI's keygen is trustworthy;
+# a wrong x, an {"error"} payload, or a missing command all fall back to openssl.
+_KEYGEN_PROBE_SEED_B64 = "nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A="
+_KEYGEN_PROBE_X = "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+# Per-process probe cache, keyed by the RESOLVED CLI path: a verdict belongs to
+# the binary that earned it, not the process — a DAIMON_VITNI_CLI repoint
+# mid-process (tests, heal) must re-probe the new binary, never inherit.
+_keygen_probe_cache: dict[str, bool] = {}
+
 
 # ---- hashes (pure stdlib) --------------------------------------------------
 
@@ -95,6 +105,20 @@ def _read_seed(seed_path: Path) -> bytes | None:
     return raw if len(raw) == 32 else None
 
 
+def _read_seed_str(seed_path: Path) -> str | None:
+    """The seed file's base64 text VERBATIM (stripped), or None. #206 consumer
+    rule: the stored string is handed to keygen/sign stdin UNTOUCHED — never
+    decode→re-encode, since a flexible base64 decoder can silently canonicalize a
+    non-canonical string into a *different* one. Daimon writes its own seed padded,
+    so verbatim == canonical here; passing the string verbatim honors the contract
+    regardless of who wrote the file."""
+    try:
+        raw = seed_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return raw or None
+
+
 def _ensure_seed(keys_dir: Path) -> bytes | None:
     """Load the Ed25519 seed, creating it (32 CSPRNG bytes, base64, mode 0600) on
     first mint. O_EXCL so two racing first-mints can never write divergent seeds
@@ -120,11 +144,70 @@ def _ensure_seed(keys_dir: Path) -> bytes | None:
         return None
 
 
+def _jwk_x(out) -> str | None:
+    """The non-empty string `jwk.x` from a keygen result, or None. Consumed
+    VERBATIM (#206) — the emitted string is never decoded/re-encoded."""
+    if not isinstance(out, dict):
+        return None
+    jwk = out.get("jwk")
+    if not isinstance(jwk, dict):
+        return None
+    x = jwk.get("x")
+    return x if isinstance(x, str) and x else None
+
+
+def _keygen_probe(cli: str) -> bool:
+    """Once per process, prove the resolved CLI's keygen derives the RFC 8032
+    TEST 1 vector EXACTLY. A wrong x, an {"error"} payload (which vitni emits on
+    exit 0), a missing command, or garbage all fail the probe → openssl fallback.
+    Never asserts on the return code — _run_cli already folds {"error"}, nonzero
+    rc, and non-JSON uniformly into None (#206)."""
+    if cli not in _keygen_probe_cache:
+        x = _jwk_x(_run_cli(cli, "keygen",
+                            json.dumps({"seed_b64": _KEYGEN_PROBE_SEED_B64})))
+        _keygen_probe_cache[cli] = x == _KEYGEN_PROBE_X
+        if not _keygen_probe_cache[cli]:
+            log.info("daimon receipts: vitni keygen probe failed (got x=%r); "
+                     "using openssl", x)
+    return _keygen_probe_cache[cli]
+
+
+def _keygen_derive_x(seed_b64: str) -> str | None:
+    """Derive the public x via vitni keygen (0.5.0+), or None to fall back to
+    openssl. Probes the CLI once; only an exact probe match trusts keygen for the
+    real seed, which is passed VERBATIM (#206). Returns the emitted x untouched."""
+    cli = _resolve_cli()
+    if cli is None or not _keygen_probe(cli):
+        return None
+    x = _jwk_x(_run_cli(cli, "keygen", json.dumps({"seed_b64": seed_b64})))
+    if x is None:
+        log.info("daimon receipts: keygen probe passed but real-seed derive "
+                 "failed; using openssl")
+    return x
+
+
+def _derive_pubkey(seed: bytes, seed_b64: str | None) -> str | None:
+    """Public x for the seed, preferring vitni keygen over openssl (#206). keygen
+    (0.5.0+) works on stock macOS, where Apple's LibreSSL has no Ed25519 in
+    `openssl pkey`; the openssl DER slice remains the fallback for older CLIs or
+    any probe deviation. Logs which path produced the key. None when both fail."""
+    if seed_b64:
+        x = _keygen_derive_x(seed_b64)
+        if x is not None:
+            log.info("daimon receipts: pubkey derived via vitni keygen")
+            return x
+    x = _derive_pubkey_x(seed)
+    if x is not None:
+        log.info("daimon receipts: pubkey derived via openssl")
+    return x
+
+
 def _derive_pubkey_x(seed: bytes) -> str | None:
-    """Raw Ed25519 public key (base64url, no pad) for `seed`, via openssl. The
-    seed is wrapped into a PKCS8 DER, `openssl pkey -pubout` emits the 44-byte
-    SPKI DER whose last 32 bytes ARE the raw public key. None on any failure —
-    e.g. macOS LibreSSL lacks Ed25519 in `openssl pkey` (fail-open to no receipt)."""
+    """Raw Ed25519 public key (base64url, no pad) for `seed`, via openssl — the
+    #206 fallback beneath vitni keygen. The seed is wrapped into a PKCS8 DER,
+    `openssl pkey -pubout` emits the 44-byte SPKI DER whose last 32 bytes ARE the
+    raw public key. None on any failure — e.g. macOS LibreSSL lacks Ed25519 in
+    `openssl pkey` (fail-open to no receipt)."""
     der = _PKCS8_ED25519_PREFIX + seed
     try:
         proc = subprocess.run(
@@ -145,9 +228,12 @@ def _pubkey_jwk(x: str) -> dict:
     return {"kty": "OKP", "crv": "Ed25519", "x": x, "alg": "EdDSA", "status": "active"}
 
 
-def _ensure_pubkey(keys_dir: Path, seed: bytes) -> dict | None:
+def _ensure_pubkey(keys_dir: Path, seed: bytes,
+                   seed_b64: str | None = None) -> dict | None:
     """Load the cached public JWK, deriving + caching it once on first mint.
-    None when derivation is impossible (no openssl) — no receipt this run."""
+    Derivation prefers vitni keygen and falls back to openssl (#206); `seed_b64`
+    is the seed file's VERBATIM string for the keygen path (None → openssl only).
+    None when both derivation paths fail — no receipt this run."""
     pub_path = keys_dir / _PUB_FILE
     try:
         jwk = json.loads(pub_path.read_text(encoding="utf-8"))
@@ -155,7 +241,7 @@ def _ensure_pubkey(keys_dir: Path, seed: bytes) -> dict | None:
             return jwk
     except (OSError, json.JSONDecodeError):
         pass
-    x = _derive_pubkey_x(seed)
+    x = _derive_pubkey(seed, seed_b64)
     if not x:
         return None
     jwk = _pubkey_jwk(x)
@@ -260,11 +346,17 @@ def plan_mint(checkpoint: dict) -> dict | None:
     seed = _ensure_seed(keys_dir)
     if seed is None:
         return None
-    if _ensure_pubkey(keys_dir, seed) is None:
+    # #206 consumer rule: the seed's stored string goes to keygen/sign stdin
+    # VERBATIM — never decode→re-encode. _ensure_seed just wrote/read the file, so
+    # the read succeeds; the b64encode(seed) fallback only covers a torn file (a
+    # seed we generated re-encodes identically anyway).
+    seed_b64 = (_read_seed_str(keys_dir / _SEED_FILE)
+                or base64.b64encode(seed).decode("ascii"))
+    if _ensure_pubkey(keys_dir, seed, seed_b64) is None:
         return None
     return {
         "cli": cli,
-        "seed_b64": base64.b64encode(seed).decode("ascii"),
+        "seed_b64": seed_b64,
         "inputs_hash": inputs_hash,
         "performer_id": str(checkpoint.get("author") or "unknown"),
     }

--- a/plugin/tests/test_receipts.py
+++ b/plugin/tests/test_receipts.py
@@ -30,6 +30,17 @@ _SEED_B64 = base64.b64encode(_SEED).decode("ascii")
 _PUB_X = "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
 _SPKI_HEX = ("302a300506032b657003210003a107bff3ce10be1d70dd18e74bc09967"
              "e4d6309ba50d5f1ddc8664125531b8")
+# vitni keygen (#206) RFC 8032 TEST 1 probe vector.
+_PROBE_SEED_B64 = "nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A="
+_PROBE_X = "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+
+
+@pytest.fixture(autouse=True)
+def _reset_keygen_probe(monkeypatch):
+    # The keygen probe verdict is cached per (process, CLI path) (#206); reset it
+    # before each test so a probe outcome can't leak across tests. monkeypatch
+    # auto-restores.
+    monkeypatch.setattr(receipts, "_keygen_probe_cache", {})
 
 # A real sha256 hex digest (of b"") for transcript_hash wiring.
 _TSCRIPT_HEX = hashlib.sha256(b"hello transcript").hexdigest()
@@ -67,6 +78,27 @@ elif cmd == "verify":
         print(json.dumps({"valid": True, "reason": "ok"}))
     else:
         print(json.dumps({"valid": False, "reason": verdict}))
+elif cmd == "keygen":
+    kmode = os.environ.get("FAKE_VITNI_KEYGEN_MODE", "ok")
+    if kmode == "unknown":          # simulate an old CLI without keygen
+        print(json.dumps({"error": "unknown_command"})); sys.exit(0)
+    if kmode == "error":            # {"error"} on exit 0 — never rc
+        print(json.dumps({"error": "invalid_seed"})); sys.exit(0)
+    if kmode == "nojwk":            # malformed output shape
+        print(json.dumps({"private_key_b64": data.get("seed_b64", "")})); sys.exit(0)
+    seed = data.get("seed_b64")
+    if seed == "":                 # present-but-empty != absent -> invalid_seed
+        print(json.dumps({"error": "invalid_seed"})); sys.exit(0)
+    PROBE = "nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A="
+    PROBE_X = "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+    if seed == PROBE:
+        x = os.environ.get("FAKE_VITNI_PROBE_X", PROBE_X)
+    else:
+        x = os.environ.get("FAKE_VITNI_KEYGEN_X",
+                           "Kg2fakeKEYGENxKg2fakeKEYGENxKg2fakeKEYGENxK")
+    print(json.dumps({"jwk": {"alg": "EdDSA", "crv": "Ed25519", "kty": "OKP",
+                              "status": "active", "x": x},
+                      "private_key_b64": seed}))
 else:
     print(json.dumps({"error": "unknown_command"}))
 sys.exit(0)
@@ -97,6 +129,18 @@ def keys_ready(tmp_path, monkeypatch):
     (kdir / "signing.pub.json").write_text(json.dumps(
         {"kty": "OKP", "crv": "Ed25519", "x": _PUB_X, "alg": "EdDSA",
          "status": "active"}))
+    monkeypatch.setenv("DAIMON_KEYS_DIR", str(kdir))
+    return kdir
+
+
+@pytest.fixture
+def keys_seed_only(tmp_path, monkeypatch):
+    """Keys dir with only the seed file (verbatim _SEED_B64) — NO cached pubkey,
+    so derivation actually runs. For exercising the #206 keygen path."""
+    kdir = tmp_path / "keys"
+    kdir.mkdir()
+    (kdir / "signing.seed").write_text(_SEED_B64)
+    (kdir / "signing.seed").chmod(0o600)
     monkeypatch.setenv("DAIMON_KEYS_DIR", str(kdir))
     return kdir
 
@@ -840,3 +884,144 @@ def test_rich_status_prints_receipts_line(monkeypatch, capsys):
 def test_keys_dir_default_when_unset(monkeypatch):
     monkeypatch.delenv("DAIMON_KEYS_DIR", raising=False)
     assert config.keys_dir() == Path.home() / ".daimon" / "keys"
+
+
+# ---- #206: vitni keygen preferred over openssl --------------------------------
+
+
+def _no_openssl(monkeypatch):
+    """Trip _derive_pubkey_x (openssl) into a recorder so a test can assert the
+    fallback was NOT taken. Returns the call list."""
+    calls = []
+    monkeypatch.setattr(receipts, "_derive_pubkey_x",
+                        lambda seed: calls.append(seed) or None)
+    return calls
+
+
+def test_pubkey_via_keygen_openssl_not_invoked(keys_seed_only, fake_cli, monkeypatch):
+    monkeypatch.setenv("FAKE_VITNI_KEYGEN_X", "ZZkeygenXZZkeygenXZZkeygenXZZkeygenXZZkeygX")
+    openssl_calls = _no_openssl(monkeypatch)
+    jwk = receipts._ensure_pubkey(config.keys_dir(), _SEED, _SEED_B64)
+    assert jwk["x"] == "ZZkeygenXZZkeygenXZZkeygenXZZkeygenXZZkeygX"  # verbatim
+    assert openssl_calls == []  # keygen worked -> openssl never called
+
+
+def test_keygen_real_seed_receives_verbatim_string(keys_seed_only, fake_cli, monkeypatch):
+    _no_openssl(monkeypatch)
+    receipts._ensure_pubkey(config.keys_dir(), _SEED, _SEED_B64)
+    keygen_calls = [x for x in _capture_lines(fake_cli) if x["cmd"] == "keygen"]
+    # two calls: the probe (probe seed) then the real derive (our seed verbatim)
+    seeds = [json.loads(c["stdin"])["seed_b64"] for c in keygen_calls]
+    assert _PROBE_SEED_B64 in seeds
+    assert _SEED_B64 in seeds  # exact stored string, not decode/re-encode
+
+
+def test_keygen_probe_wrong_x_falls_back_to_openssl(keys_seed_only, fake_cli,
+                                                    monkeypatch, caplog):
+    monkeypatch.setenv("FAKE_VITNI_PROBE_X", "WRONGxWRONGxWRONGxWRONGxWRONGxWRONGxWRONGxW")
+    monkeypatch.setattr(receipts, "_derive_pubkey_x", lambda seed: "OPENSSLDERIVEDX")
+    with caplog.at_level("INFO"):
+        jwk = receipts._ensure_pubkey(config.keys_dir(), _SEED, _SEED_B64)
+    assert jwk["x"] == "OPENSSLDERIVEDX"  # openssl fallback produced the key
+    assert any("probe failed" in r.message for r in caplog.records)
+
+
+def test_keygen_error_payload_exit0_falls_back(keys_seed_only, fake_cli, monkeypatch):
+    # {"error"} on exit 0 must fail the probe -> proves we never rely on rc.
+    monkeypatch.setenv("FAKE_VITNI_KEYGEN_MODE", "error")
+    monkeypatch.setattr(receipts, "_derive_pubkey_x", lambda seed: "OPENSSLX")
+    jwk = receipts._ensure_pubkey(config.keys_dir(), _SEED, _SEED_B64)
+    assert jwk["x"] == "OPENSSLX"
+
+
+def test_keygen_missing_command_falls_back(keys_seed_only, fake_cli, monkeypatch):
+    monkeypatch.setenv("FAKE_VITNI_KEYGEN_MODE", "unknown")  # old CLI, no keygen
+    monkeypatch.setattr(receipts, "_derive_pubkey_x", lambda seed: "OPENSSLX")
+    jwk = receipts._ensure_pubkey(config.keys_dir(), _SEED, _SEED_B64)
+    assert jwk["x"] == "OPENSSLX"
+
+
+def test_keygen_malformed_jwk_falls_back(keys_seed_only, fake_cli, monkeypatch):
+    monkeypatch.setenv("FAKE_VITNI_KEYGEN_MODE", "nojwk")
+    monkeypatch.setattr(receipts, "_derive_pubkey_x", lambda seed: "OPENSSLX")
+    jwk = receipts._ensure_pubkey(config.keys_dir(), _SEED, _SEED_B64)
+    assert jwk["x"] == "OPENSSLX"
+
+
+def test_keygen_no_cli_falls_back(keys_seed_only, monkeypatch):
+    monkeypatch.setenv("DAIMON_VITNI_CLI", "definitely-not-on-path-xyz")
+    monkeypatch.setattr(receipts, "_derive_pubkey_x", lambda seed: "OPENSSLX")
+    jwk = receipts._ensure_pubkey(config.keys_dir(), _SEED, _SEED_B64)
+    assert jwk["x"] == "OPENSSLX"
+
+
+def test_keygen_derives_and_caches_once(keys_seed_only, fake_cli, monkeypatch):
+    monkeypatch.setenv("FAKE_VITNI_KEYGEN_X", "CACHEDkeygenXCACHEDkeygenXCACHEDkeygenXCACH")
+    _no_openssl(monkeypatch)
+    kdir = config.keys_dir()
+    jwk = receipts._ensure_pubkey(kdir, _SEED, _SEED_B64)
+    assert (kdir / "signing.pub.json").exists()
+    cached = json.loads((kdir / "signing.pub.json").read_text())
+    assert cached["x"] == jwk["x"] == "CACHEDkeygenXCACHEDkeygenXCACHEDkeygenXCACH"
+    # second call reads the cache, no re-derivation (probe count unchanged)
+    before = len([x for x in _capture_lines(fake_cli) if x["cmd"] == "keygen"])
+    receipts._ensure_pubkey(kdir, _SEED, _SEED_B64)
+    after = len([x for x in _capture_lines(fake_cli) if x["cmd"] == "keygen"])
+    assert before == after
+
+
+def test_keygen_logs_which_path(keys_seed_only, fake_cli, monkeypatch, caplog):
+    _no_openssl(monkeypatch)
+    with caplog.at_level("INFO"):
+        receipts._ensure_pubkey(config.keys_dir(), _SEED, _SEED_B64)
+    assert any("via vitni keygen" in r.message for r in caplog.records)
+
+
+def test_plan_mint_uses_keygen_end_to_end(tmp_checkpoint_dir, keys_seed_only,
+                                          fake_cli, monkeypatch):
+    # macOS-without-Ed25519-openssl scenario: keygen alone lets receipts work.
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    monkeypatch.setattr(receipts, "_derive_pubkey_x",
+                        lambda seed: pytest.fail("openssl must not be used when keygen works"))
+    cp = {"session_id": "S-kg", "transcript_hash": _TSCRIPT_HEX,
+          "created": "2026-07-10T00:00:00Z"}
+    path = store.write_checkpoint("S-kg", cp)
+    assert path.with_suffix(".receipt").exists()  # minted via keygen-derived key
+    assert json.loads(path.read_text())["receipts"] is True
+
+
+def test_probe_runs_once_per_process(keys_seed_only, fake_cli, monkeypatch):
+    _no_openssl(monkeypatch)
+    receipts._derive_pubkey(_SEED, _SEED_B64)
+    receipts._derive_pubkey(_SEED, _SEED_B64)
+    probe_calls = [c for c in _capture_lines(fake_cli)
+                   if c["cmd"] == "keygen"
+                   and json.loads(c["stdin"])["seed_b64"] == _PROBE_SEED_B64]
+    assert len(probe_calls) == 1  # cached after first probe
+
+
+def test_probe_cache_is_per_cli_binary(tmp_path, keys_seed_only, monkeypatch):
+    # A verdict belongs to the binary that earned it: after CLI A passes the
+    # probe, repointing DAIMON_VITNI_CLI at binary B must re-probe B — a bad B
+    # must NOT inherit A's pass and be trusted with the real seed.
+    good = tmp_path / "cli-good"
+    good.write_text(_FAKE_CLI_SRC)
+    good.chmod(0o755)
+    bad = tmp_path / "cli-bad"
+    bad.write_text(_FAKE_CLI_SRC)
+    bad.chmod(0o755)
+    capture = tmp_path / "cap.jsonl"
+    monkeypatch.setenv("FAKE_VITNI_CAPTURE", str(capture))
+    _no_openssl(monkeypatch)
+
+    monkeypatch.setenv("DAIMON_VITNI_CLI", str(good))
+    assert receipts._derive_pubkey(_SEED, _SEED_B64) is not None
+
+    monkeypatch.setenv("DAIMON_VITNI_CLI", str(bad))
+    monkeypatch.setenv("FAKE_VITNI_PROBE_X", "WRONGxWRONGxWRONGxWRONGxWRONGxWRONGxWRONGxW")
+    assert receipts._derive_pubkey(_SEED, _SEED_B64) is None  # B re-probed, failed
+
+    probes = [c for c in _capture_lines(capture)
+              if c["cmd"] == "keygen"
+              and json.loads(c["stdin"])["seed_b64"] == _PROBE_SEED_B64]
+    assert len(probes) == 2  # one probe per binary, no inherited verdict

--- a/plugin/tests/test_receipts.py
+++ b/plugin/tests/test_receipts.py
@@ -916,6 +916,26 @@ def test_keygen_real_seed_receives_verbatim_string(keys_seed_only, fake_cli, mon
     assert _SEED_B64 in seeds  # exact stored string, not decode/re-encode
 
 
+def test_read_seed_str_unreadable_returns_none(tmp_path):
+    assert receipts._read_seed_str(tmp_path / "absent.seed") is None
+
+
+def test_keygen_probe_passes_but_real_derive_fails(keys_seed_only, monkeypatch,
+                                                   caplog):
+    # Probe succeeds, then the real-seed call comes back unusable — must log
+    # the "probe passed but real-seed derive failed" line and fall back.
+    def selective(cli, command, stdin_json):
+        if json.loads(stdin_json).get("seed_b64") == _PROBE_SEED_B64:
+            return {"jwk": {"x": _PROBE_X}}
+        return None
+    monkeypatch.setattr(receipts, "_run_cli", selective)
+    monkeypatch.setattr(receipts, "_resolve_cli", lambda: "fake-cli")
+    monkeypatch.setattr(receipts, "_derive_pubkey_x", lambda seed: "OPENSSLX")
+    with caplog.at_level("INFO"):
+        assert receipts._derive_pubkey(_SEED, _SEED_B64) == "OPENSSLX"
+    assert any("real-seed derive" in r.message for r in caplog.records)
+
+
 def test_keygen_probe_wrong_x_falls_back_to_openssl(keys_seed_only, fake_cli,
                                                     monkeypatch, caplog):
     monkeypatch.setenv("FAKE_VITNI_PROBE_X", "WRONGxWRONGxWRONGxWRONGxWRONGxWRONGxWRONGxW")


### PR DESCRIPTION
Closes #206

## What

Public-key derivation for receipts now prefers the vitni CLI's `keygen` (0.5.0+, deterministic derive-only mode) over openssl DER slicing. This turns receipts ON for stock macOS, where Apple's LibreSSL has no Ed25519 in `openssl pkey` and #204's derivation fail-opened.

- **Probe-then-derive**: `keygen` is probed once per (process, resolved CLI path) with the RFC 8032 TEST 1 vector; only an exact `x` match trusts it with the real seed. The verdict is keyed to the binary that earned it — a `DAIMON_VITNI_CLI` repoint re-probes instead of inheriting (review finding, fixed + regression-tested).
- **Error contract**: vitni emits `{"error":"<code>"}` on stdout with exit 0 — nothing here asserts on return codes; the existing CLI runner folds all failure signals uniformly.
- **Verbatim consumption** (vitni's consumer rule): the stored seed string passes to keygen and sign untouched — no base64 decode/re-encode round-trip; the emitted jwk `x` is used exactly as received.
- **Fallback intact**: missing command, error payload, wrong probe x, malformed output → the #204 openssl path, unchanged. Older vitni versions keep working with zero coordination. One log line names which path produced the key.

## Validated end-to-end on stock macOS

Against the real vitni CLI on a LibreSSL box: openssl derivation returns None, keygen derives the correct pubkey, mint writes the sidecar, `verify-receipt` returns `0 — verified: signature valid, bytes match, binding=local`.

## Tests

Suite 1367 → **1379 passed, 1 skipped** (13 new, red-first): probe pass/wrong-x/error-exit-0/missing-command/malformed-jwk/no-CLI matrix, openssl-never-invoked assertion on the happy path, verbatim seed-string capture-assert, per-binary probe cache (repoint re-probes), cache-written-once. Patch coverage verified locally at 100% before push. Independent review: one finding (probe cache not keyed to CLI), fixed.