### PR TITLE
feat(serializer): ground Spanish outcome claims (bilingual lexicon)

### DIFF
--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -903,9 +903,9 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None) -> int:
 
 GROUNDED_KEY = "grounded"
 
-# Conservative, English-only outcome lexicon: past-tense/state assertions
-# about completion. Non-English claims simply never match — grounding stays
-# absent there, which is the honest no-op (never downgrade on a guess).
+# Conservative, English outcome lexicon: past-tense/state assertions about
+# completion. A curated, BOUNDED-regex allowlist (scar 22: no unbounded prefix
+# before a keyword alternation) — never stemming, never an LLM call.
 _OUTCOME_RE = re.compile(
     r"(?:\b(?:succeeded|successfully)\b"
     r"|\btests?\s+(?:all\s+|are\s+|now\s+)*(?:pass(?:ed|ing)?|green)\b"
@@ -913,6 +913,26 @@ _OUTCOME_RE = re.compile(
     r"(?:is\s+|now\s+)*(?:pass(?:ed|ing)?|green|succeeded|failed|completed)\b"
     r"|\b(?:merged|deployed|released|published|shipped|landed)\b"
     r"|\ball\s+(?:\d+\s+)?tests?\s+pass(?:ed)?\b)",
+    re.IGNORECASE)
+# Spanish outcome lexicon (#401): the project is bilingual end to end (docs, es
+# briefings), but this gate was English-only, so a Spanish "los tests pasan"
+# sailed through ungrounded while its English twin was downgraded. Same shape
+# as the English lexicon above and the same house rules — a curated, bounded
+# allowlist, NOT stemming, NOT an LLM. Participles carry Spanish gender/number
+# agreement through a bounded (?:o|a|os|as) suffix; still fully bounded.
+_OUTCOME_ES_RE = re.compile(
+    r"(?:\bexitosamente\b"
+    r"|\bcon\s+[eé]xito\b"
+    r"|\b(?:los\s+|las\s+)?(?:tests?|pruebas)\s+"
+    r"(?:ya\s+|ahora\s+|todas\s+)*(?:pasan|pasaron)\b"
+    r"|\b(?:el\s+|la\s+)?(?:build|suite|ci|pipeline|despliegue|compilaci[oó]n)"
+    r"\s+(?:ya\s+|ahora\s+)*(?:pas[oó]|complet[oó]|termin[oó]|fall[oó]|"
+    r"en\s+verde)\b"
+    r"|\b(?:mergead|fusionad|desplegad|publicad|lanzad|liberad|completad|"
+    r"resuelt|arreglad|solucionad)(?:o|a|os|as)\b"
+    r"|\bfall(?:[oó]|aron|id[oa]s?)\b"
+    r"|\ben\s+verde\b"
+    r"|\btodas\s+(?:las\s+)?(?:\d+\s+)?pruebas\s+pas(?:an|aron)\b)",
     re.IGNORECASE)
 # Hedge/future/plan markers: "will be merged" is a plan, "whether the deploy
 # succeeded" is a question — neither ASSERTS the outcome. When one of these
@@ -923,13 +943,28 @@ _HEDGE_RE = re.compile(
     r"plan(?:ned|s|ning)?|todo|must|needs?\s+to|about\s+to|once|when|"
     r"if|whether|did|does|can|could|may|might)\b",
     re.IGNORECASE)
+# Spanish hedge markers (#401), mirror of _HEDGE_RE: future ("se va a mergear"),
+# plan ("planeo", "pendiente", "falta"), condition/question ("si", "cuando").
+_HEDGE_ES_RE = re.compile(
+    r"\b(?:se\s+van?\s+a|van?\s+a|vamos\s+a|ser[aá]n?|"
+    r"plane(?:o|as|amos|ad[oa]s?)|pendiente|"
+    r"todav[ií]a\s+no|a[uú]n\s+no|falta[nr]?|hay\s+que|hace\s+falta|"
+    r"deber[ií]an?|debe[n]?|podr[ií]an?|quiz[aá]s?|tal\s+vez|"
+    r"si|cuando|una\s+vez|acaso|a\s+punto\s+de|por\s+hacer)\b",
+    re.IGNORECASE)
 
 
 def _asserts_outcome(text: str) -> bool:
-    """True when `text` ASSERTS a completed outcome (narrow, English-only)."""
+    """True when `text` ASSERTS a completed outcome (narrow; English + Spanish).
+
+    Mirrors both language lexicons: a claim asserts an outcome only when a
+    curated verb matches AND no hedge (either language) is present — a Spanish
+    hedge blocks an English claim too, which is the conservative default."""
     if not isinstance(text, str):
         return False
-    return bool(_OUTCOME_RE.search(text)) and not _HEDGE_RE.search(text)
+    if _HEDGE_RE.search(text) or _HEDGE_ES_RE.search(text):
+        return False
+    return bool(_OUTCOME_RE.search(text) or _OUTCOME_ES_RE.search(text))
 
 
 def verification_rejections(checkpoint) -> list:

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -1912,11 +1912,71 @@ def test_asserts_outcome_lexicon_is_conservative():
     no = ["will be merged tomorrow", "should be deployed after review",
           "plan to release on Friday", "whether the deploy succeeded",
           "use the passed argument", "decide the merge strategy",
-          "el despliegue funciono bien"]  # non-English: honest no-op
+          "el despliegue funciono bien",  # #401: vague verb, deliberate miss
+          "o deploy funcionou bem"]  # not a covered language: honest no-op
     for text in yes:
         assert serializer._asserts_outcome(text), text
     for text in no:
         assert not serializer._asserts_outcome(text), text
