### PR TITLE
fix(cli): brief --team renders teammates from the header-only fallback path

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -514,6 +514,14 @@ def _cmd_brief(args) -> int:
             "Use --global-fallback or DAIMON_BRIEF_GLOBAL_FALLBACK=full to "
             "view that checkpoint here.",
         ])
+        # #223: the foreign body is suppressed above, but --team still means
+        # --team — a fresh project with no checkpoint of its own is exactly
+        # the new-teammate case where reading the team's briefings matters
+        # most. Same unprotected exposure as the main :546 call site below
+        # (no new armor here); empty team -> render_teammates no-ops, so a
+        # team-less machine's output stays byte-identical to today.
+        if getattr(args, "team", False):
+            render.render_teammates(_team_briefings(project))
         return 0
     # Label the global-pointer fallback (#29): status calls the same situation
     # "global checkpoint (fallback)"; brief must not present another project's

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -251,6 +251,14 @@ def _rich_teammates(teammates) -> None:
                             border_style="white", title_align="left"))
 
 
+def render_teammates(teammates) -> None:
+    """Public entry point for the #223 header-only fallback path: `brief --team`
+    on a project with no checkpoint of its own still needs the Teammates
+    section, without reaching into the underscore-private `_print_teammates`
+    from cli.py. Delegates as-is — same no-op-on-empty contract."""
+    _print_teammates(teammates)
+
+
 def _explain(st: dict) -> str:
     """One-line human explanation of a configure.status() snapshot."""
     rb = st["resolved_backend"]

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2955,6 +2955,63 @@ def test_brief_fallback_full_via_env(
     assert "fallback" in out.lower()
 
 
+def test_brief_fallback_header_only_with_team_shows_teammates(
+        tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
+    # #223: the header-only fallback (#96) used to `return 0` before the
+    # teammate fan-in ever ran — `brief --team` silently dropped the flag on
+    # any machine with a global pointer but no own-project checkpoint, which
+    # is exactly the new-teammate case where reading the team matters most.
+    from daimon_briefing import store
+    store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+
+    def _fake_read_team(project_dir=None):
+        assert project_dir == "/repo/some-other-project"
+        return [("grace", sample_checkpoint)]
+
+    monkeypatch.setattr(store, "read_team", _fake_read_team)
+    rc = cli.main(["brief", "--team", "--project", "/repo/some-other-project"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "no briefing for this project yet" in out.lower()  # orient note kept
+    assert "Teammates" in out
+    assert "grace" in out
+    assert "Wiring the on_session_end hook" in out  # teammate's active topic
+
+
+def test_brief_fallback_header_only_without_team_flag_unchanged(
+        tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
+    # Same setup as above, but no --team: output must stay byte-identical to
+    # the pre-#223 behavior — no teammate content, no regression of #96.
+    from daimon_briefing import store
+    store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+
+    def _fake_read_team(project_dir=None):
+        return [("grace", sample_checkpoint)]
+
+    monkeypatch.setattr(store, "read_team", _fake_read_team)
+    rc = cli.main(["brief", "--project", "/repo/some-other-project"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "no briefing for this project yet" in out.lower()
+    assert "Teammates" not in out
+    assert "grace" not in out
+
+
+def test_brief_fallback_header_only_with_team_empty_is_byte_identical(
+        tmp_checkpoint_dir, sample_checkpoint, capsys):
+    # Empty team -> _print_teammates no-ops -> --team must not change a single
+    # byte of the header-only fallback note for a team-less machine.
+    from daimon_briefing import store
+    store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+
+    rc = cli.main(["brief", "--project", "/repo/some-other-project"])
+    plain = capsys.readouterr().out
+    rc2 = cli.main(["brief", "--team", "--project", "/repo/some-other-project"])
+    teamed = capsys.readouterr().out
+    assert rc == 0 and rc2 == 0
+    assert teamed == plain
+
+
 def test_brief_withholds_resolved_item_and_notes_suppression(
         tmp_checkpoint_dir, sample_checkpoint, capsys):
     # #103: a resolved item must not print in the brief, and the withheld


### PR DESCRIPTION
Closes #223

## What

The #96 header-only fallback branch in `_cmd_brief` now honors `--team`: orient note renders exactly as before, then the Teammates section fans in (`_team_briefings` → new public `render.render_teammates` wrapper over the existing private printer), then return. Without `--team`, the branch is byte-identical to today. Empty team + `--team` is also byte-identical (the printer no-ops on empty — no new lines, no false alarms).

## Why

Field report from a team deployment: a machine whose project has no own checkpoint (new teammate, serializer not yet working) but where a global pointer exists got the orient note and `return 0` — the teammates fan-in sits below the early return and never ran, so `--team` was silently swallowed. Reproduced locally before the fix: no team read even attempted. The suppression exists to stop an accidental foreign-project body dump; it was never meant to suppress explicitly requested team state — and the user it hits hardest is the exact one who needs teammates' briefings most.

## Tests

- Red-first: fallback project + faked `store.read_team` teammate + `--team` → asserted Teammates section; failed pre-fix (orient note only), passes post-fix.
- Guard tests: same setup without `--team` → no teammate content (#96 intact); `--team` with empty team → output diffed byte-identical to the flagless run.
- Sidecar faked via `monkeypatch` on `store.read_team` — `write_checkpoint` always writes the local per-project pointer, which would defeat the no-local-checkpoint precondition.
- Full suite: 1443 passed, 1 skipped (baseline 1440 + 3); all pre-existing #96/team tests green.
