### PR TITLE
fix(llm): extract fenced JSON from anywhere in a model response

### DIFF
--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -194,30 +194,53 @@ def chat(messages, model=None, temperature=None, timeout=None, retries=3, deadli
 
 
 def extract_json(text):
-    """Pull a JSON object/array out of a model response, tolerating ```json fences.
+    """Pull a JSON object/array out of a model response, tolerating ```json
+    fences ANYWHERE in the text — not only at the start (#311: a model that
+    continues the transcript as prose and buries the payload in a mid-response
+    fence still gets its JSON recovered).
+
+    Order: whole string, then each fenced block in order (first parseable
+    wins), then a raw_decode scan over every `{`/`[` start taking the LONGEST
+    parseable span. Longest — not first — because prose can carry tiny inline
+    objects, and first-{-to-last-} (the pre-#311 heuristic) dies whenever the
+    prose contains template braces ({{ jinja }}), which any transcript
+    touching templates or shell will produce.
 
     Raises json.JSONDecodeError when nothing parseable is found.
     """
     t = text.strip()
-    if t.startswith("```"):
-        t = t.split("```", 2)[1]
-        if t.startswith("json"):
-            t = t[4:]
-        t = t.strip()
     try:
         return json.loads(t)
     except json.JSONDecodeError:
         pass
-    candidates = []
-    for op, cl in (("[", "]"), ("{", "}")):
-        i, j = t.find(op), t.rfind(cl)
-        if i != -1 and j != -1 and j > i:
-            candidates.append((i, t[i:j + 1]))
-    for _, span in sorted(candidates):
+    # Every fenced block, wherever it sits. split("```") puts fence interiors
+    # at odd indices, including an unterminated trailing fence (old behavior
+    # for a leading ``` with no closer — kept).
+    parts = t.split("```")
+    for k in range(1, len(parts), 2):
+        block = parts[k]
+        if block[:4].lower() == "json":
+            block = block[4:]
         try:
-            return json.loads(span)
+            return json.loads(block.strip())
         except json.JSONDecodeError:
             continue
+    # Balanced scan: try a strict decode at every plausible start, keep the
+    # longest span that parses. raw_decode fails in O(1) on template braces.
+    decoder = json.JSONDecoder()
+    best = None
+    best_len = -1
+    for i, ch in enumerate(t):
+        if ch not in "{[":
+            continue
+        try:
+            obj, end = decoder.raw_decode(t, i)
+        except json.JSONDecodeError:
+            continue
+        if end - i > best_len:
+            best, best_len = obj, end - i
+    if best_len >= 0:
+        return best
     raise json.JSONDecodeError("no JSON object/array found in response", t, 0)
 
 

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -792,3 +792,82 @@ def test_command_backend_stderr_stays_first_when_both_streams_speak(monkeypatch,
         llm.chat([{"role": "user", "content": "hola"}])
     text = (tmp_path / "logs" / "backend-stderr.log").read_text()
     assert text.index("the real panic") < text.index("partial body")
+
+
+# ---- #311: extract_json must reach fenced JSON embedded mid-prose ----
+
+
+def test_extract_json_bare_object():
+    assert llm.extract_json('{"a": 1}') == {"a": 1}
+
+
+def test_extract_json_leading_fence():
+    assert llm.extract_json('```json\n{"a": 1}\n```') == {"a": 1}
+
+
+def test_extract_json_leading_fence_no_tag():
+    assert llm.extract_json('```\n[1, 2]\n```') == [1, 2]
+
+
+def test_extract_json_object_with_trailing_prose():
+    # The pre-#311 span heuristic handled this shape; it must keep working.
+    assert llm.extract_json('{"a": 1}\n\nDone.') == {"a": 1}
+
+
+def test_extract_json_leading_prose_then_object():
+    assert llm.extract_json('Here it is:\n{"a": 1}') == {"a": 1}
+
+
+def test_extract_json_nothing_raises():
+    with pytest.raises(json.JSONDecodeError):
+        llm.extract_json("no json here at all")
+
+
+def test_extract_json_fence_mid_prose_with_template_braces():
+    # #311 field shape: the model continued the transcript as prose (which
+    # contained Jinja braces), emitted the checkpoint in a fence mid-response,
+    # then closed with more prose. The old first-{/last-} span started at a
+    # Jinja brace and could never parse; the fence was unreachable because the
+    # fence-strip branch only fired on a LEADING fence.
+    resp = (
+        "A: Task confirmed. Template uses {{ states('sensor.x') }} here.\n\n"
+        "Prose with {% if %} blocks too.\n\n"
+        '```json\n{"session_id": "S1", "worker_queue": []}\n```\n\n'
+        "**Session complete.** More prose."
+    )
+    assert llm.extract_json(resp) == {"session_id": "S1", "worker_queue": []}
+
+
+def test_extract_json_untagged_fence_mid_prose():
+    resp = 'intro {{ x }} prose\n```\n{"a": 1}\n```\nbye'
+    assert llm.extract_json(resp) == {"a": 1}
+
+
+def test_extract_json_skips_non_json_fence_takes_next():
+    # First fence is YAML, second is the payload — first parseable fence wins.
+    resp = (
+        "look:\n```yaml\nkey: value\n```\nthen\n"
+        '```json\n{"a": 2}\n```\n'
+    )
+    assert llm.extract_json(resp) == {"a": 2}
+
+
+def test_extract_json_unfenced_object_after_template_braces():
+    # No fence at all: the balanced scan must find the parseable object even
+    # though earlier prose contains { that can never start valid JSON.
+    resp = 'uses {{ jinja }} and then the payload {"a": 3, "b": [1]} end'
+    assert llm.extract_json(resp) == {"a": 3, "b": [1]}
+
+
+def test_extract_json_prefers_largest_parseable_span_over_prose_fragment():
+    # A tiny inline object in prose must not shadow the real payload when
+    # nothing is fenced — the scan prefers the longest parseable span.
+    resp = ('set {"debug": true} earlier, real output: '
+            '{"session_id": "S1", "working_context": {"open_questions": []}}')
+    assert llm.extract_json(resp) == {
+        "session_id": "S1", "working_context": {"open_questions": []}}
+
+
+def test_extract_json_unterminated_leading_fence():
+    # Old behavior: a leading fence with no closer still parsed. Keep it.
+    assert llm.extract_json('```json\n{"a": 4}') == {"a": 4}


### PR DESCRIPTION
Closes #311

## What

`extract_json` now recovers a JSON payload from **anywhere** in a model response:

1. Whole string (unchanged fast path).
2. **Every fenced block, in order of appearance** — not only a fence at position 0. First parseable wins. An unterminated trailing fence still counts (preserves the old leading-fence-without-closer behavior).
3. A `JSONDecoder.raw_decode` scan over every `{`/`[` start, keeping the **longest** parseable span — replacing the first-`{`-to-last-`}` heuristic.

## Why

Field failure (#311): the model continued the transcript as prose instead of serializing, emitted a complete valid checkpoint in a mid-response ```json fence, and closed with more prose. The old extractor:

- never looked at the fence (fence-strip branch fired only on a *leading* fence), and
- built its fallback span from the first `{` in the response — a Jinja `{{ ... }}` template brace in the prose — so the span could never parse.

Result: `no JSON object/array found in response: line 1 column 1 (char 0)` on a response that contained the checkpoint. The session's capture was lost, then the gateway response cache pinned the same response through every `heal --force` (#312, companion — with this PR merged, that pinned response becomes *parseable*, so a re-heal of the affected session recovers even before #312 lands).

**Longest, not first**, on the raw_decode scan: prose can carry tiny inline objects (`{"debug": true}`) that must not shadow the payload, and `raw_decode` fails in O(1) at template braces so the scan survives prose that plain brace-matching cannot. A test pins the shadowing case.

## Tests

`extract_json` had **zero direct tests** before this PR. Twelve added:

- **8 pins of pre-existing behavior** (bare object, leading fence with/without tag, trailing/leading prose, unterminated leading fence, non-JSON-fence-then-JSON-fence, nothing-parseable raises `JSONDecodeError`) — all passed before the change, guarding against regression.
- **4 new-capability tests** — all failed before the change (`assert` on the exact field error), green after:
  - fence mid-prose with template braces (the field shape, verbatim)
  - untagged fence mid-prose
  - unfenced object after template braces
  - largest-span preference over a prose fragment

Full suite: **1753 passed, 2 skipped**. `ruff` clean. The synthetic reproducer that matched the field error byte-for-byte now returns the checkpoint.
