### PR TITLE
feat(skill): session-start brief pull covers team briefings — closes the windsurf injection gap

### DIFF
--- a/docs/hosts/README.md
+++ b/docs/hosts/README.md
@@ -10,7 +10,7 @@ hook events each host actually exposes.
 | [Claude Code](./claude-code.md) | Plugin (`/plugin install daimon@daimon`) or manual `hook/daimon-hooks.py install` | `SessionEnd` hook spawns `daimon serialize` detached | `SessionStart` hook injects the briefing; `UserPromptSubmit` hook adds proactive recall | live-validated daily |
 | [Codex](./codex.md) | Manual `hook/codex-hooks.py install` (from a clone) | Throttled `Stop` hook (Codex has no session-end event) | `SessionStart` hook injects via `additionalContext` | shipped, awaiting first live run |
 | [Gemini CLI](./gemini.md) | Manual `hook/gemini-hooks.py install` (from a clone) | Blocked upstream (`gemini-cli#14715` — `transcript_path` is an empty stub) | `SessionStart` hook injects via `additionalContext` | blocked upstream (`gemini-cli#14715`) |
-| [Windsurf (Cascade)](./windsurf.md) | `daimon hooks install windsurf` | Throttled serialize on `pre_user_prompt` / `post_cascade_response(_with_transcript)` | None — Cascade has no session-start-equivalent event; read via `daimon brief` in a terminal | shipped, in live validation |
+| [Windsurf (Cascade)](./windsurf.md) | `daimon hooks install windsurf` | Throttled serialize on `pre_user_prompt` / `post_cascade_response(_with_transcript)` | None — Cascade has no session-start-equivalent event; the skill instructs the agent to run `daimon brief --team` in the terminal at session start | shipped, in live validation |
 
 ## Three moving parts
 
@@ -23,7 +23,8 @@ Every host setup combines up to three pieces, installed independently:
   Claude Code without the plugin).
 - **The skill** (`daimon skill install <host>`) teaches the agent on the other
   side of the hook how to use what the hooks capture — read the briefing at
-  session start, treat `verbatim` items as immutable quotes, verify
+  session start (pulling it with `daimon brief --team` when the host injects
+  nothing, e.g. Windsurf), treat `verbatim` items as immutable quotes, verify
   stale-looking claims before repeating them.
 - **The `daimon` CLI** is the single source of truth every hook shells out to
   for serialization, rendering, and storage — install it once

--- a/docs/hosts/windsurf.md
+++ b/docs/hosts/windsurf.md
@@ -55,8 +55,10 @@ events:
   instead of another manual probe round.
 - **No briefing injection:** Cascade's hook set has no session-start-equivalent
   event, so unlike Claude Code/Codex/Gemini the briefing is not injected as
