### PR TITLE
feat(cli): cross-project context switching — daimon projects + --slug on brief/recall

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ skill owns it outright. Re-run install after upgrading to refresh the content.
 ## What you get beyond the briefing
 
 - **`daimon recall <terms>`** — full-text search over your whole checkpoint history (and your team's, if enabled). Multi-term queries degrade to ranked partial matches instead of returning nothing.
+- **Context switching** — `daimon projects` lists every project daimon remembers (age, branch, last topic); `daimon brief --slug <slug>` and `daimon recall <terms> --slug <slug>` read one other project deliberately, provenance-labeled — crossing projects is always explicit, never automatic.
 - **Proactive recall** — when a new prompt overlaps prior work from an older session, the briefing surfaces it ("you worked on this before"), in English or Spanish — accented text is a first-class citizen.
 - **Code anchors** — `daimon anchor <file> <symbol>` pins a belief to a code symbol; if that code changes or disappears, the next briefing flags the item under **CODE DRIFT — verify before trusting**. Offline, stdlib `ast`.
 - **Team memory (opt-in)** — `daimon team init <remote>` mirrors checkpoints through a git remote; teammates' active topics and decisions appear in your briefing, clearly attributed, never merged into your own sections. See the [team memory setup guide](./docs/team.md) — start with its privacy boundary, because the shared repo must be private.
@@ -159,7 +160,7 @@ skill owns it outright. Re-run install after upgrading to refresh the content.
 | Surface | State |
 |---------|-------|
 | Claude Code plugin + hooks | live-validated daily |
-| CLI (`brief`, `status`, `recall`, `heal`, `anchor`, `configure`, `hooks`, `skill`) | stable, on PyPI |
+| CLI (`brief`, `status`, `recall`, `projects`, `heal`, `anchor`, `configure`, `hooks`, `skill`) | stable, on PyPI |
 | Windsurf adapter | shipped, in live validation |
 | Codex adapter | shipped, awaiting first live run |
 | Gemini host hooks | blocked upstream (`gemini-cli#14715`) |

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -489,8 +489,84 @@ def _team_briefings(project) -> list:
     return out
 
 
+def _render_briefing_body(checkpoint, route, *, drift_project, teammates) -> int:
+    """Shared tail of `brief` and `brief --slug`: withhold, drift, render,
+    footnotes. `route` is whatever the events ledger should be keyed by — a
+    project dir on the normal path, a bare slug on the --slug path (the store's
+    slug munging is idempotent, so a slug rides through project_dir-shaped
+    APIs unchanged; guarded by test_project_slug_is_idempotent_on_slugs).
+    `drift_project=None` skips the anchor drift check: anchor paths are
+    relative to the origin project's root, which a slug cannot recover."""
+    withheld = []
+    events = {}
+    if checkpoint:
+        # Withhold (#103): render-time derivation, fail-open — a briefing
+        # must never die over suppression machinery. #14: candidates ride
+        # along stamped on `checkpoint` itself — the deterministic path
+        # (render_plain via briefing._line) picks up the annotation; the
+        # opt-in LLM briefing path does not surface it (same pre-existing
+        # scope as [carried]), so nothing further is done with them here.
+        try:
+            events = store.resolutions(project_dir=route)
+            checkpoint, withheld, _candidates = briefing.withhold(checkpoint, events)
+        except Exception:
+            withheld = []
+            events = {}
+    # NOTE: drift is checked against the resolved project root. If read_latest fell
+    # back to the GLOBAL pointer (another project's checkpoint), its anchor file paths
+    # are relative to a different root and may report spurious "hard" drift. Acceptable
+    # for v1 (degrades safely); origin-project gating is future work (#60 follow-up).
+    drift = (anchor.drifted(checkpoint, drift_project)
+             if checkpoint and drift_project else [])
+    render.render_brief(checkpoint, drift=drift, teammates=teammates)
+    if withheld:
+        render.render_brief_note([
+            f"{len(withheld)} resolved item(s) withheld — "
+            "`daimon status --suppressed` to list"])
+    # Staleness budget (#215): reuses the SAME resolutions fold `withhold`
+    # already did above — no re-read of events.jsonl. Fail-open, same shape
+    # as the withhold try/except; a broken stale_carried must never take the
+    # briefing down with it. House rule: zero stale items -> NO line at all,
+    # never a false alarm.
+    if checkpoint:
+        try:
+            stale_items = briefing.stale_carried(checkpoint, events, time.time())
+        except Exception:
+            stale_items = []
+        if stale_items:
+            render.render_brief_note([
+                f"⚠ {len(stale_items)} carried item(s) unverified for "
+                f">{config.stale_days():g} days — world-check before "
+                "repeating as true"])
+    return 0
+
+
 def _cmd_brief(args) -> int:
     _note_usage("brief:auto" if getattr(args, "auto", False) else "brief")
+    slug = getattr(args, "slug", None)
+    if slug:
+        # Deliberate cross-project read (#243). Explicit-never-automatic is
+        # the #94/#95 lesson, so: no global-pointer fallback (the target was
+        # named — somebody else's checkpoint is never an answer), no --team
+        # (fan-in routes by path), and a provenance header so this can never
+        # masquerade as the current project's briefing.
+        if args.project:
+            print("error: --slug and --project are two answers to \"which "
+                  "bucket\" — pass one", file=sys.stderr)
+            return 2
+        if getattr(args, "team", False):
+            print("error: --team routes by project path and cannot combine "
+                  "with --slug", file=sys.stderr)
+            return 2
+        checkpoint = store.read_latest(project_dir=slug, fallback=False)
+        if not isinstance(checkpoint, dict):
+            render.render_brief_note([
+                f"no checkpoint bucket for slug {slug} — "
+                "`daimon projects` lists what exists"])
+            return 1
+        render.render_brief_note([f"cross-project briefing — project: {slug}"])
+        return _render_briefing_body(checkpoint, slug,
+                                     drift_project=None, teammates=None)
     # Route like status/serialize: --project, else DAIMON_PROJECT_DIR, else cwd.
     # read_latest still falls back to the global pointer if the project has none.
     project = _resolve_project(args.project)
@@ -529,50 +605,11 @@ def _cmd_brief(args) -> int:
     if fallback_used:
         render.render_brief_note(["⚠ no checkpoint for this project — showing the global "
                                   "checkpoint (fallback), possibly another project's."])
-    withheld = []
-    events = {}
-    if checkpoint:
-        # Withhold (#103): render-time derivation, fail-open — a briefing
-        # must never die over suppression machinery. #14: candidates ride
-        # along stamped on `checkpoint` itself — the deterministic path
-        # (render_plain via briefing._line) picks up the annotation; the
-        # opt-in LLM briefing path does not surface it (same pre-existing
-        # scope as [carried]), so nothing further is done with them here.
-        try:
-            events = store.resolutions(project_dir=project)
-            checkpoint, withheld, _candidates = briefing.withhold(checkpoint, events)
-        except Exception:
-            withheld = []
-            events = {}
-    # NOTE: drift is checked against the resolved project root. If read_latest fell
-    # back to the GLOBAL pointer (another project's checkpoint), its anchor file paths
-    # are relative to a different root and may report spurious "hard" drift. Acceptable
-    # for v1 (degrades safely); origin-project gating is future work (#60 follow-up).
-    drift = anchor.drifted(checkpoint, project) if checkpoint else []
     # --team (#111): fan in teammates for THIS project. Empty team → None → the
     # renderer emits no Teammates section, byte-identical to a non-team briefing.
     teammates = _team_briefings(project) if getattr(args, "team", False) else None
-    render.render_brief(checkpoint, drift=drift, teammates=teammates)
-    if withheld:
-        render.render_brief_note([
-            f"{len(withheld)} resolved item(s) withheld — "
-            "`daimon status --suppressed` to list"])
-    # Staleness budget (#215): reuses the SAME resolutions fold `withhold`
-    # already did above — no re-read of events.jsonl. Fail-open, same shape
-    # as the withhold try/except; a broken stale_carried must never take the
-    # briefing down with it. House rule: zero stale items -> NO line at all,
-    # never a false alarm.
-    if checkpoint:
-        try:
-            stale_items = briefing.stale_carried(checkpoint, events, time.time())
-        except Exception:
-            stale_items = []
-        if stale_items:
-            render.render_brief_note([
-                f"⚠ {len(stale_items)} carried item(s) unverified for "
-                f">{config.stale_days():g} days — world-check before "
-                "repeating as true"])
-    return 0
+    return _render_briefing_body(checkpoint, project,
+                                 drift_project=project, teammates=teammates)
 
 
 # ---- recall: FTS search over local + team checkpoint history (#112) ----
@@ -587,9 +624,18 @@ def _cmd_recall(args) -> int:
     if args.limit < 1:
         print(f"error: --limit must be >= 1 (got {args.limit})", file=sys.stderr)
         return 2
+    slug = getattr(args, "slug", None)
+    if slug and args.project:
+        print("error: --slug and --project are two answers to \"which bucket\" "
+              "— pass one", file=sys.stderr)
+        return 2
+    if slug and args.all_projects:
+        print("error: --slug scopes to one project; drop it or drop "
+              "--all-projects", file=sys.stderr)
+        return 2
     project = _resolve_project(args.project)
     try:
-        results = recall.search(query, project_dir=project,
+        results = recall.search(query, project_dir=project, slug=slug,
                                 all_projects=args.all_projects, limit=args.limit)
     except recall.RecallError as exc:
         print(f"error: {exc}", file=sys.stderr)
@@ -612,6 +658,63 @@ def _cmd_recall(args) -> int:
         lines.append(f"[{r['author']}] [{trust}] [{r['kind']}] {r['text']} "
                      f"({r['session_id']}, {age} ago){superseded}")
     render.render_recall_lines(lines)
+    return 0
+
+
+# ---- projects: cross-project bucket list (#243) ----
+
+
+_TOPIC_TEASER_CHARS = 60
+
+
+def _cmd_projects(args) -> int:
+    """One row per checkpoint bucket: which projects daimon knows about, and
+    what each was last doing. Read-only orientation for context switching —
+    the crossing itself stays explicit (`brief --slug` / `recall --slug`),
+    the #94/#95 lesson. Torn buckets show with unknown fields rather than
+    vanish: hiding one would read as "no such project"."""
+    _note_usage("projects")
+    cur_slug = store.project_slug(_resolve_project(getattr(args, "project", None)))
+    rows = []
+    for b in store.list_buckets():
+        cp = b["checkpoint"] or {}
+        created = cp.get("created")
+        topic = ((cp.get("working_context") or {}).get("active_topic") or {})
+        rows.append({
+            "slug": b["slug"],
+            "session_id": cp.get("session_id"),
+            "created": created if isinstance(created, str) else None,
+            "git_branch": cp.get("git_branch"),
+            "topic": topic.get("text") if isinstance(topic, dict) else None,
+            "current": b["slug"] == cur_slug,
+            # display sort key only, never emitted: created stamp when the
+            # pointer has one, pointer mtime for torn/stampless buckets
+            "_epoch": store._created_epoch(created) or b["mtime"],
+        })
+    rows.sort(key=lambda r: r["_epoch"], reverse=True)
+    for r in rows:
+        del r["_epoch"]
+    if args.json:
+        print(json.dumps(rows, indent=2, ensure_ascii=False))
+        return 0
+    if not rows:
+        render.render_recall_lines(
+            ["no project buckets yet — the first serialized session creates one"])
+        return 0
+    now = time.time()
+    display = []
+    for r in rows:
+        epoch = store._created_epoch(r["created"])
+        age = f"{_format_age(now - epoch)} ago" if epoch else "?"
+        topic = (r["topic"] or "").strip()
+        if len(topic) > _TOPIC_TEASER_CHARS:
+            topic = topic[:_TOPIC_TEASER_CHARS - 1] + "…"
+        display.append({
+            "mark": "*" if r["current"] else " ",
+            "slug": r["slug"], "age": age,
+            "branch": r["git_branch"] or "—", "topic": topic or "?",
+        })
+    render.render_projects(display)
     return 0
 
 
@@ -1830,6 +1933,12 @@ def main(argv=None) -> int:
              "recent decisions from the shared team memory (#111)",
     )
     p_brief.add_argument(
+        "--slug", metavar="SLUG",
+        help="brief another project's bucket by its slug (see `daimon "
+             "projects`) — deliberate cross-project read, provenance-labeled, "
+             "no fallback (#243)",
+    )
+    p_brief.add_argument(
         "--global-fallback", action="store_true",
         help="when this project has no checkpoint, render the full global "
              "checkpoint (possibly another project's) instead of the "
@@ -1879,12 +1988,31 @@ def main(argv=None) -> int:
         help="search across every project (lifts the project scope)",
     )
     p_recall.add_argument(
+        "--slug", metavar="SLUG",
+        help="scope to a project bucket by its slug (see `daimon projects`) — "
+             "reaches buckets whose source path no longer exists (#243)",
+    )
+    p_recall.add_argument(
         "--json", action="store_true", help="machine-readable output"
     )
     p_recall.add_argument(
         "--limit", type=int, default=20, help="max results (default: 20)"
     )
     p_recall.set_defaults(func=_cmd_recall)
+
+    p_projects = sub.add_parser(
+        "projects", help="list every project daimon has a checkpoint for",
+        epilog="Examples:\n  daimon projects\n  daimon projects --json\n",
+    )
+    p_projects.add_argument(
+        "--project",
+        help="project directory the current-project mark is computed against "
+             "(default: DAIMON_PROJECT_DIR, then cwd)",
+    )
+    p_projects.add_argument(
+        "--json", action="store_true", help="machine-readable output"
+    )
+    p_projects.set_defaults(func=_cmd_projects)
 
     p_resolve = sub.add_parser(
         "resolve", help="mark a checkpoint item resolved — append-only event, "
@@ -2101,6 +2229,18 @@ def main(argv=None) -> int:
     ps_uninstall.add_argument("host")
     ps_uninstall.add_argument("--project", action="store_true")
     ps_uninstall.set_defaults(func=_cmd_skill_uninstall)
+
+    # Slugs are munged absolute paths, so they START with "-" ("/Users/x" ->
+    # "-Users-x") — argparse reads `--slug -Users-x` as a missing argument and
+    # only accepts the `=` form. Fuse the pair pre-parse so both spellings
+    # work; a trailing bare `--slug` is left for argparse to reject normally.
+    if argv is None:
+        argv = sys.argv[1:]
+    argv = list(argv)
+    for i, tok in enumerate(argv[:-1]):
+        if tok == "--slug":
+            argv[i:i + 2] = [f"--slug={argv[i + 1]}"]
+            break
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -552,11 +552,15 @@ def _match_expr(query: str, join: str = " ") -> str | None:
 
 
 def search(query: str, project_dir=None, all_projects: bool = False,
-           limit: int = 20) -> list[dict]:
+           limit: int = 20, slug: str | None = None) -> list[dict]:
     """FTS5 MATCH over the (auto-refreshed) index. Live items first, then by
     bm25 rank, newest checkpoint first within equal rank. Scope: project_dir's
     slug unless all_projects (or the project is unknown — no filter then,
-    matching read_team's semantics). Never raises on hostile query text;
+    matching read_team's semantics). An explicit `slug` IS the scope (#243):
+    it addresses a bucket by its stored identity — the slug is lossy, so this
+    is the only route to buckets whose source path is gone (other machine,
+    deleted dir) — and overrides both project_dir and all_projects (callers
+    guard the flag conflict at the CLI). Never raises on hostile query text;
     raises RecallError only when FTS5 itself is unavailable.
 
     AND is primary; when a multi-term query matches nothing, the same quoted
@@ -570,7 +574,8 @@ def search(query: str, project_dir=None, all_projects: bool = False,
         _ensure_fresh()
     except (OSError, sqlite3.Error) as exc:
         _note_error("search.refresh", exc)  # then try the query on what exists
-    want = None if all_projects else store.project_slug(project_dir)
+    want = slug if slug else (None if all_projects
+                              else store.project_slug(project_dir))
 
     sql = (
         "SELECT i.text, i.quote, i.trust, i.kind, i.author, i.project_slug,"

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -621,6 +621,36 @@ def _render_lines(lines, *, footer=None) -> None:
             console.print(ln, markup=False)
 
 
+# ---- projects: `daimon projects` (#243) --------------------------------------
+
+
+def render_projects(rows) -> None:
+    """`daimon projects`: one row per checkpoint bucket. `rows` is
+    [{mark, slug, age, branch, topic}], pre-formatted strings — sorting,
+    truncation, and the current-project mark are the CLI's concern."""
+    if not supports_rich():
+        w = max((len(r["slug"]) for r in rows), default=0)
+        a = max((len(r["age"]) for r in rows), default=0)
+        b = max((len(r["branch"]) for r in rows), default=0)
+        for r in rows:
+            print(f"{r['mark']} {r['slug']:<{w}}  {r['age']:<{a}}  "
+                  f"{r['branch']:<{b}}  {r['topic']}")
+        return
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("")
+    table.add_column("project")
+    table.add_column("last")
+    table.add_column("branch")
+    table.add_column("topic")
+    for r in rows:
+        table.add_row(r["mark"], r["slug"], r["age"], r["branch"], r["topic"])
+    console.print(table)
+
+
 # ---- recall: `daimon recall` (#68) ------------------------------------------
 
 

--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -66,6 +66,20 @@ Example:
 Correct handling: run `gh pr view 60` (or equivalent) before repeating it —
 the PR may have merged since the checkpoint was written.
 
+## Context switching (other projects)
+
+Memory is per-project. To deliberately read another project's memory:
+
+- `daimon projects` — list every project daimon knows, with age, branch,
+  and last topic. The current project is marked `*`.
+- `daimon brief --slug <slug>` — that project's briefing (slugs come from
+  `daimon projects`). Output is labeled with its origin project; treat it
+  as foreign context, never as this project's state.
+- `daimon recall <query> --slug <slug>` — search one other project;
+  `--all-projects` when you don't know which project has the answer.
+
+Never present cross-project content as the current project's memory.
+
 ## When memory looks wrong
 
 | Symptom | Command |
