### PR TITLE
fix(stats): scope the stale-hook warning to auto-brief-capable hosts

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -38,6 +38,7 @@ from . import __version__
 # longer calls itself — because `cli.<name>` is a stable seam: tests and host
 # hooks resolve the ledger through this module.
 from .ledger import (
+    AUTO_BRIEF_HOSTS,
     _HEAL_SKIP_REASON,  # noqa: F401 — re-exported for compat
     _HEAL_TRANSCRIPT_RE,  # noqa: F401 — re-exported for compat
     _LEDGER_OK_RE,  # noqa: F401 — re-exported for compat
@@ -1950,7 +1951,11 @@ def _stats_retention(now=None) -> dict:
     if out["hook_briefs"]:
         out["rereads_per_hook_brief"] = round(
             out["rereads_total"] / out["hook_briefs"], 2)
-    if out["hook_briefs"] == 0 and _spawns_in_window(cutoff):
+    # #349: only spawns from auto-brief-capable hosts count — a Windsurf- or
+    # Codex-only machine can never log brief:auto, and warning it to re-run
+    # `hooks install` is a permanent false positive.
+    if out["hook_briefs"] == 0 and _spawns_in_window(
+            cutoff, hosts=AUTO_BRIEF_HOSTS):
         out["stale_hook_warning"] = True
     return out
 

--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -418,12 +418,22 @@ def _parse_stamp(token: str):
         return None
 
 
-def _spawns_in_window_count(cutoff) -> int:
+# #349: the hosts whose packaged integration runs an auto-briefing at session
+# start (and therefore logs `brief:auto`). ONLY these can satisfy the
+# stale-hook heuristic — a machine served exclusively by hosts without such a
+# hook (Windsurf, Codex today) can never log brief:auto, and warning about it
+# is a permanent false positive whose advice cannot fix anything. Add a host
+# here the day its integration gains an auto-brief.
+AUTO_BRIEF_HOSTS = ("session-end",)
+
+
+def _spawns_in_window_count(cutoff, hosts=None) -> int:
     """How many hook-spawned captures serialize.log shows inside the window —
     i.e. how many sessions the hooks OBSERVED on this machine since `cutoff`.
     The silent-capture alarm (#265) reads this against checkpoints WRITTEN in the
     same window: spawns without writes is a silent capture failure. Fails open to
-    0 when the log is absent."""
+    0 when the log is absent. `hosts` (#349) restricts the count to specific
+    host prefixes; None counts every host."""
     try:
         text = (config.log_dir() / "serialize.log").read_text(encoding="utf-8")
     except OSError:
@@ -431,7 +441,10 @@ def _spawns_in_window_count(cutoff) -> int:
     count = 0
     for line in text.splitlines():
         line = line.strip()
-        if not _STATS_HOST_RE.match(line):
+        m = _STATS_HOST_RE.match(line)
+        if not m:
+            continue
+        if hosts is not None and m.group(1) not in hosts:
             continue
         stamp = _parse_stamp(line.split()[0])
         if stamp is not None and stamp >= cutoff:
@@ -439,8 +452,8 @@ def _spawns_in_window_count(cutoff) -> int:
     return count
 
 
-def _spawns_in_window(cutoff) -> bool:
+def _spawns_in_window(cutoff, hosts=None) -> bool:
     """True when serialize.log shows any hook-spawned capture inside the
     window — i.e. sessions ARE happening on this machine. The count and the
     boolean share one regex so they can never drift on a new host prefix."""
-    return _spawns_in_window_count(cutoff) > 0
+    return _spawns_in_window_count(cutoff, hosts=hosts) > 0

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -4604,6 +4604,33 @@ def test_retention_no_warning_without_spawns(tmp_log_dir):
     assert r["stale_hook_warning"] is False
 
 
+def test_retention_no_stale_warning_on_hookless_briefing_hosts(tmp_log_dir):
+    # #349: Windsurf (and Codex) have no SessionStart auto-brief hook, so a
+    # machine served only by them can NEVER log brief:auto — the warning was
+    # permanent and its advice (re-run hooks install) could not fix it.
+    now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+    stamp = (now - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "serialize.log").write_text(
+        f"{stamp} windsurf-cascade: spawned serialize for W1 (pid 1)\n"
+        f"{stamp} windsurf-finalizer: spawned serialize for W1 (pid 2)\n"
+        f"{stamp} codex-stop: spawned serialize for C1 (pid 3)\n")
+    r = cli._stats_retention(now=now)
+    assert r["stale_hook_warning"] is False
+
+
+def test_retention_stale_warning_still_fires_on_mixed_hosts(tmp_log_dir):
+    # One auto-brief-capable spawn among hookless ones keeps the warning live.
+    now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+    stamp = (now - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "serialize.log").write_text(
+        f"{stamp} windsurf-cascade: spawned serialize for W1 (pid 1)\n"
+        f"{stamp} session-end: spawned serialize for S1 (pid 2)\n")
+    r = cli._stats_retention(now=now)
+    assert r["stale_hook_warning"] is True
+
+
 def test_spawns_in_window_skips_garbage_and_stale_spawns(tmp_log_dir):
     # Non-spawn lines are skipped, an unparseable stamp is not a crash, and a
     # spawn older than the window reports False rather than a stale True.


### PR DESCRIPTION
Closes #349

## PR Type

- [x] Bug fix

## Summary

- The stale-hook warning (`sessions captured but no hook briefings logged — re-run daimon hooks install`) counted spawns from every host, but only the Claude Code SessionStart hook ever logs `brief:auto`. A machine served exclusively by hosts without an auto-brief hook (Windsurf, Codex today) could never satisfy the heuristic — the warning was permanent and its advice could not fix it. Found live on a Windsurf-only machine with 100+ deliberate brief reads and 120 windsurf spawns.
- Fix: `_spawns_in_window`/`_spawns_in_window_count` take an optional host filter; the warning counts only `AUTO_BRIEF_HOSTS` (`session-end` today, documented as the place to add a host the day its integration gains an auto-brief). The #265 silent-capture alarm keeps the unfiltered all-hosts count.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/ledger.py` | `AUTO_BRIEF_HOSTS` constant; optional `hosts` filter on the spawn-window pair |
| `plugin/daimon_briefing/cli.py` | `_stats_retention` warning condition scoped to `AUTO_BRIEF_HOSTS` |
| `plugin/tests/test_cli.py` | Windsurf/Codex-only spawns → no warning (red-first); mixed-host spawn keeps the warning; existing warning/no-spawn pins unchanged |

## Test Plan

- [x] TDD: hookless-host test watched fail, then green
- [x] Full suite: 1846 passed, 2 skipped
- [x] `ruff` + hook-mirror drift pre-commit checks pass

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Shellcheck N/A
- [x] Docs unchanged (behavioral fix to a false warning)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
