### PR TITLE
feat(serializer): capture external-artifact identifiers verbatim (D-014)

### DIFF
--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -29,10 +29,13 @@ log = logging.getLogger(__name__)
 # Serialize-prompt version. Bumped D-008 -> D-010 (#101: emotional_valence
 # dropped from the schema; D-009 is taken by the host-adapter decision).
 # D-012 -> D-013 (#208: quote copy-paste discipline rule).
+# D-013 -> D-014 (#287: external-artifact identifier rule — "issue #5"
+# without a repo is half a pointer; capture the most specific identifier
+# the transcript states, never invent one).
 # Checkpoints are only comparable across runs sharing this version (scar
 # landmine #4); pre-bump checkpoints firing the #93 format_version mismatch
 # warning is desired, not a bug.
-PROMPT_VERSION = "D-013"
+PROMPT_VERSION = "D-014"
 
 
 class SerializeError(Exception):
@@ -142,6 +145,16 @@ RULES — follow every one exactly; this is the point of the exercise:
     labels inside a quote. If you cannot copy the exact characters of a contiguous span
     (or spans joined by `...`), use trust="inferred" with an empty quote instead —
     a correct inferred beats a downgraded verbatim.
+
+18. EXTERNAL ARTIFACT IDENTIFIERS: when an item references an external artifact — a repo,
+    issue, PR, package, ticket, deploy target — include that artifact's MOST SPECIFIC identifier
+    stated anywhere in the transcript in the item's `text`: repo slug (owner/name), issue/PR as
+    owner/name#123 or its full URL, package name with version, ticket key. "File issue #5
+    upstream" is half a pointer — a future session cannot resolve which repo it means; "file
+    issue #5 in acme/widget-lib" is whole. The identifier may come from a DIFFERENT part of the
+    transcript than the sentence you are extracting (the quote rules still apply to `quote`;
+    this rule is about `text`). Never invent an identifier the transcript does not contain;
+    if only a vague name was ever stated, keep the vague name.
 
 Schema shape:
 {

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -722,14 +722,15 @@ def test_validation_retry_note_restates_copy_paste_contract(
     assert "elisions marked with `...`" in second
 
 
-def test_prompt_version_is_d013():
+def test_prompt_version_is_d014():
     # D-008 -> D-010 (#101: emotional_valence dropped from the schema).
     # D-009 is taken by the host-adapter decision. D-010 -> D-011 (#126:
     # per-item importance added to the emitted schema). D-011 -> D-012 (#5:
     # transcript-language preservation rule). D-012 -> D-013 (#208: verbatim
-    # quote copy-paste discipline rule). Pre-bump checkpoints firing the
+    # quote copy-paste discipline rule). D-013 -> D-014 (#287: external-
+    # artifact identifier rule). Pre-bump checkpoints firing the
     # format_version mismatch warning (#93) is DESIRED behavior.
-    assert serializer.PROMPT_VERSION == "D-013"
+    assert serializer.PROMPT_VERSION == "D-014"
 
 
 def test_prompts_preserve_transcript_language():
@@ -1114,3 +1115,16 @@ def test_serialize_stamps_backend_when_model_lookup_raises(
     assert ckpt is not None
     assert ckpt["llm_backend"] == "litellm"
     assert "llm_model" not in ckpt
+
+
+def test_serialize_prompt_has_external_artifact_identifier_rule():
+    # #287: a briefing carried a fix perfectly but not the upstream repo's
+    # name — "issue #5" without a repo is half a pointer a future session
+    # cannot resolve. The serializer must pull an artifact's most specific
+    # identifier from anywhere in the transcript into the item text, and
+    # never invent one the transcript does not contain.
+    sys = serializer.SERIALIZE_SYS
+    assert "EXTERNAL ARTIFACT IDENTIFIERS" in sys
+    assert "MOST SPECIFIC identifier" in sys
+    assert "half a pointer" in sys
+    assert "Never invent an identifier" in sys


### PR DESCRIPTION
## Problem

Field report from a real session (#287): the briefing carried an upstream fix with the exact code quote intact — but NOT the upstream repo's name. The decision item amounted to "file issue #5 upstream", and "issue #5" without a repo is half a pointer: if daimon had been the sole memory, the next session would have had to rediscover which repo "upstream" meant.

## Change

New serialize-prompt rule 18 (EXTERNAL ARTIFACT IDENTIFIERS): when an item references an external artifact — repo, issue, PR, package, ticket, deploy target — the item's `text` must include the artifact's most specific identifier stated **anywhere in the transcript**: repo slug (`owner/name`), `owner/name#123` or full URL, package name with version, ticket key.

Guardrails kept explicit in the rule:
- the identifier may come from a different part of the transcript than the extracted sentence — but **inventing one the transcript never stated remains forbidden** (vague name stated → vague name kept)
- quote discipline is untouched: the rule governs `text`, never `quote`

`PROMPT_VERSION` bumped D-013 → D-014 — bench caches key on it, so cached D-013 serializations never masquerade as D-014 output, and the format-version notice on pre-bump checkpoints is the desired behavior (#93).

## Tests

- `test_serialize_prompt_has_external_artifact_identifier_rule` (RED first)
- `test_prompt_version_is_d014` (version-history comment extended)
- Full suite green, ruff clean

Closes #287