### PR TITLE
fix(stats): count status as ops polling, not a deliberate re-read

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1531,16 +1531,21 @@ _RETENTION_WINDOW_DAYS = 14
 
 def _stats_retention(now=None) -> dict:
     """usage.log -> hook-driven briefings (`brief:auto`) vs deliberate
-    re-reads, over the last _RETENTION_WINDOW_DAYS. Plain `brief` lines
-    stamped before the first `brief:auto` ever logged predate the flag and
-    are reported as untagged — ambiguous, never guessed (#54 honesty rule).
+    re-reads, over the last _RETENTION_WINDOW_DAYS. Re-reads are memory
+    reads only (`brief`, `recall`); `status` is ops polling and counts
+    apart, outside the total and the ratio (#232 — a debugging session
+    must not read as retention). Plain `brief` lines stamped before the
+    first `brief:auto` ever logged predate the flag and are reported as
+    untagged — ambiguous, never guessed (#54 honesty rule).
     stale_hook_warning: sessions were captured in the window but zero
     auto-briefings were logged — the SessionStart hook likely predates
     --auto."""
     now = now or datetime.now(timezone.utc)
     cutoff = now - timedelta(days=_RETENTION_WINDOW_DAYS)
     out = {"window_days": _RETENTION_WINDOW_DAYS, "hook_briefs": 0,
-           "rereads": {"brief": 0, "status": 0, "recall": 0},
+           # status is ops polling (serializer health, pending counts), not a
+           # memory read (#232): counted apart, never in the total or ratio.
+           "rereads": {"brief": 0, "recall": 0}, "status_checks": 0,
            "rereads_total": 0, "rereads_per_hook_brief": None,
            "untagged_briefs": 0, "stale_hook_warning": False}
     try:
@@ -1564,6 +1569,8 @@ def _stats_retention(now=None) -> dict:
             continue
         if cmd == "brief:auto":
             out["hook_briefs"] += 1
+        elif cmd == "status":
+            out["status_checks"] += 1
         elif cmd in out["rereads"]:
             out["rereads"][cmd] += 1
     out["rereads_total"] = sum(out["rereads"].values())

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -690,8 +690,9 @@ def _plain_stats(data: dict) -> None:
         print(f"retention (last {r['window_days']}d):")
         print(f"  hook briefings: {r['hook_briefs']}")
         rr = r["rereads"]
-        print(f"  deliberate re-reads: brief {rr['brief']}, status {rr['status']}, "
+        print(f"  deliberate re-reads: brief {rr['brief']}, "
               f"recall {rr['recall']}  (total {r['rereads_total']})")
+        print(f"  status checks: {r['status_checks']}  (ops, not counted)")
         ratio = r["rereads_per_hook_brief"]
         print(f"  re-reads per hook briefing: "
               f"{ratio if ratio is not None else 'n/a'}")
@@ -752,8 +753,10 @@ def _rich_stats(data: dict) -> None:
         ret_table.add_row("hook briefings", str(r["hook_briefs"]))
         rr = r["rereads"]
         ret_table.add_row("deliberate re-reads",
-                          f"brief {rr['brief']}, status {rr['status']}, "
+                          f"brief {rr['brief']}, "
                           f"recall {rr['recall']} (total {r['rereads_total']})")
+        ret_table.add_row("status checks (ops, not counted)",
+                          str(r["status_checks"]))
         ratio = r["rereads_per_hook_brief"]
         ret_table.add_row("re-reads per hook briefing",
                           "n/a" if ratio is None else str(ratio))

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -4109,9 +4109,12 @@ def test_retention_counts_hook_briefs_and_rereads_in_window(tmp_log_dir):
     r = cli._stats_retention(now=now)
     assert r["window_days"] == 14
     assert r["hook_briefs"] == 2
-    assert r["rereads"] == {"brief": 1, "status": 1, "recall": 1}
-    assert r["rereads_total"] == 3
-    assert r["rereads_per_hook_brief"] == 1.5
+    # status is ops polling, not a memory re-read (#232): tracked separately,
+    # never in the total or the ratio.
+    assert r["rereads"] == {"brief": 1, "recall": 1}
+    assert r["status_checks"] == 1
+    assert r["rereads_total"] == 2
+    assert r["rereads_per_hook_brief"] == 1.0
     assert r["untagged_briefs"] == 1
     assert r["stale_hook_warning"] is False
 
@@ -4123,6 +4126,23 @@ def test_retention_zero_hook_briefs_ratio_is_none(tmp_log_dir):
     r = cli._stats_retention(now=now)
     assert r["hook_briefs"] == 0
     assert r["rereads_per_hook_brief"] is None
+
+
+def test_retention_status_alone_never_moves_the_value_signal(tmp_log_dir):
+    """A pure debugging session (#232): status polling plus hook briefings,
+    zero memory reads. The ratio must read 0.0, not climb with ops noise."""
+    now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "usage.log").write_text(
+        _usage_line(5, "brief:auto", now)
+        + _usage_line(3, "status", now)
+        + _usage_line(2, "status", now)
+        + _usage_line(1, "status", now)
+    )
+    r = cli._stats_retention(now=now)
+    assert r["status_checks"] == 3
+    assert r["rereads_total"] == 0
+    assert r["rereads_per_hook_brief"] == 0.0
 
 
 def test_retention_all_briefs_untagged_when_no_auto_ever(tmp_log_dir):
