### PR TITLE
feat(policy): extract admission pipeline into pure policy module and gate writes on the kill switch

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -327,6 +327,15 @@ def _run_serialize(transcript_path: Path, project: str | None,
         except Exception:  # keep the unmerged checkpoint, proceed to write
             pass
     out = store.write_checkpoint(session_id, checkpoint, project_dir=project)
+    if out is None:
+        # #421: the write boundary refused (kill switch). Same "skipped" shape
+        # as the hash-match short-circuit above — matches neither _RESULT_OK_RE
+        # nor _RESULT_ERR_RE, so the ledger never reads it as a lying success.
+        msg = (f"skipped serialize for {session_id}: daimon disabled "
+               "(DAIMON_DISABLE) — checkpoint not written")
+        print(msg)
+        _append_serialize_log(msg)
+        return 0
     # #376: record what the checkers REJECTED, after write_checkpoint because
     # that is where item ids are guaranteed stamped (the merge branch above
     # only stamps when it runs). Its own append-only stream, never events.jsonl
@@ -491,6 +500,10 @@ def _cmd_write_checkpoint(args) -> int:
     checkpoint["source"] = args.source  # provenance: introspection vs reconstruction
     session_id = str(checkpoint["session_id"])
     out = store.write_checkpoint(session_id, checkpoint, project_dir=_resolve_project(args.project))
+    if out is None:  # #421: write boundary refused (kill switch)
+        print("error: daimon disabled (DAIMON_DISABLE) — checkpoint not written",
+              file=sys.stderr)
+        return 1
     render.render_write_checkpoint([f"wrote checkpoint: {out} (source: {args.source})"])
     recall.warm()  # #246: freshen off the read path; never raises
     return 0
@@ -537,7 +550,11 @@ def _cmd_anchor(args) -> int:
         return 1
     item = matches[0]
     item["anchored_to"] = a
-    store.write_checkpoint(session_id, checkpoint, project_dir=project)
+    if store.write_checkpoint(session_id, checkpoint, project_dir=project) is None:
+        # #421: write boundary refused (kill switch) — nothing was attached
+        print("error: daimon disabled (DAIMON_DISABLE) — checkpoint not written",
+              file=sys.stderr)
+        return 1
     render.render_anchor_attach([f"attached {a['qualified_name']} to: {item.get('text')}"])
     recall.warm()  # #246: the re-write staled the index; freshen off the read path
     return 0
@@ -973,16 +990,18 @@ def _cmd_forget(args) -> int:
     if not sid:
         print("checkpoint has no session_id — cannot rewrite")
         return 1
-    # Tombstone BEFORE the rewrite (#418): write_checkpoint's _drop_forgotten
+    # Tombstone BEFORE the rewrite (#418): write_checkpoint's forget gate
     # consults the ledger during the write — appended after, the new key is
     # invisible to that scrub and sibling ids carrying the same value survive.
     # Failing here leaves the checkpoint untouched: no half-removal without an
-    # audit-trail record.
+    # audit-trail record. allow_disabled (#421): forget is the ratified
+    # deletion exemption to the kill switch — the tombstone (and the rewrite
+    # below, which #418 chains to it) must land even while daimon is disabled.
     ok = store.append_event(target["id"], f"forgotten:{content_hash}",
                             note=args.reason or "", kind="tombstone",
-                            project_dir=project)
+                            project_dir=project, allow_disabled=True)
     if not ok:
-        print("tombstone event not written (daimon disabled or project unknown)")
+        print("tombstone event not written (project unknown or ledger unwritable)")
         return 1
     # Splice by VALUE, not only id (#418): one value can hold sibling ids —
     # the same sentence in two sections, or a widened hash within one
@@ -997,7 +1016,10 @@ def _cmd_forget(args) -> int:
                               and (i.get("id") == target["id"]
                                    or normalize.content_key(i.get("text") or "")
                                    == content_hash))]
-    store.write_checkpoint(sid, checkpoint, project_dir=project)
+    # allow_disabled (#421): the ONE write_checkpoint call that may run under
+    # the kill switch — the rewrite that makes the deletion real on disk.
+    store.write_checkpoint(sid, checkpoint, project_dir=project,
+                           allow_disabled=True)
     _note_usage("forget")
     print(f"forgot {target['id']} (content hash {content_hash}) — "
           "item removed from the live checkpoint; tombstone recorded")

