### PR TITLE
fix(llm): give the command fallback its own deadline budget

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1405,6 +1405,14 @@ def _cmd_status(args) -> int:
     # One-line pointer only when installed hook copies have drifted (#266);
     # silent on a clean machine. Cheap: hashes a handful of small files.
     hook_drift = _hook_drift_present()
+    # #341: a remote-gateway primary with no resolvable command backend has
+    # zero rescue coverage — surface it here, not in a post-mortem.
+    rescue_gap = bool(
+        config.llm_backend() in ("litellm", "auto")
+        and config.llm_api_key()
+        and config.llm_fallback()
+        and llm._resolve_command() is None
+    )
     health = _status_health(proj, glob, outstanding, siblings, now=now,
                             disabled=disabled)
     # ONE objective team line (#113), only when a team remote exists — the #84
@@ -1430,7 +1438,8 @@ def _cmd_status(args) -> int:
              "team": team, "crash": crash, "disabled": disabled,
              "skipped_recent": skipped_recent, "recall_error": recall_error,
              "recall_index": recall_index, "receipts": receipts_line,
-             "capture_alarm": capture_alarm, "hook_drift": hook_drift},
+             "capture_alarm": capture_alarm, "hook_drift": hook_drift,
+             "rescue_gap": rescue_gap},
             indent=2,
         ))
         return rc
@@ -1441,7 +1450,7 @@ def _cmd_status(args) -> int:
         "team": team, "crash": crash, "skipped_recent": skipped_recent,
         "recall_error": recall_error, "recall_index": recall_index,
         "receipts": receipts_line, "capture_alarm": capture_alarm,
-        "hook_drift": hook_drift,
+        "hook_drift": hook_drift, "rescue_gap": rescue_gap,
     })
     return rc
 

--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -525,6 +525,22 @@ def llm_fallback() -> bool:
     return (_get("DAIMON_LLM_FALLBACK") or "1").strip() in ("1", "true", "yes", "on")
 
 
+def fallback_min_seconds() -> int:
+    """#341: minimum budget the command fallback is guaranteed on entry.
+    The shared deadline is drained by the primary retrying the very gateway
+    failure the fallback exists to rescue — handing the fallback the
+    remainder made it dead on arrival (field data: entered 6+ times, rescued
+    0). Defaults to timeout_seconds(): the operator has already declared how
+    long one backend call may take. Override with DAIMON_FALLBACK_MIN_SECONDS."""
+    raw = _get("DAIMON_FALLBACK_MIN_SECONDS")
+    if raw:
+        try:
+            return int(raw)
+        except ValueError:
+            pass
+    return timeout_seconds()
+
+
 def llm_command() -> str | None:
     """Full CLI invocation for the command backend (binary + model + flags).
     How the prompt reaches it is controlled separately by

--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -361,6 +361,7 @@ def _stats_capture() -> dict:
     across sessions, so a failure buried under a later session's success still
     counts."""
     out = {"success": 0, "skipped": 0, "errors": 0, "fallback_serializes": 0,
+           "fallback_attempts": 0,
            "hosts": {}, "max_serialize_seconds": 0, "total_serialize_seconds": 0}
     try:
         text = (config.log_dir() / "serialize.log").read_text(encoding="utf-8")
@@ -372,6 +373,12 @@ def _stats_capture() -> dict:
         doubled = line == prev and _is_result_line(line)
         prev = line
         if doubled:
+            continue
+        # #341: fallback_serializes counts successes only; the chat() entry
+        # warning is the attempt marker. Without it, a fallback that runs and
+        # dies is indistinguishable from one that never ran.
+        if "llm.fallback backend=command" in line:
+            out["fallback_attempts"] += 1
             continue
         m = _RESULT_OK_RE.match(line)
         if m:

--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -189,6 +189,14 @@ def chat(messages, model=None, temperature=None, timeout=None, retries=3, deadli
         if config.llm_fallback() and _resolve_command() is not None:
             log.warning("llm.fallback backend=command (litellm failed)")
             _fallback_used = True
+            if deadline is not None:
+                # #341: the primary just drained the shared budget retrying
+                # the failing gateway — handing the fallback the remainder
+                # kills it on arrival in exactly the outage it exists to
+                # rescue. Re-arm to at least the configured floor; a healthy
+                # remaining budget is never shrunk.
+                deadline = max(deadline,
+                               time.monotonic() + config.fallback_min_seconds())
             return _chat_command(messages, deadline)
         raise
 

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -461,6 +461,10 @@ def _plain_status(data: dict) -> None:
             print(f"  ⚠ {w}")
     if data.get("hook_drift"):
         print("⚠ installed hooks out of date — run daimon hooks status")
+    if data.get("rescue_gap"):
+        print("⚠ primary is a remote gateway and no fallback backend resolves "
+              "— gateway failures won't be rescued (install claude or set "
+              "DAIMON_LLM_COMMAND)")
     if data.get("team"):
         print(data["team"])  # one objective line; absent when team unused (#113)
     if data.get("receipts"):
@@ -540,6 +544,10 @@ def _rich_status(data: dict) -> None:
     if data.get("hook_drift"):
         console.print("[red]⚠ installed hooks out of date — "
                       "run daimon hooks status[/red]")
+    if data.get("rescue_gap"):
+        console.print("[yellow]⚠ primary is a remote gateway and no fallback "
+                      "backend resolves — gateway failures won't be rescued "
+                      "(install claude or set DAIMON_LLM_COMMAND)[/yellow]")
     if data.get("team"):
         console.print(data["team"])  # one objective line; absent when team unused (#113)
     if data.get("receipts"):
@@ -823,7 +831,9 @@ def _plain_stats(data: dict) -> None:
                   "install` (or update the plugin)")
     print("capture:")
     print(f"  serialized: {c['success']}  skipped: {c['skipped']}  "
-          f"errors: {c['errors']}  via fallback backend: {c['fallback_serializes']}")
+          f"errors: {c['errors']}  fallback: "
+          f"attempted {c.get('fallback_attempts', 0)}, "
+          f"succeeded {c['fallback_serializes']}")
     if c["hosts"]:
         print("  spawns by host: " + ", ".join(
             f"{h}: {n}" for h, n in sorted(c["hosts"].items())))
@@ -895,7 +905,8 @@ def _rich_stats(data: dict) -> None:
     capture_table.add_row("serialized", str(c["success"]))
     capture_table.add_row("skipped", str(c["skipped"]))
     capture_table.add_row("errors", str(c["errors"]))
-    capture_table.add_row("via fallback backend", str(c["fallback_serializes"]))
+    capture_table.add_row("fallback", f"attempted {c.get('fallback_attempts', 0)}, "
+                                      f"succeeded {c['fallback_serializes']}")
     if c["hosts"]:
         capture_table.add_row("spawns by host", ", ".join(
             f"{h}: {n}" for h, n in sorted(c["hosts"].items())))

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -674,7 +674,8 @@ def test_cli_status_json_shape(
     assert set(data) == {"project", "global", "last_serialize", "outstanding",
                          "siblings", "health", "team", "crash", "disabled",
                          "skipped_recent", "recall_error", "recall_index",
-                         "receipts", "capture_alarm", "hook_drift"}
+                         "receipts", "capture_alarm", "hook_drift",
+                         "rescue_gap"}
     assert data["capture_alarm"] is None  # #265 FAIL-only probe silent by default
     assert data["team"] is None  # no team remote configured -> explicit null (#113)
     assert data["receipts"] is None  # #204 feature off -> explicit null
@@ -4151,6 +4152,52 @@ def test_stats_capture_dedupe_does_not_inflate_fallback_count(tmp_log_dir):
     cap = ledger._stats_capture()
     assert cap["success"] == 1
     assert cap["fallback_serializes"] == 1
