### PR TITLE
feat(hooks): daimon hooks status — detect stale installed hook copies

### DIFF
--- a/docs/hosts/codex.md
+++ b/docs/hosts/codex.md
@@ -21,6 +21,12 @@ unrelated entries already there. It is idempotent — re-run it after every
 CLI. After installing, open `/hooks` in Codex to review and trust the hook
 definitions — Codex skips untrusted hook definitions until you do.
 
+A stale installed copy keeps *working* on old behavior, so drift is invisible.
+Run `daimon hooks status` to audit the installed copies against the packaged
+versions (CURRENT/STALE/MISSING, plus the `hooks.json` registration state); it
+exits non-zero when anything drifted, and `daimon hooks install codex` refreshes
+it in place.
+
 Requires the `daimon` CLI on `PATH` (the deprecated `daimon-briefing` alias
 also works as a fallback):
 

--- a/docs/hosts/windsurf.md
+++ b/docs/hosts/windsurf.md
@@ -20,7 +20,9 @@ so a standalone host adapter can scrub secrets at its own write sites
 venv-only `daimon_briefing` package — a test keeps this copy byte-identical
 to the canonical `plugin/daimon_briefing/redact.py`. Re-run `daimon hooks
 install windsurf` after every `daimon` upgrade so the installed scripts (and
-the bundled `redact.py`) stay in sync with the installed CLI.
+the bundled `redact.py`) stay in sync with the installed CLI. To check whether
+they have drifted, run `daimon hooks status` — it reports each installed copy as
+CURRENT/STALE/MISSING against the packaged version and exits non-zero on drift.
 
 Point Windsurf's Cascade hooks config (user-level JSON — see
 [the Cascade hooks docs](https://docs.windsurf.com/windsurf/cascade/hooks))

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -21,6 +21,7 @@
 import argparse
 import functools
 import getpass
+import hashlib
 import json
 import logging
 import os
@@ -1284,6 +1285,9 @@ def _cmd_status(args) -> int:
     # window. A FAIL payload (or None) renders at the very TOP of status — a
     # class of failure that otherwise hides until a briefing turns up empty.
     capture_alarm = _capture_alarm(now)
+    # One-line pointer only when installed hook copies have drifted (#266);
+    # silent on a clean machine. Cheap: hashes a handful of small files.
+    hook_drift = _hook_drift_present()
     health = _status_health(proj, glob, outstanding, siblings, now=now,
                             disabled=disabled)
     # ONE objective team line (#113), only when a team remote exists — the #84
@@ -1309,7 +1313,7 @@ def _cmd_status(args) -> int:
              "team": team, "crash": crash, "disabled": disabled,
              "skipped_recent": skipped_recent, "recall_error": recall_error,
              "recall_index": recall_index, "receipts": receipts_line,
-             "capture_alarm": capture_alarm},
+             "capture_alarm": capture_alarm, "hook_drift": hook_drift},
             indent=2,
         ))
         return rc
@@ -1320,6 +1324,7 @@ def _cmd_status(args) -> int:
         "team": team, "crash": crash, "skipped_recent": skipped_recent,
         "recall_error": recall_error, "recall_index": recall_index,
         "receipts": receipts_line, "capture_alarm": capture_alarm,
+        "hook_drift": hook_drift,
     })
     return rc
 
@@ -1908,6 +1913,105 @@ def _cmd_hooks_install(args) -> int:
     return 0
 
 
