### PR TITLE
fix(forget): append tombstone before rewrite and remove by value so sibling ids cannot survive

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -906,10 +906,12 @@ def _cmd_resolve(args) -> int:
 
 
 def _cmd_forget(args) -> int:
-    """Deliberate item removal (#321): delete the item from the live
-    checkpoint, then append a tombstone event whose status carries a content
-    HASH, never the text — removal means the content leaves the audit trail
-    too. Binding is _cmd_resolve's never-guess contract verbatim: exact id
+    """Deliberate item removal (#321): append a tombstone event whose status
+    carries a content HASH, never the text — removal means the content leaves
+    the audit trail too — then rewrite the live checkpoint without the value.
+    Tombstone first (#418): the rewrite's _drop_forgotten reads the ledger, so
+    the key must land before the write scrubs sibling ids of the same value.
+    Binding is _cmd_resolve's never-guess contract verbatim: exact id
     first, else a fuzzy query that must match exactly one item. The tombstone
     rides the resolutions fold, so withhold, carry suppression, and the
     recall index deletion all inherit it with no new plumbing. The rewritten
@@ -950,22 +952,35 @@ def _cmd_forget(args) -> int:
     # suppressed at capture. Still a hash, never the text: removal means the
     # content leaves the audit trail too (#321).
     content_hash = normalize.content_key(target.get("text") or "")
-    for section, key in store._ITEM_LISTS:
-        lst = (checkpoint.get(section) or {}).get(key)
-        if isinstance(lst, list):
-            lst[:] = [i for i in lst
-                      if not (isinstance(i, dict) and i.get("id") == target["id"])]
     sid = str(checkpoint.get("session_id") or "")
     if not sid:
         print("checkpoint has no session_id — cannot rewrite")
         return 1
-    store.write_checkpoint(sid, checkpoint, project_dir=project)
+    # Tombstone BEFORE the rewrite (#418): write_checkpoint's _drop_forgotten
+    # consults the ledger during the write — appended after, the new key is
+    # invisible to that scrub and sibling ids carrying the same value survive.
+    # Failing here leaves the checkpoint untouched: no half-removal without an
+    # audit-trail record.
     ok = store.append_event(target["id"], f"forgotten:{content_hash}",
                             note=args.reason or "", kind="tombstone",
                             project_dir=project)
     if not ok:
         print("tombstone event not written (daimon disabled or project unknown)")
         return 1
+    # Splice by VALUE, not only id (#418): one value can hold sibling ids —
+    # the same sentence in two sections, or a widened hash within one
+    # (store._stamp_item_ids). Removal is content removal, so every item
+    # folding to the tombstoned key goes. Id kept in the predicate as a belt
+    # for non-string text, which content_key canonicalizes to "".
+    for section, key in store._ITEM_LISTS:
+        lst = (checkpoint.get(section) or {}).get(key)
+        if isinstance(lst, list):
+            lst[:] = [i for i in lst
+                      if not (isinstance(i, dict)
+                              and (i.get("id") == target["id"]
+                                   or normalize.content_key(i.get("text") or "")
+                                   == content_hash))]
+    store.write_checkpoint(sid, checkpoint, project_dir=project)
     _note_usage("forget")
     print(f"forgot {target['id']} (content hash {content_hash}) — "
           "item removed from the live checkpoint; tombstone recorded")

--- a/plugin/tests/test_forget_sibling_ids.py
+++ b/plugin/tests/test_forget_sibling_ids.py
@@ -1,0 +1,141 @@
+"""#418: `daimon forget` must remove the VALUE, not merely the id.
+
+One value can legitimately hold two ids: `_stamp_item_ids` hashes
+`f"{key}:{text}"`, so the same sentence in two sections gets two ids, and
+identical text within one section falls through to a widened hash. Pre-#418,
+`_cmd_forget` spliced by id and wrote the scrubbed checkpoint BEFORE appending
+the tombstone, so `_drop_forgotten` consulted a ledger that lacked the new key
+and every sibling survived — live in the briefing, in recall, and verbatim on
+disk, while forget reported success.
+
+Both sibling routes are covered, each with a never-forgotten twin (T) as the
+liveness control so no negative assertion can pass vacuously. Assertion order
+inside each test is disk first: the raw checkpoint is the source the derived
+artifacts (briefing.build, recall) are rebuilt from.
+"""
+
+import json
+from datetime import datetime, timezone
+
+from daimon_briefing import briefing, cli, config, normalize, recall, store
+
+# Fixed clock threaded into every now-consumer (scar 0016): the checkpoints
+# below carry a simulated calendar, so briefing.build must read the SAME
+# clock, never wall time.
+_NOW = datetime(2026, 8, 1, tzinfo=timezone.utc).timestamp()
+
+_P = "/repo/forget-sibling-arc"
+
+# S is forgotten; T is the never-forgotten twin. "adopt" is the hot keyword —
+# it matches BOTH, so the tombstone (not the query) is what separates them.
+_S = "adopt sqlite for the recall index cache"
+_T = "adopt postgres for the analytics warehouse"
+_HOT = "adopt"
+
+
+def _item(text):
+    return {"text": text, "trust": "inferred"}
+
+
+def _latest_raw(project_dir):
+    slug = store.project_slug(project_dir)
+    return (config.checkpoint_dir() / slug / "latest.json").read_text(encoding="utf-8")
+
+
+def _build_blob(project_dir):
+    cp = store.read_latest(project_dir=project_dir, fallback=False)
+    return json.dumps(briefing.build(cp, now=_NOW))
+
+
+def _recall_texts(project_dir):
+    recall.rebuild()
+    return [h["text"] for h in recall.search(_HOT, project_dir=project_dir)]
+
+
+def _assert_value_gone_twin_alive(project_dir):
+    raw = _latest_raw(project_dir)
+    assert _S not in raw                    # gone from disk under EVERY id
+    assert _T in raw                        # liveness (twin still present)
+    blob = _build_blob(project_dir)
+    assert _S not in blob and _T in blob
+    texts = _recall_texts(project_dir)
+    assert _S not in texts and _T in texts
+
+
+def test_forget_scrubs_same_value_sibling_in_another_section(tmp_checkpoint_dir,
+                                                             monkeypatch):
+    """Same sentence as a decision AND an open question — two ids, one value.
+    Forgetting the decision id must take the open-question sibling with it."""
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", _P)
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S1", {
+        "session_id": "S1",
+        "created": "2026-07-31T00:00:00Z",
+        "working_context": {
+            "recent_decisions": [_item(_S), _item(_T)],
+            "open_questions": [_item(_S)],
+        },
+    }, project_dir=_P)
+    stored = store.read_latest(project_dir=_P, fallback=False)
+    d_id = next(i["id"] for i in stored["working_context"]["recent_decisions"]
+                if i["text"] == _S)
+    q_id = next(i["id"] for i in stored["working_context"]["open_questions"]
+                if i["text"] == _S)
+    assert d_id != q_id                     # sibling ids: two sections, one value
+
+    assert cli.main(["forget", d_id]) == 0
+    _assert_value_gone_twin_alive(_P)
+
+
+def test_forget_scrubs_widened_hash_sibling_within_one_section(tmp_checkpoint_dir,
+                                                               monkeypatch):
+    """Same sentence twice in ONE section — the collision widens the second
+    id's hash slice. Forgetting the first id must take the widened twin too."""
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", _P)
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S1", {
+        "session_id": "S1",
+        "created": "2026-07-31T00:00:00Z",
+        "working_context": {
+            "recent_decisions": [_item(_S), _item(_S), _item(_T)],
+        },
+    }, project_dir=_P)
+    stored = store.read_latest(project_dir=_P, fallback=False)
+    ids = [i["id"] for i in stored["working_context"]["recent_decisions"]
+           if i["text"] == _S]
+    assert len(ids) == 2 and ids[0] != ids[1]   # widened-hash siblings
+
+    assert cli.main(["forget", ids[0]]) == 0
+    _assert_value_gone_twin_alive(_P)
+
+
+def test_forget_sibling_path_keeps_tombstone_and_normal_output(tmp_checkpoint_dir,
+                                                               monkeypatch,
+                                                               capsys):
+    """The sibling scrub must not change forget's contract: exit 0, the normal
+    success line, and a hash-only tombstone event on the ledger."""
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", _P)
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S1", {
+        "session_id": "S1",
+        "created": "2026-07-31T00:00:00Z",
+        "working_context": {
+            "recent_decisions": [_item(_S), _item(_T)],
+            "open_questions": [_item(_S)],
+        },
+    }, project_dir=_P)
+    stored = store.read_latest(project_dir=_P, fallback=False)
+    d_id = next(i["id"] for i in stored["working_context"]["recent_decisions"]
+                if i["text"] == _S)
+
+    assert cli.main(["forget", d_id]) == 0
+    out = capsys.readouterr().out
+    key = normalize.content_key(_S)
+    assert f"forgot {d_id} (content hash {key})" in out
+    assert "tombstone recorded" in out
+
+    res = store.resolutions(project_dir=_P)
+    assert res[d_id]["status"] == f"forgotten:{key}"
+    # Hash, never the text: removal means the content leaves the audit trail.
+    events = store._events_path(_P).read_text(encoding="utf-8")
+    assert _S not in events


