### PR TITLE
fix(status): give the format-drift warning a direction sense

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -30,7 +30,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from . import anchor, briefing, carry, config, configure, harvest, llm, recall, receipts, render, serializer, store, teamsync, transcript
+from . import anchor, briefing, carry, config, configure, harvest, llm, recall, receipts, render, schema, serializer, store, teamsync, transcript
 from . import __version__
 
 # The serialize.log ledger subsystem lives in ledger.py (#147 + #162, pure
@@ -1048,13 +1048,34 @@ def _status_health(proj, glob, outstanding, siblings, *, now,
     # global fallback): a stored format_version that differs from the current one
     # means the schema changed under it, so the briefing may render partially.
     # Legacy checkpoints (no format_version) are silent — nothing to compare (#93).
+    #
+    # #294: the two directions are different events. Older-than-code is routine
+    # drift (#93) — expected after a version bump, cleared by re-serializing.
+    # Newer-than-code is impossible by construction (PROMPT_VERSION is a source
+    # constant; code that stamps it must contain it) — a second install writing
+    # to the same checkpoint dir, a downgraded install, or a corrupted/forged
+    # stamp (#292), never a schema change. Unparseable versions fail soft into
+    # the older-style wording rather than raising.
     active = proj if proj.get("exists") else glob
     fv = active.get("format_version")
-    if fv and fv != serializer.PROMPT_VERSION:
-        warnings.append(
-            f"checkpoint format {fv} != current {serializer.PROMPT_VERSION} — "
-            f"schema changed; briefing may render partially (re-serialize to refresh)"
-        )
+    # `is not None`, not truthy: an absent key (legacy checkpoint, #93) stays
+    # silent, but an explicitly stamped "" is a garbage value that still
+    # deserves the fail-soft fallback wording below (#294).
+    if fv is not None and fv != serializer.PROMPT_VERSION:
+        order = schema.compare_format_versions(fv, serializer.PROMPT_VERSION)
+        if order is not None and order > 0:
+            warnings.append(
+                f"checkpoint format {fv} claims a version newer than this "
+                f"daimon's {serializer.PROMPT_VERSION} — a checkpoint cannot be "
+                f"newer than the code that wrote it, so the stamp is unreliable "
+                f"(check for a second daimon install writing to this checkpoint "
+                f"dir, or a downgraded install)"
+            )
+        else:
+            warnings.append(
+                f"checkpoint format {fv} != current {serializer.PROMPT_VERSION} — "
+                f"schema changed; briefing may render partially (re-serialize to refresh)"
+            )
 
     if outstanding:
         n = len(outstanding)

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -10,7 +10,7 @@ import os
 import sys
 from contextlib import contextmanager
 
-from . import briefing, config, serializer
+from . import briefing, config, schema, serializer
 
 _TRUTHY = ("1", "true", "yes", "on")
 
@@ -85,10 +85,25 @@ _SECTIONS = [
 
 def _print_version_note(checkpoint) -> None:
     """Note when the checkpoint's format_version differs from the current serialize
-    prompt: the schema changed under it, so sections may render partially. Legacy
-    checkpoints (no format_version) render silently — nothing to compare (#93)."""
+    prompt. Legacy checkpoints (no format_version) render silently — nothing to
+    compare (#93). #294: older-than-code is routine schema drift (#93); newer-
+    than-code is impossible by construction (PROMPT_VERSION is a source constant)
+    and gets distinct wording — see cli._status_health's sibling check for the
+    full reasoning. Unparseable versions fail soft into the older-style wording."""
     fv = (checkpoint or {}).get("format_version")
-    if fv and fv != serializer.PROMPT_VERSION:
+    # `is not None`, not truthy: an absent key (legacy checkpoint, #93) stays
+    # silent, but an explicitly stamped "" is a garbage value that still
+    # deserves the fail-soft fallback wording below (#294).
+    if fv is None or fv == serializer.PROMPT_VERSION:
+        return
+    order = schema.compare_format_versions(fv, serializer.PROMPT_VERSION)
+    if order is not None and order > 0:
+        print(f"⚠ checkpoint format {fv} claims a version newer than this "
+              f"daimon's {serializer.PROMPT_VERSION} — a checkpoint cannot be "
+              f"newer than the code that wrote it, so the stamp is unreliable "
+              f"(check for a second daimon install writing to this checkpoint "
+              f"dir, or a downgraded install).")
+    else:
         print(f"⚠ checkpoint format {fv} != current {serializer.PROMPT_VERSION} — "
               f"schema changed; some sections may render partially.")
 

--- a/plugin/daimon_briefing/schema.py
+++ b/plugin/daimon_briefing/schema.py
@@ -10,9 +10,12 @@ its view from ITEM_FIELDS below; a field added here propagates to all of them
 
 Deliberately import-free: store imports serializer, recall imports store,
 carry imports recall — this module sits below the whole chain so any of them
-can import it without a cycle.
+can import it without a cycle. compare_format_versions lives here for the same
+reason: cli's status check and render's brief note (#294) both need it, and
+neither one imports the other.
 """
 
+import re
 from typing import NamedTuple
 
 
@@ -63,3 +66,18 @@ CARRIED_KINDS: tuple[tuple[str, str, str], ...] = tuple(
 # dedicated rules (contradiction) are absent; lookups .get their own default.
 KIND_TO_TYPE: dict[str, str] = {
     f.kind: f.scoring_type for f in ITEM_FIELDS if f.scoring_type}
+
+_FORMAT_VERSION_RE = re.compile(r"D-(\d+)")
+
+
+def compare_format_versions(a: str, b: str) -> int | None:
+    """Order-compare two PROMPT_VERSION-shaped strings ("D-NNN") by their integer
+    suffix — a plain string compare gets multi-digit versions wrong (#294:
+    "D-9" > "D-10" lexically, backwards). Returns a positive int if `a` is newer
+    than `b`, negative if older, 0 if equal, or None if either side isn't a
+    parseable D-NNN — callers fail soft on None rather than raising."""
+    ma = _FORMAT_VERSION_RE.fullmatch(a) if isinstance(a, str) else None
+    mb = _FORMAT_VERSION_RE.fullmatch(b) if isinstance(b, str) else None
+    if ma is None or mb is None:
+        return None
+    return int(ma.group(1)) - int(mb.group(1))

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1847,6 +1847,51 @@ def test_status_health_version_mismatch_on_global_fallback():
     assert any("format" in w.lower() for w in h["warnings"])
 
 
+def test_status_health_older_checkpoint_suggests_reserialize():
+    # #294: checkpoint OLDER than the running code is routine drift (#93) —
+    # the existing wording, remedy included, still fires.
+    proj = {"exists": True, "session_id": "P", "age_seconds": 100, "age": "1m",
+            "format_version": "D-000"}
+    h = cli._status_health(proj, {"exists": True}, [], [], now=1000.0)
+    assert any("re-serialize" in w.lower() for w in h["warnings"])
+
+
+def test_status_health_newer_checkpoint_flags_impossible_stamp(monkeypatch):
+    # #294: checkpoint NEWER than the running code cannot happen by construction —
+    # PROMPT_VERSION is a source constant. Distinct wording, and NOT "re-serialize".
+    from daimon_briefing import serializer
+    monkeypatch.setattr(serializer, "PROMPT_VERSION", "D-013")
+    proj = {"exists": True, "session_id": "P", "age_seconds": 100, "age": "1m",
+            "format_version": "D-014"}
+    h = cli._status_health(proj, {"exists": True}, [], [], now=1000.0)
+    assert h["ok"] is False
+    assert any("D-014" in w and "D-013" in w for w in h["warnings"])
+    assert not any("re-serialize" in w.lower() for w in h["warnings"])
+
+
+def test_status_health_unparseable_format_version_falls_back():
+    # #294: fail soft — a status check must never raise, and a garbage stamp
+    # falls back to the existing (older-style) wording rather than crashing.
+    for garbage in ("banana", "D-", "", "D-1x"):
+        proj = {"exists": True, "session_id": "P", "age_seconds": 100, "age": "1m",
+                "format_version": garbage}
+        h = cli._status_health(proj, {"exists": True}, [], [], now=1000.0)
+        assert any("re-serialize" in w.lower() for w in h["warnings"]), garbage
+
+
+def test_status_health_version_ordering_uses_integers_not_strings(monkeypatch):
+    # #294: naive string comparison gets "D-10" vs "D-9" backwards ('1' < '9'
+    # lexically). Checkpoint D-10 against current D-9 is numerically NEWER
+    # (impossible) — a string-compare bug would misreport it as older/routine.
+    from daimon_briefing import serializer
+    monkeypatch.setattr(serializer, "PROMPT_VERSION", "D-9")
+    proj = {"exists": True, "session_id": "P", "age_seconds": 100, "age": "1m",
+            "format_version": "D-10"}
+    h = cli._status_health(proj, {"exists": True}, [], [], now=1000.0)
+    assert not any("re-serialize" in w.lower() for w in h["warnings"])
+    assert any("D-10" in w and "D-9" in w for w in h["warnings"])
+
+
 def test_cmd_status_json_has_health_and_siblings(tmp_checkpoint_dir, capsys, monkeypatch):
     from daimon_briefing import store
     # a project checkpoint + a newer sibling bucket

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -145,6 +145,46 @@ def test_render_brief_no_note_for_legacy_checkpoint(sample_checkpoint, capsys):
     assert "format" not in out.lower()
 
 
+def test_render_brief_older_checkpoint_suggests_reserialize(sample_checkpoint, capsys):
+    # #294: checkpoint OLDER than the running code is routine drift (#93) —
+    # existing wording (still framed as a schema change), unchanged.
+    render.render_brief({**sample_checkpoint, "format_version": "D-000"})
+    out = capsys.readouterr().out
+    assert "schema changed" in out.lower()
+
+
+def test_render_brief_newer_checkpoint_flags_impossible_stamp(
+        sample_checkpoint, capsys, monkeypatch):
+    # #294: checkpoint NEWER than the running code cannot happen by construction.
+    # Distinct wording — must NOT reuse "schema changed" or suggest re-serialize.
+    from daimon_briefing import serializer
+    monkeypatch.setattr(serializer, "PROMPT_VERSION", "D-013")
+    render.render_brief({**sample_checkpoint, "format_version": "D-014"})
+    out = capsys.readouterr().out
+    assert "D-014" in out and "D-013" in out
+    assert "schema changed" not in out.lower()
+    assert "re-serialize" not in out.lower()
+
+
+def test_render_brief_unparseable_format_version_falls_back(sample_checkpoint, capsys):
+    # #294: fail soft — never raise, fall back to the existing wording.
+    render.render_brief({**sample_checkpoint, "format_version": "banana"})
+    out = capsys.readouterr().out
+    assert "schema changed" in out.lower()
+
+
+def test_render_brief_version_ordering_uses_integers_not_strings(
+        sample_checkpoint, capsys, monkeypatch):
+    # #294: naive string comparison gets "D-10" vs "D-9" backwards. Checkpoint
+    # D-10 against current D-9 is numerically NEWER (impossible).
+    from daimon_briefing import serializer
+    monkeypatch.setattr(serializer, "PROMPT_VERSION", "D-9")
+    render.render_brief({**sample_checkpoint, "format_version": "D-10"})
+    out = capsys.readouterr().out
+    assert "schema changed" not in out.lower()
+    assert "D-10" in out and "D-9" in out
+
+
 def _status_data():
     return {
         "project": "/p/A",


### PR DESCRIPTION
## What

The format-drift check compared `format_version` for inequality only, so two very different events rendered the identical sentence:

- checkpoint **older** than the running code — routine drift after a version bump (#93). Expected, clears on re-serialize.
- checkpoint **newer** than the running code — impossible by construction, since `PROMPT_VERSION` is a source constant: code that stamps `D-014` must contain `D-014`. This means the stamp is unreliable (a second daimon install writing to the same checkpoint dir, a downgraded install, or a corrupted/forged stamp per #292) — not a schema change, and re-serializing does not fix it.

Both the `daimon status` health check (`cli.py`) and the brief's version note (`render.py`) now order-compare by the `D-NNN` integer suffix and use distinct wording for the impossible direction, dropping the "re-serialize to refresh" remedy since it doesn't apply.

## Where the comparator lives

`schema.compare_format_versions()` in `daimon_briefing/schema.py`. That module is explicitly documented as import-free (no project-module imports, only stdlib), sitting below the whole `store -> serializer -> recall -> carry` chain specifically so any of them can depend on it without a cycle. `cli.py` and `render.py` don't import each other, so putting the shared comparator in `serializer.py` (which owns `PROMPT_VERSION` but pulls in `config`/`configure`/`llm`/`redact`) or duplicating the parsing logic in both call sites were the alternatives; `schema.py` avoids both and matches its existing role as the schema-level source of truth.

## Behavior

- checkpoint older than current → existing wording, unchanged
- checkpoint newer than current → new wording naming the impossible direction, no "re-serialize" suggestion
- equal → silent (unchanged)
- missing `format_version` (legacy checkpoint) → silent (unchanged)
- unparseable `format_version` on either side (garbage string, empty string, non-`D-NNN` shape) → fails soft into the existing wording rather than raising
- comparison is by integer suffix, not string order, so multi-digit versions (`D-9` vs `D-10`) compare correctly

## Test plan

- [x] Added failing tests first (both `cli._status_health` and `render._print_version_note` sites) covering: older, newer, equal, legacy/missing, unparseable garbage, and multi-digit ordering
- [x] Confirmed RED: tests failed against the old inequality-only logic
- [x] Implemented `schema.compare_format_versions` + updated both call sites; tests now GREEN
- [x] Full suite: `cd plugin && uv run pytest` — 1694 passed, 2 skipped
- [x] `ruff check` clean

Closes #294