### PR TITLE
feat(serializer): ground success claims in tool results and exit codes at capture time

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -438,6 +438,10 @@ def _cmd_write_checkpoint(args) -> int:
     # model-claimed source_message_ids binding is validatable — drop them all
     # (empty id map = nothing the code can vouch for).
     serializer.sanitize_source_ids(checkpoint, {})
+    # #359: `grounded` is a code-derived attestation; with no transcript
+    # there are no signals, so a model-claimed verdict is stripped (empty
+    # signal set = strip-only, no downgrade).
+    serializer.ground_outcomes(checkpoint, set())
     checkpoint["source"] = args.source  # provenance: introspection vs reconstruction
     session_id = str(checkpoint["session_id"])
     out = store.write_checkpoint(session_id, checkpoint, project_dir=_resolve_project(args.project))

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -37,10 +37,14 @@ log = logging.getLogger(__name__)
 # D-014 -> D-015 (#358: verbatim items bind to source transcript message ids;
 # the bump also rotates the #48 chunk-cache key so pre-#358 cached
 # extractions, which carry no ids, can never satisfy a post-#358 request).
+# D-015 -> D-016 (#359: outcome claims ground in tool-result signals — rule
+# 20 asks for signal citations, and the bump rotates the #48 chunk-cache key
+# so pre-#359 cached extractions, whose chunks rendered no tool rows, can
+# never satisfy a post-#359 request).
 # Checkpoints are only comparable across runs sharing this version (scar
 # landmine #4); pre-bump checkpoints firing the #93 format_version mismatch
 # warning is desired, not a bug.
-PROMPT_VERSION = "D-015"
+PROMPT_VERSION = "D-016"
 
 
 class SerializeError(Exception):
@@ -165,9 +169,21 @@ RULES — follow every one exactly; this is the point of the exercise:
     [m12] identifying that message. For every trust="verbatim" item, add
     "source_message_ids": ["m12"] — the marker id(s) of the exact message(s) the `quote` was
     copied from, normally exactly one. Copy the id from the marker exactly, without the
