### PR TITLE
fix(llm): enforce the total deadline mid-response, not just between calls

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -247,8 +247,13 @@ def _run_serialize(transcript_path: Path, project: str | None) -> int:
     # in production and was invisible before this.
     llm.reset_fallback()  # #28: detect a silent backend downgrade during THIS run
     start = time.monotonic()
+    # Same total budget as the hook path (hooks.py:73) — this entry point had
+    # none at all, so a manual `daimon serialize` had no bound even in
+    # principle while the SessionEnd hook did (#298).
+    deadline = start + config.timeout_seconds()
     try:
-        checkpoint = serializer.serialize_strict(session_id, messages, chat=_chat)
+        checkpoint = serializer.serialize_strict(
+            session_id, messages, chat=_chat, deadline=deadline)
     except serializer.TooShortError as exc:
         msg = f"skipped serialize for {session_id}: {exc}"
         print(msg)

--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -43,6 +43,31 @@ class EmptyOutputError(ChatError):
     failure (#225)."""
 
 
+# Read granularity for _read_within_deadline (#298): urlopen's `timeout=`
+# bounds a single blocking socket read, not the call as a whole — a response
+# that keeps delivering bytes never trips it, so a single r.read() can run
+# past `deadline` while every individual read stays under attempt_timeout.
+# read1() returns after at most one such read, so checking `deadline` between
+# calls bounds total elapsed to roughly deadline + one attempt_timeout instead
+# of leaving it unbounded.
+_READ_CHUNK_BYTES = 65536
+
+
+def _read_within_deadline(r, deadline, attempt, last):
+    """Read `r` (an HTTPResponse) to EOF via read1(), checking `deadline`
+    between reads so a slow-but-live response can't run past the total
+    budget the way one blocking r.read() does (#298)."""
+    chunks = []
+    while True:
+        if deadline is not None and time.monotonic() >= deadline:
+            raise ChatError(f"LLM deadline exhausted after {attempt} tries: {last}")
+        chunk = r.read1(_READ_CHUNK_BYTES)
+        if not chunk:
+            break
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
 def _chat_litellm(messages, model=None, temperature=None, timeout=None, retries=3, deadline=None):
     """POST /v1/chat/completions. Returns the assistant message content (str).
 
@@ -53,9 +78,12 @@ def _chat_litellm(messages, model=None, temperature=None, timeout=None, retries=
     `temperature=None` (the default) resolves config.llm_temperature()
     (DAIMON_LLM_TEMPERATURE, default 0.0). An explicit argument always wins.
 
-    `deadline` (time.monotonic() seconds) is a TOTAL budget across all attempts:
-    each attempt's socket timeout is capped to the remaining time, and retrying
-    stops once the deadline would be exceeded.
+    `deadline` (time.monotonic() seconds) is a TOTAL budget across all attempts
+    AND within a single in-flight call: each attempt's socket timeout is capped
+    to the remaining time, retrying stops once the deadline would be exceeded,
+    and the response body is read in a loop that re-checks the deadline
+    between reads — a single call that keeps delivering bytes cannot outrun
+    the budget the way one blocking read() could (#298).
 
     Error messages NEVER include the HTTP response body — error payloads can echo
     request contents/secrets, and hooks log these messages.
@@ -95,7 +123,7 @@ def _chat_litellm(messages, model=None, temperature=None, timeout=None, retries=
         )
         try:
             with urllib.request.urlopen(req, timeout=attempt_timeout) as r:
-                data = json.loads(r.read())
+                data = json.loads(_read_within_deadline(r, deadline, attempt, last))
             # Surface token cost — the serializer discards the rest of the
             # response, so this log line is the only record of per-call spend.
             usage = data.get("usage") or {}

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -1,7 +1,9 @@
+import http.server
 import io
 import json
 import logging
 import os
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -161,6 +163,108 @@ def test_chat_attempt_timeout_capped_by_deadline(llm_env, monkeypatch):
             deadline=time.monotonic() + 5,
         )
     assert seen["timeout"] <= 5
+
+
+# ---- #298: urlopen's `timeout=` bounds a single blocking socket op, not the
+# call as a whole — a response that keeps delivering bytes never trips it, so
+# a single call can run past `deadline` while returning "success". These three
+# tests use a REAL socket (no mocked urlopen): the bug lives in the socket
+# layer, so a fake chat callable can't exercise it.
+
+
+class _TrickleHandler(http.server.BaseHTTPRequestHandler):
+    """Drips a chunked HTTP/1.1 body a few bytes at a time, each gap well
+    under the per-call socket timeout the test passes — proving any total
+    bound comes from `deadline`, not from urlopen's own `timeout=`."""
+
+    protocol_version = "HTTP/1.1"
+    body = b""
+    chunk_size = 1
+    gap = 0.05
+
+    def do_POST(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+        for i in range(0, len(self.body), self.chunk_size):
+            piece = self.body[i:i + self.chunk_size]
+            time.sleep(self.gap)
+            self.wfile.write(f"{len(piece):x}\r\n".encode() + piece + b"\r\n")
+            self.wfile.flush()
+        self.wfile.write(b"0\r\n\r\n")
+        self.wfile.flush()
+
+    def log_message(self, *a):
+        pass
+
+
+def _start_trickle_server(body: bytes, chunk_size: int = 1, gap: float = 0.05):
+    handler = type("_Handler", (_TrickleHandler,), {
+        "body": body, "chunk_size": chunk_size, "gap": gap,
+    })
+    srv = http.server.HTTPServer(("127.0.0.1", 0), handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv
+
+
+def test_chat_mid_response_deadline_raises_before_trickle_completes(llm_env, monkeypatch):
+    # 30 chunks x 0.05s gap = ~1.5s to fully drain, each gap far under the 5s
+    # socket timeout below, so urlopen's own timeout never fires. A 0.15s
+    # deadline must still cut this off well short of the full trickle.
+    srv = _start_trickle_server(b"x" * 30, chunk_size=1, gap=0.05)
+    try:
+        monkeypatch.setenv(
+            "DAIMON_LLM_BASE_URL", f"http://127.0.0.1:{srv.server_address[1]}")
+        start = time.monotonic()
+        with pytest.raises(llm.ChatError) as exc:
+            llm.chat(
+                [{"role": "user", "content": "hi"}],
+                timeout=5,
+                retries=1,
+                deadline=time.monotonic() + 0.15,
+            )
+        elapsed = time.monotonic() - start
+        assert "deadline" in str(exc.value).lower()
+        assert elapsed < 1.0, (
+            f"took {elapsed:.2f}s — deadline did not bound an in-flight response")
+    finally:
+        srv.shutdown()
+
+
+def test_chat_response_completing_inside_deadline_still_succeeds(llm_env, monkeypatch):
+    # Same trickling transport, but the deadline comfortably outlives it —
+    # the chunked read must still reassemble the body correctly and return
+    # the parsed content, unchanged from a single-shot read.
+    payload = json.dumps(
+        {"choices": [{"message": {"content": "trickled-ok"}}]}).encode()
+    srv = _start_trickle_server(payload, chunk_size=4, gap=0.02)
+    try:
+        monkeypatch.setenv(
+            "DAIMON_LLM_BASE_URL", f"http://127.0.0.1:{srv.server_address[1]}")
+        result = llm.chat(
+            [{"role": "user", "content": "hi"}],
+            timeout=5,
+            deadline=time.monotonic() + 5,
+        )
+        assert result == "trickled-ok"
+    finally:
+        srv.shutdown()
+
+
+def test_chat_no_deadline_reads_slow_response_to_completion(llm_env, monkeypatch):
+    # deadline=None must keep meaning "no total budget" — a slow-but-finite
+    # response is still read fully and returned, never cut short mid-flight.
+    payload = json.dumps(
+        {"choices": [{"message": {"content": "no-deadline-ok"}}]}).encode()
+    srv = _start_trickle_server(payload, chunk_size=4, gap=0.02)
+    try:
+        monkeypatch.setenv(
+            "DAIMON_LLM_BASE_URL", f"http://127.0.0.1:{srv.server_address[1]}")
+        result = llm.chat([{"role": "user", "content": "hi"}], timeout=5)
+        assert result == "no-deadline-ok"
+    finally:
+        srv.shutdown()
 
 
 def test_chat_5xx_retries_log_warnings_without_body(llm_env, monkeypatch, caplog):


### PR DESCRIPTION
## Summary

`urlopen`'s `timeout=` bounds a single blocking socket read, not the whole call. A response that keeps delivering bytes never trips it, so a single LLM call could run arbitrarily long past the computed `deadline` and still be reported as success — observed in the field at 768s / 1217s / 1243s / 1732s against a 420s budget (up to 4.1x over).

The deadline was correctly computed and threaded through every layer, but only ever checked *between* calls/retries — never *during* one. Once a call was in flight, nothing bounded it.

## Fix

Read the response body in a loop via `read1()` (which returns after at most one underlying blocking read) instead of a single blocking `r.read()`, and check `deadline` between reads. When the deadline passes mid-response, raise the existing `ChatError` with wording consistent with the pre-call check ("LLM deadline exhausted..."). This bounds total elapsed to roughly `deadline + one socket timeout` instead of leaving a single call unbounded.

No new dependency: this stays inside urllib/http.client (stdlib), matching daimon's zero-runtime-dependency stance for `llm.py`.

Preserved unchanged:
- `deadline=None` still means no total budget at all.
- The existing pre-call check (`remaining <= 0` before an attempt) still fires first.
- Retry/backoff behavior and timing are unchanged for every case except the one that was broken (mid-flight exhaustion).

## cli.py:251 decision

`daimon serialize` (the manual CLI path) called `serialize_strict(...)` with no `deadline` at all, so it had no total budget even in principle, while the SessionEnd hook (`hooks.py:73`) always computed one. I made the CLI path compute and pass the same `start + config.timeout_seconds()` deadline the hook uses, so both entry points now agree on the contract. This is in scope: the issue explicitly asked for this decision to be made and justified, not deferred.

## Testing

Per-issue requirement: a mocked/fake chat callable cannot exercise this bug, since it lives in the socket layer, not the serializer layer. The new tests spin up a real local HTTP server that trickles a chunked response a few bytes at a time (each gap well under the per-call socket timeout), proving:

- a slow trickling response that exceeds the deadline raises `ChatError` well before the full body arrives (the core regression test — fails against the pre-fix code because no exception was ever raised, only a downstream JSON-parse error from swallowing garbage);
- a response that completes inside the deadline still succeeds, byte-for-byte, through the same chunked read path;
- `deadline=None` still reads a slow-but-finite response to completion (no accidental new bound).

Existing coverage for the pre-call deadline check and retry/backoff-under-deadline behavior is untouched and still passes.

`cd plugin && uv run pytest` — 1714 passed, 2 skipped (baseline was 1711 passed, 2 skipped; the 3 new tests account for the delta).

Closes #298