+# ---- hooks status: audit installed copies against the packaged bytes (#266) ----
+#
+# A stale hook copy keeps *working* on old behavior after an upgrade, so drift is
+# invisible until a briefing turns up wrong. `daimon hooks status` hashes the
+# packaged bytes against what is installed and reports it, per host, per file.
+
+
+def _host_install_dir(spec, home: Path) -> Path:
+    """Where a host's hook files live. Codex owns ~/.codex/hooks/ (it registers
+    the scripts there itself); everyone else shares the stable ~/.daimon/hooks/
+    that `hooks install` writes to."""
+    if spec.get("register") == "codex":
+        return home / ".codex" / "hooks"
+    return home / ".daimon" / "hooks"
+
+
+def _hook_file_status(pkg, install_dir: Path, name: str) -> str:
+    """CURRENT / STALE / MISSING for one installed file vs its packaged copy.
+    ``exists()`` and ``read_bytes()`` both follow symlinks, so a symlinked
+    install is judged by the bytes it points at (a broken link → MISSING)."""
+    dest = install_dir / name
+    if not dest.exists():
+        return "MISSING"
+    try:
+        installed = dest.read_bytes()
+    except OSError:
+        return "MISSING"
+    packaged = (pkg / name).read_bytes()
+    match = hashlib.sha256(installed).digest() == hashlib.sha256(packaged).digest()
+    return "CURRENT" if match else "STALE"
+
+
+def _codex_registration_status(home: Path) -> str:
+    """REGISTERED / PARTIAL / UNREGISTERED for the ~/.codex/hooks.json entries.
+    Reuses codex_hooks' own loader and ownership check so this verdict can never
+    drift from what `hooks install codex` writes."""
+    from . import codex_hooks
+
+    settings = codex_hooks._load(home / ".codex" / "hooks.json")
+    cfg = settings.get("hooks", {})
+    if not isinstance(cfg, dict):
+        cfg = {}
+    found = sum(
+        1 for hspec in codex_hooks.HOOKS
+        if any(codex_hooks._is_ours(g, hspec["script"])
+               for g in cfg.get(hspec["event"], []) if isinstance(g, dict))
+    )
+    if found == 0:
+        return "UNREGISTERED"
+    return "REGISTERED" if found == len(codex_hooks.HOOKS) else "PARTIAL"
+
+
+def _host_status_entry(host: str, spec, pkg, home: Path) -> dict:
+    install_dir = _host_install_dir(spec, home)
+    reg = _codex_registration_status(home) if spec.get("register") == "codex" else None
+    installed = any((install_dir / n).exists() for n in spec["files"])
+    if spec.get("register") == "codex":
+        # Codex counts as installed if its hooks dir OR any of our registration
+        # entries exist — either alone is a setup we must audit, not ignore.
+        installed = installed or install_dir.exists() or reg != "UNREGISTERED"
+    entry = {"host": host, "dir": str(install_dir), "installed": installed,
+             "registration": reg, "files": [], "drift": False}
+    if not installed:
+        return entry
+    entry["files"] = [{"name": n, "status": _hook_file_status(pkg, install_dir, n)}
+                      for n in spec["files"]]
+    file_drift = any(f["status"] in ("STALE", "MISSING") for f in entry["files"])
+    reg_drift = reg is not None and reg != "REGISTERED"
+    entry["drift"] = file_drift or reg_drift
+    return entry
+
+
+def _hooks_status_report(home: Path) -> list[dict]:
+    from importlib import resources
+
+    pkg = resources.files("daimon_briefing._hooks")
+    return [_host_status_entry(host, spec, pkg, home)
+            for host, spec in sorted(_HOOK_HOSTS.items())]
+
+
+def _hook_drift_present() -> bool:
+    """Cheap yes/no for the `daimon status` pointer — hashes a handful of small
+    files. Swallows every error: status must never crash on a weird hooks tree,
+    and a probe that cannot read the packaged copies simply reports no drift."""
+    try:
+        return any(h["drift"] for h in _hooks_status_report(Path.home()))
+    except Exception:
+        return False
+
+
+def _cmd_hooks_status(args) -> int:
+    report = _hooks_status_report(Path.home())
+    if getattr(args, "json", False):
+        print(json.dumps(report, indent=2))
+    else:
+        render.render_hooks_status(report)
+    return 1 if any(h["drift"] for h in report) else 0
+
+
 # ---- skill: ship the portable agent skill from the package (#66) ----
 
 def _resolve_project_cwd() -> Path:
@@ -2298,12 +2402,19 @@ def main(argv=None) -> int:
 
     p_hooks = sub.add_parser(
         "hooks",
-        help="ship host hook scripts from the package (#43): list, install",
+        help="ship host hook scripts from the package (#43): list, install, status",
     )
     hooks_sub = p_hooks.add_subparsers(dest="hooks_cmd", required=True)
     hooks_sub.add_parser = functools.partial(hooks_sub.add_parser, formatter_class=fmt)
     ph_list = hooks_sub.add_parser("list", help="hosts with packaged hook scripts")
     ph_list.set_defaults(func=_cmd_hooks_list)
