### PR TITLE
feat(briefing): deterministic external-state spot-check for carried claims

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -81,6 +81,23 @@ def _line(item, degraded: bool = False) -> str:
         base += (f"\n  ⚠ likely superseded by {candidate} — confirm: "
                  f"daimon resolve {item_id} --status superseded-by:{candidate}"
                  f"\n    reject: daimon reverify {item_id}")
+    wc = item.get("_worldcheck")
+    if isinstance(wc, dict) and wc.get("note"):
+        # #365: worldcheck contradiction — the world moved off-session. Same
+        # philosophy as the #14 candidate flag above (a machine observation
+        # is surfaced, never suppressed), reusing the same resolve/reverify
+        # confirm/reject command surface. The note/status vocabulary is
+        # bounded at the stamp site (worldcheck._KNOWN_STATES), so nothing
+        # free-form rides into this line. ADDED lines only — the pinned
+        # prefix above never changes.
+        base += f"\n  ⚠ state changed since capture: {wc['note']}"
+        item_id = item.get("id")
+        if item_id:
+            # Confirming writes a human resolution event (source=cli), which
+            # withholds the item from future briefs; rejecting keeps it live.
+            base += (f" — confirm: daimon resolve {item_id} "
+                     f"--status {wc.get('status') or 'resolved'}"
+                     f"\n    reject: daimon reverify {item_id}")
     return base
 
 

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -30,7 +30,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from . import anchor, briefing, carry, config, configure, harvest, llm, recall, receipts, render, schema, serializer, store, teamsync, transcript
+from . import anchor, briefing, carry, config, configure, harvest, llm, recall, receipts, render, schema, serializer, store, teamsync, transcript, worldcheck
 from . import __version__
 
 # The serialize.log ledger subsystem lives in ledger.py (#147 + #162, pure
@@ -524,14 +524,20 @@ def _team_briefings(project) -> list:
     return out
 
 
-def _render_briefing_body(checkpoint, route, *, drift_project, teammates) -> int:
-    """Shared tail of `brief` and `brief --slug`: withhold, drift, render,
-    footnotes. `route` is whatever the events ledger should be keyed by — a
-    project dir on the normal path, a bare slug on the --slug path (the store's
-    slug munging is idempotent, so a slug rides through project_dir-shaped
-    APIs unchanged; guarded by test_project_slug_is_idempotent_on_slugs).
+def _render_briefing_body(checkpoint, route, *, drift_project, teammates,
+                          worldcheck_project=None) -> int:
+    """Shared tail of `brief` and `brief --slug`: withhold, worldcheck, drift,
+    render, footnotes. `route` is whatever the events ledger should be keyed
+    by — a project dir on the normal path, a bare slug on the --slug path (the
+    store's slug munging is idempotent, so a slug rides through
+    project_dir-shaped APIs unchanged; guarded by
+    test_project_slug_is_idempotent_on_slugs).
     `drift_project=None` skips the anchor drift check: anchor paths are
