### PR TITLE
docs(site): blog release post for 0.19.0 (en + es)

### DIFF
--- a/website/blog/2026-07-21-daimon-0-19.md
+++ b/website/blog/2026-07-21-daimon-0-19.md
@@ -1,0 +1,83 @@
+---
+slug: daimon-0-19
+title: "daimon 0.19.0: a docs site, an MCP server, and deletion you can prove"
+authors: [daimon]
+tags: [announcement, release]
+---
+
+daimon 0.19.0 is on PyPI, three days after 0.18. The headline is a pair of
+doors: the documentation site you are reading — in English and Spanish from
+day one — and a read-only MCP server, so hosts that speak MCP but have no
+hook system can still read your agent's memory. Also in the box: `daimon
+forget` ships, and a chunk cache stops failed serializes from re-buying work
+they already paid for.
+
+{/* truncate */}
+
+## The MCP server: memory for hosts we can't hook
+
+Daimon's capture loop attaches to hosts through hooks. Plenty of
+MCP-capable tools have no hook surface — until now they simply couldn't see
+daimon's memory. `daimon mcp serve` fixes the reading half:
+
+```bash
+daimon mcp serve   # JSON-RPC over stdio, blocks until EOF
+```
+
+Four tools, all read-only: `daimon_recall` (search with full provenance —
+trust class, author, supersession state, origin project), `daimon_brief`
+(the latest briefing, trust-tagged), `daimon_projects` (everything daimon
+has memory for), and `daimon_status` (capture health). Pure standard
+library, zero new dependencies — same deal as the rest of daimon.
+
+Read-only is a design position, not a limitation. Writes stay with the
+capture pipeline, where every verbatim claim is mechanically checked
+against a real transcript. An agent can *read* memory over MCP; it cannot
+assert new memories into it. And the server inherits daimon's
+cross-project discipline: reads are project-scoped, and a project with no
+checkpoint gets told exactly that — never another project's content.
+
+The [MCP reference](/docs/reference/mcp) has the registration snippets for
+Claude Code, Windsurf, Cursor, and any generic stdio config.
+
+## `daimon forget` ships: deletion with a tombstone
+
+Announced as merged in the last post — now released. `daimon forget`
+removes an item from the live checkpoint, the recall index, and the audit
+trail's *content*, while the event stream keeps a content-hash tombstone.
+With receipts enabled, the post-removal checkpoint is re-signed. You can
+prove the deletion happened without keeping what was deleted. Mechanics on
+the [item lifecycle](/docs/concepts/lifecycle) page.
+
+## The chunk cache: retries stop re-buying finished work
+
+Serialization extracts memory from transcripts in chunks, and until now a
+failed run threw away every chunk that *had* succeeded — the retry paid for
+all of it again, in time and tokens. 0.19 adds a content-addressed cache
+for chunk extractions: a heal or retry reuses every chunk whose content is
+unchanged and only pays for what's actually missing. First slice of a
+longer incremental-serialization arc.
+
+## And the docs site itself
+
+Quickstart (install to first briefing in one page), concept pages for the
+ideas that make daimon different — [trust
+classes](/docs/concepts/trust-classes), [carry and
+staleness](/docs/concepts/carry), [receipts](/docs/concepts/receipts),
+[item lifecycle](/docs/concepts/lifecycle) — host guides, configuration,
+team memory. Every page in Spanish as well as English, written for
+Spanish-reading developers rather than machine-dumped. This blog (with
+[RSS](https://daily-nerd.github.io/daimon/blog/rss.xml)) is the canonical
+home for announcements; the README now just points here.
+
+## Upgrade
+
+```bash
+uv tool install --force 'daimon-briefing[pretty]'
+```
+
+Full details in the
+[changelog](https://github.com/Daily-Nerd/daimon/blob/main/CHANGELOG.md).
+If something breaks, the
+[issue tracker](https://github.com/Daily-Nerd/daimon/issues) reads every
+report.

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-07-21-daimon-0-19.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-07-21-daimon-0-19.md
@@ -1,0 +1,89 @@
+---
+slug: daimon-0-19
+title: "daimon 0.19.0: sitio de docs, servidor MCP y borrado demostrable"
+authors: [daimon]
+tags: [announcement, release]
+---
+
+daimon 0.19.0 está en PyPI, tres días después de la 0.18. Lo principal son
+dos puertas: el sitio de documentación que estás leyendo — en español e
+inglés desde el primer día — y un servidor MCP de solo lectura, para que
+los hosts que hablan MCP pero no tienen sistema de hooks también puedan
+leer la memoria de tu agente. Además en la caja: sale `daimon forget`, y
+una caché de fragmentos evita que un serialize fallido vuelva a pagar
+trabajo ya hecho.
+
+{/* truncate */}
+
+## El servidor MCP: memoria para hosts que no podemos hookear
+
+El loop de captura de daimon se conecta a los hosts mediante hooks. Muchas
+herramientas compatibles con MCP no tienen superficie de hooks — hasta
+ahora, simplemente no podían ver la memoria de daimon. `daimon mcp serve`
+resuelve la mitad de lectura:
+
+```bash
+daimon mcp serve   # JSON-RPC sobre stdio, bloquea hasta EOF
+```
+
+Cuatro herramientas, todas de solo lectura: `daimon_recall` (búsqueda con
+procedencia completa — clase de confianza, autor, estado de supersesión,
+proyecto de origen), `daimon_brief` (el último briefing, etiquetado por
+confianza), `daimon_projects` (todo lo que daimon recuerda) y
+`daimon_status` (salud de la captura). Biblioteca estándar pura, cero
+dependencias nuevas — el mismo trato que el resto de daimon.
+
+Solo lectura es una posición de diseño, no una limitación. Las escrituras
+quedan en el pipeline de captura, donde cada afirmación verbatim se
+verifica mecánicamente contra una transcripción real. Un agente puede
+*leer* la memoria por MCP; no puede insertar recuerdos nuevos. Y el
+servidor hereda la disciplina entre proyectos de daimon: las lecturas
+están acotadas al proyecto, y un proyecto sin checkpoint recibe
+exactamente ese mensaje — nunca el contenido de otro proyecto.
+
+La [referencia de MCP](/docs/reference/mcp) tiene los snippets de registro
+para Claude Code, Windsurf, Cursor y cualquier config stdio genérica.
+
+## Sale `daimon forget`: borrado con tombstone
+
+En el post anterior lo anunciamos mergeado — ahora está publicado. `daimon
+forget` elimina un ítem del checkpoint vivo, del índice de recall y del
+*contenido* del rastro de auditoría, mientras el flujo de eventos conserva
+un tombstone con el hash del contenido. Con receipts activos, el
+checkpoint posterior a la eliminación se re-firma. Podés demostrar que el
+borrado ocurrió sin conservar lo borrado. La mecánica está en la página de
+[ciclo de vida de los ítems](/docs/concepts/lifecycle).
+
+## La caché de fragmentos: los reintentos dejan de re-pagar trabajo terminado
+
+La serialización extrae memoria de las transcripciones por fragmentos, y
+hasta ahora una corrida fallida tiraba a la basura cada fragmento que *sí*
+había salido bien — el reintento volvía a pagar todo, en tiempo y en
+tokens. La 0.19 agrega una caché direccionada por contenido para las
+extracciones: un heal o un reintento reutiliza cada fragmento cuyo
+contenido no cambió y solo paga lo que falta de verdad. Primera rebanada
+de un arco más largo de serialización incremental.
+
+## Y el sitio de docs en sí
+
+Inicio rápido (de la instalación al primer briefing en una página),
+páginas de conceptos para las ideas que hacen distinto a daimon — [clases
+de confianza](/docs/concepts/trust-classes), [arrastre y
+obsolescencia](/docs/concepts/carry), [receipts](/docs/concepts/receipts),
+[ciclo de vida](/docs/concepts/lifecycle) — guías de hosts, configuración,
+memoria de equipo. Cada página en español además de inglés, escrita para
+quienes desarrollan en español, no volcada por máquina. Este blog (con
+[RSS](https://daily-nerd.github.io/daimon/blog/rss.xml)) es el hogar
+canónico de los anuncios; el README ahora simplemente apunta aquí.
+
+## Actualizar
+
+```bash
+uv tool install --force 'daimon-briefing[pretty]'
+```
+
+Todos los detalles en el
+[changelog](https://github.com/Daily-Nerd/daimon/blob/main/CHANGELOG.md).
+Si algo se rompe, el
+[issue tracker](https://github.com/Daily-Nerd/daimon/issues) lee todos los
+reportes.


### PR DESCRIPTION
Closes #352

## What

- Adds the 0.19.0 release post to the site blog in English and Spanish (shared slug `daimon-0-19`, so the permalink is `/blog/daimon-0-19` and `/es/blog/daimon-0-19`).
- Covers the release headliners already public in the changelog: the docs site itself, the read-only MCP server (`daimon mcp serve`, four tools, read-only-by-design rationale), `daimon forget` shipping, and the content-addressed chunk-extraction cache.
- ES version is a native rewrite on the same skeleton, matching the inaugural post's convention.

## Why

The blog is the canonical home for release announcements, but it currently has only the inaugural post — 0.19.0 has no canonical permalink for announcements to point at.

## Tests

- Content fact-checked against CHANGELOG.md 0.19.0 and `website/docs/reference/mcp.md` (tool names: daimon_recall, daimon_brief, daimon_projects, daimon_status).
- All internal doc links verified against existing page paths (`concepts/trust-classes`, `concepts/carry`, `concepts/receipts`, `concepts/lifecycle`, `reference/mcp`).
- `rg` privacy gate on both files: clean (no usernames, machine names, private paths, or unpublishable benchmark numbers).
- Frontmatter mirrors the existing `2026-07-18-daimon-has-a-home.md` pair (same authors key, tags, truncate marker, shared slug across locales).