### PR TITLE
test(benchmark): add forbidden-hit dimension scored on the assembled brief

### DIFF
--- a/.scars/candidates/echochat-marker-is-contaminated-by-serializer-prompt.md
+++ b/.scars/candidates/echochat-marker-is-contaminated-by-serializer-prompt.md
@@ -1,0 +1,38 @@
+---
+id: 0
+type: landmine
+title: The bench EchoChat fake echoes bare "marker", not the per-session token — its topic text does NOT discriminate sessions by content
+severity: medium
+confidence: 0.85
+created: 2026-07-29
+authors: ["claude-code"]
+anchors:
+  - path: plugin/tests/test_bench_adapter.py
+  - pattern: "endswith.*marker"
+evidence:
+  - commit: 5e0f6b2
+  - note: "#405 forbidden-hit cases: assumed the gold checkpoint's topic would contain the per-session marker token (e.g. thinkpadmarker); it contained the bare word 'marker' instead, so a forbidden string keyed on the token matched nothing"
+expires:
+  condition: "EchoChat is changed to emit a token that cannot collide with the serializer prompt (e.g. a UUID-shaped marker), or serialize_strict stops prepending prompt text to the transcript blob the fake inspects"
+  review_after: 2026-12-01
+---
+
+EchoChat (test_bench_adapter.py) picks its marker with
+`next(w for w in blob.split() if w.endswith("marker"))`, where `blob` is the
+message list serialize_strict hands the chat backend. serialize_strict PREPENDS
+its own system/instruction text to that list, and that text already contains a
+word ending in "marker" — so `next(...)` returns the bare "marker" from the
+prompt, never the per-session `thinkpadmarker`/`hellomarker` token from the
+transcript. Every session therefore serializes to the IDENTICAL active_topic
+text "session about marker".
+
+Consequence: `test_run_question_retrieves_the_gold_session` passes for the wrong
+reason — recall_at_5 == 1.0 because BOTH sessions carry the same text and both
+land in the top-k, not because the marker discriminated the gold session. Any
+new test that relies on EchoChat's output being session-distinct (e.g. keying a
+forbidden string or a recall assertion on the token) will silently mis-fire:
+the string is never in the brief, so a leak test reads clean and a recall test
+reads as a coincidental hit. For content-distinct checkpoints, use a dedicated
+fake that returns a fixed, prompt-collision-proof string (see SecretChat added
+in #405), or read back the written checkpoint text rather than assuming the
+token survived.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -41,10 +41,32 @@ of the question's evidence sessions (`answer_session_ids`).
 | **Hit@k** | 1 if any gold session is in the top-k, else 0 (a laxer success rate) |
 | **MRR** | mean of 1 / rank-of-first-gold-session |
 | **avg_injected_tokens** | estimated tokens of the top-k item texts a briefing injects — daimon's efficiency story, not a quality metric (≈4 chars/token estimate, not exact) |
+| **forbidden-hit rate** | fraction of the cases that *define* forbidden material (`forbidden_hits`) whose forbidden text nonetheless appears in the assembled brief — reported alongside recall, over those cases only |
 
 Abstention questions (`*_abs`, no evidence session) are **excluded** from recall
 scoring — there is nothing to retrieve — and counted separately, never scored as
 zero.
+
+### Forbidden hits — material that must NOT surface
+
+Recall asks whether the right memory surfaces. A case may also carry an optional
+`forbidden_hits: list[str]` — material that must **not** surface (a forgotten
+item, an out-of-scope project's item, a trust-downgraded item). Two rules make
+this honest:
+
+- **Scored against the assembled brief, not the raw retriever output.** The leak
+  that matters is what reaches the prompt. A row the retriever returns but
+  assembly withholds (a superseded/resolved item) never counts as a leak; a row
+  ranked below the delivered top-k window is retrieved but not delivered.
+  Suppression the retriever performs but prompt assembly undoes is not
+  suppression — and this is the only place that catches it.
+- **Leakage is disqualifying, not averaged away.** A forbidden hit is subtracted
+  from that case's own recall — `score = max(0, recall - matched / len(forbidden))`
+  — so a full leak floors an otherwise-perfect case to zero, rather than diluting
+  into a run-wide mean.
+
+The forbidden-hit rate and the leak-penalized recall are reported under the same
+policy as every other figure: full config stamp, self-measured only.
 
 ### Known measurement choices (recorded in every result)
 

--- a/plugin/tests/bench/adapter.py
+++ b/plugin/tests/bench/adapter.py
@@ -240,6 +240,15 @@ def run_question(question: dict, *, chat, cache: cache_mod.CheckpointCache,
     gold = dataset.gold_sessions(question)
     abstention = dataset.is_abstention(question)
     ranked = metrics.attributed_sessions(results, attribution)
+    recall_at_5 = metrics.recall_at_k(ranked, gold, k)
+    # #405: forbidden-hit scoring runs against the ASSEMBLED BRIEF (the top-k
+    # withhold-filtered text delivered to the model), never the raw retriever
+    # rows — the leak that matters is what reaches the prompt. `forbidden_hit`
+    # is None when the case defines no forbidden material (not-applicable, not a
+    # clean pass); penalized recall floors the case on leakage.
+    forbidden = dataset.forbidden_of(question)
+    brief_text = metrics.assembled_brief_text(results, k)
+    matched = metrics.forbidden_hits_found(brief_text, forbidden)
     return {
         "question_id": question["question_id"],
         "question_type": question.get("question_type"),
@@ -248,8 +257,13 @@ def run_question(question: dict, *, chat, cache: cache_mod.CheckpointCache,
         "n_gold": len(gold),
         "serialize": tally,
         "n_retrieved_sessions": len(ranked),
-        "recall_at_5": metrics.recall_at_k(ranked, gold, k),
+        "recall_at_5": recall_at_5,
         "hit_at_5": metrics.hit_at_k(ranked, gold, k),
         "mrr": metrics.reciprocal_rank(ranked, gold),
         "injected_tokens": metrics.injected_tokens(results, k),
+        "forbidden_total": len(forbidden),
+        "forbidden_matched": len(matched),
+        "forbidden_hit": (bool(matched) if forbidden else None),
+        "recall_at_5_penalized": metrics.scored_recall(
+            recall_at_5, len(matched), len(forbidden)),
     }

--- a/plugin/tests/bench/dataset.py
+++ b/plugin/tests/bench/dataset.py
@@ -113,6 +113,17 @@ def gold_sessions(question: dict) -> set[str]:
     return set(question.get("answer_session_ids") or [])
 
 
+def forbidden_of(question: dict) -> list[str]:
+    """The optional `forbidden_hits` for a question (#405): material that must
+    NOT surface in the assembled brief. Absent on stock LongMemEval questions —
+    an empty list means the case is scored on recall alone. Tolerant of shape
+    drift: bare strings are kept, blanks/non-strings dropped."""
+    raw = question.get("forbidden_hits")
+    if not isinstance(raw, list):
+        return []
+    return [str(s) for s in raw if isinstance(s, str) and s.strip()]
+
+
 def sessions_of(question: dict) -> list[tuple[str, list[dict]]]:
     """(session_id, messages) pairs for the haystack, in order.
 

--- a/plugin/tests/bench/metrics.py
+++ b/plugin/tests/bench/metrics.py
@@ -114,6 +114,72 @@ def injected_tokens(recall_results: list[dict], k: int) -> int:
     return sum(estimate_tokens(str(r.get("text") or "")) for r in recall_results[:k])
 
 
+# ---- #405: forbidden-hit dimension ------------------------------------------
+#
+# Recall asks "did the right memory surface?". Forbidden hits ask the opposite:
+# "did material that must NOT surface reach the model anyway?". The load-bearing
+# rule is WHERE it is scored — against the ASSEMBLED BRIEF (the top-k rows a
+# briefing delivers), not the raw retriever output. Suppression the retriever
+# performs but assembly undoes is not suppression; suppression assembly performs
+# (withholding a resolved row recall still returns) must be credited. Scoring the
+# raw depth-N retriever rows would both miss the first and false-positive the
+# second.
+
+
+def assembled_brief_text(recall_results: list[dict], k: int) -> str:
+    """The brief text actually delivered to the model: the top-k SURVIVING rows'
+    text+quote, joined.
+
+    Two assembly steps mirror the briefing, and are exactly what makes this
+    differ from the raw retriever output:
+      - WITHHOLD: rows carrying a `superseded_by` stamp (event-resolved or
+        superseded — a downgraded standing) are dropped, as briefing.withhold
+        drops them, even though recall still returns them ranked-down. A withheld
+        row does not consume a top-k slot.
+      - WINDOW: only the first k survivors reach the prompt; a match ranked below
+        the window is retrieved but never delivered.
+    """
+    survivors: list[dict] = []
+    for row in recall_results:
+        if row.get("superseded_by"):
+            continue  # withheld at assembly — recall returns it, the brief omits it
+        parts = [str(row.get("text") or ""), str(row.get("quote") or "")]
+        survivors.append({"blob": " ".join(p for p in parts if p)})
+        if len(survivors) >= max(0, k):
+            break
+    return "\n".join(s["blob"] for s in survivors)
+
+
+def forbidden_hits_found(brief_text: str, forbidden: list[str]) -> list[str]:
+    """The forbidden strings present in the assembled brief (case-insensitive
+    substring), de-duplicated in listed order. Blank entries are ignored."""
+    haystack = brief_text.lower()
+    out: list[str] = []
+    seen: set[str] = set()
+    for needle in forbidden:
+        n = str(needle or "").strip()
+        if not n or n in seen:
+            continue
+        seen.add(n)
+        if n.lower() in haystack:
+            out.append(needle)
+    return out
+
+
+def scored_recall(base: float | None, matched: int, total: int) -> float | None:
+    """Recall floored by leakage: max(0, base - matched/total).
+
+    Leakage is disqualifying, not averaged away — it is subtracted from the
+    case's OWN score, so a full leak (matched == total) drives a perfect-recall
+    case to zero. No forbidden material defined (total <= 0) leaves base
+    untouched; an abstention/None base stays None."""
+    if base is None:
+        return None
+    if total <= 0:
+        return base
+    return max(0.0, base - matched / total)
+
+
 def _mean(values: list[float]) -> float | None:
     return sum(values) / len(values) if values else None
 
@@ -132,6 +198,22 @@ def aggregate(per_question: list[dict], k: int) -> dict:
     rrs = [q["mrr"] for q in scored if q.get("mrr") is not None]
     tokens = [q["injected_tokens"] for q in per_question
               if q.get("injected_tokens") is not None]
+    # #405: forbidden-hit dimension. The leak rate is over the questions that
+    # actually DEFINE forbidden material (forbidden_total > 0) — a question with
+    # nothing forbidden is not a clean pass, it is not-applicable, so it never
+    # dilutes the rate. Penalized recall is the leak-floored recall averaged over
+    # all scored questions (falling back to raw recall for rows that predate the
+    # dimension), reported ALONGSIDE recall under the same reporting policy.
+    forbidden_qs = [q for q in scored if (q.get("forbidden_total") or 0) > 0]
+    leak_flags = [1.0 if q.get("forbidden_hit") else 0.0 for q in forbidden_qs]
+    penalized = [
+        q["recall_at_5_penalized"] if q.get("recall_at_5_penalized") is not None
+        else q["recall_at_5"]
+        for q in scored
+        if (q.get("recall_at_5_penalized")
+            if q.get("recall_at_5_penalized") is not None
+            else q.get("recall_at_5")) is not None
+    ]
     return {
         "k": k,
         "questions_total": len(per_question),
@@ -141,4 +223,7 @@ def aggregate(per_question: list[dict], k: int) -> dict:
         "hit_at_5": _mean(hits),
         "mrr": _mean(rrs),
         "avg_injected_tokens": _mean([float(t) for t in tokens]),
+        "questions_with_forbidden": len(forbidden_qs),
+        "forbidden_hit_rate": _mean(leak_flags),
+        "recall_at_5_penalized": _mean(penalized),
     }

--- a/plugin/tests/bench/run.py
+++ b/plugin/tests/bench/run.py
@@ -165,6 +165,15 @@ def run(args) -> dict:
     print(f"Recall@{args.k}: {_fmt(agg['recall_at_5'])}   "
           f"Hit@{args.k}: {_fmt(agg['hit_at_5'])}   MRR: {_fmt(agg['mrr'])}")
     print(f"avg injected tokens/q (est): {_fmt(agg['avg_injected_tokens'])}")
+    # #405: the forbidden-hit rate is reported ALONGSIDE recall, under the same
+    # reporting policy (full config stamp above, self-measured only). Shown only
+    # when the sample defines forbidden material — a leak rate over zero cases is
+    # meaningless. `penalized` is recall floored by leakage on those cases.
+    if agg.get("questions_with_forbidden"):
+        print(f"forbidden-hit rate: {_fmt(agg['forbidden_hit_rate'])} "
+              f"(over {agg['questions_with_forbidden']} cases with forbidden "
+              f"material)   Recall@{args.k} (leak-penalized): "
+              f"{_fmt(agg['recall_at_5_penalized'])}")
     print(f"scored={agg['questions_scored']} abstention={agg['questions_abstention']} "
           f"serialize_calls={total_serialized} cache_hits={cache.hits}")
     print(f"wrote {out}")

--- a/plugin/tests/test_bench_adapter.py
+++ b/plugin/tests/test_bench_adapter.py
@@ -106,3 +106,74 @@ def test_env_is_restored_after_a_question(tmp_path, monkeypatch):
     )
     import os
     assert os.environ["DAIMON_CARRY"] == "sentinel"
+
+
+# ---- #405: forbidden-hit scoring, wired through the real pipeline -----------
+
+
+class SecretChat:
+    """Fake serializer backend that always emits a checkpoint whose active_topic
+    carries a distinctive secret token plus a query-matching term — so the token
+    reliably reaches the assembled brief regardless of the transcript."""
+
+    def __call__(self, messages, **kwargs):
+        return json.dumps({
+            "session_id": "ignored",
+            "working_context": {
+                "active_topic": {
+                    "text": "database choice: secret_leak_token was postgres",
+                    "trust": "inferred"},
+                "open_questions": [], "recent_decisions": [],
+            },
+            "epistemic_snapshot": {
+                "strong_beliefs": [], "uncertainties": [], "contradictions_flagged": [],
+            },
+            "worker_queue": [],
+        })
+
+
+def _leak_question():
+    q = _question()
+    q["question"] = "which database choice did we make"
+    return q
+
+
+def test_run_question_scores_forbidden_leak_against_the_brief(tmp_path):
+    # SecretChat leaks "secret_leak_token" into every checkpoint's topic, so the
+    # assembled brief carries it — forbidding it must count as a leak that FLOORS
+    # the case (base recall 1.0, one of one forbidden hit → penalized 0.0).
+    q = _leak_question()
+    q["forbidden_hits"] = ["secret_leak_token"]
+    result = adapter.run_question(
+        q, chat=SecretChat(), cache=cache_mod.CheckpointCache(tmp_path / "c"),
+        backend="fake", model="fake", root=tmp_path / "runs", k=5, depth=20, workers=1,
+    )
+    assert result["recall_at_5"] == 1.0
+    assert result["forbidden_total"] == 1
+    assert result["forbidden_matched"] == 1
+    assert result["forbidden_hit"] is True
+    assert result["recall_at_5_penalized"] == 0.0
+
+
+def test_run_question_clean_when_forbidden_material_absent(tmp_path):
+    q = _question()
+    q["forbidden_hits"] = ["nonexistent secret phrase xyzzy"]
+    result = adapter.run_question(
+        q, chat=EchoChat(), cache=cache_mod.CheckpointCache(tmp_path / "c"),
+        backend="fake", model="fake", root=tmp_path / "runs", k=5, depth=20, workers=1,
+    )
+    assert result["forbidden_total"] == 1
+    assert result["forbidden_matched"] == 0
+    assert result["forbidden_hit"] is False
+    # a clean case keeps its base recall untouched
+    assert result["recall_at_5_penalized"] == result["recall_at_5"]
+
+
+def test_run_question_without_forbidden_field_reports_none(tmp_path):
+    result = adapter.run_question(
+        _question(), chat=EchoChat(), cache=cache_mod.CheckpointCache(tmp_path / "c"),
+        backend="fake", model="fake", root=tmp_path / "runs", k=5, depth=20, workers=1,
+    )
+    assert result["forbidden_total"] == 0
+    assert result["forbidden_hit"] is None
+    assert result["recall_at_5_penalized"] == result["recall_at_5"]

--- a/plugin/tests/test_bench_forbidden.py
+++ b/plugin/tests/test_bench_forbidden.py
@@ -1,0 +1,115 @@
+"""Committed forbidden-hit cases (#405): material that must NOT surface.
+
+Three suppression paths, each asserted against the ASSEMBLED BRIEF (top-k
+withhold-filtered rows) rather than the raw retriever output — the leak that
+matters is what reaches the prompt:
+
+  (a) a FORGOTTEN item      — value-keyed forget tombstone (#402) drops it at
+                              capture, so it never enters the index.
+  (b) an OUT-OF-SCOPE item  — another project's checkpoint is never scoped into
+                              this project's recall.
+  (c) a TRUST-DOWNGRADED    — an item whose standing was downgraded (superseded
+      item                    / resolved) is still RETURNED by recall (ranked
+                              down, flagged) but WITHHELD from the delivered
+                              brief; scoring the raw retriever output would be a
+                              false leak.
+
+All three run the real store + recall + assembly with zero model quota — the
+serializer is never called; checkpoints are written directly and recall does the
+lexical retrieval it does in production.
+"""
+
+from daimon_briefing import normalize, recall, store
+
+from tests.bench import adapter, metrics
+
+
+def _cp(active_topic: str, decisions=None, trust: str = "inferred") -> dict:
+    """A minimal, schema-shaped checkpoint the store can write and recall index."""
+    return {
+        "working_context": {
+            "active_topic": {"text": active_topic, "trust": trust},
+            "open_questions": [],
+            "recent_decisions": [{"text": d, "trust": trust} for d in (decisions or [])],
+        },
+        "epistemic_snapshot": {
+            "strong_beliefs": [], "uncertainties": [], "contradictions_flagged": [],
+        },
+        "worker_queue": [],
+    }
+
+
+def _brief_hits(results: list[dict], forbidden: list[str], k: int = 5):
+    brief = metrics.assembled_brief_text(results, k)
+    return metrics.forbidden_hits_found(brief, forbidden)
+
+
+def test_case_a_forgotten_item_never_reaches_the_brief(tmp_path):
+    env = adapter._question_env(tmp_path, "case_a", "2")
+    proj = env["DAIMON_PROJECT_DIR"]
+    query = "migration rollback plan"
+    # non-PII so redaction is a no-op and the tombstone key matches the item text
+    secret = "the acme_migration rollback plan for the cutover"
+    with adapter._env(env):
+        # tombstone the value BEFORE capture (value-keyed forget, #402)
+        store.append_event("x-000000", f"forgotten:{normalize.content_key(secret)}",
+                           project_dir=proj)
+        # one benign item that DOES match the query + the forbidden one alongside it
+        store.write_checkpoint(
+            "a1", _cp("migration rollback runbook overview", decisions=[secret]),
+            project_dir=proj)
+        results = recall.search(query, project_dir=proj, limit=50)
+
+    # capture worked (the benign item indexed) but the forgotten value is gone
+    assert results, "expected the benign item to index"
+    assert _brief_hits(results, [secret]) == []
+
+
+def test_case_b_out_of_scope_project_item_never_reaches_the_brief(tmp_path):
+    env = adapter._question_env(tmp_path, "case_b", "2")
+    proj_a = env["DAIMON_PROJECT_DIR"]
+    proj_b = str(tmp_path / "some_other_project")
+    query = "database choice for reporting"
+    forbidden = ["clientsecret_zeta database"]
+    with adapter._env(env):
+        store.write_checkpoint(
+            "a1", _cp("we chose the database for reporting dashboards"),
+            project_dir=proj_a)
+        # a DIFFERENT project holds the forbidden secret, also query-matching
+        store.write_checkpoint(
+            "b1", _cp("clientsecret_zeta database choice for reporting"),
+            project_dir=proj_b)
+        scoped = recall.search(query, project_dir=proj_a, limit=50)
+        cross = recall.search(query, all_projects=True, limit=50)
+
+    # scoped recall never surfaces the other project's item
+    assert _brief_hits(scoped, forbidden) == []
+    # control: the item WOULD leak without project scoping — proves the guard,
+    # not merely that the string was never indexed
+    assert _brief_hits(cross, forbidden) == forbidden
+
+
+def test_case_c_trust_downgraded_item_is_withheld_from_the_brief(tmp_path):
+    env = adapter._question_env(tmp_path, "case_c", "2")
+    proj = env["DAIMON_PROJECT_DIR"]
+    query = "deployment target region"
+    stale = "deployment target region is us-east-legacy"
+    with adapter._env(env):
+        # the stale claim rides a recent_decision (a list item — it gets a
+        # stamped id; active_topic does not), alongside a live benign topic
+        store.write_checkpoint(
+            "c1", _cp("deployment notes overview", decisions=[stale]),
+            project_dir=proj)
+        # recover the stamped item id, then downgrade its standing (superseded)
+        cp = store.read_latest(proj)
+        item_id = cp["working_context"]["recent_decisions"][0]["id"]
+        store.append_event(item_id, "superseded-by:d-newid1", project_dir=proj)
+        results = recall.search(query, project_dir=proj, limit=50)
+
+    # recall STILL returns the row (ranked down, flagged) — the raw retriever leaks
+    assert any(r.get("superseded_by") for r in results), \
+        "expected the downgraded item to still be retrieved"
+    assert metrics.forbidden_hits_found(
+        " ".join(str(r.get("text") or "") for r in results), [stale]) == [stale]
+    # but the assembled brief WITHHOLDS it — no leak reaches the prompt
+    assert _brief_hits(results, [stale]) == []

--- a/plugin/tests/test_bench_metrics.py
+++ b/plugin/tests/test_bench_metrics.py
@@ -105,3 +105,115 @@ class TestAggregate:
         assert agg["questions_scored"] == 0
         assert agg["recall_at_5"] is None
         assert agg["mrr"] is None
+
+
+# ---- #405: forbidden-hit dimension ------------------------------------------
+
+
+class TestAssembledBriefText:
+    """The load-bearing seam: forbidden material is scored against the text the
+    briefing actually DELIVERS, not the raw retriever output. The delivered brief
+    is the top-k SURVIVING rows' text+quote — windowed and withhold-filtered."""
+
+    def test_joins_topk_delivered_fields(self):
+        rows = [_res("s1", "alpha topic"), _res("s2", "beta topic"),
+                _res("s3", "gamma topic")]
+        text = metrics.assembled_brief_text(rows, k=2)
+        assert "alpha topic" in text and "beta topic" in text
+        # gamma is retrieved but outside the delivered top-k window
+        assert "gamma" not in text
+
+    def test_includes_quote_payload(self):
+        # the verbatim quote reaches the prompt too — a prime leak surface
+        rows = [{"session_id": "s1", "text": "a decision", "quote": "we chose postgres"}]
+        text = metrics.assembled_brief_text(rows, k=5)
+        assert "we chose postgres" in text
+
+    def test_withholds_superseded_rows(self):
+        # recall still RETURNS a resolved/superseded row (ranked down, flagged);
+        # assembly DROPS it — scoring the raw retriever output would be a false leak
+        rows = [
+            {"session_id": "s1", "text": "live decision"},
+            {"session_id": "s2", "text": "stale secret", "superseded_by": "resolved"},
+        ]
+        text = metrics.assembled_brief_text(rows, k=5)
+        assert "live decision" in text
+        assert "stale secret" not in text
+
+    def test_withheld_rows_do_not_consume_window_slots(self):
+        rows = [
+            {"session_id": "s1", "text": "one", "superseded_by": "x-abc123"},
+            {"session_id": "s2", "text": "two"},
+            {"session_id": "s3", "text": "three"},
+        ]
+        text = metrics.assembled_brief_text(rows, k=2)
+        assert "two" in text and "three" in text
+        assert "one" not in text
+
+    def test_empty_results(self):
+        assert metrics.assembled_brief_text([], k=5) == ""
+
+
+class TestForbiddenHitsFound:
+    def test_case_insensitive_substring(self):
+        assert metrics.forbidden_hits_found("The API_KEY is abc", ["api_key"]) == ["api_key"]
+
+    def test_returns_only_matched_preserving_order(self):
+        found = metrics.forbidden_hits_found("alpha beta", ["gamma", "alpha"])
+        assert found == ["alpha"]
+
+    def test_dedups_and_ignores_blank_entries(self):
+        found = metrics.forbidden_hits_found("alpha alpha", ["alpha", "  ", "alpha"])
+        assert found == ["alpha"]
+
+    def test_empty_forbidden_list(self):
+        assert metrics.forbidden_hits_found("anything at all", []) == []
+
+
+class TestScoredRecall:
+    """score = max(0, base - matched/len(forbidden)). Leakage is disqualifying,
+    subtracted from the case's OWN score (not averaged away), floored at zero."""
+
+    def test_no_forbidden_returns_base_unchanged(self):
+        assert metrics.scored_recall(1.0, 0, 0) == 1.0
+
+    def test_clean_case_returns_base(self):
+        assert metrics.scored_recall(1.0, 0, 2) == 1.0
+
+    def test_partial_leak_subtracts_proportionally(self):
+        assert metrics.scored_recall(1.0, 1, 2) == 0.5
+
+    def test_full_leak_floors_case_to_zero(self):
+        assert metrics.scored_recall(1.0, 2, 2) == 0.0
+
+    def test_never_goes_negative(self):
+        assert metrics.scored_recall(0.5, 2, 2) == 0.0
+
+    def test_none_base_stays_none(self):
+        assert metrics.scored_recall(None, 1, 2) is None
+
+
+class TestAggregateForbidden:
+    def test_rate_and_penalized_recall(self):
+        per_q = [
+            {"recall_at_5": 1.0, "hit_at_5": True, "mrr": 1.0, "injected_tokens": 10,
+             "abstention": False, "forbidden_total": 2, "forbidden_matched": 0,
+             "forbidden_hit": False, "recall_at_5_penalized": 1.0},
+            {"recall_at_5": 1.0, "hit_at_5": True, "mrr": 1.0, "injected_tokens": 10,
+             "abstention": False, "forbidden_total": 2, "forbidden_matched": 2,
+             "forbidden_hit": True, "recall_at_5_penalized": 0.0},
+            # no forbidden material defined -> excluded from the leak rate
+            {"recall_at_5": 0.5, "hit_at_5": True, "mrr": 0.5, "injected_tokens": 10,
+             "abstention": False, "forbidden_total": 0, "forbidden_matched": 0,
+             "forbidden_hit": None, "recall_at_5_penalized": 0.5},
+        ]
+        agg = metrics.aggregate(per_q, k=5)
+        assert agg["questions_with_forbidden"] == 2
+        assert agg["forbidden_hit_rate"] == 0.5
+        # penalized recall averaged over ALL scored questions
+        assert agg["recall_at_5_penalized"] == 0.5
+
+    def test_no_forbidden_questions_rate_is_none(self):
+        agg = metrics.aggregate([], k=5)
+        assert agg["questions_with_forbidden"] == 0
+        assert agg["forbidden_hit_rate"] is None


### PR DESCRIPTION
Closes #405

## What

Adds a forbidden-hit dimension to the LongMemEval harness — asserting that particular material must **not** surface, complementing recall (which only asserts the right material does).

- Cases gain an optional `forbidden_hits: list[str]` (`dataset.forbidden_of`).
- Scoring runs against the **assembled brief delivered to the model**, not the raw retriever output (`metrics.assembled_brief_text`): superseded/resolved rows recall still returns are withheld, and only the delivered top-k window is scored.
- Leakage is disqualifying, not averaged: `score = max(0, recall - matched/len(forbidden))` (`metrics.scored_recall`), flooring a leaking case to zero.
- The runner and `aggregate` report a **forbidden-hit rate** and **leak-penalized recall** alongside recall, under the existing config-stamped, self-measured policy.
- Three committed suppression cases run the real store/recall/assembly with **zero model quota**: a forgotten item, an out-of-scope project's item, and a trust-downgraded (superseded) item.

## Why

Suppression the retriever performs but prompt assembly undoes is not suppression — and nothing in the harness caught that. The leak that matters is what reaches the prompt, so it has to be scored on the assembled brief. This is the non-obvious, load-bearing half of #405.

## Tests

New, red-first, all zero-quota (fake serializer / direct store seeding):

| File | Adds |
|------|------|
| `plugin/tests/test_bench_metrics.py` | `assembled_brief_text` (window + withhold), `forbidden_hits_found`, `scored_recall`, aggregate rate/penalized-recall |
| `plugin/tests/test_bench_adapter.py` | end-to-end through `run_question`: a leak floors the case, a clean case is untouched, no-field reports None |
| `plugin/tests/test_bench_forbidden.py` | the three committed suppression cases (forgotten / out-of-scope project / trust-downgraded), each with a control proving the material would leak absent the guard |

- `uv run pytest -q` (from `plugin/`): **2156 passed, 2 skipped** (was 2133; +23).
- `uv run --extra dev ruff check daimon_briefing tests ../scripts`: clean.
- Did **not** run any real benchmark pass — the standing benchmark directive blocks publishing numbers against the live serializer; this ships the mechanism and its unit tests only.

<!-- PR Type: test -->