### PR TITLE
fix(serializer): copy-paste quote discipline + unicode punctuation folding in tier-f verify

### DIFF
--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -27,10 +27,11 @@ log = logging.getLogger(__name__)
 
 # Serialize-prompt version. Bumped D-008 -> D-010 (#101: emotional_valence
 # dropped from the schema; D-009 is taken by the host-adapter decision).
+# D-012 -> D-013 (#208: quote copy-paste discipline rule).
 # Checkpoints are only comparable across runs sharing this version (scar
 # landmine #4); pre-bump checkpoints firing the #93 format_version mismatch
 # warning is desired, not a bug.
-PROMPT_VERSION = "D-012"
+PROMPT_VERSION = "D-013"
 
 
 class SerializeError(Exception):
@@ -65,7 +66,7 @@ RULES — follow every one exactly; this is the point of the exercise:
 1. Extract only what the transcript supports. Do NOT invent open questions, decisions, beliefs, or facts not actually present.
 
 2. For every item, set `trust`:
-   - "verbatim" -> directly supported by an explicit statement. You MUST include the exact `quote` from the transcript.
+   - "verbatim" -> directly supported by an explicit statement. You MUST copy the exact `quote` from the transcript (see rule 17: QUOTE DISCIPLINE).
    - "inferred" -> you are paraphrasing or synthesizing. Leave `quote` empty.
    Prefer "verbatim" wherever an explicit statement exists.
 
@@ -130,6 +131,16 @@ RULES — follow every one exactly; this is the point of the exercise:
     it out. NEVER attach a supersedes link from topic overlap or similarity alone; the
     replacement must be stated explicitly, not guessed. Omit `links` entirely when no such
     replacement applies — do not emit an empty array.
