### PR TITLE
feat(hosts): debounced finalizer flushes windsurf session tails after quiet period

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,7 @@ Serialize-throttle knobs for hosts that lack a clean session-end event. See
 | `DAIMON_CODEX_SERIALIZE_ON_STOP` | on | Whether the Codex `Stop` hook serializes at all. On unless set to `0`, `false`, `no`, or `off` (case-insensitive). |
 | `DAIMON_CODEX_MIN_SERIALIZE_INTERVAL` | `300` | Minimum seconds between Codex serialize spawns. `0` serializes on every `Stop`. |
 | `DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL` | `300` | Minimum seconds between Windsurf serialize spawns (Windsurf has no session-end event, so capture runs on this throttle). `0` serializes every turn. |
+| `DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS` | `600` | Quiet period after the last Windsurf activity before a debounced finalizer serializes the trajectory's final transcript state — covers sessions whose last turns land inside the throttle window. Fractional values accepted; `0` disables the finalizer. |
 
 ## Ops & diagnostics
 

--- a/docs/hosts/windsurf.md
+++ b/docs/hosts/windsurf.md
@@ -44,6 +44,11 @@ events:
   `DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL` (default 300s, `0` = every turn)
   gates the spawn per trajectory, sharing one marker so registering both
   events never double-spawns.
+- **Debounced finalizer:** every serialize-capable event also arms a detached
+  one-shot sleeper; after `DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS` (default
+  600s, `0` disables) with no further activity for the trajectory, the last
+  turn's sleeper serializes the final transcript state — so a session whose
+  last turns landed inside the throttle window still gets captured.
 - **Self-probing:** any payload shape the adapter can't handle is dumped to
   `~/.daimon/windsurf/unparsed-<event>-<stamp>.json` (at most one dump per
   event name), so the next adapter iteration has real evidence to work from
@@ -55,11 +60,16 @@ events:
 - Fail-open everywhere; kill switch `DAIMON_DISABLE=1`.
 
 Windsurf has no session-end event, so serialization runs on the throttle
-above. Two knobs worth setting for your first week:
+above, with a debounced finalizer covering the session tail: a session whose
+last turns land inside the throttle window is serialized once
+`DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS` (default 600) passes with no new
+activity, instead of losing those turns. Set the knob to `0` to disable the
+finalizer. `DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL=0` remains the zero-delay
+stopgap — it serializes every turn (one LLM call per turn), so nothing ever
+waits on the quiet period. A knob worth setting for your first week:
 
 ```sh
-echo 'DAIMON_MIN_MESSAGES=4' >> ~/.daimon/env                      # don't skip short first sessions
-echo 'DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL=0' >> ~/.daimon/env   # no tail loss while you evaluate
+echo 'DAIMON_MIN_MESSAGES=4' >> ~/.daimon/env   # don't skip short first sessions
 ```
 
 ## Teach the agent the protocol

--- a/hook/README.md
+++ b/hook/README.md
@@ -33,7 +33,15 @@ A host adapter is one or two scripts against the same host-boundary events:
 Hosts without a clean session-end event (Codex, Windsurf) serialize
 opportunistically on a throttled turn-scoped event instead
 (`DAIMON_CODEX_MIN_SERIALIZE_INTERVAL`,
-`DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL`).
+`DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL`). The Windsurf adapter additionally
+arms a **debounced finalizer** on every serialize-capable event: a detached
+sleeper (the hook script re-executed in `--finalize` mode) waits
+`DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS` (default 600, `0` disables) and
+serializes the trajectory's final transcript state only if no later turn
+refreshed the per-trajectory activity stamp — last-writer-wins by stamp
+mtime equality, no lockfile, so a session whose last turns land inside the
+throttle window is still captured. Duplicate fires are tolerated by design:
+the serialize child's identical-bytes guard skips them.
 
 Per-host lifecycle managers (`daimon-hooks.py`, `codex-hooks.py`,
 `gemini-hooks.py`) install/uninstall/status their host's script(s) into the

--- a/hook/daimon-windsurf-hooks.py
+++ b/hook/daimon-windsurf-hooks.py
@@ -127,6 +127,24 @@ def _activity_stamp(trajectory_id: str) -> Path:
     return STATE_DIR / f"{_safe_name(trajectory_id)}.last-activity"
 
 
+def _touch_activity(trajectory_id: str) -> None:
+    """Refresh the per-trajectory activity stamp (#42). EVERY trajectory event
+    counts as activity — including a user prompt: while the assistant is still
+    generating, a sleeper armed by the previous response must find a changed
+    stamp at wake, or it would serialize a mid-generation transcript (the
+    accumulation file already holds the new user turn, so the identical-bytes
+    guard would not skip that half-state). Inert when the finalizer is
+    disabled; fail-open on any write error."""
+    if _finalizer_quiet_seconds() <= 0:
+        return
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        _activity_stamp(trajectory_id).write_text(
+            str(int(time.time())), encoding="utf-8")
+    except OSError:
+        pass
+
+
 def _should_spawn(trajectory_id: str) -> bool:
     interval = _interval_seconds()
     if interval <= 0:
@@ -266,6 +284,12 @@ def main() -> int:
         return 0
 
     if event == "pre_user_prompt":
+        # A prompt is trajectory activity: touch the stamp so a sleeper armed
+        # by the PREVIOUS response defuses instead of firing while the
+        # assistant is still generating. Deliberately no arming here — if the
+        # session dies between prompt and response, the lone unanswered
+        # prompt isn't worth a finalizer; the response's post event arms.
+        _touch_activity(trajectory_id)
         text = _extract_prompt(payload)
         if text is None:
             if _dump_probe(event, payload):
@@ -338,16 +362,13 @@ def _arm_finalizer(trajectory_id: str, transcript_path) -> None:
     sleeper per event is fine and bounded by the quiet window; the stamp
     comparison at wake makes all but the last turn's sleeper exit silently.
     Fail-open: an arming failure must never break Cascade."""
-    quiet = _finalizer_quiet_seconds()
-    if quiet <= 0:
+    if _finalizer_quiet_seconds() <= 0:
         return
+    _touch_activity(trajectory_id)
     try:
-        STATE_DIR.mkdir(parents=True, exist_ok=True)
-        stamp = _activity_stamp(trajectory_id)
-        stamp.write_text(str(int(time.time())), encoding="utf-8")
-        armed_mtime_ns = stamp.stat().st_mtime_ns
+        armed_mtime_ns = _activity_stamp(trajectory_id).stat().st_mtime_ns
     except OSError:
-        return
+        return  # touch failed or stamp unreadable — nothing safe to arm on
     # Same detached shape as lib.spawn_serialize: stderr to the crash log so
     # an uncaught sleeper traceback is preserved without polluting
     # serialize.log; start_new_session so it survives the exiting hook.

--- a/hook/daimon-windsurf-hooks.py
+++ b/hook/daimon-windsurf-hooks.py
@@ -48,12 +48,27 @@ gate the spawn per trajectory — the codex-stop pattern. Both events share the
 SAME per-trajectory marker, so registering both never double-spawns.
 Accumulation itself is never throttled.
 
+Debounced finalizer (#42): Windsurf has no session-end event, so a session
+whose last turns land inside the throttle window above would never be
+serialized again — the tail is lost. Every serialize-capable post event
+therefore (a) touches a per-trajectory activity stamp and (b) arms a detached
+one-shot sleeper (this script re-executed with `--finalize`) carrying the
+stamp mtime it just wrote. The sleeper waits
+DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS (default 600, fractional accepted,
+0 disables arming), then re-reads the stamp: changed (or gone) means a later
+turn owns finality and it exits silently; unchanged means this WAS the last
+turn, so it spawns the final serialize. Last-writer-wins by stamp equality —
+deliberately no lockfile (check-then-write claims race); if two sleepers read
+equal stamps and both fire, the second serialize hits the identical-bytes
+guard and skips.
+
 Fail-open everywhere: always exit 0; a broken daimon must never break
 Cascade. Kill switch: DAIMON_DISABLE=1.
 """
 
 import json
 import os
+import subprocess
 import sys
 import time
 from datetime import datetime, timezone
@@ -93,8 +108,23 @@ def _interval_seconds() -> int:
         return 300
 
 
+def _finalizer_quiet_seconds() -> float:
+    """Quiet period before the debounced finalizer fires (#42). Fractional
+    values are accepted (tests exercise sub-second windows); 0 disables the
+    finalizer entirely."""
+    raw = os.environ.get("DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS", "600").strip()
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return 600.0
+
+
 def _safe_name(trajectory_id: str) -> str:
     return trajectory_id.replace("/", "_").replace("\\", "_").replace("..", "_")
+
+
+def _activity_stamp(trajectory_id: str) -> Path:
+    return STATE_DIR / f"{_safe_name(trajectory_id)}.last-activity"
 
 
 def _should_spawn(trajectory_id: str) -> bool:
@@ -258,6 +288,7 @@ def main() -> int:
             return 0
         _spawn_serialize_for(trajectory_id, native_path,
                              f"native transcript: {native_path}")
+        _arm_finalizer(trajectory_id, native_path)
         return 0
 
     if event != "post_cascade_response":
@@ -276,6 +307,7 @@ def main() -> int:
 
     _spawn_serialize_for(trajectory_id, transcript_path,
                          f"transcript: {transcript_path}")
