### PR TITLE
feat(scoring): trust class as an authority ceiling — recall frequency can never promote belief

### DIFF
--- a/.scars/candidates/trust-ceiling-only-bites-fresh-high-importance.md
+++ b/.scars/candidates/trust-ceiling-only-bites-fresh-high-importance.md
@@ -1,0 +1,38 @@
+---
+id: 0
+type: landmine
+title: The #408 trust ceiling only clips FRESH, high-importance items — stale ceiling tests tie misleadingly
+severity: medium
+confidence: 0.9
+created: 2026-07-29
+authors: ["claude-code"]
+anchors:
+  - path: plugin/daimon_briefing/scoring.py
+  - pattern: "trust_ceiling|TRUST_CEILING"
+evidence:
+  - pr: 408
+  - note: "recall ceiling test tied verbatim vs inferred at 39d overdue (raw ~0.30 < 0.7 lid) until now was aligned to first_seen so raw ~1.0 clipped the inferred item"
+expires:
+  condition: "TYPE_RULES reshaped so overdue-escalated inferred items can exceed the inferred ceiling, or the ceiling becomes a multiplicative discount instead of a min() clamp"
+  review_after: 2026-12-01
+---
+
+effective_weight applies the trust ceiling as `min(weight, ceiling)`. The lid
+therefore only changes anything when the RAW weight exceeds it. With the
+current TYPE_RULES, the raw product base*recency*decay*boost tops out near 1.0
+for a fresh, importance-10, non-escalated item, and — crucially — an
+overdue-escalated open_question maxes around 0.8 (recency and decay have already
+fallen by the time the boost engages). So the inferred lid of 0.7 bites ONLY in
+the fresh / high-importance corner; a stale or mid-importance inferred item is
+already below 0.7 and the ceiling is a no-op for it.
+
+Consequence for tests: a recall/ordering test that seeds an inferred vs a
+verbatim item with equal importance but STALE first_seen will see both raw
+weights sit under 0.7, so the ceiling never separates them and they TIE — the
+assertion fails for a reason that looks like "trust isn't wired in" when it
+actually is. To exercise the lid you must drive the raw weight above 0.7:
+fresh age (align the injected `now` to first_seen) and high importance. Do NOT
+"fix" a tying test by lowering the ceiling blindly — check whether the raw
+weight even reaches the lid first. Same trap applies to anyone retuning
+TYPE_RULES: verify the escalation product still cannot cross the inferred
+ceiling, or the structural guarantee (#408) silently weakens.

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -861,7 +861,11 @@ def suggest(prompt: str, project_dir=None, current_session=None,
             continue
         relevance = max(0.0, -float(r["rank"]))  # FTS5 bm25(): smaller = better
         weight = scoring.effective_weight(
-            {"importance": r["importance"], "first_seen": r["first_seen"]},
+            {"importance": r["importance"], "first_seen": r["first_seen"],
+             # trust is part of the record's authority (#408): drop it here and
+             # the trust ceiling never applies to recall ranking, letting an
+             # inferred item ride relevance x recency to a verbatim item's band.
+             "trust": r["trust"]},
             _KIND_TO_TYPE.get(r["kind"], "recent_decision"), now)
         if r["superseded_by"]:
             weight *= 0.7  # flagged and ranked down, never hidden (#112)

--- a/plugin/daimon_briefing/scoring.py
+++ b/plugin/daimon_briefing/scoring.py
@@ -29,6 +29,41 @@ _NEUTRAL_RECENCY = 0.5    # unstamped items: between fresh (1.0) and ancient (0.
 _DECAY_FLOOR = 0.1        # decay never zeroes an item — only ordering may bury it
 _ESCALATION_CAP = 3.0     # overdue boost ceiling; keeps weights comparable
 
+# Trust class is a CEILING on authority, not a display label (#408). This is a
+# monotone lid on the weight ANY read path may hand an item, keyed on the one
+# stable property set at capture: its trust class. It exists to structurally
+# kill "recall frequency becomes truth" — the self-reference loop where an
+# inferred belief that recurs, scores fresh, or escalates as an open loop drifts
+# into the standing of a verified verbatim quote. No accumulation vector
+# (importance, recency, overdue escalation, carry, recall frequency) can promote
+# a lower-trust item across its lid, because the lid is applied AFTER every one
+# of them, in the single function all consumers route through.
+#
+#   verbatim  -> _ESCALATION_CAP: the full range, overdue boost included. A
+#                verified verbatim quote is the top band; nothing clips it.
+#   inferred  -> 0.7: below the ~1.0 a fresh, max-importance NON-escalated item
+#                reaches, so an inferred item can never sit in the band a
+#                verbatim item of the same shape occupies.
+#   untagged/ -> _DEFAULT_CEILING: an item that never earned a tag gets no more
+#   unknown      authority than an inferred one — the lid, never a promotion.
+#
+# The ONLY things that lift an item's lid are a change of its trust CLASS, and
+# the class changes by exactly two routes: evidence-gated reverify (cli
+# _cmd_reverify) or explicit human action. Scoring, carry, and recall READ the
+# class; none of them raises it.
+TRUST_CEILING: dict[str, float] = {
+    "verbatim": _ESCALATION_CAP,
+    "inferred": 0.7,
+}
+_DEFAULT_CEILING = 0.7    # absent or unknown trust tag: the inferred lid
+
+
+def trust_ceiling(trust: str | None) -> float:
+    """Maximum effective_weight the given trust class may ever reach. A missing
+    or unrecognized class collapses to the default (inferred) lid — never the
+    verbatim band, which must be earned."""
+    return TRUST_CEILING.get(trust, _DEFAULT_CEILING) if trust else _DEFAULT_CEILING
+
 
 def recency_weight(age_days: float) -> float:
     """Tiered recency (ACB dynamic_relevance_score:1121 verbatim): step function,
@@ -80,10 +115,15 @@ def effective_weight(item, item_type: str, now: float) -> float:
     if not (isinstance(imp, int) and not isinstance(imp, bool) and 1 <= imp <= 10):
         imp = _DEFAULT_IMPORTANCE
     base = imp / 10.0
+    # The trust ceiling is applied LAST, to whatever the accumulation vectors
+    # produced (#408): no importance/recency/escalation combination can lift an
+    # item past the lid its trust class earns. The cap is a property of the
+    # record every caller inherits — not a policy any one of them may skip.
+    ceiling = trust_ceiling(item.get("trust"))
     age = _age_days(item, now)
     if age is None:
-        return base * _NEUTRAL_RECENCY
+        return min(base * _NEUTRAL_RECENCY, ceiling)
     weight = base * recency_weight(age) * _type_decay(age, rules)
     if rules["auto_escalation"] and age > rules["expected_lifespan"]:
         weight *= _overdue_boost(age - rules["expected_lifespan"])
-    return weight
+    return min(weight, ceiling)

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -5,8 +5,10 @@ rebuild-by-scan contract: corrupt it, delete it, add data behind its back, and
 recall must still answer correctly (or empty), never traceback.
 """
 
+import calendar
 import json
 import sqlite3
+import time
 
 import pytest
 
@@ -829,6 +831,34 @@ def test_suggest_surfaces_older_work_unflagged_without_evidence(
                          project_dir="/repo/x", current_session="S-now")
     assert out and out[0]["session_id"] == "S-old"
     assert out[0]["superseded_by"] is None
+
+
+def test_suggest_ranks_verbatim_over_equal_inferred(
+        tmp_checkpoint_dir, monkeypatch):
+    # #408: trust must reach recall ranking. Two sessions carry the SAME
+    # matching text, importance and recency — differing ONLY in trust class.
+    # relevance and effective_weight would tie them if recall dropped trust
+    # (the old leak); the trust CEILING is what breaks the tie: at fresh,
+    # max importance the inferred lid clips the inferred session below the
+    # verbatim one. An inferred item cannot ride recall to a verbatim's band.
+    stamp = "2026-06-20T00:00:00Z"
+    now = calendar.timegm(time.strptime(stamp, "%Y-%m-%dT%H:%M:%SZ"))
+    common = {"text": "litellm gateway cache pins bad responses",
+              "importance": 10, "first_seen": stamp}
+    store.write_checkpoint(
+        "S-inferred", _cp125("S-inferred", decisions=[
+            {**common, "trust": "inferred"}], created=stamp),
+        project_dir="/repo/x")
+    store.write_checkpoint(
+        "S-verbatim", _cp125("S-verbatim", decisions=[
+            {**common, "trust": "verbatim", "quote": "cache answers instantly"}],
+            created=stamp),
+        project_dir="/repo/x")
+    out = recall.suggest("debugging the litellm gateway cache pinning again",
+                         project_dir="/repo/x", current_session="S-now",
+                         limit=5, now=now)
+    sids = [r["session_id"] for r in out]
+    assert sids.index("S-verbatim") < sids.index("S-inferred")
 
 
 def test_suggest_flags_and_demotes_typed_superseded_item(

--- a/plugin/tests/test_scoring.py
+++ b/plugin/tests/test_scoring.py
@@ -96,3 +96,81 @@ def test_small_clock_skew_tolerated_as_fresh():
         "%Y-%m-%dT%H:%M:%SZ", _time.gmtime(_NOW + 60))  # 60s in the future
     w = scoring.effective_weight(skewed, "recent_decision", _NOW)
     assert w == scoring.effective_weight(_item(0, 5), "recent_decision", _NOW)
+
+
+# ---- #408: trust class as an authority CEILING ----
+
+
+def test_trust_ceiling_table_is_monotone_verbatim_on_top():
+    # The table is a monotone lid: verbatim earns the top band, and every
+    # lower-trust class (inferred, untagged/unknown) sits strictly below it.
+    v = scoring.trust_ceiling("verbatim")
+    i = scoring.trust_ceiling("inferred")
+    untagged = scoring.trust_ceiling(None)
+    unknown = scoring.trust_ceiling("not-a-real-class")
+    assert v > i                    # verbatim strictly above inferred
+    assert i >= untagged >= 0.0     # non-increasing down the ladder
+    assert untagged == unknown      # absent tag and unknown tag share the lid
+
+
+def test_no_input_lifts_effective_weight_above_trust_ceiling():
+    """Architecture guard (#408): effective_weight is the ONE authority
+    function every read path (briefing order, carry survival, recall rank)
+    routes through. Drive it with an adversarial cross-product — max
+    importance, every scoring type, ages that maximize overdue escalation,
+    future and missing stamps, out-of-range importances — and assert the
+    output NEVER crosses the record's trust ceiling.
+
+    This asserts the cap is UNCONDITIONAL: there is no combination of
+    importance / recency / overdue escalation that promotes a lower-trust
+    item into a higher band. It is a test that the promoting path does not
+    EXIST, not a test that some path behaves."""
+    types = list(scoring.TYPE_RULES) + ["no-such-type"]
+    ages = [None, -30, -1, 0, 1, 7, 14, 15, 21, 30, 45, 60, 90, 200, 3650]
+    importances = [None, -5, 0, 1, 5, 9, 10, 11, 999]  # incl. out-of-range
+    for trust in ("verbatim", "inferred", None, "bogus-class", ""):
+        ceiling = scoring.trust_ceiling(trust)
+        for t in types:
+            for age in ages:
+                for imp in importances:
+                    it: dict = {}
+                    if trust is not None:
+                        it["trust"] = trust
+                    if age is not None:
+                        it["first_seen"] = _iso(age)
+                    if imp is not None:
+                        it["importance"] = imp
+                    w = scoring.effective_weight(it, t, _NOW)
+                    assert w <= ceiling + 1e-9, (trust, t, age, imp, w, ceiling)
+
+
+def test_inferred_cannot_reach_verbatim_band():
+    # The strongest an inferred item can get — fresh, max importance — still
+    # sits strictly below the authority a verbatim item of the SAME shape
+    # reaches. Recency / importance / recall frequency cannot close this gap:
+    # the ceiling is a property of the record, not the score.
+    shape = {"first_seen": _iso(0), "importance": 10}
+    inferred = scoring.effective_weight(
+        {**shape, "trust": "inferred"}, "recent_decision", _NOW)
+    verbatim = scoring.effective_weight(
+        {**shape, "trust": "verbatim"}, "recent_decision", _NOW)
+    assert inferred < verbatim
+    assert inferred <= scoring.trust_ceiling("inferred")
+
+
+def test_overdue_inferred_open_question_still_capped():
+    # Escalation is the sharpest promotion vector — an overdue open loop grows
+    # its own weight back. It must NOT let an inferred item cross its ceiling,
+    # however far overdue: escalation counters decay, it never defeats trust.
+    for age in (15, 21, 30, 45, 90, 200):
+        w = scoring.effective_weight(
+            {"trust": "inferred", "first_seen": _iso(age), "importance": 10},
+            "open_question", _NOW)
+        assert w <= scoring.trust_ceiling("inferred") + 1e-9
+
+
+def test_verbatim_keeps_full_escalation_range():
+    # The ceiling must not clip a verified verbatim item: its lid is the
+    # escalation cap, so a verbatim open loop keeps every bit of overdue boost.
+    v_ceiling = scoring.trust_ceiling("verbatim")
+    assert v_ceiling >= scoring._ESCALATION_CAP


### PR DESCRIPTION
Closes #408

## What

Makes trust class (`verbatim` / `inferred`) a **ceiling** on authority, not just a display label.

- `scoring.TRUST_CEILING` — a monotone table mapping trust class to the maximum `effective_weight` any process may assign, plus `trust_ceiling()`. The cap is applied LAST in `effective_weight` (`min(weight, ceiling)`), after importance x recency x decay x overdue escalation. verbatim -> the escalation cap (full range); inferred and untagged/unknown -> `0.7`, below the ~1.0 a fresh, max-importance non-escalated item reaches.
- `recall.suggest` now passes `trust` into the weight computation. It was being dropped, so an inferred item could ride relevance x recency to a verbatim item's rank — the concrete leak behind the self-reference loop.

The lid is a property of the record every caller inherits, not a policy any one may skip. Only a change of trust CLASS lifts it, and the class changes by exactly two routes: evidence-gated `reverify` or explicit human action. scoring, carry, and recall READ the class; none raises it. This is the invariant that must exist before corroboration (#268) could ever be safe — corroboration is deliberately NOT implemented here.

## Why

An inferred item that recurs across sessions, scores fresh, or escalates as an overdue open loop could previously drift into the standing of a verified verbatim quote — "recall frequency becomes truth." The ceiling structurally forecloses that: no accumulation vector can cross the lid because the lid is applied after all of them, in the single function every read path routes through.

## Tests

New (all failed before the change):

- `test_no_input_lifts_effective_weight_above_trust_ceiling` — the architecture guard. Drives `effective_weight` with an adversarial cross-product (every scoring type, extreme/out-of-range importances, ages that maximize overdue escalation, future and missing stamps, bogus/empty trust) and asserts the output NEVER crosses the record's ceiling. A test that the promoting path does not EXIST, not that some path behaves.
- `test_trust_ceiling_table_is_monotone_verbatim_on_top`, `test_inferred_cannot_reach_verbatim_band`, `test_overdue_inferred_open_question_still_capped`, `test_verbatim_keeps_full_escalation_range`.
- `test_suggest_ranks_verbatim_over_equal_inferred` — proves trust reaches recall ranking: two sessions identical but for trust class; the verbatim one outranks the inferred one.

| Command | Result |
|---------|--------|
| `uv run pytest -q` | 2139 passed, 2 skipped (+6) |
| `uv run ruff check .` | passed |
| `uv run mypy` (scoring, recall) | no new errors (one pre-existing recall:681, unrelated) |

Also adds a scar candidate documenting that the ceiling only clips fresh/high-importance items (the `min()` clamp is a no-op below the lid) — a trap for future ceiling tests and anyone retuning `TYPE_RULES`.