+
+
+def test_asserts_outcome_spanish_lexicon_is_conservative():
+    # #401: the project is bilingual end to end, but this gate was English-only,
+    # so a Spanish "los tests pasan" sailed through ungrounded while its English
+    # twin was downgraded. Same shape as the English lexicon: curated, bounded,
+    # never stemming, never an LLM.
+    yes = ["los tests pasan", "las pruebas pasaron", "PR #12 mergeado",
+           "fusionado a main", "desplegado a produccion", "trabajo completado",
+           "el issue quedo resuelto", "bug arreglado", "publicado en PyPI",
+           "release lanzado", "la suite en verde", "el codigo esta desplegado",
+           "compilacion con exito", "el deploy fallo"]
+    no = ["se va a mergear manana", "sera mergeado tras revision",
+          "todavia no esta desplegado", "si los tests pasan lo mergeamos",
+          "cuando quede resuelto lo cerramos", "planeo desplegar el viernes",
+          "falta arreglar el bug", "pendiente de revision",
+          "renombrar el modulo a carry.py"]
+    for text in yes:
+        assert serializer._asserts_outcome(text), text
+    for text in no:
+        assert not serializer._asserts_outcome(text), text
+
+
+def test_asserts_outcome_long_input_completes():
+    # Scar 22: every capture-path regex gets a long-input completion test —
+    # completion IS the signal (no timing assert). Both the English and the
+    # Spanish lexicon, plus both hedge regexes, scan this text.
+    assert serializer._asserts_outcome("pasan " * 12500) in (True, False)
+    assert serializer._asserts_outcome("mergeado " * 12500) in (True, False)
+    assert serializer._asserts_outcome("a-b." * 12500) in (True, False)
+    assert serializer._asserts_outcome("x" * 50000) in (True, False)
+
+
+def test_ground_outcomes_downgrades_ungrounded_spanish_outcome_claim():
+    # #401 paired mirror of the English downgrade test: a Spanish outcome
+    # assertion with no cited signal is stored inferred, grounded: false.
+    cp = _cp_one_decision({"text": "los tests pasan", "trust": "verbatim",
+                           "quote": "los tests pasan"})
+    n = serializer.ground_outcomes(cp, {"uuid-tool"})
+    item = cp["working_context"]["recent_decisions"][0]
+    assert n == 1
+    assert item["trust"] == "inferred"
+    assert item["grounded"] is False
+    assert item["quote"] == "los tests pasan"  # transcription stays honest
+
+
+def test_ground_outcomes_leaves_hedged_spanish_claim_alone():
+    # A Spanish plan/future/question is not an outcome assertion — untouched.
+    cp = _cp_one_decision({"text": "se va a mergear manana",
+                           "trust": "verbatim", "quote": "q"})
+    cp["working_context"]["open_questions"] = [
+        {"text": "si los tests pasan lo mergeamos", "trust": "verbatim",
+         "quote": "q2"}]
+    n = serializer.ground_outcomes(cp, {"uuid-tool"})
+    assert n == 0
+    assert cp["working_context"]["recent_decisions"][0]["trust"] == "verbatim"
+    assert cp["working_context"]["open_questions"][0]["trust"] == "verbatim"
+    for item in serializer.iter_items(cp):
+        assert "grounded" not in item
 
 
 def test_ground_outcomes_marks_signal_backed_items_grounded():