+    ph_status = hooks_sub.add_parser(
+        "status",
+        help="audit installed hook copies against the packaged versions "
+             "(CURRENT/STALE/MISSING/NOT INSTALLED); non-zero exit on drift",
+    )
+    ph_status.add_argument("--json", action="store_true", help="machine-readable output")
+    ph_status.set_defaults(func=_cmd_hooks_status)
     ph_install = hooks_sub.add_parser(
         "install",
         help="copy a host's hook script(s) to the stable path ~/.daimon/hooks/ "

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -444,6 +444,8 @@ def _plain_status(data: dict) -> None:
         print(health["verdict"])
         for w in health["warnings"][1:]:
             print(f"  ⚠ {w}")
+    if data.get("hook_drift"):
+        print("⚠ installed hooks out of date — run daimon hooks status")
     if data.get("team"):
         print(data["team"])  # one objective line; absent when team unused (#113)
     if data.get("receipts"):
@@ -520,6 +522,9 @@ def _rich_status(data: dict) -> None:
         console.print(f"[{style}]{health['verdict']}[/{style}]")
         for w in health["warnings"][1:]:
             console.print(f"  ⚠ {w}")
+    if data.get("hook_drift"):
+        console.print("[red]⚠ installed hooks out of date — "
+                      "run daimon hooks status[/red]")
     if data.get("team"):
         console.print(data["team"])  # one objective line; absent when team unused (#113)
     if data.get("receipts"):
@@ -695,6 +700,27 @@ def render_hooks_list(lines) -> None:
 
 
 def render_hooks_install(lines) -> None:
+    _render_lines(lines)
+
+
+def render_hooks_status(report) -> None:
+    """Per-host, per-file drift audit (#266). NOT INSTALLED hosts get one line;
+    installed hosts list each file's verdict, the registration state where the
+    host uses one, and a single fix hint when anything drifted."""
+    lines: list[str] = []
+    for h in report:
+        if not h["installed"]:
+            lines.append(f"{h['host']}: NOT INSTALLED")
+            continue
+        lines.append(f"{h['host']}  ({h['dir']})")
+        for f in h["files"]:
+            lines.append(f"  {f['status']:<8} {f['name']}")
+        if h["registration"] is not None:
+            lines.append(f"  registration: {h['registration']}")
+        if h["drift"]:
+            lines.append(f"  → fix: daimon hooks install {h['host']}")
+    if not lines:
+        lines.append("no packaged hook hosts")
     _render_lines(lines)
 
 

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -674,7 +674,7 @@ def test_cli_status_json_shape(
     assert set(data) == {"project", "global", "last_serialize", "outstanding",
                          "siblings", "health", "team", "crash", "disabled",
                          "skipped_recent", "recall_error", "recall_index",
-                         "receipts", "capture_alarm"}
+                         "receipts", "capture_alarm", "hook_drift"}
     assert data["capture_alarm"] is None  # #265 FAIL-only probe silent by default
     assert data["team"] is None  # no team remote configured -> explicit null (#113)
     assert data["receipts"] is None  # #204 feature off -> explicit null

--- a/plugin/tests/test_hooks_status.py
+++ b/plugin/tests/test_hooks_status.py
@@ -1,0 +1,252 @@
+"""#266: `daimon hooks status` reports whether the installed hook copies still
+match the packaged versions. Drift is otherwise invisible — a stale copy keeps
+*working* on old behavior after an upgrade — so this is a byte-hash audit with a
+non-zero exit for CI, plus a one-line pointer on `daimon status` when drift
+exists. Fixtures mirror test_hooks_install.py: HOME → tmp_path, install for
+real, then mutate the installed tree."""
+
+import json
+from pathlib import Path
+
+from daimon_briefing import cli, render
+
+PKG_HOOKS_DIR = Path(__file__).parents[1] / "daimon_briefing" / "_hooks"
+
+_WINDSURF_FILES = cli._HOOK_HOSTS["windsurf"]["files"]
+_WINDSURF_DIR = (".daimon", "hooks")
+_CODEX_DIR = (".codex", "hooks")
+
+
+def _host(report, name):
+    return next(h for h in report if h["host"] == name)
+
+
+def _statuses(report, name):
+    return {f["name"]: f["status"] for f in _host(report, name)["files"]}
+
+
+# ---- nothing installed -------------------------------------------------------
+
+
+def test_status_fresh_home_reports_not_installed_and_exits_zero(tmp_path, monkeypatch, capsys):
+    # A machine that never ran `hooks install` is not "broken" — it is simply
+    # not set up. NOT INSTALLED, zero exit (requirement 5: nothing-installed = 0).
+    monkeypatch.setenv("HOME", str(tmp_path))
+    rc = cli.main(["hooks", "status"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "NOT INSTALLED" in out
+    assert "windsurf" in out and "codex" in out
+
+
+# ---- windsurf: current / stale / missing ------------------------------------
+
+
+def test_status_after_install_all_current_exits_zero(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "windsurf"]) == 0
+    capsys.readouterr()
+    rc = cli.main(["hooks", "status"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "STALE" not in out and "MISSING" not in out
+    assert "CURRENT" in out
+
+
+def test_status_mutated_file_is_stale_and_exits_one(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "windsurf"]) == 0
+    target = tmp_path.joinpath(*_WINDSURF_DIR)
+    (target / "daimon-windsurf-hooks.py").write_text("# stale drifted copy")
+    capsys.readouterr()
+    rc = cli.main(["hooks", "status"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "STALE" in out
+    # requirement 4: the drifted host prints the exact fix command
+    assert "daimon hooks install windsurf" in out
+
+
+def test_status_removed_file_is_missing_and_exits_one(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "windsurf"]) == 0
+    target = tmp_path.joinpath(*_WINDSURF_DIR)
+    (target / "redact.py").unlink()
+    capsys.readouterr()
+    rc = cli.main(["hooks", "status"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "MISSING" in out
+    assert "daimon hooks install windsurf" in out
+
+
+# ---- symlinked installs resolve to target bytes -----------------------------
+
+
+def test_status_symlink_resolves_to_target_bytes(tmp_path, monkeypatch):
+    # A symlinked install must be judged by the bytes it points AT, not the link.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    target = tmp_path.joinpath(*_WINDSURF_DIR)
+    target.mkdir(parents=True)
+    real = tmp_path / "real"
+    real.mkdir()
+    for name in _WINDSURF_FILES:
+        good = real / name
+        good.write_bytes((PKG_HOOKS_DIR / name).read_bytes())
+        (target / name).symlink_to(good)
+    report = cli._hooks_status_report(tmp_path)
+    assert all(v == "CURRENT" for v in _statuses(report, "windsurf").values())
+
+    # point one link at drifted bytes → STALE via the resolved target
+    (real / "redact.py").write_text("# drifted target")
+    report = cli._hooks_status_report(tmp_path)
+    assert _statuses(report, "windsurf")["redact.py"] == "STALE"
+
+
+def test_status_broken_symlink_is_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "windsurf"]) == 0
+    target = tmp_path.joinpath(*_WINDSURF_DIR)
+    victim = target / "redact.py"
+    victim.unlink()
+    victim.symlink_to(tmp_path / "does-not-exist")
+    report = cli._hooks_status_report(tmp_path)
+    assert _statuses(report, "windsurf")["redact.py"] == "MISSING"
+
+
+# ---- codex: registration verdicts -------------------------------------------
+
+
+def test_status_codex_fresh_install_registered_and_current(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    report = cli._hooks_status_report(tmp_path)
+    codex = _host(report, "codex")
+    assert codex["installed"] is True
+    assert codex["registration"] == "REGISTERED"
+    assert all(v == "CURRENT" for v in _statuses(report, "codex").values())
+    assert codex["drift"] is False
+
+
+def test_status_codex_missing_one_registration_is_partial_and_drifts(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    hooks_json = tmp_path / ".codex" / "hooks.json"
+    cfg = json.loads(hooks_json.read_text())
+    # drop the Stop registration; scripts on disk are still CURRENT
+    cfg["hooks"]["Stop"] = []
+    hooks_json.write_text(json.dumps(cfg))
+    report = cli._hooks_status_report(tmp_path)
+    codex = _host(report, "codex")
+    assert codex["registration"] == "PARTIAL"
+    assert codex["drift"] is True
+
+
+def test_status_codex_no_registration_is_unregistered(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    hooks_json = tmp_path / ".codex" / "hooks.json"
+    hooks_json.write_text(json.dumps({"hooks": {}}))
+    report = cli._hooks_status_report(tmp_path)
+    codex = _host(report, "codex")
+    # scripts still on disk → still installed, but nothing points at them
+    assert codex["installed"] is True
+    assert codex["registration"] == "UNREGISTERED"
+    assert codex["drift"] is True
+
+
+def test_status_codex_registered_scripts_gone_dir_present_still_installed(tmp_path, monkeypatch):
+    # Registration entries exist but scripts were deleted: host counts as
+    # installed (issue: "installed if hooks dir OR registration entries exist"),
+    # files report MISSING.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    hooks_dir = tmp_path / ".codex" / "hooks"
+    for p in list(hooks_dir.iterdir()):
+        p.unlink()
+    report = cli._hooks_status_report(tmp_path)
+    codex = _host(report, "codex")
+    assert codex["installed"] is True
+    assert all(v == "MISSING" for v in _statuses(report, "codex").values())
+    assert codex["drift"] is True
+
+
+def test_status_codex_exits_one_on_registration_drift(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    (tmp_path / ".codex" / "hooks.json").write_text(json.dumps({"hooks": {}}))
+    capsys.readouterr()
+    rc = cli.main(["hooks", "status"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "UNREGISTERED" in out
+    assert "daimon hooks install codex" in out
+
+
+# ---- json pipe --------------------------------------------------------------
+
+
+def test_status_json_shape(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "windsurf"]) == 0
+    capsys.readouterr()
+    assert cli.main(["hooks", "status", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    ws = _host(payload, "windsurf")
+    assert ws["installed"] is True
+    assert {f["name"] for f in ws["files"]} == set(_WINDSURF_FILES)
+
+
+# ---- daimon status one-line pointer (requirement 6) -------------------------
+
+
+def test_main_status_renders_drift_pointer_when_present(capsys):
+    render.render_status({
+        "project": "/p/A",
+        "proj": {"exists": False},
+        "glob": {"exists": False},
+        "last": None,
+        "hook_drift": True,
+    })
+    out = capsys.readouterr().out
+    assert "installed hooks out of date" in out
+    assert "daimon hooks status" in out
+
+
+def test_main_status_silent_when_no_drift(capsys):
+    render.render_status({
+        "project": "/p/A",
+        "proj": {"exists": False},
+        "glob": {"exists": False},
+        "last": None,
+        "hook_drift": False,
+    })
+    out = capsys.readouterr().out
+    assert "out of date" not in out
+
+
+def test_cmd_status_sets_hook_drift_when_installed_copy_stale(tmp_path, monkeypatch, capsys):
+    # End to end: install, drift a file, run the top-level `status` command and
+    # confirm it surfaces the pointer (cheap hash check wired into status).
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "windsurf"]) == 0
+    target = tmp_path.joinpath(*_WINDSURF_DIR)
+    (target / "daimon-windsurf-hooks.py").write_text("# drifted")
+    capsys.readouterr()
+    cli.main(["status"])
+    out = capsys.readouterr().out
+    assert "installed hooks out of date" in out
+
+
+def test_cmd_status_no_pointer_on_clean_machine(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    capsys.readouterr()
+    cli.main(["status"])
+    out = capsys.readouterr().out
+    assert "out of date" not in out
+
+
+def test_hook_drift_present_never_raises(tmp_path, monkeypatch):
+    # status must never crash on a weird hooks tree — the probe swallows errors.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli._hook_drift_present() is False

--- a/plugin/tests/test_hooks_status.py
+++ b/plugin/tests/test_hooks_status.py
@@ -250,3 +250,47 @@ def test_hook_drift_present_never_raises(tmp_path, monkeypatch):
     # status must never crash on a weird hooks tree — the probe swallows errors.
     monkeypatch.setenv("HOME", str(tmp_path))
     assert cli._hook_drift_present() is False
+
+
+def test_hook_drift_present_swallows_report_errors(monkeypatch):
+    # If the report itself blows up (unreadable packaged copies, etc.) the status
+    # probe reports no drift rather than crashing the whole `daimon status`.
+    monkeypatch.setattr(cli, "_hooks_status_report",
+                        lambda home: (_ for _ in ()).throw(RuntimeError("boom")))
+    assert cli._hook_drift_present() is False
+
+
+def test_hook_file_status_unreadable_path_is_missing(tmp_path):
+    # A path that exists but cannot be read as bytes (here: a directory in the
+    # file's place) reads as MISSING, not a crash.
+    from importlib import resources
+
+    pkg = resources.files("daimon_briefing._hooks")
+    (tmp_path / "redact.py").mkdir()
+    assert cli._hook_file_status(pkg, tmp_path, "redact.py") == "MISSING"
+
+
+def test_codex_registration_status_handles_non_dict_hooks(tmp_path, monkeypatch):
+    # A hooks.json whose "hooks" is not an object must not crash the audit.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    codex = tmp_path / ".codex"
+    codex.mkdir()
+    (codex / "hooks.json").write_text(json.dumps({"hooks": "not-an-object"}))
+    assert cli._codex_registration_status(tmp_path) == "UNREGISTERED"
+
+
+def test_render_hooks_status_rich_drift_pointer(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_status({
+        "project": "/p/A",
+        "proj": {"exists": False},
+        "glob": {"exists": False},
+        "last": None,
+        "hook_drift": True,
+    })
+    assert "out of date" in capsys.readouterr().out
+
+
+def test_render_hooks_status_empty_report(capsys):
+    render.render_hooks_status([])
+    assert "no packaged hook hosts" in capsys.readouterr().out


### PR DESCRIPTION
## What

Adds `daimon hooks status`: an audit of the installed hook copies against the bytes the package ships.

Installed hook scripts drift from the packaged versions after an upgrade, and a stale copy keeps *working* on old behavior — so the drift stays invisible until a briefing turns up wrong. This machine ran a weeks-stale manually-installed Codex hook copy for exactly that reason.

## Behavior

- Per host, per file: `CURRENT` (sha256 matches the packaged copy), `STALE` (differs), `MISSING` (host installed but file absent), `NOT INSTALLED` (host not set up at all).
- Symlinked installs are judged by their **target** bytes (`exists()`/`read_bytes()` follow the link; a broken link reads as `MISSING`).
- Hosts with a registration file (codex `~/.codex/hooks.json`) also report `REGISTERED` / `PARTIAL` / `UNREGISTERED`, reusing codex_hooks' own loader + ownership check so the verdict can't drift from what `hooks install` writes.
- Drifted hosts print the fix (`daimon hooks install <host>` — already an idempotent refresh).
- Exit code is non-zero when anything drifted (STALE/MISSING file, or an installed host whose registration is not fully `REGISTERED`); zero for all-CURRENT or nothing-installed. `--json` for scripting.
- `daimon status` gains a one-line pointer **only when drift exists**, silent on a clean machine (cheap: hashes a handful of small files, and the probe swallows errors so status never crashes).

## Live output on a drifted machine

```
codex  (~/.codex/hooks)
  STALE    daimon-codex-session-start.py
  STALE    daimon-codex-stop.py
  MISSING  _daimon_hook_lib.py
  registration: REGISTERED
  -> fix: daimon hooks install codex
windsurf: NOT INSTALLED
```

The scripts are stale but registration is still `REGISTERED` — the exact "keeps working, invisibly wrong" case the issue describes.

## Tests

New `plugin/tests/test_hooks_status.py` (17 cases, tmp HOME fixtures mirroring `test_hooks_install.py`): fresh install = all CURRENT / exit 0; mutated = STALE / exit 1; removed = MISSING / exit 1; uninstalled = NOT INSTALLED / exit 0; codex registration verdicts; symlink resolves to target bytes; broken symlink = MISSING; the `daimon status` pointer appears on drift and is silent when clean. Full plugin suite green (1592 passed, 1 skipped). Docs updated for the windsurf and codex hosts.

Closes #266