### PR TITLE
feat(cli): daimon forget — item removal with a tombstone event

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -831,6 +831,69 @@ def _cmd_resolve(args) -> int:
     return 0
 
 
+def _cmd_forget(args) -> int:
+    """Deliberate item removal (#321): delete the item from the live
+    checkpoint, then append a tombstone event whose status carries a content
+    HASH, never the text — removal means the content leaves the audit trail
+    too. Binding is _cmd_resolve's never-guess contract verbatim: exact id
+    first, else a fuzzy query that must match exactly one item. The tombstone
+    rides the resolutions fold, so withhold, carry suppression, and the
+    recall index deletion all inherit it with no new plumbing. The rewritten
+    checkpoint re-mints its receipt, so the post-removal state is signed."""
+    project = _resolve_project(args.project)
+    checkpoint = store.read_latest(project_dir=project, fallback=False)
+    if not isinstance(checkpoint, dict):
+        print("no checkpoint for this project yet — nothing to forget")
+        return 1
+    items = []
+    for section, key in store._ITEM_LISTS:
+        for item in ((checkpoint.get(section) or {}).get(key) or []):
+            if isinstance(item, dict) and item.get("id"):
+                items.append((section, key, item))
+    target = next((it for _, _, it in items if it["id"] == args.target), None)
+    if target is None:
+        texts = [str(it.get("text") or "") for _, _, it in items]
+        generic = carry._generic_terms(texts)
+        hits = [(s, k, it) for s, k, it in items
+                if carry._same_item(args.target, str(it.get("text") or ""), generic)]
+        if len(hits) == 1:
+            target = hits[0][2]
+        else:
+            _note_usage("forget:no-match" if not hits else "forget:ambiguous")
+            label = "no item matches" if not hits else "ambiguous — matches"
+            print(f"{label} {args.target!r}; candidates:")
+            for _, key, it in (hits or items):
+                print(f"  {it['id']}  [{key}] {it.get('text', '')}")
+            print("forget by exact id: daimon forget <id>")
+            return 1
+    if getattr(args, "dry_run", False):
+        _note_usage("forget:dry-run")
+        print(f"would forget {target['id']}: {target.get('text', '')}")
+        return 0
+    content_hash = hashlib.sha256(
+        str(target.get("text") or "").encode("utf-8")).hexdigest()[:12]
+    for section, key in store._ITEM_LISTS:
+        lst = (checkpoint.get(section) or {}).get(key)
+        if isinstance(lst, list):
+            lst[:] = [i for i in lst
+                      if not (isinstance(i, dict) and i.get("id") == target["id"])]
+    sid = str(checkpoint.get("session_id") or "")
+    if not sid:
+        print("checkpoint has no session_id — cannot rewrite")
+        return 1
+    store.write_checkpoint(sid, checkpoint, project_dir=project)
+    ok = store.append_event(target["id"], f"forgotten:{content_hash}",
+                            note=args.reason or "", kind="tombstone",
+                            project_dir=project)
+    if not ok:
+        print("tombstone event not written (daimon disabled or project unknown)")
+        return 1
+    _note_usage("forget")
+    print(f"forgot {target['id']} (content hash {content_hash}) — "
+          "item removed from the live checkpoint; tombstone recorded")
+    return 0
+
+
 def _is_supersede_candidate(item_id: str, project) -> bool:
     """True when the item's LATEST lifecycle event is a serializer-authored
     supersede-candidate — an unconfirmed machine SUGGESTION (#14) that has
@@ -2306,6 +2369,21 @@ def main(argv=None) -> int:
         "--dry-run", action="store_true",
         help="show what would resolve without writing an event — look before the write (#304)")
     p_resolve.set_defaults(func=_cmd_resolve)
+
+    p_forget = sub.add_parser(
+        "forget", help="remove ONE item from the live checkpoint and record a "
+        "signed-state tombstone — content leaves disk and index; the event "
+        "carries only a hash (#321)",
+        epilog="Examples:\n  daimon forget o-3f8a2c --reason \"contains client name\"\n"
+               "  daimon forget \"wrong belief about retry nonce\" --dry-run\n",
+    )
+    p_forget.add_argument("target", help="item id (exact) or a query that must match exactly one item")
+    p_forget.add_argument("--reason", help="recorded on the tombstone event (redacted like any note)")
+    p_forget.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    p_forget.add_argument(
+        "--dry-run", action="store_true",
+        help="show what would be forgotten without writing — look before a destructive op")
+    p_forget.set_defaults(func=_cmd_forget)
 
     p_reverify = sub.add_parser(
         "reverify", help="evidence-gated reopen of a resolved item (#103) — "

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -404,6 +404,26 @@ def _apply_event_resolutions(conn: sqlite3.Connection) -> None:
             if not store.is_resolved(evt):
                 continue
             status = str(evt.get("status") or "")
+            # #321: forgotten is removal, not resolution — the content must
+            # leave the index entirely, historical checkpoint copies included.
+            # Prefix-match like every other status reader; only the LATEST
+            # event counts (a later reopen un-hides history by design).
+            if status.lower().startswith("forgotten"):
+                rows = conn.execute(
+                    "SELECT id, text, quote, scene FROM items"
+                    " WHERE item_id = ? AND project_slug IS ?",
+                    (ref, bucket.name)).fetchall()
+                for rowid, text, quote, scene in rows:
+                    # contentless fts5: deletion is the special 'delete'
+                    # INSERT and must repeat the original column values
+                    conn.execute(
+                        "INSERT INTO items_fts(items_fts, rowid, text, quote, scene)"
+                        " VALUES('delete', ?, ?, ?, ?)",
+                        (rowid, text, quote, scene))
+                conn.execute(
+                    "DELETE FROM items WHERE item_id = ? AND project_slug IS ?",
+                    (ref, bucket.name))
+                continue
             value = "resolved"
             if status.lower().startswith("superseded-by:"):
                 value = status.split(":", 1)[1].strip() or "resolved"

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -5531,3 +5531,46 @@ def test_forget_dry_run_writes_nothing(tmp_checkpoint_dir, capsys, monkeypatch):
     assert store.resolutions(project_dir="/p/A") == {}
     after = store.read_latest(project_dir="/p/A", fallback=False)
     assert len(after["working_context"]["open_questions"]) == n_before
+
+
+def test_forget_without_checkpoint_exits_1(tmp_checkpoint_dir, capsys, monkeypatch):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/EMPTY")
+    assert cli.main(["forget", "anything"]) == 1
+    assert "nothing to forget" in capsys.readouterr().out
+
+
+def test_forget_no_match_records_usage_and_exits_1(tmp_checkpoint_dir, tmp_log_dir,
+                                                   capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    _write_cp_with_ids(store)
+    assert cli.main(["forget", "zebra quantum harpsichord"]) == 1
+    assert store.resolutions(project_dir="/p/A") == {}
+
+
+def test_forget_missing_session_id_refuses_rewrite(tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = {"working_context": {"open_questions": [
+        {"text": "orphan item without a session id", "trust": "inferred"}]}}
+    store.write_checkpoint("S1", cp, project_dir="/p/A")
+    # simulate a torn/legacy pointer whose session_id never landed
+    slug = store.project_slug("/p/A")
+    import json as _json
+    p = tmp_checkpoint_dir / slug / "latest.json"
+    blob = _json.loads(p.read_text())
+    blob.pop("session_id", None)
+    p.write_text(_json.dumps(blob))
+    iid = blob["working_context"]["open_questions"][0]["id"]
+    assert cli.main(["forget", iid]) == 1
+    assert "cannot rewrite" in capsys.readouterr().out
+
+
+def test_forget_event_write_failure_exits_1(tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    monkeypatch.setattr(store, "append_event", lambda *a, **k: False)
+    assert cli.main(["forget", iid]) == 1
+    assert "not written" in capsys.readouterr().out

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -5574,3 +5574,16 @@ def test_forget_event_write_failure_exits_1(tmp_checkpoint_dir, capsys, monkeypa
     monkeypatch.setattr(store, "append_event", lambda *a, **k: False)
     assert cli.main(["forget", iid]) == 1
     assert "not written" in capsys.readouterr().out
+
+
+def test_forget_by_unique_fuzzy_query(tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    assert cli.main(["forget", "release pipeline manual approval",
+                     "--reason", "example"]) == 0
+    after = store.read_latest(project_dir="/p/A", fallback=False)
+    ids = [i.get("id") for i in after["working_context"]["open_questions"]]
+    assert iid not in ids
+    assert store.resolutions(project_dir="/p/A")[iid]["status"].startswith("forgotten:")

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -4740,7 +4740,7 @@ def test_main_installs_crash_excepthook(monkeypatch):
 
 
 def _write_cp_with_ids(store, project="/p/A"):
-    cp = {"working_context": {"open_questions": [
+    cp = {"session_id": "S1", "working_context": {"open_questions": [
         {"text": "release pipeline awaiting manual approval step", "trust": "inferred"},
         {"text": "serializer chunk retry budget unclear", "trust": "inferred"},
     ]}}
@@ -5478,3 +5478,56 @@ def test_recall_zero_match_teaser_fails_open_on_recall_error(tmp_checkpoint_dir,
     rc = cli.main(["recall", "nonexistentword", "--project", proj])
     assert rc == 0
     assert capsys.readouterr().out.strip() == "no matches"
+
+
+# ---- #321: daimon forget — removal with tombstone event ----
+
+
+def test_forget_removes_item_from_live_checkpoint(tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    assert cli.main(["forget", iid, "--reason", "user request"]) == 0
+    after = store.read_latest(project_dir="/p/A", fallback=False)
+    ids = [i.get("id") for i in after["working_context"]["open_questions"]]
+    assert iid not in ids
+
+
+def test_forget_event_carries_hash_never_text(tmp_checkpoint_dir, capsys, monkeypatch):
+    import hashlib
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    item = cp["working_context"]["open_questions"][0]
+    iid, text = item["id"], item["text"]
+    assert cli.main(["forget", iid]) == 0
+    evt = store.resolutions(project_dir="/p/A")[iid]
+    assert evt["status"].startswith("forgotten:")
+    assert hashlib.sha256(text.encode()).hexdigest()[:12] in evt["status"]
+    assert store.is_resolved(evt)  # rides withhold/carry suppression for free
+    raw = (tmp_checkpoint_dir / store.project_slug("/p/A") / "events.jsonl").read_text()
+    assert text not in raw  # removal means the content leaves the audit trail too
+
+
+def test_forget_ambiguous_refuses_without_write(tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    _write_cp_with_ids(store)
+    assert cli.main(["forget", "the"]) == 1
+    assert store.resolutions(project_dir="/p/A") == {}
+    before = store.read_latest(project_dir="/p/A", fallback=False)
+    assert len(before["working_context"]["open_questions"]) >= 1
+
+
+def test_forget_dry_run_writes_nothing(tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    n_before = len(store.read_latest(project_dir="/p/A", fallback=False)
+                   ["working_context"]["open_questions"])
+    assert cli.main(["forget", iid, "--dry-run"]) == 0
+    assert store.resolutions(project_dir="/p/A") == {}
+    after = store.read_latest(project_dir="/p/A", fallback=False)
+    assert len(after["working_context"]["open_questions"]) == n_before

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -1485,3 +1485,22 @@ def test_schema_version_bumped_for_scene_column():
     # #317 added a scene column to items/items_fts — an old db must be discarded,
     # not queried with the new column list
     assert int(recall._SCHEMA_VERSION) >= 4
+
+
+def test_rebuild_drops_forgotten_items_from_index(tmp_checkpoint_dir, monkeypatch):
+    # #321: a forgotten item's content must leave the index entirely — old
+    # checkpoint copies included — not merely be marked superseded
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint(
+        "S1",
+        _cp("S1", decisions=[{"text": "Adopt sqlite for the recall index",
+                              "trust": "inferred"}]),
+        project_dir="/repo/x",
+    )
+    cp = store.read_latest(project_dir="/repo/x", fallback=False)
+    iid = cp["working_context"]["recent_decisions"][0]["id"]
+    store.append_event(iid, "forgotten:deadbeef1234", kind="tombstone",
+                       project_dir="/repo/x")
+    recall.rebuild()
+    hits = recall.search("sqlite", all_projects=True)
+    assert not any("recall index" in h["text"] for h in hits)


### PR DESCRIPTION
Closes #321

## What

`daimon forget <id|query> [--reason] [--dry-run]`:

- Binds with `resolve`'s never-guess contract — exact id first, else a fuzzy query that must match exactly one item; ambiguity refuses with candidates listed and its own usage tag.
- Removes the item from the live checkpoint and rewrites it through `store.write_checkpoint`, so redaction re-runs and the receipt re-mints — the post-removal state is signed.
- Appends a tombstone event (`kind: tombstone`, `status: forgotten:<12-char content hash>`) — the hash, never the text: removal means the content leaves the audit trail too. `--reason` lands on the event note, redacted like any note.
- Recall's event fold treats a latest-event `forgotten` status as deletion, not marking: rows for the item id are removed from `items` and the contentless FTS table (via the special `'delete'` insert with original column values) across ALL historical checkpoint copies, local and team.
- Briefing withhold, carry suppression, and `daimon stats` inherit the tombstone through the existing resolutions fold — zero new plumbing on those paths. A later `reopen` un-hides history by design (the live checkpoint's copy is gone regardless).
- Usage tags: `forget`, `forget:no-match`, `forget:ambiguous`, `forget:dry-run` — same refusal-visibility discipline as resolve.

## Why

Capture-time redaction protects secrets it can recognize; nothing covered deliberate removal of an item that already landed — a name, a project detail, a wrong belief that keeps carrying. Hand-editing checkpoints breaks the signed receipt and leaves no trace. Forget is the intent-based second line: the item goes, and the event stream can prove when and why (by hash) without preserving what.

## Scope notes

Two follow-ups deliberately out of v1, per the issue: a dedicated standalone signed tombstone sidecar (v1's signed artifact is the re-minted post-removal checkpoint receipt plus the append-only event), and tombstone propagation to team mirrors (v1 removes mirrored rows from the local index; teammates' own mirrors are their own).

## Tests

5 new tests, red first: removal from the live checkpoint, hash-not-text on the event (asserts the text is absent from events.jsonl bytes), ambiguous refusal writes nothing, dry-run writes nothing, and recall index deletion including historical copies. One shared fixture gained the schema-required `session_id` it had been missing. Full suite: 1794 passed, 2 skipped.
