### PR TITLE
fix(bench): key and pin the scene-traces flag so runs never share cache lanes

### DIFF
--- a/plugin/tests/bench/adapter.py
+++ b/plugin/tests/bench/adapter.py
@@ -54,12 +54,13 @@ _ENV_KEYS = (
     "DAIMON_RECALL_SEEN_DIR", "DAIMON_TEAM_DIR", "DAIMON_PROJECT_DIR",
     "DAIMON_CARRY", "DAIMON_CARRY_FLOOR", "DAIMON_CARRY_MAX",
     "DAIMON_MIN_MESSAGES", "DAIMON_TEAM", "DAIMON_DISABLE",
-    "DAIMON_RECEIPTS", "DAIMON_SCAR_HARVEST",
+    "DAIMON_RECEIPTS", "DAIMON_SCAR_HARVEST", "DAIMON_SCENE_TRACES",
 )
 
 
 def _question_env(root: Path, qid: str, min_messages: str,
-                  carry_on: bool = False) -> dict[str, str]:
+                  carry_on: bool = False,
+                  scene_on: bool = False) -> dict[str, str]:
     """The DAIMON_* environment that isolates one question's store + index."""
     home = root / _safe(qid)
     project = home / "project"
@@ -82,6 +83,10 @@ def _question_env(root: Path, qid: str, min_messages: str,
         "DAIMON_DISABLE": "0",
         "DAIMON_RECEIPTS": "0",          # receipts add cost, not retrieval signal
         "DAIMON_SCAR_HARVEST": "0",
+        # #319: pinned explicitly — the host's env file may carry the #317
+        # field experiment's flag, and process env overrides it; an unpinned
+        # baseline would silently serialize with scenes.
+        "DAIMON_SCENE_TRACES": "1" if scene_on else "0",
     }
 
 
@@ -119,7 +124,8 @@ def _created_stamp(index: int) -> str:
 
 def serialize_question(question: dict, *, chat, cache: cache_mod.CheckpointCache,
                        backend: str, model: str, project_dir: str,
-                       workers: int, carry_on: bool = False) -> tuple[dict, dict]:
+                       workers: int, carry_on: bool = False,
+                       scene_on: bool = False) -> tuple[dict, dict]:
     """Serialize every haystack session into the (already isolated) store.
 
     Returns (tally, attribution):
@@ -133,11 +139,13 @@ def serialize_question(question: dict, *, chat, cache: cache_mod.CheckpointCache
     sessions = dataset.sessions_of(question)
     cache_lock = threading.Lock()
     carry_mode = "on" if carry_on else "off"
+    scene_mode = "on" if scene_on else "off"
 
     def _produce(item):
         index, (sid, messages) = item
         key = cache_mod.cache_key(messages, backend=backend, model=model,
-                                  prompt_version=PROMPT_VERSION, carry=carry_mode)
+                                  prompt_version=PROMPT_VERSION, carry=carry_mode,
+                                  scene=scene_mode)
         with cache_lock:
             cached = cache.get(key)
         if cached is not None:
@@ -216,14 +224,16 @@ def recall_question(question: dict, *, project_dir: str, depth: int) -> list[dic
 def run_question(question: dict, *, chat, cache: cache_mod.CheckpointCache,
                  backend: str, model: str, root: Path, k: int, depth: int,
                  min_messages: str = BENCH_MIN_MESSAGES, workers: int = 1,
-                 carry_on: bool = False) -> dict:
+                 carry_on: bool = False, scene_on: bool = False) -> dict:
     """Full per-question pipeline: isolate → serialize haystack → recall → score."""
-    env = _question_env(root, question["question_id"], min_messages, carry_on)
+    env = _question_env(root, question["question_id"], min_messages, carry_on,
+                        scene_on)
     project_dir = env["DAIMON_PROJECT_DIR"]
     with _env(env):
         tally, attribution = serialize_question(
             question, chat=chat, cache=cache, backend=backend, model=model,
             project_dir=project_dir, workers=workers, carry_on=carry_on,
+            scene_on=scene_on,
         )
         results = recall_question(question, project_dir=project_dir, depth=depth)
 

--- a/plugin/tests/bench/cache.py
+++ b/plugin/tests/bench/cache.py
@@ -20,8 +20,10 @@ from pathlib import Path
 
 
 def cache_key(messages: list[dict], *, backend: str, model: str,
-              prompt_version: str, carry: str = "off") -> str:
-    """Stable content hash over (turns, backend, model, prompt_version, carry).
+              prompt_version: str, carry: str = "off",
+              scene: str = "off") -> str:
+    """Stable content hash over (turns, backend, model, prompt_version, carry,
+    scene).
 
     Turns are hashed in order and by role — a reordered transcript is a different
     session. Only role/content are hashed (the fields the serializer reads), so an
@@ -34,11 +36,18 @@ def cache_key(messages: list[dict], *, backend: str, model: str,
     correct even if serialization ever becomes mode-sensitive. Carry-off keys
     are byte-identical to pre-#274 keys, so the existing cache (minutes of LLM
     per entry) stays valid for carry-off runs.
+
+    `scene` (#319) namespaces the scene-traces flag (#317): unlike carry, the
+    flag changes the serialize prompt itself, so a scene-on run reusing a
+    scene-off entry would measure the cache, not the flag. Scene-off keys are
+    byte-identical to pre-#319 keys, same preservation rule as carry.
     """
     h = hashlib.sha256()
     h.update(f"v1\x00{backend}\x00{model}\x00{prompt_version}\x00".encode())
     if carry != "off":
         h.update(f"carry\x00{carry}\x00".encode())