+
+
+def test_stats_capture_counts_fallback_attempts(tmp_log_dir):
+    # #341: fallback_serializes counts SUCCESSES only, so a fallback that
+    # runs and dies is invisible — exactly how 6+ dead-on-arrival entries hid
+    # in the field. The chat() entry warning line is the attempt marker.
+    from daimon_briefing import ledger
+    _write_log(tmp_log_dir, [
+        "2026-07-16T01:00:00Z WARNING daimon_briefing.llm: "
+        "llm.fallback backend=command (litellm failed)",
+        "error: LLM deadline exhausted before command backend",
+        "2026-07-17T01:00:00Z WARNING daimon_briefing.llm: "
+        "llm.fallback backend=command (litellm failed)",
+        "wrote checkpoint: /c/A.json (took 9s) [fallback backend]",
+    ])
+    cap = ledger._stats_capture()
+    assert cap["fallback_attempts"] == 2
+    assert cap["fallback_serializes"] == 1
+    assert cap["errors"] == 1
+
+
+def test_status_warns_when_gateway_has_no_rescue_backend(tmp_checkpoint_dir,
+                                                         monkeypatch, capsys):
+    # #341 item 4: a box whose primary is a remote gateway and where no
+    # command backend resolves has ZERO rescue coverage — status must say so
+    # instead of leaving it to a post-mortem.
+    from daimon_briefing import llm
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_API_KEY", "k")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setattr(llm, "_resolve_command", lambda: None)
+    cli.main(["status"])   # rc reflects checkpoint health, not this warning
+    out = capsys.readouterr().out
+    assert "no fallback backend resolves" in out
+
+
+def test_status_no_rescue_warning_when_command_resolves(tmp_checkpoint_dir,
+                                                        monkeypatch, capsys):
+    from daimon_briefing import llm
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_API_KEY", "k")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("claude -p", "text", "stdin"))
+    cli.main(["status"])   # rc reflects checkpoint health, not this warning
+    out = capsys.readouterr().out
+    assert "no fallback backend resolves" not in out
 
 
 def test_stats_capture_does_not_dedupe_spawn_lines(tmp_log_dir):

--- a/plugin/tests/test_config.py
+++ b/plugin/tests/test_config.py
@@ -561,3 +561,26 @@ def test_scene_traces_default_off(monkeypatch):
 def test_scene_traces_flag_on(monkeypatch):
     monkeypatch.setenv("DAIMON_SCENE_TRACES", "1")
     assert config.scene_traces_enabled() is True
+
+
+# ---- #341: DAIMON_FALLBACK_MIN_SECONDS ---------------------------------------
+
+
+def test_fallback_min_seconds_defaults_to_timeout(monkeypatch):
+    # Unset: the operator's DAIMON_TIMEOUT already declares "one backend call
+    # may take this long" — the fallback floor inherits that judgment.
+    monkeypatch.delenv("DAIMON_FALLBACK_MIN_SECONDS", raising=False)
+    monkeypatch.setenv("DAIMON_TIMEOUT", "111")
+    assert config.fallback_min_seconds() == 111
+
+
+def test_fallback_min_seconds_env_override(monkeypatch):
+    monkeypatch.setenv("DAIMON_TIMEOUT", "111")
+    monkeypatch.setenv("DAIMON_FALLBACK_MIN_SECONDS", "77")
+    assert config.fallback_min_seconds() == 77
+
+
+def test_fallback_min_seconds_bad_value_falls_back_to_timeout(monkeypatch):
+    monkeypatch.setenv("DAIMON_TIMEOUT", "222")
+    monkeypatch.setenv("DAIMON_FALLBACK_MIN_SECONDS", "not-a-number")
+    assert config.fallback_min_seconds() == 222

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -871,3 +871,68 @@ def test_extract_json_prefers_largest_parseable_span_over_prose_fragment():
 def test_extract_json_unterminated_leading_fence():
     # Old behavior: a leading fence with no closer still parsed. Keep it.
     assert llm.extract_json('```json\n{"a": 4}') == {"a": 4}
