### PR TITLE
feat(recall): item-level supersession from typed links — recency stops crying wolf

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -604,7 +604,10 @@ def _cmd_recall(args) -> int:
     lines = []
     for r in results:
         age = _format_age(now - r["created"]) if r.get("created") else "?"
-        superseded = f" [superseded by {r['superseded_by']}]" if r.get("superseded_by") else ""
+        sup = r.get("superseded_by")
+        superseded = ("" if not sup
+                      else " [resolved]" if sup == "resolved"
+                      else f" [superseded by {sup}]")
         trust = r.get("trust") or "untagged"
         lines.append(f"[{r['author']}] [{trust}] [{r['kind']}] {r['text']} "
                      f"({r['session_id']}, {age} ago){superseded}")
@@ -787,7 +790,12 @@ def _suggest_line(r: dict, terms, now: float) -> str:
     age = _format_age(now - r["created"]) if r.get("created") else "?"
     trust = r.get("trust") or "untagged"
     text = r["text"] if len(r["text"]) <= 160 else r["text"][:157] + "..."
-    superseded = " (superseded — newer checkpoint exists)" if r.get("superseded_by") else ""
+    # v3 (#234): the flag is item-level evidence — a typed supersedes link
+    # or a logged resolution — not the old whole-checkpoint recency.
+    sup = r.get("superseded_by")
+    superseded = ("" if not sup
+                  else " (resolved)" if sup == "resolved"
+                  else " (superseded by later work)")
     more = " ".join(terms[:3])
     return (f"daimon recall: prior work — {r['kind']} from {r['session_id']} "
             f"({age} ago): \"{text}\" [{trust}]{superseded}. "

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -17,10 +17,13 @@ project_slug/session_id/created), plus two Graphiti-inspired interval slots:
 no logic yet; future contradiction intervals). A contentless FTS5 table indexes
 text + quote for MATCH; rows join back to `items` by rowid.
 
