### PR TITLE
feat(scars): qualification filter for the harvest — obligations or no candidate

### DIFF
--- a/plugin/daimon_briefing/harvest.py
+++ b/plugin/daimon_briefing/harvest.py
@@ -103,12 +103,66 @@ def _scar_type(hit):
     return "deadend" if _DEADEND_RE.search(hit.sentence) else "landmine"
 
 
+# ---- #276: qualification filter — the pipe worked, extraction didn't ----
+#
+# Running tally before this filter: 4 harvested candidates, 0 promotable.
+# The specimens shared one signature: conversational-voice titles (transcript
+# prose, not claims about code), titles truncated mid-sentence at the 80-char
+# boundary, and landmine-by-default extractions meeting none of the type's
+# obligations. Every gate below is derived from a real failed specimen.
+
+_MAX_TITLE_CHARS = 80
+
+# Transcript VOICE, not a claim about code: first-person singular ("I was
+# wrong"), markdown emphasis leaking through, TODO/FIXME imperatives. "We
+# tried X" deliberately survives — that is exactly deadend evidence voice.
+_VOICE_RE = re.compile(r"\*\*|\bI\b|\bI'm\b|\bI've\b")
+
+
+def _qualify(hit) -> str | None:
+    """Scar type for a hit that meets its type's structural obligations, or
+    None -> drop. A scar states what happened; each type has obligations:
+    deadend needs attempt-and-abandonment evidence, fence needs the stated
+    intent (its detection marker IS the reason), landmine needs BOTH sites —
+    a change to A observed breaking B. One-site avoidance prose with no
+    evidence used to fall into landmine-by-default; now it fails here."""
+    s = " ".join(hit.sentence.split())
+    # A title must be a WHOLE claim — never truncated mid-sentence.
+    if len(s) > _MAX_TITLE_CHARS:
+        return None
+    if _VOICE_RE.search(s) or s.startswith(("TODO", "FIXME")):
+        return None
+    if hit.kind == "intentional":
+        return "fence"
+    if _DEADEND_RE.search(s):
+        return "deadend"
+    if len(set(_PATH_RE.findall(s))) >= 2:
+        return "landmine"
+    return None
+
+
+def _receipt(hit) -> str:
+    """The transcript moment, verbatim: the matched sentence with its
+    surrounding context (bounded), secret-scrubbed. A candidate without a
+    receipt is unreviewable — the session id is provenance, not evidence."""
+    ctx = " ".join((hit.context or "").split())
+    sent = " ".join(hit.sentence.split())
+    pos = ctx.find(sent)
+    if pos < 0:
+        excerpt = sent
+    else:
+        start = max(0, pos - 120)
+        excerpt = ctx[start:pos + len(sent) + 120].strip()
+    scrubbed, _ = redact.redact_text(excerpt)
+    return scrubbed
+
+
 def _slug(title):
     s = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
     return s[:60] or "harvested-scar"
 
 
-def to_candidate(hit, anchor, session_id, today):
+def to_candidate(hit, anchor, session_id, today, typ=None):
     """Build (slug, markdown). Lint-valid frontmatter, single path-only anchor.
 
     `title` is emitted via json.dumps → a valid double-quoted YAML scalar even when
@@ -117,9 +171,14 @@ def to_candidate(hit, anchor, session_id, today):
     The verbatim sentence is secret-scrubbed here (#109) before it becomes the
     candidate's title, slug, and body — candidate files are committable, so a
     quoted secret must never persist to .scars/candidates/*.md. Classification
-    (_scar_type) reads the raw hit: its markers are prose, untouched by redaction.
+    (_scar_type / _qualify) reads the raw hit: its markers are prose, untouched
+    by redaction.
+
+    `typ` (#276): the qualification verdict from _qualify; None falls back to
+    the legacy _scar_type mapping for direct callers. The evidence block quotes
+    the transcript moment (#276 item 3) — a receipt, not just provenance.
     """