+
+
+# ---- #341: the fallback must get its own budget, not the drained remainder --
+
+
+def test_chat_fallback_extends_drained_deadline(monkeypatch):
+    # A dead/slow gateway drains the shared deadline BEFORE fallback runs —
+    # the exact failure fallback exists to rescue. Entry must re-arm the clock
+    # to at least fallback_min_seconds, or the rescue is dead on arrival
+    # (#341 field data: fallback entered 6+ times, killed by the inherited
+    # deadline every time, 0 rescues).
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setenv("DAIMON_FALLBACK_MIN_SECONDS", "300")
+    monkeypatch.setattr(llm, "_chat_litellm",
+                        lambda *a, **k: (_ for _ in ()).throw(llm.ChatError("down")))
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text", "stdin"))
+    seen = {}
+
+    def fake_command(messages, deadline):
+        seen["deadline"] = deadline
+        return "OK"
+
+    monkeypatch.setattr(llm, "_chat_command", fake_command)
+    drained = time.monotonic() - 1
+    assert llm.chat([{"role": "user", "content": "x"}], deadline=drained) == "OK"
+    assert seen["deadline"] >= time.monotonic() + 250
+
+
+def test_chat_fallback_keeps_larger_remaining_budget(monkeypatch):
+    # max(remaining, floor): a healthy remaining budget is never shrunk.
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setenv("DAIMON_FALLBACK_MIN_SECONDS", "300")
+    monkeypatch.setattr(llm, "_chat_litellm",
+                        lambda *a, **k: (_ for _ in ()).throw(llm.ChatError("down")))
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text", "stdin"))
+    seen = {}
+
+    def fake_command(messages, deadline):
+        seen["deadline"] = deadline
+        return "OK"
+
+    monkeypatch.setattr(llm, "_chat_command", fake_command)
+    roomy = time.monotonic() + 10_000
+    assert llm.chat([{"role": "user", "content": "x"}], deadline=roomy) == "OK"
+    assert seen["deadline"] == roomy
+
+
+def test_chat_fallback_no_deadline_stays_none(monkeypatch):
+    # deadline=None means "no budget" — the floor must not invent one.
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setattr(llm, "_chat_litellm",
+                        lambda *a, **k: (_ for _ in ()).throw(llm.ChatError("down")))
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text", "stdin"))
+    seen = {}
+
+    def fake_command(messages, deadline):
+        seen["deadline"] = deadline
+        return "OK"
+
+    monkeypatch.setattr(llm, "_chat_command", fake_command)
+    assert llm.chat([{"role": "user", "content": "x"}]) == "OK"
+    assert seen["deadline"] is None

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -703,6 +703,7 @@ def _stats_sample():
         "usage": {"brief": 2},
         "capture": {
             "success": 2, "skipped": 1, "errors": 1, "fallback_serializes": 1,
+            "fallback_attempts": 2,
             "hosts": {"session-end": 1, "windsurf-cascade": 1},
             "max_serialize_seconds": 42, "total_serialize_seconds": 50,
         },
