### PR TITLE
fix(hooks): package Codex lifecycle hooks in `daimon hooks install`

### DIFF
--- a/docs/hosts/codex.md
+++ b/docs/hosts/codex.md
@@ -5,26 +5,38 @@ recorded live sessions — the adapter and installer ship, but no logbook entry
 documents a real Codex session completing the capture -> inject loop yet.
 Treat "runs on Codex" as inferred until one is on record.
 
-## Install (manual, from a clone)
+## Install
 
-Adds Daimon's capture -> inject loop to Codex:
+Adds Daimon's capture -> inject loop to Codex from the released package (no repo
+clone needed):
 
 ```sh
-python3 hook/codex-hooks.py install   [--dry-run]
-python3 hook/codex-hooks.py uninstall [--dry-run]
-python3 hook/codex-hooks.py status
+daimon hooks install codex
 ```
 
-Install copies both hook scripts to `~/.codex/hooks/` and registers them in
-`~/.codex/hooks.json`. After installing, open `/hooks` in Codex to review and
-trust the hook definitions — Codex skips untrusted hook definitions until you
-do.
+This copies both hook scripts and their shared helper to `~/.codex/hooks/` and
+registers `SessionStart` and `Stop` in `~/.codex/hooks.json`, preserving any
+unrelated entries already there. It is idempotent — re-run it after every
+`uv tool upgrade daimon-briefing` to refresh the scripts to match the installed
+CLI. After installing, open `/hooks` in Codex to review and trust the hook
+definitions — Codex skips untrusted hook definitions until you do.
 
 Requires the `daimon` CLI on `PATH` (the deprecated `daimon-briefing` alias
 also works as a fallback):
 
 ```sh
 uv tool install ./plugin
+```
+
+### Manual install (from a clone)
+
+Working from a source checkout, the standalone lifecycle manager offers the same
+integration plus `uninstall` and `status`:
+
+```sh
+python3 hook/codex-hooks.py install   [--dry-run]
+python3 hook/codex-hooks.py uninstall [--dry-run]
+python3 hook/codex-hooks.py status
 ```
 
 ## What each script does

