### PR TITLE
ci(pr-validation): accept Refs #N so staged issues don't auto-close on merge

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,9 @@ Closes #
 
 <!--
 CI gates on this PR (pr-validation.yml):
-- body links an issue labeled status:approved (Closes/Fixes/Resolves #N)
+- body links an issue labeled status:approved (Closes/Fixes/Resolves #N;
+  use "Refs #N" for a stage of a multi-PR issue so merging doesn't close it —
+  the final stage uses Closes)
 - exactly one type:* label on the PR
 - conventional title — squash-merge makes it the commit subject on main
 - branch named type/description (lowercase)

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -35,12 +35,15 @@ jobs:
             echo "scars_only=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # `refs` links a staged issue (one issue, several sequential PRs) without
+      # GitHub's auto-close-on-merge; `closes`/`fixes`/`resolves` stay the verbs
+      # for a PR that finishes its issue.
       - name: Check Issue Reference
         if: steps.scars_only.outputs.scars_only != 'true'
         run: |
           body="$(gh pr view "$PR" --repo "$REPO" --json body -q .body)"
-          if ! grep -qiE '(closes|fixes|resolves) #[0-9]+' <<<"$body"; then
-            echo "::error::PR body must link an issue: Closes/Fixes/Resolves #N"
+          if ! grep -qiE '(closes|fixes|resolves|refs) #[0-9]+' <<<"$body"; then
+            echo "::error::PR body must link an issue: Closes/Fixes/Resolves/Refs #N"
             exit 1
           fi
 
@@ -48,7 +51,7 @@ jobs:
         if: steps.scars_only.outputs.scars_only != 'true'
         run: |
           body="$(gh pr view "$PR" --repo "$REPO" --json body -q .body)"
-          issue="$(grep -oiE '(closes|fixes|resolves) #[0-9]+' <<<"$body" | head -1 | grep -oE '[0-9]+')"
+          issue="$(grep -oiE '(closes|fixes|resolves|refs) #[0-9]+' <<<"$body" | head -1 | grep -oE '[0-9]+')"
           labels="$(gh issue view "$issue" --repo "$REPO" --json labels -q '.labels[].name')"
           if ! grep -qx 'status:approved' <<<"$labels"; then
             echo "::error::Linked issue #$issue lacks the status:approved label"


### PR DESCRIPTION
Closes #330

## What

- Adds `refs` to the accepted issue-link keywords in both validation steps (issue-reference check and approved-label lookup) in `pr-validation.yml`.
- Updates the PR template comment with the convention: `Refs #N` for a stage of a multi-PR issue, `Closes #N` for the final stage.

## Why

#330: `Closes/Fixes/Resolves` are all GitHub auto-close keywords, so every merged stage of a staged issue force-closed it — #326 was reopened three times today. `Refs #N` is not a closing keyword: the gate still verifies the linked issue carries `status:approved`, but the issue survives the merge.

## Tests

- Regex checked locally against both forms: `grep -qiE '(closes|fixes|resolves|refs) #[0-9]+'` matches `Refs #326` and still matches `Closes #330`; the issue-number extraction pulls the right number from each.
- This PR itself exercises the unchanged path (`Closes #330` — single-purpose issue, closing is correct); the next #326 stage PR will exercise the `Refs` path live.
- Note: the validation run on THIS PR uses the workflow from main (pull_request event), so the green check here proves no regression; the new keyword takes effect for PRs opened after merge.