### PR TITLE
fix(serializer): strip code-owned provenance keys at the parse boundary

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -423,6 +423,11 @@ def _cmd_write_checkpoint(args) -> int:
             file=sys.stderr,
         )
         return 1
+    # #292: this dict was just authored by a model on the other end of the
+    # pipe (the docstring's "live session emits its own cognitive state") —
+    # same spoofing risk serialize_strict guards against, since validate()
+    # never inspects top-level keys.
+    serializer.strip_code_owned_keys(checkpoint)
     checkpoint["source"] = args.source  # provenance: introspection vs reconstruction
     session_id = str(checkpoint["session_id"])
     out = store.write_checkpoint(session_id, checkpoint, project_dir=_resolve_project(args.project))

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -642,6 +642,40 @@ def _merge_partials(chat, session_id: str, partials: list, deadline,
     return partials[0]
 
 
+# #292: keys the CODE asserts about a checkpoint's origin — never data the
+# extraction model should get a vote on. The serialize prompt never asks for
+# any of these, but a transcript that happens to discuss daimon's own schema
+# (the field report behind this: a transcript quoting daimon's own format-
+# drift warning banner) can make the model emit one anyway. Nothing else on
+# the write path catches it: `_valid_item` only validates item fields, and
+# store.write_checkpoint's setdefault stamps defer to whatever key is already
+# present — which is indistinguishable from a legitimate re-write of an
+# already-stamped checkpoint (#93/#123). `session_id` needs no entry here:
+# it's already reassigned by direct `=` right after every _produce() call,
+# below, which already stomps a model-supplied value the same way.
+_CODE_OWNED_KEYS = (
+    "format_version", "created", "author",
+    "transcript_hash", "project_slug", "git_branch", "receipts",
+)
+
+
+def _strip_code_owned_keys(checkpoint: dict) -> None:
+    """Discard any code-owned key the model emitted in its own output.
+
+    Fail-safe, not fail-fast: a model that names one of these fields is not
+    an error worth failing an otherwise-good serialize over — just a value
+    that must never be load-bearing. Runs on the raw parsed dict, before
+    session_id is assigned and before store.write_checkpoint ever sees it, so
+    its later setdefault stamps land on the code's own values (cli's own
+    `created`/`transcript_hash` assignments, store's format_version/author/
+    project_slug/git_branch/receipts) — never a model-supplied one.
+    """
+    for key in _CODE_OWNED_KEYS:
+        if key in checkpoint:
+            log.info("serialize: discarding model-supplied code-owned key %r", key)
+            del checkpoint[key]
+
+
 def _stamp_llm_provenance(checkpoint: dict) -> None:
     """Stamp which backend/model actually produced this checkpoint (#230).
 
@@ -763,10 +797,12 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
                                attempt_note=note)
 
     checkpoint = _produce("")
+    _strip_code_owned_keys(checkpoint)
     checkpoint["session_id"] = session_id
     if not validate(checkpoint):
         log.info("checkpoint failed validation — one resample with attempt nonce (#118)")
         checkpoint = _produce(_RETRY_NOTE)
+        _strip_code_owned_keys(checkpoint)
         checkpoint["session_id"] = session_id
     if not validate(checkpoint):
         raise SchemaValidationError(

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -642,33 +642,43 @@ def _merge_partials(chat, session_id: str, partials: list, deadline,
     return partials[0]
 
 
-# #292: keys the CODE asserts about a checkpoint's origin — never data the
-# extraction model should get a vote on. The serialize prompt never asks for
-# any of these, but a transcript that happens to discuss daimon's own schema
-# (the field report behind this: a transcript quoting daimon's own format-
-# drift warning banner) can make the model emit one anyway. Nothing else on
-# the write path catches it: `_valid_item` only validates item fields, and
-# store.write_checkpoint's setdefault stamps defer to whatever key is already
-# present — which is indistinguishable from a legitimate re-write of an
-# already-stamped checkpoint (#93/#123). `session_id` needs no entry here:
-# it's already reassigned by direct `=` right after every _produce() call,
-# below, which already stomps a model-supplied value the same way.
+# #292: keys the CODE asserts about a checkpoint's origin — never data a
+# MODEL-authored dict should get a vote on. The serialize prompt never asks
+# for any of these, but a transcript that happens to discuss daimon's own
+# schema (the field report behind this: a transcript quoting daimon's own
+# format-drift warning banner) can make the model emit one anyway — and the
+# #23 introspection path (cli's `write-checkpoint`) has the model author a
+# schema-shaped dict directly. Nothing else on the write path catches it:
+# `_valid_item` only validates item fields, and store.write_checkpoint's
+# setdefault stamps defer to whatever key is already present — which is
+# indistinguishable from a legitimate re-write of an already-stamped
+# checkpoint (#93/#123). `session_id` needs no entry here: it's already
+# reassigned by direct `=` right after every _produce() call below, which
+# already stomps a model-supplied value the same way.
 _CODE_OWNED_KEYS = (
     "format_version", "created", "author",
     "transcript_hash", "project_slug", "git_branch", "receipts",
 )
 
 
-def _strip_code_owned_keys(checkpoint: dict) -> None:
-    """Discard any code-owned key the model emitted in its own output.
+def strip_code_owned_keys(checkpoint: dict) -> None:
+    """Discard any code-owned key a model emitted in its own output.
+
+    Public: called both here (after every fresh _produce() parse) and by
+    cli's `_cmd_write_checkpoint`, the other place a model authors a
+    checkpoint dict directly. Never call this on a checkpoint that came off
+    disk (e.g. anchor --attach's read-mutate-rewrite) — that would erase its
+    real stamps and let store.write_checkpoint's setdefault silently
+    re-date `created` and jump `format_version` to whatever's current. Only
+    dicts a model just authored are candidates for stripping.
 
     Fail-safe, not fail-fast: a model that names one of these fields is not
-    an error worth failing an otherwise-good serialize over — just a value
-    that must never be load-bearing. Runs on the raw parsed dict, before
-    session_id is assigned and before store.write_checkpoint ever sees it, so
-    its later setdefault stamps land on the code's own values (cli's own
-    `created`/`transcript_hash` assignments, store's format_version/author/
-    project_slug/git_branch/receipts) — never a model-supplied one.
+    an error worth failing an otherwise-good write over — just a value that
+    must never be load-bearing. Runs before session_id is assigned (serialize
+    path) or before store.write_checkpoint ever sees it (introspection path),
+    so store's later setdefault stamps land on the code's own values (cli's
+    own `created`/`transcript_hash` assignments, store's format_version/
+    author/project_slug/git_branch/receipts) — never a model-supplied one.
     """
     for key in _CODE_OWNED_KEYS:
         if key in checkpoint:
@@ -797,12 +807,12 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
                                attempt_note=note)
 
     checkpoint = _produce("")