+    _arm_finalizer(trajectory_id, transcript_path)
     return 0
 
 
@@ -300,8 +332,83 @@ def _spawn_serialize_for(trajectory_id: str, transcript_path, detail: str) -> No
         lib.log(f"windsurf-cascade: spawn failed ({type(exc).__name__}: {exc})")
 
 
+def _arm_finalizer(trajectory_id: str, transcript_path) -> None:
+    """Touch the per-trajectory activity stamp and arm one detached finalizer
+    sleeper for it (#42). Called on EVERY serialize-capable post event — one
+    sleeper per event is fine and bounded by the quiet window; the stamp
+    comparison at wake makes all but the last turn's sleeper exit silently.
+    Fail-open: an arming failure must never break Cascade."""
+    quiet = _finalizer_quiet_seconds()
+    if quiet <= 0:
+        return
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        stamp = _activity_stamp(trajectory_id)
+        stamp.write_text(str(int(time.time())), encoding="utf-8")
+        armed_mtime_ns = stamp.stat().st_mtime_ns
+    except OSError:
+        return
+    # Same detached shape as lib.spawn_serialize: stderr to the crash log so
+    # an uncaught sleeper traceback is preserved without polluting
+    # serialize.log; start_new_session so it survives the exiting hook.
+    try:
+        log_dir = Path.home() / ".daimon" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        with (log_dir / "serialize-crash.log").open("a", encoding="utf-8") as crashf:
+            subprocess.Popen(
+                [sys.executable, str(Path(__file__).resolve()), "--finalize",
+                 trajectory_id, str(transcript_path), str(armed_mtime_ns)],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=crashf,
+                start_new_session=True,  # survive the exiting parent
+                env=os.environ.copy(),
+            )
+    except OSError:
+        pass
+
+
+def _finalize(trajectory_id: str, transcript_path: str, armed_mtime_ns: str) -> int:
+    """Finalizer-sleeper mode (#42): sleep the quiet period, then serialize the
+    session tail ONLY if this sleeper's arming turn is still the trajectory's
+    last activity. Ownership is decided by stamp mtime equality, never a
+    lockfile — a lockfile's check-then-write would just move the race, while
+    a duplicate fire is harmless (the serialize child's identical-bytes guard
+    skips it). Transcript contents are never parsed here — only the path,
+    captured at arm time, is passed through."""
+    if lib is None or lib.disabled():
+        return 0
+    try:
+        armed_ns = int(armed_mtime_ns)
+    except ValueError:
+        return 0  # malformed arm argument — nothing safe to own
+    time.sleep(_finalizer_quiet_seconds())
+    try:
+        current_ns = _activity_stamp(trajectory_id).stat().st_mtime_ns
+    except OSError:
+        return 0  # stamp gone — nothing left to finalize
+    if current_ns != armed_ns:
+        return 0  # a later turn refreshed activity; its sleeper owns finality
+    cli = lib.resolve_cli()
+    if cli is None:
+        lib.log("windsurf-finalizer: `daimon` CLI not found — final flush skipped")
+        return 0
+    cwd = _project_cwd()
+    try:
+        lib.spawn_serialize(cli, transcript_path, lib.project_env(cwd))
+        # Logged at FIRE time, not arm time: an arm-time spawn line would sit
+        # unresolved for the whole quiet period and read as hung to the ledger.
+        lib.log(f"windsurf-finalizer: spawned serialize for {trajectory_id} "
+                f"(project: {cwd or '?'}) (transcript: {transcript_path})")
+    except OSError as exc:
+        lib.log(f"windsurf-finalizer: spawn failed ({type(exc).__name__}: {exc})")
+    return 0
+
+
 if __name__ == "__main__":
     try:
+        if len(sys.argv) >= 5 and sys.argv[1] == "--finalize":
+            sys.exit(_finalize(sys.argv[2], sys.argv[3], sys.argv[4]))
         sys.exit(main())
     except Exception as exc:  # fail-open, but leave a trace
         if lib is not None:

--- a/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
+++ b/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
@@ -127,6 +127,24 @@ def _activity_stamp(trajectory_id: str) -> Path:
     return STATE_DIR / f"{_safe_name(trajectory_id)}.last-activity"
 
 
+def _touch_activity(trajectory_id: str) -> None:
+    """Refresh the per-trajectory activity stamp (#42). EVERY trajectory event
+    counts as activity — including a user prompt: while the assistant is still
+    generating, a sleeper armed by the previous response must find a changed
+    stamp at wake, or it would serialize a mid-generation transcript (the
+    accumulation file already holds the new user turn, so the identical-bytes
+    guard would not skip that half-state). Inert when the finalizer is
+    disabled; fail-open on any write error."""
+    if _finalizer_quiet_seconds() <= 0:
+        return
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        _activity_stamp(trajectory_id).write_text(
+            str(int(time.time())), encoding="utf-8")
+    except OSError:
+        pass
+
+
 def _should_spawn(trajectory_id: str) -> bool:
     interval = _interval_seconds()
     if interval <= 0:
@@ -266,6 +284,12 @@ def main() -> int:
         return 0
 
     if event == "pre_user_prompt":
+        # A prompt is trajectory activity: touch the stamp so a sleeper armed
+        # by the PREVIOUS response defuses instead of firing while the
+        # assistant is still generating. Deliberately no arming here — if the
+        # session dies between prompt and response, the lone unanswered
+        # prompt isn't worth a finalizer; the response's post event arms.
+        _touch_activity(trajectory_id)
         text = _extract_prompt(payload)
         if text is None:
             if _dump_probe(event, payload):
@@ -338,16 +362,13 @@ def _arm_finalizer(trajectory_id: str, transcript_path) -> None:
     sleeper per event is fine and bounded by the quiet window; the stamp
     comparison at wake makes all but the last turn's sleeper exit silently.
     Fail-open: an arming failure must never break Cascade."""
-    quiet = _finalizer_quiet_seconds()
-    if quiet <= 0:
+    if _finalizer_quiet_seconds() <= 0:
         return
+    _touch_activity(trajectory_id)
     try:
-        STATE_DIR.mkdir(parents=True, exist_ok=True)
-        stamp = _activity_stamp(trajectory_id)
-        stamp.write_text(str(int(time.time())), encoding="utf-8")
-        armed_mtime_ns = stamp.stat().st_mtime_ns
+        armed_mtime_ns = _activity_stamp(trajectory_id).stat().st_mtime_ns
     except OSError:
-        return
+        return  # touch failed or stamp unreadable — nothing safe to arm on
     # Same detached shape as lib.spawn_serialize: stderr to the crash log so
     # an uncaught sleeper traceback is preserved without polluting
     # serialize.log; start_new_session so it survives the exiting hook.

--- a/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
+++ b/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
@@ -48,12 +48,27 @@ gate the spawn per trajectory — the codex-stop pattern. Both events share the
 SAME per-trajectory marker, so registering both never double-spawns.
 Accumulation itself is never throttled.
 
+Debounced finalizer (#42): Windsurf has no session-end event, so a session
+whose last turns land inside the throttle window above would never be
+serialized again — the tail is lost. Every serialize-capable post event
+therefore (a) touches a per-trajectory activity stamp and (b) arms a detached
+one-shot sleeper (this script re-executed with `--finalize`) carrying the
+stamp mtime it just wrote. The sleeper waits
+DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS (default 600, fractional accepted,
+0 disables arming), then re-reads the stamp: changed (or gone) means a later
+turn owns finality and it exits silently; unchanged means this WAS the last
+turn, so it spawns the final serialize. Last-writer-wins by stamp equality —
+deliberately no lockfile (check-then-write claims race); if two sleepers read
+equal stamps and both fire, the second serialize hits the identical-bytes
+guard and skips.
+
 Fail-open everywhere: always exit 0; a broken daimon must never break
 Cascade. Kill switch: DAIMON_DISABLE=1.
 """
 
 import json
 import os
+import subprocess
 import sys
 import time
 from datetime import datetime, timezone
@@ -93,8 +108,23 @@ def _interval_seconds() -> int:
         return 300
 
 
+def _finalizer_quiet_seconds() -> float:
+    """Quiet period before the debounced finalizer fires (#42). Fractional
+    values are accepted (tests exercise sub-second windows); 0 disables the
+    finalizer entirely."""
+    raw = os.environ.get("DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS", "600").strip()
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return 600.0
+
+
 def _safe_name(trajectory_id: str) -> str:
     return trajectory_id.replace("/", "_").replace("\\", "_").replace("..", "_")
+
+
+def _activity_stamp(trajectory_id: str) -> Path:
+    return STATE_DIR / f"{_safe_name(trajectory_id)}.last-activity"
 
 
 def _should_spawn(trajectory_id: str) -> bool:
@@ -258,6 +288,7 @@ def main() -> int:
             return 0
         _spawn_serialize_for(trajectory_id, native_path,
                              f"native transcript: {native_path}")
+        _arm_finalizer(trajectory_id, native_path)
         return 0
 
     if event != "post_cascade_response":
@@ -276,6 +307,7 @@ def main() -> int:
 
     _spawn_serialize_for(trajectory_id, transcript_path,
                          f"transcript: {transcript_path}")
+    _arm_finalizer(trajectory_id, transcript_path)
     return 0
 
 