### PR DESCRIPTION
Closes #401

## What

`ground_outcomes` matched completed-outcome assertions with an English-only verb lexicon, so a Spanish session — a language the project supports end to end (bilingual docs, es briefings) — never matched, and its verbatim outcome claims were never grounded. A Spanish "los tests pasan" sailed through as verbatim while its English twin was downgraded without cited tool evidence.

- Add a curated Spanish outcome lexicon (`_OUTCOME_ES_RE`) and hedge set (`_HEDGE_ES_RE`) mirroring the English `_OUTCOME_RE` / `_HEDGE_RE` structure exactly.
- `_asserts_outcome` now consults both languages: an outcome matches only when a curated verb hits AND no hedge (either language) is present.
- Spanish verbs added: `mergeado/fusionado`, `desplegado`, `publicado`, `lanzado`, `liberado`, `completado`, `resuelto/resuelta`, `arreglado`, `solucionado`, `(los tests / las pruebas) pasan/pasaron`, `en verde`, `con éxito`, `exitosamente`, `fall(ó/aron/ido)`; plus build/suite/ci/pipeline/despliegue/compilación state clauses.
- Spanish hedges added: `se va a`, `será`, `planeo`, `pendiente`, `falta`, `todavía no`, `si`, `cuando`, `una vez`, etc.

## Why

An English-only lexicon as a correctness gate makes the coverage gap invisible from outside: the honest no-op (never downgrade on a guess) looked identical to a real grounding check for every Spanish session. Extending the allowlist keeps the gate deterministic and cheap while closing the gap.

Kept a bounded-regex allowlist per scar 22 (no unbounded prefix before the keyword alternation) — **not** stemming, **not** an LLM call. Participles carry Spanish gender/number agreement via a bounded `(?:o|a|os|as)` suffix.

## Tests

New behavior is red-first — a Spanish "los tests pasan" without cited evidence downgrades only after the change.

- `test_asserts_outcome_spanish_lexicon_is_conservative` — Spanish YES/NO pairs (hedged Spanish stays untouched).
- `test_ground_outcomes_downgrades_ungrounded_spanish_outcome_claim` — paired mirror of the English downgrade test.
- `test_ground_outcomes_leaves_hedged_spanish_claim_alone` — future/plan/question Spanish is not an outcome assertion.
- `test_asserts_outcome_long_input_completes` — the scar-22 long-input completion test that was previously missing for this regex path (50k chars, completion is the signal).
- Updated the existing English lexicon test's stale "non-English never matches" note.

`plugin/` suite: 177 → 181 tests in `test_serializer.py`; full suite `2095 passed, 2 skipped` (with `--extra dev --extra pretty`). `ruff` clean; `mypy` unchanged (one pre-existing non-blocking error, present before this change).

Follow-up (issue slice 2, not done here): no user-facing doc currently states the per-language boundary of the gate — it lives only in source comments. Stamping the `grounded: null` semantics in the README/docs is a separate docs-only change and is left as follow-up.