### PR TITLE
feat(serializer): bind verbatim items to transcript message ids at capture time

### DIFF
--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -267,6 +267,16 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                     twin["text"] = item["text"]
                     if item.get("quote"):
                         twin["quote"] = item["quote"]
+                        # source_message_ids travel WITH the quote (#358),
+                        # same rail as quote_verified below: a binding
+                        # attests THIS quote's origin message. The twin's
+                        # own ids described its now-replaced quote — keeping
+                        # them would bind prev's quote to the wrong turn.
+                        if item.get("source_message_ids"):
+                            twin["source_message_ids"] = (
+                                item["source_message_ids"])
+                        else:
+                            twin.pop("source_message_ids", None)
                         # quote_verified travels WITH the quote (#167): the
                         # native's verdict attested its own (now replaced)
                         # quote — keeping it would stamp "verified" on a quote

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -434,6 +434,10 @@ def _cmd_write_checkpoint(args) -> int:
     # same spoofing risk serialize_strict guards against, since validate()
     # never inspects top-level keys.
     serializer.strip_code_owned_keys(checkpoint)
+    # #358, same discipline one level down: with no transcript here, no
+    # model-claimed source_message_ids binding is validatable — drop them all
+    # (empty id map = nothing the code can vouch for).
+    serializer.sanitize_source_ids(checkpoint, {})
     checkpoint["source"] = args.source  # provenance: introspection vs reconstruction
     session_id = str(checkpoint["session_id"])
     out = store.write_checkpoint(session_id, checkpoint, project_dir=_resolve_project(args.project))
@@ -1523,7 +1527,7 @@ def _cmd_audit_quotes(args) -> int:
         files = store._session_files(d)
     except OSError:
         files = []
-    scanned = paired = unpaired = items = verified = failed = 0
+    scanned = paired = unpaired = items = verified = failed = id_resolved = 0
     failures: list[tuple[str, str]] = []
     for f in sorted(files):
         try:
@@ -1539,9 +1543,12 @@ def _cmd_audit_quotes(args) -> int:
         session_id = str(cp.get("session_id") or f.stem)
         tpath = _find_audit_transcript(session_id, slug)
         haystack = None
+        texts_by_id = {}
         if tpath is not None:
             try:
-                haystack = serializer._render_transcript(transcript.from_file(tpath))
+                msgs = transcript.from_file(tpath)
+                haystack = serializer._render_transcript(msgs)
+                texts_by_id = serializer.message_texts_by_id(msgs)
             except (OSError, FileNotFoundError):
                 haystack = None
         if haystack is None:
@@ -1555,7 +1562,15 @@ def _cmd_audit_quotes(args) -> int:
             if not isinstance(quote, str) or not quote.strip():
                 continue
             items += 1
-            if serializer.quote_matches(quote, haystack):
+            # #358: an item bound to source message id(s) resolves the id and
+            # compares bytes against just that message. Missing/invalid ids
+            # (old checkpoints, moved/truncated transcripts) fall back to the
+            # whole-transcript scan — the pre-#358 verdict, byte-identical.
+            scoped = serializer.scoped_haystack(item, texts_by_id)
+            if scoped is not None and serializer.quote_matches(quote, scoped):
+                verified += 1
+                id_resolved += 1
+            elif serializer.quote_matches(quote, haystack):
                 verified += 1
             else:
                 failed += 1
@@ -1566,7 +1581,7 @@ def _cmd_audit_quotes(args) -> int:
         f"audit-quotes ({scope})",
         f"  checkpoints scanned: {scanned}  paired: {paired}  unpaired: {unpaired}",
         f"  verbatim quotes checked: {items}  verified: {verified}  "
-        f"failed: {failed}  rate: {rate:.1%}",
+        f"failed: {failed}  id-resolved: {id_resolved}  rate: {rate:.1%}",
     ]
     if failures:
         top = max(0, args.top)

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -34,10 +34,13 @@ log = logging.getLogger(__name__)
 # D-013 -> D-014 (#287: external-artifact identifier rule — "issue #5"
 # without a repo is half a pointer; capture the most specific identifier
 # the transcript states, never invent one).
+# D-014 -> D-015 (#358: verbatim items bind to source transcript message ids;
+# the bump also rotates the #48 chunk-cache key so pre-#358 cached
+# extractions, which carry no ids, can never satisfy a post-#358 request).
 # Checkpoints are only comparable across runs sharing this version (scar
 # landmine #4); pre-bump checkpoints firing the #93 format_version mismatch
 # warning is desired, not a bug.
-PROMPT_VERSION = "D-014"
+PROMPT_VERSION = "D-015"
 
 
 class SerializeError(Exception):
@@ -158,6 +161,14 @@ RULES — follow every one exactly; this is the point of the exercise:
     this rule is about `text`). Never invent an identifier the transcript does not contain;
     if only a vague name was ever stated, keep the vague name.
 
