### PR TITLE
docs(scars): promote the i18n .md-link landmine to active (0024)

### DIFF
--- a/.scars/0024-docusaurus-i18n-md-links-break-across-locales.landmine.md
+++ b/.scars/0024-docusaurus-i18n-md-links-break-across-locales.landmine.md
@@ -1,19 +1,20 @@
 ---
-id: 0
+id: 24
 type: landmine
 title: In the es build, .md-style doc links break whenever source and target sit on opposite sides of the translated/untranslated line
 severity: medium
 confidence: 0.9
 created: 2026-07-18
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: website/docs/
   - path: website/i18n/
 evidence:
-  - pr: "334 (runs 29661022607 and 29661156116 — two failures, one from each direction, same evening)"
+  - pr: 334 (runs 29661022607 and 29661156116 — two failures, one from each direction, same evening)
 expires:
-  condition: "every doc page is translated in i18n/es (no fallback pages left), or the site moves off .md-relative links entirely"
+  condition: "the site moves off .md-relative doc links entirely (URL-style everywhere), or i18n gains a build-time guarantee that no locale can fall back. NOTE: 100% es coverage does NOT retire this scar — coverage was already 15/15 when it was promoted, and the hazard returns the moment one untranslated page is added."
   review_after: 2026-10-01
+status: active
 ---
 
 Docusaurus resolves `[text](../x/y.md)` links against the set of source files
@@ -33,3 +34,10 @@ brace block is parsed as a JSX expression and acorn fails the whole es build
 (third #334 failure, run of 2026-07-18T21:22Z). A fragment pointing at a
 heading that only exists in the other locale is a build WARNING
 (onBrokenAnchors default), which is acceptable; a broken page link is not.
+
+Coverage note (verified 2026-07-28): es translation is currently complete,
+15/15 docs pages, so no fallback page exists and the hazard is DORMANT, not
+gone. Do not read "no untranslated pages" as evidence this scar is stale. It
+fires the moment a 16th English page lands without its es copy, which is the
+exact moment someone is adding docs and least likely to be thinking about the
+locale build.


### PR DESCRIPTION
Promotes the `docusaurus-i18n-md-links-break-across-locales` candidate (authored 2026-07-18) to active scar **0024**, and drops an unrelated auto-harvest candidate that was untracked.

No issue link: `pr-validation.yml` exempts scars-only PRs from the issue-first gate, because the human sign-off happens at `scar promote` and is recorded in the scar's `authors`. Every path in this diff is under `.scars/`.

## What

One rename with edits: `.scars/candidates/docusaurus-i18n-md-links-break-across-locales.md` becomes `.scars/0024-docusaurus-i18n-md-links-break-across-locales.landmine.md`, `status: active`, reviewer added to `authors`.

## Why

The record is accurate and the constrained idiom is still in use, so it earns a slot. Verified rather than assumed:

- `onBrokenLinks: 'throw'` is set (`website/docusaurus.config.ts:28`), so the failure mode really is a hard build failure and not a warning.
- The cited evidence resolves: PR #334 merged 2026-07-18T21:28Z, and runs 29661022607 and 29661156116 both exist and both concluded `failure`, at 21:07 and 21:11 that same evening. "Two failures, one from each direction" holds.
- `.md`-relative doc links are live today in `concepts/trust-classes.md`, `concepts/receipts.md`, `concepts/lifecycle.md`, `team/team.md` and `hosts/index.md`, on both sides of the locale split.

## One correction made during review

The original `expires.condition` retired the scar once every page was translated. Coverage is **already 15/15** with zero fallback pages, so promoting it unchanged would have handed the next reviewer a satisfied expiry condition on a protection that is still one page away from firing.

The condition now turns on the durable facts (leaving `.md`-relative links, or a build-time no-fallback guarantee), and both the frontmatter and a new body paragraph say explicitly that complete coverage makes the hazard **dormant, not gone**. It fires when a 16th English page lands without its Spanish copy, which is precisely when someone is adding docs and not thinking about the locale build.

## Tests

`scar lint` clean: 25 files, 0 with errors, 0 orphans, 0 partial-rot, 0 unreachable-evidence. The `scar lint` CI job covers this. No runtime code touched.
