### PR TITLE
fix(config): raise default DAIMON_TIMEOUT 120 -> 420 to fit real serialize calls

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,7 +32,7 @@ defaults calibrated against measured behavior, not user-facing configuration.
 | `DAIMON_ENV_FILE` | `~/.daimon/env` | Path to the env file that backs every other variable. Read from the process env only (it names the file, so it can't live inside it). |
 | `DAIMON_PROJECT_DIR` | unset | Working directory of the session being briefed or serialized, used to route per-project checkpoints. Hooks pass the host's cwd through it; unset means the project is unknown and daimon falls back to the global pointer. |
 | `DAIMON_MIN_MESSAGES` | `10` | Minimum message count before a session is worth serializing. Shorter sessions are skipped. |
-| `DAIMON_TIMEOUT` | `120` | Seconds a serialize subprocess may run before it is timed out. |
+| `DAIMON_TIMEOUT` | `420` | Total serialize budget in seconds, shared across retry attempts (per-attempt socket timeouts are capped to the remaining budget). Real serialize/merge calls on gateway and CLI backends run 74s–25min; keep ≥420 or slow calls and retries cannot fit. |
 | `DAIMON_HUNG_AFTER` | `1800` | Seconds past which a serialize spawn that produced no result line is treated as hung/killed rather than still running. Default 30 min sits safely beyond a slow run (production serializes take 4–25 min). |
 
 ## Checkpoint store & GC

--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -407,10 +407,15 @@ def min_messages() -> int:
 
 
 def timeout_seconds() -> int:
+    """Total serialize budget (seconds) — shared across retry attempts, with
+    per-attempt socket timeouts capped to the remaining budget. Real serialize
+    and merge calls on the zero-config claude backend run 74s-25min in
+    production (#284); 420 is the field-derived floor — a lower budget cannot
+    fit even one slow call, let alone a retry."""
     try:
-        return int(_get("DAIMON_TIMEOUT") or "120")
+        return int(_get("DAIMON_TIMEOUT") or "420")
     except ValueError:
-        return 120
+        return 420
 
 
 def hung_after_seconds() -> int:

--- a/plugin/tests/test_config.py
+++ b/plugin/tests/test_config.py
@@ -35,8 +35,11 @@ def test_min_messages_default_and_override(monkeypatch):
 
 
 def test_timeout_default_and_override(monkeypatch):
+    # #284: default must cover the measured production range of the
+    # zero-config claude backend (74s-25min observed; 120s killed real
+    # first-serialize calls). 420 is the field-derived floor.
     monkeypatch.delenv("DAIMON_TIMEOUT", raising=False)
-    assert config.timeout_seconds() == 120
+    assert config.timeout_seconds() == 420
     monkeypatch.setenv("DAIMON_TIMEOUT", "45")
     assert config.timeout_seconds() == 45
 

--- a/plugin/tests/test_config.py
+++ b/plugin/tests/test_config.py
@@ -44,6 +44,11 @@ def test_timeout_default_and_override(monkeypatch):
     assert config.timeout_seconds() == 45
 
 
+def test_timeout_garbage_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("DAIMON_TIMEOUT", "not-an-int")
+    assert config.timeout_seconds() == 420
+
+
 def test_llm_env_falls_back_to_litellm(monkeypatch):
     monkeypatch.delenv("DAIMON_LLM_BASE_URL", raising=False)
     monkeypatch.setenv("LITELLM_BASE_URL", "http://fallback:4000")


### PR DESCRIPTION
## Problem

The default `DAIMON_TIMEOUT=120` kills real serialize calls on the recommended zero-config `claude` backend. Fresh-install smoke on the two small `docs/demo/` transcripts measured 74s/94s/73s **with one kill at >120s**; long-lived installs measure avg 256s / max 1732s; and `hung_after_seconds`'s own docstring says serialize runs 4–25 min in production. Because the value is a **total budget shared across retry attempts** (per-attempt socket timeouts capped to the remaining budget), 120s cannot fit even one slow call, let alone a retry.

The failure profile is the worst possible: a fresh install's first session-end serialize dies with `ChatError: command backend timed out ... after 120s` and writes no checkpoint. Installs that work in the field tend to work because of a manual `DAIMON_TIMEOUT=420` env override new users don't have.

## Fix

Default 120 → 420 — the field-derived floor (real serialize on a ~1200-line chunk and hierarchical merge calls measure 80–250s each; a retry must also fit), safely under known gateway-side kill ceilings (~815s). Detached serialize spawns mean the larger budget holds no session hostage; genuinely hung spawns remain covered by `hung_after_seconds` (1800s).

- `config.timeout_seconds`: default + budget-semantics docstring
- `docs/configuration.md`: row updated with the budget semantics and the ≥420 guidance
- Test updated (TDD: watched it fail at 120, pass at 420); explicit-override path unchanged

Verified: full suite 1677 passed, ruff clean. The >120s kill reproduced on a fresh isolated install pre-fix.

Closes #284