### PR TITLE
feat(site): blog — canonical home for announcements, with bilingual inaugural post

### DIFF
--- a/website/blog/2026-07-18-daimon-has-a-home.md
+++ b/website/blog/2026-07-18-daimon-has-a-home.md
@@ -1,0 +1,56 @@
+---
+slug: daimon-has-a-home
+title: "daimon has a home: bilingual docs, and what shipped this week"
+authors: [daimon]
+tags: [announcement, release]
+---
+
+daimon now has a documentation site — the one you are reading — in English
+and Spanish, with a quickstart that takes you from install to your first
+briefing, and concept pages for the ideas that make daimon different: trust
+classes, carry, receipts, and the item lifecycle. This blog is the new
+canonical home for releases, feature explainers, and field incidents; every
+announcement you see from us elsewhere will link back here.
+
+{/* truncate */}
+
+## What shipped this week
+
+**daimon 0.18.0 is on PyPI** (`uv tool install 'daimon-briefing[pretty]'`).
+The headline experiment: opt-in per-item **scene traces**, indexed for
+recall. It ships behind a flag while we A/B it against our own benchmark —
+if the numbers don't earn it, it doesn't go default-on. That's the deal we
+make with every feature.
+
+**`daimon forget` is merged** and ships in the next release: item removal
+with a tombstone event. The item leaves the live checkpoint, the recall
+index, and the audit trail's *content* — but the event stream keeps a
+content-hash tombstone, and with receipts enabled the post-removal
+checkpoint is re-signed. Deletion you can prove happened, without keeping
+what was deleted. The [item lifecycle](/docs/concepts/lifecycle) page covers
+the mechanics.
+
+**The docs went bilingual.** Every page — quickstart, concepts, hosts,
+configuration, team memory — is available in Spanish. Not machine-dumped:
+written for Spanish-reading developers, because the es-speaking agent-dev
+community deserves first-class docs, not an afterthought.
+
+**Windsurf is live-validated.** The capture loop (native-transcript
+serialize) has now been tested end-to-end in real Windsurf use, joining
+Claude Code. Codex ships next; Gemini waits on an upstream fix.
+
+## Why this project exists, in one paragraph
+
+Your agent forgets everything between sessions, and most memory systems
+"fix" that by storing text a model wrote about what happened — with no way
+to tell which parts are quotes and which parts are guesses. daimon marks
+every remembered item as **verbatim** (an exact quote, mechanically verified
+against the transcript by a deterministic checker — no LLM grading its own
+homework) or **inferred** (allowed to evolve, flagged for verification). A
+recent survey of agent-memory research calls claim-level provenance an open
+problem; we think the answer is to make memory *provable*, and that is the
+axis everything here is built on.
+
+More soon — releases, war stories from the field, and deep dives into how
+the verification machinery works. Subscribe via [RSS](https://daily-nerd.github.io/daimon/blog/rss.xml) or
+follow the repo on [GitHub](https://github.com/Daily-Nerd/daimon).

--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -1,0 +1,5 @@
+daimon:
+  name: daimon maintainers
+  title: Daily-Nerd
+  url: https://github.com/Daily-Nerd/daimon
+  image_url: https://github.com/Daily-Nerd.png

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -46,7 +46,19 @@ const config: Config = {
           editUrl:
             'https://github.com/Daily-Nerd/daimon/tree/main/website/',
         },
-        blog: false,
+        blog: {
+          blogTitle: 'daimon blog',
+          blogDescription:
+            'Releases, feature explainers, and field incidents from building provable memory for AI agents.',
+          showReadingTime: true,
+          feedOptions: {
+            type: ['rss', 'atom'],
+            description:
+              'daimon — releases, explainers, and field incidents.',
+          },
+          onInlineAuthors: 'throw',
+          onUntruncatedBlogPosts: 'throw',
+        },
         theme: {
           customCss: './src/css/custom.css',
         },
@@ -73,6 +85,7 @@ const config: Config = {
           position: 'left',
           label: 'Docs',
         },
+        {to: '/blog', label: 'Blog', position: 'left'},
                 {type: 'localeDropdown', position: 'right'},
         {
           href: 'https://github.com/Daily-Nerd/daimon',
@@ -85,6 +98,7 @@ const config: Config = {
       style: 'dark',
       links: [
         {label: 'Docs', to: '/docs/'},
+        {label: 'Blog', to: '/blog'},
         {label: 'GitHub', href: 'https://github.com/Daily-Nerd/daimon'},
         {label: 'PyPI', href: 'https://pypi.org/project/daimon-briefing/'},
       ],

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-07-18-daimon-has-a-home.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-07-18-daimon-has-a-home.md
@@ -1,0 +1,62 @@
+---
+slug: daimon-has-a-home
+title: "daimon tiene casa: docs bilingües, y qué salió esta semana"
+authors: [daimon]
+tags: [announcement, release]
+---
+
+daimon ahora tiene un sitio de documentación — el que estás leyendo — en
+inglés y español, con un inicio rápido que te lleva de la instalación a tu
+primer briefing, y páginas de conceptos para las ideas que hacen distinto a
+daimon: clases de confianza, arrastre, receipts y el ciclo de vida de los
+ítems. Este blog es el nuevo hogar canónico de releases, explicaciones de
+features e incidentes de campo; cada anuncio que veas de nosotros en otro
+lado va a enlazar de vuelta aquí.
+
+{/* truncate */}
+
+## Qué salió esta semana
+
+**daimon 0.18.0 está en PyPI** (`uv tool install 'daimon-briefing[pretty]'`).
+El experimento principal: **scene traces** por ítem, opt-in, indexadas para
+recall. Sale detrás de un flag mientras la sometemos a un A/B contra nuestro
+propio benchmark — si los números no la justifican, no se activa por
+defecto. Ese es el trato que hacemos con cada feature.
+
+**`daimon forget` está mergeado** y sale en el próximo release: eliminación
+de ítems con un evento tombstone. El ítem sale del checkpoint vivo, del
+índice de recall y del *contenido* del rastro de auditoría — pero el flujo
+de eventos conserva un tombstone con el hash del contenido, y con receipts
+activos el checkpoint posterior a la eliminación se re-firma. Borrado que
+puedes demostrar que ocurrió, sin conservar lo borrado. La página del
+[ciclo de vida de los ítems](/docs/concepts/lifecycle) cubre la mecánica.
+
+**La documentación se volvió bilingüe.** Cada página — inicio rápido,
+conceptos, hosts, configuración, memoria de equipo — está disponible en
+español. No es un volcado de máquina: está escrita para desarrolladores que
+leen en español, porque la comunidad hispanohablante de agentes merece
+documentación de primera, no una ocurrencia tardía.
+
+**Windsurf está validado en uso real.** El ciclo de captura (serialización
+desde transcript nativo) ya fue probado de punta a punta en uso real de
+Windsurf, sumándose a Claude Code. Codex sigue; Gemini espera un arreglo
+upstream.
+
+## Por qué existe este proyecto, en un párrafo
+
+Tu agente olvida todo entre sesiones, y la mayoría de los sistemas de
+memoria lo "arreglan" almacenando texto que un modelo escribió sobre lo que
+pasó — sin manera de saber qué partes son citas y qué partes son conjeturas.
+daimon marca cada ítem recordado como **verbatim** (una cita exacta,
+verificada mecánicamente contra el transcript por un verificador
+determinista — ningún LLM calificando su propia tarea) o **inferido** (puede
+evolucionar, se señala para verificación). Una encuesta reciente de la
+investigación en memoria de agentes llama a la procedencia a nivel de
+afirmación un problema abierto; nosotros creemos que la respuesta es hacer
+la memoria *demostrable*, y ese es el eje sobre el que está construido todo
+esto.
+
+Pronto más — releases, historias de guerra del campo, y análisis a fondo de
+cómo funciona la maquinaria de verificación. Suscríbete por
+[RSS](https://daily-nerd.github.io/daimon/blog/rss.xml) o sigue el repo en
+[GitHub](https://github.com/Daily-Nerd/daimon).

--- a/website/i18n/es/docusaurus-plugin-content-blog/authors.yml
+++ b/website/i18n/es/docusaurus-plugin-content-blog/authors.yml
@@ -1,0 +1,5 @@
+daimon:
+  name: daimon maintainers
+  title: Daily-Nerd
+  url: https://github.com/Daily-Nerd/daimon
+  image_url: https://github.com/Daily-Nerd.png

--- a/website/i18n/es/docusaurus-plugin-content-blog/options.json
+++ b/website/i18n/es/docusaurus-plugin-content-blog/options.json
@@ -1,0 +1,10 @@
+{
+  "title": {
+    "message": "blog de daimon",
+    "description": "The title for the blog used in SEO"
+  },
+  "description": {
+    "message": "Releases, explicaciones de features e incidentes de campo construyendo memoria demostrable para agentes de IA.",
+    "description": "The description for the blog used in SEO"
+  }
+}


### PR DESCRIPTION
Closes #337

## What

- Re-enables the Docusaurus blog: `/blog` route, RSS + Atom feeds, Blog links in navbar and footer, project-identity `authors.yml` (no personal names), strict gates (`onInlineAuthors` / `onUntruncatedBlogPosts`: throw).
- Inaugural post, English + Spanish: the docs-site announcement, an honest 0.18.0 recap (scene traces explicitly framed as flag-gated pending the A/B verdict), `forget` scoped as merged-ships-next-release, Windsurf live-validated, and the provenance positioning paragraph.

## Why

#337: the marketing campaign needs a canonical permalink home — social posts link back here instead of dying in feeds. Content matches the honest-numbers voice rules (no sample benchmark figures, no over-claims).

## Tests

- Local `npm run build`: en + es compile with zero warnings, blog rendered in both locales, feeds generated.
- Two MDX/link gotchas hit locally and fixed before push (HTML-comment truncate marker → `{/* truncate */}`; RSS link must be a full URL since the feed is a file, not a route) — commit message documents both.
- CI docs build gates this PR.