### PR TITLE
feat(serializer): opt-in per-item scene traces, indexed for recall

### DIFF
--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -473,6 +473,13 @@ def scar_harvest_enabled() -> bool:
     return _flag("DAIMON_SCAR_HARVEST")
 
 
+def scene_traces_enabled() -> bool:
+    """Opt-in experiment (#317): serializer asks for a per-item `scene` —
+    1-2 sentences of episodic context — gated on the LongMemEval harness
+    before it can become default."""
+    return _flag("DAIMON_SCENE_TRACES")
+
+
 def llm_no_cache() -> bool:
     """Per-request bypass of gateway response caching (LiteLLM `no-cache`) —
     needed when a cached bad response pins a failure or when runs must be

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -71,7 +71,10 @@ def _note_error(where: str, exc: BaseException) -> None:
 # it now carries only item-level evidence (typed supersedes links, events.jsonl
 # resolutions), never whole-checkpoint recency; recency lives in `frontier` as
 # a silent rank input. The version bump makes _ensure_fresh discard old dbs.
-_SCHEMA_VERSION = "3"
+# v4 (#317): items + items_fts grew a scene column (episodic context traces);
+# an old db queried with the new column list would OperationalError, so the
+# bump forces the rebuild instead.
+_SCHEMA_VERSION = "4"
 
 _FTS5_MISSING_MSG = (
     "sqlite3 has no FTS5 module — `daimon recall` needs an FTS5-enabled "
@@ -98,12 +101,13 @@ def _load(path: Path) -> dict | None:
 
 
 def _items(cp: dict):
-    """Yield (kind, text, trust, quote, importance, first_seen, item_id,
+    """Yield (kind, text, trust, quote, scene, importance, first_seen, item_id,
     supersede_targets) for every cognitive item in a checkpoint. Tolerant of
     shape drift: bare strings become text-only items; anything without usable
     text is skipped (an index row with no text matches nothing). importance/
-    first_seen/item_id are None on pre-D-011 items. supersede_targets is the
-    item's `supersedes` link target strings (#234) — usually empty."""
+    first_seen/item_id are None on pre-D-011 items; scene is "" on items
+    without one (#317). supersede_targets is the item's `supersedes` link
+    target strings (#234) — usually empty."""
     for section, key, kind in _KIND_SOURCES:
         block = cp.get(section)
         if not isinstance(block, dict):
@@ -140,7 +144,8 @@ def _items(cp: dict):
                             and link["target"].strip()):
                         targets.append(link["target"].strip())
             yield (kind, text, str(item.get("trust") or ""),
-                   str(item.get("quote") or ""), imp, fs, item_id, targets)
+                   str(item.get("quote") or ""), str(item.get("scene") or ""),
+                   imp, fs, item_id, targets)
 
 
 def _bucket_slugs(d: Path) -> dict[str, str]:
@@ -293,6 +298,7 @@ def _init_schema(conn: sqlite3.Connection) -> None:
                 id INTEGER PRIMARY KEY,
                 text TEXT NOT NULL,
                 quote TEXT,
+                scene TEXT,
                 trust TEXT,
                 kind TEXT,
                 author TEXT,
@@ -306,7 +312,7 @@ def _init_schema(conn: sqlite3.Connection) -> None:
                 item_id TEXT,
                 frontier INTEGER NOT NULL DEFAULT 0
             );
-            CREATE VIRTUAL TABLE items_fts USING fts5(text, quote, content='');
+            CREATE VIRTUAL TABLE items_fts USING fts5(text, quote, scene, content='');
             """
         )
     except sqlite3.OperationalError as exc:
@@ -444,19 +450,20 @@ def rebuild() -> int:
                 stamped = int(store._created_epoch(cp.get("created")) is not None)
                 if key not in newest or (stamped, recency, sid) > newest[key]:
                     newest[key] = (stamped, recency, sid)
-            for (kind, text, trust, quote, importance, first_seen,
+            for (kind, text, trust, quote, scene, importance, first_seen,
                  item_id, targets) in _items(cp):
                 cur = conn.execute(
                     "INSERT INTO items"
-                    " (text, quote, trust, kind, author, project_slug,"
+                    " (text, quote, scene, trust, kind, author, project_slug,"
                     "  session_id, created, importance, first_seen, item_id)"
-                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    (text, quote, trust, kind, author, slug, sid, recency,
+                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (text, quote, scene, trust, kind, author, slug, sid, recency,
                      importance, first_seen, item_id),
                 )
                 conn.execute(
-                    "INSERT INTO items_fts(rowid, text, quote) VALUES (?, ?, ?)",
-                    (cur.lastrowid, text, quote),
+                    "INSERT INTO items_fts(rowid, text, quote, scene)"
+                    " VALUES (?, ?, ?, ?)",
+                    (cur.lastrowid, text, quote, scene),
                 )
                 count += 1
                 if slug is not None:

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -174,6 +174,44 @@ Schema shape:
   "worker_queue": []
 }"""
 
