### PR TITLE
fix(llm): log stderr on command-backend empty output and retry it like an empty response

### DIFF
--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -33,6 +33,16 @@ class ChatError(RuntimeError):
     """A chat call failed after retries. Callers catch this to give up gracefully."""
 
 
+class EmptyOutputError(ChatError):
+    """The command backend returned rc=0 with empty (or whitespace-only) stdout.
+
+    A ChatError subclass so existing `except ChatError` callers (llm.chat's
+    litellm->command fallback) are unaffected, but distinguishable so the
+    serializer's parse-retry loop can treat it like an empty HTTP 200 body
+    from a gateway — both are "the backend said nothing", not a transport
+    failure (#225)."""
+
+
 def _chat_litellm(messages, model=None, temperature=None, timeout=None, retries=3, deadline=None):
     """POST /v1/chat/completions. Returns the assistant message content (str).
 
@@ -275,6 +285,27 @@ def _apply_input_spec(argv, prompt_text, input_spec, cwd):
     return argv, prompt_text
 
 
+def _log_backend_stderr(argv0, err, header) -> str:
+    """Write redacted command-backend stderr to backend-stderr.log (truncate-
+    per-run — the log is "the last failure", not an archive, #56) and return a
+    hint embeddable in a ChatError message: the log path on success, "stderr
+    suppressed" on any OSError — logging must never mask the real failure
+    (fail-open on the logging seam, #225)."""
+    hint = "stderr suppressed"
+    try:
+        d = config.log_dir()
+        d.mkdir(parents=True, exist_ok=True)
+        p = d / "backend-stderr.log"
+        # CLI backends can echo prompt fragments (transcript text) into
+        # stderr — scrub before it persists (#141).
+        err_logged, _ = redact.redact_text(err or "")
+        p.write_text(f"{header}\n{err_logged}\n", encoding="utf-8")
+        hint = f"stderr: {p}"
+    except OSError:
+        pass
+    return hint
+
+
 def _chat_command(messages, deadline):
     """Serialize via a headless LLM CLI. Prompt reaches it per the resolved
     input spec — stdin by default, or arg/file:<flag> for CLIs that don't
@@ -308,27 +339,22 @@ def _chat_command(messages, deadline):
             # locally turned every backend failure into guesswork (#56, exit
             # 101 in the field with zero diagnostics). Truncate-per-run: the
             # log is "the last failure", not an archive.
-            hint = "stderr suppressed"
-            try:
-                d = config.log_dir()
-                d.mkdir(parents=True, exist_ok=True)
-                p = d / "backend-stderr.log"
-                # CLI backends can echo prompt fragments (transcript text)
-                # into stderr — scrub before it persists (#141).
-                err_logged, _ = redact.redact_text(err or "")
-                p.write_text(
-                    f"command backend exit {rc} (argv0: {argv[0]})\n{err_logged}\n",
-                    encoding="utf-8")
-                hint = f"stderr: {p}"
-            except OSError:
-                pass
+            hint = _log_backend_stderr(
+                argv[0], err, f"command backend exit {rc} (argv0: {argv[0]})")
             raise ChatError(f"command backend exited {rc} ({hint})")
         try:
             text = _extract_output(out, output_spec)
         except (json.JSONDecodeError, KeyError, TypeError):
             raise ChatError("command backend output unparseable (body suppressed)")
         if not text or not text.strip():
-            raise ChatError("command backend returned empty output")
+            # rc=0 with nothing to show for it (#225, field incident: 4+ full
+            # serialize runs died on this with zero diagnostics — same
+            # blind spot #56 fixed for non-zero exits). Same local stderr
+            # log, a distinguishable header, and a distinguishable exception
+            # type so the serializer can retry it like an empty HTTP 200 body.
+            hint = _log_backend_stderr(
+                argv[0], err, f"command backend empty output (argv0: {argv[0]})")
+            raise EmptyOutputError(f"command backend returned empty output ({hint})")
         log.info("LLM command backend ok argv0=%s", argv[0])
         return text
     finally:

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -513,7 +513,13 @@ def _call_and_parse(chat, system, user_content, deadline, what: str,
     parse_retries re-calls when the response parses to nothing: reasoning
     models behind gateways intermittently return an empty or prose 200, which
     chat()'s transport retries (timeout/5xx/connection) never see. Chat
-    failures are NOT retried here — chat() owns transport retries.
+    failures are NOT retried here — chat() owns transport retries. The one
+    exception is llm.EmptyOutputError (#225): the command backend's rc=0 +
+    empty-stdout case is functionally the same "the backend said nothing" as
+    an empty HTTP 200 body, so it gets the same cache-buster retry treatment
+    instead of failing on attempt 1. Every OTHER ChatError (transport
+    failures) keeps failing immediately here — those are chat()'s own retry
+    domain.
 
     Retries are never byte-identical: gateway response caches replay the same
     garbage for an identical request (H1 attempt 5 — LiteLLM returned the
@@ -528,6 +534,13 @@ def _call_and_parse(chat, system, user_content, deadline, what: str,
                 f"\n\n(retry attempt {attempt} — the previous response was "
                 f"unparseable; output ONLY the JSON object, no prose, no reasoning)"
             )
+
+        def _can_retry(_attempt=attempt):
+            # A dead deadline makes a re-call pointless — fail now, named.
+            return _attempt < attempts and (
+                deadline is None or deadline - time.monotonic() > 0
+            )
+
         try:
             raw = chat(
                 [
@@ -539,14 +552,14 @@ def _call_and_parse(chat, system, user_content, deadline, what: str,
                 # overrides for upstreams that reject non-default values).
                 deadline=deadline,
             )
+        except llm.EmptyOutputError as exc:
+            if _can_retry():
+                log.warning("empty output on %s (attempt %d/%d), "
+                            "retrying with cache-buster", what, attempt, attempts)
+                continue
+            raise LLMCallError(f"LLM call failed on {what}: {type(exc).__name__}: {exc}") from exc
         except Exception as exc:
             raise LLMCallError(f"LLM call failed on {what}: {type(exc).__name__}: {exc}") from exc
-
-        def _can_retry():
-            # A dead deadline makes a re-call pointless — fail now, named.
-            return attempt < attempts and (
-                deadline is None or deadline - time.monotonic() > 0
-            )
 
         try:
             parsed = llm.extract_json(raw)

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -583,3 +583,45 @@ def test_command_backend_stderr_log_truncates_per_run(monkeypatch, tmp_path):
         llm.chat([{"role": "user", "content": "x"}])
     text = (tmp_path / "logs" / "backend-stderr.log").read_text()
     assert "second" in text and "first" not in text
+
+
+# ---- #225: rc=0 + empty stdout gets the same local diagnostics as a non-zero
+# exit, and is raised as a distinguishable EmptyOutputError so the serializer's
+# parse-retry can treat it like an empty HTTP 200 body ----
+
+
+def test_command_backend_empty_output_writes_stderr_log(monkeypatch, tmp_path):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "quiet-cli")
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setattr(llm, "_run_command",
+                        lambda *a, **k: (0, "   \n", "warming up model..."))
+    with pytest.raises(llm.EmptyOutputError) as exc:
+        llm.chat([{"role": "user", "content": "hola"}])
+    assert "backend-stderr.log" in str(exc.value)
+    assert "suppressed" not in str(exc.value)
+    log = tmp_path / "logs" / "backend-stderr.log"
+    assert "warming up model..." in log.read_text()
+    assert "empty output" in log.read_text()
+
+
+def test_command_backend_empty_output_log_write_fails_open(monkeypatch, tmp_path):
+    # A broken log dir (disk full, permissions, ...) must never mask the real
+    # empty-output failure — fail-open on the logging seam.
+    from pathlib import Path
+
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "quiet-cli")
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setattr(llm, "_run_command", lambda *a, **k: (0, "", "some stderr"))
+    monkeypatch.setattr(Path, "mkdir",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")))
+    with pytest.raises(llm.EmptyOutputError) as exc:
+        llm.chat([{"role": "user", "content": "hola"}])
+    assert "stderr suppressed" in str(exc.value)
+
+
+def test_empty_output_error_is_a_chat_error():
+    # Callers that catch the broad ChatError (e.g. llm.chat's own fallback
+    # logic) must keep working unmodified.
+    assert issubclass(llm.EmptyOutputError, llm.ChatError)

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -586,6 +586,82 @@ def test_serialize_parse_retry_skipped_when_deadline_exhausted():
     assert len(calls) == 1  # no second call once the deadline is gone
 
 
+# --- #225: command-backend empty output retries like an empty 200 body ------
+
+
+def test_call_and_parse_retries_empty_output_error_once(fake_chat_factory, caplog):
+    # rc=0 + empty stdout raises llm.EmptyOutputError instead of parsing to
+    # nothing — it must get the SAME cache-buster retry treatment as an
+    # unparseable HTTP response, not an immediate LLMCallError.
+    import logging
+
+    from daimon_briefing import llm
+
+    chat = fake_chat_factory([llm.EmptyOutputError("command backend returned empty "
+                                                     "output (stderr: /tmp/x.log)"),
+                              _valid_checkpoint_json("S1")])
+    with caplog.at_level(logging.WARNING, logger="daimon_briefing.serializer"):
+        ckpt = serializer.serialize_strict("S1", make_messages(20), chat=chat)
+    assert ckpt is not None
+    assert len(chat.calls) == 2
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    msg = warnings[0].getMessage()
+    assert "empty output" in msg
+    assert "retrying with cache-buster" in msg
+    first_user = chat.calls[0]["messages"][1]["content"]
+    retry_user = chat.calls[1]["messages"][1]["content"]
+    assert "retry attempt 2" in retry_user
+    assert retry_user.startswith(first_user)
+
+
+def test_call_and_parse_empty_output_error_every_attempt_raises_llm_call_error(fake_chat_factory):
+    from daimon_briefing import llm
+
+    err = llm.EmptyOutputError("command backend returned empty output (stderr: "
+                               "/tmp/x.log)")
+    chat = fake_chat_factory([err, err])
+    with pytest.raises(serializer.LLMCallError,
+                       match="command backend returned empty output"):
+        serializer.serialize_strict("S1", make_messages(20), chat=chat)
+    assert len(chat.calls) == 2  # 1 + parse_retries(=1), then give up
+
+
+def test_call_and_parse_plain_chat_error_still_fails_immediately(fake_chat_factory):
+    # Regression guard: non-empty-output ChatErrors (transport failures) are
+    # chat()'s own retry domain — _call_and_parse must NOT retry them.
+    from daimon_briefing import llm
+
+    chat = fake_chat_factory(llm.ChatError("command backend exited 1 (stderr: /tmp/x.log)"))
+    with pytest.raises(serializer.LLMCallError):
+        serializer.serialize_strict("S1", make_messages(20), chat=chat)
+    assert len(chat.calls) == 1  # no retry regression
+
+
+def test_call_and_parse_empty_output_error_skipped_when_deadline_exhausted():
+    # Same guard as the parse-retry path: a dead deadline must not burn a
+    # second call even though EmptyOutputError is otherwise retryable.
+    import time
+
+    from daimon_briefing import llm
+
+    calls = []
+
+    def slow_empty_chat(chat_messages, **kwargs):
+        calls.append(chat_messages)
+        time.sleep(0.15)
+        raise llm.EmptyOutputError("command backend returned empty output "
+                                   "(stderr: /tmp/x.log)")
+
+    deadline = time.monotonic() + 0.05  # alive at entry, dead when the call returns
+    with pytest.raises(serializer.LLMCallError,
+                       match="command backend returned empty output"):
+        serializer.serialize_strict(
+            "S1", make_messages(20), chat=slow_empty_chat, deadline=deadline
+        )
+    assert len(calls) == 1  # no second call once the deadline is gone
+
+
 # --- Live progress logging (40-min runs need a heartbeat) --------------------
 
 


### PR DESCRIPTION
Closes #225

## What

- New `EmptyOutputError(ChatError)`: raised when the command backend exits 0 with empty stdout. The branch now writes redacted stderr to `~/.daimon/logs/backend-stderr.log` via a helper shared with the rc≠0 branch (headers self-describe: `empty output (argv0: ...)` vs `exit {rc}`), and the error message carries the path hint — same #56 contract, previously applied to only one of the two failure branches.
- `serializer._call_and_parse` treats `EmptyOutputError` as parse-retry-eligible: same cache-buster attempt marker, same deadline guard, same warning shape as unparseable output. Attempts exhausted → `LLMCallError` wrapping the original message, as today. All other `ChatError`s keep byte-identical immediate-fail behavior (transport retries remain `chat()`'s own domain).

## Why

Field incident (team deployment, Windsurf, command backend = sh wrapper): one chunk deterministically returned rc=0 + empty stdout; 4+ consecutive serialize runs died with zero diagnostics — the wrapper's stderr held the reason and was discarded. Meanwhile the parse-retry loop, built explicitly because gateways "intermittently return an empty or prose 200", never saw it: an empty body from an HTTP backend parses-to-nothing and retries, the command backend's empty raised straight through. Same failure mode, opposite treatment, decided by delivery mechanism.

## Tests

- 7 new, red-first (`EmptyOutputError` absent → AttributeError): stderr log written with redacted content + empty-output header and path hint in the message; OSError on log write → "stderr suppressed" fail-open; isinstance ChatError; retry-then-succeed (marker on attempt 2, warning logged); empty every attempt → LLMCallError with original message preserved; plain ChatError → exactly one chat call (no retry regression); exhausted deadline → no retry.
- Result-line/heal regex audit: `_RESULT_ERR_RE` and heal-plan matching are shape-generic (`error: ...`), nothing pins the old message — verified before changing the wrapped text.
- Full suite: 1450 passed, 1 skipped (baseline 1443 + 7).
- Live e2e: `DAIMON_LLM_BACKEND=command` with `sh -c 'echo err >&2; exit 0'` → `EmptyOutputError: command backend returned empty output (stderr: ~/.daimon/logs/backend-stderr.log)`, log contains the header + redacted stderr.