+    if scene != "off":
+        h.update(f"scene\x00{scene}\x00".encode())
     for m in messages:
         role = str(m.get("role") or "")
         content = str(m.get("content") or "")

--- a/plugin/tests/bench/run.py
+++ b/plugin/tests/bench/run.py
@@ -106,6 +106,9 @@ def _build_config_stamp(args, dataset_path: Path) -> dict:
         # Cross-session carry (#274) is a separate retrieval axis: recorded
         # truthfully so carry-on and carry-off numbers are never conflated.
         "carry": "on" if args.carry else "off",
+        # Scene traces (#317/#319): same conflation rule as carry — the flag
+        # changes the serialize prompt, so the mode is stamped and cache-keyed.
+        "scene": "on" if args.scene else "off",
         "workers": args.workers,
         "dataset_file": dataset_path.name,
         "dataset_sha256": dataset.sha256_of(dataset_path),
@@ -120,7 +123,8 @@ def run(args) -> dict:
 
     stamp = _build_config_stamp(args, dataset_path)
     print(f"suite={args.suite} sample={len(questions)} backend={stamp['backend']} "
-          f"model={stamp['model']} workers={args.workers} carry={stamp['carry']}")
+          f"model={stamp['model']} workers={args.workers} carry={stamp['carry']} "
+          f"scene={stamp['scene']}")
 
     per_question: list[dict] = []
     t0 = time.monotonic()
@@ -130,7 +134,7 @@ def run(args) -> dict:
             q, chat=chat, cache=cache, backend=stamp["backend"],
             model=stamp["model"] or "unknown", root=Path(args.work_dir),
             k=args.k, depth=args.depth, min_messages=args.min_messages,
-            workers=args.workers, carry_on=args.carry,
+            workers=args.workers, carry_on=args.carry, scene_on=args.scene,
         )
         per_question.append(result)
         print(f"[{i}/{len(questions)}] {result['question_id']} "
@@ -182,6 +186,9 @@ def build_parser() -> argparse.ArgumentParser:
                    help="recall results fetched per question (MRR sees this depth)")
     p.add_argument("--workers", type=int, default=4,
                    help="concurrent LLM serialize calls per question")
