### PR TITLE
fix(recall): resolve events invalidate the index — events.jsonl joins the fingerprint

### DIFF
--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -254,8 +254,13 @@ def _fingerprint() -> str:
             if e.is_file() and e.suffix == ".json":
                 paths.append(e)  # pointers included: rotation moves attribution
             elif e.is_dir():
+                # events.jsonl is index CONTENT (_apply_event_resolutions folds
+                # it into superseded_by), so it must be fingerprint INPUT too —
+                # else a resolve/reopen serves stale rows until an unrelated
+                # checkpoint write happens to invalidate the db (#245).
                 paths.extend(p for p in e.iterdir()
-                             if p.is_file() and p.suffix == ".json")
+                             if p.is_file() and (p.suffix == ".json"
+                                                 or p.name == "events.jsonl"))
     except OSError:
         pass
     try:

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -1243,3 +1243,37 @@ def test_search_slug_wins_over_project_dir(tmp_checkpoint_dir, monkeypatch):
     hits = recall.search("ibis", project_dir="/repo/y",
                          slug=store.project_slug("/repo/x"))
     assert [h["text"] for h in hits] == ["ibis decision in x"]
+
+
+# ---- #245: events.jsonl is index content, so it must be fingerprint input ----
+
+
+def test_resolve_event_invalidates_index_without_manual_rebuild(tmp_checkpoint_dir, monkeypatch):
+    cp = {"working_context": {"open_questions": [
+        {"text": "walrus question pending", "trust": "inferred"}]}}
+    store.write_checkpoint("S-fp", cp, project_dir="/repo/x")
+    hits = recall.search("walrus", project_dir="/repo/x")
+    assert hits and hits[0]["superseded_by"] is None  # indexed live
+
+    iid = store.read_latest(project_dir="/repo/x", fallback=False)[
+        "working_context"]["open_questions"][0]["id"]
+    store.append_event(iid, "resolved", project_dir="/repo/x")
+
+    # NO manual rebuild: the event append alone must stale the fingerprint
+    hits = recall.search("walrus", project_dir="/repo/x")
+    assert hits and hits[0]["superseded_by"] == "resolved"
+
+
+def test_reopen_event_revives_item_without_manual_rebuild(tmp_checkpoint_dir, monkeypatch):
+    cp = {"working_context": {"open_questions": [
+        {"text": "narwhal question pending", "trust": "inferred"}]}}
+    store.write_checkpoint("S-fp2", cp, project_dir="/repo/x")
+    iid = store.read_latest(project_dir="/repo/x", fallback=False)[
+        "working_context"]["open_questions"][0]["id"]
+    store.append_event(iid, "resolved", project_dir="/repo/x")
+    hits = recall.search("narwhal", project_dir="/repo/x")
+    assert hits and hits[0]["superseded_by"] == "resolved"
+
+    store.append_event(iid, "reopened", project_dir="/repo/x")
+    hits = recall.search("narwhal", project_dir="/repo/x")
+    assert hits and hits[0]["superseded_by"] is None


### PR DESCRIPTION
Closes #245

### What

`recall._fingerprint` now includes each bucket's `events.jsonl` in its scan. One condition widened, plus a comment stating the invariant: **whatever the rebuild reads must be fingerprint input**.

### Why

The rebuild folds `events.jsonl` into `superseded_by` (`_apply_event_resolutions`, #234), so lifecycle events are index content — but the staleness fingerprint scanned only `*.json`. A `daimon resolve` (or reopen) therefore changed what a rebuild would produce while leaving the fingerprint byte-identical: `_ensure_fresh` kept serving the stale db, and the just-resolved item kept surfacing as live until some unrelated checkpoint write invalidated the index — in practice, for the rest of the session in which it was resolved.

Race direction is unchanged: fingerprint is computed before the scan, so the fix errs toward one extra rebuild, never toward stale rows.

### Testing

TDD (red first): two end-to-end tests through `recall.search` with **no manual rebuild** — resolve marks the item `[resolved]` on the very next search; a subsequent `reopened` event revives it. Reproduced the bug live on main before the fix (search after resolve returned the item unmarked; forced rebuild returned `[resolved]`). Full suite: 1521 passed.

### Observed while fixing (not in this PR's scope)

Store-side readers treat any status *starting with* `reopen` as a revival (`store._tie_rank`, `resolve --status` help), while `_apply_event_resolutions` matches `"reopened"` exactly — a prefix status like `reopen-was-wrong` revives the item in `brief` but leaves it `[resolved]` in `recall`. Display-level divergence only; can be filed separately if worth aligning.