+# ---- #317: scene traces (opt-in experiment, DAIMON_SCENE_TRACES) ----
+#
+# Appended to BOTH system prompts when the flag is on; with the flag off the
+# prompts are byte-identical to the constants above (pinned by test — the
+# experiment must cost nothing until the LongMemEval harness says it earns
+# its bytes). Length cap bounds checkpoint growth; sanitize_scene enforces it
+# on whatever the model actually emits, flag or no flag.
+_SCENE_MAX_CHARS = 500
+
+_SCENE_SERIALIZE_ADDENDUM = """
+
+SCENE TRACES (optional field): every item MAY additionally carry a "scene" field —
+one or two sentences of episodic context: when in the session the item arose, what
+triggered it, and what it replaced or corrected. Narrative only, drawn from the
+transcript — never introduce a fact, name, or number that the transcript does not
+contain. "scene" never affects trust: it is always inferred narrative, and the
+rules for `text` and `quote` are unchanged. Item shapes gain one key:
+{"text": "", "trust": "", "quote": "", "scene": "", "importance": 0}"""
+
+_SCENE_MERGE_ADDENDUM = """
+
+SCENE TRACES: items may carry an optional "scene" field (episodic context). When
+merging duplicates, keep the fuller "scene"; never invent one for an item that has
+none, and never let a "scene" override the text/quote/trust rules above."""
+
+
+def _serialize_sys() -> str:
+    if config.scene_traces_enabled():
+        return SERIALIZE_SYS + _SCENE_SERIALIZE_ADDENDUM
+    return SERIALIZE_SYS
+
+
+def _merge_sys() -> str:
+    if config.scene_traces_enabled():
+        return MERGE_SYS + _SCENE_MERGE_ADDENDUM
+    return MERGE_SYS
+
+
 # Adapted from research/experiments/track-a/prompts/01c-merge-checkpoints.md (armC),
 # with two additions over the probe version: rule 9 (Q-STALE latest-state
 # preference, findings/03) and external_state preservation (rule 3 + schema),
@@ -352,6 +390,22 @@ def sanitize_importance(checkpoint) -> None:
             item["importance"] = min(10, max(1, v))
         else:
             del item["importance"]
+
+
+def sanitize_scene(checkpoint) -> None:
+    """Normalize LLM-emitted `scene` (#317) in place: strings are stripped and
+    capped at _SCENE_MAX_CHARS; anything else (lists, dicts, numbers, None,
+    empty/whitespace) is dropped. Same philosophy as sanitize_importance: a
+    malformed advisory field must NEVER fail a serialize — and it runs flag or
+    no flag, because a model can hallucinate the key without being asked."""
+    for item in iter_items(checkpoint):
+        if "scene" not in item:
+            continue
+        v = item["scene"]
+        if isinstance(v, str) and v.strip():
+            item["scene"] = v.strip()[:_SCENE_MAX_CHARS]
+        else:
+            del item["scene"]
 
 
 def validate(checkpoint) -> bool:
