### PR TITLE
docs(scars): promote the append_event kind landmine to active (0025)

### DIFF
--- a/.scars/0025-append-event-any-kind-resolves-the-item.landmine.md
+++ b/.scars/0025-append-event-any-kind-resolves-the-item.landmine.md
@@ -1,20 +1,20 @@
 ---
-id: 0
+id: 25
 type: landmine
 title: "append_event with ANY kind hides the item — resolutions() ignores kind and is_resolved() defaults unknown statuses to resolved"
 severity: critical
 confidence: 1.0
 created: 2026-07-28
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/store.py
   - pattern: "append_event[(][^)]{0,200}kind="
 evidence:
-  - note: "2026-07-28 probe while designing #376: append_event(ref, 'quote-verification-failed', kind='verification') then resolutions() then is_resolved() returned True — the item would vanish from briefing, recall and carry"
+  - note: 2026-07-28 probe while designing #376: append_event(ref, 'quote-verification-failed', kind='verification') then resolutions() then is_resolved() returned True — the item would vanish from briefing, recall and carry
 expires:
   condition: "resolutions() filters by kind (or the ledger moves to its own stream) AND is_resolved() no longer treats unknown statuses as resolved"
   review_after: 2027-07-28
-status: candidate
+status: active
 ---
 
 `store.append_event` takes a `kind` argument, which reads as if it namespaces


### PR DESCRIPTION
Promotes the `append-event-any-kind-resolves-the-item` candidate to active scar **0025**, severity critical, confidence 1.0.

No issue link: `pr-validation.yml` exempts scars-only PRs from the issue-first gate, since the human sign-off happens at `scar promote` and is recorded in `authors`. Every path in this diff is under `.scars/`.

## What it records

`store.append_event` accepts a `kind` argument that reads like it namespaces the event. It does not. `resolutions()` folds strictly on `item_ref` and never inspects `kind`, and `is_resolved()` resolves any status outside `reopen*` / `supersede-candidate*` by deliberate design.

So writing any non-lifecycle event against a real `item_ref` silently resolves that item. Three readers act on it (`briefing.py:214`, `cli.py:300`, `recall.py:404`), removing it from the briefing, from carry, and from recall.

## Why it earns a slot

This was found by probe, not review, while designing #376:

```
append_event(ref, "quote-verification-failed", kind="verification")
is_resolved(resolutions()[ref])  ->  True
```

The rejection ledger's originally-specified design would have hidden every item verification downgraded, which is the precise inverse of its purpose. #377 ships a second stream because of this finding.

It stays invisible because `kind` has exactly one non-default use today, `kind="tombstone"` for `forget` (`tests/test_recall.py:1502` asserts the item disappears). There, resolving is exactly what is wanted, so the coupling has never once been wrong in practice and reads like intentional design.

## Tests

`scar lint` clean: 26 files, 0 errors, 0 orphans, 0 partial-rot, 0 unreachable-evidence. The pattern anchor is escape-free per scar 0019 (escapes in anchors are never processed) and was verified to fire on `append_event(..., kind=...)` calls before authoring.
