### PR TITLE
fix(serializer): add a per-run nonce to retry markers so gateway caches cannot pin a bad response through heal

### DIFF
--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -16,6 +16,7 @@ import json
 import logging
 import re
 import time
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 
@@ -534,18 +535,30 @@ def _call_and_parse(chat, system, user_content, deadline, what: str,
     failures) keeps failing immediately here — those are chat()'s own retry
     domain.
 
-    Retries are never byte-identical: gateway response caches replay the same
-    garbage for an identical request (H1 attempt 5 — LiteLLM returned the
-    cached empty body in <1s). Each retry appends a per-attempt marker to the
-    user content, making it a distinct request.
+    Retries are never byte-identical — not within a run, and not ACROSS runs:
+    gateway response caches replay the same garbage for an identical request
+    (H1 attempt 5 — LiteLLM returned the cached empty body in <1s). The retry
+    marker carries the attempt number AND a per-invocation nonce, because
+    attempt numbers restart every invocation: without the nonce, a re-heal's
+    retries were byte-identical to the failed run's and ate the same pinned
+    bad response in 0s, forever (#312).
+
+    Attempt 1 stays pristine ON PURPOSE — no marker, no nonce. A gateway
+    replaying a COMPLETED good response for the clean request is a feature:
+    it is what let a deadline-killed chunked serialize recover its paid-for
+    chunks and merge in 0s on the next heal (#314's partial-loss case). If
+    attempt 1 replays pinned garbage instead, it costs milliseconds and the
+    nonce'd attempt 2 goes to a real model.
     """
     attempts = 1 + parse_retries
+    run_nonce = uuid.uuid4().hex[:12]
     for attempt in range(1, attempts + 1):
         content = user_content
         if attempt > 1:
             content += (
-                f"\n\n(retry attempt {attempt} — the previous response was "
-                f"unparseable; output ONLY the JSON object, no prose, no reasoning)"
+                f"\n\n(retry attempt {attempt} [{run_nonce}] — the previous "
+                f"response was unparseable; output ONLY the JSON object, "
+                f"no prose, no reasoning)"
             )
 
         def _can_retry(_attempt=attempt):

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -553,6 +553,36 @@ def test_serialize_first_try_success_has_no_retry_marker(fake_chat_factory):
     assert "retry attempt" not in chat.calls[0]["messages"][1]["content"]
 
 
+def test_serialize_retry_marker_differs_across_runs(fake_chat_factory):
+    # #312: gateway response caches replay a pinned bad response for a
+    # byte-identical request. The per-attempt marker de-dupes retries WITHIN a
+    # run, but attempt numbers restart on every invocation — so a re-heal sent
+    # byte-identical retries and got the same cached garbage back in 0s,
+    # forever. A per-run nonce makes every retry gateway-fresh.
+    chat1 = fake_chat_factory(["", _valid_checkpoint_json("S1")])
+    assert serializer.serialize_strict("S1", make_messages(20), chat=chat1) is not None
+    chat2 = fake_chat_factory(["", _valid_checkpoint_json("S1")])
+    assert serializer.serialize_strict("S1", make_messages(20), chat=chat2) is not None
+    retry1 = chat1.calls[1]["messages"][1]["content"]
+    retry2 = chat2.calls[1]["messages"][1]["content"]
+    assert "retry attempt 2" in retry1 and "retry attempt 2" in retry2
+    assert retry1 != retry2
+
+
+def test_serialize_first_attempt_stays_byte_identical_across_runs(fake_chat_factory):
+    # Deliberate scope limit on #312: attempt 1 carries NO nonce. Replaying a
+    # COMPLETED good response from a gateway cache is a feature, not a bug —
+    # it is exactly what healed a deadline-killed session in the field (the
+    # chunks and merge replayed in 0s on the next heal). Busting attempt 1
+    # would re-buy completed work on every heal (#314's amplification).
+    chat1 = fake_chat_factory(_valid_checkpoint_json("S1"))
+    assert serializer.serialize_strict("S1", make_messages(20), chat=chat1) is not None
+    chat2 = fake_chat_factory(_valid_checkpoint_json("S1"))
+    assert serializer.serialize_strict("S1", make_messages(20), chat=chat2) is not None
+    assert (chat1.calls[0]["messages"][1]["content"]
+            == chat2.calls[0]["messages"][1]["content"])
+
+
 def test_serialize_persistent_prose_raises_after_two_attempts(fake_chat_factory):
     # Non-list FakeChat response: every call (initial + retry) gets the same prose.
     chat = fake_chat_factory("still prose, not JSON")


### PR DESCRIPTION
Closes #312

## What

`_call_and_parse` now draws a per-invocation uuid nonce and stamps it into the retry marker:

```
(retry attempt 2 [3f9c2a1b8d4e] — the previous response was unparseable; output ONLY the JSON object, no prose, no reasoning)
```

Every retry becomes a request no gateway has seen — within a run *and* across runs. Previously the marker carried only the attempt number, and attempt numbers restart every invocation, so a re-heal's retries were byte-identical to the failed run's.

## Why

Field failure (#312): a serialize failed on an unparseable response; the gateway (exact-match response cache, temperature 0) pinned that response; every subsequent `heal --force` replayed it in ~1ms and failed `after 0s` — forever, with zero model calls. The operator's explicit "try again for real" override was satisfiable from a cache. This also silently inverted the guarantee `ledger.py` states for the heal retry cap ("a second heal is no longer a byte-identical replay").

**Deliberate scope limit — attempt 1 stays pristine (no marker, no nonce).** This is the issue's open design question, answered by field evidence from the same session: a gateway replaying a **completed good** response for the clean request is a feature. It is exactly what recovered the deadline-killed chunked serialize in #314 — chunks and merge replayed in 0s on the next heal, and the checkpoint was finally written. Busting attempt 1 would re-buy all completed work on every heal (the amplification #314 warns about). If attempt 1 replays pinned garbage instead, the cost is milliseconds and the nonce'd attempt 2 reaches a real model.

The marker format keeps both existing contracts: it is appended (never edits the user content — `startswith` pin) and still contains `retry attempt {N}` verbatim.

Note: `config.llm_no_cache()` (`DAIMON_LLM_NO_CACHE`) already exists as an opt-in LiteLLM-specific body flag; it is not a substitute — strict upstreams may reject unknown fields, and heal's correctness should not depend on gateway-specific extensions. The nonce is gateway-agnostic.

## Tests

Two added, one per side of the design line:

- `test_serialize_retry_marker_differs_across_runs` — two separate `serialize_strict` invocations, each failing attempt 1; their attempt-2 contents must differ. **Failed before the change** (byte-identical, the #312 bug), green after.
- `test_serialize_first_attempt_stays_byte_identical_across_runs` — pins the deliberate no-nonce choice on attempt 1, so a future "bust everything" refactor trips a test instead of silently re-introducing #314's re-spend amplification.

Existing marker pins (`retry attempt 2` substring, appended-not-edited, pristine first attempt within a run) all still pass.

Full suite: **1743 passed, 2 skipped**. `ruff` clean.
