### PR TITLE
fix(llm): preflight no longer kills the no-key rescue on explicit litellm

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -141,6 +141,17 @@ def _preflight_error(path: Path) -> str | None:
         return None
     if backend == "auto" and llm._resolve_command() is not None:
         return None  # llm.chat will route to the command CLI, key-free
+    # #383: an explicit litellm backend missing its key/model still has a
+    # rescue when fallback is enabled (default) and a command backend
+    # resolves — _chat_litellm raises ChatError and llm.chat routes to the
+    # command CLI. Hard-failing here killed the entire no-key error class
+    # (28% of one field install's capture errors, zero rescues attempted)
+    # before the rescue machinery could ever run. Fallback off, or nothing
+    # resolving, keeps the early named error — strictly better than an LLM
+    # failure minutes later inside a detached hook child.
+    if (not (config.llm_api_key() and config.llm_model())
+            and config.llm_fallback() and llm._resolve_command() is not None):
+        return None
     if not config.llm_api_key():
         return ("error: no LLM API key — set DAIMON_LLM_API_KEY "
                 f"(env or ~/.daimon/env) (transcript: {path})")

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -111,11 +111,14 @@ def test_cli_serialize_no_api_key_names_the_cause(
     # conflated "too short, LLM error, or invalid output".
     # Backend pinned litellm: since #52 pre-flight only requires a key on
     # litellm-bound transports (a dev machine's `claude` on PATH would
-    # otherwise legitimately pass).
+    # otherwise legitimately pass). No rescue backend either (#383): with
+    # one resolving, preflight correctly proceeds to the fallback instead.
+    from daimon_briefing import llm
     for var in ("DAIMON_LLM_API_KEY", "LITELLM_API_KEY"):
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
     monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    monkeypatch.setattr(llm, "_resolve_command", lambda: None)
     rc = cli.main(["serialize", str(FIXTURES / "sample_transcript.md")])
     assert rc != 0
     err = capsys.readouterr().err
@@ -4646,10 +4649,14 @@ def test_preflight_error_session_is_healable_when_transcript_exists():
 def test_serialize_preflight_errors_carry_transcript_suffix(
         tmp_checkpoint_dir, tmp_log_dir, monkeypatch, tmp_path):
     # End-to-end: _run_serialize's own pre-flight error lines carry the suffix.
-    # Backend pinned litellm — pre-flight is backend-aware since #52.
+    # Backend pinned litellm — pre-flight is backend-aware since #52. No
+    # rescue backend on the box (#383): with one resolving, preflight would
+    # correctly pass instead of erroring.
+    from daimon_briefing import llm
     monkeypatch.delenv("DAIMON_LLM_API_KEY", raising=False)
     monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
     monkeypatch.setattr(cli.config, "llm_api_key", lambda: None)
+    monkeypatch.setattr(llm, "_resolve_command", lambda: None)
     p = tmp_path / "S-pre.md"
     p.write_text("**user**: hola\n")
     rc = cli.main(["serialize", str(p)])
@@ -4700,9 +4707,13 @@ def test_preflight_names_missing_key_when_litellm_bound(monkeypatch):
 
 
 def test_preflight_names_missing_model_when_key_present(monkeypatch):
+    # No rescue backend on the box (#383): with one resolving, preflight
+    # would correctly pass instead of naming the missing model.
+    from daimon_briefing import llm
     _clear_llm_env_52(monkeypatch)
     monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
     monkeypatch.setenv("DAIMON_LLM_API_KEY", "sk-x")
+    monkeypatch.setattr(llm, "_resolve_command", lambda: None)
     err = cli._preflight_error(Path("/t/x.md"))
     assert err is not None and "DAIMON_LLM_MODEL" in err
 
@@ -6327,3 +6338,56 @@ def test_team_status_routing_names_local_degrade(monkeypatch, capsys,
     out = capsys.readouterr().out
     assert "this project writes to: local" in out
     assert "no remote grants it membership" in out
+
+
+# ---- #383: preflight must not kill the no-key rescue on explicit litellm ----
+#
+# Field numbers: no-API-key was 28% of all capture errors on one install,
+# attempting ZERO rescues — preflight exited before llm.chat's fallback
+# machinery could run, even with fallback enabled and a working command CLI
+# on PATH.
+
+
+def test_preflight_passes_litellm_no_key_when_rescue_resolves(monkeypatch):
+    from daimon_briefing import llm
+    _clear_llm_env_52(monkeypatch)
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setattr(llm, "_resolve_command",
+                        lambda: ("claude -p", "text", "stdin"))
+    assert cli._preflight_error(Path("/t/x.md")) is None
+
+
+def test_preflight_passes_litellm_no_model_when_rescue_resolves(monkeypatch):
+    from daimon_briefing import llm
+    _clear_llm_env_52(monkeypatch)
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_API_KEY", "sk-x")  # key but no model
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setattr(llm, "_resolve_command",
+                        lambda: ("claude -p", "text", "stdin"))
+    assert cli._preflight_error(Path("/t/x.md")) is None
+
+
+def test_preflight_still_fails_litellm_no_key_when_fallback_disabled(monkeypatch):
+    # User opted out of the rescue: the helpful early error stays.
+    from daimon_briefing import llm
+    _clear_llm_env_52(monkeypatch)
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "0")
+    monkeypatch.setattr(llm, "_resolve_command",
+                        lambda: ("claude -p", "text", "stdin"))
+    err = cli._preflight_error(Path("/t/x.md"))
+    assert err is not None and "DAIMON_LLM_API_KEY" in err
+
+
+def test_preflight_still_fails_litellm_no_key_when_nothing_resolves(monkeypatch):
+    # No rescue backend on the box: the early named error is strictly better
+    # than an LLM-call failure minutes later.
+    from daimon_briefing import llm
+    _clear_llm_env_52(monkeypatch)
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setattr(llm, "_resolve_command", lambda: None)
+    err = cli._preflight_error(Path("/t/x.md"))
+    assert err is not None and "DAIMON_LLM_API_KEY" in err


### PR DESCRIPTION
Closes #383

## Summary

- Preflight no longer hard-fails an explicit `litellm` backend with missing credentials when a rescue exists: with `DAIMON_LLM_FALLBACK` enabled (the default) and a command backend resolving, the serialize proceeds — `_chat_litellm` raises its named `ChatError` and `llm.chat` routes to the command CLI, producing a `[fallback backend]` checkpoint instead of nothing.
- Closes the mechanism behind the dominant error class from the #364 tabulation: **no-API-key was 28% of one install's capture errors with zero rescue attempts**, because the process exited at preflight before the rescue machinery could run. Only `backend=auto` had the command escape; explicit `litellm` — the configured-gateway case, exactly where key drift happens — did not.
- Both no-rescue paths keep the early named error, pinned by regression tests: fallback explicitly disabled (user opted out), or no command backend resolving (the rescue_gap-warning case). An early named error beats an LLM failure minutes later inside a detached hook child.

## Verification chain (from the issue)

1. `_chat_litellm` raises `ChatError` on missing key/model (`llm.py:93-97`) — before any HTTP.
2. `llm.chat` catches `ChatError` and rescues when fallback is on and a command resolves (`llm.py:188-200`), with the #341 deadline re-arm.
3. Preflight was the only gate preventing 1→2 from ever running.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/cli.py` | `_preflight_error`: incomplete litellm credentials + fallback on + command resolves → pass (mirroring the `auto` escape one branch above) |
| `plugin/tests/test_cli.py` | 4 new tests (no-key rescue passes, no-model rescue passes, fallback-off keeps error, nothing-resolves keeps error); 3 legacy tests now pin the no-rescue context explicitly instead of depending on the dev machine's PATH |

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Test Plan

- [x] TDD red-first: 2 driving tests watched failing; 2 no-rescue pins passed before and after
- [x] Full suite green: 2037 passed, 2 skipped
- [x] Legacy-test failures were the fix working (dev machine's real `claude` resolving) — re-pinned to their original intent, not weakened
- [x] Local patch coverage before push: all changed lines covered

## Field acceptance (deferred to data)

The #364 windowed stats are the instrument: on installs with a resolvable command backend, the no-key class should disappear from the error table and windowed `rescued` counts should rise. Worth a read after a week of the rolling window.