-Supersession v1 is whole-checkpoint recency per (author, project): items from
-any checkpoint that is not its author's newest for that project get
-`superseded_by = <newest session_id>`. Ranked down in results and flagged —
-never hidden (an old decision is still evidence).
+Supersession v3 (#234) is ITEM-LEVEL evidence only: `superseded_by` is set by
+typed `supersedes` links (#14) — id-bound directly, free-text via never-guess
+unique salient-term resolution — and by events.jsonl resolutions. Whole-
+checkpoint recency (the v1 flag, measured at coin-flip precision) now only
+populates `frontier`, a silent rank input: newest-checkpoint items tiebreak
+above older ones, no label. Flagged items rank down but are never hidden
+(an old decision is still evidence).
 
 Project attribution: team copies carry a stamped `project_slug` (#111), and
 write_checkpoint stamps local flat files the same way — pointer rotation
@@ -63,9 +66,12 @@ def _note_error(where: str, exc: BaseException) -> None:
     except OSError:
         pass
 
-# v2 (#125): items grew importance + first_seen for suggest()'s ranking; the
-# version bump makes _ensure_fresh discard any v1 db and rebuild.
-_SCHEMA_VERSION = "2"
+# v2 (#125): items grew importance + first_seen for suggest()'s ranking.
+# v3 (#234): items grew item_id + frontier, and superseded_by changed MEANING —
+# it now carries only item-level evidence (typed supersedes links, events.jsonl
+# resolutions), never whole-checkpoint recency; recency lives in `frontier` as
+# a silent rank input. The version bump makes _ensure_fresh discard old dbs.
+_SCHEMA_VERSION = "3"
 
 _FTS5_MISSING_MSG = (
     "sqlite3 has no FTS5 module — `daimon recall` needs an FTS5-enabled "
@@ -92,10 +98,12 @@ def _load(path: Path) -> dict | None:
 
 
 def _items(cp: dict):
-    """Yield (kind, text, trust, quote, importance, first_seen) for every
-    cognitive item in a checkpoint. Tolerant of shape drift: bare strings become
-    text-only items; anything without usable text is skipped (an index row with
-    no text matches nothing). importance/first_seen are None on pre-D-011 items."""
+    """Yield (kind, text, trust, quote, importance, first_seen, item_id,
+    supersede_targets) for every cognitive item in a checkpoint. Tolerant of
+    shape drift: bare strings become text-only items; anything without usable
+    text is skipped (an index row with no text matches nothing). importance/
+    first_seen/item_id are None on pre-D-011 items. supersede_targets is the
+    item's `supersedes` link target strings (#234) — usually empty."""
     for section, key, kind in _KIND_SOURCES:
         block = cp.get(section)
         if not isinstance(block, dict):
@@ -119,8 +127,20 @@ def _items(cp: dict):
             fs = item.get("first_seen")
             if not isinstance(fs, str):
                 fs = None
+            item_id = item.get("id")
+            if not isinstance(item_id, str) or not item_id.strip():
+                item_id = None
+            targets = []
+            links = item.get("links")
+            if isinstance(links, list):
+                for link in links:
+                    if (isinstance(link, dict)
+                            and link.get("type") == "supersedes"
+                            and isinstance(link.get("target"), str)
+                            and link["target"].strip()):
+                        targets.append(link["target"].strip())
             yield (kind, text, str(item.get("trust") or ""),
-                   str(item.get("quote") or ""), imp, fs)
+                   str(item.get("quote") or ""), imp, fs, item_id, targets)
 
 
 def _bucket_slugs(d: Path) -> dict[str, str]:
@@ -277,7 +297,9 @@ def _init_schema(conn: sqlite3.Connection) -> None:
                 superseded_by TEXT,
                 invalidated_by TEXT,
                 importance INTEGER,
-                first_seen TEXT
+                first_seen TEXT,
+                item_id TEXT,
+                frontier INTEGER NOT NULL DEFAULT 0
             );
             CREATE VIRTUAL TABLE items_fts USING fts5(text, quote, content='');
             """
@@ -286,6 +308,113 @@ def _init_schema(conn: sqlite3.Connection) -> None:
         if "fts5" in str(exc).lower():
             raise RecallError(_FTS5_MISSING_MSG) from exc
         raise
+
+
+# Same floor as carry._MIN_SHARED (kept in sync by test): a text link target
+# must share >= this many salient terms with exactly ONE distinct prior text.
+_MIN_LINK_SHARED = 3
+
+# The #14 item-id shape — twin of carry._ID_SHAPE (import would be circular:
+# carry imports recall).
+_ID_SHAPE = re.compile(r"[a-z]-[0-9a-f]{6,}(-\d+)?")
+
+
+def _apply_typed_supersession(conn: sqlite3.Connection, links: list) -> None:
+    """Mark link targets superseded (#234). Two target shapes:
+
+    id-shape — direct item_id match (bind_links already resolved it).
+    free text — field reality: carry-time binding rarely lands, so the
+      rebuild resolves text targets itself with bind_links' never-guess
+      semantics: same (author, project, kind), strictly older sessions,
+      >= _MIN_LINK_SHARED shared salient terms, and exactly ONE distinct
+      matching text — an item carried across N checkpoints is N rows of one
+      logical item, so uniqueness is by text, and every row of the matched
+      text is marked. Zero or several distinct matches -> leave unmarked
+      (a wrong supersession fabricates staleness; a missed one just stays
+      quiet, same bias as carry.bind_links)."""
+    for (author, slug, kind, owner_sid, owner_recency,
+         owner_item_id, owner_text, target) in links:
+        if _ID_SHAPE.fullmatch(target):
+            conn.execute(
+                "UPDATE items SET superseded_by = ?"
+                " WHERE item_id = ? AND author = ? AND project_slug IS ?"
+                " AND session_id != ?",
+                (owner_sid, target, author, slug, owner_sid),
+            )
+            continue
+        want = set(salient_terms(target))
+        if not want:
+            continue
+        rows = conn.execute(
+            "SELECT id, text, item_id FROM items"
+            " WHERE author = ? AND project_slug IS ? AND kind = ?"
+            " AND session_id != ? AND created < ?",
+            (author, slug, kind, owner_sid, owner_recency),
+        ).fetchall()
+        by_text: dict[str, list] = {}
+        for rowid, text, item_id in rows:
+            # Self/twin guard (mirrors bind_links): carried copies of the
+            # superseding item itself must never match its own target.
+            if (owner_item_id and item_id == owner_item_id) \
+                    or text == owner_text:
+                continue
+            if len(want & set(salient_terms(text))) >= _MIN_LINK_SHARED:
+                by_text.setdefault(text, []).append(rowid)
+        if len(by_text) != 1:
+            continue  # unbound or ambiguous — never guess
+        (rowids,) = by_text.values()
+        conn.executemany(
+            "UPDATE items SET superseded_by = ? WHERE id = ?",
+            [(owner_sid, rid) for rid in rowids],
+        )
+
+
+def _apply_event_resolutions(conn: sqlite3.Connection) -> None:
+    """Fold each project bucket's events.jsonl into superseded_by (#234).
+    Conservative: an item_ref is marked only when its newest resolving event
+    ("resolved" or "superseded-by:<id>") is STRICTLY newer than any reopen —
+    ties stay unmarked (never-guess). "supersede-candidate:*" never marks:
+    candidates are the unconfirmed tier by design (#111). The stored value is
+    the superseding item id when the status names one, else "resolved"."""
+    try:
+        buckets = [d for d in config.checkpoint_dir().iterdir() if d.is_dir()]
+    except OSError:
+        return
+    for bucket in buckets:
+        path = bucket / "events.jsonl"
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeDecodeError):
+            continue
+        marks: dict[str, tuple[str, str]] = {}  # ref -> (resolve_ts, value)
+        reopens: dict[str, str] = {}            # ref -> newest reopen ts
+        for line in lines:
+            try:
+                e = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(e, dict) or e.get("kind") != "resolution":
+                continue
+            ref = str(e.get("item_ref") or "")
+            ts = str(e.get("ts") or "")
+            status = str(e.get("status") or "")
+            if not ref or not ts:
+                continue
+            if status == "reopened":
+                if ts > reopens.get(ref, ""):
+                    reopens[ref] = ts
+            elif status == "resolved" or status.startswith("superseded-by:"):
+                value = status.split(":", 1)[1] if ":" in status else "resolved"
+                if ts > marks.get(ref, ("", ""))[0]:
+                    marks[ref] = (ts, value)
+        for ref, (ts, value) in marks.items():
+            if ts <= reopens.get(ref, ""):
+                continue  # reopened at/after the resolve — stays live
+            conn.execute(
+                "UPDATE items SET superseded_by = ?"
+                " WHERE item_id = ? AND project_slug IS ?",
+                (value, ref, bucket.name),
+            )
 
 
 def rebuild() -> int:
@@ -312,6 +441,9 @@ def rebuild() -> int:
         # scan order is readdir order, which is unspecified — without a stable
         # secondary key the superseded flags flip across rebuilds.
         newest: dict[tuple, tuple[int, float, str]] = {}
+        # (author, slug, kind, owner_sid, owner_recency, owner_item_id,
+        #  owner_text, target) per supersedes link (#234).
+        links: list[tuple] = []
         for sid, author, slug, recency, cp in _scan_sources():
             # Unattributed sessions never supersede each other (#31 item 6):
             # NULL slugs are UNRELATED projects sharing a non-identity, not
@@ -321,27 +453,38 @@ def rebuild() -> int:
                 stamped = int(store._created_epoch(cp.get("created")) is not None)
                 if key not in newest or (stamped, recency, sid) > newest[key]:
                     newest[key] = (stamped, recency, sid)
-            for kind, text, trust, quote, importance, first_seen in _items(cp):
+            for (kind, text, trust, quote, importance, first_seen,
+                 item_id, targets) in _items(cp):
                 cur = conn.execute(
                     "INSERT INTO items"
                     " (text, quote, trust, kind, author, project_slug,"
-                    "  session_id, created, importance, first_seen)"
-                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "  session_id, created, importance, first_seen, item_id)"
+                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (text, quote, trust, kind, author, slug, sid, recency,
-                     importance, first_seen),
+                     importance, first_seen, item_id),
                 )
                 conn.execute(
                     "INSERT INTO items_fts(rowid, text, quote) VALUES (?, ?, ?)",
                     (cur.lastrowid, text, quote),
                 )
                 count += 1
-        # Supersession v1: whole-checkpoint recency per (author, project).
+                if slug is not None:
+                    for target in targets:
+                        links.append((author, slug, kind, sid, recency,
+                                      item_id, text, target))
+        # Whole-checkpoint recency (#234 v3): a silent rank input, NEVER a
+        # label. Measured precision of the old recency-derived flag was
+        # indistinguishable from a coin flip; only item-level evidence below
+        # may set superseded_by. #240's stamped-over-stampless ordering is
+        # preserved in the newest map above.
         for (author, slug), (_stamped, _recency, sid) in newest.items():
             conn.execute(
-                "UPDATE items SET superseded_by = ?"
-                " WHERE author = ? AND project_slug IS ? AND session_id != ?",
-                (sid, author, slug, sid),
+                "UPDATE items SET frontier = 1"
+                " WHERE author = ? AND project_slug IS ? AND session_id = ?",
+                (author, slug, sid),
             )
+        _apply_typed_supersession(conn, links)
+        _apply_event_resolutions(conn)
         conn.execute("INSERT INTO meta VALUES ('schema_version', ?)",
                      (_SCHEMA_VERSION,))
         conn.execute("INSERT INTO meta VALUES ('fingerprint', ?)", (fingerprint,))
@@ -432,15 +575,17 @@ def search(query: str, project_dir=None, all_projects: bool = False,
     sql = (
         "SELECT i.text, i.quote, i.trust, i.kind, i.author, i.project_slug,"
         " i.session_id, i.created, i.superseded_by, i.invalidated_by,"
-        " i.importance, i.first_seen,"
+        " i.importance, i.first_seen, i.frontier,"
         " bm25(items_fts) AS rank"
         " FROM items_fts JOIN items i ON i.id = items_fts.rowid"
         " WHERE items_fts MATCH ?"
     )
     if want is not None:
         sql += " AND i.project_slug = ?"
+    # frontier is a TIEBREAK after relevance (#234): equally-relevant rows
+    # from the newest checkpoint edge out older ones — silently, no label.
     sql += (" ORDER BY (i.superseded_by IS NOT NULL) ASC, rank ASC,"
-            " i.created DESC LIMIT ?")
+            " i.frontier DESC, i.created DESC LIMIT ?")
 
     def _run(match_expr: str) -> list[dict]:
         params: list = [match_expr]
@@ -574,10 +719,10 @@ def suggest(prompt: str, project_dir=None, current_session=None,
       - at most `limit` results, one per session, ranked by
         FTS5 relevance x #78 effective_weight
 
-    Superseded items are INCLUDED, ranked down and flagged — supersession v1
-    is whole-checkpoint per (author, project), so "prior work" is superseded
-    almost by definition; excluding it would leave nothing but the latest
-    checkpoint, which the briefing already covered. Flag, never hide (#112).
+    Superseded items are INCLUDED, ranked down and flagged — since v3 the
+    flag means item-level evidence (a typed supersedes link or a logged
+    resolution, #234), so it is rare and load-bearing; it still never hides
+    a result (an overturned decision is still evidence, #112).
     """
     slug = store.project_slug(project_dir)
     if slug is None:

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2439,23 +2439,30 @@ def test_cli_recall_multiword_query(tmp_checkpoint_dir, capsys, monkeypatch, tmp
     assert "pangolin caching" in capsys.readouterr().out
 
 
-def test_cli_recall_flags_superseded(tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):
+def test_cli_recall_flags_typed_supersession_only(
+        tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):
+    # v3 (#234): recency alone renders NO flag; a typed supersedes link does.
     from daimon_briefing import store
 
     proj = str((tmp_path / "proj").resolve())
     monkeypatch.setenv("DAIMON_AUTHOR", "ada")
     store.write_checkpoint(
-        "S-old", _recall_checkpoint("S-old", "meerkat plan v1", "2021-01-01T00:00:00Z"),
+        "S-old", _recall_checkpoint(
+            "S-old", "meerkat burrow mapping plan for the colony",
+            "2021-01-01T00:00:00Z"),
         project_dir=proj)
-    store.write_checkpoint(
-        "S-new", _recall_checkpoint("S-new", "meerkat plan v2", "2025-01-01T00:00:00Z"),
-        project_dir=proj)
+    newer = _recall_checkpoint(
+        "S-new", "abandoned meerkat burrow mapping plan colony too unstable",
+        "2025-01-01T00:00:00Z")
+    newer["working_context"]["recent_decisions"][0]["links"] = [
+        {"type": "supersedes", "target": "meerkat burrow mapping plan colony"}]
+    store.write_checkpoint("S-new", newer, project_dir=proj)
     rc = cli.main(["recall", "meerkat", "--project", proj])
     assert rc == 0
     lines = [ln for ln in capsys.readouterr().out.splitlines() if "meerkat" in ln]
     assert len(lines) == 2
-    assert "superseded" not in lines[0]  # live item first
-    assert "superseded by S-new" in lines[1]
+    assert "superseded" not in lines[0]  # live item first, no recency flag
+    assert "superseded by S-new" in lines[1]  # link evidence renders
 
 
 def test_cli_recall_json(tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -205,10 +205,13 @@ def test_local_and_team_copies_not_double_indexed(tmp_checkpoint_dir, monkeypatc
     assert len(hits) == 1
 
 
-# ---- supersession: whole-checkpoint recency per (author, project) ----
+# ---- supersession v3 (#234): item-level evidence flags, recency only ranks ----
 
 
-def test_supersession_flags_older_checkpoint_items(tmp_checkpoint_dir, monkeypatch):
+def test_recency_alone_never_sets_the_superseded_flag(tmp_checkpoint_dir, monkeypatch):
+    # v3 (#234): the old whole-checkpoint flag measured at coin-flip
+    # precision. Mere recency now populates `frontier` (a silent rank
+    # tiebreak) and NEVER superseded_by.
     monkeypatch.setenv("DAIMON_AUTHOR", "ada")
     store.write_checkpoint("S-old", _cp(
         "S-old", decisions=[{"text": "narwhal decision v1", "trust": "inferred"}],
@@ -218,11 +221,140 @@ def test_supersession_flags_older_checkpoint_items(tmp_checkpoint_dir, monkeypat
         created="2025-01-01T00:00:00Z"), project_dir="/repo/x")
     hits = recall.search("narwhal", all_projects=True)
     by_sid = {h["session_id"]: h for h in hits}
-    assert by_sid["S-old"]["superseded_by"] == "S-new"
+    assert by_sid["S-old"]["superseded_by"] is None
     assert by_sid["S-new"]["superseded_by"] is None
-    # superseded items are ranked DOWN, not hidden
+    assert by_sid["S-new"]["frontier"] == 1
+    assert by_sid["S-old"]["frontier"] == 0
+    # frontier tiebreak: the newest checkpoint's row edges out the older one
     assert hits[0]["session_id"] == "S-new"
     assert hits[-1]["session_id"] == "S-old"
+
+
+def test_typed_link_text_target_sets_superseded_flag(tmp_checkpoint_dir, monkeypatch):
+    # #234 tier 1: a supersedes link with a free-text target resolves to the
+    # unique older same-kind item sharing >= 3 salient terms — that item (and
+    # only that item) gets the flag.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-old", _cp(
+        "S-old",
+        decisions=[
+            {"text": "adopt the pelican cache eviction strategy for briefings",
+             "trust": "inferred"},
+            {"text": "unrelated walrus formatting choice", "trust": "inferred"},
+        ],
+        created="2021-01-01T00:00:00Z"), project_dir="/repo/x")
+    store.write_checkpoint("S-new", _cp(
+        "S-new",
+        decisions=[{
+            "text": "reversed: drop pelican cache eviction, it thrashed",
+            "trust": "inferred",
+            "links": [{"type": "supersedes",
+                       "target": "pelican cache eviction strategy briefings"}],
+        }],
+        created="2025-01-01T00:00:00Z"), project_dir="/repo/x")
+    hits = recall.search("pelican OR walrus", all_projects=True, limit=10)
+    by_text = {h["text"]: h for h in hits}
+    assert by_text["adopt the pelican cache eviction strategy for briefings"][
+        "superseded_by"] == "S-new"
+    assert by_text["unrelated walrus formatting choice"]["superseded_by"] is None
+    assert by_text["reversed: drop pelican cache eviction, it thrashed"][
+        "superseded_by"] is None
+
+
+def test_typed_link_ambiguous_text_target_never_guesses(tmp_checkpoint_dir, monkeypatch):
+    # Two distinct older texts match the target -> nobody gets flagged
+    # (a wrong supersession fabricates staleness; same bias as bind_links).
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-old", _cp(
+        "S-old",
+        decisions=[
+            {"text": "toucan retry budget applies to gateway calls",
+             "trust": "inferred"},
+            {"text": "toucan retry budget applies to serializer calls",
+             "trust": "inferred"},
+        ],
+        created="2021-01-01T00:00:00Z"), project_dir="/repo/x")
+    store.write_checkpoint("S-new", _cp(
+        "S-new",
+        decisions=[{
+            "text": "dropped the toucan retry budget entirely",
+            "trust": "inferred",
+            "links": [{"type": "supersedes",
+                       "target": "toucan retry budget applies"}],
+        }],
+        created="2025-01-01T00:00:00Z"), project_dir="/repo/x")
+    hits = recall.search("toucan", all_projects=True, limit=10)
+    assert all(h["superseded_by"] is None for h in hits)
+
+
+def test_typed_link_id_target_sets_superseded_flag(tmp_checkpoint_dir, monkeypatch):
+    # A bound (id-shape) target marks the carrying rows directly.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    old = _cp("S-old", decisions=[{"text": "ibis pagination decision",
+                                   "trust": "inferred", "id": "r-abc123"}],
+              created="2021-01-01T00:00:00Z")
+    store.write_checkpoint("S-old", old, project_dir="/repo/x")
+    store.write_checkpoint("S-new", _cp(
+        "S-new",
+        decisions=[{
+            "text": "replaced ibis pagination with cursors",
+            "trust": "inferred",
+            "links": [{"type": "supersedes", "target": "r-abc123"}],
+        }],
+        created="2025-01-01T00:00:00Z"), project_dir="/repo/x")
+    hits = recall.search("ibis", all_projects=True, limit=10)
+    by_text = {h["text"]: h for h in hits}
+    assert by_text["ibis pagination decision"]["superseded_by"] == "S-new"
+    assert by_text["replaced ibis pagination with cursors"]["superseded_by"] is None
+
+
+def test_event_resolution_sets_superseded_flag(tmp_checkpoint_dir, monkeypatch):
+    # #234 tier 1b: a logged resolution marks the item; a strictly newer
+    # reopen un-marks it (ties stay unmarked — never guess).
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-old", _cp(
+        "S-old", questions=[
+            {"text": "should the gannet exporter batch writes",
+             "trust": "inferred", "id": "o-111aaa"},
+            {"text": "does the gannet importer need locks",
+             "trust": "inferred", "id": "o-222bbb"},
+        ],
+        created="2021-01-01T00:00:00Z"), project_dir="/repo/x")
+    slug = store.project_slug("/repo/x")
+    ev = config.checkpoint_dir() / slug / "events.jsonl"
+    ev.parent.mkdir(parents=True, exist_ok=True)
+    ev.write_text(
+        '{"ts": "2026-01-01T00:00:00Z", "kind": "resolution",'
+        ' "item_ref": "o-111aaa", "status": "resolved", "source": "cli"}\n'
+        '{"ts": "2026-01-01T00:00:00Z", "kind": "resolution",'
+        ' "item_ref": "o-222bbb", "status": "resolved", "source": "cli"}\n'
+        '{"ts": "2026-01-02T00:00:00Z", "kind": "resolution",'
+        ' "item_ref": "o-222bbb", "status": "reopened", "source": "cli"}\n',
+        encoding="utf-8")
+    hits = recall.search("gannet", all_projects=True, limit=10)
+    by_text = {h["text"]: h for h in hits}
+    assert by_text["should the gannet exporter batch writes"][
+        "superseded_by"] == "resolved"
+    assert by_text["does the gannet importer need locks"]["superseded_by"] is None
+
+
+def test_supersede_candidate_status_never_marks(tmp_checkpoint_dir, monkeypatch):
+    # Candidates are the UNCONFIRMED tier (#111) — only a confirmed
+    # resolution may flag.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-old", _cp(
+        "S-old", questions=[{"text": "heron cache warmup open question",
+                             "trust": "inferred", "id": "o-333ccc"}],
+        created="2021-01-01T00:00:00Z"), project_dir="/repo/x")
+    slug = store.project_slug("/repo/x")
+    ev = config.checkpoint_dir() / slug / "events.jsonl"
+    ev.parent.mkdir(parents=True, exist_ok=True)
+    ev.write_text(
+        '{"ts": "2026-01-01T00:00:00Z", "kind": "resolution",'
+        ' "item_ref": "o-333ccc", "status": "supersede-candidate:r-abc123",'
+        ' "source": "serializer"}\n', encoding="utf-8")
+    hits = recall.search("heron", all_projects=True, limit=10)
+    assert hits and all(h["superseded_by"] is None for h in hits)
 
 
 def test_supersession_is_per_author(tmp_checkpoint_dir, monkeypatch):