@@ -721,7 +775,7 @@ def _merge_partials(chat, session_id: str, partials: list, deadline,
                 return group[0]
             t0 = time.monotonic()
             merged = _call_and_parse(
-                chat, MERGE_SYS,
+                chat, _merge_sys(),
                 f"session_id: {session_id}\n\n"
                 f"PARTIAL CHECKPOINTS (JSON array, one per chunk, in chronological order):\n"
                 f"{json.dumps(group, ensure_ascii=False)}"
@@ -888,7 +942,7 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
         if len(chunks) == 1:
             log.info("single-pass serialize: %d lines", len(transcript_text.splitlines()))
             return _call_and_parse(
-                chat, SERIALIZE_SYS,
+                chat, _serialize_sys(),
                 f"session_id: {session_id}\n\nTRANSCRIPT:\n{transcript_text}{note}",
                 deadline, "transcript",
             )
@@ -912,7 +966,7 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
                     return key, cached
                 t0 = time.monotonic()
                 partial = _call_and_parse(
-                    chat, SERIALIZE_SYS,
+                    chat, _serialize_sys(),
                     f"session_id: {session_id}\n\n"
                     f"TRANSCRIPT (chunk {i + 1} of {len(chunks)}):\n{chunk_text}",
                     deadline, f"chunk {i + 1} of {len(chunks)}",
@@ -947,6 +1001,7 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
             "class, or verbatim item without a quote)"
         )
     sanitize_importance(checkpoint)
+    sanitize_scene(checkpoint)
     # #125: verify verbatim quotes against the SAME rendered text the extractor
     # read, PRE-redaction (redaction runs later in write_checkpoint and would
     # otherwise mass-downgrade legitimate quotes it had masked). Verify once,

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -416,6 +416,7 @@ def _redact_checkpoint(checkpoint: dict) -> None:
             if isinstance(item, dict):
                 _scrub(item, "text")
                 _scrub(item, "quote")
+                _scrub(item, "scene")
                 links = item.get("links")
                 if isinstance(links, list):
                     for link in links:
@@ -425,6 +426,7 @@ def _redact_checkpoint(checkpoint: dict) -> None:
     if isinstance(topic, dict):
         _scrub(topic, "text")
         _scrub(topic, "quote")
+        _scrub(topic, "scene")
     if counts:
         # MERGE, never overwrite: a re-write (anchor --attach reads, mutates,
         # writes the same dict) only re-matches NEW secrets — old markers don't

--- a/plugin/tests/test_briefing.py
+++ b/plugin/tests/test_briefing.py
@@ -945,3 +945,25 @@ def test_stale_carried_default_threshold_reads_config():
                   "carried_from": "S-prev", "first_seen": _ts215(10)}])
     stale = briefing.stale_carried(cp, {}, _NOW215)
     assert len(stale) == 1  # default 7.0 days < 10 days old
+
+
+def test_render_never_prints_scene():
+    # #317: scenes exist for retrieval, not display — the briefing must not
+    # leak them into the rendered text
+    cp = {
+        "session_id": "S1",
+        "working_context": {
+            "active_topic": {"text": "wave plan", "trust": "inferred"},
+            "open_questions": [
+                {"text": "is the wave plan scaling right?", "trust": "inferred",
+                 "scene": "SCENE-MARKER-NEVER-RENDERED"}],
+            "recent_decisions": [],
+        },
+        "epistemic_snapshot": {
+            "strong_beliefs": [],
+            "uncertainties": [],
+            "contradictions_flagged": [],
+        },
+    }
+    out = briefing.render(cp)
+    assert "SCENE-MARKER-NEVER-RENDERED" not in out

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -1065,3 +1065,16 @@ def test_twin_freeze_neither_has_last_verified_stays_absent():
     new = _cp("S-new", 0, questions=[_item(_VERB_TWIN, days=0)])
     out = carry.merge(new, prev, NOW)
     assert "last_verified" not in out["working_context"]["open_questions"][0]
+
+
+def test_carry_preserves_scene(monkeypatch):
+    # #317: scene rides the item deepcopy — pin it so a future selective-copy
+    # refactor cannot silently drop episodic context
+    prev = _cp("S-old", questions=[{"text": "does the retry nonce land?",
+                                    "trust": "inferred",
+                                    "scene": "asked right after the gateway pinned a bad response"}])
+    new = _cp("S-new")
+    merged = carry.merge(new, prev, NOW)
+    carried = merged["working_context"]["open_questions"]
+    assert any(i.get("scene") == "asked right after the gateway pinned a bad response"
+               for i in carried)

--- a/plugin/tests/test_config.py
+++ b/plugin/tests/test_config.py
@@ -548,3 +548,16 @@ def test_stale_days_default_override_malformed(monkeypatch):
     assert config.carry_max() == 1
     monkeypatch.setenv("DAIMON_CARRY_MAX", "x")
     assert config.carry_max() == 8
