### PR TITLE
test(bench): carry-on configuration as a separate retrieval axis

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -52,9 +52,18 @@ zero.
   enter the index. The product's live default is **10**; in production, sessions
   shorter than that are skipped. This is a real limitation, surfaced here rather
   than hidden — the run config records the value used.
-- **Carry is off.** Each session's checkpoint stands alone, giving a clean
-  session→id mapping for scoring. Cross-session carry (a real product feature) is
-  a separate axis to benchmark later.
+- **Carry is a separate axis.** By default carry is off: each session's
+  checkpoint stands alone, giving a clean session→id mapping for scoring.
+  `--carry` turns on cross-session carry (a real product feature: prior
+  unresolved items fold forward into later checkpoints), recorded as
+  `carry: "on"` in the config stamp and cached under separate keys, so carry-on
+  vs carry-off Recall@k / MRR are comparable on the same sample and backend.
+  Scoring stays honest under carry: a retrieved carried copy is credited to the
+  session that *originated* the item (its `carried_from`), never to the later
+  session hosting the copy, and each session counts at most once — no
+  double-counting a gold session. The fold is applied in listed-session order
+  (the exact state the product sees), so carry-on runs stay deterministic at any
+  `--workers` value.
 - **Determinism** holds given the seed and a pinned backend. Backends with
   non-zero temperature introduce serializer variance; the configured temperature
   rides in daimon's own config.

