### PR TITLE
feat(recall): zero-match scoped search reports where matches exist

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -651,6 +651,34 @@ def _cmd_recall(args) -> int:
         print(json.dumps(results, indent=2, ensure_ascii=False))
         return 0
     if not results:
+        # #259: a zero-match SCOPED search is a signpost, not a dead end —
+        # rerun the same query unscoped (one extra FTS query, same index)
+        # and report COUNTS by project, never content: crossing projects
+        # stays user-invoked (#94/#95), the system just stops hiding that
+        # crossing would pay. Explicit scopes (--all-projects already
+        # searched everything; --slug named its target) get no second-guess.
+        # Same doctrine as the AND->OR retry (#25): a narrower scope must
+        # never mean a silent dead end.
+        if not args.all_projects and not slug:
+            try:
+                wide = recall.search(query, all_projects=True, limit=50)
+            except recall.RecallError:
+                wide = []
+            counts: dict = {}
+            here = store.project_slug(project)
+            for r in wide:
+                s = r.get("project_slug")
+                if s and s != here:
+                    counts[s] = counts.get(s, 0) + 1
+            if counts:
+                lines = [f"no matches in this project — "
+                         f"{sum(counts.values())} match(es) elsewhere:"]
+                lines += [f"  {s} ({n})" for s, n in
+                          sorted(counts.items(), key=lambda kv: -kv[1])]
+                lines.append("rerun with --all-projects, or --slug <slug> "
+                             "for one project")
+                render.render_recall_lines(lines)
+                return 0
         render.render_recall_lines(["no matches"])
         return 0
     now = time.time()

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -4820,3 +4820,67 @@ def test_team_sync_warms_index(tmp_checkpoint_dir, capsys, monkeypatch):
     calls = _count_warm(monkeypatch)
     assert cli.main(["team", "sync"]) == 0
     assert calls == [1]
+
+
+# ---- #259: zero-match scoped recall reports WHERE matches exist (counts only) ----
+
+
+def test_recall_zero_match_teases_other_projects(tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):
+    from daimon_briefing import store
+
+    proj_a = str((tmp_path / "proj-a").resolve())
+    proj_b = str((tmp_path / "proj-b").resolve())
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-b1", _recall_checkpoint("S-b1", "homeauto wiring notes"),
+                           project_dir=proj_b)
+
+    rc = cli.main(["recall", "homeauto", "--project", proj_a])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "no matches in this project" in out
+    assert store.project_slug(proj_b) in out
+    assert "(1)" in out
+    assert "--all-projects" in out
+    # counts only — the foreign item's content must NOT appear
+    assert "homeauto wiring notes" not in out
+
+
+def test_recall_zero_match_everywhere_stays_plain_no_matches(tmp_checkpoint_dir, capsys, tmp_path):
+    proj = str((tmp_path / "proj").resolve())
+    rc = cli.main(["recall", "nonexistentword", "--project", proj])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert out.strip() == "no matches"
+
+
+def test_recall_zero_match_json_contract_untouched(tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):
+    from daimon_briefing import store
+
+    proj_a = str((tmp_path / "proj-a").resolve())
+    proj_b = str((tmp_path / "proj-b").resolve())
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-b2", _recall_checkpoint("S-b2", "homeauto wiring notes"),
+                           project_dir=proj_b)
+    rc = cli.main(["recall", "homeauto", "--project", proj_a, "--json"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out) == []
+
+
+def test_recall_zero_match_no_tease_under_explicit_scope(tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):
+    # --all-projects already searched everything; --slug was an explicit
+    # target — neither gets a second-guess teaser
+    from daimon_briefing import store
+
+    proj_b = str((tmp_path / "proj-b").resolve())
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-b3", _recall_checkpoint("S-b3", "homeauto wiring notes"),
+                           project_dir=proj_b)
+    rc = cli.main(["recall", "zebrafish", "--all-projects"])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "no matches"
+    rc = cli.main(["recall", "homeauto", "--slug", "-p-empty"])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "no matches"

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -4884,3 +4884,23 @@ def test_recall_zero_match_no_tease_under_explicit_scope(tmp_checkpoint_dir, cap
     rc = cli.main(["recall", "homeauto", "--slug", "-p-empty"])
     assert rc == 0
     assert capsys.readouterr().out.strip() == "no matches"
+
+
+def test_recall_zero_match_teaser_fails_open_on_recall_error(tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):
+    # the widening probe is best-effort: if the unscoped rerun dies (e.g.
+    # FTS5 vanished between calls), the plain no-matches line still prints
+    from daimon_briefing import recall as recall_mod
+
+    real_search = recall_mod.search
+
+    def flaky(query, project_dir=None, all_projects=False, limit=20, slug=None):
+        if all_projects:
+            raise recall_mod.RecallError("no FTS5")
+        return real_search(query, project_dir=project_dir,
+                           all_projects=all_projects, limit=limit, slug=slug)
+
+    monkeypatch.setattr(cli.recall, "search", flaky)
+    proj = str((tmp_path / "proj").resolve())
+    rc = cli.main(["recall", "nonexistentword", "--project", proj])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "no matches"


### PR DESCRIPTION
Closes #259

### What

A project-scoped `recall` that finds nothing now reruns the query unscoped (one extra FTS query, same index, zero-match path only) and prints **counts by project — never content**:

```
$ daimon recall gateway
no matches in this project — 5 match(es) elsewhere:
  -Users-me-projects-infra (5)
rerun with --all-projects, or --slug <slug> for one project
```

### Why

Live field shape: a search whose answer lived in another project's bucket returned `no matches`; the user guessed `--global` and hit a usage error — while `--all-projects` sat there undiscoverable. A zero-match scoped search is a signpost moment, not a dead end.

Design constraints honored:

- **Explicit crossing preserved** — foreign content never enters a scoped view uninvited (the read-side of the cross-project-bleed doctrine); the teaser names where matches exist and the exact verbs, the user does the crossing.
- **True negatives stay quiet** — zero matches everywhere prints the plain `no matches` line, byte-identical.
- **Machine contract untouched** — `--json` still returns the bare empty array.
- **No second-guessing explicit scopes** — `--all-projects` already searched everything; `--slug` named its target.

Same doctrine as recall's AND→OR retry: a richer cue must never mean less recall, and a narrower scope must never mean a silent dead end.

### Testing

TDD (red first): teaser lists the other project's slug + count and excludes the foreign item's text; genuinely-zero output byte-identical; JSON contract untouched; no teaser under `--all-projects`/`--slug`; the widening probe fails open to the plain no-matches line. Full suite: 1548 passed. Live end-to-end on a real 14-bucket corpus: a term indexed only in another project's bucket now signposts that bucket with its count, and the suggested follow-up returns the items.