--- a/plugin/daimon_briefing/_hooks/daimon-codex-session-start.py
+++ b/plugin/daimon_briefing/_hooks/daimon-codex-session-start.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Codex SessionStart hook: inject the latest daimon briefing as developer context.
+
+Codex hook contract (official docs, verified 2026-06-12):
+- command hooks receive JSON on stdin with common fields like session_id, cwd,
+  transcript_path, hook_event_name, and model.
+- SessionStart stdout can add extra developer context; JSON stdout can use
+  hookSpecificOutput.additionalContext.
+
+This script shells out to `daimon brief`, matching the Claude hook path
+so the renderer stays single-source-of-truth.
+"""
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Shared helpers live in a same-dir sibling module (see _daimon_hook_lib.py).
+# A stale/partial install may lack it: fail open with a one-line diagnostic
+# rather than crash.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    import _daimon_hook_lib as lib
+except Exception:  # noqa: BLE001 — missing/corrupt lib must never crash the hook
+    lib = None
+
+TIMEOUT = 8
+
+
+def _age_line(latest: Path) -> str:
+    # Host-specific: Codex's age line is mtime-only. It deliberately does NOT use
+    # lib.age_line (which prefers the `created` stamp, #93) — kept as-is to hold
+    # behavior byte-identical; adopting the created-stamp form is a follow-up.
+    secs = max(0, time.time() - latest.stat().st_mtime)
+    if secs < 3600:
+        age = f"{int(secs // 60)}m"
+    elif secs < 86400:
+        age = f"{secs / 3600:.1f}h"
+    else:
+        age = f"{secs / 86400:.1f}d"
+    try:
+        session_id = json.loads(latest.read_text(encoding="utf-8")).get("session_id", "?")
+    except Exception:
+        session_id = "?"
+    return f"(checkpoint: {session_id}, written {age} ago)"
+
+
+def _emit_context(text: str) -> None:
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": text,
+        }
+    }))
+
+
+def _emit_briefing(cwd: str, cli) -> None:
+    slug = lib.slug(cwd)
+    ckpt_dir = lib.checkpoint_dir()
+    latest = ckpt_dir / slug / "latest.json" if slug else None
+    fallback = False
+    if latest is None or not latest.exists():
+        fallback = latest is not None
+        latest = ckpt_dir / "latest.json"
+    if not latest.exists():
+        return
+
+    if cli is None:
+        _emit_context("daimon: checkpoint exists but `daimon` CLI was not found")
+        return
+
+    try:
+        proc = subprocess.run(
+            [cli, "brief"], capture_output=True, text=True, timeout=TIMEOUT,
+            env=lib.project_env(cwd),
+        )
+    except subprocess.TimeoutExpired:
+        _emit_context(f"daimon: `daimon brief` timed out after {TIMEOUT}s")
+        return
+
+    text = proc.stdout.strip()
+    if proc.returncode != 0:
+        err = (proc.stderr or "").strip().splitlines()
+        msg = f"daimon: brief failed (exit {proc.returncode})"
+        _emit_context(msg + (f": {err[0]}" if err else ""))
+        return
+    if not text or text.startswith("No checkpoint yet"):
+        return
+
+    suffix = " (global fallback - checkpoint may be from another project)" if fallback else ""
+    _emit_context(f"DAIMON BRIEFING {_age_line(latest)}{suffix}\n{text}")
+
+
+def main() -> int:
+    if lib is None:
+        _emit_context("daimon: hook library missing (_daimon_hook_lib.py) - briefing skipped")
+        return 0
+    if lib.disabled():
+        return 0
+
+    data = lib.payload()
+    cwd = str(data.get("cwd") or "").strip()
+    session_id = str(data.get("session_id") or "").strip()
+    transcript_path = str(data.get("transcript_path") or "").strip()
+    cli = lib.resolve_cli()
+    try:
+        _emit_briefing(cwd, cli)
+    except Exception as exc:  # fail-open, but say so
+        _emit_context(f"daimon: hook error - briefing skipped ({type(exc).__name__}: {exc})")
+    # Opportunistic self-heal runs regardless of whether a briefing emitted: a
+    # failed serialize leaves NO checkpoint, exactly the case where heal matters.
+    lib.spawn_heal(cli, cwd)
+    # Orphan catch-up sweep (#188), porting Claude Code's #185 mechanism as-is:
+    # Codex's Stop hook throttles serialize per session, so a session whose
+    # final activity lands inside the throttle window and never resumes is
+    # never captured again. Scanning this session's transcript-sibling
+    # directory at the NEXT session's start recovers it. Runs LAST, after the
+    # briefing is already emitted — lib.sweep_orphans' own fail-open guarantee
+    # means it can never affect what Codex already saw.
+    lib.sweep_orphans(cli, cwd, session_id, transcript_path)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:
+        _emit_context(f"daimon: hook error - briefing skipped ({type(exc).__name__}: {exc})")
+        sys.exit(0)

--- a/plugin/daimon_briefing/_hooks/daimon-codex-stop.py
+++ b/plugin/daimon_briefing/_hooks/daimon-codex-stop.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Codex Stop hook: checkpoint the current transcript opportunistically.
+
+Codex currently exposes `Stop` at turn scope, not a clean session-end event.
+Serializing after every turn would be expensive, so this hook is throttled by
+DAIMON_CODEX_MIN_SERIALIZE_INTERVAL (default: 300 seconds per session). Set it
+to 0 to serialize on every Stop, or DAIMON_CODEX_SERIALIZE_ON_STOP=0 to disable
+this hook while keeping SessionStart briefing injection.
+
+The LLM work runs detached via `daimon serialize <transcript_path>` so
+the hook returns immediately. Diagnostics land in ~/.daimon/logs/serialize.log.
+"""
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Shared helpers live in a same-dir sibling module (see _daimon_hook_lib.py).
+# A stale/partial install may lack it: fail open with a logged one-liner rather
+# than crash. _fallback_log below mirrors lib.log for exactly that window.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    import _daimon_hook_lib as lib
+except Exception:  # noqa: BLE001 — missing/corrupt lib must never crash the hook
+    lib = None
+
+STATE_DIR = Path.home() / ".daimon" / "codex"
+
+
+def _fallback_log(line: str) -> None:
+    """Best-effort serialize.log write when the shared lib is unavailable
+    (stale/partial install). Mirrors lib.log so a broken install still leaves a
+    breadcrumb instead of a crash. Never raises."""
+    try:
+        log_dir = Path.home() / ".daimon" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with (log_dir / "serialize.log").open("a", encoding="utf-8") as f:
+            f.write(f"{stamp} {line}\n")
+    except OSError:
+        pass
+
+
+def _enabled() -> bool:
+    if lib.disabled():
+        return False
+    val = os.environ.get("DAIMON_CODEX_SERIALIZE_ON_STOP", "1").strip().lower()
+    return val not in ("0", "false", "no", "off")
+
+
+def _interval_seconds() -> int:
+    raw = os.environ.get("DAIMON_CODEX_MIN_SERIALIZE_INTERVAL", "300").strip()
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return 300
+
+
+def _safe_name(session_id: str) -> str:
+    return session_id.replace("/", "_").replace("\\", "_").replace("..", "_")
+
+
+def _marker_path(session_id: str) -> Path:
+    return STATE_DIR / f"{_safe_name(session_id)}.last-stop"
+
+
+def _should_spawn(session_id: str) -> bool:
+    interval = _interval_seconds()
+    if interval <= 0:
+        return True
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        marker = _marker_path(session_id)
+        now = time.time()
+        if marker.exists() and now - marker.stat().st_mtime < interval:
+            return False
+        return True
+    except OSError:
+        return True
+
+
+def _mark_spawned(session_id: str) -> None:
+    if _interval_seconds() <= 0:
+        return
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        _marker_path(session_id).write_text(str(int(time.time())), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def main() -> int:
+    if lib is None:
+        _fallback_log("codex-stop: hook library missing (_daimon_hook_lib.py) - skipped")
+        return 0
+    if not _enabled():
+        return 0
+
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        lib.log("codex-stop: unparseable stdin payload - skipped")
+        return 0
+
+    transcript_path = payload.get("transcript_path", "")
+    if not transcript_path or not Path(transcript_path).exists():
+        lib.log(f"codex-stop: transcript not found ({transcript_path!r}) - skipped")
+        return 0
+
+    session_id = str(payload.get("session_id") or Path(transcript_path).stem)
+    if not _should_spawn(session_id):
+        lib.log(f"codex-stop: skipped serialize for {session_id} (throttled)")
+        return 0
+
+    cli = lib.resolve_cli()
+    if cli is None:
+        lib.log("codex-stop: `daimon` CLI not found - checkpoint skipped")
+        return 0
+
+    cwd = str(payload.get("cwd") or "").strip()
+    child_env = lib.project_env(cwd)
+    try:
+        lib.spawn_serialize(cli, transcript_path, child_env)
+        _mark_spawned(session_id)
+        lib.log(f"codex-stop: spawned serialize for {session_id} "
+                f"(project: {cwd or '?'}) (transcript: {transcript_path})")
+    except OSError as exc:
+        lib.log(f"codex-stop: spawn failed ({type(exc).__name__}: {exc})")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:
+        if lib is not None:
+            lib.log(f"codex-stop: hook error ({type(exc).__name__}: {exc})")
+        else:
+            _fallback_log(f"codex-stop: hook error ({type(exc).__name__}: {exc})")
+        sys.exit(0)

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1792,6 +1792,16 @@ _HOOK_HOSTS = {
         "events": ("pre_user_prompt", "post_cascade_response",
                    "post_cascade_response_with_transcript"),
     },
+    # Codex needs two distinct scripts under two events plus a real hooks.json
+    # registration, so it carries `register: "codex"` and the install command
+    # delegates the whole flow to codex_hooks.install (#262). `files`/`events`
+    # here drive `hooks list` only; codex_hooks owns the copy + registration.
+    "codex": {
+        "files": ("daimon-codex-session-start.py", "daimon-codex-stop.py",
+                  "_daimon_hook_lib.py"),
+        "events": ("SessionStart", "Stop"),
+        "register": "codex",
+    },
 }
 
 
