### PR TITLE
fix(llm): backend failure log carries stdout too — CLIs that error on stdout no longer leave a bare header

### DIFF
--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -285,21 +285,31 @@ def _apply_input_spec(argv, prompt_text, input_spec, cwd):
     return argv, prompt_text
 
 
-def _log_backend_stderr(argv0, err, header) -> str:
-    """Write redacted command-backend stderr to backend-stderr.log (truncate-
-    per-run — the log is "the last failure", not an archive, #56) and return a
-    hint embeddable in a ChatError message: the log path on success, "stderr
-    suppressed" on any OSError — logging must never mask the real failure
-    (fail-open on the logging seam, #225)."""
+def _log_backend_stderr(argv0, err, header, out=None) -> str:
+    """Write redacted command-backend diagnostics to backend-stderr.log
+    (truncate-per-run — the log is "the last failure", not an archive, #56)
+    and return a hint embeddable in a ChatError message: the log path on
+    success, "stderr suppressed" on any OSError — logging must never mask the
+    real failure (fail-open on the logging seam, #225).
+
+    `out` is the backend's stdout, appended under a label AFTER stderr:
+    agent-style CLIs (claude among them) report errors on stdout with an
+    empty stderr, so a stderr-only log was a bare header exactly when the
+    user most needed the cause (#250). Both streams are the user's own disk,
+    same trust domain as the transcript — scrubbed, never on any wire."""
     hint = "stderr suppressed"
     try:
         d = config.log_dir()
         d.mkdir(parents=True, exist_ok=True)
         p = d / "backend-stderr.log"
         # CLI backends can echo prompt fragments (transcript text) into
-        # stderr — scrub before it persists (#141).
+        # either stream — scrub before it persists (#141).
         err_logged, _ = redact.redact_text(err or "")
-        p.write_text(f"{header}\n{err_logged}\n", encoding="utf-8")
+        body = f"{header}\n{err_logged}\n"
+        if out is not None:
+            out_logged, _ = redact.redact_text(out)
+            body += f"--- stdout ---\n{out_logged}\n"
+        p.write_text(body, encoding="utf-8")
         hint = f"stderr: {p}"
     except OSError:
         pass
@@ -340,7 +350,8 @@ def _chat_command(messages, deadline):
             # 101 in the field with zero diagnostics). Truncate-per-run: the
             # log is "the last failure", not an archive.
             hint = _log_backend_stderr(
-                argv[0], err, f"command backend exit {rc} (argv0: {argv[0]})")
+                argv[0], err, f"command backend exit {rc} (argv0: {argv[0]})",
+                out=out)
             raise ChatError(f"command backend exited {rc} ({hint})")
         try:
             text = _extract_output(out, output_spec)
@@ -353,7 +364,8 @@ def _chat_command(messages, deadline):
             # log, a distinguishable header, and a distinguishable exception
             # type so the serializer can retry it like an empty HTTP 200 body.
             hint = _log_backend_stderr(
-                argv[0], err, f"command backend empty output (argv0: {argv[0]})")
+                argv[0], err, f"command backend empty output (argv0: {argv[0]})",
+                out=out)
             raise EmptyOutputError(f"command backend returned empty output ({hint})")
         log.info("LLM command backend ok argv0=%s", argv[0])
         return text

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -625,3 +625,66 @@ def test_empty_output_error_is_a_chat_error():
     # Callers that catch the broad ChatError (e.g. llm.chat's own fallback
     # logic) must keep working unmodified.
     assert issubclass(llm.EmptyOutputError, llm.ChatError)
