### PR TITLE
docs(site): concepts pages — trust classes, carry, receipts, item lifecycle

### DIFF
--- a/website/docs/concepts/architecture.md
+++ b/website/docs/concepts/architecture.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 5
+---
+
 # Architecture Overview
 
 > ## ⚠️ SUPERSEDED — read this first

--- a/website/docs/concepts/carry.md
+++ b/website/docs/concepts/carry.md
@@ -1,0 +1,70 @@
+---
+sidebar_position: 2
+---
+
+# Carry and staleness
+
+A checkpoint captures one session. Carry is what makes memory span many: items
+that are still open — unresolved questions, standing decisions, unfinished
+work — are carried forward from older checkpoints into the next briefing, so
+they keep appearing until something closes them.
+
+## The `[carried]` suffix
+
+An item written by the most recent session appears plain. An item riding
+forward from an older checkpoint gets a visible suffix:
+
+```
+- [~ inferred] The staging config drift needs an owner [carried]
+```
+
+`[carried]` means: *no session has re-confirmed this recently — it may be
+stale.* The older a carried item gets, the more skeptically it should be read.
+Carry deliberately never rewords items — a carried verbatim quote is the same
+bytes it was on day one (see [trust classes](./trust-classes.md)).
+
+## Carry is bounded, not infinite
+
+Unclosed items do not accumulate forever:
+
+- Each item's carry weight **decays** over time, importance-graded. With the
+  default floor (`DAIMON_CARRY_FLOOR`), decisions expire from carry in roughly
+  5–6 weeks; escalated open questions live around 3–4 months.
+- At most `DAIMON_CARRY_MAX` items per kind are carried (default: 8), so a
+  briefing stays skimmable no matter how long a project runs.
+- [Resolving](./lifecycle.md) an item ends its carry immediately — that is the
+  intended way items leave, decay is the backstop.
+
+All knobs live in the
+[configuration reference](../getting-started/configuration.md), including
+`DAIMON_CARRY` (master switch, on by default).
+
+## The staleness warning
+
+Carry has a failure mode daimon warns about explicitly: an item can ride
+along, restated briefing after briefing, without anyone actually re-checking
+it against the world. Two of daimon's own artifacts agreeing — the briefing
+and an old checkpoint — is **not corroboration**; they are the same source
+repeated.
+
+So when a carried item's last-verified stamp ages past `DAIMON_STALE_DAYS`
+(default: 7 days), the briefing says so:
+
+```
+N carried item(s) unverified for >N days — world-check before repeating as true
+```
+
+The intended response is to check the world — code, git, the issue tracker —
+and then either [resolve](./lifecycle.md) the item (it's done or wrong) or
+`daimon reverify` it with evidence (it's still true), which resets the clock.
+
+## Supersession: carry that argues with itself
+
+When a newer session contradicts a carried item — the project committed to X,
+then later committed to Y — carry does not silently drop the old item or
+silently keep injecting it as fact. The briefing flags it as a **supersession
+candidate**, presenting both sides with the confirm/reject commands inline.
+Confirming (`daimon resolve <id>`) withholds the stale side from every future
+briefing; rejecting (`daimon reverify <id>`) keeps the item and records why.
+Nothing is guessed on your behalf — see the
+[item lifecycle](./lifecycle.md) for the full mechanics.

--- a/website/docs/concepts/lifecycle.md
+++ b/website/docs/concepts/lifecycle.md
@@ -1,0 +1,95 @@
+---
+sidebar_position: 4
+---
+
+# The item lifecycle
+
+A briefing item is not a static row — it moves through a lifecycle: it is
+born in a session, carried while open, and eventually closed, revived, or
+removed. Three commands drive the transitions, and all three share one
+contract: **nothing is ever guessed on your behalf.**
+
+## The never-guess contract
+
+`resolve` and `forget` accept either an exact item id (`o-3f8a2c`) or a
+free-text query — but the query must match **exactly one** item. An ambiguous
+match is refused with the candidates listed; you pick one by id. Both commands
+take `--dry-run`, which runs the same match and prints what *would* happen
+without writing anything — look before the write.
+
+One caveat the contract cannot cover: a confident match on the *wrong* item is
+not ambiguous, so the refusal never fires. That is what `--dry-run` is for.
+
+## `daimon resolve` — close a loop
+
+```sh
+daimon resolve "retry policy for the payments webhook" --dry-run
+daimon resolve o-3f8a2c --note "shipped exponential backoff in #212"
+```
+
+Resolving records an append-only event; from then on, briefings **withhold**
+the item instead of carrying it stale. The item is not deleted — its history
+stays searchable, and the event trail shows when and why it closed.
+`--status` accepts a free-form lifecycle status; any status starting with
+`reopen` revives the item.
+
+## `daimon reverify` — assert it's still true
+
+```sh
+daimon reverify o-3f8a2c --evidence "checked the release page"
+```
+
+Reverify is the answer to the [staleness warning](./carry.md#the-staleness-warning):
+a carried item aged past the threshold, you checked the world, and it still
+holds. The event resets the item's last-verified stamp, so the warning clock
+restarts. Reverify takes **exact ids only** — re-asserting a claim is
+deliberate, so there is no fuzzy match to mis-fire.
+
+Reverify is also the **reject** half of a supersession candidate (below).
+
+## `daimon forget` — remove, provably
+
+```sh
+daimon forget o-3f8a2c --reason "contains client name"
+daimon forget "wrong belief about retry nonce" --dry-run
+```
+
+Resolve closes an item but keeps its content in history. Forget is for the
+cases where the content itself must go — a name that should never have been
+captured, a project detail, a wrong belief that keeps carrying. Capture-time
+redaction is the first line of defense; forget is the second, for judgment
+calls no redaction pattern can know about.
+
+What happens on forget:
+
+- The item is removed from the live checkpoint, which is rewritten through
+  the normal store path — redaction re-runs and, with receipts on, the
+  **receipt re-mints over the post-removal bytes** (see
+  [receipts](./receipts.md)).
+- An append-only **tombstone event** records `forgotten:<12-char content
+  hash>` — the hash, never the text. Removal means the content leaves the
+  audit trail too; the trail can still prove *that* something was removed,
+  when, and why (`--reason`, redacted like any note).
+- The recall index deletes the item's rows across **all** historical
+  checkpoint copies in your local index — including your local copies of team
+  mirrors — so recall cannot resurrect it. (Propagating tombstones into
+  teammates' own mirrors is a deliberate follow-up, not in v1.)
+- Briefing withhold, carry suppression, and `daimon stats` all inherit the
+  tombstone through the same event stream.
+
+## Supersession candidates
+
+When a newer session contradicts a carried item, the briefing presents a
+**supersession candidate**: both sides, with the confirm/reject commands
+inline. You verify which side is true in the world, then answer with exactly
+those commands:
+
+- **Confirm** — `daimon resolve <id>`: the old item is genuinely superseded;
+  future briefings withhold it.
+- **Reject** — `daimon reverify <id>`: the contradiction was apparent, not
+  real; the item stands, freshly verified.
+
+The design principle across the whole lifecycle: daimon flags, you decide.
+Contradiction, staleness, and removal are all surfaced with evidence and
+resolved by an explicit human (or explicitly-instructed agent) action —
+never by a silent merge.

--- a/website/docs/concepts/receipts.md
+++ b/website/docs/concepts/receipts.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 3
+---
+
+# Receipts and offline verification
+
+Receipts are daimon's answer to a question most memory systems cannot take
+seriously: *how do you know the memory file wasn't edited after it was
+written?*
+
+## What a receipt is
+
+With `DAIMON_RECEIPTS=1`, every checkpoint is paired with a
+[vitni](https://github.com/Daily-Nerd/vitni) receipt — an Ed25519-signed
+statement written to a `<session>.receipt` sidecar file that binds:
+
+- the checkpoint's **exact on-disk bytes** (`outputs_hash`), to
+- its **source transcript** (`inputs_hash`).
+
+If anyone edits the checkpoint file after the fact — by hand, by script, by a
+well-meaning cleanup job — the bytes no longer match the signature, and the
+edit is detectable.
+
+Everything happens locally. Receipts are minted offline, verified offline, and
+nothing ever leaves the machine. There is no service, no timestamping
+authority, no network call.
+
+## Verifying
+
+```sh
+daimon verify-receipt              # this project's latest checkpoint
+daimon verify-receipt <session-id> # a specific one
+```
+
+Verification is also woven into the briefing path: when a checkpoint from the
+receipt era has a missing receipt, or a receipt that no longer matches the
+file's bytes, the briefing does not silently trust it — the affected
+`✓ verbatim` labels are **degraded with a visible note**. A verbatim claim is
+only as strong as the integrity of the bytes behind it, and the briefing says
+so when that integrity cannot be shown (see
+[trust classes](./trust-classes.md)).
+
+## Fail-open by design
+
+Receipts never block memory. A missing vitni CLI, a timeout, or a bad signing
+step logs one line and the serialize proceeds without a receipt — a receipts
+failure cannot cost you a checkpoint or a briefing. Signing keys are
+auto-created on first mint under `~/.daimon/keys` (mode 0600).
+
+Receipts are **off by default** (each mint spawns a subprocess); the full knob
+list — `DAIMON_RECEIPTS`, `DAIMON_VITNI_CLI`, `DAIMON_KEYS_DIR` — is in the
+[configuration reference](../getting-started/configuration.md#receipts).
+
+## Receipts and deletion
+
+Deletion composes with receipts instead of fighting them. `daimon forget`
+removes an item and **re-mints the receipt over the post-removal checkpoint**,
+while an append-only tombstone event records that a removal happened — by
+content hash, never by content. Hand-editing a checkpoint breaks its receipt;
+forgetting through the CLI leaves a signed, provable trail. The
+[item lifecycle](./lifecycle.md) page covers the mechanics.

--- a/website/docs/concepts/trust-classes.md
+++ b/website/docs/concepts/trust-classes.md
@@ -1,0 +1,89 @@
+---
+sidebar_position: 1
+---
+
+# Trust classes
+
+Every item in a briefing carries a trust class — a visible marker of *how the
+item came to exist*. This is the core idea in daimon: memory that tells you
+which parts of it are quotes and which parts are guesses.
+
+## The three classes
+
+### `[✓ verbatim]`
+
+An exact quote from a past session's transcript, pinned character-for-character.
+Verbatim items are never reworded — not by carry-over between sessions, not by
+rendering, not by budget truncation. When a briefing shows
+
+```
+- [✓ verbatim] PR #60 awaiting review  — "review requested 2026-07-01"
+```
+
+the trailing quote is the actual text from the transcript, and it stays
+byte-identical for as long as the item lives.
+
+An agent reading the briefing should repeat verbatim items exactly, never
+summarize or paraphrase them.
+
+### `[~ inferred]`
+
+A conclusion the serializing model drew from the session — a summary, a
+diagnosis, a connection between events. Inferred items are honest about being
+derivations: they are allowed to evolve as later sessions refine them, and they
+should be verified against the world (code, docs, the issue tracker) before
+anything load-bearing is built on them.
+
+### `[? untagged]`
+
+An item that never had trust recorded — typically from an older checkpoint
+written before trust classes existed, or from a degraded capture. Treat
+untagged items like inferred ones: verify before relying on them.
+
+## Why the distinction matters
+
+Most memory systems store one kind of thing: text a model wrote about what
+happened. When that text is wrong — and models summarizing long sessions are
+wrong regularly — there is no way to tell from the memory itself. It all reads
+with the same confidence.
+
+Trust classes split the memory into two populations with different failure
+modes:
+
+- A **verbatim** item can be *stale* (the world moved on since the quote was
+  said) but it cannot be *misremembered* — the quote is what was said, provably.
+- An **inferred** item can be both stale *and* wrong — the model may have
+  misread the session when it wrote it.
+
+That difference changes how a reader (human or agent) should act on each item,
+which is why the briefing makes it visible on every line instead of burying it
+in metadata.
+
+## Verification is mechanical, not claimed
+
+Verbatim status is not the extracting model's opinion of itself. At serialize
+time, every verbatim item's quote is checked against the rendered transcript
+by a deterministic verifier — pure string operations, no LLM, on the principle
+that *the checker must be dumber than the thing it checks*. A quote that
+verifies gets stamped; a quote that doesn't is **downgraded to `~ inferred`**
+on the spot, so a hallucinated "quote" can never wear the verbatim badge.
+
+The guarantee extends past write time: with [receipts](./receipts.md) enabled,
+the checkpoint's exact bytes are signed when written — so if a checkpoint file
+is edited after the fact, briefing-time verification notices, and the affected
+`✓ verbatim` labels are **visibly degraded** rather than silently trusted.
+
+## VERIFY BEFORE TRUSTING
+
+Briefings open with a section of items describing state that may have changed
+*outside* the session — merged PRs, rotated keys, moved files. A verbatim tag
+means the quote is faithful; it does not mean the world still looks like that.
+The intended reading protocol, for humans and agents alike:
+
+1. Read the item.
+2. Check the world (files, git, the issue tracker) before repeating it as
+   current fact.
+3. [Resolve](./lifecycle.md) it once it is closed, so it stops carrying.
+
+A briefing is context, not instructions — it never overrides what the user is
+asking for now.


### PR DESCRIPTION
Closes #326

> **Staged issue** — concepts stage of #326. Remaining: content curation, prose pass, Spanish. Reopen #326 after merge (the `Closes` keyword is required by PR validation).

## What

Four new pages under **Concepts**:

- **Trust classes** — verbatim / inferred / untagged semantics, the deterministic serialize-time quote verifier (pure string ops, downgrade-to-inferred on miss), receipt-degraded labels, and the VERIFY BEFORE TRUSTING reading protocol.
- **Carry and staleness** — the `[carried]` suffix, decay bounds (floor/max), the "unverified for >N days" world-check warning, and supersession candidates.
- **Receipts** — vitni Ed25519 binding of checkpoint bytes to source transcript, offline `verify-receipt`, fail-open design, and how `forget` re-mints.
- **Item lifecycle** — `resolve` / `reverify` / `forget`, the never-guess contract with `--dry-run`, tombstone-by-hash semantics, and the confirm/reject supersession flow.

Also pins the superseded Architecture Overview to the bottom of the section (new pages ranked above it).

## Why

#326 stage 3: the site had no pages for the concepts that make daimon different — the README sells trust classes in one paragraph, and nothing on the site explained carry, receipts, or the lifecycle at all.

## Tests

- Every behavioral claim verified against source or the released CLI: `verify_quotes` (serializer.py:525) for downgrade-on-miss, `--help` output for all three lifecycle commands (including reverify's exact-id-only rule and resolve's `reopen` status), the configuration reference for carry/staleness/receipts knobs and defaults, PR #322 for forget semantics — including the deliberate v1 scope-out of teammate-mirror tombstone propagation, stated precisely on the page.
- Cross-page links and the `configuration.md#receipts` anchor checked against actual headings.
- Site build + broken-link check runs in CI (docs.yml gates `website/**` PRs).