### PR TITLE
fix(stats): reclassify too-short error lines as skips at fold time

### DIFF
--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -351,7 +351,14 @@ def _stats_capture() -> dict:
             out["skipped"] += 1
             continue
         if _RESULT_ERR_RE.match(line):
-            out["errors"] += 1
+            # #235: too-short is a policy skip, not a failure. The write side
+            # has emitted it as a skip line since e2eb989; older logs carry it
+            # in error shape, so the fold reclassifies retroactively — `errors`
+            # stays "capture should have worked and didn't".
+            if "transcript too short" in line:
+                out["skipped"] += 1
+            else:
+                out["errors"] += 1
             continue
         hm = _STATS_HOST_RE.match(line)
         if hm:

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3846,6 +3846,24 @@ def test_stats_host_re_counts_windsurf_finalizer(tmp_log_dir):
     assert ledger._stats_capture()["hosts"]["windsurf-finalizer"] == 1
 
 
+def test_stats_capture_too_short_error_lines_count_as_skipped(tmp_log_dir):
+    # #235: pre-0.2.0 logs carry too-short outcomes in error shape (the write
+    # side skips them since e2eb989). The fold reclassifies retroactively so
+    # `errors` means "capture should have worked and didn't" — nothing else.
+    from daimon_briefing import ledger
+    _write_log(tmp_log_dir, [
+        "error: transcript too short (2 < 10 messages) "
+        "(transcript: /t/S1.jsonl) after 0s",
+        "error: transcript too short (0 < 10 messages)",
+        "error: LLM call failed on transcript: ChatError: unreachable "
+        "(transcript: /t/S2.jsonl) after 12s",
+        "skipped serialize for S3: transcript too short (4 < 10 messages)",
+    ])
+    cap = ledger._stats_capture()
+    assert cap["errors"] == 1        # only the LLM failure
+    assert cap["skipped"] == 3       # both fossils join the real skip line
+
+
 # ---- #49: heal crash on hung targets + preflight-error attribution ----
 
 


### PR DESCRIPTION
## What

`_stats_capture` counted every `error:`-shaped result line as a capture error, including `transcript too short` — a policy skip the write side has emitted as a skip line since e2eb989. Old logs still carry the error shape, so stats read `errors: 57` (24% of attempts) when 24 of those were benign short transcripts.

## How

Fold-time reclassification in `_stats_capture` (ledger.py): an error-shaped line containing `transcript too short` counts as `skipped`. Retroactive over historical logs, no log rewriting, `_session_ledger`/heal semantics untouched.

**Live store before/after:** `skipped: 37, errors: 57` → `skipped: 61, errors: 33`. The remaining 33 are real (missing API key, backend unreachable, schema validation) — the number that should page you is finally readable.

## Testing

- New test: error-shaped too-short lines (with and without transcript suffix) count as skipped alongside a real skip line; an LLM failure still counts as error
- Full test_cli.py: 282 passed
- e2e via working tree on live store: counts above

Closes #235
