### PR TITLE
docs(site): complete Spanish coverage — all remaining doc pages translated

### DIFF
--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
@@ -1,0 +1,176 @@
+---
+sidebar_position: 2
+---
+
+# Configuración
+
+Daimon se configura por completo con variables de entorno. Cada variable se
+resuelve en el mismo orden: **gana el entorno del proceso**, y todo lo que no
+esté ahí cae al archivo de entorno en `~/.daimon/env`. La ubicación del
+archivo se puede cambiar con `DAIMON_ENV_FILE`.
+
+El archivo de entorno existe porque los hooks corren con el entorno que el
+proceso host haya heredado — un agente lanzado desde la GUI no tiene perfil
+de shell, así que los exports del shell no son un canal confiable. Su formato
+es líneas `KEY=VALUE`; se toleran un `export ` inicial, comillas alrededor,
+líneas en blanco y comentarios `#`. Mantenlo en `chmod 600` — puede contener
+API keys.
+
+`daimon configure` gestiona las perillas del backend LLM (mira
+[Backend LLM](#backend-llm)) y las escribe en `~/.daimon/env`. Todo lo demás
+se configura editando ese archivo o exportando la variable.
+
+Las **variables booleanas** aceptan `1`, `true`, `yes` u `on` como verdaderos
+(sin distinción de mayúsculas donde se indica). Unas pocas usan convenciones
+distintas — interruptores de apagado que están activos salvo que valgan `0`,
+o flags por presencia — y se señalan en la columna "Qué hace".
+
+Las perillas internas de ajuste de la serialización (umbrales de chunking,
+solapamiento, concurrencia, tamaño de grupo de merge) deliberadamente no se
+documentan aquí — son defaults de carga calibrados contra comportamiento
+medido, no configuración de usuario.
+
+## Núcleo
+
+| Variable | Default | Qué hace |
+|---|---|---|
+| `DAIMON_DISABLE` | off | Interruptor de apagado. Cuando es verdadero, cada hook se vuelve un no-op — sin captura, sin briefing. |
+| `DAIMON_ENV_FILE` | `~/.daimon/env` | Ruta del archivo de entorno que respalda a todas las demás variables. Se lee solo del entorno del proceso (nombra al archivo, así que no puede vivir dentro de él). |
+| `DAIMON_PROJECT_DIR` | sin definir | Directorio de trabajo de la sesión que se briefea o serializa, usado para enrutar checkpoints por proyecto. Los hooks pasan el cwd del host a través de ella; sin definir significa proyecto desconocido y daimon cae al puntero global. |
+| `DAIMON_MIN_MESSAGES` | `10` | Conteo mínimo de mensajes para que una sesión valga la pena serializar. Las sesiones más cortas se omiten. |
+| `DAIMON_TIMEOUT` | `420` | Presupuesto total de serialización en segundos, compartido entre reintentos (los timeouts de socket por intento se limitan al presupuesto restante). Las llamadas reales de serialize/merge en backends gateway y CLI corren 74s–25min; mantén ≥420 o las llamadas lentas y los reintentos no caben. |
+| `DAIMON_HUNG_AFTER` | `1800` | Segundos tras los cuales un proceso de serialización sin línea de resultado se trata como colgado/matado en lugar de aún corriendo. El default de 30 min queda con margen sobre una corrida lenta (las serializaciones en producción toman 4–25 min). |
+
+## Almacén de checkpoints y GC
+
+| Variable | Default | Qué hace |
+|---|---|---|
+| `DAIMON_CHECKPOINT_DIR` | `~/.daimon/checkpoints` | Raíz del almacén de checkpoints por sesión. |
+| `DAIMON_CHECKPOINT_KEEP` | `100` | Cuántos archivos de checkpoint por sesión retener (los N más nuevos). Los más viejos se recolectan tras una escritura exitosa. `0` desactiva el GC por completo (conservar para siempre). |
+| `DAIMON_CHECKPOINT_HISTORY` | `3` | Cuántos punteros de checkpoint retener por directorio (`latest.json` más `prev-1` … `prev-(N-1)`), para que una serialización fallida pueda caer a un puntero previo. Mínimo 1 (solo latest). |
+| `DAIMON_GC_PIN_IMPORTANCE` | `9` | Umbral de importancia de ítem que fija un archivo de checkpoint contra el GC: un archivo cuya importancia máxima de ítem alcanza este valor sobrevive fuera de la ventana de los N más nuevos. `0` desactiva el fijado (ventana de recencia pura); valores sobre 10 se recortan a 10. |
+
+## Arrastre (carry)
+
+Arrastre determinista de ítems sin resolver entre sesiones.
+
+| Variable | Default | Qué hace |
+|---|---|---|
+| `DAIMON_CARRY` | on | Interruptor maestro del arrastre. Activo salvo que valga exactamente `0` (cualquier otro valor lo mantiene activo). |
+| `DAIMON_CARRY_FLOOR` | `0.05` | Peso efectivo mínimo para que un ítem arrastrado siga arrastrándose. Con el default, las decisiones expiran en ~5–6 semanas (graduado por importancia) y las preguntas abiertas escaladas viven ~3–4 meses. |
+| `DAIMON_CARRY_MAX` | `8` | Tope de ítems arrastrados por tipo (los ítems nativos nunca cuentan contra él ni se descartan). Mínimo 1. |
+
+## Briefing
+
+| Variable | Default | Qué hace |
+|---|---|---|
+| `DAIMON_BRIEF_MAX_TOKENS` | `3000` | Presupuesto de tokens para el briefing inyectado, estimado como `len(text)//4` (sin dependencia de tokenizador). `0` = sin límite. |
+| `DAIMON_MAX_BRIEFING_DECISIONS` | `10` | Tope de decisiones mostradas en el briefing (solo vista de renderizado — el checkpoint las conserva todas). `0` = sin límite. |
+| `DAIMON_BRIEF_GLOBAL_FALLBACK` | solo encabezado | Controla el fallback al puntero global entre proyectos cuando un proyecto no tiene checkpoint propio. El default muestra solo un encabezado; ponlo en `full` (o `1`) para inyectar el cuerpo foráneo completo. |
+| `DAIMON_STALE_DAYS` | `7.0` | Umbral de edad (días) tras el cual el sello efectivo de última verificación de un ítem arrastrado (su `last_verified`, si no el último evento de resolutions.jsonl, si no `first_seen`) está lo bastante desactualizado para que `brief` lo advierta. `0` advierte en cada ítem arrastrado. |
+| `DAIMON_PLAIN` | off | Cuando es verdadero (sin distinción de mayúsculas), fuerza salida de texto plano — desactiva las tablas/paneles enriquecidos en `status`, `brief` y `--help`. |
+| `NO_COLOR` | sin definir | Por presencia, según la [convención NO_COLOR](https://no-color.org/): si la variable está definida con *cualquier* valor (incluso vacío), la salida enriquecida se desactiva. |
+
+## Recall
+
+| Variable | Default | Qué hace |
+|---|---|---|
+| `DAIMON_RECALL_DB` | `~/.daimon/recall.db` | Ubicación del índice derivado de recall (SQLite FTS). Nunca es fuente de verdad — es seguro borrarlo en cualquier momento; recall lo reconstruye escaneando los directorios de checkpoints y de equipo. |
+| `DAIMON_RECALL_SEEN_DIR` | `~/.daimon/recall_seen` | Estado de enfriamiento de sugerencias por sesión para que un tema repetido nunca se re-inyecte. Desechable — borrarlo solo reinicia los enfriamientos. |
+
+## Memoria de equipo
+
+Mirror de memoria compartida opt-in. Mira [memoria de equipo](../team/team.md)
+para el flujo completo.
+
+| Variable | Default | Qué hace |
+|---|---|---|
+| `DAIMON_TEAM` | off | Cuando es verdadero, refleja cada checkpoint en el directorio de equipo compartido para que `brief --team` pueda mostrar a los compañeros. Regula **escrituras** solamente — las lecturas del directorio de equipo siempre están permitidas. Un remoto sincronizado exige además que el proyecto esté en su allowlist de alcance (mira [team.md](../team/team.md)); los proyectos fuera de alcance se reflejan solo al directorio local. |
+| `DAIMON_AUTHOR` | `user.name` de git, luego el usuario del SO | Identidad de autor de equipo usada para separar tus checkpoints. Cae a `git config user.name`, luego al usuario del SO, luego a `unknown`. |
+| `DAIMON_TEAM_DIR` | `~/.daimon/team` | Raíz del mirror de memoria de equipo compartida. |
+| `DAIMON_TEAM_PROJECT` | sin definir | Ruta lógica de proyecto explícita para las sesiones de esta máquina (relativa, p. ej. `core/api-gateway`). Prevalece sobre el mapeo de `daimon-team.toml` del sidecar y sobre el fallback derivado del origin al enrutar checkpoints bajo `projects/`. |
+| `DAIMON_TEAM_RETENTION_DAYS` | `365` | Ventana de edad al leer: los checkpoints de compañeros más viejos que esta cantidad de días se omiten al leer. `0` = conservar todos. Nunca borra físicamente de la rama compartida de solo-anexado. |
+
+## Receipts
+
+Receipts de procedencia firmados, opt-in (#204). Al habilitarlos, cada
+checkpoint se empareja con un receipt de vinculación `local` de
+[vitni](https://github.com/Daily-Nerd/vitni): una declaración firmada con
+Ed25519 que vincula los bytes exactos en disco del checkpoint
+(`outputs_hash`) con su transcript de origen (`inputs_hash`), escrita en un
+archivo lateral `<session>.receipt`. Esto hace detectable una edición
+posterior al archivo del checkpoint. Los receipts son totalmente válidos
+offline — nada sale de la máquina.
+
+Cada paso es **fail-open**: un CLI ausente, un openssl ausente, un timeout o
+una salida mala registran una línea en `serialize.log` y se continúa sin
+receipt — una falla de receipts nunca bloquea ni hace fallar una
+serialización o un briefing. Verifica un checkpoint bajo demanda con
+`daimon verify-receipt [session]`; al momento del briefing, un checkpoint de
+la era de receipts cuyo receipt falta o ya no coincide con sus bytes tiene
+sus etiquetas `✓ verbatim` degradadas con una nota visible.
+
+La derivación de la llave pública prefiere el comando `keygen` del CLI de
+vitni (vitni 0.5.0+) y cae a openssl en CLIs más viejos o ante un probe
+fallido — así en macOS, donde el LibreSSL de Apple no tiene Ed25519 en
+`openssl pkey`, los receipts funcionan una vez instalado vitni ≥ 0.5.0, sin
+necesidad de un openssl con Ed25519.
+
+| Variable | Default | Qué hace |
+|---|---|---|
+| `DAIMON_RECEIPTS` | off | Cuando es verdadero, mintea un receipt firmado junto a cada checkpoint. Off por defecto — un subproceso nuevo por serialización es opt-in. |
+| `DAIMON_VITNI_CLI` | `vitni-verify` (en el PATH) | El CLI verificador de vitni usado para firmar/verificar. Una ruta o un nombre resuelto en el PATH. Contrato: `<cli> <command>` con un objeto JSON por stdin y una línea JSON por stdout. |
+| `DAIMON_KEYS_DIR` | `~/.daimon/keys` | Dónde viven la semilla de firma Ed25519 (`signing.seed`, modo 0600, auto-creada en el primer minteo) y la llave pública cacheada (`signing.pub.json`). |
+
+## Hooks de host
+
+Perillas de throttle de serialización para hosts sin un evento limpio de fin
+de sesión. Mira [Hosts](../hosts/) para la configuración por host.
+
+| Variable | Default | Qué hace |
+|---|---|---|
+| `DAIMON_CODEX_SERIALIZE_ON_STOP` | on | Si el hook `Stop` de Codex serializa en absoluto. Activo salvo que valga `0`, `false`, `no` u `off` (sin distinción de mayúsculas). |
+| `DAIMON_CODEX_MIN_SERIALIZE_INTERVAL` | `300` | Segundos mínimos entre lanzamientos de serialización de Codex. `0` serializa en cada `Stop`. |
+| `DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL` | `300` | Segundos mínimos entre lanzamientos de serialización de Windsurf (Windsurf no tiene evento de fin de sesión, así que la captura corre con este throttle). `0` serializa cada turno. |
+| `DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS` | `600` | Periodo de silencio tras la última actividad de Windsurf antes de que un finalizador con debounce serialice el estado final del transcript de la trayectoria — cubre sesiones cuyos últimos turnos caen dentro de la ventana del throttle. Acepta valores fraccionarios; `0` desactiva el finalizador. |
+
+## Operación y diagnóstico
+
+| Variable | Default | Qué hace |
+|---|---|---|
+| `DAIMON_LOG_DIR` | `~/.daimon/logs` | Dónde escribe `serialize.log` el hook de fin de sesión. El hook en sí tiene `~/.daimon/logs` fijo; este override existe para que el CLI (y los tests) puedan apuntar `status` a otra parte. |
+| `DAIMON_CLAUDE_PROJECTS_DIR` | `~/.claude/projects` | Dónde viven los transcripts del host (`<slug>/<session>.jsonl`). Solo-lectura — la auditoría de re-verificación de citas los lee para re-revisar citas almacenadas contra su fuente. |
+| `DAIMON_SCAR_HARVEST` | off | Cuando es verdadero, borra candidatos de scar (conocimiento negativo) desde el transcript al fin de sesión. |
+
+## Backend LLM
+
+La serialización necesita un endpoint de LLM. `daimon configure` es la vía
+prevista para definir estas variables. La URL, la key y el modelo caen cada
+uno a una variable `LITELLM_*` si la forma `DAIMON_*` no está definida.
+
+| Variable | Default | Qué hace |
+|---|---|---|
+| `DAIMON_LLM_BACKEND` | `auto` | Transporte: `auto` (litellm si hay credenciales, si no un CLI de comando si alguno resuelve), `litellm`, `command` o `claude-cli`. |
+| `DAIMON_LLM_BASE_URL` | `http://localhost:4000` | URL del endpoint compatible con OpenAI (se recorta la barra final). Cae a `LITELLM_BASE_URL`. |
+| `DAIMON_LLM_API_KEY` | sin definir | API key del endpoint. Cae a `LITELLM_API_KEY`. |
+| `DAIMON_LLM_MODEL` | sin definir | Nombre de modelo a enviar. Cae a `LITELLM_MODEL`. |
+| `DAIMON_LLM_TEMPERATURE` | `0.0` | Temperatura de muestreo de cada llamada de chat. `0.0` para extracción determinista; algunos upstreams rechazan cualquier valor que no sea uno fijo. |
+| `DAIMON_LLM_FALLBACK` | on | Cuando el backend litellm falla, cae automáticamente a un backend de comando (resiliencia ante fallas del gateway). Ponlo en `0` para desactivarlo. |
+| `DAIMON_LLM_NO_CACHE` | off | Cuando es verdadero, evita el cache de respuestas del gateway por request — necesario cuando una respuesta mala cacheada fija una falla o cuando las corridas deben ser estadísticamente independientes. |
+| `DAIMON_LLM_BRIEFING` | off | Cuando es verdadero, renderiza el briefing vía LLM en lugar de la plantilla determinista. |
+| `DAIMON_LLM_COMMAND` | sin definir | Invocación completa del CLI para el backend `command` (binario + modelo + flags). |
+| `DAIMON_LLM_COMMAND_OUTPUT` | sin definir | Cómo extraer el texto del asistente del stdout del comando: `text` (stdout crudo) o `json:<key>` (parsear JSON, leer `<key>`). |
+| `DAIMON_LLM_COMMAND_INPUT` | `stdin` | Cómo llega el prompt al backend de comando: `stdin` (por tubería), `arg` (anexado como último elemento de argv) o `file:<flag>` (escrito a un archivo temporal, luego se anexa `<flag> <path>`). Un valor no reconocido registra una advertencia y cae a `stdin`. |
+
+## Chunking del serializador
+
+Las sesiones largas se serializan en chunks solapados cuyos checkpoints
+parciales se fusionan jerárquicamente. Los defaults vienen de mediciones de
+campo; solo importan si tus sesiones son rutinariamente muy largas.
+
+| Variable | Default | Qué hace |
+|---|---|---|
+| `DAIMON_CHUNK_LINES` | `1200` | Conteo de líneas del transcript renderizado sobre el cual la serialización cambia a modo chunked. |
+| `DAIMON_CHUNK_OVERLAP` | `100` | Líneas de solapamiento entre chunks adyacentes, para que un ítem que cruza un borde sea visto entero por al menos un chunk. |
+| `DAIMON_CHUNK_CONCURRENCY` | `4` | Llamadas LLM de serialización de chunks en paralelo. Mínimo 1 (secuencial). |
+| `DAIMON_MERGE_GROUP_SIZE` | `3` | Máximo de checkpoints parciales fusionados por llamada de merge jerárquico. Mínimo 2. Bájalo a `2` si las llamadas de merge mueren en un gateway con techo de request del lado del servidor (los modelos de razonamiento generando merges de 3 vías pueden excederlo; subir `DAIMON_TIMEOUT` no ayuda — el kill es del lado del servidor). |

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/claude-code.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/claude-code.md
@@ -1,0 +1,118 @@
+# Claude Code
+
+Claude Code es el host con soporte más profundo: el ciclo completo
+(serialize -> carry -> brief -> recall) corre en él en uso real a diario, y
+los incidentes de campo retroalimentan el código — el rastro de evidencia
+vive en el
+[logbook de investigación](https://github.com/Daily-Nerd/daimon/blob/main/research/README.md).
+
+## Instalación (plugin — recomendado)
+
+```
+/plugin marketplace add Daily-Nerd/daimon
+/plugin install daimon@daimon
+```
+
+El plugin registra por sí mismo los hooks `SessionStart` / `UserPromptSubmit`
+/ `SessionEnd` vía `.claude-plugin/plugin.json` + `hooks/hooks.json`. El orden
+no importa respecto a instalar el CLI `daimon`: si los hooks llegan antes que
+el CLI, las sesiones arrancan con normalidad y el hook imprime una línea con
+la sugerencia de instalación en lugar de un briefing.
+
+> **No mezcles rutas de instalación.** Quien usa el plugin **no** debe correr
+> además el instalador manual de abajo — ambas rutas coexistiendo registran
+> los hooks dos veces (briefings dobles, llamadas LLM de serialización
+> dobles). Para pasar de manual a plugin: ejecuta primero
+> `python3 hook/daimon-hooks.py uninstall`.
+
+## Instalación (manual, desde un clon)
+
+Trabajando desde un checkout del código sin el sistema de plugins,
+`hook/daimon-hooks.py` es el gestor de ciclo de vida:
+
+```sh
+python3 hook/daimon-hooks.py install   [--dry-run]
+python3 hook/daimon-hooks.py uninstall [--dry-run]
+python3 hook/daimon-hooks.py status
+```
+
+Install copia los scripts de hook a `~/.claude/hooks/` y los registra bajo
+`SessionStart` / `SessionEnd` en `~/.claude/settings.json` (idempotente; los
+settings se respaldan antes de cada mutación). Requiere el CLI `daimon` en el
+PATH — `uv tool install 'daimon-briefing[pretty]'`, mira el
+[inicio rápido](../getting-started/quickstart) — y los hooks también aceptan
+el alias obsoleto `daimon-briefing` como respaldo. Después de actualizar el
+CLI, re-ejecuta install para que los scripts de hook queden sincronizados.
+
+## Qué hace cada script
+
+Tres scripts cierran el ciclo de captura -> inyección, sea cual sea la ruta de
+instalación que los registre:
+
+- **`daimon-session-brief.py`** — hook `SessionStart`. Lee el payload de stdin
+  y delega en el CLI `daimon brief` instalado (única fuente de verdad para el
+  renderizado); imprime el briefing a stdout, que Claude Code inyecta como
+  contexto de sesión. **Enrutamiento por proyecto:** el `cwd` del payload se
+  convierte en slug (estilo Claude Code: `/Users/x/proj` -> `-Users-x-proj`) y
+  se prefiere el `<checkpoint-dir>/<slug>/latest.json` de este proyecto; si el
+  proyecto no tiene checkpoint propio, se usa el `latest.json` global y el
+  encabezado del briefing se etiqueta `(global fallback — checkpoint may be
+  from another project)`. El cwd se reenvía al CLI vía `DAIMON_PROJECT_DIR`
+  para que ambos enruten igual. Sin `cwd` en el payload -> comportamiento
+  global, sin etiqueta. Fail-open: siempre sale con 0, imprime una línea de
+  diagnóstico ante una falla en lugar de morir en silencio. Respeta
+  `DAIMON_DISABLE` y `DAIMON_CHECKPOINT_DIR`.
+- **`daimon-session-end.py`** — hook `SessionEnd`. Lee el payload de stdin y
+  lanza `daimon serialize <transcript_path>` como proceso desacoplado en
+  segundo plano — la serialización es una llamada LLM (30s+ en sesiones
+  largas) y nunca debe bloquear `/exit`. El `cwd` del payload se pasa al hijo
+  como `DAIMON_PROJECT_DIR`, así el serializador escribe el
+  `<slug>/latest.json` de este proyecto además del `latest.json` global
+  (conservado por compatibilidad y para la ruta de fallback). Sin `cwd` ->
+  entorno del hijo intacto, solo-global como antes. Los diagnósticos y la
+  salida del serializador aterrizan en `~/.daimon/logs/serialize.log` — tanto
+  la línea de éxito `wrote checkpoint: <path> (took Ns)` como las líneas de
+  error con nombre (`... after Ns`) llevan los segundos transcurridos.
+  Fail-open, respeta `DAIMON_DISABLE`. No se dispara en kills duros (terminal
+  cerrada, SIGKILL) — los briefings aún pueden quedar desactualizados, y por
+  eso el encabezado de `SessionStart` muestra la edad del checkpoint.
+
+  Las credenciales del LLM vienen de `~/.daimon/env` (mira
+  [Conecta un LLM](../getting-started/quickstart#2-conecta-un-llm)) — los
+  hooks heredan el entorno del proceso host, no tu perfil de shell, así que
+  `DAIMON_LLM_API_KEY` / `DAIMON_LLM_MODEL` / `DAIMON_LLM_BASE_URL` van en
+  ese archivo (chmod 600). Sin él, la serialización falla rápido con un error
+  con nombre en `~/.daimon/logs/serialize.log`.
+- **`daimon-prompt-recall.py`** — hook `UserPromptSubmit` (recall proactivo:
+  "trabajaste en esto antes"). Se dispara en cada prompt, envía el prompt a
+  `daimon recall-inject` por stdin, e inyecta un puntero de una línea cuando
+  el prompt se solapa con un pendiente previo. Como se dispara por prompt,
+  las fallas son silenciosas (exit 0, sin salida) — lo único que imprime es
+  una sugerencia real — y los comandos slash (directivas del host, no
+  enunciados de trabajo) nunca coinciden.
+
+Estos dos scripts de captura/inyección se cablean de una de dos maneras
+mutuamente excluyentes — elige UNA (ambas a la vez disparan todo dos veces
+por sesión: dos inyecciones de briefing, dos llamadas LLM de serialización).
+Mira las secciones de instalación de arriba.
+
+## Enséñale el protocolo al agente
+
+```sh
+daimon skill install claude      # ~/.claude/skills/daimon/SKILL.md
+```
+
+`daimon skill show` imprime el contenido de la skill; `daimon skill list`
+muestra qué alcances soporta cada host. Re-ejecuta install después de
+actualizar `daimon` para refrescar el contenido.
+
+## Verificar
+
+```sh
+daimon status
+```
+
+`daimon status` reporta la salud de captura con honestidad, incluidas fallas,
+omisiones y crashes; una captura fallida se auto-repara en el siguiente
+inicio. Termina una sesión -> se escribe un checkpoint; inicia la siguiente ->
+aparece el briefing.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/codex.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/codex.md
@@ -1,0 +1,88 @@
+# Codex
+
+Codex está verificado a nivel de código y con tests unitarios
+(`test_codex_hooks.py`), pero tiene cero sesiones reales registradas — el
+adaptador y el instalador están publicados, pero ninguna entrada del logbook
+documenta todavía una sesión real de Codex completando el ciclo de captura ->
+inyección. Trata "corre en Codex" como inferido hasta que haya una en
+registro.
+
+## Instalación
+
+Agrega el ciclo de captura -> inyección de Daimon a Codex desde el paquete
+publicado (sin necesidad de clonar el repo):
+
+```sh
+daimon hooks install codex
+```
+
+Esto copia ambos scripts de hook y su helper compartido a `~/.codex/hooks/` y
+registra `SessionStart` y `Stop` en `~/.codex/hooks.json`, preservando
+cualquier entrada no relacionada que ya exista. Es idempotente — re-ejecútalo
+después de cada `uv tool upgrade daimon-briefing` para refrescar los scripts
+y que coincidan con el CLI instalado. Tras instalar, abre `/hooks` en Codex
+para revisar y confiar en las definiciones de hooks — Codex omite las
+definiciones no confiadas hasta que lo hagas.
+
+Una copia instalada obsoleta sigue *funcionando* con el comportamiento viejo,
+así que la deriva es invisible. Ejecuta `daimon hooks status` para auditar
+las copias instaladas contra las versiones empaquetadas
+(CURRENT/STALE/MISSING, más el estado de registro en `hooks.json`); sale con
+código distinto de cero cuando algo derivó, y `daimon hooks install codex` lo
+refresca en el lugar.
+
+Requiere el CLI `daimon` en el `PATH` (el alias obsoleto `daimon-briefing`
+también funciona como respaldo):
+
+```sh
+uv tool install 'daimon-briefing[pretty]'
+```
+
+### Instalación manual (desde un clon)
+
+Trabajando desde un checkout del código, el gestor de ciclo de vida
+independiente ofrece la misma integración más `uninstall` y `status`:
+
+```sh
+python3 hook/codex-hooks.py install   [--dry-run]
+python3 hook/codex-hooks.py uninstall [--dry-run]
+python3 hook/codex-hooks.py status
+```
+
+## Qué hace cada script
+
+- **`daimon-codex-session-start.py`** — hook `SessionStart`. Lee el último
+  checkpoint del proyecto y devuelve JSON `additionalContext` de Codex, así
+  el briefing se inyecta como contexto de desarrollo.
+- **`daimon-codex-stop.py`** — hook `Stop`. Codex expone `Stop` a nivel de
+  turno, no como un evento limpio de fin de sesión, así que este hook
+  serializa de forma oportunista y está regulado por
+  `DAIMON_CODEX_MIN_SERIALIZE_INTERVAL` (por defecto `300` segundos por
+  sesión). Ponlo en `0` para serializar cada turno, o pon
+  `DAIMON_CODEX_SERIALIZE_ON_STOP=0` para desactivar la captura de Codex
+  dejando instalada la inyección del briefing.
+
+La documentación de Codex señala que `transcript_path` se provee por
+conveniencia pero su formato no es una interfaz estable. El parser JSONL de
+Daimon es deliberadamente best-effort e ignora filas desconocidas en lugar de
+tratar JSON crudo como texto del transcript.
+
+## Enséñale el protocolo al agente
+
+```sh
+daimon skill install codex       # bloque gestionado en ~/.codex/AGENTS.md
+```
+
+En el archivo compartido `AGENTS.md`, daimon solo toca su propio bloque
+marcado — `daimon skill uninstall codex` elimina exactamente ese bloque.
+Re-ejecuta install después de actualizar `daimon` para refrescar el
+contenido.
+
+## Verificar
+
+```sh
+daimon status
+```
+
+`daimon status` reporta la salud de captura con honestidad, incluidas fallas,
+omisiones y crashes.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/gemini.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/gemini.md
@@ -1,0 +1,60 @@
+# Gemini CLI
+
+El soporte de Gemini replica la forma de Claude Code, dividido en dos
+scripts. El hook del briefing está publicado, pero la serialización **hoy no
+puede correr de punta a punta**: la captura está detenida detrás del issue
+upstream `gemini-cli#14715` (`transcript_path` es un stub) — medio ciclo, por
+restricción upstream, no por un bug de daimon.
+
+## Qué hace cada script
+
+- **`daimon-gemini-session-start.py`** — hook `SessionStart`. Delega en
+  `daimon brief` e inyecta el resultado vía el sobre
+  `{"hookSpecificOutput": {"additionalContext": ...}}` de Gemini. Gemini
+  exige **stdout JSON-puro** ("Silence is Mandatory") — a diferencia del hook
+  de Claude Code, nada se imprime crudo; los diagnósticos para el operador
+  viajan en `{"systemMessage": ...}`. `SessionStart` es solo-consultivo:
+  siempre exit 0, el arranque nunca se bloquea.
+- **`daimon-gemini-session-end.py`** — hook `SessionEnd`. Replica el hook
+  `SessionEnd` de Claude Code (lanza `daimon serialize <transcript_path>`
+  desacoplado), pero Gemini CLI actualmente envía `transcript_path` como un
+  **stub vacío** (`gemini-cli#14715`, limitación upstream al 2026-07-01), así
+  que el comportamiento principal de este hook hoy es una omisión elegante y
+  registrada. La ruta de lanzamiento queda lista para cuando upstream
+  complete el campo.
+
+## Instalación (manual, desde un clon)
+
+`gemini-hooks.py` es el gestor de ciclo de vida (misma forma que
+`codex-hooks.py`):
+
+```sh
+python3 hook/gemini-hooks.py install   [--dry-run]
+python3 hook/gemini-hooks.py uninstall [--dry-run]
+python3 hook/gemini-hooks.py status
+```
+
+Install copia ambos scripts (más `_daimon_hook_lib.py`) a `~/.gemini/hooks/`
+y los registra en `~/.gemini/settings.json` (capa de usuario). Requiere el
+CLI `daimon` en el `PATH` (`uv tool install 'daimon-briefing[pretty]'`).
+
+## Enséñale el protocolo al agente
+
+```sh
+daimon skill install gemini      # bloque gestionado en ~/.gemini/GEMINI.md
+```
+
+En el archivo compartido `GEMINI.md`, daimon solo toca su propio bloque
+marcado — `daimon skill uninstall gemini` elimina exactamente ese bloque.
+Re-ejecuta install después de actualizar `daimon` para refrescar el
+contenido.
+
+## Verificar
+
+```sh
+daimon status
+```
+
+Hasta que `gemini-cli#14715` se resuelva upstream, espera que `daimon status`
+muestre la captura como omitida en lugar de escrita — la inyección del
+briefing en `SessionStart` funciona con independencia de la captura.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/index.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/index.md
@@ -1,0 +1,36 @@
+# Guías de configuración por host
+
+Daimon cierra un ciclo de captura -> inyección alrededor del host de agentes
+que uses: un hook de fin de sesión escribe un checkpoint, y un hook de inicio
+de sesión (o por prompt) convierte el último checkpoint en un briefing. La
+profundidad del soporte varía según los eventos de hook que cada host expone.
+
+| Host | Instalación | Captura | Inyección del briefing | Estado |
+|---|---|---|---|---|
+| [Claude Code](./claude-code.md) | Plugin (`/plugin install daimon@daimon`) o manual `hook/daimon-hooks.py install` | El hook `SessionEnd` lanza `daimon serialize` en segundo plano | El hook `SessionStart` inyecta el briefing; el hook `UserPromptSubmit` agrega recall proactivo | validado en uso real a diario |
+| [Codex](./codex.md) | Manual `hook/codex-hooks.py install` (desde un clon) | Hook `Stop` con throttle (Codex no tiene evento de fin de sesión) | El hook `SessionStart` inyecta vía `additionalContext` | publicado, a la espera de su primera ejecución real |
+| [Gemini CLI](./gemini.md) | Manual `hook/gemini-hooks.py install` (desde un clon) | Bloqueado upstream (`gemini-cli#14715` — `transcript_path` es un stub vacío) | El hook `SessionStart` inyecta vía `additionalContext` | bloqueado upstream (`gemini-cli#14715`) |
+| [Windsurf (Cascade)](./windsurf.md) | `daimon hooks install windsurf` | Serialización con throttle en `pre_user_prompt` / `post_cascade_response(_with_transcript)` | Ninguna — Cascade no tiene evento equivalente a inicio de sesión; la skill instruye al agente a ejecutar `daimon brief --team` en la terminal al empezar | validado en uso real |
+
+## Tres piezas móviles
+
+Cada configuración de host combina hasta tres piezas, instaladas de forma
+independiente:
+
+- **Los hooks** capturan tus sesiones y (donde el host lo permite) inyectan el
+  briefing como contexto. Claude Code tiene un plugin empaquetado; los demás
+  hosts instalan scripts de hook independientes vía
+  `daimon hooks install <host>` (actualmente Windsurf) o los scripts manuales
+  de ciclo de vida bajo `hook/` (Codex, Gemini, y Claude Code sin el plugin).
+- **La skill** (`daimon skill install <host>`) le enseña al agente del otro
+  lado del hook cómo usar lo que los hooks capturan — leer el briefing al
+  inicio de sesión (obteniéndolo con `daimon brief --team` cuando el host no
+  inyecta nada, p. ej. Windsurf), tratar los ítems `verbatim` como citas
+  inmutables, verificar afirmaciones que parezcan desactualizadas antes de
+  repetirlas.
+- **El CLI `daimon`** es la única fuente de verdad a la que todos los hooks
+  delegan la serialización, el renderizado y el almacenamiento — instálalo una
+  vez (`uv tool install 'daimon-briefing[pretty]'`) y los hooks de todos los
+  hosts comparten el mismo almacén de checkpoints.
+
+Elige tu host arriba para la guía completa.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/windsurf.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/windsurf.md
@@ -1,0 +1,112 @@
+# Windsurf (Cascade)
+
+El adaptador de Windsurf está publicado y validado en uso real: el ciclo de
+captura (serialización desde transcript nativo, endurecido con probes) fue
+probado de punta a punta en uso real de Windsurf.
+
+## Instalación
+
+```sh
+daimon hooks install windsurf   # copia daimon-windsurf-hooks.py, _daimon_hook_lib.py
+                                 # y redact.py a ~/.daimon/hooks/, y luego imprime el
+                                 # snippet de registro para la config de hooks de Cascade
+daimon hooks list                # hosts con scripts de hook empaquetados
+```
+
+`daimon hooks install <host>` incluye `redact.py` junto a los scripts de hook
+para que el adaptador limpie secretos en cada uno de sus propios puntos de
+escritura (acumulación de transcript, checkpoint, log de eventos) — la
+redacción no depende de que el paquete completo de `daimon` sea importable
+desde el hook. Re-ejecuta `daimon hooks install windsurf` después de cada
+actualización de `daimon` para que los scripts instalados queden
+sincronizados con el CLI instalado. Para revisar si derivaron, ejecuta
+`daimon hooks status` — reporta cada copia instalada como
+CURRENT/STALE/MISSING contra la versión empaquetada y sale con código
+distinto de cero ante deriva.
+
+Apunta la configuración de hooks de Cascade en Windsurf (JSON a nivel de
+usuario — mira
+[la documentación de hooks de Cascade](https://docs.windsurf.com/windsurf/cascade/hooks))
+al script instalado para los **tres** eventos: `pre_user_prompt`,
+`post_cascade_response` y `post_cascade_response_with_transcript`.
+
+## Cómo un solo script cubre tres eventos
+
+Un script, `daimon-windsurf-hooks.py`, se registra para tres eventos de hook
+de Cascade:
+
+- **Transcript nativo preferido:** cuando `post_cascade_response_with_transcript`
+  está registrado y existe el transcript nativo `.jsonl` de Cascade
+  (`~/.windsurf/transcripts/<trajectory_id>.jsonl`) para la trayectoria, se
+  serializa directamente — sin acumulación.
+- **Fallback de acumulación:** `pre_user_prompt` / `post_cascade_response` no
+  traen ruta de transcript, así que el adaptador anexa cada turno a su propio
+  `~/.daimon/windsurf/transcripts/<trajectory_id>.md` con la misma forma
+  marcada `**role**:` que `daimon serialize` ya parsea.
+- **Serialización con throttle:** ambos eventos capaces de serializar se
+  disparan cada turno; `DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL` (por defecto
+  300s, `0` = cada turno) regula el lanzamiento por trayectoria, compartiendo
+  un marcador para que registrar ambos eventos nunca lance doble.
+- **Finalizador con debounce:** cada evento capaz de serializar también arma
+  un temporizador desacoplado de un solo disparo; tras
+  `DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS` (por defecto 600s, `0` lo
+  desactiva) sin más actividad en la trayectoria, el temporizador del último
+  turno serializa el estado final del transcript — así una sesión cuyos
+  últimos turnos cayeron dentro de la ventana del throttle igual se captura.
+- **Auto-sondeo:** cualquier forma de payload que el adaptador no pueda
+  manejar se vuelca a `~/.daimon/windsurf/unparsed-<event>-<stamp>.json`
+  (como máximo un volcado por nombre de evento), para que la siguiente
+  iteración del adaptador tenga evidencia real en lugar de otra ronda de
+  probes manuales.
+- **Sin inyección de briefing:** el conjunto de hooks de Cascade no tiene un
+  evento equivalente a inicio de sesión, así que a diferencia de Claude
+  Code/Codex/Gemini el briefing no se inyecta como contexto. Es una
+  restricción permanente del host, no un bug — la skill cierra el ciclo desde
+  el lado del agente: instruye a Cascade a ejecutar `daimon brief --team` al
+  inicio de sesión (mira
+  [Enséñale el protocolo al agente](#enséñale-el-protocolo-al-agente)).
+- Fail-open en todas partes; interruptor de apagado `DAIMON_DISABLE=1`.
+
+Windsurf no tiene evento de fin de sesión, así que la serialización corre con
+el throttle de arriba, con un finalizador con debounce cubriendo la cola de
+la sesión: una sesión cuyos últimos turnos caen dentro de la ventana del
+throttle se serializa una vez que pasa
+`DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS` (por defecto 600) sin actividad
+nueva, en lugar de perder esos turnos. Pon la perilla en `0` para desactivar
+el finalizador. `DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL=0` sigue siendo el
+recurso de demora-cero — serializa cada turno (una llamada LLM por turno),
+así nada espera al periodo de silencio. Una perilla que vale la pena en tu
+primera semana:
+
+```sh
+echo 'DAIMON_MIN_MESSAGES=4' >> ~/.daimon/env   # no omitas sesiones cortas iniciales
+```
+
+## Enséñale el protocolo al agente
+
+```sh
+daimon skill install windsurf             # ~/.codeium/windsurf/skills/daimon/SKILL.md
+daimon skill install windsurf --project   # .windsurf/rules/daimon.md
+```
+
+En Windsurf la skill no es solo etiqueta de protocolo — es la vía de entrega
+del briefing. Como Cascade no tiene evento de inicio de sesión donde
+inyectar, la skill instruye al agente a ejecutar `daimon brief --team` en la
+terminal antes de otro trabajo (con los briefings de compañeros incluidos
+cuando el proyecto comparte un equipo daimon; idéntico a `daimon brief` sin
+uno), y a continuar en silencio cuando daimon no está configurado.
+
+Re-ejecuta install después de actualizar `daimon` para refrescar el
+contenido.
+
+## Verificar
+
+```sh
+daimon status
+```
+
+Los briefings se leen con `daimon brief` en una terminal — no se inyectan —
+así que `daimon status` (y no un prompt de inicio de sesión) es la manera de
+confirmar que se escribió un checkpoint tras tu última sesión. Con la skill
+instalada, el agente ejecuta la lectura por sí mismo (`daimon brief --team`)
+al inicio de sesión.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/index.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/index.md
@@ -1,0 +1,15 @@
+---
+sidebar_position: 0
+sidebar_label: Resumen
+slug: /
+---
+
+# daimon
+
+Memoria de sesión que tus agentes pueden demostrar. Instala, conéctalo a tu
+host de agentes, y cada sesión termina con un checkpoint firmado desde el cual
+la siguiente sesión retoma — briefings con clases de confianza, citas verbatim
+verificadas contra el transcript, y receipts.
+
+Elige tu host en **Hosts** para instalar, o empieza por
+**Primeros pasos → Inicio rápido**.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/backends-tested.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/backends-tested.md
@@ -1,0 +1,99 @@
+# Backends y modelos probados en campo
+
+Qué combinaciones de modelo/backend funcionan de verdad con el serializador
+de daimon — medidas en uso real, no asumidas. Una fila por combinación
+(modelo, ruta de backend) que alguien haya corrido en el campo.
+
+Dos reglas mantienen esto como fuente de verdad en lugar de una página de
+sensaciones:
+
+1. **Medido, no auto-reportado.** La columna de calidad es la *tasa de
+   degradación verbatim*: la proporción de afirmaciones verbatim frescas cuya
+   cita falló la verificación contra el transcript y fue degradada a
+   inferida. La computa el verificador; la opinión del modelo sobre su propia
+   salida nunca se acepta. Mira la receta abajo.
+2. **Con fecha y versión, o no cuenta.** Cada fila lleva la versión de daimon
+   y la fecha de prueba. Las filas viejas envejecen a la vista en lugar de
+   mentir para siempre.
+
+Las filas se contribuyen por PR — daimon no tiene telemetría por diseño, así
+que nada de esto se recolecta automáticamente. Agrega tu combinación con la
+receta de abajo.
+
+## Matriz
+
+| Modelo | Ruta de backend | daimon | Tasa de degradación (muestra) | Fecha | Notas |
+|-------|--------------|--------|-------------------------|------|-------|
+| MIXED — claude-haiku-4-5 (litellm proxy) + sesiones claude-cli, atribución por sesión perdida | ver notas | 0.13.0 | 29% de 51 afirmaciones verbatim frescas, 3 sesiones — rango por sesión 6%–77% | 2026-07-10 | máquina de desarrollo del maintainer. El backend cambió entre estas sesiones y los checkpoints no registran cuál serializó cada una, así que esta fila NO PUEDE separarse — se conserva como ejemplo práctico de por qué las muestras sin atribución son casi inútiles y de por qué el serializador necesita un sello de backend/modelo. Reemplázala con filas atribuidas ahora que el sellado existe. |
+| _tu modelo_ | _anthropic / openai-compatible / claude-cli / command_ | | | | |
+
+**Regla de atribución (aprendida llenando la primera fila):** una fila solo
+es válida si cada checkpoint muestreado se sabe proveniente de ese par
+exacto (modelo, backend). Antes de que los checkpoints llevaran sello de
+serializador, eso significaba "el backend no cambió durante la ventana de la
+muestra" — verifica antes de contar, o tu fila mezcla combinaciones. Los
+checkpoints de 0.15.0+ llevan ese sello directamente: `llm_backend` (y
+`llm_model`, cuando la config realmente conoce uno) se registra al
+serializar, así que la atribución ya no tiene que reconstruirse de memoria
+de cuándo cambió el backend.
+
+Leyendo los números: una degradación es el **verificador atrapando una cita
+incorrecta**, no pérdida de datos — el ítem sobrevive como `[~ inferred]` con
+el sello del chequeo fallido. Más bajo es mejor; las señales interesantes son
+el nivel *y* la varianza. Las tasas de una sola sesión sobre conteos chicos
+de afirmaciones (< 20) son ruidosas — dilo en la fila.
+
+## Receta para llenar una fila
+
+La tasa de degradación queda sellada en cada checkpoint fresco:
+`verify_quotes` marca cada afirmación verbatim fresca con
+`quote_verified: true` (acierto) o la degrada a `trust: "inferred"` +
+`quote_verified: false` (fallo). Cuenta ambos en tus checkpoints más nuevos —
+nota que el filtro es sobre el *sello*, no sobre `trust` (los ítems
+degradados ya no son `verbatim`, que es exactamente por qué filtrar por trust
+los ocultaría). Agrupa por el par de sellos `(llm_backend, llm_model)`
+(0.15.0+) para que un lote mixto de checkpoints nunca pueda mezclar
+combinaciones por accidente — los checkpoints pre-0.15.0 no llevan sello y
+caen a un bucket `(unstamped)`, que es una señal de verificar la atribución a
+mano en lugar de una combinación citable en una fila:
+
+```python
+import json, sys
+from collections import defaultdict
+
+def items(c):
+    w, e = c.get("working_context", {}), c.get("epistemic_snapshot", {})
+    for k in ("open_questions", "recent_decisions"):
+        yield from (w.get(k) or [])
+    if isinstance(w.get("active_topic"), dict):
+        yield w["active_topic"]
+    for k in ("strong_beliefs", "uncertainties", "contradictions_flagged"):
+        yield from (e.get(k) or [])
+
+groups = defaultdict(lambda: [0, 0])  # (backend, model) -> [claims, downgraded]
+for path in sys.argv[1:]:
+    cp = json.load(open(path))
+    key = (cp.get("llm_backend") or "(unstamped)", cp.get("llm_model") or "(no model)")
+    fresh = [i for i in items(cp) if isinstance(i, dict)
+             and not i.get("carried_from") and i.get("quote_verified") is not None]
+    bad = sum(1 for i in fresh if i["quote_verified"] is False)
+    g = groups[key]
+    g[0] += len(fresh)
+    g[1] += bad
+
+for (backend, model), (claims, bad) in sorted(groups.items()):
+    print(f"{backend}/{model}: {claims} claims, {bad} downgraded")
+```
+
+Córrelo sobre `~/.daimon/checkpoints/<project>/latest.json` y sus hermanos
+`prev-*.json`, suma varias sesiones (una sola es demasiado ruidosa), y abre
+un PR con la fila — una fila por grupo impreso, nunca un total fusionado a
+mano entre grupos. Solo los checkpoints de 0.13.0+ llevan sellos de cita
+confiables por checkpoint (`quote_verified: false` se volvió una señal
+solo-de-frescos entonces; los ítems arrastrados más viejos pueden cargar
+sellos obsoletos).
+
+La *confiabilidad* de la serialización (si la corrida completa siquiera
+termina) es un eje distinto de la fidelidad de citas — si tu combinación
+falla por completo, eso es un reporte de issue con
+`~/.daimon/logs/serialize.log` adjunto, no una fila de la matriz.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/team/team.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/team/team.md
@@ -1,0 +1,275 @@
+# Memoria de equipo
+
+La memoria de equipo refleja cada uno de tus checkpoints de sesión —
+inmutables, un archivo por autor — a través de un repo git sidecar
+compartido, así la memoria de todo un equipo converge sin fusionar las notas
+de nadie con las de nadie más. Una vez habilitada, los temas activos y las
+decisiones de tus compañeros aparecen atribuidos (nunca mezclados con los
+tuyos) en `daimon brief --team`, y su historia es buscable junto a la tuya en
+`daimon recall`.
+
+## El repo compartido es la frontera de privacidad — lee esto primero
+
+**El control de acceso del sidecar ES la frontera de membresía y privacidad.
+Quien pueda leer ese repo git puede leer todo lo que las sesiones de cada
+miembro produjeron, así que el remoto DEBE ser un repositorio privado.** No
+hay una segunda puerta. Con la memoria de equipo activa, lo que una sesión
+discutió se refleja al repo compartido *verbatim*, tras una pasada de
+redacción de secretos basada en formas.
+
+Esa redacción es deliberadamente estrecha. Atrapa secretos con una forma
+concreta y reconocible — pares estilo asignación `api_key=…` / `token:…`,
+bloques PEM de llaves y certificados, encabezados `Bearer`, URLs
+`credential://user:pass@host`, y tokens de proveedor con prefijo fijo (AWS
+`AKIA…`, Stripe `sk_live_…`, GitHub `ghp_…`, GitLab, Slack, Google, llaves de
+OpenAI, JWTs). Cada coincidencia se reemplaza con un marcador visible
+`[redacted:<kind>]`. **No** entiende significado: la prosa confidencial de
+texto libre — el nombre de un cliente, un plan sin publicar, una URL interna
+escrita como palabras comunes — no es una forma de secreto y se sincroniza
+intacta. Trata el repo compartido como si cada miembro pudiera leer cada
+palabra, porque pueden.
+
+La identidad de autor se declara, no se autentica. Cualquier miembro del repo
+puede escribir bajo cualquier nombre de autor; daimon cruza el nombre
+sellado en cada archivo entrante contra el autor git que lo commiteó y
+muestra la discrepancia como advertencia, pero nunca bloquea la escritura. El
+control de acceso del repo es lo que deja fuera a los extraños — la etiqueta
+de autor solo te dice de quién *afirma* ser un archivo.
+
+## Configuración (dos personas)
+
+Haz esto una vez por repo compartido, y luego una vez en cada máquina.
+
+**1. Crea un repo git privado vacío** en el host que prefieras (GitHub,
+GitLab, auto-hospedado — cualquier cosa que git pueda clonar por SSH o
+HTTPS). Déjalo vacío; el primer `daimon team init` lo siembra. Asegúrate de
+que sea **privado** y de que cada compañero tenga acceso de push.
+
+**2. En cada máquina**, habilita la memoria de equipo y define tu nombre de
+autor. Pon esto en `~/.daimon/env` (cargado por daimon) o expórtalo en tu
+shell:
+
+```sh
+DAIMON_TEAM=1
+DAIMON_AUTHOR="Ada Lovelace"   # opcional — mira abajo
+```
+
+`DAIMON_AUTHOR` es opcional. Sin definir, daimon cae a
+`git config user.name`, luego a tu usuario del SO, y finalmente a `unknown`.
+Defínelo explícitamente si tu identidad git no es el nombre que quieres que
+vean tus compañeros.
+
+**3. En cada máquina**, clona el sidecar:
+
+```sh
+daimon team init git@github.com:your-org/team-memory.git
+```
+
+Un remoto vacío está bien — la primera máquina en hacer init siembra un
+commit raíz y lo pushea. Correr init una segunda vez contra un directorio que
+ya existe es un error, no un re-clon.
+
+**4. Verifica** en cada máquina:
+
+```sh
+daimon team status
+```
+
+Deberías ver el remoto listado con su frescura y los autores vistos hasta
+ahora.
+
+## Qué pasa, y cuándo
+
+Al inicio de cada sesión, daimon dispara `daimon team sync` desacoplado en
+segundo plano. Nunca bloquea tu briefing y nunca hace fallar tu sesión — si
+algo sale mal, la sesión continúa exactamente como si la memoria de equipo
+estuviera apagada. El lanzamiento está condicionado a que exista realmente un
+remoto de equipo, así que las máquinas que nunca corrieron
+`daimon team init` solo pagan un escaneo de directorio.
+
+Una pasada de sync hace tres cosas, en orden:
+
+- **Commitea y pushea solo tu propio directorio de autor.** Prepara y
+  commitea archivos nuevos bajo `authors/<your-author-slug>/`, nada más —
+  nunca archivos de otro autor, nunca algo que hayas dejado staged en el
+  sidecar.
+- **Trae las actualizaciones de tus compañeros**, pero solo cuando el remoto
+  realmente cambió. Un probe `ls-remote` de solo-refs compara hashes primero;
+  los objetos se transfieren solo ante una discrepancia, así un sync sin
+  cambios cuesta un viaje de red liviano.
+- Deja todo lo demás en paz.
+
+Solo archivos de checkpoint inmutables por autor se sincronizan. En disco
+viven bajo `~/.daimon/team/<remote-slug>/`; dentro del repo compartido la
+ruta es
+`projects/<logical/path>/authors/<author-slug>/<session_id>.json` (mira la
+sección de layout de proyectos abajo), o
+`authors/<author-slug>/<session_id>.json` cuando no resuelve ninguna
+identidad de proyecto. Nunca se escriben punteros mutables al sidecar — como
+cada autor anexa a una ruta disjunta y nada se reescribe, los merges son
+libres de conflictos por construcción. Tus punteros locales de "último
+checkpoint" permanecen privados en tu máquina y nunca se sincronizan.
+
+`DAIMON_TEAM=1` regula **solo las escrituras**. Sin definirla, tus
+checkpoints no se reflejan al sidecar — pero las lecturas del directorio de
+equipo siempre están activas, así que puedes ver la memoria de tus compañeros
+incluso antes de empezar a contribuir la tuya.
+
+## Layout de proyectos: el árbol de squad escrito por el arquitecto
+
+Los checkpoints en el sidecar se agrupan por **proyecto lógico**, así varios
+repos pueden compartir un pool de memoria y el mismo repo mapea al mismo pool
+en la máquina de cada compañero. La jerarquía es organizacional, no derivada
+del forge: un arquitecto del equipo escribe `daimon-team.toml` en la raíz del
+sidecar — el árbol de squad con los repos mapeados — y lo commitea como
+cualquier otro archivo. **Daimon solo lee este archivo; los humanos lo
+escriben y commitean.**
+
+```toml
+# daimon-team.toml — at the sidecar repo root, written by your team architect.
+#
+# One table per logical project. The key is the project's path in the squad
+# tree (any depth); `repos` lists every repo that feeds that project's pool.
+# ssh/https/scp spellings of the same repo are equivalent — the origin URL is
+# normalized (scheme, credentials, `.git`, case) before matching.
+
+[projects."core/cosmo/dusters/finance-1"]
+repos = [
+  "git@github.com:org/finance-svc.git",    # several repos → ONE shared pool
+  "https://github.com/org/finance-web",
+]
+
+[projects."core/api-gateway"]
+repos = ["git@github.com:org/gateway.git"]
+```
+
+En disco, los checkpoints de un repo mapeado aterrizan en
+`projects/core/cosmo/dusters/finance-1/authors/<author-slug>/<session_id>.json`
+— cada segmento de ruta se sanea para el filesystem, así una clave de config
+nunca puede escapar del sidecar.
+
+El proyecto lógico de una sesión se resuelve en este orden:
+
+1. **`DAIMON_TEAM_PROJECT`** — una ruta relativa como `core/api-gateway`,
+   definida por máquina. Intención local explícita; le gana al archivo de
+   config.
+2. **El mapeo de `daimon-team.toml`** — la URL `origin` del repo de la sesión
+   se normaliza y se compara contra los `repos` de cada proyecto.
+3. **Fallback derivado del origin** — la ruta de la URL de origin sin el host
+   (`git@github.com:org/repo.git` → `projects/org/repo/…`). Los repos sin
+   mapear igual obtienen identidad portátil, así el archivo de config es
+   opcional e incremental — agrega mapeos a medida que el árbol de squad tome
+   forma.
+4. **Sin origin en absoluto** (sin git, sin remoto) — los archivos de
+   checkpoint directamente bajo `authors/<author-slug>/`, exactamente como
+   antes de que existiera este layout.
+
+El archivo de config es opcional y puede agregarse o cambiarse en cualquier
+momento — los repos sin mapear sincronizan bajo su ruta derivada del origin
+desde el día uno. Remapear un repo nunca huérfana su historia previa: las
+lecturas cubren también la ubicación anterior, así los checkpoints que ya
+están bajo la ruta vieja siguen visibles tras la mudanza.
+
+Un `daimon-team.toml` roto o imposible de parsear nunca bloquea una
+escritura: el mapeo se trata como ausente (la resolución cae al fallback
+derivado del origin) y el error de parseo se muestra como advertencia en
+`daimon team status`. La membresía (abajo) es la única excepción — falla
+**cerrada**, así un error de pegado nunca puede abrir el remoto a toda la
+máquina.
+
+**Nota de legado:** los sidecars escritos antes de este layout conservan sus
+archivos planos `authors/<author-slug>/`. Esa era permanece legible para
+siempre — las lecturas abarcan ambos layouts y no hay migración; los
+checkpoints nuevos simplemente empiezan a aterrizar bajo `projects/` cuando
+resuelve una identidad de proyecto.
+
+## Qué proyectos sincronizan: la allowlist de alcance (cerrada por defecto)
+
+`DAIMON_TEAM=1` es global a la máquina, pero un remoto sincronizado solo
+acepta checkpoints de proyectos a los que **otorgó membresía**. Todo lo demás
+se queda en el mirror local de la máquina (`<team_dir>/local/`) — retenido
+del remoto, nunca perdido. Sin esta puerta, un remoto habilitado recibiría
+cada proyecto de la máquina, incluidos los personales.
+
+Un proyecto está en alcance para un remoto cuando se cumple cualquiera de
+estas:
+
+1. Su URL de origin está listada bajo la tabla `[scope]` de nivel superior
+   del sidecar:
+
+   ```toml
+   [scope]
+   repos = ["git@github.com:org/finance-svc.git"]
+   ```
+
+2. Su URL de origin está mapeada bajo cualquier tabla `[projects.*]` — un
+   repo que el arquitecto colocó en el árbol de squad es miembro, así los
+   sidecars mapeados existentes siguen sincronizando sin configuración
+   nueva.
+3. `DAIMON_TEAM_PROJECT` está definida en la máquina — intención local
+   explícita.
+
+`daimon team init` siembra un remoto fresco (vacío) con un
+`daimon-team.toml` que limita el equipo al proyecto desde el que lo
+corriste, así las configuraciones nuevas no necesitan pasos extra. Unirse a
+un remoto establecido nunca escribe config — el arquitecto es dueño del
+archivo después del nacimiento.
+
+**Migrar un sidecar existente** (creado antes de que existiera el alcance):
+agrega el bloque `[scope]` de arriba — una línea por repo que deba
+sincronizar — commitea y pushea. Hasta entonces `daimon team status` muestra
+`scope: none — this remote receives no checkpoints`. Si ya se acumularon
+árboles de proyectos ajenos bajo `projects/`, elimínalos con un simple
+`git rm -r projects/<path>` + push (reescribir la historia es opcional; sin
+ella los archivos permanecen en la historia de git).
+
+## Leyendo a tus compañeros
+
+- **`daimon brief --team`** — tu briefing normal, más una sección Teammates:
+  un bloque atribuido por compañero (excluyéndote), el más nuevo primero. Sin
+  datos de equipo la sección simplemente no aparece.
+- **`daimon recall <query>`** — búsqueda de texto completo (SQLite FTS5)
+  sobre tu historia local *y* la del equipo.
+- **`daimon team status`** — frescura por remoto, tu propio conteo de
+  checkpoints sin pushear, los autores vistos en el sidecar, y la allowlist
+  de alcance (qué repos pueden sincronizar a cada remoto).
+
+Los checkpoints de compañeros se muestran dentro de una ventana de edad de
+lectura controlada por `DAIMON_TEAM_RETENTION_DAYS` (default 365; `0`
+significa conservar todo). Salir por edad es solo un filtro de lectura —
+ningún archivo se borra físicamente de la rama compartida de solo-anexado.
+
+## Referencia de entorno
+
+| Variable | Default | Qué hace |
+|---|---|---|
+| `DAIMON_TEAM` | sin definir (off) | Ponla en `1` para reflejar tus checkpoints en el directorio de equipo. Regula solo escrituras; las lecturas siempre están activas. |
+| `DAIMON_AUTHOR` | `git config user.name` → usuario del SO → `unknown` | El nombre de autor bajo el cual se archivan tus checkpoints. |
+| `DAIMON_TEAM_DIR` | `~/.daimon/team` | Raíz del mirror local de equipo (un subdirectorio por clon de sidecar). |
+| `DAIMON_TEAM_PROJECT` | sin definir | Ruta lógica de proyecto explícita (p. ej. `core/api-gateway`) para las sesiones de esta máquina. Le gana al mapeo de `daimon-team.toml` y al fallback derivado del origin. |
+| `DAIMON_TEAM_RETENTION_DAYS` | `365` | Ventana de edad al leer los checkpoints de compañeros; `0` = conservar todos. |
+
+Mira la [referencia de configuración](../getting-started/configuration.md)
+para el entorno completo.
+
+## Cuando algo sale mal
+
+El sync es fail-open por diseño: cualquier resultado degradado te deja en el
+último estado sincronizado y nunca rompe la sesión.
+
+| Situación | Qué pasa |
+|---|---|
+| Sin conexión | El sync se pospone; conservas el último estado de equipo sincronizado. Tus checkpoints nuevos commitean localmente y quedan en cola para el siguiente push. |
+| Credenciales git ausentes | Git corre no-interactivo (`GIT_TERMINAL_PROMPT=0`) — falla rápido en lugar de colgarse en un prompt de credenciales, y el sync se degrada a sin-conexión. |
+| Pushes concurrentes | Un push rechazado es benigno (un compañero ganó la carrera). Daimon integra su cambio y reintenta, acotado a 3 intentos, y luego advierte si sigue rechazado. |
+| Historia compartida reescrita | Advertencia fuerte; daimon deja tu copia local intacta y se niega a auto-reparar. Daimon nunca hace force-push — resuélvelo a mano con git y con tu equipo. |
+| Git no instalado | El sync se omite y devuelve éxito (rc 0) — la memoria de equipo simplemente está inactiva. |
+
+## Estado
+
+La memoria de equipo es temprana. Está diseñada y validada a escala de 1–2
+personas, donde el modelo de anexado libre de conflictos del sidecar git y la
+frontera del repo privado se sostienen limpiamente. **No** es una frontera
+multi-tenant defendida: el modelo de seguridad es "todos en el repo privado
+confían en todos en el repo privado". Dimensiona la membresía del repo en
+consecuencia.


### PR DESCRIPTION
Closes #335

## What

Translates the nine pages that still fell back to English in the es locale: the site overview (`index`), all five host pages, the configuration reference, the backends matrix, and team memory. The es locale now has zero fallback pages — clicking through the Spanish site never lands on English.

Same conventions as #334: neutral Latin-American Spanish, second person; code blocks, commands, table variable names/defaults, and product output stay English.

Bonus: with the es claude-code page translated, its Connect-an-LLM link now targets the Spanish quickstart anchor (`#2-conecta-un-llm`), eliminating the last broken-anchor warning from the es build.

## Why

#335: Spanish-first is the positioning; the first pass covered quickstart + concepts but every navigation path out of them still hit English. Full coverage also retires the cross-locale link hazard (docusaurus-i18n scar) — all intra-es links are now same-side.

## Tests

- Local `npm run build`: en + es both compile with **zero warnings** (previous es builds carried a broken-anchor warning; now clean).
- CI docs build + broken-link check gates this PR.