### PR TITLE
feat(heal): perspective-diverse extraction as the escalation tier for failed serializes

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -192,11 +192,17 @@ def _attach_serialize_log_handler() -> None:
     pkg_log.setLevel(logging.INFO)
 
 
-def _run_serialize(transcript_path: Path, project: str | None) -> int:
+def _run_serialize(transcript_path: Path, project: str | None,
+                   escalate: bool = False) -> int:
     """Serialize one transcript to a checkpoint routed to `project` (used AS-IS;
     None => global pointer only, NO cwd fallback). The caller decides routing —
     this never calls _resolve_project, so `heal` can route to the FAILED
     session's project rather than the heal-time cwd.
+
+    `escalate` (#360): forwarded to serialize_strict — perspective-diverse
+    extraction instead of the default single shape. Only `heal` may pass True
+    (behind DAIMON_HEAL_ESCALATION); the hook/`serialize` command paths never
+    do, so escalation cost scales with failure, not usage.
 
     Every result line is built once into `msg`, printed, AND logged via
     _append_serialize_log — the logged string is byte-identical to the printed
@@ -254,7 +260,8 @@ def _run_serialize(transcript_path: Path, project: str | None) -> int:
     deadline = start + config.timeout_seconds()
     try:
         checkpoint = serializer.serialize_strict(
-            session_id, messages, chat=_chat, deadline=deadline)
+            session_id, messages, chat=_chat, deadline=deadline,
+            escalate=escalate)
     except serializer.TooShortError as exc:
         msg = f"skipped serialize for {session_id}: {exc}"
         print(msg)
@@ -1639,8 +1646,13 @@ def _cmd_heal(args) -> int:
     # sessions healable) — the retry marker still needs a prior (#49).
     prior = (t["line"] or "hung: spawned, no result").split(" (transcript:")[0]
     _append_retry_log(t["sid"], prior)
+    # #360: the default retry re-runs the SAME extraction shape that already
+    # failed. Opt-in escalation (DAIMON_HEAL_ESCALATION) re-serializes from
+    # multiple perspectives instead — heal-path only, so the extra token cost
+    # scales with failure, never with usage.
+    escalate = config.heal_escalation_enabled()
     with render.working(f"healing {t['sid']} — re-serializing transcript"):
-        return _run_serialize(transcript_path, t["project"])
+        return _run_serialize(transcript_path, t["project"], escalate=escalate)
 
 
 # ---- team: sidecar private-repo sync (#113) ----

--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -498,6 +498,17 @@ def scene_traces_enabled() -> bool:
     return _flag("DAIMON_SCENE_TRACES")
 
 
+def heal_escalation_enabled() -> bool:
+    """Opt-in (#360): `daimon heal` escalates its re-serialize to
+    perspective-diverse extraction — N passes over the transcript from
+    distinct perspectives, merged by the ordinary merge pass. Multiplies the
+    LLM token cost of a heal by ~the perspective count on the user's own
+    backend, so it ships default OFF (#318 flag precedent). Gates the HEAL
+    path only — the session-end default serialize never escalates, flag or
+    no flag."""
+    return _flag("DAIMON_HEAL_ESCALATION")
+
+
 def llm_no_cache() -> bool:
     """Per-request bypass of gateway response caching (LiteLLM `no-cache`) —
     needed when a cached bad response pins a failure or when runs must be

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -323,6 +323,76 @@ Schema shape:
   "worker_queue": []
 }"""
 
+# ---- #360: perspective-diverse escalation (heal-path only) ----
+#
+# The default serialize is deliberately ONE shape: chunk fan-out under one
+# prompt, one merge pass. When it fails, heal used to retry that same shape —
+# same perspective, same blind spots, just again (now with cached chunks,
+# #48). Escalation is the heal tier: N extraction passes over the same
+# transcript from DISTINCT perspectives (stage 1), combined by the ordinary
+# merge pass (stage 2). The merge model is a PRODUCER, never a verifier
+# (scar #10): everything still crosses the existing deterministic gates —
+# sanitize_source_ids, verify_quotes, ground_outcomes, redaction downstream —
+# byte-for-byte unchanged.
+#
+# Each addendum is APPENDED to the full base prompt (composing with the #317
+# scene appendix), so every extraction rule — quote discipline, source
+# message ids, outcome grounding — stays in force in every pass. Triggered
+# only via serialize_strict(escalate=True), which only cli's heal path passes
+# (behind DAIMON_HEAL_ESCALATION): token cost scales with failure, never with
+# usage.
+
+ESCALATION_PERSPECTIVES = (
+    ("decisions-and-outcomes", """
+
+EXTRACTION PERSPECTIVE — DECISIONS AND OUTCOMES: this pass is one of several
+independent passes over the same transcript, each reading from a different
+angle; other passes cover open questions and artifacts in depth. YOUR angle:
+be EXHAUSTIVE on recent_decisions — explicit user choices, terse
+ratifications, [Fix]/[Diagnosis] items, implementation-level decisions — and
+on claims that assert an outcome (succeeded, failed, merged, deployed, tests
+green), each with its tool-result evidence cited per rule 20. Still populate
+every schema section (the shape is mandatory) and extract items outside your
+angle when they are clearly load-bearing, but spend your effort here. Every
+rule above stays in force."""),
+    ("open-loops-and-questions", """
+
+EXTRACTION PERSPECTIVE — OPEN LOOPS AND QUESTIONS: this pass is one of
+several independent passes over the same transcript, each reading from a
+different angle; other passes cover decisions and artifacts in depth. YOUR
+angle: be EXHAUSTIVE on open_questions and uncertainties — things left
+genuinely unresolved, work the assistant said it would do "next" or "after",
+verifications that never happened, optional follow-ups explicitly flagged,
+stated doubts, and anything whose answer may have changed outside the session
+(mark external_state per rule 10). Still populate every schema section (the
+shape is mandatory) and extract items outside your angle when they are
+clearly load-bearing, but spend your effort here. Every rule above stays in
+force."""),
+    ("artifacts-and-identifiers", """
+
+EXTRACTION PERSPECTIVE — ARTIFACTS AND IDENTIFIERS: this pass is one of
+several independent passes over the same transcript, each reading from a
+different angle; other passes cover decisions and open questions in depth.
+YOUR angle: be EXHAUSTIVE about concrete artifacts and their EXACT
+identifiers — repos as owner/name, issues/PRs as owner/name#123 or full
+URLs, file paths, function and symbol names, commit hashes, version numbers,
+package names with versions, ports, counts and ranges — copied exactly per
+rules 13 and 18 and attached to the items they belong to. Never invent an
+identifier the transcript does not contain. Still populate every schema
+section (the shape is mandatory) and extract items outside your angle when
+they are clearly load-bearing, but spend your effort here. Every rule above
+stays in force."""),
+)
+
+
+def escalation_systems() -> list[tuple[str, str]]:
+    """(name, full system prompt) per perspective — the base serialize prompt
+    (scene appendix included when flagged) plus that perspective's addendum,
+    so escalation composes with #317 instead of forking it."""
+    base = _serialize_sys()
+    return [(name, base + addendum) for name, addendum in ESCALATION_PERSPECTIVES]
+
+
 _TRUST_CLASSES = {"verbatim", "inferred"}
 
 
@@ -1049,12 +1119,19 @@ def _chunk_cache_dir():
     return config.checkpoint_dir() / ".chunk-cache"
 
 
-def _chunk_cache_key(chunk_text: str) -> str:
+def _chunk_cache_key(chunk_text: str, system: str | None = None) -> str:
+    # `system` (#360): the actual system prompt this extraction runs under;
+    # defaults to the plain serialize prompt. Escalation's perspective passes
+    # send DIFFERENT prompts over the same chunks — hashing the per-pass
+    # prompt gives each perspective its own cache lane (no cross-
+    # contamination) while a re-escalation reuses its own prior partials.
     try:
         backend = configure.resolved_backend()
     except Exception:
         backend = "unknown"
-    sys_hash = hashlib.sha256(_serialize_sys().encode("utf-8")).hexdigest()[:16]
+    if system is None:
+        system = _serialize_sys()
+    sys_hash = hashlib.sha256(system.encode("utf-8")).hexdigest()[:16]
     stamp = (f"v1\x00{backend}\x00{config.llm_model() or ''}"
              f"\x00{config.llm_temperature()}\x00{PROMPT_VERSION}"
              f"\x00{sys_hash}\x00")
@@ -1237,7 +1314,8 @@ def _stamp_llm_provenance(checkpoint: dict) -> None:
         checkpoint["llm_model"] = model
 
 
-def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dict:
+def serialize_strict(session_id: str, messages, chat=None, deadline=None,
+                     escalate=False) -> dict:
     """Transcript -> validated checkpoint, or a named SerializeError.
 
     `chat` is an injectable callable (messages, **kwargs) -> str; defaults to the
@@ -1248,6 +1326,13 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
 
     Rendered transcripts over DAIMON_CHUNK_LINES go chunked (armC): per-chunk
     D-007 serialize -> 01c merge -> validate. Shorter ones stay single-pass.
+
+    `escalate` (#360, heal-path only): run stage 1 as one extraction pass per
+    ESCALATION_PERSPECTIVES entry over every chunk (distinct prompts, own
+    #48 cache lanes), stage 2 as the ordinary merge, then the unchanged
+    deterministic gates. The wave plan counts every perspective pass, so the
+    deadline scales with the real call count (#314 machinery, no new budget).
+    Default False keeps this function byte-identical to today.
     """
     if chat is None:
         chat = llm.chat
@@ -1272,14 +1357,22 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
     # guaranteed a starved merge on slow gateways, so scale the total by the
     # wave count. Per-call socket timeouts stay capped at the base budget
     # (llm.py), so no single request grows past gateway ceilings (scar #17).
-    if deadline is not None and len(chunks) > 1:
-        waves = _plan_waves(len(chunks), config.chunk_concurrency(),
+    # #360: an escalated run makes one call per (perspective x chunk) — the
+    # wave plan must count them all, or the merge starts starved exactly the
+    # way #314 fixed for chunks. Same machinery, no new budget dimension.
+    n_units = len(chunks) * (len(ESCALATION_PERSPECTIVES) if escalate else 1)
+    if deadline is not None and n_units > 1:
+        waves = _plan_waves(n_units, config.chunk_concurrency(),
                             config.merge_group_size())
         if waves > 1:
             extra = (waves - 1) * config.timeout_seconds()
             deadline += extra
-            log.info("chunked call plan: %d wave(s) — deadline extended by %ds (#314)",
-                     waves, extra)
+            if escalate:
+                log.info("escalated call plan (#360): %d wave(s) — deadline "
+                         "extended by %ds", waves, extra)
+            else:
+                log.info("chunked call plan: %d wave(s) — deadline extended by %ds (#314)",
+                         waves, extra)
 
     # Validation-failure retry note (#118): one resample with a non-identical
     # request. Occasional invalid output (the live case: quote inlined into a
@@ -1296,8 +1389,61 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None) -> dic
     )
     partials: list | None = None
 
