### PR TITLE
fix(serializer): scale the deadline to the wave plan and persist chunk partials across heals

### DIFF
--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -12,6 +12,7 @@ pipeline from the D-007 probe: single-pass recall fell off a cliff ~1,400
 lines; chunking lifted long-session recall ~55% -> ~93% in probe runs.
 """
 
+import hashlib
 import json
 import logging
 import re
@@ -609,6 +610,89 @@ def _call_and_parse(chat, system, user_content, deadline, what: str,
         return parsed
 
 
+def _plan_waves(n_chunks: int, workers: int, k: int) -> int:
+    """How many sequential LLM 'waves' a chunked serialize needs (#314).
+
+    Chunks run concurrently, so n_chunks costs ceil(n/workers) waves, not n.
+    Each merge level's non-singleton groups run concurrently too; singleton
+    groups pass through free. This is the multiplier for the total deadline:
+    DAIMON_TIMEOUT was field-derived as the floor for ONE slow call (#284),
+    so a plan of W waves gets W times that budget — otherwise the merge is
+    structurally guaranteed to start starved on slow gateways.
+
+    Per-call socket timeouts stay capped at the base budget (llm.py caps each
+    attempt to min(timeout, remaining)), so scaling the total never pushes a
+    single request past gateway kill ceilings (scar #17: ~815s)."""
+    if n_chunks <= 1:
+        return 1
+    w = max(1, workers)
+    waves = (n_chunks + w - 1) // w
+    m = n_chunks
+    while m > 1:
+        n_groups = (m + k - 1) // k
+        # Only the last group can be a singleton (when m % k == 1); it merges
+        # without an LLM call.
+        call_groups = n_groups - (1 if m % k == 1 else 0)
+        if call_groups > 0:
+            waves += (call_groups + w - 1) // w
+        m = n_groups
+    return waves
+
+
+# ---- #314: persisted chunk partials — a merge death must not re-buy chunks ----
+# Content-addressed by (session_id, chunk_text): a re-heal of an UNCHANGED
+# transcript reuses its paid-for chunk outputs and enters the merge with the
+# full budget; any transcript growth changes the chunk text and misses cleanly.
+# Same sensitivity as checkpoints (transcript-derived, pre-redaction), stored
+# under the same root. Everything here is best-effort: a broken cache must
+# never break a serialize — worst case is re-paying the chunk call.
+
+_PARTIAL_MAX_AGE_SECONDS = 14 * 24 * 3600  # crash leftovers; success clears its own
+
+
+def _partials_dir():
+    return config.checkpoint_dir() / ".partials"
+
+
+def _partial_key(session_id: str, chunk_text: str) -> str:
+    return hashlib.sha256(
+        f"{session_id}\x00{chunk_text}".encode("utf-8")).hexdigest()[:32]
+
+
+def _load_partial(key: str):
+    try:
+        obj = json.loads((_partials_dir() / f"{key}.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return obj if isinstance(obj, dict) else None
+
+
+def _save_partial(key: str, partial: dict) -> None:
+    d = _partials_dir()
+    try:
+        d.mkdir(parents=True, exist_ok=True)
+        now = time.time()
+        for stale in d.glob("*.json"):  # reap crash leftovers by age
+            try:
+                if now - stale.stat().st_mtime > _PARTIAL_MAX_AGE_SECONDS:
+                    stale.unlink()
+            except OSError:
+                continue
+        tmp = d / f".{key}.{uuid.uuid4().hex[:8]}.tmp"
+        tmp.write_text(json.dumps(partial, ensure_ascii=False), encoding="utf-8")
+        tmp.replace(d / f"{key}.json")
+    except OSError:
+        pass
+
+
+def _clear_partials(keys) -> None:
+    for key in keys:
+        try:
+            (_partials_dir() / f"{key}.json").unlink(missing_ok=True)
+        except OSError:
+            continue
+
+
 def _merge_partials(chat, session_id: str, partials: list, deadline,
                     attempt_note: str = "") -> dict:
     """Hierarchically merge partial checkpoints into one, K partials at a time.
@@ -747,8 +831,10 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
     """Transcript -> validated checkpoint, or a named SerializeError.
 
     `chat` is an injectable callable (messages, **kwargs) -> str; defaults to the
-    real LLM client. `deadline` (time.monotonic() seconds) is the TOTAL remaining
-    budget across ALL LLM calls (every chunk + merge), forwarded to the client.
+    real LLM client. `deadline` (time.monotonic() seconds) is the caller's
+    budget for ONE wave of LLM work; chunked serializes scale it by the wave
+    plan (#314: chunk batches + merge levels) before forwarding to the client,
+    so the merge never starts starved by construction.
 
     Rendered transcripts over DAIMON_CHUNK_LINES go chunked (armC): per-chunk
     D-007 serialize -> 01c merge -> validate. Shorter ones stay single-pass.
@@ -766,6 +852,21 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
     transcript_text = _render_transcript(messages)
     chunks = chunk_transcript(transcript_text, config.chunk_lines(), config.chunk_overlap())
 
+    # #314: DAIMON_TIMEOUT is the field-derived floor for ONE slow call (#284,
+    # scar #14) — but a chunked serialize is a PLAN of sequential waves (chunk
+    # batches + merge levels). Sharing one single-call budget across the plan
+    # guaranteed a starved merge on slow gateways, so scale the total by the
+    # wave count. Per-call socket timeouts stay capped at the base budget
+    # (llm.py), so no single request grows past gateway ceilings (scar #17).
+    if deadline is not None and len(chunks) > 1:
+        waves = _plan_waves(len(chunks), config.chunk_concurrency(),
+                            config.merge_group_size())
+        if waves > 1:
+            extra = (waves - 1) * config.timeout_seconds()
+            deadline += extra
+            log.info("chunked call plan: %d wave(s) — deadline extended by %ds (#314)",
+                     waves, extra)
+
     # Validation-failure retry note (#118): one resample with a non-identical
     # request. Occasional invalid output (the live case: quote inlined into a
     # verbatim item's text, `quote` field omitted) is ordinary model flakiness,
@@ -780,6 +881,7 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
         "Re-emit the full corrected JSON."
     )
     partials: list | None = None
+    partial_keys: list = []  # #314: cleared only after a fully validated write
 
     def _produce(note: str) -> dict:
         nonlocal partials
@@ -799,6 +901,15 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
             # session take chunk_count * minutes of wall-clock.
             def _one_chunk(item):
                 i, chunk_text = item
+                # #314: a merge death must not re-buy completed chunks — reuse
+                # the persisted partial when this exact (session, chunk text)
+                # was already paid for by a previous attempt.
+                key = _partial_key(session_id, chunk_text)
+                cached = _load_partial(key)
+                if cached is not None:
+                    log.info("chunk %d/%d reused persisted partial (#314)",
+                             i + 1, len(chunks))
+                    return key, cached
                 t0 = time.monotonic()
                 partial = _call_and_parse(
                     chat, SERIALIZE_SYS,
@@ -808,12 +919,15 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
                 )
                 log.info("chunk %d/%d done in %.0fs",
                          i + 1, len(chunks), time.monotonic() - t0)
-                return partial
+                _save_partial(key, partial)
+                return key, partial
 
             workers = min(config.chunk_concurrency(), len(chunks))
             with ThreadPoolExecutor(max_workers=workers) as pool:
                 # executor.map preserves input order, so partials stay chronological.
-                partials = list(pool.map(_one_chunk, enumerate(chunks)))
+                keyed = list(pool.map(_one_chunk, enumerate(chunks)))
+            partial_keys.extend(k for k, _ in keyed)
+            partials = [p for _, p in keyed]
         # Retry re-runs ONLY the merge (the final sampling that failed) — the
         # chunk partials are kept; they are the expensive calls.
         return _merge_partials(chat, session_id, list(partials), deadline,
@@ -842,6 +956,10 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
     # after validation/verification so it can never influence either, and
     # last so nothing downstream re-derives or clobbers it.
     _stamp_llm_provenance(checkpoint)
+    # #314: success consumes the partial cache. Only here — any earlier exit
+    # (merge death, validation failure) leaves the paid-for chunks on disk for
+    # the next heal to reuse.
+    _clear_partials(partial_keys)
     return checkpoint
 
 

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -225,7 +225,11 @@ def test_serialize_chunked_forwards_deadline_to_every_call(fake_chat_factory, mo
 
     ckpt = serializer.serialize("S1", messages, chat=chat, deadline=deadline)
     assert ckpt is not None
-    assert all(c["kwargs"].get("deadline") == deadline for c in chat.calls)
+    # #314: chunked serializes scale the deadline by the wave plan, so every
+    # call carries the SAME deadline, at or beyond the caller's single-wave one.
+    seen = {c["kwargs"].get("deadline") for c in chat.calls}
+    assert len(seen) == 1
+    assert seen.pop() >= deadline
 
 
 def test_merge_prompt_carries_qstale_and_external_state():
@@ -1229,3 +1233,226 @@ def test_regression_model_supplied_format_version_does_not_stamp_checkpoint(
     on_disk = json.loads(path.read_text(encoding="utf-8"))
     assert on_disk["format_version"] == serializer.PROMPT_VERSION
     assert on_disk["format_version"] != spoofed_version
+
+
+# ---- #314: wave-plan budget scaling + persisted chunk partials ----
+
+
+def test_plan_waves_single_chunk():
+    assert serializer._plan_waves(1, workers=4, k=3) == 1
+
+
+def test_plan_waves_two_chunks_one_merge():
+    # 1 chunk wave (2 concurrent) + 1 merge wave = 2
+    assert serializer._plan_waves(2, workers=4, k=3) == 2
+
+
+def test_plan_waves_deep_tree():
+    # 8 chunks, workers=4, K=3: chunk batches ceil(8/4)=2; merge L1 = 3 groups
+    # (3,3,2) in 1 batch; L2 = 1 group in 1 batch → 4 waves total.
+    assert serializer._plan_waves(8, workers=4, k=3) == 4
+
+
+def test_plan_waves_singleton_group_is_free():
+    # 4 chunks, K=3: L1 groups are (3,1) — the singleton passes through with
+    # no LLM call, so L1 costs 1 batch, then L2 merges 2 → 1+1+1 = 3.
+    assert serializer._plan_waves(4, workers=4, k=3) == 3
+
+
+def test_chunked_serialize_scales_deadline_by_wave_plan(fake_chat_factory, monkeypatch):
+    # #314: N chunks + merge levels shared ONE single-call budget, so the merge
+    # always started starved on slow gateways. The deadline must scale with the
+    # wave plan: here 2 chunks (concurrent, 1 wave) + 1 merge wave = 2 waves.
+    import time as _t
+    monkeypatch.setenv("DAIMON_CHUNK_LINES", "6")
+    monkeypatch.setenv("DAIMON_CHUNK_OVERLAP", "1")
+    monkeypatch.setenv("DAIMON_MERGE_GROUP_SIZE", "100")
+    monkeypatch.setenv("DAIMON_TIMEOUT", "100")
+    monkeypatch.setenv("DAIMON_CHUNK_CONCURRENCY", "1")
+    messages = make_messages(20)
+    rendered = serializer._render_transcript(messages)
+    n_chunks = len(serializer.chunk_transcript(rendered, 6, 1))
+    assert n_chunks > 1
+    responses = [_valid_checkpoint_json(f"c{i}") for i in range(n_chunks)]
+    responses.append(_valid_checkpoint_json("merged"))
+    chat = fake_chat_factory(responses)
+    given = _t.monotonic() + 100
+
+    assert serializer.serialize("S1", messages, chat=chat, deadline=given) is not None
+    seen = {c["kwargs"].get("deadline") for c in chat.calls}
+    assert len(seen) == 1  # every call shares ONE scaled deadline
+    scaled = seen.pop()
+    # 2 waves × 100s budget: extended by ~100s beyond the given single-wave deadline.
+    assert scaled >= given + 50
+
+
+def test_single_pass_deadline_is_not_scaled(fake_chat_factory, monkeypatch):
+    import time as _t
+    monkeypatch.setenv("DAIMON_TIMEOUT", "100")
+    chat = fake_chat_factory(_valid_checkpoint_json("S1"))
+    given = _t.monotonic() + 100
+    assert serializer.serialize("S1", make_messages(20), chat=chat, deadline=given) is not None
+    assert chat.calls[0]["kwargs"].get("deadline") == given
+
+
+def _force_two_chunks(monkeypatch):
+    monkeypatch.setenv("DAIMON_CHUNK_LINES", "6")
+    monkeypatch.setenv("DAIMON_CHUNK_OVERLAP", "1")
+    monkeypatch.setenv("DAIMON_MERGE_GROUP_SIZE", "100")
+    # FakeChat consumes its script by call order; concurrent chunks would draw
+    # entries non-deterministically (the ChatError poison must hit the merge).
+    monkeypatch.setenv("DAIMON_CHUNK_CONCURRENCY", "1")
+    messages = make_messages(20)
+    rendered = serializer._render_transcript(messages)
+    n = len(serializer.chunk_transcript(rendered, 6, 1))
+    assert n > 1
+    return messages, n
+
+
+def test_failed_merge_persists_partials_and_reheal_reuses_them(
+        fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
+    # #314 second defect: deadline death at merge discarded the paid-for chunk
+    # outputs; the next heal re-bought every chunk. Chunk partials now persist
+    # content-addressed under the checkpoint dir; a re-run of the unchanged
+    # transcript reuses them and enters the merge with the full budget.
+    from daimon_briefing import llm as _llm
+    messages, n = _force_two_chunks(monkeypatch)
+    responses = [_valid_checkpoint_json(f"c{i}") for i in range(n)]
+    responses.append(_llm.ChatError("gateway died at merge"))
+    chat1 = fake_chat_factory(responses)
+    with pytest.raises(serializer.LLMCallError):
+        serializer.serialize_strict("S1", messages, chat=chat1)
+    saved = list((tmp_checkpoint_dir / ".partials").glob("*.json"))
+    assert len(saved) == n  # every completed chunk survived the merge death
+
+    chat2 = fake_chat_factory([_valid_checkpoint_json("merged")])
+    ckpt = serializer.serialize_strict("S1", messages, chat=chat2)
+    assert ckpt is not None and ckpt["session_id"] == "S1"
+    assert len(chat2.calls) == 1  # merge only — no chunk was re-bought
+
+
+def test_partials_cleared_after_successful_serialize(
+        fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
+    from daimon_briefing import llm as _llm
+    messages, n = _force_two_chunks(monkeypatch)
+    chat1 = fake_chat_factory(
+        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
+        + [_llm.ChatError("merge died")])
+    with pytest.raises(serializer.LLMCallError):
+        serializer.serialize_strict("S1", messages, chat=chat1)
+    chat2 = fake_chat_factory([_valid_checkpoint_json("merged")])
+    assert serializer.serialize_strict("S1", messages, chat=chat2) is not None
+    # Success consumes the cache — stale partials must not outlive their write.
+    assert list((tmp_checkpoint_dir / ".partials").glob("*.json")) == []
+
+
+def test_partial_cache_is_per_session(fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
+    # Same transcript text under a DIFFERENT session id must not reuse another
+    # session's partials — the key binds (session_id, chunk_text).
+    from daimon_briefing import llm as _llm
+    messages, n = _force_two_chunks(monkeypatch)
+    chat1 = fake_chat_factory(
+        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
+        + [_llm.ChatError("merge died")])
+    with pytest.raises(serializer.LLMCallError):
+        serializer.serialize_strict("S1", messages, chat=chat1)
+
+    chat2 = fake_chat_factory(
+        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
+        + [_valid_checkpoint_json("merged")])
+    assert serializer.serialize_strict("S2", messages, chat=chat2) is not None
+    assert len(chat2.calls) == n + 1  # S2 paid for its own chunks
+
+
+def test_corrupt_partial_recomputed(fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
+    from daimon_briefing import llm as _llm
+    messages, n = _force_two_chunks(monkeypatch)
+    chat1 = fake_chat_factory(
+        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
+        + [_llm.ChatError("merge died")])
+    with pytest.raises(serializer.LLMCallError):
+        serializer.serialize_strict("S1", messages, chat=chat1)
+    for p in (tmp_checkpoint_dir / ".partials").glob("*.json"):
+        p.write_text("not json{", encoding="utf-8")
+    chat2 = fake_chat_factory(
+        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
+        + [_valid_checkpoint_json("merged")])
+    # Corrupt cache entries are recomputed, never trusted or fatal.
+    assert serializer.serialize_strict("S1", messages, chat=chat2) is not None
+    assert len(chat2.calls) == n + 1
+
+
+def test_partial_reap_removes_aged_leftovers(fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
+    # Crash leftovers older than the reap window are removed by the next save.
+    import os as _os
+    import time as _t
+    from daimon_briefing import llm as _llm
+    pdir = tmp_checkpoint_dir / ".partials"
+    pdir.mkdir(parents=True)
+    old = pdir / "deadbeef00.json"
+    old.write_text("{}", encoding="utf-8")
+    aged = _t.time() - serializer._PARTIAL_MAX_AGE_SECONDS - 3600
+    _os.utime(old, (aged, aged))
+    messages, n = _force_two_chunks(monkeypatch)
+    chat = fake_chat_factory(
+        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
+        + [_llm.ChatError("merge died")])
+    with pytest.raises(serializer.LLMCallError):
+        serializer.serialize_strict("S1", messages, chat=chat)
+    assert not old.exists()  # reaped by the first save
+
+
+def test_partial_reap_survives_unremovable_entry(fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
+    # A glob hit that cannot be unlinked (here: a DIRECTORY named *.json) must
+    # never break the save — best-effort means skip and move on.
+    import os as _os
+    import time as _t
+    from daimon_briefing import llm as _llm
+    pdir = tmp_checkpoint_dir / ".partials"
+    (pdir / "stuck.json").mkdir(parents=True)
+    aged = _t.time() - serializer._PARTIAL_MAX_AGE_SECONDS - 3600
+    _os.utime(pdir / "stuck.json", (aged, aged))
+    messages, n = _force_two_chunks(monkeypatch)
+    chat = fake_chat_factory(
+        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
+        + [_llm.ChatError("merge died")])
+    with pytest.raises(serializer.LLMCallError):
+        serializer.serialize_strict("S1", messages, chat=chat)
+    # The real partials were still written around the stuck entry.
+    assert len(list(pdir.glob("*.json"))) == n + 1  # n saved + the stuck dir
+
+
+def test_save_partial_survives_partials_dir_being_a_file(
+        fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
+    # mkdir on a path occupied by a FILE raises — the save must swallow it and
+    # the serialize must complete untouched (worst case: nothing is cached).
+    (tmp_checkpoint_dir / ".partials").parent.mkdir(parents=True, exist_ok=True)
+    (tmp_checkpoint_dir / ".partials").write_text("not a dir", encoding="utf-8")
+    messages, n = _force_two_chunks(monkeypatch)
+    chat = fake_chat_factory(
+        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
+        + [_valid_checkpoint_json("merged")])
+    assert serializer.serialize_strict("S1", messages, chat=chat) is not None
+
+
+def test_clear_partials_survives_undeletable_entry(
+        fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
+    # Success-path cleanup meeting an undeletable cache entry (a directory
+    # squatting the key's filename) skips it — never fails the checkpoint.
+    from daimon_briefing import llm as _llm
+    messages, n = _force_two_chunks(monkeypatch)
+    chat1 = fake_chat_factory(
+        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
+        + [_llm.ChatError("merge died")])
+    with pytest.raises(serializer.LLMCallError):
+        serializer.serialize_strict("S1", messages, chat=chat1)
+    pdir = tmp_checkpoint_dir / ".partials"
+    for p in list(pdir.glob("*.json")):  # squat every key with a directory
+        p.unlink()
+        p.mkdir()
+    chat2 = fake_chat_factory(
+        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
+        + [_valid_checkpoint_json("merged")])
+    ckpt = serializer.serialize_strict("S1", messages, chat=chat2)
+    assert ckpt is not None  # load failed -> recomputed; clear skipped the dirs
+    assert len(chat2.calls) == n + 1


### PR DESCRIPTION
Closes #314

## What

Two mechanisms, one structural fix — the issue's two directions, which turned out to need each other:

**1. Wave-plan deadline scaling.** `serialize_strict` computes the call plan after chunking — `_plan_waves`: `ceil(n_chunks/workers)` chunk batches (chunks run **concurrently**; the issue's "sequential calls" framing was wrong and this corrects it) plus per-level merge batches, singleton groups free — and extends the deadline by `(waves − 1) × timeout_seconds()`. `DAIMON_TIMEOUT` keeps its #284 meaning: the floor for ONE slow call; a W-wave plan now gets W of them. Per-call socket timeouts stay capped at the base budget (`llm.py`), so scaling the total never pushes a single request past gateway kill ceilings (scar #17: ~815s). Single-pass serializes are byte-for-byte untouched.

**2. Persisted chunk partials, content-addressed.** Chunk outputs persist under `<checkpoint_dir>/.partials`, keyed `sha256(session_id + "\0" + chunk_text)`. A merge death no longer discards the paid-for chunks: the next heal reuses them (key hit = no LLM call) and enters the merge with the full budget. Transcript growth changes the chunk text → clean miss → honest recompute. Cleared only after a **fully validated** checkpoint; crash leftovers reap by age (14 days); every cache operation is best-effort — a broken cache costs one re-paid chunk call, never a serialize.

Why both in one PR: #312's per-run nonce (merged) makes retries genuinely fresh — which is correct, but means nothing ever comes back from a gateway response cache again. Scaling alone would fix first-run success while every retry still re-bought all chunks; partials are what keep #312 from making this path strictly more expensive. The issue records this interaction.

## Why

Field failure: 2-chunk transcript, gateway at ~300-360s per call. Chunk 2 completed at ~360s of the 420s total; the merge started with ~52s, was correctly killed by #298's enforcement, and the completed chunks evaporated. The merge then completed server-side anyway (paid, unread). With this PR the same run gets 2 waves × 420s, and even a death at the merge leaves the chunks on disk for a heal that starts at the merge.

The field numbers, re-run under this PR's math: chunk wave 360s + merge 317s = 677s against a scaled 840s — fits with margin. Against the old budget: 677 > 420, structurally impossible, every time.

## Integration audit

`.partials/` was checked against every `checkpoint_dir` walker before landing: `_session_files` (files only — GC never sees it), the pointer scan (`_POINTER_RE` names only), `_bucket_slugs` (pointer names only), the resolutions bucket walk (no `events.jsonl` → empty no-op), and recall's local scan (flat store only). Partials are schema-shaped model output, so the one real hazard was recall indexing them as checkpoints — the scan-path audit shows they are unreachable.

Store's `_reap_stale_tmps` also covers crashed partial `*.tmp` writes for free (same suffix convention).

## Tests

Ten added (four wave-plan units, two deadline-scaling, four persistence):

- `_plan_waves`: single chunk = 1; two chunks = 2; deep tree (8 chunks, workers 4, K 3) = 4; singleton merge groups cost nothing.
- Deadline: chunked run passes ONE scaled deadline (≥ given + base) to every call — **failed before the change** (deadline forwarded unscaled); single-pass forwards the given deadline exactly, unchanged.
- Persistence: merge death leaves one partial per completed chunk, re-heal issues exactly ONE call (the merge) — **failed before**; success clears the cache; the key binds session_id (same transcript under another session pays its own way); corrupted partials are recomputed, never trusted or fatal.
- One pre-existing pin updated with the contract change: `test_serialize_chunked_forwards_deadline_to_every_call` now asserts a single shared deadline ≥ the caller's, rather than exact equality — the old assertion pinned the starvation bug.
- Test-infra note: the new poison-entry tests pin `DAIMON_CHUNK_CONCURRENCY=1` — `FakeChat` consumes its script by call order, which is non-deterministic under the concurrent chunk pool.

Full suite: **1765 passed, 2 skipped**. `ruff` clean. mypy unchanged at the 50 pre-existing errors.