@@ -300,8 +332,83 @@ def _spawn_serialize_for(trajectory_id: str, transcript_path, detail: str) -> No
         lib.log(f"windsurf-cascade: spawn failed ({type(exc).__name__}: {exc})")
 
 
+def _arm_finalizer(trajectory_id: str, transcript_path) -> None:
+    """Touch the per-trajectory activity stamp and arm one detached finalizer
+    sleeper for it (#42). Called on EVERY serialize-capable post event — one
+    sleeper per event is fine and bounded by the quiet window; the stamp
+    comparison at wake makes all but the last turn's sleeper exit silently.
+    Fail-open: an arming failure must never break Cascade."""
+    quiet = _finalizer_quiet_seconds()
+    if quiet <= 0:
+        return
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        stamp = _activity_stamp(trajectory_id)
+        stamp.write_text(str(int(time.time())), encoding="utf-8")
+        armed_mtime_ns = stamp.stat().st_mtime_ns
+    except OSError:
+        return
+    # Same detached shape as lib.spawn_serialize: stderr to the crash log so
+    # an uncaught sleeper traceback is preserved without polluting
+    # serialize.log; start_new_session so it survives the exiting hook.
+    try:
+        log_dir = Path.home() / ".daimon" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        with (log_dir / "serialize-crash.log").open("a", encoding="utf-8") as crashf:
+            subprocess.Popen(
+                [sys.executable, str(Path(__file__).resolve()), "--finalize",
+                 trajectory_id, str(transcript_path), str(armed_mtime_ns)],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=crashf,
+                start_new_session=True,  # survive the exiting parent
+                env=os.environ.copy(),
+            )
+    except OSError:
+        pass
+
+
+def _finalize(trajectory_id: str, transcript_path: str, armed_mtime_ns: str) -> int:
+    """Finalizer-sleeper mode (#42): sleep the quiet period, then serialize the
+    session tail ONLY if this sleeper's arming turn is still the trajectory's
+    last activity. Ownership is decided by stamp mtime equality, never a
+    lockfile — a lockfile's check-then-write would just move the race, while
+    a duplicate fire is harmless (the serialize child's identical-bytes guard
+    skips it). Transcript contents are never parsed here — only the path,
+    captured at arm time, is passed through."""
+    if lib is None or lib.disabled():
+        return 0
+    try:
+        armed_ns = int(armed_mtime_ns)
+    except ValueError:
+        return 0  # malformed arm argument — nothing safe to own
+    time.sleep(_finalizer_quiet_seconds())
+    try:
+        current_ns = _activity_stamp(trajectory_id).stat().st_mtime_ns
+    except OSError:
+        return 0  # stamp gone — nothing left to finalize
+    if current_ns != armed_ns:
+        return 0  # a later turn refreshed activity; its sleeper owns finality
+    cli = lib.resolve_cli()
+    if cli is None:
+        lib.log("windsurf-finalizer: `daimon` CLI not found — final flush skipped")
+        return 0
+    cwd = _project_cwd()
+    try:
+        lib.spawn_serialize(cli, transcript_path, lib.project_env(cwd))
+        # Logged at FIRE time, not arm time: an arm-time spawn line would sit
+        # unresolved for the whole quiet period and read as hung to the ledger.
+        lib.log(f"windsurf-finalizer: spawned serialize for {trajectory_id} "
+                f"(project: {cwd or '?'}) (transcript: {transcript_path})")
+    except OSError as exc:
+        lib.log(f"windsurf-finalizer: spawn failed ({type(exc).__name__}: {exc})")
+    return 0
+
+
 if __name__ == "__main__":
     try:
+        if len(sys.argv) >= 5 and sys.argv[1] == "--finalize":
+            sys.exit(_finalize(sys.argv[2], sys.argv[3], sys.argv[4]))
         sys.exit(main())
     except Exception as exc:  # fail-open, but leave a trace
         if lib is not None:

--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -69,7 +69,7 @@ def _append_retry_log(session_id: str, prior: str) -> None:
 # here or its serializes are invisible to status/hung detection/heal.
 _SPAWN_RE = re.compile(
     r"^(\S+) (?:gemini-session-end|session-end|codex-stop|windsurf-cascade|"
-    r"session-start): "
+    r"windsurf-finalizer|session-start): "
     r"(?:spawned|retry) serialize for (\S+)"
 )
 # Child stdout/stderr land in the log RAW (no timestamp): the serialize
@@ -321,7 +321,8 @@ def _heal_plan(text, now, force=False) -> dict:
 # Host prefix on a spawn line, for per-host capture counts. Deliberately the
 # same alternation as _SPAWN_RE (a new host adapter updates both).
 _STATS_HOST_RE = re.compile(
-    r"^\S+ (gemini-session-end|session-end|codex-stop|windsurf-cascade): "
+    r"^\S+ (gemini-session-end|session-end|codex-stop|windsurf-cascade|"
+    r"windsurf-finalizer): "
     r"spawned serialize for "
 )
 

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3635,6 +3635,29 @@ def test_spawn_re_recognizes_windsurf_cascade_prefix():
     assert led["T-1"]["project"] == "/p/A"
 
 