+    def _produce_escalated_partials() -> list:
+        # #360 stage 1: one extraction pass per (chunk, perspective). Jobs are
+        # CHUNK-MAJOR — a later chunk's passes sit later in the partial list —
+        # so MERGE_SYS's chronology rules (4/9, and the oldest-first
+        # recent_decisions order the briefing's decision cap depends on,
+        # scar #6) still see partials in session order.
+        systems = escalation_systems()
+        log.info("escalated serialize (#360): %d perspective(s) x %d chunk(s)",
+                 len(systems), len(chunks))
+        jobs = [(i, chunk_text, name, system)
+                for i, chunk_text in enumerate(chunks)
+                for name, system in systems]
+
+        def _one_pass(job):
+            i, chunk_text, name, system = job
+            # Own #48 cache lane per perspective (the key hashes the actual
+            # system prompt): a re-escalation reuses its prior paid-for
+            # passes; the default lane is never read or written here.
+            key = _chunk_cache_key(chunk_text, system)
+            cached = _load_chunk_cache(key)
+            if cached is not None:
+                log.info("perspective %s: chunk %d/%d reused cached extraction (#48)",
+                         name, i + 1, len(chunks))
+                return cached
+            if len(chunks) == 1:
+                body = f"TRANSCRIPT:\n{chunk_text}"
+            else:
+                body = f"TRANSCRIPT (chunk {i + 1} of {len(chunks)}):\n{chunk_text}"
+            t0 = time.monotonic()
+            partial = _call_and_parse(
+                chat, system,
+                f"session_id: {session_id}\n\n{body}",
+                deadline, f"perspective {name}, chunk {i + 1} of {len(chunks)}",
+            )
+            log.info("perspective %s: chunk %d/%d done in %.0fs",
+                     name, i + 1, len(chunks), time.monotonic() - t0)
+            _save_chunk_cache(key, partial)
+            return partial
+
+        workers = min(config.chunk_concurrency(), len(jobs))
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            # pool.map preserves input order — chunk-major stays chronological.
+            return list(pool.map(_one_pass, jobs))
+
     def _produce(note: str) -> dict:
         nonlocal partials