@@ -680,10 +812,11 @@ def test_suggest_short_prompt_is_silent(tmp_checkpoint_dir, monkeypatch):
     assert recall.suggest("ok", project_dir="/repo/x", current_session="S-now") == []
 
 
-def test_suggest_includes_superseded_flagged_not_hidden(tmp_checkpoint_dir, monkeypatch):
-    # Supersession v1 is whole-checkpoint per (author, project): PRIOR WORK is
-    # superseded almost by definition. Hiding it would leave only the latest
-    # checkpoint — which the briefing already covered. Flag, never hide (#112).
+def test_suggest_surfaces_older_work_unflagged_without_evidence(
+        tmp_checkpoint_dir, monkeypatch):
+    # v3 (#234): prior work from an older checkpoint is NOT flagged by mere
+    # recency — it surfaces clean. Only item-level evidence may flag (and
+    # flagged items still surface, ranked down — flag, never hide, #112).
     monkeypatch.setenv("DAIMON_AUTHOR", "ada")
     _seed_history()
     store.write_checkpoint(
@@ -695,7 +828,37 @@ def test_suggest_includes_superseded_flagged_not_hidden(tmp_checkpoint_dir, monk
     out = recall.suggest("debugging the litellm gateway cache pinning again",
                          project_dir="/repo/x", current_session="S-now")
     assert out and out[0]["session_id"] == "S-old"
-    assert out[0]["superseded_by"] == "S-newer"
+    assert out[0]["superseded_by"] is None
+
+
+def test_suggest_flags_and_demotes_typed_superseded_item(
+        tmp_checkpoint_dir, monkeypatch):
+    # A typed supersedes link flags the old item in suggestions too —
+    # included, demoted, never hidden (#112). Same-kind fixture: links bind
+    # within a kind, mirroring carry.bind_links.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint(
+        "S-old", _cp125("S-old", decisions=[{
+            "text": "pin the litellm gateway cache for bad responses",
+            "trust": "verbatim", "quote": "pin it",
+            "importance": 9, "first_seen": "2026-06-20T00:00:00Z",
+        }], created="2026-06-20T00:00:00Z"),
+        project_dir="/repo/x",
+    )
+    store.write_checkpoint(
+        "S-newer", _cp125("S-newer", decisions=[{
+            "text": "unpinned the litellm gateway cache, old diagnosis wrong",
+            "trust": "inferred",
+            "links": [{"type": "supersedes",
+                       "target": "pin litellm gateway cache bad responses"}],
+        }], created="2026-06-25T00:00:00Z"),
+        project_dir="/repo/x",
+    )
+    out = recall.suggest("debugging the litellm gateway cache pinning again",
+                         project_dir="/repo/x", current_session="S-now")
+    assert out
+    flagged = [r for r in out if r["superseded_by"] == "S-newer"]
+    assert flagged and flagged[0]["session_id"] == "S-old"
 
 
 def test_suggest_matches_accented_spanish_content(tmp_checkpoint_dir, monkeypatch):
@@ -887,10 +1050,10 @@ def test_unattributed_sessions_never_supersede_each_other(tmp_checkpoint_dir, mo
     assert rows == [(None,)], f"unattributed session was superseded: {rows}"
 
 
-def test_supersession_same_second_tie_breaks_deterministically(tmp_checkpoint_dir, monkeypatch):
-    # #31 item 7: newest-per-(author, slug) tie-broke by arbitrary scan order
-    # on same-second recency — nondeterministic superseded flags across
-    # rebuilds. Ties must break on session_id (greater wins), stable always.
+def test_frontier_same_second_tie_breaks_deterministically(tmp_checkpoint_dir, monkeypatch):
+    # #31 item 7 (v3: the winner is now `frontier`, not a flag): newest-per-
+    # (author, slug) tie-broke by arbitrary scan order on same-second recency.
+    # Ties must break on session_id (greater wins), stable across rebuilds.
     monkeypatch.setenv("DAIMON_AUTHOR", "ada")
     same = "2026-06-20T00:00:00Z"
     # S-aaa written FIRST: pre-fix, the first-scanned session won ties, so
@@ -907,14 +1070,14 @@ def test_supersession_same_second_tie_breaks_deterministically(tmp_checkpoint_di
         recall.rebuild()
         conn = sqlite3.connect(str(config.recall_db()))
         try:
-            old = conn.execute("SELECT DISTINCT superseded_by FROM items"
+            old = conn.execute("SELECT DISTINCT frontier FROM items"
                                " WHERE session_id = 'S-aaa'").fetchall()
-            new = conn.execute("SELECT DISTINCT superseded_by FROM items"
+            new = conn.execute("SELECT DISTINCT frontier FROM items"
                                " WHERE session_id = 'S-zzz'").fetchall()
         finally:
             conn.close()
-        assert old == [("S-zzz",)]
-        assert new == [(None,)]
+        assert old == [(0,)]
+        assert new == [(1,)]
 
 
 # ---- #233: index_attribution — dark-matter visibility, read-only ----
@@ -978,7 +1141,15 @@ def test_stamped_checkpoint_outranks_stampless_legacy_in_newest_map(
     (config.checkpoint_dir() / "S-legacy.json").write_text(
         json.dumps(legacy, ensure_ascii=False), encoding="utf-8")
     recall.rebuild()
-    rows = {r["session_id"]: r["superseded_by"]
+    rows = {r["session_id"]: r["frontier"]
             for r in recall.search("decision", all_projects=True, limit=20)}
-    assert rows["S-new"] is None          # the stamped latest IS the frontier
-    assert rows["S-legacy"] == "S-new"    # legacy superseded, not the reverse
+    assert rows["S-new"] == 1     # the stamped latest IS the frontier
+    assert rows["S-legacy"] == 0  # the mtime-newer legacy file is not
+
+
+def test_link_shared_floor_stays_in_sync_with_carry():
+    # recall._MIN_LINK_SHARED mirrors carry._MIN_SHARED (import would be
+    # circular) — rebuild-side text resolution must not drift looser or
+    # stricter than carry-time binding.
+    from daimon_briefing import carry
+    assert recall._MIN_LINK_SHARED == carry._MIN_SHARED

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -1153,3 +1153,68 @@ def test_link_shared_floor_stays_in_sync_with_carry():
     # stricter than carry-time binding.
     from daimon_briefing import carry
     assert recall._MIN_LINK_SHARED == carry._MIN_SHARED
+
+
+def test_typed_link_stopword_target_never_matches(tmp_checkpoint_dir, monkeypatch):
+    # A target with no salient terms can identify nothing — skipped outright.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-old", _cp(
+        "S-old", decisions=[{"text": "keep the flamingo exporter synchronous",
+                             "trust": "inferred"}],
+        created="2021-01-01T00:00:00Z"), project_dir="/repo/x")
+    store.write_checkpoint("S-new", _cp(
+        "S-new", decisions=[{
+            "text": "made the flamingo exporter async after all",
+            "trust": "inferred",
+            "links": [{"type": "supersedes", "target": "the one about it"}],
+        }],
+        created="2025-01-01T00:00:00Z"), project_dir="/repo/x")
+    hits = recall.search("flamingo", all_projects=True, limit=10)
+    assert all(h["superseded_by"] is None for h in hits)
+
+
+def test_typed_link_never_matches_own_carried_copy(tmp_checkpoint_dir, monkeypatch):
+    # Self/twin guard: the superseding item's own carried copy in an older
+    # checkpoint shares the target's vocabulary by construction — it must
+    # never be treated as the thing being superseded.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    reversal = {
+        "text": "dropped condor batching for the exporter queue",
+        "trust": "inferred", "id": "r-fff999",
+        "links": [{"type": "supersedes",
+                   "target": "condor batching exporter queue"}],
+    }
+    # Older checkpoint holds the carried copy of the reversal itself — and
+    # nothing else matching — so a match here could only be the self-twin.
+    store.write_checkpoint("S-old", _cp(
+        "S-old", decisions=[dict(reversal)],
+        created="2021-01-01T00:00:00Z"), project_dir="/repo/x")
+    store.write_checkpoint("S-new", _cp(
+        "S-new", decisions=[dict(reversal)],
+        created="2025-01-01T00:00:00Z"), project_dir="/repo/x")
+    hits = recall.search("condor", all_projects=True, limit=10)
+    assert all(h["superseded_by"] is None for h in hits)
+
+
+def test_event_fold_tolerates_hostile_lines(tmp_checkpoint_dir, monkeypatch):
+    # The events fold must skip torn JSON, note-kind lines, and ref-less
+    # resolutions without dropping the valid mark that follows them.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-old", _cp(
+        "S-old", questions=[{"text": "does the skua poller need jitter",
+                             "trust": "inferred", "id": "o-444ddd"}],
+        created="2021-01-01T00:00:00Z"), project_dir="/repo/x")
+    slug = store.project_slug("/repo/x")
+    ev = config.checkpoint_dir() / slug / "events.jsonl"
+    ev.parent.mkdir(parents=True, exist_ok=True)
+    ev.write_text(
+        'not json at all{{{\n'
+        '{"ts": "2026-01-01T00:00:00Z", "kind": "note", "note": "hi"}\n'
+        '{"ts": "2026-01-01T00:00:00Z", "kind": "resolution",'
+        ' "item_ref": "", "status": "resolved"}\n'
+        '{"kind": "resolution", "item_ref": "o-444ddd", "status": "resolved"}\n'
+        '{"ts": "2026-01-02T00:00:00Z", "kind": "resolution",'
+        ' "item_ref": "o-444ddd", "status": "superseded-by:r-abc123"}\n',
+        encoding="utf-8")
+    hits = recall.search("skua", all_projects=True, limit=10)
+    assert hits and hits[0]["superseded_by"] == "r-abc123"


### PR DESCRIPTION
## What

The whole-checkpoint superseded flag measured at coin-flip precision (53%, CI [35%, 69%] — methodology and strata on the issue) and fired on 38% of a live corpus. A warning that frequent trains every reader to skim past it, which also buries the rare genuine supersessions. Schema v3 splits the two meanings the flag conflated.

## How

**Tier 1 — `superseded_by` carries item-level evidence only:**
- Typed `supersedes` links (#14): id-bound targets match `item_id` directly; free-text targets (the field-dominant shape — carry-time binding rarely lands) resolve at rebuild with `bind_links`' never-guess semantics: same author/project/kind, strictly older sessions, ≥ 3 shared salient terms (floor kept in sync with `carry._MIN_SHARED` by test), and exactly ONE distinct matching text — an item carried across N checkpoints is N rows of one logical item. Zero or several matches → unmarked.
- events.jsonl resolutions: `resolved` / `superseded-by:*` mark; `supersede-candidate:*` never marks (unconfirmed tier, #111); a strictly newer `reopened` un-marks; ties stay unmarked.

**Tier 2 — `frontier` (new column):** whole-checkpoint recency demoted to a silent rank tiebreak after relevance. #240's stamped-over-stampless ordering preserved.

**Render follows:** `[superseded by <sid>]` / `[resolved]` only on evidence; recall-inject drops the "newer checkpoint exists" phrasing.

## Testing

- New: text-target unique resolution, ambiguous-target never-guess, id-target, event resolution + reopen, candidate-never-marks, suggest flag-and-demote, carry-floor sync guard
- Rewritten to v3 contract: recency-never-flags, frontier tiebreak, same-second determinism, #240 frontier assert, cli render
- Full suite: 1,489 passed, 1 skipped
- e2e on a live store via scratch index: flag drops from 1,306 items (38%) to 2 — both verifiable real supersessions; 481 frontier rows rank silently

Closes #234
