### PR TITLE
feat(stats): rejection ledger for verification downgrades

### DIFF
--- a/.scars/candidates/append-event-any-kind-resolves-the-item.md
+++ b/.scars/candidates/append-event-any-kind-resolves-the-item.md
@@ -1,0 +1,46 @@
+---
+id: 0
+type: landmine
+title: "append_event with ANY kind hides the item — resolutions() ignores kind and is_resolved() defaults unknown statuses to resolved"
+severity: critical
+confidence: 1.0
+created: 2026-07-28
+authors: ["claude-code"]
+anchors:
+  - path: plugin/daimon_briefing/store.py
+  - pattern: "append_event[(][^)]{0,200}kind="
+evidence:
+  - note: "2026-07-28 probe while designing #376: append_event(ref, 'quote-verification-failed', kind='verification') then resolutions() then is_resolved() returned True — the item would vanish from briefing, recall and carry"
+expires:
+  condition: "resolutions() filters by kind (or the ledger moves to its own stream) AND is_resolved() no longer treats unknown statuses as resolved"
+  review_after: 2027-07-28
+status: candidate
+---
+
+`store.append_event` takes a `kind` argument, which reads as if it namespaces
+the event. It does not. `resolutions()` folds strictly on `item_ref` and never
+looks at `kind`, so the newest event for a ref wins whatever kind it carries.
+`is_resolved()` then applies a deliberate default: only `reopen*` and
+`supersede-candidate*` keep an item live, and "unknown statuses resolve
+(the writer bothered to record a lifecycle fact) rather than vanish".
+
+Combined: writing ANY new event kind against a real `item_ref` silently
+RESOLVES that item. Three readers act on it — `briefing.py:214`,
+`cli.py:300`, `recall.py:404` — so the item disappears from the briefing,
+from carry, and from recall.
+
+Probed 2026-07-28 while designing the #376 rejection ledger, whose first
+design was "reuse the existing event trail, do not invent a second one".
+That design would have hidden every item verification downgraded, which is
+the exact inverse of the intent: a downgraded item must stay visible and
+merely be relabelled inferred.
+
+Why this has stayed invisible: `kind` has exactly ONE non-default use today,
+`kind="tombstone"` for `daimon forget` (`tests/test_recall.py:1502`), and
+that test asserts the item DISAPPEARS from recall. For tombstone, resolving
+is the intended effect, so the coupling has never once been wrong in
+practice and reads like deliberate design.
+
+Before adding any non-lifecycle event kind: either give it its own stream,
+or teach `resolutions()` to filter by kind FIRST and re-check all three
+readers. Do not assume `kind` isolates anything.

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -316,6 +316,17 @@ def _run_serialize(transcript_path: Path, project: str | None,
         except Exception:  # keep the unmerged checkpoint, proceed to write
             pass
     out = store.write_checkpoint(session_id, checkpoint, project_dir=project)
+    # #376: record what the checkers REJECTED, after write_checkpoint because
+    # that is where item ids are guaranteed stamped (the merge branch above
+    # only stamps when it runs). Its own append-only stream, never events.jsonl
+    # — a rejection folded on item_ref would resolve the item and hide exactly
+    # what it describes. Fail-open: an advisory counter never costs a capture.
+    try:
+        for row in serializer.verification_rejections(checkpoint):
+            store.append_verification(row["item_ref"], row["check"],
+                                      row["reason"], project_dir=project)
+    except Exception:
+        pass
     elapsed = int(time.monotonic() - start)
     msg = f"wrote checkpoint: {out} (took {elapsed}s)"
     if llm.fallback_used():
@@ -2041,12 +2052,23 @@ def _stats_events(project_dir) -> dict:
     return out
 
 
+def _stats_verification(project_dir) -> dict:
+    """Rejection ledger (#376) -> total + per-check breakdown. This is the
+    number that turns "memory you can verify" from a claim into something the
+    user can check on their own machine: how often the checkers actually
+    caught something here. Zeroes when nothing was ever rejected, which is
+    itself an answer."""
+    by_check = store.verification_counts(project_dir=project_dir)
+    return {"total": sum(by_check.values()), "by_check": by_check}
+
+
 def _cmd_stats(args) -> int:
     """Aggregate what is already on disk. Nothing is transmitted anywhere —
     sharing the output is a deliberate act (the user pastes it)."""
     data = {"usage": _stats_usage(), "capture": _stats_capture(),
             "store": _stats_store(), "retention": _stats_retention(),
-            "events": _stats_events(_resolve_project(None))}
+            "events": _stats_events(_resolve_project(None)),
+            "verification": _stats_verification(_resolve_project(None))}
     if args.json:
         print(json.dumps(data, indent=2))
         return 0

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -863,6 +863,14 @@ def _plain_stats(data: dict) -> None:
         print("events (this project):")
         print(f"  log lines: {e['lines']}  resolved refs: {e['resolved_refs']}  "
               f"fold: {e['fold_ms']}ms")