+        if escalate:
+            # #360 stage 2: the ordinary merge combines the perspective
+            # reports — a PRODUCER of one candidate checkpoint, never a
+            # verifier (scar #10); the deterministic gates below are the only
+            # judges. Retry (`note`) re-runs ONLY the merge, like chunked.
+            if partials is None:
+                partials = _produce_escalated_partials()
+            return _merge_partials(chat, session_id, list(partials), deadline,
+                                   attempt_note=note)
         if len(chunks) == 1:
             log.info("single-pass serialize: %d lines", len(transcript_text.splitlines()))
             return _call_and_parse(

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -987,6 +987,91 @@ def test_cli_heal_noop_when_no_log(tmp_checkpoint_dir, tmp_log_dir, fake_chat_fa
     assert chat.calls == []
 
 
+# ---- #360: perspective-diverse escalation on the heal path (opt-in) ----
+
+
+def test_cli_heal_escalates_when_flag_on(
+    tmp_checkpoint_dir, tmp_log_dir, fake_chat_factory, monkeypatch
+):
+    # DAIMON_HEAL_ESCALATION=1: heal's re-serialize runs the escalation tier —
+    # one extraction pass per perspective plus the ordinary merge.
+    from daimon_briefing import serializer, store
+
+    stem = "sample_transcript"
+    transcript = FIXTURES / "sample_transcript.md"
+    _write_log(
+        tmp_log_dir,
+        [
+            f"2026-06-10T12:00:00Z session-end: spawned serialize for {stem} (reason: exit, project: /p/A)",
+            f"error: LLM call failed: bad temperature (transcript: {transcript}) after 1s",
+        ],
+    )
+    chat = fake_chat_factory([_valid_json()] * 4)  # 3 perspectives + 1 merge
+    monkeypatch.setattr(cli, "_chat", chat)
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    monkeypatch.setenv("DAIMON_HEAL_ESCALATION", "1")
+    monkeypatch.setenv("DAIMON_CHUNK_CONCURRENCY", "1")
+    # scar #8: merge-call count is hierarchical — pin K so 3 partials = 1 merge
+    monkeypatch.setenv("DAIMON_MERGE_GROUP_SIZE", "100")
+
+    rc = cli.main(["heal"])
+    assert rc == 0
+    assert store.read_checkpoint(stem) is not None
+    assert len(chat.calls) == 4
+    for c in chat.calls[:3]:
+        assert "EXTRACTION PERSPECTIVE" in c["messages"][0]["content"]
+    assert chat.calls[3]["messages"][0]["content"] == serializer.MERGE_SYS
+
+
+def test_cli_heal_flag_off_stays_byte_identical(
+    tmp_checkpoint_dir, tmp_log_dir, fake_chat_factory, monkeypatch
+):
+    # Flag off (the default): heal keeps today's exact shape — one single-pass
+    # call under the plain serialize prompt, no perspective text anywhere.
+    from daimon_briefing import serializer, store
+
+    stem = "sample_transcript"
+    transcript = FIXTURES / "sample_transcript.md"
+    _write_log(
+        tmp_log_dir,
+        [
+            f"2026-06-10T12:00:00Z session-end: spawned serialize for {stem} (reason: exit, project: /p/A)",
+            f"error: LLM call failed: bad temperature (transcript: {transcript}) after 1s",
+        ],
+    )
+    chat = fake_chat_factory(_valid_json())
+    monkeypatch.setattr(cli, "_chat", chat)
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    monkeypatch.delenv("DAIMON_HEAL_ESCALATION", raising=False)
+    monkeypatch.delenv("DAIMON_SCENE_TRACES", raising=False)
+
+    rc = cli.main(["heal"])
+    assert rc == 0
+    assert store.read_checkpoint(stem) is not None
+    assert len(chat.calls) == 1
+    assert chat.calls[0]["messages"][0]["content"] == serializer.SERIALIZE_SYS
+
+
+def test_cli_serialize_never_escalates_even_with_flag_on(
+    tmp_checkpoint_dir, fake_chat_factory, monkeypatch
+):
+    # The trigger is heal-path ONLY: the session-end default (`daimon
+    # serialize`) never escalates, flag or no flag — token cost scales with
+    # failure, not usage.
+    from daimon_briefing import serializer
+
+    chat = fake_chat_factory(_valid_json())
+    monkeypatch.setattr(cli, "_chat", chat)
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    monkeypatch.setenv("DAIMON_HEAL_ESCALATION", "1")
+    monkeypatch.delenv("DAIMON_SCENE_TRACES", raising=False)
+
+    rc = cli.main(["serialize", str(FIXTURES / "sample_transcript.md")])
+    assert rc == 0
+    assert len(chat.calls) == 1
+    assert chat.calls[0]["messages"][0]["content"] == serializer.SERIALIZE_SYS
+
+
 # ---- #219: live progress indicator (render.working) around heal's re-serialize ----
 
 
@@ -2122,7 +2207,7 @@ def test_cmd_heal_real_serializes_target(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "_heal_plan", lambda text, now, force=False: plan)
     monkeypatch.setattr(cli, "_append_retry_log", lambda *a, **k: None)
     seen = {}
-    monkeypatch.setattr(cli, "_run_serialize", lambda path, proj: seen.update(path=path, proj=proj) or 0)
+    monkeypatch.setattr(cli, "_run_serialize", lambda path, proj, escalate=False: seen.update(path=path, proj=proj) or 0)
 
     class A:
         dry_run = False
@@ -4332,7 +4417,7 @@ def test_heal_hung_target_does_not_crash(tmp_checkpoint_dir, tmp_log_dir, tmp_pa
         f"(project: /p/H) (transcript: {transcript})",
     ])
     ran = {}
-    monkeypatch.setattr(cli, "_run_serialize", lambda p, proj: ran.update(p=p) or 0)
+    monkeypatch.setattr(cli, "_run_serialize", lambda p, proj, escalate=False: ran.update(p=p) or 0)
     monkeypatch.setattr(cli.time, "time",
                         lambda: datetime(2026, 7, 3, 23, 0, 0, tzinfo=timezone.utc).timestamp())
     rc = cli.main(["heal"])

--- a/plugin/tests/test_config.py
+++ b/plugin/tests/test_config.py
@@ -563,6 +563,19 @@ def test_scene_traces_flag_on(monkeypatch):
     assert config.scene_traces_enabled() is True
 
 
+# ---- #360: heal escalation flag ----
+
+
+def test_heal_escalation_default_off(monkeypatch):
+    monkeypatch.delenv("DAIMON_HEAL_ESCALATION", raising=False)
+    assert config.heal_escalation_enabled() is False
+
+
+def test_heal_escalation_flag_on(monkeypatch):
+    monkeypatch.setenv("DAIMON_HEAL_ESCALATION", "1")
+    assert config.heal_escalation_enabled() is True
+
+
 # ---- #341: DAIMON_FALLBACK_MIN_SECONDS ---------------------------------------
 
 

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -2026,3 +2026,184 @@ def test_serialize_strict_min_messages_ignores_tool_rows(
     chat = fake_chat_factory(_valid_checkpoint_json("S1"))
     assert serializer.serialize("S1", msgs, chat=chat) is None
     assert chat.calls == []
+
+
+# ---- #360: perspective-diverse escalation (heal-path only) ----
+#
+# Escalation is the heal tier for failed serializes: N extraction passes over
+# the same transcript from distinct perspectives, one ordinary merge, then the
+# UNCHANGED deterministic gates (sanitize_source_ids, verify_quotes,
+# ground_outcomes, redaction downstream). The merge model is a producer, never
+# a verifier (scar #10). Only serialize_strict(escalate=True) triggers it —
+# the session-end default path never escalates.
+
+
+def test_escalation_perspectives_are_three_distinct_lanes():
+    names = [name for name, _ in serializer.ESCALATION_PERSPECTIVES]
+    assert names == ["decisions-and-outcomes", "open-loops-and-questions",
+                     "artifacts-and-identifiers"]
+    systems = [system for _, system in serializer.escalation_systems()]
+    assert len(set(systems)) == 3
+    for system in systems:
+        # each pass keeps the FULL base prompt (all rules stay in force) and
+        # appends its perspective — never replaces the extraction contract
+        assert system.startswith(serializer.SERIALIZE_SYS)
+        assert "EXTRACTION PERSPECTIVE" in system
+
+
+def test_base_prompt_untouched_by_escalation():
+    # flag-off / non-escalated path must stay byte-identical: the perspective
+    # text lives only in the escalation addenda, never in the base constants.
+    assert "EXTRACTION PERSPECTIVE" not in serializer.SERIALIZE_SYS
+    assert "EXTRACTION PERSPECTIVE" not in serializer.MERGE_SYS
+
+
+def test_escalated_single_chunk_runs_one_pass_per_perspective_plus_merge(
+        fake_chat_factory, monkeypatch):
+    monkeypatch.setenv("DAIMON_CHUNK_CONCURRENCY", "1")
+    # scar #8: merge-call count is hierarchical — pin K so 3 partials = 1 merge
+    monkeypatch.setenv("DAIMON_MERGE_GROUP_SIZE", "100")
+    chat = fake_chat_factory(
+        [_valid_checkpoint_json(f"p{i}") for i in range(3)]
+        + [_valid_checkpoint_json("merged")])
+    ckpt = serializer.serialize_strict(
+        "S1", make_messages(20), chat=chat, escalate=True)
+    assert ckpt is not None and ckpt["session_id"] == "S1"
+    assert len(chat.calls) == 4
+    extraction_systems = [c["messages"][0]["content"] for c in chat.calls[:3]]
+    assert len(set(extraction_systems)) == 3  # three DISTINCT perspectives
+    for system in extraction_systems:
+        assert "EXTRACTION PERSPECTIVE" in system
+    # stage 2 is the ordinary merge — same MERGE_SYS producer, no new verifier
+    assert chat.calls[3]["messages"][0]["content"] == serializer.MERGE_SYS
+
+
+def test_serialize_strict_default_never_escalates(fake_chat_factory, monkeypatch):
+    # The session-end default path (no escalate arg) is byte-identical to
+    # today: one single-pass call under the plain serialize prompt.
+    monkeypatch.delenv("DAIMON_SCENE_TRACES", raising=False)
+    chat = fake_chat_factory(_valid_checkpoint_json("S1"))
+    assert serializer.serialize_strict("S1", make_messages(20), chat=chat) is not None
+    assert len(chat.calls) == 1
+    assert chat.calls[0]["messages"][0]["content"] == serializer.SERIALIZE_SYS
+
+
+def test_escalated_result_still_crosses_deterministic_gates(
+        fake_chat_factory, monkeypatch):
+    # The merge model is a PRODUCER, never a verifier: a quote the transcript
+    # does not contain must still be downgraded by verify_quotes, exactly as
+    # on the default path.
+    monkeypatch.setenv("DAIMON_CHUNK_CONCURRENCY", "1")
+    monkeypatch.setenv("DAIMON_MERGE_GROUP_SIZE", "100")
+    merged = json.loads(_valid_checkpoint_json("S1"))
+    merged["working_context"]["recent_decisions"][0] = {
+        "text": "d", "trust": "verbatim",
+        "quote": "this sentence appears nowhere in the transcript"}
+    chat = fake_chat_factory(
+        [_valid_checkpoint_json(f"p{i}") for i in range(3)]
+        + [json.dumps(merged)])
+    ckpt = serializer.serialize_strict(
+        "S1", make_messages(20), chat=chat, escalate=True)
+    item = ckpt["working_context"]["recent_decisions"][0]
+    assert item["trust"] == "inferred"
+    assert item["quote_verified"] is False
+
+
+def test_escalated_strips_model_supplied_code_owned_keys(
+        fake_chat_factory, monkeypatch):
+    monkeypatch.setenv("DAIMON_CHUNK_CONCURRENCY", "1")
+    monkeypatch.setenv("DAIMON_MERGE_GROUP_SIZE", "100")
+    merged = json.loads(_valid_checkpoint_json("S1"))
+    merged["format_version"] = "D-999-spoofed"
+    chat = fake_chat_factory(
+        [_valid_checkpoint_json(f"p{i}") for i in range(3)]
+        + [json.dumps(merged)])
+    ckpt = serializer.serialize_strict(
+        "S1", make_messages(20), chat=chat, escalate=True)
+    assert "format_version" not in ckpt
+
+
+def test_escalated_too_short_still_skips(fake_chat_factory):
+    chat = fake_chat_factory(_valid_checkpoint_json("S1"))
+    with pytest.raises(serializer.TooShortError):
+        serializer.serialize_strict("S1", make_messages(4), chat=chat,
+                                    escalate=True)
+    assert chat.calls == []
+
+
+def test_chunk_cache_key_gives_each_perspective_its_own_lane():
+    # #48 keying already hashes the system prompt; passing each perspective's
+    # actual prompt must yield distinct, stable lanes — and the default lane
+    # (no system arg) must be byte-identical to hashing the plain prompt.
+    base = serializer._chunk_cache_key("chunk text")
+    assert base == serializer._chunk_cache_key(
+        "chunk text", system=serializer._serialize_sys())
+    keys = [serializer._chunk_cache_key("chunk text", system=system)
+            for _, system in serializer.escalation_systems()]
+    assert len(set(keys)) == 3          # perspectives never cross-contaminate
+    assert base not in keys             # nor bleed into the default lane
+    assert keys == [serializer._chunk_cache_key("chunk text", system=system)
+                    for _, system in serializer.escalation_systems()]  # stable
+
+
+def test_escalated_reheal_reuses_own_cached_partials(
+        fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
+    # A re-escalation must reuse its OWN prior perspective partials (#48):
+    # second run pays only the merge.
+    monkeypatch.setenv("DAIMON_CHUNK_CONCURRENCY", "1")
+    monkeypatch.setenv("DAIMON_MERGE_GROUP_SIZE", "100")
+    messages = make_messages(20)
+    chat1 = fake_chat_factory(
+        [_valid_checkpoint_json(f"p{i}") for i in range(3)]
+        + [_valid_checkpoint_json("merged")])
+    assert serializer.serialize_strict(
+        "S1", messages, chat=chat1, escalate=True) is not None
+    assert len(list((tmp_checkpoint_dir / ".chunk-cache").glob("*.json"))) == 3
+
+    chat2 = fake_chat_factory([_valid_checkpoint_json("merged2")])
+    assert serializer.serialize_strict(
+        "S1", messages, chat=chat2, escalate=True) is not None
+    assert len(chat2.calls) == 1  # merge only — every perspective pass reused
+
+
+def test_escalated_run_never_reuses_default_lane_chunks(
+        fake_chat_factory, monkeypatch, tmp_checkpoint_dir):
+    # A prior DEFAULT chunked run's cached extractions were produced under a
+    # different prompt — the escalated run must not consume them (and vice
+    # versa): perspective passes pay their own calls.
+    messages, n = _force_two_chunks(monkeypatch)
+    chat1 = fake_chat_factory(
+        [_valid_checkpoint_json(f"c{i}") for i in range(n)]
+        + [_valid_checkpoint_json("merged")])
+    assert serializer.serialize_strict("S1", messages, chat=chat1) is not None
+    assert len(list((tmp_checkpoint_dir / ".chunk-cache").glob("*.json"))) == n
+
+    chat2 = fake_chat_factory(
+        [_valid_checkpoint_json(f"e{i}") for i in range(3 * n)]
+        + [_valid_checkpoint_json("merged2")])
+    assert serializer.serialize_strict(
+        "S1", messages, chat=chat2, escalate=True) is not None
+    assert len(chat2.calls) == 3 * n + 1  # no cross-lane reuse
+
+
+def test_escalated_deadline_scales_by_perspective_wave_plan(
+        fake_chat_factory, monkeypatch):
+    # An escalated run makes MORE calls — the wave plan must count every
+    # perspective pass (#314 machinery, no new budget): 1 chunk x 3
+    # perspectives at concurrency 1 = 3 chunk waves + 1 merge wave = 4 waves,
+    # so the deadline extends by (4-1) x DAIMON_TIMEOUT.
+    import time as _t
+    monkeypatch.setenv("DAIMON_TIMEOUT", "100")
+    monkeypatch.setenv("DAIMON_CHUNK_CONCURRENCY", "1")
+    monkeypatch.setenv("DAIMON_MERGE_GROUP_SIZE", "100")
+    chat = fake_chat_factory(
+        [_valid_checkpoint_json(f"p{i}") for i in range(3)]
+        + [_valid_checkpoint_json("merged")])
+    given = _t.monotonic() + 100
+    assert serializer.serialize_strict(
+        "S1", make_messages(20), chat=chat, escalate=True,
+        deadline=given) is not None
+    seen = {c["kwargs"].get("deadline") for c in chat.calls}
+    assert len(seen) == 1  # every call shares ONE scaled deadline
+    scaled = seen.pop()
+    assert scaled >= given + 250  # ~300s extension for 4 waves


### PR DESCRIPTION
Closes #360

## What

Perspective-diverse extraction as the opt-in escalation tier for heal's re-serialize. With `DAIMON_HEAL_ESCALATION=1`, `daimon heal` runs stage 1 as one extraction pass per perspective (`decisions-and-outcomes`, `open-loops-and-questions`, `artifacts-and-identifiers`) over every chunk — each pass is the FULL base serialize prompt plus a perspective addendum, so quote discipline, source-message-id citation (#358) and outcome-signal citation (#359) stay in force in every pass — and stage 2 as the ordinary hierarchical merge. The merged candidate then crosses the existing deterministic gates byte-for-byte unchanged: `sanitize_source_ids`, `verify_quotes` (id-resolve + whole-transcript fallback), `ground_outcomes`, redaction at write.

## Why

Serialize runs at every session end, so the default path is deliberately one cheap shape: chunk fan-out under one prompt, one merge. When it fails, heal retried the exact same shape — same perspective, same blind spots — just again (now with cached chunks, #48). Escalation gives the retry a genuinely different read of the transcript while keeping every trust guarantee: the merge model is a producer, never a verifier (scar #10) — the final gate stays a matcher it cannot argue with.

## Tests

16 new tests (1904 → 1920 passed, 2 skipped; full suite green, ruff clean):

- serializer: 3 distinct perspective lanes, each prefixed by the full base prompt; base `SERIALIZE_SYS`/`MERGE_SYS` contain no perspective text (flag-off byte-identical); escalated single-chunk run = 3 extraction passes + ordinary `MERGE_SYS` merge; default `serialize_strict` call shape unchanged; escalated output still downgraded by `verify_quotes` on a fabricated quote and still stripped of model-supplied code-owned keys; too-short gate fires before any escalated call; per-perspective #48 cache lanes distinct, stable, and disjoint from the default lane; re-escalation reuses its own cached partials (merge-only second run); escalated run never consumes default-lane chunks; deadline scales by the perspective-aware wave plan (1 chunk x 3 perspectives at concurrency 1 = 4 waves).
- cli: heal with flag on escalates (3 perspective systems + merge); heal with flag off stays byte-identical (one call, plain `SERIALIZE_SYS`); `daimon serialize` never escalates even with the flag set.
- config: `DAIMON_HEAL_ESCALATION` default off / flag on.

Merge-call counts are pinned via `DAIMON_MERGE_GROUP_SIZE` (scar #8) and fan-out via `DAIMON_CHUNK_CONCURRENCY=1` for scripted-chat determinism.

## Design decisions

- **Trigger = heal-path hard failures only, no thin-detection heuristic.** Escalation fires only from `_cmd_heal` → `_run_serialize(escalate=...)` — exactly the ledger's `healable` set (error/hung spawn with a transcript on disk, one-retry-ever, `--force` unchanged). No signal about checkpoint thinness survives a *successful* serialize into the ledger today, so any "thin" threshold would have been an invented heuristic; per the issue, thin-detection is scoped out as a follow-up. The session-end hook and `daimon serialize` paths never pass `escalate` — token cost scales with failure, not usage.
- **Env flag default OFF** (`DAIMON_HEAL_ESCALATION`, #318 `DAIMON_SCENE_TRACES` precedent): a heal costs ~3x the default retry's extraction calls on the user's own backend, so it must be a deliberate opt-in. Flag-off is test-pinned byte-identical: base prompts untouched, same call count, same systems, same cache keys.
- **No PROMPT_VERSION bump (D-016 stays).** The perspective addenda are new prompt surfaces appended only on the escalated path; the base serialize prompt and merge prompt are byte-unchanged, so default-path cache-key semantics and checkpoint comparability are untouched. Isolation comes from the #48 key already hashing the actual system prompt: `_chunk_cache_key` now takes the per-pass prompt, same mechanism that already isolates the #317 scene appendix.
- **Cache lanes verified per perspective.** Each perspective pass keys its own #48 lane (prompt hash in the key), so passes never cross-contaminate and never consume the default lane's extractions — while a re-escalation reuses its own prior paid-for partials (test-pinned: second escalated run is merge-only).
- **Budget = existing wave-plan machinery, no new knob.** The #314 wave plan now counts `chunks x perspectives` units when escalating, so the deadline scales with the real call count; per-call socket timeouts stay capped at the base budget (scar #17 gateway ceiling). Retry replay safety rides the existing #315 attempt-nonce in `_call_and_parse`, and perspective requests are never byte-identical to the failed default run's requests in the first place.
- **Merge is a producer, never a verifier (scar #10).** Stage 2 is the unchanged `MERGE_SYS` hierarchical merge; partials are ordered chunk-major so chronology rules (merge rules 4/9, and the briefing's tail-keeping decision cap, scar #6) still see session order. All verification stays in the deterministic gates, which this PR does not touch.
