### PR TITLE
fix(recall): dedupe results by item content — one hit per distinct item, newest checkpoint wins

### DIFF
--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -561,6 +561,30 @@ def _match_expr(query: str, join: str = " ") -> str | None:
     return join.join(parts) or None
 
 
+def _dedupe_rows(rows: list[dict], want_n: int) -> list[dict]:
+    """#288: one result per distinct item. Key (kind, author, text) — the
+    same words from two authors is attribution, not duplication. Among
+    duplicates the NEWEST row (max created) supplies the result: its
+    supersession/frontier stamps are the current state. Position is the
+    group's best-ranked appearance, so relevance order survives. The
+    replace branch matters when the newest copy sorts BELOW an older one
+    (e.g. the newest is superseded and the superseded-last ordering demotes
+    it) — content still comes from the newest, position from the best."""
+    by_key: dict[tuple, int] = {}
+    out: list[dict] = []
+    for row in rows:
+        key = (row.get("kind"), row.get("author"),
+               " ".join(str(row.get("text") or "").split()))
+        slot = by_key.get(key)
+        if slot is not None:
+            if (row.get("created") or 0) > (out[slot].get("created") or 0):
+                out[slot] = row
+            continue
+        by_key[key] = len(out)
+        out.append(row)
+    return out[:want_n]
+
+
 def search(query: str, project_dir=None, all_projects: bool = False,
            limit: int = 20, slug: str | None = None) -> list[dict]:
     """FTS5 MATCH over the (auto-refreshed) index. Live items first, then by
@@ -622,33 +646,13 @@ def search(query: str, project_dir=None, all_projects: bool = False,
         finally:
             conn.close()
 
-    def _dedupe(rows: list[dict]) -> list[dict]:
-        """#288: one result per distinct item. Key (kind, author, text) —
-        the same words from two authors is attribution, not duplication.
-        Among duplicates the NEWEST row (max created) supplies the result:
-        its supersession/frontier stamps are the current state. Position is
-        the group's best-ranked appearance, so relevance order survives."""
-        by_key: dict[tuple, int] = {}
-        out: list[dict] = []
-        for row in rows:
-            key = (row.get("kind"), row.get("author"),
-                   " ".join(str(row.get("text") or "").split()))
-            slot = by_key.get(key)
-            if slot is not None:
-                if (row.get("created") or 0) > (out[slot].get("created") or 0):
-                    out[slot] = row
-                continue
-            by_key[key] = len(out)
-            out.append(row)
-        return out[:want_n]
-
     def _query() -> list[dict]:
         rows = _run(expr)
         if not rows:
             or_expr = _match_expr(query, " OR ")
             if or_expr != expr:  # differs only when there are >=2 tokens
                 rows = _run(or_expr)
