### PR TITLE
docs(demo): fix the flag-rerun recipe — delete the checkpoint before re-serializing

### DIFF
--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -32,10 +32,19 @@ daimon brief --project demo-project        # stale decision withheld
 ```
 
 Serialization is an LLM pass, so item ids and exact wording vary between runs —
-read the ⚠ line for the two ids to plug into `daimon resolve`. Occasionally the
-model omits the supersession link on the pivot decision; rerun session 2 if the
-flag doesn't appear (`DAIMON_LLM_NO_CACHE=1` forces a fresh generation behind a
-caching gateway).
+read the ⚠ line for the two ids to plug into `daimon resolve`. The model
+sometimes omits the supersession link on the pivot decision, or emits a target
+too vague to bind (binding never guesses) — expect the flag to take a rerun or
+two of session 2. Rerunning needs two things:
+
+```sh
+# 1. delete the session-2 checkpoint — daimon refuses to re-serialize an
+#    unchanged transcript (identical-bytes guard), so a plain rerun is skipped
+rm demo-store/session2-gcp-pivot.json
+
+# 2. force a fresh generation (busts any caching gateway in front of the LLM)
+DAIMON_LLM_NO_CACHE=1 daimon serialize --project demo-project session2-gcp-pivot.md
+```
 
 ## Ask the agent instead
 


### PR DESCRIPTION
## Problem

`docs/demo/README.md`'s recovery step for the known-flaky supersession flag ("rerun session 2 with `DAIMON_LLM_NO_CACHE=1`") is dead-ended by the identical-bytes guard: the rerun is skipped with `transcript unchanged since checkpoint (hash match)`. The env var busts the LLM gateway cache but not the transcript-hash guard, and `daimon serialize` has no `--force`. Reproduced on a fresh isolated install.

## Fix

Docs-only. The recipe now:
1. deletes `demo-store/session2-gcp-pivot.json` first (with the one-line reason: the guard refuses to re-serialize unchanged bytes),
2. keeps `DAIMON_LLM_NO_CACHE=1` (still required — gateways replay cached responses for identical bodies),
3. states honest odds: the flag can take a rerun or two — the model sometimes omits the link, or emits a target too vague for never-guess binding. (Measured tonight: fired on the third fresh generation, correctly id-bound.)

Recipe verified end-to-end on a fresh install: delete + no-cache rerun produces a fresh generation, and the ⚠ flag fired with correct `daimon resolve` ids.

Closes #283