### PR TITLE
test(bench): LongMemEval-S retrieval benchmark harness

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,65 @@
+name: benchmark
+
+# Manual only — the LongMemEval harness serializes many sessions through an LLM
+# backend, which costs real money and minutes. Never on push/PR. Run it to
+# refresh a baseline (e.g. around a release) and download the result artifact.
+on:
+  workflow_dispatch:
+    inputs:
+      sample:
+        description: "Questions to run (<=0 = full 500)"
+        required: false
+        default: "50"
+      seed:
+        description: "Sampling seed"
+        required: false
+        default: "0"
+      workers:
+        description: "Concurrent serialize calls per question"
+        required: false
+        default: "6"
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: plugin
+    env:
+      # Backend is read from daimon's own config env vars. Set these as repo
+      # secrets; the harness records the model but never writes the key/URL.
+      DAIMON_LLM_API_KEY: ${{ secrets.DAIMON_LLM_API_KEY }}
+      DAIMON_LLM_MODEL: ${{ secrets.DAIMON_LLM_MODEL }}
+      DAIMON_LLM_BASE_URL: ${{ secrets.DAIMON_LLM_BASE_URL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+          enable-cache: true
+          cache-dependency-glob: plugin/uv.lock
+
+      - name: Guard — backend must be configured
+        run: |
+          if [ -z "$DAIMON_LLM_API_KEY" ]; then
+            echo "::error::DAIMON_LLM_API_KEY secret is not set — cannot run the benchmark"
+            exit 1
+          fi
+
+      - name: Run LongMemEval-S harness
+        run: |
+          uv run --extra dev python -m tests.bench.run \
+            --suite longmemeval-s \
+            --sample "${{ github.event.inputs.sample }}" \
+            --seed "${{ github.event.inputs.seed }}" \
+            --workers "${{ github.event.inputs.workers }}"
+
+      - name: Upload result artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: longmemeval-s-result
+          path: benchmark/results/*.json
+          if-no-files-found: warn

--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,0 +1,5 @@
+# Downloaded dataset (~277 MB) — fetched on demand, never vendored (#267).
+.data/
+# Serialized-checkpoint cache and per-question scratch stores.
+.cache/
+.work/

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,103 @@
+# daimon retrieval benchmark
+
+A reproducible harness that measures daimon's recall on a public long-horizon
+memory benchmark — **LongMemEval-S** (ICLR 2025). It answers one question we
+otherwise cannot answer honestly: *how good is recall?*
+
+The harness feeds benchmark session histories through daimon's **real** serializer
+and answers questions using **only** what `daimon recall` surfaces. There is no
+bypass of the product to flatter the number.
+
+## Reporting policy
+
+This is the part that matters more than any single figure:
+
+- **We publish only numbers we measured ourselves**, with the exact harness
+  version, backend, model, prompt version, seed, and dataset checksum attached.
+  Every result file under `results/` carries that full config stamp.
+- **Third-party figures are labeled as their publishers' claims**, never
+  reproduced or presented as ours. If we quote another tool's LongMemEval number,
+  it is cited as their claim under their setup — not a head-to-head we ran.
+- **The number is meaningless without its backend.** Serializer quality varies by
+  model (measured in this repo). A recall figure is always reported together with
+  the backend/model that produced it; a figure with no backend stamp is not a
+  daimon benchmark result.
+- **We report the trade, not just the win.** daimon trades some raw recall for
+  verifiability (provenance, trust tags, quote-checking). The honest framing
+  publishes both the recall number and that trade — including the efficiency
+  story (`avg_injected_tokens`), which is what the recall buys you at answer time.
+
+## What is measured
+
+For each question, every haystack session is serialized into a checkpoint (the
+same `serialize_strict` call the SessionEnd hook makes), written to an isolated
+store, and indexed. The question is then run through `recall.search`. The unit of
+retrieval is the **session**: a hit means a retrieved item's source session is one
+of the question's evidence sessions (`answer_session_ids`).
+
+| Metric | Definition |
+| --- | --- |
+| **Recall@k** | fraction of gold (evidence) sessions in the top-k retrieved sessions, averaged over scored questions |
+| **Hit@k** | 1 if any gold session is in the top-k, else 0 (a laxer success rate) |
+| **MRR** | mean of 1 / rank-of-first-gold-session |
+| **avg_injected_tokens** | estimated tokens of the top-k item texts a briefing injects — daimon's efficiency story, not a quality metric (≈4 chars/token estimate, not exact) |
+
+Abstention questions (`*_abs`, no evidence session) are **excluded** from recall
+scoring — there is nothing to retrieve — and counted separately, never scored as
+zero.
+
+### Known measurement choices (recorded in every result)
+
+- **`min_messages` is lowered to 2** for the benchmark so short evidence sessions
+  enter the index. The product's live default is **10**; in production, sessions
+  shorter than that are skipped. This is a real limitation, surfaced here rather
+  than hidden — the run config records the value used.
+- **Carry is off.** Each session's checkpoint stands alone, giving a clean
+  session→id mapping for scoring. Cross-session carry (a real product feature) is
+  a separate axis to benchmark later.
+- **Determinism** holds given the seed and a pinned backend. Backends with
+  non-zero temperature introduce serializer variance; the configured temperature
+  rides in daimon's own config.
+
+## Running it
+
+From the `plugin/` directory (uv-managed environment):
+
+```bash
+# smoke tier (default 50 questions)
+uv run python -m tests.bench.run --suite longmemeval-s --sample 50
+
+# tiny end-to-end check
+uv run python -m tests.bench.run --suite longmemeval-s --sample 5 --workers 8
+
+# full 500-question suite (opt-in — expensive)
+uv run python -m tests.bench.run --suite longmemeval-s --sample 0
+```
+
+The dataset (~277 MB) is **downloaded on demand** from HuggingFace
+(`xiaowu0162/longmemeval-cleaned`, MIT license) and **never vendored** into the
+repo. Its SHA-256 is pinned in `longmemeval_s.sha256` on first download
+(trust-on-first-use) and verified on every later run; a mismatch is a hard error.
+
+**Cost control.** Serializing a session is the one expensive step. The harness
+caches each serialized checkpoint keyed by `(session content hash, backend, model,
+prompt version)` under `.cache/`, so re-runs pay the LLM only for sessions never
+seen under the current config. A backend/model/prompt change misses on purpose — a
+cached checkpoint from a different pipeline is a different measurement.
+
+The backend/model come from daimon's own config (`~/.daimon/env` /
+`DAIMON_LLM_*`). No secret (API key, base URL) is ever written to a result file.
+
+## Results
+
+Baseline artifacts live under `results/`, each a self-contained JSON with its
+config stamp, aggregate metrics, cost accounting, and per-question detail. A
+manual GitHub Actions workflow (`.github/workflows/benchmark.yml`,
+`workflow_dispatch`) reproduces a run so releases can refresh the baseline — it is
+**not** run on every PR (cost).
+
+## Dataset license
+
+LongMemEval is released under the **MIT license**
+(github.com/xiaowu0162/LongMemEval). The dataset is fetched at run time; this repo
+vendors none of it.

--- a/benchmark/longmemeval_s.sha256
+++ b/benchmark/longmemeval_s.sha256
@@ -1,0 +1,1 @@
+d6f21ea9d60a0d56f34a05b609c79c88a451d2ae03597821ea3d5a9678c3a442  longmemeval_s_cleaned.json

--- a/benchmark/results/longmemeval-s-baseline.json
+++ b/benchmark/results/longmemeval-s-baseline.json
@@ -2,14 +2,14 @@
   "config": {
     "harness_version": "1.0.0",
     "suite": "longmemeval-s",
-    "generated_at": "2026-07-12T23:40:11Z",
-    "git_commit": "4f98566",
+    "generated_at": "2026-07-12T23:56:00Z",
+    "git_commit": "889d1ee",
     "backend": "litellm",
     "backend_configured": "auto",
     "model": "claude-haiku-4-5-via-meridian",
     "prompt_version": "D-013",
     "seed": 0,
-    "sample": 1,
+    "sample": 5,
     "k": 5,
     "recall_depth": 50,
     "min_messages": "2",
@@ -20,21 +20,78 @@
   },
   "metrics": {
     "k": 5,
-    "questions_total": 1,
-    "questions_scored": 1,
+    "questions_total": 5,
+    "questions_scored": 5,
     "questions_abstention": 0,
-    "recall_at_5": 0.5,
+    "recall_at_5": 0.8,
     "hit_at_5": 1.0,
-    "mrr": 0.25,
-    "avg_injected_tokens": 152.0
+    "mrr": 0.85,
+    "avg_injected_tokens": 149.6
   },
   "cost": {
-    "llm_serialize_calls": 51,
-    "cache_hits": 0,
-    "cache_misses": 51,
-    "wall_seconds": 877.9
+    "llm_serialize_calls": 192,
+    "cache_hits": 51,
+    "cache_misses": 193,
+    "wall_seconds": 3337.3
   },
   "per_question": [
+    {
+      "question_id": "1c549ce4",
+      "question_type": "multi-session",
+      "abstention": false,
+      "n_haystack": 45,
+      "n_gold": 2,
+      "serialize": {
+        "serialized": 45,
+        "cached": 0,
+        "too_short": 0,
+        "failed": 0,
+        "indexed": 45
+      },
+      "n_retrieved_sessions": 21,
+      "recall_at_5": 1.0,
+      "hit_at_5": true,
+      "mrr": 1.0,
+      "injected_tokens": 111
+    },
+    {
+      "question_id": "55241a1f",
+      "question_type": "multi-session",
+      "abstention": false,
+      "n_haystack": 49,
+      "n_gold": 2,
+      "serialize": {
+        "serialized": 49,
+        "cached": 0,
+        "too_short": 0,
+        "failed": 0,
+        "indexed": 49
+      },
+      "n_retrieved_sessions": 26,
+      "recall_at_5": 1.0,
+      "hit_at_5": true,
+      "mrr": 1.0,
+      "injected_tokens": 205
+    },
+    {
+      "question_id": "5a4f22c0",
+      "question_type": "knowledge-update",
+      "abstention": false,
+      "n_haystack": 49,
+      "n_gold": 2,
+      "serialize": {
+        "serialized": 49,
+        "cached": 0,
+        "too_short": 0,
+        "failed": 0,
+        "indexed": 49
+      },
+      "n_retrieved_sessions": 25,
+      "recall_at_5": 0.5,
+      "hit_at_5": true,
+      "mrr": 1.0,
+      "injected_tokens": 142
+    },
     {
       "question_id": "5c40ec5b",
       "question_type": "knowledge-update",
@@ -42,8 +99,8 @@
       "n_haystack": 51,
       "n_gold": 2,
       "serialize": {
-        "serialized": 51,
-        "cached": 0,
+        "serialized": 0,
+        "cached": 51,
         "too_short": 0,
         "failed": 0,
         "indexed": 51
@@ -53,6 +110,25 @@
       "hit_at_5": true,
       "mrr": 0.25,
       "injected_tokens": 152
+    },
+    {
+      "question_id": "fea54f57",
+      "question_type": "single-session-assistant",
+      "abstention": false,
+      "n_haystack": 50,
+      "n_gold": 1,
+      "serialize": {
+        "serialized": 49,
+        "cached": 0,
+        "too_short": 1,
+        "failed": 0,
+        "indexed": 49
+      },
+      "n_retrieved_sessions": 25,
+      "recall_at_5": 1.0,
+      "hit_at_5": true,
+      "mrr": 1.0,
+      "injected_tokens": 138
     }
   ]
 }

--- a/benchmark/results/longmemeval-s-baseline.json
+++ b/benchmark/results/longmemeval-s-baseline.json
@@ -1,0 +1,58 @@
+{
+  "config": {
+    "harness_version": "1.0.0",
+    "suite": "longmemeval-s",
+    "generated_at": "2026-07-12T23:40:11Z",
+    "git_commit": "4f98566",
+    "backend": "litellm",
+    "backend_configured": "auto",
+    "model": "claude-haiku-4-5-via-meridian",
+    "prompt_version": "D-013",
+    "seed": 0,
+    "sample": 1,
+    "k": 5,
+    "recall_depth": 50,
+    "min_messages": "2",
+    "carry": "off",
+    "workers": 6,
+    "dataset_file": "longmemeval_s_cleaned.json",
+    "dataset_sha256": "d6f21ea9d60a0d56f34a05b609c79c88a451d2ae03597821ea3d5a9678c3a442"
+  },
+  "metrics": {
+    "k": 5,
+    "questions_total": 1,
+    "questions_scored": 1,
+    "questions_abstention": 0,
+    "recall_at_5": 0.5,
+    "hit_at_5": 1.0,
+    "mrr": 0.25,
+    "avg_injected_tokens": 152.0
+  },
+  "cost": {
+    "llm_serialize_calls": 51,
+    "cache_hits": 0,
+    "cache_misses": 51,
+    "wall_seconds": 877.9
+  },
+  "per_question": [
+    {
+      "question_id": "5c40ec5b",
+      "question_type": "knowledge-update",
+      "abstention": false,
+      "n_haystack": 51,
+      "n_gold": 2,
+      "serialize": {
+        "serialized": 51,
+        "cached": 0,
+        "too_short": 0,
+        "failed": 0,
+        "indexed": 51
+      },
+      "n_retrieved_sessions": 31,
+      "recall_at_5": 0.5,
+      "hit_at_5": true,
+      "mrr": 0.25,
+      "injected_tokens": 152
+    }
+  ]
+}

--- a/plugin/tests/bench/__init__.py
+++ b/plugin/tests/bench/__init__.py
@@ -1,0 +1,6 @@
+"""LongMemEval retrieval benchmark harness for daimon (#267).
+
+Not shipped in the wheel — lives under tests/ so it can import daimon_briefing
+directly and is linted by CI, but never packaged. See benchmark/README.md for
+the runner command and the reporting policy.
+"""

--- a/plugin/tests/bench/adapter.py
+++ b/plugin/tests/bench/adapter.py
@@ -1,0 +1,183 @@
+"""The benchmark adapter seam (#267).
+
+Runs ONE LongMemEval question through daimon's real pipeline, with no shortcuts:
+every haystack session is serialized by `serializer.serialize_strict` (the same
+call the SessionEnd hook makes) and written to the store by `store.write_checkpoint`;
+the question is then answered only by what `recall.search` surfaces from that index.
+
+Isolation: each question gets its own checkpoint dir + recall index under a temp
+root, addressed through the same DAIMON_* env vars the test suite uses. Carry is
+off so each session's checkpoint stands alone (a clean session→id mapping for
+scoring); the min-messages floor is lowered so short evidence sessions still enter
+the index (the product default of 10 would skip ~half the haystack — recorded in
+the run config, and called out in the README).
+
+The expensive step (the LLM serialize) runs concurrently across sessions; the
+store writes are serialized under a lock because pointer rotation and GC are not
+concurrency-safe. Recall indexes the per-session flat files, not the pointers, so
+serializing the writes costs nothing in fidelity.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import copy
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from daimon_briefing import recall, serializer, store
+
+from tests.bench import cache as cache_mod
+from tests.bench import dataset, metrics
+
+PROMPT_VERSION = serializer.PROMPT_VERSION
+
+# Every session enters the index for the benchmark (the product's live default is
+# 10; sessions shorter than that are skipped in production — a real limitation,
+# recorded in the run config and the README, not hidden by the harness).
+BENCH_MIN_MESSAGES = "2"
+
+_ENV_KEYS = (
+    "DAIMON_CHECKPOINT_DIR", "DAIMON_RECALL_DB", "DAIMON_LOG_DIR",
+    "DAIMON_RECALL_SEEN_DIR", "DAIMON_TEAM_DIR", "DAIMON_PROJECT_DIR",
+    "DAIMON_CARRY", "DAIMON_MIN_MESSAGES", "DAIMON_TEAM", "DAIMON_DISABLE",
+    "DAIMON_RECEIPTS", "DAIMON_SCAR_HARVEST",
+)
+
+
+def _question_env(root: Path, qid: str, min_messages: str) -> dict[str, str]:
+    """The DAIMON_* environment that isolates one question's store + index."""
+    home = root / _safe(qid)
+    project = home / "project"
+    return {
+        "DAIMON_CHECKPOINT_DIR": str(home / "checkpoints"),
+        "DAIMON_RECALL_DB": str(home / "recall.db"),
+        "DAIMON_LOG_DIR": str(home / "logs"),
+        "DAIMON_RECALL_SEEN_DIR": str(home / "recall_seen"),
+        "DAIMON_TEAM_DIR": str(home / "team"),
+        "DAIMON_PROJECT_DIR": str(project),
+        "DAIMON_CARRY": "0",             # per-session checkpoints stand alone
+        "DAIMON_MIN_MESSAGES": min_messages,
+        "DAIMON_TEAM": "0",              # no team dual-write during the benchmark
+        "DAIMON_DISABLE": "0",
+        "DAIMON_RECEIPTS": "0",          # receipts add cost, not retrieval signal
+        "DAIMON_SCAR_HARVEST": "0",
+    }
+
+
+def _safe(name: str) -> str:
+    return "".join(c if (c.isalnum() or c in "-_") else "_" for c in name)
+
+
+@contextlib.contextmanager
+def _env(mapping: dict[str, str]):
+    """Set env vars for the block, restoring prior values (or unsetting) after."""
+    saved = {k: os.environ.get(k) for k in _ENV_KEYS}
+    try:
+        for k in _ENV_KEYS:
+            os.environ.pop(k, None)
+        os.environ.update(mapping)
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def _created_stamp(index: int) -> str:
+    """A deterministic, strictly-increasing `created` stamp per haystack index.
+
+    Recency is only a recall tiebreak (bm25 relevance dominates), so the exact
+    times do not matter — determinism does. Later-listed sessions read as newer.
+    """
+    minute = index % 60
+    hour = (index // 60) % 24
+    return f"2024-01-01T{hour:02d}:{minute:02d}:00Z"
+
+
+def serialize_question(question: dict, *, chat, cache: cache_mod.CheckpointCache,
+                       backend: str, model: str, project_dir: str,
+                       workers: int) -> dict:
+    """Serialize every haystack session into the (already isolated) store.
+
+    Returns a tally: {serialized, cached, too_short, failed, indexed}.
+    """
+    sessions = dataset.sessions_of(question)
+    cache_lock = threading.Lock()
+
+    def _produce(item):
+        index, (sid, messages) = item
+        key = cache_mod.cache_key(messages, backend=backend, model=model,
+                                  prompt_version=PROMPT_VERSION)
+        with cache_lock:
+            cached = cache.get(key)
+        if cached is not None:
+            return index, sid, cached, "cached"
+        try:
+            checkpoint = serializer.serialize_strict(sid, messages, chat=chat)
+        except serializer.TooShortError:
+            return index, sid, None, "too_short"
+        except serializer.SerializeError:
+            return index, sid, None, "failed"
+        except Exception:
+            return index, sid, None, "failed"
+        with cache_lock:
+            cache.put(key, checkpoint)
+        return index, sid, checkpoint, "serialized"
+
+    workers = max(1, min(workers, len(sessions) or 1))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        produced = list(pool.map(_produce, enumerate(sessions)))
+
+    tally = {"serialized": 0, "cached": 0, "too_short": 0, "failed": 0, "indexed": 0}
+    # Store writes are single-threaded: pointer rotation + GC are not concurrency-safe.
+    for index, sid, checkpoint, status in sorted(produced, key=lambda r: r[0]):
+        tally[status] += 1
+        if checkpoint is None:
+            continue
+        cp = copy.deepcopy(checkpoint)
+        cp["session_id"] = sid
+        cp["created"] = _created_stamp(index)
+        store.write_checkpoint(sid, cp, project_dir=project_dir)
+        tally["indexed"] += 1
+    return tally
+
+
+def recall_question(question: dict, *, project_dir: str, depth: int) -> list[dict]:
+    """Answer the question with recall over this question's index (top-`depth`)."""
+    return recall.search(question["question"], project_dir=project_dir, limit=depth)
+
+
+def run_question(question: dict, *, chat, cache: cache_mod.CheckpointCache,
+                 backend: str, model: str, root: Path, k: int, depth: int,
+                 min_messages: str = BENCH_MIN_MESSAGES, workers: int = 1) -> dict:
+    """Full per-question pipeline: isolate → serialize haystack → recall → score."""
+    env = _question_env(root, question["question_id"], min_messages)
+    project_dir = env["DAIMON_PROJECT_DIR"]
+    with _env(env):
+        tally = serialize_question(
+            question, chat=chat, cache=cache, backend=backend, model=model,
+            project_dir=project_dir, workers=workers,
+        )
+        results = recall_question(question, project_dir=project_dir, depth=depth)
+
+    gold = dataset.gold_sessions(question)
+    abstention = dataset.is_abstention(question)
+    ranked = metrics.ranked_sessions(results)
+    return {
+        "question_id": question["question_id"],
+        "question_type": question.get("question_type"),
+        "abstention": abstention,
+        "n_haystack": len(question.get("haystack_session_ids") or []),
+        "n_gold": len(gold),
+        "serialize": tally,
+        "n_retrieved_sessions": len(ranked),
+        "recall_at_5": metrics.recall_at_k(ranked, gold, k),
+        "hit_at_5": metrics.hit_at_k(ranked, gold, k),
+        "mrr": metrics.reciprocal_rank(ranked, gold),
+        "injected_tokens": metrics.injected_tokens(results, k),
+    }

--- a/plugin/tests/bench/cache.py
+++ b/plugin/tests/bench/cache.py
@@ -1,0 +1,79 @@
+"""Serialized-checkpoint cache for the LongMemEval harness (#267).
+
+Serializing a haystack session is the one expensive step (an LLM call, minutes
+each). The cache keys the produced checkpoint by the exact things that determine
+it — the session's message content, the backend, the model, and the serializer
+prompt version — so a re-run pays the LLM only for sessions it has never seen
+under the current config. A backend, model, or prompt-version change misses on
+purpose: a cached checkpoint from a different pipeline is a different measurement.
+
+The cache stores the RAW `serialize_strict` output (pre-store mutation). Callers
+deep-copy on write, so a cached checkpoint is never mutated in place by the store.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+
+
+def cache_key(messages: list[dict], *, backend: str, model: str,
+              prompt_version: str) -> str:
+    """Stable content hash over (turns, backend, model, prompt_version).
+
+    Turns are hashed in order and by role — a reordered transcript is a different
+    session. Only role/content are hashed (the fields the serializer reads), so an
+    incidental metadata field on a turn does not bust the cache.
+    """
+    h = hashlib.sha256()
+    h.update(f"v1\x00{backend}\x00{model}\x00{prompt_version}\x00".encode())
+    for m in messages:
+        role = str(m.get("role") or "")
+        content = str(m.get("content") or "")
+        h.update(role.encode("utf-8"))
+        h.update(b"\x1f")
+        h.update(content.encode("utf-8"))
+        h.update(b"\x1e")
+    return h.hexdigest()
+
+
+class CheckpointCache:
+    """A directory of `<key>.json` checkpoint files. One instance per run.
+
+    Best-effort by design: a corrupt or unreadable entry is a miss, never a
+    crash — a re-serialize is always safe, only slower.
+    """
+
+    def __init__(self, cache_dir: Path):
+        self.dir = Path(cache_dir)
+        self.dir.mkdir(parents=True, exist_ok=True)
+        self.hits = 0
+        self.misses = 0
+
+    def _path(self, key: str) -> Path:
+        # keys are hex digests (or test literals) — no separators to contain.
+        return self.dir / f"{key}.json"
+
+    def get(self, key: str) -> dict | None:
+        p = self._path(key)
+        try:
+            checkpoint = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            self.misses += 1
+            return None
+        if not isinstance(checkpoint, dict):
+            self.misses += 1
+            return None
+        self.hits += 1
+        # Copy out: the store mutates checkpoints in place (redaction, id stamps).
+        return copy.deepcopy(checkpoint)
+
+    def put(self, key: str, checkpoint: dict) -> None:
+        try:
+            self._path(key).write_text(
+                json.dumps(checkpoint, ensure_ascii=False), encoding="utf-8"
+            )
+        except OSError:
+            pass  # an uncacheable checkpoint just re-serializes next run

--- a/plugin/tests/bench/dataset.py
+++ b/plugin/tests/bench/dataset.py
@@ -1,0 +1,134 @@
+"""LongMemEval-S dataset access for the harness (#267).
+
+The dataset (MIT, github.com/xiaowu0162/LongMemEval; distributed on HuggingFace)
+is NEVER vendored into this repo — it is fetched on demand and checksum-pinned.
+`longmemeval_s_cleaned.json` is ~277 MB (~500 questions, ~40-50 haystack sessions
+each), so the download is cached to disk and reused.
+
+Each question is a dict with (fields used here):
+- question_id           unique id; a `_abs` suffix marks an abstention question
+- question              the query text
+- haystack_session_ids  ids of the history sessions (the haystack)
+- haystack_sessions     parallel list; each entry is a list of {role, content, ...}
+- answer_session_ids    the EVIDENCE sessions — the retrieval gold set
+
+Abstention questions carry no evidence session; the harness excludes them from
+retrieval scoring (see metrics).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+import urllib.request
+from pathlib import Path
+
+# Official distribution. The deprecated `longmemeval` repo is replaced by
+# `-cleaned`, which removes history sessions that corrupted answer correctness.
+DATASET_URL = (
+    "https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/"
+    "resolve/main/longmemeval_s_cleaned.json?download=true"
+)
+DATASET_FILENAME = "longmemeval_s_cleaned.json"
+
+
+class ChecksumError(RuntimeError):
+    """A downloaded dataset file did not match the pinned checksum."""
+
+
+def verify_sha256(path: Path, expected: str | None) -> bool:
+    """True when `path` matches `expected`. Raise ChecksumError on mismatch.
+
+    `expected=None` means no checksum is pinned yet (trust-on-first-use): the
+    caller records the computed digest, so later runs verify against it. Returns
+    False in that case — verification did not happen — without raising.
+    """
+    actual = sha256_of(path)
+    if expected is None:
+        return False
+    if actual.lower() != expected.lower():
+        raise ChecksumError(
+            f"{path.name}: sha256 {actual} != pinned {expected} — "
+            "the download is corrupt or the upstream file changed"
+        )
+    return True
+
+
+def sha256_of(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for block in iter(lambda: f.read(1 << 20), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def download(dest: Path, url: str = DATASET_URL) -> Path:
+    """Fetch the dataset to `dest` (atomic). No-op if `dest` already exists."""
+    dest = Path(dest)
+    if dest.exists():
+        return dest
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    with urllib.request.urlopen(url) as resp, open(tmp, "wb") as out:  # noqa: S310
+        while True:
+            chunk = resp.read(1 << 20)
+            if not chunk:
+                break
+            out.write(chunk)
+    tmp.replace(dest)
+    return dest
+
+
+def load(path: Path) -> list[dict]:
+    """Parse the dataset JSON array into a list of question dicts."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, list):
+        raise ValueError(f"{path}: expected a JSON array of questions")
+    return data
+
+
+def sample(questions: list[dict], n: int, seed: int) -> list[dict]:
+    """A deterministic, seed-stable subset of `n` questions (all if n<=0 or n>=len).
+
+    Order-preserving: the sampled questions are returned in their dataset order so
+    a run reads the same regardless of the RNG's selection order.
+    """
+    if n <= 0 or n >= len(questions):
+        return list(questions)
+    idx = sorted(random.Random(seed).sample(range(len(questions)), n))
+    return [questions[i] for i in idx]
+
+
+def is_abstention(question: dict) -> bool:
+    """True for abstention questions: `_abs` id suffix, or no evidence session."""
+    if str(question.get("question_id", "")).endswith("_abs"):
+        return True
+    return not question.get("answer_session_ids")
+
+
+def gold_sessions(question: dict) -> set[str]:
+    """The evidence (gold) session ids for a question."""
+    return set(question.get("answer_session_ids") or [])
+
+
+def sessions_of(question: dict) -> list[tuple[str, list[dict]]]:
+    """(session_id, messages) pairs for the haystack, in order.
+
+    Each message is trimmed to the {role, content} shape the serializer reads;
+    the `has_answer` evidence marker and any other per-turn keys are dropped so a
+    session serializes exactly as a captured transcript would. Ids and sessions
+    are zipped — a length mismatch keeps only the aligned prefix (never crashes).
+    """
+    ids = question.get("haystack_session_ids") or []
+    sessions = question.get("haystack_sessions") or []
+    out: list[tuple[str, list[dict]]] = []
+    for sid, turns in zip(ids, sessions):
+        messages = [
+            {"role": str(t.get("role") or ""), "content": str(t.get("content") or "")}
+            for t in turns
+            if isinstance(t, dict)
+        ]
+        out.append((str(sid), messages))
+    return out

--- a/plugin/tests/bench/metrics.py
+++ b/plugin/tests/bench/metrics.py
@@ -1,0 +1,113 @@
+"""Retrieval metrics for the LongMemEval harness (#267).
+
+The unit of retrieval is a SESSION: daimon serializes each haystack session into
+a checkpoint whose items carry that session's id, so a recall hit is scored by
+whether a retrieved item's source session is one of the question's evidence
+(`answer_session_ids`) sessions. Definitions used throughout:
+
+- Recall@k  = |gold ∩ top-k retrieved sessions| / |gold|, averaged over questions.
+              A coverage metric — did we surface the evidence, and how much of it.
+- Hit@k     = 1 if any gold session is in the top-k, else 0 (a laxer success rate).
+- MRR       = mean of 1 / rank-of-first-gold-session (0 when no gold is retrieved).
+- Injected tokens = estimated token cost of the top-k item texts a briefing would
+              inject — daimon's efficiency story, not a quality metric.
+
+Abstention questions (LongMemEval `*_abs`, empty `answer_session_ids`) have no
+evidence session to retrieve, so retrieval metrics are None for them and they are
+excluded from the means — never scored as zero, which would understate recall.
+
+All functions are pure and deterministic given their inputs.
+"""
+
+from __future__ import annotations
+
+# A briefing has no tokenizer (daimon is stdlib-only), so the injected-token
+# figure is an estimate, not an exact count. ~4 chars/token is the standard
+# rough English ratio; the number is comparative (across configs/runs), and the
+# harness records that it is an estimate so it is never quoted as exact.
+_CHARS_PER_TOKEN = 4
+
+
+def ranked_sessions(recall_results: list[dict]) -> list[str]:
+    """Ranked, de-duplicated source-session ids from recall results.
+
+    recall.search returns items (multiple per session); the retrieval unit is the
+    session, so collapse to first-occurrence order — an item's rank is its
+    session's rank the first time that session appears.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for row in recall_results:
+        sid = row.get("session_id")
+        if not sid or sid in seen:
+            continue
+        seen.add(sid)
+        out.append(sid)
+    return out
+
+
+def recall_at_k(ranked: list[str], gold: set[str], k: int) -> float | None:
+    """Fraction of gold sessions present in the top-k. None when gold is empty."""
+    if not gold:
+        return None
+    window = set(ranked[:k])
+    return len(gold & window) / len(gold)
+
+
+def hit_at_k(ranked: list[str], gold: set[str], k: int) -> bool | None:
+    """True when at least one gold session is in the top-k. None when gold empty."""
+    if not gold:
+        return None
+    return bool(gold & set(ranked[:k]))
+
+
+def reciprocal_rank(ranked: list[str], gold: set[str]) -> float | None:
+    """1 / (1-based rank) of the first gold session, 0.0 if none. None when empty."""
+    if not gold:
+        return None
+    for i, sid in enumerate(ranked):
+        if sid in gold:
+            return 1.0 / (i + 1)
+    return 0.0
+
+
+def estimate_tokens(text: str) -> int:
+    """Rough token count via the ~4-chars/token heuristic. Estimate, not exact."""
+    if not text:
+        return 0
+    return len(text) // _CHARS_PER_TOKEN
+
+
+def injected_tokens(recall_results: list[dict], k: int) -> int:
+    """Estimated tokens of the top-k retrieved item texts — the briefing budget."""
+    return sum(estimate_tokens(str(r.get("text") or "")) for r in recall_results[:k])
+
+
+def _mean(values: list[float]) -> float | None:
+    return sum(values) / len(values) if values else None
+
+
+def aggregate(per_question: list[dict], k: int) -> dict:
+    """Roll per-question rows into run-level metrics.
+
+    Retrieval means (recall@k, hit@k, mrr) are taken over SCORED questions only
+    (abstention rows excluded). The token average is over ALL questions — it is
+    the efficiency of the whole run, abstentions included.
+    """
+    scored = [q for q in per_question if not q.get("abstention")]
+    recalls = [q["recall_at_5"] for q in scored if q.get("recall_at_5") is not None]
+    hits = [1.0 if q["hit_at_5"] else 0.0 for q in scored
+            if q.get("hit_at_5") is not None]
+    rrs = [q["mrr"] for q in scored if q.get("mrr") is not None]
+    tokens = [q["injected_tokens"] for q in per_question
+              if q.get("injected_tokens") is not None]
+    return {
+        "k": k,
+        "questions_total": len(per_question),
+        "questions_scored": len(scored),
+        "questions_abstention": len(per_question) - len(scored),
+        "recall_at_5": _mean(recalls),
+        "hit_at_5": _mean(hits),
+        "mrr": _mean(rrs),
+        "avg_injected_tokens": _mean([float(t) for t in tokens]),
+    }

--- a/plugin/tests/bench/run.py
+++ b/plugin/tests/bench/run.py
@@ -1,0 +1,203 @@
+"""LongMemEval-S benchmark runner (#267).
+
+Usage (from the plugin/ directory, uv-managed env):
+
+    uv run python -m tests.bench.run --suite longmemeval-s --sample 50
+    uv run python -m tests.bench.run --suite longmemeval-s --sample 5 --workers 8
+
+Downloads the dataset on demand (checksum-pinned, never vendored), serializes each
+sampled question's haystack through daimon's real pipeline, answers via recall, and
+writes a machine-readable JSON result with a full, reproducible config stamp. The
+LLM backend/model are read from daimon's own config and RECORDED — the number is
+meaningless without them. See benchmark/README.md for the reporting policy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from daimon_briefing import config, llm
+
+from tests.bench import adapter, cache as cache_mod
+from tests.bench import dataset, metrics
+
+HARNESS_VERSION = "1.0.0"
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_BENCH_DIR = _REPO_ROOT / "benchmark"
+_DATA_DIR = _BENCH_DIR / ".data"
+_CACHE_DIR = _BENCH_DIR / ".cache"
+_RESULTS_DIR = _BENCH_DIR / "results"
+_CHECKSUM_FILE = _BENCH_DIR / "longmemeval_s.sha256"
+
+
+def _effective_backend() -> str:
+    """The backend llm.chat will actually dispatch to, mirroring its own routing."""
+    backend = config.llm_backend()
+    if backend != "auto":
+        return backend
+    if config.llm_api_key():
+        return "litellm"
+    if llm._resolve_command() is not None:
+        return "command"
+    return "litellm"
+
+
+def _git_commit() -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"], cwd=str(_REPO_ROOT),
+            capture_output=True, text=True, timeout=10,
+        )
+        return out.stdout.strip() or None
+    except Exception:
+        return None
+
+
+def _resolve_dataset(args) -> Path:
+    """Return the dataset path, downloading + checksum-verifying on demand.
+
+    Checksum is trust-on-first-use: if none is pinned yet, the computed digest is
+    written to benchmark/longmemeval_s.sha256 so every later run verifies against
+    it. A mismatch is a hard error (corrupt download or changed upstream file).
+    """
+    if args.dataset_path:
+        return Path(args.dataset_path)
+    dest = _DATA_DIR / dataset.DATASET_FILENAME
+    if not dest.exists():
+        if args.no_download:
+            raise SystemExit(f"dataset missing at {dest} and --no-download set")
+        print(f"downloading LongMemEval-S -> {dest} (~277 MB, one time)...")
+        dataset.download(dest, args.url)
+    expected = None
+    if _CHECKSUM_FILE.exists():
+        expected = _CHECKSUM_FILE.read_text(encoding="utf-8").split()[0].strip()
+    if not dataset.verify_sha256(dest, expected):
+        digest = dataset.sha256_of(dest)
+        _CHECKSUM_FILE.write_text(f"{digest}  {dataset.DATASET_FILENAME}\n",
+                                  encoding="utf-8")
+        print(f"pinned dataset checksum (trust-on-first-use): {digest}")
+    return dest
+
+
+def _build_config_stamp(args, dataset_path: Path) -> dict:
+    """Everything needed to reproduce the number — and NOTHING secret (no key/url)."""
+    return {
+        "harness_version": HARNESS_VERSION,
+        "suite": args.suite,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "git_commit": _git_commit(),
+        "backend": _effective_backend(),
+        "backend_configured": config.llm_backend(),
+        "model": config.llm_model(),
+        "prompt_version": adapter.PROMPT_VERSION,
+        "seed": args.seed,
+        "sample": args.sample,
+        "k": args.k,
+        "recall_depth": args.depth,
+        "min_messages": args.min_messages,
+        "carry": "off",
+        "workers": args.workers,
+        "dataset_file": dataset_path.name,
+        "dataset_sha256": dataset.sha256_of(dataset_path),
+    }
+
+
+def run(args) -> dict:
+    dataset_path = _resolve_dataset(args)
+    questions = dataset.sample(dataset.load(dataset_path), args.sample, args.seed)
+    cache = cache_mod.CheckpointCache(Path(args.cache_dir))
+    chat = llm.chat
+
+    stamp = _build_config_stamp(args, dataset_path)
+    print(f"suite={args.suite} sample={len(questions)} backend={stamp['backend']} "
+          f"model={stamp['model']} workers={args.workers}")
+
+    per_question: list[dict] = []
+    t0 = time.monotonic()
+    for i, q in enumerate(questions, 1):
+        qt0 = time.monotonic()
+        result = adapter.run_question(
+            q, chat=chat, cache=cache, backend=stamp["backend"],
+            model=stamp["model"] or "unknown", root=Path(args.work_dir),
+            k=args.k, depth=args.depth, min_messages=args.min_messages,
+            workers=args.workers,
+        )
+        per_question.append(result)
+        print(f"[{i}/{len(questions)}] {result['question_id']} "
+              f"hit@{args.k}={result['hit_at_5']} r@{args.k}={result['recall_at_5']} "
+              f"indexed={result['serialize']['indexed']}/{result['n_haystack']} "
+              f"({time.monotonic() - qt0:.0f}s)")
+
+    agg = metrics.aggregate(per_question, args.k)
+    total_serialized = sum(r["serialize"]["serialized"] for r in per_question)
+    report = {
+        "config": stamp,
+        "metrics": agg,
+        "cost": {
+            "llm_serialize_calls": total_serialized,
+            "cache_hits": cache.hits,
+            "cache_misses": cache.misses,
+            "wall_seconds": round(time.monotonic() - t0, 1),
+        },
+        "per_question": per_question,
+    }
+
+    out = Path(args.out) if args.out else (
+        _RESULTS_DIR / f"{args.suite}-{stamp['generated_at'].replace(':', '')}.json")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    print("\n=== result ===")
+    print(f"Recall@{args.k}: {_fmt(agg['recall_at_5'])}   "
+          f"Hit@{args.k}: {_fmt(agg['hit_at_5'])}   MRR: {_fmt(agg['mrr'])}")
+    print(f"avg injected tokens/q (est): {_fmt(agg['avg_injected_tokens'])}")
+    print(f"scored={agg['questions_scored']} abstention={agg['questions_abstention']} "
+          f"serialize_calls={total_serialized} cache_hits={cache.hits}")
+    print(f"wrote {out}")
+    return report
+
+
+def _fmt(v) -> str:
+    return "n/a" if v is None else f"{v:.4f}"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="bench", description="daimon retrieval benchmark")
+    p.add_argument("--suite", default="longmemeval-s", choices=["longmemeval-s"])
+    p.add_argument("--sample", type=int, default=50,
+                   help="questions to run (<=0 = full 500; default 50 smoke tier)")
+    p.add_argument("--seed", type=int, default=0, help="sampling seed (determinism)")
+    p.add_argument("--k", type=int, default=5, help="Recall@k / Hit@k window")
+    p.add_argument("--depth", type=int, default=50,
+                   help="recall results fetched per question (MRR sees this depth)")
+    p.add_argument("--workers", type=int, default=4,
+                   help="concurrent LLM serialize calls per question")
+    p.add_argument("--min-messages", default=adapter.BENCH_MIN_MESSAGES,
+                   help="serialize floor for the benchmark (product default is 10)")
+    p.add_argument("--dataset-path", help="use a local dataset file (skip download)")
+    p.add_argument("--url", default=dataset.DATASET_URL, help="dataset download URL")
+    p.add_argument("--no-download", action="store_true",
+                   help="fail instead of downloading a missing dataset")
+    p.add_argument("--cache-dir", default=str(_CACHE_DIR),
+                   help="serialized-checkpoint cache (persist across runs)")
+    p.add_argument("--work-dir", default=str(_BENCH_DIR / ".work"),
+                   help="per-question isolated store + index scratch")
+    p.add_argument("--out", help="result JSON path (default benchmark/results/...)")
+    return p
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    run(args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugin/tests/test_bench_adapter.py
+++ b/plugin/tests/test_bench_adapter.py
@@ -1,0 +1,108 @@
+"""End-to-end adapter test (#267): serialize → store → recall, deterministic LLM.
+
+Uses an echo fake for `chat` that reflects a distinctive marker token from each
+session's transcript into its checkpoint, so recall genuinely discriminates
+sessions by content — the real FTS path, no LLM.
+"""
+
+import json
+
+from tests.bench import adapter, cache as cache_mod
+
+
+class EchoChat:
+    """Fake serializer backend: emits a valid checkpoint whose active_topic echoes
+    the `*marker` token found in the session transcript it is handed."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, messages, **kwargs):
+        self.calls += 1
+        blob = " ".join(str(m.get("content") or "") for m in messages)
+        marker = next((w for w in blob.split() if w.endswith("marker")), "nomarker")
+        return json.dumps({
+            "session_id": "ignored",
+            "working_context": {
+                "active_topic": {"text": f"session about {marker}", "trust": "inferred"},
+                "open_questions": [],
+                "recent_decisions": [],
+            },
+            "epistemic_snapshot": {
+                "strong_beliefs": [], "uncertainties": [], "contradictions_flagged": [],
+            },
+            "worker_queue": [],
+        })
+
+
+def _turns(marker):
+    return [
+        {"role": "user", "content": f"let us discuss {marker} today please"},
+        {"role": "assistant", "content": f"sure, {marker} is interesting"},
+        {"role": "user", "content": f"tell me more about {marker}"},
+        {"role": "assistant", "content": f"here is more on {marker}"},
+    ]
+
+
+def _question():
+    return {
+        "question_id": "q_bench_1",
+        "question_type": "single-session-user",
+        "question": "what about thinkpadmarker did we conclude",
+        "answer": "x",
+        "haystack_session_ids": ["sess_hello", "sess_gold"],
+        "haystack_sessions": [_turns("hellomarker"), _turns("thinkpadmarker")],
+        "answer_session_ids": ["sess_gold"],
+    }
+
+
+def test_run_question_retrieves_the_gold_session(tmp_path):
+    result = adapter.run_question(
+        _question(), chat=EchoChat(), cache=cache_mod.CheckpointCache(tmp_path / "c"),
+        backend="fake", model="fake", root=tmp_path / "runs", k=5, depth=20, workers=1,
+    )
+    assert result["serialize"]["indexed"] == 2
+    assert result["serialize"]["serialized"] == 2
+    assert result["n_retrieved_sessions"] >= 1
+    # the gold session's checkpoint carries the query's marker; the other does not
+    assert result["hit_at_5"] is True
+    assert result["recall_at_5"] == 1.0
+    assert result["mrr"] == 1.0
+    assert result["injected_tokens"] > 0
+
+
+def test_cache_hit_skips_the_llm_on_second_run(tmp_path):
+    cache = cache_mod.CheckpointCache(tmp_path / "c")
+    chat = EchoChat()
+    q = _question()
+    adapter.run_question(q, chat=chat, cache=cache, backend="fake", model="fake",
+                         root=tmp_path / "r1", k=5, depth=20, workers=1)
+    first = chat.calls
+    assert first == 2
+    # second run, same content+config -> all cache hits, zero new LLM calls
+    adapter.run_question(q, chat=chat, cache=cache, backend="fake", model="fake",
+                         root=tmp_path / "r2", k=5, depth=20, workers=1)
+    assert chat.calls == first  # no additional serialize calls
+
+
+def test_abstention_question_scores_none(tmp_path):
+    q = _question()
+    q["question_id"] = "q_bench_abs"
+    q["answer_session_ids"] = []
+    result = adapter.run_question(
+        q, chat=EchoChat(), cache=cache_mod.CheckpointCache(tmp_path / "c"),
+        backend="fake", model="fake", root=tmp_path / "runs", k=5, depth=20, workers=1,
+    )
+    assert result["abstention"] is True
+    assert result["recall_at_5"] is None
+    assert result["mrr"] is None
+
+
+def test_env_is_restored_after_a_question(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_CARRY", "sentinel")
+    adapter.run_question(
+        _question(), chat=EchoChat(), cache=cache_mod.CheckpointCache(tmp_path / "c"),
+        backend="fake", model="fake", root=tmp_path / "runs", k=5, depth=20, workers=1,
+    )
+    import os
+    assert os.environ["DAIMON_CARRY"] == "sentinel"

--- a/plugin/tests/test_bench_cache.py
+++ b/plugin/tests/test_bench_cache.py
@@ -1,0 +1,76 @@
+"""Unit tests for the serialized-checkpoint cache (#267)."""
+
+import json
+
+from tests.bench import cache
+
+
+def _messages(a="hi", b="there"):
+    return [{"role": "user", "content": a}, {"role": "assistant", "content": b}]
+
+
+class TestCacheKey:
+    def test_key_is_stable_for_same_inputs(self):
+        k1 = cache.cache_key(_messages(), backend="litellm", model="m1", prompt_version="D-013")
+        k2 = cache.cache_key(_messages(), backend="litellm", model="m1", prompt_version="D-013")
+        assert k1 == k2
+
+    def test_key_changes_with_message_content(self):
+        k1 = cache.cache_key(_messages("hi"), backend="b", model="m", prompt_version="v")
+        k2 = cache.cache_key(_messages("bye"), backend="b", model="m", prompt_version="v")
+        assert k1 != k2
+
+    def test_key_changes_with_backend_model_and_prompt_version(self):
+        base = dict(backend="b", model="m", prompt_version="v")
+        k0 = cache.cache_key(_messages(), **base)
+        assert cache.cache_key(_messages(), **{**base, "backend": "other"}) != k0
+        assert cache.cache_key(_messages(), **{**base, "model": "other"}) != k0
+        assert cache.cache_key(_messages(), **{**base, "prompt_version": "other"}) != k0
+
+    def test_key_is_order_sensitive_on_turns(self):
+        fwd = [{"role": "user", "content": "a"}, {"role": "assistant", "content": "b"}]
+        rev = [{"role": "assistant", "content": "b"}, {"role": "user", "content": "a"}]
+        args = dict(backend="b", model="m", prompt_version="v")
+        assert cache.cache_key(fwd, **args) != cache.cache_key(rev, **args)
+
+
+class TestCacheRoundTrip:
+    def test_miss_then_hit(self, tmp_path):
+        c = cache.CheckpointCache(tmp_path)
+        key = "abc123"
+        assert c.get(key) is None
+        checkpoint = {"session_id": "s1", "working_context": {}}
+        c.put(key, checkpoint)
+        got = c.get(key)
+        assert got == checkpoint
+
+    def test_get_returns_a_copy_not_the_stored_object(self, tmp_path):
+        c = cache.CheckpointCache(tmp_path)
+        c.put("k", {"session_id": "s1", "n": [1, 2]})
+        got = c.get("k")
+        got["n"].append(3)
+        # mutating the returned dict must not corrupt the on-disk cache
+        assert c.get("k")["n"] == [1, 2]
+
+    def test_persists_across_instances(self, tmp_path):
+        cache.CheckpointCache(tmp_path).put("k", {"session_id": "s1"})
+        assert cache.CheckpointCache(tmp_path).get("k") == {"session_id": "s1"}
+
+    def test_corrupt_entry_is_a_miss_not_a_crash(self, tmp_path):
+        c = cache.CheckpointCache(tmp_path)
+        (tmp_path / "deadbeef.json").write_text("{not json", encoding="utf-8")
+        assert c.get("deadbeef") is None
+
+    def test_stats_track_hits_and_misses(self, tmp_path):
+        c = cache.CheckpointCache(tmp_path)
+        c.get("missing")            # miss
+        c.put("k", {"session_id": "s"})
+        c.get("k")                  # hit
+        assert c.hits == 1
+        assert c.misses == 1
+
+    def test_put_writes_valid_json(self, tmp_path):
+        c = cache.CheckpointCache(tmp_path)
+        c.put("k", {"session_id": "s1"})
+        stored = json.loads((tmp_path / "k.json").read_text(encoding="utf-8"))
+        assert stored["session_id"] == "s1"

--- a/plugin/tests/test_bench_dataset.py
+++ b/plugin/tests/test_bench_dataset.py
@@ -1,0 +1,115 @@
+"""Unit tests for the LongMemEval dataset adapter (#267). No network."""
+
+import hashlib
+import json
+
+import pytest
+
+from tests.bench import dataset
+
+
+def _question(qid="q1", gold=("s2",), abstention=False):
+    """A minimal LongMemEval-S question with two haystack sessions."""
+    return {
+        "question_id": qid + ("_abs" if abstention else ""),
+        "question_type": "single-session-user",
+        "question": "What laptop did I buy?",
+        "answer": "a ThinkPad",
+        "question_date": "2023/05/20",
+        "haystack_session_ids": ["s1", "s2"],
+        "haystack_dates": ["2023/05/01", "2023/05/10"],
+        "haystack_sessions": [
+            [{"role": "user", "content": "hi"},
+             {"role": "assistant", "content": "hello"}],
+            [{"role": "user", "content": "I bought a ThinkPad", "has_answer": True},
+             {"role": "assistant", "content": "nice"}],
+        ],
+        "answer_session_ids": [] if abstention else list(gold),
+    }
+
+
+def _write_dataset(path, questions):
+    path.write_text(json.dumps(questions), encoding="utf-8")
+
+
+class TestLoad:
+    def test_load_returns_list_of_questions(self, tmp_path):
+        p = tmp_path / "ds.json"
+        _write_dataset(p, [_question("q1"), _question("q2")])
+        qs = dataset.load(p)
+        assert [q["question_id"] for q in qs] == ["q1", "q2"]
+
+
+class TestSample:
+    def test_sample_is_deterministic_for_a_seed(self, tmp_path):
+        qs = [_question(f"q{i}") for i in range(20)]
+        a = dataset.sample(qs, 5, seed=42)
+        b = dataset.sample(qs, 5, seed=42)
+        assert [q["question_id"] for q in a] == [q["question_id"] for q in b]
+        assert len(a) == 5
+
+    def test_different_seeds_differ(self, tmp_path):
+        qs = [_question(f"q{i}") for i in range(50)]
+        a = dataset.sample(qs, 10, seed=1)
+        b = dataset.sample(qs, 10, seed=2)
+        assert [q["question_id"] for q in a] != [q["question_id"] for q in b]
+
+    def test_sample_larger_than_pool_returns_all(self):
+        qs = [_question("q1"), _question("q2")]
+        assert len(dataset.sample(qs, 10, seed=0)) == 2
+
+    def test_zero_or_negative_sample_returns_all(self):
+        qs = [_question(f"q{i}") for i in range(5)]
+        assert len(dataset.sample(qs, 0, seed=0)) == 5
+
+
+class TestAccessors:
+    def test_gold_sessions(self):
+        assert dataset.gold_sessions(_question(gold=("s2", "s5"))) == {"s2", "s5"}
+
+    def test_is_abstention_by_empty_gold(self):
+        assert dataset.is_abstention(_question(abstention=True)) is True
+        assert dataset.is_abstention(_question()) is False
+
+    def test_is_abstention_by_id_suffix(self):
+        q = _question()
+        q["question_id"] = "abc_abs"
+        q["answer_session_ids"] = ["s2"]  # id suffix still marks abstention
+        assert dataset.is_abstention(q) is True
+
+    def test_sessions_of_pairs_ids_with_messages(self):
+        sessions = dataset.sessions_of(_question())
+        assert [sid for sid, _ in sessions] == ["s1", "s2"]
+        sid, msgs = sessions[1]
+        # has_answer and any non-role/content keys are stripped to OpenAI shape
+        assert msgs == [
+            {"role": "user", "content": "I bought a ThinkPad"},
+            {"role": "assistant", "content": "nice"},
+        ]
+
+    def test_sessions_of_tolerates_length_mismatch(self):
+        q = _question()
+        q["haystack_session_ids"] = ["s1"]  # fewer ids than sessions
+        sessions = dataset.sessions_of(q)
+        # only the pairs that line up are returned; no crash
+        assert [sid for sid, _ in sessions] == ["s1"]
+
+
+class TestChecksum:
+    def test_verify_matching_digest_passes(self, tmp_path):
+        p = tmp_path / "f.json"
+        p.write_bytes(b"payload")
+        digest = hashlib.sha256(b"payload").hexdigest()
+        assert dataset.verify_sha256(p, digest) is True
+
+    def test_verify_mismatch_raises(self, tmp_path):
+        p = tmp_path / "f.json"
+        p.write_bytes(b"payload")
+        with pytest.raises(dataset.ChecksumError):
+            dataset.verify_sha256(p, "0" * 64)
+
+    def test_verify_none_expected_returns_false_without_raising(self, tmp_path):
+        p = tmp_path / "f.json"
+        p.write_bytes(b"payload")
+        # no pinned checksum yet (trust-on-first-use): reports unverified, no raise
+        assert dataset.verify_sha256(p, None) is False

--- a/plugin/tests/test_bench_metrics.py
+++ b/plugin/tests/test_bench_metrics.py
@@ -1,0 +1,107 @@
+"""Unit tests for the benchmark metrics (#267). Pure functions — no LLM, no I/O."""
+
+from tests.bench import metrics
+
+
+def _res(session_id, text="some item", rank=1.0):
+    """A recall.search result row, trimmed to the fields metrics reads."""
+    return {"session_id": session_id, "text": text, "rank": rank}
+
+
+class TestRankedSessions:
+    def test_dedup_preserves_first_occurrence_order(self):
+        rows = [_res("s3"), _res("s1"), _res("s3"), _res("s2"), _res("s1")]
+        assert metrics.ranked_sessions(rows) == ["s3", "s1", "s2"]
+
+    def test_empty_results(self):
+        assert metrics.ranked_sessions([]) == []
+
+    def test_rows_without_session_id_are_dropped(self):
+        rows = [_res("s1"), {"text": "no session"}, {"session_id": None}]
+        assert metrics.ranked_sessions(rows) == ["s1"]
+
+
+class TestRecallAtK:
+    def test_full_coverage(self):
+        assert metrics.recall_at_k(["s1", "s2", "s3"], {"s1", "s2"}, 5) == 1.0
+
+    def test_partial_coverage(self):
+        # one of two gold sessions inside the window
+        assert metrics.recall_at_k(["s1", "x", "y"], {"s1", "s2"}, 5) == 0.5
+
+    def test_gold_outside_window_scores_zero(self):
+        assert metrics.recall_at_k(["a", "b", "c", "d", "e", "s1"], {"s1"}, 5) == 0.0
+
+    def test_empty_gold_returns_none(self):
+        # abstention questions carry no evidence session — excluded, not zero
+        assert metrics.recall_at_k(["s1"], set(), 5) is None
+
+
+class TestHitAtK:
+    def test_hit_when_any_gold_in_window(self):
+        assert metrics.hit_at_k(["x", "s1", "y"], {"s1"}, 5) is True
+
+    def test_miss_when_gold_outside_window(self):
+        assert metrics.hit_at_k(["a", "b", "c", "d", "e", "s1"], {"s1"}, 5) is False
+
+    def test_empty_gold_returns_none(self):
+        assert metrics.hit_at_k(["s1"], set(), 5) is None
+
+
+class TestReciprocalRank:
+    def test_first_position(self):
+        assert metrics.reciprocal_rank(["s1", "s2"], {"s1"}) == 1.0
+
+    def test_third_position(self):
+        assert metrics.reciprocal_rank(["a", "b", "s2"], {"s2"}) == 1 / 3
+
+    def test_earliest_gold_wins(self):
+        # two gold sessions -> rank of the first one encountered
+        assert metrics.reciprocal_rank(["a", "s2", "s1"], {"s1", "s2"}) == 0.5
+
+    def test_no_gold_retrieved(self):
+        assert metrics.reciprocal_rank(["a", "b"], {"s1"}) == 0.0
+
+    def test_empty_gold_returns_none(self):
+        assert metrics.reciprocal_rank(["a"], set()) is None
+
+
+class TestTokenEstimate:
+    def test_char_over_four_heuristic(self):
+        assert metrics.estimate_tokens("a" * 40) == 10
+
+    def test_empty_string(self):
+        assert metrics.estimate_tokens("") == 0
+
+    def test_injected_tokens_sums_topk_texts(self):
+        rows = [_res("s1", "a" * 40), _res("s2", "b" * 40), _res("s3", "c" * 40)]
+        # only the top-2 texts count toward the injected budget
+        assert metrics.injected_tokens(rows, 2) == 20
+
+
+class TestAggregate:
+    def test_means_skip_none_and_count_buckets(self):
+        per_q = [
+            {"recall_at_5": 1.0, "hit_at_5": True, "mrr": 1.0,
+             "injected_tokens": 100, "abstention": False},
+            {"recall_at_5": 0.0, "hit_at_5": False, "mrr": 0.0,
+             "injected_tokens": 50, "abstention": False},
+            # abstention row: retrieval metrics are None, excluded from means
+            {"recall_at_5": None, "hit_at_5": None, "mrr": None,
+             "injected_tokens": 0, "abstention": True},
+        ]
+        agg = metrics.aggregate(per_q, k=5)
+        assert agg["questions_total"] == 3
+        assert agg["questions_scored"] == 2
+        assert agg["questions_abstention"] == 1
+        assert agg["recall_at_5"] == 0.5
+        assert agg["hit_at_5"] == 0.5
+        assert agg["mrr"] == 0.5
+        # tokens averaged over ALL questions (efficiency of the whole run)
+        assert agg["avg_injected_tokens"] == 50.0
+
+    def test_no_scored_questions(self):
+        agg = metrics.aggregate([], k=5)
+        assert agg["questions_scored"] == 0
+        assert agg["recall_at_5"] is None
+        assert agg["mrr"] is None

--- a/plugin/tests/test_bench_smoke.py
+++ b/plugin/tests/test_bench_smoke.py
@@ -1,0 +1,51 @@
+"""LLM-dependent smoke test for the harness (#267).
+
+Skipped unless a backend is configured AND opt-in RUN_BENCH_SMOKE=1 is set, so CI
+stays green and free. Exercises the real serialize→recall path on one tiny
+synthetic question against the live backend — proves the wiring, not a score.
+"""
+
+import os
+
+import pytest
+
+from tests.bench import adapter, cache as cache_mod, run as bench_run
+
+_SKIP = not (os.getenv("DAIMON_LLM_API_KEY") and os.getenv("RUN_BENCH_SMOKE"))
+
+
+def test_runner_parser_accepts_documented_flags():
+    args = bench_run.build_parser().parse_args(
+        ["--suite", "longmemeval-s", "--sample", "5", "--workers", "8"])
+    assert args.sample == 5 and args.workers == 8 and args.suite == "longmemeval-s"
+
+
+@pytest.mark.skipif(_SKIP, reason="set DAIMON_LLM_API_KEY and RUN_BENCH_SMOKE=1")
+def test_real_backend_serialize_and_recall(tmp_path):
+    from daimon_briefing import llm
+
+    question = {
+        "question_id": "smoke_1",
+        "question_type": "single-session-user",
+        "question": "which database did we choose for the project",
+        "answer": "postgres",
+        "haystack_session_ids": ["s_distractor", "s_gold"],
+        "haystack_sessions": [
+            [{"role": "user", "content": "let's talk about the CI pipeline setup"},
+             {"role": "assistant", "content": "sure, we can use GitHub Actions"},
+             {"role": "user", "content": "and caching for uv"},
+             {"role": "assistant", "content": "yes, cache the uv lock"}],
+            [{"role": "user", "content": "we decided to use Postgres for the database"},
+             {"role": "assistant", "content": "good — Postgres it is for storage"},
+             {"role": "user", "content": "with SQLAlchemy on top"},
+             {"role": "assistant", "content": "agreed, SQLAlchemy ORM over Postgres"}],
+        ],
+        "answer_session_ids": ["s_gold"],
+    }
+    result = adapter.run_question(
+        question, chat=llm.chat, cache=cache_mod.CheckpointCache(tmp_path / "c"),
+        backend=bench_run._effective_backend(), model="live",
+        root=tmp_path / "runs", k=5, depth=20, workers=2,
+    )
+    assert result["serialize"]["indexed"] >= 1
+    assert result["n_retrieved_sessions"] >= 1


### PR DESCRIPTION
## What

A public retrieval benchmark harness for daimon on **LongMemEval-S** (ICLR 2025),
producing a measured, reproducible recall number through daimon's real pipeline.

Closes #267.

## How it works

The harness feeds each question's haystack sessions through the **actual**
serializer (`serializer.serialize_strict` — the same call the SessionEnd hook
makes), writes them to an isolated store, and answers the question using only what
`recall.search` surfaces. No bypass of the product to flatter the number.

- **Adapter seam** (`plugin/tests/bench/adapter.py`): isolates each question in its
  own checkpoint dir + recall index via the `DAIMON_*` env vars, serializes the
  haystack, and scores retrieval. The retrieval unit is the session: a hit means a
  retrieved item's source session is one of the question's evidence sessions.
- **Dataset** (`dataset.py`): downloads LongMemEval-S on demand from HuggingFace
  (`xiaowu0162/longmemeval-cleaned`, MIT), checksum-pinned (`benchmark/longmemeval_s.sha256`),
  **never vendored** into the repo (~277 MB).
- **Cost control** (`cache.py`): serialized checkpoints are cached by
  `(session content hash, backend, model, prompt version)`, so re-runs pay the LLM
  only for sessions never seen under the current config. A `--sample N` smoke tier
  (default 50) keeps the default run affordable; full 500 is opt-in.
- **Metrics** (`metrics.py`): Recall@5, Hit@5, MRR, and estimated injected-tokens
  per question — deterministic given seed + pinned backend. Abstention questions
  are excluded from recall scoring (no evidence session to retrieve).
- **Runner** (`run.py`): `uv run python -m tests.bench.run --suite longmemeval-s --sample 50`.
  Emits machine-readable JSON with a full, secret-free config stamp.
- **Reporting policy** (`benchmark/README.md`): we publish only numbers we measured
  ourselves, stamped with harness version + backend + model + dataset checksum;
  third-party figures are labeled as their publishers' claims, never reproduced as
  ours. A recall number is always reported with the backend that produced it.
- **CI** (`.github/workflows/benchmark.yml`): manual `workflow_dispatch` only —
  never on push/PR (cost). Refreshes a baseline and uploads the result artifact.

## Measured baseline (committed)

`benchmark/results/longmemeval-s-baseline.json` — see the file for the full config
stamp and per-question detail. Backend: `claude-haiku-4-5` via a LiteLLM proxy,
prompt version D-013, temperature 0. This is a small end-to-end smoke sample, not
the full 500-question suite; the harness reproduces any sample via the workflow.

Measurement choices (recorded in every result, documented in the README): the
benchmark lowers the serialize floor to `min_messages=2` so short evidence sessions
enter the index (product default is 10 — a real limitation, surfaced not hidden),
and runs with carry off for a clean session→id gold mapping.

## Tests

Unit tests for metrics, cache keying, dataset parsing, and the full serialize→recall
adapter path (deterministic, no LLM). The LLM-dependent path has a smoke test behind
a skip-without-backend marker. New: 48 tests. Full suite green (1645 passed).

## Follow-ups (separate issues)

- Full 500-question baseline run via the workflow (cost/time; not run in this PR).
- Benchmark the carry-on configuration as a separate retrieval axis.
