### PR TITLE
test(mcp): freeze the clock in the status-tool parity test

### DIFF
--- a/plugin/tests/test_mcp_server.py
+++ b/plugin/tests/test_mcp_server.py
@@ -7,6 +7,7 @@ bottom of the file, kept cheap).
 """
 import io
 import json
+import time
 
 import pytest
 
@@ -209,6 +210,12 @@ def test_projects_tool_matches_cli_rows(tmp_checkpoint_dir, sample_checkpoint,
 def test_status_tool_matches_cli_payload(tmp_checkpoint_dir, sample_checkpoint,
                                          monkeypatch):
     from daimon_briefing import cli, store
+    # #390: the payload embeds a checkpoint age truncated to whole seconds,
+    # recomputed from the live clock on each call. Freeze it so the tool call
+    # and status_payload see the same instant — a diff must mean the payloads
+    # diverged, not that a second ticked over between them.
+    frozen = time.time()
+    monkeypatch.setattr(time, "time", lambda: frozen)
     store.write_checkpoint("S-a", sample_checkpoint, project_dir="/p/A")
     monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
     _, out = rpc(_init(), _call("daimon_status", {}))


### PR DESCRIPTION
Closes #390

## PR Type
- [x] Bug fix (test flake)

## Summary
- `test_status_tool_matches_cli_payload` read the live clock twice (MCP tool call, then `cli.status_payload`); crossing a whole-second boundary diverged the rendered checkpoint age (`0s` vs `1s`) and failed CI at random — bit the v0.21.0 release merge commit (run 30419563287, py3.13).
- Freeze `time.time` before both calls, same recipe as #307 / 8cc1951. Any payload diff now means the tool and CLI genuinely diverged.

## Changes
| File | Change |
|------|--------|
| `plugin/tests/test_mcp_server.py` | Freeze the clock in `test_status_tool_matches_cli_payload`; add `time` import |

## Test Plan
- [x] `uv run pytest tests/test_mcp_server.py -q` — 24 passed
- [x] Full plugin suite — 2037 passed, 2 skipped

## Checklist
- [x] Linked an approved issue (#390, status:approved)
- [x] Exactly one `type:*` label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers