### PR TITLE
chore(serializer): key chunk cache on extraction semantics, not prompt text

### DIFF
--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -46,6 +46,14 @@ log = logging.getLogger(__name__)
 # warning is desired, not a bug.
 PROMPT_VERSION = "D-016"
 
+# #367: the chunk-cache rotation lever, deliberately SEPARATE from
+# PROMPT_VERSION. Bump ONLY when extraction semantics change — the output
+# contract, or what a chunk pass extracts (a D-016-grade change like #359's
+# rule 20 warrants a bump; a wording clarification does not). PROMPT_VERSION
+# keeps versioning the checkpoint format; this keeps the #48 cache warm
+# across prompt edits that don't change what gets extracted.
+EXTRACTION_VERSION = 1
+
 
 class SerializeError(Exception):
     """Base for named serialization failures. str(e) is log/CLI-ready."""
@@ -1125,13 +1133,17 @@ def _plan_waves(n_chunks: int, workers: int, k: int) -> int:
 
 # ---- #48: content-addressed chunk-extraction cache (generalizes #314) --------
 # Keyed on chunk TEXT plus every config dimension that shapes extraction
-# (backend, model, temperature, prompt version, and a hash of the actual
-# serialize system prompt — so an un-versioned prompt edit, like the #317
-# scene appendix, invalidates cleanly). session_id is deliberately NOT in the
-# key: prefix chunks of a grown or resume-forked transcript are byte-identical
-# and their paid-for outputs transfer (#48). The prompt embeds a positional
-# "chunk i of n" label that the key ignores — presentation metadata, not
-# extraction semantics.
+# (backend, model, temperature, scene flag, extraction-semantics version, and
+# a lane label for perspective passes). Deliberately NOT keyed on prompt text
+# or PROMPT_VERSION (#367): the prompt evolves nearly every release, and
+# hashing it rotated the whole cache on wording-only edits — re-buying every
+# chunk at full price, exactly the cost the cache exists to avoid.
+# EXTRACTION_VERSION below is the deliberate rotation lever; the scene flag is
+# an explicit dimension because it changes what gets extracted (#317).
+# session_id is deliberately NOT in the key: prefix chunks of a grown or
+# resume-forked transcript are byte-identical and their paid-for outputs
+# transfer (#48). The prompt embeds a positional "chunk i of n" label that the
+# key ignores — presentation metadata, not extraction semantics.
 #
 # Entries persist across successful serializes (that IS the feature) and are
 # reaped by age. Cached output is PRE-redaction — forced by #125: quotes are
@@ -1147,22 +1159,22 @@ def _chunk_cache_dir():
     return config.checkpoint_dir() / ".chunk-cache"
 
 
-def _chunk_cache_key(chunk_text: str, system: str | None = None) -> str:
-    # `system` (#360): the actual system prompt this extraction runs under;
-    # defaults to the plain serialize prompt. Escalation's perspective passes
-    # send DIFFERENT prompts over the same chunks — hashing the per-pass
-    # prompt gives each perspective its own cache lane (no cross-
-    # contamination) while a re-escalation reuses its own prior partials.
+def _chunk_cache_key(chunk_text: str, lane: str = "default") -> str:
+    # `lane` (#360, re-keyed by #367): escalation's perspective passes send
+    # DIFFERENT prompts over the same chunks — the perspective NAME labels
+    # each lane (no cross-contamination) while a re-escalation reuses its own
+    # prior partials. A wording tweak to any prompt keeps every lane warm;
+    # EXTRACTION_VERSION is the deliberate rotation. A forgotten bump serves
+    # a stale extraction for at most chunk_cache_days (default 3) — the same
+    # rotation window the privacy design already relies on.
     try:
         backend = configure.resolved_backend()
     except Exception:
         backend = "unknown"
-    if system is None:
-        system = _serialize_sys()
-    sys_hash = hashlib.sha256(system.encode("utf-8")).hexdigest()[:16]
-    stamp = (f"v1\x00{backend}\x00{config.llm_model() or ''}"
-             f"\x00{config.llm_temperature()}\x00{PROMPT_VERSION}"
-             f"\x00{sys_hash}\x00")
+    scene = "scene" if config.scene_traces_enabled() else ""
+    stamp = (f"v2\x00{backend}\x00{config.llm_model() or ''}"
+             f"\x00{config.llm_temperature()}\x00{EXTRACTION_VERSION}"
+             f"\x00{scene}\x00{lane}\x00")
     return hashlib.sha256(
         stamp.encode("utf-8") + chunk_text.encode("utf-8")).hexdigest()[:32]
 
@@ -1432,10 +1444,10 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
 
         def _one_pass(job):
             i, chunk_text, name, system = job