--- a/plugin/daimon_briefing/policy.py
+++ b/plugin/daimon_briefing/policy.py
@@ -1,0 +1,157 @@
+"""Checkpoint admission policy (#421) — the ordered write-boundary pipeline.
+
+Pure by the same contract carry.py documents: no file I/O, no env, no clock —
+the caller (store.write_checkpoint) reads the forgotten-keys set off disk and
+injects it, so this module owns the ORDER of the gates and nothing else. The
+order is load-bearing and must not change:
+
+1. redact_checkpoint — capture-time secret redaction (#104) runs FIRST, so
+2. drop_forgotten — the value-keyed forget gate (#402) compares against the
+   STORED (post-redaction) text the forget command keyed its tombstone on —
+   a raw re-extraction of a redacted-then-forgotten sentence only folds to
+   the tombstoned key because redaction already ran; and
+3. stamp_item_ids — ids (#102) are stamped LAST, so they hash redacted text
+   and a dropped item is never minted an id at all.
+
+Like the helpers it absorbed, every function mutates its checkpoint argument
+IN PLACE (the established store.py contract — callers rely on it).
+"""
+
+import hashlib
+
+from . import normalize, redact, schema
+
+# The five list sections that hold checkpoint items, from the shared schema
+# (#146 — one definition; serializer/recall/carry derive theirs from the same
+# table). active_topic is a single per-session dict and never needs an id (it
+# does not carry, #33).
+_ITEM_LISTS = schema.ITEM_LISTS
+
+
+def redact_checkpoint(checkpoint: dict) -> None:
+    """Capture-time secret redaction (#104): runs before this module's own
+    stamp_item_ids call below, so ids stamped HERE hash redacted text. On
+    the serialize path the cli stamps ids earlier (before bind_links, #14),
+    so ids there hash pre-redaction text — no leak (sha1 slices are not
+    reversible) and no consumer recomputes ids from text, but identity for
+    secret-bearing items differs between the two paths.
+    Covers text AND quote on every list item plus active_topic — verbatim
+    quotes are the likeliest secret carriers. Stamps a visible
+    checkpoint["redactions"] counter only when something was scrubbed."""
+    counts: dict = {}
+
+    def _scrub(d: dict, field: str) -> None:
+        val = d.get(field)
+        red, c = redact.redact_text(val)
+        if c:
+            d[field] = red
+            for k, n in c.items():
+                counts[k] = counts.get(k, 0) + n
+
+    for section, key in _ITEM_LISTS:
+        items = (checkpoint.get(section) or {}).get(key)
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if isinstance(item, dict):
+                _scrub(item, "text")
+                _scrub(item, "quote")
+                _scrub(item, "scene")
+                links = item.get("links")
+                if isinstance(links, list):
+                    for link in links:
+                        if isinstance(link, dict) and isinstance(link.get("target"), str):
+                            _scrub(link, "target")
+    topic = (checkpoint.get("working_context") or {}).get("active_topic")
+    if isinstance(topic, dict):
+        _scrub(topic, "text")
+        _scrub(topic, "quote")
+        _scrub(topic, "scene")
+    if counts:
+        # MERGE, never overwrite: a re-write (anchor --attach reads, mutates,
+        # writes the same dict) only re-matches NEW secrets — old markers don't
+        # match the patterns again, so overwriting would drop kinds still
+        # physically present in the checkpoint.
+        merged = dict(checkpoint.get("redactions") or {})
+        for k, n in counts.items():
+            merged[k] = merged.get(k, 0) + n
+        checkpoint["redactions"] = merged
+
+
+def drop_forgotten(checkpoint: dict, forgotten_keys: set) -> list:
+    """Value-keyed re-capture gate (#402): drop every item whose canonicalized
+    text hashes into the injected forgotten set BEFORE it reaches the
+    checkpoint on disk. This is what makes "a forgotten value stays gone" hold
+    across a fresh re-extraction of the same sentence — not merely a
+    render-time withhold, which leaves the value sitting on disk. Returns the
+    dropped items so the caller can account the suppression hit (#404).
+
+    The set comes from the CALLER (store.forgotten_content_keys reads the
+    ledger — the one I/O dependency this module refuses to own). Fail-safe:
+    over-suppresses on a hash collision (via the bounded content key) — a
+    forgotten value re-appearing is the worse failure. A no-op with zero cost
+    when nothing was ever forgotten here."""
+    if not forgotten_keys:
+        return []
+    dropped: list = []
+    for section, key in _ITEM_LISTS:
+        block = checkpoint.get(section)
+        if not isinstance(block, dict):
+            continue
+        lst = block.get(key)
+        if not isinstance(lst, list):
+            continue
+        kept = []
+        for item in lst:
+            if (isinstance(item, dict)
+                    and normalize.content_key(item.get("text") or "") in forgotten_keys):
+                dropped.append(item)
+            else:
+                kept.append(item)
+        if len(kept) != len(lst):
+            block[key] = kept
+    return dropped
+
+
+def stamp_item_ids(checkpoint: dict) -> None:
+    """Stable per-item ids (#102): sha1 of kind:text, 6 hex chars, prefixed
+    with the kind's initial. setdefault semantics — an item that already
+    carries an id (a carried twin, a re-write) is never re-stamped, so
+    identity survives rotation and re-serialization. Collisions within one
+    checkpoint widen the slice; identical-text twins fall through to a
+    counter suffix (same text, same kind, still two loops)."""
+    seen: set = set()
+    for section, key in _ITEM_LISTS:
+        items = (checkpoint.get(section) or {}).get(key)
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict) or not str(item.get("text") or "").strip():
+                continue
+            if item.get("id"):
+                seen.add(item["id"])
+                continue
+            digest = hashlib.sha1(
+                f"{key}:{item['text']}".encode("utf-8")).hexdigest()
+            cand = ""
+            for width in (6, 8, 12, 40):
+                cand = f"{key[0]}-{digest[:width]}"
+                if cand not in seen:
+                    break
+            n = 2
+            while cand in seen:
+                cand = f"{key[0]}-{digest[:6]}-{n}"
+                n += 1
+            item["id"] = cand
+            seen.add(cand)
+
+
+def admit_checkpoint(checkpoint: dict, forgotten_keys: set) -> list:
+    """Run the full admission pipeline, in the only valid order (module
+    docstring): redact, then the forget gate, then id-stamping. Mutates
+    `checkpoint` in place; returns the forget-dropped items for the caller's
+    hit accounting (#404)."""
+    redact_checkpoint(checkpoint)
+    dropped = drop_forgotten(checkpoint, forgotten_keys)
+    stamp_item_ids(checkpoint)
+    return dropped

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -24,7 +24,6 @@ one a live pointer still references. The default is generous on purpose so #33's
 merged checkpoint history keeps a deep well of files to reconstruct from.
 """
 
-import hashlib
 import json
 import logging
 import os
@@ -34,7 +33,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
-from . import config, normalize, receipts, redact, schema, serializer, teamproject
+from . import config, normalize, policy, receipts, redact, schema, serializer, teamproject
 
 log = logging.getLogger("daimon_briefing")
 
@@ -391,96 +390,32 @@ def _gc_checkpoints(d: Path, keep: int) -> None:
 _ITEM_LISTS = schema.ITEM_LISTS
 
 
-def _redact_checkpoint(checkpoint: dict) -> None:
-    """Capture-time secret redaction (#104): runs before this module's own
-    _stamp_item_ids call below, so ids stamped HERE hash redacted text. On
-    the serialize path the cli stamps ids earlier (before bind_links, #14),
-    so ids there hash pre-redaction text — no leak (sha1 slices are not
-    reversible) and no consumer recomputes ids from text, but identity for
-    secret-bearing items differs between the two paths.
-    Covers text AND quote on every list item plus active_topic — verbatim
-    quotes are the likeliest secret carriers. Stamps a visible
-    checkpoint["redactions"] counter only when something was scrubbed."""
-    counts: dict = {}
-
-    def _scrub(d: dict, field: str) -> None:
-        val = d.get(field)
-        red, c = redact.redact_text(val)
-        if c:
-            d[field] = red
-            for k, n in c.items():
-                counts[k] = counts.get(k, 0) + n
-
-    for section, key in _ITEM_LISTS:
-        items = (checkpoint.get(section) or {}).get(key)
-        if not isinstance(items, list):
-            continue
-        for item in items:
-            if isinstance(item, dict):
-                _scrub(item, "text")
-                _scrub(item, "quote")
-                _scrub(item, "scene")
-                links = item.get("links")
-                if isinstance(links, list):
-                    for link in links:
-                        if isinstance(link, dict) and isinstance(link.get("target"), str):
-                            _scrub(link, "target")
-    topic = (checkpoint.get("working_context") or {}).get("active_topic")
-    if isinstance(topic, dict):
-        _scrub(topic, "text")
-        _scrub(topic, "quote")
-        _scrub(topic, "scene")
-    if counts:
-        # MERGE, never overwrite: a re-write (anchor --attach reads, mutates,
-        # writes the same dict) only re-matches NEW secrets — old markers don't
-        # match the patterns again, so overwriting would drop kinds still
-        # physically present in the checkpoint.
-        merged = dict(checkpoint.get("redactions") or {})
-        for k, n in counts.items():
-            merged[k] = merged.get(k, 0) + n
-        checkpoint["redactions"] = merged
+# #421: the admission pipeline (redact -> forget-gate -> id-stamp) moved to
+# policy.py, the pure module that owns its order. Aliased here because cli,
+# bench and tests call the store names; the behavior is byte-identical.
+_redact_checkpoint = policy.redact_checkpoint
+_stamp_item_ids = policy.stamp_item_ids
 
 
-def _stamp_item_ids(checkpoint: dict) -> None:
-    """Stable per-item ids (#102): sha1 of kind:text, 6 hex chars, prefixed
-    with the kind's initial. setdefault semantics — an item that already
-    carries an id (a carried twin, a re-write) is never re-stamped, so
-    identity survives rotation and re-serialization. Collisions within one
-    checkpoint widen the slice; identical-text twins fall through to a
-    counter suffix (same text, same kind, still two loops)."""
-    seen: set = set()
-    for section, key in _ITEM_LISTS:
-        items = (checkpoint.get(section) or {}).get(key)
-        if not isinstance(items, list):
-            continue
-        for item in items:
-            if not isinstance(item, dict) or not str(item.get("text") or "").strip():
-                continue
-            if item.get("id"):
-                seen.add(item["id"])
-                continue
-            digest = hashlib.sha1(
-                f"{key}:{item['text']}".encode("utf-8")).hexdigest()
-            cand = ""
-            for width in (6, 8, 12, 40):
-                cand = f"{key[0]}-{digest[:width]}"
-                if cand not in seen:
-                    break
-            n = 2
-            while cand in seen:
-                cand = f"{key[0]}-{digest[:6]}-{n}"
-                n += 1
-            item["id"] = cand
-            seen.add(cand)
-
-
-def write_checkpoint(session_id: str, checkpoint: dict, project_dir=None) -> Path:
+def write_checkpoint(session_id: str, checkpoint: dict, project_dir=None,
+                     allow_disabled: bool = False) -> Path | None:
     """Write the session checkpoint + the global latest pointer, and — when the
     project is known — the per-project latest pointer too. The global pointer is
     kept for backward compatibility (pre-routing consumers and the fallback).
 
     Each latest pointer is rotated first (#33 Phase 1): the previous latest is
-    retained as prev-1.json, keeping the last DAIMON_CHECKPOINT_HISTORY writes."""
+    retained as prev-1.json, keeping the last DAIMON_CHECKPOINT_HISTORY writes.
+
+    Kill switch (#421): the FIRST gate, before any directory is even created —
+    disabled means no belief mutations, one consistent answer at the write
+    boundary regardless of entry point (hook, CLI serialize, model-authored
+    write-checkpoint, anchor rewrite). Refusal is a None return, never an
+    exception — the same never-fatal posture as the ledger appenders. The ONE
+    exemption is `allow_disabled=True`, passed only by cli._cmd_forget's
+    rewrite: the maintainer ratified that deletion must still work while
+    disabled (the deletion promise outranks "disabled writes nothing")."""
+    if config.is_disabled() and not allow_disabled:
+        return None
     d = config.checkpoint_dir()
     d.mkdir(parents=True, exist_ok=True)
     path = _contained_path(d, session_id)
@@ -496,18 +431,19 @@ def write_checkpoint(session_id: str, checkpoint: dict, project_dir=None) -> Pat
     # store stays free of the git/subprocess dependency (scar 0). Present on every
     # checkpoint so read_team can attribute it later, even when team-write is off.
     checkpoint.setdefault("author", config.author())
-    _redact_checkpoint(checkpoint)
-    # #402: value-keyed re-capture gate — drop any item whose canonical value
-    # was forgotten for this project, BEFORE it is stamped, signed, indexed, or
-    # mirrored. Runs after redaction so the compared text matches the stored
-    # (post-redaction) text the forget command keyed the tombstone on. No-op
-    # (zero cost) when nothing was forgotten here.
-    forget_dropped = _drop_forgotten(checkpoint, project_dir)
+    # #421: the ordered admission pipeline — redact, then the #402 value-keyed
+    # forget gate (drop any item whose canonical value was forgotten for this
+    # project BEFORE it is stamped, signed, indexed, or mirrored; the gate runs
+    # after redaction so the compared text matches the stored post-redaction
+    # text the forget command keyed the tombstone on), then id-stamping — lives
+    # in policy.admit_checkpoint, pure by contract. The forgotten-keys ledger
+    # read is its one I/O dependency, so it happens HERE and is injected.
+    forget_dropped = policy.admit_checkpoint(
+        checkpoint, forgotten_content_keys(project_dir))
     if forget_dropped:
         # #404: account each suppression on the telemetry ledger. Best-effort
         # (never fatal) — a hit record must never fail the capture it observes.
         record_forget_hits(forget_dropped, project_dir)
-    _stamp_item_ids(checkpoint)
     # Stamp project attribution the same idempotent way. Bucket pointers rotate
     # away after `history` writes, so pointer-derived attribution EXPIRES — a
     # session older than the pointer window would lose its project forever and
@@ -1109,13 +1045,18 @@ def forget_hit_stats(project_dir=None) -> dict:
 
 def append_event(item_ref: str, status: str, note: str = "",
                  kind: str = "resolution", source: str = "cli",
-                 project_dir=None, item_text: str = "") -> bool:
+                 project_dir=None, item_text: str = "",
+                 allow_disabled: bool = False) -> bool:
     """One appended JSON line per lifecycle fact (#102). Append-only: the
     file is never rewritten — resolution is a derivation at read, so the
     audit trail must stay byte-stable. Silent no-op under the kill switch
     and when the project is unknown (an event without a bucket has no
-    reader)."""
-    if config.is_disabled():
+    reader). `allow_disabled` (#421) is the narrow deletion exemption:
+    passed ONLY by cli._cmd_forget's tombstone append — forget must work
+    while disabled, and #418 mandates its tombstone lands before the
+    rewrite, so the tombstone shares the rewrite's exemption. No other
+    caller may pass it."""
+    if config.is_disabled() and not allow_disabled:
         return False
     path = _events_path(project_dir)
     if path is None:
@@ -1252,35 +1193,6 @@ def forgotten_content_keys(project_dir=None) -> set[str]:
     return keys
 
 
-def _drop_forgotten(checkpoint: dict, project_dir) -> list[dict]:
-    """Value-keyed re-capture gate (#402): drop every item whose canonicalized
-    text hashes into this project's forgotten set BEFORE it reaches the
-    checkpoint on disk. This is what makes "a forgotten value stays gone" hold
-    across a fresh re-extraction of the same sentence — not merely a
-    render-time withhold, which leaves the value sitting on disk. Returns the
-    dropped items so the caller can account the suppression hit (#404).
-
-    Fail-safe: over-suppresses on a hash collision (via the bounded content
-    key) — a forgotten value re-appearing is the worse failure. A no-op with
-    zero cost when nothing was ever forgotten here."""
-    keys = forgotten_content_keys(project_dir)
-    if not keys:
-        return []
-    dropped: list[dict] = []
-    for section, key in _ITEM_LISTS:
-        block = checkpoint.get(section)
-        if not isinstance(block, dict):
-            continue
-        lst = block.get(key)
-        if not isinstance(lst, list):
-            continue
-        kept = []
-        for item in lst:
-            if (isinstance(item, dict)
-                    and normalize.content_key(item.get("text") or "") in keys):
-                dropped.append(item)
-            else:
-                kept.append(item)
-        if len(kept) != len(lst):
-            block[key] = kept
-    return dropped
+# #421: the pure splice half of the gate moved to policy.drop_forgotten;
+# write_checkpoint injects forgotten_content_keys(project_dir) (the ledger
+# read above — the one I/O half that stays in the store).

--- a/plugin/tests/test_carry_forget_adversarial.py
+++ b/plugin/tests/test_carry_forget_adversarial.py
@@ -3,10 +3,12 @@
 `carry.merge`'s only forget suppression is ID-keyed (`item.get("id") in
 resolved`, carry.py). When a prev checkpoint still holds a forgotten VALUE under
 an id the ledger never tombstoned, carry forwards the item in memory; the only
-thing between it and disk is `store._drop_forgotten` running inside
-`store.write_checkpoint`. The lookalike tests (test_forget_reassertion_e2e's
-carry section, test_deletion_durability_protocol's carry step) feed carry a prev
-that the forget rewrite ALREADY scrubbed — delete `_drop_forgotten` and they all
+thing between it and disk is the value-keyed forget gate —
+`policy.drop_forgotten`, run by `store.write_checkpoint` via
+`policy.admit_checkpoint` (#421). The lookalike tests
+(test_forget_reassertion_e2e's carry section,
+test_deletion_durability_protocol's carry step) feed carry a prev that the
+forget rewrite ALREADY scrubbed — delete the gate and they all
 stay green. This file pins the boundary, architecture-guard style: the first
 test proves the resurrection path does not exist; the second is the committed
 MUTATION CHECK — it disables the gate and asserts the value DOES reach disk,
@@ -33,7 +35,8 @@ import json
 import os
 from datetime import datetime, timezone
 
-from daimon_briefing import briefing, carry, cli, config, normalize, recall, store
+from daimon_briefing import (briefing, carry, cli, config, normalize, policy,
+                             recall, store)
 from tests.conftest import FakeChat
 
 _P = "/repo/carry-forget-adversarial-420"
@@ -261,17 +264,22 @@ def test_ungated_prev_cannot_resurrect_forgotten_value_through_carry(
 
 def test_gate_removed_carried_value_reaches_disk(tmp_checkpoint_dir, tmp_path,
                                                  monkeypatch):
-    """The committed MUTATION CHECK (#420 acceptance): with _drop_forgotten
-    no-opped, the SAME fixture drives the forgotten value through carry onto
-    disk. This proves the sibling test is sensitive to exactly this gate —
-    delete `_drop_forgotten` and that test goes red, because this one shows
-    the resurrection genuinely happens without it."""
+    """The committed MUTATION CHECK (#420 acceptance): with the value-keyed
+    gate no-opped, the SAME fixture drives the forgotten value through carry
+    onto disk. This proves the sibling test is sensitive to exactly this gate —
+    delete `policy.drop_forgotten` and that test goes red, because this one
+    shows the resurrection genuinely happens without it."""
     monkeypatch.setenv("DAIMON_PROJECT_DIR", _P)
     monkeypatch.setenv("DAIMON_AUTHOR", "ada")
 
     _arm_adversarial_state()
-    # The mutation: the write boundary loses its value-keyed scrub.
-    monkeypatch.setattr(store, "_drop_forgotten", lambda checkpoint, project_dir: [])
+    # The mutation: the write boundary loses its value-keyed scrub. Patched at
+    # the gate's home (#421) — policy.admit_checkpoint dispatches through the
+    # module global `drop_forgotten`, so this name is what the write path
+    # resolves at call time. The resurrection assertions below double as the
+    # patch's own liveness check: they only pass if the no-op really bit.
+    monkeypatch.setattr(policy, "drop_forgotten",
+                        lambda checkpoint, forgotten_keys: [])
 
     stored = _serialize_new_session(tmp_path, monkeypatch)
 

--- a/plugin/tests/test_policy.py
+++ b/plugin/tests/test_policy.py
@@ -1,0 +1,202 @@
+"""#421 slice 1: pure admission policy + kill-switch gate at the write boundary.
+
+The ordered checkpoint admission pipeline (redact -> forget-gate -> id-stamp)
+moves into `policy.admit_checkpoint`, a pure function with the same no-I/O
+contract carry.py documents — the caller reads the forgotten-keys set off disk
+and injects it. `store.write_checkpoint` gains the kill switch as its FIRST
+gate so every entry point (hook, CLI serialize, model-authored write-checkpoint,
+anchor rewrite) inherits one consistent answer — with a single narrow
+exemption: `daimon forget` must still work while disabled (deletion is the one
+promise that outranks "disabled means daimon writes nothing").
+"""
+
+import ast
+import json
+from pathlib import Path
+
+from daimon_briefing import cli, normalize, redact, store
+from tests.conftest import FIXTURES
+
+_A = "/repo/policy-A"
+# A secret redaction masks (AWS access key id: AKIA + 16 uppercase/digits).
+_SECRET_RAW = "rotate the deploy key AKIAABCDEFGHIJKLMNOP before release"
+_S = "adopt sqlite for the recall index cache"
+_T = "adopt postgres for the analytics warehouse"
+
+
+def _cp(sid, created, decisions):
+    return {
+        "session_id": sid,
+        "created": created,
+        "working_context": {
+            "recent_decisions": [{"text": d, "trust": "inferred"} for d in decisions]
+        },
+    }
+
+
+def _valid_serialize_json(session_id="sample_transcript"):
+    return json.dumps(
+        {
+            "session_id": session_id,
+            "working_context": {
+                "active_topic": {"text": "t", "trust": "inferred"},
+                "open_questions": [],
+                "recent_decisions": [{"text": "adopt D-007", "trust": "inferred"}],
+            },
+            "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []},
+        }
+    )
+
+
+# ---- (a) gate order: redact BEFORE forget-gate, stamp AFTER ----
+
+
+def test_admit_checkpoint_forget_gate_sees_redacted_text():
+    """Unit proof of the load-bearing order: the tombstone keys on the STORED
+    (post-redaction) text, so a re-extraction carrying the RAW secret only
+    folds to the tombstoned key if redaction runs before the forget gate."""
+    from daimon_briefing import policy
+
+    redacted, counts = redact.redact_text(_SECRET_RAW)
+    assert counts  # the fixture really is secret-shaped
+    forgotten = {normalize.content_key(redacted)}
+    checkpoint = _cp("S2", "2026-07-03T00:00:00Z", [_SECRET_RAW, _T])
+
+    dropped = policy.admit_checkpoint(checkpoint, forgotten)
+
+    kept = checkpoint["working_context"]["recent_decisions"]
+    assert [d["text"] for d in kept] == [_T]
+    assert len(dropped) == 1
+    # stamping runs AFTER the gate: survivors get ids, the dropped item never did
+    assert kept[0].get("id")
+    assert not dropped[0].get("id")
+
+
+def test_write_checkpoint_drops_reasserted_secret_via_redacted_tombstone(
+        tmp_checkpoint_dir, monkeypatch):
+    """E2E through the store wiring: forget an item whose stored text was
+    redacted, then re-capture the RAW sentence — the write pipeline must
+    redact first so the forget gate matches and the value stays gone."""
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", _A)
+    store.write_checkpoint("S1", _cp("S1", "2026-07-01T00:00:00Z", [_SECRET_RAW]),
+                           project_dir=_A)
+    stored = store.read_latest(project_dir=_A, fallback=False)
+    item = stored["working_context"]["recent_decisions"][0]
+    assert "[redacted:aws-key]" in item["text"]  # the tombstone keys on THIS form
+    assert cli.main(["forget", item["id"]]) == 0
+
+    store.write_checkpoint("S2", _cp("S2", "2026-07-03T00:00:00Z", [_SECRET_RAW, _T]),
+                           project_dir=_A)
+    latest = store.read_latest(project_dir=_A, fallback=False)
+    assert latest["session_id"] == "S2"
+    assert [d["text"] for d in latest["working_context"]["recent_decisions"]] == [_T]
+
+
+# ---- (b) kill switch: disabled writes nothing, from every entry ----
+
+
+def test_disabled_write_checkpoint_refuses_and_touches_nothing(
+        tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", _A)
+    monkeypatch.setenv("DAIMON_DISABLE", "1")
+    out = store.write_checkpoint("S1", _cp("S1", "2026-07-01T00:00:00Z", [_S]),
+                                 project_dir=_A)
+    assert out is None
+    # no checkpoint file, no pointer, not even the directory
+    assert not tmp_checkpoint_dir.exists()
+
+
+def test_disabled_cli_serialize_writes_no_checkpoint(
+        tmp_checkpoint_dir, fake_chat_factory, capsys, monkeypatch):
+    chat = fake_chat_factory(_valid_serialize_json())
+    monkeypatch.setattr(cli, "_chat", chat)
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    monkeypatch.setenv("DAIMON_DISABLE", "1")
+
+    rc = cli.main(["serialize", str(FIXTURES / "sample_transcript.md")])
+    assert rc == 0  # never-fatal posture, same as the ledger appenders
+    out = capsys.readouterr().out
+    assert "wrote checkpoint" not in out  # no lying success line ("... None")
+    files = (list(tmp_checkpoint_dir.rglob("*.json"))
+             if tmp_checkpoint_dir.exists() else [])
+    assert files == []
+
+
+def test_disabled_cli_write_checkpoint_writes_no_checkpoint(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    import io
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO(_valid_serialize_json("S-intro")))
+    monkeypatch.setenv("DAIMON_DISABLE", "1")
+    rc = cli.main(["write-checkpoint", "--project", _A])
+    assert rc != 0  # a deliberate write command may say no, loudly
+    files = (list(tmp_checkpoint_dir.rglob("*.json"))
+             if tmp_checkpoint_dir.exists() else [])
+    assert files == []
+
+
+# ---- (c) deletion exemption: `daimon forget` works while disabled ----
+
+
+def test_disabled_forget_still_removes_value_and_appends_tombstone(
+        tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", _A)
+    store.write_checkpoint("S1", _cp("S1", "2026-07-01T00:00:00Z", [_S, _T]),
+                           project_dir=_A)
+    stored = store.read_latest(project_dir=_A, fallback=False)
+    x_id = next(d["id"] for d in stored["working_context"]["recent_decisions"]
+                if d["text"] == _S)
+
+    monkeypatch.setenv("DAIMON_DISABLE", "1")
+    assert cli.main(["forget", x_id]) == 0
+
+    # the value left the live checkpoint on disk (latest AND per-session file)
+    latest = store.read_latest(project_dir=_A, fallback=False)
+    texts = [d["text"] for d in latest["working_context"]["recent_decisions"]]
+    assert _S not in texts and _T in texts
+    per_session = store.read_checkpoint("S1")
+    texts = [d["text"] for d in per_session["working_context"]["recent_decisions"]]
+    assert _S not in texts
+    # and its tombstone landed despite the kill switch
+    assert normalize.content_key(_S) in store.forgotten_content_keys(_A)
+
+
+def test_exemption_is_narrow_default_paths_still_refuse(
+        tmp_checkpoint_dir, monkeypatch):
+    """Only the forget path opts out. A plain append_event and a plain
+    write_checkpoint under the kill switch keep refusing."""
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", _A)
+    store.write_checkpoint("S1", _cp("S1", "2026-07-01T00:00:00Z", [_S]),
+                           project_dir=_A)
+    monkeypatch.setenv("DAIMON_DISABLE", "1")
+    assert store.append_event("r-x", "resolved", project_dir=_A) is False
+    assert store.write_checkpoint("S2", _cp("S2", "2026-07-02T00:00:00Z", [_T]),
+                                  project_dir=_A) is None
+
+
+# ---- (d) purity guard: policy.py stays I/O-free (carry.py's contract) ----
+
+
+def test_policy_module_is_pure():
+    from daimon_briefing import policy
+
+    src = Path(policy.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    banned_stdlib = {"os", "io", "pathlib", "shutil", "subprocess", "socket",
+                     "tempfile", "sqlite3", "json", "logging"}
+    # sibling modules that do I/O or read env — policy must not reach them
+    banned_siblings = {"config", "store", "llm", "receipts", "teamproject",
+                       "transcript", "recall", "ledger", "cli", "hooks"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".")[0] not in banned_stdlib, alias.name
+        elif isinstance(node, ast.ImportFrom):
+            names = {alias.name for alias in node.names}
+            if node.level:  # relative: from . import x, y
+                hit = names & banned_siblings
+                assert not hit, f"policy imports I/O sibling(s): {hit}"
+            else:
+                assert (node.module or "").split(".")[0] not in banned_stdlib
+    for token in ("open(", ".write_text", ".read_text", ".write_bytes",
+                  ".read_bytes", ".mkdir", "os.environ", "getenv"):
+        assert token not in src, f"policy.py contains I/O-shaped token {token!r}"


### PR DESCRIPTION
Closes #421

## What

- New `plugin/daimon_briefing/policy.py`: a pure, I/O-free module (same invariant carry.py documents) owning the ordered checkpoint admission pipeline as `admit_checkpoint(checkpoint, forgotten_keys)` — redact (#104), then the value-keyed forget gate (#402), then id-stamping (#102). The redact/drop/stamp helpers moved in verbatim; `store.forgotten_content_keys` (the one I/O dependency) stays in the store and is read by `write_checkpoint`, then injected. `store._redact_checkpoint`/`store._stamp_item_ids` remain as aliases for existing callers (cli, bench, tests).
- `store.write_checkpoint` gains the kill switch as its FIRST gate: under `config.is_disabled()` it refuses with a never-fatal `None` (the ledger appenders' posture), before any directory is created — so every entry point (hook, CLI serialize, model-authored write-checkpoint, anchor rewrite) inherits one consistent answer.
- Deletion exemption (maintainer-ratified): `daimon forget` still works while disabled. `cli._cmd_forget` passes `allow_disabled=True` on its tombstone `append_event` and rewrite `write_checkpoint` — the tombstone shares the exemption because #418 mandates it lands before the rewrite. No other caller gets it.
- CLI call sites report refusals honestly: serialize logs a `skipped` line (matches neither `_RESULT_OK_RE` nor `_RESULT_ERR_RE`, so the ledger never records a lying success), `write-checkpoint` and `anchor --attach` error out with rc 1.

## Why

The kill switch was enforced unevenly (#421): ledger appenders and hooks checked it, but `write_checkpoint` did not — so with daimon disabled, CLI serialize, model-authored writes, and anchor rewrites still mutated the store. Disabled must mean no belief mutations at all, answered once at the write boundary, not per-caller. Extracting the pipeline into a pure module also pins its load-bearing order (redact BEFORE the forget gate — tombstones key on stored post-redaction text; stamping AFTER — a dropped item is never minted an id) as slice 1 of the governed-write-gateway design.

## Tests

New `plugin/tests/test_policy.py` (8 tests, written RED-first):

- `test_admit_checkpoint_forget_gate_sees_redacted_text` + `test_write_checkpoint_drops_reasserted_secret_via_redacted_tombstone` — a raw secret re-extraction only folds to a tombstone keyed on the redacted form if redaction runs first; survivors get ids, dropped items never do (order proof, unit + E2E).
- `test_disabled_write_checkpoint_refuses_and_touches_nothing`, `test_disabled_cli_serialize_writes_no_checkpoint`, `test_disabled_cli_write_checkpoint_writes_no_checkpoint` — kill switch on: `None` return, no file, no pointer, not even the directory; failed before the change (checkpoint was written).
- `test_disabled_forget_still_removes_value_and_appends_tombstone` — failed before the change (forget aborted at the gated tombstone with rc 1).
- `test_exemption_is_narrow_default_paths_still_refuse` — plain `append_event`/`write_checkpoint` keep refusing while disabled.
- `test_policy_module_is_pure` — AST + token scan: no I/O stdlib modules, no I/O sibling imports, no `open(`/`.write_*`/env access in policy.py.

Full suite: `uv run pytest` from `plugin/` — 2182 passed, 2 skipped (2174 pre-existing tests unchanged and green; redaction/forget behavior tests untouched).