-    _strip_code_owned_keys(checkpoint)
+    strip_code_owned_keys(checkpoint)
     checkpoint["session_id"] = session_id
     if not validate(checkpoint):
         log.info("checkpoint failed validation — one resample with attempt nonce (#118)")
         checkpoint = _produce(_RETRY_NOTE)
-        _strip_code_owned_keys(checkpoint)
+        strip_code_owned_keys(checkpoint)
         checkpoint["session_id"] = session_id
     if not validate(checkpoint):
         raise SchemaValidationError(

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1405,6 +1405,30 @@ def test_cli_write_checkpoint_no_session_id(tmp_checkpoint_dir, monkeypatch, cap
     assert "session_id" in capsys.readouterr().err.lower()
 
 
+def test_cli_write_checkpoint_strips_model_supplied_code_owned_keys(
+        tmp_checkpoint_dir, monkeypatch):
+    # #292: the introspection path (#23) pipes a MODEL-authored checkpoint
+    # straight to store.write_checkpoint after serializer.validate — which
+    # never inspects top-level keys. Without a strip here, the same spoofing
+    # the fresh-serialize paths were fixed against is still open on the one
+    # path where the model is most schema-aware (it is deliberately authoring
+    # schema-shaped JSON).
+    from daimon_briefing import serializer, store
+
+    spoofed_version = serializer.PROMPT_VERSION + "-bogus"
+    spoofed = json.loads(_valid_json("S-intro"))
+    spoofed["format_version"] = spoofed_version
+    spoofed["author"] = "not-the-real-author"
+    spoofed["created"] = "1999-01-01T00:00:00Z"
+    _stdin(monkeypatch, json.dumps(spoofed))
+    rc = cli.main(["write-checkpoint", "--project", "/p/A"])
+    assert rc == 0
+    ck = store.read_latest(project_dir="/p/A")
+    assert ck["format_version"] == serializer.PROMPT_VERSION
+    assert ck["author"] != "not-the-real-author"
+    assert ck["created"] != "1999-01-01T00:00:00Z"
+
+
 def test_top_level_help_has_examples(capsys):
     with pytest.raises(SystemExit) as exc:
         cli.main(["--help"])
@@ -1609,6 +1633,35 @@ def test_cli_anchor_attach_missing_session_id_exits_nonzero(
                    "--project", str(proj)])
     assert rc != 0
     assert "session_id" in capsys.readouterr().err
+
+
+def test_cli_anchor_attach_preserves_existing_code_owned_stamps(
+    tmp_checkpoint_dir, capsys, monkeypatch, tmp_path, sample_checkpoint
+):
+    # #292 asymmetry lock: --attach reads an EXISTING checkpoint (already
+    # carrying real stamps) and re-writes it through the normal store path.
+    # Stripping code-owned keys here would erase those real stamps and let
+    # store.write_checkpoint's setdefault silently re-date `created` and jump
+    # `format_version` to whatever PROMPT_VERSION is now — the opposite of a
+    # fresh-serialize spoof, but just as wrong. Only paths where the MODEL
+    # authored the dict get stripped; a dict that came off disk never does.
+    from daimon_briefing import serializer, store
+
+    proj = _anchor_proj(tmp_path, monkeypatch)
+    stamped = {**sample_checkpoint, "format_version": "D-000",
+               "created": "2020-01-01T00:00:00Z", "author": "ada"}
+    store.write_checkpoint("S-prev", stamped, project_dir=proj)
+    capsys.readouterr()
+
+    rc = cli.main(["anchor", "pkg/m.py", "foo", "--attach", "PINNING",
+                   "--project", str(proj)])
+    assert rc == 0
+
+    latest = store.read_latest(project_dir=proj)
+    assert latest["format_version"] == "D-000"
+    assert latest["format_version"] != serializer.PROMPT_VERSION
+    assert latest["created"] == "2020-01-01T00:00:00Z"
+    assert latest["author"] == "ada"
 
 
 def test_cli_anchor_without_attach_writes_nothing(

--- a/plugin/tests/test_hooks.py
+++ b/plugin/tests/test_hooks.py
@@ -95,6 +95,29 @@ def test_on_session_end_writes_checkpoint(tmp_checkpoint_dir, fake_chat_factory,
     assert store.read_latest()["session_id"] == "S-end"
 
 
+def test_on_session_end_strips_model_supplied_format_version(
+        tmp_checkpoint_dir, fake_chat_factory, monkeypatch):
+    # #292: on_session_end never goes through cli._run_serialize, so the strip
+    # has to live where BOTH entry points call through — this proves it
+    # covers the hooks path too, not just cli.
+    from daimon_briefing import serializer, store, transcript
+
+    spoofed_version = serializer.PROMPT_VERSION + "-bogus"
+    spoofed = json.loads(_valid_json("S-end"))
+    spoofed["format_version"] = spoofed_version
+    chat = fake_chat_factory(json.dumps(spoofed))
+    monkeypatch.setattr(transcript, "from_session", lambda sid: make_messages(20))
+    monkeypatch.setattr(hooks, "_chat", chat)
+
+    hooks.on_session_end(
+        session_id="S-end", completed=True, interrupted=False, model="m", platform="cli"
+    )
+    on_disk = store.read_checkpoint("S-end")
+    assert on_disk is not None
+    assert on_disk["format_version"] == serializer.PROMPT_VERSION
+    assert on_disk["format_version"] != spoofed_version
+
+
 def test_on_session_end_disabled_noop(tmp_checkpoint_dir, fake_chat_factory, monkeypatch):
     from daimon_briefing import store, transcript
 

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -1128,3 +1128,74 @@ def test_serialize_prompt_has_external_artifact_identifier_rule():
     assert "MOST SPECIFIC identifier" in sys
     assert "half a pointer" in sys
     assert "Never invent an identifier" in sys
+
+
+# ---- #292: code-owned provenance keys stripped at the serializer boundary ----
+#
+# format_version/created/author/etc. are facts the CODE asserts about a
+# checkpoint's origin — never data the extraction model should get a vote on.
+# The serialize prompt never asks for these keys, but a transcript that
+# happens to discuss daimon's own schema (this bug's field report: the
+# transcript quoted daimon's own format-drift warning banner) can make the
+# model emit one anyway. Nothing else on the write path catches it —
+# `_valid_item` only validates item fields, and store.write_checkpoint's
+# setdefault stamps defer to whatever key is already present, which cannot
+# tell a fresh serialize from a legitimate re-write. Stripping right after
+# parse — before session_id is even assigned — means every serialize()
+# caller (cli, hooks) hands store a clean dict, so its setdefault stamps
+# land on the code's own values.
+
+
+@pytest.mark.parametrize("key,spoofed", [
+    ("format_version", "D-999"),
+    ("created", "1999-01-01T00:00:00Z"),
+    ("author", "not-the-real-author"),
+    ("transcript_hash", "deadbeef"),
+    ("project_slug", "some-other-project"),
+    ("git_branch", "not-the-real-branch"),
+    ("receipts", "not-a-real-receipt-marker"),
+])
+def test_serialize_strips_model_supplied_code_owned_key(fake_chat_factory, key, spoofed):
+    spoofed_ckpt = json.loads(_valid_checkpoint_json("S1"))
+    spoofed_ckpt[key] = spoofed
+    chat = fake_chat_factory(json.dumps(spoofed_ckpt))
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+    assert ckpt is not None
+    assert key not in ckpt  # stripped, not carried through as the model's value
+
+
+def test_serialize_strip_survives_the_validation_retry_pass(fake_chat_factory):
+    # A spoofed format_version alongside output that FAILS validation forces
+    # the #118 resample retry — the strip must apply to the retried output
+    # too, not just the first attempt.
+    bad = json.loads(_valid_checkpoint_json("S1"))
+    bad["working_context"]["recent_decisions"][0] = {"text": "d", "trust": "verbatim"}  # no quote -> invalid
+    bad["format_version"] = "D-999"
+    good = json.loads(_valid_checkpoint_json("S1"))
+    good["format_version"] = "D-999"
+    chat = fake_chat_factory([json.dumps(bad), json.dumps(good)])
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+    assert ckpt is not None
+    assert "format_version" not in ckpt
+
+
+def test_regression_model_supplied_format_version_does_not_stamp_checkpoint(
+        tmp_checkpoint_dir, fake_chat_factory):
+    # The exact field report behind #292: a transcript quoting daimon's own
+    # format-drift banner (which cites a format_version string) made the
+    # model emit format_version in its extracted JSON. The checkpoint that
+    # reaches disk must carry the CODE's PROMPT_VERSION, never a model-
+    # supplied one — regardless of how plausible the spoofed value looks.
+    from daimon_briefing import store
+
+    spoofed_version = serializer.PROMPT_VERSION + "-bogus"
+    spoofed = json.loads(_valid_checkpoint_json("S1"))
+    spoofed["format_version"] = spoofed_version
+    chat = fake_chat_factory(json.dumps(spoofed))
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+    assert ckpt is not None
+    assert "format_version" not in ckpt
+    path = store.write_checkpoint("S1", ckpt)
+    on_disk = json.loads(path.read_text(encoding="utf-8"))
+    assert on_disk["format_version"] == serializer.PROMPT_VERSION
+    assert on_disk["format_version"] != spoofed_version


### PR DESCRIPTION
## Summary

A checkpoint's `format_version`, `created`, and `author` are facts the code asserts about where a checkpoint came from — but nothing stopped the extraction model from emitting these keys in its own output. `store.write_checkpoint` stamps them with `setdefault`, which means a key already present in the model's output wins over the code constant. This is triggerable whenever a transcript happens to discuss daimon's own schema or provenance fields — the exact field report: a session that quoted daimon's own format-drift warning banner ended up with a checkpoint stamped `format_version: "D-014"` by a machine still running `D-013` code.

## Key set chosen

Stripped at the boundary: `format_version`, `created`, `author`, `transcript_hash`, `project_slug`, `git_branch`, `receipts`. Each is stamped downstream via `setdefault` (store.py) or direct assignment after `serialize_strict` returns (cli's `created`/`transcript_hash`) — all facts about *how* a checkpoint was produced, never data the extraction step should originate.

`session_id` is intentionally **not** in the strip set — it's already protected. `serialize_strict` does `checkpoint["session_id"] = session_id` (direct assignment, not setdefault) immediately after every parse, which already stomps any model-supplied value.

## Where the fix lives — two call sites, one shared helper

`serializer.strip_code_owned_keys` (public — was private in an earlier revision of this PR) is called from:

1. Inside `serializer.serialize_strict`, immediately after each `_produce()` call (both the first attempt and the `#118` validation-retry resample), before `session_id` is assigned and before the dict reaches `store.write_checkpoint`. Covers both `cli._run_serialize` and `hooks.on_session_end`, since both call `serialize_strict`.
2. Inside `cli._cmd_write_checkpoint` — the `#23` introspection path, where a model pipes a checkpoint dict to `daimon write-checkpoint` on stdin. This path never goes through `serialize_strict` at all (only `serializer.validate`, which never inspects top-level keys), so it needed its own call site. Same spoofing risk, different entry point: the model is deliberately authoring schema-shaped JSON here.

Both call sites use the same seam `_stamp_llm_provenance` already established for the identical `llm_backend`/`llm_model` spoofing concern (`#230`).

**Deliberately NOT stripped:** `cli._cmd_anchor`'s `--attach` path. It reads an *existing* checkpoint off disk, mutates one item, and re-writes it through the normal store path — that checkpoint's `format_version`/`author`/`created` are real, already-verified stamps, not a model's fresh claim. Stripping there would erase them and let `store.write_checkpoint`'s `setdefault` silently re-date `created` and jump `format_version` to whatever's current. The rule the strip set encodes: only a dict a model just authored is a stripping candidate; a dict that came off disk never is. Now locked by a regression test (`test_cli_anchor_attach_preserves_existing_code_owned_stamps`).

**Why not in `store.write_checkpoint` itself:** that function cannot distinguish a fresh model-authored dict from a legitimate re-write of an already-stamped checkpoint — both arrive with the key already present, and the `setdefault` idempotency there is deliberate (`#93`/`#123`). Stripping at the two call sites above instead of in `store.py` means `anchor --attach`'s re-write behavior is untouched by construction, not by a special case, and the two pre-existing idempotency tests never had to change.

## A model emitting these keys is not fatal

The strip runs unconditionally and logs at `info` level (`serialize: discarding model-supplied code-owned key %r`) — no exception, no failed write.

## Testing

Strict TDD throughout: every new test written and confirmed failing (RED) against the pre-fix behavior before the corresponding implementation change.

- One parametrized regression test per code-owned key: a model-supplied value must not survive `serializer.serialize()`.
- A retry-path test: the strip applies to the `#118` resample output too, not just the first attempt.
- A hooks-path test: `on_session_end` (which never goes through `cli._run_serialize`) also produces a checkpoint stamped with the real `PROMPT_VERSION`, not a model-supplied one.
- A regression test seeded from the real-world case: a model-supplied `format_version` distinct from the running code's `PROMPT_VERSION` must not reach disk, via `serializer.serialize()` + `store.write_checkpoint()` end-to-end.
- A CLI-level regression test for the introspection path (`write-checkpoint` on stdin): spoofed `format_version`/`author`/`created` must not survive to the written checkpoint.
- A lock test for `anchor --attach`: an existing checkpoint's real `format_version`/`created`/`author` survive the attach re-write untouched — this test already passed before the introspection-path fix (proving that path was never broken) and still passes after.
- Both pre-existing re-write idempotency tests (`test_write_does_not_overwrite_existing_stamp`, `test_write_does_not_overwrite_existing_author`) pass unchanged — this fix never touches `store.py`.

Full suite: 1698 passed, 2 skipped (pre-existing, unrelated).

Closes #292
