### PR TITLE
feat(status): silent-capture alarm — sessions observed vs checkpoints written

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -58,6 +58,7 @@ from .ledger import (
     _parse_stamp,
     _session_ledger,
     _spawns_in_window,
+    _spawns_in_window_count,
     _stats_capture,
 )
 
@@ -1215,6 +1216,39 @@ def _cmd_verify_receipt(args) -> int:
     return rc
 
 
+# The silent-capture alarm (#265) ships the FAIL tier ONLY: sessions were
+# observed but ZERO checkpoints landed. The issue also describes a WARN "capture
+# ratio low" tier — deferred until the ratio threshold is calibrated against real
+# capture distributions. An uncalibrated cutoff false-alarms on low-activity
+# projects (this repo's overlap thresholds did exactly that), so below
+# _CAPTURE_MIN_SESSIONS spawns the probe stays SILENT — too little signal to
+# judge — rather than guessing OK. 3 is the smallest count that reads as a
+# pattern rather than a one-off, and matches the retention-window scope.
+_CAPTURE_MIN_SESSIONS = 3
+
+
+def _capture_alarm(now: float) -> dict | None:
+    """Silent-capture probe (#265): compare hook spawns OBSERVED against
+    checkpoints WRITTEN over the retention window, machine-wide (serialize.log
+    and the checkpoint store are per-machine, not per-project). Returns a FAIL
+    payload only when >= _CAPTURE_MIN_SESSIONS sessions spawned but ZERO
+    checkpoints landed in the window; otherwise None (no verdict — the WARN
+    ratio tier is deferred, see _CAPTURE_MIN_SESSIONS). Reuses the same in-window
+    spawn logic as the stats stale-hook warning. `now` is epoch seconds; both
+    the ledger (tz-aware) and store (epoch) cutoffs derive from it for a single
+    deterministic window edge."""
+    cutoff_epoch = now - _RETENTION_WINDOW_DAYS * 86400
+    cutoff_dt = datetime.fromtimestamp(cutoff_epoch, tz=timezone.utc)
+    spawns = _spawns_in_window_count(cutoff_dt)
+    if spawns < _CAPTURE_MIN_SESSIONS:
+        return None
+    checkpoints = store.checkpoints_written_since(cutoff_epoch)
+    if checkpoints > 0:
+        return None
+    return {"verdict": "fail", "spawns": spawns, "checkpoints": checkpoints,
+            "window_days": _RETENTION_WINDOW_DAYS}
+
+
 def _cmd_status(args) -> int:
     _note_usage("status")
     project = _resolve_project(args.project)
@@ -1246,6 +1280,10 @@ def _cmd_status(args) -> int:
         if e["result_kind"] == "skipped"
     )
     siblings = store.sibling_buckets(project)
+    # Silent-capture alarm (#265): machine-wide spawns-vs-checkpoints over the
+    # window. A FAIL payload (or None) renders at the very TOP of status — a
+    # class of failure that otherwise hides until a briefing turns up empty.
+    capture_alarm = _capture_alarm(now)
     health = _status_health(proj, glob, outstanding, siblings, now=now,
                             disabled=disabled)
     # ONE objective team line (#113), only when a team remote exists — the #84
@@ -1270,7 +1308,8 @@ def _cmd_status(args) -> int:
              "outstanding": outstanding, "siblings": siblings, "health": health,
              "team": team, "crash": crash, "disabled": disabled,
              "skipped_recent": skipped_recent, "recall_error": recall_error,
-             "recall_index": recall_index, "receipts": receipts_line},
+             "recall_index": recall_index, "receipts": receipts_line,
+             "capture_alarm": capture_alarm},
             indent=2,
         ))
         return rc
@@ -1280,7 +1319,7 @@ def _cmd_status(args) -> int:
         "outstanding": outstanding, "identity": identity, "health": health,
         "team": team, "crash": crash, "skipped_recent": skipped_recent,
         "recall_error": recall_error, "recall_index": recall_index,
-        "receipts": receipts_line,
+        "receipts": receipts_line, "capture_alarm": capture_alarm,
     })
     return rc
 

--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -376,18 +376,29 @@ def _parse_stamp(token: str):
         return None
 
 
