### PR TITLE
fix(teamsync): surface uncommitted pending checkpoints in team status

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1294,8 +1294,16 @@ def _cmd_team_status(args) -> int:
     lines = []
     for row in rows:
         authors = ", ".join(row["authors"]) or "none yet"
+        # #217: uncommitted checkpoints (dual-written to disk, staged+committed
+        # only on the next sync) are invisible to `unpushed` alone — surface
+        # them and nudge a sync, but only when there's something to nudge
+        # about, so the common case's wording stays byte-identical.
+        pending = row.get("pending", 0)
+        pending_part = (f", {pending} pending checkpoint(s) — run "
+                        "`daimon team sync`") if pending > 0 else ""
         lines.append(f"{row['slug']}: {row['freshness']} — "
-                     f"{row['unpushed']} unpushed checkpoint(s), authors: {authors}")
+                     f"{row['unpushed']} unpushed checkpoint(s)"
+                     f"{pending_part}, authors: {authors}")
         # #200: a broken daimon-team.toml fails open (mapping ignored) on the
         # write path — status is the one place the parse error surfaces.
         if row.get("config_warning"):

--- a/plugin/daimon_briefing/teamsync.py
+++ b/plugin/daimon_briefing/teamsync.py
@@ -499,6 +499,29 @@ def _unpushed_count(sidecar, branch) -> int:
         return 0
 
 
