### PR TITLE
feat(recall): warm the index at write time — rebuild off the first-prompt path

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -310,6 +310,11 @@ def _run_serialize(transcript_path: Path, project: str | None) -> int:
         msg += " [fallback backend]"
     print(msg)
     _append_serialize_log(msg)
+    # #246: the write above staled the recall index; freshen it HERE, where
+    # nobody is waiting, instead of on the next session's first-prompt
+    # recall-inject. After the print/log so the byte-identical result
+    # contract above is untouched; warm() itself never raises.
+    recall.warm()
     # Opt-in scar-candidate harvest (#100), mirroring the hermes host wiring
     # (hooks.on_session_end). It runs AFTER the result line is printed AND logged,
     # and ANY failure is swallowed here — the harvest must never change this
@@ -420,6 +425,7 @@ def _cmd_write_checkpoint(args) -> int:
     session_id = str(checkpoint["session_id"])
     out = store.write_checkpoint(session_id, checkpoint, project_dir=_resolve_project(args.project))
     render.render_write_checkpoint([f"wrote checkpoint: {out} (source: {args.source})"])
+    recall.warm()  # #246: freshen off the read path; never raises
     return 0
 
 
@@ -466,6 +472,7 @@ def _cmd_anchor(args) -> int:
     item["anchored_to"] = a
     store.write_checkpoint(session_id, checkpoint, project_dir=project)
     render.render_anchor_attach([f"attached {a['qualified_name']} to: {item.get('text')}"])
+    recall.warm()  # #246: the re-write staled the index; freshen off the read path
     return 0
 
 
@@ -1413,6 +1420,12 @@ def _cmd_team_sync(args) -> int:
         render.render_team_sync(["daimon team: git not found on PATH — sync skipped"])
         return 0
     reports = teamsync.sync()