-    relative to the origin project's root, which a slug cannot recover."""
+    relative to the origin project's root, which a slug cannot recover.
+    `worldcheck_project=None` skips the #365 external-state spot-check for the
+    same reason drift skips: --slug and global-fallback briefs render ANOTHER
+    project's checkpoint, and `gh` probes resolve against THIS cwd's repo —
+    the wrong repo context for those claims."""
     withheld = []
     events = {}
     if checkpoint:
@@ -547,6 +553,21 @@ def _render_briefing_body(checkpoint, route, *, drift_project, teammates) -> int
         except Exception:
             withheld = []
             events = {}
+    # Worldcheck (#365): opt-in, budget-bounded, read-only `gh` spot-check of
+    # carried PR/issue-state claims — stamps contradicted items on the
+    # IN-MEMORY checkpoint before render (transient, like withhold's
+    # candidate stamps; never persisted). Fail-open like withhold above: a
+    # briefing must never block or die on the network. Counters ride the
+    # same usage.log every other counter uses, so `daimon stats` surfaces
+    # the fires-true rate with zero extra machinery.
+    if checkpoint and worldcheck_project and config.worldcheck_enabled():
+        try:
+            wc_stats = worldcheck.check(checkpoint, worldcheck_project)
+            for outcome in ("confirmed", "contradicted", "skipped"):
+                for _ in range(int(wc_stats.get(outcome, 0))):
+                    _note_usage(f"worldcheck:{outcome}")
+        except Exception:
+            pass
     # NOTE: drift is checked against the resolved project root. If read_latest fell
     # back to the GLOBAL pointer (another project's checkpoint), its anchor file paths
     # are relative to a different root and may report spurious "hard" drift. Acceptable
@@ -643,8 +664,13 @@ def _cmd_brief(args) -> int:
     # --team (#111): fan in teammates for THIS project. Empty team → None → the
     # renderer emits no Teammates section, byte-identical to a non-team briefing.
     teammates = _team_briefings(project) if getattr(args, "team", False) else None
+    # #365: never worldcheck a fallback body — the global pointer may belong
+    # to ANOTHER project, and probing this cwd's repo against that
+    # checkpoint's claims answers for the wrong repo.
     return _render_briefing_body(checkpoint, project,
-                                 drift_project=project, teammates=teammates)
+                                 drift_project=project, teammates=teammates,
+                                 worldcheck_project=None if fallback_used
+                                 else project)
 
 
 # ---- recall: FTS search over local + team checkpoint history (#112) ----

--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -498,6 +498,17 @@ def scene_traces_enabled() -> bool:
     return _flag("DAIMON_SCENE_TRACES")
 
 
+def worldcheck_enabled() -> bool:
+    """Opt-in (#365): brief-time spot-check of carried PR/issue-state claims
+    against reality via read-only `gh` probes. Default OFF (#318 flag
+    precedent): `daimon brief` runs on the SessionStart hook's latency-
+    critical injection path (8s subprocess budget inside a 10s hook budget),
+    and even budget-bounded network probes there must be deliberately chosen.
+    Flag off, the render path never touches the worldcheck module — output
+    stays byte-identical (test-pinned)."""
+    return _flag("DAIMON_WORLDCHECK")
+
+
 def heal_escalation_enabled() -> bool:
     """Opt-in (#360): `daimon heal` escalates its re-serialize to
     perspective-diverse extraction — N passes over the transcript from

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -204,6 +204,17 @@ def _rich_brief(b: dict, degraded: bool = False) -> None:
                     f"daimon resolve {item_id} --status superseded-by:{candidate}\n"
                     f"    reject: daimon reverify {item_id}\n",
                     style="yellow")
+            wc = i.get("_worldcheck")
+            if isinstance(wc, dict) and wc.get("note"):
+                # #365: parity with briefing._line's worldcheck flag, same
+                # repeated-here reasoning as the candidate block above.
+                flag = f"    ⚠ state changed since capture: {wc['note']}"
+                item_id = i.get("id")
+                if item_id:
+                    flag += (f" — confirm: daimon resolve {item_id} "
+                             f"--status {wc.get('status') or 'resolved'}\n"
+                             f"    reject: daimon reverify {item_id}")
+                body.append(flag + "\n", style="yellow")
         if key == "decisions":
             note = briefing._overflow_note(b.get("decisions_overflow", 0))
             if note:

--- a/plugin/daimon_briefing/worldcheck.py
+++ b/plugin/daimon_briefing/worldcheck.py
@@ -1,0 +1,217 @@
+"""#365 slice 1: deterministic external-state spot-check for carried PR/issue-
+state claims at briefing render.
+
+A claim true at capture can go false OFF-session (a PR merged by someone
+else). Carry's supersession detection only fires when a later session
+contradicts the item, and the briefing's VERIFY BEFORE TRUSTING section is
+advice, not machinery — so a carried "PR #N awaiting review" whose PR merged
+yesterday renders as confidently as a fresh fact. This module is the
+machinery: at brief time, carried items making a CHECKABLE claim (repo-local
+"#N" ref + a state word) are spot-checked against reality with read-only `gh`
+probes, and a contradicted item is flagged in the render + offered the
+existing resolve/reverify confirm path.
+
+Hard constraints (the briefing must never block or fail on the network):
+- strict aggregate wall-clock budget (BUDGET_SECONDS) — probes run in
+  parallel and anything unfinished at the deadline is killed and SKIPPED;
+- probe count cap (MAX_PROBES) — first N distinct refs only;
+- `gh` missing / no GitHub remote / non-zero exit / bad output -> skip
+  SILENTLY: the render is exactly what it would be without this module.
+
+The stamp is TRANSIENT (underscore key, same convention as withhold's
+`_supersede_candidate`): it lives only on the in-memory checkpoint the brief
+renders; nothing here writes to disk. Probes are read-only by construction —
+`gh pr view` / `gh issue view` only.
+
+Slice 1 is deliberately narrow: PR/issue state claims only. The measurable
+question it answers — via the worldcheck:confirmed/contradicted/skipped usage
+counters the CLI writes — is how often a carried repo-state claim is already
+false at next read; that fires-true rate is the evidence for (or against)
+later claim classes (file-exists, dependency-version, branch-state).
+"""
+
+import json
+import re
+import shutil
+import subprocess
+import time
+from collections import namedtuple
+
+from . import serializer
+
+# Aggregate wall-clock budget for ALL probes together (sub-second by
+# contract). Probes run in parallel, so this bounds the render delay, not a
+# per-probe allowance.
+BUDGET_SECONDS = 0.8
+
+# First N distinct refs get probed; further claims count as skipped. Caps the
+# subprocess fan-out no matter how claim-heavy a checkpoint gets.
+MAX_PROBES = 5
+
+Claim = namedtuple("Claim", "num kind expected")
+
+# Repo-LOCAL ref: "#N" optionally preceded by an explicit "PR"/"pull
+# request"/"issue" kind word. The lookbehind rejects any word char (or
+# '/', '#', '-') butting up against the '#', so cross-repo refs like
+# "gemini-cli#14715" or "owner/repo#12" NEVER match — `gh` here would answer
+# for the wrong repository. Bounded quantifiers throughout: this fullmatches
+# nothing, but it does scan checkpoint text, which is attacker-adjacent.
+_REF_RE = re.compile(
+    r"(?i)(?:\b(?P<kind>pr|pull request|issue)\s+)?(?<![\w/#-])#(?P<num>\d{1,6})\b")
+
+# The state vocabulary that makes a ref an actual STATE CLAIM (issue #365's
+# list). Bare "#48 slice 1" has no state word -> no claim -> nothing to check.
+_STATE_RE = re.compile(r"(?i)\b(awaiting|open|merged|closed|review)\b")
+
+# Claim direction: open-ish words assert the thing is still live; done-ish
+# words assert it landed. A text containing BOTH is ambiguous — skip, because
+# a wrong contradiction flag is worse than no check (don't-guess bias, same
+# stance as carry's unique-match gate).
+_OPENISH = frozenset({"awaiting", "open", "review"})
+_DONEISH = frozenset({"merged", "closed"})
+
+# The only actual states allowed to reach the rendered flag. The note text
+# rides into briefing output (and the hook-injected LLM context), so the
+# vocabulary is bounded here — `gh` output is trusted for truth, not for text.
+_KNOWN_STATES = frozenset({"OPEN", "CLOSED", "MERGED"})
+
+
+def claim_of(text):
+    """The PR/issue-state claim in `text`, or None when there is nothing
+    checkable. Conservative by design: requires a repo-local "#N" ref AND
+    unambiguous state vocabulary; the FIRST ref wins when several appear
+    (one claim per item keeps the probe budget honest)."""
+    ref = _REF_RE.search(str(text or ""))
+    if not ref:
+        return None
+    words = {w.lower() for w in _STATE_RE.findall(str(text))}
+    open_words, done_words = words & _OPENISH, words & _DONEISH
+    if not words or (open_words and done_words):
+        return None  # no state claim, or an ambiguous one — nothing to check
+    if open_words:
+        expected = frozenset({"OPEN"})
+    elif "merged" in done_words and "closed" not in done_words:
+        expected = frozenset({"MERGED"})
+    else:
+        # "closed" (possibly alongside "merged"): for a PR either terminal
+        # state satisfies the claim; an issue can only ever answer CLOSED.
+        expected = frozenset({"CLOSED", "MERGED"})
+    kind = (ref.group("kind") or "").lower()
+    if kind in ("pr", "pull request"):
+        kind = "pr"
+    elif kind != "issue":
+        # Bare ref: merge/review vocabulary is PR-shaped; plain open/closed
+        # reads as an issue (a wrong guess fails closed — the probe errors
+        # and the item is silently skipped, never mis-flagged).
+        kind = "pr" if (words & {"merged", "review", "awaiting"}) else "issue"
+    return Claim(num=ref.group("num"), kind=kind, expected=expected)
+
+
+def _gh_path():
+    """Seam for tests; None -> no gh on PATH -> skip everything silently."""
+    return shutil.which("gh")
+
+
+def _github_repo(project) -> bool:
+    """True only when `project` is inside a git repo with a GitHub remote —
+    the context `gh` resolves "#N" against. Anything else (no git, no
+    remote, git itself missing/slow) -> False, and the caller skips: probing
+    from the wrong repo answers the wrong question."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(project), "remote", "-v"],
+            capture_output=True, text=True, timeout=2)
+    except Exception:
+        return False
+    return proc.returncode == 0 and "github.com" in proc.stdout
+
+
+def _run_probes(probes: dict, cwd) -> dict:
+    """Run every probe in parallel under ONE aggregate deadline.
+    `probes` is {(kind, num): argv}; returns {(kind, num): STATE | None} —
+    None for anything killed at the deadline, failed, or unparseable. Never
+    raises: a probe error is a skip, not a briefing failure."""
+    deadline = time.monotonic() + BUDGET_SECONDS
+    procs: dict = {}
+    results: dict = {key: None for key in probes}
+    for key, argv in probes.items():
+        try:
+            procs[key] = subprocess.Popen(
+                argv, cwd=str(cwd), stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True)
+        except Exception:
+            continue  # spawn failure (gh vanished mid-flight) -> skip
+    while (any(p.poll() is None for p in procs.values())
+           and time.monotonic() < deadline):
+        time.sleep(0.02)
+    for key, p in procs.items():
+        if p.poll() is None:
+            # Budget exhausted: kill and reap — a briefing never waits.
+            p.kill()
+            try:
+                p.communicate(timeout=1)
+            except Exception:
+                pass
+            continue
+        try:
+            out, _ = p.communicate(timeout=1)
+        except Exception:
+            continue
+        if p.returncode != 0:
+            continue
+        try:
+            state = str(json.loads(out).get("state") or "").strip().upper()
+        except Exception:
+            continue
+        if state in _KNOWN_STATES:
+            results[key] = state
+    return results
+
+
+def check(checkpoint, project_dir) -> dict:
+    """Spot-check the checkpoint's CARRIED claim-bearing items against `gh`,
+    stamping contradicted items with a transient `_worldcheck` annotation
+    IN PLACE (the caller owns the in-memory dict; nothing is persisted).
+
+    Returns {"confirmed": n, "contradicted": n, "skipped": n} — per ITEM, so
+    the caller's usage counters measure the fires-true rate this slice
+    exists to answer. Zero-claim checkpoints return all-zeros and cost one
+    iteration, no subprocess. Confirmed items are untouched: only a
+    contradiction earns any surface at all."""
+    stats = {"confirmed": 0, "contradicted": 0, "skipped": 0}
+    if not isinstance(checkpoint, dict) or not project_dir:
+        return stats
+    claims = []
+    for item in serializer.iter_items(checkpoint):
+        if not item.get("carried_from"):
+            continue  # native items were just re-extracted — not in question
+        claim = claim_of(item.get("text"))
+        if claim is not None:
+            claims.append((item, claim))
+    if not claims:
+        return stats
+    gh = _gh_path()
+    if gh is None or not _github_repo(project_dir):
+        stats["skipped"] = len(claims)
+        return stats
+    probes: dict = {}
+    for _item, claim in claims:
+        key = (claim.kind, claim.num)
+        if key in probes or len(probes) >= MAX_PROBES:
+            continue
+        if claim.kind == "pr":
+            probes[key] = [gh, "pr", "view", claim.num, "--json", "state,mergedAt"]
+        else:
+            probes[key] = [gh, "issue", "view", claim.num, "--json", "state"]
+    results = _run_probes(probes, cwd=project_dir)
+    for item, claim in claims:
+        state = results.get((claim.kind, claim.num))
+        if state is None:
+            stats["skipped"] += 1
+        elif state in claim.expected:
+            stats["confirmed"] += 1
+        else:
+            stats["contradicted"] += 1
+            item["_worldcheck"] = {"note": f"#{claim.num} {state.lower()}",
+                                   "status": state.lower()}
+    return stats

--- a/plugin/tests/test_worldcheck.py
+++ b/plugin/tests/test_worldcheck.py
@@ -47,6 +47,15 @@ def _cp(texts, carried=True, with_ids=True):
 
 
 @pytest.fixture
+def proj(tmp_path):
+    """A real directory to act as the project root — Popen(cwd=...) needs it
+    to exist (a nonexistent cwd is a spawn failure -> silent skip)."""
+    d = tmp_path / "projroot"
+    d.mkdir()
+    return str(d)
+
+
+@pytest.fixture
 def fake_gh(tmp_path):
     """Executable fake `gh` + its invocation log. `body` is the shell that
     produces stdout; every call appends its argv (and cwd) to the log."""
@@ -139,22 +148,22 @@ def test_claim_explicit_kind_wins_over_state_heuristic():
 # ---- check(): probes, budget, stamping --------------------------------------
 
 
-def test_check_confirmed_leaves_item_untouched(monkeypatch, fake_gh):
+def test_check_confirmed_leaves_item_untouched(monkeypatch, fake_gh, proj):
     gh, log = fake_gh("echo '{\"state\":\"OPEN\"}'")
     _enable_probes(monkeypatch, gh)
     cp = _cp(["PR #60 awaiting review"])
-    stats = worldcheck.check(cp, "/p/A")
+    stats = worldcheck.check(cp, proj)
     assert stats == {"confirmed": 1, "contradicted": 0, "skipped": 0}
     item = cp["working_context"]["open_questions"][0]
     assert "_worldcheck" not in item
     assert len(_calls(log)) == 1
 
 
-def test_check_contradicted_stamps_item(monkeypatch, fake_gh):
+def test_check_contradicted_stamps_item(monkeypatch, fake_gh, proj):
     gh, _log = fake_gh("echo '{\"state\":\"MERGED\",\"mergedAt\":\"2026-07-20T00:00:00Z\"}'")
     _enable_probes(monkeypatch, gh)
     cp = _cp(["PR #60 awaiting review"])
-    stats = worldcheck.check(cp, "/p/A")
+    stats = worldcheck.check(cp, proj)
     assert stats == {"confirmed": 0, "contradicted": 1, "skipped": 0}
     item = cp["working_context"]["open_questions"][0]
     assert item["_worldcheck"] == {"note": "#60 merged", "status": "merged"}
@@ -179,49 +188,49 @@ def test_check_no_github_remote_skips_without_probing(monkeypatch, fake_gh):
     assert _calls(log) == []
 
 
-def test_check_probe_failure_skips(monkeypatch, fake_gh):
+def test_check_probe_failure_skips(monkeypatch, fake_gh, proj):
     gh, _log = fake_gh("exit 1")
     _enable_probes(monkeypatch, gh)
     cp = _cp(["PR #60 awaiting review"])
-    stats = worldcheck.check(cp, "/p/A")
+    stats = worldcheck.check(cp, proj)
     assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1}
 
 
-def test_check_bad_json_skips(monkeypatch, fake_gh):
+def test_check_bad_json_skips(monkeypatch, fake_gh, proj):
     gh, _log = fake_gh("echo 'not json at all'")
     _enable_probes(monkeypatch, gh)
-    stats = worldcheck.check(_cp(["PR #60 awaiting review"]), "/p/A")
+    stats = worldcheck.check(_cp(["PR #60 awaiting review"]), proj)
     assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1}
 
 
-def test_check_unknown_state_vocabulary_skips(monkeypatch, fake_gh):
+def test_check_unknown_state_vocabulary_skips(monkeypatch, fake_gh, proj):
     # Only OPEN/CLOSED/MERGED may reach the rendered flag (the note rides
     # into briefing text — bounded vocabulary, not a passthrough).
     gh, _log = fake_gh("echo '{\"state\":\"WEIRD\"}'")
     _enable_probes(monkeypatch, gh)
     cp = _cp(["PR #60 awaiting review"])
-    stats = worldcheck.check(cp, "/p/A")
+    stats = worldcheck.check(cp, proj)
     assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1}
     assert "_worldcheck" not in cp["working_context"]["open_questions"][0]
 
 
-def test_check_budget_kills_slow_probe(monkeypatch, fake_gh):
+def test_check_budget_kills_slow_probe(monkeypatch, fake_gh, proj):
     gh, _log = fake_gh("sleep 5\necho '{\"state\":\"OPEN\"}'")
     _enable_probes(monkeypatch, gh)
     monkeypatch.setattr(worldcheck, "BUDGET_SECONDS", 0.2)
     cp = _cp(["PR #60 awaiting review"])
     start = time.monotonic()
-    stats = worldcheck.check(cp, "/p/A")
+    stats = worldcheck.check(cp, proj)
     elapsed = time.monotonic() - start
     assert elapsed < 2.0  # never blocks anywhere near the hook budget
     assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1}
 
 
-def test_check_probe_cap(monkeypatch, fake_gh):
+def test_check_probe_cap(monkeypatch, fake_gh, proj):
     gh, log = fake_gh("echo '{\"state\":\"OPEN\"}'")
     _enable_probes(monkeypatch, gh)
     texts = [f"PR #{n} awaiting review" for n in range(101, 108)]  # 7 claims
-    stats = worldcheck.check(_cp(texts), "/p/A")
+    stats = worldcheck.check(_cp(texts), proj)
     assert len(_calls(log)) == worldcheck.MAX_PROBES == 5
     assert stats["confirmed"] == 5
     assert stats["skipped"] == 2
@@ -236,11 +245,11 @@ def test_check_non_carried_items_never_probed(monkeypatch, fake_gh):
     assert _calls(log) == []
 
 
-def test_check_dedup_same_ref_probes_once_stamps_all(monkeypatch, fake_gh):
+def test_check_dedup_same_ref_probes_once_stamps_all(monkeypatch, fake_gh, proj):
     gh, log = fake_gh("echo '{\"state\":\"MERGED\"}'")
     _enable_probes(monkeypatch, gh)
     cp = _cp(["PR #60 awaiting review", "PR #60 review pending on Omar"])
-    stats = worldcheck.check(cp, "/p/A")
+    stats = worldcheck.check(cp, proj)
     assert len(_calls(log)) == 1
     assert stats["contradicted"] == 2
     for item in cp["working_context"]["open_questions"]:
@@ -259,11 +268,11 @@ def test_check_probes_run_in_project_cwd(monkeypatch, fake_gh, tmp_path):
     assert cwd == str(project.resolve())
 
 
-def test_check_issue_claim_uses_issue_probe(monkeypatch, fake_gh):
+def test_check_issue_claim_uses_issue_probe(monkeypatch, fake_gh, proj):
     gh, log = fake_gh("echo '{\"state\":\"CLOSED\"}'")
     _enable_probes(monkeypatch, gh)
     cp = _cp(["issue #171 still open"])
-    stats = worldcheck.check(cp, "/p/A")
+    stats = worldcheck.check(cp, proj)
     assert stats["contradicted"] == 1
     assert "issue view 171" in _calls(log)[0]
     assert cp["working_context"]["open_questions"][0]["_worldcheck"]["note"] == "#171 closed"
@@ -366,11 +375,12 @@ def test_cli_brief_flag_off_never_probes(monkeypatch, tmp_path, capsys):
 
 
 def test_cli_brief_flag_on_flags_contradiction_and_counts(
-    monkeypatch, tmp_path, capsys, fake_gh
+    monkeypatch, tmp_path, capsys, fake_gh, proj
 ):
-    _write_claim_checkpoint()
+    # A real project dir: probes spawn with cwd=<project>, so it must exist.
+    _write_claim_checkpoint(project=proj)
     body = (
-        'case "$@" in\n'
+        'case "$*" in\n'
         "  *\"pr view 60\"*) echo '{\"state\":\"MERGED\"}' ;;\n"
         "  *) echo '{\"state\":\"OPEN\"}' ;;\n"
         "esac"
@@ -378,7 +388,7 @@ def test_cli_brief_flag_on_flags_contradiction_and_counts(
     gh, _log = fake_gh(body)
     _enable_probes(monkeypatch, gh)
     monkeypatch.setenv("DAIMON_WORLDCHECK", "1")
-    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", proj)
     rc = cli.main(["brief"])
     assert rc == 0
     out = capsys.readouterr().out

--- a/plugin/tests/test_worldcheck.py
+++ b/plugin/tests/test_worldcheck.py
@@ -1,0 +1,456 @@
+"""#365 slice 1: deterministic external-state spot-check for carried PR/issue-
+state claims at briefing render.
+
+Contract pinned here:
+- claim_of: conservative claim-class extraction — a repo-local "#N" ref PLUS a
+  state word, never bare refs, never cross-repo refs, never conflicting words.
+- check: read-only `gh` probes under a strict aggregate budget + probe cap;
+  confirmed items untouched, contradicted items stamped with a transient
+  `_worldcheck` annotation, everything else skipped SILENTLY.
+- rendering: the stamped item gains an ADDED flag line reusing the existing
+  confirm/reject command surface (`daimon resolve` / `daimon reverify`) —
+  existing pinned literals never change.
+- CLI wiring: DAIMON_WORLDCHECK opt-in (default OFF, byte-identical off-path),
+  cross-project (--slug) and global-fallback briefs never probe, and outcomes
+  land in usage.log as worldcheck:confirmed/contradicted/skipped.
+
+All gh probes in this suite hit a fake `gh` script on disk — zero network.
+"""
+
+import json
+import subprocess
+import time
+
+import pytest
+
+from daimon_briefing import briefing, cli, config, store, worldcheck
+
+
+# ---- helpers ----------------------------------------------------------------
+
+
+def _cp(texts, carried=True, with_ids=True):
+    """Checkpoint whose open_questions carry the given texts."""
+    items = []
+    for i, text in enumerate(texts):
+        item = {"text": text, "trust": "inferred"}
+        if carried:
+            item["carried_from"] = "S-prev"
+        if with_ids:
+            item["id"] = f"o-{i + 1:06x}"
+        items.append(item)
+    return {
+        "session_id": "S-now",
+        "working_context": {"open_questions": items},
+        "epistemic_snapshot": {},
+    }
+
+
+@pytest.fixture
+def fake_gh(tmp_path):
+    """Executable fake `gh` + its invocation log. `body` is the shell that
+    produces stdout; every call appends its argv (and cwd) to the log."""
+
+    def make(body="echo '{\"state\":\"OPEN\"}'"):
+        script = tmp_path / "fake-gh"
+        log = tmp_path / "gh-calls.log"
+        script.write_text(
+            "#!/bin/sh\n"
+            f'echo "$PWD|$@" >> "{log}"\n'
+            f"{body}\n"
+        )
+        script.chmod(0o755)
+        return str(script), log
+
+    return make
+
+
+def _enable_probes(monkeypatch, gh_path):
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: gh_path)
+    monkeypatch.setattr(worldcheck, "_github_repo", lambda project: True)
+
+
+def _calls(log):
+    if not log.exists():
+        return []
+    return [line for line in log.read_text().splitlines() if line.strip()]
+
+
+# ---- claim extraction -------------------------------------------------------
+
+
+def test_claim_pr_awaiting_review():
+    claim = worldcheck.claim_of("PR #60 awaiting review")
+    assert claim is not None
+    assert claim.num == "60"
+    assert claim.kind == "pr"
+    assert claim.expected == frozenset({"OPEN"})
+
+
+def test_claim_bare_ref_without_state_word_is_none():
+    # "#48 slice 1" makes no state claim — nothing to check.
+    assert worldcheck.claim_of("#48 slice 1 landed the cache") is None
+
+
+def test_claim_cross_repo_ref_is_none():
+    # gemini-cli#14715 belongs to ANOTHER repo — `gh` here would answer for
+    # the wrong project. Never probe.
+    assert worldcheck.claim_of("gemini-cli#14715 still open upstream") is None
+
+
+def test_claim_issue_closed():
+    claim = worldcheck.claim_of("issue #171 closed by the fix")
+    assert claim is not None
+    assert claim.num == "171"
+    assert claim.kind == "issue"
+    assert "CLOSED" in claim.expected
+
+
+def test_claim_bare_merged_ref_is_pr():
+    claim = worldcheck.claim_of("#60 merged last night")
+    assert claim is not None
+    assert claim.kind == "pr"
+    assert claim.expected == frozenset({"MERGED"})
+
+
+def test_claim_bare_open_ref_is_issue():
+    claim = worldcheck.claim_of("#12 still open on the tracker")
+    assert claim is not None
+    assert claim.kind == "issue"
+    assert claim.expected == frozenset({"OPEN"})
+
+
+def test_claim_conflicting_state_words_is_none():
+    # Both open-ish and done-ish vocabulary: the claim direction is ambiguous
+    # and a wrong contradiction flag is worse than no check.
+    assert worldcheck.claim_of("PR #60 was open, now merged") is None
+
+
+def test_claim_state_word_without_ref_is_none():
+    assert worldcheck.claim_of("awaiting review from the team") is None
+
+
+def test_claim_explicit_kind_wins_over_state_heuristic():
+    claim = worldcheck.claim_of("issue #9 awaiting triage")
+    assert claim is not None
+    assert claim.kind == "issue"
+
+
+# ---- check(): probes, budget, stamping --------------------------------------
+
+
+def test_check_confirmed_leaves_item_untouched(monkeypatch, fake_gh):
+    gh, log = fake_gh("echo '{\"state\":\"OPEN\"}'")
+    _enable_probes(monkeypatch, gh)
+    cp = _cp(["PR #60 awaiting review"])
+    stats = worldcheck.check(cp, "/p/A")
+    assert stats == {"confirmed": 1, "contradicted": 0, "skipped": 0}
+    item = cp["working_context"]["open_questions"][0]
+    assert "_worldcheck" not in item
+    assert len(_calls(log)) == 1
+
+
+def test_check_contradicted_stamps_item(monkeypatch, fake_gh):
+    gh, _log = fake_gh("echo '{\"state\":\"MERGED\",\"mergedAt\":\"2026-07-20T00:00:00Z\"}'")
+    _enable_probes(monkeypatch, gh)
+    cp = _cp(["PR #60 awaiting review"])
+    stats = worldcheck.check(cp, "/p/A")
+    assert stats == {"confirmed": 0, "contradicted": 1, "skipped": 0}
+    item = cp["working_context"]["open_questions"][0]
+    assert item["_worldcheck"] == {"note": "#60 merged", "status": "merged"}
+
+
+def test_check_gh_missing_skips_silently(monkeypatch):
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    monkeypatch.setattr(worldcheck, "_github_repo", lambda project: True)
+    cp = _cp(["PR #60 awaiting review"])
+    stats = worldcheck.check(cp, "/p/A")
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1}
+    assert "_worldcheck" not in cp["working_context"]["open_questions"][0]
+
+
+def test_check_no_github_remote_skips_without_probing(monkeypatch, fake_gh):
+    gh, log = fake_gh()
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: gh)
+    monkeypatch.setattr(worldcheck, "_github_repo", lambda project: False)
+    cp = _cp(["PR #60 awaiting review"])
+    stats = worldcheck.check(cp, "/p/A")
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1}
+    assert _calls(log) == []
+
+
+def test_check_probe_failure_skips(monkeypatch, fake_gh):
+    gh, _log = fake_gh("exit 1")
+    _enable_probes(monkeypatch, gh)
+    cp = _cp(["PR #60 awaiting review"])
+    stats = worldcheck.check(cp, "/p/A")
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1}
+
+
+def test_check_bad_json_skips(monkeypatch, fake_gh):
+    gh, _log = fake_gh("echo 'not json at all'")
+    _enable_probes(monkeypatch, gh)
+    stats = worldcheck.check(_cp(["PR #60 awaiting review"]), "/p/A")
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1}
+
+
+def test_check_unknown_state_vocabulary_skips(monkeypatch, fake_gh):
+    # Only OPEN/CLOSED/MERGED may reach the rendered flag (the note rides
+    # into briefing text — bounded vocabulary, not a passthrough).
+    gh, _log = fake_gh("echo '{\"state\":\"WEIRD\"}'")
+    _enable_probes(monkeypatch, gh)
+    cp = _cp(["PR #60 awaiting review"])
+    stats = worldcheck.check(cp, "/p/A")
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1}
+    assert "_worldcheck" not in cp["working_context"]["open_questions"][0]
+
+
+def test_check_budget_kills_slow_probe(monkeypatch, fake_gh):
+    gh, _log = fake_gh("sleep 5\necho '{\"state\":\"OPEN\"}'")
+    _enable_probes(monkeypatch, gh)
+    monkeypatch.setattr(worldcheck, "BUDGET_SECONDS", 0.2)
+    cp = _cp(["PR #60 awaiting review"])
+    start = time.monotonic()
+    stats = worldcheck.check(cp, "/p/A")
+    elapsed = time.monotonic() - start
+    assert elapsed < 2.0  # never blocks anywhere near the hook budget
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1}
+
+
+def test_check_probe_cap(monkeypatch, fake_gh):
+    gh, log = fake_gh("echo '{\"state\":\"OPEN\"}'")
+    _enable_probes(monkeypatch, gh)
+    texts = [f"PR #{n} awaiting review" for n in range(101, 108)]  # 7 claims
+    stats = worldcheck.check(_cp(texts), "/p/A")
+    assert len(_calls(log)) == worldcheck.MAX_PROBES == 5
+    assert stats["confirmed"] == 5
+    assert stats["skipped"] == 2
+
+
+def test_check_non_carried_items_never_probed(monkeypatch, fake_gh):
+    gh, log = fake_gh()
+    _enable_probes(monkeypatch, gh)
+    cp = _cp(["PR #60 awaiting review"], carried=False)
+    stats = worldcheck.check(cp, "/p/A")
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 0}
+    assert _calls(log) == []
+
+
+def test_check_dedup_same_ref_probes_once_stamps_all(monkeypatch, fake_gh):
+    gh, log = fake_gh("echo '{\"state\":\"MERGED\"}'")
+    _enable_probes(monkeypatch, gh)
+    cp = _cp(["PR #60 awaiting review", "PR #60 review pending on Omar"])
+    stats = worldcheck.check(cp, "/p/A")
+    assert len(_calls(log)) == 1
+    assert stats["contradicted"] == 2
+    for item in cp["working_context"]["open_questions"]:
+        assert item["_worldcheck"]["note"] == "#60 merged"
+
+
+def test_check_probes_run_in_project_cwd(monkeypatch, fake_gh, tmp_path):
+    gh, log = fake_gh()
+    _enable_probes(monkeypatch, gh)
+    project = tmp_path / "projroot"
+    project.mkdir()
+    worldcheck.check(_cp(["PR #60 awaiting review"]), str(project))
+    calls = _calls(log)
+    assert len(calls) == 1
+    cwd = calls[0].split("|", 1)[0]
+    assert cwd == str(project.resolve())
+
+
+def test_check_issue_claim_uses_issue_probe(monkeypatch, fake_gh):
+    gh, log = fake_gh("echo '{\"state\":\"CLOSED\"}'")
+    _enable_probes(monkeypatch, gh)
+    cp = _cp(["issue #171 still open"])
+    stats = worldcheck.check(cp, "/p/A")
+    assert stats["contradicted"] == 1
+    assert "issue view 171" in _calls(log)[0]
+    assert cp["working_context"]["open_questions"][0]["_worldcheck"]["note"] == "#171 closed"
+
+
+def test_github_repo_gate_against_real_git(tmp_path):
+    def git(*args, cwd):
+        subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+    repo = tmp_path / "with-remote"
+    repo.mkdir()
+    git("init", cwd=repo)
+    git("remote", "add", "origin", "https://github.com/example/example.git", cwd=repo)
+    assert worldcheck._github_repo(str(repo)) is True
+
+    bare = tmp_path / "no-remote"
+    bare.mkdir()
+    git("init", cwd=bare)
+    assert worldcheck._github_repo(str(bare)) is False
+
+    plain = tmp_path / "not-a-repo"
+    plain.mkdir()
+    assert worldcheck._github_repo(str(plain)) is False
+
+
+# ---- rendering: ADDED lines only --------------------------------------------
+
+
+def test_line_renders_worldcheck_flag_with_confirm_reject():
+    item = {"text": "PR #60 awaiting review", "trust": "inferred", "id": "o-abc123",
+            "carried_from": "S-prev",
+            "_worldcheck": {"note": "#60 merged", "status": "merged"}}
+    line = briefing._line(item)
+    # The pre-existing pinned prefix is untouched — the flag is an ADDED line.
+    assert line.startswith("- [~ inferred] PR #60 awaiting review [carried]")
+    assert "⚠ state changed since capture: #60 merged" in line
+    assert "confirm: daimon resolve o-abc123 --status merged" in line
+    assert "reject: daimon reverify o-abc123" in line
+
+
+def test_line_without_id_renders_flag_only():
+    item = {"text": "PR #60 awaiting review", "trust": "inferred",
+            "carried_from": "S-prev",
+            "_worldcheck": {"note": "#60 merged", "status": "merged"}}
+    line = briefing._line(item)
+    assert "⚠ state changed since capture: #60 merged" in line
+    assert "daimon resolve" not in line
+    assert "daimon reverify" not in line
+
+
+def test_line_unstamped_item_byte_identical():
+    item = {"text": "PR #60 awaiting review", "trust": "inferred",
+            "carried_from": "S-prev"}
+    assert briefing._line(item) == "- [~ inferred] PR #60 awaiting review [carried]"
+
+
+# ---- config flag ------------------------------------------------------------
+
+
+def test_worldcheck_flag_default_off(monkeypatch):
+    monkeypatch.delenv("DAIMON_WORLDCHECK", raising=False)
+    assert config.worldcheck_enabled() is False
+
+
+def test_worldcheck_flag_opt_in(monkeypatch):
+    monkeypatch.setenv("DAIMON_WORLDCHECK", "1")
+    assert config.worldcheck_enabled() is True
+
+
+# ---- CLI wiring -------------------------------------------------------------
+
+
+def _write_claim_checkpoint(project="/p/A"):
+    cp = _cp(["PR #60 awaiting review", "issue #12 still open"])
+    store.write_checkpoint("S-now", cp, project_dir=project)
+    return cp
+
+
+def _usage_lines(tmp_path):
+    log = tmp_path / ".daimon" / "logs" / "usage.log"
+    if not log.exists():
+        return []
+    return log.read_text().splitlines()
+
+
+def test_cli_brief_flag_off_never_probes(monkeypatch, tmp_path, capsys):
+    _write_claim_checkpoint()
+    monkeypatch.delenv("DAIMON_WORLDCHECK", raising=False)
+
+    def _boom(*a, **k):
+        raise AssertionError("worldcheck.check must not run with the flag off")
+
+    monkeypatch.setattr(worldcheck, "check", _boom)
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    rc = cli.main(["brief"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "state changed since capture" not in out
+    assert not any("worldcheck" in ln for ln in _usage_lines(tmp_path))
+
+
+def test_cli_brief_flag_on_flags_contradiction_and_counts(
+    monkeypatch, tmp_path, capsys, fake_gh
+):
+    _write_claim_checkpoint()
+    body = (
+        'case "$@" in\n'
+        "  *\"pr view 60\"*) echo '{\"state\":\"MERGED\"}' ;;\n"
+        "  *) echo '{\"state\":\"OPEN\"}' ;;\n"
+        "esac"
+    )
+    gh, _log = fake_gh(body)
+    _enable_probes(monkeypatch, gh)
+    monkeypatch.setenv("DAIMON_WORLDCHECK", "1")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    rc = cli.main(["brief"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "⚠ state changed since capture: #60 merged" in out
+    assert "confirm: daimon resolve o-000001 --status merged" in out
+    assert "reject: daimon reverify o-000001" in out
+    usage = _usage_lines(tmp_path)
+    assert sum(1 for ln in usage if ln.endswith(" worldcheck:contradicted")) == 1
+    assert sum(1 for ln in usage if ln.endswith(" worldcheck:confirmed")) == 1
+
+
+def test_cli_brief_slug_path_never_probes(monkeypatch, capsys):
+    _write_claim_checkpoint(project="/p/A")
+    slug = store.project_slug("/p/A")
+    monkeypatch.setenv("DAIMON_WORLDCHECK", "1")
+
+    def _boom(*a, **k):
+        raise AssertionError("--slug briefs must never probe (wrong repo context)")
+
+    monkeypatch.setattr(worldcheck, "check", _boom)
+    rc = cli.main(["brief", "--slug", slug])
+    assert rc == 0
+    assert "state changed since capture" not in capsys.readouterr().out
+
+
+def test_cli_brief_global_fallback_never_probes(monkeypatch, capsys):
+    # Global pointer belongs to ANOTHER project — probing this cwd's repo
+    # against that checkpoint's claims would answer for the wrong repo.
+    cp = _cp(["PR #60 awaiting review"])
+    store.write_checkpoint("S-other", cp)  # global pointer only
+    monkeypatch.setenv("DAIMON_WORLDCHECK", "1")
+    monkeypatch.setenv("DAIMON_BRIEF_GLOBAL_FALLBACK", "full")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/never-seen")
+
+    def _boom(*a, **k):
+        raise AssertionError("global-fallback briefs must never probe")
+
+    monkeypatch.setattr(worldcheck, "check", _boom)
+    rc = cli.main(["brief"])
+    assert rc == 0
+    assert "state changed since capture" not in capsys.readouterr().out
+
+
+def test_cli_brief_worldcheck_failure_is_silent(monkeypatch, capsys):
+    # A broken worldcheck must never take the briefing down (fail-open).
+    _write_claim_checkpoint()
+    monkeypatch.setenv("DAIMON_WORLDCHECK", "1")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+
+    def _boom(*a, **k):
+        raise RuntimeError("probe machinery exploded")
+
+    monkeypatch.setattr(cli.worldcheck, "check", _boom)
+    rc = cli.main(["brief"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "PR #60" in out  # briefing still rendered
+    assert "state changed since capture" not in out
+
+
+def test_stats_surfaces_worldcheck_counters(monkeypatch, tmp_path, capsys):
+    # Counters ride the existing usage.log -> `daimon stats` aggregation.
+    log_dir = tmp_path / ".daimon" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "usage.log").write_text(
+        "2026-07-21T00:00:00Z worldcheck:contradicted\n"
+        "2026-07-21T00:00:01Z worldcheck:confirmed\n"
+        "2026-07-21T00:00:02Z worldcheck:confirmed\n"
+    )
+    rc = cli.main(["stats", "--json"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    usage = data.get("usage") or {}
+    assert usage.get("worldcheck:contradicted") == 1
+    assert usage.get("worldcheck:confirmed") == 2


### PR DESCRIPTION
Closes #365

## What

At briefing render, carried items whose text makes a checkable PR/issue-state claim ("PR #60 awaiting review", "issue #171 closed", bare "#60 merged") are spot-checked against reality via read-only `gh` probes. Confirmed-current items render untouched. Contradicted items gain an ADDED flag line — `⚠ state changed since capture: #60 merged` — plus the existing confirm/reject command surface (`daimon resolve <id> --status merged` / `daimon reverify <id>`), so a stale claim becomes a one-command supersession the way #14 candidates already do. Every outcome lands in usage.log as `worldcheck:confirmed` / `worldcheck:contradicted` / `worldcheck:skipped`, so `daimon stats` surfaces the fires-true rate with zero extra machinery.

Slice 1 only: PR/issue state claims. No file-exists/dep-version classes, no MCP surface changes.

## Why

A claim true at capture can go false off-session (a PR merged by someone else). Carry's supersession detection only fires when a LATER session contradicts the item, and the briefing's VERIFY BEFORE TRUSTING section is advice, not machinery — so a carried "PR #N awaiting review" whose PR merged yesterday renders as confidently as a fresh fact. The contradicted counter is the measurable question this slice answers: how often is a carried repo-state claim already false at next read? That rate is the evidence for (or against) further claim classes.

## Tests

`uv run --all-extras pytest` from `plugin/`: 1954 passed, 2 skipped (+34 new in `tests/test_worldcheck.py`, written first and red before the implementation landed — the test commit precedes the feature commit). Ruff clean.

Covered: claim-class regex boundaries (positive + all three negative classes), confirmed/contradicted/skip paths, aggregate-budget kill of a hung probe (wall-clock asserted), probe cap, ref dedup, carried-only population, probe cwd, real-git remote gate, render additions (plain `_line` pins the pre-existing prefix byte-identical), flag default-off byte-identity (worldcheck.check monkeypatched to raise — brief succeeds, proving the off path never enters the module), --slug and global-fallback never probe, fail-open on a raising worldcheck, and stats surfacing the counters. All `gh` probes in the suite hit a fake on-disk script — zero network.

## Design decisions

- **Flag, default OFF (`DAIMON_WORLDCHECK`, #318 pattern).** The probes run inside `daimon brief`, which the SessionStart hook shells to with an 8s subprocess timeout inside a 10s hook budget — the latency-critical injection path. Even budget-bounded network probes there must be deliberately chosen, so this ships opt-in with a test-pinned byte-identical off path. The counters exist precisely to earn (or refuse) a future default-on argument.
- **Where probes run:** `cli._render_briefing_body`, after withhold, before render — the shared tail of `brief` and `brief --slug`. A new `worldcheck_project` parameter is `None` on the --slug path and on the global-pointer fallback (both render ANOTHER project's checkpoint; `gh` resolves against THIS cwd's repo — wrong repo context, never probe). The in-process hermes `pre_llm_call` path is deliberately unwired in this slice; Claude Code's hook reaches the check through the CLI it already shells to.
- **Budget mechanics:** one aggregate wall-clock deadline (0.8s) over ALL probes, run in parallel via `Popen`; anything unfinished at the deadline is killed and counted skipped. Probe count capped at the first 5 distinct refs; duplicate refs share one probe. `gh` missing, no GitHub remote (`git remote -v` grep, 2s timeout), non-zero exit, bad JSON, or unknown state vocabulary → silent skip, render exactly as today.
- **Regex boundaries (conservative by design):** a claim needs a repo-LOCAL `#N` ref (lookbehind rejects `gemini-cli#14715` / `owner/repo#12` — cross-repo refs would probe the wrong repo) AND a state word (awaiting/open/merged/closed/review). Bare "#48 slice 1" makes no state claim → nothing to check. Texts mixing open-ish and done-ish vocabulary are ambiguous → skipped, because a wrong contradiction flag is worse than no check. Explicit "PR"/"issue" prefix picks the probe; bare refs route by vocabulary (merge/review-shaped → pr, open/closed → issue) and a wrong guess fails closed via the probe erroring.
- **Supersession surface, not a new mechanism:** the `supersede-candidate:<new-id>` event contract requires a superseding item id, which a world-move doesn't have — so instead of bending that shape gate, the contradicted item gets a transient `_worldcheck` stamp (same underscore convention as withhold's `_supersede_candidate`, in-memory only, never persisted) and renders the same confirm/reject command pair. Confirming writes a human resolution event (source=cli) through the existing `daimon resolve`, which withholds the item from future briefs; rejecting via `daimon reverify` keeps it live. The rendered note/status vocabulary is bounded to open/closed/merged at the stamp site — `gh` output is trusted for truth, not for text.
