### PR TITLE
docs(site): prose pass on host pages — user tone, no repo-internal references

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ That's it. End a session → a checkpoint is written; start the next → the bri
 
 - **Trust-classed, quote-pinned memory** — every briefing item is marked verbatim (exact quote, immutable everywhere) or inferred (allowed to evolve), with provenance and supersession tracked extractively. No embeddings, no graph database, no server: per-project JSON plus a derived SQLite FTS5 index, stdlib-first and offline-first.
 - **The briefing UX** — memory that arrives as a session-*start* artifact you can skim in 30 seconds, ordered by what to verify first.
-- **Host-agnostic hooks** — Claude Code (live-validated daily), Windsurf (adapter shipped, in live validation), Codex (adapter shipped, awaiting first live run); other hosts are reachable via the same thin adapter shape.
+- **Host-agnostic hooks** — Claude Code (live-validated daily), Windsurf (live-validated), Codex (adapter shipped, awaiting first live run); other hosts are reachable via the same thin adapter shape.
 
 ## Status
 
@@ -86,7 +86,7 @@ That's it. End a session → a checkpoint is written; start the next → the bri
 |---------|-------|
 | Claude Code plugin + hooks | live-validated daily |
 | CLI (`brief`, `status`, `recall`, `projects`, `heal`, `anchor`, `forget`, `configure`, `hooks`, `skill`) | stable, on PyPI |
-| Windsurf adapter | shipped, in live validation |
+| Windsurf adapter | live-validated |
 | Codex adapter | shipped, awaiting first live run |
 | Gemini host hooks | blocked upstream (`gemini-cli#14715`) |
 | Team memory | shipped, opt-in, early |

--- a/website/docs/hosts/claude-code.md
+++ b/website/docs/hosts/claude-code.md
@@ -1,8 +1,9 @@
 # Claude Code
 