@@ -4175,7 +4195,8 @@ def test_stats_json_includes_retention(tmp_checkpoint_dir, tmp_log_dir,
     data = json.loads(capsys.readouterr().out)
     assert "retention" in data
     assert set(data["retention"]) >= {"window_days", "hook_briefs", "rereads",
-                                      "rereads_total", "rereads_per_hook_brief",
+                                      "status_checks", "rereads_total",
+                                      "rereads_per_hook_brief",
                                       "untagged_briefs", "stale_hook_warning"}
 
 
@@ -4192,7 +4213,9 @@ def test_stats_plain_renders_retention_section(tmp_checkpoint_dir, tmp_log_dir,
     out = capsys.readouterr().out
     assert "retention (last 14d):" in out
     assert "hook briefings: 1" in out
-    assert "re-reads per hook briefing: 1.0" in out
+    # the lone status poll is ops, not retention (#232)
+    assert "status checks: 1  (ops, not counted)" in out
+    assert "re-reads per hook briefing: 0.0" in out
 
 
 def test_stats_rich_renders_retention_section(tmp_checkpoint_dir, tmp_log_dir,
@@ -4209,7 +4232,8 @@ def test_stats_rich_renders_retention_section(tmp_checkpoint_dir, tmp_log_dir,
     out = capsys.readouterr().out
     assert "retention (last 14d)" in out
     assert "hook briefings" in out
-    assert "1.0" in out  # re-reads per hook briefing ratio
+    assert "status checks (ops, not counted)" in out
+    assert "0.0" in out  # ratio: the status poll counts apart (#232)
 
 
 def test_stats_plain_warns_on_stale_hook(tmp_checkpoint_dir, tmp_log_dir,


### PR DESCRIPTION
## What

`_stats_retention` filed `status` invocations in the deliberate re-reads bucket, inflating the re-reads-per-hook-briefing ratio — the value signal the measure-first policy (#100/#115) rests on. A debugging session full of `daimon status` polls read as retention.

**Live-store evidence:** 149 of 208 counted "re-reads" were status polls. Ratio read 16.0; corrected it reads 4.54 — 3.5x inflation.

## How

- `status` counts under its own `status_checks` key (cli.py `_stats_retention`), outside `rereads_total` and the ratio
- Plain + rich render show `status checks: N (ops, not counted)` — raw signal stays visible, honest split, same one-screen output
- JSON schema gains `status_checks`; existing keys unchanged otherwise

## Testing

- New test: pure debugging session (hook briefings + status polls, zero memory reads) → ratio 0.0, not climbing
- Updated retention fixtures to the corrected semantics
- Full suite: 1,473 passed, 1 skipped
- e2e on live store via working tree: ratio 16.0 → 4.54, status checks 149 shown apart

Closes #232