+
+17. QUOTE DISCIPLINE: a verbatim `quote` is a COPY-PASTE of ONE contiguous transcript span.
+    Copy the characters exactly — punctuation, quotation marks, apostrophes, word for word.
+    Never substitute quote characters, never add or drop a word, never reflow a list into
+    prose. To skip content inside a quote you MUST mark the gap with `...` — an unmarked gap
+    fails verification and the item loses verbatim status. Never stitch text from different
+    speakers or turns into one quote, and never add scaffolding such as "User:" or "A:"
+    labels inside a quote. If you cannot copy the exact characters of a contiguous span
+    (or spans joined by `...`), use trust="inferred" with an empty quote instead —
+    a correct inferred beats a downgraded verbatim.
 
 Schema shape:
 {
@@ -378,17 +389,37 @@ _REDACTED_RE = re.compile(r"\[redacted:[^\]]*\]")
 _LIST_MARKER_RE = re.compile(r"^[ \t]*(?:[-*+]\s+|\d+\.\s+)", re.MULTILINE)
 _MD_MARKER_RE = re.compile(r"[*`_~]")
 _WS_RE = re.compile(r"\s+")
+# Unicode punctuation folded to its ASCII look-alike before any stripping:
+# extraction models routinely swap curly/straight quote glyphs and dash widths
+# inside otherwise byte-faithful quotes (#208). U+2026 (…) is deliberately NOT
+# folded — quote_matches splits the RAW quote on it as an elision marker before
+# fragments reach this normalization.
+_PUNCT_FOLD = str.maketrans({
+    "‘": "'", "’": "'",   # curly single quotes / apostrophe
+    "“": '"', "”": '"',   # curly double quotes
+    "–": "-", "—": "-",   # en dash / em dash
+    "\u00a0": " ",             # non-breaking space (escaped: invisible in source)
+})
+# List markers that survive line-anchored stripping because they sit mid-string
+# (a quote reflowing "- item" list lines into one line, #208). After whitespace
+# folding, a marker token is one bounded by spaces (or string start) — bounding
+# keeps hyphenated words ("re-verify") and decimals ("3.14") intact.
+_INLINE_MARKER_RE = re.compile(r"(?:^|(?<= ))(?:[-*+]|\d+\.) ")
 
 
 def _normalize_for_match(text: str) -> str:
-    """Tier-f normalization shared by both sides of a quote match: strip markdown
-    markers (list markers + emphasis chars) BEFORE folding whitespace so
-    `**text**` equals `text`, then collapse whitespace and casefold. Applied
-    identically to quote and haystack, so symmetric stripping never manufactures
-    a match the raw text wouldn't support."""
+    """Tier-f normalization shared by both sides of a quote match: fold unicode
+    punctuation look-alikes to ASCII, strip markdown markers (list markers +
+    emphasis chars) BEFORE folding whitespace so `**text**` equals `text`, then
+    collapse whitespace, strip the space-bounded list markers the fold exposes
+    mid-string, and casefold. Applied identically to quote and haystack, so
+    symmetric folding/stripping never manufactures a match the raw text
+    wouldn't support under the same fold."""
+    text = text.translate(_PUNCT_FOLD)
     text = _LIST_MARKER_RE.sub("", text)
     text = _MD_MARKER_RE.sub("", text)
     text = _WS_RE.sub(" ", text).strip()
+    text = _INLINE_MARKER_RE.sub("", text)
     return text.casefold()
 
 
@@ -600,8 +631,9 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
     _RETRY_NOTE = (
         "\n\nattempt 2: the previous output failed schema validation — "
         'every trust="verbatim" item MUST carry its exact transcript quote in '
-        "its `quote` field (never inlined into `text`). Re-emit the full "
-        "corrected JSON."
+        "its `quote` field (never inlined into `text`). The quote must be "
+        "copy-pasted exactly from the transcript, elisions marked with `...`. "
+        "Re-emit the full corrected JSON."
     )
     partials: list | None = None
 

--- a/plugin/tests/test_quote_verification.py
+++ b/plugin/tests/test_quote_verification.py
@@ -91,6 +91,87 @@ def test_empty_or_nonstring_quote_is_false():
     assert not serializer.quote_matches(None, "some haystack text here")
 
 
+# ---- Unicode punctuation folding + inline list markers (#208) ----
+
+def test_curly_apostrophe_in_transcript_matches_straight_in_quote():
+    # Real downgrade shape: transcript renders a curly apostrophe (U+2019),
+    # the model quotes the ASCII one — otherwise byte-faithful.
+    hay = "assistant: we don’t rotate the pointer before the write lands"
+    assert serializer.quote_matches(
+        "we don't rotate the pointer before the write lands", hay)
+
+
+def test_straight_apostrophe_in_transcript_matches_curly_in_quote():
+    hay = "assistant: we don't rotate the pointer before the write lands"
+    assert serializer.quote_matches(
+        "we don’t rotate the pointer before the write lands", hay)
+
+
+def test_curly_double_quotes_fold_to_straight():
+    hay = "user: call it “the pointer chain” in the docs"
+    assert serializer.quote_matches('call it "the pointer chain" in the docs', hay)
+
+
+def test_en_and_em_dash_fold_to_hyphen():
+    hay = ("assistant: retry windows are 3–5 seconds — "
+           "measured on the gateway")
+    assert serializer.quote_matches(
+        "retry windows are 3-5 seconds - measured on the gateway", hay)
+
+
+def test_nonbreaking_space_folds_to_space():
+    hay = "assistant: bump the limit to 1200 lines for chunking"
+    assert serializer.quote_matches(
+        "bump the limit to 1200 lines for chunking", hay)
+
+
+def test_unicode_ellipsis_still_splits_before_folding():
+    # U+2026 is an elision marker split on the RAW quote — punctuation folding
+    # must not eat it before quote_matches sees it.
+    hay = ("assistant: first we rotate the pointer chain, then much later "
+           "we write the new latest atomically")
+    assert serializer.quote_matches(
+        "first we rotate the pointer chain…write the new latest atomically",
+        hay)
+
+
+def test_inline_list_marker_in_quote_matches_line_anchored_haystack():
+    # Real downgrade shape: the haystack marker sits at a line start (which
+    # line-anchored stripping removes) while the quote reflows the same marker
+    # mid-string — stripping must be symmetric across both placements.
+    hay = ("assistant: PR up: **https://github.com/x/y/pull/11**\n"
+           "- Branch `feat/thing`")
+    assert serializer.quote_matches(
+        "PR up: **https://github.com/x/y/pull/11** - Branch `feat/thing`", hay)
+
+
+def test_inline_numbered_markers_match_numbered_list():
+    hay = "assistant: plan:\n1. rotate the pointer chain\n2. write the new latest"
+    assert serializer.quote_matches(
+        "1. rotate the pointer chain 2. write the new latest", hay)
+
+
+def test_hyphenated_words_survive_marker_stripping():
+    hay = "assistant: we must re-verify the foo-bar pointer chain now"
+    assert serializer.quote_matches(
+        "we must re-verify the foo-bar pointer chain now", hay)
+    # The hyphen is load-bearing: a de-hyphenated haystack must NOT match.
+    assert not serializer.quote_matches(
+        "we must re-verify the foo-bar pointer chain now",
+        "assistant: we must re verify the foo bar pointer chain now")
+
+
+def test_decimals_survive_marker_stripping():
+    hay = "assistant: the sampling constant stays at 3.14 for this run"
+    assert serializer.quote_matches(
+        "the sampling constant stays at 3.14 for this run", hay)
+    # `3. ` is a marker-shaped token only when space-delimited; the intact
+    # decimal in the quote must NOT match a haystack where it is broken up.
+    assert not serializer.quote_matches(
+        "the sampling constant stays at 3.14 for this run",
+        "assistant: the sampling constant stays at 3. 14 for this run")
+
+
 # ---- Unit B: verify_quotes (in-place mutation + logging) ----
 
 def _cp_with(items_by_kind):

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -618,13 +618,42 @@ def test_serialize_prompt_has_d008_fidelity_rules():
     assert "Omission is safer than fabrication" in sys
 
 
-def test_prompt_version_is_d012():
+def test_serialize_prompt_has_quote_discipline():
+    # #208: over half of real verbatim downgrades were light edits to the quote
+    # (substituted quote glyphs, an added/dropped word, lists reflowed to prose)
+    # or mid-quote elisions left unmarked. The copy-paste contract must be
+    # explicit in the prompt.
+    sys = serializer.SERIALIZE_SYS
+    assert "QUOTE DISCIPLINE" in sys
+    assert "COPY-PASTE" in sys
+    assert "contiguous" in sys
+    assert "mark the gap with `...`" in sys
+    assert "never add or drop a word" in sys
+    assert "Never stitch" in sys
+    assert "a correct inferred beats a downgraded verbatim" in sys
+
+
+def test_validation_retry_note_restates_copy_paste_contract(
+    fake_chat_factory, monkeypatch
+):
+    # #208: the schema-validation retry is a second chance at quote fidelity
+    # too — the nudge must restate exact copy-paste and `...`-marked elisions.
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    chat = fake_chat_factory([_invalid_checkpoint_json(), _valid_checkpoint_json("S1")])
+    serializer.serialize_strict("S1", make_messages(6), chat=chat)
+    second = chat.calls[1]["messages"][-1]["content"]
+    assert "copy-pasted exactly" in second
+    assert "elisions marked with `...`" in second
+
+
+def test_prompt_version_is_d013():
     # D-008 -> D-010 (#101: emotional_valence dropped from the schema).
     # D-009 is taken by the host-adapter decision. D-010 -> D-011 (#126:
     # per-item importance added to the emitted schema). D-011 -> D-012 (#5:
-    # transcript-language preservation rule). Pre-bump checkpoints firing the
+    # transcript-language preservation rule). D-012 -> D-013 (#208: verbatim
+    # quote copy-paste discipline rule). Pre-bump checkpoints firing the
     # format_version mismatch warning (#93) is DESIRED behavior.
-    assert serializer.PROMPT_VERSION == "D-012"
+    assert serializer.PROMPT_VERSION == "D-013"
 
 
 def test_prompts_preserve_transcript_language():


### PR DESCRIPTION
Closes #208

## What

- `SERIALIZE_SYS` rule 17 (QUOTE DISCIPLINE): a verbatim quote is a copy-paste of one contiguous span — exact characters, gaps marked with `...`, no stitching across speakers/turns, no `User:`/`A:` scaffolding; when exact copying isn't possible, use `trust="inferred"` instead. `PROMPT_VERSION` bumped D-012 → D-013; parse-retry note restates the contract.
- Tier-f normalization: fold unicode punctuation look-alikes to ASCII (curly quotes/apostrophes, en/em dash, NBSP) before marker stripping, and strip space-bounded list markers that survive line-anchored stripping mid-string. Applied symmetrically to quote and haystack; pure string ops.

## Why

Field data across 8 recent checkpoints: ~17% of fresh verbatim claims (35/201, worst run 48%) were downgraded to inferred at verify time. Classification of all 35: 0% fabricated — 51% light model edits to real quotes, 40% unmarked elisions/stitched composites, 9% verifier normalization gaps (curly-apostrophe mismatch, asymmetric inline list markers). The prompt rule targets the 91%; the folding fixes the 9%.

## Tests

- 11 new tests in `plugin/tests/test_quote_verification.py`: glyph folding both directions, dash folding, inline list markers, plus guards proving hyphenated words (`re-verify`) and decimals (`3.14`) survive marker stripping and that `…` still splits as an elision marker before folding.
- 3 in `plugin/tests/test_serializer.py`: prompt carries the discipline rule, retry note restates it, version pinned at D-013.
- Full suite: 1393 passed, 1 skipped.
- Replay of the 35 real-world downgraded quotes against their original transcripts: old verifier reproduces all 35 failures; new verifier rescues exactly the 3 normalization-gap items with zero unexpected passes (each rescue manually audited as byte-faithful modulo glyph). The remaining 32 are model-edit failures the prompt rule addresses — measurable in `serialize.log` downgrade counts on future serializes.