### PR TITLE
test(cli): freeze the clock in brief byte-identity tests

### DIFF
--- a/.scars/0023-tmp-symlink-breaks-project-slug-match.landmine.md
+++ b/.scars/0023-tmp-symlink-breaks-project-slug-match.landmine.md
@@ -1,0 +1,31 @@
+---
+id: 23
+type: landmine
+title: Manual CLI checks under /tmp silently fail slug match — macOS /tmp is a symlink to /private/tmp
+severity: low
+confidence: 0.9
+created: 2026-07-15
+authors: ["claude-code", "Kibukx"]
+anchors:
+  - path: plugin/daimon_briefing/store.py
+  - pattern: "project_slug"
+evidence:
+  - note: 2026-07-15: two agents independently lost time to this while manually exercising `daimon resolve` (#303/#304 verification). Both saw 'no checkpoint for this project yet — nothing to resolve' and assumed a code fault; the checkpoint existed, under a different slug.
+expires:
+  condition: "project_slug resolves symlinks (or the CLI reports a slug mismatch instead of 'no checkpoint')"
+  review_after: 2027-01-15
+status: active
+---
+
+On macOS `/tmp` is a symlink to `/private/tmp`. `store.project_slug()` derives the bucket from the
+project path, so a checkpoint written while cwd resolves one way does not match a CLI run that
+resolves the other. The scoped read (`store.read_latest(project_dir=..., fallback=False)`) then finds
+nothing.
+
+The failure is silent and misleading: `daimon resolve` prints **"no checkpoint for this project yet —
+nothing to resolve"**, which reads as "the checkpoint is missing", not "your slug doesn't match". The
+same shape will hit any scoped read (`brief`, `resolve`) driven from a `/tmp` path.
+
+Only bites hand-rolled CLI verification (pytest fixtures use `tmp_path`, which is already
+`/private/var/...`). Use `/private/tmp/...` explicitly, or compute the slug with
+`store.project_slug(dir)` and place the checkpoint under `<ckpt-dir>/<slug>/latest.json`.

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2491,6 +2491,13 @@ def test_cli_brief_team_empty_is_byte_identical(tmp_checkpoint_dir, sample_check
     # DAIMON_TEAM off (fixture default) → nothing mirrored → empty team dir.
     store.write_checkpoint("S-prev", sample_checkpoint, project_dir=proj)
 
+    # #307 sweep: no rendered age on this path, but briefing.build defaults
+    # `now` to the live clock for #78 weight ordering, so byte-identity across
+    # two calls is still clock-coupled in principle. Frozen for the same
+    # reason as the fallback test: a diff must mean --team leaked, full stop.
+    frozen = time.time()
+    monkeypatch.setattr(time, "time", lambda: frozen)
+
     cli.main(["brief", "--project", proj])
     plain = capsys.readouterr().out
     cli.main(["brief", "--team", "--project", proj])
@@ -3202,11 +3209,19 @@ def test_brief_fallback_header_only_without_team_flag_unchanged(
 
 
 def test_brief_fallback_header_only_with_team_empty_is_byte_identical(
-        tmp_checkpoint_dir, sample_checkpoint, capsys):
+        tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
     # Empty team -> _print_teammates no-ops -> --team must not change a single
     # byte of the header-only fallback note for a team-less machine.
     from daimon_briefing import store
     store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+
+    # #307: the fallback header embeds a truncated relative age read from the
+    # live clock (cli's `_format_age(time.time() - epoch)`), so two calls
+    # straddling an integer-second boundary render `0s ago` vs `1s ago` and
+    # the byte-identity assertion fails on the clock, not the flag. Freeze the
+    # clock so any byte difference is attributable to --team and nothing else.
+    frozen = time.time()
+    monkeypatch.setattr(time, "time", lambda: frozen)
 
     rc = cli.main(["brief", "--project", "/repo/some-other-project"])
     plain = capsys.readouterr().out


### PR DESCRIPTION
Closes #307

## What

Freezes the clock in the two double-call byte-identity `brief` tests, so the assertion means what it says: any byte difference is attributable to `--team` and nothing else.

- `test_brief_fallback_header_only_with_team_empty_is_byte_identical` — the observed CI flake. The fallback header embeds `_format_age(time.time() - epoch)` with `int()` truncation, so calls straddling a second boundary render `0s ago` vs `1s ago`.
- `test_cli_brief_team_empty_is_byte_identical` — no rendered age on this path, but `briefing.build` defaults `now` to the live clock for #78 weight ordering, so byte-identity across two calls is still clock-coupled in principle. Frozen for the same reason.

Also promotes scar candidate **`tmp-symlink-breaks-project-slug-match` → scar #23** (reviewer: Kibukx): on macOS `/tmp` is a symlink to `/private/tmp`, so hand-rolled CLI verification under `/tmp` silently fails `project_slug` matching and `daimon resolve` misreports "no checkpoint for this project yet". Bit two agents independently during #303/#304 verification. `scar lint`: 26 files, 0 errors.

## Why

The flake fired on PR #306: py3.10 red, py3.13 green, identical commit, diff touching neither `brief` nor the test. A red run on this test could not distinguish "the flag leaked into the output" from "the clock moved." Failure probability ≈ (first call duration) / 1s per run — small, permanent, independent of the change under test.

Freezing beats the alternatives named on the issue:
- **Normalising the age token** — weaker; stops asserting byte-identity on the part of the output most likely to reveal accidental divergence.
- **Retry on failure** — hides the flake and trains readers to disregard red.

The patch covers every `now`-consumer at once (scar #16's rule): all of `daimon_briefing` reads `time.time()` through the module attribute — verified there are zero `from time import` bindings that would dodge it.

## Tests

- **Race reproduced deterministically before the fix**: a patched clock advancing 1.0s between the two calls flips the age token and fails the old assertion — proving the assertion was clock-coupled, not flag-coupled.
- **Sweep of every byte-identity assertion** in the suite for the same race:

| Assertion | Verdict |
|---|---|
| `test_cli.py:1680` checkpoint file bytes | single read, no clock |
| `test_cli.py` print/log contract (`log[-1] == out`) | single invocation, no clock |
| `test_cli.py` real-brief `teamed == plain` | clock-coupled via weight ordering → **frozen** |
| `test_cli.py` fallback `teamed == plain` | clock-coupled via rendered age → **frozen** (the observed flake) |
| `test_redact.py:83` second-pass redact | pure string function, no clock |

- Full suite: **1741 passed, 2 skipped**. `ruff check` clean. `scar lint` clean.