-    typ = _scar_type(hit)
+    typ = typ or _scar_type(hit)
     sentence, _ = redact.redact_text(hit.sentence)
     title = " ".join(sentence.split())[:80].rstrip()
     slug = _slug(title)
@@ -138,6 +197,7 @@ def to_candidate(hit, anchor, session_id, today):
         "anchors:\n"
         f"  - path: {anchor}\n"
         "evidence:\n"
+        f"  - note: {json.dumps('transcript receipt (verbatim): ' + _receipt(hit))}\n"
         f"  - note: {json.dumps('auto-harvested from session ' + session_id)}\n"
         "expires:\n"
         '  condition: "the referenced code is removed or the constraint no longer holds"\n'
@@ -151,7 +211,9 @@ def to_candidate(hit, anchor, session_id, today):
     return slug, md
 
 
-_MAX_CANDIDATES = 5
+# #276: 2-3 reviewable candidates beat 5 noisy ones — review attention is the
+# scarce resource the qualification filter exists to protect.
+_MAX_CANDIDATES = 3
 
 
 def run(messages, project_root, session_id):
@@ -172,10 +234,18 @@ def run(messages, project_root, session_id):
     written, dropped = 0, 0
     seen = set()
     for hit in detect(messages):
+        typ = _qualify(hit)  # #276: no type obligations met -> no candidate
+        if typ is None:
+            continue
         anchor = anchor_of(hit, project_root)
         if anchor is None:
             continue
-        slug, md = to_candidate(hit, anchor, session_id, today)
+        # #276 anchor discipline: never anchor scar infrastructure — the
+        # first naive harvest anchored .scars/candidates/ itself, a scar
+        # that would fire on every future candidate write.
+        if anchor == ".scars" or anchor.startswith(".scars/"):
+            continue
+        slug, md = to_candidate(hit, anchor, session_id, today, typ)
         if slug in seen:
             continue
         seen.add(slug)

--- a/plugin/tests/test_harvest.py
+++ b/plugin/tests/test_harvest.py
@@ -205,8 +205,16 @@ def _scars_repo(tmp_path):
 
 
 def test_run_writes_anchored_candidate(tmp_path):
+    # #276: the fixture must MEET its type's obligations — attempt +
+    # abandonment evidence makes this a qualified deadend.
     root = _scars_repo(tmp_path)
-    n = harvest.run([_assistant("Never route by raw cwd in config.py.")], str(root), "S1")
+    # Same sentence twice: the in-run slug dedupe emits one candidate.
+    msg = "We tried routing by raw cwd in config.py and it broke."
+    n = harvest.run(
+        [_assistant(msg), _assistant(msg),
+         # single-site avoidance with no evidence: fails qualification in-run
+         _assistant("Never route by raw cwd in config.py.")],
+        str(root), "S1")
     assert n == 1
     files = list((root / ".scars" / "candidates").glob("*.md"))
     assert len(files) == 1
@@ -215,15 +223,18 @@ def test_run_writes_anchored_candidate(tmp_path):
 
 def test_run_is_idempotent(tmp_path):
     root = _scars_repo(tmp_path)
-    msgs = [_assistant("Never route by raw cwd in config.py.")]
+    msgs = [_assistant("We tried routing by raw cwd in config.py and it broke.")]
     assert harvest.run(msgs, str(root), "S1") == 1
     assert harvest.run(msgs, str(root), "S1") == 0  # existing file not overwritten
     assert len(list((root / ".scars" / "candidates").glob("*.md"))) == 1
 
 
 def test_run_skips_unanchored_hits(tmp_path):
+    # Qualifies as a deadend but the named path does not exist in the repo —
+    # the anchor gate drops it.
     root = _scars_repo(tmp_path)
-    n = harvest.run([_assistant("Never do the risky thing, it breaks everything.")], str(root), "S1")
+    n = harvest.run([_assistant("We tried the migration in missing_file.py "
+                                "and it broke.")], str(root), "S1")
     assert n == 0
 
 