-  context — it's read via the terminal (`daimon brief`). This is a permanent
-  host constraint, not a bug.
+  context. This is a permanent host constraint, not a bug — the skill closes
+  the loop from the agent's side instead: it instructs Cascade to run
+  `daimon brief --team` at session start (see
+  [Teach the agent the protocol](#teach-the-agent-the-protocol)).
 - Fail-open everywhere; kill switch `DAIMON_DISABLE=1`.
 
 Windsurf has no session-end event, so serialization runs on the throttle
@@ -79,6 +81,13 @@ daimon skill install windsurf             # ~/.codeium/windsurf/skills/daimon/SK
 daimon skill install windsurf --project   # .windsurf/rules/daimon.md
 ```
 
+On Windsurf the skill is not just protocol etiquette — it is the briefing
+delivery path. Because Cascade has no session-start event to inject into,
+the skill instructs the agent to run `daimon brief --team` in the terminal
+before other work (teammates' briefings included when the project shares a
+daimon team; identical to `daimon brief` without one), and to proceed
+silently when daimon is not set up.
+
 Re-run install after upgrading `daimon` to refresh the content.
 
 ## Verify
@@ -89,4 +98,5 @@ daimon status
 
 Briefings are read with `daimon brief` in a terminal — not injected — so
 `daimon status` (rather than a session-start prompt) is the way to confirm a
-checkpoint was written after your last session.
+checkpoint was written after your last session. With the skill installed the
+agent runs the pull itself (`daimon brief --team`) at session start.

--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -30,9 +30,11 @@ Everything is local — nothing is transmitted.
 
 ## Session start
 
-If no daimon briefing is in context, run `daimon brief` in the terminal
-before other work. If the command is missing or reports no checkpoint,
-proceed silently — do NOT mention daimon or suggest installing it.
+If no daimon briefing is in context, run `daimon brief --team` in the
+terminal before other work (`--team` folds in teammates' briefings when the
+project shares a daimon team; without one the output is unchanged). If the
+command is missing or reports no checkpoint, proceed silently — do NOT
+mention daimon or suggest installing it.
 
 ## Reading a briefing
 
@@ -81,10 +83,11 @@ _COMPACT_BODY = """\
 ## Daimon memory protocol
 
 Daimon keeps cross-session memory on this machine (all local, never
-transmitted). At session start you MUST run `daimon brief` in the terminal
-before other work, unless a daimon briefing is already in context. If the
-command is missing or reports no checkpoint, proceed silently — do not
-mention daimon.
+transmitted). At session start you MUST run `daimon brief --team` in the
+terminal before other work, unless a daimon briefing is already in context
+(`--team` adds teammates' briefings when a team is configured; harmless
+otherwise). If the command is missing or reports no checkpoint, proceed
+silently — do not mention daimon.
 
 When a briefing is in context:
 - `[✓ verbatim]` items are exact quotes from a past session — repeat exactly,
@@ -103,7 +106,7 @@ When a briefing is in context:
 If memory looks wrong: `daimon status` (stale/missing briefing),
 `daimon heal` (failed capture), `daimon stats` (usage overview).
 
-MUST: at session start run `daimon brief` before other work; stay silent if daimon is not set up.
+MUST: at session start run `daimon brief --team` before other work; stay silent if daimon is not set up.
 """
 
 

--- a/plugin/tests/test_skill_content.py
+++ b/plugin/tests/test_skill_content.py
@@ -41,8 +41,25 @@ def test_compact_repeats_must_win_rule_at_end():
     # session-start rule must occur at least twice (top protocol + MUST line).
     # Count the backtick-delimited command, not the bare substring "daimon
     # brief" — that also matches "daimon briefing" and would pass on a
-    # confounded count.
-    assert body.count("run `daimon brief`") >= 2
+    # confounded count. The command carries --team since #214.
+    assert body.count("run `daimon brief --team`") >= 2
+
+
+def test_session_start_pull_covers_team_variant():
+    # #214: on hosts without briefing injection (Windsurf Cascade has no
+    # session-start event — a permanent host constraint) the skill IS the
+    # briefing delivery path. `daimon brief --team` supersets `daimon brief`:
+    # pure file-ops, and byte-identical output when no team is configured —
+    # so every session-start rule teaches the team-inclusive command
+    # unconditionally instead of a condition an agent cannot evaluate (the
+    # team config lives in the machine-level sidecar, not the project).
+    full = skill_content.render_full()
+    session_start = full.split("## Session start")[1].split("\n## ")[0]
+    assert "`daimon brief --team`" in session_start
+    compact = skill_content.render_compact()
+    # Top protocol block AND the later-wins MUST line both carry the flag.
+    assert compact.count("run `daimon brief --team`") >= 2
+    assert "--team" in compact.strip().splitlines()[-1]
 
 
 def test_compact_has_concrete_example():


### PR DESCRIPTION
Closes #214

## What

- The skill's session-start rule (all three renderings: full body, compact protocol block, compact MUST line) now instructs the agent to run `daimon brief --team` before other work when no briefing is in context. One clause explains the flag; the fail-silent rule (missing command / no checkpoint → say nothing) is preserved verbatim in every spot.
- docs/hosts/windsurf.md: the "no briefing injection" constraint stands, but the skill-side pull is now documented as the loop-closer — the agent pulls what the host cannot push. Support matrix and skill mentions updated in docs/hosts/README.md.

## Why

Windsurf Cascade has no session-start event, so briefing injection is impossible by host constraint — capture works (#212 closed tail loss) but every session started blind unless the user manually ran `daimon brief`. Teaching the pull to the agent via the skill closes the loop with zero new machinery, and matters most for team deployments on Windsurf where squad-tree team briefings (#201) had no delivery path.

One deliberate deviation from the issue sketch: `--team` is taught unconditionally rather than "when a team remote is configured." Confirmed from source that `daimon brief --team` is a strict superset — pure local file-ops, and with no team configured its output is byte-identical to plain `daimon brief` — while the team config lives in the machine-level sidecar where an agent cannot cheaply test for it. Unconditional is simpler and degrades perfectly.

## Tests

- Red-first: `test_session_start_pull_covers_team_variant` (full-body section, compact occurrences, final MUST line); updated `test_compact_repeats_must_win_rule_at_end` literal. Trust-tag literal assertions and the compact-body Windsurf character-budget guard untouched and passing.
- Full suite: 1408 passed, 1 skipped. Ruff clean.