-def _spawns_in_window(cutoff) -> bool:
-    """True when serialize.log shows any hook-spawned capture inside the
-    window — i.e. sessions ARE happening on this machine."""
+def _spawns_in_window_count(cutoff) -> int:
+    """How many hook-spawned captures serialize.log shows inside the window —
+    i.e. how many sessions the hooks OBSERVED on this machine since `cutoff`.
+    The silent-capture alarm (#265) reads this against checkpoints WRITTEN in the
+    same window: spawns without writes is a silent capture failure. Fails open to
+    0 when the log is absent."""
     try:
         text = (config.log_dir() / "serialize.log").read_text(encoding="utf-8")
     except OSError:
-        return False
+        return 0
+    count = 0
     for line in text.splitlines():
         line = line.strip()
         if not _STATS_HOST_RE.match(line):
             continue
         stamp = _parse_stamp(line.split()[0])
         if stamp is not None and stamp >= cutoff:
-            return True
-    return False
+            count += 1
+    return count
+
+
+def _spawns_in_window(cutoff) -> bool:
+    """True when serialize.log shows any hook-spawned capture inside the
+    window — i.e. sessions ARE happening on this machine. The count and the
+    boolean share one regex so they can never drift on a new host prefix."""
+    return _spawns_in_window_count(cutoff) > 0

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -415,7 +415,27 @@ def _outstanding_lines(outstanding) -> list:
     return lines
 
 
+def _capture_alarm_lines(alarm: dict) -> list[str]:
+    """The silent-capture FAIL banner (#265), shared verbatim by the plain and
+    rich renderers (#29): a headline plus the three concrete fix hints. Rendered
+    at the very TOP of status because it flags a class of failure — hooks firing
+    but zero checkpoints landing — that otherwise stays invisible until a
+    briefing turns up empty."""
+    n, days = alarm["spawns"], alarm["window_days"]
+    return [
+        f"FAIL — silent capture failure: {n} session{'s' if n != 1 else ''} "
+        f"observed in the last {days} days, 0 checkpoints written",
+        "  → run `daimon heal` to recover the most recent lost session",
+        "  → inspect serialize.log for the underlying error",
+        "  → run `daimon configure --test` to verify the serialize backend",
+    ]
+
+
 def _plain_status(data: dict) -> None:
+    alarm = data.get("capture_alarm")
+    if alarm:
+        for line in _capture_alarm_lines(alarm):
+            print(line)
     ident = data.get("identity")
     if ident:
         print(f"identity: {ident['cwd']}  →  git-root {ident['git_root']}  →  bucket {ident['slug']}")
@@ -485,6 +505,12 @@ def _rich_status(data: dict) -> None:
     from rich.table import Table
 
     console = Console()
+    alarm = data.get("capture_alarm")
+    if alarm:
+        lines = _capture_alarm_lines(alarm)
+        console.print(f"[bold red]{lines[0]}[/bold red]")
+        for line in lines[1:]:
+            console.print(f"[red]{line}[/red]")
     ident = data.get("identity")
     if ident:
         console.print(f"identity: {ident['cwd']}  →  git-root {ident['git_root']}  →  bucket {ident['slug']}")

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -233,6 +233,28 @@ def _session_files(d: Path) -> list[Path]:
     ]
 
 