@@ -236,21 +247,112 @@ def test_run_skips_when_project_root_falsy():
     assert harvest.run([_assistant("Never touch config.py.")], None, "S1") == 0
 
 
-def test_run_caps_at_five(tmp_path):
-    root = _scars_repo(tmp_path)
-    for i in range(7):
-        (root / f"f{i}.py").write_text("x\n")
-    msgs = [_assistant(f"Gotcha number {i}: never touch f{i}.py mid-run.") for i in range(7)]
-    assert harvest.run(msgs, str(root), "S1") == 5
-
-
 def test_emitted_candidate_passes_scar_lint(tmp_path):
     if shutil.which("scar") is None:
         pytest.skip("scar binary not installed")
     (tmp_path / ".scars").mkdir()
     (tmp_path / "config.py").write_text("x = 1\n")
     (tmp_path / ".scars" / "template.md").write_text("---\nstatus: template\n---\n")
-    n = harvest.run([_assistant("Never route by raw cwd in config.py.")], str(tmp_path), "S1")
+    n = harvest.run([_assistant("We tried routing by raw cwd in config.py "
+                                "and it broke.")], str(tmp_path), "S1")
     assert n == 1
     out = subprocess.run(["scar", "lint"], cwd=tmp_path, capture_output=True, text=True)
     assert "with errors" not in out.stdout or "0 with errors" in out.stdout
+
+
+# ---- #276: qualification filter — the pipe worked, signal extraction didn't ----
+#
+# Running tally before this filter: 4 harvested candidates, 0 promotable.
+# Failure signature (from the #276 specimens): conversational-voice titles,
+# mid-sentence truncation, landmine-by-default with no obligations met, no
+# transcript receipt, self-referential .scars anchors.
+
+
+def test_qualify_rejects_first_person_voice():
+    # Specimen 2: "**The agent is right and I was wrong.**" — transcript
+    # prose leaked verbatim into what should be a claim about code.
+    hit = harvest.Hit("avoidance",
+                      "I was wrong, never call verify() in config.py.", "", 0)
+    assert harvest._qualify(hit) is None
+
+
+def test_qualify_rejects_markdown_bold():
+    hit = harvest.Hit("avoidance",
+                      "**Never** touch the flag in config.py, it breaks.", "", 0)
+    assert harvest._qualify(hit) is None
+
+
+def test_qualify_rejects_overlong_sentence():
+    # Specimen 1's title was truncated at the 80-char boundary with a broken
+    # escape. A title must be a WHOLE claim: sentences that don't fit are
+    # dropped, never truncated.
+    long = ("We tried the approach where the serializer walks every message "
+            "twice in config.py and it turned out the second walk clobbered "
+            "the first one's markers.")
+    assert len(long) > 80
+    hit = harvest.Hit("avoidance", long, "", 0)
+    assert harvest._qualify(hit) is None
+
+
+def test_qualify_rejects_todo_shape():
+    hit = harvest.Hit("avoidance",
+                      "TODO: never write to config.py during flush.", "", 0)
+    assert harvest._qualify(hit) is None
+
+
+def test_qualify_demotes_landmine_default_single_site():
+    # A landmine states "a change to A breaks B" — it needs BOTH sites.
+    # One path + no deadend evidence used to fall into landmine-by-default;
+    # now it fails qualification.
+    hit = harvest.Hit("avoidance",
+                      "Never route by raw cwd in config.py.", "", 0)
+    assert harvest._qualify(hit) is None
+
+
+def test_qualify_accepts_landmine_with_two_sites():
+    hit = harvest.Hit("avoidance",
+                      "Editing config.py breaks the loader in store.py.", "", 0)
+    assert harvest._qualify(hit) == "landmine"
+
+
+def test_qualify_keeps_deadend_and_fence():
+    dead = harvest.Hit("avoidance",
+                       "We tried the mmap approach in store.py; it doesn't work.",
+                       "", 0)
+    fence = harvest.Hit("intentional",
+                        "This cast looks wrong but is intentional in x.py.", "", 0)
+    assert harvest._qualify(dead) == "deadend"
+    assert harvest._qualify(fence) == "fence"
+
+
+def test_run_never_anchors_scar_infrastructure(tmp_path):
+    # The first naive harvest anchored .scars/candidates/ itself — a scar
+    # that would fire on every future candidate write.
+    root = _scars_repo(tmp_path)
+    (root / ".scars" / "candidates").mkdir(parents=True)
+    n = harvest.run(
+        [_assistant("We tried writing to .scars/candidates/ and gave up; "
+                    "it broke.")], str(root), "S1")
+    assert n == 0
+
+
+def test_candidate_carries_transcript_receipt(tmp_path):
+    # #276 item 3: a candidate without a receipt is unreviewable. The
+    # evidence block quotes the transcript moment, not just the session id.
+    root = _scars_repo(tmp_path)
+    msg = ("Some earlier context sentence. We tried the mmap approach in "
+           "config.py and it broke. Later trailing sentence here.")
+    assert harvest.run([_assistant(msg)], str(root), "S1") == 1
+    (path,) = (root / ".scars" / "candidates").glob("*.md")
+    text = path.read_text()
+    assert "transcript receipt" in text
+    assert "Some earlier context sentence" in text  # context, not title echo
+
+
+def test_run_caps_at_three(tmp_path):
+    root = _scars_repo(tmp_path)
+    for i in range(5):
+        (root / f"f{i}.py").write_text("x\n")
+    msgs = [_assistant(f"We tried patching f{i}.py in place and it broke.")
+            for i in range(5)]
+    assert harvest.run(msgs, str(root), "S1") == 3


