### PR TITLE
fix(carry): stop inheriting quote_verified:false — failed-check stamps are fresh-only signals

### DIFF
--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -270,10 +270,15 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                         # quote_verified travels WITH the quote (#167): the
                         # native's verdict attested its own (now replaced)
                         # quote — keeping it would stamp "verified" on a quote
-                        # this session never checked. Prev's verdict rides
-                        # along; absent (pre-#125 checkpoint) means unknown.
-                        if "quote_verified" in item:
-                            twin["quote_verified"] = item["quote_verified"]
+                        # this session never checked. Only True rides along
+                        # (#209): False is a fresh-only signal (see the carry
+                        # path below), and post-#125 a verbatim item cannot
+                        # legally hold it — but pre-#125 and hand-edited
+                        # checkpoints exist, so anything but True (False,
+                        # malformed) collapses to absent = unknown, same as a
+                        # pre-#125 checkpoint.
+                        if item.get("quote_verified") is True:
+                            twin["quote_verified"] = True
                         else:
                             twin.pop("quote_verified", None)
                     twin["trust"] = "verbatim"
@@ -301,6 +306,16 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                    for c in carried):
                 continue
             kept = copy.deepcopy(item)
+            # quote_verified:false is a FRESH-ONLY signal (#209): it asserts
+            # THIS serialize's verify_quotes failed the item, which a carried
+            # copy never ran — inheriting it makes checkpoint-level metrics
+            # double-count one failure forever. Origin checkpoint keeps the
+            # stamp (and the retained quote/trust, untouched here) for
+            # forensics; the copy reverts to absent = unverified/unknown.
+            # `is False` only — never touch True (a real attestation, #167)
+            # or malformed values (not carry's mess to clean).
+            if kept.get("quote_verified") is False:
+                kept.pop("quote_verified")
             kept.setdefault("carried_from", prev_sid)
             carried.append(kept)
             native_texts.add(text)  # two identical prev items must carry once

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -948,3 +948,64 @@ def test_quantity_conflict_guard_does_not_defeat_reversal_pipeline():
     native["id"] = "r-qty-new"  # what store._stamp_item_ids does pre-bind
     pairs = carry.bind_links(out, prev)
     assert pairs == [("r-qty001", "r-qty-new", _REV_QTY_PREV)]
+
+
+# --- quote_verified:false is a fresh-only signal (#209) ----------------------
+# A False stamp means THIS serialize's verify_quotes failed the item. The
+# origin checkpoint keeps it (forensics); a carried copy never re-ran the
+# check, so inheriting False makes checkpoint-level metrics double-count one
+# failure forever. Carry strips False on both paths; True (a real attestation
+# bound to the pinned quote) still travels.
+
+def test_plain_carry_strips_inherited_quote_verified_false():
+    # Downgraded-at-origin item (trust already inferred, quote retained for
+    # forensics, False stamp). Plain no-twin carry must drop ONLY the stamp.
+    prev = _cp("S-prev", 1, questions=[_item(
+        "quorint gateway retry loop still unresolved after downgrade",
+        quote="retry loop still unresolved", quote_verified=False, days=5)])
+    out = carry.merge(_cp("S-new"), prev, NOW)
+    q = out["working_context"]["open_questions"][0]
+    assert "quote_verified" not in q
+    assert q["quote"] == "retry loop still unresolved"  # forensics untouched
+    assert q["trust"] == "inferred"
+
+
+def test_plain_carry_keeps_true_attestation():
+    # Regression guard: True is a real attestation and must keep traveling.
+    prev = _cp("S-prev", 1, questions=[_item(
+        "quorint gateway retry loop still unresolved verbatim",
+        trust="verbatim", quote="retry loop still unresolved",
+        quote_verified=True, days=5)])
+    out = carry.merge(_cp("S-new"), prev, NOW)
+    q = out["working_context"]["open_questions"][0]
+    assert q["quote_verified"] is True
+    assert q["trust"] == "verbatim"
+
+
+def test_freeze_pops_illegal_prev_quote_verified_false():
+    # Post-#125 a verbatim item cannot legally carry False (the downgrade
+    # strips trust), but pre-#125 and hand-edited checkpoints exist. The twin
+    # freeze must treat anything but True as absent, not copy it.
+    prev = _cp("S-prev", 1, questions=[_item(
+        _VERB_ORIG, trust="verbatim", quote=_VERB_QUOTE,
+        quote_verified=False, days=45)])
+    new = _cp("S-new", 0, questions=[_item(_VERB_TWIN, days=0)])
+    out = carry.merge(new, prev, NOW)
+    q = out["working_context"]["open_questions"][0]
+    assert q["quote"] == _VERB_QUOTE
+    assert "quote_verified" not in q
+
+
+def test_chained_carry_false_stamp_stays_absent():
+    # The stamp is stripped on the FIRST carry; a second merge of the already
+    # -clean copy must not resurrect it (absence is the stable state).
+    cp_a = _cp("S-a", 2, questions=[_item(
+        "quorint gateway retry loop still unresolved after downgrade",
+        quote="retry loop still unresolved", quote_verified=False, days=5)])
+    hop1 = carry.merge(_cp("S-b", 1), cp_a, NOW)
+    assert "quote_verified" not in hop1["working_context"]["open_questions"][0]
+    hop2 = carry.merge(_cp("S-c", 0), hop1, NOW)
+    q = hop2["working_context"]["open_questions"][0]
+    assert "quote_verified" not in q
+    assert q["quote"] == "retry loop still unresolved"
+    assert q["carried_from"] == "S-a"


### PR DESCRIPTION
Closes #209

## What

- `carry.merge()` plain carry path: a prev item's `quote_verified: false` stamp is stripped from the carried copy (`is False` only — `true` attestations and malformed values untouched). The origin checkpoint keeps the stamp, the retained quote, and the downgraded trust for diagnostics; the carried copy reverts to absent = unverified/unknown, the same shape as pre-#125 items.
- Twin verbatim-freeze path: the #167 verdict copy now propagates only `true`; anything else (a legacy or hand-edited verbatim item holding `false`) collapses to absent on the twin. Post-#125 a verbatim item cannot legally hold `false`, but older checkpoints exist.

## Why

`quote_verified: false` means "this serialize's quote verification failed the item." A carried copy never ran that check, yet inheritance propagated the stamp byte-identically forever: in a recent 8-checkpoint window, 7 of 42 stamped-false entries were inherited copies, so checkpoint-level measurements double-count one failure indefinitely, and the stamp's meaning ("failed against WHICH transcript?") degrades with every hop. After this change the invariant is simple: a `false` stamp in a checkpoint refers to that checkpoint's own serialize. Items re-stated in a later session already regain verbatim through the normal twin path (native wording wins for non-verbatim prev items), which this change does not alter.

## Tests

- New in `plugin/tests/test_carry.py` (red-first): plain carry strips inherited `false`; plain carry keeps `true`; freeze pops illegal `false` on a verbatim prev; chained carry keeps the stamp absent across a second merge. Existing `test_freeze_copies_prev_quote_verified_with_quote` still pins the `true`-propagation behavior.
- Full suite: 1407 passed, 1 skipped. Ruff clean.