### PR TITLE
fix(hooks): skip sweep_orphans candidates the ledger already shows failed

### DIFF
--- a/hook/_daimon_hook_lib.py
+++ b/hook/_daimon_hook_lib.py
@@ -236,6 +236,44 @@ def spawn_team_sync(cli, cwd) -> None:
 
 _ORPHAN_MAX_AGE_SECONDS = 14 * 24 * 3600  # 14 days — bounds the sweep's directory scan
 
+# Duplicated from daimon_briefing.ledger's _RESULT_ERR_RE / _HEAL_TRANSCRIPT_RE /
+# _LEDGER_OK_RE (this module is stdlib-only and cannot import the package — see
+# module docstring). Keep in sync with ledger.py if those line shapes change.
+_LOG_RESULT_OK_RE = re.compile(r"^wrote checkpoint: (.+?) \(took \d+s\)")
+_LOG_RESULT_ERR_RE = re.compile(r"^error: .*?(?: after (\d+)s)?$")
+_LOG_ERR_TRANSCRIPT_RE = re.compile(r"\(transcript: (.+?)\)(?: after \d+s|$)")
+
+
+def _failed_session_stems() -> set:
+    """Transcript stems (session ids) whose LATEST serialize.log outcome is a
+    recorded failure — a lightweight, read-only echo of
+    daimon_briefing.ledger._session_ledger's error/success fold, scoped to just
+    what sweep_orphans needs (#299): a transcript that was ATTEMPTED and FAILED
+    belongs to `heal` (already capped at one retry, #15/#26), not to this sweep,
+    which owns only the never-attempted case (#185/#188). A later success for
+    the same stem clears the failure, matching the ledger's own fold.
+
+    Fails open to an empty set on any read/parse error, so a broken or missing
+    ledger never blocks the genuine #185/#188 recovery sweep — it just leaves
+    the sweep unable to tell 'failed' from 'never attempted', which is exactly
+    today's behavior without this check."""
+    try:
+        text = (LOG_DIR / "serialize.log").read_text(encoding="utf-8")
+        state = {}
+        for line in text.splitlines()[-200:]:  # tail is plenty; matches ledger.py
+            line = line.strip()
+            m = _LOG_RESULT_OK_RE.match(line)
+            if m:
+                state[Path(m.group(1)).stem] = "success"
+                continue
+            if _LOG_RESULT_ERR_RE.match(line):
+                tm = _LOG_ERR_TRANSCRIPT_RE.search(line)
+                if tm:
+                    state[Path(tm.group(1)).stem] = "error"
+        return {stem for stem, outcome in state.items() if outcome == "error"}
+    except Exception:  # noqa: BLE001 — fail-open, see docstring
+        return set()
+
 
 def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
     """Catch-up sweep for a transcript that was never captured because the
@@ -259,8 +297,12 @@ def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
     siblings are every other session ever run against this project) for the
     most recently modified transcript that looks uncaptured: no checkpoint on
     disk for it at all, or a checkpoint OLDER than the transcript (written
-    before the session actually ended). Spawns AT MOST ONE detached serialize
-    per session start — the newest candidate — the exact same way
+    before the session actually ended) — EXCLUDING any candidate the ledger
+    already shows as attempted-and-failed (#299, via _failed_session_stems):
+    that transcript is heal's territory now (capped at one retry, #15/#26),
+    not an un-attempted orphan, so the sweep must not re-spawn it every
+    session start for up to 14 days. Spawns AT MOST ONE detached serialize per
+    session start — the newest remaining candidate — the exact same way
     `daimon-session-end.py` does.
 
     Idempotent by construction, so the mtime heuristic alone is enough: the
@@ -277,6 +319,7 @@ def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
             return
         cutoff = time.time() - _ORPHAN_MAX_AGE_SECONDS
         ckpt_dir = checkpoint_dir()
+        failed_stems = _failed_session_stems()
         best_path = None
         best_mtime = None
         for candidate in directory.glob("*.jsonl"):
@@ -288,6 +331,8 @@ def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
                 continue
             if mtime < cutoff:
                 continue  # outside the bounded scan window
+            if candidate.stem in failed_stems:
+                continue  # attempted and failed -> heal's job, not an orphan (#299)
             ckpt_path = ckpt_dir / f"{candidate.stem}.json"
             try:
                 if ckpt_path.stat().st_mtime >= mtime:

--- a/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
+++ b/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
@@ -236,6 +236,44 @@ def spawn_team_sync(cli, cwd) -> None:
 
 _ORPHAN_MAX_AGE_SECONDS = 14 * 24 * 3600  # 14 days — bounds the sweep's directory scan
 
+# Duplicated from daimon_briefing.ledger's _RESULT_ERR_RE / _HEAL_TRANSCRIPT_RE /
+# _LEDGER_OK_RE (this module is stdlib-only and cannot import the package — see
+# module docstring). Keep in sync with ledger.py if those line shapes change.
+_LOG_RESULT_OK_RE = re.compile(r"^wrote checkpoint: (.+?) \(took \d+s\)")
+_LOG_RESULT_ERR_RE = re.compile(r"^error: .*?(?: after (\d+)s)?$")
+_LOG_ERR_TRANSCRIPT_RE = re.compile(r"\(transcript: (.+?)\)(?: after \d+s|$)")
+
+
+def _failed_session_stems() -> set:
+    """Transcript stems (session ids) whose LATEST serialize.log outcome is a
+    recorded failure — a lightweight, read-only echo of
+    daimon_briefing.ledger._session_ledger's error/success fold, scoped to just
+    what sweep_orphans needs (#299): a transcript that was ATTEMPTED and FAILED
+    belongs to `heal` (already capped at one retry, #15/#26), not to this sweep,
+    which owns only the never-attempted case (#185/#188). A later success for
+    the same stem clears the failure, matching the ledger's own fold.
+
+    Fails open to an empty set on any read/parse error, so a broken or missing
+    ledger never blocks the genuine #185/#188 recovery sweep — it just leaves
+    the sweep unable to tell 'failed' from 'never attempted', which is exactly
+    today's behavior without this check."""
+    try:
+        text = (LOG_DIR / "serialize.log").read_text(encoding="utf-8")
+        state = {}
+        for line in text.splitlines()[-200:]:  # tail is plenty; matches ledger.py
+            line = line.strip()
+            m = _LOG_RESULT_OK_RE.match(line)
+            if m:
+                state[Path(m.group(1)).stem] = "success"
+                continue
+            if _LOG_RESULT_ERR_RE.match(line):
+                tm = _LOG_ERR_TRANSCRIPT_RE.search(line)
+                if tm:
+                    state[Path(tm.group(1)).stem] = "error"
+        return {stem for stem, outcome in state.items() if outcome == "error"}
+    except Exception:  # noqa: BLE001 — fail-open, see docstring
+        return set()
+
 
 def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
     """Catch-up sweep for a transcript that was never captured because the
@@ -259,8 +297,12 @@ def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
     siblings are every other session ever run against this project) for the
     most recently modified transcript that looks uncaptured: no checkpoint on
     disk for it at all, or a checkpoint OLDER than the transcript (written
-    before the session actually ended). Spawns AT MOST ONE detached serialize
-    per session start — the newest candidate — the exact same way
+    before the session actually ended) — EXCLUDING any candidate the ledger
+    already shows as attempted-and-failed (#299, via _failed_session_stems):
+    that transcript is heal's territory now (capped at one retry, #15/#26),
+    not an un-attempted orphan, so the sweep must not re-spawn it every
+    session start for up to 14 days. Spawns AT MOST ONE detached serialize per
+    session start — the newest remaining candidate — the exact same way
     `daimon-session-end.py` does.
 
     Idempotent by construction, so the mtime heuristic alone is enough: the
@@ -277,6 +319,7 @@ def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
             return
         cutoff = time.time() - _ORPHAN_MAX_AGE_SECONDS
         ckpt_dir = checkpoint_dir()
+        failed_stems = _failed_session_stems()
         best_path = None
         best_mtime = None
         for candidate in directory.glob("*.jsonl"):
@@ -288,6 +331,8 @@ def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
                 continue
             if mtime < cutoff:
                 continue  # outside the bounded scan window
+            if candidate.stem in failed_stems:
+                continue  # attempted and failed -> heal's job, not an orphan (#299)
             ckpt_path = ckpt_dir / f"{candidate.stem}.json"
             try:
                 if ckpt_path.stat().st_mtime >= mtime:

--- a/plugin/tests/test_claude_hooks.py
+++ b/plugin/tests/test_claude_hooks.py
@@ -527,6 +527,87 @@ def test_sweep_orphans_ignores_transcripts_older_than_14_days(tmp_path, monkeypa
     assert calls == []
 
 
+def test_sweep_orphans_skips_transcript_with_recorded_failure(tmp_path, monkeypatch):
+    # #299: a transcript that already FAILED to serialize is heal's job (capped
+    # at one retry, #15/#26), not an un-attempted orphan — the sweep must not
+    # re-spawn it just because no checkpoint landed.
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
+    log_dir = tmp_path / "logs"
+    monkeypatch.setattr(lib, "LOG_DIR", log_dir)
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+    failed = transcripts / "S-failed.jsonl"
+    failed.write_text("{}\n")
+    _age(failed, 3600)  # no checkpoint -> would look like an orphan candidate
+
+    log_dir.mkdir(parents=True)
+    (log_dir / "serialize.log").write_text(
+        "2026-07-09T18:00:00Z session-start: spawned serialize for S-failed "
+        f"(reason: catch-up-orphan, project: /p/A) (transcript: {failed})\n"
+        f"error: boom (transcript: {failed}) after 12s\n",
+        encoding="utf-8",
+    )
+
+    calls = []
+    monkeypatch.setattr(lib, "spawn_serialize", lambda cli, path, env: calls.append(path))
+    lib.sweep_orphans("daimon", "/p/A", "S-new", str(current))
+    assert calls == []
+
+
+def test_sweep_orphans_still_sweeps_transcript_absent_from_ledger(tmp_path, monkeypatch):
+    # #185/#188 recovery must survive the #299 fix: a transcript with NO ledger
+    # entry at all (genuinely never attempted) is still swept, even when the
+    # log has unrelated entries for other sessions.
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
+    log_dir = tmp_path / "logs"
+    monkeypatch.setattr(lib, "LOG_DIR", log_dir)
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+    orphan = transcripts / "S-orphan.jsonl"
+    orphan.write_text("{}\n")
+    _age(orphan, 3600)
+
+    log_dir.mkdir(parents=True)
+    (log_dir / "serialize.log").write_text(
+        "2026-07-01T00:00:00Z session-end: spawned serialize for S-unrelated "
+        "(reason: exit, project: /p/B) (transcript: /tmp/S-unrelated.jsonl)\n"
+        "wrote checkpoint: /home/u/.daimon/checkpoints/S-unrelated.json (took 5s)\n",
+        encoding="utf-8",
+    )
+
+    calls = []
+    monkeypatch.setattr(lib, "spawn_serialize", lambda cli, path, env: calls.append(path))
+    lib.sweep_orphans("daimon", "/p/A", "S-new", str(current))
+    assert calls == [str(orphan)]
+
+
+def test_sweep_orphans_still_sweeps_when_ledger_read_raises(tmp_path, monkeypatch):
+    # Fail-open contract: a broken ledger (unreadable serialize.log) must not
+    # disable the genuine #185/#188 recovery path.
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
+    log_dir = tmp_path / "logs"
+    monkeypatch.setattr(lib, "LOG_DIR", log_dir)
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+    orphan = transcripts / "S-orphan.jsonl"
+    orphan.write_text("{}\n")
+    _age(orphan, 3600)
+
+    log_dir.mkdir(parents=True)
+    (log_dir / "serialize.log").mkdir()  # a directory where a file is expected -> read raises
+
+    calls = []
+    monkeypatch.setattr(lib, "spawn_serialize", lambda cli, path, env: calls.append(path))
+    lib.sweep_orphans("daimon", "/p/A", "S-new", str(current))  # must not raise
+    assert calls == [str(orphan)]
+
+
 def test_sweep_orphans_logs_breadcrumb_on_spawn(tmp_path, monkeypatch):
     monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
     # _daimon_hook_lib.LOG_DIR is a module-level constant (Path.home()-derived,

--- a/plugin/tests/test_claude_hooks.py
+++ b/plugin/tests/test_claude_hooks.py
@@ -16,6 +16,7 @@ import time
 from pathlib import Path
 
 from daimon_briefing import store
+from tests.conftest import FIXTURES
 
 HOOK_DIR = Path(__file__).parents[2] / "hook"
 BRIEF_HOOK = HOOK_DIR / "daimon-session-brief.py"
@@ -606,6 +607,52 @@ def test_sweep_orphans_still_sweeps_when_ledger_read_raises(tmp_path, monkeypatc
     monkeypatch.setattr(lib, "spawn_serialize", lambda cli, path, env: calls.append(path))
     lib.sweep_orphans("daimon", "/p/A", "S-new", str(current))  # must not raise
     assert calls == [str(orphan)]
+
+
+def test_hook_lib_failure_regexes_stay_in_sync_with_ledger():
+    # #299: _daimon_hook_lib._failed_session_stems() duplicates three of
+    # ledger.py's line-shape regexes (this module is stdlib-only and cannot
+    # import the package). scripts/sync_hooks.py --check only enforces
+    # byte-identity between the TWO HOOK-LIB COPIES; nothing enforces this
+    # module against its ledger.py source. If ledger's shapes drift silently,
+    # _failed_session_stems() returns an empty set, sweep_orphans reverts to
+    # the exact unbounded retry #299 exists to fix, and no test fails — the
+    # fail-open design makes a drifted regex indistinguishable from a clean
+    # ledger. Lock the three duplicated patterns to their source of truth.
+    from daimon_briefing import ledger
+
+    assert lib._LOG_RESULT_ERR_RE.pattern == ledger._RESULT_ERR_RE.pattern
+    assert lib._LOG_RESULT_OK_RE.pattern == ledger._LEDGER_OK_RE.pattern
+    assert lib._LOG_ERR_TRANSCRIPT_RE.pattern == ledger._HEAL_TRANSCRIPT_RE.pattern
+
+
+def test_failed_session_stems_matches_real_serialize_failure_output(
+    tmp_path, monkeypatch, tmp_checkpoint_dir, fake_chat_factory
+):
+    # Belt to the pattern-lock test's suspenders: drive the ACTUAL cli.py
+    # writer path (not hand-built log strings) so this also catches a
+    # writer-format change that doesn't touch ledger's regexes directly.
+    # A genuinely failed `daimon serialize` must land the same session id in
+    # lib._failed_session_stems() as ledger._session_ledger() classifies as
+    # "error" — the two consumers of serialize.log must agree.
+    from daimon_briefing import cli, ledger
+
+    log_dir = tmp_path / ".daimon" / "logs"
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(log_dir))
+    monkeypatch.setattr(lib, "LOG_DIR", log_dir)  # hook lib's LOG_DIR has no env seam
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    monkeypatch.setattr(cli, "_chat", fake_chat_factory("prose, definitely not JSON"))
+
+    transcript = FIXTURES / "sample_transcript.md"
+    rc = cli.main(["serialize", str(transcript)])
+    assert rc != 0
+
+    stems = lib._failed_session_stems()
+    assert transcript.stem in stems
+
+    log_text = (log_dir / "serialize.log").read_text(encoding="utf-8")
+    led = ledger._session_ledger(log_text, time.time())
+    assert led[transcript.stem]["result_kind"] == "error"
 
 
 def test_sweep_orphans_logs_breadcrumb_on_spawn(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #299

## Summary

- `sweep_orphans` treated a repeatedly-**failed** serialize identically to a **never-attempted** one, since a failed serialize writes no checkpoint — so it was re-spawned at full LLM cost on every SessionStart for up to 14 days (the only existing bound).
- Adds a lightweight, read-only fold over `serialize.log` (a scoped echo of `daimon_briefing.ledger`'s error/success classification, duplicated here because `_daimon_hook_lib.py` is stdlib-only and cannot import the package) and excludes any candidate whose latest recorded outcome is an error.
- That case now belongs to `heal`, which already caps retries at one (#15/#26) — the sweep and heal no longer overlap on "attempted and failed." The genuine #185/#188 recovery case (no ledger entry at all) is untouched, and a broken/unreadable ledger fails open to "no recorded failures" so it can never disable orphan recovery.

## Changes

| File | Change |
|------|--------|
| `hook/_daimon_hook_lib.py` | Add `_failed_session_stems()` (fail-open ledger echo) and skip candidates in that set inside `sweep_orphans` |
| `plugin/daimon_briefing/_hooks/_daimon_hook_lib.py` | Synced mirror copy (`scripts/sync_hooks.py`) |
| `plugin/tests/test_claude_hooks.py` | 3 new tests: recorded failure is skipped, never-attempted transcript is still swept, ledger read raising doesn't block the sweep |

## Test Plan

- [x] RED: new test `test_sweep_orphans_skips_transcript_with_recorded_failure` failed before the fix (transcript re-swept despite a recorded error)
- [x] GREEN: all `sweep_orphans` tests pass (14/14), including the two new regression guards (recovery preserved, ledger-read fail-open)
- [x] Full suite: `cd plugin && uv run pytest` — 1717 passed, 2 skipped
- [x] `uv run python scripts/sync_hooks.py --check` — hook copies in sync
- [x] `ruff check` — passed (also runs via pre-commit)

## Contributor Checklist

- [x] Linked an approved issue (#299, `status:approved`)
- [x] Exactly one `type:*` label to be added (`type:fix`)
- [x] No shell scripts modified — shellcheck N/A
- [x] Conventional commit format
- [x] No `Co-Authored-By` / AI-attribution trailers