+def _pending_count(sidecar) -> int:
+    """Count uncommitted files under the own-author dirs (#217): checkpoints
+    are dual-written straight to disk and only staged+committed later, by
+    `_commit_own`, on the next sync pass. Between write and sync, those files
+    are invisible to `_unpushed_count` (commits-ahead-of-tracking only) — this
+    closes that blind spot so `daimon team status` and the `daimon status`
+    team line stop reporting "fresh" while a checkpoint sits uncommitted.
+    Same own-dir resolution `_commit_own` uses; fails open (0) on git error,
+    matching the rest of this module."""
+    own = store.project_slug(config.author()) or "unknown"
+    own_dirs = _own_pathspecs(sidecar, own)
+    if not own_dirs:
+        return 0
+    # --untracked-files=all: without it, git collapses an untracked directory
+    # holding several new checkpoint files into ONE "?? authors/<own>/" line —
+    # undercounting exactly the case this helper exists to catch.
+    status = _git(sidecar, "status", "--porcelain", "--untracked-files=all",
+                  "--", *own_dirs)
+    if status.returncode != 0:
+        return 0
+    return len([ln for ln in status.stdout.splitlines() if ln.strip()])
+
+
 def team_status() -> list[dict]:
     """Per-remote view for `daimon team status`: freshness (ls-remote when
     online, 'as of last sync' when offline), own unpushed count, authors seen.
@@ -519,6 +542,7 @@ def team_status() -> list[dict]:
             "branch": branch,
             "freshness": freshness,
             "unpushed": _unpushed_count(sidecar, branch),
+            "pending": _pending_count(sidecar),
             "authors": _authors_seen(sidecar),
             # #200: a broken daimon-team.toml fails open on the write path
             # (mapping ignored) — status is where the parse error surfaces.
@@ -538,8 +562,10 @@ def status_line() -> str | None:
     for sidecar in remotes:
         branch = _branch(sidecar)
         unpushed = _unpushed_count(sidecar, branch)
+        pending = _pending_count(sidecar)
         authors = len(_authors_seen(sidecar))
-        parts.append(f"{sidecar.name}: {unpushed} unpushed, "
+        pending_part = f"{pending} pending, " if pending > 0 else ""
+        parts.append(f"{sidecar.name}: {unpushed} unpushed, {pending_part}"
                      f"{authors} author{'s' if authors != 1 else ''} seen")
     return f"team: {len(remotes)} remote{'s' if len(remotes) != 1 else ''} — " \
            + "; ".join(parts)

--- a/plugin/tests/test_teamsync.py
+++ b/plugin/tests/test_teamsync.py
@@ -444,6 +444,98 @@ def test_cli_team_status_freshness_unpushed_authors(bare_remote, monkeypatch, ca
     assert "fresh" in out              # ls-remote hash matches tracking ref
     assert "1 unpushed" in out
     assert "Ada" in out
+    assert "pending" not in out        # nothing uncommitted: wording unchanged
+
+
+# ---- pending checkpoints: uncommitted own-author files (#217) --------------
+#
+# #217: `_unpushed_count` only sees commits ahead of tracking. A checkpoint
+# JSON dual-written into the sidecar sits uncommitted (own-author files are
+# staged+committed later, by `_commit_own`) and was invisible to both `daimon
+# team status` and the `daimon status` team line — "fresh, 0 unpushed" while a
+# file sat on disk unaccounted for. `_pending_count` closes that gap by
+# counting `git status --porcelain` entries under the own-author dirs.
+
+
+def test_pending_count_zero_when_no_own_dir(bare_remote, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    sidecar = teamsync.init(str(bare_remote))
+    assert teamsync._pending_count(sidecar) == 0
+
+
+def test_pending_count_counts_uncommitted_own_files(bare_remote, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    sidecar = teamsync.init(str(bare_remote))
+    _write_team_file(sidecar, "Ada", "S1.json")
+    _write_team_file(sidecar, "Ada", "S2.json")
+    assert teamsync._pending_count(sidecar) == 2
+
+
+def test_pending_count_counts_nested_era_files(bare_remote, monkeypatch):
+    # #200: nested-era files (projects/**/authors/<own>/) count too.
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    sidecar = teamsync.init(str(bare_remote))
+    _write_nested_team_file(sidecar, "core/api", "Ada", "S1.json")
+    assert teamsync._pending_count(sidecar) == 1
+
+
+def test_pending_count_ignores_other_authors_files(bare_remote, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    sidecar = teamsync.init(str(bare_remote))
+    _write_team_file(sidecar, "Bob", "S9.json")
+    assert teamsync._pending_count(sidecar) == 0
+
+
+def test_pending_count_zero_after_commit(bare_remote, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    sidecar = teamsync.init(str(bare_remote))
+    _write_team_file(sidecar, "Ada", "S1.json")
+    teamsync.sync_remote(sidecar)  # _commit_own lands it
+    assert teamsync._pending_count(sidecar) == 0
+
+
+def test_pending_count_fails_open_on_git_error(bare_remote, monkeypatch):
+    # Fail-open (matches the rest of the module's style): a git error must
+    # never surface as a crash or a false alarm.
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    sidecar = teamsync.init(str(bare_remote))
+    _write_team_file(sidecar, "Ada", "S1.json")
+    real_git = teamsync._git
+
+    def failing_status(cwd, *args, **kwargs):
+        if args and args[0] == "status":
+            return subprocess.CompletedProcess(args, 1, stdout="", stderr="status failed")
+        return real_git(cwd, *args, **kwargs)
+
+    monkeypatch.setattr(teamsync, "_git", failing_status)
+    assert teamsync._pending_count(sidecar) == 0
+
+
+def test_team_status_row_includes_pending(bare_remote, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    sidecar = teamsync.init(str(bare_remote))
+    _write_team_file(sidecar, "Ada", "S1.json")
+    rows = teamsync.team_status()
+    assert rows[0]["pending"] == 1
+
+
+def test_status_line_includes_pending_only_when_nonzero(bare_remote, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    sidecar = teamsync.init(str(bare_remote))
+    assert "pending" not in teamsync.status_line()
+    _write_team_file(sidecar, "Ada", "S1.json")
+    assert "1 pending" in teamsync.status_line()
+
+
+def test_cli_team_status_reports_pending_checkpoints(bare_remote, monkeypatch, capsys):
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    sidecar = teamsync.init(str(bare_remote))
+    _write_team_file(sidecar, "Ada", "S1.json")  # uncommitted: pending, not unpushed
+    assert cli.main(["team", "status"]) == 0
+    out = capsys.readouterr().out
+    assert "0 unpushed" in out
+    assert "1 pending checkpoint(s)" in out
+    assert "daimon team sync" in out
 
 
 def test_status_authors_seen_includes_nested(bare_remote, monkeypatch):


### PR DESCRIPTION
Closes #217

## What

`daimon team status` and the `daimon status` team line now report checkpoint files that were written to the sidecar but not yet committed, as a separate "pending" count next to the existing unpushed-commit count:

```
github-com-<org>-<repo>-memories: fresh — 0 unpushed checkpoint(s), 1 pending checkpoint(s) — run `daimon team sync`, authors: Kibukx
team: 1 remote — github-com-<org>-<repo>-memories: 0 unpushed, 1 pending, 1 author seen
```

When nothing is pending, both lines stay byte-identical to their current wording.

- New `_pending_count(sidecar)` in `teamsync.py`: same own-dir resolution `_commit_own` uses, `git status --porcelain --untracked-files=all` scoped to the own-author pathspecs, fail-open (0) on git error. `--untracked-files=all` matters: without it git collapses several new files in an untracked dir into one `?? authors/<own>/` line and undercounts.
- `team_status()` rows gain a `pending` key; CLI render and `status_line()` show it only when > 0.

## Why

`_unpushed_count` counts commits ahead of tracking only. Checkpoints are written straight to disk and only staged+committed by `_commit_own` on the next sync — so between write and sync, status claimed "fresh — 0 unpushed checkpoint(s)" while local content had never left the machine (observed live: status said 0, the immediately following `team sync` committed and pushed 1). A user asking "did my teammates get my checkpoints?" got a false yes, and status was useless for verifying the write path fired.

## Tests

- 9 new tests in `test_teamsync.py` (written first, all failed pre-change): `_pending_count` counts uncommitted files / returns 0 after commit / 0 with no own dir, `team_status()` carries `pending`, render and `status_line()` show pending only when > 0.
- Full suite: 1417 passed, 1 skipped (was 1408 + 1 before; net +9, no regressions).
- Live end-to-end on a real sidecar: dropped an uncommitted file into the own-author dir → status showed "1 pending checkpoint(s) — run `daimon team sync`" and `daimon status` showed "1 pending"; removed it → wording reverted to the exact pre-change string.
