### PR TITLE
feat(mcp): opt-in read-only MCP server over stdio

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -714,14 +714,12 @@ def _cmd_recall(args) -> int:
 _TOPIC_TEASER_CHARS = 60
 
 
-def _cmd_projects(args) -> int:
-    """One row per checkpoint bucket: which projects daimon knows about, and
-    what each was last doing. Read-only orientation for context switching —
-    the crossing itself stays explicit (`brief --slug` / `recall --slug`),
-    the #94/#95 lesson. Torn buckets show with unknown fields rather than
-    vanish: hiding one would read as "no such project"."""
-    _note_usage("projects")
-    cur_slug = store.project_slug(_resolve_project(getattr(args, "project", None)))
+def projects_rows(project_arg=None) -> list:
+    """One JSON-ready row per checkpoint bucket, newest first. Single
+    assembler for `daimon projects --json` AND the MCP projects tool (#261) —
+    two consumers, one shape. Torn buckets show with unknown fields rather
+    than vanish: hiding one would read as "no such project"."""
+    cur_slug = store.project_slug(_resolve_project(project_arg))
     rows = []
     for b in store.list_buckets():
         cp = b["checkpoint"] or {}
@@ -741,6 +739,14 @@ def _cmd_projects(args) -> int:
     rows.sort(key=lambda r: r["_epoch"], reverse=True)
     for r in rows:
         del r["_epoch"]
+    return rows
+
+
+def _cmd_projects(args) -> int:
+    """Read-only orientation for context switching — the crossing itself
+    stays explicit (`brief --slug` / `recall --slug`), the #94/#95 lesson."""
+    _note_usage("projects")
+    rows = projects_rows(getattr(args, "project", None))
     if args.json:
         print(json.dumps(rows, indent=2, ensure_ascii=False))
         return 0
@@ -1367,11 +1373,10 @@ def _capture_alarm(now: float) -> dict | None:
             "window_days": _RETENTION_WINDOW_DAYS}
 
 
-def _cmd_status(args) -> int:
-    _note_usage("status")
-    project = _resolve_project(args.project)
-    if getattr(args, "suppressed", False):
-        return _print_suppressed(project)
+def _status_world(project_arg=None) -> dict:
+    """Every status fact, computed once — the single source for the plain
+    render, `status --json`, and the MCP status tool (#261)."""
+    project = _resolve_project(project_arg)
     now = time.time()
     proj = _checkpoint_info(store.project_latest_path(project), now)
     glob = _checkpoint_info(store.global_latest_path(), now)
@@ -1422,37 +1427,67 @@ def _cmd_status(args) -> int:
     # line's "no line when unused" rule so status stays quiet by default.
     receipts_line = receipts.status_line(project)
     identity = {
-        "cwd": str(Path(args.project or ".").expanduser().resolve()),
+        "cwd": str(Path(project_arg or ".").expanduser().resolve()),
         "git_root": project,
         "slug": store.project_slug(project),
     }
     # 0 = some checkpoint would back a briefing; 1 = neither pointer exists
     # (cheap existence test for scripts / the FR #23 hook guard).
     rc = 0 if (proj["exists"] or glob["exists"]) else 1