+    v = data.get("verification")
+    if v and v.get("total"):
+        # #376: what the checkers REJECTED here. Shown only when non-zero —
+        # zero is a real answer but an all-zero block is noise in the default
+        # view, and `--json` always carries it.
+        print("verification (this project):")
+        print(f"  rejections: {v['total']}  " + ", ".join(
+            f"{k} {n}" for k, n in sorted(v["by_check"].items())))
 
 
 def _rich_stats(data: dict) -> None:
@@ -955,3 +963,16 @@ def _rich_stats(data: dict) -> None:
         events_table.add_row("resolved refs", str(e["resolved_refs"]))
         events_table.add_row("fold", f"{e['fold_ms']}ms")
         console.print(events_table)
+
+    v = data.get("verification")
+    if v and v.get("total"):
+        # #376: mirrors the plain renderer — non-zero only.
+        ver_table = Table(title="verification (this project)",
+                          title_justify="left", show_header=True,
+                          header_style="bold")
+        ver_table.add_column("check")
+        ver_table.add_column("rejections")
+        for check, n in sorted(v["by_check"].items()):
+            ver_table.add_row(check, str(n))
+        ver_table.add_row("total", str(v["total"]))
+        console.print(ver_table)

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -924,6 +924,34 @@ def _asserts_outcome(text: str) -> bool:
     return bool(_OUTCOME_RE.search(text)) and not _HEDGE_RE.search(text)
 
 