+def test_spawn_re_recognizes_windsurf_finalizer_prefix():
+    # #42: the debounced finalizer spawns serializes of its own. Same hard
+    # rule as any host adapter — its prefix must be in _SPAWN_RE or those
+    # spawns are invisible to status/hung detection/heal.
+    text = ("2026-07-10T23:00:00Z windsurf-finalizer: spawned serialize for T-2 "
+            "(project: /p/A) (transcript: /t/T-2.md)")
+    led = cli._session_ledger(text, now=0.0)
+    assert led["T-2"]["spawned"] is True
+    assert led["T-2"]["transcript"] == "/t/T-2.md"
+    assert led["T-2"]["project"] == "/p/A"
+
+
+def test_stats_host_re_counts_windsurf_finalizer(tmp_log_dir):
+    # #42: _STATS_HOST_RE is deliberately the same alternation as _SPAWN_RE —
+    # the finalizer's fires must show up in per-host capture counts too.
+    from daimon_briefing import ledger
+    _write_log(tmp_log_dir, [
+        "2026-07-10T11:00:00Z windsurf-finalizer: spawned serialize for W2 "
+        "(project: /p/B) (transcript: /t/W2.md)",
+    ])
+    assert ledger._stats_capture()["hosts"]["windsurf-finalizer"] == 1
+
+
 # ---- #49: heal crash on hung targets + preflight-error attribution ----
 
 

--- a/plugin/tests/test_windsurf_hooks.py
+++ b/plugin/tests/test_windsurf_hooks.py
@@ -353,6 +353,132 @@ def test_redaction_unavailable_skips_and_persists_no_raw_text(tmp_path):
             assert _STRIPE not in p.read_text(encoding="utf-8", errors="replace")
 
 
