### PR TITLE
feat(hooks): heartbeat liveness for hung-serialize detection

### DIFF
--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -16,6 +16,7 @@ slice): the every-line tally (_stats_capture) and the in-window spawn probe
 """
 
 import re
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -210,7 +211,8 @@ def _session_ledger(text: str, now: float) -> dict:
     return sessions
 
 
-def _outstanding_failures(ledger, now, has_checkpoint, ceiling, transcript_exists, force=False) -> list:
+def _outstanding_failures(ledger, now, has_checkpoint, ceiling, transcript_exists,
+                          force=False, heartbeat_age=None) -> list:
     """Sessions still LOST — no checkpoint AND latest state != success.
     `has_checkpoint(sid)` and `transcript_exists(path)` are injected so this
     stays pure/testable. error+spawn+transcript-on-disk+not-retried -> healable
@@ -243,6 +245,16 @@ def _outstanding_failures(ledger, now, has_checkpoint, ceiling, transcript_exist
                         "transcript": e["transcript"], "project": e["project"],
                         "spawned": e["spawned"], "line": e["result_line"]})
         elif e["result_kind"] is None and e["spawned"] and age is not None and age > ceiling:
+            # #342: liveness beats wall-clock. A heartbeat fresher than the
+            # ceiling means the serialize is ALIVE — not outstanding, so
+            # status stays quiet and heal cannot fork a retry against a
+            # still-running child. Absent heartbeat (pre-#342 host hook, or
+            # a child dead before its first touch) falls through to the
+            # wall-clock rule unchanged.
+            if heartbeat_age is not None:
+                hb = heartbeat_age(sid)
+                if hb is not None and hb <= ceiling:
+                    continue
             # #28: a spawn line that recorded its transcript makes a hung
             # (crashed/killed) serialize healable — the checkpoint is
             # recoverable as long as the transcript is still on disk. The
@@ -271,6 +283,9 @@ def _compute_outstanding(text: str, now: float, force: bool = False) -> list:
         config.hung_after_seconds(),
         lambda p: bool(p) and Path(p).exists(),
         force=force,
+        # #342: module-level heartbeat_age resolves via the global, not the
+        # classifier's same-named parameter.
+        heartbeat_age=lambda sid: heartbeat_age(sid, now),
     )
 
 
@@ -316,6 +331,56 @@ def _heal_plan(text, now, force=False) -> dict:
         n = len(skipped)
         note = f"nothing to heal — {n} failure{'s' if n != 1 else ''} can't be auto-repaired:"
     return {"target": target, "skipped": skipped, "note": note}
+
+
+# ---- #342: per-session liveness heartbeat ----
+#
+# Wall-clock hung detection has a cliff: a field install completed a
+# serialize at 1732s — 96% of the 1800s ceiling — so a slightly slower but
+# alive run would read as hung, and heal would fork a retry while the
+# original still worked. Liveness beats wall-clock: the serialize child
+# touches <log_dir>/heartbeats/<session_id> at entry and during every
+# chunk/pass/merge step; "hung" means no heartbeat for the ceiling window,
+# not total duration > ceiling. No heartbeat file at all (crashed child,
+# legacy host hook) degrades to exactly the pre-#342 wall-clock rule.
+
+_HEARTBEAT_REAP_SECONDS = 7 * 86400
+
+
+def _heartbeat_dir() -> Path:
+    return config.log_dir() / "heartbeats"
+
+
+def touch_heartbeat(session_id: str) -> None:
+    """Stamp liveness for a running serialize (#342). Best-effort: a full
+    disk or unwritable dir must never break the serialize doing the
+    touching. Old stamps are reaped opportunistically here — result lines
+    end a session's classification, so a leftover file is disk hygiene,
+    never a liveness signal."""
+    try:
+        d = _heartbeat_dir()
+        d.mkdir(parents=True, exist_ok=True)
+        (d / Path(session_id).name).touch()
+        now = time.time()
+        for p in d.iterdir():
+            try:
+                if now - p.stat().st_mtime > _HEARTBEAT_REAP_SECONDS:
+                    p.unlink()
+            except OSError:
+                continue
+    except OSError:
+        pass
+
+
+def heartbeat_age(session_id: str, now: float | None = None) -> float | None:
+    """Seconds since this session's serialize last proved liveness, or None
+    when it never has (no stamp — pre-#342 host hook or a child that died
+    before its first touch)."""
+    try:
+        mtime = (_heartbeat_dir() / Path(session_id).name).stat().st_mtime
+    except OSError:
+        return None
+    return max(0.0, (now if now is not None else time.time()) - mtime)
 
 
 # Host prefix on a spawn line, for per-host capture counts. Deliberately the

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -21,7 +21,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 
-from . import config, configure, llm, redact, schema
+from . import config, configure, ledger, llm, redact, schema
 
 # No handlers/basicConfig here — the library stays silent unless the caller
 # configures logging. Multi-hour serialize runs need this heartbeat to be killable.