-
-    if args.json:
-        proj = {"dir": project, "slug": identity["slug"], **proj}
-        print(json.dumps(
-            {"project": proj, "global": glob, "last_serialize": last,
-             "outstanding": outstanding, "siblings": siblings, "health": health,
-             "team": team, "crash": crash, "disabled": disabled,
-             "skipped_recent": skipped_recent, "recall_error": recall_error,
-             "recall_index": recall_index, "receipts": receipts_line,
-             "capture_alarm": capture_alarm, "hook_drift": hook_drift,
-             "rescue_gap": rescue_gap},
-            indent=2,
-        ))
-        return rc
-
-    render.render_status({
-        "project": project, "proj": proj, "glob": glob, "same": same, "last": last,
-        "outstanding": outstanding, "identity": identity, "health": health,
-        "team": team, "crash": crash, "skipped_recent": skipped_recent,
+    return {
+        "project": project, "proj": proj, "glob": glob, "same": same,
+        "last": last, "outstanding": outstanding, "siblings": siblings,
+        "identity": identity, "health": health, "team": team, "crash": crash,
+        "disabled": disabled, "skipped_recent": skipped_recent,
         "recall_error": recall_error, "recall_index": recall_index,
         "receipts": receipts_line, "capture_alarm": capture_alarm,
-        "hook_drift": hook_drift, "rescue_gap": rescue_gap,
+        "hook_drift": hook_drift, "rescue_gap": rescue_gap, "rc": rc,
+    }
+
+
+def status_payload(project_arg=None) -> tuple:
+    """(json payload, rc) — byte-identical facts for `status --json` and the
+    MCP status tool. Payload key order is part of the --json contract."""
+    w = _status_world(project_arg)
+    proj = {"dir": w["project"], "slug": w["identity"]["slug"], **w["proj"]}
+    payload = {
+        "project": proj, "global": w["glob"], "last_serialize": w["last"],
+        "outstanding": w["outstanding"], "siblings": w["siblings"],
+        "health": w["health"], "team": w["team"], "crash": w["crash"],
+        "disabled": w["disabled"], "skipped_recent": w["skipped_recent"],
+        "recall_error": w["recall_error"], "recall_index": w["recall_index"],
+        "receipts": w["receipts"], "capture_alarm": w["capture_alarm"],
+        "hook_drift": w["hook_drift"], "rescue_gap": w["rescue_gap"],
+    }
+    return payload, w["rc"]
+
+
+def _cmd_status(args) -> int:
+    _note_usage("status")
+    if getattr(args, "suppressed", False):
+        return _print_suppressed(_resolve_project(args.project))
+    if args.json:
+        payload, rc = status_payload(args.project)
+        print(json.dumps(payload, indent=2))
+        return rc
+    w = _status_world(args.project)
+    render.render_status({
+        "project": w["project"], "proj": w["proj"], "glob": w["glob"],
+        "same": w["same"], "last": w["last"], "outstanding": w["outstanding"],
+        "identity": w["identity"], "health": w["health"], "team": w["team"],
+        "crash": w["crash"], "skipped_recent": w["skipped_recent"],
+        "recall_error": w["recall_error"], "recall_index": w["recall_index"],
+        "receipts": w["receipts"], "capture_alarm": w["capture_alarm"],
+        "hook_drift": w["hook_drift"], "rescue_gap": w["rescue_gap"],
     })
-    return rc
+    return w["rc"]
+
+
+def _cmd_mcp_serve(args) -> int:
+    """#261: blocking stdio MCP server. No usage note here — each tool call
+    notes `mcp:<tool>` itself; serving is not reading."""
+    from . import mcp_server
+    return mcp_server.serve()
 
 
 def _find_audit_transcript(session_id: str, slug):
@@ -2602,6 +2637,18 @@ def main(argv=None) -> int:
     ps_uninstall.add_argument("host")
     ps_uninstall.add_argument("--project", action="store_true")
     ps_uninstall.set_defaults(func=_cmd_skill_uninstall)
+
+    p_mcp = sub.add_parser(
+        "mcp",
+        help="opt-in read-only MCP server (#261): recall/brief/projects/"
+             "status as a self-describing tool surface for MCP-capable hosts")
+    mcp_sub = p_mcp.add_subparsers(dest="mcp_cmd", required=True)
+    mcp_sub.add_parser = functools.partial(mcp_sub.add_parser, formatter_class=fmt)
+    pm_serve = mcp_sub.add_parser(
+        "serve",
+        help="serve MCP over stdio until EOF — reads only, never writes; "
+             "register in your host's MCP config (see the docs site)")
+    pm_serve.set_defaults(func=_cmd_mcp_serve)
 
     # Slugs are munged absolute paths, so they START with "-" ("/Users/x" ->
     # "-Users-x") — argparse reads `--slug -Users-x` as a missing argument and

--- a/plugin/daimon_briefing/mcp_server.py
+++ b/plugin/daimon_briefing/mcp_server.py
@@ -1,0 +1,208 @@
+"""#261: opt-in, read-only MCP server over stdio — pure stdlib.
+
+Newline-delimited JSON-RPC 2.0 on stdin/stdout (one message per line, no
+embedded newlines); logging goes to stderr via the package logger, never to
+stdout — a stray print would corrupt the protocol stream.
+
+Deliberately NOT the official MCP SDK: daimon's zero-runtime-dependency
+contract is a product claim, and a tools-only stdio server needs exactly five
+methods of the spec. The tool registry (TOOLS/_HANDLERS) is decoupled from the
+transport loop so a future migration to the SDK — if daimon ever needs
+resources/prompts/HTTP — replaces serve() mechanically.
+
+Every tool is a thin shim over the existing library (#255: one owner per
+semantic rule — this module owns serialization to MCP shapes, nothing else).
+"""
+import json
+import logging
+
+from . import config
+
+log = logging.getLogger(__name__)
+
+# Newest first. Unknown client versions are answered with our latest: the
+# client may then disconnect if it cannot speak it (spec-sanctioned behavior).
+SUPPORTED_PROTOCOL_VERSIONS = ("2025-06-18", "2024-11-05")
+
+_PARSE_ERROR = -32700
+_METHOD_NOT_FOUND = -32601
+_INVALID_PARAMS = -32602
+
+
+def _tool_descriptors():
+    """Static tools/list payload. Input schemas are hand-written dicts —
+    they describe the shim's arguments, not the library's internals."""
+    return [
+        {
+            "name": "daimon_recall",
+            "description": (
+                "Search daimon's cross-session memory. Rows carry provenance: "
+                "trust class (verbatim = exact quote, inferred = model "
+                "conclusion), author, supersession state, and origin project "
+                "slug. Cross-project search only via all_projects/slug — "
+                "never implicit."),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string",
+                              "description": "search terms"},
+                    "all_projects": {"type": "boolean",
+                                     "description": "search every project"},
+                    "slug": {"type": "string",
+                             "description": "search one other project by slug"},
+                    "limit": {"type": "integer", "default": 20},
+                },
+                "required": ["query"],
+            },
+            "annotations": {"readOnlyHint": True},
+        },
+        {
+            "name": "daimon_brief",
+            "description": (
+                "The latest briefing for this project: what the last session "
+                "was doing, decisions, open loops — trust-tagged. Strictly "
+                "project-scoped: no checkpoint here answers 'none', never "
+                "another project's content (pass slug to read one "
+                "explicitly)."),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "slug": {"type": "string",
+                             "description": "read another project by slug"},
+                    "project": {"type": "string",
+                                "description": "project directory path"},
+                },
+            },
+            "annotations": {"readOnlyHint": True},
+        },
+        {
+            "name": "daimon_projects",
+            "description": ("Every project daimon has memory for: slug, age, "
+                            "last topic. Use a slug with daimon_brief/"
+                            "daimon_recall for explicit cross-project reads."),
+            "inputSchema": {"type": "object", "properties": {}},
+            "annotations": {"readOnlyHint": True},
+        },
+        {
+            "name": "daimon_status",
+            "description": ("Capture health for this project: checkpoint "
+                            "freshness, last serialize result, outstanding "
+                            "failures, alarms."),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "project": {"type": "string",
+                                "description": "project directory path"},
+                },
+            },
+            "annotations": {"readOnlyHint": True},
+        },
+    ]
+
+
+def _response(id_, result=None, error=None):
+    msg = {"jsonrpc": "2.0", "id": id_}
+    if error is not None:
+        msg["error"] = error
+    else:
+        msg["result"] = result
+    return msg
+
+
+def _handle_initialize(params):
+    client_version = str((params or {}).get("protocolVersion") or "")
+    version = (client_version if client_version in SUPPORTED_PROTOCOL_VERSIONS
+               else SUPPORTED_PROTOCOL_VERSIONS[0])
+    from . import __version__
+    return {
+        "protocolVersion": version,
+        "capabilities": {"tools": {}},
+        "serverInfo": {"name": "daimon", "version": __version__},
+    }
+
+
+def _handle_tools_call(params):
+    """Dispatch one tool call. Tool-level failures come back as isError
+    content (the agent can read them); only an unknown tool is a protocol
+    error — that's a client bug, not a daimon state."""
+    from . import mcp_tools
+    name = str((params or {}).get("name") or "")
+    arguments = (params or {}).get("arguments") or {}
+    handler = mcp_tools.HANDLERS.get(name)
+    if handler is None:
+        raise _UnknownTool(name)
+    try:
+        payload = handler(arguments)
+    except mcp_tools.ToolError as e:
+        return {"content": [{"type": "text", "text": str(e)}],
+                "isError": True}
+    return {"content": [{"type": "text", "text": payload}], "isError": False}
+
+
+class _UnknownTool(Exception):
+    pass
+
+
+def serve(in_stream=None, out_stream=None) -> int:
+    """Blocking request loop. Returns 0 on clean EOF.
+
+    Rules the loop lives by:
+    - never respond to a message without an `id` (notifications);
+    - never write anything but protocol JSON to out_stream;
+    - one bad line never kills the loop (parse errors get -32700, id null).
+    """
+    import sys
+    in_stream = in_stream if in_stream is not None else sys.stdin
+    out_stream = out_stream if out_stream is not None else sys.stdout
+
+    if config.is_disabled():
+        # Kill switch: refuse to serve, but exit clean — a disabled daimon
+        # must never break a host's MCP startup (printed to stderr via log).
+        log.warning("daimon disabled (DAIMON_DISABLE) — mcp serve exiting")
+        return 0
+
+    def emit(msg):
+        out_stream.write(json.dumps(msg, ensure_ascii=False) + "\n")
+        out_stream.flush()
+
+    for line in in_stream:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except ValueError:
+            emit(_response(None, error={"code": _PARSE_ERROR,
+                                        "message": "parse error"}))
+            continue
+        if not isinstance(req, dict):
+            emit(_response(None, error={"code": _PARSE_ERROR,
+                                        "message": "parse error"}))
+            continue
+        method = str(req.get("method") or "")
+        has_id = "id" in req
+        id_ = req.get("id")
+        try:
+            if method == "initialize":
+                result = _handle_initialize(req.get("params"))
+            elif method == "ping":
+                result = {}
+            elif method == "tools/list":
+                result = {"tools": _tool_descriptors()}
+            elif method == "tools/call":
+                result = _handle_tools_call(req.get("params"))
+            else:
+                if has_id:
+                    emit(_response(id_, error={
+                        "code": _METHOD_NOT_FOUND,
+                        "message": f"method not found: {method}"}))
+                continue  # notifications (known or unknown): silence
+        except _UnknownTool as e:
+            if has_id:
+                emit(_response(id_, error={
+                    "code": _INVALID_PARAMS,
+                    "message": f"unknown tool: {e}"}))
+            continue
+        if has_id:
+            emit(_response(id_, result=result))
+    return 0