+
+
+# ---- #250: CLIs that report errors on STDOUT (claude does) must not leave an
+# empty breadcrumb — the failure log carries both streams, labeled ----
+
+
+def test_command_backend_failure_logs_stdout_too(monkeypatch, tmp_path):
+    # the live claude shape: "Not logged in · Please run /login" on stdout,
+    # stderr empty, rc 1
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "claude-like")
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setattr(llm, "_run_command",
+                        lambda *a, **k: (1, "Not logged in · Please run /login", ""))
+    with pytest.raises(llm.ChatError):
+        llm.chat([{"role": "user", "content": "hola"}])
+    text = (tmp_path / "logs" / "backend-stderr.log").read_text()
+    assert "Not logged in" in text
+    assert "stdout" in text  # labeled, so the reader knows which stream spoke
+
+
+def test_command_backend_empty_output_logs_stdout_when_stderr_silent(monkeypatch, tmp_path):
+    # the zero-config claude preset shape: rc 0, json:result output spec, an
+    # empty result field — but the raw stdout envelope carries the actual
+    # error details. Empty stderr made the old log a bare header (#250).
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "claude-like")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND_OUTPUT", "json:result")
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(tmp_path / "logs"))
+    envelope = '{"result": "", "is_error": true, "subtype": "error_during_execution"}'
+    monkeypatch.setattr(llm, "_run_command",
+                        lambda *a, **k: (0, envelope, ""))
+    with pytest.raises(llm.EmptyOutputError):
+        llm.chat([{"role": "user", "content": "hola"}])
+    text = (tmp_path / "logs" / "backend-stderr.log").read_text()
+    assert "error_during_execution" in text
+
+
+def test_command_backend_stdout_in_log_is_redacted(monkeypatch, tmp_path):
+    # same #141 argument as stderr: stdout can echo prompt fragments
+    secret = "AKIAIOSFODNN7EXAMPLE"
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "leaky-cli")
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setattr(llm, "_run_command",
+                        lambda *a, **k: (1, f"echoing key {secret}", ""))
+    with pytest.raises(llm.ChatError):
+        llm.chat([{"role": "user", "content": "hola"}])
+    text = (tmp_path / "logs" / "backend-stderr.log").read_text()
+    assert secret not in text
+    assert "[redacted:aws-key]" in text
+
+
+def test_command_backend_stderr_stays_first_when_both_streams_speak(monkeypatch, tmp_path):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "noisy-cli")
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setattr(llm, "_run_command",
+                        lambda *a, **k: (2, "partial body", "the real panic"))
+    with pytest.raises(llm.ChatError):
+        llm.chat([{"role": "user", "content": "hola"}])
+    text = (tmp_path / "logs" / "backend-stderr.log").read_text()
+    assert text.index("the real panic") < text.index("partial body")


### PR DESCRIPTION
Closes #250

### What

`_log_backend_stderr` gains an `out=` parameter; both command-backend failure paths (non-zero exit, rc-0-empty-output) now append the backend's **redacted stdout** to `backend-stderr.log` under a labeled `--- stdout ---` section. Stderr stays first and byte-identical when it has content.

### Why

Found during the pre-launch fresh-install audit. Agent-style CLIs report errors on **stdout** with an empty stderr:

- Unauthenticated claude: `Not logged in · Please run /login` on stdout, exit 1 — the old log was a bare `command backend exit 1 (argv0: claude)`.
- The zero-config claude preset (`json:result`) can return rc 0 with an empty `result` whose JSON envelope carries the actual diagnosis (`is_error: true`, `terminal_reason: "api_error"`) — the #225 empty-output shape, still guesswork after that fix because only stderr was persisted.

The #56 principle — "discarding it locally turned every backend failure into guesswork" — now covers both streams. Same trust-domain argument: the user's own disk, scrubbed by redact before persisting (#141), truncate-per-run. `ChatError`/`EmptyOutputError` messages still never echo stream content onto any wire.

### Testing

TDD (red first): stdout-erroring CLI lands its message labeled in the log; claude-preset empty-result envelope lands its error details; stdout is redacted like stderr; stderr stays first when both streams speak. Full suite: 1534 passed.

Live end-to-end: `daimon configure --test` against a genuinely unauthenticated claude CLI — the breadcrumb went from a bare header to the full envelope including `"Not logged in · Please run /login"` and `terminal_reason: "api_error"`.