@@ -1799,8 +1809,17 @@ def _hooks_target_dir() -> Path:
     return Path.home() / ".daimon" / "hooks"
 
 
+def _host_scripts(spec) -> str:
+    """Display label of a host's hook script(s): the single `entry` when the
+    host has one, else the registered scripts (everything but shared helpers)."""
+    if spec.get("entry"):
+        return spec["entry"]
+    return ", ".join(n for n in spec["files"]
+                     if n not in ("_daimon_hook_lib.py", "redact.py"))
+
+
 def _cmd_hooks_list(args) -> int:
-    lines = [f"{host}  ({spec['entry']}; events: {', '.join(spec['events'])})"
+    lines = [f"{host}  ({_host_scripts(spec)}; events: {', '.join(spec['events'])})"
              for host, spec in sorted(_HOOK_HOSTS.items())]
     render.render_hooks_list(lines)
     return 0
@@ -1818,9 +1837,16 @@ def _cmd_hooks_install(args) -> int:
         known = ", ".join(sorted(_HOOK_HOSTS))
         print(f"error: unknown host '{args.host}' (known: {known})", file=sys.stderr)
         return 2
+    pkg = resources.files("daimon_briefing._hooks")
+    if spec.get("register") == "codex":
+        # Codex owns its own install path: two scripts registered under two
+        # events straight into ~/.codex/hooks.json (#262), not a printed snippet.
+        from . import codex_hooks
+
+        render.render_hooks_install(codex_hooks.install(pkg, Path.home()))
+        return 0
     target = _hooks_target_dir()
     target.mkdir(parents=True, exist_ok=True)
-    pkg = resources.files("daimon_briefing._hooks")
     for name in spec["files"]:
         data = (pkg / name).read_bytes()
         dest = target / name

--- a/plugin/daimon_briefing/codex_hooks.py
+++ b/plugin/daimon_briefing/codex_hooks.py
@@ -1,0 +1,137 @@
+"""Packaged Codex hook installer — the released `daimon hooks install codex`
+path (#262).
+
+Codex is unlike the other packaged hosts: instead of a single entry script that
+the user registers by hand, it runs two distinct scripts under two events
+(SessionStart briefing injection, Stop opportunistic capture) and discovers them
+from ``~/.codex/hooks.json``. So this installer BOTH copies the scripts into
+``~/.codex/hooks/`` AND writes the registration itself, merging idempotently and
+preserving any unrelated entries already in ``hooks.json``.
+
+This adapts the standalone ``hook/codex-hooks.py`` lifecycle manager (which only
+runs from a repo clone) into the package. The registration shapes below are kept
+in sync with that manager's ``HOOKS`` — the standalone script cannot import this
+package (it runs in whatever interpreter Codex invokes, outside the uv-tool
+venv), so the shape necessarily lives in both. Idempotency keys on the script
+name inside the command string, so a machine that ran the standalone manager and
+then the packaged installer never ends up double-registered.
+"""
+
+import json
+import shutil
+import time
+
+LIB = "_daimon_hook_lib.py"
+
+# event -> (script filename, hooks.json registration entry). Byte-for-byte the
+# same shapes as hook/codex-hooks.py::HOOKS.
+HOOKS = (
+    {
+        "script": "daimon-codex-session-start.py",
+        "event": "SessionStart",
+        "entry": {
+            "matcher": "startup|resume",
+            "hooks": [{
+                "type": "command",
+                "command": "python3 ~/.codex/hooks/daimon-codex-session-start.py",
+                "timeout": 10,
+                "statusMessage": "Reading daimon briefing...",
+            }],
+        },
+    },
+    {
+        "script": "daimon-codex-stop.py",
+        "event": "Stop",
+        "entry": {
+            "hooks": [{
+                "type": "command",
+                "command": "python3 ~/.codex/hooks/daimon-codex-stop.py",
+                "timeout": 10,
+                "statusMessage": "Writing daimon checkpoint...",
+            }],
+        },
+    },
+)
+
+# Everything installed into ~/.codex/hooks/: the two scripts plus the shared
+# stdlib-only helper module they import by same-dir lookup. No redact.py — the
+# Codex hooks spawn `daimon serialize` (the CLI redacts) and never scrub at
+# their own write sites, so the redaction module they'd load is dead weight.
+FILES = tuple(spec["script"] for spec in HOOKS) + (LIB,)
+
+
+def _is_ours(group, script):
+    """True when a hooks.json group already registers our `script`. Keys on the
+    command substring so it matches regardless of surrounding entry shape."""
+    return any(script in h.get("command", "")
+               for h in group.get("hooks", []) if isinstance(h, dict))
+
+
+def _load(hooks_json):
+    """Parse ~/.codex/hooks.json, degrading a missing/corrupt file to {} so a
+    fresh or hand-broken install still merges cleanly instead of crashing."""
+    if not hooks_json.exists():
+        return {}
+    try:
+        data = json.loads(hooks_json.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save(hooks_json, settings):
+    """Write hooks.json, backing up any existing file first so a merge can be
+    undone by hand if Codex ever rejects the result."""
+    hooks_json.parent.mkdir(parents=True, exist_ok=True)
+    if hooks_json.exists():
+        backup = hooks_json.with_name(f"hooks.json.daimon-backup-{int(time.time())}")
+        shutil.copy2(hooks_json, backup)
+    hooks_json.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+
+
+def install(pkg, home):
+    """Install/refresh the Codex hook integration and return the output lines.
+
+    ``pkg`` is a traversable for ``daimon_briefing._hooks`` (importlib.resources
+    files() or a plain Path); ``home`` is the home directory, passed in so tests
+    can install into a temp HOME. Idempotent: re-running refreshes the scripts to
+    match the installed CLI and never duplicates a registration.
+    """
+    codex_dir = home / ".codex"
+    hooks_dir = codex_dir / "hooks"
+    hooks_json = codex_dir / "hooks.json"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+
+    for name in FILES:
+        dest = hooks_dir / name
+        dest.write_bytes((pkg / name).read_bytes())
+        if name != LIB:  # the lib is imported, not executed
+            dest.chmod(dest.stat().st_mode | 0o100)  # u+x — Codex runs the scripts
+
+    settings = _load(hooks_json)
+    hooks_cfg = settings.setdefault("hooks", {})
+    lines = [f"installed {len(FILES)} file(s) to {hooks_dir}"]
+    changed = False
+    for spec in HOOKS:
+        groups = hooks_cfg.setdefault(spec["event"], [])
+        if any(_is_ours(g, spec["script"]) for g in groups):
+            lines.append(f"  {spec['event']}: already registered ({spec['script']})")
+        else:
+            groups.append(spec["entry"])
+            changed = True
+            lines.append(f"  {spec['event']}: registered {spec['script']}")
+    if changed:
+        _save(hooks_json, settings)
+        lines.append(f"updated {hooks_json}")
+    else:
+        lines.append(f"{hooks_json} already up to date")
+
+    lines += [
+        "",
+        "Open /hooks in Codex to review and trust the hook definitions — "
+        "Codex skips untrusted hooks until you do.",
+        "",
+        "Re-run `daimon hooks install codex` after every "
+        "`uv tool upgrade daimon-briefing`.",
+    ]
+    return lines

--- a/plugin/tests/test_hooks_install.py
+++ b/plugin/tests/test_hooks_install.py
@@ -161,6 +161,20 @@ def test_hooks_install_codex_preserves_unrelated_entries(tmp_path, monkeypatch):
     assert cfg["PreToolUse"][0]["hooks"][0]["command"] == "echo hi"  # unrelated event kept
 
 
+def test_hooks_install_codex_recovers_corrupt_hooks_json(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    codex = tmp_path / ".codex"
+    codex.mkdir()
+    (codex / "hooks.json").write_text("{not json", encoding="utf-8")
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    cfg = json.loads((codex / "hooks.json").read_text())["hooks"]
+    assert any("daimon-codex-session-start.py" in h["command"]
+               for g in cfg["SessionStart"] for h in g["hooks"])
+    # the corrupt original is preserved as a backup, not silently destroyed
+    backups = list(codex.glob("hooks.json.daimon-backup-*"))
+    assert backups and backups[0].read_text(encoding="utf-8") == "{not json"
+
+
 def test_hooks_install_codex_is_idempotent(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     assert cli.main(["hooks", "install", "codex"]) == 0

--- a/plugin/tests/test_hooks_install.py
+++ b/plugin/tests/test_hooks_install.py
@@ -1,6 +1,7 @@
 """#43: hook scripts ship in the package; `daimon hooks install <host>` puts
 them at a stable path so registration survives every upgrade."""
 
+import json
 import stat
 import sys
 from pathlib import Path
@@ -23,6 +24,10 @@ _PKG_HOOKS_REL = "plugin/daimon_briefing/_hooks/"
 _SHIPPED = tuple(
     Path(dst).name for _, dst in SYNC_PAIRS if dst.startswith(_PKG_HOOKS_REL)
 )
+
+_WINDSURF_FILES = cli._HOOK_HOSTS["windsurf"]["files"]
+_CODEX_SCRIPTS = ("daimon-codex-session-start.py", "daimon-codex-stop.py")
+_CODEX_FILES = _CODEX_SCRIPTS + ("_daimon_hook_lib.py",)
 
 
 @pytest.mark.parametrize("name", _SHIPPED)
@@ -49,7 +54,7 @@ def test_hooks_install_windsurf_writes_stable_executable_copies(tmp_path, monkey
     rc = cli.main(["hooks", "install", "windsurf"])
     assert rc == 0
     target = tmp_path / ".daimon" / "hooks"
-    for name in _SHIPPED:
+    for name in _WINDSURF_FILES:
         p = target / name
         assert p.is_file(), f"{name} not installed"
         assert p.stat().st_mode & stat.S_IXUSR, f"{name} not executable"
@@ -80,3 +85,121 @@ def test_hooks_list_names_windsurf(capsys):
     rc = cli.main(["hooks", "list"])
     assert rc == 0
     assert "windsurf" in capsys.readouterr().out
+
+
+# ---- codex: two scripts, two events, real hooks.json registration (#262) ----
+
+
+def test_codex_scripts_are_packaged_and_drift_guarded():
+    # The drift guard (test_packaged_hook_matches_repo_copy) parametrizes over
+    # _SHIPPED, so proving the codex scripts are in _SHIPPED proves they are
+    # both packaged AND covered by the byte-identity drift test.
+    for name in _CODEX_SCRIPTS:
+        assert name in _SHIPPED, f"{name} not shipped via sync_hooks manifest"
+
+
+def test_hooks_list_names_codex_with_events(capsys):
+    assert cli.main(["hooks", "list"]) == 0
+    out = capsys.readouterr().out
+    assert "codex" in out
+    assert "SessionStart" in out and "Stop" in out
+
+
+def test_hooks_install_codex_copies_scripts_and_lib_to_codex_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    hooks_dir = tmp_path / ".codex" / "hooks"
+    for name in _CODEX_FILES:
+        p = hooks_dir / name
+        assert p.is_file(), f"{name} not installed"
+        assert p.read_bytes() == (PKG_HOOKS_DIR / name).read_bytes()
+    # Codex executes the scripts directly, so they must be executable.
+    for name in _CODEX_SCRIPTS:
+        assert (hooks_dir / name).stat().st_mode & stat.S_IXUSR, f"{name} not executable"
+
+
+def test_hooks_install_codex_registers_both_events(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    cfg = json.loads((tmp_path / ".codex" / "hooks.json").read_text())["hooks"]
+
+    assert "SessionStart" in cfg and "Stop" in cfg
+    ss = cfg["SessionStart"][0]
+    assert ss["matcher"] == "startup|resume"
+    ss_hook = ss["hooks"][0]
+    assert "daimon-codex-session-start.py" in ss_hook["command"]
+    assert ss_hook["timeout"] == 10
+    assert ss_hook["statusMessage"] == "Reading daimon briefing..."
+
+    stop_hook = cfg["Stop"][0]["hooks"][0]
+    assert "daimon-codex-stop.py" in stop_hook["command"]
+    assert stop_hook["statusMessage"] == "Writing daimon checkpoint..."
+
+
+def test_hooks_install_codex_preserves_unrelated_entries(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    codex = tmp_path / ".codex"
+    codex.mkdir()
+    (codex / "hooks.json").write_text(json.dumps({
+        "hooks": {
+            # a foreign entry under an event daimon ALSO uses
+            "SessionStart": [
+                {"hooks": [{"type": "command", "command": "python3 /other/thing.py"}]}
+            ],
+            # an event daimon never touches
+            "PreToolUse": [
+                {"hooks": [{"type": "command", "command": "echo hi"}]}
+            ],
+        }
+    }))
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    cfg = json.loads((codex / "hooks.json").read_text())["hooks"]
+
+    ss_cmds = [h["command"] for g in cfg["SessionStart"] for h in g["hooks"]]
+    assert "python3 /other/thing.py" in ss_cmds  # foreign entry untouched
+    assert any("daimon-codex-session-start.py" in c for c in ss_cmds)  # ours added
+    assert cfg["PreToolUse"][0]["hooks"][0]["command"] == "echo hi"  # unrelated event kept
+
+
+def test_hooks_install_codex_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    assert cli.main(["hooks", "install", "codex"]) == 0  # re-run must not duplicate
+    cfg = json.loads((tmp_path / ".codex" / "hooks.json").read_text())["hooks"]
+    assert len(cfg["SessionStart"]) == 1
+    assert len(cfg["Stop"]) == 1
+
+
+def test_hooks_install_codex_refreshes_stale_script(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    stale = tmp_path / ".codex" / "hooks" / "daimon-codex-stop.py"
+    stale.write_text("# stale old version")
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    assert stale.read_bytes() == (PKG_HOOKS_DIR / "daimon-codex-stop.py").read_bytes()
+
+
+def test_hooks_install_codex_output_tells_user_to_trust(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    out = capsys.readouterr().out
+    assert "/hooks" in out
+    assert "trust" in out.lower()
+
+
+def test_hooks_install_codex_is_lifecycle_not_skill(tmp_path, monkeypatch):
+    # `daimon hooks install codex` installs LIFECYCLE hooks (scripts + hooks.json).
+    # It must NOT write the agent skill — ~/.codex/AGENTS.md is the skill's file.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    assert (tmp_path / ".codex" / "hooks.json").exists()
+    assert not (tmp_path / ".codex" / "AGENTS.md").exists()
+
+
+def test_skill_install_codex_is_not_lifecycle_hooks(tmp_path, monkeypatch):
+    # Converse: `daimon skill install codex` teaches the agent (AGENTS.md) and
+    # must NOT register lifecycle hooks — no hooks.json.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["skill", "install", "codex"]) == 0
+    assert (tmp_path / ".codex" / "AGENTS.md").exists()
+    assert not (tmp_path / ".codex" / "hooks.json").exists()

--- a/scripts/sync_hooks.py
+++ b/scripts/sync_hooks.py
@@ -25,6 +25,8 @@ SYNC_PAIRS = (
     ("plugin/daimon_briefing/redact.py", "plugin/daimon_briefing/_hooks/redact.py"),
     ("plugin/daimon_briefing/redact.py", "hook/redact.py"),
     ("hook/daimon-windsurf-hooks.py", "plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py"),
+    ("hook/daimon-codex-session-start.py", "plugin/daimon_briefing/_hooks/daimon-codex-session-start.py"),
+    ("hook/daimon-codex-stop.py", "plugin/daimon_briefing/_hooks/daimon-codex-stop.py"),
     ("hook/_daimon_hook_lib.py", "plugin/daimon_briefing/_hooks/_daimon_hook_lib.py"),
 )
 


### PR DESCRIPTION
## Summary

Codex appeared in `daimon skill list` but not `daimon hooks list`, so a released install had no supported way to install the Codex `SessionStart`/`Stop` lifecycle hooks — the only installer lived in the source checkout (`hook/codex-hooks.py`). This packages the Codex integration so `daimon hooks install codex` works from the released package.

## Changes

- **`scripts/sync_hooks.py`** — packages `daimon-codex-session-start.py` and `daimon-codex-stop.py` into `daimon_briefing/_hooks/`. The existing byte-identity drift guard is derived from this manifest, so it now covers the Codex scripts automatically.
- **`plugin/daimon_briefing/codex_hooks.py`** (new) — copies the two scripts plus the shared `_daimon_hook_lib.py` into `~/.codex/hooks/` and merges `SessionStart`/`Stop` registrations into `~/.codex/hooks.json`. Idempotent (re-run refreshes scripts, never duplicates a registration) and preserves unrelated entries. Adapts the merge logic from the standalone `hook/codex-hooks.py`, which cannot import the venv-only package.
- **`plugin/daimon_briefing/cli.py`** — `_HOOK_HOSTS` gains a `codex` entry with a `register` flag; `hooks list` shows multi-script hosts and `hooks install` delegates the Codex flow to `codex_hooks.install` rather than special-casing it with a parallel path.
- **`docs/hosts/codex.md`** — leads with the packaged CLI path; the standalone manager is documented as the from-a-clone alternative offering `uninstall`/`status`.
- **Tests** — new coverage in `test_hooks_install.py`: list names Codex with its events, install copies executable scripts + lib into `~/.codex/hooks/`, both events registered with correct commands/settings, unrelated entries preserved, idempotent re-run, stale-script refresh, trust/review output, and tests distinguishing lifecycle-hook install from skill install (and the converse).

## Design notes

- Codex installs into `~/.codex/hooks/` (not the `~/.daimon/hooks/` stable path Windsurf uses) because Codex's native `hooks.json` commands reference that directory.
- Codex ships no `redact.py`: its hooks spawn `daimon serialize` (which redacts) and never scrub at their own write sites, so the redaction module would be dead weight.

## Verification

- Full plugin suite: 1560 passed, 1 skipped.
- Hook mirror drift check (`sync_hooks.py --check`): in sync.
- `daimon hooks list` now reports `codex (daimon-codex-session-start.py, daimon-codex-stop.py; events: SessionStart, Stop)`.

Closes #262