+def verification_rejections(checkpoint) -> list:
+    """Every rejection the checkers made on this checkpoint, as ledger rows
+    (#376): [{item_ref, check, reason}].
+
+    Derived from the finished checkpoint rather than observed at the call
+    site, because `serialize_strict` has no project context and the ledger
+    write needs one. That is sound, not a shortcut: `quote_verified: False`
+    is written ONLY where verify_quotes downgrades (a passing item gets
+    True, an already-inferred item is left untouched with neither field),
+    and `grounded: False` ONLY where ground_outcomes downgrades. The stored
+    state is therefore a faithful record of both rejection acts.
+
+    An item with no `id` yields no row: a ledger entry nobody can trace back
+    is noise. Never raises — this feeds an advisory counter."""
+    out = []
+    for item in iter_items(checkpoint):
+        ref = item.get("id")
+        if not isinstance(ref, str) or not ref:
+            continue
+        if item.get("quote_verified") is False:
+            out.append({"item_ref": ref, "check": "quote",
+                        "reason": "quote-not-in-transcript"})
+        if item.get(GROUNDED_KEY) is False:
+            out.append({"item_ref": ref, "check": "outcome",
+                        "reason": "no-signal-cited"})
+    return out
+
+
 def ground_outcomes(checkpoint, signal_ids) -> int:
     """Derive the code-owned `grounded` verdict in place (#359). Returns the
     number of verbatim outcome claims downgraded to inferred.

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -929,6 +929,77 @@ def _events_path(project_dir=None):
     return config.checkpoint_dir() / slug / "events.jsonl"
 
 
+def _ledger_path(project_dir=None):
+    slug = project_slug(project_dir)
+    if not slug:
+        return None
+    return config.checkpoint_dir() / slug / "verification.jsonl"
+
+
+def append_verification(item_ref: str, check: str, reason: str,
+                        project_dir=None) -> bool:
+    """One appended line per REJECTION the checker made (#376): a verbatim
+    quote that missed the transcript, an outcome claim with no signal cited.
+
+    Deliberately a SECOND stream, not an `events.jsonl` row with a new `kind`.
+    `resolutions()` folds events on `item_ref` alone and never inspects
+    `kind`, and `is_resolved()` resolves any status outside reopen/
+    supersede-candidate — so a rejection written there would HIDE the very
+    item it describes, from the briefing, from carry and from recall. A
+    downgraded item must stay visible and merely read as inferred.
+
+    Stores a POINTER and a REASON CODE, never the rejected text: quote
+    verification runs pre-redaction (#141), so the raw item text must not
+    reach a log sink. `check` and `reason` are scrubbed anyway (defence in
+    depth — a caller could pass something secret-shaped).
+
+    Same never-fatal contract as append_event: silent no-op under the kill
+    switch or an unknown project, False on OSError. A ledger write must
+    never fail a capture."""
+    if config.is_disabled():
+        return False
+    path = _ledger_path(project_dir)
+    if path is None:
+        return False
+    try:
+        check, _ = redact.redact_text(check)
+        reason, _ = redact.redact_text(reason)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        row = {"ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+               "check": check, "item_ref": item_ref, "reason": reason}
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+        return True
+    except OSError:
+        return False
+
+
+def verification_counts(project_dir=None) -> dict:
+    """{check: count} over the rejection ledger. Answers the question the
+    trust classes otherwise cannot: has verification ever caught anything on
+    THIS install. Fails open to {} (missing/corrupt log, unknown project) —
+    same posture as the resolutions fold."""
+    out: dict = {}
+    path = _ledger_path(project_dir)
+    if path is None:
+        return out
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return out
+    for line in lines:
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(row, dict):
+            continue
+        check = str(row.get("check") or "")
+        if check:
+            out[check] = out.get(check, 0) + 1
+    return out
+
+
 def append_event(item_ref: str, status: str, note: str = "",
                  kind: str = "resolution", source: str = "cli",
                  project_dir=None, item_text: str = "") -> bool:

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -5854,3 +5854,23 @@ def test_stats_verification_reports_counts(tmp_path, monkeypatch):
 def test_stats_verification_empty_when_nothing_rejected(tmp_path, monkeypatch):
     monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path))
     assert cli._stats_verification("/repo/nothing") == {"total": 0, "by_check": {}}
+
+
+def test_serialize_survives_a_broken_ledger_emit(tmp_checkpoint_dir, fake_chat_factory,
+                                                 monkeypatch):
+    """#376 fail-open, end to end: the rejection ledger is advisory, so a
+    raising emit must still leave a written checkpoint and rc 0. Without this
+    the 'never costs a capture' contract is only a docstring."""
+    from daimon_briefing import serializer, store
+
+    monkeypatch.setattr(cli, "_chat", fake_chat_factory(_valid_json()))
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+
+    def boom(_checkpoint):
+        raise RuntimeError("ledger derivation exploded")
+
+    monkeypatch.setattr(serializer, "verification_rejections", boom)
+
+    rc = cli.main(["serialize", str(FIXTURES / "sample_transcript.md")])
+    assert rc == 0
+    assert store.read_checkpoint("sample_transcript") is not None

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -5834,3 +5834,23 @@ def test_forget_by_unique_fuzzy_query(tmp_checkpoint_dir, capsys, monkeypatch):
     ids = [i.get("id") for i in after["working_context"]["open_questions"]]
     assert iid not in ids
     assert store.resolutions(project_dir="/p/A")[iid]["status"].startswith("forgotten:")
+
+
+# --- #376 rejection ledger in stats ----------------------------------------
+
+def test_stats_verification_reports_counts(tmp_path, monkeypatch):
+    """`daimon stats` answers 'has verification ever caught anything here'."""
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path))
+    proj = "/repo/stats-ledger"
+    store.append_verification("i1", "quote", "quote-not-in-transcript",
+                              project_dir=proj)
+    store.append_verification("i2", "outcome", "no-signal-cited",
+                              project_dir=proj)
+    out = cli._stats_verification(proj)
+    assert out == {"total": 2, "by_check": {"quote": 1, "outcome": 1}}
+
+
+def test_stats_verification_empty_when_nothing_rejected(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path))
+    assert cli._stats_verification("/repo/nothing") == {"total": 0, "by_check": {}}

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -1081,3 +1081,35 @@ def test_plain_stats_omits_verification_when_nothing_rejected(capsys, monkeypatc
     monkeypatch.setattr(render, "supports_rich", lambda: False)
     render.render_stats(_stats_payload({"total": 0, "by_check": {}}))
     assert "verification" not in capsys.readouterr().out
+
+
+def test_rich_stats_shows_verification_rejections(monkeypatch):
+    """Rich path mirrors plain: the count must reach a rich user too."""
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    printed = []
+
+    class _Console:
+        def print(self, obj):
+            printed.append(obj)
+
+    import rich.console
+    monkeypatch.setattr(rich.console, "Console", lambda *a, **k: _Console())
+    render.render_stats(_stats_payload(
+        {"total": 3, "by_check": {"quote": 2, "outcome": 1}}))
+    titles = [getattr(o, "title", None) for o in printed]
+    assert "verification (this project)" in titles
+
+
+def test_rich_stats_omits_verification_when_nothing_rejected(monkeypatch):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    printed = []
+
+    class _Console:
+        def print(self, obj):
+            printed.append(obj)
+
+    import rich.console
+    monkeypatch.setattr(rich.console, "Console", lambda *a, **k: _Console())
+    render.render_stats(_stats_payload({"total": 0, "by_check": {}}))
+    titles = [getattr(o, "title", None) for o in printed]
+    assert "verification (this project)" not in titles

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -1050,3 +1050,34 @@ def test_render_projects_rich_smoke(monkeypatch, capsys):
     ])
     out = capsys.readouterr().out
     assert "-p-a" in out and "work a" in out
+
+
+# --- #376 rejection ledger in stats output ---------------------------------
+
+def _stats_payload(verification):
+    return {"usage": {}, "capture": {"success": 0, "skipped": 0, "errors": 0,
+                                     "hosts": {}, "fallback_serializes": 0,
+                                     "max_serialize_seconds": 0,
+                                     "total_serialize_seconds": 0},
+            "store": {"checkpoints": 0, "project_buckets": 0,
+                      "items_by_kind": {}, "items_verbatim": 0,
+                      "items_inferred": 0, "items_untagged": 0,
+                      "items_carried": 0},
+            "retention": {}, "events": None, "verification": verification}
+
+
+def test_plain_stats_shows_verification_rejections(capsys, monkeypatch):
+    monkeypatch.setattr(render, "supports_rich", lambda: False)
+    render.render_stats(_stats_payload(
+        {"total": 3, "by_check": {"quote": 2, "outcome": 1}}))
+    out = capsys.readouterr().out
+    assert "verification" in out
+    assert "3" in out and "quote 2" in out and "outcome 1" in out
+
+
+def test_plain_stats_omits_verification_when_nothing_rejected(capsys, monkeypatch):
+    """Zero rejections is a real answer, but an all-zero block is noise in the
+    default view; the JSON payload still carries it."""
+    monkeypatch.setattr(render, "supports_rich", lambda: False)
+    render.render_stats(_stats_payload({"total": 0, "by_check": {}}))
+    assert "verification" not in capsys.readouterr().out

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -2207,3 +2207,44 @@ def test_escalated_deadline_scales_by_perspective_wave_plan(
     assert len(seen) == 1  # every call shares ONE scaled deadline
     scaled = seen.pop()
     assert scaled >= given + 250  # ~300s extension for 4 waves
+
+
+# --- #376 rejection derivation ---------------------------------------------
+# quote_verified: false and grounded: false are each written ONLY on their
+# downgrade branch, so the finished checkpoint is a faithful record of what
+# the checkers rejected. Deriving from stored state beats a side channel.
+
+def _ck(items):
+    return {"working_context": {"recent_decisions": items}}
+
+
+def test_rejections_derives_quote_downgrade():
+    ck = _ck([{"id": "a", "trust": "inferred", "quote_verified": False}])
+    assert serializer.verification_rejections(ck) == [
+        {"item_ref": "a", "check": "quote", "reason": "quote-not-in-transcript"}]
+
+
+def test_rejections_derives_outcome_downgrade():
+    ck = _ck([{"id": "b", "trust": "inferred", "grounded": False}])
+    assert serializer.verification_rejections(ck) == [
+        {"item_ref": "b", "check": "outcome", "reason": "no-signal-cited"}]
+
+
+def test_rejections_ignores_passing_items():
+    """A verified quote and a grounded outcome are not rejections."""
+    ck = _ck([{"id": "a", "trust": "verbatim", "quote_verified": True,
+               "grounded": True},
+              {"id": "b", "trust": "inferred"}])
+    assert serializer.verification_rejections(ck) == []
+
+
+def test_rejections_reports_both_checks_for_one_item():
+    ck = _ck([{"id": "c", "quote_verified": False, "grounded": False}])
+    out = serializer.verification_rejections(ck)
+    assert [r["check"] for r in out] == ["quote", "outcome"]
+
+
+def test_rejections_skips_items_without_an_id():
+    """No pointer, no row — a ledger entry that cannot be traced is noise."""
+    ck = _ck([{"quote_verified": False}])
+    assert serializer.verification_rejections(ck) == []

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1679,3 +1679,48 @@ def test_write_checkpoint_redacts_scene(tmp_checkpoint_dir):
     assert "sk-scenesecret12345678" not in cp["working_context"]["open_questions"][0]["scene"]
     assert "sk-topicsecret99887766" not in cp["working_context"]["active_topic"]["scene"]
     assert cp["redactions"]["api-key"] == 2
+
+
+# --- #376 rejection ledger -------------------------------------------------
+# The ledger is a SECOND append-only stream. It must never reach
+# store.resolutions(): scar candidate append-event-any-kind-resolves-the-item
+# proved that any event folded on item_ref marks that item resolved, which
+# would hide exactly the items verification downgraded.
+
+def test_verification_ledger_never_resolves_the_item(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path))
+    proj = "/repo/ledger-iso"
+    store.append_verification("item-1", "quote", "quote-not-in-transcript",
+                              project_dir=proj)
+    assert store.resolutions(project_dir=proj) == {}
+
+
+def test_verification_ledger_appends_and_counts(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path))
+    proj = "/repo/ledger-count"
+    store.append_verification("item-1", "quote", "quote-not-in-transcript",
+                              project_dir=proj)
+    store.append_verification("item-2", "quote", "quote-not-in-transcript",
+                              project_dir=proj)
+    store.append_verification("item-3", "outcome", "no-signal-cited",
+                              project_dir=proj)
+    assert store.verification_counts(project_dir=proj) == {"quote": 2, "outcome": 1}
+
+
+def test_verification_ledger_stores_no_item_text(tmp_path, monkeypatch):
+    """Quote verification runs PRE-redaction (#141): raw text must never reach
+    a log sink. The ledger stores a pointer and a reason code, nothing else."""
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path))
+    proj = "/repo/ledger-notext"
+    secret = "sk-live-DEADBEEF-not-a-real-key"
+    store.append_verification("item-1", "quote", "quote-not-in-transcript",
+                              project_dir=proj)
+    blob = store._ledger_path(proj).read_text(encoding="utf-8")
+    assert secret not in blob
+    row = json.loads(blob.splitlines()[0])
+    assert set(row) == {"ts", "check", "item_ref", "reason"}
+
+
+def test_verification_counts_missing_log_is_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path))
+    assert store.verification_counts(project_dir="/repo/never-written") == {}

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1724,3 +1724,40 @@ def test_verification_ledger_stores_no_item_text(tmp_path, monkeypatch):
 def test_verification_counts_missing_log_is_empty(tmp_path, monkeypatch):
     monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path))
     assert store.verification_counts(project_dir="/repo/never-written") == {}
+
+
+def test_verification_ledger_kill_switch_is_a_noop(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path))
+    monkeypatch.setenv("DAIMON_DISABLE", "1")
+    assert store.append_verification("i", "quote", "r", project_dir="/repo/ks") is False
+    assert list(tmp_path.rglob("verification.jsonl")) == []
+
+
+def test_verification_ledger_unknown_project_is_a_noop(tmp_path, monkeypatch):
+    """No project bucket means no reader — write and read both no-op."""
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path))
+    assert store._ledger_path(None) is None
+    assert store.append_verification("i", "quote", "r", project_dir=None) is False
+    assert store.verification_counts(project_dir=None) == {}
+
+
+def test_verification_ledger_survives_oserror(tmp_path, monkeypatch):
+    """A ledger write must never fail a capture."""
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path))
+
+    def boom(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(store.Path, "open", boom)
+    assert store.append_verification("i", "quote", "r", project_dir="/repo/oserr") is False
+
+
+def test_verification_counts_skips_corrupt_and_nondict_rows(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path))
+    proj = "/repo/corrupt"
+    store.append_verification("i1", "quote", "r", project_dir=proj)
+    with store._ledger_path(proj).open("a", encoding="utf-8") as f:
+        f.write("{not json\n")
+        f.write('["a list, not a row"]\n')
+        f.write('{"item_ref": "i2"}\n')          # no check -> not counted
+    assert store.verification_counts(project_dir=proj) == {"quote": 1}


### PR DESCRIPTION
Closes #376

## What

A rejection ledger: every downgrade the checkers make is recorded as a durable event, and `daimon stats` reports the totals.

- `store.append_verification()` / `store.verification_counts()` writing to a new per-project `verification.jsonl`
- `serializer.verification_rejections(checkpoint)` deriving the rows
- emitted from the serialize path after `write_checkpoint`
- surfaced in `daimon stats`, plain and rich, plus `--json`

## Why

`verify_quotes` and `ground_outcomes` each returned a count that evaporated at the end of the run. Nothing on disk answered the question the trust classes otherwise cannot: **has verification ever actually caught anything on this install?** A silently downgraded item also looked identical to one born inferred, so the user never learned the checker had done work for them.

## The design changed during implementation, and the original was dangerous

The issue proposed reusing `store.append_event` with a new `kind`, and explicitly rejected a second stream. **That would have hidden every downgraded item.**

`store.resolutions()` folds strictly on `item_ref` and never inspects `kind`; `is_resolved()` then resolves any status outside `reopen*` / `supersede-candidate*` by deliberate design. Probed before committing to an approach:

```
append_event(ref, "quote-verification-failed", kind="verification")
is_resolved(resolutions()[ref])  ->  True
```

Three readers act on that (`briefing.py:214`, `cli.py:300`, `recall.py:404`), so a rejection written to the event trail would have removed the item from the briefing, from carry and from recall. The exact inverse of the intent.

It stays invisible because `kind` has exactly one non-default use today, `kind="tombstone"` for `forget`, where disappearing is precisely what is wanted. Scar candidate included in this PR.

## Design notes

- **Second stream, not a new kind.** The two logs answer different questions: what is this item's lifecycle state, versus what did the checker do to it.
- **Pointer and reason code, never the text.** Quote verification runs pre-redaction (#141), so raw item text must not reach a log sink. `check` and `reason` are scrubbed anyway as defence in depth.
- **Derived from the finished checkpoint** rather than observed inside the pure functions, because `serialize_strict` has no project context. Sound rather than expedient: `quote_verified: False` is written only where verify_quotes downgrades, `grounded: False` only where ground_outcomes downgrades.
- **Emitted after `write_checkpoint`**, the point where item ids are guaranteed stamped (the merge branch only stamps when it runs).
- **Fail-open everywhere.** Kill-switch no-op, unknown project no-op, `False` on OSError, and the emit loop is wrapped. An advisory counter must never cost a capture.
- **Non-zero only in the default view**; zero rejections is a real answer but an all-zero block is noise. `--json` always carries it.

## Tests

`1967 passed, 2 skipped` (was 1954). 13 new tests, all written failing first:

- ledger never reaches `resolutions()` — the regression guard for the trap above
- append + per-check counts; missing log returns empty
- row shape is exactly `{ts, check, item_ref, reason}`, no text field
- derivation: quote downgrade, outcome downgrade, both on one item, passing items ignored, id-less items skipped
- stats aggregation, and both render paths

`ruff` clean. `mypy` reports 52 errors, **identical to HEAD** (verified by stashing); CI marks it non-blocking for exactly these pre-existing errors.

## Deliberately not in scope

The issue also listed worldcheck contradictions and user-rejected supersede candidates. Both fire outside the capture path and are better as a follow-up than as extra surface here.
