### PR TITLE
feat(briefing): staleness budget for carried items — last_verified stamp + age-aware brief warning

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,6 +61,7 @@ Deterministic cross-session carry-over of unresolved items.
 | `DAIMON_BRIEF_MAX_TOKENS` | `3000` | Token budget for the injected briefing, estimated at `len(text)//4` (no tokenizer dependency). `0` = unbounded. |
 | `DAIMON_MAX_BRIEFING_DECISIONS` | `10` | Cap on decisions shown in the briefing (render-time view only — the checkpoint keeps all of them). `0` = unbounded. |
 | `DAIMON_BRIEF_GLOBAL_FALLBACK` | header-only | Controls the cross-project global-pointer fallback when a project has no checkpoint of its own. Default shows a header only; set to `full` (or `1`) to inject the full foreign body. |
+| `DAIMON_STALE_DAYS` | `7.0` | Age threshold (days) past which a carried item's effective last-verified stamp (its `last_verified`, else the latest resolutions.jsonl event, else `first_seen`) is stale enough for `brief` to warn about it. `0` warns on every carried item. |
 | `DAIMON_PLAIN` | off | When truthy (case-insensitive), forces plain-text output — disables the rich tables/panels in `status`, `brief`, and `--help`. |
 | `NO_COLOR` | unset | Presence-based, per the [NO_COLOR convention](https://no-color.org/): if the variable is set to *any* value (even empty), rich output is disabled. |
 

--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -16,10 +16,11 @@ import logging
 import re
 import time
 
-# store/carry import graph checked (#103): neither store, carry, recall, nor
-# scoring imports briefing — no cycle, so this stays a normal module-level
-# import (contrast carry.py's own local-import notes, which don't apply here).
-from . import carry, config, llm, receipts, schema, scoring, store
+# store/carry import graph checked (#103): neither store, carry, recall,
+# scoring, nor serializer imports briefing — no cycle, so this stays a normal
+# module-level import (contrast carry.py's own local-import notes, which
+# don't apply here).
+from . import carry, config, llm, receipts, schema, scoring, serializer, store
 
 log = logging.getLogger("daimon.briefing")
 
@@ -290,6 +291,71 @@ def withhold(checkpoint, resolutions: dict) -> tuple[dict, list, list]:
         items[:] = kept
 
     return out, withheld, candidates
+
+
+# ---- #215: staleness budget — carried items nobody has world-checked ----
+
+
+def stale_carried(checkpoint, resolutions: dict, now, threshold_days=None) -> list:
+    """Carried items whose EFFECTIVE last-verified age exceeds
+    `threshold_days`, or [] if none. Pure — `now` is injected (mirrors
+    cli._status_health's purity), no I/O; the caller does resolutions'
+    read (store.resolutions(), same shape `withhold` already consumes) and
+    passes it in.
+
+    Why this exists: a carried item survives into a fresh checkpoint by
+    exact-copy (carry.merge), and the fresh checkpoint restating it is
+    NOT corroboration — both sources trace back to the same original
+    extraction. This is the render-time signal that a carried claim has
+    ridden along for a while with nobody actually re-checking it against the
+    world (code, git, issue tracker).
+
+    A candidate must carry `carried_from` (native, this-session items were
+    just re-extracted — not in question). Its EFFECTIVE last-verified is the
+    NEWEST of, when parseable:
+      - `last_verified` (#215/#125: stamped by verify_quotes at serialize
+        time, ONLY there — checkpoints are append-only, so this field is
+        never rewritten by carry or by a resolve/reverify action)
+      - the latest events.jsonl event's `ts` for the item's id, from
+        `resolutions` (store.resolutions()'s {item_ref: latest_event} shape
+        — the read-time fold of `daimon resolve`/`reverify`, which is where a
+        user's real world-check moment lands; carry never touches the
+        checkpoint for it, per #215's design constraint)
+      - `first_seen` (birth stamp, the oldest and least informative fallback)
+
+    Timestamps are parsed via store._created_epoch, which returns None on
+    anything torn/legacy/malformed — fail-open: an unparseable candidate
+    contributes NOTHING to the age (never itself the reason for a false
+    alarm), and an item where EVERY candidate is unparseable is not counted
+    stale at all (house rule: no evidence beats a false no-line guarantee,
+    same as _status_health's no-age-threshold-without-data stance)."""
+    if threshold_days is None:
+        threshold_days = config.stale_days()
+    if not isinstance(checkpoint, dict):
+        return []
+    resolutions = resolutions if isinstance(resolutions, dict) else {}
+    stale = []
+    for item in serializer.iter_items(checkpoint):
+        if not isinstance(item, dict) or not item.get("carried_from"):
+            continue
+        candidates = []
+        lv = store._created_epoch(item.get("last_verified"))
+        if lv is not None:
+            candidates.append(lv)
+        evt = resolutions.get(item.get("id"))
+        if isinstance(evt, dict):
+            evt_ts = store._created_epoch(evt.get("ts"))
+            if evt_ts is not None:
+                candidates.append(evt_ts)
+        fs = store._created_epoch(item.get("first_seen"))
+        if fs is not None:
+            candidates.append(fs)
+        if not candidates:
+            continue  # no parseable stamp at all — fail open, not stale
+        age_days = (now - max(candidates)) / 86400.0
+        if age_days > threshold_days:
+            stale.append(item)
+    return stale
 
 
 # ---- #79: token budget — section-preserving truncation ----

--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -289,6 +289,20 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                     cur = store._created_epoch(twin["first_seen"])
                     if old is not None and (cur is None or old < cur):
                         twin["first_seen"] = item["first_seen"]
+                # last_verified (#215): the OPPOSITE bias from first_seen —
+                # NEWER wins, not older. first_seen is a birth stamp (age must
+                # never reset); last_verified is a world-check stamp. A native
+                # twin's own last_verified, when present, is ALWAYS freshest
+                # by construction — it can only have been stamped by THIS
+                # session's #125 verify_quotes run (carry folds prev into a
+                # checkpoint that already went through verify_quotes), so it
+                # is never overwritten. Only when the twin carries no stamp of
+                # its own does prev's older one propagate (still better than
+                # nothing). Checkpoints are append-only: this is carry's one
+                # READ of last_verified, never a write-back onto prev — prev's
+                # own copy is left untouched.
+                if item.get("last_verified") and not twin.get("last_verified"):
+                    twin["last_verified"] = item["last_verified"]
                 # Identity rides the same rail as first_seen (#102): the prev
                 # item's id lands on the reworded native twin, so a resolution
                 # recorded against the old id still binds after re-extraction.

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -522,6 +522,7 @@ def _cmd_brief(args) -> int:
         render.render_brief_note(["⚠ no checkpoint for this project — showing the global "
                                   "checkpoint (fallback), possibly another project's."])
     withheld = []
+    events = {}
     if checkpoint:
         # Withhold (#103): render-time derivation, fail-open — a briefing
         # must never die over suppression machinery. #14: candidates ride
@@ -534,6 +535,7 @@ def _cmd_brief(args) -> int:
             checkpoint, withheld, _candidates = briefing.withhold(checkpoint, events)
         except Exception:
             withheld = []
+            events = {}
     # NOTE: drift is checked against the resolved project root. If read_latest fell
     # back to the GLOBAL pointer (another project's checkpoint), its anchor file paths
     # are relative to a different root and may report spurious "hard" drift. Acceptable
@@ -547,6 +549,21 @@ def _cmd_brief(args) -> int:
         render.render_brief_note([
             f"{len(withheld)} resolved item(s) withheld — "
             "`daimon status --suppressed` to list"])
+    # Staleness budget (#215): reuses the SAME resolutions fold `withhold`
+    # already did above — no re-read of events.jsonl. Fail-open, same shape
+    # as the withhold try/except; a broken stale_carried must never take the
+    # briefing down with it. House rule: zero stale items -> NO line at all,
+    # never a false alarm.
+    if checkpoint:
+        try:
+            stale_items = briefing.stale_carried(checkpoint, events, time.time())
+        except Exception:
+            stale_items = []
+        if stale_items:
+            render.render_brief_note([
+                f"⚠ {len(stale_items)} carried item(s) unverified for "
+                f">{config.stale_days():g} days — world-check before "
+                "repeating as true"])
     return 0
 
 

--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -138,6 +138,21 @@ def gc_pin_importance() -> int:
         return 9
 
 
+def stale_days() -> float:
+    """Age threshold (days) before a carried item's EFFECTIVE last-verified
+    age (#215: last_verified stamp, else the latest resolutions.jsonl event
+    ts, else first_seen — in that priority) is stale enough for `daimon
+    brief` to warn about it. Agreement between two agent-written sources
+    (the checkpoint restating a carried item) is not corroboration — this is
+    the budget past which that agreement alone stops being enough. Default
+    7.0 days; DAIMON_STALE_DAYS overrides, garbage falls back to the default
+    (fail-open, same try/except-float shape as carry_floor)."""
+    try:
+        return max(0.0, float(_get("DAIMON_STALE_DAYS") or "7.0"))
+    except ValueError:
+        return 7.0
+
+
 def max_briefing_decisions() -> int:
     """Cap on decisions shown in the briefing (render-time view). Default 10; 0 =
     unbounded. The checkpoint keeps ALL decisions — this bounds only the injected

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -17,6 +17,7 @@ import logging
 import re
 import time
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
 
 from . import config, llm, redact, schema
 
@@ -454,14 +455,28 @@ def quote_matches(quote, haystack) -> bool:
 
 def verify_quotes(checkpoint, transcript_text: str) -> int:
     """Verify every verbatim item's quote against the rendered transcript, in
-    place (#125). On a hit the item gets `quote_verified: true`; on a miss it is
-    downgraded to trust="inferred" with `quote_verified: false` and the downgrade
-    is logged (count + redacted item-text prefix — this runs pre-redaction, so
-    the raw text must not reach a log sink; #141). Items already trust="inferred"
-    are left untouched — no stamp. Runs ONCE at serialize, PRE-redaction, so the
-    quote is still the raw text (a quote whose secret redaction will later mask
-    still verifies here against the raw rendered text). Returns the downgrade
-    count."""
+    place (#125). On a hit the item gets `quote_verified: true` AND a
+    `last_verified` ISO-8601 UTC stamp (#215: the staleness-budget's freshest
+    signal — a carried item's world-check age is measured from here). On a
+    miss it is downgraded to trust="inferred" with `quote_verified: false` and
+    the downgrade is logged (count + redacted item-text prefix — this runs
+    pre-redaction, so the raw text must not reach a log sink; #141). Items
+    already trust="inferred" are left untouched — no stamp, either field.
+    Runs ONCE at serialize, PRE-redaction, so the quote is still the raw text
+    (a quote whose secret redaction will later mask still verifies here
+    against the raw rendered text). Returns the downgrade count.
+
+    `last_verified` is checkpoint-append-only by design (#215): it is stamped
+    ONLY here, at serialize time. No other code path may rewrite it — user
+    resolve/reverify actions live in events.jsonl and are folded in at READ
+    time (briefing.stale_carried), never written back onto the item.
+
+    No injected `now` here (unlike briefing.build's now=None idiom): this
+    function's existing two-positional-arg signature is called from exactly
+    one site (serialize_strict, itself not now-aware), and datetime.now(...)
+    inline matches store.append_event's own stamping idiom (store.py) rather
+    than threading a new param through a call chain that has no other use
+    for it."""
     downgraded = 0
     for item in iter_items(checkpoint):
         if item.get("trust") != "verbatim":
@@ -471,6 +486,8 @@ def verify_quotes(checkpoint, transcript_text: str) -> int:
             continue
         if quote_matches(quote, transcript_text):
             item["quote_verified"] = True
+            item["last_verified"] = datetime.now(timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ")
         else:
             item["trust"] = "inferred"
             item["quote_verified"] = False

--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -47,6 +47,12 @@ mention daimon or suggest installing it.
 - A trailing `[carried]` suffix means the item was carried forward from an
   older checkpoint, not written this session — it may be stale; age it
   accordingly and verify before trusting.
+- A briefing may show a line like "N carried item(s) unverified for >N days —
+  world-check before repeating as true": that item has ridden along, restated
+  session after session, without anyone actually re-checking it against the
+  world. Agreement between two of daimon's own sources is not corroboration —
+  when you see that warning (or any `[carried]` item that looks old), check
+  the world (code, git, issue tracker) before repeating the claim as true.
 - Items under "VERIFY BEFORE TRUSTING" describe state that may have changed
   outside this session (merged PRs, rotated keys, moved files). Check the
   world — files, git, issue tracker — before repeating them as true.
@@ -96,6 +102,9 @@ When a briefing is in context:
   on them. `[? untagged]` = treat as inferred (trust was never recorded);
   `[carried]` suffix = carried from an older session, may be stale — verify
   before trusting.
+- A "carried item(s) unverified for >N days" warning means that item has
+  ridden along unchecked across sessions — restating it is not
+  corroboration; world-check it before repeating as true.
 - "VERIFY BEFORE TRUSTING" items may be stale — check files/git/issues
   before repeating them as true.
 - Example: `[✓ verbatim] PR #60 awaiting review  — "review requested

--- a/plugin/skills/daimon-briefing/SKILL.md
+++ b/plugin/skills/daimon-briefing/SKILL.md
@@ -23,6 +23,12 @@ instead of a confident guess.
 Each item is marked `✓ verbatim` (pinned to an exact quote — trust it) or
 `~ inferred` (paraphrased — treat with appropriate caution).
 
+A briefing can also show a staleness warning: `N carried item(s) unverified
+for >N days — world-check before repeating as true`. A carried item that
+keeps getting restated session after session is not corroborated just
+because it agrees with itself — check the world (code, git, issue tracker)
+before treating it as current fact.
+
 ## Automatic behavior
 
 You do not need to invoke anything. The plugin wires the host's native session
@@ -63,7 +69,10 @@ backend, stdlib-only at runtime. The capabilities behind the briefing:
 - **Deterministic carry.** Unresolved open loops that still matter are carried
   forward into the next checkpoint by exact term overlap (no LLM in the carry
   step) and marked `[carried]` so you can see a loop survived from an earlier
-  session rather than being freshly observed.
+  session rather than being freshly observed. When a carried item goes too
+  long without anyone actually re-checking it against the world, the brief
+  surfaces a staleness warning naming how many days it's been riding
+  unverified.
 - **Proactive recall.** A per-prompt pointer to prior work when your current
   prompt overlaps an open loop (see *Automatic behavior*).
 - **Trust classing.** Every item is `✓ verbatim` (pinned to an exact quote) or

--- a/plugin/tests/test_briefing.py
+++ b/plugin/tests/test_briefing.py
@@ -885,6 +885,13 @@ def test_stale_carried_not_stale_when_within_threshold():
     assert stale == []
 
 
+def test_stale_carried_non_dict_checkpoint_returns_empty():
+    # Fail-open guard: a torn/absent checkpoint (None, junk) yields [] —
+    # the staleness budget must never be the thing that breaks a brief.
+    assert briefing.stale_carried(None, {}, _NOW215, threshold_days=7.0) == []
+    assert briefing.stale_carried("junk", {}, _NOW215, threshold_days=7.0) == []
+
+
 def test_stale_carried_fresh_last_verified_overrides_old_first_seen():
     cp = _cp215([{"text": "old but re-verified", "id": "o-verif",
                   "carried_from": "S-prev", "first_seen": _ts215(30),

--- a/plugin/tests/test_briefing.py
+++ b/plugin/tests/test_briefing.py
@@ -836,3 +836,105 @@ def test_reopen_clears_candidate_flag():
     assert candidates == []
     kept = filtered["working_context"]["recent_decisions"]
     assert "_supersede_candidate" not in kept[0]
+
+
+# ---- #215: staleness budget — stale_carried() ----
+#
+# Agreement between agent-written sources (a fresh checkpoint restating a
+# carried item) is not corroboration. stale_carried flags carried items whose
+# EFFECTIVE last-verified age — max of last_verified, the latest resolutions
+# event ts, first_seen (fallback, in that priority) — exceeds threshold_days.
+# Pure: now and threshold_days injected, no I/O (mirrors _status_health).
+
+_NOW215 = 1_900_000_000  # whole seconds — round-trips exactly through the
+                        # ISO-8601 stamp format (no sub-second precision).
+
+
+def _ts215_secs(seconds_before_now):
+    return _time.strftime("%Y-%m-%dT%H:%M:%SZ", _time.gmtime(_NOW215 - seconds_before_now))
+
+
+def _ts215(days_before_now):
+    return _ts215_secs(days_before_now * 86400)
+
+
+def _cp215(open_qs):
+    return {
+        "working_context": {
+            "active_topic": {"text": "t", "trust": "inferred"},
+            "open_questions": open_qs,
+            "recent_decisions": [],
+        },
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": [],
+                               "contradictions_flagged": []},
+    }
+
+
+def test_stale_carried_flags_old_carried_item_by_first_seen():
+    cp = _cp215([{"text": "old carried loop", "id": "o-old1",
+                  "carried_from": "S-prev", "first_seen": _ts215(10)}])
+    stale = briefing.stale_carried(cp, {}, _NOW215, threshold_days=7.0)
+    assert len(stale) == 1
+    assert stale[0]["id"] == "o-old1"
+
+
+def test_stale_carried_not_stale_when_within_threshold():
+    cp = _cp215([{"text": "recent carried loop", "id": "o-recent",
+                  "carried_from": "S-prev", "first_seen": _ts215(2)}])
+    stale = briefing.stale_carried(cp, {}, _NOW215, threshold_days=7.0)
+    assert stale == []
+
+
+def test_stale_carried_fresh_last_verified_overrides_old_first_seen():
+    cp = _cp215([{"text": "old but re-verified", "id": "o-verif",
+                  "carried_from": "S-prev", "first_seen": _ts215(30),
+                  "last_verified": _ts215(1)}])
+    stale = briefing.stale_carried(cp, {}, _NOW215, threshold_days=7.0)
+    assert stale == []
+
+
+def test_stale_carried_recent_resolution_event_overrides_old_first_seen():
+    cp = _cp215([{"text": "old but recently resolved", "id": "o-res",
+                  "carried_from": "S-prev", "first_seen": _ts215(30)}])
+    resolutions = {"o-res": {"ts": _ts215(1), "status": "resolved"}}
+    stale = briefing.stale_carried(cp, resolutions, _NOW215, threshold_days=7.0)
+    assert stale == []
+
+
+def test_stale_carried_ignores_non_carried_items():
+    cp = _cp215([{"text": "native old item", "id": "o-native",
+                  "first_seen": _ts215(30)}])  # no carried_from
+    stale = briefing.stale_carried(cp, {}, _NOW215, threshold_days=7.0)
+    assert stale == []
+
+
+def test_stale_carried_unparseable_stamps_fail_open_not_stale():
+    cp = _cp215([{"text": "torn stamp", "id": "o-torn",
+                  "carried_from": "S-prev", "first_seen": "not-a-date"}])
+    stale = briefing.stale_carried(cp, {}, _NOW215, threshold_days=7.0)
+    assert stale == []
+
+
+def test_stale_carried_threshold_boundary_exact_is_not_stale():
+    # Exactly at the threshold: NOT stale — only STRICTLY over triggers.
+    cp = _cp215([{"text": "exactly at threshold", "id": "o-edge",
+                  "carried_from": "S-prev", "first_seen": _ts215(7.0)}])
+    stale = briefing.stale_carried(cp, {}, _NOW215, threshold_days=7.0)
+    assert stale == []
+
+
+def test_stale_carried_threshold_boundary_just_over_is_stale():
+    cp = _cp215([{"text": "just over threshold", "id": "o-over",
+                  "carried_from": "S-prev",
+                  "first_seen": _ts215_secs(7 * 86400 + 3600)}])
+    stale = briefing.stale_carried(cp, {}, _NOW215, threshold_days=7.0)
+    assert len(stale) == 1
+
+
+def test_stale_carried_default_threshold_reads_config():
+    # No threshold_days passed -> falls back to config.stale_days() (#215
+    # env knob), same "None -> config default" shape as other pure builders.
+    cp = _cp215([{"text": "old carried loop", "id": "o-old2",
+                  "carried_from": "S-prev", "first_seen": _ts215(10)}])
+    stale = briefing.stale_carried(cp, {}, _NOW215)
+    assert len(stale) == 1  # default 7.0 days < 10 days old

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -1009,3 +1009,59 @@ def test_chained_carry_false_stamp_stays_absent():
     assert "quote_verified" not in q
     assert q["quote"] == "retry loop still unresolved"
     assert q["carried_from"] == "S-a"
+
+
+# ---- #215: last_verified survives carry ----
+#
+# Checkpoints are append-only — last_verified is stamped ONLY at serialize
+# time (#125's verify_quotes). Carry must never rewrite or refresh it on its
+# own; the plain path is a straight deepcopy (nothing to prove but that no
+# strip was added), and the twin-freeze path applies a NEWER-wins rule since
+# a re-discussed-and-re-verified quote was just world-checked again.
+
+def test_plain_carry_preserves_last_verified_unchanged():
+    prev = _cp("S-prev", 1, questions=[_item(
+        "quorint gateway retry loop still unresolved", days=5,
+        last_verified=_iso(4))])
+    out = carry.merge(_cp("S-new"), prev, NOW)
+    q = out["working_context"]["open_questions"][0]
+    assert q["last_verified"] == _iso(4)  # byte-identical, never refreshed
+
+
+def test_plain_carry_with_no_last_verified_stays_absent():
+    prev = _cp("S-prev", 1, questions=[_item(
+        "quorint gateway retry loop still unresolved", days=5)])
+    out = carry.merge(_cp("S-new"), prev, NOW)
+    q = out["working_context"]["open_questions"][0]
+    assert "last_verified" not in q
+
+
+def test_twin_freeze_fresh_last_verified_wins_over_prev():
+    # Native twin was JUST re-verified this session (fresh, newer) — prev's
+    # older stamp must NOT overwrite it.
+    prev = _cp("S-prev", 1, questions=[_item(
+        _VERB_ORIG, trust="verbatim", quote=_VERB_QUOTE, days=45,
+        last_verified=_iso(44))])
+    new = _cp("S-new", 0, questions=[_item(
+        _VERB_TWIN, days=0, last_verified=_iso(0))])
+    out = carry.merge(new, prev, NOW)
+    qs = out["working_context"]["open_questions"]
+    assert qs[0]["last_verified"] == _iso(0)  # fresh kept, newer wins
+
+
+def test_twin_freeze_propagates_prev_last_verified_when_twin_has_none():
+    prev = _cp("S-prev", 1, questions=[_item(
+        _VERB_ORIG, trust="verbatim", quote=_VERB_QUOTE, days=45,
+        last_verified=_iso(44))])
+    new = _cp("S-new", 0, questions=[_item(_VERB_TWIN, days=0)])  # no stamp
+    out = carry.merge(new, prev, NOW)
+    qs = out["working_context"]["open_questions"]
+    assert qs[0]["last_verified"] == _iso(44)  # propagated from prev, only source
+
+
+def test_twin_freeze_neither_has_last_verified_stays_absent():
+    prev = _cp("S-prev", 1, questions=[_item(
+        _VERB_ORIG, trust="verbatim", quote=_VERB_QUOTE, days=45)])
+    new = _cp("S-new", 0, questions=[_item(_VERB_TWIN, days=0)])
+    out = carry.merge(new, prev, NOW)
+    assert "last_verified" not in out["working_context"]["open_questions"][0]

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3015,6 +3015,25 @@ def test_brief_no_stale_note_when_nothing_stale(
     assert "world-check" not in out
 
 
+def test_brief_fails_open_when_stale_carried_raises(
+        tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
+    # #215 fail-open: a broken stale_carried must never take the briefing
+    # down with it — the brief still renders and exits clean, just without
+    # the budget line.
+    from daimon_briefing import briefing, store
+    store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(briefing, "stale_carried", _boom)
+    rc = cli.main(["brief", "--project", "/repo/x"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "While you were away" in out
+    assert "world-check" not in out
+
+
 def test_brief_fails_open_when_resolutions_raises(
         tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
     # #103: withhold machinery must never take the briefing down with it —

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2976,6 +2976,45 @@ def test_brief_withholds_resolved_item_and_notes_suppression(
     assert "--suppressed" in out
 
 
+def test_brief_warns_on_stale_carried_item(
+        tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
+    # #215: a carried item whose effective last-verified age exceeds the
+    # staleness budget gets a visible warning line — agreement between two
+    # agent-written sources (the carried item + the fresh checkpoint restating
+    # it) is not corroboration.
+    from daimon_briefing import store
+    import time as _time
+    monkeypatch.setenv("DAIMON_STALE_DAYS", "7")
+    stale_iso = _time.strftime(
+        "%Y-%m-%dT%H:%M:%SZ", _time.gmtime(_time.time() - 10 * 86400))
+    cp = dict(sample_checkpoint)
+    cp["working_context"] = dict(cp["working_context"])
+    cp["working_context"]["open_questions"] = [{
+        "text": "an old carried loop nobody rechecked",
+        "trust": "inferred", "carried_from": "S-prev",
+        "first_seen": stale_iso,
+    }]
+    store.write_checkpoint("S-mine", cp, project_dir="/repo/x")
+    rc = cli.main(["brief", "--project", "/repo/x"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "carried item(s) unverified for >7 days" in out
+    assert "world-check before repeating as true" in out
+
+
+def test_brief_no_stale_note_when_nothing_stale(
+        tmp_checkpoint_dir, sample_checkpoint, capsys):
+    # House rule: no line, no false alarms — a briefing with no stale carried
+    # items must emit NOTHING about staleness.
+    from daimon_briefing import store
+    store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+    rc = cli.main(["brief", "--project", "/repo/x"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "unverified for" not in out
+    assert "world-check" not in out
+
+
 def test_brief_fails_open_when_resolutions_raises(
         tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
     # #103: withhold machinery must never take the briefing down with it —

--- a/plugin/tests/test_config.py
+++ b/plugin/tests/test_config.py
@@ -447,6 +447,17 @@ def test_carry_max_default_clamp_malformed(monkeypatch):
     assert config.carry_max() == 8
     monkeypatch.setenv("DAIMON_CARRY_MAX", "3")
     assert config.carry_max() == 3
+
+
+def test_stale_days_default_override_malformed(monkeypatch):
+    # #215: staleness-budget threshold. Default 7.0; garbage falls back
+    # (fail-open), same try/except-float shape as carry_floor.
+    monkeypatch.delenv("DAIMON_STALE_DAYS", raising=False)
+    assert config.stale_days() == 7.0
+    monkeypatch.setenv("DAIMON_STALE_DAYS", "3.5")
+    assert config.stale_days() == 3.5
+    monkeypatch.setenv("DAIMON_STALE_DAYS", "garbage")
+    assert config.stale_days() == 7.0
     monkeypatch.setenv("DAIMON_CARRY_MAX", "0")
     assert config.carry_max() == 1
     monkeypatch.setenv("DAIMON_CARRY_MAX", "x")

--- a/plugin/tests/test_quote_verification.py
+++ b/plugin/tests/test_quote_verification.py
@@ -240,6 +240,37 @@ def test_verify_quotes_leaves_inferred_items_unstamped():
     assert "quote_verified" not in cp["working_context"]["recent_decisions"][0]
 
 
+# ---- #215: last_verified stamp on a verify hit ----
+
+def test_verify_quotes_stamps_last_verified_iso_on_hit():
+    cp = _cp_with({("working_context", "recent_decisions"): [
+        {"text": "d", "trust": "verbatim", "quote": "adopt the D-007 prompt"}]})
+    serializer.verify_quotes(cp, "assistant: adopt the D-007 prompt today")
+    item = cp["working_context"]["recent_decisions"][0]
+    assert item["quote_verified"] is True
+    # Parseable by the same ISO-8601 UTC stamp store.py's `created`/`ts` use.
+    import datetime as dt
+    parsed = dt.datetime.strptime(item["last_verified"], "%Y-%m-%dT%H:%M:%SZ")
+    assert parsed.tzinfo is None  # naive per strptime; the format IS UTC (Z)
+
+
+def test_verify_quotes_does_not_stamp_last_verified_on_miss():
+    cp = _cp_with({("working_context", "recent_decisions"): [
+        {"text": "a fabricated decision line", "trust": "verbatim",
+         "quote": "this exact sentence is nowhere in the transcript at all"}]})
+    serializer.verify_quotes(cp, "assistant: something entirely unrelated")
+    item = cp["working_context"]["recent_decisions"][0]
+    assert item["quote_verified"] is False
+    assert "last_verified" not in item
+
+
+def test_verify_quotes_does_not_stamp_last_verified_for_inferred_items():
+    cp = _cp_with({("working_context", "recent_decisions"): [
+        {"text": "d", "trust": "inferred", "quote": ""}]})
+    serializer.verify_quotes(cp, "assistant: anything")
+    assert "last_verified" not in cp["working_context"]["recent_decisions"][0]
+
+
 # ---- Unit C: serialize_strict integration ----
 
 def _script(items):

--- a/plugin/tests/test_skill_content.py
+++ b/plugin/tests/test_skill_content.py
@@ -80,3 +80,13 @@ def test_variants_use_real_trust_tag_literals():
 def test_both_variants_state_silence_guard():
     for text in (skill_content.render_full(), skill_content.render_compact()):
         assert "silent" in text.lower()
+
+
+def test_full_body_teaches_staleness_world_check():
+    # #215: the staleness-budget warning ("N carried item(s) unverified for
+    # >N days") is new surface in the brief — the skill must teach agents to
+    # world-check a carried claim before repeating it as true, not just note
+    # it "may be stale" as the pre-#215 [carried] guidance already does.
+    full = skill_content.render_full()
+    reading = full.split("## Reading a briefing")[1].split("\n## ")[0]
+    assert "world-check" in reading.lower()


### PR DESCRIPTION
Closes #215

## What

Carried briefing items now carry a visible staleness budget instead of aging silently:

- `verify_quotes` stamps `last_verified` (ISO-8601 UTC) alongside `quote_verified: true` on every verify hit — the freshest world-check signal an item can have. Stamped ONLY at serialize time: checkpoints stay append-only, no other code path writes it.
- Carry preserves the stamp but never refreshes it (plain carry: rides through deepcopy unchanged, proven by test; twin freeze: newer wins — the native twin's own stamp is kept, prev's propagates only when the twin has none — the opposite bias from `first_seen`'s older-wins, since one is a birth stamp and the other a world-check stamp).
- New pure `briefing.stale_carried(checkpoint, resolutions, now, threshold_days)`: a carried item's EFFECTIVE last-verified is the newest of `last_verified`, the latest `events.jsonl` event ts for its id (the read-time fold of `daimon resolve`/`reverify` — user world-check moments never mutate the checkpoint), or `first_seen` as fallback. Unparseable stamps contribute nothing; an item with no parseable stamp at all is not counted (fail-open, no false alarms).
- `daimon brief` emits one advisory line when the count is non-zero, reusing the resolutions fold `withhold` already did: `⚠ N carried item(s) unverified for >7 days — world-check before repeating as true`. Zero stale → no line at all.
- Threshold: `DAIMON_STALE_DAYS` (default 7, garbage falls back), resolved through `config.py`'s standard env-then-`~/.daimon/env` contract; documented in `docs/configuration.md`.
- Skill: both generated densities (`skill_content.py`) and the marketplace `SKILL.md` gain the matching age-aware sentence in the reading rules — carried items past the budget get world-checked before being repeated as true.

## Why

A carried item survives into each fresh checkpoint by exact copy, and the new checkpoint restating it is not corroboration — both trace to the same original extraction. When the same sessions also write other notes, correlated agent-written sources agree because they share authors, not because the claim is still true (field incident: a wrong scheduling fact got repeated twice in conversation; the human caught it, nothing rendered the drift). The trust machinery distinguishes verbatim/inferred/carried but nothing showed how long a carried item had gone unverified. Visibility-first, human-as-judge — consistent with the confirm/reject supersede UX; no auto-reverification, no hard expiry.

## Tests

- 21 new tests, all red-first (13 failed pre-implementation for the expected missing-attribute/key reasons; 4 no-op-contract carry tests passed immediately and are kept as behavioral locks, e.g. plain carry preserving the stamp byte-identical).
- Coverage: verify hit stamps / miss doesn't; carry preserve + twin newer-wins both directions; `stale_carried` age math incl. event-ts rescue, non-carried exclusion, unparseable-stamp fail-open, threshold boundary; brief renders the ⚠ note with stale items and stays silent at zero; `DAIMON_STALE_DAYS` honored with garbage fallback; skill budget tests still green with the new sentence.
- Full suite: 1438 passed, 1 skipped (baseline 1417 + 21, no regressions).
- Live end-to-end on a real checkpoint: default 7d → no line (nothing currently stale), `DAIMON_STALE_DAYS=1` → `⚠ 17 carried item(s) unverified for >1 days — world-check before repeating as true`, `DAIMON_STALE_DAYS=9999` → no line.
