### PR TITLE
feat(worldcheck): extend spot-check to file-exists, branch-state, and dependency-version claim classes

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -585,9 +585,13 @@ def _render_briefing_body(checkpoint, route, *, drift_project, teammates,
     if checkpoint and worldcheck_project and config.worldcheck_enabled():
         try:
             wc_stats = worldcheck.check(checkpoint, worldcheck_project)
-            for outcome in ("confirmed", "contradicted", "skipped"):
-                for _ in range(int(wc_stats.get(outcome, 0))):
-                    _note_usage(f"worldcheck:{outcome}")
+            # #397: the dict carries the aggregate outcomes AND a
+            # "<class>:<outcome>" key per class, so one pass emits both the
+            # slice-1 counters (unchanged meaning) and the per-class
+            # fires-true rate the next expansion gate reads.
+            for counter, count in sorted(wc_stats.items()):
+                for _ in range(int(count)):
+                    _note_usage(f"worldcheck:{counter}")
         except Exception:
             pass
     # NOTE: drift is checked against the resolved project root. If read_latest fell

--- a/plugin/daimon_briefing/worldcheck.py
+++ b/plugin/daimon_briefing/worldcheck.py
@@ -309,7 +309,7 @@ def _git_common_dir(project):
     """The git dir whose refs/heads is authoritative for `project`, or None.
     In a linked WORKTREE `.git` is a file pointing at <common>/worktrees/<x>,
     whose refs live back in the common dir — reading the worktree dir instead
-    would report every branch gone (the bench lane runs in worktrees)."""
+    would report every branch gone for anyone working out of a worktree."""
     dot = Path(project) / ".git"
     if dot.is_file():
         text = dot.read_text(encoding="utf-8", errors="replace").strip()

--- a/plugin/daimon_briefing/worldcheck.py
+++ b/plugin/daimon_briefing/worldcheck.py
@@ -23,11 +23,30 @@ The stamp is TRANSIENT (underscore key, same convention as withhold's
 renders; nothing here writes to disk. Probes are read-only by construction —
 `gh pr view` / `gh issue view` only.
 
-Slice 1 is deliberately narrow: PR/issue state claims only. The measurable
-question it answers — via the worldcheck:confirmed/contradicted/skipped usage
+Slice 1 was deliberately narrow: PR/issue state claims only. The measurable
+question it answered — via the worldcheck:confirmed/contradicted/skipped usage
 counters the CLI writes — is how often a carried repo-state claim is already
-false at next read; that fires-true rate is the evidence for (or against)
-later claim classes (file-exists, dependency-version, branch-state).
+false at next read; that fires-true rate was the pre-registered evidence gate
+for later claim classes.
+
+#397 slice 2 opens that gate and adds three DETERMINISTIC classes that need
+no network at all — file-exists (`Path.exists()`, no subprocess), branch-state
+(git's on-disk refs, read directly), dependency-version (the lockfile or
+manifest on disk). Everything the slice-1 contract promised holds across all
+four classes: ONE aggregate budget, ONE probe cap, silent skip on any failure,
+contradicted items flagged and never dropped. Two rules make the shared budget
+fair rather than first-come-lucky:
+
+- ALLOCATION follows checkpoint order, so no class is privileged when the cap
+  binds;
+- EXECUTION runs the on-disk classes BEFORE the `gh` fan-out, so a hanging
+  network probe can never starve a probe that costs microseconds.
+
+Counters now also land per class (worldcheck:<class>:<outcome>) while the
+aggregate three keep their slice-1 meaning, so the fires-true rate is
+readable per class before any further expansion. Content-hash — the strongest
+form — is deliberately NOT here: it would have to capture a hash at serialize
+time, which changes the serializer contract, so it is its own issue.
 """
 
 import json
@@ -36,6 +55,7 @@ import shutil
 import subprocess
 import time
 from collections import namedtuple
+from pathlib import Path
 
 from . import serializer
 
@@ -44,11 +64,27 @@ from . import serializer
 # per-probe allowance.
 BUDGET_SECONDS = 0.8
 
-# First N distinct refs get probed; further claims count as skipped. Caps the
-# subprocess fan-out no matter how claim-heavy a checkpoint gets.
+# First N distinct targets get probed; further claims count as skipped. Caps
+# the fan-out no matter how claim-heavy a checkpoint gets. The cap is shared
+# across ALL classes: cheap disk probes spend from the same allowance as `gh`,
+# which is why allocation follows checkpoint order rather than class.
 MAX_PROBES = 5
 
+# Claim classes, in the fixed priority order claim_for tries them. The order
+# is part of the contract: it keeps an item's reading stable as classes are
+# added, so a text carrying both a PR ref and a path keeps its slice-1 claim.
+PR_STATE = "pr-state"
+BRANCH_STATE = "branch-state"
+FILE_EXISTS = "file-exists"
+DEPENDENCY_VERSION = "dependency-version"
+
+# Classes answered from disk alone — no subprocess, no network.
+_LOCAL_CLASSES = frozenset({BRANCH_STATE, FILE_EXISTS, DEPENDENCY_VERSION})
+
 Claim = namedtuple("Claim", "num kind expected")
+PathClaim = namedtuple("PathClaim", "path expected")
+BranchClaim = namedtuple("BranchClaim", "name expected")
+DepClaim = namedtuple("DepClaim", "name version")
 
 # Repo-LOCAL ref: "#N" optionally preceded by an explicit "PR"/"pull
 # request"/"issue" kind word. The lookbehind rejects any word char (or
@@ -107,6 +143,137 @@ def claim_of(text):
     return Claim(num=ref.group("num"), kind=kind, expected=expected)
 
 
+# A repo-relative source path. Segments are [\w-] ONLY, so the single literal
+# dot before the extension is the only ambiguous split point in the whole
+# pattern — no overlapping prefix class, no quadratic backtracking (scar 22).
+# The extension is a WHITELIST rather than \w{1,8}: prose abbreviations
+# ("e.g.", "i.e.") are word.word shaped and would otherwise read as files.
+_PATH_EXT = ("tsx|jsx|toml|yaml|json|html|java|lock|yml|txt|cfg|ini|sql|css|"
+             "md|py|js|ts|go|rs|sh|rb|c|h")
+
+# The lookbehind rejects any '/', '~', '.' or word char butting up against the
+# first segment, which is what keeps ABSOLUTE paths (/etc/x.toml), HOME paths
+# (~/.config/x.json), URLs (https://host/docs/x.md) and parent traversal
+# (../other/x.py) from ever matching: every candidate start inside them is
+# preceded by one of those characters. Probing them would answer about a tree
+# that is not this project — the same refusal as slice 1's cross-repo refs.
+_PATH_RE = re.compile(
+    r"(?<![\w/~.-])(?P<path>(?:[\w-]{1,40}/){0,6}[\w-]{1,40}"
+    r"\.(?:" + _PATH_EXT + r"))\b")
+
+_PATH_STATE_RE = re.compile(
+    r"(?i)\b(lives in|implemented in|added|created|exists"
+    r"|deleted|removed|missing|gone)\b")
+_PATH_PRESENT = frozenset({"lives in", "implemented in", "added", "created", "exists"})
+_PATH_ABSENT = frozenset({"deleted", "removed", "missing", "gone"})
+
+# Branch names are only recognised after an explicit "branch" keyword. Without
+# it any slash-bearing token would read as a branch, and a wrong contradiction
+# flag is worse than no check. An optional backtick lets the common
+# "branch `feat/x`" phrasing through.
+_BRANCH_RE = re.compile(r"(?i)\bbranch\s+`?(?P<name>[\w][\w./-]{0,80})")
+_BRANCH_STATE_RE = re.compile(
+    r"(?i)\b(unmerged|active|current|checked out|deleted|gone)\b")
+_BRANCH_PRESENT = frozenset({"unmerged", "active", "current", "checked out"})
+_BRANCH_ABSENT = frozenset({"deleted", "gone"})
+
+# Version literal, shared by the claim patterns and the manifest scan.
+_VER = r"\d{1,4}(?:\.\d{1,4}){0,3}"
+
+# Three phrasings, all PAST tense on purpose: "should bump X to 2.1" is a
+# proposal, not a state claim, and must not be probed.
+_DEP_PIN_RE = re.compile(
+    r"(?i)(?<![\w.-])(?P<name>[A-Za-z][\w.-]{0,39})==(?P<ver>" + _VER + r")\b")
+_DEP_RE = re.compile(
+    r"(?i)(?<![\w.-])(?P<name>[A-Za-z][\w.-]{0,39})\s+(?:is\s+|was\s+|now\s+){0,2}"
+    r"(?:pinned|bumped|upgraded|downgraded)\s+(?:to|at)\s+v?(?P<ver>" + _VER + r")\b")
+_DEP_VERB_RE = re.compile(
+    r"(?i)\b(?:pinned|bumped|upgraded|downgraded)\s+(?P<name>[A-Za-z][\w.-]{0,39})\s+"
+    r"(?:to|at)\s+v?(?P<ver>" + _VER + r")\b")
+
+
+def _direction(text, state_re, present_words, absent_words):
+    """Shared claim-direction fold (slice 1's stance, reused verbatim by every
+    slice-2 class): no vocabulary means no claim, and BOTH directions at once
+    means an ambiguous one. Returns True for a present-claim, False for an
+    absent-claim, None for neither."""
+    words = {w.lower() for w in state_re.findall(text)}
+    present, absent = words & present_words, words & absent_words
+    if not words or (present and absent):
+        return None
+    return bool(present)
+
+
+def path_claim_of(text):
+    """The file-exists claim in `text`, or None. Requires assertion
+    vocabulary AND a repo-relative source path — a bare path MENTION is not a
+    claim, the same bar slice 1 sets for a bare "#N"."""
+    text = str(text or "")
+    present = _direction(text, _PATH_STATE_RE, _PATH_PRESENT, _PATH_ABSENT)
+    if present is None:
+        return None
+    ref = _PATH_RE.search(text)
+    if ref is None:
+        return None
+    return PathClaim(path=ref.group("path"),
+                     expected=frozenset({"EXISTS"} if present else {"MISSING"}))
+
+
+def branch_claim_of(text):
+    """The branch-state claim in `text`, or None. Scoped to EXISTENCE: whether
+    a branch is merged depends on a base this module cannot infer, but a
+    branch that is simply GONE already falsifies every "still on branch X"
+    claim a session carried."""
+    text = str(text or "")
+    present = _direction(text, _BRANCH_STATE_RE, _BRANCH_PRESENT, _BRANCH_ABSENT)
+    if present is None:
+        return None
+    ref = _BRANCH_RE.search(text)
+    if ref is None:
+        return None
+    name = ref.group("name").rstrip("./-")
+    if ".." in name:
+        return None  # would resolve outside refs/heads — never probe it
+    return BranchClaim(name=name,
+                       expected=frozenset({"EXISTS"} if present else {"MISSING"}))
+
+
+def dep_claim_of(text):
+    """The dependency-version claim in `text`, or None. Unlike the other
+    classes there is no direction to resolve: every accepted phrasing asserts
+    the SAME thing, that `name` currently sits at `version`."""
+    text = str(text or "")
+    for pattern in (_DEP_PIN_RE, _DEP_RE, _DEP_VERB_RE):
+        ref = pattern.search(text)
+        if ref is not None:
+            return DepClaim(name=ref.group("name"), version=ref.group("ver"))
+    return None
+
+
+def claim_for(text):
+    """The ONE checkable claim in `text` as (class, claim), or None. First
+    class to match wins: one claim per item is what keeps the shared probe
+    budget honest."""
+    text = str(text or "")
+    for cls, extract in ((PR_STATE, claim_of), (BRANCH_STATE, branch_claim_of),
+                         (FILE_EXISTS, path_claim_of),
+                         (DEPENDENCY_VERSION, dep_claim_of)):
+        claim = extract(text)
+        if claim is not None:
+            return cls, claim
+    return None
+
+
+def _target(cls, claim):
+    """The dedup key for a claim's probe — distinct targets are probed once
+    and every claim naming them is scored against its OWN expectation."""
+    if cls == PR_STATE:
+        return f"{claim.kind}/{claim.num}"
+    if cls == FILE_EXISTS:
+        return claim.path
+    return claim.name
+
+
 def _gh_path():
     """Seam for tests; None -> no gh on PATH -> skip everything silently."""
     return shutil.which("gh")
@@ -126,12 +293,161 @@ def _github_repo(project) -> bool:
     return proc.returncode == 0 and "github.com" in proc.stdout
 
 
-def _run_probes(probes: dict, cwd) -> dict:
-    """Run every probe in parallel under ONE aggregate deadline.
-    `probes` is {(kind, num): argv}; returns {(kind, num): STATE | None} —
-    None for anything killed at the deadline, failed, or unparseable. Never
-    raises: a probe error is a skip, not a briefing failure."""
-    deadline = time.monotonic() + BUDGET_SECONDS
+def _probe_path(project, relpath):
+    """EXISTS / MISSING for a repo-relative path, or None when the resolved
+    target escapes the project root. A symlink pointing out of the tree
+    answers about ANOTHER checkout — refuse rather than mis-flag, the same
+    stance as slice 1's cross-repo refusal. Pure stdlib, no subprocess."""
+    root = Path(project).resolve()
+    target = (root / relpath).resolve()
+    if target != root and root not in target.parents:
+        return None
+    return "EXISTS" if target.exists() else "MISSING"
+
+
+def _git_common_dir(project):
+    """The git dir whose refs/heads is authoritative for `project`, or None.
+    In a linked WORKTREE `.git` is a file pointing at <common>/worktrees/<x>,
+    whose refs live back in the common dir — reading the worktree dir instead
+    would report every branch gone (the bench lane runs in worktrees)."""
+    dot = Path(project) / ".git"
+    if dot.is_file():
+        text = dot.read_text(encoding="utf-8", errors="replace").strip()
+        if not text.startswith("gitdir:"):
+            return None
+        gitdir = Path(text.split(":", 1)[1].strip())
+        if not gitdir.is_absolute():
+            gitdir = Path(project) / gitdir
+        common = gitdir / "commondir"
+        if common.is_file():
+            rel = common.read_text(encoding="utf-8", errors="replace").strip()
+            if rel:
+                gitdir = gitdir / rel
+        dot = gitdir.resolve()
+    # No refs/heads means this is not a readable repo (or not a repo at all):
+    # answering MISSING there would fabricate a contradiction for every claim.
+    return dot if (dot / "refs" / "heads").is_dir() else None
+
+
+def _probe_branch(project, name):
+    """EXISTS / MISSING for a local branch, read straight off git's on-disk
+    refs. Both halves of git's ref storage are consulted: a branch with no
+    LOOSE ref file is not gone if packed-refs still carries it (every fresh
+    clone packs its refs, so missing this would contradict on sight)."""
+    git = _git_common_dir(project)
+    if git is None:
+        return None
+    if (git / "refs" / "heads" / name).is_file():
+        return "EXISTS"
+    packed = git / "packed-refs"
+    if packed.is_file():
+        needle = f" refs/heads/{name}"
+        for line in packed.read_text(encoding="utf-8", errors="replace").splitlines():
+            if line.endswith(needle):
+                return "EXISTS"
+    return "MISSING"
+
+
+# Consulted in THIS order, lockfiles first: a lock records the resolved
+# version, a manifest usually records a RANGE, and reading both would leave
+# every real project with two conflicting answers and nothing to say.
+_MANIFESTS = ("uv.lock", "package-lock.json", "Cargo.lock", "pyproject.toml",
+              "requirements.txt", "package.json", "Cargo.toml")
+
+# A manifest larger than this is not read at all — the briefing's budget is
+# sub-second and a pathological lockfile must not eat it.
+_MAX_MANIFEST_BYTES = 2_000_000
+
+
+def _probe_dep(project, name):
+    """The version the on-disk manifests pin for `name`, or None when nothing
+    answers or the answer is ambiguous. The first manifest yielding exactly
+    ONE distinct version wins; two versions for one name in the same file
+    (transitive duplicates) is ambiguous and stays unanswered — don't-guess
+    bias, same as slice 1's conflicting-vocabulary refusal.
+
+    A scan, not a parse: the repo floor is py3.10, which has no stdlib
+    tomllib, and the kernel takes no dependencies (ADR). The two shapes below
+    cover the TOML block form used by lockfiles and the inline `name<op>ver`
+    form used by every manifest here."""
+    esc = re.escape(name)
+    block = re.compile(r'(?i)name\s*=\s*["\']' + esc
+                       + r'["\']\s*\r?\n\s*version\s*=\s*["\'](' + _VER + r")")
+    inline = re.compile(r'(?i)(?<![\w.-])["\']?' + esc
+                        + r'["\']?\s*(?:==|>=|~=|[:=])\s*["\']?[\^~>=v]{0,3}('
+                        + _VER + r")")
+    root = Path(project)
+    for fname in _MANIFESTS:
+        path = root / fname
+        try:
+            if not path.is_file() or path.stat().st_size > _MAX_MANIFEST_BYTES:
+                continue
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        found = set(block.findall(text)) or set(inline.findall(text))
+        if len(found) == 1:
+            return found.pop()
+        if found:
+            return None  # ambiguous in the authoritative file — don't guess
+    return None
+
+
+def _local_probe(cls, project, target):
+    """Dispatch for the on-disk classes. Looked up by name at CALL time so
+    each probe stays an individually patchable seam, like `_gh_path`."""
+    if cls == FILE_EXISTS:
+        return _probe_path(project, target)
+    if cls == BRANCH_STATE:
+        return _probe_branch(project, target)
+    return _probe_dep(project, target)
+
+
+def _run_local(plan: dict, project, deadline) -> dict:
+    """Answer every on-disk claim in the plan. Runs BEFORE the `gh` fan-out:
+    these probes cost microseconds, so letting a hanging network probe starve
+    them would trade the reliable classes for the unreliable one. Still bound
+    by the shared deadline — the budget covers all classes, not just `gh`."""
+    out: dict = {}
+    for key in plan:
+        if key[0] not in _LOCAL_CLASSES:
+            continue
+        if time.monotonic() >= deadline:
+            break
+        try:
+            value = _local_probe(key[0], project, key[1])
+        except Exception:
+            value = None  # any probe failure is a SKIP, never a raise
+        if value is not None:
+            out[key] = value
+    return out
+
+
+def _run_gh(plan: dict, project, deadline) -> dict:
+    """Slice 1's read-only `gh` probes, now sharing the aggregate deadline and
+    cap with the on-disk classes. The `gh`/GitHub-remote gate is per CLASS:
+    a missing `gh` skips the PR/issue claims ONLY, and a checkpoint with no
+    PR/issue claim never shells out at all."""
+    wanted = {key: claim for key, claim in plan.items() if key[0] == PR_STATE}
+    if not wanted:
+        return {}
+    gh = _gh_path()
+    if gh is None or not _github_repo(project):
+        return {}
+    probes = {}
+    for key, claim in wanted.items():
+        if claim.kind == "pr":
+            probes[key] = [gh, "pr", "view", claim.num, "--json", "state,mergedAt"]
+        else:
+            probes[key] = [gh, "issue", "view", claim.num, "--json", "state"]
+    return _run_probes(probes, cwd=project, deadline=deadline)
+
+
+def _run_probes(probes: dict, cwd, deadline) -> dict:
+    """Run every probe in parallel under the SHARED aggregate deadline.
+    `probes` is {key: argv}; returns {key: STATE | None} — None for anything
+    killed at the deadline, failed, or unparseable. Never raises: a probe
+    error is a skip, not a briefing failure."""
     procs: dict = {}
     results: dict = {key: None for key in probes}
     for key, argv in probes.items():
@@ -168,16 +484,43 @@ def _run_probes(probes: dict, cwd) -> dict:
     return results
 
 
-def check(checkpoint, project_dir) -> dict:
-    """Spot-check the checkpoint's CARRIED claim-bearing items against `gh`,
-    stamping contradicted items with a transient `_worldcheck` annotation
-    IN PLACE (the caller owns the in-memory dict; nothing is persisted).
+def _satisfied(cls, claim, value) -> bool:
+    """Does the probed reality match what the item claimed? Version claims
+    compare by PREFIX — an item pinning "2.31" is not falsified by 2.31.4, a
+    coarser claim is not a false one — every other class is set membership."""
+    if cls == DEPENDENCY_VERSION:
+        return value == claim.version or value.startswith(claim.version + ".")
+    return value in claim.expected
 
-    Returns {"confirmed": n, "contradicted": n, "skipped": n} — per ITEM, so
-    the caller's usage counters measure the fires-true rate this slice
-    exists to answer. Zero-claim checkpoints return all-zeros and cost one
-    iteration, no subprocess. Confirmed items are untouched: only a
-    contradiction earns any surface at all."""
+
+def _flag(cls, claim, value):
+    """The (note, status) a contradicted item is stamped with. Every word that
+    can reach the render is chosen HERE, from a bounded vocabulary — probe
+    output is trusted for truth, never for text. `status` rides into the
+    suggested `daimon resolve --status` command."""
+    if cls == PR_STATE:
+        return f"#{claim.num} {value.lower()}", value.lower()
+    if cls == FILE_EXISTS:
+        return f"{claim.path} {value.lower()}", value.lower()
+    if cls == BRANCH_STATE:
+        word = "gone" if value == "MISSING" else "exists"
+        return f"branch {claim.name} {word}", word
+    return f"{claim.name} {value} not {claim.version}", "changed"
+
+
+def check(checkpoint, project_dir) -> dict:
+    """Spot-check the checkpoint's CARRIED claim-bearing items against
+    reality, stamping contradicted items with a transient `_worldcheck`
+    annotation IN PLACE (the caller owns the in-memory dict; nothing is
+    persisted).
+
+    Returns {"confirmed": n, "contradicted": n, "skipped": n} counted per
+    ITEM, plus a "<class>:<outcome>" key for every outcome that actually
+    occurred (#397) — so the caller's usage counters measure the fires-true
+    rate per claim class while the aggregate three keep their slice-1
+    meaning. Zero-claim checkpoints return all-zeros and cost one iteration,
+    no probe of any kind. Confirmed items are untouched: only a contradiction
+    earns any surface at all."""
     stats = {"confirmed": 0, "contradicted": 0, "skipped": 0}
     if not isinstance(checkpoint, dict) or not project_dir:
         return stats
@@ -185,33 +528,33 @@ def check(checkpoint, project_dir) -> dict:
     for item in serializer.iter_items(checkpoint):
         if not item.get("carried_from"):
             continue  # native items were just re-extracted — not in question
-        claim = claim_of(item.get("text"))
-        if claim is not None:
-            claims.append((item, claim))
+        found = claim_for(item.get("text"))
+        if found is not None:
+            claims.append((item, found[0], found[1]))
     if not claims:
         return stats
-    gh = _gh_path()
-    if gh is None or not _github_repo(project_dir):
-        stats["skipped"] = len(claims)
-        return stats
-    probes: dict = {}
-    for _item, claim in claims:
-        key = (claim.kind, claim.num)
-        if key in probes or len(probes) >= MAX_PROBES:
+    # ONE deadline for every class. Allocation of the shared cap follows
+    # checkpoint order so no class is privileged when it binds; execution
+    # then runs local-before-network so the cheap classes cannot be starved.
+    deadline = time.monotonic() + BUDGET_SECONDS
+    plan: dict = {}
+    for _item, cls, claim in claims:
+        key = (cls, _target(cls, claim))
+        if key in plan or len(plan) >= MAX_PROBES:
             continue
-        if claim.kind == "pr":
-            probes[key] = [gh, "pr", "view", claim.num, "--json", "state,mergedAt"]
+        plan[key] = claim
+    results = _run_local(plan, project_dir, deadline)
+    results.update(_run_gh(plan, project_dir, deadline))
+    for item, cls, claim in claims:
+        value = results.get((cls, _target(cls, claim)))
+        if value is None:
+            outcome = "skipped"
+        elif _satisfied(cls, claim, value):
+            outcome = "confirmed"
         else:
-            probes[key] = [gh, "issue", "view", claim.num, "--json", "state"]
-    results = _run_probes(probes, cwd=project_dir)
-    for item, claim in claims:
-        state = results.get((claim.kind, claim.num))
-        if state is None:
-            stats["skipped"] += 1
-        elif state in claim.expected:
-            stats["confirmed"] += 1
-        else:
-            stats["contradicted"] += 1
-            item["_worldcheck"] = {"note": f"#{claim.num} {state.lower()}",
-                                   "status": state.lower()}
+            outcome = "contradicted"
+            note, status = _flag(cls, claim, value)
+            item["_worldcheck"] = {"note": note, "status": status}
+        stats[outcome] += 1
+        stats[f"{cls}:{outcome}"] = stats.get(f"{cls}:{outcome}", 0) + 1
     return stats

--- a/plugin/tests/test_worldcheck.py
+++ b/plugin/tests/test_worldcheck.py
@@ -562,7 +562,7 @@ def test_check_branch_probe_follows_relative_worktree_gitdir(monkeypatch, tmp_pa
 def test_check_branch_probe_follows_worktree_gitdir(monkeypatch, tmp_path):
     # In a git worktree `.git` is a FILE pointing at the worktree's gitdir,
     # whose refs live in the COMMON dir. Reading the wrong one reports every
-    # branch gone (the bench lane runs in worktrees — #267).
+    # branch gone for anyone working out of a worktree.
     main = _git_repo(tmp_path / "main", branches=["feat/397-slice-2"])
     common = main / ".git"
     wt_gitdir = common / "worktrees" / "wt"

--- a/plugin/tests/test_worldcheck.py
+++ b/plugin/tests/test_worldcheck.py
@@ -1,20 +1,29 @@
-"""#365 slice 1: deterministic external-state spot-check for carried PR/issue-
-state claims at briefing render.
+"""#365 slice 1 / #397 slice 2: deterministic external-state spot-check for
+carried claims at briefing render.
 
 Contract pinned here:
-- claim_of: conservative claim-class extraction — a repo-local "#N" ref PLUS a
-  state word, never bare refs, never cross-repo refs, never conflicting words.
-- check: read-only `gh` probes under a strict aggregate budget + probe cap;
-  confirmed items untouched, contradicted items stamped with a transient
-  `_worldcheck` annotation, everything else skipped SILENTLY.
+- claim extraction: conservative per class — slice 1 wants a repo-local "#N"
+  ref PLUS a state word (never bare refs, never cross-repo refs, never
+  conflicting words); slice 2's file-exists / branch-state /
+  dependency-version classes hold the same bar, so a bare path mention, a
+  branch name with no "branch" keyword, and a future-tense version bump are
+  all non-claims.
+- check: read-only probes under ONE aggregate budget and ONE probe cap shared
+  by every class; confirmed items untouched, contradicted items stamped with
+  a transient `_worldcheck` annotation, everything else skipped SILENTLY.
+- budget fairness (#397): the cap is allocated in checkpoint order (no class
+  privileged) and on-disk probes execute before the `gh` fan-out (a hanging
+  network probe cannot starve them).
 - rendering: the stamped item gains an ADDED flag line reusing the existing
   confirm/reject command surface (`daimon resolve` / `daimon reverify`) —
-  existing pinned literals never change.
+  existing pinned literals never change, and every class stamps the same
+  {note, status} shape so the render path stays class-agnostic.
 - CLI wiring: DAIMON_WORLDCHECK opt-in (default OFF, byte-identical off-path),
   cross-project (--slug) and global-fallback briefs never probe, and outcomes
-  land in usage.log as worldcheck:confirmed/contradicted/skipped.
+  land in usage.log as worldcheck:<outcome> AND worldcheck:<class>:<outcome>.
 
 All gh probes in this suite hit a fake `gh` script on disk — zero network.
+Slice 2's probes touch only tmp_path trees — zero network, zero subprocess.
 """
 
 import json
@@ -153,7 +162,8 @@ def test_check_confirmed_leaves_item_untouched(monkeypatch, fake_gh, proj):
     _enable_probes(monkeypatch, gh)
     cp = _cp(["PR #60 awaiting review"])
     stats = worldcheck.check(cp, proj)
-    assert stats == {"confirmed": 1, "contradicted": 0, "skipped": 0}
+    assert stats == {"confirmed": 1, "contradicted": 0, "skipped": 0,
+                     "pr-state:confirmed": 1}
     item = cp["working_context"]["open_questions"][0]
     assert "_worldcheck" not in item
     assert len(_calls(log)) == 1
@@ -164,7 +174,8 @@ def test_check_contradicted_stamps_item(monkeypatch, fake_gh, proj):
     _enable_probes(monkeypatch, gh)
     cp = _cp(["PR #60 awaiting review"])
     stats = worldcheck.check(cp, proj)
-    assert stats == {"confirmed": 0, "contradicted": 1, "skipped": 0}
+    assert stats == {"confirmed": 0, "contradicted": 1, "skipped": 0,
+                     "pr-state:contradicted": 1}
     item = cp["working_context"]["open_questions"][0]
     assert item["_worldcheck"] == {"note": "#60 merged", "status": "merged"}
 
@@ -174,7 +185,8 @@ def test_check_gh_missing_skips_silently(monkeypatch):
     monkeypatch.setattr(worldcheck, "_github_repo", lambda project: True)
     cp = _cp(["PR #60 awaiting review"])
     stats = worldcheck.check(cp, "/p/A")
-    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1}
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "pr-state:skipped": 1}
     assert "_worldcheck" not in cp["working_context"]["open_questions"][0]
 
 
@@ -184,7 +196,8 @@ def test_check_no_github_remote_skips_without_probing(monkeypatch, fake_gh):
     monkeypatch.setattr(worldcheck, "_github_repo", lambda project: False)
     cp = _cp(["PR #60 awaiting review"])
     stats = worldcheck.check(cp, "/p/A")
-    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1}
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "pr-state:skipped": 1}
     assert _calls(log) == []
 
 
@@ -193,14 +206,16 @@ def test_check_probe_failure_skips(monkeypatch, fake_gh, proj):
     _enable_probes(monkeypatch, gh)
     cp = _cp(["PR #60 awaiting review"])
     stats = worldcheck.check(cp, proj)
-    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1}
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "pr-state:skipped": 1}
 
 
 def test_check_bad_json_skips(monkeypatch, fake_gh, proj):
     gh, _log = fake_gh("echo 'not json at all'")
     _enable_probes(monkeypatch, gh)
     stats = worldcheck.check(_cp(["PR #60 awaiting review"]), proj)
-    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1}
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "pr-state:skipped": 1}
 
 
 def test_check_unknown_state_vocabulary_skips(monkeypatch, fake_gh, proj):
@@ -210,7 +225,8 @@ def test_check_unknown_state_vocabulary_skips(monkeypatch, fake_gh, proj):
     _enable_probes(monkeypatch, gh)
     cp = _cp(["PR #60 awaiting review"])
     stats = worldcheck.check(cp, proj)
-    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1}
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "pr-state:skipped": 1}
     assert "_worldcheck" not in cp["working_context"]["open_questions"][0]
 
 
@@ -223,7 +239,8 @@ def test_check_budget_kills_slow_probe(monkeypatch, fake_gh, proj):
     stats = worldcheck.check(cp, proj)
     elapsed = time.monotonic() - start
     assert elapsed < 2.0  # never blocks anywhere near the hook budget
-    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1}
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "pr-state:skipped": 1}
 
 
 def test_check_probe_cap(monkeypatch, fake_gh, proj):
@@ -298,6 +315,523 @@ def test_github_repo_gate_against_real_git(tmp_path):
     assert worldcheck._github_repo(str(plain)) is False
 
 
+# ---- #397 slice 2: file-exists claims ---------------------------------------
+
+
+def test_path_claim_present_vocabulary():
+    claim = worldcheck.path_claim_of("the fix lives in plugin/daimon_briefing/carry.py")
+    assert claim is not None
+    assert claim.path == "plugin/daimon_briefing/carry.py"
+    assert claim.expected == frozenset({"EXISTS"})
+
+
+def test_path_claim_absent_vocabulary():
+    claim = worldcheck.path_claim_of("the old shim was deleted — legacy/adapter.py is gone")
+    assert claim is not None
+    assert claim.path == "legacy/adapter.py"
+    assert claim.expected == frozenset({"MISSING"})
+
+
+def test_path_claim_bare_path_without_vocabulary_is_none():
+    # A path MENTION is not a claim — same bar as slice 1's bare "#N".
+    assert worldcheck.path_claim_of("see plugin/daimon_briefing/carry.py for context") is None
+
+
+def test_path_claim_conflicting_vocabulary_is_none():
+    assert worldcheck.path_claim_of("added then deleted src/tmp.py") is None
+
+
+def test_path_claim_rejects_absolute_and_home_paths():
+    # Outside the project root: `Path.exists()` here answers about the WRONG
+    # tree, exactly like slice 1's cross-repo "#N" refusal.
+    assert worldcheck.path_claim_of("the config lives in /etc/daimon/prod.toml") is None
+    assert worldcheck.path_claim_of("the config lives in ~/.config/app/settings.json") is None
+
+
+def test_path_claim_rejects_url_paths():
+    assert worldcheck.path_claim_of(
+        "the doc lives in https://example.com/docs/guide.md") is None
+
+
+def test_path_claim_rejects_prose_abbreviations():
+    # "e.g." is [word].[word] shaped; only whitelisted source extensions count.
+    assert worldcheck.path_claim_of("added a guard, e.g. for the null case") is None
+
+
+def test_path_claim_rejects_parent_traversal():
+    assert worldcheck.path_claim_of("the fix lives in ../other-repo/main.py") is None
+
+
+def test_path_claim_long_input_completes():
+    # Scar 22: every capture-path regex gets a long-input completion test —
+    # completion IS the signal, no timing assert.
+    assert worldcheck.path_claim_of("lives in " + "a-b." * 12500) is None
+    assert worldcheck.path_claim_of("lives in " + "x" * 50000) is None
+
+
+def test_check_file_exists_confirmed(monkeypatch, tmp_path):
+    project = tmp_path / "repo"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "fix.py").write_text("x = 1\n")
+    # No gh, no GitHub remote: a deterministic disk probe must not need either.
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    monkeypatch.setattr(worldcheck, "_github_repo", lambda project: False)
+    cp = _cp(["the fix lives in src/fix.py"])
+    stats = worldcheck.check(cp, str(project))
+    assert stats == {"confirmed": 1, "contradicted": 0, "skipped": 0,
+                     "file-exists:confirmed": 1}
+    assert "_worldcheck" not in cp["working_context"]["open_questions"][0]
+
+
+def test_check_file_exists_contradicted_stamps_item(monkeypatch, tmp_path):
+    project = tmp_path / "repo"
+    project.mkdir()
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    cp = _cp(["the fix lives in src/fix.py"])
+    stats = worldcheck.check(cp, str(project))
+    assert stats == {"confirmed": 0, "contradicted": 1, "skipped": 0,
+                     "file-exists:contradicted": 1}
+    assert cp["working_context"]["open_questions"][0]["_worldcheck"] == {
+        "note": "src/fix.py missing", "status": "missing"}
+
+
+def test_check_file_absent_claim_contradicted_when_file_returned(monkeypatch, tmp_path):
+    project = tmp_path / "repo"
+    (project / "legacy").mkdir(parents=True)
+    (project / "legacy" / "adapter.py").write_text("x = 1\n")
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    cp = _cp(["legacy/adapter.py was deleted in the cleanup"])
+    stats = worldcheck.check(cp, str(project))
+    assert stats["contradicted"] == 1
+    assert cp["working_context"]["open_questions"][0]["_worldcheck"] == {
+        "note": "legacy/adapter.py exists", "status": "exists"}
+
+
+def test_check_file_exists_never_spawns_a_subprocess(monkeypatch, tmp_path):
+    # Contract: file-exists is a pure Path.exists() probe (issue #397).
+    project = tmp_path / "repo"
+    project.mkdir()
+
+    def _boom(*a, **k):
+        raise AssertionError("file-exists must never spawn a process")
+
+    monkeypatch.setattr(worldcheck.subprocess, "Popen", _boom)
+    monkeypatch.setattr(worldcheck.subprocess, "run", _boom)
+    stats = worldcheck.check(_cp(["the fix lives in src/fix.py"]), str(project))
+    assert stats["contradicted"] == 1
+
+
+def test_check_file_exists_symlink_escape_is_skipped(monkeypatch, tmp_path):
+    # A symlink whose target sits OUTSIDE the project root answers about
+    # another tree — refuse rather than guess.
+    project = tmp_path / "repo"
+    project.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.py").write_text("x = 1\n")
+    (project / "link").symlink_to(outside)
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    stats = worldcheck.check(_cp(["the fix lives in link/secret.py"]), str(project))
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "file-exists:skipped": 1}
+
+
+# ---- #397 slice 2: branch-state claims --------------------------------------
+
+
+def test_branch_claim_present_vocabulary():
+    claim = worldcheck.branch_claim_of("work continues on branch feat/397-slice-2, unmerged")
+    assert claim is not None
+    assert claim.name == "feat/397-slice-2"
+    assert claim.expected == frozenset({"EXISTS"})
+
+
+def test_branch_claim_absent_vocabulary():
+    claim = worldcheck.branch_claim_of("branch feat/old was deleted after the merge")
+    assert claim is not None
+    assert claim.name == "feat/old"
+    assert claim.expected == frozenset({"MISSING"})
+
+
+def test_branch_claim_requires_the_branch_keyword():
+    # Without an explicit "branch" keyword any token could be a branch name.
+    assert worldcheck.branch_claim_of("feat/397 is still unmerged") is None
+
+
+def test_branch_claim_without_vocabulary_is_none():
+    assert worldcheck.branch_claim_of("opened from branch feat/397") is None
+
+
+def test_branch_claim_strips_backticks():
+    claim = worldcheck.branch_claim_of("branch `feat/x` is still current")
+    assert claim is not None
+    assert claim.name == "feat/x"
+
+
+def test_branch_claim_rejects_traversal_names():
+    # A name that would resolve outside refs/heads is never probed.
+    assert worldcheck.branch_claim_of("branch ../../etc/passwd is gone") is None
+    assert worldcheck.branch_claim_of("branch feat/../../../etc is gone") is None
+
+
+def test_branch_claim_long_input_completes():
+    assert worldcheck.branch_claim_of("branch " + "a/b." * 12500) is None
+
+
+def _git_repo(path, branches=(), packed=()):
+    """A minimal on-disk .git the branch probe can read without git itself."""
+    git = path / ".git"
+    (git / "refs" / "heads").mkdir(parents=True)
+    for name in branches:
+        ref = git / "refs" / "heads" / name
+        ref.parent.mkdir(parents=True, exist_ok=True)
+        ref.write_text("0" * 40 + "\n")
+    if packed:
+        (git / "packed-refs").write_text(
+            "# pack-refs with: peeled fully-peeled sorted\n"
+            + "".join(f"{'0' * 40} refs/heads/{n}\n" for n in packed))
+    return path
+
+
+def test_check_branch_present_confirmed(monkeypatch, tmp_path):
+    project = _git_repo(tmp_path / "repo", branches=["feat/397-slice-2"])
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    cp = _cp(["work continues on branch feat/397-slice-2, unmerged"])
+    stats = worldcheck.check(cp, str(project))
+    assert stats == {"confirmed": 1, "contradicted": 0, "skipped": 0,
+                     "branch-state:confirmed": 1}
+
+
+def test_check_branch_gone_contradicted(monkeypatch, tmp_path):
+    project = _git_repo(tmp_path / "repo", branches=["main"])
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    cp = _cp(["work continues on branch feat/397-slice-2, unmerged"])
+    stats = worldcheck.check(cp, str(project))
+    assert stats == {"confirmed": 0, "contradicted": 1, "skipped": 0,
+                     "branch-state:contradicted": 1}
+    assert cp["working_context"]["open_questions"][0]["_worldcheck"] == {
+        "note": "branch feat/397-slice-2 gone", "status": "gone"}
+
+
+def test_check_branch_found_in_packed_refs(monkeypatch, tmp_path):
+    # A branch with no loose ref file is NOT gone — packed-refs is the other
+    # half of git's ref storage, and missing it would fabricate a
+    # contradiction on every freshly cloned repo.
+    project = _git_repo(tmp_path / "repo", packed=["feat/397-slice-2"])
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    cp = _cp(["work continues on branch feat/397-slice-2, unmerged"])
+    stats = worldcheck.check(cp, str(project))
+    assert stats["confirmed"] == 1
+
+
+def test_check_branch_outside_git_repo_is_skipped(monkeypatch, tmp_path):
+    project = tmp_path / "plain"
+    project.mkdir()
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    cp = _cp(["work continues on branch feat/397-slice-2, unmerged"])
+    stats = worldcheck.check(cp, str(project))
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "branch-state:skipped": 1}
+
+
+def test_check_branch_dot_git_file_without_gitdir_pointer_is_skipped(
+    monkeypatch, tmp_path
+):
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / ".git").write_text("something else entirely\n")
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    cp = _cp(["work continues on branch feat/397-slice-2, unmerged"])
+    assert worldcheck.check(cp, str(project))["skipped"] == 1
+
+
+def test_check_branch_probe_follows_relative_worktree_gitdir(monkeypatch, tmp_path):
+    # `gitdir:` may be recorded relative to the worktree, not absolute.
+    main = _git_repo(tmp_path / "main", branches=["feat/397-slice-2"])
+    tree = tmp_path / "wt"
+    gitdir = tree / "nested" / "gd"
+    gitdir.mkdir(parents=True)
+    (gitdir / "commondir").write_text("../../../main/.git\n")
+    (tree / ".git").write_text("gitdir: nested/gd\n")
+    assert main.exists()
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    cp = _cp(["work continues on branch feat/397-slice-2, unmerged"])
+    assert worldcheck.check(cp, str(tree))["confirmed"] == 1
+
+
+def test_check_branch_probe_follows_worktree_gitdir(monkeypatch, tmp_path):
+    # In a git worktree `.git` is a FILE pointing at the worktree's gitdir,
+    # whose refs live in the COMMON dir. Reading the wrong one reports every
+    # branch gone (the bench lane runs in worktrees — #267).
+    main = _git_repo(tmp_path / "main", branches=["feat/397-slice-2"])
+    common = main / ".git"
+    wt_gitdir = common / "worktrees" / "wt"
+    wt_gitdir.mkdir(parents=True)
+    (wt_gitdir / "commondir").write_text("../..\n")
+    tree = tmp_path / "wt"
+    tree.mkdir()
+    (tree / ".git").write_text(f"gitdir: {wt_gitdir}\n")
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    cp = _cp(["work continues on branch feat/397-slice-2, unmerged"])
+    stats = worldcheck.check(cp, str(tree))
+    assert stats["confirmed"] == 1
+
+
+# ---- #397 slice 2: dependency-version claims --------------------------------
+
+
+def test_dep_claim_pinned_to():
+    claim = worldcheck.dep_claim_of("requests is pinned to 2.31.0 for the retry fix")
+    assert claim is not None
+    assert claim.name == "requests"
+    assert claim.version == "2.31.0"
+
+
+def test_dep_claim_operator_form():
+    claim = worldcheck.dep_claim_of("we ship rich==13.7.1 in the pretty extra")
+    assert claim is not None
+    assert claim.name == "rich"
+    assert claim.version == "13.7.1"
+
+
+def test_dep_claim_bumped_strips_v_prefix():
+    claim = worldcheck.dep_claim_of("bumped pytest to v8.2")
+    assert claim is not None
+    assert claim.name == "pytest"
+    assert claim.version == "8.2"
+
+
+def test_dep_claim_future_tense_is_none():
+    # "should bump X to 2.1" is a PROPOSAL, not a state claim.
+    assert worldcheck.dep_claim_of("we should bump requests to 2.31.0") is None
+
+
+def test_dep_claim_without_a_name_is_none():
+    assert worldcheck.dep_claim_of("pinned to 2.1 for now") is None
+
+
+def test_dep_claim_long_input_completes():
+    # Scar 22: completion IS the signal — three patterns scan this text.
+    assert worldcheck.dep_claim_of("x" * 50000) is None
+    assert worldcheck.dep_claim_of("a.b-" * 12500) is None
+    assert worldcheck.dep_claim_of("rich==13.7.1 " + "y" * 50000) is not None
+
+
+def test_check_dependency_version_confirmed(monkeypatch, tmp_path):
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "uv.lock").write_text(
+        '[[package]]\nname = "requests"\nversion = "2.31.0"\n')
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    cp = _cp(["requests is pinned to 2.31.0 for the retry fix"])
+    stats = worldcheck.check(cp, str(project))
+    assert stats == {"confirmed": 1, "contradicted": 0, "skipped": 0,
+                     "dependency-version:confirmed": 1}
+
+
+def test_check_dependency_version_prefix_claim_is_satisfied(monkeypatch, tmp_path):
+    # "pinned to 2.31" is satisfied by 2.31.0 — a coarser claim is not a
+    # false one.
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "uv.lock").write_text(
+        '[[package]]\nname = "requests"\nversion = "2.31.0"\n')
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    stats = worldcheck.check(_cp(["requests is pinned to 2.31"]), str(project))
+    assert stats["confirmed"] == 1
+
+
+def test_check_dependency_version_contradicted(monkeypatch, tmp_path):
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "uv.lock").write_text(
+        '[[package]]\nname = "requests"\nversion = "2.32.4"\n')
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    cp = _cp(["requests is pinned to 2.31.0 for the retry fix"])
+    stats = worldcheck.check(cp, str(project))
+    assert stats["contradicted"] == 1
+    assert cp["working_context"]["open_questions"][0]["_worldcheck"] == {
+        "note": "requests 2.32.4 not 2.31.0", "status": "changed"}
+
+
+def test_check_dependency_version_reads_package_json(monkeypatch, tmp_path):
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "package.json").write_text(
+        '{"dependencies": {"react": "^18.3.1"}}\n')
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    stats = worldcheck.check(_cp(["react is pinned to 18.3.1"]), str(project))
+    assert stats["confirmed"] == 1
+
+
+def test_check_dependency_version_lockfile_wins_over_manifest(monkeypatch, tmp_path):
+    # uv.lock is ground truth; pyproject's range would otherwise read as a
+    # second, conflicting answer and skip every real Python project.
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "uv.lock").write_text(
+        '[[package]]\nname = "requests"\nversion = "2.31.0"\n')
+    (project / "pyproject.toml").write_text(
+        '[project]\ndependencies = ["requests>=2.0"]\n')
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    stats = worldcheck.check(_cp(["requests is pinned to 2.31.0"]), str(project))
+    assert stats["confirmed"] == 1
+
+
+def test_check_dependency_version_ambiguous_answer_is_skipped(monkeypatch, tmp_path):
+    # Two different versions for one name in the SAME file (transitive
+    # duplicates in a lockfile): don't guess — skip, like slice 1's
+    # conflicting-vocabulary refusal.
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "uv.lock").write_text(
+        '[[package]]\nname = "requests"\nversion = "2.31.0"\n\n'
+        '[[package]]\nname = "requests"\nversion = "2.32.4"\n')
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    stats = worldcheck.check(_cp(["requests is pinned to 2.31.0"]), str(project))
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "dependency-version:skipped": 1}
+
+
+def test_check_dependency_version_unknown_name_is_skipped(monkeypatch, tmp_path):
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "uv.lock").write_text(
+        '[[package]]\nname = "requests"\nversion = "2.31.0"\n')
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    stats = worldcheck.check(_cp(["nosuchpkg is pinned to 1.0"]), str(project))
+    assert stats["skipped"] == 1
+
+
+def test_check_dependency_version_unreadable_manifest_is_skipped(
+    monkeypatch, tmp_path
+):
+    # Patched rather than chmod'd: a permission test passes trivially when
+    # the suite runs as root, which it does in some CI images.
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "uv.lock").write_text(
+        '[[package]]\nname = "requests"\nversion = "2.31.0"\n')
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+
+    def _unreadable(self, *a, **k):
+        raise OSError("nope")
+
+    monkeypatch.setattr(worldcheck.Path, "read_text", _unreadable)
+    stats = worldcheck.check(_cp(["requests is pinned to 2.31.0"]), str(project))
+    assert stats["skipped"] == 1
+
+
+def test_check_no_manifest_on_disk_is_skipped(monkeypatch, tmp_path):
+    project = tmp_path / "repo"
+    project.mkdir()
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    stats = worldcheck.check(_cp(["requests is pinned to 2.31.0"]), str(project))
+    assert stats["skipped"] == 1
+
+
+# ---- #397 slice 2: shared budget, cap, and class priority -------------------
+
+
+def test_pr_state_claim_wins_over_slice_2_classes():
+    # Fixed priority: an item making a PR/issue claim keeps its slice-1
+    # reading even when a path also appears in the text.
+    cls, claim = worldcheck.claim_for("PR #60 awaiting review, lives in src/fix.py")
+    assert cls == "pr-state"
+    assert claim.num == "60"
+
+
+def test_claim_for_returns_none_when_no_class_matches():
+    assert worldcheck.claim_for("we talked about the retry semantics") is None
+
+
+def test_shared_probe_cap_is_allocated_in_item_order(monkeypatch, tmp_path):
+    # MAX_PROBES is aggregate across ALL classes (#397). Allocation follows
+    # checkpoint order so no class is privileged; the 6th claim skips.
+    project = tmp_path / "repo"
+    project.mkdir()
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    texts = [f"the fix lives in src/f{n}.py" for n in range(worldcheck.MAX_PROBES + 1)]
+    stats = worldcheck.check(_cp(texts), str(project))
+    assert stats["contradicted"] == worldcheck.MAX_PROBES == 5
+    assert stats["skipped"] == 1
+    assert stats["file-exists:skipped"] == 1
+
+
+def test_exhausted_budget_skips_local_probes(monkeypatch, tmp_path):
+    # The aggregate wall-clock budget bounds every class, not just `gh`.
+    project = tmp_path / "repo"
+    project.mkdir()
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    monkeypatch.setattr(worldcheck, "BUDGET_SECONDS", -1.0)
+    stats = worldcheck.check(_cp(["the fix lives in src/fix.py"]), str(project))
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "file-exists:skipped": 1}
+
+
+def test_local_probes_survive_a_hanging_gh(monkeypatch, fake_gh, tmp_path):
+    # Execution order protects the deterministic classes: a `gh` probe that
+    # eats the whole budget must not starve a disk probe that costs nothing.
+    project = tmp_path / "repo"
+    project.mkdir()
+    gh, _log = fake_gh("sleep 5\necho '{\"state\":\"OPEN\"}'")
+    _enable_probes(monkeypatch, gh)
+    monkeypatch.setattr(worldcheck, "BUDGET_SECONDS", 0.2)
+    cp = _cp(["PR #60 awaiting review", "the fix lives in src/fix.py"])
+    stats = worldcheck.check(cp, str(project))
+    assert stats["pr-state:skipped"] == 1
+    assert stats["file-exists:contradicted"] == 1
+
+
+def test_mixed_classes_report_per_class_counters(monkeypatch, tmp_path):
+    project = _git_repo(tmp_path / "repo", branches=["feat/live"])
+    (project / "src").mkdir()
+    (project / "src" / "fix.py").write_text("x = 1\n")
+    (project / "uv.lock").write_text(
+        '[[package]]\nname = "requests"\nversion = "2.32.4"\n')
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    cp = _cp(["the fix lives in src/fix.py",
+              "branch feat/live is still current",
+              "requests is pinned to 2.31.0"])
+    stats = worldcheck.check(cp, str(project))
+    assert stats["confirmed"] == 2
+    assert stats["contradicted"] == 1
+    assert stats["file-exists:confirmed"] == 1
+    assert stats["branch-state:confirmed"] == 1
+    assert stats["dependency-version:contradicted"] == 1
+
+
+def test_probe_failure_in_one_class_never_raises(monkeypatch, tmp_path):
+    # Silent skip on ANY probe failure — the briefing is never blocked.
+    project = tmp_path / "repo"
+    project.mkdir()
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+
+    def _boom(*a, **k):
+        raise RuntimeError("disk exploded")
+
+    monkeypatch.setattr(worldcheck, "_probe_path", _boom)
+    stats = worldcheck.check(_cp(["the fix lives in src/fix.py"]), str(project))
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "file-exists:skipped": 1}
+
+
+def test_check_rejects_a_torn_checkpoint_or_missing_project():
+    # Fail-safe guard: nothing to iterate and nowhere to probe FROM.
+    zero = {"confirmed": 0, "contradicted": 0, "skipped": 0}
+    assert worldcheck.check(None, "/p/A") == zero
+    assert worldcheck.check(_cp(["PR #60 awaiting review"]), "") == zero
+
+
+def test_slice_2_claims_are_carried_only(monkeypatch, tmp_path):
+    project = tmp_path / "repo"
+    project.mkdir()
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    cp = _cp(["the fix lives in src/fix.py"], carried=False)
+    assert worldcheck.check(cp, str(project)) == {
+        "confirmed": 0, "contradicted": 0, "skipped": 0}
+
+
 # ---- rendering: ADDED lines only --------------------------------------------
 
 
@@ -327,6 +861,18 @@ def test_line_unstamped_item_byte_identical():
     item = {"text": "PR #60 awaiting review", "trust": "inferred",
             "carried_from": "S-prev"}
     assert briefing._line(item) == "- [~ inferred] PR #60 awaiting review [carried]"
+
+
+def test_line_renders_slice_2_stamps_through_the_same_surface():
+    # #397: new claim classes stamp the SAME {note,status} shape, so the
+    # render path needs no per-class knowledge.
+    item = {"text": "the fix lives in src/fix.py", "trust": "inferred",
+            "id": "o-abc123", "carried_from": "S-prev",
+            "_worldcheck": {"note": "src/fix.py missing", "status": "missing"}}
+    line = briefing._line(item)
+    assert "⚠ state changed since capture: src/fix.py missing" in line
+    assert "confirm: daimon resolve o-abc123 --status missing" in line
+    assert "reject: daimon reverify o-abc123" in line
 
 
 # ---- config flag ------------------------------------------------------------
@@ -398,6 +944,32 @@ def test_cli_brief_flag_on_flags_contradiction_and_counts(
     usage = _usage_lines(tmp_path)
     assert sum(1 for ln in usage if ln.endswith(" worldcheck:contradicted")) == 1
     assert sum(1 for ln in usage if ln.endswith(" worldcheck:confirmed")) == 1
+    # #397: the aggregate counters keep their slice-1 meaning AND every
+    # outcome also lands under its class, so the fires-true rate is
+    # measurable per class before any further expansion.
+    assert sum(
+        1 for ln in usage if ln.endswith(" worldcheck:pr-state:contradicted")) == 1
+    assert sum(
+        1 for ln in usage if ln.endswith(" worldcheck:pr-state:confirmed")) == 1
+
+
+def test_cli_brief_emits_per_class_counters_for_slice_2(
+    monkeypatch, tmp_path, capsys
+):
+    project = tmp_path / "repo"
+    project.mkdir()
+    cp = _cp(["the fix lives in src/fix.py"])
+    store.write_checkpoint("S-now", cp, project_dir=str(project))
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    monkeypatch.setenv("DAIMON_WORLDCHECK", "1")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", str(project))
+    rc = cli.main(["brief"])
+    assert rc == 0
+    assert "⚠ state changed since capture: src/fix.py missing" in capsys.readouterr().out
+    usage = _usage_lines(tmp_path)
+    assert sum(
+        1 for ln in usage if ln.endswith(" worldcheck:file-exists:contradicted")) == 1
+    assert sum(1 for ln in usage if ln.endswith(" worldcheck:contradicted")) == 1
 
 
 def test_cli_brief_slug_path_never_probes(monkeypatch, capsys):


### PR DESCRIPTION
Closes #397

## What

Extends `worldcheck` from one claim class to four. Alongside slice 1's PR/issue-state probes, a carried item can now be spot-checked as:

- **`file-exists`** — a repo-relative source path plus assertion vocabulary ("the fix lives in `src/fix.py`") is probed with `Path.exists()`. No subprocess at all.
- **`branch-state`** — "on branch `feat/x`, unmerged" is answered from git's on-disk refs, read directly. Both halves of git's ref storage are consulted (a branch with no loose ref file is not gone if `packed-refs` still carries it), and the worktree indirection is followed so a linked worktree does not report every branch missing.
- **`dependency-version`** — "requests is pinned to 2.31.0" is answered from the lockfile or manifest on disk.

Every slice-1 guarantee holds across all four classes: one aggregate `BUDGET_SECONDS`, one `MAX_PROBES` cap, silent skip on any failure, contradicted items flagged and never dropped, nothing persisted. Two rules keep the shared budget fair rather than first-come-lucky:

- the cap is **allocated** in checkpoint order, so no class is privileged when it binds;
- probes **execute** local-before-network, so a hanging `gh` can never starve a probe that costs microseconds.

The `gh` / GitHub-remote gate moves per class as a result: a missing `gh` now skips the PR/issue claims only, and a checkpoint with no PR/issue claim never shells out at all.

Telemetry gains a per-class dimension. `check()` still returns the aggregate `confirmed`/`contradicted`/`skipped` with unchanged meaning, plus a `<class>:<outcome>` key per outcome that occurred, so `usage.log` now carries both `worldcheck:<outcome>` and `worldcheck:<class>:<outcome>` and the fires-true rate is readable per class before any further expansion.

**Not in this PR: content-hash.** It would have to capture a hash at serialize time, which changes the serializer contract. Filed as #398 — which first asks whether `anchor.check()`'s existing symbol-body hashing already covers the need, since building a second mechanism that answers "did this file change" differently would be worse than either alone.

## Why

Slice 1 pre-registered this expansion in its own module docstring: the fires-true rate of repo-state claims was the evidence gate for later classes, and #397 records that gate as met. The classes added here are the deterministic ones — they need no network, so they extend the check to items that were previously unverifiable at any budget.

Claim extraction holds slice 1's conservative bar everywhere, because a wrong contradiction flag is worse than no check:

- a bare path *mention* is not a claim (assertion vocabulary is required, exactly as slice 1 requires a state word beside `#N`);
- a branch name is only recognised after an explicit `branch` keyword — without it any slash-bearing token would read as a branch;
- version claims are past-tense only, so "we should bump X to 2.1" is read as a proposal, not a state claim;
- absolute paths, home paths, URLs and parent traversal never match, and a symlink resolving outside the project root is refused rather than answered — all of them would answer about a tree that is not this project, the same refusal slice 1 applies to cross-repo `#N` refs;
- conflicting vocabulary in either direction skips, and a dependency name resolving to two different versions in one file stays unanswered.

Two implementation constraints worth flagging for review:

- **Per scar 22**, every new capture-path regex is bounded, has no overlapping prefix class before an alternation, and carries a long-input completion test (50k chars, completion is the signal, no timing assert). Path segments are `[\w-]` only, so the single dot before the extension is the one ambiguous split point in the pattern; the extension is a whitelist rather than `\w{1,8}` so prose abbreviations like "e.g." cannot read as filenames.
- **`dependency-version` scans rather than parses.** The floor is py3.10, which has no stdlib `tomllib`, and the kernel takes no dependencies per the zero-required-dependency ADR. Lockfiles are consulted before manifests, since a lock records a resolved version where a manifest usually records a range — reading both would leave every real project with two conflicting answers and nothing to say.

The render path needed no change: every class stamps the same `{note, status}` shape, so the existing flag line and `daimon resolve` / `daimon reverify` confirm-reject surface carry the new classes unmodified. Contradiction notes are built from a bounded vocabulary chosen at the stamp site — probe output is trusted for truth, never for text.

## Tests

Red first, then implemented: the new tests failed 56/83 against the unmodified module before any implementation existed.

- `uv run pytest -q` — **2091 passed, 2 skipped** (2037 before this branch, +54 tests).
- `uv run ruff check daimon_briefing tests ../scripts` — clean.
- `uv run mypy daimon_briefing` — 63 errors, byte-identical to `main`'s 63 (all pre-existing, none in the touched code; non-blocking in CI).
- Line coverage on `worldcheck.py` is 97%; the 7 uncovered lines all sit outside this diff's hunks, in unchanged slice-1 code.

What the new tests prove, beyond the happy path for each class:

- **Refusals**: bare mentions, missing keywords, future tense, conflicting vocabulary, absolute/home/URL/traversal paths, prose abbreviations, traversal branch names, ambiguous dependency answers.
- **Isolation**: `file-exists` is asserted to work with no `gh` on `PATH` and no GitHub remote, and separately asserted never to spawn a process (`subprocess.Popen`/`run` patched to raise).
- **Containment**: a symlink pointing out of the project root is skipped, not answered.
- **git realism**: a branch found only in `packed-refs` confirms rather than contradicting; both absolute and relative worktree `gitdir:` pointers resolve to the common dir.
- **Shared budget**: the cap is allocated across classes in item order; an exhausted budget skips local probes too; and a `gh` probe that eats the entire budget still leaves the disk probe answered in the same run.
- **Fail-open**: a probe raising mid-run is a skip, never a raise, and the briefing still renders.

All `gh` probes hit a fake `gh` script on disk and the new probes touch only `tmp_path` trees — zero network throughout.
