### PR TITLE
fix(recall): stamped checkpoints outrank stampless in the supersession frontier

### DIFF
--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -301,19 +301,26 @@ def rebuild() -> int:
     try:
         _init_schema(conn)
         count = 0
-        # (author, project_slug) -> (recency, session_id) of the newest checkpoint.
-        # session_id is the same-second tie-break (#31 item 7): scan order is
-        # readdir order, which is unspecified — without a stable secondary key
-        # the superseded flags flip across rebuilds. Tuple compare gives it.
-        newest: dict[tuple, tuple[float, str]] = {}
+        # (author, project_slug) -> (stamped, recency, session_id) of the newest
+        # checkpoint. `stamped` leads the tuple (#240): a stampless legacy file's
+        # recency is its mtime — when the file was last TOUCHED (migration,
+        # copy, GC), not when the session happened — so letting it compete with
+        # real `created` stamps inverts the frontier and flags the true latest
+        # as superseded by an older session. A stamped checkpoint always
+        # outranks a stampless one; mtime ordering applies among stampless
+        # peers only. session_id is the same-second tie-break (#31 item 7):
+        # scan order is readdir order, which is unspecified — without a stable
+        # secondary key the superseded flags flip across rebuilds.
+        newest: dict[tuple, tuple[int, float, str]] = {}
         for sid, author, slug, recency, cp in _scan_sources():
             # Unattributed sessions never supersede each other (#31 item 6):
             # NULL slugs are UNRELATED projects sharing a non-identity, not
             # one project's history — they stay out of the newest map entirely.
             if slug is not None:
                 key = (author, slug)
-                if key not in newest or (recency, sid) > newest[key]:
-                    newest[key] = (recency, sid)
+                stamped = int(store._created_epoch(cp.get("created")) is not None)
+                if key not in newest or (stamped, recency, sid) > newest[key]:
+                    newest[key] = (stamped, recency, sid)
             for kind, text, trust, quote, importance, first_seen in _items(cp):
                 cur = conn.execute(
                     "INSERT INTO items"
@@ -329,7 +336,7 @@ def rebuild() -> int:
                 )
                 count += 1
         # Supersession v1: whole-checkpoint recency per (author, project).
-        for (author, slug), (_recency, sid) in newest.items():
+        for (author, slug), (_stamped, _recency, sid) in newest.items():
             conn.execute(
                 "UPDATE items SET superseded_by = ?"
                 " WHERE author = ? AND project_slug IS ? AND session_id != ?",

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -951,3 +951,34 @@ def test_index_attribution_none_on_corrupt_db(tmp_checkpoint_dir):
     config.recall_db().parent.mkdir(parents=True, exist_ok=True)
     config.recall_db().write_bytes(b"not a sqlite file at all")
     assert recall.index_attribution() is None
+
+
+# ---- #240: stamped checkpoints outrank stampless in the supersession frontier ----
+
+
+def test_stamped_checkpoint_outranks_stampless_legacy_in_newest_map(
+        tmp_checkpoint_dir, monkeypatch):
+    """The #240 inversion: a legacy stampless file competes with its mtime —
+    which records when the file was touched (migration, copy), not when the
+    session happened — and outranks the REAL latest, flagging live context
+    superseded by an older session. Stamped must always beat stampless."""
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint(
+        "S-new",
+        _cp("S-new", decisions=[{"text": "the real latest decision",
+                                 "trust": "inferred"}],
+            created="2026-06-19T20:52:44Z"),
+        project_dir="/repo/x",
+    )
+    # Legacy pre-stamp file: attributed via embedded slug, no `created` —
+    # recency falls back to file mtime, which is NOW (newer than S-new's stamp).
+    legacy = _cp("S-legacy", decisions=[{"text": "an old legacy decision",
+                                         "trust": "inferred"}])
+    legacy["project_slug"] = store.project_slug("/repo/x")
+    (config.checkpoint_dir() / "S-legacy.json").write_text(
+        json.dumps(legacy, ensure_ascii=False), encoding="utf-8")
+    recall.rebuild()
+    rows = {r["session_id"]: r["superseded_by"]
+            for r in recall.search("decision", all_projects=True, limit=20)}
+    assert rows["S-new"] is None          # the stamped latest IS the frontier
+    assert rows["S-legacy"] == "S-new"    # legacy superseded, not the reverse


### PR DESCRIPTION
## What

The recall rebuild's newest map compared raw `_file_recency` values across checkpoints. For legacy stampless files that value is the file mtime — when the file was last *touched* (migration, copy, GC), not when the session happened. A stampless file touched after the real latest's `created` stamp inverts the supersession frontier: every item in the true latest checkpoint gets `superseded_by` an older session, and recall renders live context as stale.

Found while measuring the #234 baseline: 49 items on a live store sat in this inverted state (one project bucket, stamped `created: 2026-06-19` losing to a stampless file with mtime `2026-07-01`).

## How

The newest map compares `(stamped, recency, session_id)` — a created-stamped checkpoint always outranks a stampless one; mtime ordering applies among stampless peers only. `_file_recency` itself is untouched, so GC/pruning and file ordering behave exactly as before; only the supersession frontier comparison changes.

## Testing

- New test reproducing the inversion: stamped latest + stampless legacy file with newer mtime → stamped stays unsuperseded, legacy flags as superseded (fails on main, passes here)
- Full suite: 1,482 passed, 1 skipped
- e2e on the live specimen via a scratch index: frontier corrected — the stamped latest reigns, the legacy file is superseded by it

Closes #240
