### PR TITLE
fix(store): make transcript_unchanged version-aware

### DIFF
--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -657,7 +657,17 @@ def transcript_unchanged(session_id: str, transcript_hash: str | None) -> bool:
     checkpoint. Fail-open on every edge — no fresh hash, no existing checkpoint,
     or a missing/malformed stored hash all return False (proceed with a normal
     serialize); only an exact hex-digest match, computed the same way
-    (transcript.file_sha256, over raw pre-render bytes — #125), justifies a skip."""
+    (transcript.file_sha256, over raw pre-render bytes — #125), justifies a skip.
+
+    #293: identical bytes alone are not enough — the guard's own rationale is
+    "identical bytes AND identical prompt ⇒ identical output ⇒ skip", and it
+    never checked the second half. A checkpoint stamped under an older
+    `serializer.PROMPT_VERSION` cannot be reproduced by the current prompt, so
+    it is stale, not a duplicate-SessionEnd case, and must not be skipped — this
+    is what makes the format-drift warning's "re-serialize to refresh" remedy
+    actually work. A legacy checkpoint with no `format_version` at all (pre-#93)
+    can't be confirmed to match the current prompt either, so — consistent with
+    every other uncertain edge here — it also fails open (no skip)."""
     if not transcript_hash:
         return False
     existing = read_checkpoint(session_id)
@@ -665,6 +675,8 @@ def transcript_unchanged(session_id: str, transcript_hash: str | None) -> bool:
         return False
     stored = existing.get("transcript_hash")
     if not isinstance(stored, str) or not stored:
+        return False
+    if existing.get("format_version") != serializer.PROMPT_VERSION:
         return False
     return stored == transcript_hash
 

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2095,6 +2095,30 @@ def test_run_serialize_proceeds_when_transcript_hash_differs(
     assert "skipped" not in out
 
 
+def test_run_serialize_proceeds_when_format_version_is_stale(
+    tmp_checkpoint_dir, tmp_log_dir, fake_chat_factory, monkeypatch, capsys
+):
+    # #293: bytes match but the checkpoint predates a PROMPT_VERSION bump — the
+    # guard must not skip, since re-serializing is the only way to refresh it.
+    from daimon_briefing import store, transcript
+
+    tp = FIXTURES / "sample_transcript.md"
+    sid = tp.stem
+    sha = transcript.file_sha256(tp)
+    store.write_checkpoint(
+        sid,
+        {**json.loads(_valid_json(sid)), "transcript_hash": sha, "format_version": "D-000"},
+    )
+
+    monkeypatch.setattr(cli, "_chat", fake_chat_factory(_valid_json(sid)))
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    rc = cli._run_serialize(tp, "/p")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "wrote checkpoint" in out
+    assert "skipped" not in out
+
+
 def test_run_serialize_proceeds_when_no_existing_checkpoint(
     tmp_checkpoint_dir, tmp_log_dir, fake_chat_factory, monkeypatch, capsys
 ):

--- a/plugin/tests/test_hooks.py
+++ b/plugin/tests/test_hooks.py
@@ -191,6 +191,32 @@ def test_on_session_end_proceeds_when_transcript_hash_differs(
     assert store.read_checkpoint("S-end") is not None
 
 
+def test_on_session_end_proceeds_when_format_version_is_stale(
+    tmp_checkpoint_dir, fake_chat_factory, monkeypatch, tmp_path
+):
+    # #293: bytes match but the checkpoint predates a PROMPT_VERSION bump —
+    # the hooks path must get the same version-aware behavior as cli._run_serialize.
+    from daimon_briefing import store, transcript as transcript_mod
+
+    tpath = tmp_path / "S-end.jsonl"
+    tpath.write_text('{"role": "user", "content": "hi"}\n')
+    sha = transcript_mod.file_sha256(tpath)
+    store.write_checkpoint(
+        "S-end",
+        {**json.loads(_valid_json("S-end")), "transcript_hash": sha, "format_version": "D-000"},
+    )
+
+    chat = fake_chat_factory(_valid_json("S-end"))
+    monkeypatch.setattr(transcript_mod, "from_session", lambda sid: make_messages(20))
+    monkeypatch.setattr(hooks, "_chat", chat)
+
+    hooks.on_session_end(
+        session_id="S-end", completed=True, interrupted=False, model="m", platform="cli",
+        transcript_path=str(tpath),
+    )
+    assert len(chat.calls) == 1
+
+
 def test_on_session_end_proceeds_when_no_transcript_path_given(
     tmp_checkpoint_dir, fake_chat_factory, monkeypatch
 ):

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1523,6 +1523,52 @@ def test_transcript_unchanged_false_when_new_hash_is_none(tmp_checkpoint_dir, sa
     assert store.transcript_unchanged("S-hash2", None) is False
 
 
+# ---- #293: transcript_unchanged is version-aware ----
+
+
+def test_transcript_unchanged_true_when_format_version_matches_current(
+    tmp_checkpoint_dir, sample_checkpoint
+):
+    # #185's original contract: identical bytes AND identical prompt version
+    # still skips. Must not regress.
+    ck = {
+        **sample_checkpoint,
+        "session_id": "S-samever",
+        "transcript_hash": "abc123",
+        "format_version": serializer.PROMPT_VERSION,
+    }
+    store.write_checkpoint("S-samever", ck)
+    assert store.transcript_unchanged("S-samever", "abc123") is True
+
+
+def test_transcript_unchanged_false_when_format_version_is_stale(
+    tmp_checkpoint_dir, sample_checkpoint
+):
+    # #293: a PROMPT_VERSION bump means identical bytes no longer imply an
+    # identical prompt, so a stale-format checkpoint must not be skipped.
+    ck = {
+        **sample_checkpoint,
+        "session_id": "S-stalever",
+        "transcript_hash": "abc123",
+        "format_version": "D-000",
+    }
+    store.write_checkpoint("S-stalever", ck)
+    assert store.transcript_unchanged("S-stalever", "abc123") is False
+
+
+def test_transcript_unchanged_false_when_checkpoint_is_legacy_no_format_version(
+    tmp_checkpoint_dir,
+):
+    # A pre-#93 checkpoint on disk carries no format_version at all (hand-written
+    # here to bypass write_checkpoint's own setdefault stamping). We can't confirm
+    # it came from the current prompt, so — consistent with this guard's existing
+    # fail-open stance on every other uncertain edge — it does not skip.
+    ck = {"session_id": "S-legacyver", "transcript_hash": "abc123"}
+    (tmp_checkpoint_dir).mkdir(parents=True, exist_ok=True)
+    (tmp_checkpoint_dir / "S-legacyver.json").write_text(json.dumps(ck), encoding="utf-8")
+    assert store.transcript_unchanged("S-legacyver", "abc123") is False
+
+
 # ---- list_buckets: every project bucket, for `daimon projects` (#243) ----
 
 


### PR DESCRIPTION
## Summary

The #185 identical-bytes guard (`store.transcript_unchanged`) skipped a re-serialize whenever transcript bytes matched the stored `transcript_hash`, but never checked the checkpoint's `format_version` against the current `serializer.PROMPT_VERSION`. After a `PROMPT_VERSION` bump, the transcript is unchanged but the checkpoint is stale — exactly the case where re-serializing is correct, and the only case the guard unconditionally blocked. That made the format-drift warning's "re-serialize to refresh" remedy a permanent no-op.

`transcript_unchanged` now returns `True` (skip) only when the bytes match **and** the existing checkpoint's `format_version` equals the current `PROMPT_VERSION`. This preserves the #185 rationale in full — "identical bytes AND identical prompt ⇒ identical output ⇒ skip" — it just finally checks both halves.

Both call sites (`cli.py:223`, `hooks.py:84`) delegate to this one function, so both inherit the fix with no duplicated logic.

## Legacy checkpoint decision

A checkpoint with no `format_version` at all (pre-#93) fails open — it does **not** skip, and proceeds to a normal serialize (which then stamps the current version). This is consistent with the guard's existing fail-open stance on every other uncertain edge (no hash, no checkpoint, malformed stored hash): when we can't confirm the checkpoint came from the current prompt, we don't assume it did.

`serialize --force` is out of scope for this PR, per the issue's own scoping.

## Test plan

- [x] RED: added failing tests for stale-version and legacy-checkpoint cases in `test_store.py`, `test_cli.py`, `test_hooks.py` before touching implementation
- [x] GREEN: implemented the fix; full suite passes (1691 passed, 2 skipped)
- [x] Confirmed all pre-existing #185 guard tests pass unchanged (same-version-implicit checkpoints still skip)
- [x] `ruff check` clean

Closes #293