+# ---- #42: debounced finalizer — flush the session tail after a quiet period ----
+#
+# Windsurf has no session-end event; a session whose last turns land inside the
+# serialize throttle window would otherwise never be serialized again. Every
+# post event arms a detached one-shot sleeper; the LAST turn's sleeper (the only
+# one whose activity stamp is still unchanged at wake) fires the final serialize.
+
+
+def _activity_stamp(tmp_path):
+    return tmp_path / ".daimon" / "windsurf" / f"{TRAJ}.last-activity"
+
+
+def _preload_throttle_marker(tmp_path):
+    """Pre-date the per-trajectory throttle marker so the IMMEDIATE spawn path
+    is throttled — any serialize the fake CLI then records came from the
+    finalizer, not from the turn itself."""
+    state = tmp_path / ".daimon" / "windsurf"
+    state.mkdir(parents=True, exist_ok=True)
+    (state / f"{TRAJ}.last-serialize").write_text(str(int(time.time())), encoding="utf-8")
+
+
+def _wait_for_log(tmp_path, needle, timeout=10.0) -> str:
+    """Poll serialize.log for a line — finalizer children are detached."""
+    log = tmp_path / ".daimon" / "logs" / "serialize.log"
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if log.exists():
+            text = log.read_text(encoding="utf-8")
+            if needle in text:
+                return text
+        time.sleep(0.05)
+    raise AssertionError(f"{needle!r} never appeared in {log}")
+
+
+def test_finalizer_fires_after_quiet_period_with_accumulation_path(tmp_path):
+    # The last turn of a session lands inside the throttle window (immediate
+    # spawn skipped); after the quiet period the finalizer must serialize the
+    # ACCUMULATED .md transcript and leave a ledger-shaped spawn line.
+    _preload_throttle_marker(tmp_path)
+    extra = {"DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL": "3600",
+             "DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS": "0.2"}
+    proc, capture = _run(_post_payload("tail turn"), tmp_path, extra_env=extra)
+    assert proc.returncode == 0
+    assert _activity_stamp(tmp_path).exists()  # armed
+    calls = _wait_for_capture(capture)
+    assert "serialize" in calls
+    assert str(_transcript(tmp_path)) in calls
+    log = _wait_for_log(tmp_path, f"windsurf-finalizer: spawned serialize for {TRAJ}")
+    assert "(transcript:" in log
+
+
+def test_finalizer_with_transcript_event_arms_native_path(tmp_path):
+    # A with_transcript tail turn must arm the finalizer with the NATIVE
+    # .jsonl path — the source of truth for that trajectory.
+    _preload_throttle_marker(tmp_path)
+    native = tmp_path / "native-transcript.jsonl"
+    native.write_text('{"type": "user_input", "status": "done", '
+                      '"user_input": {"user_response": "hola"}}\n',
+                      encoding="utf-8")
+    extra = {"DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL": "3600",
+             "DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS": "0.2"}
+    proc, capture = _run(_with_transcript_payload(native), tmp_path, extra_env=extra)
+    assert proc.returncode == 0
+    calls = _wait_for_capture(capture)
+    assert str(native) in calls
+    _wait_for_log(tmp_path, f"windsurf-finalizer: spawned serialize for {TRAJ}")
+
+
+def test_finalizer_stays_quiet_when_a_later_turn_refreshes_activity(tmp_path):
+    # Last-writer-wins: refreshing the activity stamp after arming means a
+    # later turn owns finality — the armed sleeper must wake and exit silently.
+    _preload_throttle_marker(tmp_path)
+    extra = {"DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL": "3600",
+             "DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS": "0.6"}
+    proc, capture = _run(_post_payload("not the tail"), tmp_path, extra_env=extra)
+    assert proc.returncode == 0
+    stamp = _activity_stamp(tmp_path)
+    assert stamp.exists()
+    os.utime(stamp)  # simulate a later turn touching the stamp
+    time.sleep(1.2)  # quiet period elapsed with margin
+    assert not capture.exists() or "serialize" not in capture.read_text()
+    log = tmp_path / ".daimon" / "logs" / "serialize.log"
+    assert "windsurf-finalizer:" not in (
+        log.read_text(encoding="utf-8") if log.exists() else "")
+
+
+def test_finalizer_quiet_zero_disables_arming(tmp_path):
+    extra = {"DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL": "0",
+             "DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS": "0"}
+    proc, capture = _run(_post_payload(), tmp_path, extra_env=extra)
+    assert proc.returncode == 0
+    _wait_for_capture(capture)  # the immediate (unthrottled) spawn still runs
+    assert not _activity_stamp(tmp_path).exists()
+    time.sleep(0.4)
+    assert capture.read_text().count("serialize") == 1
+    log = tmp_path / ".daimon" / "logs" / "serialize.log"
+    assert "windsurf-finalizer:" not in (
+        log.read_text(encoding="utf-8") if log.exists() else "")
+
+
+def test_finalizer_respects_kill_switch(tmp_path):
+    proc, capture = _run(
+        _post_payload(), tmp_path,
+        extra_env={"DAIMON_DISABLE": "1",
+                   "DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS": "0.1"})
+    assert proc.returncode == 0
+    assert not _activity_stamp(tmp_path).exists()
+    time.sleep(0.4)
+    assert not capture.exists() or "serialize" not in capture.read_text()
+
+
+def test_pre_user_prompt_does_not_arm_finalizer(tmp_path):
+    # Only serialize-capable post events arm — a user prompt is the START of
+    # activity, not a candidate session tail.
+    payload = {"agent_action_name": "pre_user_prompt", "trajectory_id": TRAJ,
+               "tool_info": {"prompt": "hola"}}
+    proc, capture = _run(payload, tmp_path,
+                         extra_env={"DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS": "0.1"})
+    assert proc.returncode == 0
+    assert not _activity_stamp(tmp_path).exists()
+    time.sleep(0.4)
+    log = tmp_path / ".daimon" / "logs" / "serialize.log"
+    assert "windsurf-finalizer:" not in (
+        log.read_text(encoding="utf-8") if log.exists() else "")
+
+
 def test_pre_user_prompt_docs_shape_appends_user_turn(tmp_path):
     # Documented shape (docs.devin.ai/desktop/cascade/hooks): text lives in
     # tool_info.user_prompt. Regression guard — passes on the current

--- a/plugin/tests/test_windsurf_hooks.py
+++ b/plugin/tests/test_windsurf_hooks.py
@@ -465,15 +465,51 @@ def test_finalizer_respects_kill_switch(tmp_path):
 
 
 def test_pre_user_prompt_does_not_arm_finalizer(tmp_path):
-    # Only serialize-capable post events arm — a user prompt is the START of
-    # activity, not a candidate session tail.
+    # A user prompt is trajectory ACTIVITY (it must touch the stamp) but not a
+    # candidate session tail (it must NOT arm a sleeper): if the session dies
+    # between prompt and response, the lone unanswered prompt isn't worth a
+    # finalizer — the response's post event arms as usual.
     payload = {"agent_action_name": "pre_user_prompt", "trajectory_id": TRAJ,
                "tool_info": {"prompt": "hola"}}
     proc, capture = _run(payload, tmp_path,
                          extra_env={"DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS": "0.1"})
     assert proc.returncode == 0