--- a/plugin/daimon_briefing/mcp_tools.py
+++ b/plugin/daimon_briefing/mcp_tools.py
@@ -1,0 +1,101 @@
+"""#261: MCP tool handlers — thin shims over the existing library.
+
+Each handler takes the tools/call `arguments` dict and returns the payload
+TEXT for content[0]. Tool-level failures raise ToolError (rendered as
+isError content, never a protocol error). Handlers own nothing semantic:
+recall/brief/status/projects logic lives where it always lived (#255) —
+this module owns argument validation and JSON/text serialization only.
+
+Usage counters: every call notes `mcp:<tool>` through the same local ledger
+as the CLI (#54) — the #257 demand counters must see MCP reads
+distinguishably or the gate they measure goes blind.
+"""
+import json
+
+from . import briefing, recall, store
+
+
+class ToolError(Exception):
+    """A tool-level failure the calling agent should read, not a crash."""
+
+
+def _note(tool: str) -> None:
+    from . import cli
+    cli._note_usage(f"mcp:{tool}")
+
+
+def _recall(arguments: dict) -> str:
+    _note("recall")
+    query = str(arguments.get("query") or "").strip()
+    if not query:
+        raise ToolError("query is required")
+    slug = arguments.get("slug") or None
+    all_projects = bool(arguments.get("all_projects"))
+    if slug and all_projects:
+        # Same guard as the CLI: slug scopes to ONE project.
+        raise ToolError("slug scopes to one project; drop it or drop "
+                        "all_projects")
+    limit = arguments.get("limit")
+    limit = 20 if not isinstance(limit, int) or limit < 1 else limit
+    from . import cli
+    project = cli._resolve_project(None)
+    try:
+        rows = recall.search(query, project_dir=project, slug=slug,
+                             all_projects=all_projects, limit=limit)
+    except recall.RecallError as e:
+        raise ToolError(str(e))
+    return json.dumps(rows, ensure_ascii=False, indent=2)
+
+
+def _brief(arguments: dict) -> str:
+    _note("brief")
+    slug = arguments.get("slug") or None
+    project_arg = arguments.get("project") or None
+    if slug and project_arg:
+        raise ToolError('slug and project are two answers to "which bucket" '
+                        "— pass one")
+    from . import cli
+    # Strictly scoped read (#94): never the global pointer. A named slug is
+    # passed straight through; otherwise the resolved project's own bucket.
+    target = slug if slug else cli._resolve_project(project_arg)
+    checkpoint = store.read_latest(project_dir=target, fallback=False)
+    if checkpoint is None:
+        # Orientation without content: name the explicit path, leak nothing
+        # (#96, machine edition — an agent tool result carrying another
+        # project's briefing is contamination, not convenience).
+        others = len(store.list_buckets())
+        hint = (f"daimon knows {others} project(s) — call daimon_projects "
+                "and pass a slug to read one explicitly."
+                if others else
+                "no projects have checkpoints yet — the first serialized "
+                "session creates one.")
+        return f"no checkpoint for this project. {hint}"
+    filtered, _withheld, _candidates = briefing.withhold(
+        checkpoint, store.resolutions(project_dir=target))
+    b = briefing.build(filtered)
+    if b is None:
+        return "checkpoint exists but has nothing worth surfacing."
+    # Deterministic render only over MCP — the opt-in LLM re-render is a
+    # human-display affordance, and a machine consumer wants stable bytes.
+    return briefing.render_plain(b, briefing.receipt_degraded(filtered))
+
+
+def _projects(arguments: dict) -> str:
+    _note("projects")
+    from . import cli
+    return json.dumps(cli.projects_rows(None), ensure_ascii=False, indent=2)
+
+
+def _status(arguments: dict) -> str:
+    _note("status")
+    from . import cli
+    payload, _rc = cli.status_payload(arguments.get("project") or None)
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+HANDLERS = {
+    "daimon_recall": _recall,
+    "daimon_brief": _brief,
+    "daimon_projects": _projects,
+    "daimon_status": _status,
+}

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -4173,6 +4173,55 @@ def test_stats_capture_counts_fallback_attempts(tmp_log_dir):
     assert cap["errors"] == 1
 
 
