### PR TITLE
feat(team): scope-routed dual-write across multiple remotes

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1793,6 +1793,15 @@ def _cmd_team_status(args) -> int:
         else:
             lines.append("  scope: none — this remote receives no checkpoints "
                          "(add [scope] repos to daimon-team.toml)")
+    # #387: where the CURRENT project's checkpoints route — the one place a
+    # misconfigured toml is visible BEFORE a session's checkpoint quietly
+    # stays in the local mirror.
+    dests = store._team_write_slugs(_resolve_project(getattr(args, "project", None)))
+    line = "this project writes to: " + ", ".join(dests)
+    if dests == [store._TEAM_LOCAL_REMOTE]:
+        line += ("  (no remote grants it membership — add its repo URL to a "
+                 "sidecar's daimon-team.toml [scope] repos)")
+    lines.append(line)
     render.render_team_status(lines)
     return 0
 

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -26,6 +26,7 @@ merged checkpoint history keeps a deep well of files to reconstruct from.
 
 import hashlib
 import json
+import logging
 import os
 import re
 import time
@@ -34,6 +35,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from . import config, receipts, redact, schema, serializer, teamproject
+
+log = logging.getLogger("daimon_briefing")
 
 _LATEST = "latest.json"
 # Rotation pointers, not per-session checkpoints. Anything else ending in .json in
@@ -735,22 +738,43 @@ def read_latest(project_dir=None, fallback: bool = True) -> dict | None:
 _TEAM_LOCAL_REMOTE = "local"
 
 
-def _team_write_slug() -> str:
-    """Which remote-slug dir _dual_write_team targets. When exactly ONE real
-    remote (a sidecar git clone, detected purely by the presence of a .git
-    entry — store stays git/subprocess-free) exists, write straight into it so
-    `daimon team sync` picks the file up. Zero or MULTIPLE remotes -> the
-    Phase 1 'local' dir: with several remotes there is no principled routing
-    choice, so ambiguity degrades to the documented local mirror rather than a
-    guess. Never raises."""
+def _team_write_slugs(project_dir) -> list[str]:
+    """Which remote-slug dir(s) _dual_write_team targets (#387). Each sidecar
+    clone (detected purely by the presence of a .git entry — clone LISTING
+    stays git/subprocess-free) declares its own membership in daimon-team.toml,
+    and that allowlist is the router: the checkpoint goes into EVERY sidecar
+    that grants this project membership, and to the Phase 1 'local' dir when
+    none does (withheld, never lost — the #279 default-closed semantics are
+    unchanged; only routing among willing sidecars is new).
+
+    Single remote keeps the exact #279 contract, including the
+    DAIMON_TEAM_PROJECT env grant. With MULTIPLE remotes the env grant is
+    ignored for routing (honor_env=False): it is machine-global and cannot
+    say which remote it means — honoring it would broadcast every project on
+    the machine into every team. Never raises."""
     try:
         clones = [
             p.name for p in config.team_dir().iterdir()
             if p.is_dir() and p.name != _TEAM_LOCAL_REMOTE and (p / ".git").exists()
         ]
     except OSError:
-        return _TEAM_LOCAL_REMOTE
-    return clones[0] if len(clones) == 1 else _TEAM_LOCAL_REMOTE
+        return [_TEAM_LOCAL_REMOTE]
+    if not clones:
+        return [_TEAM_LOCAL_REMOTE]
+    if len(clones) == 1:
+        ok = teamproject.in_scope(project_dir, config.team_dir() / clones[0])
+        return clones if ok else [_TEAM_LOCAL_REMOTE]
+    if config.team_project():
+        log.warning(
+            "daimon team: DAIMON_TEAM_PROJECT cannot route among %d remotes "
+            "— grant membership in each sidecar's daimon-team.toml instead",
+            len(clones))
+    dests = sorted(
+        c for c in clones
+        if teamproject.in_scope(project_dir, config.team_dir() / c,
+                                honor_env=False)
+    )
+    return dests or [_TEAM_LOCAL_REMOTE]
 
 
 def _dual_write_team(session_id: str, checkpoint: dict, project_dir) -> None:
@@ -758,8 +782,8 @@ def _dual_write_team(session_id: str, checkpoint: dict, project_dir) -> None:
         <team_dir>/<remote-slug>/projects/<seg…>/authors/<author-slug>/<sid>.json
     under the #200 logical project path when one resolves, else the legacy flat
         <team_dir>/<remote-slug>/authors/<author-slug>/<sid>.json