-        return _dedupe(rows)
+        return _dedupe_rows(rows, want_n)
 
     try:
         return _query()

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -602,11 +602,18 @@ def search(query: str, project_dir=None, all_projects: bool = False,
     sql += (" ORDER BY (i.superseded_by IS NOT NULL) ASC, rank ASC,"
             " i.frontier DESC, i.created DESC LIMIT ?")
 
+    want_n = max(1, int(limit))
+
     def _run(match_expr: str) -> list[dict]:
         params: list = [match_expr]
         if want is not None:
             params.append(want)
-        params.append(max(1, int(limit)))
+        # #288 overfetch: a carried item occupies one row PER checkpoint that
+        # carries it, and dedupe below collapses those — fetch headroom so the
+        # deduped list can still fill the caller's limit. 4x covers typical
+        # carry depth; pathological fan-out may under-fill, which reads as
+        # "fewer results", never as duplicates.
+        params.append(want_n * 4)
         conn = sqlite3.connect(str(config.recall_db()))
         try:
             cur = conn.execute(sql, params)
@@ -615,13 +622,33 @@ def search(query: str, project_dir=None, all_projects: bool = False,
         finally:
             conn.close()
 
+    def _dedupe(rows: list[dict]) -> list[dict]:
+        """#288: one result per distinct item. Key (kind, author, text) —
+        the same words from two authors is attribution, not duplication.
+        Among duplicates the NEWEST row (max created) supplies the result:
+        its supersession/frontier stamps are the current state. Position is
+        the group's best-ranked appearance, so relevance order survives."""
+        by_key: dict[tuple, int] = {}
+        out: list[dict] = []
+        for row in rows:
+            key = (row.get("kind"), row.get("author"),
+                   " ".join(str(row.get("text") or "").split()))
+            slot = by_key.get(key)
+            if slot is not None:
+                if (row.get("created") or 0) > (out[slot].get("created") or 0):
+                    out[slot] = row
+                continue
+            by_key[key] = len(out)
+            out.append(row)
+        return out[:want_n]
+
     def _query() -> list[dict]:
         rows = _run(expr)
         if not rows:
             or_expr = _match_expr(query, " OR ")
             if or_expr != expr:  # differs only when there are >=2 tokens
                 rows = _run(or_expr)
-        return rows
+        return _dedupe(rows)
 
     try:
         return _query()

--- a/plugin/tests/test_bench_carry.py
+++ b/plugin/tests/test_bench_carry.py
@@ -173,11 +173,12 @@ class TestScoringRule:
             metrics.ranked_sessions(rows)
 
     def test_end_to_end_no_double_count_of_the_gold_session(self, tmp_path):
-        """The live double-counting hazard: the later session's checkpoint hosts
+        """The live attribution hazard: the later session's checkpoint hosts
         a verbatim carried copy of the gold item, indexed under the LATER
-        session's id — and it outranks gold's own row (frontier + recency
-        tiebreaks). Naive scoring credits the wrong session; the attribution
-        rule credits the origin, once."""
+        session's id — and since #288 dedupe (newest occurrence wins) that
+        carried copy is the item's SOLE surviving row. Naive scoring credits
+        the wrong session and gold is entirely invisible to it; only the
+        attribution rule credits the origin."""
         q = _question(["goldmarker", "coffeemarker"])
         env = adapter._question_env(tmp_path / "runs", q["question_id"], "2",
                                     carry_on=True)
@@ -197,10 +198,11 @@ class TestScoringRule:
                    if i.get("carried_from")]
         assert [i["carried_from"] for i in carried] == ["sess_gold"]
         assert carried[0]["text"] == _OQ["goldmarker"]
-        # naive scoring ranks the HOSTING session first (the hazard is real)
+        # naive scoring credits only the HOSTING session: #288 dedupe keeps
+        # the newest occurrence, so the carried copy is the item's sole row
+        # and gold never appears under its own id (the hazard got stronger)
         naive = metrics.ranked_sessions(results)
-        assert naive[0] == "sess_coffee"
-        assert "sess_gold" in naive
+        assert naive == ["sess_coffee"]
         # honest scoring: the carried copy is attributable to gold — gold ranks
         # first, once, and the host earns nothing for gold's evidence
         honest = metrics.attributed_sessions(results, attribution)

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -1371,3 +1371,61 @@ def test_supersede_candidate_never_marks(tmp_checkpoint_dir):
                        source="serializer", project_dir="/repo/x")
     hits = recall.search("bittern", project_dir="/repo/x")
     assert hits and hits[0]["superseded_by"] is None
+
+
+# ---- #288: the same carried item must not surface once per checkpoint ----
+
+
+def test_search_dedupes_same_item_across_checkpoints(tmp_checkpoint_dir, monkeypatch):
+    # A carried item lives in every checkpoint that carries it; recall must
+    # return it once, sourced from the newest checkpoint (its supersession /
+    # frontier state is the current one).
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    item = {"text": "Quokka panel unregister fix shipped", "trust": "verbatim",
+            "quote": "the quokka panel fix is in"}
+    store.write_checkpoint("S1", _cp("S1", decisions=[dict(item)]),
+                           project_dir="/repo/x")
+    store.write_checkpoint("S2", _cp("S2", decisions=[dict(item)]),
+                           project_dir="/repo/x")
+    hits = recall.search("quokka", all_projects=True)
+    assert len(hits) == 1
+    assert hits[0]["session_id"] == "S2"  # newest occurrence wins
+
+
+def test_search_dedupe_keeps_distinct_items_sharing_words(tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S1", _cp("S1", decisions=[
+        {"text": "Wombat cache invalidation uses hashes", "trust": "inferred"},
+        {"text": "Wombat cache warming happens at write", "trust": "inferred"},
+    ]), project_dir="/repo/x")
+    hits = recall.search("wombat cache", all_projects=True)
+    assert len(hits) == 2  # different content, no merge
+
+
+def test_search_dedupe_preserves_distinct_authors(tmp_checkpoint_dir, monkeypatch):
+    # Two humans stating the same thing is attribution, not duplication.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    text = "Axolotl deploys are frozen on Fridays"
+    store.write_checkpoint("S1", _cp("S1", decisions=[
+        {"text": text, "trust": "inferred"}]), project_dir="/repo/x")
+    _write_team_file("grace", "S-g", _cp("S-g", decisions=[
+        {"text": text, "trust": "inferred"}]))
+    hits = recall.search("axolotl", all_projects=True)
+    assert len(hits) == 2
+    assert {h["author"] for h in hits} == {"ada", "grace"}
+
+
+def test_search_dedupe_backfills_to_limit(tmp_checkpoint_dir, monkeypatch):
+    # Dedupe must not under-fill: with limit=2, one duplicated item plus two
+    # distinct ones still yields 2 DISTINCT results, not a dup-padded list.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    dup = {"text": "Numbat retries use exponential backoff", "trust": "inferred"}
+    store.write_checkpoint("S1", _cp("S1", decisions=[
+        dict(dup),
+        {"text": "Numbat retries cap at five attempts", "trust": "inferred"},
+    ]), project_dir="/repo/x")
+    store.write_checkpoint("S2", _cp("S2", decisions=[dict(dup)]),
+                           project_dir="/repo/x")
+    hits = recall.search("numbat retries", all_projects=True, limit=2)
+    assert len(hits) == 2
+    assert len({h["text"] for h in hits}) == 2

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -1429,3 +1429,35 @@ def test_search_dedupe_backfills_to_limit(tmp_checkpoint_dir, monkeypatch):
     hits = recall.search("numbat retries", all_projects=True, limit=2)
     assert len(hits) == 2
     assert len({h["text"] for h in hits}) == 2