--- a/plugin/tests/bench/adapter.py
+++ b/plugin/tests/bench/adapter.py
@@ -6,11 +6,21 @@ call the SessionEnd hook makes) and written to the store by `store.write_checkpo
 the question is then answered only by what `recall.search` surfaces from that index.
 
 Isolation: each question gets its own checkpoint dir + recall index under a temp
-root, addressed through the same DAIMON_* env vars the test suite uses. Carry is
-off so each session's checkpoint stands alone (a clean session→id mapping for
-scoring); the min-messages floor is lowered so short evidence sessions still enter
-the index (the product default of 10 would skip ~half the haystack — recorded in
-the run config, and called out in the README).
+root, addressed through the same DAIMON_* env vars the test suite uses. Carry
+defaults off so each session's checkpoint stands alone (a clean session→id
+mapping for scoring); the min-messages floor is lowered so short evidence
+sessions still enter the index (the product default of 10 would skip ~half the
+haystack — recorded in the run config, and called out in the README).
+
+Carry-on (#274) mirrors the product's SessionEnd path (cli._run_serialize):
+after each raw serialize, the previous checkpoint is read back via
+store.read_latest and folded forward with carry.merge before the write. The
+fold is order-dependent (each session must see the one before it), but the LLM
+serialize is NOT — serialize_strict reads only its own transcript — so the
+expensive concurrent step stays concurrent and the fold runs in the
+single-threaded, listed-session-order write loop below. That reproduces the
+product's strictly-sequential semantics deterministically at any worker count;
+no worker forcing is needed.
 
 The expensive step (the LLM serialize) runs concurrently across sessions; the
 store writes are serialized under a lock because pointer rotation and GC are not
@@ -27,7 +37,7 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-from daimon_briefing import recall, serializer, store
+from daimon_briefing import carry, config, recall, serializer, store
 
 from tests.bench import cache as cache_mod
 from tests.bench import dataset, metrics
@@ -42,12 +52,14 @@ BENCH_MIN_MESSAGES = "2"
 _ENV_KEYS = (
     "DAIMON_CHECKPOINT_DIR", "DAIMON_RECALL_DB", "DAIMON_LOG_DIR",
     "DAIMON_RECALL_SEEN_DIR", "DAIMON_TEAM_DIR", "DAIMON_PROJECT_DIR",
-    "DAIMON_CARRY", "DAIMON_MIN_MESSAGES", "DAIMON_TEAM", "DAIMON_DISABLE",
+    "DAIMON_CARRY", "DAIMON_CARRY_FLOOR", "DAIMON_CARRY_MAX",
+    "DAIMON_MIN_MESSAGES", "DAIMON_TEAM", "DAIMON_DISABLE",
     "DAIMON_RECEIPTS", "DAIMON_SCAR_HARVEST",
 )
 
 
-def _question_env(root: Path, qid: str, min_messages: str) -> dict[str, str]:
+def _question_env(root: Path, qid: str, min_messages: str,
+                  carry_on: bool = False) -> dict[str, str]:
     """The DAIMON_* environment that isolates one question's store + index."""
     home = root / _safe(qid)
     project = home / "project"
@@ -58,7 +70,13 @@ def _question_env(root: Path, qid: str, min_messages: str) -> dict[str, str]:
         "DAIMON_RECALL_SEEN_DIR": str(home / "recall_seen"),
         "DAIMON_TEAM_DIR": str(home / "team"),
         "DAIMON_PROJECT_DIR": str(project),
-        "DAIMON_CARRY": "0",             # per-session checkpoints stand alone
+        # off: per-session checkpoints stand alone. on (#274): the write loop
+        # folds prior checkpoints forward, mirroring the product path.
+        "DAIMON_CARRY": "1" if carry_on else "0",
+        # Carry knobs pinned to the product defaults so an ambient override on
+        # the host can never change the measurement (determinism).
+        "DAIMON_CARRY_FLOOR": "0.05",
+        "DAIMON_CARRY_MAX": "8",
         "DAIMON_MIN_MESSAGES": min_messages,
         "DAIMON_TEAM": "0",              # no team dual-write during the benchmark
         "DAIMON_DISABLE": "0",
@@ -101,18 +119,25 @@ def _created_stamp(index: int) -> str:
 
 def serialize_question(question: dict, *, chat, cache: cache_mod.CheckpointCache,
                        backend: str, model: str, project_dir: str,
-                       workers: int) -> dict:
+                       workers: int, carry_on: bool = False) -> tuple[dict, dict]:
     """Serialize every haystack session into the (already isolated) store.
 
-    Returns a tally: {serialized, cached, too_short, failed, indexed}.
+    Returns (tally, attribution):
+      tally       — {serialized, cached, too_short, failed, indexed}
+      attribution — (checkpoint session_id, item text) -> origin session id, for
+                    every indexed item. With carry off this is the identity map;
+                    with carry on, a carried copy maps to `carried_from` (the
+                    session that first produced it — chains preserve the origin
+                    because carry.merge stamps carried_from with setdefault).
     """
     sessions = dataset.sessions_of(question)
     cache_lock = threading.Lock()
+    carry_mode = "on" if carry_on else "off"
 
     def _produce(item):
         index, (sid, messages) = item
         key = cache_mod.cache_key(messages, backend=backend, model=model,
-                                  prompt_version=PROMPT_VERSION)
+                                  prompt_version=PROMPT_VERSION, carry=carry_mode)
         with cache_lock:
             cached = cache.get(key)
         if cached is not None:
@@ -134,7 +159,12 @@ def serialize_question(question: dict, *, chat, cache: cache_mod.CheckpointCache
         produced = list(pool.map(_produce, enumerate(sessions)))
 
     tally = {"serialized": 0, "cached": 0, "too_short": 0, "failed": 0, "indexed": 0}
+    attribution: dict[tuple[str, str], str] = {}
     # Store writes are single-threaded: pointer rotation + GC are not concurrency-safe.
+    # With carry on this loop is ALSO the ordering seam: each session folds in the
+    # checkpoint written just before it (listed-session order), so carry-on output
+    # is deterministic even though the LLM serialize above ran concurrently — the
+    # raw serialize has no dependence on prior state (see the module docstring).
     for index, sid, checkpoint, status in sorted(produced, key=lambda r: r[0]):
         tally[status] += 1
         if checkpoint is None:
@@ -142,9 +172,40 @@ def serialize_question(question: dict, *, chat, cache: cache_mod.CheckpointCache
         cp = copy.deepcopy(checkpoint)
         cp["session_id"] = sid
         cp["created"] = _created_stamp(index)
+        if carry_on:
+            # Product-faithful fold, mirroring cli._run_serialize (#33 Phase 2):
+            # prev = this project's own latest only (fallback=False, #94), clock =
+            # this checkpoint's deterministic stamp, knobs from config (pinned in
+            # _question_env), resolutions folded the same way (empty in the
+            # isolated bench store, read anyway for fidelity).
+            prev = store.read_latest(project_dir, fallback=False)
+            now = store._created_epoch(cp["created"]) or 0.0
+            events = store.resolutions(project_dir=project_dir)
+            resolved = frozenset(ref for ref, evt in events.items()
+                                 if store.is_resolved(evt))
+            cp = carry.merge(cp, prev, now, floor=config.carry_floor(),
+                             cap=config.carry_max(), resolved=resolved)
+            store._stamp_item_ids(cp)
+            carry.bind_links(cp, prev)
         store.write_checkpoint(sid, cp, project_dir=project_dir)
         tally["indexed"] += 1
-    return tally
+        # Attribution is harvested AFTER the write: write_checkpoint mutates the
+        # checkpoint in place (redaction, id stamps), and recall indexes the
+        # written text — the map must key on exactly what recall will return.
+        for item in serializer.iter_items(cp):
+            text = str(item.get("text") or "")
+            if not text:
+                continue
+            origin = str(item.get("carried_from") or "") or sid
+            key2 = (sid, text)
+            if key2 in attribution and attribution[key2] != origin:
+                # Same text native in one kind and carried in another: ambiguous.
+                # Never guess — fall back to the hosting session (can only
+                # under-credit gold, never over-credit it).
+                attribution[key2] = sid
+            else:
+                attribution[key2] = origin
+    return tally, attribution
 
 
 def recall_question(question: dict, *, project_dir: str, depth: int) -> list[dict]:
@@ -154,20 +215,21 @@ def recall_question(question: dict, *, project_dir: str, depth: int) -> list[dic
 
 def run_question(question: dict, *, chat, cache: cache_mod.CheckpointCache,
                  backend: str, model: str, root: Path, k: int, depth: int,
-                 min_messages: str = BENCH_MIN_MESSAGES, workers: int = 1) -> dict:
+                 min_messages: str = BENCH_MIN_MESSAGES, workers: int = 1,
+                 carry_on: bool = False) -> dict:
     """Full per-question pipeline: isolate → serialize haystack → recall → score."""
-    env = _question_env(root, question["question_id"], min_messages)
+    env = _question_env(root, question["question_id"], min_messages, carry_on)
     project_dir = env["DAIMON_PROJECT_DIR"]
     with _env(env):
-        tally = serialize_question(
+        tally, attribution = serialize_question(
             question, chat=chat, cache=cache, backend=backend, model=model,
-            project_dir=project_dir, workers=workers,
+            project_dir=project_dir, workers=workers, carry_on=carry_on,
         )
         results = recall_question(question, project_dir=project_dir, depth=depth)
 
     gold = dataset.gold_sessions(question)
     abstention = dataset.is_abstention(question)
-    ranked = metrics.ranked_sessions(results)
+    ranked = metrics.attributed_sessions(results, attribution)
     return {
         "question_id": question["question_id"],
         "question_type": question.get("question_type"),

--- a/plugin/tests/bench/cache.py
+++ b/plugin/tests/bench/cache.py
@@ -20,15 +20,25 @@ from pathlib import Path
 
 
 def cache_key(messages: list[dict], *, backend: str, model: str,
-              prompt_version: str) -> str:
-    """Stable content hash over (turns, backend, model, prompt_version).
+              prompt_version: str, carry: str = "off") -> str:
+    """Stable content hash over (turns, backend, model, prompt_version, carry).
 
     Turns are hashed in order and by role — a reordered transcript is a different
     session. Only role/content are hashed (the fields the serializer reads), so an
     incidental metadata field on a turn does not bust the cache.
+
+    `carry` (#274) namespaces the run mode: a carry-on run must never read a
+    carry-off entry, or vice versa. The separation is deliberately defensive —
+    today the cached blob is the raw pre-carry `serialize_strict` output (the
+    fold happens downstream, at store-write time), but the cache must stay
+    correct even if serialization ever becomes mode-sensitive. Carry-off keys
+    are byte-identical to pre-#274 keys, so the existing cache (minutes of LLM
+    per entry) stays valid for carry-off runs.
     """
     h = hashlib.sha256()
     h.update(f"v1\x00{backend}\x00{model}\x00{prompt_version}\x00".encode())
+    if carry != "off":
+        h.update(f"carry\x00{carry}\x00".encode())
     for m in messages:
         role = str(m.get("role") or "")
         content = str(m.get("content") or "")

--- a/plugin/tests/bench/metrics.py
+++ b/plugin/tests/bench/metrics.py
@@ -46,6 +46,37 @@ def ranked_sessions(recall_results: list[dict]) -> list[str]:
     return out
 
 
+def attributed_sessions(recall_results: list[dict],
+                        attribution: dict[tuple[str, str], str]) -> list[str]:
+    """Ranked sessions with carried copies credited to their ORIGIN session.
+
+    Scoring rule for carry-on runs (#274): a retrieval counts for a session only
+    when it is ATTRIBUTABLE to that session — the session that first produced
+    the item. With carry on, a later checkpoint hosts verbatim copies of earlier
+    sessions' unresolved items, and the recall index knows only the hosting
+    checkpoint's session_id; scoring the hosting session would credit a non-gold
+    session for gold evidence (or rank gold below its own carried copy). So each
+    retrieved row is mapped through `attribution` — (hosting session_id, item
+    text) -> origin session, built by the adapter from `carried_from` at write
+    time — and falls back to the hosting session when unmapped (native items,
+    carry-off runs). First-occurrence dedup then guarantees a session is
+    credited at most once: gold surfaced both natively and as a carried copy
+    counts once, at its best rank, and never double-counts.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for row in recall_results:
+        sid = row.get("session_id")
+        if not sid:
+            continue
+        sid = attribution.get((sid, str(row.get("text") or "")), sid)
+        if sid in seen:
+            continue
+        seen.add(sid)
+        out.append(sid)
+    return out
+
+
 def recall_at_k(ranked: list[str], gold: set[str], k: int) -> float | None:
     """Fraction of gold sessions present in the top-k. None when gold is empty."""
     if not gold:

--- a/plugin/tests/bench/run.py
+++ b/plugin/tests/bench/run.py
@@ -4,6 +4,7 @@ Usage (from the plugin/ directory, uv-managed env):
 
     uv run python -m tests.bench.run --suite longmemeval-s --sample 50
     uv run python -m tests.bench.run --suite longmemeval-s --sample 5 --workers 8
+    uv run python -m tests.bench.run --suite longmemeval-s --sample 50 --carry
 
 Downloads the dataset on demand (checksum-pinned, never vendored), serializes each
 sampled question's haystack through daimon's real pipeline, answers via recall, and
@@ -102,7 +103,9 @@ def _build_config_stamp(args, dataset_path: Path) -> dict:
         "k": args.k,
         "recall_depth": args.depth,
         "min_messages": args.min_messages,
-        "carry": "off",
+        # Cross-session carry (#274) is a separate retrieval axis: recorded
+        # truthfully so carry-on and carry-off numbers are never conflated.
+        "carry": "on" if args.carry else "off",
         "workers": args.workers,
         "dataset_file": dataset_path.name,
         "dataset_sha256": dataset.sha256_of(dataset_path),
@@ -117,7 +120,7 @@ def run(args) -> dict:
 
     stamp = _build_config_stamp(args, dataset_path)
     print(f"suite={args.suite} sample={len(questions)} backend={stamp['backend']} "
-          f"model={stamp['model']} workers={args.workers}")
+          f"model={stamp['model']} workers={args.workers} carry={stamp['carry']}")
 
     per_question: list[dict] = []
     t0 = time.monotonic()
@@ -127,7 +130,7 @@ def run(args) -> dict:
             q, chat=chat, cache=cache, backend=stamp["backend"],
             model=stamp["model"] or "unknown", root=Path(args.work_dir),
             k=args.k, depth=args.depth, min_messages=args.min_messages,
-            workers=args.workers,
+            workers=args.workers, carry_on=args.carry,
         )
         per_question.append(result)
         print(f"[{i}/{len(questions)}] {result['question_id']} "
@@ -179,6 +182,10 @@ def build_parser() -> argparse.ArgumentParser:
                    help="recall results fetched per question (MRR sees this depth)")
     p.add_argument("--workers", type=int, default=4,
                    help="concurrent LLM serialize calls per question")
+    p.add_argument("--carry", action="store_true",
+                   help="fold prior checkpoints forward (cross-session carry, "
+                        "#274) — a separate retrieval axis; recorded in the "
+                        "config stamp and cached under separate keys")
     p.add_argument("--min-messages", default=adapter.BENCH_MIN_MESSAGES,
                    help="serialize floor for the benchmark (product default is 10)")
     p.add_argument("--dataset-path", help="use a local dataset file (skip download)")

--- a/plugin/tests/test_bench_carry.py
+++ b/plugin/tests/test_bench_carry.py
@@ -1,0 +1,255 @@
+"""Carry-on benchmark axis (#274): stamp, cache separation, honest scoring.
+
+Carry folds prior unresolved items forward into later checkpoints, so a later
+(non-gold) session's checkpoint can host a verbatim copy of a gold session's
+item. These tests pin the three guarantees the axis needs:
+
+- the run config stamps the carry mode truthfully (``carry: "on"/"off"``);
+- carry-on and carry-off runs never share cache entries (disjoint key spaces),
+  while carry-off keys stay byte-identical to pre-#274 keys;
+- scoring credits a carried copy to the session that ORIGINATED the item
+  (``carried_from``), never to the hosting session, deduped so a gold session
+  counts at most once — and the fold is deterministic at any worker count
+  because it runs in the single-threaded, listed-session-order write loop.
+
+Deterministic LLM fake throughout (no backend needed), same pattern as
+test_bench_adapter.EchoChat.
+"""
+
+import json
+from pathlib import Path
+
+from tests.bench import adapter, cache as cache_mod, metrics
+from tests.bench import run as bench_run
+
+# Distinct vocabularies on purpose: carry.merge dedups items by salient-term
+# overlap, so texts sharing >=3 terms would twin-merge instead of carrying.
+_OQ = {
+    "goldmarker": "must retest goldmarker battery drain overnight",
+    "coffeemarker": "book espresso coffeemarker tasting slot",
+    "flightmarker": "renew flightmarker visa paperwork stack",
+}
+
+
+class CarryChat:
+    """Fake serializer backend: emits a valid checkpoint whose open question is
+    a fixed, marker-keyed text — a carried kind, so carry.merge folds it into
+    later sessions' checkpoints."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, messages, **kwargs):
+        self.calls += 1
+        blob = " ".join(str(m.get("content") or "") for m in messages)
+        marker = next((w for w in blob.split() if w.endswith("marker")), "nomarker")
+        return json.dumps({
+            "session_id": "ignored",
+            "working_context": {
+                "active_topic": {"text": f"session about {marker}",
+                                 "trust": "inferred"},
+                "open_questions": [
+                    {"text": _OQ.get(marker, f"open item on {marker}"),
+                     "trust": "inferred"},
+                ],
+                "recent_decisions": [],
+            },
+            "epistemic_snapshot": {
+                "strong_beliefs": [], "uncertainties": [],
+                "contradictions_flagged": [],
+            },
+            "worker_queue": [],
+        })
+
+
+def _turns(marker):
+    return [
+        {"role": "user", "content": f"let us discuss {marker} today please"},
+        {"role": "assistant", "content": f"sure, {marker} is interesting"},
+        {"role": "user", "content": f"tell me more about {marker}"},
+        {"role": "assistant", "content": f"here is more on {marker}"},
+    ]
+
+
+def _question(markers, qid="q_carry_1"):
+    """Gold is always the FIRST listed session, so carry folds its open item
+    into every later session's checkpoint."""
+    sids = [f"sess_{m.removesuffix('marker')}" for m in markers]
+    return {
+        "question_id": qid,
+        "question_type": "single-session-user",
+        "question": "goldmarker battery drain",
+        "answer": "x",
+        "haystack_session_ids": sids,
+        "haystack_sessions": [_turns(m) for m in markers],
+        "answer_session_ids": [sids[0]],
+    }
+
+
+class TestConfigStamp:
+    def test_stamp_records_carry_on_and_off(self, tmp_path):
+        ds = tmp_path / "dataset.json"
+        ds.write_text("[]", encoding="utf-8")
+        on = bench_run.build_parser().parse_args(["--carry"])
+        off = bench_run.build_parser().parse_args([])
+        assert bench_run._build_config_stamp(on, ds)["carry"] == "on"
+        assert bench_run._build_config_stamp(off, ds)["carry"] == "off"
+
+
+class TestCacheSeparation:
+    def test_carry_modes_never_share_a_key(self):
+        msgs = [{"role": "user", "content": "hello"}]
+        base = dict(backend="b", model="m", prompt_version="v")
+        assert cache_mod.cache_key(msgs, carry="on", **base) != \
+            cache_mod.cache_key(msgs, carry="off", **base)
+
+    def test_carry_off_key_is_backward_compatible(self):
+        # Pre-#274 entries (keyed without a carry axis) must stay valid for
+        # carry-off runs — the default and the explicit "off" are one key space.
+        msgs = [{"role": "user", "content": "hello"}]
+        base = dict(backend="b", model="m", prompt_version="v")
+        assert cache_mod.cache_key(msgs, **base) == \
+            cache_mod.cache_key(msgs, carry="off", **base)
+
+    def test_carry_on_run_never_reads_carry_off_entries(self, tmp_path):
+        cache = cache_mod.CheckpointCache(tmp_path / "c")
+        chat = CarryChat()
+        q = _question(["goldmarker", "coffeemarker"])
+        adapter.run_question(q, chat=chat, cache=cache, backend="f", model="f",
+                             root=tmp_path / "r1", k=5, depth=20, workers=1)
+        assert chat.calls == 2
+        # carry-on must MISS the carry-off entries and re-serialize...
+        adapter.run_question(q, chat=chat, cache=cache, backend="f", model="f",
+                             root=tmp_path / "r2", k=5, depth=20, workers=1,
+                             carry_on=True)
+        assert chat.calls == 4
+        # ...then HIT its own lane on a re-run.
+        adapter.run_question(q, chat=chat, cache=cache, backend="f", model="f",
+                             root=tmp_path / "r3", k=5, depth=20, workers=1,
+                             carry_on=True)
+        assert chat.calls == 4
+
+
+class TestEnvPinning:
+    def test_carry_env_var_follows_the_mode(self, tmp_path):
+        on = adapter._question_env(tmp_path, "q", "2", carry_on=True)
+        off = adapter._question_env(tmp_path, "q", "2", carry_on=False)
+        assert on["DAIMON_CARRY"] == "1"
+        assert off["DAIMON_CARRY"] == "0"
+
+    def test_carry_knobs_are_pinned_to_product_defaults(self, tmp_path):
+        env = adapter._question_env(tmp_path, "q", "2", carry_on=True)
+        # Determinism: an ambient host override must never change the fold.
+        assert env["DAIMON_CARRY_FLOOR"] == "0.05"
+        assert env["DAIMON_CARRY_MAX"] == "8"
+        assert "DAIMON_CARRY_FLOOR" in adapter._ENV_KEYS
+        assert "DAIMON_CARRY_MAX" in adapter._ENV_KEYS
+
+
+class TestScoringRule:
+    def test_carried_copy_credits_origin_not_host(self):
+        rows = [
+            {"session_id": "s_later", "text": "carried gold text"},
+            {"session_id": "s_gold", "text": "carried gold text"},
+            {"session_id": "s_later", "text": "native later text"},
+        ]
+        attribution = {
+            ("s_later", "carried gold text"): "s_gold",
+            ("s_gold", "carried gold text"): "s_gold",
+            ("s_later", "native later text"): "s_later",
+        }
+        # gold counted ONCE, at the carried copy's (better) rank; the hosting
+        # session keeps only its own native credit.
+        assert metrics.attributed_sessions(rows, attribution) == \
+            ["s_gold", "s_later"]
+
+    def test_empty_attribution_matches_naive_ranking(self):
+        rows = [
+            {"session_id": "b", "text": "x"},
+            {"session_id": "a", "text": "y"},
+            {"session_id": "b", "text": "z"},
+        ]
+        assert metrics.attributed_sessions(rows, {}) == \
+            metrics.ranked_sessions(rows)
+
+    def test_end_to_end_no_double_count_of_the_gold_session(self, tmp_path):
+        """The live double-counting hazard: the later session's checkpoint hosts
+        a verbatim carried copy of the gold item, indexed under the LATER
+        session's id — and it outranks gold's own row (frontier + recency
+        tiebreaks). Naive scoring credits the wrong session; the attribution
+        rule credits the origin, once."""
+        q = _question(["goldmarker", "coffeemarker"])
+        env = adapter._question_env(tmp_path / "runs", q["question_id"], "2",
+                                    carry_on=True)
+        with adapter._env(env):
+            _tally, attribution = adapter.serialize_question(
+                q, chat=CarryChat(), cache=cache_mod.CheckpointCache(tmp_path / "c"),
+                backend="f", model="f", project_dir=env["DAIMON_PROJECT_DIR"],
+                workers=2, carry_on=True)
+            results = adapter.recall_question(
+                q, project_dir=env["DAIMON_PROJECT_DIR"], depth=20)
+        # the fold really ran through the store: the later checkpoint on disk
+        # hosts the gold item labeled with its origin
+        later = json.loads(
+            (Path(env["DAIMON_CHECKPOINT_DIR"]) / "sess_coffee.json")
+            .read_text(encoding="utf-8"))
+        carried = [i for i in later["working_context"]["open_questions"]
+                   if i.get("carried_from")]
+        assert [i["carried_from"] for i in carried] == ["sess_gold"]
+        assert carried[0]["text"] == _OQ["goldmarker"]
+        # naive scoring ranks the HOSTING session first (the hazard is real)
+        naive = metrics.ranked_sessions(results)
+        assert naive[0] == "sess_coffee"
+        assert "sess_gold" in naive
+        # honest scoring: the carried copy is attributable to gold — gold ranks
+        # first, once, and the host earns nothing for gold's evidence
+        honest = metrics.attributed_sessions(results, attribution)
+        assert honest == ["sess_gold"]
+
+    def test_run_question_scores_gold_at_rank_one_under_carry(self, tmp_path):
+        result = adapter.run_question(
+            _question(["goldmarker", "coffeemarker"]), chat=CarryChat(),
+            cache=cache_mod.CheckpointCache(tmp_path / "c"),
+            backend="f", model="f", root=tmp_path / "runs", k=5, depth=20,
+            workers=2, carry_on=True)
+        assert result["hit_at_5"] is True
+        assert result["recall_at_5"] == 1.0
+        assert result["mrr"] == 1.0  # not 0.5 — the carried copy is gold's rank
+        assert result["n_retrieved_sessions"] == 1
+
+
+class TestDeterminism:
+    def test_workers_do_not_change_a_carry_on_result(self, tmp_path):
+        """Carry folds prior checkpoints forward, so the fold is order-dependent
+        — but it runs in the single-threaded, listed-session-order write loop,
+        not in the concurrent serialize pool. Same result at any worker count."""
+        q = _question(["goldmarker", "coffeemarker", "flightmarker"])
+        r1 = adapter.run_question(
+            q, chat=CarryChat(), cache=cache_mod.CheckpointCache(tmp_path / "c1"),
+            backend="f", model="f", root=tmp_path / "w1", k=5, depth=20,
+            workers=1, carry_on=True)
+        r4 = adapter.run_question(
+            q, chat=CarryChat(), cache=cache_mod.CheckpointCache(tmp_path / "c4"),
+            backend="f", model="f", root=tmp_path / "w4", k=5, depth=20,
+            workers=4, carry_on=True)
+        assert r1 == r4
+
+    def test_chained_carry_preserves_the_origin_session(self, tmp_path):
+        """A -> B -> C: C's copy of A's item must still say carried_from=A
+        (carry.merge stamps with setdefault), or attribution would credit B."""
+        q = _question(["goldmarker", "coffeemarker", "flightmarker"])
+        env = adapter._question_env(tmp_path / "runs", q["question_id"], "2",
+                                    carry_on=True)
+        with adapter._env(env):
+            adapter.serialize_question(
+                q, chat=CarryChat(), cache=cache_mod.CheckpointCache(tmp_path / "c"),
+                backend="f", model="f", project_dir=env["DAIMON_PROJECT_DIR"],
+                workers=4, carry_on=True)
+        last = json.loads(
+            (Path(env["DAIMON_CHECKPOINT_DIR"]) / "sess_flight.json")
+            .read_text(encoding="utf-8"))
+        origins = {i["carried_from"]: i["text"]
+                   for i in last["working_context"]["open_questions"]
+                   if i.get("carried_from")}
+        assert set(origins) == {"sess_gold", "sess_coffee"}
+        assert origins["sess_gold"] == _OQ["goldmarker"]


### PR DESCRIPTION
## Problem

The LongMemEval-S harness (#267) serializes each question's haystack with cross-session carry hardcoded off (`carry: "off"` in the config stamp). Carry — folding prior unresolved items forward into later checkpoints — is a real product feature, and we cannot say whether it helps or hurts retrieval until the harness can run it as a measured, truthfully-stamped axis.

## Approach

- **`--carry` flag on the runner.** Sets `DAIMON_CARRY=1` in the per-question isolated env (the actual kill-switch variable, verified in `config.py`) and stamps `carry: "on"` in the run config, so carry-on and carry-off numbers can never be conflated. Carry knobs (`DAIMON_CARRY_FLOOR`/`DAIMON_CARRY_MAX`) are pinned to product defaults in the env so an ambient host override cannot change the measurement.
- **Product-faithful fold.** The adapter mirrors the SessionEnd path in `cli._run_serialize`: `store.read_latest(project, fallback=False)` → `carry.merge` (clock = the checkpoint's own deterministic stamp) → `store._stamp_item_ids` → `carry.bind_links` → write.
- **Determinism at any worker count.** Carry is order-dependent (each session must see the one before it), but the LLM serialize is not — `serialize_strict` reads only its own transcript. The fold therefore runs in the already single-threaded, listed-session-order store-write loop, while the expensive serialize stays concurrent. Carry-on output is identical at `--workers 1` and `--workers 4` (covered by test), so no worker forcing is needed.
- **Cache separation.** `cache_key` gains a `carry` axis: carry-on and carry-off runs occupy disjoint key spaces and can never read each other's entries. Carry-off keys stay byte-identical to pre-change keys, so the existing cache (minutes of LLM per entry) remains valid. The separation is deliberately defensive — today the cached blob is the raw pre-carry serializer output — but the cache stays correct even if serialization ever becomes mode-sensitive.

## Scoring rule

With carry on, a later session's checkpoint hosts verbatim copies of earlier sessions' unresolved items, and the recall index attributes every item to the checkpoint that hosts it. Naive scoring therefore credits a non-gold session for gold evidence — and in practice the carried copy *outranks* gold's own row (frontier + recency tiebreaks on identical text), so MRR would silently reward the wrong session.

The rule implemented (`metrics.attributed_sessions`): **a retrieval counts for a session only when it is attributable to that session — the session that originated the item.** Each retrieved row is mapped through an attribution table built by the adapter at write time from `carried_from` (which preserves the *origin* across chained carries, because `carry.merge` stamps it with `setdefault`); unmapped rows fall back to the hosting session. First-occurrence dedup then guarantees a session is credited at most once: gold surfaced both natively and as a carried copy counts once, at its best rank — never double-counted — and a hosting session earns nothing for carried gold evidence. Ambiguous keys (same text native in one kind, carried in another) fall back to the hosting session: never guess, and the fallback can only under-credit gold, never inflate it.

Running the actual carry-on vs carry-off comparison is out of scope here (backend lanes are busy); this PR makes the paired runs possible and honest.

## Verification

- `uv run --extra dev python -m pytest tests/ -k bench` → 60 passed (12 new in `tests/test_bench_carry.py`): stamp records the mode; cache keys separate modes (and stay backward-compatible for carry-off); env pinning; the end-to-end double-counting hazard reproduced and scored correctly (naive ranks the hosting session first, honest scoring returns gold at rank 1, once); worker-count determinism; chained carry preserves the origin session.
- Full suite: `uv run --extra dev --extra pretty python -m pytest tests/ -q` → 1657 passed, 2 skipped.
- `ruff` and `mypy` clean on the changed files.

Closes #274