+
+
+# ---- #317: scene traces flag ----
+
+
+def test_scene_traces_default_off(monkeypatch):
+    monkeypatch.delenv("DAIMON_SCENE_TRACES", raising=False)
+    assert config.scene_traces_enabled() is False
+
+
+def test_scene_traces_flag_on(monkeypatch):
+    monkeypatch.setenv("DAIMON_SCENE_TRACES", "1")
+    assert config.scene_traces_enabled() is True

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -1461,3 +1461,27 @@ def test_dedupe_rows_missing_created_treated_as_oldest():
                  "session_id": "S-unstamped"}
     out = recall._dedupe_rows([unstamped, stamped], want_n=10)
     assert out[0]["session_id"] == "S-stamped"
+
+
+# ---- #317: scene traces indexed for retrieval ----
+
+
+def test_rebuild_indexes_scene_text(tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint(
+        "S1",
+        _cp("S1", decisions=[{"text": "Adopt sqlite for the recall index",
+                              "trust": "inferred",
+                              "scene": "chosen after the flatfile scan grew quadratic"}]),
+        project_dir="/repo/x",
+    )
+    recall.rebuild()
+    # "quadratic" appears ONLY in the scene — a hit proves scene is FTS-indexed
+    hits = recall.search("quadratic", all_projects=True)
+    assert any("recall index" in h["text"] for h in hits)
+
+
+def test_schema_version_bumped_for_scene_column():
+    # #317 added a scene column to items/items_fts — an old db must be discarded,
+    # not queried with the new column list
+    assert int(recall._SCHEMA_VERSION) >= 4

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -1456,3 +1456,67 @@ def test_clear_partials_survives_undeletable_entry(
     ckpt = serializer.serialize_strict("S1", messages, chat=chat2)
     assert ckpt is not None  # load failed -> recomputed; clear skipped the dirs
     assert len(chat2.calls) == n + 1
+
+
+# ---- #317: scene traces (encode-time episodic context, bench-gated experiment) ----
+
+
+def test_prompts_unchanged_when_scene_flag_off(monkeypatch):
+    monkeypatch.delenv("DAIMON_SCENE_TRACES", raising=False)
+    assert serializer._serialize_sys() == serializer.SERIALIZE_SYS
+    assert serializer._merge_sys() == serializer.MERGE_SYS
+    # the constants themselves must stay scene-free — flag off is byte-identical
+    assert "scene" not in serializer.SERIALIZE_SYS
+    assert "scene" not in serializer.MERGE_SYS
+
+
+def test_prompts_mention_scene_when_flag_on(monkeypatch):
+    monkeypatch.setenv("DAIMON_SCENE_TRACES", "1")
+    assert '"scene"' in serializer._serialize_sys()
+    assert '"scene"' in serializer._merge_sys()
+
+
+def test_serialize_sends_scene_prompt_when_flag_on(fake_chat_factory, monkeypatch):
+    monkeypatch.setenv("DAIMON_SCENE_TRACES", "1")
+    chat = fake_chat_factory(_valid_checkpoint_json("S1"))
+    serializer.serialize("S1", make_messages(20), chat=chat)
+    assert '"scene"' in chat.calls[0]["messages"][0]["content"]
+
+
+def test_scene_preserved_and_trimmed_through_serialize(fake_chat_factory, monkeypatch):
+    monkeypatch.setenv("DAIMON_SCENE_TRACES", "1")
+    cp = json.loads(_valid_checkpoint_json("S1"))
+    cp["working_context"]["open_questions"][0]["scene"] = (
+        "  came up while debugging the retry path  ")
+    chat = fake_chat_factory(json.dumps(cp))
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+    assert (ckpt["working_context"]["open_questions"][0]["scene"]
+            == "came up while debugging the retry path")
+
+
+def test_sanitize_scene_drops_non_str_and_empty():
+    cp = json.loads(_valid_checkpoint_json("S1"))
+    cp["working_context"]["open_questions"][0]["scene"] = 42
+    cp["working_context"]["recent_decisions"][0]["scene"] = "   "
+    serializer.sanitize_scene(cp)
+    assert "scene" not in cp["working_context"]["open_questions"][0]
+    assert "scene" not in cp["working_context"]["recent_decisions"][0]
+
+
+def test_sanitize_scene_caps_length():
+    cp = json.loads(_valid_checkpoint_json("S1"))
+    cp["working_context"]["open_questions"][0]["scene"] = "x" * 2000
+    serializer.sanitize_scene(cp)
+    scene = cp["working_context"]["open_questions"][0]["scene"]
+    assert len(scene) == serializer._SCENE_MAX_CHARS
+
+
+def test_sanitize_scene_runs_even_with_flag_off(fake_chat_factory, monkeypatch):
+    # a model that hallucinates a malformed scene with the flag off must not
+    # write garbage to disk — sanitize always runs
+    monkeypatch.delenv("DAIMON_SCENE_TRACES", raising=False)
+    cp = json.loads(_valid_checkpoint_json("S1"))
+    cp["working_context"]["open_questions"][0]["scene"] = ["not", "a", "string"]
+    chat = fake_chat_factory(json.dumps(cp))
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+    assert "scene" not in ckpt["working_context"]["open_questions"][0]

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1665,3 +1665,17 @@ def test_checkpoints_written_since_skips_unstattable_file(monkeypatch):
 
     monkeypatch.setattr(store, "_session_files", lambda d: [_Ghost()])
     assert store.checkpoints_written_since(_time.time() - 14 * 86400) == 0
+
+
+def test_write_checkpoint_redacts_scene(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    cp = {"working_context": {
+        "active_topic": {"text": "t",
+                         "scene": "was rotating DAIMON_LLM_API_KEY=sk-topicsecret99887766"},
+        "open_questions": [
+            {"text": "clean",
+             "scene": "arose pasting DAIMON_LLM_API_KEY=sk-scenesecret12345678"}]}}
+    store.write_checkpoint("S1", cp)
+    assert "sk-scenesecret12345678" not in cp["working_context"]["open_questions"][0]["scene"]
+    assert "sk-topicsecret99887766" not in cp["working_context"]["active_topic"]["scene"]
+    assert cp["redactions"]["api-key"] == 2


### PR DESCRIPTION
Closes #317

## What

Opt-in experiment (`DAIMON_SCENE_TRACES=1`): the serializer asks for an optional per-item `scene` field — 1–2 sentences of episodic context (when the item arose, what triggered it, what it replaced) — and recall indexes it for retrieval.

- Flag off (default): serialize and merge prompts are byte-identical to today's constants, pinned by test. Zero behavior change.
- `sanitize_scene` runs unconditionally: strip, 500-char cap, non-strings dropped — a hallucinated scene can never fail or pollute a write (same philosophy as `sanitize_importance`).
- `scene` passes capture-time redaction exactly like `text` and `quote`.
- Carried items keep their scene (rides carry's deepcopy — pinned so a selective-copy refactor can't silently drop it).
- The briefing never renders scenes — they exist for retrieval, not display (pinned).
- `items` and `items_fts` grow a `scene` column; recall `_SCHEMA_VERSION` bumps 3→4 so stale index dbs rebuild instead of raising on the new column list.

## Why

Encoding-depth evidence (#317): on LongMemEval-S, pairing stored facts with elaborated narrative context raised recall +20.2pp, concentrated in temporal reasoning and knowledge updates — the same category as the measured half-misses in the #267 baseline. Items already have the structured half of that pairing (text + verbatim quote); this adds the episodic half, at completion-token cost only.

Default stays off until the harness (#267/#273 infrastructure) shows the temporal/knowledge-update slices actually move. If they don't, the flag dies and the issue closes with the measurement.

## Tests

17 new tests, each red before the change (except the two regression pins noted): prompt byte-identity flag-off / scene-mention flag-on, prompt reaches the chat call, scene preserved+trimmed through serialize, sanitize drops non-str/empty and caps length, sanitize runs flag-off, redaction scrubs scene on items and active_topic, FTS hit on a term that appears only in a scene, schema-version bump, carry keeps scene (regression pin — deepcopy already passes), briefing never prints scene (regression pin).

Full suite: 1783 passed, 2 skipped. (5 `test_render.py` failures in a color-forcing terminal are pre-existing on main and pass under `NO_COLOR=1`; untouched by this PR.)