-    where <remote-slug> is the single synced remote when one exists, else
-    'local' (see _team_write_slug). Immutable append — NO pointers are EVER
+    where <remote-slug> is every scope-granting synced remote (#387), else
+    'local' (see _team_write_slugs). Immutable append — NO pointers are EVER
     written here (the multi-writer git spike verdict: mutable pointers don't
     survive concurrent writers). Best-effort: never raises (mirrors the GC/log
     swallow) — a team-mirror failure must not fail the serialize that already
@@ -776,33 +800,29 @@ def _dual_write_team(session_id: str, checkpoint: dict, project_dir) -> None:
         # non-word char to '-'. Post-munge collisions ("a b" vs "a-b") remain a
         # documented edge — distinct humans colliding there is unrealistic.
         author_slug = project_slug(config.author()) or "unknown"
-        slug = _team_write_slug()
-        # #279 default-closed scope gate: a synced clone accepts a project's
-        # checkpoints only when its daimon-team.toml (or DAIMON_TEAM_PROJECT)
-        # grants membership — DAIMON_TEAM is machine-global, and without this
-        # check the single clone would receive EVERY project on the machine
-        # and push it to teammates. Out-of-scope writes degrade to the local
-        # mirror: withheld from the remote, never lost.
-        if slug != _TEAM_LOCAL_REMOTE and not teamproject.in_scope(
-                project_dir, config.team_dir() / slug):
-            slug = _TEAM_LOCAL_REMOTE
-        base = config.team_dir() / slug
+        # #279 default-closed membership + #387 scope routing live together in
+        # _team_write_slugs: every sidecar whose daimon-team.toml grants this
+        # project receives the checkpoint; none willing -> the local mirror
+        # (withheld from remotes, never lost). Multi-destination is safe by
+        # construction: paths are append-only and per-author.
         # #200: env/config/origin-derived logical path (segments are munged in
         # teamproject and can never escape the sidecar); None = flat era.
         segs = teamproject.resolve(project_dir)
-        if segs:
-            d = base.joinpath("projects", *segs, "authors", author_slug)
-        else:
-            d = base / "authors" / author_slug
-        d.mkdir(parents=True, exist_ok=True)
         # Shallow copy is deliberate and sufficient: only top-level keys are
         # stamped below; nested structures are never mutated on this path.
         blob = dict(checkpoint)
         blob.setdefault("project_slug", project_slug(project_dir))
         if segs:
             blob.setdefault("team_project", "/".join(segs))
-        _atomic_write(d / f"{_safe_name(session_id)}.json",
-                      json.dumps(blob, indent=2, ensure_ascii=False))
+        payload = json.dumps(blob, indent=2, ensure_ascii=False)
+        for slug in _team_write_slugs(project_dir):
+            base = config.team_dir() / slug
+            if segs:
+                d = base.joinpath("projects", *segs, "authors", author_slug)
+            else:
+                d = base / "authors" / author_slug
+            d.mkdir(parents=True, exist_ok=True)
+            _atomic_write(d / f"{_safe_name(session_id)}.json", payload)
     except OSError:
         pass
 

--- a/plugin/daimon_briefing/teamproject.py
+++ b/plugin/daimon_briefing/teamproject.py
@@ -245,15 +245,20 @@ def _membership(sidecar) -> set[str]:
     return allowed
 
 
-def in_scope(project_dir, sidecar) -> bool:
+def in_scope(project_dir, sidecar, honor_env=True) -> bool:
     """May this project's checkpoints enter this synced remote? Default
     CLOSED: membership must be granted by the sidecar's daimon-team.toml
     ([scope] repos or a [projects.*] mapping) or stated explicitly on the
     machine via DAIMON_TEAM_PROJECT. Broken/absent config, no origin,
     unlisted origin — all deny. Never raises; the write path degrades to the
-    local mirror, so a deny withholds, it never loses."""
+    local mirror, so a deny withholds, it never loses.
+
+    `honor_env=False` (#387): answer from the sidecar's toml ONLY. The env
+    grant is machine-global — it cannot say WHICH remote it means — so the
+    multi-remote router must ignore it or it would broadcast every project
+    into every team."""
     try:
-        if config.team_project():
+        if honor_env and config.team_project():
             return True
         allowed = _membership(sidecar)
         if not allowed:

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -6294,3 +6294,36 @@ def test_configure_init_noninteractive_without_flags_guides(monkeypatch,
     assert cli.main(["configure", "--init"]) == 0
     assert "--init needs a terminal" in capsys.readouterr().out
     assert not env_file.exists()
+
+
+# ---- #387: team status shows where the current project routes ----
+
+
+def test_team_status_shows_project_routing(monkeypatch, capsys,
+                                           tmp_checkpoint_dir):
+    from daimon_briefing import store, teamsync
+    monkeypatch.setattr(teamsync, "git_available", lambda: True)
+    monkeypatch.setattr(teamsync, "team_status", lambda: [
+        {"slug": "team-a", "branch": "main", "freshness": "fresh",
+         "unpushed": 0, "pending": 0, "authors": [], "config_warning": None,
+         "scope": ["github.com/org/alpha"]}])
+    monkeypatch.setattr(store, "_team_write_slugs", lambda project: ["team-a"])
+    assert cli.main(["team", "status"]) == 0
+    assert "this project writes to: team-a" in capsys.readouterr().out
+
+
+def test_team_status_routing_names_local_degrade(monkeypatch, capsys,
+                                                 tmp_checkpoint_dir):
+    # The #387 trap made visible: when no sidecar grants membership, status
+    # says so instead of letting checkpoints quietly stay local.
+    from daimon_briefing import store, teamsync
+    monkeypatch.setattr(teamsync, "git_available", lambda: True)
+    monkeypatch.setattr(teamsync, "team_status", lambda: [
+        {"slug": "team-a", "branch": "main", "freshness": "fresh",
+         "unpushed": 0, "pending": 0, "authors": [], "config_warning": None,
+         "scope": []}])
+    monkeypatch.setattr(store, "_team_write_slugs", lambda project: ["local"])
+    assert cli.main(["team", "status"]) == 0
+    out = capsys.readouterr().out
+    assert "this project writes to: local" in out
+    assert "no remote grants it membership" in out

--- a/plugin/tests/test_teamproject.py
+++ b/plugin/tests/test_teamproject.py
@@ -506,7 +506,7 @@ def test_read_candidates_swallows_resolver_bugs(tmp_path, monkeypatch):
 
 
 def _remote_clone(name="team-mem"):
-    """A dir store._team_write_slug treats as a real synced remote (.git present)."""
+    """A dir store._team_write_slugs treats as a real synced remote (.git present)."""
     d = config.team_dir() / name
     (d / ".git").mkdir(parents=True, exist_ok=True)
     return d
@@ -630,3 +630,106 @@ def test_dual_write_env_project_reaches_remote(
     sidecar = _remote_clone()  # no config: env intent alone grants membership
     store.write_checkpoint("S-a", sample_checkpoint, project_dir=repo)
     assert any(sidecar.rglob("*.json"))
+
+
+# ---- #387: scope-routed dual-write — the toml is the router, not just a gate ----
+#
+# Repro'd before filing: with two sidecar clones, EVERY project's checkpoints
+# degraded to the local mirror — including projects a sidecar's toml
+# explicitly granted. A second team remote silently disabled team sync for
+# the whole machine.
+
+
+def test_in_scope_honor_env_false_ignores_team_project(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, "gamma", "https://github.com/org/gamma")
+    sidecar = _remote_clone()
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/gamma")
+    assert teamproject.in_scope(repo, sidecar, honor_env=False) is False
+
+
+def test_dual_write_multi_remote_routes_by_scope(tmp_path, sample_checkpoint,
+                                                 monkeypatch):
+    # The filed repro, expectation inverted: the member sidecar receives the
+    # checkpoint, the unrelated one does not, local stays empty.
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    repo = _repo(tmp_path, "alpha", "https://github.com/org/alpha")
+    _remote_clone("team-a")
+    _remote_clone("team-b")
+    _write_config('[scope]\nrepos = ["https://github.com/org/alpha"]\n',
+                  remote="team-a")
+    _write_config('[scope]\nrepos = ["https://github.com/org/other"]\n',
+                  remote="team-b")
+    store._dual_write_team("S1", sample_checkpoint, str(repo))
+    team = config.team_dir()
+    assert list((team / "team-a").rglob("S1.json"))
+    assert not list((team / "team-b").rglob("S1.json"))
+    assert not list((team / "local").rglob("S1.json"))
+
+
+def test_dual_write_multi_remote_fans_to_every_member(tmp_path,
+                                                      sample_checkpoint,
+                                                      monkeypatch):
+    # Append-only per-author paths make multi-destination writes safe by
+    # construction — a repo in two teams' scopes reaches both.
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    repo = _repo(tmp_path, "alpha", "https://github.com/org/alpha")
+    _remote_clone("team-a")
+    _remote_clone("team-b")
+    for r in ("team-a", "team-b"):
+        _write_config('[scope]\nrepos = ["https://github.com/org/alpha"]\n',
+                      remote=r)
+    store._dual_write_team("S1", sample_checkpoint, str(repo))
+    team = config.team_dir()
+    assert list((team / "team-a").rglob("S1.json"))
+    assert list((team / "team-b").rglob("S1.json"))
+    assert not list((team / "local").rglob("S1.json"))
+
+
+def test_dual_write_multi_remote_none_in_scope_degrades_local(
+        tmp_path, sample_checkpoint, monkeypatch):
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    repo = _repo(tmp_path, "personal", "https://github.com/me/personal-notes")
+    _remote_clone("team-a")
+    _remote_clone("team-b")
+    for r in ("team-a", "team-b"):
+        _write_config('[scope]\nrepos = ["https://github.com/org/alpha"]\n',
+                      remote=r)
+    store._dual_write_team("S1", sample_checkpoint, str(repo))
+    team = config.team_dir()
+    assert not list((team / "team-a").rglob("S1.json"))
+    assert not list((team / "team-b").rglob("S1.json"))
+    assert list((team / "local").rglob("S1.json"))
+
+
+def test_dual_write_multi_remote_env_grant_does_not_fan_out(
+        tmp_path, sample_checkpoint, monkeypatch):
+    # DAIMON_TEAM_PROJECT is machine-global explicit intent; under multiple
+    # remotes it must NOT broadcast the project into every team. Toml-only
+    # routing applies; nothing grants -> local.
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/alpha")
+    repo = _repo(tmp_path, "alpha", "https://github.com/org/alpha")
+    _remote_clone("team-a")
+    _remote_clone("team-b")
+    store._dual_write_team("S1", sample_checkpoint, str(repo))
+    team = config.team_dir()
+    assert not list((team / "team-a").rglob("S1.json"))
+    assert not list((team / "team-b").rglob("S1.json"))
+    assert list((team / "local").rglob("S1.json"))
+
+
+def test_dual_write_single_remote_env_grant_still_honored(
+        tmp_path, sample_checkpoint, monkeypatch):
+    # Single-remote semantics are a compatibility contract: the env grant
+    # keeps working exactly as #279 shipped it.
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/alpha")
+    repo = _repo(tmp_path, "alpha", "https://github.com/org/alpha")
+    _remote_clone("team-a")
+    store._dual_write_team("S1", sample_checkpoint, str(repo))
+    assert list((config.team_dir() / "team-a").rglob("S1.json"))


### PR DESCRIPTION
Closes #387

## Summary

- The per-sidecar `daimon-team.toml` allowlist becomes the **router**, not just the gate: `_dual_write_team` writes the checkpoint into every sidecar clone whose toml grants the project membership, and to the local mirror only when none does. The multi-team topology from the issue (repo-group → memory repo A, other project → memory repo B) now just works.
- Kills the trap the issue repro'd: a second, unrelated team remote no longer silently disables sync for every project on the machine.
- `daimon team status` prints `this project writes to: <remotes>` — with an explicit pointer to the toml fix when the answer is the local degrade — so misrouting is visible *before* a session's checkpoint quietly stays home.

## The repro, before and after this PR

```
before:  2 remotes, teamA grants membership → local/projects/org/proj/.../S-repro.json
after:   2 remotes, teamA grants membership → teamA/projects/org/proj/.../S-repro.json
```

## Design decisions

- **Default-closed unchanged**: this changes routing among *willing* sidecars, not membership. An unlisted project still degrades to local (withheld, never lost).
- **Multi-destination is safe by construction**: sidecar paths are append-only and per-author — a repo in two teams' scopes reaches both without conflict.
- **`DAIMON_TEAM_PROJECT` (the issue's open design question)**: single-remote semantics preserved exactly as #279 shipped them; with multiple remotes the env grant is *ignored for routing* (`in_scope` grows `honor_env=False`) and a warning names the fix — the env var is machine-global and cannot say which remote it means, so honoring it would broadcast every project into every team. Regression tests pin both sides.
- Single-remote behavior overall is a compatibility contract — pinned by the existing #279 acceptance tests plus new regression tests, all passing unchanged.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/store.py` | `_team_write_slug` → `_team_write_slugs(project_dir)` (scope-routed, multi-destination); `_dual_write_team` loops destinations, blob built once |
| `plugin/daimon_briefing/teamproject.py` | `in_scope(..., honor_env=True)` — toml-only answer for the multi-remote router |
| `plugin/daimon_briefing/cli.py` | `team status` routing line with local-degrade explanation |
| `plugin/tests/test_teamproject.py` | 7 tests: route-by-scope (the inverted repro), fan-to-every-member, none-in-scope degrade, env-no-fan-out, single-remote env preserved, honor_env unit |
| `plugin/tests/test_cli.py` | 2 tests: status routing line, local-degrade wording |

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Test Plan

- [x] TDD red-first: 3 driving tests watched failing (multi-remote scope routing, fan-out, honor_env); 3 regression pins passed before and after
- [x] Full suite green: 2033 passed, 2 skipped
- [x] The exact repro filed on #387 rerun against the fix: checkpoint routes to the granting sidecar
- [x] Local patch coverage before push: all new lines covered