+    # #246: fetched teammate files are fingerprint input — freshen here (the
+    # SessionStart hook spawns sync detached, off the prompt path) so the
+    # first recall after a fetch doesn't pay the rebuild. Unconditional on
+    # purpose: a no-op sync warms in ~ms, and any staleness left by other
+    # writers gets healed opportunistically.
+    recall.warm()
     if not reports:
         render.render_team_sync([
             "daimon team: no team remote configured — nothing to sync "

--- a/plugin/daimon_briefing/hooks.py
+++ b/plugin/daimon_briefing/hooks.py
@@ -13,7 +13,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-from . import briefing, config, harvest, llm, serializer, store, transcript
+from . import briefing, config, harvest, llm, recall, serializer, store, transcript
 
 log = logging.getLogger("daimon_briefing")
 
@@ -108,6 +108,13 @@ def on_session_end(session_id, completed=None, interrupted=None, model=None, pla
             session_id,
             int(time.monotonic() - start),
         )
+        # #246: the write staled the recall index. This hook runs after the
+        # session ends — the one place a full rebuild costs nobody anything —
+        # so the NEXT session's first-prompt recall-inject finds it fresh
+        # instead of paying the rebuild on the user's critical path. warm()
+        # never raises (and the outer except would ledger a lie: the
+        # checkpoint IS written by this point).
+        recall.warm()
         if config.scar_harvest_enabled():
             try:
                 harvest.run(messages, project_root=root, session_id=session_id)

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -521,6 +521,25 @@ def _ensure_fresh() -> None:
         rebuild()
 
 
+def warm() -> None:
+    """Eagerly freshen the index at write time (#246). Staleness is CREATED
+    where files change (serialize, team sync, checkpoint re-writes) but the
+    lazy _ensure_fresh pays for it on the READ side — and the first reader
+    after a serialize is recall-inject on the user's next prompt, putting a
+    full rebuild (~800ms on a real corpus) on the per-prompt critical path.
+    Call sites are all off that path, so the rebuild happens where nobody is
+    waiting; the read side then finds a matching fingerprint and no-ops.
+
+    Idempotent (~ms when already fresh) and fail-open: a broken or FTS5-less
+    rebuild must never fail the write that triggered it — swallowed with the
+    standard breadcrumb, and the lazy read-side path stays as the safety
+    net."""
+    try:
+        _ensure_fresh()
+    except Exception as exc:  # noqa: BLE001 — see docstring: never fail a write
+        _note_error("warm", exc)
+
+
 def index_attribution() -> dict | None:
     """Attribution counts from the EXISTING index, read-only (#233): never
     rebuilds — status must not pay the rebuild cost, and a missing index is

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -4770,3 +4770,53 @@ def test_main_defaults_to_sys_argv(tmp_checkpoint_dir, capsys, monkeypatch):
     monkeypatch.setattr(sys, "argv", ["daimon", "projects"])
     assert cli.main() == 0
     assert "no project" in capsys.readouterr().out.lower()
+
+
+# ---- #246: eager index warm at write time ----
+
+
+def _count_warm(monkeypatch):
+    from daimon_briefing import recall
+    calls = []
+    monkeypatch.setattr(recall, "warm", lambda: calls.append(1))
+    return calls
+
+
+def test_serialize_warms_index_after_write(tmp_checkpoint_dir, fake_chat_factory, capsys, monkeypatch):
+    chat = fake_chat_factory(_valid_json())
+    monkeypatch.setattr(cli, "_chat", chat)
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    calls = _count_warm(monkeypatch)
+    assert cli.main(["serialize", str(FIXTURES / "sample_transcript.md")]) == 0
+    assert calls == [1]
+    # the byte-identical result contract is untouched
+    assert "wrote checkpoint:" in capsys.readouterr().out
+
+
+def test_write_checkpoint_cmd_warms_index(tmp_checkpoint_dir, capsys, monkeypatch):
+    calls = _count_warm(monkeypatch)
+    _stdin(monkeypatch, _valid_json("S-wc"))
+    assert cli.main(["write-checkpoint", "--project", "/p/A"]) == 0
+    assert calls == [1]
+
+
+def test_anchor_attach_warms_index(tmp_checkpoint_dir, tmp_path, capsys, monkeypatch):
+    from daimon_briefing import store
+    src = tmp_path / "mod.py"
+    src.write_text("def fn():\n    return 1\n")
+    cp = {"session_id": "S-anchor", "working_context": {"open_questions": [
+        {"text": "anchor target item", "trust": "inferred"}]}}
+    store.write_checkpoint("S-anchor", cp, project_dir=str(tmp_path))
+    calls = _count_warm(monkeypatch)
+    rc = cli.main(["anchor", "mod.py", "fn", "--project", str(tmp_path),
+                   "--attach", "anchor target"])
+    assert rc == 0
+    assert calls == [1]
+
+
+def test_team_sync_warms_index(tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import teamsync
+    monkeypatch.setattr(teamsync, "sync", lambda: [])
+    calls = _count_warm(monkeypatch)
+    assert cli.main(["team", "sync"]) == 0
+    assert calls == [1]

--- a/plugin/tests/test_hooks.py
+++ b/plugin/tests/test_hooks.py
@@ -705,3 +705,20 @@ def test_on_session_end_never_raises_when_ledger_write_fails(
 
 def test_hooks_docstring_no_stale_project_name():
     assert "hermes" not in (hooks.__doc__ or "").lower()
+
+
+def test_on_session_end_warms_index_after_write(tmp_checkpoint_dir, fake_chat_factory, monkeypatch):
+    # #246: the SessionEnd hook is the background home of the rebuild — the
+    # next session's first-prompt recall-inject must find the index fresh.
+    from daimon_briefing import recall, transcript
+
+    chat = fake_chat_factory(_valid_json("S-warm"))
+    monkeypatch.setattr(transcript, "from_session", lambda sid: make_messages(20))
+    monkeypatch.setattr(hooks, "_chat", chat)
+    calls = []
+    monkeypatch.setattr(recall, "warm", lambda: calls.append(1))
+
+    hooks.on_session_end(
+        session_id="S-warm", completed=True, interrupted=False, model="m", platform="cli"
+    )
+    assert calls == [1]

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -1277,3 +1277,43 @@ def test_reopen_event_revives_item_without_manual_rebuild(tmp_checkpoint_dir, mo
     store.append_event(iid, "reopened", project_dir="/repo/x")
     hits = recall.search("narwhal", project_dir="/repo/x")
     assert hits and hits[0]["superseded_by"] is None
+
+
+# ---- warm(): eager freshness at write time (#246) ----
+
+
+def test_warm_rebuilds_stale_index_so_search_pays_nothing(tmp_checkpoint_dir, monkeypatch):
+    store.write_checkpoint("S-warm", _cp("S-warm", decisions=[
+        {"text": "quokka decision", "trust": "inferred"}]), project_dir="/repo/x")
+    calls = []
+    real = recall.rebuild
+    monkeypatch.setattr(recall, "rebuild", lambda: (calls.append(1), real())[1])
+    recall.warm()
+    assert calls == [1]  # stale after the write -> warm rebuilt
+    hits = recall.search("quokka", project_dir="/repo/x")
+    assert [h["text"] for h in hits] == ["quokka decision"]
+    assert calls == [1]  # read side found it fresh: no second rebuild
+
+
+def test_warm_is_noop_when_already_fresh(tmp_checkpoint_dir, monkeypatch):
+    store.write_checkpoint("S-warm2", _cp("S-warm2", decisions=[
+        {"text": "axolotl decision", "trust": "inferred"}]), project_dir="/repo/x")
+    recall.warm()
+    calls = []
+    monkeypatch.setattr(recall, "rebuild", lambda: calls.append(1))
+    recall.warm()
+    assert calls == []
+
+
+def test_warm_never_raises(tmp_checkpoint_dir, monkeypatch):
+    def boom():
+        raise RuntimeError("index exploded")
+    monkeypatch.setattr(recall, "_ensure_fresh", boom)
+    recall.warm()  # must swallow — a write must never fail over its index
+
+
+def test_warm_swallows_fts5_missing(tmp_checkpoint_dir, monkeypatch):
+    def no_fts5():
+        raise recall.RecallError("no FTS5")
+    monkeypatch.setattr(recall, "_ensure_fresh", no_fts5)
+    recall.warm()


### PR DESCRIPTION
Closes #246

### What

`recall.warm()` — a fail-open freshness call placed where index staleness is *created*, so the rebuild happens where nobody is waiting instead of on the next session's first prompt.

Measured on a real corpus (~100 checkpoints + team mirrors): full rebuild **811ms**, warm freshness check **3ms**. Before this change the rebuild landed on `recall-inject` — the UserPromptSubmit hook — i.e. on the user's first-prompt latency after essentially every session.

### How

`warm()` wraps `_ensure_fresh()`: rebuild only if actually stale (idempotent, ~3ms when fresh), swallow everything (`RecallError`/FTS5-less included) with the standard `_note_error` breadcrumb — a write must never fail over its index. The lazy read-side path is untouched and remains the safety net.

Call sites (all off the per-prompt critical path):

- **serialize (CLI)** and the **SessionEnd hook** — after the print/log result line, same position as the scar harvest, so the byte-identical result contract is unaffected. In the hook it runs before the outer catch-all `except` would matter: the checkpoint is already written and warm never raises, so the failure ledger can't record a lie.
- **write-checkpoint** (introspection path) and **anchor --attach** (checkpoint re-write).
- **team sync** — spawned detached by the SessionStart hook; fetched teammate files are fingerprint input. Unconditional on purpose: a no-op sync warms in ~ms, and staleness left by any other writer gets healed opportunistically.

### Testing

TDD (red first). Library: warm rebuilds a stale index exactly once and the subsequent search pays nothing; no-ops when fresh; never raises (generic exception and `RecallError` both). Call sites: one test per site asserting `warm` fires after the write (serialize CLI, SessionEnd hook, write-checkpoint, anchor --attach, team sync) with the serialize result line unchanged. Full suite: 1528 passed.

Live end-to-end on the real corpus: staled the fingerprint, `warm()` absorbed the rebuild (**869ms**, background side), read-side check after it: **4ms**.

### Note

Independent of #247 (fingerprint misses events.jsonl) — different lines, no conflict; together they make the index both *correct* on lifecycle events and *cheap* at first prompt.
