### PR TITLE
fix(recall): index liveness fold reuses store.is_resolved — one rule, no drift

### DIFF
--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -376,45 +376,31 @@ def _apply_typed_supersession(conn: sqlite3.Connection, links: list) -> None:
 
 def _apply_event_resolutions(conn: sqlite3.Connection) -> None:
     """Fold each project bucket's events.jsonl into superseded_by (#234).
-    Conservative: an item_ref is marked only when its newest resolving event
-    ("resolved" or "superseded-by:<id>") is STRICTLY newer than any reopen —
-    ties stay unmarked (never-guess). "supersede-candidate:*" never marks:
-    candidates are the unconfirmed tier by design (#111). The stored value is
-    the superseding item id when the status names one, else "resolved"."""
+
+    The liveness rule is store.is_resolved over the store.resolutions fold —
+    the SAME rule and fold brief/withhold/carry use, not a re-implementation
+    (#255: the hand-rolled exact-match copy here silently disagreed with the
+    briefing on every free-form status and on reopen-prefix revivals). That
+    inherits the whole contract: free-form statuses resolve, reopen* revives
+    (case-insensitive), supersede-candidate:* never marks (a machine guess
+    must never suppress, #111), and same-second ties break on content (#143;
+    reopen wins a tie → unmarked, never-guess). The stored value is the
+    superseding item id when the status names one, else "resolved"."""
     try:
         buckets = [d for d in config.checkpoint_dir().iterdir() if d.is_dir()]
     except OSError:
         return
     for bucket in buckets:
-        path = bucket / "events.jsonl"
-        try:
-            lines = path.read_text(encoding="utf-8").splitlines()
-        except (OSError, UnicodeDecodeError):
-            continue
-        marks: dict[str, tuple[str, str]] = {}  # ref -> (resolve_ts, value)
-        reopens: dict[str, str] = {}            # ref -> newest reopen ts
-        for line in lines:
-            try:
-                e = json.loads(line)
-            except json.JSONDecodeError:
+        # The bucket dir NAME is the slug, and slug munging is idempotent
+        # (guarded by test_project_slug_is_idempotent_on_slugs), so it routes
+        # store.resolutions exactly like a project dir.
+        for ref, evt in store.resolutions(project_dir=bucket.name).items():
+            if not store.is_resolved(evt):
                 continue
-            if not isinstance(e, dict) or e.get("kind") != "resolution":
-                continue
-            ref = str(e.get("item_ref") or "")
-            ts = str(e.get("ts") or "")
-            status = str(e.get("status") or "")
-            if not ref or not ts:
-                continue
-            if status == "reopened":
-                if ts > reopens.get(ref, ""):
-                    reopens[ref] = ts
-            elif status == "resolved" or status.startswith("superseded-by:"):
-                value = status.split(":", 1)[1] if ":" in status else "resolved"
-                if ts > marks.get(ref, ("", ""))[0]:
-                    marks[ref] = (ts, value)
-        for ref, (ts, value) in marks.items():
-            if ts <= reopens.get(ref, ""):
-                continue  # reopened at/after the resolve — stays live
+            status = str(evt.get("status") or "")
+            value = "resolved"
+            if status.lower().startswith("superseded-by:"):
+                value = status.split(":", 1)[1].strip() or "resolved"
             conn.execute(
                 "UPDATE items SET superseded_by = ?"
                 " WHERE item_id = ? AND project_slug IS ?",

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -1317,3 +1317,57 @@ def test_warm_swallows_fts5_missing(tmp_checkpoint_dir, monkeypatch):
         raise recall.RecallError("no FTS5")
     monkeypatch.setattr(recall, "_ensure_fresh", no_fts5)
     recall.warm()
+
+
+# ---- #255: ONE liveness rule — the index fold reuses store.is_resolved ----
+
+
+def _one_question_bucket(text, sid, project="/repo/x"):
+    cp = {"working_context": {"open_questions": [
+        {"text": text, "trust": "inferred"}]}}
+    store.write_checkpoint(sid, cp, project_dir=project)
+    return store.read_latest(project_dir=project, fallback=False)[
+        "working_context"]["open_questions"][0]["id"]
+
+
+def test_free_form_resolving_status_marks_resolved(tmp_checkpoint_dir):
+    # store.is_resolved: unknown statuses resolve ("the writer bothered to
+    # record a lifecycle fact") — the --status help's own example must not
+    # diverge between brief and recall
+    iid = _one_question_bucket("wombat question pending", "S-lv1")
+    store.append_event(iid, "shipped in 0.9", project_dir="/repo/x")
+    hits = recall.search("wombat", project_dir="/repo/x")
+    assert hits and hits[0]["superseded_by"] == "resolved"
+
+
+def test_reopen_prefix_status_revives(tmp_checkpoint_dir):
+    # help text: "a status starting with 'reopen' revives the item"
+    iid = _one_question_bucket("gecko question pending", "S-lv2")
+    store.append_event(iid, "resolved", project_dir="/repo/x")
+    store.append_event(iid, "reopen-was-wrong", project_dir="/repo/x")
+    hits = recall.search("gecko", project_dir="/repo/x")
+    assert hits and hits[0]["superseded_by"] is None
+
+
+def test_reopen_status_is_case_insensitive(tmp_checkpoint_dir):
+    iid = _one_question_bucket("heron question pending", "S-lv3")
+    store.append_event(iid, "resolved", project_dir="/repo/x")
+    store.append_event(iid, "Reopened", project_dir="/repo/x")
+    hits = recall.search("heron", project_dir="/repo/x")
+    assert hits and hits[0]["superseded_by"] is None
+
+
+def test_superseded_by_status_still_carries_target_id(tmp_checkpoint_dir):
+    iid = _one_question_bucket("osprey question pending", "S-lv4")
+    store.append_event(iid, "superseded-by:o-9f3a2b", project_dir="/repo/x")
+    hits = recall.search("osprey", project_dir="/repo/x")
+    assert hits and hits[0]["superseded_by"] == "o-9f3a2b"
+
+
+def test_supersede_candidate_never_marks(tmp_checkpoint_dir):
+    # unconfirmed tier by design — a machine guess must never suppress
+    iid = _one_question_bucket("bittern question pending", "S-lv5")
+    store.append_event(iid, "supersede-candidate:o-9f3a2b",
+                       source="serializer", project_dir="/repo/x")
+    hits = recall.search("bittern", project_dir="/repo/x")
+    assert hits and hits[0]["superseded_by"] is None


### PR DESCRIPTION
Closes #255

### What

`recall._apply_event_resolutions` no longer re-implements the lifecycle liveness rule. Per bucket it now runs `store.resolutions(project_dir=<bucket name>)` (the bucket name is the slug; slug munging is idempotent, guarded by test since #243) and marks `superseded_by` where `store.is_resolved` says so. Net −33/+? lines: the hand-rolled JSON parse loop, its own newest-resolve/newest-reopen bookkeeping, and its tie handling are all deleted.

### Why

Two liveness rules existed. The store's documented contract (`is_resolved`, shared by brief/withhold/carry): status is **free-form by design** — `reopen*` revives (case-insensitive), `supersede-candidate:*` never suppresses, anything else resolves. The index fold matched exact strings instead, so brief and recall disagreed on everything but the literal spellings — including the `resolve --status` help text's own examples:

| Action | brief | recall (before) | recall (after) |
|---|---|---|---|
| `--status "shipped in 0.9"` | withheld | unmarked | `[resolved]` |
| `--status reopen` after a resolve | live | `[resolved]` | live |
| `--status Reopened` | live | `[resolved]` | live |

### Behavior notes

- Same-second ties now break on the #143 content rule (reopen > resolving > candidate, then canonical JSON) instead of raw ts-string comparison — position-independent, and a tie still leaves the item unmarked (reopen wins the tie → not resolved), preserving the old fold's never-guess direction.
- `superseded-by:<id>` target extraction unchanged, now prefix-gated so a free-form status containing `:` can't masquerade as an item id.
- Candidates stay unmarked, as before — inherited from `is_resolved` instead of re-stated.

### Testing

TDD (red first): free-form status marks `[resolved]`; `reopen-*` prefix and case-insensitive `Reopened` revive; `superseded-by:<id>` still carries the target id; candidates never mark. All existing recall tests (exact `"resolved"`/`"reopened"` spellings, #247 no-manual-rebuild pair) pass unchanged. Full suite: 1539 passed.