+    p.add_argument("--scene", action="store_true",
+                   help="serialize with scene traces (#317, DAIMON_SCENE_TRACES=1); "
+                        "stamped in the config and cached under separate keys")
     p.add_argument("--carry", action="store_true",
                    help="fold prior checkpoints forward (cross-session carry, "
                         "#274) — a separate retrieval axis; recorded in the "

--- a/plugin/tests/test_bench_scene.py
+++ b/plugin/tests/test_bench_scene.py
@@ -1,0 +1,59 @@
+"""#319: the bench must key and pin the scene-traces flag (#317).
+
+Twin of the carry-axis tests (#274) in test_bench_carry.py: a scene-on run
+must never read a scene-off cache entry, the env pin must make the host's
+ambient DAIMON_SCENE_TRACES (env var or ~/.daimon/env) invisible to the
+measurement, and the result stamp must record which mode produced the number.
+"""
+
+from tests.bench import adapter
+from tests.bench import cache as cache_mod
+from tests.bench import run as bench_run
+
+
+class TestConfigStamp:
+    def test_stamp_records_scene_on_and_off(self, tmp_path):
+        ds = tmp_path / "dataset.json"
+        ds.write_text("[]", encoding="utf-8")
+        on = bench_run.build_parser().parse_args(["--scene"])
+        off = bench_run.build_parser().parse_args([])
+        assert bench_run._build_config_stamp(on, ds)["scene"] == "on"
+        assert bench_run._build_config_stamp(off, ds)["scene"] == "off"
+
+
+class TestCacheSeparation:
+    def test_scene_modes_never_share_a_key(self):
+        msgs = [{"role": "user", "content": "hello"}]
+        base = dict(backend="b", model="m", prompt_version="v")
+        assert cache_mod.cache_key(msgs, scene="on", **base) != \
+            cache_mod.cache_key(msgs, scene="off", **base)
+
+    def test_scene_off_key_is_backward_compatible(self):
+        # Pre-#319 entries (keyed without a scene axis) must stay valid for
+        # scene-off runs — the default and the explicit "off" are one key space.
+        msgs = [{"role": "user", "content": "hello"}]
+        base = dict(backend="b", model="m", prompt_version="v")
+        assert cache_mod.cache_key(msgs, **base) == \
+            cache_mod.cache_key(msgs, scene="off", **base)
+
+    def test_scene_and_carry_axes_compose(self):
+        msgs = [{"role": "user", "content": "hello"}]
+        base = dict(backend="b", model="m", prompt_version="v")
+        assert cache_mod.cache_key(msgs, carry="on", scene="on", **base) != \
+            cache_mod.cache_key(msgs, carry="on", scene="off", **base)
+
+
+class TestEnvPinning:
+    def test_scene_env_var_follows_the_mode(self, tmp_path):
+        on = adapter._question_env(tmp_path, "q", "2", scene_on=True)
+        off = adapter._question_env(tmp_path, "q", "2", scene_on=False)
+        assert on["DAIMON_SCENE_TRACES"] == "1"
+        assert off["DAIMON_SCENE_TRACES"] == "0"
+
+    def test_scene_env_is_pinned_by_default(self, tmp_path):
+        # The host machine may carry DAIMON_SCENE_TRACES=1 in its env file
+        # (the #317 field experiment does) — the default bench env must pin
+        # it OFF explicitly, or a "baseline" silently runs with scenes.
+        env = adapter._question_env(tmp_path, "q", "2")
+        assert env["DAIMON_SCENE_TRACES"] == "0"
+        assert "DAIMON_SCENE_TRACES" in adapter._ENV_KEYS


### PR DESCRIPTION
Closes #319

## What

- `cache_key` gains a `scene` axis mirroring carry (#274): folded into the hash only when `"on"`, so scene-off keys stay byte-identical to pre-#319 keys and the existing cache (minutes of LLM per entry) remains valid for baseline runs.
- `DAIMON_SCENE_TRACES` joins the bench's pinned per-question env, default `"0"` — an unpinned baseline on a host running the #317 field experiment would silently serialize with scenes (process env and env file both leak in otherwise).
- `--scene` CLI flag plumbs the mode through `run_question`/`serialize_question` and stamps `"scene": "on"/"off"` in the result config so the two modes' numbers can never be conflated.

## Why

The scene-traces flag (#317) changes the serialize prompt without changing `PROMPT_VERSION`. Without a cache axis, a scene-on run reuses scene-off cached serializations and reads as a perfect null — measuring the cache, not the flag. Same failure class as the fallback-contamination trap found during #273 feasibility. This blocks the #317 flag-on comparison run; the flag-off #273 baseline is unaffected (keys unchanged).

## Tests

6 new tests in `test_bench_scene.py`, all red before the change, mirroring the #274 carry-axis suite: scene modes never share a key, scene-off keys byte-identical to keyless calls (cache preservation), scene and carry axes compose, env var follows the mode, and the default env pins the flag off even when the host carries it on. Config stamp records the mode. Full suite green; existing carry/cache tests untouched and passing.
