### PR TITLE
feat(serializer): stamp checkpoints with the resolved backend and model

### DIFF
--- a/docs/backends-tested.md
+++ b/docs/backends-tested.md
@@ -27,6 +27,9 @@ collected automatically. Add your combination with the recipe below.
 sampled checkpoint is known to come from that exact (model, backend) pair. Until
 checkpoints carry a serializer stamp, that means "the backend did not change during
 the sample window" — verify before counting, or your row blends combinations.
+0.15.0+ checkpoints carry that stamp directly: `llm_backend` (and `llm_model`,
+when config actually knows one) is recorded at serialize time, so attribution
+no longer has to be reconstructed from memory of when the backend changed.
 
 Reading the numbers: a downgrade is the **verifier catching a misquote**, not data
 loss — the item survives as `[~ inferred]` with the failed-check stamp. Lower is
@@ -39,10 +42,15 @@ The downgrade rate is stamped on every fresh checkpoint: `verify_quotes` marks e
 fresh verbatim claim `quote_verified: true` (hit) or downgrades it to
 `trust: "inferred"` + `quote_verified: false` (miss). Count both on your newest
 checkpoints — note the filter is on the *stamp*, not on `trust` (downgraded items
-are no longer `verbatim`, which is exactly why filtering by trust would hide them):
+are no longer `verbatim`, which is exactly why filtering by trust would hide them).
+Group by the `(llm_backend, llm_model)` stamp pair (0.15.0+) so a mixed batch of
+checkpoints can never blend combinations by accident — pre-0.15.0 checkpoints
+carry no stamp at all and fall into an `(unstamped)` bucket, which is a signal to
+verify attribution by hand rather than a combination you can cite in a row:
 
 ```python
 import json, sys
+from collections import defaultdict
 
 def items(c):
     w, e = c.get("working_context", {}), c.get("epistemic_snapshot", {})
@@ -53,17 +61,25 @@ def items(c):
     for k in ("strong_beliefs", "uncertainties", "contradictions_flagged"):
         yield from (e.get(k) or [])
 
+groups = defaultdict(lambda: [0, 0])  # (backend, model) -> [claims, downgraded]
 for path in sys.argv[1:]:
     cp = json.load(open(path))
+    key = (cp.get("llm_backend") or "(unstamped)", cp.get("llm_model") or "(no model)")
     fresh = [i for i in items(cp) if isinstance(i, dict)
              and not i.get("carried_from") and i.get("quote_verified") is not None]
     bad = sum(1 for i in fresh if i["quote_verified"] is False)
-    print(f"{path}: {len(fresh)} claims, {bad} downgraded")
+    g = groups[key]
+    g[0] += len(fresh)
+    g[1] += bad
+
+for (backend, model), (claims, bad) in sorted(groups.items()):
+    print(f"{backend}/{model}: {claims} claims, {bad} downgraded")
 ```
 
 Run it over `~/.daimon/checkpoints/<project>/latest.json` and the `prev-*.json`
 siblings, sum across several sessions (single sessions are too noisy), and open a
-PR with the row. Only checkpoints from 0.13.0+ carry trustworthy per-checkpoint
+PR with the row — one row per printed group, never a hand-merged total across
+groups. Only checkpoints from 0.13.0+ carry trustworthy per-checkpoint quote
 stamps (`quote_verified: false` became a fresh-only signal then; older carried
 items can hold stale stamps).
 

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -19,7 +19,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 
-from . import config, llm, redact, schema
+from . import config, configure, llm, redact, schema
 
 # No handlers/basicConfig here — the library stays silent unless the caller
 # configures logging. Multi-hour serialize runs need this heartbeat to be killable.