### PR DESCRIPTION
Closes #418

## What

- `_cmd_forget` now appends the `forgotten:<content_key>` tombstone BEFORE rewriting the checkpoint, so `store._drop_forgotten` sees the new key during that same write and scrubs every sibling.
- The splice itself is now value-keyed: items are removed when their `normalize.content_key(text)` matches the tombstoned key, not only when their id matches (id kept as a belt for non-string text).
- Side effect of the order swap: a failed tombstone append now aborts before the rewrite — no half-removal without an audit-trail record (previously the rewrite landed first, then the command returned 1).

## Why

Removal was id-keyed while the tombstone is value-keyed, and the rewrite landed before the tombstone. One value legitimately holds sibling ids (`_stamp_item_ids` hashes `key:text`: same sentence in two sections = two ids; duplicated within one section = widened hash), so `daimon forget` reported success while the value stayed live in the briefing, in recall, and verbatim in `latest.json`. Forget is documented as content removal; the deletion-durability protocol requires the value gone at the source.

## Tests

New `plugin/tests/test_forget_sibling_ids.py` — all three failed on the sibling surviving on disk before the fix (the contract test passed pre-fix by design, proving behavior preservation):

- `test_forget_scrubs_same_value_sibling_in_another_section` — same sentence as a decision and an open question; forget one id → absent from `latest.json`, `briefing.build`, and recall; never-forgotten twin stays (liveness control).
- `test_forget_scrubs_widened_hash_sibling_within_one_section` — same sentence twice in one section (widened-hash id route); same assertions.
- `test_forget_sibling_path_keeps_tombstone_and_normal_output` — exit 0, normal success line, `forgotten:<content_key>` tombstone on the ledger, no forgotten text in `events.jsonl`.

Full suite: `uv run pytest` from `plugin/` — 2171 passed, 2 skipped.