### PR TITLE
docs(scars): give scar harvest the receipts-grade discovery path

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ That's it. End a session → a checkpoint is written; start the next → the bri
 - **Item lifecycle** — `daimon resolve` closes loops, `daimon forget` removes an item with a tombstone event; supersession is tracked, not silently overwritten.
 - **[Team memory](https://daily-nerd.github.io/daimon/docs/team/) (opt-in)** — checkpoints mirrored through a private git remote; teammates' topics and decisions appear clearly attributed, never merged into yours.
 - **Signed receipts (opt-in)** — `DAIMON_RECEIPTS=1` pairs each checkpoint with an offline [vitni](https://github.com/Daily-Nerd/vitni) signature binding its exact bytes to its source transcript; verify with `daimon verify-receipt`.
+- **Scar harvest (opt-in)** — `DAIMON_SCAR_HARVEST=1` drafts negative-knowledge *candidates* (dead ends, intentional-looking weirdness, non-obvious couplings) from each session into `.scars/candidates/` for human review. Zero-LLM, path-anchored, active only in repos that already have a `.scars/` directory; review and promotion tooling lives in [Scar](https://github.com/Daily-Nerd/Scar).
 
 ## What's net-new here
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,13 +123,40 @@ Serialize-throttle knobs for hosts that lack a clean session-end event. See
 | `DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL` | `300` | Minimum seconds between Windsurf serialize spawns (Windsurf has no session-end event, so capture runs on this throttle). `0` serializes every turn. |
 | `DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS` | `600` | Quiet period after the last Windsurf activity before a debounced finalizer serializes the trajectory's final transcript state — covers sessions whose last turns land inside the throttle window. Fractional values accepted; `0` disables the finalizer. |
 
+## Scar harvest
+
+Opt-in negative-knowledge drafting (#76). At session end, daimon scans the
+transcript for scar-shaped lessons — dead ends ("we tried X, it broke"),
+intentional-looking weirdness worth fencing, non-obvious couplings — and
+drafts *candidate* files into `<project_root>/.scars/candidates/`. The scan
+is zero-LLM (pure-stdlib marker matching, English and Spanish) and
+path-anchored: a hit that names no real file or directory in its own
+sentence is dropped. Precision over recall — a scar system dies from noise,
+not from a missed lesson.
+
+The boundary with the [Scar](https://github.com/Daily-Nerd/Scar) project,
+stated plainly: **daimon only drafts candidates.** Linting, pre-edit
+injection, and promotion to active scars are Scar's job — install it in the
+target repo to make the candidates useful. daimon never writes into
+`.scars/` itself, never overwrites an existing candidate (a human may have
+edited it), and caps how many candidates one session can emit.
+
+Honest limits: candidates are heuristic drafts and require human review
+before promotion. The harvest only runs in repos that have opted in by
+having a `.scars/` directory — without one it is a silent no-op even with
+the flag on. Candidate text passes through the same secret redaction as
+checkpoints, so candidate files are committable.
+
+| Variable | Default | What it does |
+|---|---|---|
+| `DAIMON_SCAR_HARVEST` | off | When truthy, draft scar (negative-knowledge) candidates at session end into `.scars/candidates/` — repos with a `.scars/` directory only. |
+
 ## Ops & diagnostics
 
 | Variable | Default | What it does |
 |---|---|---|
 | `DAIMON_LOG_DIR` | `~/.daimon/logs` | Where the session-end hook writes `serialize.log`. The hook itself hardcodes `~/.daimon/logs`; this override exists so the CLI (and tests) can point `status` elsewhere. |
 | `DAIMON_CLAUDE_PROJECTS_DIR` | `~/.claude/projects` | Where host transcripts live (`<slug>/<session>.jsonl`). Read-only — the quote-reverification audit reads them to re-check stored quotes against their source. |
-| `DAIMON_SCAR_HARVEST` | off | When truthy, draft scar (negative-knowledge) candidates from the transcript at session-end. |
 
 ## LLM backend
 


### PR DESCRIPTION
Closes #280

## Summary

- README gains a **Scar harvest (opt-in)** feature bullet beside the receipts one — the harvest now has the same front-door discovery the receipts integration has had all along.
- `docs/configuration.md` gains a dedicated **Scar harvest** section mirroring the Receipts section layout: what gets drafted (dead ends, fences, landmines — the full scar taxonomy `_scar_type` emits), the zero-LLM path-anchored design, the daimon/Scar boundary stated plainly (**daimon only drafts candidates**; linting, injection, and promotion are [Scar](https://github.com/Daily-Nerd/Scar)'s job), and the honest limits (human review required, `.scars/`-directory opt-in gate, per-session cap, secret redaction).
- The `DAIMON_SCAR_HARVEST` row moves from the Ops & diagnostics table into the new section, matching how `DAIMON_RECEIPTS` lives in its own section.

## Correction against the issue text

The issue's proposed wording said candidates are "LLM-drafted". Verified against `harvest.py`: the harvester is deliberately **zero-LLM** (pure-stdlib marker scan, English + Spanish, #76). The docs state the truth — that's a stronger claim for the trust thesis, not a weaker one.

## Changes

| File | Change |
|------|--------|
| `README.md` | Scar-harvest opt-in bullet after the receipts bullet |
| `docs/configuration.md` | New `## Scar harvest` section (design, boundary, limits, env table); `DAIMON_SCAR_HARVEST` row relocated out of Ops & diagnostics |

## PR Type

- [ ] Bug fix
- [ ] New feature
- [x] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Test Plan

- [x] Docs-only — no code paths changed; every documented claim verified against `harvest.py` (zero-LLM, `.scars/` existence gate, never-overwrite, per-session cap, redaction, en+es markers, all three scar types)
- [x] Scar repo link resolves (`gh repo view Daily-Nerd/Scar`)

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
- [x] Docs updated — that is the change

## Follow-up (not in scope)

The website (`website/docs/`, en + es) has no scar-harvest page; the receipts feature has `concepts/receipts.md`. Full parity would add a bilingual concepts page — separate issue if wanted, since it doubles the scope with translation.
