### PR TITLE
feat(status): surface unattributed recall items — dark matter made visible

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1089,6 +1089,9 @@ def _cmd_status(args) -> int:
     outstanding = _compute_outstanding(_ledger_text, now)
     crash = _crash_log_info(config.log_dir() / "serialize-crash.log", now)
     recall_error = _tail_log_info(config.log_dir() / "recall-error.log", now)
+    # #233: dark-matter visibility — read-only peek at the existing index;
+    # None (absent/corrupt db) simply drops the line, never triggers a rebuild.
+    recall_index = recall.index_attribution()
     disabled = config.is_disabled()
     # Skips are terminal by design (too-short sessions), but invisible skips
     # read as captured sessions (#28) — count them for display.
@@ -1121,7 +1124,7 @@ def _cmd_status(args) -> int:
              "outstanding": outstanding, "siblings": siblings, "health": health,
              "team": team, "crash": crash, "disabled": disabled,
              "skipped_recent": skipped_recent, "recall_error": recall_error,
-             "receipts": receipts_line},
+             "recall_index": recall_index, "receipts": receipts_line},
             indent=2,
         ))
         return rc
@@ -1130,7 +1133,8 @@ def _cmd_status(args) -> int:
         "project": project, "proj": proj, "glob": glob, "same": same, "last": last,
         "outstanding": outstanding, "identity": identity, "health": health,
         "team": team, "crash": crash, "skipped_recent": skipped_recent,
-        "recall_error": recall_error, "receipts": receipts_line,
+        "recall_error": recall_error, "recall_index": recall_index,
+        "receipts": receipts_line,
     })
     return rc
 

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -366,6 +366,30 @@ def _ensure_fresh() -> None:
         rebuild()
 
 