+    assert _activity_stamp(tmp_path).exists()  # touched: a prompt is activity
+    time.sleep(0.4)  # quiet elapsed, stamp unchanged — an armed sleeper WOULD fire
+    assert not capture.exists() or "serialize" not in capture.read_text()
+    log = tmp_path / ".daimon" / "logs" / "serialize.log"
+    assert "windsurf-finalizer:" not in (
+        log.read_text(encoding="utf-8") if log.exists() else "")
+
+
+def test_pre_user_prompt_quiet_zero_touches_nothing(tmp_path):
+    # With the finalizer disabled, the prompt-side touch stays inert too — no
+    # stamp file appears.
+    payload = {"agent_action_name": "pre_user_prompt", "trajectory_id": TRAJ,
+               "tool_info": {"prompt": "hola"}}
+    proc, _ = _run(payload, tmp_path,
+                   extra_env={"DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS": "0"})
+    assert proc.returncode == 0
     assert not _activity_stamp(tmp_path).exists()
-    time.sleep(0.4)
+
+
+def test_pre_user_prompt_defuses_previously_armed_sleeper(tmp_path):
+    # A prompt arriving inside the quiet window means the assistant is still
+    # generating a response — the sleeper armed by the PREVIOUS post event
+    # must see the refreshed stamp at wake and exit without serializing a
+    # mid-generation transcript state.
+    _preload_throttle_marker(tmp_path)
+    extra = {"DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL": "3600",
+             "DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS": "0.6"}
+    proc, capture = _run(_post_payload("previous response"), tmp_path, extra_env=extra)
+    assert proc.returncode == 0
+    assert _activity_stamp(tmp_path).exists()  # armed
+    prompt = {"agent_action_name": "pre_user_prompt", "trajectory_id": TRAJ,
+              "tool_info": {"prompt": "follow-up question"}}
+    proc, _ = _run(prompt, tmp_path, extra_env=extra)  # inside the quiet window
+    assert proc.returncode == 0
+    time.sleep(1.2)  # quiet period elapsed with margin
+    assert not capture.exists() or "serialize" not in capture.read_text()
     log = tmp_path / ".daimon" / "logs" / "serialize.log"
     assert "windsurf-finalizer:" not in (
         log.read_text(encoding="utf-8") if log.exists() else "")


### PR DESCRIPTION
Closes #42

## What

- Windsurf hook: every serialize-capable post event now touches a per-trajectory activity stamp and arms a detached one-shot finalizer sleeper (the hook script re-executed with `--finalize`). After `DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS` (default 600, fractional accepted, `0` disables) of no trajectory activity, the last-armed sleeper spawns one final serialize on the same transcript path the throttle path uses; all earlier sleepers see a refreshed stamp at wake and exit silently. `pre_user_prompt` refreshes the stamp (a user prompt is activity) but never arms.
- Ownership is decided by stamp mtime equality — deliberately no lockfile. A duplicate fire is harmless: the serialize child hits the identical-bytes guard and skips without LLM work.
- The spawn line is logged at fire time (arm-time logging would sit unresolved for the whole quiet window and read as hung), with prefix `windsurf-finalizer:` added to `ledger.py` `_SPAWN_RE` and `_STATS_HOST_RE` so fires are visible to `daimon status`, hung-detection, heal, and per-host stats.
- Fail-open throughout: exit 0 on every path, `DAIMON_DISABLE` honored, arming failures swallowed, finalizer never parses transcript contents (paths only). Docs updated (hosts/windsurf.md, configuration.md, hook/README.md, module docstring); packaged hook mirror re-synced.

## Why

Windsurf's Cascade has no session-start and no session-end event. Serialization runs on a per-turn throttle, so a session whose last turns land inside the throttle window and never resume loses its tail permanently — the catch-up sweep that closed this gap for Claude Code (#186) and Codex (#189) cannot run without a session-start event. The quiet-period finalizer is the only hook-reachable flush mechanism, and it directly serves the first team deployment, which runs on Windsurf.

## Tests

- 9 new subprocess-harness tests in `plugin/tests/test_windsurf_hooks.py` (fake `daimon` CLI on PATH, HOME sandbox, sub-second quiet windows — no real sleeps): fires after quiet on accumulation path, fires on native transcript path, defused by later post-event activity, defused by a later user prompt (red run reproduced the mid-generation misfire), quiet=0 disables arming and touching, kill switch, pre_user_prompt touches but never arms.
- 2 ledger tests in `plugin/tests/test_cli.py`: `windsurf-finalizer:` spawn lines parsed by `_SPAWN_RE` (per-session attribution) and counted by `_STATS_HOST_RE`.
- Full suite: 1403 passed, 1 skipped. Ruff + mirror-drift checks clean. Patch coverage 100% on measured lines (hook adapter scripts are subprocess-executed and excluded from coverage by design; behavior covered by the harness tests).