### PR TITLE
chore(ci): bump action majors across workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,10 +32,10 @@ jobs:
       DAIMON_LLM_MODEL: ${{ secrets.DAIMON_LLM_MODEL }}
       DAIMON_LLM_BASE_URL: ${{ secrets.DAIMON_LLM_BASE_URL }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: "3.13"
           enable-cache: true
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload result artifact
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: longmemeval-s-result
           path: benchmark/results/*.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
       run:
         working-directory: plugin
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -51,7 +51,7 @@ jobs:
         # Reporting only — no coverage threshold gates the build yet. The
         # upload no-ops gracefully when CODECOV_TOKEN is unset, so a missing
         # secret never turns CI red.
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: Daily-Nerd/daimon
@@ -68,10 +68,10 @@ jobs:
       run:
         working-directory: plugin
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: "3.13"
           enable-cache: true
@@ -95,10 +95,10 @@ jobs:
     name: scar lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v9.0.0
 
       # Dogfood: the repo's own scar graph must always parse and lint clean.
       # A malformed scar silently never fires — this gate makes that class

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,8 +21,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -31,7 +31,7 @@ jobs:
         working-directory: website
       - run: npm run build
         working-directory: website
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: website/build
 
@@ -44,4 +44,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
       - id: rp
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           # config-file + manifest so extra-files keep plugin/pyproject.toml,
           # .claude-plugin/plugin.json and marketplace.json in version lock-step.
@@ -33,10 +33,10 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v9.0.0
       # the package lives in plugin/, not the repo root
       - run: uv build --project plugin -o dist
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Closes #355

## What

Bumps every GitHub Action in `.github/workflows/` to its latest major, verified against each repo's releases as of today:

| Action | Before | After | Notes |
|---|---|---|---|
| `actions/checkout` | v4 | v7 | |
| `actions/setup-node` | v4 | v7 | |
| `actions/upload-artifact` | v4 | v7 | |
| `codecov/codecov-action` | v4 | v7 | already on `files` (the v5 rename); all other inputs unchanged in v7 schema |
| `astral-sh/setup-uv` | v5 | **v9.0.0** | upstream stopped publishing major tags in v8 (supply-chain hardening) — `@v9` does not exist, full immutable tag is the documented pin |
| `googleapis/release-please-action` | v4 | v5 | |
| `actions/upload-pages-artifact` | v3 | v5 | |
| `actions/deploy-pages` | v4 | v5 | |

Checked and left alone:

| Action | Pin | Reason |
|---|---|---|
| `pypa/gh-action-pypi-publish` | `release/v1` | README still documents `release/v1` as the recommended pin (latest v1.14.1 lives under it) |
| `codecov/test-results-action` | v1 | latest release is v1.2.1 — already current major |

## Why

Proactive hygiene: several pins were 3+ majors behind. Bumping while CI is green is cheap and reviewable; doing it later under a broken pipeline conflates the bump with the breakage.

## Tests

Workflows cannot be executed locally — **full CI on this PR is the validation gate.** What was verified beforehand:

- Parse check: all four workflow files load clean through a YAML `safe_load` sweep.
- Per-action breaking-change audit — every skipped major's release notes read, reconciled against our actual inputs:

| Action | Audit |
|---|---|
| `actions/checkout` v4→v7 | v5/v6 = node24 + creds moved to a separate file; v7 blocks fork-PR checkout only for `pull_request_target`/`workflow_run` triggers — we use `pull_request`/`push`. No input changes affecting us. |
| `actions/setup-node` v4→v7 | v5 auto-caching via `packageManager` and v6 npm-only auto-cache are irrelevant: we set `cache: npm` + `cache-dependency-path` explicitly; `node-version: 22` is pinned so runtime defaults don't apply. v7 = ESM + new cache outputs, additive. |
| `actions/upload-artifact` v4→v7 | v5/v6 = node24 runtime only; v7 adds opt-in `archive: false` direct uploads (we don't use it). Our `name`/`path`/`if-no-files-found` inputs unchanged. |
| `codecov/codecov-action` v4→v7 | v5 wrapper rewrite renamed `file`→`files` and `plugin`→`plugins` — ci.yml already uses `files` and never used `plugin`. Confirmed against the v7.0.0 `action.yml`: `token`, `slug`, `files`, `flags`, `fail_ci_if_error` all present. v6/v7 = node24 + signing-key rotation, no schema change. |
| `astral-sh/setup-uv` v5→v9 | v6: venv activation now opt-in (`activate-environment`, default false) — we only use `uv run`/`uvx`, unaffected; removed `pyproject-file`/`uv-file` inputs, unused. v7: node24 + removed `server-url`, unused. v8: major tags discontinued → pinned `v9.0.0`. v9: `prune-cache` default flipped to false — slightly larger Actions cache, no input change needed. Confirmed `python-version`/`enable-cache`/`cache-dependency-glob` in the v9.0.0 `action.yml`. |
| `googleapis/release-please-action` v4→v5 | node24 only; `config-file`/`manifest-file` unchanged. |
| `actions/upload-pages-artifact` v3→v5 | v4 stops including hidden files — the Pages artifact is served as-is (no Jekyll pass), so the Docusaurus `website/build` dotfiles (e.g. `.nojekyll`) are not load-bearing; `include-hidden-files` exists as an escape hatch if ever needed. v5 = internal upload-artifact v7. |
| `actions/deploy-pages` v4→v5 | node24 only, no input changes. |

All runners are `ubuntu-latest` (GitHub-hosted), so the node24/runner-minimum-version requirements across these majors are automatically satisfied.
