### PR TITLE
feat(serializer): prefer quote spans that preserve temporal detail

### DIFF
--- a/.scars/candidates/prompt-version-bump-does-not-rotate-chunk-cache.md
+++ b/.scars/candidates/prompt-version-bump-does-not-rotate-chunk-cache.md
@@ -1,0 +1,41 @@
+---
+id: 0
+type: landmine
+title: A PROMPT_VERSION bump does NOT rotate the #48 chunk cache — its own historical comment says it does, but the cache key is EXTRACTION_VERSION
+severity: medium
+confidence: 0.9
+created: 2026-07-29
+authors: ["claude-code"]
+anchors:
+  - path: plugin/daimon_briefing/serializer.py
+    pattern: "rotates the #48 chunk-cache key"
+evidence:
+  - commit: "#416"
+  - note: "#416 added extraction rule 21 (prefer a quote span that keeps a temporal span). The pre-#367 D-015/D-016 comment blocks claim the PROMPT_VERSION bump 'rotates the #48 chunk-cache key' — but since #367 the cache key (_chunk_cache_key) hashes EXTRACTION_VERSION, not PROMPT_VERSION. Bumping only PROMPT_VERSION would have served stale date-dropping cached extractions for up to chunk_cache_days (default 3), silently poisoning the citable-date re-measurement the change exists to make honest."
+expires:
+  condition: "the outdated 'rotates the #48 chunk-cache key' phrasing is removed from every pre-#367 comment block above PROMPT_VERSION, or the cache key is re-keyed on PROMPT_VERSION"
+  review_after: 2026-12-01
+---
+
+When you add an extraction-behavior change (a new numbered rule that changes
+what a chunk pass extracts — quote-span selection, a new emitted field, etc.),
+bumping `PROMPT_VERSION` alone is NOT enough. `_chunk_cache_key` (serializer.py,
+#48/#367) is keyed on `EXTRACTION_VERSION`, the scene flag, backend, model, and
+temperature — deliberately NOT on `PROMPT_VERSION` or the prompt text, so
+wording-only edits keep the cache warm. This is pinned by
+`test_chunk_cache_key_survives_prompt_version_bump` and
+`test_chunk_cache_key_rotates_on_extraction_version_bump`.
+
+The trap: the older comment blocks (D-015 -> D-016, D-014 -> D-015) still say
+the PROMPT_VERSION bump "rotates the #48 chunk-cache key." That was true before
+#367 introduced the separate `EXTRACTION_VERSION` lever; it is false now. A
+future author who trusts that comment and bumps only PROMPT_VERSION will get a
+correct-looking checkpoint format version while the chunk cache keeps returning
+pre-change extractions for up to `config.chunk_cache_days` (default 3) — the
+exact window the privacy design relies on. For #416 this would have meant new
+sessions serving cached quotes that dropped the date, defeating the point.
+
+Rule of thumb: if the change alters WHAT gets extracted, bump BOTH
+`PROMPT_VERSION` (checkpoint format / comparability) and `EXTRACTION_VERSION`
+(cache rotation). If it only reworded the prompt without changing extraction,
+bump neither the cache lever nor, arguably, the format version.

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -41,10 +41,17 @@ log = logging.getLogger(__name__)
 # 20 asks for signal citations, and the bump rotates the #48 chunk-cache key
 # so pre-#359 cached extractions, whose chunks rendered no tool rows, can
 # never satisfy a post-#359 request).
+# D-016 -> D-017 (#416: rule 21 asks extraction to PREFER a quote span that
+# preserves a temporal span the transcript states — pure data-gathering for
+# the deferred bi-temporal design (#406), NO new schema field or storage. The
+# EXTRACTION_VERSION bump below rotates the #48 chunk-cache key so pre-#416
+# cached extractions, which never tried to keep a date, can never satisfy a
+# post-#416 request — a later re-measurement of the citable-date rate must
+# reflect the new behavior, not stale accidental survival.)
 # Checkpoints are only comparable across runs sharing this version (scar
 # landmine #4); pre-bump checkpoints firing the #93 format_version mismatch
 # warning is desired, not a bug.
-PROMPT_VERSION = "D-016"
+PROMPT_VERSION = "D-017"
 
 # #367: the chunk-cache rotation lever, deliberately SEPARATE from
 # PROMPT_VERSION. Bump ONLY when extraction semantics change — the output
@@ -52,7 +59,12 @@ PROMPT_VERSION = "D-016"
 # rule 20 warrants a bump; a wording clarification does not). PROMPT_VERSION
 # keeps versioning the checkpoint format; this keeps the #48 cache warm
 # across prompt edits that don't change what gets extracted.
-EXTRACTION_VERSION = 1
+# 1 -> 2 (#416): rule 21 changes which span extraction selects for a quote
+# (it now prefers one that keeps a stated temporal span) — that is what a
+# chunk pass extracts, so the cache must rotate. Serving a pre-#416 cached
+# extraction that dropped the date would poison the later citable-date
+# re-measurement the whole change exists to make honest.
+EXTRACTION_VERSION = 2
 
 
 class SerializeError(Exception):
@@ -193,6 +205,15 @@ RULES — follow every one exactly; this is the point of the exercise:
     output into `text` or `quote` because of this rule. If no tool-result message evidences
     the outcome, add nothing — the absence is itself a signal.
 
+21. TEMPORAL SPANS: when the transcript states a date, time, or interval that is relevant
+    to an item — when something happened, is due, or holds true (e.g. "on 2026-08-14", "by
+    Friday", "from March to June", "during the Q3 freeze") — PREFER a contiguous quote span
+    that KEEPS that temporal detail over an equally-valid span that drops it. The chosen span
+    must still obey rule 17: a real, contiguous, verifiable copy-paste — never widen a span
+    past what verifies just to reach a date, and never invent, normalize, or infer a date the
+    transcript does not state. Add nothing when no temporal detail is present; this rule only
+    stops you from discarding one that is.
+
 Schema shape:
 {
   "session_id": "<id>",
@@ -314,6 +335,11 @@ MERGE RULES — follow every one exactly:
     like `links` — dropping them loses provenance. Ids may ALSO point at tool-result
     messages that evidence an outcome claim (these can appear on inferred items too):
     preserve those on the canonical item exactly the same way, even when it has no quote.
+
+15. TEMPORAL SPANS: when two versions of the same item differ only in whether the quote keeps
+    a date, time, or interval, keep the version whose quote PRESERVES that temporal detail — it
+    is the more specific quote. Never invent, alter, or normalize a date while merging; this
+    rule only prevents dropping a temporal detail a chunk already captured.
 
 Schema shape:
 {

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -756,7 +756,7 @@ def test_validation_retry_note_restates_copy_paste_contract(
     assert "elisions marked with `...`" in second
 
 
-def test_prompt_version_is_d016():
+def test_prompt_version_is_d017():
     # D-008 -> D-010 (#101: emotional_valence dropped from the schema).
     # D-009 is taken by the host-adapter decision. D-010 -> D-011 (#126:
     # per-item importance added to the emitted schema). D-011 -> D-012 (#5:
@@ -764,12 +764,73 @@ def test_prompt_version_is_d016():
     # quote copy-paste discipline rule). D-013 -> D-014 (#287: external-
     # artifact identifier rule). D-014 -> D-015 (#358: verbatim items bind
     # to source transcript message ids). D-015 -> D-016 (#359: outcome
-    # claims ground in tool-result signals). Pre-bump checkpoints firing the
-    # format_version mismatch warning (#93) is DESIRED behavior. The bump
-    # also rotates the #48 chunk-cache key, so pre-#359 cached extractions
-    # (no tool-result rows in their chunks) can never satisfy a post-#359
-    # request.
-    assert serializer.PROMPT_VERSION == "D-016"
+    # claims ground in tool-result signals). D-016 -> D-017 (#416: prefer a
+    # quote span that preserves a temporal span the transcript states —
+    # data-gathering for the deferred bi-temporal design, no new schema).
+    # Pre-bump checkpoints firing the format_version mismatch warning (#93)
+    # is DESIRED behavior.
+    assert serializer.PROMPT_VERSION == "D-017"
+
+
+def test_serialize_prompt_prefers_temporal_span_preserving_quote():
+    # #416: extraction discarded dates/intervals because nothing asked it to
+    # keep them — the ~0.3% citable-date rate was endogenous. The prompt must
+    # now nudge the model to PREFER a span that keeps a stated temporal detail,
+    # without loosening quote discipline or inventing dates.
+    sys = serializer.SERIALIZE_SYS
+    assert "TEMPORAL SPANS" in sys
+    assert "PREFER a contiguous quote span" in sys
+    assert "temporal detail" in sys
+    # must not force or fabricate a date where none exists
+    assert "never invent, normalize, or infer a date" in sys
+    # the chosen span must still be a real, verifiable copy-paste (rule 17)
+    assert "rule 17" in sys
+
+
+def test_merge_prompt_preserves_temporal_span_across_chunks():
+    # #416: a chunked session's merge picks one canonical quote per item —
+    # it must not drop the temporal detail a chunk already captured.
+    merge = serializer.MERGE_SYS
+    assert "TEMPORAL SPANS" in merge
+    assert "temporal detail" in merge
+
+
+def test_temporal_span_survives_into_extracted_quote(fake_chat_factory):
+    # #416 (observable end-to-end): when the transcript contains a date and the
+    # extractor selects a span that keeps it, the pipeline preserves that span
+    # verbatim rather than stripping the date. What CANNOT be unit-tested is
+    # that a real model chooses the date-bearing span — that is prompt-driven
+    # model behavior and needs quota; here FakeChat stands in for that choice,
+    # and we prove the surrounding pipeline does not discard the temporal span.
+    messages = make_messages(20)
+    messages[4] = {
+        "role": "user",
+        "content": "We agreed to ship the migration on 2026-08-14 after the freeze.",
+    }
+    dated_quote = "ship the migration on 2026-08-14"
+    checkpoint = {
+        "session_id": "S1",
+        "working_context": {
+            "active_topic": {"text": "topic", "trust": "inferred"},
+            "open_questions": [{"text": "q", "trust": "inferred"}],
+            "recent_decisions": [
+                {"text": "ship migration", "trust": "verbatim", "quote": dated_quote}
+            ],
+        },
+        "epistemic_snapshot": {
+            "strong_beliefs": [],
+            "uncertainties": [],
+            "contradictions_flagged": [],
+        },
+        "worker_queue": [],
+    }
+    chat = fake_chat_factory(json.dumps(checkpoint))
+    ckpt = serializer.serialize_strict("S1", messages, chat=chat)
+    decision = ckpt["working_context"]["recent_decisions"][0]
+    # the date-bearing span survives verification and stays verbatim
+    assert decision["trust"] == "verbatim"
+    assert decision["quote_verified"] is True
+    assert "2026-08-14" in decision["quote"]
 
 
 def test_prompts_preserve_transcript_language():


### PR DESCRIPTION
Closes #416

## What

- Add extraction **rule 21** to `SERIALIZE_SYS`: when the transcript states a date, time, or interval relevant to an item, PREFER a contiguous quote span that keeps that temporal detail over an equally-valid span that drops it. The span must still obey rule 17 (real, contiguous, verifiable copy-paste); no date is invented, normalized, or forced.
- Add a parallel **rule 15** to `MERGE_SYS` so a chunked session's dedup keeps the version whose quote preserves a temporal detail a chunk already captured.
- Bump `PROMPT_VERSION` D-016 → D-017 and `EXTRACTION_VERSION` 1 → 2.

This is **prompt/extraction-selection tuning only** — it landed as prompt wording plus the two version bumps, not new selection code. It is **data-gathering for the deferred bi-temporal design (#406)**: it adds **NO** `valid_from`/`valid_to` schema, no storage field, and no bi-temporal logic. Its only job is to stop discarding temporal signal so a later re-measurement of the citable-date rate is evidence-backed instead of measured against a corpus the pipeline never tried to populate.

## Why

The ~0.3% citable-date rate that shelved #406 is endogenous: extraction never tried to preserve dates, so the number reflects accidental survival, not the real addressable population. Rule 21 fixes that so a re-measurement after a few weeks of real usage means something. The `EXTRACTION_VERSION` bump rotates the #48 chunk cache so pre-#416 cached extractions (which dropped dates) can never satisfy a post-#416 request and poison that re-measurement.

## Tests

`uv run pytest -q` (from `plugin/`, `uv sync --all-extras`): **2168 passed, 2 skipped** (was 2165 — +3 net). Red-first TDD.

New tests in `tests/test_serializer.py`:
- `test_serialize_prompt_prefers_temporal_span_preserving_quote` — rule 21 present in `SERIALIZE_SYS`, still bound to rule 17, forbids inventing dates.
- `test_merge_prompt_preserves_temporal_span_across_chunks` — parallel rule in `MERGE_SYS`.
- `test_temporal_span_survives_into_extracted_quote` — observable end-to-end via `FakeChat`: a date-bearing quote verifies and stays verbatim (`2026-08-14` survives into the stored quote).
- `test_prompt_version_is_d016` → `test_prompt_version_is_d017` (version tripwire updated).

**Honest note on what is / isn't unit-testable:** a prompt change's *effect* — a real model actually choosing the date-preserving span — is model behavior that needs quota and cannot be unit-tested. What is unit-tested is (a) the rule text is present and correctly constrained, and (b) the surrounding pipeline preserves a temporal-span-bearing quote verbatim rather than stripping it (`FakeChat` stands in for the model's choice).

`uv run ruff check .` clean. `mypy` error count unchanged (63, all pre-existing, none in `serializer.py` from this change).

<!-- PR type -->
- [x] New feature (`type:feat`)

## Notes

Also adds a scar candidate (`prompt-version-bump-does-not-rotate-chunk-cache`): a `PROMPT_VERSION` bump alone does not rotate the #48 chunk cache — its historical comment says it does, but the cache key has been `EXTRACTION_VERSION` since #367. `scar lint` clean.