### PR TITLE
docs(site): concept blog post on verbatim vs inferred trust classes (en + es)

### DIFF
--- a/website/blog/2026-07-28-verbatim-vs-inferred.md
+++ b/website/blog/2026-07-28-verbatim-vs-inferred.md
@@ -1,0 +1,123 @@
+---
+slug: verbatim-vs-inferred
+title: "Verbatim vs. inferred: the trust class your agent's memory needs"
+authors: [daimon]
+tags: [concepts, trust-classes]
+---
+
+Your agent opens a session and tells you what you decided last time. Some of
+that is a quote. Some of it is the model's summary of a quote. Some of it is a
+conclusion the model drew at 2am from a session it was already losing track of.
+
+All three arrive in the same font, in the same confident tone, with no way to
+tell them apart. That is the actual problem with agent memory, and it is not
+solved by remembering more.
+
+{/* truncate */}
+
+## Two populations, two failure modes
+
+Daimon tags every item it carries with a trust class, visible on the line
+itself:
+
+```
+- [✓ verbatim] PR #60 awaiting review  — "review requested 2026-07-01"
+- [~ inferred] The retry storm was caused by a shared deadline across three calls
+```
+
+The tag is not decoration. The two classes fail in genuinely different ways:
+
+- A **verbatim** item can be *stale* — the world moved on since the quote was
+  said — but it cannot be *misremembered*. The quote is what was said.
+- An **inferred** item can be stale *and* wrong. The model may have misread the
+  session at the moment it wrote the summary down.
+
+That difference should change how you act on a line. A stale quote needs a
+world check. A wrong inference needs to be thrown away. Collapsing both into
+"the memory says" destroys the distinction exactly when you need it.
+
+## The checker has to be dumber than the thing it checks
+
+A trust class is worthless if the model assigns it to itself. A model that
+hallucinates a quote will also happily label the hallucination `verbatim`.
+
+So the model never gets a vote. At serialize time every candidate quote is
+checked against the rendered transcript by a deterministic verifier: pure
+string operations, no LLM, no judgment. A quote that matches gets the stamp. A
+quote that does not match is **downgraded to `~ inferred`** on the spot and
+kept, not deleted. The claim survives; the certification does not.
+
+This is the principle the whole design rests on. The checker must be dumber
+than the thing it checks, because anything smart enough to be fooled by the
+extractor is not a check.
+
+## The harder problem: a perfect quote can be perfectly false
+
+Here is the part we got wrong for months, and the reason this post exists.
+
+Verbatim matching certifies **transcription, not truth**.
+
+The failure that taught us: an agent finished a long session and wrote
+"serialization succeeded" into its own memory. It had not succeeded. The next
+session read that line, believed the memory layer was healthy, and built on a
+foundation that was not there.
+
+Every step of that is faithful. The model did say it. The transcript records it
+exactly. The quote verifier matched it character for character and stamped it
+`✓ verbatim`, correctly. The trust class did its job and the memory was still
+false, because the thing being certified was that the sentence was *said*, not
+that the event *happened*.
+
+## Outcomes need a witness, not a quote
+
+As of 0.20, claims that assert a completed outcome get held to a second
+standard.
+
+If an item's text asserts something finished — succeeded, merged, deployed,
+tests green, shipped — it has to cite a concrete signal from that same session:
+a tool result, an exit status. Something the session actually produced rather
+than something the model concluded.
+
+An outcome claim that cites a real signal stays `verbatim`. An outcome claim
+with no citation, in a session that *did* surface signals, gets downgraded to
+`~ inferred`. The quote and its verification stamp stay attached, because the
+transcription is still honestly attested. It is the outcome that is unwitnessed.
+
+An unwitnessed outcome is a report, not a fact.
+
+Two deliberate limits on that rule, both in the direction of doing nothing
+rather than guessing:
+
+- **Hedges are not assertions.** "will be merged" is a plan. "whether the
+  deploy succeeded" is a question. Neither is touched.
+- **Signal-free sessions never downgrade.** Some hosts surface no parseable
+  tool results at all. Grounding is impossible there, and absence of evidence
+  about the *host* is not evidence against the *claim*.
+
+## What none of this fixes
+
+Trust classes tell you where a claim came from. They tell you nothing about
+whether it is still true.
+
+A `✓ verbatim` quote with a real tool-result behind it is fully attested and
+goes stale the moment someone merges the PR it describes. Provenance is not
+currency, and pretending otherwise would be the same mistake one layer up.
+
+That is why every briefing opens with a **VERIFY BEFORE TRUSTING** block rather
+than a summary, and why 0.20 adds an opt-in spot-check that re-reads external
+state at briefing time and visibly flags carried claims the world has since
+contradicted. We are measuring how often that fires before we say anything
+about how big the problem is.
+
+## Try it
+
+```bash
+uv tool install 'daimon-briefing[pretty]'
+```
+
+The full mechanics live on the [trust
+classes](/docs/concepts/trust-classes) page, with
+[carry and staleness](/docs/concepts/carry) for the currency half and
+[receipts](/docs/concepts/receipts) for what happens if a checkpoint is edited
+after it is written. Code and issue tracker:
+[Daily-Nerd/daimon](https://github.com/Daily-Nerd/daimon).

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-07-28-verbatim-vs-inferred.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-07-28-verbatim-vs-inferred.md
@@ -1,0 +1,129 @@
+---
+slug: verbatim-vs-inferred
+title: "Verbatim vs. inferido: la clase de confianza que le falta a la memoria de tu agente"
+authors: [daimon]
+tags: [concepts, trust-classes]
+---
+
+Tu agente abre una sesión y te cuenta lo que decidiste la vez anterior. Una
+parte es una cita textual. Otra parte es el resumen que el modelo hizo de esa
+cita. Y otra parte es una conclusión que el modelo sacó a las 2am, en una
+sesión de la que ya venía perdiendo el hilo.
+
+Las tres llegan con la misma tipografía, el mismo tono seguro y ninguna forma
+de distinguirlas. Ese es el problema real de la memoria de agentes, y no se
+arregla recordando más cosas.
+
+{/* truncate */}
+
+## Dos poblaciones, dos formas de fallar
+
+Daimon etiqueta cada ítem que arrastra con una clase de confianza, visible en
+la línea misma:
+
+```
+- [✓ verbatim] PR #60 esperando review  — "review requested 2026-07-01"
+- [~ inferred] La tormenta de reintentos vino de un deadline compartido entre tres llamadas
+```
+
+La etiqueta no es decoración. Las dos clases fallan de maneras distintas:
+
+- Un ítem **verbatim** puede quedar *viejo* (el mundo siguió andando después de
+  la cita) pero no puede estar *mal recordado*. La cita es lo que se dijo.
+- Un ítem **inferido** puede estar viejo *y además* equivocado. El modelo pudo
+  haber leído mal la sesión en el momento exacto en que escribió el resumen.
+
+Esa diferencia debería cambiar qué hacés con la línea. Una cita vieja pide
+verificar contra el mundo. Una inferencia equivocada va a la basura. Meter las
+dos en la misma bolsa de "la memoria dice" destruye la distinción justo cuando
+más la necesitás.
+
+## El verificador tiene que ser más tonto que lo que verifica
+
+Una clase de confianza no vale nada si el modelo se la asigna a sí mismo. Un
+modelo que alucina una cita también va a etiquetar felizmente esa alucinación
+como `verbatim`.
+
+Así que el modelo no vota. Al momento de serializar, cada cita candidata se
+compara contra el transcript renderizado con un verificador determinista:
+operaciones de string puras, sin LLM, sin criterio. La cita que coincide recibe
+el sello. La cita que no coincide **baja a `~ inferred`** en el acto, y se
+conserva, no se borra. Sobrevive la afirmación; lo que no sobrevive es la
+certificación.
+
+Sobre este principio se apoya todo el diseño. El verificador tiene que ser más
+tonto que lo que verifica, porque cualquier cosa lo bastante inteligente como
+para que el extractor la engañe no es una verificación.
+
+## El problema difícil: una cita perfecta puede ser perfectamente falsa
+
+Acá está la parte que tuvimos mal durante meses, y la razón de este post.
+
+La coincidencia verbatim certifica **transcripción, no verdad**.
+
+El fallo que nos lo enseñó: un agente terminó una sesión larga y escribió
+"serialización exitosa" en su propia memoria. No había sido exitosa. La sesión
+siguiente leyó esa línea, creyó que la capa de memoria estaba sana y construyó
+sobre unos cimientos que no existían.
+
+Cada paso es fiel. El modelo lo dijo. El transcript lo registra exacto. El
+verificador de citas lo hizo coincidir carácter por carácter y lo selló como
+`✓ verbatim`, correctamente. La clase de confianza hizo su trabajo y la memoria
+igual era falsa, porque lo que se estaba certificando era que la frase *se
+dijo*, no que el evento *pasó*.
+
+## Los resultados necesitan un testigo, no una cita
+
+Desde la 0.20, las afirmaciones que declaran un resultado terminado tienen que
+pasar por una segunda vara.
+
+Si el texto de un ítem afirma que algo terminó (funcionó, se mergeó, se
+deployó, los tests pasan, salió) tiene que citar una señal concreta de esa
+misma sesión: un resultado de herramienta, un exit status. Algo que la sesión
+haya producido de verdad, no algo que el modelo concluyó.
+
+Una afirmación de resultado que cita una señal real sigue siendo `verbatim`.
+Una afirmación de resultado sin cita, en una sesión que *sí* produjo señales,
+baja a `~ inferred`. La cita y su sello de verificación quedan, porque la
+transcripción sigue estando honestamente atestiguada. Lo que queda sin testigo
+es el resultado.
+
+Un resultado sin testigo es un reporte, no un hecho.
+
+Dos límites deliberados en esa regla, los dos en la dirección de no hacer nada
+antes que adivinar:
+
+- **Los condicionales no son afirmaciones.** "se va a mergear" es un plan.
+  "si el deploy funcionó" es una pregunta. No se tocan.
+- **Las sesiones sin señales nunca bajan de clase.** Hay hosts que no exponen
+  ningún resultado de herramienta parseable. Ahí verificar es imposible, y la
+  ausencia de evidencia sobre el *host* no es evidencia contra la *afirmación*.
+
+## Lo que nada de esto arregla
+
+Las clases de confianza te dicen de dónde salió una afirmación. No te dicen
+nada sobre si sigue siendo cierta.
+
+Una cita `✓ verbatim` con un resultado de herramienta real detrás está
+completamente atestiguada y queda vieja en el instante en que alguien mergea el
+PR que describe. La procedencia no es actualidad, y fingir lo contrario sería
+el mismo error una capa más arriba.
+
+Por eso cada briefing abre con un bloque **VERIFY BEFORE TRUSTING** en lugar de
+un resumen, y por eso la 0.20 suma un chequeo opcional que vuelve a leer el
+estado externo al momento de armar el briefing y marca de forma visible las
+afirmaciones que el mundo ya contradijo. Estamos midiendo cada cuánto salta eso
+antes de decir nada sobre el tamaño del problema.
+
+## Probalo
+
+```bash
+uv tool install 'daimon-briefing[pretty]'
+```
+
+La mecánica completa está en la página de [clases de
+confianza](/docs/concepts/trust-classes), con [carry y
+obsolescencia](/docs/concepts/carry) para la mitad de actualidad y
+[receipts](/docs/concepts/receipts) para qué pasa si alguien edita un
+checkpoint después de escrito. Código e issue tracker:
+[Daily-Nerd/daimon](https://github.com/Daily-Nerd/daimon).


### PR DESCRIPTION
Closes #370

## What

Adds the first concept-genre post to the site blog, in English and Spanish under the shared slug `verbatim-vs-inferred`. The Spanish version is a native rewrite rather than a translation, matching the approach used for the existing posts.

The post covers, in order: the two trust-class populations and their distinct failure modes; why the model never votes on its own tag and the deterministic verifier behind that; the gap 0.20 closed, that verbatim matching certifies transcription rather than truth; outcome grounding and its two deliberate no-ops; and a closing section on what trust classes still do not solve.

## Why

Every blog post so far is an announcement. There was no concept post explaining what a trust class is or why the quote-versus-conclusion split is the load-bearing idea rather than a formatting detail.

The `trust-classes` doc describes the three classes and the quote verifier but does not state the sharper point that outcome grounding was built around. A model can say "serialization succeeded", have that recorded faithfully, verify character for character, and still leave a false memory behind. #359 and #362 exist because the original verifier did not close that hole, and it had no public writeup.

The closing section deliberately concedes what trust classes do not fix, and quotes no worldcheck rate while that measurement is still running.

## Tests

Docs-only change, no runtime code touched, so no unit test applies.

Verified before opening:

- Claims checked against the implementation rather than against issue titles: `serializer.ground_outcomes`, the `_OUTCOME_RE` / `_HEDGE_RE` lexicon (hedged claims are not assertions), the signal-free-session no-op, and `worldcheck.check` gated behind `config.worldcheck_enabled()`.
- `rg` privacy gate on both files: clean. Gate re-run after an initial version reported a false pass, where an unquoted multi-path variable made `rg` exit 2 and the `||` branch printed "clean" without scanning anything. Re-run asserts exit status 1 and empty output.
- Frontmatter, slug, and `{/* truncate */}` placement mirror the existing release posts. Blog tags are inline; no `tags.yml` exists, so this warns rather than fails.

Permalinks `/blog/verbatim-vs-inferred` and `/es/blog/verbatim-vs-inferred` to be verified 200 after the Pages deploy.