-            # Own #48 cache lane per perspective (the key hashes the actual
-            # system prompt): a re-escalation reuses its prior paid-for
-            # passes; the default lane is never read or written here.
-            key = _chunk_cache_key(chunk_text, system)
+            # Own #48 cache lane per perspective (the key carries the
+            # perspective name, #367): a re-escalation reuses its prior
+            # paid-for passes; the default lane is never read or written here.
+            key = _chunk_cache_key(chunk_text, lane=name)
             cached = _load_chunk_cache(key)
             if cached is not None:
                 log.info("perspective %s: chunk %d/%d reused cached extraction (#48)",

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -1330,9 +1330,37 @@ def test_chunk_cache_key_changes_with_config_dimensions(monkeypatch):
     monkeypatch.setenv("DAIMON_LLM_TEMPERATURE", "0.7")
     assert serializer._chunk_cache_key("chunk text") != base
     monkeypatch.delenv("DAIMON_LLM_TEMPERATURE", raising=False)
-    # scene flag reshapes the serialize prompt WITHOUT a PROMPT_VERSION bump —
-    # the key hashes the actual prompt text, so it must move (#319 trap class).
+    # scene flag changes what gets extracted (#317) — an EXPLICIT key
+    # dimension since #367, no longer discovered via prompt-text hashing.
     monkeypatch.setenv("DAIMON_SCENE_TRACES", "1")
+    assert serializer._chunk_cache_key("chunk text") != base
+
+
+def test_chunk_cache_key_survives_wording_only_prompt_edit(monkeypatch):
+    # #367: the treadmill. Prompt text evolves nearly every release; a
+    # wording tweak that does not change extraction semantics must NOT
+    # rotate the cache — that re-buys every chunk at full price, exactly
+    # the cost the cache exists to avoid.
+    base = serializer._chunk_cache_key("chunk text")
+    monkeypatch.setattr(serializer, "SERIALIZE_SYS",
+                        serializer.SERIALIZE_SYS + "\n(clarified wording)")
+    assert serializer._chunk_cache_key("chunk text") == base
+
+
+def test_chunk_cache_key_survives_prompt_version_bump(monkeypatch):
+    # #367: PROMPT_VERSION is the checkpoint format_version, not an
+    # extraction-semantics marker — a bump alone must not rotate the cache.
+    base = serializer._chunk_cache_key("chunk text")
+    monkeypatch.setattr(serializer, "PROMPT_VERSION", "D-999")
+    assert serializer._chunk_cache_key("chunk text") == base
+
+
+def test_chunk_cache_key_rotates_on_extraction_version_bump(monkeypatch):
+    # The deliberate rotation lever: bump EXTRACTION_VERSION when the output
+    # contract or extraction behavior actually changes.
+    base = serializer._chunk_cache_key("chunk text")
+    monkeypatch.setattr(serializer, "EXTRACTION_VERSION",
+                        serializer.EXTRACTION_VERSION + 1)
     assert serializer._chunk_cache_key("chunk text") != base
 
 
@@ -2132,18 +2160,17 @@ def test_escalated_too_short_still_skips(fake_chat_factory):
 
 
 def test_chunk_cache_key_gives_each_perspective_its_own_lane():
-    # #48 keying already hashes the system prompt; passing each perspective's
-    # actual prompt must yield distinct, stable lanes — and the default lane
-    # (no system arg) must be byte-identical to hashing the plain prompt.
+    # #360 lanes, re-keyed by #367: each perspective's NAME labels its lane —
+    # distinct, stable, never bleeding into the default lane. A wording tweak
+    # to a perspective addendum keeps its lane warm (same treadmill argument
+    # as the base prompt); EXTRACTION_VERSION is the deliberate rotation.
     base = serializer._chunk_cache_key("chunk text")
-    assert base == serializer._chunk_cache_key(
-        "chunk text", system=serializer._serialize_sys())
-    keys = [serializer._chunk_cache_key("chunk text", system=system)
-            for _, system in serializer.escalation_systems()]
+    keys = [serializer._chunk_cache_key("chunk text", lane=name)
+            for name, _ in serializer.escalation_systems()]
     assert len(set(keys)) == 3          # perspectives never cross-contaminate
     assert base not in keys             # nor bleed into the default lane
-    assert keys == [serializer._chunk_cache_key("chunk text", system=system)
-                    for _, system in serializer.escalation_systems()]  # stable
+    assert keys == [serializer._chunk_cache_key("chunk text", lane=name)
+                    for name, _ in serializer.escalation_systems()]  # stable
 
 
 def test_escalated_reheal_reuses_own_cached_partials(


### PR DESCRIPTION
Closes #367

## Summary

- Chunk-cache key no longer rotates on prompt *text*: `PROMPT_VERSION` and `sys_hash` leave the key, replaced by an explicit `EXTRACTION_VERSION` (bumped only when extraction semantics actually change) and a lane label (perspective name) for #360 escalation passes.
- Wording-only prompt edits now keep the cache warm; semantic changes rotate it deliberately — ending the treadmill where every prompt-touching release re-bought every chunk at full price.
- Scene flag (#317) becomes an explicit key dimension, since it changes what gets extracted and was previously caught only via prompt hashing.

## Design

- `PROMPT_VERSION` keeps its job as checkpoint `format_version`; it never belonged in the cache key (any semantic bump also rotates via `EXTRACTION_VERSION`).
- Perspective lanes key on the stable perspective *name* instead of hashing each perspective's prompt — same isolation (no cross-contamination, no default-lane bleed), no treadmill for perspective wording tweaks.
- Safety unchanged: a forgotten `EXTRACTION_VERSION` bump serves a stale extraction for at most `chunk_cache_days` (default 3) — the same rotation window the privacy design already relies on.
- Stamp version `v1` → `v2`: one deliberate full-cache rotation on upgrade.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/serializer.py` | `EXTRACTION_VERSION` constant; `_chunk_cache_key(chunk_text, lane="default")` — drops `PROMPT_VERSION`/`sys_hash`, adds semantics version + scene dim + lane; escalation call site passes `lane=name` |
| `plugin/tests/test_serializer.py` | 3 new tests (wording-edit survives, PROMPT_VERSION-bump survives, EXTRACTION_VERSION rotates); perspective-lane test re-keyed to lane names; scene-flag dimension asserted explicitly |

## PR Type

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Test Plan

- [x] TDD red-first: 4 failing tests watched before implementation
- [x] Full suite green: 1987 passed, 2 skipped
- [x] Escalation reheal test (`test_escalated_reheal_reuses_own_cached_partials`) still green — lane wiring preserved

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
- [x] Docs unchanged (internal cache mechanics)
