### PR TITLE
feat(serializer): content-addressed chunk-extraction cache (#48 slice 1)

### DIFF
--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -96,6 +96,24 @@ def carry_enabled() -> bool:
     return (_get("DAIMON_CARRY") or "1") != "0"
 
 
+def chunk_cache_enabled() -> bool:
+    """#48: content-addressed chunk-extraction cache. Default ON — same risk
+    class as the #314 partials it replaces (correctness fully keyed; failure
+    mode = re-pay the call). DAIMON_CHUNK_CACHE=0 is the kill switch."""
+    return (_get("DAIMON_CHUNK_CACHE") or "1") != "0"
+
+
+def chunk_cache_days() -> int:
+    """#48: chunk-cache rotation window, days. Cached chunk output is
+    PRE-redaction (forced by #125 quote verification ordering), so the window
+    is a privacy bound, not just a disk bound — 3 days covers the heal/retry
+    win while keeping exposure short. Override with DAIMON_CHUNK_CACHE_DAYS."""
+    try:
+        return int(_get("DAIMON_CHUNK_CACHE_DAYS") or "3")
+    except ValueError:
+        return 3
+
+
 def carry_floor() -> float:
     """Minimum #78 effective weight for a carried item to keep carrying.
     Default 0.05: decisions expire ~5-6 weeks (importance-graded), escalated

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -693,58 +693,82 @@ def _plan_waves(n_chunks: int, workers: int, k: int) -> int:
     return waves
 
 
-# ---- #314: persisted chunk partials — a merge death must not re-buy chunks ----
-# Content-addressed by (session_id, chunk_text): a re-heal of an UNCHANGED
-# transcript reuses its paid-for chunk outputs and enters the merge with the
-# full budget; any transcript growth changes the chunk text and misses cleanly.
-# Same sensitivity as checkpoints (transcript-derived, pre-redaction), stored
-# under the same root. Everything here is best-effort: a broken cache must
-# never break a serialize — worst case is re-paying the chunk call.
+# ---- #48: content-addressed chunk-extraction cache (generalizes #314) --------
+# Keyed on chunk TEXT plus every config dimension that shapes extraction
+# (backend, model, temperature, prompt version, and a hash of the actual
+# serialize system prompt — so an un-versioned prompt edit, like the #317
+# scene appendix, invalidates cleanly). session_id is deliberately NOT in the
+# key: prefix chunks of a grown or resume-forked transcript are byte-identical
+# and their paid-for outputs transfer (#48). The prompt embeds a positional
+# "chunk i of n" label that the key ignores — presentation metadata, not
+# extraction semantics.
+#
+# Entries persist across successful serializes (that IS the feature) and are
+# reaped by age. Cached output is PRE-redaction — forced by #125: quotes are
+# verified against the pre-redaction transcript, and caching redacted output
+# would mass-downgrade legitimate verbatim items on every hit. The rotation
+# window (config.chunk_cache_days, default 3) is therefore a privacy bound;
+# files are written 0600. Same sensitivity and root as checkpoints.
+# Everything here is best-effort: a broken cache must never break a
+# serialize — worst case is re-paying the chunk call.
 
-_PARTIAL_MAX_AGE_SECONDS = 14 * 24 * 3600  # crash leftovers; success clears its own
+
+def _chunk_cache_dir():
+    return config.checkpoint_dir() / ".chunk-cache"
 
 
-def _partials_dir():
-    return config.checkpoint_dir() / ".partials"
-
-
-def _partial_key(session_id: str, chunk_text: str) -> str:
-    return hashlib.sha256(
-        f"{session_id}\x00{chunk_text}".encode("utf-8")).hexdigest()[:32]
-
-
-def _load_partial(key: str):
+def _chunk_cache_key(chunk_text: str) -> str:
     try:
-        obj = json.loads((_partials_dir() / f"{key}.json").read_text(encoding="utf-8"))
+        backend = configure.resolved_backend()
+    except Exception:
+        backend = "unknown"
+    sys_hash = hashlib.sha256(_serialize_sys().encode("utf-8")).hexdigest()[:16]
+    stamp = (f"v1\x00{backend}\x00{config.llm_model() or ''}"
+             f"\x00{config.llm_temperature()}\x00{PROMPT_VERSION}"
+             f"\x00{sys_hash}\x00")
+    return hashlib.sha256(
+        stamp.encode("utf-8") + chunk_text.encode("utf-8")).hexdigest()[:32]
+
+
+def _load_chunk_cache(key: str):
+    # DAIMON_LLM_NO_CACHE is the gateway-cache bypass, but a user reaching for
+    # it means "no replayed LLM output" — honor the intent here too (reads
+    # only; writing a fresh result is still fine).
+    if not config.chunk_cache_enabled() or config.llm_no_cache():
+        return None
+    try:
+        obj = json.loads(
+            (_chunk_cache_dir() / f"{key}.json").read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
     return obj if isinstance(obj, dict) else None
 
 
-def _save_partial(key: str, partial: dict) -> None:
-    d = _partials_dir()
+def _save_chunk_cache(key: str, partial: dict) -> None:
+    if not config.chunk_cache_enabled():
+        return
+    if llm.fallback_used():
+        # #28/#343 lesson: once the weaker fallback backend has fired in this
+        # process, nothing from this run may be cached under the primary
+        # backend's key — that is exactly how caches get poisoned.
+        return
+    d = _chunk_cache_dir()
     try:
         d.mkdir(parents=True, exist_ok=True)
+        max_age = config.chunk_cache_days() * 24 * 3600
         now = time.time()
-        for stale in d.glob("*.json"):  # reap crash leftovers by age
+        for stale in d.glob("*.json"):  # reap by age on every write
             try:
-                if now - stale.stat().st_mtime > _PARTIAL_MAX_AGE_SECONDS:
+                if now - stale.stat().st_mtime > max_age:
                     stale.unlink()
             except OSError:
                 continue
         tmp = d / f".{key}.{uuid.uuid4().hex[:8]}.tmp"
         tmp.write_text(json.dumps(partial, ensure_ascii=False), encoding="utf-8")
+        tmp.chmod(0o600)
         tmp.replace(d / f"{key}.json")
     except OSError:
         pass
-
-
-def _clear_partials(keys) -> None:
-    for key in keys:
-        try:
-            (_partials_dir() / f"{key}.json").unlink(missing_ok=True)
-        except OSError:
-            continue
 
 
 def _merge_partials(chat, session_id: str, partials: list, deadline,
@@ -935,7 +959,6 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
         "Re-emit the full corrected JSON."
     )
     partials: list | None = None
-    partial_keys: list = []  # #314: cleared only after a fully validated write
 
     def _produce(note: str) -> dict:
         nonlocal partials
@@ -955,15 +978,16 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
             # session take chunk_count * minutes of wall-clock.
             def _one_chunk(item):
                 i, chunk_text = item
-                # #314: a merge death must not re-buy completed chunks — reuse
-                # the persisted partial when this exact (session, chunk text)
-                # was already paid for by a previous attempt.
-                key = _partial_key(session_id, chunk_text)
-                cached = _load_partial(key)
+                # #48: reuse any prior run's paid-for output for this exact
+                # chunk text under the current config — merge deaths, heals,
+                # resume forks, and grown transcripts all hit on their
+                # unchanged prefix chunks.
+                key = _chunk_cache_key(chunk_text)
+                cached = _load_chunk_cache(key)
                 if cached is not None:
-                    log.info("chunk %d/%d reused persisted partial (#314)",
+                    log.info("chunk %d/%d reused cached extraction (#48)",
                              i + 1, len(chunks))
-                    return key, cached
+                    return cached
                 t0 = time.monotonic()
                 partial = _call_and_parse(
                     chat, _serialize_sys(),
@@ -973,15 +997,13 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
                 )
                 log.info("chunk %d/%d done in %.0fs",
                          i + 1, len(chunks), time.monotonic() - t0)
-                _save_partial(key, partial)
-                return key, partial
+                _save_chunk_cache(key, partial)
+                return partial
 
             workers = min(config.chunk_concurrency(), len(chunks))
             with ThreadPoolExecutor(max_workers=workers) as pool:
                 # executor.map preserves input order, so partials stay chronological.
-                keyed = list(pool.map(_one_chunk, enumerate(chunks)))
-            partial_keys.extend(k for k, _ in keyed)
-            partials = [p for _, p in keyed]
+                partials = list(pool.map(_one_chunk, enumerate(chunks)))
         # Retry re-runs ONLY the merge (the final sampling that failed) — the
         # chunk partials are kept; they are the expensive calls.
         return _merge_partials(chat, session_id, list(partials), deadline,
@@ -1011,10 +1033,9 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
     # after validation/verification so it can never influence either, and
     # last so nothing downstream re-derives or clobbers it.
     _stamp_llm_provenance(checkpoint)
-    # #314: success consumes the partial cache. Only here — any earlier exit
-    # (merge death, validation failure) leaves the paid-for chunks on disk for
-    # the next heal to reuse.
-    _clear_partials(partial_keys)
+    # #48: success does NOT consume the chunk cache — persistence across
+    # successful serializes is the feature (grown transcripts and resume
+    # forks reuse their prefix chunks). Age-based reaping bounds the store.
     return checkpoint
 
 

--- a/plugin/tests/test_config.py
+++ b/plugin/tests/test_config.py
@@ -584,3 +584,12 @@ def test_fallback_min_seconds_bad_value_falls_back_to_timeout(monkeypatch):
     monkeypatch.setenv("DAIMON_TIMEOUT", "222")
     monkeypatch.setenv("DAIMON_FALLBACK_MIN_SECONDS", "not-a-number")
     assert config.fallback_min_seconds() == 222
+
+
+def test_chunk_cache_days_default_override_and_bad_value(monkeypatch):
+    monkeypatch.delenv("DAIMON_CHUNK_CACHE_DAYS", raising=False)
+    assert config.chunk_cache_days() == 3
+    monkeypatch.setenv("DAIMON_CHUNK_CACHE_DAYS", "7")
+    assert config.chunk_cache_days() == 7
+    monkeypatch.setenv("DAIMON_CHUNK_CACHE_DAYS", "not-a-number")
+    assert config.chunk_cache_days() == 3

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -1331,6 +1331,18 @@ def test_chunk_cache_key_changes_with_config_dimensions(monkeypatch):
     assert serializer._chunk_cache_key("chunk text") != base
 
 
+def test_chunk_cache_key_survives_backend_resolution_failure(monkeypatch):
+    # A raising resolved_backend() must never break key computation — the
+    # cache degrades to an "unknown"-backend namespace, not an exception.
+    from daimon_briefing import configure as _configure
+    def boom():
+        raise RuntimeError("no backend configured")
+    monkeypatch.setattr(_configure, "resolved_backend", boom)
+    key = serializer._chunk_cache_key("chunk text")
+    assert key == serializer._chunk_cache_key("chunk text")
+    assert len(key) == 32
+
+
 def test_chunk_transcript_prefix_chunks_byte_stable_under_growth():
     # The property the whole cache rests on: full windows re-materialize
     # byte-identically when the transcript grows; only the tail changes.

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -1309,12 +1309,47 @@ def _force_two_chunks(monkeypatch):
     return messages, n
 
 
-def test_failed_merge_persists_partials_and_reheal_reuses_them(
+# ---- #48: content-addressed chunk cache (replaces the #314 partials store) ----
+
+
+def test_chunk_cache_key_changes_with_config_dimensions(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_MODEL", "m1")
+    monkeypatch.delenv("DAIMON_SCENE_TRACES", raising=False)
+    base = serializer._chunk_cache_key("chunk text")
+    assert base == serializer._chunk_cache_key("chunk text")  # stable
+    assert base != serializer._chunk_cache_key("other text")
+    monkeypatch.setenv("DAIMON_LLM_MODEL", "m2")
+    assert serializer._chunk_cache_key("chunk text") != base
+    monkeypatch.setenv("DAIMON_LLM_MODEL", "m1")
+    monkeypatch.setenv("DAIMON_LLM_TEMPERATURE", "0.7")
+    assert serializer._chunk_cache_key("chunk text") != base
+    monkeypatch.delenv("DAIMON_LLM_TEMPERATURE", raising=False)
+    # scene flag reshapes the serialize prompt WITHOUT a PROMPT_VERSION bump —
+    # the key hashes the actual prompt text, so it must move (#319 trap class).
+    monkeypatch.setenv("DAIMON_SCENE_TRACES", "1")
+    assert serializer._chunk_cache_key("chunk text") != base
+
+
+def test_chunk_transcript_prefix_chunks_byte_stable_under_growth():
+    # The property the whole cache rests on: full windows re-materialize
+    # byte-identically when the transcript grows; only the tail changes.
+    lines = [f"line {i}" for i in range(40)]
+    grown = lines + [f"line {i}" for i in range(40, 64)]
+    old_chunks = serializer.chunk_transcript("\n".join(lines), 6, 1)
+    new_chunks = serializer.chunk_transcript("\n".join(grown), 6, 1)
+    # every FULL window of the old run reappears identically in the new run
+    full = [c for c in old_chunks if len(c.splitlines()) == 6]
+    assert full and all(c in new_chunks for c in full)
+    # threshold crossing: single-chunk fast path returns the raw text, which
+    # differs from the chunked rendering of the same region — crossing pays once
+    small = "\n".join(lines[:5])
+    assert serializer.chunk_transcript(small, 6, 1) == [small]
+
+
+def test_failed_merge_persists_chunks_and_reheal_reuses_them(
         fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
-    # #314 second defect: deadline death at merge discarded the paid-for chunk
-    # outputs; the next heal re-bought every chunk. Chunk partials now persist
-    # content-addressed under the checkpoint dir; a re-run of the unchanged
-    # transcript reuses them and enters the merge with the full budget.
+    # #314 guarantee, survived migration: a merge death must not re-buy chunks.
     from daimon_briefing import llm as _llm
     messages, n = _force_two_chunks(monkeypatch)
     responses = [_valid_checkpoint_json(f"c{i}") for i in range(n)]
@@ -1322,7 +1357,7 @@ def test_failed_merge_persists_partials_and_reheal_reuses_them(
     chat1 = fake_chat_factory(responses)
     with pytest.raises(serializer.LLMCallError):
         serializer.serialize_strict("S1", messages, chat=chat1)
-    saved = list((tmp_checkpoint_dir / ".partials").glob("*.json"))
+    saved = list((tmp_checkpoint_dir / ".chunk-cache").glob("*.json"))
     assert len(saved) == n  # every completed chunk survived the merge death
 
     chat2 = fake_chat_factory([_valid_checkpoint_json("merged")])
@@ -1331,7 +1366,93 @@ def test_failed_merge_persists_partials_and_reheal_reuses_them(
     assert len(chat2.calls) == 1  # merge only — no chunk was re-bought
 
 
-def test_partials_cleared_after_successful_serialize(
+def test_chunk_cache_survives_success_and_transfers_across_sessions(
+        fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
+    # #48 core: the cache persists after a fully successful serialize, and the
+    # key binds chunk TEXT + config, not session_id — a resume fork or a
+    # periodic re-serialize of the same content reuses every paid-for chunk.
+    messages, n = _force_two_chunks(monkeypatch)
+    chat1 = fake_chat_factory(
+        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
+        + [_valid_checkpoint_json("merged")])
+    assert serializer.serialize_strict("S1", messages, chat=chat1) is not None
+    assert len(list((tmp_checkpoint_dir / ".chunk-cache").glob("*.json"))) == n
+
+    chat2 = fake_chat_factory([_valid_checkpoint_json("merged2")])
+    assert serializer.serialize_strict("S2", messages, chat=chat2) is not None
+    assert len(chat2.calls) == 1  # merge only — S2 reused S1's chunks
+
+
+def test_grown_transcript_pays_only_tail_chunks(
+        fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
+    from daimon_briefing import llm as _llm  # noqa: F401 (parity with siblings)
+    messages, n = _force_two_chunks(monkeypatch)
+    chat1 = fake_chat_factory(
+        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
+        + [_valid_checkpoint_json("merged")])
+    assert serializer.serialize_strict("S1", messages, chat=chat1) is not None
+
+    grown = messages + make_messages(20)
+    rendered = serializer._render_transcript(grown)
+    n2 = len(serializer.chunk_transcript(rendered, 6, 1))
+    assert n2 > n
+    chat2 = fake_chat_factory(
+        [_valid_checkpoint_json(f"g{i}") for i in range(n2)]
+        + [_valid_checkpoint_json("merged2")])
+    assert serializer.serialize_strict("S1", grown, chat=chat2) is not None
+    # full prefix windows hit the cache; only new/changed tail windows + merge pay
+    paid = len(chat2.calls) - 1
+    assert 0 < paid < n2
+
+
+def test_fallback_poisoned_run_skips_cache_writes(
+        fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
+    # #343 lesson product-side: once the weaker fallback backend fired, this
+    # run's outputs must not be cached under the primary backend's key.
+    from daimon_briefing import llm as _llm
+    monkeypatch.setattr(_llm, "fallback_used", lambda: True)
+    messages, n = _force_two_chunks(monkeypatch)
+    chat = fake_chat_factory(
+        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
+        + [_valid_checkpoint_json("merged")])
+    assert serializer.serialize_strict("S1", messages, chat=chat) is not None
+    assert not list((tmp_checkpoint_dir / ".chunk-cache").glob("*.json"))
+
+
+def test_chunk_cache_kill_switch_no_reads_no_writes(
+        fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
+    monkeypatch.setenv("DAIMON_CHUNK_CACHE", "0")
+    messages, n = _force_two_chunks(monkeypatch)
+    chat1 = fake_chat_factory(
+        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
+        + [_valid_checkpoint_json("merged")])
+    assert serializer.serialize_strict("S1", messages, chat=chat1) is not None
+    assert not (tmp_checkpoint_dir / ".chunk-cache").exists()
+    chat2 = fake_chat_factory(
+        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
+        + [_valid_checkpoint_json("merged")])
+    assert serializer.serialize_strict("S1", messages, chat=chat2) is not None
+    assert len(chat2.calls) == n + 1  # no reads either
+
+
+def test_llm_no_cache_skips_reads_but_still_writes(
+        fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
+    # DAIMON_LLM_NO_CACHE means "no replayed LLM output" — honor the intent:
+    # never serve a cached chunk, but caching THIS run's fresh output is fine.
+    messages, n = _force_two_chunks(monkeypatch)
+    chat1 = fake_chat_factory(
+        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
+        + [_valid_checkpoint_json("merged")])
+    assert serializer.serialize_strict("S1", messages, chat=chat1) is not None
+    monkeypatch.setenv("DAIMON_LLM_NO_CACHE", "1")
+    chat2 = fake_chat_factory(
+        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
+        + [_valid_checkpoint_json("merged")])
+    assert serializer.serialize_strict("S1", messages, chat=chat2) is not None
+    assert len(chat2.calls) == n + 1  # cache reads bypassed
+
+
+def test_corrupt_chunk_cache_entry_recomputed(
         fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
     from daimon_briefing import llm as _llm
     messages, n = _force_two_chunks(monkeypatch)
@@ -1340,58 +1461,26 @@ def test_partials_cleared_after_successful_serialize(
         + [_llm.ChatError("merge died")])
     with pytest.raises(serializer.LLMCallError):
         serializer.serialize_strict("S1", messages, chat=chat1)
-    chat2 = fake_chat_factory([_valid_checkpoint_json("merged")])
-    assert serializer.serialize_strict("S1", messages, chat=chat2) is not None
-    # Success consumes the cache — stale partials must not outlive their write.
-    assert list((tmp_checkpoint_dir / ".partials").glob("*.json")) == []
-
-
-def test_partial_cache_is_per_session(fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
-    # Same transcript text under a DIFFERENT session id must not reuse another
-    # session's partials — the key binds (session_id, chunk_text).
-    from daimon_briefing import llm as _llm
-    messages, n = _force_two_chunks(monkeypatch)
-    chat1 = fake_chat_factory(
-        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
-        + [_llm.ChatError("merge died")])
-    with pytest.raises(serializer.LLMCallError):
-        serializer.serialize_strict("S1", messages, chat=chat1)
-
-    chat2 = fake_chat_factory(
-        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
-        + [_valid_checkpoint_json("merged")])
-    assert serializer.serialize_strict("S2", messages, chat=chat2) is not None
-    assert len(chat2.calls) == n + 1  # S2 paid for its own chunks
-
-
-def test_corrupt_partial_recomputed(fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
-    from daimon_briefing import llm as _llm
-    messages, n = _force_two_chunks(monkeypatch)
-    chat1 = fake_chat_factory(
-        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
-        + [_llm.ChatError("merge died")])
-    with pytest.raises(serializer.LLMCallError):
-        serializer.serialize_strict("S1", messages, chat=chat1)
-    for p in (tmp_checkpoint_dir / ".partials").glob("*.json"):
+    for p in (tmp_checkpoint_dir / ".chunk-cache").glob("*.json"):
         p.write_text("not json{", encoding="utf-8")
     chat2 = fake_chat_factory(
         [_valid_checkpoint_json(f"c{i}") for i in range(n)]
         + [_valid_checkpoint_json("merged")])
-    # Corrupt cache entries are recomputed, never trusted or fatal.
     assert serializer.serialize_strict("S1", messages, chat=chat2) is not None
-    assert len(chat2.calls) == n + 1
+    assert len(chat2.calls) == n + 1  # corrupt entries recomputed, never fatal
 
 
-def test_partial_reap_removes_aged_leftovers(fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
-    # Crash leftovers older than the reap window are removed by the next save.
+def test_chunk_cache_reap_removes_aged_entries(
+        fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
     import os as _os
     import time as _t
+    from daimon_briefing import config as _config
     from daimon_briefing import llm as _llm
-    pdir = tmp_checkpoint_dir / ".partials"
-    pdir.mkdir(parents=True)
-    old = pdir / "deadbeef00.json"
+    cdir = tmp_checkpoint_dir / ".chunk-cache"
+    cdir.mkdir(parents=True)
+    old = cdir / "deadbeef00.json"
     old.write_text("{}", encoding="utf-8")
-    aged = _t.time() - serializer._PARTIAL_MAX_AGE_SECONDS - 3600
+    aged = _t.time() - _config.chunk_cache_days() * 24 * 3600 - 3600
     _os.utime(old, (aged, aged))
     messages, n = _force_two_chunks(monkeypatch)
     chat = fake_chat_factory(
@@ -1402,32 +1491,29 @@ def test_partial_reap_removes_aged_leftovers(fake_chat_factory, monkeypatch, tmp
     assert not old.exists()  # reaped by the first save
 
 
-def test_partial_reap_survives_unremovable_entry(fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
-    # A glob hit that cannot be unlinked (here: a DIRECTORY named *.json) must
-    # never break the save — best-effort means skip and move on.
+def test_chunk_cache_reap_survives_unremovable_entry(
+        fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
     import os as _os
     import time as _t
+    from daimon_briefing import config as _config
     from daimon_briefing import llm as _llm
-    pdir = tmp_checkpoint_dir / ".partials"
-    (pdir / "stuck.json").mkdir(parents=True)
-    aged = _t.time() - serializer._PARTIAL_MAX_AGE_SECONDS - 3600
-    _os.utime(pdir / "stuck.json", (aged, aged))
+    cdir = tmp_checkpoint_dir / ".chunk-cache"
+    (cdir / "stuck.json").mkdir(parents=True)
+    aged = _t.time() - _config.chunk_cache_days() * 24 * 3600 - 3600
+    _os.utime(cdir / "stuck.json", (aged, aged))
     messages, n = _force_two_chunks(monkeypatch)
     chat = fake_chat_factory(
         [_valid_checkpoint_json(f"c{i}") for i in range(n)]
         + [_llm.ChatError("merge died")])
     with pytest.raises(serializer.LLMCallError):
         serializer.serialize_strict("S1", messages, chat=chat)
-    # The real partials were still written around the stuck entry.
-    assert len(list(pdir.glob("*.json"))) == n + 1  # n saved + the stuck dir
+    assert len(list(cdir.glob("*.json"))) == n + 1  # n saved + the stuck dir
 
 
-def test_save_partial_survives_partials_dir_being_a_file(
+def test_save_chunk_cache_survives_dir_being_a_file(
         fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
-    # mkdir on a path occupied by a FILE raises — the save must swallow it and
-    # the serialize must complete untouched (worst case: nothing is cached).
-    (tmp_checkpoint_dir / ".partials").parent.mkdir(parents=True, exist_ok=True)
-    (tmp_checkpoint_dir / ".partials").write_text("not a dir", encoding="utf-8")
+    (tmp_checkpoint_dir / ".chunk-cache").parent.mkdir(parents=True, exist_ok=True)
+    (tmp_checkpoint_dir / ".chunk-cache").write_text("not a dir", encoding="utf-8")
     messages, n = _force_two_chunks(monkeypatch)
     chat = fake_chat_factory(
         [_valid_checkpoint_json(f"c{i}") for i in range(n)]
@@ -1435,27 +1521,18 @@ def test_save_partial_survives_partials_dir_being_a_file(
     assert serializer.serialize_strict("S1", messages, chat=chat) is not None
 
 
-def test_clear_partials_survives_undeletable_entry(
+def test_chunk_cache_files_written_0600(
         fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
-    # Success-path cleanup meeting an undeletable cache entry (a directory
-    # squatting the key's filename) skips it — never fails the checkpoint.
-    from daimon_briefing import llm as _llm
+    # Pre-redaction content on disk gets key-file permissions (env-file
+    # precedent) — the privacy half of the #48 design.
+    import stat as _stat
     messages, n = _force_two_chunks(monkeypatch)
-    chat1 = fake_chat_factory(
-        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
-        + [_llm.ChatError("merge died")])
-    with pytest.raises(serializer.LLMCallError):
-        serializer.serialize_strict("S1", messages, chat=chat1)
-    pdir = tmp_checkpoint_dir / ".partials"
-    for p in list(pdir.glob("*.json")):  # squat every key with a directory
-        p.unlink()
-        p.mkdir()
-    chat2 = fake_chat_factory(
+    chat = fake_chat_factory(
         [_valid_checkpoint_json(f"c{i}") for i in range(n)]
         + [_valid_checkpoint_json("merged")])
-    ckpt = serializer.serialize_strict("S1", messages, chat=chat2)
-    assert ckpt is not None  # load failed -> recomputed; clear skipped the dirs
-    assert len(chat2.calls) == n + 1
+    assert serializer.serialize_strict("S1", messages, chat=chat) is not None
+    for p in (tmp_checkpoint_dir / ".chunk-cache").glob("*.json"):
+        assert _stat.S_IMODE(p.stat().st_mode) == 0o600
 
 
 # ---- #317: scene traces (encode-time episodic context, bench-gated experiment) ----


### PR DESCRIPTION
Refs #48

## PR Type

- [x] New feature

## Summary

- Slice 1 of #48: content-addressed chunk-extraction cache, generalizing the #314 partials store it replaces. Key = chunk text + backend + model + temperature + PROMPT_VERSION + a hash of the actual serialize system prompt (an un-versioned prompt change — e.g. the scene-traces appendix — invalidates cleanly instead of silently reusing stale extractions). session_id is deliberately out of the key: prefix chunks of grown or resume-forked transcripts are byte-identical, so their paid-for outputs transfer.
- Justification is today's field data, not the issue's original growing-trajectory case (that gate stays unmet — see the issue): every failed-serialize retry and heal currently re-buys all chunks at full cost, and 33 such full-cost error attempts were measured on a single install this week. With this cache, attempt N+1 pays only missing chunks plus the merge — and unlike #314's clear-on-success, the win survives intervening successes.
- Privacy is the deliberate tradeoff, designed in: cached output is pre-redaction (forced by the #125 quote-verification ordering — caching redacted output would mass-downgrade legitimate verbatim quotes on every hit). Mitigations: 0600 file mode, 3-day default rotation window (`DAIMON_CHUNK_CACHE_DAYS`), checkpoint-dir trust domain, `DAIMON_CHUNK_CACHE=0` kill switch. Maintainer signed off on the 3-day default.
- Poisoning guards inherited from the bench-cache lessons: cache writes are skipped for the entire run once the fallback backend has fired; `DAIMON_LLM_NO_CACHE=1` also bypasses chunk-cache reads (a user reaching for that flag means "no replayed LLM output").
- `Refs` not `Closes`: slice 2 (byte-offset watermark for merge-cost flattening) stays gated on real long-lived-trajectory evidence, per the issue's own 07-15 scoping note.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/serializer.py` | `.partials` store replaced by `.chunk-cache`: config-dimension key, persistent entries, age reap, 0600, fallback write-guard; `_one_chunk` reuse path; success no longer clears |
| `plugin/daimon_briefing/config.py` | `chunk_cache_enabled()` (default on, `DAIMON_CHUNK_CACHE=0` kills), `chunk_cache_days()` (default 3) |
| `plugin/tests/test_serializer.py` | Old #314 contract tests replaced by 13 new-contract tests: key dimensions, chunker byte-stability pin (incl. threshold crossing), merge-death reuse, cross-session transfer, grown-transcript tail-only pay, fallback poisoning guard, kill switch, no-cache read bypass, corruption, reap, robustness, 0600 |

## Test Plan

- [x] Full suite: 1842 passed, 2 skipped
- [x] The new tests and the old #314 tests are mutually exclusive contracts — the old six fail against this implementation and the new thirteen fail against the old one, so the suite discriminates the migration in both directions
- [x] `ruff` + hook-mirror drift pre-commit checks pass

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Shellcheck N/A
- [x] Docs: env vars documented in config docstrings; site reference can pick up the knobs in the next docs pass
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
