### PR TITLE
fix(site): Spanish landing page — wire translate() into custom index

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -88,7 +88,7 @@ const config: Config = {
         {label: 'GitHub', href: 'https://github.com/Daily-Nerd/daimon'},
         {label: 'PyPI', href: 'https://pypi.org/project/daimon-briefing/'},
       ],
-      copyright: `MIT licensed. Built with Docusaurus.`,
+      copyright: `Apache-2.0 licensed. Built with Docusaurus.`,
     },
     prism: {
       theme: prismThemes.github,

--- a/website/i18n/es/code.json
+++ b/website/i18n/es/code.json
@@ -1,0 +1,47 @@
+{
+  "landing.subtitle": {
+    "message": "Memoria de sesión que tus agentes de código pueden demostrar. Briefings con clases de confianza, citas verificadas contra el transcript, y receipts firmados."
+  },
+  "landing.cta.start": {
+    "message": "Empezar"
+  },
+  "landing.quote": {
+    "message": "Deja de re-explicarte en cada sesión. La siguiente sesión abre sabiendo ya en qué estabas, qué decidiste y qué sigue abierto — con la evidencia para comprobarlo."
+  },
+  "landing.feature.briefings.title": {
+    "message": "Briefings, no arranques en frío"
+  },
+  "landing.feature.briefings.body": {
+    "message": "Cada sesión termina en un checkpoint; la siguiente abre con lo que estabas haciendo, lo que se decidió y lo que sigue abierto."
+  },
+  "landing.feature.trust.title": {
+    "message": "Clases de confianza en cada ítem"
+  },
+  "landing.feature.trust.body": {
+    "message": "Los ítems verbatim llevan citas exactas verificadas contra el transcript al serializar. Los inferidos lo dicen. Los arrastres desactualizados se señalan para re-verificación."
+  },
+  "landing.feature.receipts.title": {
+    "message": "Receipts que puedes verificar offline"
+  },
+  "landing.feature.receipts.body": {
+    "message": "Los checkpoints van firmados. Un tercero puede comprobar qué sabía una sesión, y cuándo, sin confiar en la máquina que lo escribió."
+  },
+  "landing.feature.team.title": {
+    "message": "Memoria de equipo sobre git"
+  },
+  "landing.feature.team.body": {
+    "message": "Los checkpoints se sincronizan por un remoto git normal con una allowlist de alcance cerrada por defecto. Sin servidor, sin cuentas."
+  },
+  "landing.feature.hosts.title": {
+    "message": "Funciona con tu host"
+  },
+  "landing.feature.hosts.body": {
+    "message": "Claude Code, Codex, Gemini CLI y Windsurf — instalado como hooks, removido igual de fácil."
+  },
+  "landing.feature.local.title": {
+    "message": "Local y sin dependencias"
+  },
+  "landing.feature.local.body": {
+    "message": "Solo stdlib de Python. Tus transcripts nunca salen de tu máquina salvo que configures un remoto de equipo."
+  }
+}

--- a/website/i18n/es/docusaurus-theme-classic/footer.json
+++ b/website/i18n/es/docusaurus-theme-classic/footer.json
@@ -1,0 +1,22 @@
+{
+  "link.item.label.Docs": {
+    "message": "Documentación",
+    "description": "The label of footer link with label=Docs"
+  },
+  "link.item.label.Blog": {
+    "message": "Blog",
+    "description": "The label of footer link with label=Blog"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub"
+  },
+  "link.item.label.PyPI": {
+    "message": "PyPI",
+    "description": "The label of footer link with label=PyPI"
+  },
+  "copyright": {
+    "message": "Licencia Apache-2.0. Construido con Docusaurus.",
+    "description": "The footer copyright"
+  }
+}

--- a/website/i18n/es/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/es/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,14 @@
+{
+  "item.label.Docs": {
+    "message": "Documentación",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.Blog": {
+    "message": "Blog",
+    "description": "Navbar item with label Blog"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  }
+}

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import Link from '@docusaurus/Link';
+import {translate} from '@docusaurus/Translate';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import {useEffect, useState} from 'react';
@@ -35,49 +36,97 @@ function InstallBlock(): ReactNode {
   );
 }
 
