### PR TITLE
feat(heal): live progress indicator during re-serialize

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1226,7 +1226,24 @@ def _cmd_heal(args) -> int:
     Every no-op returns 0 (a no-op heal is never an error). `--dry-run` explains
     without serializing. `--force` (#15) ignores a prior retry marker so a
     retry-exhausted session becomes healable again — the default one-retry-ever
-    policy is unchanged when --force is absent."""
+    policy is unchanged when --force is absent.
+
+    #219: a real target means `_run_serialize` runs next — the same ~15s-2min
+    silent LLM roundtrip `configure --test` already covers with the house
+    `render.working()` spinner (#182/#183). Unlike that call site, which wraps
+    only the LLM call and prints its verdict AFTER the `with` exits,
+    `_run_serialize` prints its own byte-identical result line (the
+    `_RESULT_OK_RE`/`_RESULT_ERR_RE` contract, see its docstring) from deep
+    inside its own body — hoisting that print out would touch the layering
+    shared with `_run_serialize`'s other, non-interactive callers (the hook
+    path and the `serialize` command), which must stay untouched. A manual
+    check (rich `Console().status(...)` wrapping a body that calls plain
+    `print()`) confirmed Rich's Live-backed Status intercepts stdout writes
+    cleanly during the spinner: the printed line lands undisturbed between
+    spinner frames and the spinner's own line is cleared before the `with`
+    exits, both on the rich/TTY path and the plain path (which never touches
+    Live at all). So the whole `_run_serialize` call — print included — is
+    wrapped directly; no restructuring of `_run_serialize` needed."""
     dry_run = getattr(args, "dry_run", False)
     force = getattr(args, "force", False)
     try:
@@ -1247,7 +1264,8 @@ def _cmd_heal(args) -> int:
     # sessions healable) — the retry marker still needs a prior (#49).
     prior = (t["line"] or "hung: spawned, no result").split(" (transcript:")[0]
     _append_retry_log(t["sid"], prior)
-    return _run_serialize(transcript_path, t["project"])
+    with render.working(f"healing {t['sid']} — re-serializing transcript"):
+        return _run_serialize(transcript_path, t["project"])
 
 
 # ---- team: sidecar private-repo sync (#113) ----

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -47,7 +47,15 @@ def working(message: str):
     the first thing a new user runs (`configure --test`) is a ~15s silent
     LLM roundtrip, and dead terminal at that moment reads as hung. Plain
     path prints the message once and returns (hook/log-safe, exact-format
-    testable). Body exceptions propagate untouched either way."""
+    testable). Body exceptions propagate untouched either way.
+
+    #219: `daimon heal`'s re-serialize is the second call site, and unlike
+    `configure --test` its body (`_run_serialize`) prints its own result line
+    from inside the `with`, not after. That's safe here — rich's Status is a
+    Live display with stdout redirection enabled, so a plain `print()` during
+    the spinner is captured and rendered cleanly above the live line rather
+    than garbling it (verified with a manual check: `Console(force_terminal=
+    True).status(...)` wrapping a body that calls `print()` mid-spin)."""
     if not supports_rich():
         print(f"{message}...", flush=True)
         yield

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -984,6 +984,79 @@ def test_cli_heal_noop_when_no_log(tmp_checkpoint_dir, tmp_log_dir, fake_chat_fa
     assert chat.calls == []
 
 
+# ---- #219: live progress indicator (render.working) around heal's re-serialize ----
+
+
+def test_cli_heal_shows_working_indicator_before_result(
+    tmp_checkpoint_dir, tmp_log_dir, fake_chat_factory, capsys, monkeypatch
+):
+    # A real target: the plain (non-TTY, as in tests) working() line must
+    # print exactly once, BEFORE _run_serialize's own result line — a house
+    # spinner that fires after the result would be silently useless.
+    stem = "sample_transcript"
+    transcript = FIXTURES / "sample_transcript.md"
+    _write_log(
+        tmp_log_dir,
+        [
+            f"2026-06-10T12:00:00Z session-end: spawned serialize for {stem} (reason: exit, project: /p/A)",
+            f"error: LLM call failed: bad temperature (transcript: {transcript}) after 1s",
+        ],
+    )
+    chat = fake_chat_factory(_valid_json())
+    monkeypatch.setattr(cli, "_chat", chat)
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+
+    rc = cli.main(["heal"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    working_line = f"healing {stem} — re-serializing transcript...\n"
+    assert out.count(working_line) == 1
+    working_at = out.index(working_line)
+    result_at = out.index("wrote checkpoint:")
+    assert working_at < result_at  # spinner line precedes the result line
+
+
+def test_cli_heal_dry_run_has_no_working_indicator(
+    tmp_checkpoint_dir, tmp_log_dir, fake_chat_factory, capsys, monkeypatch
+):
+    # --dry-run never touches _run_serialize — nothing slow happens, so no
+    # spinner/line should appear alongside the "would heal" explanation.
+    stem = "sample_transcript"
+    transcript = FIXTURES / "sample_transcript.md"
+    _write_log(
+        tmp_log_dir,
+        [
+            f"2026-06-10T12:00:00Z session-end: spawned serialize for {stem} (reason: exit, project: /p/A)",
+            f"error: LLM call failed: bad temperature (transcript: {transcript}) after 1s",
+        ],
+    )
+    chat = fake_chat_factory(_valid_json())
+    monkeypatch.setattr(cli, "_chat", chat)
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+
+    rc = cli.main(["heal", "--dry-run"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert f"would heal {stem}" in out
+    assert "re-serializing transcript" not in out
+    assert chat.calls == []
+
+
+def test_cli_heal_no_target_has_no_working_indicator(
+    tmp_checkpoint_dir, tmp_log_dir, fake_chat_factory, capsys, monkeypatch
+):
+    # No serialize.log -> no healable target -> nothing slow happens -> no
+    # working() line, only the plan's "nothing to heal" note.
+    chat = fake_chat_factory(_valid_json())
+    monkeypatch.setattr(cli, "_chat", chat)
+
+    rc = cli.main(["heal"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "re-serializing transcript" not in out
+    assert chat.calls == []
+
+
 # ---- #15: `heal --force` — explicit escape hatch past the one-retry-ever cap ----
 
 


### PR DESCRIPTION
Closes #219

## What

`daimon heal` wraps its `_run_serialize` call in `render.working("healing <sid> — re-serializing transcript")` — the #183 house indicator. Rich+TTY: animated status spinner for the duration; plain/non-TTY: exactly one `healing <sid> — re-serializing transcript...` line before the existing result line. `--dry-run`, no-target, and every non-heal caller of `_run_serialize` (hook serialize, bare `serialize`) are untouched.

## Why

Heal's re-serialize is a full LLM roundtrip — 15s to ~2min on large transcripts — with a dead terminal until the result line, indistinguishable from a hang. Same problem #182 named for `configure --test`; heal was the other slow command and never adopted the shipped fix.

## Design note

`_run_serialize` prints its result line itself (byte-identical to the serialize.log line — the `_RESULT_OK_RE`/`_RESULT_ERR_RE` contract), so the print happens inside the spinner context. Verified safe before choosing this shape: Rich's `Status` (built on `Live` with stdout redirection) intercepts interleaved `print()` calls — captured raw bytes show it clearing the spinner line, emitting the print untouched, resuming frames, and cleaning up on exit. Documented at both call sites; no restructuring of `_run_serialize`'s layering or its non-interactive callers.

## Tests

- Red-first: plain path prints the working line exactly once, ordered before the result line (failed pre-change — line absent).
- `--dry-run` and no-healable-target → no working line (nothing slow happens on those paths).
- Full suite: 1453 passed, 1 skipped (baseline 1450 + 3).
- Live sanity: `heal --dry-run` and no-target heal outputs unchanged.
