### PR TITLE
feat(store): stamp checkpoints with the git branch at capture time

### DIFF
--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -367,6 +367,38 @@ def resolve_project_root(raw: str | None) -> str | None:
     return top or raw
 
 
+def git_branch(project_dir) -> str | None:
+    """Current branch name for a project working dir at capture time (#222), or
+    None on ANY failure/ambiguity — never raises, never returns an empty string:
+    not a project dir (falsy input), not a git repo, git binary missing,
+    timeout, an unborn HEAD (a fresh `git init` with no commits — rev-parse
+    fails "ambiguous argument"), or a DETACHED HEAD (rev-parse --abbrev-ref
+    prints the literal "HEAD" for that case, which is not a branch name).
+
+    Lives here, not in store.py: store stays free of the git/subprocess
+    dependency (the same reasoning `resolve_project_root` above documents).
+    Short timeout — this runs on every checkpoint write, including from hooks
+    on session end, which must never block on a slow/hung git.
+    """
+    if not project_dir:
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    branch = result.stdout.strip()
+    if not branch or branch == "HEAD":
+        return None
+    return branch
+
+
 def min_messages() -> int:
     try:
         return int(_get("DAIMON_MIN_MESSAGES") or "10")

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -481,6 +481,16 @@ def write_checkpoint(session_id: str, checkpoint: dict, project_dir=None) -> Pat
     slug = project_slug(project_dir)
     if slug:
         checkpoint.setdefault("project_slug", slug)
+    # Stamp the git branch at capture time (#222), same idempotent setdefault
+    # shape. Capture-side only — read-side filtering is a follow-up. Resolved
+    # from `project_dir` (the session's OWN project), never os.getcwd(): heal
+    # re-serializes from the FAILED session's project on purpose
+    # (cli._run_serialize routes to it deliberately, not the heal-time cwd).
+    # Absent (never None/empty) when project_dir is None, isn't a git repo, or
+    # HEAD is detached — absent field = unknown, same convention as project_slug.
+    branch = config.git_branch(project_dir)
+    if branch:
+        checkpoint.setdefault("git_branch", branch)
     # Birth stamps (#126) need the previous latest BEFORE this write moves it.
     # read_latest never raises (returns None on absent/torn pointers). When the
     # project is KNOWN, suppress the global fallback (#139): _stamp_first_seen

--- a/plugin/tests/test_config.py
+++ b/plugin/tests/test_config.py
@@ -1,4 +1,5 @@
 import getpass
+import os
 import subprocess
 from pathlib import Path
 
@@ -320,6 +321,83 @@ def test_scar_harvest_opt_in(monkeypatch):
     assert config.scar_harvest_enabled() is False
     monkeypatch.setenv("DAIMON_SCAR_HARVEST", "1")
     assert config.scar_harvest_enabled() is True
