### PR TITLE
fix(team): default-closed per-remote scope gate on checkpoint dual-write

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,7 +78,7 @@ Opt-in shared-memory mirror. See [docs/team.md](./team.md) for the full workflow
 
 | Variable | Default | What it does |
 |---|---|---|
-| `DAIMON_TEAM` | off | When truthy, mirror each checkpoint into the shared team dir so `brief --team` can surface teammates. Gates **writes** only — reads of the team dir are always allowed. |
+| `DAIMON_TEAM` | off | When truthy, mirror each checkpoint into the shared team dir so `brief --team` can surface teammates. Gates **writes** only — reads of the team dir are always allowed. A synced remote additionally requires the project to be in its scope allowlist (see [team.md](./team.md#which-projects-sync-the-scope-allowlist-default-closed)); out-of-scope projects mirror to the local dir only. |
 | `DAIMON_AUTHOR` | git `user.name`, then OS user | Team author identity used to namespace your checkpoints. Falls back to `git config user.name`, then the OS username, then `unknown`. |
 | `DAIMON_TEAM_DIR` | `~/.daimon/team` | Root of the shared team-memory mirror. |
 | `DAIMON_TEAM_PROJECT` | unset | Explicit logical project path for this machine's sessions (relative, e.g. `core/api-gateway`). Overrides the sidecar's `daimon-team.toml` mapping and the origin-derived fallback when routing checkpoints under `projects/`. |

--- a/docs/team.md
+++ b/docs/team.md
@@ -154,12 +154,47 @@ checkpoints already sitting under the old path stay visible after the move.
 A broken or unparseable `daimon-team.toml` never blocks a write: the mapping
 is treated as absent (resolution falls through to the origin-derived
 fallback) and the parse error is surfaced as a warning in `daimon team
-status`.
+status`. Membership (below) is the one exception — it fails **closed**, so a
+paste error can never open the remote to the whole machine.
 
 **Legacy note:** sidecars written before this layout keep their flat
 `authors/<author-slug>/` files. That era stays readable forever — reads fan in
 across both layouts and there is no migration; new checkpoints simply start
 landing under `projects/` once a project identity resolves.
+
+## Which projects sync: the scope allowlist (default-closed)
+
+`DAIMON_TEAM=1` is machine-global, but a synced remote only accepts
+checkpoints from projects it has **granted membership**. Everything else stays
+in the machine-local mirror (`<team_dir>/local/`) — withheld from the remote,
+never lost. Without this gate, one enabled remote would receive every project
+on the machine, including personal ones.
+
+A project is in scope for a remote when any of these holds:
+
+1. Its origin URL is listed under the sidecar's top-level `[scope]` table:
+
+   ```toml
+   [scope]
+   repos = ["git@github.com:org/finance-svc.git"]
+   ```
+
+2. Its origin URL is mapped under any `[projects.*]` table — a repo the
+   architect placed in the squad tree is a member, so existing mapped
+   sidecars keep syncing with no new configuration.
+3. `DAIMON_TEAM_PROJECT` is set on the machine — explicit local intent.
+
+`daimon team init` seeds a fresh (empty) remote with a `daimon-team.toml`
+scoping the team to the project you ran it from, so new setups need no extra
+step. Joining an established remote never writes config — the architect owns
+the file after birth.
+
+**Migrating an existing sidecar** (created before scoping existed): add the
+`[scope]` block above — one line per repo that should sync — commit, and
+push. Until then `daimon team status` shows `scope: none — this remote
+receives no checkpoints`. If foreign project trees already accumulated under
+`projects/`, remove them with plain `git rm -r projects/<path>` + push
+(history rewrite optional; the files remain in git history without it).
 
 ## Reading teammates
 
@@ -169,7 +204,8 @@ landing under `projects/` once a project identity resolves.
 - **`daimon recall <query>`** — full-text (SQLite FTS5) search over your local
   history *and* the team's.
 - **`daimon team status`** — per-remote freshness, your own unpushed checkpoint
-  count, and the authors seen in the sidecar.
+  count, the authors seen in the sidecar, and the scope allowlist (which
+  repos may sync into each remote).
 
 Teammates' checkpoints are shown within a read-time age window controlled by
 `DAIMON_TEAM_RETENTION_DAYS` (default 365; `0` means keep everything). Aging out

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1467,7 +1467,8 @@ def _cmd_heal(args) -> int:
 
 def _cmd_team_init(args) -> int:
     try:
-        dest = teamsync.init(args.remote_url)
+        # #279: a fresh team is born scoped to the project init ran from.
+        dest = teamsync.init(args.remote_url, project_dir=Path.cwd())
     except teamsync.TeamError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
@@ -1551,6 +1552,17 @@ def _cmd_team_status(args) -> int:
         # write path — status is the one place the parse error surfaces.
         if row.get("config_warning"):
             lines.append(f"  warning: {row['config_warning']}")
+        # #279: scope is default-closed — an empty allowlist means the remote
+        # receives nothing, which must be visible, not a silent surprise.
+        scope = row.get("scope") or []
+        if scope:
+            lines.append(f"  scope: {', '.join(scope)}")
+        elif config.team_project():
+            lines.append("  scope: none configured — DAIMON_TEAM_PROJECT "
+                         "grants this machine's sessions")
+        else:
+            lines.append("  scope: none — this remote receives no checkpoints "
+                         "(add [scope] repos to daimon-team.toml)")
     render.render_team_status(lines)
     return 0
 

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -762,7 +762,17 @@ def _dual_write_team(session_id: str, checkpoint: dict, project_dir) -> None:
         # non-word char to '-'. Post-munge collisions ("a b" vs "a-b") remain a
         # documented edge — distinct humans colliding there is unrealistic.
         author_slug = project_slug(config.author()) or "unknown"
-        base = config.team_dir() / _team_write_slug()
+        slug = _team_write_slug()
+        # #279 default-closed scope gate: a synced clone accepts a project's
+        # checkpoints only when its daimon-team.toml (or DAIMON_TEAM_PROJECT)
+        # grants membership — DAIMON_TEAM is machine-global, and without this
+        # check the single clone would receive EVERY project on the machine
+        # and push it to teammates. Out-of-scope writes degrade to the local
+        # mirror: withheld from the remote, never lost.
+        if slug != _TEAM_LOCAL_REMOTE and not teamproject.in_scope(
+                project_dir, config.team_dir() / slug):
+            slug = _TEAM_LOCAL_REMOTE
+        base = config.team_dir() / slug
         # #200: env/config/origin-derived logical path (segments are munged in
         # teamproject and can never escape the sidecar); None = flat era.
         segs = teamproject.resolve(project_dir)

--- a/plugin/daimon_briefing/teamproject.py
+++ b/plugin/daimon_briefing/teamproject.py
@@ -86,22 +86,32 @@ def normalize_repo_url(url) -> str | None:
     return s.strip("/").lower() or None
 
 
-def _parse_config(path: Path) -> tuple[list[tuple[tuple[str, ...], set[str]]], str | None]:
-    """One config file -> ([(logical segments, normalized repo urls)], error).
+def _parse_config(
+    path: Path,
+) -> tuple[list[tuple[tuple[str, ...], set[str]]], set[str], str | None]:
+    """One config file -> ([(logical segments, normalized repo urls)],
+    normalized [scope] repos, error).
 
-    Absent file = ([], None). Broken TOML or an unreadable file = ([], message)
-    — the config is treated as absent (fail open) but the error is surfaced.
-    Junk shapes inside valid TOML are skipped entry-by-entry, never fatal."""
+    Absent file = ([], set(), None). Broken TOML or an unreadable file =
+    ([], set(), message) — the config is treated as absent (fail open for
+    path resolution, fail CLOSED for scope — see in_scope) but the error is
+    surfaced. Junk shapes inside valid TOML are skipped entry-by-entry,
+    never fatal."""
     try:
         data = tomllib.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
-        return [], None
+        return [], set(), None
     except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
-        return [], f"{CONFIG_NAME} unreadable ({exc}) — mapping ignored"
+        return [], set(), f"{CONFIG_NAME} unreadable ({exc}) — mapping ignored"
+    # #279: top-level [scope] repos — the per-remote membership allowlist.
+    scope: set[str] = set()
+    scope_table = data.get("scope")
+    if isinstance(scope_table, dict) and isinstance(scope_table.get("repos"), list):
+        scope = {n for n in (normalize_repo_url(r) for r in scope_table["repos"]) if n}
     entries: list[tuple[tuple[str, ...], set[str]]] = []
     projects = data.get("projects")
     if not isinstance(projects, dict):
-        return [], None
+        return [], scope, None
     for logical, table in projects.items():
         segs = logical_segments(logical)
         repos = table.get("repos") if isinstance(table, dict) else None
@@ -110,14 +120,14 @@ def _parse_config(path: Path) -> tuple[list[tuple[tuple[str, ...], set[str]]], s
         normalized = {n for n in (normalize_repo_url(r) for r in repos) if n}
         if normalized:
             entries.append((segs, normalized))
-    return entries, None
+    return entries, scope, None
 
 
 def config_error(sidecar: Path) -> str | None:
     """Parse error for a sidecar's daimon-team.toml, or None (missing/valid).
     `daimon team status` surfaces this — a broken mapping fails open silently
     on the write path and must not stay invisible."""
-    _entries, err = _parse_config(Path(sidecar) / CONFIG_NAME)
+    _entries, _scope, err = _parse_config(Path(sidecar) / CONFIG_NAME)
     return err
 
 
@@ -131,7 +141,7 @@ def _config_entries() -> list[tuple[tuple[str, ...], set[str]]]:
     except OSError:
         return []
     for d in subdirs:
-        rows, _err = _parse_config(d / CONFIG_NAME)
+        rows, _scope, _err = _parse_config(d / CONFIG_NAME)
         entries.extend(rows)
     return entries
 
@@ -207,3 +217,57 @@ def _candidates(project_dir) -> list[tuple[str, ...]]:
     # Tier 4: nothing resolved → [] → flat era. Dedupe preserves tier order.
     seen: set[tuple[str, ...]] = set()
     return [s for s in out if not (s in seen or seen.add(s))]
+
+
+# ---- #279: per-remote scope — default-closed membership for synced remotes ----
+
+# origin probes are bounded but not free; one per (project, process) is the
+# same budget the read_candidates cache already grants the resolver.
+_origin_cache: dict[str, str | None] = {}
+
+
+def _cached_origin(project_dir) -> str | None:
+    key = str(project_dir or "")
+    if key not in _origin_cache:
+        _origin_cache[key] = normalize_repo_url(_origin_url(project_dir)) \
+            if project_dir else None
+    return _origin_cache[key]
+
+
+def _membership(sidecar) -> set[str]:
+    """The normalized repo allowlist ONE sidecar grants: its [scope] repos
+    plus every repo the architect mapped in [projects.*] (a mapped repo IS a
+    member — established sidecars keep syncing with zero new config)."""
+    entries, scope, _err = _parse_config(Path(sidecar) / CONFIG_NAME)
+    allowed = set(scope)
+    for _segs, repos in entries:
+        allowed |= repos
+    return allowed
+
+
+def in_scope(project_dir, sidecar) -> bool:
+    """May this project's checkpoints enter this synced remote? Default
+    CLOSED: membership must be granted by the sidecar's daimon-team.toml
+    ([scope] repos or a [projects.*] mapping) or stated explicitly on the
+    machine via DAIMON_TEAM_PROJECT. Broken/absent config, no origin,
+    unlisted origin — all deny. Never raises; the write path degrades to the
+    local mirror, so a deny withholds, it never loses."""
+    try:
+        if config.team_project():
+            return True
+        allowed = _membership(sidecar)
+        if not allowed:
+            return False
+        origin = _cached_origin(project_dir)
+        return origin is not None and origin in allowed
+    except Exception:  # membership bugs must deny, never leak or break writes
+        return False
+
+
+def scope_entries(sidecar) -> list[str]:
+    """Sorted normalized repo allowlist for `daimon team status` — the one
+    place a human can see which projects a remote accepts. Never raises."""
+    try:
+        return sorted(_membership(sidecar))
+    except Exception:
+        return []

--- a/plugin/daimon_briefing/teamsync.py
+++ b/plugin/daimon_briefing/teamsync.py
@@ -188,11 +188,37 @@ def _validate_remote_url(url: str) -> None:
         raise TeamError(f"unsupported remote transport: {url!r}")
 
 
-def init(url: str) -> Path:
+def _seed_scope_toml(project_dir) -> str:
+    """The daimon-team.toml a FRESH team is born with (#279): scoped to the
+    project that ran `daimon team init` when its origin resolves, else an
+    empty template the human fills in. Written once, at sidecar birth, on the
+    unborn-branch path only — after that the file belongs to the humans."""
+    origin = teamproject._origin_url(project_dir) if project_dir else None
+    if origin:
+        # json.dumps: a JSON string is a valid TOML basic string — quotes and
+        # backslashes in exotic origins can't break the seed file.
+        repos_line = f"repos = [{json.dumps(origin)}]"
+    else:
+        repos_line = ('repos = []  # add repo URLs that may sync here, '
+                      'e.g. "git@github.com:org/x.git"')
+    return (
+        "# daimon team sidecar config — humans edit and commit; daimon only reads.\n"
+        "# [scope] repos is the membership allowlist: ONLY these repos'\n"
+        "# checkpoints sync into this remote. Repos mapped under [projects.*]\n"
+        "# are members too. Everything else stays in the machine-local mirror.\n"
+        "[scope]\n"
+        f"{repos_line}\n"
+    )
+
+
+def init(url: str, project_dir=None) -> Path:
     """`daimon team init <remote-url>`: clone the private sidecar into
     <team_dir>/<remote-slug>/. An EMPTY remote is fine — the unborn branch is
-    seeded with a README-stub root commit and pushed, so every later sync has a
-    branch to ls-remote against. Raises TeamError on real user errors."""
+    seeded with a README-stub root commit (plus a daimon-team.toml scoping the
+    team to the initiating project, #279) and pushed, so every later sync has a
+    branch to ls-remote against. Joining an ESTABLISHED remote never writes
+    config — the architect owns daimon-team.toml after birth. Raises TeamError
+    on real user errors."""
     _validate_remote_url(url)
     slug = remote_slug(url)
     if shutil.which("git") is None:
@@ -210,8 +236,13 @@ def init(url: str) -> Path:
         raise TeamError(f"git clone failed: {_last_line(proc.stderr)}")
     if _head(dest) is None:  # unborn branch: the remote was empty
         (dest / "README.md").write_text(_STUB_README, encoding="utf-8")
-        _git(dest, "add", "--", "README.md")
-        cp = _commit(dest, "sync: initialize team memory sidecar", ["README.md"])
+        seeds = ["README.md"]
+        if not (dest / teamproject.CONFIG_NAME).exists():
+            (dest / teamproject.CONFIG_NAME).write_text(
+                _seed_scope_toml(project_dir), encoding="utf-8")
+            seeds.append(teamproject.CONFIG_NAME)
+        _git(dest, "add", "--", *seeds)
+        cp = _commit(dest, "sync: initialize team memory sidecar", seeds)
         if cp.returncode != 0:
             raise TeamError(f"could not seed root commit: {_last_line(cp.stderr or cp.stdout)}")
         push = _git(dest, "push", "-u", "origin", _branch(dest), timeout=NET_TIMEOUT)
@@ -547,6 +578,9 @@ def team_status() -> list[dict]:
             # #200: a broken daimon-team.toml fails open on the write path
             # (mapping ignored) — status is where the parse error surfaces.
             "config_warning": teamproject.config_error(sidecar),
+            # #279: the membership allowlist — which repos may sync here.
+            # Empty = default-closed: the remote receives no checkpoints.
+            "scope": teamproject.scope_entries(sidecar),
         })
     return rows
 

--- a/plugin/tests/test_teamproject.py
+++ b/plugin/tests/test_teamproject.py
@@ -492,3 +492,141 @@ def test_read_candidates_swallows_resolver_bugs(tmp_path, monkeypatch):
 
     monkeypatch.setattr(teamproject, "_candidates", buggy)
     assert teamproject.read_candidates(tmp_path) == []
+
+
+# ---- #279: per-remote scope — default-closed membership for synced remotes ----
+#
+# DAIMON_TEAM=1 is machine-global; without a membership gate the single
+# sidecar clone receives EVERY project on the machine — a privacy leak the
+# tidy tier-3 origin-derived layout actively masks. A synced remote accepts a
+# project's checkpoints only when the sidecar's daimon-team.toml grants it
+# ([scope] repos, or an architect [projects.*] mapping) or the machine states
+# explicit intent via DAIMON_TEAM_PROJECT. Everything else falls back to the
+# Phase-1 local mirror: withheld from the clone, never lost.
+
+
+def _remote_clone(name="team-mem"):
+    """A dir store._team_write_slug treats as a real synced remote (.git present)."""
+    d = config.team_dir() / name
+    (d / ".git").mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def test_in_scope_when_repo_listed_in_scope_table(tmp_path):
+    repo = _repo(tmp_path, "alpha", "git@github.com:Org/Alpha.git")
+    sidecar = _remote_clone()
+    _write_config('[scope]\nrepos = ["https://github.com/org/alpha"]\n',
+                  remote="team-mem")
+    assert teamproject.in_scope(repo, sidecar) is True
+
+
+def test_in_scope_when_repo_mapped_in_projects_table(tmp_path):
+    # Grandfathering: an architect-mapped repo IS a member — existing mapped
+    # sidecars keep syncing with zero new configuration.
+    repo = _repo(tmp_path, "beta", "https://github.com/org/beta")
+    sidecar = _remote_clone()
+    _write_config('[projects."core/beta"]\nrepos = ["https://github.com/org/beta"]\n',
+                  remote="team-mem")
+    assert teamproject.in_scope(repo, sidecar) is True
+
+
+def test_in_scope_env_project_is_explicit_intent(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, "gamma", "https://github.com/org/gamma")
+    sidecar = _remote_clone()  # no config at all
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/gamma")
+    assert teamproject.in_scope(repo, sidecar) is True
+
+
+def test_out_of_scope_when_repo_unlisted(tmp_path):
+    repo = _repo(tmp_path, "intruder", "https://github.com/me/personal-notes")
+    sidecar = _remote_clone()
+    _write_config('[scope]\nrepos = ["https://github.com/org/alpha"]\n',
+                  remote="team-mem")
+    assert teamproject.in_scope(repo, sidecar) is False
+
+
+def test_default_closed_when_no_config(tmp_path):
+    repo = _repo(tmp_path, "alpha", "https://github.com/org/alpha")
+    assert teamproject.in_scope(repo, _remote_clone()) is False
+
+
+def test_default_closed_when_config_broken(tmp_path):
+    # Path resolution fails OPEN on broken TOML (#200); membership fails
+    # CLOSED — a paste error must not open the remote to the whole machine.
+    repo = _repo(tmp_path, "alpha", "https://github.com/org/alpha")
+    sidecar = _remote_clone()
+    _write_config("[scope\nbroken", remote="team-mem")
+    assert teamproject.in_scope(repo, sidecar) is False
+
+
+def test_default_closed_when_project_has_no_origin(tmp_path):
+    repo = _repo(tmp_path, "no-origin")  # git repo, no origin remote
+    sidecar = _remote_clone()
+    _write_config('[scope]\nrepos = ["https://github.com/org/alpha"]\n',
+                  remote="team-mem")
+    assert teamproject.in_scope(repo, sidecar) is False
+
+
+def test_scope_entries_union_normalized_sorted(tmp_path):
+    sidecar = _remote_clone()
+    _write_config(
+        '[scope]\nrepos = ["git@github.com:Org/Zeta.git"]\n'
+        '[projects."core/beta"]\nrepos = ["https://github.com/org/beta"]\n',
+        remote="team-mem",
+    )
+    assert teamproject.scope_entries(sidecar) == \
+        ["github.com/org/beta", "github.com/org/zeta"]
+
+
+def test_scope_entries_empty_when_no_config():
+    assert teamproject.scope_entries(_remote_clone()) == []
+
+
+# ---- #279 acceptance: an out-of-scope project never dual-writes into a remote ----
+
+
+def test_dual_write_scoped_remote_receives_only_member_project(
+        tmp_path, sample_checkpoint, monkeypatch):
+    # THE leak test: two local projects, one scoped remote — only the member
+    # project's checkpoints reach the sidecar clone; the foreign project's
+    # fall back to the local mirror and are never staged for a push.
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    member = _repo(tmp_path, "alpha", "https://github.com/org/alpha")
+    foreign = _repo(tmp_path, "personal", "https://github.com/me/personal-notes")
+    sidecar = _remote_clone()
+    _write_config('[scope]\nrepos = ["https://github.com/org/alpha"]\n',
+                  remote="team-mem")
+    store.write_checkpoint("S-in", {**sample_checkpoint, "session_id": "S-in"},
+                           project_dir=member)
+    store.write_checkpoint("S-out", {**sample_checkpoint, "session_id": "S-out"},
+                           project_dir=foreign)
+    clone_files = {p.name for p in sidecar.rglob("*.json")}
+    assert "S-in.json" in clone_files
+    assert "S-out.json" not in clone_files  # nothing foreign enters the clone
+    local_files = {p.name for p in (config.team_dir() / "local").rglob("*.json")}
+    assert "S-out.json" in local_files      # withheld, not lost
+
+
+def test_dual_write_unscoped_remote_default_closed(
+        tmp_path, sample_checkpoint, monkeypatch):
+    # A sidecar with NO daimon-team.toml grants nothing: writes fall back to
+    # the local mirror (default-closed; migration is one [scope] line).
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    repo = _repo(tmp_path, "alpha", "https://github.com/org/alpha")
+    sidecar = _remote_clone()
+    store.write_checkpoint("S-a", sample_checkpoint, project_dir=repo)
+    assert not any(sidecar.rglob("*.json"))
+    assert any((config.team_dir() / "local").rglob("*.json"))
+
+
+def test_dual_write_env_project_reaches_remote(
+        tmp_path, sample_checkpoint, monkeypatch):
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/alpha")
+    repo = _repo(tmp_path, "alpha", "https://github.com/org/alpha")
+    sidecar = _remote_clone()  # no config: env intent alone grants membership
+    store.write_checkpoint("S-a", sample_checkpoint, project_dir=repo)
+    assert any(sidecar.rglob("*.json"))

--- a/plugin/tests/test_teamsync.py
+++ b/plugin/tests/test_teamsync.py
@@ -13,7 +13,7 @@ import time
 
 import pytest
 
-from daimon_briefing import cli, config, store, teamsync
+from daimon_briefing import cli, config, store, teamproject, teamsync
 
 
 def _git(cwd, *args) -> subprocess.CompletedProcess:
@@ -403,9 +403,12 @@ def _checkpoint(session_id):
 def test_dual_write_routes_into_single_remote_sidecar(bare_remote, monkeypatch):
     monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
     monkeypatch.setenv("DAIMON_TEAM", "1")
+    # #279: membership is default-closed — explicit DAIMON_TEAM_PROJECT intent
+    # grants it (and, as tier-1 resolution, also names the nested path).
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "repo-x")
     sidecar = teamsync.init(str(bare_remote))
     store.write_checkpoint("S-r", _checkpoint("S-r"), project_dir="/repo/x")
-    assert (sidecar / "authors" / "Ada" / "S-r.json").exists()
+    assert (sidecar / "projects" / "repo-x" / "authors" / "Ada" / "S-r.json").exists()
     assert not (config.team_dir() / "local").exists()
 
 
@@ -757,3 +760,80 @@ def test_merge_works_without_any_git_identity(bare_remote, tmp_path, monkeypatch
         json.dumps({"session_id": "S1", "author": "ada"}), encoding="utf-8")
     report = teamsync.sync_remote(ada)
     assert report["pushed"] is True, report
+
+
+# ---- #279: init seeds the scope config; team status surfaces scope ----
+
+
+def _project_with_origin(tmp_path, origin):
+    proj = tmp_path / "proj"
+    proj.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", str(proj)],
+                   check=True, capture_output=True, timeout=30)
+    if origin:
+        subprocess.run(["git", "-C", str(proj), "remote", "add", "origin", origin],
+                       check=True, capture_output=True, timeout=30)
+    return proj
+
+
+def test_init_seeds_scope_config_from_project_origin(bare_remote, tmp_path):
+    # A FRESH team (empty remote) is born scoped to the project that ran
+    # `daimon team init` — new setups stay zero-touch under default-closed.
+    proj = _project_with_origin(tmp_path, "https://github.com/org/alpha")
+    dest = teamsync.init(str(bare_remote), project_dir=proj)
+    toml_path = dest / teamproject.CONFIG_NAME
+    assert toml_path.exists()
+    assert "github.com/org/alpha" in toml_path.read_text(encoding="utf-8").lower()
+    assert teamproject.CONFIG_NAME in _bare_files(bare_remote)  # rode the seed push
+
+
+def test_init_without_origin_seeds_scope_template(bare_remote, tmp_path):
+    proj = tmp_path / "no-origin-proj"
+    proj.mkdir()
+    dest = teamsync.init(str(bare_remote), project_dir=proj)
+    text = (dest / teamproject.CONFIG_NAME).read_text(encoding="utf-8")
+    assert "[scope]" in text  # template — the human fills repos in
+
+
+def test_init_established_remote_keeps_architect_config(bare_remote, tmp_path):
+    # Joining an ESTABLISHED sidecar must never overwrite (or add) config —
+    # the architect owns daimon-team.toml after birth.
+    seed = tmp_path / "seed-clone2"
+    subprocess.run(["git", "clone", str(bare_remote), str(seed)],
+                   check=True, capture_output=True, timeout=30)
+    (seed / teamproject.CONFIG_NAME).write_text(
+        '[scope]\nrepos = ["https://github.com/org/established"]\n',
+        encoding="utf-8")
+    _git(seed, "add", teamproject.CONFIG_NAME)
+    _git(seed, "-c", "user.name=Arch", "-c", "user.email=a@x", "commit", "-m", "cfg")
+    _git(seed, "push", "origin", "HEAD")
+    proj = _project_with_origin(tmp_path, "https://github.com/me/other")
+    dest = teamsync.init(str(bare_remote), project_dir=proj)
+    text = (dest / teamproject.CONFIG_NAME).read_text(encoding="utf-8")
+    assert "org/established" in text
+    assert "me/other" not in text
+
+
+def test_team_status_row_includes_scope(bare_remote, monkeypatch, tmp_path):
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    proj = _project_with_origin(tmp_path, "https://github.com/org/alpha")
+    teamsync.init(str(bare_remote), project_dir=proj)
+    rows = teamsync.team_status()
+    assert rows[0]["scope"] == ["github.com/org/alpha"]
+
+
+def test_cli_team_status_warns_when_scope_empty(bare_remote, monkeypatch, capsys):
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    teamsync.init(str(bare_remote))  # no project: template config, empty scope
+    assert cli.main(["team", "status"]) == 0
+    out = capsys.readouterr().out
+    assert "scope" in out
+    assert "receives no checkpoints" in out
+
+
+def test_cli_team_status_lists_scope_repos(bare_remote, monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    proj = _project_with_origin(tmp_path, "https://github.com/org/alpha")
+    teamsync.init(str(bare_remote), project_dir=proj)
+    assert cli.main(["team", "status"]) == 0
+    assert "github.com/org/alpha" in capsys.readouterr().out


### PR DESCRIPTION
## Problem

`DAIMON_TEAM=1` is machine-global and checkpoint routing had no membership check: with exactly one sidecar clone present, `_dual_write_team` routed **every project on the machine** into it. A shared team remote paired with personal projects published personal session memories to teammates on the next sync — and the tier-3 origin-derived layout filed each foreign project under a tidy path, masking the leak. Scrubbing the sidecar was symptomatic relief only; files re-accumulated on the next session.

## Fix

**Default-closed scope gate.** A synced remote accepts a project's checkpoints only when membership is granted:

1. the project's origin is listed in the sidecar's new top-level `[scope] repos` allowlist in `daimon-team.toml`, or
2. the origin is mapped under any `[projects.*]` table — an architect-mapped repo IS a member, so established mapped sidecars keep syncing with **zero new configuration**, or
3. `DAIMON_TEAM_PROJECT` is set — explicit machine intent.

Out-of-scope writes degrade to the machine-local mirror (`<team_dir>/local/`): **withheld from the remote, never lost**. Membership fails **closed** on broken or absent config — deliberately opposite to path resolution's fail-open (#200): a paste error must not open the remote to the whole machine.

- `daimon team init` seeds a fresh (empty) remote with a config scoped to the initiating project — new setups stay zero-touch. Joining an established remote never writes config; the architect owns the file after birth.
- `daimon team status` lists each remote's scope allowlist and warns loudly when it is empty (`scope: none — this remote receives no checkpoints`).
- Migration for pre-scoping sidecars documented in `docs/team.md`: one `[scope]` block, plus `git rm` guidance for already-accumulated foreign trees.

## Acceptance criteria (from #279)

- [x] A project outside a remote's scope never dual-writes into that remote's sidecar — `test_dual_write_scoped_remote_receives_only_member_project` (two local repos, one scoped remote)
- [x] Scope visible in `daimon team status` — row `scope` key + CLI lines, tested
- [x] Existing setups: mapped sidecars keep working with no new config; unmapped ones get a documented one-line migration
- [x] Default-closed edge tests: no config, broken config, no origin, env intent

Also verified end-to-end against a real bare remote + two working repos: member checkpoint landed in the clone under `projects/org/alpha/`, foreign checkpoint stayed in `local/`, status rendered the scope line.

Closes #279