@@ -719,7 +720,8 @@ def _stats_empty():
     return {
         "usage": {},
         "capture": {"success": 0, "skipped": 0, "errors": 0,
-                    "fallback_serializes": 0, "hosts": {},
+                    "fallback_serializes": 0, "fallback_attempts": 0,
+                    "hosts": {},
                     "max_serialize_seconds": 0, "total_serialize_seconds": 0},
         "store": {"checkpoints": 0, "project_buckets": 0, "items_by_kind": {},
                   "items_verbatim": 0, "items_inferred": 0, "items_untagged": 0,
@@ -734,7 +736,7 @@ def test_render_stats_plain_exact_format(capsys):
         "usage (local, never transmitted):\n"
         "  brief: 2\n"
         "capture:\n"
-        "  serialized: 2  skipped: 1  errors: 1  via fallback backend: 1\n"
+        "  serialized: 2  skipped: 1  errors: 1  fallback: attempted 2, succeeded 1\n"
         "  spawns by host: session-end: 1, windsurf-cascade: 1\n"
         "  serialize seconds: max 42, avg 25\n"
         "store:\n"
@@ -751,7 +753,7 @@ def test_render_stats_plain_empty_world(capsys):
         "usage (local, never transmitted):\n"
         "  none recorded yet\n"
         "capture:\n"
-        "  serialized: 0  skipped: 0  errors: 0  via fallback backend: 0\n"
+        "  serialized: 0  skipped: 0  errors: 0  fallback: attempted 0, succeeded 0\n"
         "store:\n"
         "  checkpoints: 0  project buckets: 0\n"
         "  trust: verbatim 0, inferred 0, untagged 0  (carried: 0)\n"

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -123,6 +123,19 @@ def test_render_status_rich_and_plain_state_same_serialize_facts(monkeypatch, ca
         assert fact in plain and fact in rich_out
 
 
+def test_render_status_rescue_gap_same_warning_rich_and_plain(monkeypatch, capsys):
+    # #341: the rescue-gap warning must state the same fact regardless of
+    # `rich` — the plain branch was covered, the rich branch was not.
+    data = {**_status_data(), "rescue_gap": True}
+    render.render_status(data)
+    plain = capsys.readouterr().out
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_status(data)
+    rich_out = capsys.readouterr().out
+    for out in (plain, rich_out):
+        assert "no fallback backend resolves" in out
+
+
 def test_render_brief_notes_version_mismatch(sample_checkpoint, capsys):
     # #93: a checkpoint whose format_version differs from the current one gets a
     # note instead of silently rendering against a changed schema.


### PR DESCRIPTION
Closes #341

## PR Type

- [x] Bug fix

## Summary

- The command fallback now gets its own guaranteed deadline budget on entry (`max(remaining, DAIMON_FALLBACK_MIN_SECONDS)`, default `DAIMON_TIMEOUT`) — previously it inherited whatever the primary left after retrying the failing gateway, which was ~0 in exactly the outages it exists to rescue. Field data in #341: fallback entered 6+ times, killed by the inherited deadline every time, 3 rescues total out of 33 errors.
- `daimon stats` now counts fallback **attempts** separately from successes (`fallback: attempted N, succeeded M`) — a fallback that ran and died was previously indistinguishable from one that never ran; this diagnosis would have been a one-line stat read.
- `daimon status` warns (`rescue_gap`, text + `--json`) when the primary is a remote gateway, fallback is enabled, and no command backend resolves — that box has zero rescue coverage and should say so before the post-mortem.

Out of scope, per the diagnosis: parse/schema failures are not fallback-eligible by design (they reproduce against the same model) — that class is tracked separately.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/llm.py` | Re-arm deadline to the configured floor on fallback entry; healthy budgets never shrunk |
| `plugin/daimon_briefing/config.py` | `fallback_min_seconds()` — `DAIMON_FALLBACK_MIN_SECONDS`, defaults to `timeout_seconds()` |
| `plugin/daimon_briefing/ledger.py` | `fallback_attempts` counter folded from the chat() entry warning line |
| `plugin/daimon_briefing/render.py` | stats line/table show attempted vs succeeded; status renders the rescue-gap warning (plain + rich) |
| `plugin/daimon_briefing/cli.py` | `_cmd_status` computes `rescue_gap`, threads it into text and `--json` payloads |
| `plugin/tests/*` | 3 llm deadline tests, 3 config tests, 1 ledger fold test, 2 status tests, render exact-format updates, json-shape pin updated |

## Test Plan

- [x] TDD: every behavior change red-first, watched fail, then green
- [x] Full suite: 1808 passed, 2 skipped
- [x] `ruff` + hook-mirror drift pre-commit checks pass

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Shellcheck N/A (no shell scripts touched)
- [x] Docs unchanged (env var documented in config docstring; site reference page can pick it up with the next docs pass)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