+
+
+# ---- git_branch: current branch stamp at capture time (#222) ----
+
+
+def _init_git_repo_with_commit(path: Path, monkeypatch, branch: str = "main") -> None:
+    """A real local repo with ONE commit on `branch` — `rev-parse --abbrev-ref
+    HEAD` needs a born HEAD (an empty `git init` repo is unborn and rev-parse
+    fails, see test below), so callers that need a resolvable branch name go
+    through this instead of the bare `_init_git_repo` helper above."""
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+    monkeypatch.setenv("GIT_TERMINAL_PROMPT", "0")
+    subprocess.run(["git", "init", "-q", "-b", branch, str(path)],
+                   check=True, capture_output=True, timeout=30)
+    (path / "f.txt").write_text("x", encoding="utf-8")
+    subprocess.run(["git", "-C", str(path), "add", "f.txt"],
+                   check=True, capture_output=True, timeout=30)
+    subprocess.run(
+        ["git", "-C", str(path), "-c", "user.name=Test", "-c", "user.email=test@x",
+         "commit", "-q", "-m", "init"],
+        check=True, capture_output=True, timeout=30,
+    )
+
+
+def test_git_branch_returns_branch_name(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo_with_commit(repo, monkeypatch, branch="feat/thing")
+    assert config.git_branch(str(repo)) == "feat/thing"
+
+
+def test_git_branch_none_for_non_git_dir(tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert config.git_branch(str(plain)) is None
+
+
+def test_git_branch_none_for_unborn_head(tmp_path):
+    # `git init` with zero commits: HEAD is a symbolic ref to an unborn branch —
+    # rev-parse --abbrev-ref HEAD fails (ambiguous argument), not a name.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    assert config.git_branch(str(repo)) is None
+
+
+def test_git_branch_none_for_detached_head(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo_with_commit(repo, monkeypatch)
+    subprocess.run(["git", "-C", str(repo), "checkout", "-q", "--detach"],
+                   check=True, capture_output=True, timeout=30)
+    # rev-parse --abbrev-ref HEAD returns the literal string "HEAD" for a
+    # detached checkout — treated as absent, never as a branch named "HEAD".
+    assert config.git_branch(str(repo)) is None
+
+
+def test_git_branch_none_when_git_binary_missing(tmp_path, monkeypatch):
+    def _no_git(*_a, **_k):
+        raise FileNotFoundError("git: command not found")
+
+    monkeypatch.setattr(subprocess, "run", _no_git)
+    assert config.git_branch(str(tmp_path)) is None
+
+
+def test_git_branch_none_on_timeout(tmp_path, monkeypatch):
+    def _timeout(*_a, **_k):
+        raise subprocess.TimeoutExpired(cmd="git", timeout=2)
+
+    monkeypatch.setattr(subprocess, "run", _timeout)
+    assert config.git_branch(str(tmp_path)) is None
+
+
+def test_git_branch_none_and_empty_passthrough():
+    assert config.git_branch(None) is None
+    assert config.git_branch("") is None
 
 
 def test_max_briefing_decisions_default(monkeypatch):

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -187,6 +187,84 @@ def test_write_does_not_overwrite_existing_project_slug(tmp_checkpoint_dir, samp
     assert blob["project_slug"] == "-original-home"
 
 
+# ---- git_branch: capture-time branch stamp (#222, capture side only) ----
+
+
+def _init_git_repo_with_commit(path, monkeypatch, branch: str = "main") -> None:
+    """A real local repo with one commit on `branch` — mirrors the
+    test_config.py helper (rev-parse --abbrev-ref HEAD needs a born HEAD)."""
+    import os
+    import subprocess
+
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+    monkeypatch.setenv("GIT_TERMINAL_PROMPT", "0")
+    subprocess.run(["git", "init", "-q", "-b", branch, str(path)],
+                   check=True, capture_output=True, timeout=30)
+    (path / "f.txt").write_text("x", encoding="utf-8")
+    subprocess.run(["git", "-C", str(path), "add", "f.txt"],
+                   check=True, capture_output=True, timeout=30)
+    subprocess.run(
+        ["git", "-C", str(path), "-c", "user.name=Test", "-c", "user.email=test@x",
+         "commit", "-q", "-m", "init"],
+        check=True, capture_output=True, timeout=30,
+    )
+
+
+def test_write_stamps_git_branch_when_project_dir_is_a_repo(
+        tmp_checkpoint_dir, sample_checkpoint, tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo_with_commit(repo, monkeypatch, branch="feat/222-git-branch-stamp")
+    store.write_checkpoint("S1", sample_checkpoint, project_dir=str(repo))
+    blob = json.loads((tmp_checkpoint_dir / "S1.json").read_text(encoding="utf-8"))
+    assert blob["git_branch"] == "feat/222-git-branch-stamp"
+
+
+def test_write_no_git_branch_stamp_for_non_repo_project_dir(
+        tmp_checkpoint_dir, sample_checkpoint, tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    store.write_checkpoint("S1", sample_checkpoint, project_dir=str(plain))
+    blob = json.loads((tmp_checkpoint_dir / "S1.json").read_text(encoding="utf-8"))
+    assert "git_branch" not in blob
+
+
+def test_write_no_git_branch_stamp_when_project_dir_is_none(
+        tmp_checkpoint_dir, sample_checkpoint):
+    store.write_checkpoint("S1", sample_checkpoint)
+    blob = json.loads((tmp_checkpoint_dir / "S1.json").read_text(encoding="utf-8"))
+    assert "git_branch" not in blob
+
+
+def test_write_does_not_overwrite_existing_git_branch(
+        tmp_checkpoint_dir, sample_checkpoint, tmp_path, monkeypatch):
+    # setdefault semantics: a heal re-serialize of a session that already
+    # carries a git_branch stamp (e.g. hand-edited, or re-written from a repo
+    # that has since switched branches) must keep the ORIGINAL value.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo_with_commit(repo, monkeypatch, branch="main")
+    pre = {**sample_checkpoint, "git_branch": "feat/original"}
+    store.write_checkpoint("S1", pre, project_dir=str(repo))
+    blob = json.loads((tmp_checkpoint_dir / "S1.json").read_text(encoding="utf-8"))
+    assert blob["git_branch"] == "feat/original"
+
+
+def test_git_branch_survives_redaction(tmp_checkpoint_dir, tmp_path, monkeypatch):
+    # The stamp must survive the write pipeline end to end, including the
+    # in-place _redact_checkpoint pass that runs before it.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo_with_commit(repo, monkeypatch, branch="feat/222-git-branch-stamp")
+    cp = {"working_context": {"open_questions": [
+        {"text": "creds AKIAIOSFODNN7EXAMPLE leaked?"}]}}
+    store.write_checkpoint("S1", cp, project_dir=str(repo))
+    on_disk = json.loads((tmp_checkpoint_dir / "S1.json").read_text(encoding="utf-8"))
+    assert on_disk["git_branch"] == "feat/222-git-branch-stamp"
+    assert "redactions" in on_disk  # sanity: redaction actually ran
+
+
 def test_write_project_latest_is_atomic(tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
     import os
 


### PR DESCRIPTION
Closes #222

## What

- New `config.git_branch(project_dir)`: `git rev-parse --abbrev-ref HEAD` in the project dir, 2s timeout, mirroring `resolve_project_root`'s subprocess shape. Returns None for: non-repo, missing git, timeout, unborn HEAD, and detached HEAD (literal `HEAD` output is not a branch). Lives in config.py — store.py stays git/subprocess-free by design.
- `store.write_checkpoint` stamps `checkpoint.setdefault("git_branch", ...)` next to the `project_slug` stamp, resolved from `project_dir` (never cwd — heal re-serializes route to the FAILED session's project). Helper returns None → field stays absent (house convention: absent = unknown, never null). `project_dir=None` (global-only write) → no stamp.
- Write-pipeline audit: nothing rebuilds the top-level checkpoint dict (`_redact_checkpoint` mutates in place, `carry.merge` deepcopies, `_dual_write_team` shallow-copies all keys) — the stamp survives to disk and to the team sidecar with zero additional changes. Read-side filters (`brief --team --branch`) are follow-up work per the issue.

## Why

Team memory's most concrete cross-teammate ask — "brief me on what my teammate was doing on this feature branch" — needs branch scoping, and a stamp not captured at write time is unrecoverable. Capture side ships first for exactly that reason; branch topology in the sidecar stays explicitly out of scope (single-branch, conflict-free-by-construction invariant).

## Tests

- 12 new, red-first (9 failed for missing helper/stamp; 3 absence-assertions trivially green pre-change and kept as contracts): helper on real tmp repos (on-branch, detached, unborn, non-repo, git-absent), stamping (present on repo, absent on non-repo/None project_dir, setdefault preserves an existing value through re-serialize), and survives-redaction verified by reading the on-disk JSON back.
- Full suite: 1462 passed, 1 skipped (baseline 1450 + 12).
- Live e2e: helper returned this repo's branch, None for /tmp, None for detached/unborn HEAD.