+19. SOURCE MESSAGE IDS: transcript messages may be prefixed with a bracketed marker such as
+    [m12] identifying that message. For every trust="verbatim" item, add
+    "source_message_ids": ["m12"] — the marker id(s) of the exact message(s) the `quote` was
+    copied from, normally exactly one. Copy the id from the marker exactly, without the
+    brackets. Item shapes gain this one optional key; inferred items never carry it. If the
+    transcript shows no [mN] markers, or you cannot tell exactly which message the quote came
+    from, omit the field entirely — never guess or invent an id.
+
 Schema shape:
 {
   "session_id": "<id>",
@@ -273,6 +284,11 @@ MERGE RULES — follow every one exactly:
     item's `links` is the union of both items' links (dedupe identical {type, target} pairs)
     so neither side's links are lost.
 
+14. SOURCE MESSAGE IDS: an item's optional "source_message_ids" array travels WITH its quote:
+    the canonical item keeps the ids of the version whose quote it keeps. Never invent ids,
+    never alter them, and never move them onto an item with a different quote. Preserve them
+    like `links` — dropping them loses provenance.
+
 Schema shape:
 {
   "session_id": "<id>",
@@ -312,17 +328,64 @@ def chunk_transcript(text: str, chunk_lines: int, overlap_lines: int) -> list[st
     return chunks
 
 
+def _message_text(m) -> str:
+    content = m.get("content", "")
+    if isinstance(content, list):  # tool/multipart content -> flatten text parts
+        content = " ".join(
+            p.get("text", "") for p in content if isinstance(p, dict)
+        )
+    return content
+
+
+def _message_id(m) -> str | None:
+    """The host-stable per-message id transcript.py attached (#358), or None."""
+    if not isinstance(m, dict):
+        return None
+    mid = m.get("id")
+    if isinstance(mid, str) and mid.strip():
+        return mid.strip()
+    return None
+
+
 def _render_transcript(messages) -> str:
     lines = []
-    for m in messages:
+    for i, m in enumerate(messages):
         role = m.get("role", "unknown")
-        content = m.get("content", "")
-        if isinstance(content, list):  # tool/multipart content -> flatten text parts
-            content = " ".join(
-                p.get("text", "") for p in content if isinstance(p, dict)
-            )
-        lines.append(f"{role}: {content}")
+        content = _message_text(m)
+        # #358: a bracketed [mN] marker names an identified message so the
+        # extractor can cite where each verbatim quote came from. Id-less
+        # messages (hosts without stable ids) render byte-identical to the
+        # pre-#358 format — no marker, no behavior change.
+        if _message_id(m) is not None:
+            lines.append(f"[m{i + 1}] {role}: {content}")
+        else:
+            lines.append(f"{role}: {content}")
     return "\n\n".join(lines)
+
+
+def message_id_map(messages) -> dict[str, str]:
+    """Rendered marker ("m3") -> host message id, for messages carrying one.
+
+    Positional 1-based numbering over the FULL message list, matching the
+    markers _render_transcript emits — stable under transcript growth for the
+    unchanged prefix, which is what lets #48 cached chunk extractions keep
+    citing valid markers."""
+    out: dict[str, str] = {}
+    for i, m in enumerate(messages or []):
+        mid = _message_id(m)
+        if mid is not None:
+            out[f"m{i + 1}"] = mid
+    return out
+
+
+def message_texts_by_id(messages) -> dict[str, str]:
+    """Host message id -> flattened message text, for id-scoped quote checks."""
+    out: dict[str, str] = {}
+    for m in messages or []:
+        mid = _message_id(m)
+        if mid is not None:
+            out[mid] = _message_text(m)
+    return out
 
 
 def _valid_item(item) -> bool:
@@ -441,6 +504,80 @@ def validate(checkpoint) -> bool:
     return True
 
 
+# ---- #358: verbatim items bind to transcript message ids ----
+#
+# Capture-time binding: the extractor cites, per verbatim item, the [mN]
+# marker of the message its quote came from (rule 19). The parse boundary
+# below translates markers to host ids and drops anything the actual
+# transcript cannot vouch for — the same code-owned-key discipline as
+# #292/#295, one level down: the model proposes, only ids the code resolved
+# survive. Ids ride inside the item payload, so receipts cover them with no
+# receipt-machinery change.
+
+SOURCE_IDS_KEY = "source_message_ids"
+
+
+def sanitize_source_ids(checkpoint, id_map) -> None:
+    """Validate model-emitted source message ids in place (#358).
+
+    `id_map` maps rendered markers ("m3") to host message ids
+    (message_id_map). Per item: a bare string becomes a one-entry list;
+    marker entries (brackets tolerated) translate to their host id; entries
+    already equal to a known host id pass through (merged/cached partials);
+    everything else — unknown ids, non-strings, ids on inferred or
+    quote-less items — is dropped, and the key is removed when nothing valid
+    remains. Same never-fatal philosophy as sanitize_importance: an advisory
+    field must never fail a serialize. Callers with no transcript to
+    validate against (cli's #23 write-checkpoint path) pass {} — every
+    claimed binding drops."""
+    id_map = id_map or {}
+    known_hosts = set(id_map.values())
+    for item in iter_items(checkpoint):
+        if SOURCE_IDS_KEY not in item:
+            continue
+        raw = item[SOURCE_IDS_KEY]
+        if isinstance(raw, str):
+            raw = [raw]
+        out: list[str] = []
+        quote = item.get("quote")
+        bindable = (item.get("trust") == "verbatim"
+                    and isinstance(quote, str) and quote.strip())
+        if bindable and isinstance(raw, list):
+            for entry in raw:
+                if not isinstance(entry, str):
+                    continue
+                marker = entry.strip().strip("[]")
+                host = id_map.get(marker)
+                if host is None and entry.strip() in known_hosts:
+                    host = entry.strip()
+                if host is not None and host not in out:
+                    out.append(host)
+        if out:
+            item[SOURCE_IDS_KEY] = out
+        else:
+            del item[SOURCE_IDS_KEY]
+
+
+def scoped_haystack(item, texts_by_id) -> str | None:
+    """The id-scoped haystack for an item's bound message(s), or None.
+
+    None means "no usable binding" — ids absent, or ANY cited id missing from
+    `texts_by_id` (old checkpoints, moved/truncated transcripts, carried
+    items from another session) — and the caller falls back to the
+    whole-transcript scan, exactly today's behavior. An unresolvable id is
+    not a disproven one."""
+    ids = item.get(SOURCE_IDS_KEY) if isinstance(item, dict) else None
+    if not (isinstance(ids, list) and ids and texts_by_id):
+        return None
+    parts = []
+    for mid in ids:
+        text = texts_by_id.get(mid) if isinstance(mid, str) else None
+        if text is None:
+            return None
+        parts.append(text)
+    return "\n\n".join(parts)
+
+
 # ---- #125: deterministic verbatim-quote verification ----
 #
 # The `verbatim` trust class promises the quote appears in the transcript, but
@@ -522,7 +659,7 @@ def quote_matches(quote, haystack) -> bool:
     return True
 
 
-def verify_quotes(checkpoint, transcript_text: str) -> int:
+def verify_quotes(checkpoint, transcript_text: str, messages=None) -> int:
     """Verify every verbatim item's quote against the rendered transcript, in
     place (#125). On a hit the item gets `quote_verified: true` AND a
     `last_verified` ISO-8601 UTC stamp (#215: the staleness-budget's freshest
@@ -535,17 +672,28 @@ def verify_quotes(checkpoint, transcript_text: str) -> int:
     (a quote whose secret redaction will later mask still verifies here
     against the raw rendered text). Returns the downgrade count.
 
+    #358: when `messages` is given, an item bound to source message id(s) is
+    checked against JUST those messages first — resolve id, compare bytes. A
+    scoped hit keeps the binding; a scoped MISS falls back to the
+    whole-transcript scan so the verdict is byte-identical to today's, but a
+    real-quote-in-the-wrong-message binding (scar #10's item-identity
+    ambiguity, disproven direction) is dropped rather than stored as false
+    provenance. Unresolvable ids (not in `messages`) are not disproven —
+    fallback rules, binding left alone. Without `messages` (legacy two-arg
+    callers) bindings are neither used nor touched.
+
     `last_verified` is checkpoint-append-only by design (#215): it is stamped
     ONLY here, at serialize time. No other code path may rewrite it — user
     resolve/reverify actions live in events.jsonl and are folded in at READ
     time (briefing.stale_carried), never written back onto the item.
 
     No injected `now` here (unlike briefing.build's now=None idiom): this
-    function's existing two-positional-arg signature is called from exactly
-    one site (serialize_strict, itself not now-aware), and datetime.now(...)
-    inline matches store.append_event's own stamping idiom (store.py) rather
-    than threading a new param through a call chain that has no other use
-    for it."""
+    function's signature is called from exactly one production site
+    (serialize_strict, itself not now-aware), and datetime.now(...) inline
+    matches store.append_event's own stamping idiom (store.py) rather than
+    threading a new param through a call chain that has no other use for
+    it."""
+    texts_by_id = message_texts_by_id(messages) if messages else {}
     downgraded = 0
     for item in iter_items(checkpoint):
         if item.get("trust") != "verbatim":
@@ -553,13 +701,28 @@ def verify_quotes(checkpoint, transcript_text: str) -> int:
         quote = item.get("quote")
         if not isinstance(quote, str) or not quote.strip():
             continue
-        if quote_matches(quote, transcript_text):
+        scoped = scoped_haystack(item, texts_by_id)
+        if scoped is not None and quote_matches(quote, scoped):
+            item["quote_verified"] = True
+            item["last_verified"] = datetime.now(timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ")
+        elif quote_matches(quote, transcript_text):
+            if scoped is not None:
+                # Resolved AND mismatched: the quote is real but not in its
+                # cited message — drop the disproven binding, keep the
+                # pre-#358 verdict.
+                item.pop(SOURCE_IDS_KEY, None)
+                log.warning("quote verification: quote not found in its cited "
+                            "message(s) — binding dropped, verified via "
+                            "whole-transcript scan (#358)")
             item["quote_verified"] = True
             item["last_verified"] = datetime.now(timezone.utc).strftime(
                 "%Y-%m-%dT%H:%M:%SZ")
         else:
             item["trust"] = "inferred"
             item["quote_verified"] = False
+            # A downgraded quote is not evidence; a binding for it is noise.
+            item.pop(SOURCE_IDS_KEY, None)
             downgraded += 1
             # Log-line-only scrub: item ids are not stamped until store-save,
             # so the text is the only diagnostic handle here. The item itself
@@ -1024,11 +1187,17 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
         )
     sanitize_importance(checkpoint)
     sanitize_scene(checkpoint)
+    # #358: translate cited [mN] markers to host message ids and drop any id
+    # the transcript cannot vouch for — BEFORE verification, so verify_quotes
+    # only ever sees code-validated bindings.
+    sanitize_source_ids(checkpoint, message_id_map(messages))
     # #125: verify verbatim quotes against the SAME rendered text the extractor
     # read, PRE-redaction (redaction runs later in write_checkpoint and would
     # otherwise mass-downgrade legitimate quotes it had masked). Verify once,
-    # stamp the verdict — the briefing never re-greps.
-    verify_quotes(checkpoint, transcript_text)
+    # stamp the verdict — the briefing never re-greps. #358: items with a
+    # validated binding resolve their id and compare bytes against just that
+    # message, whole-transcript scan as fallback.
+    verify_quotes(checkpoint, transcript_text, messages)
     # #230: stamp provenance last, immediately before hand-off to store/write —
     # after validation/verification so it can never influence either, and
     # last so nothing downstream re-derives or clobbers it.

--- a/plugin/daimon_briefing/transcript.py
+++ b/plugin/daimon_briefing/transcript.py
@@ -6,7 +6,13 @@
    transcript; anything else as plain text/markdown. Includes a dedicated
    branch for Windsurf Cascade's native transcript (#70).
 
-All messages normalize to OpenAI-format dicts: {"role": str, "content": str}.
+All messages normalize to OpenAI-format dicts: {"role": str, "content": str},
+plus an optional "id" (#358) when the host row carries a stable per-message
+identifier (Claude Code JSONL `uuid`). Hosts without one — Windsurf Cascade's
+native rows ({type, status, payload}, field-confirmed #70), the Codex event
+stream (payload is just {type, message}), hermes SessionDB, markdown/plain
+text — keep the exact two-key shape, and downstream quote verification falls
+back to whole-transcript scanning.
 """
 
 import hashlib
@@ -144,7 +150,16 @@ def _from_jsonl(text: str) -> list[dict]:
             continue
         content = _content_of(obj)
         if content:
-            messages.append({"role": role, "content": content})
+            msg = {"role": role, "content": content}
+            # #358: Claude Code rows carry a stable per-message `uuid` —
+            # keep it as the message id so verbatim items can bind to the
+            # exact transcript entry their quote came from. A discriminating
+            # FIELD, not a row shape (deadend #20): rows without a usable
+            # string uuid keep the exact two-key shape.
+            mid = obj.get("uuid")
+            if isinstance(mid, str) and mid.strip():
+                msg["id"] = mid.strip()
+            messages.append(msg)
     return messages
 
 

--- a/plugin/tests/test_bench_carry.py
+++ b/plugin/tests/test_bench_carry.py
@@ -41,8 +41,13 @@ class CarryChat:
 
     def __call__(self, messages, **kwargs):
         self.calls += 1
-        blob = " ".join(str(m.get("content") or "") for m in messages)
-        marker = next((w for w in blob.split() if w.endswith("marker")), "nomarker")
+        # Transcript turns only — the SYSTEM prompt is instructions, not
+        # haystack, and since #358 it legitimately contains the word "marker"
+        # (rule 19's [mN] source-id markers), which this scan must not key on.
+        blob = " ".join(str(m.get("content") or "") for m in messages
+                        if m.get("role") != "system")
+        marker = next((w for w in blob.split()
+                       if w.endswith("marker") and w != "marker"), "nomarker")
         return json.dumps({
             "session_id": "ignored",
             "working_context": {

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -276,6 +276,39 @@ def test_verbatim_identical_twin_survives_byte_identical():
     assert qs[0]["trust"] == "verbatim"
 
 
+def test_verbatim_freeze_source_ids_travel_with_quote():
+    # #358: source_message_ids ride the same rail as quote_verified — the
+    # binding attests THIS quote's origin message. When the freeze overwrites
+    # the twin's quote with prev's pinned original, the twin's own ids would
+    # bind prev's quote to the wrong turn; prev's ids replace them.
+    prev = _cp("S-prev", 1, questions=[_item(
+        _VERB_ORIG, trust="verbatim", quote=_VERB_QUOTE, days=45,
+        source_message_ids=["u-orig"])])
+    new = _cp("S-new", 0, questions=[_item(
+        _VERB_TWIN, days=0, trust="verbatim", quote="different exact words",
+        source_message_ids=["u-new"])])
+    out = carry.merge(new, prev, NOW)
+    qs = out["working_context"]["open_questions"]
+    assert len(qs) == 1
+    assert qs[0]["quote"] == _VERB_QUOTE
+    assert qs[0]["source_message_ids"] == ["u-orig"]
+
+
+def test_verbatim_freeze_pops_twin_ids_when_prev_has_none():
+    # Prev pinned quote without a binding (pre-#358 checkpoint): the twin's
+    # own ids must not survive attached to a quote they never described.
+    prev = _cp("S-prev", 1, questions=[_item(
+        _VERB_ORIG, trust="verbatim", quote=_VERB_QUOTE, days=45)])
+    new = _cp("S-new", 0, questions=[_item(
+        _VERB_TWIN, days=0, trust="verbatim", quote="different exact words",
+        source_message_ids=["u-new"])])
+    out = carry.merge(new, prev, NOW)
+    qs = out["working_context"]["open_questions"]
+    assert len(qs) == 1
+    assert qs[0]["quote"] == _VERB_QUOTE
+    assert "source_message_ids" not in qs[0]
+
+
 def test_verbatim_freeze_inherits_older_first_seen():
     # first_seen birth-stamp inheritance still works on the freeze path: the
     # native twin has a NEWER stamp; the older prev original stamp must win,

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1430,6 +1430,26 @@ def test_cli_write_checkpoint_strips_model_supplied_code_owned_keys(
     assert ck["created"] != "1999-01-01T00:00:00Z"
 
 
+def test_cli_write_checkpoint_drops_model_claimed_source_ids(
+        tmp_checkpoint_dir, monkeypatch):
+    # #358, same discipline as #292/#295 one level down: the introspection
+    # path has NO transcript to validate against, so a model-claimed
+    # source_message_ids binding is unverifiable and must not persist.
+    from daimon_briefing import store
+
+    cp = json.loads(_valid_json("S-intro"))
+    cp["working_context"]["recent_decisions"] = [{
+        "text": "d", "trust": "verbatim", "quote": "some exact words",
+        "source_message_ids": ["m3", "uuid-fabricated"],
+    }]
+    _stdin(monkeypatch, json.dumps(cp))
+    rc = cli.main(["write-checkpoint", "--project", "/p/A"])
+    assert rc == 0
+    ck = store.read_latest(project_dir="/p/A")
+    dec = ck["working_context"]["recent_decisions"][0]
+    assert "source_message_ids" not in dec
+
+
 def test_top_level_help_has_examples(capsys):
     with pytest.raises(SystemExit) as exc:
         cli.main(["--help"])

--- a/plugin/tests/test_quote_verification.py
+++ b/plugin/tests/test_quote_verification.py
@@ -271,6 +271,87 @@ def test_verify_quotes_does_not_stamp_last_verified_for_inferred_items():
     assert "last_verified" not in cp["working_context"]["recent_decisions"][0]
 
 
+# ---- #358: id-scoped verification with whole-transcript fallback ----
+
+_ID_MSGS = [
+    {"role": "user", "content": "we adopt the D-007 prompt", "id": "u-1"},
+    {"role": "assistant", "content": "understood, cache stays keyed", "id": "a-2"},
+]
+
+
+def test_verify_quotes_id_scoped_hit_keeps_binding_and_stamps():
+    cp = _cp_with({("working_context", "recent_decisions"): [
+        {"text": "d", "trust": "verbatim", "quote": "adopt the D-007 prompt",
+         "source_message_ids": ["u-1"]}]})
+    n = serializer.verify_quotes(
+        cp, serializer._render_transcript(_ID_MSGS), _ID_MSGS)
+    item = cp["working_context"]["recent_decisions"][0]
+    assert n == 0
+    assert item["quote_verified"] is True
+    assert item["source_message_ids"] == ["u-1"]  # binding survives
+    assert "last_verified" in item
+
+
+def test_verify_quotes_wrong_binding_falls_back_and_drops_ids(caplog):
+    # Scar #10's ambiguity, disproven direction: the quote is real but it
+    # lives in u-1, not the cited a-2. Verdict stays exactly today's (the
+    # whole-transcript scan verifies it) but the false binding must die.
+    cp = _cp_with({("working_context", "recent_decisions"): [
+        {"text": "d", "trust": "verbatim", "quote": "adopt the D-007 prompt",
+         "source_message_ids": ["a-2"]}]})
+    with caplog.at_level(logging.WARNING, logger="daimon_briefing.serializer"):
+        n = serializer.verify_quotes(
+            cp, serializer._render_transcript(_ID_MSGS), _ID_MSGS)
+    item = cp["working_context"]["recent_decisions"][0]
+    assert n == 0
+    assert item["trust"] == "verbatim"
+    assert item["quote_verified"] is True
+    assert "source_message_ids" not in item
+    assert any("cited message" in r.getMessage() for r in caplog.records)
+
+
+def test_verify_quotes_miss_downgrades_and_drops_ids():
+    cp = _cp_with({("working_context", "recent_decisions"): [
+        {"text": "d", "trust": "verbatim",
+         "quote": "this exact sentence is nowhere in the transcript at all",
+         "source_message_ids": ["u-1"]}]})
+    n = serializer.verify_quotes(
+        cp, serializer._render_transcript(_ID_MSGS), _ID_MSGS)
+    item = cp["working_context"]["recent_decisions"][0]
+    assert n == 1
+    assert item["trust"] == "inferred"
+    assert "source_message_ids" not in item  # nothing left worth binding
+
+
+def test_verify_quotes_unresolvable_id_falls_back_and_keeps_ids():
+    # An id that does not resolve (old checkpoint against a rewritten
+    # transcript, carried item from another session) is NOT disproven — the
+    # whole-transcript fallback rules, today's behavior byte-for-byte, and
+    # the binding is left alone for a future audit with the right transcript.
+    cp = _cp_with({("working_context", "recent_decisions"): [
+        {"text": "d", "trust": "verbatim", "quote": "adopt the D-007 prompt",
+         "source_message_ids": ["ghost-9"]}]})
+    n = serializer.verify_quotes(
+        cp, serializer._render_transcript(_ID_MSGS), _ID_MSGS)
+    item = cp["working_context"]["recent_decisions"][0]
+    assert n == 0
+    assert item["quote_verified"] is True
+    assert item["source_message_ids"] == ["ghost-9"]
+
+
+def test_verify_quotes_two_arg_call_ignores_bindings():
+    # Without messages the function must behave exactly as before #358 —
+    # bindings are neither used nor touched.
+    cp = _cp_with({("working_context", "recent_decisions"): [
+        {"text": "d", "trust": "verbatim", "quote": "adopt the D-007 prompt",
+         "source_message_ids": ["u-1"]}]})
+    n = serializer.verify_quotes(cp, "assistant: adopt the D-007 prompt today")
+    item = cp["working_context"]["recent_decisions"][0]
+    assert n == 0
+    assert item["quote_verified"] is True
+    assert item["source_message_ids"] == ["u-1"]
+
+
 # ---- Unit C: serialize_strict integration ----
 
 def _script(items):
@@ -575,3 +656,63 @@ def test_audit_quotes_all_flag_spans_projects(
     assert "2" in all_out  # both checkpoints scanned under --all
     # sanity: the two runs differ (default is narrower)
     assert default_out != all_out
+
+
+# ---- #358: audit resolves stored message-id bindings before scanning ----
+
+
+def _write_id_transcript(projects_dir, slug, session_id, turns):
+    # Claude Code-shaped rows: per-message uuid rides to messages as `id`.
+    d = projects_dir / slug
+    d.mkdir(parents=True, exist_ok=True)
+    lines = [json.dumps({"role": r, "content": c, "uuid": u})
+             for r, c, u in turns]
+    (d / f"{session_id}.jsonl").write_text("\n".join(lines) + "\n",
+                                           encoding="utf-8")
+
+
+def test_audit_quotes_resolves_bound_ids(
+    tmp_checkpoint_dir, _projects_dir, capsys
+):
+    slug = store.project_slug("/p/A")
+    _write_id_transcript(_projects_dir, slug, "SA", [
+        ("user", "we adopt the D-007 prompt for the serializer", "u-111"),
+        ("assistant", "understood, wiring it now", "a-222"),
+    ])
+    cp = _stored_checkpoint("SA", slug, [
+        {"text": "bound decision", "trust": "verbatim",
+         "quote": "adopt the D-007 prompt for the serializer",
+         "source_message_ids": ["u-111"], "id": "d-aaa"},
+    ])
+    store.write_checkpoint("SA", cp, project_dir="/p/A")
+
+    rc = cli.main(["audit-quotes", "--project", "/p/A"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "id-resolved: 1" in out
+    assert "verified: 1" in out
+
+
+def test_audit_quotes_stale_id_falls_back_to_whole_scan(
+    tmp_checkpoint_dir, _projects_dir, capsys
+):
+    # An id the current transcript no longer carries (moved/truncated/old
+    # checkpoint) must not fail the item — the whole-transcript scan is the
+    # fallback and its verdict is today's verdict.
+    slug = store.project_slug("/p/A")
+    _write_id_transcript(_projects_dir, slug, "SA", [
+        ("user", "we adopt the D-007 prompt for the serializer", "u-111"),
+    ])
+    cp = _stored_checkpoint("SA", slug, [
+        {"text": "stale binding decision", "trust": "verbatim",
+         "quote": "adopt the D-007 prompt for the serializer",
+         "source_message_ids": ["gone-999"], "id": "d-bbb"},
+    ])
+    store.write_checkpoint("SA", cp, project_dir="/p/A")
+
+    rc = cli.main(["audit-quotes", "--project", "/p/A"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "id-resolved: 0" in out
+    assert "verified: 1" in out
+    assert "failed: 0" in out

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -756,15 +756,18 @@ def test_validation_retry_note_restates_copy_paste_contract(
     assert "elisions marked with `...`" in second
 
 
-def test_prompt_version_is_d014():
+def test_prompt_version_is_d015():
     # D-008 -> D-010 (#101: emotional_valence dropped from the schema).
     # D-009 is taken by the host-adapter decision. D-010 -> D-011 (#126:
     # per-item importance added to the emitted schema). D-011 -> D-012 (#5:
     # transcript-language preservation rule). D-012 -> D-013 (#208: verbatim
     # quote copy-paste discipline rule). D-013 -> D-014 (#287: external-
-    # artifact identifier rule). Pre-bump checkpoints firing the
-    # format_version mismatch warning (#93) is DESIRED behavior.
-    assert serializer.PROMPT_VERSION == "D-014"
+    # artifact identifier rule). D-014 -> D-015 (#358: verbatim items bind
+    # to source transcript message ids). Pre-bump checkpoints firing the
+    # format_version mismatch warning (#93) is DESIRED behavior. The bump
+    # also rotates the #48 chunk-cache key, so pre-#358 cached extractions
+    # (no ids) can never satisfy a post-#358 request.
+    assert serializer.PROMPT_VERSION == "D-015"
 
 
 def test_prompts_preserve_transcript_language():
@@ -1609,3 +1612,184 @@ def test_sanitize_scene_runs_even_with_flag_off(fake_chat_factory, monkeypatch):
     chat = fake_chat_factory(json.dumps(cp))
     ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
     assert "scene" not in ckpt["working_context"]["open_questions"][0]
+
+
+# ---- #358: verbatim items bind to transcript message ids ----
+#
+# Capture-time binding: hosts whose transcripts carry a stable per-message id
+# (Claude Code JSONL `uuid`) render each identified message with a bracketed
+# [mN] marker; the extractor cites the marker per verbatim item; the parse
+# boundary translates markers to host ids and drops anything that does not
+# resolve against the actual transcript (same code-owned-key discipline as
+# #292/#295, one level down). Hosts without ids render byte-identical to the
+# pre-#358 format and keep whole-transcript scanning.
+
+
+def _msgs_with_ids(n=6):
+    out = []
+    for i in range(n):
+        role = "user" if i % 2 == 0 else "assistant"
+        out.append({"role": role, "content": f"line {i} from {role}",
+                    "id": f"uuid-{i}"})
+    return out
+
+
+def test_render_transcript_without_ids_is_byte_identical_to_today():
+    msgs = [{"role": "user", "content": "hola"},
+            {"role": "assistant", "content": "todo bien"}]
+    assert serializer._render_transcript(msgs) == (
+        "user: hola\n\nassistant: todo bien")
+
+
+def test_render_transcript_prefixes_markers_only_for_id_messages():
+    msgs = [{"role": "user", "content": "first", "id": "uuid-a"},
+            {"role": "assistant", "content": "second"},
+            {"role": "user", "content": "third", "id": "uuid-c"}]
+    assert serializer._render_transcript(msgs) == (
+        "[m1] user: first\n\nassistant: second\n\n[m3] user: third")
+
+
+def test_message_id_map_maps_markers_to_host_ids():
+    msgs = [{"role": "user", "content": "first", "id": "uuid-a"},
+            {"role": "assistant", "content": "second"},
+            {"role": "user", "content": "third", "id": " uuid-c "}]
+    assert serializer.message_id_map(msgs) == {"m1": "uuid-a", "m3": "uuid-c"}
+    assert serializer.message_id_map([]) == {}
+    assert serializer.message_id_map(None) == {}
+
+
+def test_prompts_carry_source_message_id_rule():
+    # Always-on (no flag): the prompts are content-pinned, not byte-pinned, so
+    # the rule ships unconditionally. Both prompts must know the key — merge
+    # re-emits items and would silently drop the binding otherwise.
+    assert "SOURCE MESSAGE IDS" in serializer.SERIALIZE_SYS
+    assert '"source_message_ids"' in serializer.SERIALIZE_SYS
+    assert "SOURCE MESSAGE IDS" in serializer.MERGE_SYS
+    assert '"source_message_ids"' in serializer.MERGE_SYS
+
+
+def _cp_one_decision(item):
+    return {
+        "session_id": "S1",
+        "working_context": {
+            "active_topic": {"text": "t", "trust": "inferred"},
+            "open_questions": [],
+            "recent_decisions": [item],
+        },
+        "epistemic_snapshot": {
+            "strong_beliefs": [], "uncertainties": [],
+            "contradictions_flagged": [],
+        },
+    }
+
+
+def test_sanitize_source_ids_translates_marker_to_host_id():
+    cp = _cp_one_decision({"text": "d", "trust": "verbatim",
+                           "quote": "line 3 from assistant",
+                           "source_message_ids": ["m4"]})
+    serializer.sanitize_source_ids(cp, {"m4": "uuid-3"})
+    item = cp["working_context"]["recent_decisions"][0]
+    assert item["source_message_ids"] == ["uuid-3"]
+
+
+def test_sanitize_source_ids_accepts_bare_string_and_bracketed_marker():
+    # Models reflow "[m4]" or emit a bare string instead of a list — both
+    # normalize instead of losing the binding.
+    for raw in ("m4", "[m4]", ["[m4]"]):
+        cp = _cp_one_decision({"text": "d", "trust": "verbatim",
+                               "quote": "line 3 from assistant",
+                               "source_message_ids": raw})
+        serializer.sanitize_source_ids(cp, {"m4": "uuid-3"})
+        item = cp["working_context"]["recent_decisions"][0]
+        assert item["source_message_ids"] == ["uuid-3"], raw
+
+
+def test_sanitize_source_ids_drops_unknown_ids_and_garbage():
+    # An id the transcript cannot vouch for is an invented id — parse boundary
+    # drops it; nothing valid left removes the key entirely.
+    cp = _cp_one_decision({"text": "d", "trust": "verbatim",
+                           "quote": "line 3 from assistant",
+                           "source_message_ids": ["m99", 7, None, {"m": 1}]})
+    serializer.sanitize_source_ids(cp, {"m4": "uuid-3"})
+    assert "source_message_ids" not in cp["working_context"]["recent_decisions"][0]
+
+
+def test_sanitize_source_ids_passes_through_known_host_ids():
+    # A merged/cached partial can already carry the translated host id — it is
+    # still validated against the transcript's actual ids, then kept.
+    cp = _cp_one_decision({"text": "d", "trust": "verbatim",
+                           "quote": "line 3 from assistant",
+                           "source_message_ids": ["uuid-3", "uuid-3"]})
+    serializer.sanitize_source_ids(cp, {"m4": "uuid-3"})
+    item = cp["working_context"]["recent_decisions"][0]
+    assert item["source_message_ids"] == ["uuid-3"]  # deduped, validated
+
+
+def test_sanitize_source_ids_drops_key_on_inferred_items():
+    # Binding rides the verbatim quote; an inferred item has no quote to bind.
+    cp = _cp_one_decision({"text": "d", "trust": "inferred",
+                           "source_message_ids": ["m4"]})
+    serializer.sanitize_source_ids(cp, {"m4": "uuid-3"})
+    assert "source_message_ids" not in cp["working_context"]["recent_decisions"][0]
+
+
+def test_sanitize_source_ids_with_empty_map_drops_everything():
+    # The #23 introspection path (cli write-checkpoint) has no transcript: no
+    # model-claimed binding is validatable, so all of them go.
+    cp = _cp_one_decision({"text": "d", "trust": "verbatim",
+                           "quote": "line 3 from assistant",
+                           "source_message_ids": ["m4", "uuid-3"]})
+    serializer.sanitize_source_ids(cp, {})
+    assert "source_message_ids" not in cp["working_context"]["recent_decisions"][0]
+
+
+def _decision_checkpoint_json(item):
+    return json.dumps(_cp_one_decision(item))
+
+
+def test_serialize_strict_stores_host_ids_for_cited_marker(
+        fake_chat_factory, monkeypatch):
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    chat = fake_chat_factory(_decision_checkpoint_json(
+        {"text": "d", "trust": "verbatim", "quote": "line 3 from assistant",
+         "source_message_ids": ["m4"]}))
+    out = serializer.serialize_strict("S1", _msgs_with_ids(6), chat=chat)
+    item = out["working_context"]["recent_decisions"][0]
+    assert item["source_message_ids"] == ["uuid-3"]  # marker -> host id
+    assert item["trust"] == "verbatim"
+    assert item["quote_verified"] is True
+    # The extractor actually saw the marker it was asked to cite.
+    sent = chat.calls[0]["messages"][1]["content"]
+    assert "[m4] assistant: line 3 from assistant" in sent
+
+
+def test_serialize_strict_drops_invented_marker_and_falls_back(
+        fake_chat_factory, monkeypatch):
+    # Model cites a marker that does not exist: the binding dies at the parse
+    # boundary and verification falls back to the whole-transcript scan —
+    # exactly today's behavior, verdict included.
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    chat = fake_chat_factory(_decision_checkpoint_json(
+        {"text": "d", "trust": "verbatim", "quote": "line 3 from assistant",
+         "source_message_ids": ["m99"]}))
+    out = serializer.serialize_strict("S1", _msgs_with_ids(6), chat=chat)
+    item = out["working_context"]["recent_decisions"][0]
+    assert "source_message_ids" not in item
+    assert item["trust"] == "verbatim"
+    assert item["quote_verified"] is True
+
+
+def test_serialize_strict_idless_host_stays_on_todays_path(
+        fake_chat_factory, monkeypatch):
+    # Hosts without per-message ids (Windsurf, Codex, markdown): no markers in
+    # the rendered prompt, and a hallucinated citation cannot survive.
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    chat = fake_chat_factory(_decision_checkpoint_json(
+        {"text": "d", "trust": "verbatim", "quote": "line 3 from assistant",
+         "source_message_ids": ["m2"]}))
+    out = serializer.serialize_strict("S1", make_messages(6), chat=chat)
+    sent = chat.calls[0]["messages"][1]["content"]
+    assert "[m" not in sent  # rendered transcript is marker-free
+    item = out["working_context"]["recent_decisions"][0]
+    assert "source_message_ids" not in item
+    assert item["quote_verified"] is True

--- a/plugin/tests/test_transcript.py
+++ b/plugin/tests/test_transcript.py
@@ -202,6 +202,46 @@ def test_from_file_windsurf_cascade_noise_only_returns_empty(tmp_path):
     assert transcript.from_file(p) == []
 
 
+# ---- #358: per-message identity capture ----
+
+
+def test_from_file_claude_jsonl_binds_message_uuid_as_id(tmp_path):
+    # Claude Code rows carry a stable per-message `uuid` (field-verified on
+    # live transcripts) — bind it to the normalized message as `id` so
+    # verbatim items can anchor to the exact transcript entry their quote
+    # came from (#358).
+    p = _write_jsonl(tmp_path / "session.jsonl", [
+        {"type": "user", "uuid": "aaa-111",
+         "message": {"role": "user", "content": "where did we leave off?"}},
+        {"type": "assistant", "uuid": "bbb-222",
+         "message": {"role": "assistant", "content": [
+             {"type": "text", "text": "PR #10 merged."}]}},
+    ])
+    assert transcript.from_file(p) == [
+        {"role": "user", "content": "where did we leave off?", "id": "aaa-111"},
+        {"role": "assistant", "content": "PR #10 merged.", "id": "bbb-222"},
+    ]
+
+
+def test_from_file_rows_without_usable_uuid_get_no_id_key(tmp_path):
+    # Hosts without a stable per-message id — and malformed uuid values — keep
+    # today's exact {"role", "content"} shape: no id key, so downstream falls
+    # back to whole-transcript quote scanning (#358). Windsurf Cascade and the
+    # Codex event stream are covered by their own strict-equality tests above.
+    p = _write_jsonl(tmp_path / "session.jsonl", [
+        {"type": "user", "uuid": 42,
+         "message": {"role": "user", "content": "malformed uuid row"}},
+        {"type": "user", "uuid": "   ",
+         "message": {"role": "user", "content": "blank uuid row"}},
+        {"type": "user", "message": {"role": "user", "content": "no uuid row"}},
+    ])
+    assert transcript.from_file(p) == [
+        {"role": "user", "content": "malformed uuid row"},
+        {"role": "user", "content": "blank uuid row"},
+        {"role": "user", "content": "no uuid row"},
+    ]
+
+
 def test_from_session_returns_empty_when_hermes_unavailable(monkeypatch):
     # Force the hermes import seam to fail; must degrade to [] not raise.
     monkeypatch.setattr(transcript, "_load_session_db", lambda: None)


### PR DESCRIPTION
Closes #358

## What

Slice 1 of message-id binding: verbatim items now carry the transcript message id(s) their quote came from, captured at serialization time, validated at the parse boundary, and used by verification with the whole-transcript scan as fallback.

- **Capture**: `transcript.py` binds Claude Code JSONL rows' per-message `uuid` to the normalized message as `id`. Hosts without a stable id keep the exact two-key `{role, content}` shape.
- **Prompt**: identified messages render with a `[mN]` marker; serialize rule 19 asks the extractor to cite the marker per verbatim item (`source_message_ids`); merge rule 14 makes ids travel with their quote. Always-on — the prompts are content-pinned, not byte-pinned, so no flag gate (the #317 scene flag stayed gated because its prompts are pinned byte-identical flag-off; this rule is a permanent part of the extraction contract, and PROMPT_VERSION versions it). `PROMPT_VERSION` bumped D-014 → D-015.
- **Parse boundary** (`sanitize_source_ids`): same code-owned-key discipline as #292/#295 one level down — markers translate to host ids via a code-built map; unknown ids, non-strings, and ids on inferred/quote-less items are dropped. The #23 introspection path (`write-checkpoint`) passes an empty map, so unvalidatable model-claimed bindings never persist.
- **Verification**: `verify_quotes` resolves bound id(s) and compares bytes against just those messages first. Scoped miss falls back to the whole-transcript scan (verdict byte-identical to today) and drops the disproven binding — scar #10's item-identity ambiguity, real-quote-wrong-message direction. Unresolvable ids are not disproven: fallback rules, binding left alone. `audit-quotes` does the same and reports an `id-resolved` count.
- **Carry**: the verbatim-freeze path moves `source_message_ids` with the quote (same rail as `quote_verified`), so a twin's stale ids can never bind the frozen quote to the wrong turn.
- **Receipts**: untouched — ids ride inside the item payload, so checkpoint-byte receipts cover them automatically.

## Why

Verbatim verification anchored on quote strings alone: a quote can be real yet belong to a different context than the item citing it (scar #10), and every re-check paid a whole-transcript scan. Binding each quote to the transcript entry it came from makes verification resolve-id-then-compare-bytes and gives #359/#360 the grounding hook — while behavior without ids stays byte-identical to today.

## Tests

TDD: commit 1 pins the contract red (22 failing), commit 2 goes green. Suite: 1852 → 1874 passed (+22), `uv run --all-extras pytest` green, `ruff check` clean.

- `test_transcript.py` — uuid capture; malformed/absent uuid keeps the two-key shape
- `test_serializer.py` — marker rendering (id-less render pinned byte-identical), `message_id_map`, prompt rules in both prompts, `sanitize_source_ids` (translation, bracket/string tolerance, unknown/garbage drops, inferred drops, empty-map drops), serialize-strict E2E (marker → host id, invented marker → fallback, id-less host marker-free), D-015 pin
- `test_quote_verification.py` — id-scoped hit keeps binding + stamps; wrong-message binding falls back and drops ids; miss downgrades and drops ids; unresolvable id falls back and keeps ids; legacy two-arg call untouched; audit `id-resolved` + stale-id fallback
- `test_cli.py` — write-checkpoint drops model-claimed bindings
- `test_carry.py` — freeze path: ids travel with the quote / twin ids popped
- `test_bench_carry.py` — harness fix: `CarryChat` scans transcript turns only (rule 19's wording legitimately contains the literal word "marker")

### Per-host message-id findings

| Host | Per-message identity | Result |
|------|----------------------|--------|
| Claude Code JSONL | Top-level `uuid` on every user/assistant row (verified on live transcripts) | Captured as message `id` → markers rendered, bindings stored |
| Windsurf Cascade (native) | Rows are `{type, status, <payload-key>}` (+`timestamp`), field-confirmed #70 — no stable per-message id | No id captured → marker-free render, whole-transcript fallback (today's behavior) |
| Codex (rollout event stream) | `event_msg` payloads are `{type, message}` (+`kind`) — no id in the preferred stream (verified on a live rollout); `response_item` ids exist but that stream is the duplicate/injected one the parser deliberately skips | No id captured → fallback |
| hermes `from_session` | SessionDB returns `{role, content}` only | No id captured → fallback |
| Markdown / plain text | No row structure | No id captured → fallback |

### Cache keying (#348)

The chunk-extraction cache key already hashes the serialize system prompt (`sys_hash`) and `PROMPT_VERSION`; this change moves both (rule 19 + D-015), so pre-#358 cached extractions can never satisfy a post-#358 request. Additionally the rendered chunk text itself changes when markers are present (the key's primary input). Marker numbering is positional over the full message list, so #48's prefix-chunk reuse on grown transcripts keeps citing valid markers.