+def checkpoints_written_since(cutoff: float) -> int:
+    """How many per-session checkpoints were WRITTEN since `cutoff` (epoch
+    seconds), counted by file mtime — the write-side signal for the silent-
+    capture alarm (#265). Pointers and in-flight *.tmp writes are excluded
+    (via _session_files), so this is checkpoints actually landed, not rotations.
+    Fails open to 0 when the store dir is absent or unreadable — no store yet is
+    zero writes, never a crash."""
+    d = config.checkpoint_dir()
+    try:
+        files = _session_files(d)
+    except OSError:
+        return 0
+    count = 0
+    for p in files:
+        try:
+            if p.stat().st_mtime >= cutoff:
+                count += 1
+        except OSError:
+            continue
+    return count
+
+
 def _pointer_stems(d: Path) -> set[str] | None:
     """File stems of every per-session checkpoint a LIVE pointer still references —
     latest.json / prev-N.json in the flat dir AND in every per-project bucket. GC

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -674,7 +674,8 @@ def test_cli_status_json_shape(
     assert set(data) == {"project", "global", "last_serialize", "outstanding",
                          "siblings", "health", "team", "crash", "disabled",
                          "skipped_recent", "recall_error", "recall_index",
-                         "receipts"}
+                         "receipts", "capture_alarm"}
+    assert data["capture_alarm"] is None  # #265 FAIL-only probe silent by default
     assert data["team"] is None  # no team remote configured -> explicit null (#113)
     assert data["receipts"] is None  # #204 feature off -> explicit null
     assert data["project"]["exists"] is True
@@ -4284,6 +4285,128 @@ def test_spawns_in_window_skips_garbage_and_stale_spawns(tmp_log_dir):
     )
     assert ledger._spawns_in_window(now - timedelta(days=14)) is False
     assert ledger._parse_stamp("not-a-stamp") is None
+
+
+def test_spawns_in_window_count_tallies_in_window_only(tmp_log_dir):
+    # The FAIL-alarm's read side (#265): count every hook spawn inside the
+    # window, skip stale ones and non-spawn noise. The boolean probe is just
+    # count > 0, so both stay in lockstep on one regex.
+    from daimon_briefing import ledger
+
+    now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+    recent = (now - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    old = (now - timedelta(days=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "serialize.log").write_text(
+        "not a spawn line\n"
+        f"{recent} session-end: spawned serialize for S1 (pid 1)\n"
+        f"{recent} codex-stop: spawned serialize for S2 (pid 2)\n"
+        f"{old} session-end: spawned serialize for S-old (pid 3)\n"
+    )
+    cutoff = now - timedelta(days=14)
+    assert ledger._spawns_in_window_count(cutoff) == 2
+    assert ledger._spawns_in_window(cutoff) is True
+
+
+# ---- capture alarm: silent-capture FAIL tier (#265) ----
+
+
+def _spawn_line(days_ago, sid, now_epoch):
+    stamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now_epoch - days_ago * 86400))
+    return f"{stamp} session-end: spawned serialize for {sid} (reason: exit, project: /p/A)\n"
+
+
+def test_capture_alarm_fails_on_spawns_without_checkpoints(tmp_log_dir, tmp_checkpoint_dir):
+    now = time.time()
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "serialize.log").write_text(
+        _spawn_line(2, "S1", now) + _spawn_line(3, "S2", now) + _spawn_line(4, "S3", now))
+    alarm = cli._capture_alarm(now)
+    assert alarm is not None
+    assert alarm["verdict"] == "fail"
+    assert alarm["spawns"] == 3
+    assert alarm["checkpoints"] == 0
+    assert alarm["window_days"] == 14
+
+
+def test_capture_alarm_silent_below_min_sessions(tmp_log_dir, tmp_checkpoint_dir):
+    # Two spawns, zero checkpoints — still below the guard, so NO verdict at all:
+    # silence, never a false FAIL on a low-activity machine.
+    now = time.time()
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "serialize.log").write_text(
+        _spawn_line(1, "S1", now) + _spawn_line(2, "S2", now))
+    assert cli._capture_alarm(now) is None
+
+
+def test_capture_alarm_silent_when_checkpoints_landing(
+    tmp_log_dir, tmp_checkpoint_dir, sample_checkpoint
+):
+    from daimon_briefing import store
+
+    now = time.time()
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "serialize.log").write_text(
+        _spawn_line(2, "S1", now) + _spawn_line(3, "S2", now) + _spawn_line(4, "S3", now))
+    store.write_checkpoint("S1", {**sample_checkpoint, "session_id": "S1"})
+    assert cli._capture_alarm(now) is None
+
+
+def test_capture_alarm_stale_spawns_dont_count(tmp_log_dir, tmp_checkpoint_dir):
+    # Three spawns but all older than the window → below the in-window guard → silence.
+    now = time.time()
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "serialize.log").write_text(
+        _spawn_line(20, "S1", now) + _spawn_line(21, "S2", now) + _spawn_line(22, "S3", now))
+    assert cli._capture_alarm(now) is None
+
+
+def test_status_shows_capture_fail_at_top(tmp_log_dir, tmp_checkpoint_dir, capsys, monkeypatch):
+    now = time.time()
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    monkeypatch.setenv("DAIMON_PLAIN", "1")
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "serialize.log").write_text(
+        _spawn_line(1, "S1", now) + _spawn_line(2, "S2", now)
+        + _spawn_line(3, "S3", now) + _spawn_line(4, "S4", now))
+    cli.main(["status"])
+    out = capsys.readouterr().out
+    first = out.strip().splitlines()[0]
+    assert "FAIL" in first and "silent capture" in first.lower()
+    # Every fix hint the operator needs, unmissable near the top.
+    assert "daimon heal" in out
+    assert "serialize.log" in out
+    assert "daimon configure --test" in out
+
+
+def test_status_json_includes_capture_alarm(tmp_log_dir, tmp_checkpoint_dir, capsys, monkeypatch):
+    now = time.time()
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "serialize.log").write_text(
+        _spawn_line(1, "S1", now) + _spawn_line(2, "S2", now) + _spawn_line(3, "S3", now))
+    cli.main(["status", "--json"])
+    data = json.loads(capsys.readouterr().out)
+    assert data["capture_alarm"]["verdict"] == "fail"
+    assert data["capture_alarm"]["spawns"] == 3
+
+
+def test_status_no_capture_alarm_when_healthy(
+    tmp_log_dir, tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch
+):
+    from daimon_briefing import store
+
+    now = time.time()
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    monkeypatch.setenv("DAIMON_PLAIN", "1")
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "serialize.log").write_text(
+        _spawn_line(1, "S1", now) + _spawn_line(2, "S2", now) + _spawn_line(3, "S3", now))
+    store.write_checkpoint("S1", {**sample_checkpoint, "session_id": "S1"}, project_dir="/p/A")
+    cli.main(["status"])
+    assert "silent capture" not in capsys.readouterr().out.lower()
+    cli.main(["status", "--json"])
+    assert json.loads(capsys.readouterr().out)["capture_alarm"] is None
 
 
 def test_stats_json_includes_retention(tmp_checkpoint_dir, tmp_log_dir,

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -192,6 +192,34 @@ def test_render_status_rich_smoke(monkeypatch, capsys):
     assert "success" in out
 
 
+def test_render_status_capture_alarm_plain_at_top(capsys):
+    # The #265 FAIL banner leads the output and carries all three fix hints.
+    data = _status_data()
+    data["capture_alarm"] = {"verdict": "fail", "spawns": 4, "checkpoints": 0,
+                             "window_days": 14}
+    render.render_status(data)
+    out = capsys.readouterr().out
+    assert out.splitlines()[0] == (
+        "FAIL — silent capture failure: 4 sessions observed in the last 14 days, "
+        "0 checkpoints written")
+    assert "run `daimon heal`" in out
+    assert "inspect serialize.log" in out
+    assert "run `daimon configure --test`" in out
+
+
+def test_render_status_capture_alarm_rich_smoke(monkeypatch, capsys):
+    # Rich path renders the same banner (content-only, styling stripped).
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    data = _status_data()
+    data["capture_alarm"] = {"verdict": "fail", "spawns": 1, "checkpoints": 0,
+                             "window_days": 14}
+    render.render_status(data)
+    out = capsys.readouterr().out
+    # Singular session wording, plus the fix hints.
+    assert "1 session observed" in out
+    assert "daimon configure --test" in out
+
+
 def _outstanding_sample():
     return [
         {"sid": "S-A", "kind": "error", "class": "healable", "age": 180,

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1607,3 +1607,15 @@ def test_checkpoints_written_since_ignores_pointers(tmp_checkpoint_dir, sample_c
 def test_checkpoints_written_since_fails_open_when_dir_absent(tmp_checkpoint_dir):
     # No checkpoint dir yet (nothing ever written) → zero, never a crash.
     assert store.checkpoints_written_since(_time.time() - 14 * 86400) == 0
+
+
+def test_checkpoints_written_since_skips_unstattable_file(monkeypatch):
+    # A file that vanishes/errors mid-stat (raced against GC) is skipped, not fatal.
+    class _Ghost:
+        name = "ghost.json"
+
+        def stat(self):
+            raise OSError("stat failed")
+
+    monkeypatch.setattr(store, "_session_files", lambda d: [_Ghost()])
+    assert store.checkpoints_written_since(_time.time() - 14 * 86400) == 0

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1580,3 +1580,30 @@ def test_list_buckets_non_dict_pointer_yields_none_checkpoint(tmp_checkpoint_dir
     buckets = store.list_buckets()
     assert len(buckets) == 1
     assert buckets[0]["checkpoint"] is None
+
+
+# ---- checkpoints_written_since: the silent-capture alarm's write-side count (#265) ----
+
+
+def test_checkpoints_written_since_counts_recent_only(tmp_checkpoint_dir, sample_checkpoint):
+    import os
+
+    now = _time.time()
+    store.write_checkpoint("S-fresh", {**sample_checkpoint, "session_id": "S-fresh"})
+    old = store.write_checkpoint("S-old", {**sample_checkpoint, "session_id": "S-old"})
+    os.utime(old, (now - 20 * 86400, now - 20 * 86400))  # aged out of a 14d window
+    cutoff = now - 14 * 86400
+    # Only the fresh session file counts; the aged one is outside the window.
+    assert store.checkpoints_written_since(cutoff) == 1
+
+
+def test_checkpoints_written_since_ignores_pointers(tmp_checkpoint_dir, sample_checkpoint):
+    # A write lands one session file plus latest.json (and per-project pointers);
+    # only the per-session checkpoint is a "checkpoint written", never a pointer.
+    store.write_checkpoint("S1", {**sample_checkpoint, "session_id": "S1"}, project_dir="/p/A")
+    assert store.checkpoints_written_since(_time.time() - 14 * 86400) == 1
+
+
+def test_checkpoints_written_since_fails_open_when_dir_absent(tmp_checkpoint_dir):
+    # No checkpoint dir yet (nothing ever written) → zero, never a crash.
+    assert store.checkpoints_written_since(_time.time() - 14 * 86400) == 0


### PR DESCRIPTION
## What

`daimon status` gains a machine-wide capture-health probe over the 14-day retention window, comparing **hook spawns observed** against **checkpoints written**. When at least 3 sessions spawned in the window but **zero** checkpoints landed, a loud `FAIL — silent capture failure` banner renders at the **top** of status output with concrete fix hints:

```
FAIL — silent capture failure: 4 sessions observed in the last 14 days, 0 checkpoints written
  → run `daimon heal` to recover the most recent lost session
  → inspect serialize.log for the underlying error
  → run `daimon configure --test` to verify the serialize backend
```

This surfaces the most damaging failure mode in the field — hooks firing, sessions happening, zero checkpoints written — which otherwise stays invisible until a briefing turns up empty or stale.

## Scope: FAIL tier only

Ships the **FAIL** tier only. The `WARN — capture ratio low` tier described in the issue is **deferred** until its threshold is calibrated against real capture distributions. An uncalibrated ratio cutoff false-alarms on low-activity projects. Below the minimum session count (`_CAPTURE_MIN_SESSIONS = 3`) the probe stays **silent** — too little signal to judge — rather than guessing OK.

## How

- **ledger**: `_spawns_in_window_count(cutoff)` counts in-window hook spawns; the existing boolean `_spawns_in_window` becomes `count > 0` so both share one host-prefix regex and can't drift.
- **store**: `checkpoints_written_since(cutoff)` counts per-session checkpoint files by mtime (pointers/tmp excluded), failing open to 0.
- **cli**: `_capture_alarm(now)` composes the two counts into a FAIL-or-None verdict over the retention window, wired into `status` (JSON key `capture_alarm` + rendered banner at top).

## Tests

New coverage for every tier and the low-activity guard: the ledger counter, the store accessor (recency window, pointer exclusion, fail-open), `_capture_alarm` (FAIL, below-guard silence, healthy silence, stale-spawn silence), and status integration (FAIL at top with fix hints, JSON shape, silent when healthy). Full plugin suite green: 1572 passed, 1 skipped.

Closes #265