@@ -629,6 +629,50 @@ def _merge_partials(chat, session_id: str, partials: list, deadline,
     return partials[0]
 
 
+def _stamp_llm_provenance(checkpoint: dict) -> None:
+    """Stamp which backend/model actually produced this checkpoint (#230).
+
+    `llm_backend` is resolved via configure.resolved_backend() — the EXACT
+    function llm.chat()'s `auto` branch mirrors (configure.py's own docstring
+    promise) — so this can never disagree with what the serialize actually
+    ran on. Not re-derived here with separate logic that could drift.
+
+    `llm_model` is stamped only when config actually knows a model string
+    (DAIMON_LLM_MODEL/LITELLM_MODEL — an HTTP backend's model, or whatever a
+    command/claude-cli setup has explicitly configured). The claude-cli
+    preset's hardcoded `--model haiku` isn't config-known, so a bare
+    command/claude-cli backend with no explicit model setting leaves
+    `llm_model` ABSENT rather than guessing one.
+
+    Direct ASSIGNMENT, not setdefault — deliberate contrast with
+    git_branch's setdefault in store.py (#222):
+    (a) a heal/re-serialize is a fresh LLM run, and the backend that ran
+        THIS TIME is the fact worth recording — overwriting a stale stamp
+        from a prior attempt is correct, not a bug;
+    (b) setdefault would let a model that happens to emit a field named
+        `llm_backend` in its extracted JSON spoof its own provenance —
+        assignment always stomps any model-authored value with the
+        resolved truth.
+
+    Fail-open: called right before the checkpoint is handed off to
+    store/write, so a resolver exception must never fail an otherwise-
+    successful serialize. Both fields are simply left absent.
+    """
+    try:
+        backend = configure.resolved_backend()
+    except Exception:
+        log.warning("llm provenance stamp: resolved_backend() raised — "
+                    "leaving llm_backend/llm_model absent")
+        return
+    checkpoint["llm_backend"] = backend
+    try:
+        model = config.llm_model()
+    except Exception:
+        model = None
+    if model:
+        checkpoint["llm_model"] = model
+
+
 def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dict:
     """Transcript -> validated checkpoint, or a named SerializeError.
 
@@ -722,6 +766,10 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
     # otherwise mass-downgrade legitimate quotes it had masked). Verify once,
     # stamp the verdict — the briefing never re-greps.
     verify_quotes(checkpoint, transcript_text)
+    # #230: stamp provenance last, immediately before hand-off to store/write —
+    # after validation/verification so it can never influence either, and
+    # last so nothing downstream re-derives or clobbers it.
+    _stamp_llm_provenance(checkpoint)
     return checkpoint
 
 

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -1017,3 +1017,81 @@ def test_merge_sys_preserves_links():
     assert "LINKS PRESERVATION" in sys_prompt
     assert "verbatim" in sys_prompt
     assert "union" in sys_prompt.lower()
+
+
+# ---- #230: llm_backend / llm_model provenance stamp ----
+
+
+def test_serialize_stamps_backend_and_model_for_http_style_config(fake_chat_factory, monkeypatch):
+    # auto backend + an API key resolves to "litellm" — same resolution
+    # configure.resolved_backend() promises to mirror from llm.chat().
+    monkeypatch.setenv("DAIMON_LLM_API_KEY", "sk-test")
+    monkeypatch.setenv("DAIMON_LLM_MODEL", "test-model")
+    chat = fake_chat_factory(_valid_checkpoint_json("S1"))
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+    assert ckpt is not None
+    assert ckpt["llm_backend"] == "litellm"
+    assert ckpt["llm_model"] == "test-model"
+
+
+def test_serialize_leaves_model_absent_when_config_has_no_model_string(fake_chat_factory, monkeypatch):
+    # No API key, no DAIMON_LLM_MODEL, but an explicit command resolves —
+    # auto picks "command". The command backend's model (if any) lives in
+    # the command string itself, not a config key the stamp can cheaply
+    # read, so llm_model must be ABSENT — never guessed.
+    monkeypatch.delenv("DAIMON_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("DAIMON_LLM_MODEL", raising=False)
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "echo hi")
+    chat = fake_chat_factory(_valid_checkpoint_json("S1"))
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+    assert ckpt is not None
+    assert ckpt["llm_backend"] == "command"
+    assert "llm_model" not in ckpt
+
+
+def test_serialize_overwrites_model_authored_llm_backend_field(fake_chat_factory, monkeypatch):
+    # A checkpoint whose extracted JSON already carries an `llm_backend` key
+    # (model-authored, whether hallucinated or adversarially spoofed) must
+    # have it stomped by the resolved truth — direct assignment, not
+    # setdefault (deliberate contrast with git_branch, #222).
+    monkeypatch.setenv("DAIMON_LLM_API_KEY", "sk-test")
+    monkeypatch.setenv("DAIMON_LLM_MODEL", "test-model")
+    spoofed = json.loads(_valid_checkpoint_json("S1"))
+    spoofed["llm_backend"] = "totally-fake-backend-the-model-made-up"
+    chat = fake_chat_factory(json.dumps(spoofed))
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+    assert ckpt is not None
+    assert ckpt["llm_backend"] == "litellm"
+
+
+def test_serialize_reserialize_after_backend_switch_stamps_fresh_values(fake_chat_factory, monkeypatch):
+    # Heal-style re-serialize: a fresh LLM run recorded with whatever backend
+    # resolves THIS TIME, not whatever an earlier attempt saw.
+    monkeypatch.delenv("DAIMON_LLM_API_KEY", raising=False)
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "echo hi")
+    chat1 = fake_chat_factory(_valid_checkpoint_json("S1"))
+    first = serializer.serialize("S1", make_messages(20), chat=chat1)
+    assert first["llm_backend"] == "command"
+
+    monkeypatch.setenv("DAIMON_LLM_API_KEY", "sk-test")
+    monkeypatch.setenv("DAIMON_LLM_MODEL", "test-model")
+    chat2 = fake_chat_factory(_valid_checkpoint_json("S1"))
+    second = serializer.serialize("S1", make_messages(20), chat=chat2)
+    assert second["llm_backend"] == "litellm"
+    assert second["llm_model"] == "test-model"
+
+
+def test_serialize_completes_when_backend_resolver_raises(fake_chat_factory, monkeypatch):
+    # Fail-open: a broken resolver must never sink an otherwise-successful
+    # serialize. Both provenance fields are simply left absent.
+    from daimon_briefing import configure
+
+    def _boom():
+        raise RuntimeError("resolver exploded")
+
+    monkeypatch.setattr(configure, "resolved_backend", _boom)
+    chat = fake_chat_factory(_valid_checkpoint_json("S1"))
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+    assert ckpt is not None
+    assert "llm_backend" not in ckpt
+    assert "llm_model" not in ckpt

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -1095,3 +1095,22 @@ def test_serialize_completes_when_backend_resolver_raises(fake_chat_factory, mon
     assert ckpt is not None
     assert "llm_backend" not in ckpt
     assert "llm_model" not in ckpt
+
+
+def test_serialize_stamps_backend_when_model_lookup_raises(
+        fake_chat_factory, monkeypatch):
+    # Fail-open, per-field: config.llm_model() blowing up costs only the
+    # model stamp — the resolved backend (already in hand) still lands.
+    from daimon_briefing import config, configure
+
+    monkeypatch.setattr(configure, "resolved_backend", lambda: "litellm")
+
+    def _boom():
+        raise RuntimeError("model lookup exploded")
+
+    monkeypatch.setattr(config, "llm_model", _boom)
+    chat = fake_chat_factory(_valid_checkpoint_json("S1"))
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+    assert ckpt is not None
+    assert ckpt["llm_backend"] == "litellm"
+    assert "llm_model" not in ckpt

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -265,6 +265,25 @@ def test_git_branch_survives_redaction(tmp_checkpoint_dir, tmp_path, monkeypatch
     assert "redactions" in on_disk  # sanity: redaction actually ran
 
 
+# ---- #230: llm_backend / llm_model stamp survives the write pipeline ----
+
+
+def test_llm_backend_and_model_survive_write_and_read_back(tmp_checkpoint_dir, sample_checkpoint):
+    # The serializer stamps these BEFORE write_checkpoint ever sees the
+    # checkpoint (assignment, not a store-side setdefault, #230) — the write
+    # pipeline audit from #222 found nothing strips top-level keys, but this
+    # is a contract, not an assumption: verify the round trip to disk.
+    stamped = {**sample_checkpoint, "llm_backend": "litellm", "llm_model": "test-model"}
+    store.write_checkpoint("S1", stamped)
+    on_disk = json.loads((tmp_checkpoint_dir / "S1.json").read_text(encoding="utf-8"))
+    assert on_disk["llm_backend"] == "litellm"
+    assert on_disk["llm_model"] == "test-model"
+
+    loaded = store.read_checkpoint("S1")
+    assert loaded["llm_backend"] == "litellm"
+    assert loaded["llm_model"] == "test-model"
+
+
 def test_write_project_latest_is_atomic(tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
     import os
 


### PR DESCRIPTION
Closes #230

## What

- `_stamp_llm_provenance(checkpoint)` in the serializer, called at the very end of `serialize_strict` (after `verify_quotes`, so it can't influence validation): `llm_backend` = `configure.resolved_backend()` — the exact function `llm.chat()`'s auto branch mirrors, not re-derived logic that could drift; `llm_model` stamped only when config actually knows a model string, absent otherwise (a bare claude-cli/command setup with no explicit model knob stays unstamped — never guessed).
- Direct assignment, not setdefault — deliberate contrast with `git_branch` (#222), documented in the docstring: a heal/re-serialize is a fresh LLM run whose backend is the fact worth recording (overwrite correct), and setdefault would let a model emitting a field named `llm_backend` in its JSON spoof its own provenance.
- Fail-open: resolver exception logs and leaves both fields absent; a serialize never dies over its own metadata.
- docs/backends-tested.md: attribution rule notes 0.15.0+ checkpoints carry the stamps; the row-filling recipe now groups by `(llm_backend, llm_model)` with an `(unstamped)` bucket for older checkpoints.

## Why

The matrix's first row (#221) was invalidated within hours of merging: the backend changed mid-sample and checkpoints recorded nothing, so a 3-session downgrade-rate measurement turned out to blend two backends with per-session attribution permanently unrecoverable. Same lesson as #222 — metadata not captured at write time is gone forever. With the stamp, quality rows become verifiable from checkpoints alone instead of trusting the tester's memory of their config history.

## Tests

- 6 new; 4 red-first (missing stamps → KeyError, spoofed field surviving), 2 deliberate contracts that hold by design (resolver-raise absence, store passthrough read-back — no store.py change needed, #222's pipeline audit reconfirmed by test).
- Coverage: HTTP-style config stamps both; model absent (missing, not None) without a model knob; model-authored `llm_backend` overwritten with resolved truth; backend-switch re-serialize stamps fresh values; survives write_checkpoint + redaction to disk and back.
- Full suite: 1471 passed, 1 skipped (baseline 1465 + 6).
- Live e2e on a real config: resolver returns `litellm` + the configured model string, matching what a checkpoint would be stamped with.