-    brackets. Item shapes gain this one optional key; inferred items never carry it. If the
-    transcript shows no [mN] markers, or you cannot tell exactly which message the quote came
-    from, omit the field entirely — never guess or invent an id.
+    brackets. Item shapes gain this one optional key; inferred items carry it only in the
+    rule-20 outcome-signal case. If the transcript shows no [mN] markers, or you cannot tell
+    exactly which message the quote came from, omit the field entirely — never guess or
+    invent an id.
+
+20. OUTCOME GROUNDING: messages rendered as "tool:" (or "tool (error):") are TOOL RESULTS —
+    command output, exit status, test runs — evidence, not conversation. When an item's claim
+    asserts a concrete OUTCOME (something succeeded or failed, was merged, deployed,
+    released, tests passed or went green, a build completed), and a tool-result message in
+    this transcript actually SHOWS that outcome happening, add that message's [mN] marker id
+    to the item's "source_message_ids" — alongside the quote's own marker for verbatim items
+    (keep both). This is the one case where an inferred item carries "source_message_ids".
+    Cite only a tool-result message that genuinely evidences the outcome; never copy tool
+    output into `text` or `quote` because of this rule. If no tool-result message evidences
+    the outcome, add nothing — the absence is itself a signal.
 
 Schema shape:
 {
@@ -287,7 +303,9 @@ MERGE RULES — follow every one exactly:
 14. SOURCE MESSAGE IDS: an item's optional "source_message_ids" array travels WITH its quote:
     the canonical item keeps the ids of the version whose quote it keeps. Never invent ids,
     never alter them, and never move them onto an item with a different quote. Preserve them
-    like `links` — dropping them loses provenance.
+    like `links` — dropping them loses provenance. Ids may ALSO point at tool-result
+    messages that evidence an outcome claim (these can appear on inferred items too):
+    preserve those on the canonical item exactly the same way, even when it has no quote.
 
 Schema shape:
 {
@@ -351,6 +369,12 @@ def _render_transcript(messages) -> str:
     lines = []
     for i, m in enumerate(messages):
         role = m.get("role", "unknown")
+        # #359: a failed tool result renders its error status inline — the
+        # extractor must see WHICH way the signal points, not just that one
+        # exists. Only flagged tool rows (transcript.py's Claude Code branch)
+        # qualify; a markdown "tool:" role row renders exactly as before.
+        if m.get("tool_result") and m.get("tool_error"):
+            role = f"{role} (error)"
         content = _message_text(m)
         # #358: a bracketed [mN] marker names an identified message so the
         # extractor can cite where each verbatim quote came from. Id-less
@@ -385,6 +409,24 @@ def message_texts_by_id(messages) -> dict[str, str]:
         mid = _message_id(m)
         if mid is not None:
             out[mid] = _message_text(m)
+    return out
+
+
+def signal_message_ids(messages) -> set[str]:
+    """Host ids of signal-bearing messages: tool results (#359).
+
+    Keyed on the `tool_result` flag transcript.py sets, never on the role
+    string — a markdown transcript's "tool:" role row has no tool payload
+    behind it and must not count as evidence. Empty for hosts that surface
+    no tool rows (Windsurf, Codex, hermes, markdown): grounding degrades to
+    a no-op there."""
+    out: set[str] = set()
+    for m in messages or []:
+        if not (isinstance(m, dict) and m.get("tool_result")):
+            continue
+        mid = _message_id(m)
+        if mid is not None:
+            out.add(mid)
     return out
 
 
@@ -517,7 +559,7 @@ def validate(checkpoint) -> bool:
 SOURCE_IDS_KEY = "source_message_ids"
 
 
-def sanitize_source_ids(checkpoint, id_map) -> None:
+def sanitize_source_ids(checkpoint, id_map, signal_ids=frozenset()) -> None:
     """Validate model-emitted source message ids in place (#358).
 
     `id_map` maps rendered markers ("m3") to host message ids
@@ -529,8 +571,15 @@ def sanitize_source_ids(checkpoint, id_map) -> None:
     remains. Same never-fatal philosophy as sanitize_importance: an advisory
     field must never fail a serialize. Callers with no transcript to
     validate against (cli's #23 write-checkpoint path) pass {} — every
-    claimed binding drops."""
+    claimed binding drops.
+
+    #359 widens "bindable" by exactly one case: an id resolving into
+    `signal_ids` (host ids of tool-result messages, signal_message_ids) is a
+    SIGNAL pointer — an outcome claim's evidence — and is kept on ANY item,
+    inferred and quote-less included. Non-signal ids on inferred items still
+    drop: the quote-binding rule is unchanged."""
     id_map = id_map or {}
+    signal_ids = set(signal_ids or ())
     known_hosts = set(id_map.values())
     for item in iter_items(checkpoint):
         if SOURCE_IDS_KEY not in item:
@@ -542,7 +591,7 @@ def sanitize_source_ids(checkpoint, id_map) -> None:
         quote = item.get("quote")
         bindable = (item.get("trust") == "verbatim"
                     and isinstance(quote, str) and quote.strip())
-        if bindable and isinstance(raw, list):
+        if isinstance(raw, list):
             for entry in raw:
                 if not isinstance(entry, str):
                     continue
@@ -550,7 +599,9 @@ def sanitize_source_ids(checkpoint, id_map) -> None:
                 host = id_map.get(marker)
                 if host is None and entry.strip() in known_hosts:
                     host = entry.strip()
-                if host is not None and host not in out:
+                if host is None or host in out:
+                    continue
+                if bindable or host in signal_ids:
                     out.append(host)
         if out:
             item[SOURCE_IDS_KEY] = out
@@ -558,16 +609,24 @@ def sanitize_source_ids(checkpoint, id_map) -> None:
             del item[SOURCE_IDS_KEY]
 
 
-def scoped_haystack(item, texts_by_id) -> str | None:
+def scoped_haystack(item, texts_by_id, exclude=frozenset()) -> str | None:
     """The id-scoped haystack for an item's bound message(s), or None.
 
     None means "no usable binding" — ids absent, or ANY cited id missing from
     `texts_by_id` (old checkpoints, moved/truncated transcripts, carried
     items from another session) — and the caller falls back to the
     whole-transcript scan, exactly today's behavior. An unresolvable id is
-    not a disproven one."""
+    not a disproven one.
+
+    `exclude` (#359): ids to leave OUT of the haystack — verify_quotes passes
+    the session's signal ids, because a tool-result pointer asserts "this
+    evidences the outcome", not "the quote lives here". An item whose cited
+    ids are ALL excluded has no quote-source claim at all -> None."""
     ids = item.get(SOURCE_IDS_KEY) if isinstance(item, dict) else None
     if not (isinstance(ids, list) and ids and texts_by_id):
+        return None
+    ids = [i for i in ids if not (isinstance(i, str) and i in exclude)]
+    if not ids:
         return None
     parts = []
     for mid in ids:
@@ -694,6 +753,10 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None) -> int:
     threading a new param through a call chain that has no other use for
     it."""
     texts_by_id = message_texts_by_id(messages) if messages else {}
+    # #359: signal pointers (tool-result ids) are outcome evidence, not
+    # quote-source claims — they never scope the quote check, and a scoped
+    # MISS must not execute them for the quote-id's crime.
+    signals = signal_message_ids(messages) if messages else set()
     downgraded = 0
     for item in iter_items(checkpoint):
         if item.get("trust") != "verbatim":
@@ -701,7 +764,7 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None) -> int:
         quote = item.get("quote")
         if not isinstance(quote, str) or not quote.strip():
             continue
-        scoped = scoped_haystack(item, texts_by_id)
+        scoped = scoped_haystack(item, texts_by_id, exclude=signals)
         if scoped is not None and quote_matches(quote, scoped):
             item["quote_verified"] = True
             item["last_verified"] = datetime.now(timezone.utc).strftime(
@@ -709,9 +772,14 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None) -> int:
         elif quote_matches(quote, transcript_text):
             if scoped is not None:
                 # Resolved AND mismatched: the quote is real but not in its
-                # cited message — drop the disproven binding, keep the
-                # pre-#358 verdict.
-                item.pop(SOURCE_IDS_KEY, None)
+                # cited message — drop the disproven QUOTE binding (signal
+                # pointers survive, #359), keep the pre-#358 verdict.
+                kept = [i for i in item.get(SOURCE_IDS_KEY) or []
+                        if isinstance(i, str) and i in signals]
+                if kept:
+                    item[SOURCE_IDS_KEY] = kept
+                else:
+                    item.pop(SOURCE_IDS_KEY, None)
                 log.warning("quote verification: quote not found in its cited "
                             "message(s) — binding dropped, verified via "
                             "whole-transcript scan (#358)")
@@ -734,6 +802,107 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None) -> int:
                         logged)
     if downgraded:
         log.info("quote verification: %d verbatim item(s) downgraded to inferred",
+                 downgraded)
+    return downgraded
+
+
+# ---- #359: outcome claims ground in tool-result signals ----
+#
+# The hard trust-class gap (#185/#194 lineage): the model concludes X, X is
+# false, the transcript faithfully records the model saying X — verbatim
+# matching certifies TRANSCRIPTION, not truth. For claims that assert an
+# OUTCOME (succeeded/failed/merged/deployed/tests green), the transcript
+# usually holds a concrete signal — a tool result, an exit status — and
+# rule 20 asks the extractor to cite it. `grounded` is the code-derived
+# verdict over the validated pointers: True = cites a real signal message,
+# False = outcome-shaped claim in a signal-bearing session with no citation
+# (stored inferred — an unwitnessed outcome is a report, not a fact).
+# Deliberately NO new trust class and NO new rendered tag: briefing trust
+# literals are pinned (skill-distribution scar), so this ships as an
+# additive advisory field the briefing can surface later. Items only ever
+# carry the POINTER (message id) — never the signal payload, so redaction
+# semantics are untouched.
+
+GROUNDED_KEY = "grounded"
+
+# Conservative, English-only outcome lexicon: past-tense/state assertions
+# about completion. Non-English claims simply never match — grounding stays
+# absent there, which is the honest no-op (never downgrade on a guess).
+_OUTCOME_RE = re.compile(
+    r"(?:\b(?:succeeded|successfully)\b"
+    r"|\btests?\s+(?:all\s+|are\s+|now\s+)*(?:pass(?:ed|ing)?|green)\b"
+    r"|\b(?:build|suite|ci|pipeline|deploy(?:ment)?)\s+"
+    r"(?:is\s+|now\s+)*(?:pass(?:ed|ing)?|green|succeeded|failed|completed)\b"
+    r"|\b(?:merged|deployed|released|published|shipped|landed)\b"
+    r"|\ball\s+(?:\d+\s+)?tests?\s+pass(?:ed)?\b)",
+    re.IGNORECASE)
+# Hedge/future/plan markers: "will be merged" is a plan, "whether the deploy
+# succeeded" is a question — neither ASSERTS the outcome. When one of these
+# is present the claim is not an outcome assertion and stays untouched
+# (when in doubt, keep today's behavior).
+_HEDGE_RE = re.compile(
+    r"\b(?:will|would|should|shall|going\s+to|to\s+be|not\s+yet|pending|"
+    r"plan(?:ned|s|ning)?|todo|must|needs?\s+to|about\s+to|once|when|"
+    r"if|whether|did|does|can|could|may|might)\b",
+    re.IGNORECASE)
+
+
+def _asserts_outcome(text: str) -> bool:
+    """True when `text` ASSERTS a completed outcome (narrow, English-only)."""
+    if not isinstance(text, str):
+        return False
+    return bool(_OUTCOME_RE.search(text)) and not _HEDGE_RE.search(text)
+
+
+def ground_outcomes(checkpoint, signal_ids) -> int:
+    """Derive the code-owned `grounded` verdict in place (#359). Returns the
+    number of verbatim outcome claims downgraded to inferred.
+
+    Runs AFTER sanitize_source_ids (only code-validated pointers exist) and
+    AFTER verify_quotes (which may drop disproven bindings — grounding must
+    judge the surviving set, or a dropped pointer could leave a stale True).
+
+    Per item, in order:
+    - the model never gets a vote: any model-emitted `grounded` is stripped
+      first (#292 discipline), then re-derived or left absent;
+    - a validated pointer into `signal_ids` -> grounded: true (the claim
+      cites a concrete tool-result signal in this session);
+    - otherwise, IF this session surfaced signals at all AND the item is
+      trust="verbatim" AND its `text` asserts an outcome -> trust becomes
+      "inferred", grounded: false. The quote (and its quote_verified stamp)
+      stays: transcription remains honestly attested — it is the OUTCOME
+      that is unwitnessed;
+    - everything else is untouched. Signal-free sessions (Windsurf, Codex,
+      hermes, markdown — no parseable tool results) never downgrade:
+      grounding is impossible there, and absence of evidence about the HOST
+      is not evidence against the claim.
+
+    Same never-fatal philosophy as sanitize_importance: pure dict walking,
+    an advisory field must never fail a serialize."""
+    signal_ids = set(signal_ids or ())
+    downgraded = 0
+    for item in iter_items(checkpoint):
+        item.pop(GROUNDED_KEY, None)
+        ids = item.get(SOURCE_IDS_KEY)
+        if (isinstance(ids, list)
+                and any(isinstance(i, str) and i in signal_ids for i in ids)):
+            item[GROUNDED_KEY] = True
+            continue
+        if not signal_ids:
+            continue
+        if item.get("trust") != "verbatim":
+            continue
+        if not _asserts_outcome(item.get("text") or ""):
+            continue
+        item["trust"] = "inferred"
+        item[GROUNDED_KEY] = False
+        downgraded += 1
+        # Same log-line-only scrub as verify_quotes: runs pre-redaction.
+        logged, _ = redact.redact_text(item.get("text") or "")
+        log.warning("outcome grounding: unwitnessed outcome claim downgraded "
+                    "verbatim->inferred (no signal cited): %s", logged)
+    if downgraded:
+        log.info("outcome grounding: %d outcome claim(s) downgraded to inferred",
                  downgraded)
     return downgraded
 
@@ -1082,7 +1251,11 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
     """
     if chat is None:
         chat = llm.chat
-    n = len(messages) if messages else 0
+    # #359: tool rows are evidence, not conversation — they never count
+    # toward the too-short gate, so surfacing them cannot let a two-turn
+    # session sneak past it.
+    n = sum(1 for m in messages or []
+            if not (isinstance(m, dict) and m.get("tool_result")))
     if n < config.min_messages():
         raise TooShortError(
             f"transcript too short ({n} < {config.min_messages()} messages)"
@@ -1189,8 +1362,10 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
     sanitize_scene(checkpoint)
     # #358: translate cited [mN] markers to host message ids and drop any id
     # the transcript cannot vouch for — BEFORE verification, so verify_quotes
-    # only ever sees code-validated bindings.
-    sanitize_source_ids(checkpoint, message_id_map(messages))
+    # only ever sees code-validated bindings. #359: signal pointers (ids of
+    # tool-result messages) survive on any item, evidence for outcome claims.
+    sig_ids = signal_message_ids(messages)
+    sanitize_source_ids(checkpoint, message_id_map(messages), sig_ids)
     # #125: verify verbatim quotes against the SAME rendered text the extractor
     # read, PRE-redaction (redaction runs later in write_checkpoint and would
     # otherwise mass-downgrade legitimate quotes it had masked). Verify once,
@@ -1198,6 +1373,11 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
     # validated binding resolve their id and compare bytes against just that
     # message, whole-transcript scan as fallback.
     verify_quotes(checkpoint, transcript_text, messages)
+    # #359: derive the code-owned `grounded` verdict AFTER verification (it
+    # must judge the surviving bindings) — outcome claims with a validated
+    # signal pointer are marked grounded; unwitnessed verbatim outcome
+    # claims in a signal-bearing session store as inferred.
+    ground_outcomes(checkpoint, sig_ids)
     # #230: stamp provenance last, immediately before hand-off to store/write —
     # after validation/verification so it can never influence either, and
     # last so nothing downstream re-derives or clobbers it.

--- a/plugin/daimon_briefing/transcript.py
+++ b/plugin/daimon_briefing/transcript.py
@@ -13,6 +13,13 @@ native rows ({type, status, payload}, field-confirmed #70), the Codex event
 stream (payload is just {type, message}), hermes SessionDB, markdown/plain
 text — keep the exact two-key shape, and downstream quote verification falls
 back to whole-transcript scanning.
+
+#359: Claude Code rows whose only payload is tool_result blocks — previously
+dropped as noise — surface as {"role": "tool", "content": <capped output>,
+"id": uuid, "tool_result": True, ["tool_error": True]} so outcome claims can
+ground in the concrete signal (exit status, test summary) they carry. Claude
+Code only: it is the one host with BOTH stable ids and parseable tool
+results; the other hosts' output stays byte-identical.
 """
 
 import hashlib
@@ -56,7 +63,8 @@ def _text_of(content) -> str:
     """Flatten Claude Code message content to plain text.
 
     String content passes through; block arrays keep only `text` blocks —
-    thinking, tool_use, and tool_result blocks are noise for the serializer.
+    thinking, tool_use, and tool_result blocks are noise for the serializer
+    (tool_result rows get their own dedicated extraction, #359).
     """
     if isinstance(content, str):
         return content.strip()
@@ -65,6 +73,43 @@ def _text_of(content) -> str:
                  if isinstance(b, dict) and b.get("type") == "text"]
         return "\n".join(p for p in parts if p).strip()
     return ""
+
+
+# #359: rendered tool output is a SIGNAL (exit status, test summary, error
+# line), not conversation — the useful part lives at the head, and full
+# payloads (a Read of a 2000-line file) would bloat the serialize prompt for
+# nothing. Cap applies at parse time so every downstream consumer (chunking,
+# rendering, quote verification) sees the same bounded text.
+_TOOL_RESULT_MAX_CHARS = 500
+
+
+def _tool_result_of(obj: dict) -> tuple[str, bool] | None:
+    """(flattened text, is_error) for a row whose payload is tool_result
+    blocks, or None when the row carries none. `content` inside a block can be
+    a plain string or a nested block list — both flatten. Empty output is
+    still a signal ("ran, said nothing"), kept via a placeholder."""
+    msg = obj.get("message")
+    content = msg.get("content") if isinstance(msg, dict) else None
+    if not isinstance(content, list):
+        return None
+    parts: list[str] = []
+    is_error = False
+    found = False
+    for block in content:
+        if not isinstance(block, dict) or block.get("type") != "tool_result":
+            continue
+        found = True
+        if block.get("is_error"):
+            is_error = True
+        inner = block.get("content")
+        if isinstance(inner, str):
+            parts.append(inner.strip())
+        elif isinstance(inner, list):
+            parts.append(_text_of(inner))
+    if not found:
+        return None
+    text = "\n".join(p for p in parts if p).strip()[:_TOOL_RESULT_MAX_CHARS]
+    return (text or "(no output)", is_error)
 
 
 def _from_jsonl(text: str) -> list[dict]:
@@ -148,18 +193,38 @@ def _from_jsonl(text: str) -> list[dict]:
         role = _role_of(obj)
         if role is None:
             continue
+        # #358: Claude Code rows carry a stable per-message `uuid` —
+        # keep it as the message id so verbatim items can bind to the
+        # exact transcript entry their quote came from. A discriminating
+        # FIELD, not a row shape (deadend #20): rows without a usable
+        # string uuid keep the exact two-key shape.
+        raw_uuid = obj.get("uuid")
+        mid = (raw_uuid.strip()
+               if isinstance(raw_uuid, str) and raw_uuid.strip() else None)
         content = _content_of(obj)
         if content:
             msg = {"role": role, "content": content}
-            # #358: Claude Code rows carry a stable per-message `uuid` —
-            # keep it as the message id so verbatim items can bind to the
-            # exact transcript entry their quote came from. A discriminating
-            # FIELD, not a row shape (deadend #20): rows without a usable
-            # string uuid keep the exact two-key shape.
-            mid = obj.get("uuid")
-            if isinstance(mid, str) and mid.strip():
-                msg["id"] = mid.strip()
+            if mid is not None:
+                msg["id"] = mid
             messages.append(msg)
+            continue
+        # #359: a row whose ONLY payload is tool_result blocks used to be
+        # dropped as noise — surface it as a signal-bearing "tool" message so
+        # outcome claims can ground in the concrete evidence it holds (exit
+        # status, test summary, error line). Only rows with a usable uuid
+        # qualify: grounding is pointer-based ([mN] marker -> host id), and an
+        # id-less tool row cannot be cited — id-less hosts keep pre-#359
+        # output byte-identical. Discriminating FIELDS again (deadend #20):
+        # tool_result block type + uuid, never a row shape.
+        if mid is not None:
+            tool = _tool_result_of(obj)
+            if tool is not None:
+                text, is_error = tool
+                tool_msg: dict = {"role": "tool", "content": text, "id": mid,
+                                  "tool_result": True}
+                if is_error:
+                    tool_msg["tool_error"] = True
+                messages.append(tool_msg)
     return messages
 
 

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1450,6 +1450,25 @@ def test_cli_write_checkpoint_drops_model_claimed_source_ids(
     assert "source_message_ids" not in dec
 
 
+def test_cli_write_checkpoint_strips_model_claimed_grounded(
+        tmp_checkpoint_dir, monkeypatch):
+    # #359, same discipline: `grounded` is a code-derived attestation. The
+    # introspection path has no transcript, hence no signals — a model
+    # claiming its own claim is grounded must not persist.
+    from daimon_briefing import store
+
+    cp = json.loads(_valid_json("S-intro"))
+    cp["working_context"]["recent_decisions"] = [{
+        "text": "deploy succeeded", "trust": "inferred", "grounded": True,
+    }]
+    _stdin(monkeypatch, json.dumps(cp))
+    rc = cli.main(["write-checkpoint", "--project", "/p/A"])
+    assert rc == 0
+    ck = store.read_latest(project_dir="/p/A")
+    dec = ck["working_context"]["recent_decisions"][0]
+    assert "grounded" not in dec
+
+
 def test_top_level_help_has_examples(capsys):
     with pytest.raises(SystemExit) as exc:
         cli.main(["--help"])

--- a/plugin/tests/test_quote_verification.py
+++ b/plugin/tests/test_quote_verification.py
@@ -339,6 +339,76 @@ def test_verify_quotes_unresolvable_id_falls_back_and_keeps_ids():
     assert item["source_message_ids"] == ["ghost-9"]
 
 
+# ---- #359: signal ids never scope the quote check ----
+#
+# A tool-result signal pointer (#359) asserts "this message evidences the
+# outcome", NOT "the quote lives here" — so verify_quotes must scope the
+# quote check to the NON-signal cited ids only, and a scoped miss must never
+# execute an innocent signal pointer for the quote-id's crime.
+
+_SIG_MSGS = [
+    {"role": "user", "content": "we adopt the D-007 prompt", "id": "u-1"},
+    {"role": "assistant", "content": "understood, cache stays keyed", "id": "a-2"},
+    {"role": "tool", "content": "exit code 0", "id": "t-3", "tool_result": True},
+]
+
+
+def test_verify_quotes_signal_only_binding_is_not_a_quote_scope():
+    # The item cites ONLY the signal: there is no quote-source claim to
+    # disprove. Whole-transcript scan rules, and the signal pointer survives.
+    cp = _cp_with({("working_context", "recent_decisions"): [
+        {"text": "d", "trust": "verbatim", "quote": "adopt the D-007 prompt",
+         "source_message_ids": ["t-3"]}]})
+    n = serializer.verify_quotes(
+        cp, serializer._render_transcript(_SIG_MSGS), _SIG_MSGS)
+    item = cp["working_context"]["recent_decisions"][0]
+    assert n == 0
+    assert item["quote_verified"] is True
+    assert item["source_message_ids"] == ["t-3"]
+
+
+def test_verify_quotes_scoped_miss_keeps_signal_ids_drops_quote_ids(caplog):
+    # Quote is real but lives in u-1, not the cited a-2: the false QUOTE
+    # binding dies (today's #358 behavior), the signal pointer stays.
+    cp = _cp_with({("working_context", "recent_decisions"): [
+        {"text": "d", "trust": "verbatim", "quote": "adopt the D-007 prompt",
+         "source_message_ids": ["a-2", "t-3"]}]})
+    with caplog.at_level(logging.WARNING, logger="daimon_briefing.serializer"):
+        n = serializer.verify_quotes(
+            cp, serializer._render_transcript(_SIG_MSGS), _SIG_MSGS)
+    item = cp["working_context"]["recent_decisions"][0]
+    assert n == 0
+    assert item["quote_verified"] is True
+    assert item["source_message_ids"] == ["t-3"]
+
+
+def test_verify_quotes_scoped_hit_keeps_quote_and_signal_ids():
+    cp = _cp_with({("working_context", "recent_decisions"): [
+        {"text": "d", "trust": "verbatim", "quote": "adopt the D-007 prompt",
+         "source_message_ids": ["u-1", "t-3"]}]})
+    n = serializer.verify_quotes(
+        cp, serializer._render_transcript(_SIG_MSGS), _SIG_MSGS)
+    item = cp["working_context"]["recent_decisions"][0]
+    assert n == 0
+    assert item["quote_verified"] is True
+    assert item["source_message_ids"] == ["u-1", "t-3"]
+
+
+def test_verify_quotes_full_miss_still_drops_everything():
+    # A quote found NOWHERE downgrades the item; a downgraded quote is not
+    # evidence and neither is its signal pointer — conservative, unchanged.
+    cp = _cp_with({("working_context", "recent_decisions"): [
+        {"text": "d", "trust": "verbatim",
+         "quote": "this exact sentence is nowhere in the transcript at all",
+         "source_message_ids": ["u-1", "t-3"]}]})
+    n = serializer.verify_quotes(
+        cp, serializer._render_transcript(_SIG_MSGS), _SIG_MSGS)
+    item = cp["working_context"]["recent_decisions"][0]
+    assert n == 1
+    assert item["trust"] == "inferred"
+    assert "source_message_ids" not in item
+
+
 def test_verify_quotes_two_arg_call_ignores_bindings():
     # Without messages the function must behave exactly as before #358 —
     # bindings are neither used nor touched.

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -1940,6 +1940,21 @@ def test_ground_outcomes_is_a_noop_when_session_has_no_signals():
     assert "grounded" not in item
 
 
+def test_ground_outcomes_tolerates_malformed_item_text():
+    # A torn or hand-edited checkpoint can hold a non-string `text` (the #134
+    # lesson lives at the validate boundary, but ground_outcomes also runs on
+    # the cli write-checkpoint path where shapes vary). Grounding is advisory:
+    # garbage must neither raise nor downgrade — never-fatal, same philosophy
+    # as sanitize_importance.
+    cp = _cp_one_decision({"text": ["deploy", "succeeded"], "trust": "verbatim",
+                           "quote": "q"})
+    n = serializer.ground_outcomes(cp, {"uuid-tool"})
+    item = cp["working_context"]["recent_decisions"][0]
+    assert n == 0
+    assert item["trust"] == "verbatim"
+    assert "grounded" not in item
+
+
 def test_ground_outcomes_strips_model_claimed_grounded():
     # `grounded` is code-owned (#292 discipline): a model that emits it gets
     # stomped — re-derived from validated pointers or removed, never trusted.

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -756,18 +756,20 @@ def test_validation_retry_note_restates_copy_paste_contract(
     assert "elisions marked with `...`" in second
 
 
-def test_prompt_version_is_d015():
+def test_prompt_version_is_d016():
     # D-008 -> D-010 (#101: emotional_valence dropped from the schema).
     # D-009 is taken by the host-adapter decision. D-010 -> D-011 (#126:
     # per-item importance added to the emitted schema). D-011 -> D-012 (#5:
     # transcript-language preservation rule). D-012 -> D-013 (#208: verbatim
     # quote copy-paste discipline rule). D-013 -> D-014 (#287: external-
     # artifact identifier rule). D-014 -> D-015 (#358: verbatim items bind
-    # to source transcript message ids). Pre-bump checkpoints firing the
+    # to source transcript message ids). D-015 -> D-016 (#359: outcome
+    # claims ground in tool-result signals). Pre-bump checkpoints firing the
     # format_version mismatch warning (#93) is DESIRED behavior. The bump
-    # also rotates the #48 chunk-cache key, so pre-#358 cached extractions
-    # (no ids) can never satisfy a post-#358 request.
-    assert serializer.PROMPT_VERSION == "D-015"
+    # also rotates the #48 chunk-cache key, so pre-#359 cached extractions
+    # (no tool-result rows in their chunks) can never satisfy a post-#359
+    # request.
+    assert serializer.PROMPT_VERSION == "D-016"
 
 
 def test_prompts_preserve_transcript_language():
@@ -1793,3 +1795,219 @@ def test_serialize_strict_idless_host_stays_on_todays_path(
     item = out["working_context"]["recent_decisions"][0]
     assert "source_message_ids" not in item
     assert item["quote_verified"] is True
+
+
+# ---- #359: outcome claims ground in tool-result signals ----
+#
+# Capture-time grounding: transcript.py surfaces tool-result rows as "tool"
+# messages (Claude Code only — the one host with stable ids AND parseable
+# tool results). The extractor cites the signal's [mN] marker in
+# source_message_ids; the parse boundary validates it; ground_outcomes()
+# derives the code-owned advisory `grounded` field and narrowly downgrades
+# verbatim OUTCOME claims that cite no signal in a signal-bearing session.
+# Hosts without tool rows degrade to a no-op: no downgrade, no `grounded`.
+
+
+def _msgs_with_tool(n_conv=4):
+    out = []
+    for i in range(n_conv):
+        role = "user" if i % 2 == 0 else "assistant"
+        out.append({"role": role, "content": f"line {i} from {role}",
+                    "id": f"uuid-{i}"})
+    out.append({"role": "tool", "content": "2 passed, 0 failed - exit code 0",
+                "id": "uuid-tool", "tool_result": True})
+    return out
+
+
+def test_render_transcript_labels_tool_rows():
+    msgs = [{"role": "user", "content": "run it", "id": "u-1"},
+            {"role": "tool", "content": "ok", "id": "t-2", "tool_result": True},
+            {"role": "tool", "content": "boom", "id": "t-3",
+             "tool_result": True, "tool_error": True}]
+    assert serializer._render_transcript(msgs) == (
+        "[m1] user: run it\n\n[m2] tool: ok\n\n[m3] tool (error): boom")
+
+
+def test_signal_message_ids_collects_tool_result_ids():
+    msgs = _msgs_with_tool(4)
+    assert serializer.signal_message_ids(msgs) == {"uuid-tool"}
+    assert serializer.signal_message_ids([]) == set()
+    assert serializer.signal_message_ids(None) == set()
+    # role alone is not a signal — the flag is (markdown transcripts can have
+    # "tool:" role rows with no tool_result payload behind them).
+    assert serializer.signal_message_ids(
+        [{"role": "tool", "content": "x", "id": "t-1"}]) == set()
+
+
+def test_prompts_carry_outcome_grounding_rule():
+    assert "OUTCOME GROUNDING" in serializer.SERIALIZE_SYS
+    assert "tool" in serializer.SERIALIZE_SYS
+    # merge re-emits items: it must know signal ids can ride inferred items
+    # too, or it would silently drop them (rule 14 said "never on inferred").
+    assert "tool-result" in serializer.MERGE_SYS
+
+
+def test_sanitize_source_ids_keeps_signal_ids_on_inferred_items():
+    # The #358 rule was "binding rides the verbatim quote" — #359 adds the one
+    # exception: a pointer to a tool-result signal is valid on ANY item.
+    cp = _cp_one_decision({"text": "deploy succeeded", "trust": "inferred",
+                           "source_message_ids": ["m5"]})
+    serializer.sanitize_source_ids(cp, {"m4": "uuid-3", "m5": "uuid-tool"},
+                                   {"uuid-tool"})
+    item = cp["working_context"]["recent_decisions"][0]
+    assert item["source_message_ids"] == ["uuid-tool"]
+
+
+def test_sanitize_source_ids_still_drops_non_signal_ids_on_inferred_items():
+    cp = _cp_one_decision({"text": "d", "trust": "inferred",
+                           "source_message_ids": ["m4", "m5"]})
+    serializer.sanitize_source_ids(cp, {"m4": "uuid-3", "m5": "uuid-tool"},
+                                   {"uuid-tool"})
+    item = cp["working_context"]["recent_decisions"][0]
+    assert item["source_message_ids"] == ["uuid-tool"]  # m4 dropped, m5 kept
+
+
+def test_sanitize_source_ids_verbatim_item_keeps_quote_and_signal_ids():
+    cp = _cp_one_decision({"text": "deploy succeeded", "trust": "verbatim",
+                           "quote": "line 3 from assistant",
+                           "source_message_ids": ["m4", "m5"]})
+    serializer.sanitize_source_ids(cp, {"m4": "uuid-3", "m5": "uuid-tool"},
+                                   {"uuid-tool"})
+    item = cp["working_context"]["recent_decisions"][0]
+    assert item["source_message_ids"] == ["uuid-3", "uuid-tool"]
+
+
+def test_asserts_outcome_lexicon_is_conservative():
+    yes = ["deploy succeeded", "PR #12 merged", "tests pass now",
+           "the build failed", "released 0.19.0 to PyPI",
+           "all 42 tests passed", "serialization completed successfully"]
+    no = ["will be merged tomorrow", "should be deployed after review",
+          "plan to release on Friday", "whether the deploy succeeded",
+          "use the passed argument", "decide the merge strategy",
+          "el despliegue funciono bien"]  # non-English: honest no-op
+    for text in yes:
+        assert serializer._asserts_outcome(text), text
+    for text in no:
+        assert not serializer._asserts_outcome(text), text
+
+
+def test_ground_outcomes_marks_signal_backed_items_grounded():
+    cp = _cp_one_decision({"text": "deploy succeeded", "trust": "verbatim",
+                           "quote": "q", "source_message_ids":
+                           ["uuid-3", "uuid-tool"]})
+    cp["working_context"]["open_questions"] = [
+        {"text": "tests pass on CI too?", "trust": "inferred",
+         "source_message_ids": ["uuid-tool"]}]
+    serializer.ground_outcomes(cp, {"uuid-tool"})
+    assert cp["working_context"]["recent_decisions"][0]["grounded"] is True
+    assert cp["working_context"]["open_questions"][0]["grounded"] is True
+
+
+def test_ground_outcomes_downgrades_ungrounded_verbatim_outcome_claim():
+    cp = _cp_one_decision({"text": "deploy succeeded", "trust": "verbatim",
+                           "quote": "deploy succeeded"})
+    n = serializer.ground_outcomes(cp, {"uuid-tool"})
+    item = cp["working_context"]["recent_decisions"][0]
+    assert n == 1
+    assert item["trust"] == "inferred"
+    assert item["grounded"] is False
+    assert item["quote"] == "deploy succeeded"  # transcription stays honest
+
+
+def test_ground_outcomes_leaves_non_outcome_and_hedged_items_alone():
+    cp = _cp_one_decision({"text": "rename the module to carry.py",
+                           "trust": "verbatim", "quote": "q"})
+    cp["working_context"]["open_questions"] = [
+        {"text": "will be merged tomorrow", "trust": "verbatim", "quote": "q2"}]
+    n = serializer.ground_outcomes(cp, {"uuid-tool"})
+    assert n == 0
+    assert cp["working_context"]["recent_decisions"][0]["trust"] == "verbatim"
+    assert cp["working_context"]["open_questions"][0]["trust"] == "verbatim"
+    for item in serializer.iter_items(cp):
+        assert "grounded" not in item
+
+
+def test_ground_outcomes_is_a_noop_when_session_has_no_signals():
+    # Windsurf/Codex/hermes/markdown surface no tool rows: grounding is
+    # IMPOSSIBLE there, so an outcome claim keeps today's exact treatment —
+    # absence of evidence about the host is not evidence against the claim.
+    cp = _cp_one_decision({"text": "deploy succeeded", "trust": "verbatim",
+                           "quote": "q"})
+    n = serializer.ground_outcomes(cp, set())
+    item = cp["working_context"]["recent_decisions"][0]
+    assert n == 0
+    assert item["trust"] == "verbatim"
+    assert "grounded" not in item
+
+
+def test_ground_outcomes_strips_model_claimed_grounded():
+    # `grounded` is code-owned (#292 discipline): a model that emits it gets
+    # stomped — re-derived from validated pointers or removed, never trusted.
+    cp = _cp_one_decision({"text": "d", "trust": "inferred", "grounded": True})
+    cp["working_context"]["open_questions"] = [
+        {"text": "q", "trust": "inferred", "grounded": "yes"}]
+    serializer.ground_outcomes(cp, set())
+    for item in serializer.iter_items(cp):
+        assert "grounded" not in item
+
+
+def test_serialize_strict_grounds_cited_outcome_claim(
+        fake_chat_factory, monkeypatch):
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    chat = fake_chat_factory(_decision_checkpoint_json(
+        {"text": "deploy succeeded", "trust": "verbatim",
+         "quote": "line 3 from assistant",
+         "source_message_ids": ["m4", "m5"]}))
+    out = serializer.serialize_strict("S1", _msgs_with_tool(4), chat=chat)
+    item = out["working_context"]["recent_decisions"][0]
+    assert item["source_message_ids"] == ["uuid-3", "uuid-tool"]
+    assert item["trust"] == "verbatim"
+    assert item["quote_verified"] is True
+    assert item["grounded"] is True
+    # the extractor saw the tool row, marked as such
+    sent = chat.calls[0]["messages"][1]["content"]
+    assert "[m5] tool: 2 passed, 0 failed - exit code 0" in sent
+
+
+def test_serialize_strict_downgrades_uncited_outcome_claim(
+        fake_chat_factory, monkeypatch):
+    # Signals existed in this session; the claim cites none of them. The
+    # quote is a faithful transcription (quote_verified stays True) but the
+    # OUTCOME is unwitnessed: stored as inferred, marked grounded: false.
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    chat = fake_chat_factory(_decision_checkpoint_json(
+        {"text": "deploy succeeded", "trust": "verbatim",
+         "quote": "line 3 from assistant"}))
+    out = serializer.serialize_strict("S1", _msgs_with_tool(4), chat=chat)
+    item = out["working_context"]["recent_decisions"][0]
+    assert item["trust"] == "inferred"
+    assert item["grounded"] is False
+    assert item["quote_verified"] is True
+    assert item["quote"] == "line 3 from assistant"
+
+
+def test_serialize_strict_signal_free_host_keeps_todays_behavior(
+        fake_chat_factory, monkeypatch):
+    # No tool rows (Windsurf/Codex/markdown): outcome claims are untouched
+    # and unmarked — grounding degrades to a no-op, not a mass downgrade.
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    chat = fake_chat_factory(_decision_checkpoint_json(
+        {"text": "deploy succeeded", "trust": "verbatim",
+         "quote": "line 3 from assistant"}))
+    out = serializer.serialize_strict("S1", make_messages(6), chat=chat)
+    item = out["working_context"]["recent_decisions"][0]
+    assert item["trust"] == "verbatim"
+    assert "grounded" not in item
+
+
+def test_serialize_strict_min_messages_ignores_tool_rows(
+        fake_chat_factory, monkeypatch):
+    # Tool rows are evidence, not conversation — surfacing them must not let
+    # a 2-turn session sneak past the too-short gate.
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    msgs = _msgs_with_tool(2)  # 2 conversation turns + 1 tool row
+    msgs.append({"role": "tool", "content": "out", "id": "t-x",
+                 "tool_result": True})
+    chat = fake_chat_factory(_valid_checkpoint_json("S1"))
+    assert serializer.serialize("S1", msgs, chat=chat) is None
+    assert chat.calls == []

--- a/plugin/tests/test_transcript.py
+++ b/plugin/tests/test_transcript.py
@@ -348,6 +348,41 @@ def test_from_file_mixed_text_and_tool_result_row_keeps_text_only(tmp_path):
     ]
 
 
+def test_from_file_uuid_rows_without_tool_results_stay_dropped(tmp_path):
+    # Rows that reach the tool-result probe (uuid present, no text) but carry
+    # no tool payload keep pre-#359 behavior — dropped, never surfaced as a
+    # phantom signal: whitespace-only string content is not a block list, and
+    # a block list with no tool_result blocks (image-only row) holds nothing
+    # an outcome claim could ground in.
+    p = _write_jsonl(tmp_path / "session.jsonl", [
+        {"type": "user", "uuid": "u-1",
+         "message": {"role": "user", "content": "real question"}},
+        {"type": "user", "uuid": "e-2",
+         "message": {"role": "user", "content": "   "}},
+        {"type": "user", "uuid": "i-3",
+         "message": {"role": "user", "content": [
+             {"type": "image", "source": {"type": "base64", "data": "AAAA"}}]}},
+    ])
+    assert transcript.from_file(p) == [
+        {"role": "user", "content": "real question", "id": "u-1"},
+    ]
+
+
+def test_from_file_tool_result_row_skips_non_tool_blocks(tmp_path):
+    # A tool_result row can carry sibling non-tool blocks (an image attached
+    # to a screenshot result): they are skipped, the textual signal survives.
+    p = _write_jsonl(tmp_path / "session.jsonl", [
+        {"type": "user", "uuid": "t-1",
+         "message": {"role": "user", "content": [
+             {"type": "image", "source": {"type": "base64", "data": "AAAA"}},
+             {"type": "tool_result", "content": "deploy ok - exit code 0"}]}},
+    ])
+    assert transcript.from_file(p) == [
+        {"role": "tool", "content": "deploy ok - exit code 0", "id": "t-1",
+         "tool_result": True},
+    ]
+
+
 def test_from_session_returns_empty_when_hermes_unavailable(monkeypatch):
     # Force the hermes import seam to fail; must degrade to [] not raise.
     monkeypatch.setattr(transcript, "_load_session_db", lambda: None)

--- a/plugin/tests/test_transcript.py
+++ b/plugin/tests/test_transcript.py
@@ -242,6 +242,112 @@ def test_from_file_rows_without_usable_uuid_get_no_id_key(tmp_path):
     ]
 
 
+# ---- #359: tool-result rows surface as signal-bearing "tool" messages ----
+
+
+def test_from_file_claude_jsonl_surfaces_tool_result_rows(tmp_path):
+    # Pre-#359 the parser dropped tool_result rows as noise; a row carrying a
+    # stable uuid now surfaces as a "tool" message so outcome claims can
+    # ground in the concrete signal it holds (exit status, test summary).
+    p = _write_jsonl(tmp_path / "session.jsonl", [
+        {"type": "user", "uuid": "u-1",
+         "message": {"role": "user", "content": "run the tests"}},
+        {"type": "assistant", "uuid": "a-2",
+         "message": {"role": "assistant", "content": [
+             {"type": "text", "text": "running the suite"},
+             {"type": "tool_use", "name": "Bash", "input": {"command": "pytest"}}]}},
+        {"type": "user", "uuid": "t-3",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "content": "42 passed in 1.2s"}]},
+         "toolUseResult": {"stdout": "42 passed in 1.2s", "stderr": ""}},
+    ])
+    assert transcript.from_file(p) == [
+        {"role": "user", "content": "run the tests", "id": "u-1"},
+        {"role": "assistant", "content": "running the suite", "id": "a-2"},
+        {"role": "tool", "content": "42 passed in 1.2s", "id": "t-3",
+         "tool_result": True},
+    ]
+
+
+def test_from_file_tool_result_error_rows_carry_the_error_flag(tmp_path):
+    # is_error is the closest thing Claude Code exposes to an exit status on
+    # every tool result — preserve it so the failure signal survives.
+    p = _write_jsonl(tmp_path / "session.jsonl", [
+        {"type": "user", "uuid": "u-1",
+         "message": {"role": "user", "content": "deploy it"}},
+        {"type": "user", "uuid": "t-2",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "is_error": True,
+              "content": "Exit code 1\nfatal: deploy failed"}]}},
+    ])
+    assert transcript.from_file(p) == [
+        {"role": "user", "content": "deploy it", "id": "u-1"},
+        {"role": "tool", "content": "Exit code 1\nfatal: deploy failed",
+         "id": "t-2", "tool_result": True, "tool_error": True},
+    ]
+
+
+def test_from_file_tool_result_rows_without_uuid_stay_dropped(tmp_path):
+    # No uuid means no [mN] marker and no way to cite the row — grounding is
+    # pointer-based, so an id-less tool result stays dropped: byte-identical
+    # pre-#359 behavior for hosts without stable ids.
+    p = _write_jsonl(tmp_path / "session.jsonl", [
+        {"type": "user", "message": {"role": "user", "content": "hi"}},
+        {"type": "user", "message": {"role": "user", "content": [
+            {"type": "tool_result", "content": "198191d some output"}]}},
+    ])
+    assert transcript.from_file(p) == [{"role": "user", "content": "hi"}]
+
+
+def test_from_file_tool_result_flattens_block_lists_and_truncates(tmp_path):
+    # tool_result `content` can itself be a block list; flatten text blocks.
+    # Output is truncated to the cap — the signal (exit status, summary line)
+    # lives at the head, and full payloads would bloat the serialize prompt.
+    long_tail = "x" * 5000
+    p = _write_jsonl(tmp_path / "session.jsonl", [
+        {"type": "user", "uuid": "t-1",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "content": [
+                 {"type": "text", "text": "head line"},
+                 {"type": "text", "text": long_tail}]}]}},
+    ])
+    msgs = transcript.from_file(p)
+    assert len(msgs) == 1
+    content = msgs[0]["content"]
+    assert content.startswith("head line")
+    assert len(content) <= transcript._TOOL_RESULT_MAX_CHARS
+    assert msgs[0]["tool_result"] is True
+
+
+def test_from_file_tool_result_empty_output_gets_placeholder(tmp_path):
+    # An empty stdout on success is still a signal ("ran, said nothing") —
+    # a placeholder keeps the row alive instead of dropping the signal.
+    p = _write_jsonl(tmp_path / "session.jsonl", [
+        {"type": "user", "uuid": "t-1",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "content": ""}]}},
+    ])
+    assert transcript.from_file(p) == [
+        {"role": "tool", "content": "(no output)", "id": "t-1",
+         "tool_result": True},
+    ]
+
+
+def test_from_file_mixed_text_and_tool_result_row_keeps_text_only(tmp_path):
+    # A row carrying BOTH text and tool_result blocks keeps its pre-#359
+    # shape: the text wins, the tool payload is not split into a second
+    # message (live Claude Code rows are pure tool_result rows).
+    p = _write_jsonl(tmp_path / "session.jsonl", [
+        {"type": "user", "uuid": "u-1",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "content": "198191d output"},
+             {"type": "text", "text": "build the SessionEnd hook"}]}},
+    ])
+    assert transcript.from_file(p) == [
+        {"role": "user", "content": "build the SessionEnd hook", "id": "u-1"},
+    ]
+
+
 def test_from_session_returns_empty_when_hermes_unavailable(monkeypatch):
     # Force the hermes import seam to fail; must degrade to [] not raise.
     monkeypatch.setattr(transcript, "_load_session_db", lambda: None)


### PR DESCRIPTION
Closes #359

## What

Capture-time grounding for outcome claims, composing directly with #358's message-id binding:

- **transcript.py** now surfaces Claude Code JSONL rows whose only payload is `tool_result` blocks — previously dropped as noise — as `{"role": "tool", "content": <capped output>, "id": uuid, "tool_result": true}` messages, with `tool_error: true` when a block carries `is_error` (the closest thing Claude Code exposes to an exit status on every tool result; Bash failures additionally carry their `Exit code N` line inside the surfaced content). Output is capped at 500 chars — the signal (exit status, test summary, error line) lives at the head, and full payloads would bloat the serialize prompt. Only rows with a usable uuid qualify: grounding is pointer-based, and an id-less tool row cannot be cited.
- **Rendering**: tool rows render as `[mN] tool:` / `[mN] tool (error):` so the extractor sees which way the signal points.
- **Prompt (D-015 → D-016)**: new serialize rule 20 (OUTCOME GROUNDING) asks the extractor to add the evidencing tool-result message's `[mN]` marker to `source_message_ids` when an item's claim asserts a concrete outcome — alongside the quote's own marker for verbatim items. Merge rule 14 extended so signal ids survive merging, including on inferred items. The bump rotates the #48 chunk-cache key (pre-#359 cached extractions rendered no tool rows).
- **Parse boundary**: `sanitize_source_ids` gains a `signal_ids` parameter — an id resolving to a tool-result message is kept on ANY item (inferred and quote-less included); the #358 quote-binding rule is otherwise unchanged, and non-signal ids on inferred items still drop.
- **Verification**: signal ids never scope the #358 quote check (`scoped_haystack` gains `exclude`), and a scoped quote miss now drops only the disproven quote ids — the signal pointer survives. A full quote miss still drops everything (a downgraded quote is not evidence, and neither is its pointer).
- **`ground_outcomes()`** derives the code-owned advisory `grounded` field after verification; `daimon write-checkpoint` (#23 introspection path) strips model-claimed `grounded` the same way it strips claimed bindings. Tool rows never count toward the min-messages gate.

## Why

The hard trust-class gap (#185/#194 lineage): the model concludes X, X is false, and the transcript faithfully records the model saying X. Verbatim matching certifies transcription, not truth — "serialization succeeded" enters memory as fact and the next session builds on it. Host transcripts already carry the concrete signals (tool results, exit statuses) that could witness those claims; the parser discarded them. This slice binds outcome-shaped claims to those signals via the same follow-the-pointer mechanism #358 shipped: the signal pointer is a `source_message_ids` entry whose payload is a tool result. Items only ever store the POINTER (message id), never the signal payload — redaction semantics untouched.

Honest scope: a partial defense. Derived signals can also lie (#185 was tooling misreporting state with no LLM involved), so this narrows the gap rather than closing it; the receipts layer stays the tamper-evidence backstop.

## Semantics

Exactly when each thing happens, in `ground_outcomes()` (runs after `sanitize_source_ids` and `verify_quotes`, so it judges only code-validated, verification-surviving pointers — deterministic string ops, no LLM verdicts, per scars #4/#10):

1. **`grounded: true`** — the item carries at least one validated `source_message_ids` entry resolving to a tool-result message in this session's transcript. Any trust class, any section.
2. **Downgrade (`trust: "inferred"` + `grounded: false`)** — ALL of: the session surfaced at least one signal (Claude Code with tool rows), AND the item is `trust="verbatim"`, AND its `text` matches a conservative English-only outcome-assertion lexicon (succeeded / merged / deployed / released / shipped / tests pass / build failed / …) with no hedge/future/question marker (will / should / plan / whether / …), AND it cites no signal. The quote and its `quote_verified` stamp are KEPT: the transcription remains honestly attested — it is the outcome that is unwitnessed. This is the narrow reading of the issue's contract: only items whose claim IS the outcome downgrade.
3. **Nothing happens** — everything else: signal-free sessions (Windsurf, Codex, hermes, markdown — grounding is impossible there, so no downgrade and no `grounded` key ever appears; absence of evidence about the HOST is not evidence against the claim), non-outcome claims, hedged/planned/questioned outcomes, non-English outcome claims (the lexicon deliberately never guesses), and inferred outcome claims without signals (already their honest class).

`grounded` is code-owned (#292 discipline): a model-emitted value is stripped and re-derived on every path, `write-checkpoint` included. No new trust class and no new rendered tag — briefing trust literals stay pinned; `grounded` is additive and the briefing can surface it in a follow-up slice.

Per-host signal availability: **Claude Code** — full (stable uuids + parseable `tool_result` blocks + `is_error` flag; no universal numeric exit-code field exists in the JSONL, so `is_error` plus the in-content `Exit code N` line is the exit-status signal). **Windsurf Cascade / Codex / hermes / markdown** — no stable ids and/or no parseable tool results today: grounding degrades to a no-op, output byte-identical to pre-#359.

## Tests

23 new tests, TDD (red first — 23 failing — then implementation green). Suite: 1878 → 1901 passed (+23), 2 skipped, `uv run --all-extras pytest` green, `ruff check` clean.

- `test_transcript.py` — tool rows surfaced with id/flag/error-flag; id-less tool rows stay dropped (byte-identical pre-#359 output); block-list flattening + 500-char cap; empty-output placeholder; mixed text+tool rows keep text-only shape
- `test_serializer.py` — `tool (error)` rendering; `signal_message_ids` keyed on the flag, never the role; prompt-rule pins; D-016 pin; sanitize keeps signal ids on inferred items and both id kinds on verbatim items; outcome-lexicon conservatism (incl. hedges and non-English no-op); `ground_outcomes` grounding / downgrade / no-signal no-op / model-claim stripping; serialize_strict E2E for grounded, downgraded, signal-free-host, and min-messages-ignores-tool-rows paths
- `test_quote_verification.py` — signal-only bindings never scope the quote check; scoped miss keeps signal ids while dropping quote ids; scoped hit keeps both; full miss still drops everything
- `test_cli.py` — `write-checkpoint` strips model-claimed `grounded`

The bench `CarryChat` fake scans transcript turns only (system prompt excluded since #361); rule 20 lives in the system prompt and introduces no `*marker` user-content tokens — `test_bench_carry.py` stays green.

Follow-ups flagged (not in this slice): briefing surfacing of `grounded` deserves its own slice; `carry.py`'s verbatim-freeze path replaces a twin's quote+ids but leaves the twin's own `grounded` verdict in place — worth aligning when `grounded` becomes render-visible. #360 not touched.