-const features = [
-  {
-    title: 'Briefings, not cold starts',
-    body: 'Every session ends in a checkpoint; the next one opens with what you were doing, what was decided, and what is still open.',
-  },
-  {
-    title: 'Trust classes on every item',
-    body: 'Verbatim items carry exact quotes verified against the transcript at serialize time. Inferred items say so. Stale carries get flagged for re-verification.',
-  },
-  {
-    title: 'Receipts you can verify offline',
-    body: 'Checkpoints are signed. A third party can check what a session knew, when, without trusting the machine that wrote it.',
-  },
-  {
-    title: 'Team memory over git',
-    body: 'Checkpoints sync through a plain git remote with a default-closed scope allowlist. No server, no accounts.',
-  },
-  {
-    title: 'Works with your host',
-    body: 'Claude Code, Codex, Gemini CLI, and Windsurf — installed as hooks, removed as easily.',
-  },
-  {
-    title: 'Local and zero-dependency',
-    body: 'Python stdlib only. Your transcripts never leave your machine unless you configure a team remote.',
-  },
-];
+function getFeatures() {
+  return [
+    {
+      title: translate({
+        id: 'landing.feature.briefings.title',
+        message: 'Briefings, not cold starts',
+      }),
+      body: translate({
+        id: 'landing.feature.briefings.body',
+        message:
+          'Every session ends in a checkpoint; the next one opens with what you were doing, what was decided, and what is still open.',
+      }),
+    },
+    {
+      title: translate({
+        id: 'landing.feature.trust.title',
+        message: 'Trust classes on every item',
+      }),
+      body: translate({
+        id: 'landing.feature.trust.body',
+        message:
+          'Verbatim items carry exact quotes verified against the transcript at serialize time. Inferred items say so. Stale carries get flagged for re-verification.',
+      }),
+    },
+    {
+      title: translate({
+        id: 'landing.feature.receipts.title',
+        message: 'Receipts you can verify offline',
+      }),
+      body: translate({
+        id: 'landing.feature.receipts.body',
+        message:
+          'Checkpoints are signed. A third party can check what a session knew, when, without trusting the machine that wrote it.',
+      }),
+    },
+    {
+      title: translate({
+        id: 'landing.feature.team.title',
+        message: 'Team memory over git',
+      }),
+      body: translate({
+        id: 'landing.feature.team.body',
+        message:
+          'Checkpoints sync through a plain git remote with a default-closed scope allowlist. No server, no accounts.',
+      }),
+    },
+    {
+      title: translate({
+        id: 'landing.feature.hosts.title',
+        message: 'Works with your host',
+      }),
+      body: translate({
+        id: 'landing.feature.hosts.body',
+        message:
+          'Claude Code, Codex, Gemini CLI, and Windsurf — installed as hooks, removed as easily.',
+      }),
+    },
+    {
+      title: translate({
+        id: 'landing.feature.local.title',
+        message: 'Local and zero-dependency',
+      }),
+      body: translate({
+        id: 'landing.feature.local.body',
+        message:
+          'Python stdlib only. Your transcripts never leave your machine unless you configure a team remote.',
+      }),
+    },
+  ];
+}
 
 export default function Home(): ReactNode {
   const {siteConfig} = useDocusaurusContext();
+  const features = getFeatures();
   return (
     <Layout description={siteConfig.tagline}>
       <header className="hero--daimon text--center">
         <h1>{siteConfig.title}</h1>
         <p className="subtitle">
-          Session memory your coding agents can prove. Briefings with trust
-          classes, quotes verified against the transcript, and signed receipts.
+          {translate({
+            id: 'landing.subtitle',
+            message:
+              'Session memory your coding agents can prove. Briefings with trust classes, quotes verified against the transcript, and signed receipts.',
+          })}
         </p>
         <div className="install">
           <InstallBlock />
         </div>
         <div>
           <Link className="button button--primary" to="/docs/">
-            Get started
+            {translate({id: 'landing.cta.start', message: 'Get started'})}
           </Link>{' '}
           <Link
             className="button button--secondary"
@@ -88,9 +137,11 @@ export default function Home(): ReactNode {
       </header>
       <main>
         <p className="quoteRow">
-          Stop re-explaining yourself every session. The next session opens
-          already knowing what you were doing, what you decided, and what is
-          still open — with the evidence to check it.
+          {translate({
+            id: 'landing.quote',
+            message:
+              'Stop re-explaining yourself every session. The next session opens already knowing what you were doing, what you decided, and what is still open — with the evidence to check it.',
+          })}
         </p>
         <div className="featureGrid">
           {features.map((f) => (


### PR DESCRIPTION
Closes #339

## What

- Wraps every user-facing landing string (`src/pages/index.tsx`) in `@docusaurus/Translate`'s `translate()` with stable ids; `i18n/es/code.json` carries the Spanish messages.
- Adds theme translations for navbar/footer labels (Docs → Documentación) and the footer copyright.
- Fixes a real error found on the way: the footer said **MIT licensed** — the repo is **Apache-2.0** (LICENSE verified). Corrected in both locales.

## Why

#339: every doc page is translated (#336) but `/es/` still served an English landing — the first thing a Spanish visitor sees contradicted the bilingual positioning.

## Tests

- Local `npm run build`: en + es, zero warnings.
- Built output greps confirm `build/es/index.html` renders the Spanish subtitle, feature cards, and CTA, and both locales show the corrected license line.
- No conflict with #338 (blog): this PR touches only the copyright line in `docusaurus.config.ts`; #338 touches the blog/navbar sections.