### PR TITLE
fix(llm): log command backend stdout on failure

### DIFF
--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -285,8 +285,8 @@ def _apply_input_spec(argv, prompt_text, input_spec, cwd):
     return argv, prompt_text
 
 
-def _log_backend_stderr(argv0, err, header) -> str:
-    """Write redacted command-backend stderr to backend-stderr.log (truncate-
+def _log_backend_stderr(argv0, err, out, header) -> str:
+    """Write redacted command-backend streams to backend-stderr.log (truncate-
     per-run — the log is "the last failure", not an archive, #56) and return a
     hint embeddable in a ChatError message: the log path on success, "stderr
     suppressed" on any OSError — logging must never mask the real failure
@@ -296,10 +296,14 @@ def _log_backend_stderr(argv0, err, header) -> str:
         d = config.log_dir()
         d.mkdir(parents=True, exist_ok=True)
         p = d / "backend-stderr.log"
-        # CLI backends can echo prompt fragments (transcript text) into
-        # stderr — scrub before it persists (#141).
+        # CLI backends can echo prompt fragments (transcript text) into either
+        # stream — scrub both before they persist (#141, #250).
         err_logged, _ = redact.redact_text(err or "")
-        p.write_text(f"{header}\n{err_logged}\n", encoding="utf-8")
+        out_logged, _ = redact.redact_text(out or "")
+        p.write_text(
+            f"{header}\n{err_logged}\n--- stdout ---\n{out_logged}\n",
+            encoding="utf-8",
+        )
         hint = f"stderr: {p}"
     except OSError:
         pass
@@ -340,7 +344,8 @@ def _chat_command(messages, deadline):
             # 101 in the field with zero diagnostics). Truncate-per-run: the
             # log is "the last failure", not an archive.
             hint = _log_backend_stderr(
-                argv[0], err, f"command backend exit {rc} (argv0: {argv[0]})")
+                argv[0], err, out,
+                f"command backend exit {rc} (argv0: {argv[0]})")
             raise ChatError(f"command backend exited {rc} ({hint})")
         try:
             text = _extract_output(out, output_spec)
@@ -353,7 +358,8 @@ def _chat_command(messages, deadline):
             # log, a distinguishable header, and a distinguishable exception
             # type so the serializer can retry it like an empty HTTP 200 body.
             hint = _log_backend_stderr(
-                argv[0], err, f"command backend empty output (argv0: {argv[0]})")
+                argv[0], err, out,
+                f"command backend empty output (argv0: {argv[0]})")
             raise EmptyOutputError(f"command backend returned empty output ({hint})")
         log.info("LLM command backend ok argv0=%s", argv[0])
         return text

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -554,6 +554,31 @@ def test_command_backend_failure_writes_stderr_log(monkeypatch, tmp_path):
     assert "exit 101" in log.read_text()
 
 
+def test_command_backend_failure_writes_stdout_log(monkeypatch, tmp_path):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "failing-cli")
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setattr(llm, "_run_command",
+                        lambda *a, **k: (1, "Not logged in · Please run /login", ""))
+    with pytest.raises(llm.ChatError) as exc:
+        llm.chat([{"role": "user", "content": "hola"}])
+    assert "Not logged in" not in str(exc.value)
+    text = (tmp_path / "logs" / "backend-stderr.log").read_text()
+    assert "--- stdout ---\nNot logged in · Please run /login" in text
+
+
+def test_command_backend_failure_log_labels_both_streams(monkeypatch, tmp_path):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "failing-cli")
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setattr(llm, "_run_command",
+                        lambda *a, **k: (1, "stdout detail", "stderr detail"))
+    with pytest.raises(llm.ChatError):
+        llm.chat([{"role": "user", "content": "hola"}])
+    text = (tmp_path / "logs" / "backend-stderr.log").read_text()
+    assert "stderr detail\n--- stdout ---\nstdout detail" in text
+
+
 def test_command_backend_stderr_log_redacts_secret(monkeypatch, tmp_path):
     # #141: CLI backends can echo prompt fragments (transcript text) into
     # stderr on failure — the local stderr log is a disk artifact and must be
@@ -571,18 +596,40 @@ def test_command_backend_stderr_log_redacts_secret(monkeypatch, tmp_path):
     assert "[redacted:aws-key]" in text
 
 
+def test_command_backend_failure_log_redacts_both_streams(monkeypatch, tmp_path):
+    aws_secret = "AKIAIOSFODNN7EXAMPLE"
+    github_secret = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn"
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "failing-cli")
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setattr(
+        llm, "_run_command",
+        lambda *a, **k: (1, f"stdout token {github_secret}",
+                          f"stderr key {aws_secret}"))
+    with pytest.raises(llm.ChatError):
+        llm.chat([{"role": "user", "content": "hola"}])
+    text = (tmp_path / "logs" / "backend-stderr.log").read_text()
+    assert aws_secret not in text
+    assert github_secret not in text
+    assert "[redacted:aws-key]" in text
+    assert "[redacted:github-token]" in text
+
+
 def test_command_backend_stderr_log_truncates_per_run(monkeypatch, tmp_path):
     monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
     monkeypatch.setenv("DAIMON_LLM_COMMAND", "failing-cli")
     monkeypatch.setenv("DAIMON_LOG_DIR", str(tmp_path / "logs"))
-    monkeypatch.setattr(llm, "_run_command", lambda *a, **k: (1, "", "first"))
+    monkeypatch.setattr(llm, "_run_command",
+                        lambda *a, **k: (1, "first stdout", "first stderr"))
     with pytest.raises(llm.ChatError):
         llm.chat([{"role": "user", "content": "x"}])
-    monkeypatch.setattr(llm, "_run_command", lambda *a, **k: (1, "", "second"))
+    monkeypatch.setattr(llm, "_run_command",
+                        lambda *a, **k: (1, "second stdout", "second stderr"))
     with pytest.raises(llm.ChatError):
         llm.chat([{"role": "user", "content": "x"}])
     text = (tmp_path / "logs" / "backend-stderr.log").read_text()
-    assert "second" in text and "first" not in text
+    assert "second stdout" in text and "second stderr" in text
+    assert "first stdout" not in text and "first stderr" not in text
 
 
 # ---- #225: rc=0 + empty stdout gets the same local diagnostics as a non-zero
@@ -602,6 +649,7 @@ def test_command_backend_empty_output_writes_stderr_log(monkeypatch, tmp_path):
     assert "suppressed" not in str(exc.value)
     log = tmp_path / "logs" / "backend-stderr.log"
     assert "warming up model..." in log.read_text()
+    assert "--- stdout ---\n   \n" in log.read_text()
     assert "empty output" in log.read_text()
 
 


### PR DESCRIPTION
## Summary
- persist command-backend stdout alongside stderr on failure
- label and redact both streams while preserving per-run truncation
- cover stdout-only, mixed-stream, redaction, truncation, and empty-output failures

## Testing
- `pytest plugin/tests/test_llm.py` (50 passed)
- `ruff check plugin/daimon_briefing/llm.py plugin/tests/test_llm.py`
- hook drift gate and scar lint
- project suite: 1531 passed, 1 skipped, 2 unrelated time-sensitive tests deselected

Fixes #250