-Claude Code is the live-validated host: daily dogfood, full loop (serialize
--> carry -> brief -> recall), field incidents recorded in
-[research/LOGBOOK.md](https://github.com/Daily-Nerd/daimon/blob/main/research/README.md).
+Claude Code is the most deeply supported host: the full loop (serialize ->
+carry -> brief -> recall) runs on it in real daily use, and field incidents
+feed back into the code — the evidence trail lives in the
+[research logbook](https://github.com/Daily-Nerd/daimon/blob/main/research/README.md).
 
 ## Install (plugin — recommended)
 
@@ -22,10 +23,10 @@ hint instead of a briefing.
 > (double briefings, double serialize LLM calls). Switching from manual to
 > plugin: run `python3 hook/daimon-hooks.py uninstall` first.
 
-## Install (manual / dogfood hooks)
+## Install (manual, from a clone)
 
-For a repo clone without the plugin system, `hook/daimon-hooks.py` is a
-lifecycle manager (same shape as SCAR's `scar-hooks.py`):
+Working from a source checkout without the plugin system, `hook/daimon-hooks.py`
+is the lifecycle manager:
 
 ```sh
 python3 hook/daimon-hooks.py install   [--dry-run]
@@ -35,11 +36,11 @@ python3 hook/daimon-hooks.py status
 
 Install copies the hook scripts to `~/.claude/hooks/` and registers them
 under `SessionStart` / `SessionEnd` in `~/.claude/settings.json` (idempotent;
-settings backed up before every mutation). Requires the plugin CLI on PATH:
-`uv tool install ./plugin` (or equivalent) so `daimon` resolves (the hooks
-also accept the deprecated `daimon-briefing` alias as a fallback) — reinstall
-after updating `plugin/` so the CLI picks up `.jsonl` transcript support,
-which `SessionEnd` depends on.
+settings backed up before every mutation). Requires the `daimon` CLI on PATH —
+`uv tool install 'daimon-briefing[pretty]'`, see the
+[quickstart](../getting-started/quickstart.md) — and the hooks also accept the
+deprecated `daimon-briefing` alias as a fallback. After upgrading the CLI,
+re-run install so the hook scripts stay in sync.
 
 ## What each script does
 
@@ -73,8 +74,8 @@ registers them:
   (terminal closed, SIGKILL) — briefings can still be stale, which is why the
   `SessionStart` header shows checkpoint age.
 
-  LLM credentials come from `~/.daimon/env` (see the
-  [plugin README](https://github.com/Daily-Nerd/daimon/blob/main/plugin/README.md) Connect an LLM section) — hooks
+  LLM credentials come from `~/.daimon/env` (see
+  [Connect an LLM](../getting-started/quickstart.md#2-connect-an-llm)) — hooks
   inherit the host process environment, not your shell profile, so
   `DAIMON_LLM_API_KEY` / `DAIMON_LLM_MODEL` / `DAIMON_LLM_BASE_URL` belong in
   that file (chmod 600). Without it, serialize fails fast with a named error

--- a/website/docs/hosts/codex.md
+++ b/website/docs/hosts/codex.md
@@ -31,7 +31,7 @@ Requires the `daimon` CLI on `PATH` (the deprecated `daimon-briefing` alias
 also works as a fallback):
 
 ```sh
-uv tool install ./plugin
+uv tool install 'daimon-briefing[pretty]'
 ```
 
 ### Manual install (from a clone)

--- a/website/docs/hosts/gemini.md
+++ b/website/docs/hosts/gemini.md
@@ -33,7 +33,7 @@ python3 hook/gemini-hooks.py status
 
 Install copies both scripts (plus `_daimon_hook_lib.py`) to `~/.gemini/hooks/`
 and registers them in `~/.gemini/settings.json` (user layer). Requires the
-`daimon` CLI on `PATH` (`uv tool install ./plugin` or equivalent).
+`daimon` CLI on `PATH` (`uv tool install 'daimon-briefing[pretty]'`).
 
 ## Teach the agent the protocol
 

--- a/website/docs/hosts/index.md
+++ b/website/docs/hosts/index.md
@@ -10,7 +10,7 @@ hook events each host actually exposes.
 | [Claude Code](./claude-code.md) | Plugin (`/plugin install daimon@daimon`) or manual `hook/daimon-hooks.py install` | `SessionEnd` hook spawns `daimon serialize` detached | `SessionStart` hook injects the briefing; `UserPromptSubmit` hook adds proactive recall | live-validated daily |
 | [Codex](./codex.md) | Manual `hook/codex-hooks.py install` (from a clone) | Throttled `Stop` hook (Codex has no session-end event) | `SessionStart` hook injects via `additionalContext` | shipped, awaiting first live run |
 | [Gemini CLI](./gemini.md) | Manual `hook/gemini-hooks.py install` (from a clone) | Blocked upstream (`gemini-cli#14715` — `transcript_path` is an empty stub) | `SessionStart` hook injects via `additionalContext` | blocked upstream (`gemini-cli#14715`) |
-| [Windsurf (Cascade)](./windsurf.md) | `daimon hooks install windsurf` | Throttled serialize on `pre_user_prompt` / `post_cascade_response(_with_transcript)` | None — Cascade has no session-start-equivalent event; the skill instructs the agent to run `daimon brief --team` in the terminal at session start | shipped, in live validation |
+| [Windsurf (Cascade)](./windsurf.md) | `daimon hooks install windsurf` | Throttled serialize on `pre_user_prompt` / `post_cascade_response(_with_transcript)` | None — Cascade has no session-start-equivalent event; the skill instructs the agent to run `daimon brief --team` in the terminal at session start | live-validated |
 
 ## Three moving parts
 

--- a/website/docs/hosts/windsurf.md
+++ b/website/docs/hosts/windsurf.md
@@ -1,8 +1,8 @@
 # Windsurf (Cascade)
 
 Windsurf's adapter is shipped and code-verified (native-transcript serialize,
-probe-hardened), live validation in progress. No logbook entry yet documents
-a complete dogfooded loop the way Claude Code's does — treat end-to-end "runs
+probe-hardened), live validation in progress. No recorded live session yet
+completes the full loop the way Claude Code's does — treat end-to-end "runs
 on Windsurf" as inferred from code + unit tests until one is on record.
 
 ## Install
@@ -15,14 +15,13 @@ daimon hooks list                # hosts with packaged hook scripts
 ```
 
 `daimon hooks install <host>` ships `redact.py` alongside the hook script(s)
-so a standalone host adapter can scrub secrets at its own write sites
-(transcript accumulation, checkpoint, event log) without importing the
-venv-only `daimon_briefing` package — a test keeps this copy byte-identical
-to the canonical `plugin/daimon_briefing/redact.py`. Re-run `daimon hooks
-install windsurf` after every `daimon` upgrade so the installed scripts (and
-the bundled `redact.py`) stay in sync with the installed CLI. To check whether
-they have drifted, run `daimon hooks status` — it reports each installed copy as
-CURRENT/STALE/MISSING against the packaged version and exits non-zero on drift.
+so the adapter scrubs secrets at every one of its own write sites (transcript
+accumulation, checkpoint, event log) — redaction does not depend on the full
+`daimon` package being importable from the hook. Re-run `daimon hooks install
+windsurf` after every `daimon` upgrade so the installed scripts stay in sync
+with the installed CLI. To check whether they have drifted, run `daimon hooks
+status` — it reports each installed copy as CURRENT/STALE/MISSING against the
+packaged version and exits non-zero on drift.
 
 Point Windsurf's Cascade hooks config (user-level JSON — see
 [the Cascade hooks docs](https://docs.windsurf.com/windsurf/cascade/hooks))

--- a/website/docs/hosts/windsurf.md
+++ b/website/docs/hosts/windsurf.md
@@ -1,9 +1,8 @@
 # Windsurf (Cascade)
 
-Windsurf's adapter is shipped and code-verified (native-transcript serialize,
-probe-hardened), live validation in progress. No recorded live session yet
-completes the full loop the way Claude Code's does — treat end-to-end "runs
-on Windsurf" as inferred from code + unit tests until one is on record.
+Windsurf's adapter is shipped and live-validated: the capture loop
+(native-transcript serialize, probe-hardened) has been tested end-to-end in
+real Windsurf use.
 
 ## Install
 


### PR DESCRIPTION
Refs #326

> Intermediate stage of #326 — does not close it on merge. Remaining after this: Spanish first pass (quickstart + concepts).

## What

Prose pass over the four host pages — the only retained pages that still read repo-internal (team, configuration, and backends-tested scanned clean):

- **claude-code**: drops "daily dogfood" framing and the SCAR hook-manager comparison; the LLM-credentials pointer now links the site quickstart instead of the plugin README on GitHub; the manual-install prerequisite now shows the released-package command.
- **codex + gemini**: both pages told users to run `uv tool install ./plugin` — a command that only works from a source checkout, in codex's case directly under a heading that says "no repo clone needed". Now `uv tool install 'daimon-briefing[pretty]'`.
- **windsurf**: rewords the dogfood reference; trims the byte-identical-test note on `redact.py` to the user-relevant fact (redaction works from the standalone hook without the package installed).

## Why

#326 stage 4: site tone — second person, present tense, no repo-internal references. The `./plugin` fixes are more than tone: they were wrong instructions for package users.

## Tests

- `rg` over `website/docs/` confirms zero remaining `dogfood`, `./plugin`, or SCAR references (the `DAIMON_SCAR_HARVEST` config row excepted — real variable name).
- The new quickstart anchor link (`quickstart.md#2-connect-an-llm`) matches the actual heading; docs build + broken-link check gates this PR in CI.