@@ -114,6 +128,8 @@ When a briefing is in context:
 
 If memory looks wrong: `daimon status` (stale/missing briefing),
 `daimon heal` (failed capture), `daimon stats` (usage overview).
+Other projects: `daimon projects` lists them; `brief --slug <slug>` /
+`recall <q> --slug <slug>` read one deliberately — label output as foreign.
 
 MUST: at session start run `daimon brief --team` before other work; stay silent if daimon is not set up.
 """

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -595,6 +595,36 @@ def sibling_buckets(project_dir) -> list[dict]:
     return out
 
 
+def list_buckets() -> list[dict]:
+    """Every per-project bucket in the checkpoint dir, for `daimon projects`
+    (#243): [{slug, checkpoint, mtime}], unsorted — ordering is a display
+    concern. A bucket is any subdir holding a latest.json; flat per-session
+    files and the global pointer are not buckets. Torn/corrupt pointers are
+    listed with checkpoint=None (the bucket exists — hiding it would read as
+    "no such project"), matching the module's tolerant readers. Pure file-ops,
+    never raises."""
+    d = config.checkpoint_dir()
+    try:
+        entries = sorted(d.iterdir())
+    except OSError:
+        return []
+    out: list[dict] = []
+    for child in entries:
+        latest = child / _LATEST
+        try:
+            mtime = latest.stat().st_mtime
+        except OSError:
+            continue  # not a dir, or a bucket that never got a pointer
+        try:
+            cp = json.loads(latest.read_text(encoding="utf-8"))
+            if not isinstance(cp, dict):
+                cp = None
+        except (OSError, json.JSONDecodeError):
+            cp = None
+        out.append({"slug": child.name, "checkpoint": cp, "mtime": mtime})
+    return out
+
+
 def transcript_unchanged(session_id: str, transcript_hash: str | None) -> bool:
     """True when `transcript_hash` matches the `transcript_hash` already stamped
     on the PER-SESSION checkpoint for `session_id` (#185): the identical-bytes

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -4581,3 +4581,173 @@ def test_reverify_still_refuses_resolved_item_without_evidence(tmp_checkpoint_di
     assert cli.main(["reverify", iid]) == 1
     out = capsys.readouterr().out
     assert "without evidence" in out
+
+
+# ---- daimon projects: cross-project bucket list (#243) ----
+
+
+def _write_bucket(d, slug, session_id, created, branch=None, topic=None):
+    bucket = d / slug
+    bucket.mkdir(parents=True, exist_ok=True)
+    cp = {"session_id": session_id, "project_slug": slug, "created": created}
+    if branch:
+        cp["git_branch"] = branch
+    if topic:
+        cp["working_context"] = {"active_topic": {"text": topic, "trust": "inferred"}}
+    (bucket / "latest.json").write_text(json.dumps(cp))
+
+
+def test_projects_lists_buckets_newest_first(tmp_checkpoint_dir, capsys, monkeypatch):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    _write_bucket(tmp_checkpoint_dir, "-p-old", "S-old", "2026-07-01T00:00:00Z",
+                  branch="main", topic="old work")
+    _write_bucket(tmp_checkpoint_dir, "-p-new", "S-new", "2026-07-11T00:00:00Z",
+                  branch="feat-x", topic="new work")
+    assert cli.main(["projects"]) == 0
+    out = capsys.readouterr().out
+    assert out.index("-p-new") < out.index("-p-old")
+    assert "feat-x" in out
+    assert "new work" in out
+
+
+def test_projects_marks_current_project(tmp_checkpoint_dir, capsys, monkeypatch):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    _write_bucket(tmp_checkpoint_dir, slug, "S-me", "2026-07-11T00:00:00Z")
+    _write_bucket(tmp_checkpoint_dir, "-p-other", "S-o", "2026-07-10T00:00:00Z")
+    assert cli.main(["projects"]) == 0
+    out = capsys.readouterr().out
+    me = next(ln for ln in out.splitlines() if slug in ln)
+    other = next(ln for ln in out.splitlines() if "-p-other" in ln)
+    assert "*" in me and "*" not in other
+
+
+def test_projects_json_shape(tmp_checkpoint_dir, capsys, monkeypatch):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    _write_bucket(tmp_checkpoint_dir, "-p-b", "S-1", "2026-07-11T00:00:00Z",
+                  branch="main", topic="topic text")
+    assert cli.main(["projects", "--json"]) == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert rows == [{
+        "slug": "-p-b", "session_id": "S-1", "created": "2026-07-11T00:00:00Z",
+        "git_branch": "main", "topic": "topic text", "current": False,
+    }]
+
+
+def test_projects_torn_bucket_listed_with_unknowns(tmp_checkpoint_dir, capsys, monkeypatch):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    torn = tmp_checkpoint_dir / "-p-torn"
+    torn.mkdir(parents=True)
+    (torn / "latest.json").write_text("{not json")
+    assert cli.main(["projects"]) == 0
+    assert "-p-torn" in capsys.readouterr().out
+
+
+def test_projects_empty_store_says_so(tmp_checkpoint_dir, capsys, monkeypatch):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    assert cli.main(["projects"]) == 0
+    assert "no project" in capsys.readouterr().out.lower()
+
+
+# ---- recall --slug: bucket-identity scoping (#243) ----
+
+
+def test_cli_recall_slug_scopes_by_bucket_identity(tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):
+    from daimon_briefing import store
+
+    proj_a = str((tmp_path / "proj-a").resolve())
+    proj_b = str((tmp_path / "proj-b").resolve())
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-a", _recall_checkpoint("S-a", "marmot work in a"),
+                           project_dir=proj_a)
+    store.write_checkpoint("S-b", _recall_checkpoint("S-b", "marmot work in b"),
+                           project_dir=proj_b)
+
+    # run from proj_a's scope, target proj_b by slug — no path involved
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", proj_a)
+    rc = cli.main(["recall", "marmot", "--slug", store.project_slug(proj_b)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "marmot work in b" in out
+    assert "marmot work in a" not in out
+
+
+def test_cli_recall_slug_conflicts_with_project(tmp_checkpoint_dir, capsys, tmp_path):
+    rc = cli.main(["recall", "x", "--slug", "-p-b", "--project", str(tmp_path)])
+    assert rc == 2
+    assert "--slug" in capsys.readouterr().err
+
+
+def test_cli_recall_slug_conflicts_with_all_projects(tmp_checkpoint_dir, capsys):
+    rc = cli.main(["recall", "x", "--slug", "-p-b", "--all-projects"])
+    assert rc == 2
+    assert "--slug" in capsys.readouterr().err
+
+
+# ---- brief --slug: deliberate cross-project briefing (#243) ----
+
+
+def test_cli_brief_slug_renders_target_bucket(tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
+    from daimon_briefing import store
+
+    other = json.loads(json.dumps(sample_checkpoint))
+    other["session_id"] = "S-other"
+    other["working_context"]["open_questions"][0]["text"] = "PR #99 state — project B loop"
+    store.write_checkpoint("S-other", other, project_dir="/p/B")
+
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    slug = store.project_slug("/p/B")
+    rc = cli.main(["brief", "--slug", slug])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "PR #99" in out
+    # provenance header: a cross-project briefing must name its origin
+    assert slug in out
+
+
+def test_cli_brief_slug_missing_bucket_never_falls_back(tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
+    from daimon_briefing import store
+
+    # a global pointer exists — an implicit fallback would leak it
+    store.write_checkpoint("S-global", sample_checkpoint)
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    rc = cli.main(["brief", "--slug", "-p-nonexistent"])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "daimon projects" in out
+    assert "PR #6" not in out  # sample_checkpoint body must not render
+
+
+def test_cli_brief_slug_conflicts_with_project(tmp_checkpoint_dir, capsys, tmp_path):
+    rc = cli.main(["brief", "--slug", "-p-b", "--project", str(tmp_path)])
+    assert rc == 2
+    assert "--slug" in capsys.readouterr().err
+
+
+def test_cli_brief_slug_conflicts_with_team(tmp_checkpoint_dir, capsys):
+    rc = cli.main(["brief", "--slug", "-p-b", "--team"])
+    assert rc == 2
+    assert "--slug" in capsys.readouterr().err
+
+
+def test_cli_brief_slug_withholds_resolved_items(tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
+    # the events ledger is slug-routed, so lifecycle folding must survive the
+    # path-less read
+    from daimon_briefing import store
+
+    cp = json.loads(json.dumps(sample_checkpoint))
+    cp["session_id"] = "S-b"
+    store.write_checkpoint("S-b", cp, project_dir="/p/B")
+    written = store.read_latest(project_dir="/p/B", fallback=False)
+    iid = written["working_context"]["open_questions"][0]["id"]
+    q_text = written["working_context"]["open_questions"][0]["text"]
+    store.append_event(iid, "resolved", project_dir="/p/B")
+
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    rc = cli.main(["brief", "--slug", store.project_slug("/p/B")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert q_text not in out
+    assert "withheld" in out

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -4751,3 +4751,22 @@ def test_cli_brief_slug_withholds_resolved_items(tmp_checkpoint_dir, sample_chec
     out = capsys.readouterr().out
     assert q_text not in out
     assert "withheld" in out
+
+
+def test_projects_truncates_long_topic(tmp_checkpoint_dir, capsys, monkeypatch):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    long_topic = "x" * 200
+    _write_bucket(tmp_checkpoint_dir, "-p-long", "S-1", "2026-07-11T00:00:00Z",
+                  topic=long_topic)
+    assert cli.main(["projects"]) == 0
+    out = capsys.readouterr().out
+    assert "…" in out
+    assert long_topic not in out
+
+
+def test_main_defaults_to_sys_argv(tmp_checkpoint_dir, capsys, monkeypatch):
+    # the --slug pre-parse fuse reads sys.argv when main() gets no argv —
+    # the installed console_script path
+    monkeypatch.setattr(sys, "argv", ["daimon", "projects"])
+    assert cli.main() == 0
+    assert "no project" in capsys.readouterr().out.lower()

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -1218,3 +1218,28 @@ def test_event_fold_tolerates_hostile_lines(tmp_checkpoint_dir, monkeypatch):
         encoding="utf-8")
     hits = recall.search("skua", all_projects=True, limit=10)
     assert hits and hits[0]["superseded_by"] == "r-abc123"
+
+
+# ---- --slug: address a bucket by its real identity (#243) ----
+
+
+def test_search_slug_scopes_without_a_path(tmp_checkpoint_dir, monkeypatch):
+    _write_team_file("grace", "S-x", _cp("S-x", decisions=[
+        {"text": "toucan decision in x", "trust": "inferred"}]),
+        project_dir="/repo/x")
+    _write_team_file("grace", "S-y", _cp("S-y", decisions=[
+        {"text": "toucan decision in y", "trust": "inferred"}]),
+        project_dir="/repo/y")
+    hits = recall.search("toucan", slug=store.project_slug("/repo/y"))
+    assert [h["text"] for h in hits] == ["toucan decision in y"]
+
+
+def test_search_slug_wins_over_project_dir(tmp_checkpoint_dir, monkeypatch):
+    # Callers guard the conflict at the CLI; the library keeps one rule: an
+    # explicit slug IS the scope.
+    _write_team_file("grace", "S-x", _cp("S-x", decisions=[
+        {"text": "ibis decision in x", "trust": "inferred"}]),
+        project_dir="/repo/x")
+    hits = recall.search("ibis", project_dir="/repo/y",
+                         slug=store.project_slug("/repo/x"))
+    assert [h["text"] for h in hits] == ["ibis decision in x"]

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -948,3 +948,22 @@ def test_working_plain_body_exception_propagates(capsys):
         pass
     else:  # pragma: no cover - the assert below documents intent
         raise AssertionError("working() swallowed the body's exception")
+
+
+def test_render_projects_plain_exact_format(capsys):
+    render.render_projects([
+        {"mark": "*", "slug": "-p-a", "age": "1h ago", "branch": "main", "topic": "work a"},
+        {"mark": " ", "slug": "-p-bb", "age": "2d ago", "branch": "—", "topic": "work b"},
+    ])
+    out = capsys.readouterr().out
+    assert out == ("* -p-a   1h ago  main  work a\n"
+                   "  -p-bb  2d ago  —     work b\n")
+
+
+def test_render_projects_rich_smoke(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_projects([
+        {"mark": "*", "slug": "-p-a", "age": "1h ago", "branch": "main", "topic": "work a"},
+    ])
+    out = capsys.readouterr().out
+    assert "-p-a" in out and "work a" in out

--- a/plugin/tests/test_skill_content.py
+++ b/plugin/tests/test_skill_content.py
@@ -90,3 +90,16 @@ def test_full_body_teaches_staleness_world_check():
     full = skill_content.render_full()
     reading = full.split("## Reading a briefing")[1].split("\n## ")[0]
     assert "world-check" in reading.lower()
+
+
+def test_full_teaches_context_switching():
+    # #243: the cross-project verbs must be taught, or the feature is invisible.
+    full = skill_content.render_full()
+    assert "daimon projects" in full
+    assert "--slug" in full
+
+
+def test_compact_teaches_context_switching():
+    body = skill_content.render_compact()
+    assert "daimon projects" in body
+    assert "--slug" in body

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1570,3 +1570,13 @@ def test_project_slug_is_idempotent_on_slugs():
     for raw in ("/Users/me/proj.x", "/a/b c/d", "C:\\work\\repo"):
         slug = store.project_slug(raw)
         assert store.project_slug(slug) == slug
+
+
+def test_list_buckets_non_dict_pointer_yields_none_checkpoint(tmp_checkpoint_dir):
+    # valid JSON that is not an object is as unusable as torn bytes
+    d = tmp_checkpoint_dir / "-Users-me-array"
+    d.mkdir(parents=True)
+    (d / "latest.json").write_text("[1, 2]")
+    buckets = store.list_buckets()
+    assert len(buckets) == 1
+    assert buckets[0]["checkpoint"] is None

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1521,3 +1521,52 @@ def test_transcript_unchanged_false_when_new_hash_is_none(tmp_checkpoint_dir, sa
     ck = {**sample_checkpoint, "session_id": "S-hash2", "transcript_hash": "abc123"}
     store.write_checkpoint("S-hash2", ck)
     assert store.transcript_unchanged("S-hash2", None) is False
+
+
+# ---- list_buckets: every project bucket, for `daimon projects` (#243) ----
+
+
+def test_list_buckets_enumerates_all_project_buckets(tmp_checkpoint_dir):
+    d = tmp_checkpoint_dir
+    for slug, sid in (("-Users-me-proj-a", "A"), ("-Users-me-proj-b", "B")):
+        (d / slug).mkdir(parents=True)
+        (d / slug / "latest.json").write_text(
+            json.dumps({"session_id": sid, "project_slug": slug}))
+    buckets = store.list_buckets()
+    assert {b["slug"] for b in buckets} == {"-Users-me-proj-a", "-Users-me-proj-b"}
+    by_slug = {b["slug"]: b for b in buckets}
+    assert by_slug["-Users-me-proj-a"]["checkpoint"]["session_id"] == "A"
+    assert all(isinstance(b["mtime"], float) for b in buckets)
+
+
+def test_list_buckets_ignores_flat_files_and_pointerless_dirs(tmp_checkpoint_dir):
+    d = tmp_checkpoint_dir
+    d.mkdir(parents=True)
+    (d / "S-flat.json").write_text('{"session_id": "S-flat"}')  # per-session file
+    (d / "latest.json").write_text('{"session_id": "S-flat"}')  # global pointer
+    (d / "-Users-me-empty").mkdir()  # bucket dir without a latest.json
+    assert store.list_buckets() == []
+
+
+def test_list_buckets_torn_pointer_yields_none_checkpoint(tmp_checkpoint_dir):
+    d = tmp_checkpoint_dir / "-Users-me-torn"
+    d.mkdir(parents=True)
+    (d / "latest.json").write_text("{not json")
+    buckets = store.list_buckets()
+    assert len(buckets) == 1
+    assert buckets[0]["slug"] == "-Users-me-torn"
+    assert buckets[0]["checkpoint"] is None
+
+
+def test_list_buckets_empty_when_no_dir(tmp_checkpoint_dir):
+    assert store.list_buckets() == []
+
+
+def test_project_slug_is_idempotent_on_slugs():
+    """Load-bearing for --slug (#243): brief/recall pass a SLUG through
+    project_dir-shaped APIs (read_latest, resolutions), relying on
+    project_slug(slug) == slug. If the munging scheme ever changes, this
+    must fail before the feature silently misroutes."""
+    for raw in ("/Users/me/proj.x", "/a/b c/d", "C:\\work\\repo"):
+        slug = store.project_slug(raw)
+        assert store.project_slug(slug) == slug


### PR DESCRIPTION
Closes #243

### What

Cross-project context switching, three read-only pieces:

1. **`daimon projects [--json]`** — one row per checkpoint bucket: slug, checkpoint age, `git_branch` (#228 stamp), `active_topic` teaser; newest first, current project marked `*`. ~N small `latest.json` reads, no index. Torn pointers list with unknown fields instead of vanishing (hiding one would read as "no such project").
2. **`--slug SLUG` on `brief` and `recall`** — address a bucket by its stored identity. The slug is lossy (`store.project_slug` munges every non-word char), so this is the only route to buckets whose source path is gone (written on another machine, directory deleted/moved) — and it works for every legacy bucket with zero migration.
3. **Skill (full + compact) and README** teach the verbs.

### Design constraints honored

- **Explicit, never automatic** — the #94/#95 lesson. `brief --slug` has **no global-pointer fallback** (a named target that's missing is an error pointing at `daimon projects`, never somebody else's checkpoint) and opens with a provenance header naming the origin slug. Conflicting scope flags are rejected (`--slug` vs `--project` on both commands; `--slug` vs `--team` on brief, since team fan-in routes by path; `--slug` vs `--all-projects` on recall).
- **Withhold/staleness survive the path-less read** — the events ledger is already slug-routed (`store._events_path`), so lifecycle folding works identically under `--slug`.
- **Drift is skipped under `--slug`** — anchor paths are relative to the origin project's root, which a slug cannot recover. Same degradation the global fallback already accepts (cli.py drift NOTE), now explicit instead of spurious.

### Implementation notes

- `store.list_buckets()`: tolerant bucket enumeration, same conventions as `sibling_buckets`.
- `--slug` rides through `project_dir`-shaped store APIs unchanged because `project_slug` is **idempotent on slugs**; guarded by a dedicated test (`test_project_slug_is_idempotent_on_slugs`) so a future munging change fails loudly instead of misrouting.
- Real slugs start with `-` (munged absolute paths), which argparse reads as a missing option argument. `main()` fuses `--slug <value>` into `--slug=<value>` pre-parse so both spellings work.
- `recall.search` gains a `slug=` parameter that sets the existing query-time `project_slug` filter directly — the index was already global.
- The shared tail of `brief` (withhold → drift → render → footnotes) is extracted into `_render_briefing_body`, used by both the normal and `--slug` paths.

### Testing

TDD throughout (red first). 1514 passed, 1 skipped locally. New coverage: bucket enumeration (valid/torn/pointerless/empty), slug idempotence guard, `projects` output ordering + current-marker + JSON shape + torn/empty cases, recall slug scoping (library + CLI) and flag conflicts, brief slug render + provenance + no-fallback + conflicts + withhold-under-slug, skill/README content.

Verified live end-to-end on a machine with 14 real buckets: `daimon projects`, `brief --slug`, and `recall --slug` against a foreign bucket, including the leading-dash slug spelling both ways.