+
+
+def test_dedupe_rows_replace_branch_newest_arrives_later():
+    # The newest copy can sort BELOW an older one (superseded-last ordering
+    # demotes a superseded newest copy) — the survivor must still be the
+    # newest row's content, sitting at the older row's (better) position.
+    older = {"kind": "decision", "author": "ada", "text": "gecko retry policy",
+             "created": 100.0, "session_id": "S-old"}
+    newer = {"kind": "decision", "author": "ada", "text": "gecko retry policy",
+             "created": 200.0, "session_id": "S-new"}
+    other = {"kind": "decision", "author": "ada", "text": "gecko cache policy",
+             "created": 150.0, "session_id": "S-mid"}
+    out = recall._dedupe_rows([older, other, newer], want_n=10)
+    assert [r["session_id"] for r in out] == ["S-new", "S-mid"]  # position kept
+
+
+def test_dedupe_rows_older_duplicate_is_skipped():
+    newer = {"kind": "decision", "author": "ada", "text": "gecko retry policy",
+             "created": 200.0, "session_id": "S-new"}
+    older = {"kind": "decision", "author": "ada", "text": "gecko retry policy",
+             "created": 100.0, "session_id": "S-old"}
+    out = recall._dedupe_rows([newer, older], want_n=10)
+    assert [r["session_id"] for r in out] == ["S-new"]
+
+
+def test_dedupe_rows_missing_created_treated_as_oldest():
+    stamped = {"kind": "q", "author": "a", "text": "t", "created": 1.0,
+               "session_id": "S-stamped"}
+    unstamped = {"kind": "q", "author": "a", "text": "t",
+                 "session_id": "S-unstamped"}
+    out = recall._dedupe_rows([unstamped, stamped], want_n=10)
+    assert out[0]["session_id"] == "S-stamped"


### PR DESCRIPTION
## Problem

A carried item lives in every checkpoint that carries it, so `recall.search` returned it once per checkpoint. Field report from a real session: the same item echoed from checkpoints 15 minutes and 17 hours old, padding the result list and pushing distinct relevant items below the cutoff. (#288)

## Fix

Query-time dedupe in `search()`:

- **Overfetch 4x** the caller's limit, then collapse rows whose `(kind, author, normalized text)` match — same words from two authors stay two results (attribution, not duplication).
- **Newest occurrence wins** (max `created`): its supersession/frontier stamps are the current state.
- **Best-ranked position survives**: the surviving row sits where the group first appeared, so relevance order is preserved.
- No index-format change; the derived DB is untouched.

## Bench interaction

The carry-attribution bench test codified the pre-dedupe contract (gold item visible under both its own and the hosting session's id). Under dedupe the carried copy is the item's sole surviving row, so gold is entirely invisible to naive session ranking — the attribution hazard got stronger, and the scoring rule (#274) handles it unchanged: the carried copy still maps to its origin via the `carried_from` attribution map. Test updated to document the new shape; the honest-scoring assertions are untouched and pass.

## Tests

- `test_search_dedupes_same_item_across_checkpoints` (RED first — reproduced the field report)
- `test_search_dedupe_keeps_distinct_items_sharing_words`
- `test_search_dedupe_preserves_distinct_authors`
- `test_search_dedupe_backfills_to_limit` (overfetch prevents under-filled results)
- Full suite: 1682 passed

Closes #288