### PR TITLE
chore(stats): rolling-window capture rate with 10% reopen gate

### DIFF
--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -16,7 +16,7 @@ slice): the every-line tally (_stats_capture) and the in-window spawn probe
 """
 
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from . import config, store
@@ -335,10 +335,28 @@ def _is_result_line(line: str) -> bool:
                 or _RESULT_ERR_RE.match(line))
 
 
-def _stats_capture() -> dict:
+# #364: the rolling window behind "is capture healthy NOW" — matches the
+# retention window so both instruments describe the same recent past. The gate
+# is the reopen/escalate threshold recorded on #364: a rolling error rate above
+# it means the foundation the whole product sits on is failing too often.
+_CAPTURE_WINDOW_DAYS = 14
+_CAPTURE_ERROR_GATE_PCT = 10
+
+
+def _stats_capture(now=None) -> dict:
     """serialize.log -> aggregate counters. Tallies EVERY line (scar #9: no
     last-of-kind collapse — a buried failure still counts), except an
     ADJACENT-identical repeat of a result line (#300).
+
+    #364 adds a `window` sub-dict: the same tallies restricted to the last
+    _CAPTURE_WINDOW_DAYS, plus an error-rate percentage over in-window capture
+    ATTEMPTS (success + errors; skips are policy outcomes, not attempts).
+    Result lines are unstamped, so each inherits the most recent stamped
+    line's timestamp; result lines before any stamped line have unknown age
+    and count lifetime only (#54 honesty rule: ambiguous, never guessed).
+    The window shares this fold's line classification verbatim — dedupe and
+    the too-short reclassification below apply identically, so the window can
+    never disagree with the lifetime counters about what a line IS.
 
     #300: every result line is built once, printed to stdout, AND logged
     first-class by _run_serialize. Any spawn path that redirected the child's
@@ -360,13 +378,20 @@ def _stats_capture() -> dict:
     This is NOT the last-of-kind collapse scar #9 forbids: it never reaches
     across sessions, so a failure buried under a later session's success still
     counts."""
+    win = {"days": _CAPTURE_WINDOW_DAYS, "success": 0, "skipped": 0,
+           "errors": 0, "fallback_attempts": 0, "fallback_serializes": 0,
+           "error_rate_pct": None}
     out = {"success": 0, "skipped": 0, "errors": 0, "fallback_serializes": 0,
            "fallback_attempts": 0,
-           "hosts": {}, "max_serialize_seconds": 0, "total_serialize_seconds": 0}
+           "hosts": {}, "max_serialize_seconds": 0, "total_serialize_seconds": 0,
+           "window": win}
     try:
         text = (config.log_dir() / "serialize.log").read_text(encoding="utf-8")
     except OSError:
         return out
+    cutoff = ((now or datetime.now(timezone.utc))
+              - timedelta(days=_CAPTURE_WINDOW_DAYS))
+    in_window = False  # was the most recent stamped line inside the window?
     prev = None
     for line in text.splitlines():
         line = line.strip()
@@ -374,11 +399,17 @@ def _stats_capture() -> dict:
         prev = line
         if doubled:
             continue
+        if line:
+            stamp = _parse_stamp(line.split()[0])
+            if stamp is not None:
+                in_window = stamp >= cutoff
         # #341: fallback_serializes counts successes only; the chat() entry
         # warning is the attempt marker. Without it, a fallback that runs and
         # dies is indistinguishable from one that never ran.
         if "llm.fallback backend=command" in line:
             out["fallback_attempts"] += 1
+            if in_window:
+                win["fallback_attempts"] += 1
             continue
         m = _RESULT_OK_RE.match(line)
         if m:
@@ -386,11 +417,17 @@ def _stats_capture() -> dict:
             took = int(m.group(1))
             out["max_serialize_seconds"] = max(out["max_serialize_seconds"], took)
             out["total_serialize_seconds"] += took
+            if in_window:
+                win["success"] += 1
             if "[fallback backend]" in line:
                 out["fallback_serializes"] += 1
+                if in_window:
+                    win["fallback_serializes"] += 1
             continue
         if _LEDGER_SKIP_RE.match(line):
             out["skipped"] += 1
+            if in_window:
+                win["skipped"] += 1
             continue
         if _RESULT_ERR_RE.match(line):
             # #235: too-short is a policy skip, not a failure. The write side
@@ -399,12 +436,19 @@ def _stats_capture() -> dict:
             # stays "capture should have worked and didn't".
             if "transcript too short" in line:
                 out["skipped"] += 1
+                if in_window:
+                    win["skipped"] += 1
             else:
                 out["errors"] += 1
+                if in_window:
+                    win["errors"] += 1
             continue
         hm = _STATS_HOST_RE.match(line)
         if hm:
             out["hosts"][hm.group(1)] = out["hosts"].get(hm.group(1), 0) + 1
+    attempts = win["success"] + win["errors"]
+    if attempts:
+        win["error_rate_pct"] = round(win["errors"] * 100 / attempts, 1)
     return out
 
 

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -815,6 +815,25 @@ def render_stats(data: dict) -> None:
         _plain_stats(data)
 
 
+def _capture_window_lines(c: dict) -> list[str]:
+    """#364: the rolling-window capture-rate line(s), shared verbatim by the
+    plain and rich stats renderers. Second line only when the rolling error
+    rate trips the reopen gate recorded on #364."""
+    from .ledger import _CAPTURE_ERROR_GATE_PCT
+    w = c.get("window")
+    if not w:
+        return []
+    rate = w["error_rate_pct"]
+    lines = [f"last {w['days']}d: serialized {w['success']}  "
+             f"errors {w['errors']}  rescued {w['fallback_serializes']}  "
+             f"error rate: {'n/a' if rate is None else f'{rate}%'}"]
+    if rate is not None and rate > _CAPTURE_ERROR_GATE_PCT:
+        lines.append(f"⚠ capture error rate {rate}% (last {w['days']}d) "
+                     f"exceeds the {_CAPTURE_ERROR_GATE_PCT}% gate — see "
+                     "`daimon status` for failing serializes")
+    return lines
+
+
 def _plain_stats(data: dict) -> None:
     u, c, s = data["usage"], data["capture"], data["store"]
     print("usage (local, never transmitted):")
@@ -845,6 +864,8 @@ def _plain_stats(data: dict) -> None:
           f"errors: {c['errors']}  fallback: "
           f"attempted {c.get('fallback_attempts', 0)}, "
           f"succeeded {c['fallback_serializes']}")
+    for line in _capture_window_lines(c):
+        print(f"  {line}")
     if c["hosts"]:
         print("  spawns by host: " + ", ".join(
             f"{h}: {n}" for h, n in sorted(c["hosts"].items())))
@@ -926,6 +947,11 @@ def _rich_stats(data: dict) -> None:
     capture_table.add_row("errors", str(c["errors"]))
     capture_table.add_row("fallback", f"attempted {c.get('fallback_attempts', 0)}, "
                                       f"succeeded {c['fallback_serializes']}")
+    window_lines = _capture_window_lines(c)
+    if window_lines:
+        # first line is `last Nd: <values>` — split it into the two columns
+        label, _, values = window_lines[0].partition(": ")
+        capture_table.add_row(label, values)
     if c["hosts"]:
         capture_table.add_row("spawns by host", ", ".join(
             f"{h}: {n}" for h, n in sorted(c["hosts"].items())))
@@ -936,6 +962,8 @@ def _rich_stats(data: dict) -> None:
             f"avg {c['total_serialize_seconds'] // c['success']}",
         )
     console.print(capture_table)