### PR DESCRIPTION
Refs #276

## Summary

- Adds the qualification filter #276 proposed: the harvest now refuses to write a candidate that doesn't meet its scar type's structural obligations. Running tally before this change: **4 harvested candidates, 0 promotable** — every gate below is derived from a real failed specimen on the issue.
- Voice gates: first-person singular ("I was wrong…"), markdown bold, and TODO/FIXME shapes rejected — a scar states what happened, not what to do, and never in the transcript's voice. "We tried X" survives deliberately: that's deadend evidence voice.
- Whole-claim titles: sentences over 80 chars are **dropped, never truncated** (specimen 1's title broke mid-escape at the filename boundary).
- Type obligations: deadend needs attempt+abandonment evidence; fence keeps its intent marker; **landmine needs both sites named** (a change to A observed breaking B). The landmine-by-default bucket — where all three unpromotable specimens landed — is gone.
- Anchor discipline: candidates anchored under `.scars/` rejected (the first naive harvest anchored `.scars/candidates/` itself — a scar that would fire on every future candidate write).
- Evidence receipt: each candidate quotes the transcript moment verbatim (matched sentence + bounded context, secret-scrubbed). The session id stays as provenance, no longer posing as evidence.
- Cap 5 → 3: review attention is the scarce resource the filter protects.

## Deliberately not in this slice

- Runtime `scar lint` before writing and skip-when-CLI-absent (subprocess dependency at serialize time — needs a design call against the zero-required-dependency policy).
- Dedup against issues/PRs the session touched (needs network reads at serialize time). Both noted on #276.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/harvest.py` | `_qualify` (voice gates + type obligations), `_receipt` (bounded verbatim context excerpt), `.scars/` anchor rejection in `run`, `to_candidate` gains explicit `typ`, cap 3 |
| `plugin/tests/test_harvest.py` | 10 new tests (one per gate + receipt + cap + anchor discipline); legacy fixtures reworded to meet their type's obligations — the old canonical sentence was itself a landmine-by-default specimen |

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Test Plan

- [x] TDD red-first: 9 failing tests watched before implementation (plus one vacuous fixture caught and fixed — detect-marker mismatch)
- [x] Full suite green: 2017 passed, 2 skipped
- [x] Local patch coverage before push: harvest.py 98%, only pre-existing lines uncovered

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
- [x] Docs: configuration.md's harvest section (merged in #384) already describes candidates as human-review-gated; filter details are internal
