### PR TITLE
docs(site): Spanish first pass — quickstart and concepts pages

### DIFF
--- a/.scars/candidates/docusaurus-i18n-md-links-break-across-locales.md
+++ b/.scars/candidates/docusaurus-i18n-md-links-break-across-locales.md
@@ -1,0 +1,31 @@
+---
+id: 0
+type: landmine
+title: In the es build, .md-style doc links break whenever source and target sit on opposite sides of the translated/untranslated line
+severity: medium
+confidence: 0.9
+created: 2026-07-18
+authors: ["claude-code"]
+anchors:
+  - path: website/docs/
+  - path: website/i18n/
+evidence:
+  - pr: "334 (runs 29661022607 and 29661156116 — two failures, one from each direction, same evening)"
+expires:
+  condition: "every doc page is translated in i18n/es (no fallback pages left), or the site moves off .md-relative links entirely"
+  review_after: 2026-10-01
+---
+
+Docusaurus resolves `[text](../x/y.md)` links against the set of source files
+the docs plugin loaded *for that locale* — for `es`, that is the translated
+copy when one exists, else the English fallback. Consequence, hit twice in
+PR #334: (1) a translated es page linking an untranslated doc by `.md` path
+fails (the file is not in `i18n/es/`); (2) an untranslated English page
+linking a *translated* doc by `.md` path also fails in the es build (the
+English file was replaced by the es copy in the plugin's map). Both throw at
+build time via `onBrokenLinks: 'throw'`, but only in the es locale pass.
+Rule: `.md`-relative links are safe only between pages on the SAME side of
+the translated/untranslated line. Anywhere the line is crossed, use URL-style
+links (no `.md`; category-index pages like `hosts/index.md` and
+`team/team.md` are `../hosts/`, `../team/`), and pin explicit heading ids
+(`{#english-anchor}`) on translated headings that English pages target.

--- a/.scars/candidates/docusaurus-i18n-md-links-break-across-locales.md
+++ b/.scars/candidates/docusaurus-i18n-md-links-break-across-locales.md
@@ -27,5 +27,9 @@ build time via `onBrokenLinks: 'throw'`, but only in the es locale pass.
 Rule: `.md`-relative links are safe only between pages on the SAME side of
 the translated/untranslated line. Anywhere the line is crossed, use URL-style
 links (no `.md`; category-index pages like `hosts/index.md` and
-`team/team.md` are `../hosts/`, `../team/`), and pin explicit heading ids
-(`{#english-anchor}`) on translated headings that English pages target.
+`team/team.md` are `../hosts/`, `../team/`). Do NOT try to fix cross-locale
+anchors with `{#custom-id}` heading syntax — in this site's MDX pipeline the
+brace block is parsed as a JSX expression and acorn fails the whole es build
+(third #334 failure, run of 2026-07-18T21:22Z). A fragment pointing at a
+heading that only exists in the other locale is a build WARNING
+(onBrokenAnchors default), which is acceptable; a broken page link is not.

--- a/website/docs/hosts/claude-code.md
+++ b/website/docs/hosts/claude-code.md
@@ -38,7 +38,7 @@ Install copies the hook scripts to `~/.claude/hooks/` and registers them
 under `SessionStart` / `SessionEnd` in `~/.claude/settings.json` (idempotent;
 settings backed up before every mutation). Requires the `daimon` CLI on PATH —
 `uv tool install 'daimon-briefing[pretty]'`, see the
-[quickstart](../getting-started/quickstart.md) — and the hooks also accept the
+[quickstart](../getting-started/quickstart) — and the hooks also accept the
 deprecated `daimon-briefing` alias as a fallback. After upgrading the CLI,
 re-run install so the hook scripts stay in sync.
 
@@ -75,7 +75,7 @@ registers them:
   `SessionStart` header shows checkpoint age.
 
   LLM credentials come from `~/.daimon/env` (see
-  [Connect an LLM](../getting-started/quickstart.md#2-connect-an-llm)) — hooks
+  [Connect an LLM](../getting-started/quickstart#2-connect-an-llm)) — hooks
   inherit the host process environment, not your shell profile, so
   `DAIMON_LLM_API_KEY` / `DAIMON_LLM_MODEL` / `DAIMON_LLM_BASE_URL` belong in
   that file (chmod 600). Without it, serialize fails fast with a named error

--- a/website/i18n/es/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,22 @@
+{
+  "sidebar.tutorialSidebar.category.Getting Started": {
+    "message": "Primeros pasos",
+    "description": "Sidebar category label: Getting Started"
+  },
+  "sidebar.tutorialSidebar.category.Concepts": {
+    "message": "Conceptos",
+    "description": "Sidebar category label: Concepts"
+  },
+  "sidebar.tutorialSidebar.category.Hosts": {
+    "message": "Hosts",
+    "description": "Sidebar category label: Hosts"
+  },
+  "sidebar.tutorialSidebar.category.Team": {
+    "message": "Equipo",
+    "description": "Sidebar category label: Team"
+  },
+  "sidebar.tutorialSidebar.category.Reference": {
+    "message": "Referencia",
+    "description": "Sidebar category label: Reference"
+  }
+}

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/carry.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/carry.md
@@ -40,7 +40,7 @@ Los ítems sin cerrar no se acumulan para siempre:
   es la vía prevista de salida; el decaimiento es la red de seguridad.
 
 Todas las perillas están en la
-[referencia de configuración](../getting-started/configuration.md), incluido
+[referencia de configuración](../getting-started/configuration), incluido
 `DAIMON_CARRY` (interruptor maestro, encendido por defecto).
 
 ## La advertencia de desactualización

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/carry.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/carry.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 2
+---
+
+# Arrastre y desactualización
+
+Un checkpoint captura una sesión. El arrastre (carry) es lo que hace que la
+memoria abarque muchas: los ítems que siguen abiertos — preguntas sin
+resolver, decisiones vigentes, trabajo sin terminar — se arrastran desde
+checkpoints anteriores al siguiente briefing, y siguen apareciendo hasta que
+algo los cierra.
+
+## El sufijo `[carried]`
+
+Un ítem escrito por la sesión más reciente aparece sin marca. Un ítem que
+viene de un checkpoint anterior lleva un sufijo visible:
+
+```
+- [~ inferred] The staging config drift needs an owner [carried]
+```
+
+`[carried]` significa: *ninguna sesión reciente re-confirmó esto — puede
+estar desactualizado.* Cuanto más viejo es un ítem arrastrado, con más
+escepticismo hay que leerlo. El arrastre deliberadamente nunca reformula
+ítems — una cita verbatim arrastrada tiene los mismos bytes que el primer día
+(mira [clases de confianza](./trust-classes.md)).
+
+## El arrastre es acotado, no infinito
+
+Los ítems sin cerrar no se acumulan para siempre:
+
+- El peso de arrastre de cada ítem **decae** con el tiempo, graduado por
+  importancia. Con el piso por defecto (`DAIMON_CARRY_FLOOR`), las decisiones
+  expiran del arrastre en unas 5–6 semanas; las preguntas abiertas escaladas
+  viven alrededor de 3–4 meses.
+- Se arrastran como máximo `DAIMON_CARRY_MAX` ítems por tipo (por defecto:
+  8), así el briefing se mantiene legible sin importar cuánto dure un
+  proyecto.
+- [Resolver](./lifecycle.md) un ítem termina su arrastre de inmediato — esa
+  es la vía prevista de salida; el decaimiento es la red de seguridad.
+
+Todas las perillas están en la
+[referencia de configuración](../getting-started/configuration.md), incluido
+`DAIMON_CARRY` (interruptor maestro, encendido por defecto).
+
+## La advertencia de desactualización
+
+El arrastre tiene un modo de falla del que daimon advierte explícitamente: un
+ítem puede viajar, repetido briefing tras briefing, sin que nadie lo
+re-verifique contra el mundo. Que dos artefactos del propio daimon coincidan
+— el briefing y un checkpoint viejo — **no es corroboración**; son la misma
+fuente repetida.
+
+Por eso, cuando el sello de última verificación de un ítem arrastrado
+envejece más allá de `DAIMON_STALE_DAYS` (por defecto: 7 días), el briefing
+lo dice:
+
+```
+N carried item(s) unverified for >N days — world-check before repeating as true
+```
+
+La respuesta prevista es verificar el mundo — código, git, el issue
+tracker — y luego o [resolver](./lifecycle.md) el ítem (ya está hecho o está
+mal) o ejecutar `daimon reverify` con evidencia (sigue siendo cierto), lo
+cual reinicia el reloj.
+
+## Supersesión: arrastre que discute consigo mismo
+
+Cuando una sesión nueva contradice un ítem arrastrado — el proyecto se
+comprometió con X, y después con Y — el arrastre no descarta el ítem viejo en
+silencio ni lo sigue inyectando como hecho. El briefing lo marca como
+**candidato a supersesión**, presentando ambos lados con los comandos de
+confirmar/rechazar en línea. Confirmar (`daimon resolve <id>`) oculta el lado
+obsoleto de todos los briefings futuros; rechazar (`daimon reverify <id>`)
+conserva el ítem y registra por qué. Nada se decide por ti — mira el
+[ciclo de vida de los ítems](./lifecycle.md) para la mecánica completa.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/lifecycle.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/lifecycle.md
@@ -1,0 +1,102 @@
+---
+sidebar_position: 4
+---
+
+# El ciclo de vida de los ítems
+
+Un ítem de briefing no es una fila estática — atraviesa un ciclo de vida:
+nace en una sesión, se arrastra mientras está abierto, y eventualmente se
+cierra, se revive o se elimina. Tres comandos manejan las transiciones, y los
+tres comparten un contrato: **nunca se adivina nada por ti.**
+
+## El contrato de nunca-adivinar
+
+`resolve` y `forget` aceptan un id exacto de ítem (`o-3f8a2c`) o una consulta
+de texto libre — pero la consulta debe coincidir con **exactamente un** ítem.
+Una coincidencia ambigua se rechaza listando los candidatos; eliges uno por
+id. Ambos comandos aceptan `--dry-run`, que ejecuta la misma búsqueda e
+imprime lo que *pasaría* sin escribir nada — mira antes de escribir.
+
+Una salvedad que el contrato no puede cubrir: una coincidencia segura con el
+ítem *equivocado* no es ambigua, así que el rechazo nunca se dispara. Para
+eso existe `--dry-run`.
+
+## `daimon resolve` — cerrar un pendiente
+
+```sh
+daimon resolve "retry policy for the payments webhook" --dry-run
+daimon resolve o-3f8a2c --note "shipped exponential backoff in #212"
+```
+
+Resolver registra un evento de solo-anexado; desde entonces, los briefings
+**retienen** el ítem en lugar de arrastrarlo desactualizado. El ítem no se
+borra — su historia sigue siendo buscable, y el rastro de eventos muestra
+cuándo y por qué se cerró. `--status` acepta un estado de ciclo de vida
+libre; cualquier estado que empiece con `reopen` revive el ítem.
+
+## `daimon reverify` — afirmar que sigue siendo cierto
+
+```sh
+daimon reverify o-3f8a2c --evidence "checked the release page"
+```
+
+Reverify es la respuesta a la
+[advertencia de desactualización](./carry.md#la-advertencia-de-desactualización):
+un ítem arrastrado envejeció más allá del umbral, verificaste el mundo, y
+sigue en pie. El evento reinicia el sello de última verificación del ítem,
+así que el reloj de la advertencia arranca de nuevo. Reverify acepta
+**solo ids exactos** — re-afirmar una afirmación es deliberado, así que no
+hay búsqueda difusa que pueda dispararse mal.
+
+Reverify es también la mitad de **rechazo** de un candidato a supersesión
+(abajo).
+
+## `daimon forget` — eliminar, de forma demostrable
+
+```sh
+daimon forget o-3f8a2c --reason "contains client name"
+daimon forget "wrong belief about retry nonce" --dry-run
+```
+
+Resolve cierra un ítem pero conserva su contenido en la historia. Forget es
+para los casos donde el contenido mismo debe irse — un nombre que nunca debió
+capturarse, un detalle de proyecto, una creencia equivocada que se sigue
+arrastrando. La redacción en el momento de captura es la primera línea de
+defensa; forget es la segunda, para los juicios que ningún patrón de
+redacción puede conocer.
+
+Qué ocurre al olvidar:
+
+- El ítem se elimina del checkpoint vivo, que se reescribe por el camino
+  normal del store — la redacción se re-ejecuta y, con receipts activos, el
+  **receipt se re-mintea sobre los bytes posteriores a la eliminación**
+  (mira [receipts](./receipts.md)).
+- Un **evento tombstone** de solo-anexado registra
+  `forgotten:<hash de 12 caracteres>` — el hash, nunca el texto. Eliminar
+  significa que el contenido también sale del rastro de auditoría; el rastro
+  aún puede demostrar *que* algo se eliminó, cuándo y por qué (`--reason`,
+  redactado como cualquier nota).
+- El índice de recall borra las filas del ítem en **todas** las copias
+  históricas de checkpoints de tu índice local — incluidas tus copias
+  locales de los mirrors de equipo — así recall no puede resucitarlo.
+  (Propagar tombstones a los mirrors propios de tus compañeros es un
+  seguimiento deliberado, no está en v1.)
+- La retención en el briefing, la supresión del arrastre y `daimon stats`
+  heredan el tombstone a través del mismo flujo de eventos.
+
+## Candidatos a supersesión
+
+Cuando una sesión nueva contradice un ítem arrastrado, el briefing presenta
+un **candidato a supersesión**: ambos lados, con los comandos de
+confirmar/rechazar en línea. Verificas cuál lado es cierto en el mundo, y
+respondes con exactamente esos comandos:
+
+- **Confirmar** — `daimon resolve <id>`: el ítem viejo está genuinamente
+  superado; los briefings futuros lo retienen.
+- **Rechazar** — `daimon reverify <id>`: la contradicción era aparente, no
+  real; el ítem se mantiene, recién verificado.
+
+El principio de diseño en todo el ciclo de vida: daimon señala, tú decides.
+La contradicción, la desactualización y la eliminación se presentan con
+evidencia y se resuelven con una acción explícita de un humano (o de un
+agente explícitamente instruido) — nunca con un merge silencioso.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/receipts.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/receipts.md
@@ -1,0 +1,64 @@
+---
+sidebar_position: 3
+---
+
+# Receipts y verificación offline
+
+Los receipts son la respuesta de daimon a una pregunta que la mayoría de los
+sistemas de memoria no puede tomarse en serio: *¿cómo sabes que el archivo de
+memoria no fue editado después de escribirse?*
+
+## Qué es un receipt
+
+Con `DAIMON_RECEIPTS=1`, cada checkpoint se empareja con un receipt de
+[vitni](https://github.com/Daily-Nerd/vitni) — una declaración firmada con
+Ed25519, escrita en un archivo lateral `<session>.receipt`, que vincula:
+
+- los **bytes exactos en disco** del checkpoint (`outputs_hash`), con
+- su **transcript de origen** (`inputs_hash`).
+
+Si alguien edita el archivo del checkpoint después — a mano, con un script,
+con un job de limpieza bienintencionado — los bytes ya no coinciden con la
+firma, y la edición es detectable.
+
+Todo ocurre localmente. Los receipts se firman offline, se verifican offline,
+y nada sale de la máquina. No hay servicio, ni autoridad de sellado de
+tiempo, ni llamada de red.
+
+## Verificar
+
+```sh
+daimon verify-receipt              # el último checkpoint de este proyecto
+daimon verify-receipt <session-id> # uno específico
+```
+
+La verificación también está tejida en el camino del briefing: cuando a un
+checkpoint de la era de receipts le falta el receipt, o el receipt ya no
+coincide con los bytes del archivo, el briefing no le cree en silencio — las
+etiquetas `✓ verbatim` afectadas se **degradan con una nota visible**. Una
+afirmación verbatim vale lo que vale la integridad de los bytes que la
+respaldan, y el briefing lo dice cuando esa integridad no puede demostrarse
+(mira [clases de confianza](./trust-classes.md)).
+
+## Fail-open por diseño
+
+Los receipts nunca bloquean la memoria. Un CLI de vitni ausente, un timeout o
+un paso de firma fallido registran una línea en el log y la serialización
+continúa sin receipt — una falla de receipts no puede costarte un checkpoint
+ni un briefing. Las llaves de firma se crean automáticamente en el primer
+minteo bajo `~/.daimon/keys` (modo 0600).
+
+Los receipts están **apagados por defecto** (cada minteo lanza un
+subproceso); la lista completa de perillas — `DAIMON_RECEIPTS`,
+`DAIMON_VITNI_CLI`, `DAIMON_KEYS_DIR` — está en la
+[referencia de configuración](../getting-started/configuration.md#receipts).
+
+## Receipts y borrado
+
+El borrado se compone con los receipts en lugar de pelear contra ellos.
+`daimon forget` elimina un ítem y **re-mintea el receipt sobre el checkpoint
+posterior a la eliminación**, mientras un evento tombstone de solo-anexado
+registra que hubo una eliminación — por hash del contenido, nunca por el
+contenido. Editar un checkpoint a mano rompe su receipt; olvidar a través del
+CLI deja un rastro firmado y demostrable. La página del
+[ciclo de vida de los ítems](./lifecycle.md) cubre la mecánica.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/receipts.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/receipts.md
@@ -51,7 +51,7 @@ minteo bajo `~/.daimon/keys` (modo 0600).
 Los receipts están **apagados por defecto** (cada minteo lanza un
 subproceso); la lista completa de perillas — `DAIMON_RECEIPTS`,
 `DAIMON_VITNI_CLI`, `DAIMON_KEYS_DIR` — está en la
-[referencia de configuración](../getting-started/configuration.md#receipts).
+[referencia de configuración](../getting-started/configuration#receipts).
 
 ## Receipts y borrado
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/trust-classes.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/trust-classes.md
@@ -1,0 +1,97 @@
+---
+sidebar_position: 1
+---
+
+# Clases de confianza
+
+Cada ítem de un briefing lleva una clase de confianza — un marcador visible de
+*cómo llegó a existir ese ítem*. Esta es la idea central de daimon: memoria
+que te dice qué partes son citas y qué partes son conjeturas.
+
+## Las tres clases
+
+### `[✓ verbatim]`
+
+Una cita exacta del transcript de una sesión pasada, fijada
+carácter por carácter. Los ítems verbatim nunca se reformulan — ni al
+arrastrarse entre sesiones, ni al renderizarse, ni al truncarse por
+presupuesto. Cuando un briefing muestra
+
+```
+- [✓ verbatim] PR #60 awaiting review  — "review requested 2026-07-01"
+```
+
+la cita final es el texto real del transcript, y se mantiene idéntica byte a
+byte mientras el ítem viva.
+
+Un agente que lee el briefing debe repetir los ítems verbatim exactamente,
+nunca resumirlos ni parafrasearlos.
+
+### `[~ inferred]`
+
+Una conclusión que el modelo serializador sacó de la sesión — un resumen, un
+diagnóstico, una conexión entre eventos. Los ítems inferidos son honestos
+sobre su naturaleza derivada: pueden evolucionar a medida que sesiones
+posteriores los refinan, y deben verificarse contra el mundo (código,
+documentación, el issue tracker) antes de construir nada importante sobre
+ellos.
+
+### `[? untagged]`
+
+Un ítem que nunca tuvo confianza registrada — típicamente de un checkpoint
+antiguo escrito antes de que existieran las clases de confianza, o de una
+captura degradada. Trata los ítems sin etiqueta como inferidos: verifica
+antes de confiar en ellos.
+
+## Por qué importa la distinción
+
+La mayoría de los sistemas de memoria almacenan una sola clase de cosa: texto
+que un modelo escribió sobre lo que pasó. Cuando ese texto está mal — y los
+modelos que resumen sesiones largas se equivocan con regularidad — no hay
+manera de saberlo desde la memoria misma. Todo se lee con la misma confianza.
+
+Las clases de confianza dividen la memoria en dos poblaciones con modos de
+falla distintos:
+
+- Un ítem **verbatim** puede estar *desactualizado* (el mundo cambió desde
+  que se dijo la cita) pero no puede estar *mal recordado* — la cita es lo
+  que se dijo, de forma demostrable.
+- Un ítem **inferido** puede estar desactualizado *y además* equivocado — el
+  modelo pudo haber malinterpretado la sesión cuando lo escribió.
+
+Esa diferencia cambia cómo un lector (humano o agente) debe actuar sobre cada
+ítem, y por eso el briefing la hace visible en cada línea en lugar de
+enterrarla en metadatos.
+
+## La verificación es mecánica, no declarada
+
+El estatus verbatim no es la opinión del modelo extractor sobre sí mismo. Al
+serializar, la cita de cada ítem verbatim se verifica contra el transcript
+renderizado con un verificador determinista — operaciones de strings puras,
+sin LLM, bajo el principio de que *el verificador debe ser más tonto que lo
+que verifica*. Una cita que verifica queda sellada; una que no, se **degrada
+a `~ inferred`** en el acto — una "cita" alucinada nunca puede llevar la
+insignia verbatim.
+
+La garantía se extiende más allá del momento de escritura: con
+[receipts](./receipts.md) habilitados, los bytes exactos del checkpoint se
+firman al escribirse — si alguien edita el archivo después, la verificación
+al momento del briefing lo nota, y las etiquetas `✓ verbatim` afectadas se
+**degradan visiblemente** en lugar de confiarse en silencio.
+
+## VERIFY BEFORE TRUSTING
+
+Los briefings abren con una sección de ítems que describen estado que pudo
+haber cambiado *fuera* de la sesión — PRs mergeados, llaves rotadas, archivos
+movidos. Una etiqueta verbatim significa que la cita es fiel; no significa
+que el mundo siga siendo así. El protocolo de lectura, para humanos y agentes
+por igual:
+
+1. Lee el ítem.
+2. Verifica el mundo (archivos, git, el issue tracker) antes de repetirlo
+   como hecho vigente.
+3. [Resuélvelo](./lifecycle.md) cuando esté cerrado, para que deje de
+   arrastrarse.
+
+Un briefing es contexto, no instrucciones — nunca prevalece sobre lo que el
+usuario pide ahora.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
@@ -16,7 +16,7 @@ uv tool install 'daimon-briefing[pretty]'
 agrega tablas y paneles enriquecidos a `status` y `brief`; sin él, la salida
 es texto plano.
 
-## 2. Conecta un LLM
+## 2. Conecta un LLM {#2-connect-an-llm}
 
 La serialización — convertir una sesión terminada en un checkpoint — necesita
 un endpoint de LLM. Ejecuta:

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
@@ -43,8 +43,8 @@ daimon configure --test
 
 Esto envía un prompt mínimo por el backend resuelto y reporta si pasó o
 falló. La configuración se escribe en `~/.daimon/env` — mira
-[Configuración](./configuration.md) para todas las variables, y la
-[matriz de backends](../reference/backends-tested.md) para combinaciones de
+[Configuración](./configuration) para todas las variables, y la
+[matriz de backends](../reference/backends-tested) para combinaciones de
 modelos medidas en uso real.
 
 ## 3. Conecta tu host
@@ -58,7 +58,7 @@ plugin — registra los hooks de sesión por sí solo:
 ```
 
 Para Windsurf, Codex o Gemini CLI, sigue la página de tu host en
-[Hosts](../hosts/index.md) — cada host expone una superficie de hooks
+[Hosts](../hosts/) — cada host expone una superficie de hooks
 distinta, y las guías por host cubren los pasos exactos de registro y sus
 particularidades.
 
@@ -133,9 +133,9 @@ fallida se auto-repara al inicio de la siguiente sesión — o ejecuta
 
 ## Adónde seguir
 
-- [Configuración](./configuration.md) — todas las variables de entorno,
+- [Configuración](./configuration) — todas las variables de entorno,
   incluido el interruptor de apagado `DAIMON_DISABLE`.
-- [Hosts](../hosts/index.md) — detalle de configuración por host y
+- [Hosts](../hosts/) — detalle de configuración por host y
   limitaciones conocidas.
-- [Memoria de equipo](../team/team.md) — comparte checkpoints con tu equipo
+- [Memoria de equipo](../team/) — comparte checkpoints con tu equipo
   a través de un remoto git privado (opt-in).

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
@@ -16,7 +16,7 @@ uv tool install 'daimon-briefing[pretty]'
 agrega tablas y paneles enriquecidos a `status` y `brief`; sin él, la salida
 es texto plano.
 
-## 2. Conecta un LLM {#2-connect-an-llm}
+## 2. Conecta un LLM
 
 La serialización — convertir una sesión terminada en un checkpoint — necesita
 un endpoint de LLM. Ejecuta:

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
@@ -1,0 +1,141 @@
+---
+sidebar_position: 1
+---
+
+# Inicio rápido
+
+De la instalación a tu primer briefing. Cuatro pasos, uno opcional.
+
+## 1. Instala el CLI
+
+```sh
+uv tool install 'daimon-briefing[pretty]'
+```
+
+`pipx install 'daimon-briefing[pretty]'` funciona igual. El extra `[pretty]`
+agrega tablas y paneles enriquecidos a `status` y `brief`; sin él, la salida
+es texto plano.
+
+## 2. Conecta un LLM
+
+La serialización — convertir una sesión terminada en un checkpoint — necesita
+un endpoint de LLM. Ejecuta:
+
+```sh
+daimon configure
+```
+
+Si el CLI `claude` está en tu PATH, esto imprime `✓ ready` y ya está — cero
+configuración. Si no, apunta daimon a cualquier endpoint compatible con
+OpenAI:
+
+```sh
+daimon configure --backend litellm \
+  --base-url https://generativelanguage.googleapis.com/v1beta/openai \
+  --api-key <TU-KEY> --model gemini-2.5-flash
+```
+
+Después verifica el backend de punta a punta antes de confiar en él:
+
+```sh
+daimon configure --test
+```
+
+Esto envía un prompt mínimo por el backend resuelto y reporta si pasó o
+falló. La configuración se escribe en `~/.daimon/env` — mira
+[Configuración](./configuration.md) para todas las variables, y la
+[matriz de backends](../reference/backends-tested.md) para combinaciones de
+modelos medidas en uso real.
+
+## 3. Conecta tu host
+
+Los hooks son lo que captura tus sesiones. Para Claude Code, instala el
+plugin — registra los hooks de sesión por sí solo:
+
+```
+/plugin marketplace add Daily-Nerd/daimon
+/plugin install daimon@daimon
+```
+
+Para Windsurf, Codex o Gemini CLI, sigue la página de tu host en
+[Hosts](../hosts/index.md) — cada host expone una superficie de hooks
+distinta, y las guías por host cubren los pasos exactos de registro y sus
+particularidades.
+
+## 4. Enséñale el protocolo a tu agente (opcional, recomendado)
+
+Los hooks capturan sesiones; la skill le enseña al agente del otro lado cómo
+*usar* el briefing — leerlo al inicio de sesión, tratar los ítems `verbatim`
+como citas inmutables, verificar afirmaciones que parezcan desactualizadas
+antes de repetirlas:
+
+```sh
+daimon skill install claude
+```
+
+`daimon skill list` muestra los destinos de instalación para otros hosts.
+
+## 5. Termina una sesión, inicia la siguiente
+
+Ese es todo el ciclo:
+
+1. Trabaja una sesión normal en tu agente.
+2. Termínala. El hook de fin de sesión serializa un checkpoint en segundo
+   plano.
+3. Inicia la siguiente sesión. El briefing se inyecta al arrancar:
+
+```
+While you were away — here's where we left off.
+
+VERIFY BEFORE TRUSTING (state may have changed outside this session):
+- [✓ verbatim] PR #212 state — you said you'd merge it yourself from the UI  — "I'll merge it after the demo"
+
+Open loops:
+- [✓ verbatim] Retry policy for the payments webhook — exponential or fixed?  — "don't ship the retry loop until we pick a policy"
+
+Decisions made:
+- [✓ verbatim] Postgres advisory locks over Redis locks for the scheduler  — "let's not add a Redis dependency for this"
+
+Active topic: Migrating the scheduler off cron to the new worker pool
+```
+
+También puedes leerlo en una terminal en cualquier momento con
+`daimon brief`.
+
+:::note Las sesiones cortas se omiten a propósito
+Una sesión con menos mensajes que `DAIMON_MIN_MESSAGES` (por defecto: 10) no
+se serializa — no hay nada que valga la pena recordar en un intercambio de
+dos mensajes. Si estás evaluando daimon y quieres capturar tus sesiones
+cortas de prueba, baja el umbral por ahora:
+
+```sh
+echo 'DAIMON_MIN_MESSAGES=4' >> ~/.daimon/env
+```
+:::
+
+## Confirma que funciona
+
+```sh
+daimon status
+```
+
+Status reporta la salud de captura con honestidad — fallas, omisiones y
+crashes incluidos. Las líneas que importan en una instalación fresca:
+
+```
+project checkpoint: <session id>, written <n>m ago
+last serialize result: success — wrote checkpoint: ...
+```
+
+Si la última serialización falló o una sesión nunca se capturó, una captura
+fallida se auto-repara al inicio de la siguiente sesión — o ejecuta
+`daimon heal` para reintentar de inmediato.
+
+## Adónde seguir
+
+- [Configuración](./configuration.md) — todas las variables de entorno,
+  incluido el interruptor de apagado `DAIMON_DISABLE`.
+- [Hosts](../hosts/index.md) — detalle de configuración por host y
+  limitaciones conocidas.
+- [Memoria de equipo](../team/team.md) — comparte checkpoints con tu equipo
+  a través de un remoto git privado (opt-in).


### PR DESCRIPTION
Closes #326

> **Final stage of #326** — closing is correct this time. All prior stages merged: README slim (#327), quickstart (#328), concepts (#329), curation (#332), prose pass (#333, open in parallel — independent files).

## What

- Translates the five pages #326 scoped for the Spanish first pass — `getting-started/quickstart` and the four concepts pages — under `i18n/es/docusaurus-plugin-content-docs/current/`.
- Adds `current.json` with the five sidebar category labels (Primeros pasos, Conceptos, Hosts, Equipo, Referencia).
- Neutral Latin-American Spanish, second person. Code blocks, commands, and product-output samples stay in English — the briefing sample is what the product actually renders.

## Why

#326 stage 5 (last): Spanish-first is the roadmap wedge; the es locale was wired since #325 but had zero translated content.

## Tests

- Internal anchor links use the translated heading slugs (Docusaurus preserves accents in slugs); links to not-yet-translated pages resolve through the default-locale fallback.
- The CI docs build compiles both locales and runs the broken-link check on this PR.