+    for warning in window_lines[1:]:  # the #364 gate warning, when tripped
+        console.print(f"[yellow]{warning}[/yellow]")
 
     store_table = Table(title="store", title_justify="left",
                         show_header=True, header_style="bold")

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -4403,6 +4403,200 @@ def test_stats_capture_dedupe_does_not_mask_a_buried_failure(tmp_log_dir):
     assert cap["success"] == 1
 
 
+# ---- #364: rolling-window capture rate — "is capture healthy NOW", not ever ----
+
+
+def _iso(dt):
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_stats_capture_window_counts_only_recent_results(tmp_log_dir):
+    # #364: lifetime counters can't say whether capture is healthy NOW. Result
+    # lines are unstamped, so each inherits the most recent stamped line above
+    # it; only results attributed inside the window count.
+    from daimon_briefing import ledger
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc)
+    old = now - timedelta(days=20)
+    recent = now - timedelta(days=2)
+    _write_log(tmp_log_dir, [
+        f"{_iso(old)} session-end: spawned serialize for A (project: /p/A)",
+        "wrote checkpoint: /c/A.json (took 10s)",
+        "error: boom (transcript: /t/B.jsonl) after 3s",
+        f"{_iso(recent)} session-end: spawned serialize for C (project: /p/A)",
+        "wrote checkpoint: /c/C.json (took 20s)",
+        "error: boom (transcript: /t/D.jsonl) after 5s",
+    ])
+    cap = ledger._stats_capture(now=now)
+    assert cap["success"] == 2 and cap["errors"] == 2   # lifetime unchanged
+    w = cap["window"]
+    assert w["days"] == 14
+    assert w["success"] == 1
+    assert w["errors"] == 1
+    assert w["error_rate_pct"] == 50.0
+
+
+def test_stats_capture_window_excludes_unstamped_prefix(tmp_log_dir):
+    # A result line before ANY stamped line has an unknown age — it counts
+    # lifetime but never in the window (#54 honesty rule: ambiguous, never
+    # guessed).
+    from daimon_briefing import ledger
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc)
+    _write_log(tmp_log_dir, [
+        "wrote checkpoint: /c/A.json (took 10s)",
+        f"{_iso(now - timedelta(days=1))} session-end: spawned serialize for B "
+        "(project: /p/B)",
+        "wrote checkpoint: /c/B.json (took 20s)",
+    ])
+    cap = ledger._stats_capture(now=now)
+    assert cap["success"] == 2
+    assert cap["window"]["success"] == 1
+
+
+def test_stats_capture_window_rate_none_when_no_attempts(tmp_log_dir):
+    # No in-window successes or errors -> no rate, not 0% (a skip is a policy
+    # outcome, not a capture attempt).
+    from daimon_briefing import ledger
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc)
+    _write_log(tmp_log_dir, [
+        f"{_iso(now - timedelta(days=1))} session-end: spawned serialize for A "
+        "(project: /p/A)",
+        "skipped serialize for A: transcript too short (2 < 10 messages)",
+    ])
+    cap = ledger._stats_capture(now=now)
+    w = cap["window"]
+    assert w["success"] == 0 and w["errors"] == 0 and w["skipped"] == 1
+    assert w["error_rate_pct"] is None
+
+
+def test_stats_capture_window_shares_reclassify_and_dedupe(tmp_log_dir):
+    # The window tally rides the SAME line classification as the lifetime
+    # fold: too-short errors reclassify to skips (#235) and adjacent doubles
+    # collapse (#300) — the window must never disagree with the lifetime
+    # counters about what a line IS.
+    from daimon_briefing import ledger
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc)
+    _write_log(tmp_log_dir, [
+        f"{_iso(now - timedelta(days=1))} session-end: spawned serialize for A "
+        "(project: /p/A)",
+        "error: transcript too short (2 < 10 messages) "
+        "(transcript: /t/A.jsonl) after 0s",
+        "wrote checkpoint: /c/B.json (took 10s)",
+        "wrote checkpoint: /c/B.json (took 10s)",
+    ])
+    cap = ledger._stats_capture(now=now)
+    w = cap["window"]
+    assert w["skipped"] == 1
+    assert w["errors"] == 0
+    assert w["success"] == 1
+    assert w["error_rate_pct"] == 0.0
+
+
+def test_stats_capture_window_counts_fallback(tmp_log_dir):
+    # #364 asks for rescue counts in the window: attempts (the chat() entry
+    # warning, itself stamped) and successes (the [fallback backend] suffix).
+    from daimon_briefing import ledger
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc)
+    _write_log(tmp_log_dir, [
+        f"{_iso(now - timedelta(days=1))} WARNING daimon_briefing.llm: "
+        "llm.fallback backend=command (litellm failed)",
+        "wrote checkpoint: /c/A.json (took 9s) [fallback backend]",
+    ])
+    cap = ledger._stats_capture(now=now)
+    w = cap["window"]
+    assert w["fallback_attempts"] == 1
+    assert w["fallback_serializes"] == 1
+    assert w["success"] == 1
+
+
+def test_stats_json_includes_capture_window(tmp_checkpoint_dir, tmp_log_dir,
+                                            sample_checkpoint, capsys):
+    from daimon_briefing import store
+    store.write_checkpoint("S1", sample_checkpoint)
+    assert cli.main(["stats", "--json"]) == 0
+    data = json.loads(capsys.readouterr().out)
+    assert set(data["capture"]["window"]) == {
+        "days", "success", "skipped", "errors", "fallback_attempts",
+        "fallback_serializes", "error_rate_pct"}
+
+
+def test_stats_plain_renders_capture_window_line(tmp_checkpoint_dir,
+                                                 tmp_log_dir,
+                                                 sample_checkpoint, capsys,
+                                                 monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PLAIN", "1")
+    store.write_checkpoint("S1", sample_checkpoint)
+    now = datetime.now(timezone.utc)
+    _write_log(tmp_log_dir, [
+        f"{_iso(now - timedelta(days=1))} session-end: spawned serialize for A "
+        "(project: /p/A)",
+        "wrote checkpoint: /c/A.json (took 10s)",
+        "error: boom (transcript: /t/B.jsonl) after 3s",
+    ])
+    assert cli.main(["stats"]) == 0
+    out = capsys.readouterr().out
+    assert "last 14d: serialized 1  errors 1  rescued 0" in out
+    assert "error rate: 50.0%" in out
+
+
+def test_stats_plain_warns_when_window_error_rate_exceeds_gate(
+        tmp_checkpoint_dir, tmp_log_dir, sample_checkpoint, capsys,
+        monkeypatch):
+    # #364 gate: >10% rolling error rate is the reopen/escalate threshold —
+    # any install must be able to see itself trip it.
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PLAIN", "1")
+    store.write_checkpoint("S1", sample_checkpoint)
+    now = datetime.now(timezone.utc)
+    _write_log(tmp_log_dir, [
+        f"{_iso(now - timedelta(days=1))} session-end: spawned serialize for A "
+        "(project: /p/A)",
+        "wrote checkpoint: /c/A.json (took 10s)",
+        "error: boom (transcript: /t/B.jsonl) after 3s",
+    ])
+    assert cli.main(["stats"]) == 0
+    out = capsys.readouterr().out
+    assert "⚠ capture error rate 50.0% (last 14d) exceeds the 10% gate" in out
+
+
+def test_stats_plain_no_gate_warning_at_or_below_threshold(
+        tmp_checkpoint_dir, tmp_log_dir, sample_checkpoint, capsys,
+        monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PLAIN", "1")
+    store.write_checkpoint("S1", sample_checkpoint)
+    now = datetime.now(timezone.utc)
+    _write_log(tmp_log_dir, [
+        f"{_iso(now - timedelta(days=1))} session-end: spawned serialize for A "
+        "(project: /p/A)",
+        "wrote checkpoint: /c/A.json (took 10s)",
+    ])
+    assert cli.main(["stats"]) == 0
+    out = capsys.readouterr().out
+    assert "exceeds the 10% gate" not in out
+    assert "error rate: 0.0%" in out
+
+
+def test_stats_rich_renders_capture_window_row(tmp_checkpoint_dir, tmp_log_dir,
+                                               sample_checkpoint, capsys,
+                                               monkeypatch):
+    pytest.importorskip("rich")
+    from daimon_briefing import render, store
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    store.write_checkpoint("S1", sample_checkpoint)
+    now = datetime.now(timezone.utc)
+    _write_log(tmp_log_dir, [
+        f"{_iso(now - timedelta(days=1))} session-end: spawned serialize for A "
+        "(project: /p/A)",
+        "wrote checkpoint: /c/A.json (took 10s)",
+        "error: boom (transcript: /t/B.jsonl) after 3s",
+    ])
+    assert cli.main(["stats"]) == 0
+    out = capsys.readouterr().out
+    assert "last 14d" in out
+    assert "50.0%" in out
+
+
 # ---- #49: heal crash on hung targets + preflight-error attribution ----
 
 


### PR DESCRIPTION
Refs #364

## Summary

- `daimon stats` now surfaces a rolling 14-day capture window: serialized / errors / rescued counts plus an error-rate percentage over capture attempts — the "is capture healthy NOW" number #364 asks for, readable on any install.
- Adds the 10% reopen gate from #364: when the rolling rate exceeds it, stats prints a warning pointing at `daimon status`.
- Field check on a live install: 31 serialized / 10 errors = 24.4% — the gate trips, turning the audit's capture-reliability finding into a self-reported number.

## Design

Result lines in `serialize.log` are unstamped; only spawn/retry/logger lines carry timestamps. Each result line therefore inherits the most recent stamped line's timestamp for window attribution. Result lines before any stamped line have unknown age and count lifetime only (ambiguous, never guessed). The window tally rides the same single-pass fold as the lifetime counters — #300 adjacent-dedupe and #235 too-short reclassification apply identically, so the two tallies cannot disagree about what a line is.

Skips are excluded from the rate denominator: a policy skip (too-short transcript) is not a capture attempt.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/ledger.py` | `_stats_capture(now=None)` grows a `window` sub-dict (14d counts + `error_rate_pct`); `_CAPTURE_WINDOW_DAYS` / `_CAPTURE_ERROR_GATE_PCT` constants |
| `plugin/daimon_briefing/render.py` | Shared `_capture_window_lines` helper; plain + rich stats render the window line and the gate warning |
| `plugin/tests/test_cli.py` | 10 new tests: window attribution, unstamped-prefix exclusion, rate-none semantics, shared reclassify/dedupe, fallback counts, JSON contract, plain/rich render, gate on/off |

## PR Type

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Test Plan

- [x] Full suite green: 1984 passed, 2 skipped (was 1974)
- [x] TDD red-first: all 10 new tests watched failing before implementation
- [x] Live smoke on a real serialize.log: window line and gate warning render correctly in plain and rich

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
- [x] Docs unchanged (stats output is self-describing)