+def test_cli_mcp_serve_registered_and_honors_kill_switch(monkeypatch):
+    # #261: `daimon mcp serve` exists; disabled daimon refuses to serve but
+    # exits 0 — it must never break a host's MCP startup.
+    monkeypatch.setenv("DAIMON_DISABLE", "1")
+    assert cli.main(["mcp", "serve"]) == 0
+
+
+def test_cli_mcp_help_lists_serve(capsys):
+    with pytest.raises(SystemExit):
+        cli.main(["mcp", "--help"])
+    assert "serve" in capsys.readouterr().out
+
+
+def test_status_payload_matches_status_json_output(
+    tmp_checkpoint_dir, tmp_log_dir, sample_checkpoint, capsys, monkeypatch
+):
+    # #261: the MCP status tool must serve byte-identical facts to
+    # `daimon status --json` — one payload assembler, two consumers.
+    from daimon_briefing import store
+
+    store.write_checkpoint("S-prev", sample_checkpoint, project_dir="/p/A")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    _write_log(tmp_log_dir, [
+        "2026-06-10T12:00:00Z session-end: spawned serialize for S-prev "
+        "(reason: exit, project: /p/A)",
+        "wrote checkpoint: /tmp/ck/S-prev.json (took 7s)",
+    ])
+    rc = cli.main(["status", "--json"])
+    data = json.loads(capsys.readouterr().out)
+    payload, prc = cli.status_payload(None)
+    assert payload == data
+    assert prc == rc
+
+
+def test_projects_rows_matches_projects_json_output(
+    tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch
+):
+    # #261: same single-assembler rule for the projects table.
+    from daimon_briefing import store
+
+    store.write_checkpoint("S-a", sample_checkpoint, project_dir="/p/A")
+    store.write_checkpoint("S-b", sample_checkpoint, project_dir="/p/B")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    rc = cli.main(["projects", "--json"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert cli.projects_rows(None) == data
+
+
 def test_status_warns_when_gateway_has_no_rescue_backend(tmp_checkpoint_dir,
                                                          monkeypatch, capsys):
     # #341 item 4: a box whose primary is a remote gateway and where no

--- a/plugin/tests/test_mcp_server.py
+++ b/plugin/tests/test_mcp_server.py
@@ -218,6 +218,52 @@ def test_status_tool_matches_cli_payload(tmp_checkpoint_dir, sample_checkpoint,
     assert json.loads(text) == payload
 
 
+def test_blank_lines_between_messages_are_ignored():
+    fake_in = io.StringIO(json.dumps(_init()) + "\n\n   \n" +
+                          json.dumps({"jsonrpc": "2.0", "id": 2,
+                                      "method": "ping"}) + "\n")
+    fake_out = io.StringIO()
+    rc = mcp_server.serve(in_stream=fake_in, out_stream=fake_out)
+    assert rc == 0
+    assert len(fake_out.getvalue().splitlines()) == 2
+
+
+def test_non_object_json_line_yields_parse_error():
+    # Valid JSON, wrong shape — an array is not a JSON-RPC message here.
+    fake_in = io.StringIO('[1, 2, 3]\n')
+    fake_out = io.StringIO()
+    mcp_server.serve(in_stream=fake_in, out_stream=fake_out)
+    resp = json.loads(fake_out.getvalue().splitlines()[0])
+    assert resp["error"]["code"] == -32700
+
+
+def test_recall_tool_fts5_error_is_tool_error(tmp_checkpoint_dir, monkeypatch):
+    # RecallError (FTS5-less sqlite) must land as isError content the agent
+    # can read — never a crash, never a protocol error.
+    from daimon_briefing import recall
+    def boom(*a, **k):
+        raise recall.RecallError("sqlite3 lacks FTS5")
+    monkeypatch.setattr(recall, "search", boom)
+    _, out = rpc(_init(), _call("daimon_recall", {"query": "x"}))
+    text, is_err = _result(out)
+    assert is_err is True
+    assert "FTS5" in text
+
+
+def test_brief_tool_empty_briefing_states_it(tmp_checkpoint_dir,
+                                             sample_checkpoint, monkeypatch):
+    # build() returning None means "nothing worth surfacing" — the tool says
+    # so instead of returning empty bytes.
+    from daimon_briefing import briefing, store
+    store.write_checkpoint("S-a", sample_checkpoint, project_dir="/p/A")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    monkeypatch.setattr(briefing, "build", lambda cp: None)
+    _, out = rpc(_init(), _call("daimon_brief", {}))
+    text, is_err = _result(out)
+    assert is_err is False
+    assert "nothing worth surfacing" in text
+
+
 # ---- usage logging + kill switch ----------------------------------------------
 
 

--- a/plugin/tests/test_mcp_server.py
+++ b/plugin/tests/test_mcp_server.py
@@ -1,0 +1,242 @@
+"""#261: opt-in read-only MCP server — protocol loop tests.
+
+The server is newline-delimited JSON-RPC 2.0 over injected streams; every
+test builds an input of one-JSON-per-line requests, runs serve(), and parses
+the response lines. No network, no subprocess (one e2e smoke lives at the
+bottom of the file, kept cheap).
+"""
+import io
+import json
+
+import pytest
+
+from daimon_briefing import mcp_server
+
+
+@pytest.fixture
+def tmp_log_dir(tmp_path):
+    # The autouse fixture already points DAIMON_LOG_DIR here; expose the path.
+    return tmp_path / ".daimon" / "logs"
+
+
+def rpc(*messages):
+    """Run serve() over the given request objects; return response objects."""
+    fake_in = io.StringIO("".join(json.dumps(m) + "\n" for m in messages))
+    fake_out = io.StringIO()
+    rc = mcp_server.serve(in_stream=fake_in, out_stream=fake_out)
+    lines = [ln for ln in fake_out.getvalue().splitlines() if ln.strip()]
+    return rc, [json.loads(ln) for ln in lines]
+
+
+def _init(protocol="2025-06-18", id_=1):
+    return {"jsonrpc": "2.0", "id": id_, "method": "initialize",
+            "params": {"protocolVersion": protocol,
+                       "capabilities": {},
+                       "clientInfo": {"name": "test", "version": "0"}}}
+
+
+# ---- handshake ---------------------------------------------------------------
+
+
+def test_initialize_handshake_negotiates_known_version():
+    rc, out = rpc(_init("2025-06-18"))
+    assert rc == 0
+    assert len(out) == 1
+    resp = out[0]
+    assert resp["jsonrpc"] == "2.0" and resp["id"] == 1
+    result = resp["result"]
+    assert result["protocolVersion"] == "2025-06-18"
+    assert result["serverInfo"]["name"] == "daimon"
+    assert "tools" in result["capabilities"]
+
+
+def test_initialize_older_supported_version_is_echoed():
+    _, out = rpc(_init("2024-11-05"))
+    assert out[0]["result"]["protocolVersion"] == "2024-11-05"
+
+
+def test_initialize_unknown_version_answers_with_latest():
+    _, out = rpc(_init("1999-01-01"))
+    assert out[0]["result"]["protocolVersion"] == "2025-06-18"
+
+
+def test_initialized_notification_produces_no_output():
+    _, out = rpc(_init(),
+                 {"jsonrpc": "2.0", "method": "notifications/initialized"})
+    assert len(out) == 1  # only the initialize response
+
+
+# ---- protocol errors ----------------------------------------------------------
+
+
+def test_malformed_json_line_yields_parse_error():
+    fake_in = io.StringIO('{"jsonrpc": "2.0", "id": 1, "method"\n')
+    fake_out = io.StringIO()
+    mcp_server.serve(in_stream=fake_in, out_stream=fake_out)
+    resp = json.loads(fake_out.getvalue().splitlines()[0])
+    assert resp["error"]["code"] == -32700
+    assert resp["id"] is None
+
+
+def test_unknown_method_with_id_yields_method_not_found():
+    _, out = rpc(_init(),
+                 {"jsonrpc": "2.0", "id": 2, "method": "resources/list"})
+    assert out[1]["error"]["code"] == -32601
+    assert out[1]["id"] == 2
+
+
+def test_unknown_notification_is_consumed_silently():
+    _, out = rpc(_init(),
+                 {"jsonrpc": "2.0", "method": "notifications/cancelled"})
+    assert len(out) == 1
+
+
+def test_ping_answers_empty_object():
+    _, out = rpc(_init(), {"jsonrpc": "2.0", "id": 7, "method": "ping"})
+    assert out[1] == {"jsonrpc": "2.0", "id": 7, "result": {}}
+
+
+# ---- tools/list ----------------------------------------------------------------
+
+
+def test_tools_list_exposes_four_read_only_tools():
+    _, out = rpc(_init(), {"jsonrpc": "2.0", "id": 3, "method": "tools/list"})
+    tools = out[1]["result"]["tools"]
+    names = {t["name"] for t in tools}
+    assert names == {"daimon_recall", "daimon_brief",
+                     "daimon_projects", "daimon_status"}
+    for t in tools:
+        assert t["description"]
+        assert t["inputSchema"]["type"] == "object"
+        assert t["annotations"]["readOnlyHint"] is True
+
+
+def test_tools_call_unknown_tool_yields_invalid_params():
+    _, out = rpc(_init(),
+                 {"jsonrpc": "2.0", "id": 4, "method": "tools/call",
+                  "params": {"name": "daimon_forget", "arguments": {}}})
+    assert out[1]["error"]["code"] == -32602
+
+
+# ---- tools/call handlers over real store state --------------------------------
+
+
+def _call(name, arguments, id_=9):
+    return {"jsonrpc": "2.0", "id": id_, "method": "tools/call",
+            "params": {"name": name, "arguments": arguments}}
+
+
+def _result(out):
+    """content[0].text of the LAST response + its isError flag."""
+    r = out[-1]["result"]
+    return r["content"][0]["text"], r["isError"]
+
+
+def test_recall_tool_returns_provenance_rows(tmp_checkpoint_dir,
+                                             sample_checkpoint, monkeypatch):
+    from daimon_briefing import store
+    store.write_checkpoint("S-a", sample_checkpoint, project_dir="/p/A")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    _, out = rpc(_init(), _call("daimon_recall", {"query": "merge"}))
+    text, is_err = _result(out)
+    assert is_err is False
+    rows = json.loads(text)
+    assert isinstance(rows, list)
+    if rows:  # sample checkpoint may or may not match "merge" — shape matters
+        assert "trust" in rows[0]
+
+
+def test_recall_tool_slug_all_projects_conflict_is_tool_error(tmp_checkpoint_dir):
+    _, out = rpc(_init(), _call("daimon_recall",
+                                {"query": "x", "slug": "s", "all_projects": True}))
+    text, is_err = _result(out)
+    assert is_err is True
+    assert "slug" in text
+
+
+def test_recall_tool_missing_query_is_tool_error(tmp_checkpoint_dir):
+    _, out = rpc(_init(), _call("daimon_recall", {}))
+    _, is_err = _result(out)
+    assert is_err is True
+
+
+def test_brief_tool_renders_checkpoint_text(tmp_checkpoint_dir,
+                                            sample_checkpoint, monkeypatch):
+    from daimon_briefing import store
+    store.write_checkpoint("S-a", sample_checkpoint, project_dir="/p/A")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    _, out = rpc(_init(), _call("daimon_brief", {}))
+    text, is_err = _result(out)
+    assert is_err is False
+    assert "S-a" in text or "left off" in text or len(text) > 40
+
+
+def test_brief_tool_no_checkpoint_gives_orientation_never_foreign_content(
+    tmp_checkpoint_dir, sample_checkpoint, monkeypatch
+):
+    # #94/#96 lesson, machine edition: a fresh project must NEVER receive
+    # another project's briefing inside a tool result. Orientation only.
+    from daimon_briefing import store
+    store.write_checkpoint("S-other", sample_checkpoint, project_dir="/p/OTHER")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/FRESH")
+    _, out = rpc(_init(), _call("daimon_brief", {}))
+    text, is_err = _result(out)
+    assert is_err is False              # absence is an answer, not an error
+    assert "no checkpoint" in text
+    assert "daimon_projects" in text    # the explicit path is named
+    assert "S-other" not in text        # foreign content never leaks
+
+
+def test_brief_tool_slug_and_project_conflict_is_tool_error(tmp_checkpoint_dir):
+    _, out = rpc(_init(), _call("daimon_brief",
+                                {"slug": "s", "project": "/p/X"}))
+    _, is_err = _result(out)
+    assert is_err is True
+
+
+def test_projects_tool_matches_cli_rows(tmp_checkpoint_dir, sample_checkpoint,
+                                        monkeypatch):
+    from daimon_briefing import cli, store
+    store.write_checkpoint("S-a", sample_checkpoint, project_dir="/p/A")
+    store.write_checkpoint("S-b", sample_checkpoint, project_dir="/p/B")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    _, out = rpc(_init(), _call("daimon_projects", {}))
+    text, is_err = _result(out)
+    assert is_err is False
+    assert json.loads(text) == cli.projects_rows(None)
+
+
+def test_status_tool_matches_cli_payload(tmp_checkpoint_dir, sample_checkpoint,
+                                         monkeypatch):
+    from daimon_briefing import cli, store
+    store.write_checkpoint("S-a", sample_checkpoint, project_dir="/p/A")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    _, out = rpc(_init(), _call("daimon_status", {}))
+    text, is_err = _result(out)
+    assert is_err is False
+    payload, _rc = cli.status_payload(None)
+    assert json.loads(text) == payload
+
+
+# ---- usage logging + kill switch ----------------------------------------------
+
+
+def test_tools_call_logs_mcp_usage(tmp_checkpoint_dir, tmp_log_dir,
+                                   sample_checkpoint, monkeypatch):
+    from daimon_briefing import config, store
+    store.write_checkpoint("S-a", sample_checkpoint, project_dir="/p/A")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    rpc(_init(), _call("daimon_projects", {}), _call("daimon_recall",
+                                                     {"query": "x"}))
+    usage = (config.log_dir() / "usage.log").read_text(encoding="utf-8")
+    assert "mcp:projects" in usage
+    assert "mcp:recall" in usage
+
+
+def test_serve_disabled_exits_clean_without_reading(monkeypatch):
+    monkeypatch.setenv("DAIMON_DISABLE", "1")
+    fake_in = io.StringIO(json.dumps(_init()) + "\n")
+    fake_out = io.StringIO()
+    rc = mcp_server.serve(in_stream=fake_in, out_stream=fake_out)
+    assert rc == 0
+    assert fake_out.getvalue() == ""

--- a/website/docs/reference/mcp.md
+++ b/website/docs/reference/mcp.md
@@ -1,0 +1,71 @@
+# MCP server (read-only)
+
+`daimon mcp serve` exposes daimon's memory as an MCP tool surface over stdio —
+for hosts that speak MCP but have no hook system daimon can attach to. It is
+opt-in (nothing registers it for you), read-only (four tools, no writes), and
+pure standard library (no extra dependency, same as the rest of daimon).
+
+```bash
+daimon mcp serve   # blocks, serves JSON-RPC on stdio until EOF
+```
+
+## Tools
+
+| Tool | What it returns |
+|------|-----------------|
+| `daimon_recall` | Search results with full provenance: trust class (`verbatim` = exact quote, `inferred` = model conclusion), author, supersession state, origin project slug |
+| `daimon_brief` | The latest briefing for the current project — deterministic render, trust-tagged, resolutions withheld |
+| `daimon_projects` | Every project daimon has memory for: slug, session, branch, last topic |
+| `daimon_status` | Capture health: checkpoint freshness, last serialize result, outstanding failures, alarms — same payload as `daimon status --json` |
+
+All four carry `readOnlyHint`. Tool-level failures (bad arguments, missing
+FTS5) come back as `isError` results the agent can read; they never kill the
+server.
+
+## Scoping rules
+
+The server inherits daimon's cross-project discipline:
+
+- **Reads are project-scoped.** The project is resolved from the process
+  working directory, or `DAIMON_PROJECT_DIR` when set — put one of them in
+  your host's MCP config.
+- **No implicit fallback.** A project with no checkpoint gets
+  `no checkpoint for this project` plus a pointer to `daimon_projects` —
+  never another project's content. Crossing projects is always explicit:
+  pass a `slug` to `daimon_brief` or `daimon_recall`.
+- **Kill switch honored.** With `DAIMON_DISABLE=1` the server exits cleanly
+  without serving, so a disabled daimon never breaks host startup.
+- **Usage stays local.** Each call writes one `mcp:<tool>` line to daimon's
+  local usage log (the same `daimon stats` counters as the CLI). Nothing is
+  transmitted.
+
+## Registering with a host
+
+Claude Code (CLI):
+
+```bash
+claude mcp add daimon -- daimon mcp serve
+```
+
+Generic stdio MCP config (Windsurf, Cursor, and most others accept this
+shape):
+
+```json
+{
+  "mcpServers": {
+    "daimon": {
+      "command": "daimon",
+      "args": ["mcp", "serve"],
+      "env": { "DAIMON_PROJECT_DIR": "/path/to/your/project" }
+    }
+  }
+}
+```
+
+If your host launches MCP servers from the project directory you can omit
+`DAIMON_PROJECT_DIR` — the working directory resolves the same way.
+
+Note: on hosts where daimon's hooks already run (Claude Code, Windsurf,
+Codex), the hook briefing is the richer integration — the MCP server is for
+reads on demand and for hosts without hooks. Running both is fine; the tools
+are read-only.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/mcp.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/mcp.md
@@ -1,0 +1,72 @@
+# Servidor MCP (solo lectura)
+
+`daimon mcp serve` expone la memoria de daimon como una superficie de
+herramientas MCP sobre stdio — para hosts que hablan MCP pero no tienen un
+sistema de hooks al que daimon pueda engancharse. Es opt-in (nada lo registra
+por ti), de solo lectura (cuatro herramientas, cero escrituras) y biblioteca
+estándar pura (sin dependencias extra, igual que el resto de daimon).
+
+```bash
+daimon mcp serve   # bloquea y sirve JSON-RPC por stdio hasta EOF
+```
+
+## Herramientas
+
+| Herramienta | Qué devuelve |
+|-------------|--------------|
+| `daimon_recall` | Resultados de búsqueda con procedencia completa: clase de confianza (`verbatim` = cita exacta, `inferred` = conclusión del modelo), autor, estado de supersesión, slug del proyecto de origen |
+| `daimon_brief` | El último briefing del proyecto actual — render determinista, etiquetado por confianza, con resoluciones retenidas |
+| `daimon_projects` | Cada proyecto del que daimon tiene memoria: slug, sesión, rama, último tema |
+| `daimon_status` | Salud de captura: frescura del checkpoint, resultado del último serialize, fallas pendientes, alarmas — el mismo payload que `daimon status --json` |
+
+Las cuatro llevan `readOnlyHint`. Las fallas a nivel de herramienta
+(argumentos inválidos, FTS5 ausente) vuelven como resultados `isError` que el
+agente puede leer; nunca matan el servidor.
+
+## Reglas de alcance
+
+El servidor hereda la disciplina entre proyectos de daimon:
+
+- **Las lecturas tienen alcance de proyecto.** El proyecto se resuelve desde
+  el directorio de trabajo del proceso, o desde `DAIMON_PROJECT_DIR` si está
+  definido — pon uno de los dos en la configuración MCP de tu host.
+- **Sin fallback implícito.** Un proyecto sin checkpoint recibe
+  `no checkpoint for this project` más un puntero a `daimon_projects` —
+  nunca el contenido de otro proyecto. Cruzar de proyecto es siempre
+  explícito: pasa un `slug` a `daimon_brief` o `daimon_recall`.
+- **Kill switch respetado.** Con `DAIMON_DISABLE=1` el servidor sale limpio
+  sin servir, así un daimon deshabilitado nunca rompe el arranque del host.
+- **El uso queda local.** Cada llamada escribe una línea `mcp:<tool>` en el
+  log de uso local de daimon (los mismos contadores de `daimon stats` que la
+  CLI). Nada se transmite.
+
+## Registrarlo en un host
+
+Claude Code (CLI):
+
+```bash
+claude mcp add daimon -- daimon mcp serve
+```
+
+Configuración stdio MCP genérica (Windsurf, Cursor y la mayoría aceptan esta
+forma):
+
+```json
+{
+  "mcpServers": {
+    "daimon": {
+      "command": "daimon",
+      "args": ["mcp", "serve"],
+      "env": { "DAIMON_PROJECT_DIR": "/ruta/a/tu/proyecto" }
+    }
+  }
+}
+```
+
+Si tu host lanza los servidores MCP desde el directorio del proyecto puedes
+omitir `DAIMON_PROJECT_DIR` — el directorio de trabajo resuelve igual.
+
+Nota: en hosts donde los hooks de daimon ya corren (Claude Code, Windsurf,
+Codex), el briefing por hook es la integración más rica — el servidor MCP es
+para lecturas a demanda y para hosts sin hooks. Correr ambos está bien; las
+herramientas son de solo lectura.


### PR DESCRIPTION
Closes #261

## PR Type

- [x] New feature

## Summary

- `daimon mcp serve`: opt-in, read-only MCP server over stdio — pure stdlib JSON-RPC 2.0 (initialize / ping / tools/list / tools/call), no new dependency, no `[mcp]` extra. Four tools: `daimon_recall`, `daimon_brief`, `daimon_projects`, `daimon_status`, all with `readOnlyHint` and full provenance in their payloads.
- Scoping keeps the house rules: brief is strictly project-scoped — a fresh project gets `no checkpoint` plus an orientation pointer to `daimon_projects`, never another project's content; cross-project reads require an explicit `slug`. Kill switch (`DAIMON_DISABLE`) exits clean without serving. Every call notes `mcp:<tool>` in the local usage ledger so the demand counters see MCP reads distinguishably.
- `status --json` / `projects --json` payloads are now assembled by extracted `status_payload()` / `projects_rows()`; the MCP tools serve byte-identical facts (equality-pinned by tests).
- Docs: `website/docs/reference/mcp.md` — tool table, scoping rules, host registration snippets. Registration is docs-only for v1; an install helper is a follow-up if a second host asks.

Design decisions (maintainer-approved): stdlib transport over the SDK extra — the zero-runtime-dependency contract is a product claim, a tools-only stdio server needs five methods of the spec, and the registry/transport split keeps an SDK migration mechanical. Protocol versions supported: 2025-06-18 and 2024-11-05.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/mcp_server.py` | New: JSON-RPC stdio loop, version negotiation, error codes, static tool descriptors |
| `plugin/daimon_briefing/mcp_tools.py` | New: four thin handlers over recall/briefing/store + the cli payload assemblers |
| `plugin/daimon_briefing/cli.py` | `mcp serve` subcommand; `_status_world()`/`status_payload()`/`projects_rows()` extractions (render paths unchanged) |
| `plugin/tests/test_mcp_server.py` | New: 20 tests — handshake, protocol errors, tools/list, all four handlers over real store fixtures, usage logging, kill switch |
| `plugin/tests/test_cli.py` | Payload-equality pins (`status_payload` vs `--json`, `projects_rows` vs `--json`) + mcp wiring tests |
| `website/docs/reference/mcp.md` | New reference page with registration snippets |

## Test Plan

- [x] TDD: protocol loop, handlers, extractions, wiring — all red-first
- [x] Full suite: 1833 passed, 2 skipped
- [x] Live stdio smoke: initialize + tools/list round-trip through `daimon mcp serve` (handshake negotiates 2025-06-18, four tools listed)
- [x] `ruff` + hook-mirror drift pre-commit checks pass

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Shellcheck N/A (no shell scripts touched)
- [x] Docs updated (new reference page)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