+def index_attribution() -> dict | None:
+    """Attribution counts from the EXISTING index, read-only (#233): never
+    rebuilds — status must not pay the rebuild cost, and a missing index is
+    not an error. Returns {"items": N, "unattributed": M} (M = project_slug
+    NULL rows: legacy stampless sessions, reachable only under
+    --all-projects), or None when the db is absent/corrupt/foreign."""
+    path = config.recall_db()
+    if not path.exists():
+        return None
+    try:
+        conn = sqlite3.connect(str(path))
+        try:
+            row = conn.execute(
+                "SELECT count(*), count(*) - count(project_slug) FROM items"
+            ).fetchone()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return None
+    if row is None:
+        return None
+    return {"items": int(row[0]), "unattributed": int(row[1])}
+
+
 def _match_expr(query: str, join: str = " ") -> str | None:
     """User text -> a safe FTS5 MATCH expression: every whitespace token becomes
     a quoted phrase (internal quotes doubled), joined by implicit AND (or the

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -385,8 +385,7 @@ def index_attribution() -> dict | None:
             conn.close()
     except sqlite3.Error:
         return None
-    if row is None:
-        return None
+    # fetchone on an aggregate SELECT always yields exactly one row.
     return {"items": int(row[0]), "unattributed": int(row[1])}
 
 

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -370,6 +370,19 @@ def _print_recall_error_plain(err) -> None:
     print(f"last recall error: {err['age']} ago — {err['last_line']}")
 
 
+def _recall_index_line(att) -> str | None:
+    """One line of index attribution (#233), or None when there is no index.
+    The unattributed clause appears only when dark matter exists — silence
+    stays the default for a fully-stamped store."""
+    if not att:
+        return None
+    if att["unattributed"]:
+        return (f"recall index: {att['items']} items "
+                f"({att['unattributed']} unattributed — reachable only via "
+                f"recall --all-projects)")
+    return f"recall index: {att['items']} items"
+
+
 def _outstanding_lines(outstanding) -> list:
     """Human lines for lost sessions; empty list when nothing is outstanding."""
     lines = []
@@ -436,6 +449,9 @@ def _plain_status(data: dict) -> None:
         print("last serialize: no serialize history")
         _print_crash_plain(data.get("crash"))
         _print_recall_error_plain(data.get("recall_error"))
+        idx = _recall_index_line(data.get("recall_index"))
+        if idx:
+            print(idx)
         _print_skips_plain(data.get("skipped_recent"))
         return
     if last["result"]:
@@ -450,6 +466,9 @@ def _plain_status(data: dict) -> None:
         print("last serialize spawn: none logged yet")
     _print_crash_plain(data.get("crash"))
     _print_recall_error_plain(data.get("recall_error"))
+    idx = _recall_index_line(data.get("recall_index"))
+    if idx:
+        print(idx)
     _print_skips_plain(data.get("skipped_recent"))
 
     outstanding = data.get("outstanding") or []
@@ -522,6 +541,9 @@ def _rich_status(data: dict) -> None:
     if recall_err:
         console.print(f"[red]last recall error:[/red] {recall_err['age']} ago — "
                       f"{recall_err['last_line']}")
+    idx = _recall_index_line(data.get("recall_index"))
+    if idx:
+        console.print(f"[dim]{idx}[/dim]")
     if data.get("skipped_recent"):
         console.print(f"[dim]recent sessions skipped (too short to serialize): "
                       f"{data['skipped_recent']}[/dim]")

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -673,7 +673,8 @@ def test_cli_status_json_shape(
     data = json.loads(capsys.readouterr().out)
     assert set(data) == {"project", "global", "last_serialize", "outstanding",
                          "siblings", "health", "team", "crash", "disabled",
-                         "skipped_recent", "recall_error", "receipts"}
+                         "skipped_recent", "recall_error", "recall_index",
+                         "receipts"}
     assert data["team"] is None  # no team remote configured -> explicit null (#113)
     assert data["receipts"] is None  # #204 feature off -> explicit null
     assert data["project"]["exists"] is True
@@ -3528,6 +3529,41 @@ def test_status_plain_shows_crash_line(tmp_checkpoint_dir, sample_checkpoint, ca
     out = capsys.readouterr().out
     assert "last serialize crash" in out.lower()
     assert "RuntimeError: child exploded" in out
+
+
+def test_status_plain_shows_recall_index_attribution(
+        tmp_checkpoint_dir, sample_checkpoint, capsys):
+    # #233: dark matter must be visible — a stampless legacy flat file indexes
+    # with project_slug NULL and only status can tell the user it exists.
+    from daimon_briefing import config, recall, store
+    store.write_checkpoint("S1", sample_checkpoint, project_dir="/p/A")
+    (config.checkpoint_dir() / "S9.json").write_text(json.dumps({
+        "session_id": "S9",
+        "working_context": {
+            "active_topic": {"text": "orphaned prior work", "trust": "inferred"},
+            "open_questions": [], "recent_decisions": [],
+        },
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": [],
+                               "contradictions_flagged": []},
+    }), encoding="utf-8")
+    recall.rebuild()
+    capsys.readouterr()
+    assert cli.main(["status"]) == 0
+    out = capsys.readouterr().out
+    assert "recall index:" in out
+    assert "unattributed — reachable only via recall --all-projects" in out
+
+
+def test_status_plain_no_recall_index_line_without_db(
+        tmp_checkpoint_dir, sample_checkpoint, capsys):
+    # No index on disk -> no line, and status must NOT build one as a side
+    # effect (the helper is read-only by contract).
+    from daimon_briefing import config, store
+    store.write_checkpoint("S1", sample_checkpoint)
+    assert cli.main(["status"]) == 0
+    out = capsys.readouterr().out
+    assert "recall index:" not in out
+    assert not config.recall_db().exists()
 
 
 def test_status_plain_no_crash_line_for_warnings_only_log(

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3554,6 +3554,44 @@ def test_status_plain_shows_recall_index_attribution(
     assert "unattributed — reachable only via recall --all-projects" in out
 
 
+def test_status_plain_recall_index_clause_drops_when_fully_attributed(
+        tmp_checkpoint_dir, sample_checkpoint, capsys):
+    # Silence stays the default: a fully-stamped store shows the count with
+    # no dark-matter clause.
+    from daimon_briefing import recall, store
+    store.write_checkpoint("S1", sample_checkpoint, project_dir="/p/A")
+    recall.rebuild()
+    capsys.readouterr()
+    assert cli.main(["status"]) == 0
+    out = capsys.readouterr().out
+    assert "recall index:" in out
+    assert "unattributed" not in out
+
+
+def test_status_rich_shows_recall_index_attribution(
+        tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
+    # #29 mirror rule: the rich path must state the same fact as plain.
+    pytest.importorskip("rich")
+    from daimon_briefing import config, recall, render, store
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    store.write_checkpoint("S1", sample_checkpoint, project_dir="/p/A")
+    (config.checkpoint_dir() / "S9.json").write_text(json.dumps({
+        "session_id": "S9",
+        "working_context": {
+            "active_topic": {"text": "orphaned prior work", "trust": "inferred"},
+            "open_questions": [], "recent_decisions": [],
+        },
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": [],
+                               "contradictions_flagged": []},
+    }), encoding="utf-8")
+    recall.rebuild()
+    capsys.readouterr()
+    assert cli.main(["status"]) == 0
+    out = capsys.readouterr().out
+    assert "recall index:" in out
+    assert "unattributed" in out
+
+
 def test_status_plain_no_recall_index_line_without_db(
         tmp_checkpoint_dir, sample_checkpoint, capsys):
     # No index on disk -> no line, and status must NOT build one as a side

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -915,3 +915,39 @@ def test_supersession_same_second_tie_breaks_deterministically(tmp_checkpoint_di
             conn.close()
         assert old == [("S-zzz",)]
         assert new == [(None,)]
+
+
+# ---- #233: index_attribution — dark-matter visibility, read-only ----
+
+
+def test_index_attribution_counts_unattributed_items(tmp_checkpoint_dir):
+    store.write_checkpoint(
+        "S1", _cp("S1", decisions=[{"text": "keep sqlite", "trust": "inferred"}]),
+        project_dir="/repo/x",
+    )
+    # A stampless, pointerless flat file — exactly the legacy shape that
+    # indexes with project_slug NULL (rotated-out pre-stamp session).
+    (config.checkpoint_dir() / "S2.json").write_text(
+        json.dumps(_cp("S2", decisions=[{"text": "orphan decision",
+                                         "trust": "inferred"}])),
+        encoding="utf-8",
+    )
+    recall.rebuild()
+    att = recall.index_attribution()
+    assert att is not None
+    assert att["items"] == 4          # 2 topics + 2 decisions
+    assert att["unattributed"] == 2   # S2's topic + decision
+
+
+def test_index_attribution_none_when_db_missing(tmp_checkpoint_dir):
+    # Read-only contract: no db -> None, and importantly NO rebuild happens
+    # (status must never pay the rebuild cost).
+    assert not config.recall_db().exists()
+    assert recall.index_attribution() is None
+    assert not config.recall_db().exists()
+
+
+def test_index_attribution_none_on_corrupt_db(tmp_checkpoint_dir):
+    config.recall_db().parent.mkdir(parents=True, exist_ok=True)
+    config.recall_db().write_bytes(b"not a sqlite file at all")
+    assert recall.index_attribution() is None


### PR DESCRIPTION
## What

49% of a live index (1,667 of 3,422 items) carries `project_slug = NULL` — legacy pre-#111 sessions whose pointers rotated out. Scoped `recall` and the #125 prompt hook filter on the slug, so half of history was silently unreachable, and "no prior work" was indistinguishable from "captured but unattributed."

## How

- `recall.index_attribution()` — read-only counts from the EXISTING db; returns None (line drops) when the index is absent/corrupt, and **never rebuilds** — status stays fast and side-effect-free
- `daimon status` renders one line, plain + rich mirrored (#29):
  `recall index: 3422 items (1667 unattributed — reachable only via recall --all-projects)`
- Unattributed clause drops at zero — silence stays the default for a fully-stamped store
- `status --json` gains `recall_index`; the no-fuzzy-backfill design rule is untouched

## Testing

- `index_attribution` unit tests: mixed stamped/stampless store counts, missing-db → None without creating one, corrupt-db → None
- Status render tests: line appears with dark matter present; absent (and no db created) when there is no index
- JSON shape contract updated
- Full suite: 1,478 passed, 1 skipped
- e2e on live store: exact line above

Closes #233
