### PR TITLE
fix(stats): collapse adjacent-duplicate result lines in the capture fold

### DIFF
--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -327,17 +327,52 @@ _STATS_HOST_RE = re.compile(
 )
 
 
+def _is_result_line(line: str) -> bool:
+    """A line the CLI both prints AND logs first-class (_run_serialize's
+    print + _append_serialize_log pair) — success, skip, or error. Spawn/host
+    lines are hook-written and timestamped, so they are NOT result lines."""
+    return bool(_RESULT_OK_RE.match(line) or _LEDGER_SKIP_RE.match(line)
+                or _RESULT_ERR_RE.match(line))
+
+
 def _stats_capture() -> dict:
     """serialize.log -> aggregate counters. Tallies EVERY line (scar #9: no
-    last-of-kind collapse — a buried failure still counts)."""
+    last-of-kind collapse — a buried failure still counts), except an
+    ADJACENT-identical repeat of a result line (#300).
+
+    #300: every result line is built once, printed to stdout, AND logged
+    first-class by _run_serialize. Any spawn path that redirected the child's
+    stdout into this log therefore wrote it twice — adjacent, byte-identical,
+    untimestamped. The write side is fixed (all spawn_serialize sites set
+    stdout=DEVNULL) but historical logs carry the doubles permanently, and this
+    fold is what `status` reports, so they are collapsed on READ. Diagnosed
+    cosmetic, not double spend: doubled pairs carry exactly one LLM token
+    record between them.
+
+    ADJACENCY is the dedupe key, never payload equality: two genuine serializes
+    of one session are separated by their own spawn lines, and an immediate
+    genuine re-run is short-circuited to a `skipped` line by the
+    transcript_unchanged guard (#185/#296) rather than writing a second
+    identical success. Scoped to result lines for the same reason — spawn lines
+    cannot double via this mechanism, and collapsing two same-second spawns
+    would hide a real capture from the #265 silent-capture alarm.
+
+    This is NOT the last-of-kind collapse scar #9 forbids: it never reaches
+    across sessions, so a failure buried under a later session's success still
+    counts."""
     out = {"success": 0, "skipped": 0, "errors": 0, "fallback_serializes": 0,
            "hosts": {}, "max_serialize_seconds": 0, "total_serialize_seconds": 0}
     try:
         text = (config.log_dir() / "serialize.log").read_text(encoding="utf-8")
     except OSError:
         return out
+    prev = None
     for line in text.splitlines():
         line = line.strip()
+        doubled = line == prev and _is_result_line(line)
+        prev = line
+        if doubled:
+            continue
         m = _RESULT_OK_RE.match(line)
         if m:
             out["success"] += 1

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -4068,6 +4068,106 @@ def test_stats_capture_too_short_error_lines_count_as_skipped(tmp_log_dir):
     assert cap["skipped"] == 3       # both fossils join the real skip line
 
 
+# ---- #300: adjacent-identical result lines are one serialize, logged twice ----
+
+
+def test_stats_capture_collapses_adjacent_duplicate_result_lines(tmp_log_dir):
+    # #300: a hook that redirected the child's stdout into serialize.log wrote
+    # every result line twice — the CLI prints it AND logs it first-class
+    # (cli.py: print + _append_serialize_log). The write side is fixed
+    # (spawn_serialize sets stdout=DEVNULL), but historical logs carry the
+    # doubles forever, and this fold is what `status` reports. One serialize
+    # must count once, and its duration must not be counted twice.
+    from daimon_briefing import ledger
+    _write_log(tmp_log_dir, [
+        "2026-07-12T01:12:35Z codex-stop: spawned serialize for A (project: /p/A)",
+        "wrote checkpoint: /c/A.json (took 114s)",
+        "wrote checkpoint: /c/A.json (took 114s)",
+    ])
+    cap = ledger._stats_capture()
+    assert cap["success"] == 1
+    assert cap["total_serialize_seconds"] == 114
+    assert cap["max_serialize_seconds"] == 114
+
+
+def test_stats_capture_keeps_non_adjacent_identical_results(tmp_log_dir):
+    # The dedupe key is ADJACENCY, not payload equality. Two genuine serializes
+    # of one session are separated by their own spawn lines, and an immediate
+    # genuine re-run is short-circuited to a `skipped` line by the
+    # transcript_unchanged guard (#185/#296) — so identical payloads that are
+    # NOT neighbours are real repeats and must both count.
+    from daimon_briefing import ledger
+    _write_log(tmp_log_dir, [
+        "2026-07-12T01:12:35Z codex-stop: spawned serialize for A (project: /p/A)",
+        "wrote checkpoint: /c/A.json (took 114s)",
+        "2026-07-12T01:19:36Z codex-stop: spawned serialize for A (project: /p/A)",
+        "wrote checkpoint: /c/A.json (took 114s)",
+    ])
+    cap = ledger._stats_capture()
+    assert cap["success"] == 2
+    assert cap["total_serialize_seconds"] == 228
+
+
+def test_stats_capture_collapses_adjacent_duplicate_error_and_skip_lines(tmp_log_dir):
+    # The doubling rides on the print+log path, which every result line shares —
+    # errors and skips double exactly like successes.
+    from daimon_briefing import ledger
+    _write_log(tmp_log_dir, [
+        "error: LLM call failed on transcript: ChatError: unreachable "
+        "(transcript: /t/S2.jsonl) after 12s",
+        "error: LLM call failed on transcript: ChatError: unreachable "
+        "(transcript: /t/S2.jsonl) after 12s",
+        "skipped serialize for S3: transcript too short (4 < 10 messages)",
+        "skipped serialize for S3: transcript too short (4 < 10 messages)",
+    ])
+    cap = ledger._stats_capture()
+    assert cap["errors"] == 1
+    assert cap["skipped"] == 1
+
+
+def test_stats_capture_dedupe_does_not_inflate_fallback_count(tmp_log_dir):
+    # #28's [fallback backend] marker is a suffix on the success line, so a
+    # doubled success doubled the downgrade count too.
+    from daimon_briefing import ledger
+    _write_log(tmp_log_dir, [
+        "wrote checkpoint: /c/A.json (took 9s) [fallback backend]",
+        "wrote checkpoint: /c/A.json (took 9s) [fallback backend]",
+    ])
+    cap = ledger._stats_capture()
+    assert cap["success"] == 1
+    assert cap["fallback_serializes"] == 1
+
+
+def test_stats_capture_does_not_dedupe_spawn_lines(tmp_log_dir):
+    # Deliberately NOT deduped: spawn lines are timestamped and written only by
+    # the hook (lib.log), never by the CLI's print+log path, so they cannot
+    # double via #300's mechanism. Two spawns that genuinely land in the same
+    # second are real captures, and _spawns_in_window_count feeds the #265
+    # silent-capture alarm — collapsing them would hide a real capture.
+    from daimon_briefing import ledger
+    _write_log(tmp_log_dir, [
+        "2026-07-12T01:12:35Z codex-stop: spawned serialize for A (project: /p/A)",
+        "2026-07-12T01:12:35Z codex-stop: spawned serialize for A (project: /p/A)",
+    ])
+    assert ledger._stats_capture()["hosts"]["codex-stop"] == 2
+
+
+def test_stats_capture_dedupe_does_not_mask_a_buried_failure(tmp_log_dir):
+    # scar #9 guard: the dedupe must stay adjacency-scoped. A failure separated
+    # from a later success by other sessions' lines still counts — this is NOT
+    # last-of-kind collapse.
+    from daimon_briefing import ledger
+    _write_log(tmp_log_dir, [
+        "error: LLM call failed on transcript: ChatError: boom "
+        "(transcript: /t/A.jsonl) after 12s",
+        "2026-07-12T01:19:36Z session-end: spawned serialize for B (project: /p/B)",
+        "wrote checkpoint: /c/B.json (took 20s)",
+    ])
+    cap = ledger._stats_capture()
+    assert cap["errors"] == 1
+    assert cap["success"] == 1
+
+
 # ---- #49: heal crash on hung targets + preflight-error attribution ----
 
 


### PR DESCRIPTION
Closes #300

## What

Collapses **adjacent-identical result lines** in `_stats_capture`'s fold over `serialize.log`, so one serialize counts once.

Diagnosis is on the issue: **cosmetic, not double spend.** One serialize, two log lines.

- Doubled pairs carry exactly **one** `LLM usage total_tokens=` record between them — zero pairs have two. Two concurrent serializes would each bill their own call. (Caveat, stated on the issue too: only 2 of the doubled results carry token evidence; the rest predate #194, which added the handler that writes those records. The direct evidence is n=2, corroborated by the structural evidence below rather than carried by it.)
- **Every duplicate is adjacent** — no exceptions. Two concurrent 100-500s serializes would interleave with other log traffic.
- **Durations agree to the exact second**, every time.

Mechanism is the one already recorded in `spawn_serialize`'s docstring: each result line is built once, `print`ed to stdout, **and** logged first-class via `_append_serialize_log`, so any spawn path that redirected the child's stdout into the log wrote it twice. The write side is already correct — all three `spawn_serialize` sites set `stdout=DEVNULL`. Only historical data is affected, and `_stats_capture` tallies every line.

Also corrects a claim in the issue body: `usage.log` is **not** a token oracle (it records `<timestamp> <event>` only). The token records live in `serialize.log`.

## Why

`daimon stats` over-reported real work. On the author's log:

| counter | before | after |
|---|---|---|
| `success` | 163 | **120** |
| `skipped` | 70 | **55** |
| `errors` | 34 | **24** |
| `total_serialize_seconds` | 44307 | **32220** |
| `max_serialize_seconds` | 1732 | 1732 |
| `hosts` | `{session-end: 138, codex-stop: 13}` | unchanged |

A 36% inflated success count, and 12.31h of reported serialize time against a real 8.95h. This is the log whose repeat count turned out to be unusable as evidence — the point of the fix is to make historical data trustworthy without rewriting anyone's log.

Two deliberate scope limits:

- **Adjacency is the dedupe key, never payload equality.** Genuine repeats of one session are separated by their own spawn lines, and an immediate genuine re-run is short-circuited to a `skipped` line by the `transcript_unchanged` guard (#185/#296) rather than writing a second identical success.
- **Result lines only.** Spawn lines are timestamped and hook-written, so they cannot double via this mechanism; collapsing two same-second spawns would hide a real capture from the #265 silent-capture alarm. `hosts` is unchanged above, and a test pins it.

Not the last-of-kind collapse **scar #9** forbids: the dedupe never reaches across sessions, so a failure buried under a later session's success still counts. A test pins that too.

## Tests

Six new tests in `plugin/tests/test_cli.py`. The three dedupe tests **failed before the change** (`assert 2 == 1`); the three guard tests passed before and after, so they catch an over-broad fix rather than the bug.

| Test | Proves |
|---|---|
| `..._collapses_adjacent_duplicate_result_lines` | one serialize counts once; duration not double-counted |
| `..._keeps_non_adjacent_identical_results` | genuine repeats still count twice |
| `..._collapses_adjacent_duplicate_error_and_skip_lines` | errors and skips double on the same path |
| `..._dedupe_does_not_inflate_fallback_count` | #28 `[fallback backend]` suffix not double-counted |
| `..._does_not_dedupe_spawn_lines` | #265 alarm intact — same-second spawns both count |
| `..._dedupe_does_not_mask_a_buried_failure` | scar #9 guard — no cross-session collapse |

Full suite: **1741 passed, 2 skipped**. `ruff check` clean. `scar lint` clean (26 files, 0 errors). mypy unchanged at 50 pre-existing errors (verified by running it against the tree with and without this change — identical counts).

Behaviour verified against the real `serialize.log` producing the table above, not only against fixtures.

## What this does NOT close

The **Codex** mechanism. The obvious theory — a stale installed hook lib predating the `DEVNULL` fix — is refuted: cached bytecode from 07-13 already contains the fix and the docstring recording it. The 07-12 copy is overwritten and unrecoverable. Codex has had zero completed serializes since, so that path is untested rather than proven clean. The Claude path is clean for 21 consecutive serializes across six days.

This PR fixes the read side, which is the part that is still wrong today regardless of which writer produced the doubles.

<!-- PR type: Bug fix -> type:fix -->
