### PR TITLE
feat(serializer): deterministic auto-pin for hard-imperative constraints

### DIFF
--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -1013,6 +1013,120 @@ def ground_outcomes(checkpoint, signal_ids) -> int:
     return downgraded
 
 
+# ---- #369: deterministic auto-pin for hard-imperative constraints ----
+#
+# Verbatim trust-class assignment is model-chosen: if the model paraphrases a
+# "must not X" into summary prose, no quote exists, verification has nothing
+# to check, and later softening is undetectable. Constraint inversion is the
+# highest-damage drift class — a "never" that comes back as "usually" silently
+# reweights every downstream decision. This pass is the deterministic
+# backstop: scan USER text for hard-imperative sentences and force-pin any
+# the model skipped as verbatim items, bound to their message ids like any
+# other quote. Tiering bounds noise: only hard imperatives pin (must / must
+# not / never / don't / always / forbidden); soft modals (should, could,
+# prefer) stay at model discretion. The whole value is a check that needs no
+# model to trust.
+
+PINNED_KEY = "pinned"
+
+# Hard imperatives are rare per session; the cap bounds pathological inputs
+# (a pasted style guide) so the verification matcher's workload stays flat.
+_MAX_AUTO_PINS = 10
+_PIN_MAX_CHARS = 300
+
+_IMPERATIVE_RE = re.compile(
+    r"\b(?:must(?:\s+not)?|never|do\s+not|don['’]t|always|forbidden)\b",
+    re.IGNORECASE)
+
+# Injected scaffolding (briefings, hook output) rides inside user turns
+# wrapped in <system-reminder> — pinning it would quote daimon's own output
+# back as a user constraint (the self-reference loop, parked 07-15).
+_SYSTEM_REMINDER_RE = re.compile(r"<system-reminder>.*?</system-reminder>",
+                                 re.DOTALL | re.IGNORECASE)
+
+
+def _constraint_sentences(text: str):
+    """Sentences worth considering for a pin: terminator kept (the quote must
+    match the transcript byte-for-byte under tier-f normalization), leading
+    list markers shed, questions and fragments dropped."""
+    for raw in re.split(r"(?<=[.!?])\s+|\n+", text or ""):
+        s = raw.strip().lstrip("-*>•# ").strip()
+        if not s or s.endswith("?"):
+            continue
+        if len(s) > _PIN_MAX_CHARS or len(s.split()) < 3:
+            continue
+        yield s
+
+
+def pin_imperatives(checkpoint, messages) -> int:
+    """Force-pin hard-imperative user constraints the model skipped (#369).
+    Returns the number of items added.
+
+    Runs AFTER sanitize_source_ids (host ids are inserted directly, never
+    marker-translated) and BEFORE verify_quotes, so every pin earns its
+    quote_verified/last_verified stamps through the same gauntlet as a
+    model-chosen quote — a pin is self-verifying by construction (the
+    sentence came from the transcript), and a broken one must fail loudly
+    there, not pass silently here.
+
+    Only user-authored text is scanned: assistant imperatives are
+    commentary, tool rows are payloads, and <system-reminder> spans are
+    daimon's own injected output. `pinned` is code-owned (#292 discipline,
+    same as `grounded`): model-emitted values are stripped first. Never
+    fatal — pure text scanning and dict appends."""
+    for item in iter_items(checkpoint):
+        item.pop(PINNED_KEY, None)
+    existing = [q for q in (
+        _normalize_for_match(item.get("quote"))
+        for item in iter_items(checkpoint)
+        if item.get("trust") == "verbatim"
+        and isinstance(item.get("quote"), str))
+        if q]
+    block = checkpoint.get("epistemic_snapshot")
+    if not isinstance(block, dict):
+        return 0
+    beliefs = block.get("strong_beliefs")
+    if not isinstance(beliefs, list):
+        beliefs = block["strong_beliefs"] = []
+    pinned = dropped = 0
+    seen: set = set()
+    for m in messages or []:
+        if not isinstance(m, dict) or m.get("role") != "user":
+            continue
+        if m.get("tool_result"):
+            continue
+        text = _SYSTEM_REMINDER_RE.sub(" ", _message_text(m))
+        mid = _message_id(m)
+        for sentence in _constraint_sentences(text):
+            if not _IMPERATIVE_RE.search(sentence):
+                continue
+            norm = _normalize_for_match(sentence)
+            if not norm or norm in seen:
+                continue
+            seen.add(norm)
+            # The model already pinned it (quote covers the sentence, or the
+            # sentence covers the quote): the backstop has nothing to add.
+            if any(norm in q or q in norm for q in existing):
+                continue
+            if pinned >= _MAX_AUTO_PINS:
+                dropped += 1
+                continue
+            item = {"text": sentence, "trust": "verbatim", "quote": sentence,
+                    PINNED_KEY: True}
+            if mid is not None:
+                item[SOURCE_IDS_KEY] = [mid]
+            beliefs.append(item)
+            pinned += 1
+    if dropped:
+        # No silent caps: a constraint that didn't pin must be visible.
+        log.warning("imperative auto-pin: cap %d reached, %d constraint "
+                    "sentence(s) not pinned", _MAX_AUTO_PINS, dropped)
+    if pinned:
+        log.info("imperative auto-pin: %d hard-imperative constraint(s) "
+                 "force-pinned (#369)", pinned)
+    return pinned
+
+
 def _call_and_parse(chat, system, user_content, deadline, what: str,
                     parse_retries: int = 1) -> dict:
     """One LLM call -> parsed JSON dict, with named failures.
@@ -1552,6 +1666,12 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
     # tool-result messages) survive on any item, evidence for outcome claims.
     sig_ids = signal_message_ids(messages)
     sanitize_source_ids(checkpoint, message_id_map(messages), sig_ids)
+    # #369: deterministic backstop for constraint pinning — hard-imperative
+    # user sentences the model paraphrased away are force-pinned as verbatim
+    # items here, AFTER id sanitization (host ids go in directly) and BEFORE
+    # verification, so every pin earns quote_verified/last_verified through
+    # the same gauntlet as a model-chosen quote.
+    pin_imperatives(checkpoint, messages)
     # #125: verify verbatim quotes against the SAME rendered text the extractor
     # read, PRE-redaction (redaction runs later in write_checkpoint and would
     # otherwise mass-downgrade legitimate quotes it had masked). Verify once,

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -2377,3 +2377,35 @@ def test_serialize_strict_pins_and_verifies_skipped_constraint(
     assert pin["quote_verified"] is True
     assert "last_verified" in pin
     assert pin["source_message_ids"] == ["uuid-2"]
+
+
+def test_pin_imperatives_tolerates_torn_checkpoint_sections():
+    # Never-fatal contract: a torn checkpoint (no epistemic_snapshot, or a
+    # non-list strong_beliefs) must not crash the pass — it degrades to
+    # no-op or repairs the list, respectively.
+    torn = {"session_id": "S1", "working_context": {}}
+    msgs = [{"role": "user", "id": "u-1",
+             "content": "You must never ship on red CI."}]
+    assert serializer.pin_imperatives(torn, msgs) == 0
+
+    cp = _cp_one_decision({"text": "d", "trust": "inferred"})
+    cp["epistemic_snapshot"]["strong_beliefs"] = None
+    assert serializer.pin_imperatives(cp, msgs) == 1
+    assert len(cp["epistemic_snapshot"]["strong_beliefs"]) == 1
+
+
+def test_pin_imperatives_skips_user_role_tool_results():
+    # A tool payload relayed under a user role is still a payload, not a
+    # user-authored constraint.
+    cp = _cp_one_decision({"text": "d", "trust": "inferred"})
+    msgs = [{"role": "user", "id": "u-1", "tool_result": True,
+             "content": "error: you must never pass --force to this tool."}]
+    assert serializer.pin_imperatives(cp, msgs) == 0
+
+
+def test_pin_imperatives_dedupes_repeated_sentence_across_messages():
+    cp = _cp_one_decision({"text": "d", "trust": "inferred"})
+    sentence = "You must never edit generated files by hand."
+    msgs = [{"role": "user", "id": "u-1", "content": sentence},
+            {"role": "user", "id": "u-2", "content": sentence}]
+    assert serializer.pin_imperatives(cp, msgs) == 1

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -2275,3 +2275,105 @@ def test_rejections_skips_items_without_an_id():
     """No pointer, no row — a ledger entry that cannot be traced is noise."""
     ck = _ck([{"quote_verified": False}])
     assert serializer.verification_rejections(ck) == []
+
+
+# ---- #369: deterministic auto-pin for hard-imperative constraints ----
+#
+# Constraint inversion is the highest-damage drift class: a "never" that
+# comes back as "usually" reweights every downstream decision. Nothing
+# guaranteed the model pinned a constraint as a quote — pin_imperatives is
+# the deterministic backstop.
+
+
+def _pinned(cp):
+    return [i for i in serializer.iter_items(cp) if i.get("pinned")]
+
+
+def test_pin_imperatives_pins_skipped_hard_constraint():
+    cp = _cp_one_decision({"text": "d", "trust": "inferred"})
+    msgs = [{"role": "user", "id": "u-1",
+             "content": "Context first. You must never push directly to main."}]
+    added = serializer.pin_imperatives(cp, msgs)
+    assert added == 1
+    (pin,) = _pinned(cp)
+    assert pin["trust"] == "verbatim"
+    assert pin["quote"] == "You must never push directly to main."
+    assert pin["text"] == pin["quote"]
+    assert pin["source_message_ids"] == ["u-1"]
+    assert pin in cp["epistemic_snapshot"]["strong_beliefs"]
+
+
+def test_pin_imperatives_skips_already_quoted_constraint():
+    sentence = "You must never push directly to main."
+    cp = _cp_one_decision({"text": "no direct pushes", "trust": "verbatim",
+                           "quote": f"Context first. {sentence}"})
+    msgs = [{"role": "user", "id": "u-1",
+             "content": f"Context first. {sentence}"}]
+    assert serializer.pin_imperatives(cp, msgs) == 0
+    assert _pinned(cp) == []
+
+
+def test_pin_imperatives_ignores_assistant_and_tool_messages():
+    # Assistant imperatives are commentary, tool rows are payloads — only
+    # the user authors constraints.
+    cp = _cp_one_decision({"text": "d", "trust": "inferred"})
+    msgs = [{"role": "assistant", "id": "a-1",
+             "content": "You must never call this API twice."},
+            {"role": "tool", "id": "t-1", "tool_result": True,
+             "content": "error: you must not pass --force to this command."}]
+    assert serializer.pin_imperatives(cp, msgs) == 0
+
+
+def test_pin_imperatives_ignores_system_reminder_spans():
+    # Self-echo defense (the #292/self-reference lineage): injected briefing
+    # and hook text rides inside user turns wrapped in <system-reminder> —
+    # pinning it would let daimon quote its own output back as a user
+    # constraint.
+    cp = _cp_one_decision({"text": "d", "trust": "inferred"})
+    msgs = [{"role": "user", "id": "u-1",
+             "content": ("<system-reminder>You must never quote briefings."
+                         "</system-reminder> Unrelated user text here.")}]
+    assert serializer.pin_imperatives(cp, msgs) == 0
+
+
+def test_pin_imperatives_ignores_questions_and_soft_modals():
+    cp = _cp_one_decision({"text": "d", "trust": "inferred"})
+    msgs = [{"role": "user", "id": "u-1",
+             "content": ("Must we always deploy on Fridays? "
+                         "You should prefer rebase over merge here.")}]
+    assert serializer.pin_imperatives(cp, msgs) == 0
+
+
+def test_pin_imperatives_caps_pins():
+    cp = _cp_one_decision({"text": "d", "trust": "inferred"})
+    lines = [f"You must never touch config file number {i} in production."
+             for i in range(serializer._MAX_AUTO_PINS + 5)]
+    msgs = [{"role": "user", "id": "u-1", "content": " ".join(lines)}]
+    assert serializer.pin_imperatives(cp, msgs) == serializer._MAX_AUTO_PINS
+    assert len(_pinned(cp)) == serializer._MAX_AUTO_PINS
+
+
+def test_pin_imperatives_strips_model_claimed_pinned():
+    # `pinned` is code-owned (#292 discipline, same as `grounded`).
+    cp = _cp_one_decision({"text": "d", "trust": "inferred", "pinned": True})
+    assert serializer.pin_imperatives(cp, []) == 0
+    for item in serializer.iter_items(cp):
+        assert "pinned" not in item
+
+
+def test_serialize_strict_pins_and_verifies_skipped_constraint(
+        fake_chat_factory, monkeypatch):
+    # Integration: the model paraphrases the constraint away; the pin pass
+    # restores it and the normal verification gauntlet stamps it.
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    chat = fake_chat_factory(_decision_checkpoint_json(
+        {"text": "d", "trust": "verbatim", "quote": "line 3 from assistant"}))
+    msgs = _msgs_with_ids(6)
+    msgs[2]["content"] += ". You must never commit secrets to this repo."
+    out = serializer.serialize_strict("S1", msgs, chat=chat)
+    (pin,) = _pinned(out)
+    assert pin["trust"] == "verbatim"
+    assert pin["quote"] == "You must never commit secrets to this repo."
+    assert pin["quote_verified"] is True
+    assert "last_verified" in pin
+    assert pin["source_message_ids"] == ["uuid-2"]


### PR DESCRIPTION
Closes #369

## Summary

- `pin_imperatives`: a deterministic pass in the serialize gauntlet that scans user-authored transcript text for hard-imperative constraint sentences (must / must not / never / don't / always / forbidden) and force-pins any the model skipped as verbatim `strong_beliefs` items — exact quote, bound to its source message id.
- Closes the gap where a paraphrased "must not X" left no quote for verification to check, making later constraint softening undetectable — the highest-damage drift class.
- Pins run before `verify_quotes`, so every pin earns `quote_verified`/`last_verified` through the same gauntlet as a model-chosen quote (self-verifying by construction; a broken one fails loudly there).

## Noise bounds (the issue's tiering)

- Hard imperatives only — soft modals (should, could, prefer) stay at model discretion.
- Questions and fragments dropped (sentence must have ≥3 words, ≤300 chars, not end in `?`).
- Only user-role messages scanned: assistant imperatives are commentary, tool rows are payloads.
- `<system-reminder>` spans excluded — injected briefing/hook text must never round-trip into a pinned "user constraint" (the self-reference loop defense).
- Dedupe against quotes the model already pinned; logged cap of 10 pins per session (no silent caps).
- `pinned` is code-owned (#292 discipline, same as `grounded`): model-emitted values stripped.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/serializer.py` | `pin_imperatives` + `_constraint_sentences` + regexes/constants; wired into `serialize_strict` after `sanitize_source_ids`, before `verify_quotes` |
| `plugin/tests/test_serializer.py` | 8 new tests: pin + bind, dedupe, role filtering, system-reminder exclusion, question/soft-modal rejection, cap, code-owned strip, full-gauntlet integration |

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Test Plan

- [x] TDD red-first: 8 failing tests watched before implementation
- [x] Full suite green: 1995 passed, 2 skipped
- [x] Integration test proves the pipeline: skipped constraint → pinned → `quote_verified: true` + id binding survives

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
- [x] Docs unchanged (serializer-internal; briefing rendering of `pinned` is future work)