@@ -1360,6 +1360,7 @@ def _merge_partials(chat, session_id: str, partials: list, deadline,
             if len(group) == 1:
                 # Singleton — pass through without an LLM call.
                 return group[0]
+            ledger.touch_heartbeat(session_id)  # #342: alive, merging
             t0 = time.monotonic()
             merged = _call_and_parse(
                 chat, _merge_sys(),
@@ -1499,6 +1500,12 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
         raise TooShortError(
             f"transcript too short ({n} < {config.min_messages()} messages)"
         )
+    # #342: first liveness stamp — from here on the child proves it is alive
+    # via heartbeats (entry, every chunk/pass, every merge group), so hung
+    # detection can trust freshness over total wall-clock. After the
+    # too-short gate: a skipped session writes its result line immediately
+    # and needs no liveness trail.
+    ledger.touch_heartbeat(session_id)
     if deadline is not None and deadline - time.monotonic() <= 0:
         raise LLMCallError("deadline exhausted before the first LLM call")
 
@@ -1558,6 +1565,7 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
 
         def _one_pass(job):
             i, chunk_text, name, system = job
+            ledger.touch_heartbeat(session_id)  # #342: alive, working
             # Own #48 cache lane per perspective (the key carries the
             # perspective name, #367): a re-escalation reuses its prior
             # paid-for passes; the default lane is never read or written here.
@@ -1614,6 +1622,7 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
             # session take chunk_count * minutes of wall-clock.
             def _one_chunk(item):
                 i, chunk_text = item
+                ledger.touch_heartbeat(session_id)  # #342: alive, working
                 # #48: reuse any prior run's paid-for output for this exact
                 # chunk text under the current config — merge deaths, heals,
                 # resume forks, and grown transcripts all hit on their

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -6068,3 +6068,102 @@ def test_serialize_survives_a_broken_ledger_emit(tmp_checkpoint_dir, fake_chat_f
     rc = cli.main(["serialize", str(FIXTURES / "sample_transcript.md")])
     assert rc == 0
     assert store.read_checkpoint("sample_transcript") is not None
+
+
+# ---- #342: heartbeat liveness — slow-but-alive serializes are not hung ----
+#
+# Field reading: a completed serialize at 1732s = 96% of the 1800s ceiling.
+# Wall-clock alone would soon declare a slow-but-alive serialize hung, and
+# heal would fork a retry while the original still runs. Liveness = a
+# per-session heartbeat the serialize child touches; "hung" means no
+# heartbeat for the ceiling window, not total duration > ceiling.
+
+
+def test_heartbeat_touch_age_roundtrip(tmp_log_dir):
+    from daimon_briefing import ledger
+    ledger.touch_heartbeat("S-hb")
+    age = ledger.heartbeat_age("S-hb")
+    assert age is not None and 0 <= age < 30
+    assert ledger.heartbeat_age("S-none") is None
+
+
+def test_heartbeat_touch_reaps_ancient_files(tmp_log_dir):
+    from daimon_briefing import ledger
+    ledger.touch_heartbeat("S-old")
+    old = tmp_log_dir / "heartbeats" / "S-old"
+    ancient = time.time() - 8 * 86400
+    os.utime(old, (ancient, ancient))
+    ledger.touch_heartbeat("S-new")
+    assert not old.exists()
+    assert (tmp_log_dir / "heartbeats" / "S-new").exists()
+
+
+def test_outstanding_hung_age_spawn_with_fresh_heartbeat_is_alive():
+    rows = {"X": _led(result_kind=None, result_line=None, spawn_age=2000)}
+    out = cli._outstanding_failures(
+        rows, 0.0, lambda sid: False, 1800, lambda p: True,
+        heartbeat_age=lambda sid: 60)
+    assert out == []
+
+
+def test_outstanding_hung_age_spawn_with_stale_heartbeat_stays_hung():
+    rows = {"X": _led(result_kind=None, result_line=None, spawn_age=4000)}
+    out = cli._outstanding_failures(
+        rows, 0.0, lambda sid: False, 1800, lambda p: True,
+        heartbeat_age=lambda sid: 3600)
+    assert len(out) == 1
+    assert out[0]["kind"] == "hung"
+
+
+def test_outstanding_hung_age_spawn_without_heartbeat_keeps_legacy_behavior():
+    rows = {"X": _led(result_kind=None, result_line=None, spawn_age=2000)}
+    out = cli._outstanding_failures(
+        rows, 0.0, lambda sid: False, 1800, lambda p: True,
+        heartbeat_age=lambda sid: None)
+    assert len(out) == 1
+    assert out[0]["kind"] == "hung"
+
+
+def test_outstanding_error_rows_never_consult_heartbeat():
+    # A result line ends the question — a heartbeat must not resurrect a
+    # session that already reported an error.
+    rows = {"X": _led()}
+    out = cli._outstanding_failures(
+        rows, 0.0, lambda sid: False, 1800, lambda p: True,
+        heartbeat_age=lambda sid: 1)
+    assert len(out) == 1
+    assert out[0]["kind"] == "error"
+
+
+def test_compute_outstanding_reads_real_heartbeat(tmp_log_dir,
+                                                  tmp_checkpoint_dir):
+    from daimon_briefing import ledger
+    stamp = (datetime.now(timezone.utc) - timedelta(seconds=3600)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ")
+    text = (f"{stamp} session-end: spawned serialize for HB1 "
+            "(reason: exit, project: /p/A) (transcript: /t/HB1.jsonl)\n")
+    # No heartbeat: the old-age spawn classifies hung (legacy).
+    assert len(cli._compute_outstanding(text, time.time())) == 1
+    # Fresh heartbeat: alive — vanishes from outstanding, heal stays away.
+    ledger.touch_heartbeat("HB1")
+    assert cli._compute_outstanding(text, time.time()) == []
+
+
+def test_heartbeat_touch_never_raises(monkeypatch, tmp_log_dir):
+    from daimon_briefing import ledger
+    # Reap hits an ancient entry it cannot unlink (a directory): skip it,
+    # keep stamping.
+    stubborn = tmp_log_dir / "heartbeats" / "S-dir"
+    stubborn.mkdir(parents=True)
+    ancient = time.time() - 8 * 86400
+    os.utime(stubborn, (ancient, ancient))
+    ledger.touch_heartbeat("S-ok")
+    assert (tmp_log_dir / "heartbeats" / "S-ok").exists()
+    assert stubborn.exists()
+    # Log-dir resolution failing entirely must not break the serialize
+    # doing the touching (best-effort contract).
+    def _boom():
+        raise OSError("boom")
+    monkeypatch.setattr(ledger.config, "log_dir", _boom)
+    ledger.touch_heartbeat("S-ok")
+    assert ledger.heartbeat_age("S-ok") is None

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -2409,3 +2409,40 @@ def test_pin_imperatives_dedupes_repeated_sentence_across_messages():
     msgs = [{"role": "user", "id": "u-1", "content": sentence},
             {"role": "user", "id": "u-2", "content": sentence}]
     assert serializer.pin_imperatives(cp, msgs) == 1
+
+
+# ---- #342: the serialize child feeds the liveness heartbeat ----
+
+
+def test_serialize_strict_touches_heartbeat(fake_chat_factory, monkeypatch):
+    from daimon_briefing import ledger
+    calls = []
+    monkeypatch.setattr(ledger, "touch_heartbeat",
+                        lambda sid: calls.append(sid))
+    chat = fake_chat_factory(_valid_checkpoint_json("S1"))
+    serializer.serialize_strict("S1", make_messages(20), chat=chat)
+    assert "S1" in calls
+
+
+def test_chunked_serialize_touches_heartbeat_per_chunk(fake_chat_factory,
+                                                       monkeypatch):
+    # The heartbeat must advance DURING the work, not just at entry — a
+    # long chunked serialize with an entry-only touch would go stale by the
+    # merge phase and read as hung exactly on the sessions that hurt most.
+    from daimon_briefing import ledger
+    monkeypatch.setenv("DAIMON_CHUNK_LINES", "6")
+    monkeypatch.setenv("DAIMON_CHUNK_OVERLAP", "1")
+    monkeypatch.setenv("DAIMON_MERGE_GROUP_SIZE", "100")
+    calls = []
+    monkeypatch.setattr(ledger, "touch_heartbeat",
+                        lambda sid: calls.append(sid))
+    messages = make_messages(20)
+    rendered = serializer._render_transcript(messages)
+    n_chunks = len(serializer.chunk_transcript(rendered, 6, 1))
+    assert n_chunks > 1
+    responses = [_valid_checkpoint_json(f"chunk{i}") for i in range(n_chunks)]
+    responses.append(_valid_checkpoint_json("S-long"))
+    chat = fake_chat_factory(responses)
+    assert serializer.serialize("S-long", messages, chat=chat) is not None
+    # entry + per-chunk + merge: strictly more touches than chunks
+    assert len([c for c in calls if c == "S-long"]) > n_chunks


### PR DESCRIPTION
Closes #342

## Summary

- Hung-serialize detection now keys on **liveness, not wall-clock** (the issue's preferred option 1): the serialize child touches a per-session heartbeat file at entry and during every chunk, perspective pass, and merge group; "hung" means no heartbeat for the `DAIMON_HUNG_AFTER` window, not total duration > ceiling.
- Fixes the false-positive cliff: a field install completed a serialize at 1732s — 96% of the 1800s ceiling. A slower-but-alive run would have been classified hung, and `heal` would fork a retry against a still-running child. Slow serializes correlate with the longest sessions — exactly the captures whose loss hurts most.

## Design

- **One knob**: `DAIMON_HUNG_AFTER` doubles as the heartbeat-staleness window. The largest honest heartbeat gap is one LLM call (gateway kills calls well under the ceiling), so a fresh heartbeat is a reliable liveness proof.
- **Graceful degradation**: no heartbeat file (pre-upgrade host hook, or a child that died before its first touch) falls through to exactly the old wall-clock rule — zero behavior change for legacy spawns. A result line always ends classification; heartbeats never resurrect a reported error.
- **Never-fatal**: touching is best-effort (unwritable dir, full disk — the serialize proceeds). Stale stamps are reaped opportunistically after 7 days; leftover files are hygiene, never a signal.
- `heal` and `status` share the classification via `_compute_outstanding`, so heal cannot double-spawn against a live serialize by construction.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/ledger.py` | `touch_heartbeat` / `heartbeat_age` helpers + reap; `_outstanding_failures` gains injected `heartbeat_age`; `_compute_outstanding` wires the real reader |
| `plugin/daimon_briefing/serializer.py` | Heartbeat touches: `serialize_strict` entry, `_one_chunk`, `_one_pass`, `_one_group` |
| `plugin/tests/test_cli.py` | 8 tests: roundtrip, reap, alive/stale/absent classification, error-rows-never-consult, real-fs integration, never-raises |
| `plugin/tests/test_serializer.py` | 2 tests: entry touch, per-chunk touches during chunked serialize |

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Test Plan

- [x] TDD red-first: 9 failing tests watched before implementation
- [x] Full suite green: 2008 passed, 2 skipped
- [x] Patch coverage checked locally before push (learned from the #381 cycle): all new lines covered, including defensive OSError paths

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
- [x] Docs unchanged (env var semantics extended, not renamed)
