### PR TITLE
docs: field-tested backend/model matrix — measured, dated, versioned

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Or any headless CLI that reads a prompt on stdin and prints the response:
 daimon configure --backend command --command '<your-llm-cli>' --output text
 ```
 
-Config lives in `~/.daimon/env` (hooks run with the host's inherited env, not your shell profile). Kill switch: `DAIMON_DISABLE=1`. Every tunable variable — checkpoint retention, carry, briefing budget, team memory, backend selection — is listed in [docs/configuration.md](./docs/configuration.md).
+Config lives in `~/.daimon/env` (hooks run with the host's inherited env, not your shell profile). Kill switch: `DAIMON_DISABLE=1`. Every tunable variable — checkpoint retention, carry, briefing budget, team memory, backend selection — is listed in [docs/configuration.md](./docs/configuration.md). Wondering which model to point it at? [docs/backends-tested.md](./docs/backends-tested.md) is the field-measured matrix — and your combination is a welcome PR.
 
 ### Hook up your host
 

--- a/docs/backends-tested.md
+++ b/docs/backends-tested.md
@@ -1,0 +1,67 @@
+# Field-tested backends and models
+
+Which model/backend combinations actually work with daimon's serializer — measured
+in real use, not assumed. One row per (model, backend path) combination someone has
+run in the field.
+
+Two rules keep this a source of truth instead of a vibes page:
+
+1. **Measured, not self-reported.** The quality column is the *verbatim downgrade
+   rate*: the share of fresh verbatim claims whose quote failed verification against
+   the transcript and got downgraded to inferred. The verifier computes it; the
+   model's own opinion of its output is never accepted. See the recipe below.
+2. **Dated and versioned, or it doesn't count.** Every row carries the daimon
+   version and test date. Old rows age visibly instead of lying forever.
+
+Rows are contributed by PR — daimon has no telemetry by design, so nothing here is
+collected automatically. Add your combination with the recipe below.
+
+## Matrix
+
+| Model | Backend path | daimon | Downgrade rate (sample) | Date | Notes |
+|-------|--------------|--------|-------------------------|------|-------|
+| claude-haiku-4-5 | openai-compatible (litellm proxy) | 0.13.0 | 29% of 51 fresh verbatim claims, 3 sessions — per-session range 6%–77% | 2026-07-10 | maintainer dev box; high per-session variance, small per-session samples; serialize itself reliable |
+| _your model_ | _anthropic / openai-compatible / claude-cli / command_ | | | | |
+
+Reading the numbers: a downgrade is the **verifier catching a misquote**, not data
+loss — the item survives as `[~ inferred]` with the failed-check stamp. Lower is
+better; the interesting signals are the level *and* the variance. Single-session
+rates on small claim counts (< 20) are noisy — say so in the row.
+
+## Row-filling recipe
+
+The downgrade rate is stamped on every fresh checkpoint: `verify_quotes` marks each
+fresh verbatim claim `quote_verified: true` (hit) or downgrades it to
+`trust: "inferred"` + `quote_verified: false` (miss). Count both on your newest
+checkpoints — note the filter is on the *stamp*, not on `trust` (downgraded items
+are no longer `verbatim`, which is exactly why filtering by trust would hide them):
+
+```python
+import json, sys
+
+def items(c):
+    w, e = c.get("working_context", {}), c.get("epistemic_snapshot", {})
+    for k in ("open_questions", "recent_decisions"):
+        yield from (w.get(k) or [])
+    if isinstance(w.get("active_topic"), dict):
+        yield w["active_topic"]
+    for k in ("strong_beliefs", "uncertainties", "contradictions_flagged"):
+        yield from (e.get(k) or [])
+
+for path in sys.argv[1:]:
+    cp = json.load(open(path))
+    fresh = [i for i in items(cp) if isinstance(i, dict)
+             and not i.get("carried_from") and i.get("quote_verified") is not None]
+    bad = sum(1 for i in fresh if i["quote_verified"] is False)
+    print(f"{path}: {len(fresh)} claims, {bad} downgraded")
+```
+
+Run it over `~/.daimon/checkpoints/<project>/latest.json` and the `prev-*.json`
+siblings, sum across several sessions (single sessions are too noisy), and open a
+PR with the row. Only checkpoints from 0.13.0+ carry trustworthy per-checkpoint
+stamps (`quote_verified: false` became a fresh-only signal then; older carried
+items can hold stale stamps).
+
+Serialize *reliability* (does the run complete at all) is a different axis from
+quote fidelity — if your combination fails outright, that's an issue report with
+`~/.daimon/logs/serialize.log` attached, not a matrix row.

--- a/docs/backends-tested.md
+++ b/docs/backends-tested.md
@@ -20,8 +20,13 @@ collected automatically. Add your combination with the recipe below.
 
 | Model | Backend path | daimon | Downgrade rate (sample) | Date | Notes |
 |-------|--------------|--------|-------------------------|------|-------|
-| claude-haiku-4-5 | openai-compatible (litellm proxy) | 0.13.0 | 29% of 51 fresh verbatim claims, 3 sessions — per-session range 6%–77% | 2026-07-10 | maintainer dev box; high per-session variance, small per-session samples; serialize itself reliable |
+| MIXED — claude-haiku-4-5 (litellm proxy) + claude-cli sessions, per-session attribution lost | see notes | 0.13.0 | 29% of 51 fresh verbatim claims, 3 sessions — per-session range 6%–77% | 2026-07-10 | maintainer dev box. The backend changed between these sessions and checkpoints don't record which one serialized them, so this row CANNOT be split — kept as a worked example of why unattributed samples are near-useless and why the serializer needs a backend/model stamp. Replace with attributed rows once stamping ships. |
 | _your model_ | _anthropic / openai-compatible / claude-cli / command_ | | | | |
+
+**Attribution rule (learned filling the first row):** a row is only valid if every
+sampled checkpoint is known to come from that exact (model, backend) pair. Until
+checkpoints carry a serializer stamp, that means "the backend did not change during
+the sample window" — verify before counting, or your row blends combinations.
 
 Reading the numbers: a downgrade is the **verifier catching a misquote**, not data
 loss — the item survives as `[~ inferred]` with the failed-check stamp. Lower is


### PR DESCRIPTION
Closes #221

## What

- `docs/backends-tested.md`: matrix of field-exercised (model, backend path) combinations. Quality column = verbatim downgrade rate measured by the verifier (`quote_verified` stamps), never model self-report; every row dated + versioned. Includes the row-filling recipe (stamp-based counting — filtering by `trust` would hide exactly the downgrades being counted, since downgrade flips trust to inferred) and a note separating quote-fidelity from serialize-reliability (failures are issue reports, not rows).
- One honest starting row from real data: claude-haiku-4-5 via an openai-compatible litellm proxy, daimon 0.13.0, 51 fresh verbatim claims across 3 sessions → 29% overall, 6%–77% per-session variance (variance called out; small samples flagged as noisy in the doc's reading guide).
- README: one sentence pointing at the matrix from the existing backend-selection paragraph, inviting rows by PR.

## Why

"Which model works with daimon?" had no answer except reading source or asking. Combinations already run in the field live only in scattered experience, and undated "works" claims rot silently. Two rules (measured + dated/versioned) keep the page a source of truth; community rows arrive by PR since daimon collects nothing by design.

## Tests

Docs-only; no runtime surface. The recipe script was run against real local checkpoints to produce the seeded row (output quoted in the row itself).
