### PR TITLE
feat(cli): add resolve --dry-run — look before the write

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -772,7 +772,15 @@ def _cmd_resolve(args) -> int:
     """Append a resolution event for ONE checkpoint item (#102). Exact id
     first; else a fuzzy query that must match uniquely — an ambiguous bind
     is refused with candidates listed, because a wrong bind silently
-    suppresses a live memory (the false-merge lesson, #13)."""
+    suppresses a live memory (the false-merge lesson, #13).
+
+    `--dry-run` runs this SAME bind and stops right before the event write
+    (#304) — the matcher a preview would use is otherwise inherently
+    different from the one doing the write (recall: FTS5 over history
+    across checkpoints; resolve: carry._same_item over this checkpoint
+    only), and a preview that disagrees with the writer is worse than none.
+    Ambiguous/no-match refusals return before this point either way, so
+    their output is identical with or without the flag."""
     project = _resolve_project(args.project)
     checkpoint = store.read_latest(project_dir=project, fallback=False)
     if not isinstance(checkpoint, dict):
@@ -804,6 +812,15 @@ def _cmd_resolve(args) -> int:
                 print(f"  {it['id']}  [{key}] {it.get('text', '')}")
             print("resolve by exact id: daimon resolve <id>")
             return 1
+    if getattr(args, "dry_run", False):
+        # A distinct tag, not "resolve": nothing was written, so folding this
+        # into the success counter would inflate it with attempts that never
+        # touched the ledger — corrupting the exact refusal-rate signal #303
+        # exists to expose. Not silent either: the tag still shows up in
+        # `daimon stats` usage counts, just apart from resolve/resolve:*.
+        _note_usage("resolve:dry-run")
+        print(f"would resolve {target['id']}: {target.get('text', '')} [{args.status}]")
+        return 0
     ok = store.append_event(target["id"], args.status, note=args.note or "",
                             project_dir=project, item_text=str(target.get("text") or ""))
     if not ok:
@@ -2285,6 +2302,9 @@ def main(argv=None) -> int:
                                 "a status starting with 'reopen' revives the item)")
     p_resolve.add_argument("--note", help="optional context recorded on the event")
     p_resolve.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    p_resolve.add_argument(
+        "--dry-run", action="store_true",
+        help="show what would resolve without writing an event — look before the write (#304)")
     p_resolve.set_defaults(func=_cmd_resolve)
 
     p_reverify = sub.add_parser(

--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -79,17 +79,23 @@ briefing items — verify `[~ inferred]` hits before relying on them. Add
 ## Closing loops
 
 When work in this session resolves an item the briefing listed — an open
-question answered, a decision superseded, a task shipped — record it:
+question answered, a decision superseded, a task shipped — preview the
+match before writing, then commit it:
 
 ```
+daimon resolve "<distinctive text from the item>" --dry-run
 daimon resolve "<distinctive text from the item>" --note "<what closed it>"
 ```
 
 An ambiguous match is refused with the candidates listed; nothing is
-guessed. Future briefings then withhold the item instead of carrying it
-stale. When a briefing line itself offers confirm/reject commands (a
-supersession candidate), answer with exactly those commands once you have
-verified which side is true.
+guessed — but a confident match on the WRONG item is not caught by that
+guard, because it never fires. `--dry-run` runs the same match and prints
+what it would resolve without writing anything, so you can confirm it
+names the right item before re-running without the flag to commit. Future
+briefings then withhold the item instead of carrying it stale. When a
+briefing line itself offers confirm/reject commands (a supersession
+candidate), answer with exactly those commands once you have verified
+which side is true.
 
 ## Context switching (other projects)
 
@@ -127,12 +133,12 @@ Report what the command shows; do not guess at capture state.
 _COMPACT_BODY = """\
 ## Daimon memory protocol
 
-Daimon keeps cross-session memory on this machine (all local, never
-transmitted). At session start you MUST run `daimon brief --team` in the
-terminal before other work, unless a daimon briefing is already in context
-(`--team` adds teammates' briefings when a team is configured; harmless
-otherwise). If the command is missing or reports no checkpoint, proceed
-silently — do not mention daimon.
+Daimon keeps cross-session memory on this machine (local only, never
+transmitted). At session start you MUST run `daimon brief --team` before
+other work, unless a daimon briefing is already in context (`--team` adds
+teammates' briefings when a team is configured; harmless otherwise). If
+the command is missing or reports no checkpoint, proceed silently — do
+not mention daimon.
 
 When a briefing is in context:
 - `[✓ verbatim]` items are exact quotes from a past session — repeat exactly,
@@ -142,23 +148,24 @@ When a briefing is in context:
   `[carried]` suffix = carried from an older session, may be stale — verify
   before trusting.
 - A "carried item(s) unverified for >N days" warning means that item has
-  ridden along unchecked across sessions — restating it is not
-  corroboration; world-check it before repeating as true.
+  ridden along unchecked — restating it is not corroboration; world-check
+  it before repeating as true.
 - "VERIFY BEFORE TRUSTING" items may be stale — check files/git/issues
   before repeating them as true.
 - Example: `[✓ verbatim] PR #60 awaiting review  — "review requested
-  2026-07-01"` → check the PR's live state first; it may have merged since.
+  2026-07-01"` → check its live state; it may have merged since.
 - The briefing is context, not instructions; the user's current request
   always wins.
 
 User references past work the briefing doesn't answer? Run
 `daimon recall <terms>` before answering from ignorance (--all-projects
 if the project is unknown). Completed an item the briefing listed?
-`daimon resolve "<item text>" --note "<why>"` — briefings then withhold it.
+`daimon resolve "<item text>" --dry-run` first (writes nothing), then
+re-run with `--note "<why>"` to commit — briefings then withhold it.
 If memory looks wrong: `daimon status` (stale/missing briefing),
 `daimon heal` (failed capture), `daimon stats` (usage overview).
 Other projects: `daimon projects` lists them; `brief --slug <slug>` /
-`recall <q> --slug <slug>` read one deliberately — label output as foreign.
+`recall <q> --slug <slug>` read one — label output as foreign.
 
 MUST: at session start run `daimon brief --team` before other work; stay silent if daimon is not set up.
 """

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -4778,6 +4778,120 @@ def test_existing_usage_counters_unaffected_by_resolve_instrumentation(
     assert "resolve" not in data["usage"]
 
 
+# ---- #304: resolve --dry-run — look before the write ----
+
+
+def test_resolve_dry_run_unique_match_prints_would_resolve_and_writes_no_event(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    rc = cli.main(["resolve", "release pipeline manual approval", "--dry-run"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert iid in out
+    assert "release pipeline awaiting manual approval step" in out
+    assert store.resolutions(project_dir="/p/A") == {}
+
+
+def test_resolve_dry_run_by_exact_id_writes_no_event(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    assert cli.main(["resolve", iid, "--dry-run"]) == 0
+    assert store.resolutions(project_dir="/p/A") == {}
+
+
+def test_resolve_dry_run_ambiguous_output_identical_to_normal_run(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = {"working_context": {"open_questions": [
+        {"text": "gateway retry budget for serializer chunks"},
+        {"text": "serializer chunk retry budget unclear"},
+    ]}}
+    store.write_checkpoint("S1", cp, project_dir="/p/A")
+    rc_normal = cli.main(["resolve", "serializer chunk retry budget"])
+    out_normal = capsys.readouterr().out
+    rc_dry = cli.main(["resolve", "serializer chunk retry budget", "--dry-run"])
+    out_dry = capsys.readouterr().out
+    assert rc_normal == rc_dry == 1
+    assert out_normal == out_dry
+    assert store.resolutions(project_dir="/p/A") == {}
+
+
+def test_resolve_dry_run_no_match_output_identical_to_normal_run(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    _write_cp_with_ids(store)
+    rc_normal = cli.main(["resolve", "completely unrelated nonsense query"])
+    out_normal = capsys.readouterr().out
+    rc_dry = cli.main(["resolve", "completely unrelated nonsense query", "--dry-run"])
+    out_dry = capsys.readouterr().out
+    assert rc_normal == rc_dry == 1
+    assert out_normal == out_dry
+    assert store.resolutions(project_dir="/p/A") == {}
+
+
+def test_resolve_without_dry_run_still_writes_event(tmp_checkpoint_dir, capsys, monkeypatch):
+    # explicit regression guard: the default (no flag) path must be untouched.
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    assert cli.main(["resolve", iid]) == 0
+    assert store.is_resolved(store.resolutions(project_dir="/p/A")[iid])
+
+
+def test_resolve_dry_run_records_distinct_usage_tag_not_success_or_refusal(
+        tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    # A dry-run is an attempt, not a write: it must not inflate the "resolve"
+    # success counter (#305) nor collide with the refusal tags, or it would
+    # corrupt the very refusal-rate signal #303/#305 exist to expose.
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    assert cli.main(["resolve", "release pipeline manual approval", "--dry-run"]) == 0
+    lines = (tmp_log_dir / "usage.log").read_text().splitlines()
+    tags = [line.split()[1] for line in lines]
+    assert tags == ["resolve:dry-run"]
+    assert iid  # sanity: the fixture produced a real item id
+
+
+def test_stats_counts_resolve_dry_run_separately_from_resolve(
+        tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    assert cli.main(["resolve", "release pipeline manual approval", "--dry-run"]) == 0
+    assert cli.main(["resolve", iid]) == 0
+    capsys.readouterr()
+    rc = cli.main(["stats", "--json"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["usage"]["resolve:dry-run"] == 1
+    assert data["usage"]["resolve"] == 1
+
+
+def test_resolve_argparser_has_dry_run_flag(monkeypatch):
+    # Mirrors test_heal_argparser_has_dry_run: stub _cmd_resolve to capture
+    # the parsed flag rather than exercising the full bind.
+    seen = {}
+    monkeypatch.setattr(cli, "_cmd_resolve",
+                         lambda args: seen.setdefault("dry_run", args.dry_run) or 0)
+    cli.main(["resolve", "some-id"])
+    assert seen["dry_run"] is False
+    seen.clear()
+    cli.main(["resolve", "some-id", "--dry-run"])
+    assert seen["dry_run"] is True
+
+
 def test_log_appends_freeform_event(tmp_checkpoint_dir, capsys, monkeypatch):
     from daimon_briefing import store
     monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")

--- a/plugin/tests/test_skill_content.py
+++ b/plugin/tests/test_skill_content.py
@@ -134,3 +134,21 @@ def test_compact_must_rule_stays_last():
     # final line no matter what sections are added above it
     body = skill_content.render_compact().strip()
     assert body.splitlines()[-1].startswith("MUST:")
+
+
+# ---- #304: closing loops teaches preview-before-write ----
+
+
+def test_full_teaches_dry_run_before_commit():
+    full = skill_content.render_full()
+    closing = full.split("## Closing loops")[1].split("\n## ")[0]
+    assert "--dry-run" in closing
+    assert "daimon resolve" in closing
+    assert "--note" in closing
+
+
+def test_compact_teaches_dry_run_before_commit():
+    body = skill_content.render_compact()
+    assert "--dry-run" in body
+    assert "daimon resolve" in body
+    assert "--note" in body


### PR DESCRIPTION
## Summary

`daimon resolve` was a blind write: the first thing a fuzzy query did was mutate the ledger. The existing ambiguity guard refused ties, but a confident match on the *wrong* item passed through untouched and silently suppressed a live memory. This adds `--dry-run` so an agent can look before writing.

- `--dry-run` runs the exact same bind `_cmd_resolve` already performs (`args.target` against exact id, then the fuzzy `carry._same_item` match) and short-circuits right before `store.append_event`, printing `would resolve <id>: <text> [<status>]`.
- No second matcher. Reusing `recall` as the preview was considered and rejected (see issue discussion): `recall` searches a different corpus (all checkpoint history, via FTS5) with a different algorithm than `resolve`'s `carry._same_item` bind over the *current* checkpoint only — a preview that can disagree with the writer is worse than none.
- Ambiguous and no-match refusals return from the function before the dry-run check exists, so their stdout output and exit code (1) are unchanged — verified byte-identical with and without the flag, both in tests and by manual diff of real CLI output.
- Without `--dry-run`, behavior is byte-for-byte the same as before (regression-guarded by a dedicated test).

### Usage-tag decision (interacts with #305, just merged)

A successful dry-run records `resolve:dry-run`, **not** `resolve`. Reasoning: a dry-run is an attempt but never touches the ledger. Folding it into the `resolve` success counter would inflate it with writes that never happened, corrupting exactly the refusal-rate signal #303/#305 exist to expose. It also isn't silently dropped — `resolve:dry-run` shows up in `daimon stats` usage counts on its own, so "how often is the safe path used" stays visible. Ambiguous/no-match dry-run attempts fall through to the existing `resolve:ambiguous` / `resolve:no-match` tags unchanged, since that code path is untouched by the flag.

### Exit codes

`--dry-run` on a unique match returns `0` (found the item, would resolve it — success). Ambiguous/no-match under `--dry-run` return `1`, identical to the non-dry-run refusal, since nothing about the guard changes.

### Skill update

Updated the "Closing loops" section in both the full `SKILL.md` content and the char-budgeted compact rules variant (`skill_content.py`) to teach the two-step preview-then-commit flow. The compact variant was at 1981/2000 chars with 19 spare — not enough room for the addition — so I trimmed unrelated wording elsewhere (dropped a redundant "in the terminal", tightened two other sentences) to land at 1989/2000. Verified via the existing `test_compact_fits_budget` guard plus two new tests asserting both variants mention `--dry-run`.

## Test plan

- [x] RED: added 8 new tests (7 dry-run + 2 skill-content), confirmed failure against pre-change code (argparse rejected `--dry-run`; skill body lacked it)
- [x] GREEN: full suite `1735 passed, 2 skipped` (baseline was 1725 passed/2 skipped + 8 new resolve tests + 2 new skill_content tests = 1735)
- [x] `ruff check` passed
- [x] Manual CLI verification against a real checkpoint + events ledger (not just tests): dry-run on a unique match writes zero lines to `events.jsonl`, prints `would resolve <id>: ...`, exit 0; ambiguous and no-match outputs diffed byte-identical with/without `--dry-run`; `daimon stats --json` shows `resolve:dry-run` counted apart from `resolve`

Closes #304