### PR TITLE
fix(forget): purge the serializer chunk cache so deletion covers the pre-redaction window

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1020,9 +1020,27 @@ def _cmd_forget(args) -> int:
     # the kill switch — the rewrite that makes the deletion real on disk.
     store.write_checkpoint(sid, checkpoint, project_dir=project,
                            allow_disabled=True)
+    # #422: the serializer chunk cache holds PRE-redaction extraction output
+    # (quote verification forbids redacting before caching, #125), keyed by
+    # chunk text — the forgotten value cannot be located selectively, so the
+    # purge is WHOLESALE and default-on. Never fatal: the belief-state
+    # deletion above is the primary contract; a failed purge is reported
+    # honestly below, and the age reaper still bounds any survivor at
+    # chunk_cache_days.
+    try:
+        purged, purge_err = serializer.purge_chunk_cache()
+    except Exception as e:  # belt: purge_chunk_cache itself never raises
+        purged, purge_err = 0, str(e)
     _note_usage("forget")
     print(f"forgot {target['id']} (content hash {content_hash}) — "
           "item removed from the live checkpoint; tombstone recorded")
+    if purge_err is not None:
+        print(f"warning: chunk cache purge failed: {purge_err} — "
+              "cached pre-redaction chunks may persist up to "
+              f"{config.chunk_cache_days()} day(s) (age reaper)")
+    else:
+        print(f"purged {purged} cached chunk extraction(s) "
+              "(pre-redaction serializer cache)")
     return 0
 
 

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -1395,6 +1395,37 @@ def _save_chunk_cache(key: str, partial: dict) -> None:
         pass
 
 
+def purge_chunk_cache():
+    """#422: wholesale removal of every cached chunk extraction. `daimon
+    forget` calls this after a successful tombstone+rewrite: cached output is
+    PRE-redaction (see the block comment above _chunk_cache_dir) and keyed by
+    chunk TEXT plus config dimensions — a forgotten value cannot be located
+    selectively, so the whole cache goes. Accepted cost: re-paying extraction
+    for chunks younger than chunk_cache_days (default 3), the same window the
+    age reaper already bounds. The directory itself is kept — the next
+    serialize re-populates in place. Orphaned `.*.tmp` writer droppings carry
+    the same pre-redaction bytes, so they go too.
+
+    Returns (purged_count, error_or_None) and NEVER raises: the caller's
+    deletion of belief state is the primary contract; a failed purge is
+    reported, not fatal."""
+    d = _chunk_cache_dir()
+    if not d.is_dir():
+        return 0, None  # nothing cached — vacuously purged
+    purged, error = 0, None
+    try:
+        targets = sorted(set(d.glob("*.json")) | set(d.glob(".*.tmp")))
+    except OSError as e:
+        return 0, str(e)
+    for entry in targets:
+        try:
+            entry.unlink()
+            purged += 1
+        except OSError as e:
+            error = str(e)
+    return purged, error
+
+
 def _merge_partials(chat, session_id: str, partials: list, deadline,
                     attempt_note: str = "") -> dict:
     """Hierarchically merge partial checkpoints into one, K partials at a time.

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -6186,6 +6186,52 @@ def test_forget_by_unique_fuzzy_query(tmp_checkpoint_dir, capsys, monkeypatch):
     assert store.resolutions(project_dir="/p/A")[iid]["status"].startswith("forgotten:")
 
 
+def test_forget_purges_chunk_cache(tmp_checkpoint_dir, capsys, monkeypatch):
+    """#422: the serializer chunk cache holds PRE-redaction extraction output
+    keyed by chunk TEXT — a forgotten value cannot be located selectively, so
+    forget purges the cache WHOLESALE and reports the count honestly."""
+    from daimon_briefing import llm, serializer, store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    item = cp["working_context"]["open_questions"][0]
+    llm.reset_fallback()  # _save_chunk_cache refuses after a fallback fired
+    serializer._save_chunk_cache(
+        serializer._chunk_cache_key("chunk quoting: " + item["text"]),
+        {"working_context": {"open_questions": [
+            {"text": item["text"], "trust": "inferred"}]}})
+    cache_dir = serializer._chunk_cache_dir()
+    assert list(cache_dir.glob("*.json"))  # seeded (control precondition)
+    assert cli.main(["forget", item["id"]]) == 0
+    assert cache_dir.is_dir()              # dir kept — entries gone
+    assert list(cache_dir.glob("*.json")) == []
+    out = capsys.readouterr().out
+    assert "forgot" in out
+    assert "purged 1 cached chunk" in out  # honest reporting, success path
+
+
+def test_forget_cache_purge_failure_warns_but_still_succeeds(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    """#422: the purge is never-fatal — deletion of belief state is the
+    primary contract — but a failed purge is reported, never silent."""
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+
+    def boom():
+        raise RuntimeError("cache dir on fire")
+
+    monkeypatch.setattr(cli.serializer, "purge_chunk_cache", boom)
+    assert cli.main(["forget", iid]) == 0  # forget itself still succeeds
+    after = store.read_latest(project_dir="/p/A", fallback=False)
+    assert iid not in [i.get("id")
+                       for i in after["working_context"]["open_questions"]]
+    out = capsys.readouterr().out
+    assert "forgot" in out
+    assert "cache purge failed" in out
+    assert "cache dir on fire" in out
+
+
 # --- #376 rejection ledger in stats ----------------------------------------
 
 def test_stats_verification_reports_counts(tmp_path, monkeypatch):

--- a/plugin/tests/test_deletion_durability_protocol.py
+++ b/plugin/tests/test_deletion_durability_protocol.py
@@ -14,12 +14,16 @@ steps that lineage does not yet cover:
   * step 10 asserts the append-only audit trail records the deletion while
     holding NONE of the forgotten text.
 
-Ten steps, each re-asserting on the accumulated state, each paired with a
+Eleven steps, each re-asserting on the accumulated state, each paired with a
 never-forgotten twin (T) that MUST stay retrievable so no negative assertion
 can pass vacuously:
 
   1. write a distinctive fact through the serializer; assert retrievable
-  2. forget it; confirm removal from briefing, carry, recall
+     (and seed the #48 chunk cache exactly as a chunked capture would)
+  2. forget it; confirm removal from briefing, carry, recall — and that the
+     serializer chunk cache (PRE-redaction by #125 necessity) is purged
+     WHOLESALE (#422): entries are keyed by chunk text, not searchable by
+     value, so selective removal is impossible and every entry goes
   3. re-feed the SAME source transcript + re-serialize; assert non-resurrection
   4. background job — recall index rebuild; re-assert absence
   5. background job — a subsequent carry; re-assert absence
@@ -28,6 +32,8 @@ can pass vacuously:
   8. derived artifact — recall's SQLite rows
   9. derived artifact — the signed receipt binds the POST-deletion bytes
  10. audit trail — the deletion is recorded, with no forgotten text on disk
+ 11. chunk-cache sink on the ACCUMULATED state — after every background job
+     above, no file under .chunk-cache holds the forgotten value
 
 Deterministic and ZERO model quota: the serializer's LLM is a canned
 `fake_chat` and the vitni signer is a monkeypatched stub — this is a
@@ -50,6 +56,7 @@ from daimon_briefing import (
     carry,
     cli,
     config,
+    llm,
     normalize,
     receipts,
     recall,
@@ -241,6 +248,21 @@ def test_deletion_durability_protocol(tmp_checkpoint_dir, monkeypatch,
     r1 = _recall_texts()
     assert _S in r1 and _T in r1
 
+    # Seed the #48 chunk cache through the PRODUCTION writer, exactly as a
+    # chunked capture of this transcript would have: cached output is
+    # PRE-redaction extraction (forced by #125 quote verification), so the
+    # forgotten value's bytes land here verbatim. This transcript is too
+    # small to trigger chunking, so the sink is seeded explicitly.
+    llm.reset_fallback()  # _save_chunk_cache refuses after a fallback fired
+    cache_dir = serializer._chunk_cache_dir()
+    seed_key = serializer._chunk_cache_key(
+        serializer._render_transcript(_transcript()))
+    serializer._save_chunk_cache(seed_key, json.loads(_extraction_json("S1")))
+    seeded = cache_dir / f"{seed_key}.json"
+    # Control precondition: the sink genuinely holds the value, so the
+    # negative assertions below cannot pass vacuously.
+    assert _S in seeded.read_text(encoding="utf-8")
+
     # --- Step 2: forget it; confirm removal from briefing/carry/recall -----
     assert cli.main(["forget", x_id]) == 0
     res = store.resolutions(project_dir=_P)
@@ -253,6 +275,16 @@ def test_deletion_durability_protocol(tmp_checkpoint_dir, monkeypatch,
     assert _S not in c2 and _T in c2
     r2 = _recall_texts()
     assert _S not in r2 and _T in r2
+
+    # Chunk-cache sink (#422): forget purges the cache WHOLESALE — entries
+    # are keyed by chunk text plus config dimensions, never by contained
+    # value, so selective removal is impossible. The directory survives (the
+    # next serialize re-populates in place); every entry is gone. Accepted
+    # cost: re-paying extraction for chunks younger than chunk_cache_days.
+    assert cache_dir.is_dir()
+    assert list(cache_dir.glob("*.json")) == []
+    for leftover in cache_dir.iterdir():
+        assert _S not in leftover.read_text(encoding="utf-8")
 
     # --- Step 3: re-feed the ORIGINAL SOURCE TRANSCRIPT + re-serialize -----
     # The resurrection vector: the same raw material is re-ingested. The
@@ -332,6 +364,16 @@ def test_deletion_durability_protocol(tmp_checkpoint_dir, monkeypatch,
     assert _S not in events
     for token in (t for t in _S.split() if len(t) >= 4):
         assert token not in events
+
+    # --- Step 11: chunk-cache sink on the ACCUMULATED state ---------------
+    # Steps 3-6 re-ran the serializer after the forget; whatever they left
+    # behind, no file under .chunk-cache may hold the forgotten value. (A
+    # post-forget re-ingest MAY re-cache raw material until the age reaper
+    # or the next forget fires — this transcript serializes single-pass, so
+    # here the cache must simply hold nothing containing S.)
+    assert cache_dir.is_dir()
+    for cached in cache_dir.iterdir():
+        assert _S not in cached.read_text(encoding="utf-8")
 
 
 # =========================================================================

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -1437,6 +1437,47 @@ def test_chunk_cache_key_survives_backend_resolution_failure(monkeypatch):
     assert len(key) == 32
 
 
+def test_purge_chunk_cache_continues_past_a_failing_entry(
+        monkeypatch, tmp_checkpoint_dir):
+    # #422 contract: one undeletable entry must not shield the rest — the
+    # purge keeps going, counts only the real deletions, and surfaces the
+    # failure so the caller's forget output can report it honestly.
+    d = tmp_checkpoint_dir / ".chunk-cache"
+    d.mkdir(parents=True)
+    stuck = d / "aaaa.json"
+    stuck.write_text("{}")
+    (d / "bbbb.json").write_text("{}")
+
+    real_unlink = Path.unlink
+
+    def flaky_unlink(self, *args, **kwargs):
+        if self.name == "aaaa.json":
+            raise OSError("Operation not permitted")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", flaky_unlink)
+    purged, error = serializer.purge_chunk_cache()  # must not raise
+    assert purged == 1                      # only the healthy entry counted
+    assert not (d / "bbbb.json").exists()   # ... and it is genuinely gone
+    assert stuck.exists()                   # honest: the stuck one survived
+    assert "not permitted" in error
+
+
+def test_purge_chunk_cache_reports_unscannable_dir_without_raising(monkeypatch):
+    # #422 contract: purge NEVER raises. A cache dir that exists but cannot
+    # even be enumerated comes back as (0, reason) — reported, not fatal,
+    # because the belief-state deletion is the caller's primary contract.
+    class _EvilDir:
+        def is_dir(self):
+            return True
+
+        def glob(self, pattern):
+            raise OSError("scan denied")
+
+    monkeypatch.setattr(serializer, "_chunk_cache_dir", lambda: _EvilDir())
+    assert serializer.purge_chunk_cache() == (0, "scan denied")
+
+
 def test_chunk_transcript_prefix_chunks_byte_stable_under_growth():
     # The property the whole cache rests on: full windows re-materialize
     # byte-identically when the transcript grows; only the tail changes.

--- a/website/docs/concepts/lifecycle.md
+++ b/website/docs/concepts/lifecycle.md
@@ -74,6 +74,15 @@ What happens on forget:
   checkpoint copies in your local index — including your local copies of team
   mirrors — so recall cannot resurrect it. (Propagating tombstones into
   teammates' own mirrors is a deliberate follow-up, not in v1.)
+- The serializer's **chunk cache** is purged **wholesale**. That cache keeps
+  pre-redaction extraction output for a few days so an interrupted capture
+  never re-pays its LLM calls — and because its entries are keyed by chunk
+  text, not searchable by contained value, selective removal is impossible.
+  Forget clears all of it (the cost: chunks younger than the rotation window,
+  `chunk_cache_days`, default 3 days, get re-extracted next time). Entries
+  are also age-reaped at that window independently of forget. The purge is
+  never fatal — removal of the belief state always completes — and the
+  command reports honestly whether the purge succeeded.
 - Briefing withhold, carry suppression, and `daimon stats` all inherit the
   tombstone through the same event stream.
 
@@ -97,14 +106,23 @@ retrievable so no check can pass vacuously:
 | 8 | Recall SQLite rows | absent |
 | 9 | Signed receipt | binds the post-deletion bytes |
 | 10 | Audit trail | records the deletion, holds none of its text |
+| 11 | Serializer chunk cache (pre-redaction) | purged wholesale on forget |
 
-**Result: 10 / 10 steps compliant.** The tests are deterministic and use zero
+**Result: 11 / 11 steps compliant.** The tests are deterministic and use zero
 model quota — a canned extractor and a stubbed signer stand in for the LLM and
 the vitni CLI — so this is a compliance check that runs on every commit, not a
 benchmark. Step 3 is the one that matters most: re-ingesting the raw material a
 deleted item came from is how systems quietly bring it back, and the
 value-keyed tombstone drops it at the write boundary regardless of what the
 extractor re-produces.
+
+One bound worth stating exactly: the chunk cache is pre-redaction *by
+necessity* (quote verification needs the raw text), so before this step
+joined the protocol a forgotten value's bytes could sit in the cache until
+the age reaper fired. Now `forget` purges the local chunk cache in the same
+command, and the `chunk_cache_days` reaper (default 3 days) remains the
+independent upper bound for anything written after a forget. The claim is
+scoped to this machine: the cache never syncs anywhere.
 
 ## Supersession candidates
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/lifecycle.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/lifecycle.md
@@ -81,6 +81,16 @@ Qué ocurre al olvidar:
   locales de los mirrors de equipo — así recall no puede resucitarlo.
   (Propagar tombstones a los mirrors propios de tus compañeros es un
   seguimiento deliberado, no está en v1.)
+- La **caché de chunks** del serializer se purga **por completo**. Esa caché
+  guarda salida de extracción pre-redacción durante unos días para que una
+  captura interrumpida nunca re-pague sus llamadas al LLM — y como sus
+  entradas se indexan por el texto del chunk, no por el valor contenido, la
+  eliminación selectiva es imposible. Forget la vacía entera (el costo: los
+  chunks más jóvenes que la ventana de rotación, `chunk_cache_days`, 3 días
+  por defecto, se re-extraen la próxima vez). Las entradas también se
+  cosechan por edad en esa ventana, independientemente de forget. La purga
+  nunca es fatal — la eliminación del estado de creencias siempre se
+  completa — y el comando reporta honestamente si la purga tuvo éxito.
 - La retención en el briefing, la supresión del arrastre y `daimon stats`
   heredan el tombstone a través del mismo flujo de eventos.
 
@@ -104,14 +114,25 @@ permanece recuperable para que ninguna verificación pase de forma vacua:
 | 8 | Filas SQLite de recall | ausente |
 | 9 | Receipt firmado | vincula los bytes posteriores a la eliminación |
 | 10 | Rastro de auditoría | registra la eliminación, sin nada de su texto |
+| 11 | Caché de chunks del serializer (pre-redacción) | purgada por completo al olvidar |
 
-**Resultado: 10 / 10 pasos en cumplimiento.** Las pruebas son deterministas y
+**Resultado: 11 / 11 pasos en cumplimiento.** Las pruebas son deterministas y
 usan cero cuota de modelo — un extractor precargado y un firmante simulado
 reemplazan al LLM y a la CLI de vitni — así que es una verificación de
 cumplimiento que corre en cada commit, no un benchmark. El paso 3 es el que más
 importa: re-ingerir el material crudo del que salió un ítem eliminado es cómo
 los sistemas lo traen de vuelta sin querer, y el tombstone por-valor lo
 descarta en el límite de escritura sin importar qué re-produzca el extractor.
+
+Un límite que vale la pena declarar con exactitud: la caché de chunks es
+pre-redacción *por necesidad* (la verificación de citas necesita el texto
+crudo), así que antes de que este paso entrara al protocolo, los bytes de un
+valor olvidado podían quedarse en la caché hasta que actuara la cosecha por
+edad. Ahora `forget` purga la caché local de chunks en el mismo comando, y la
+cosecha de `chunk_cache_days` (3 días por defecto) sigue siendo el límite
+superior independiente para todo lo escrito después de un forget. La
+afirmación se limita a esta máquina: la caché nunca se sincroniza a ningún
+lado.
 
 ## Candidatos a supersesión
 


### PR DESCRIPTION
Closes #422

## What

`daimon forget` now purges the serializer chunk cache (`<checkpoint_dir>/.chunk-cache/`) wholesale after the successful tombstone+rewrite — default-on, never fatal. The command reports honestly either way: `purged N cached chunk extraction(s)` on success, or a warning naming the failure and the `chunk_cache_days` bound that still applies. The deletion-durability protocol enumerates the cache as step 11 (seeded through the production `_save_chunk_cache` writer as a control precondition, purge asserted right after the forget and re-asserted on the accumulated end state), and the compliance docs (en + es) add the sink row, move to 11/11, and state the pre-redaction cache bound exactly instead of leaving it implicit.

## Why

The cache holds **pre-redaction** extraction output by necessity (#125: quote verification needs the raw transcript text) and is keyed by chunk text plus config dimensions — not searchable by contained value — so selective removal is impossible by construction. Before this change a forgotten value's bytes could persist under `.chunk-cache` for up to the reap window (`chunk_cache_days`, default 3) while the compliance doc's enumeration was silent about it. Ratified maintainer decision: wholesale purge, accepted cost = re-paying extraction for up-to-window-old chunks. Purge failure must not block the forget — deletion of belief state is the primary contract — but it must be reported, never silent.

## Tests

- `test_deletion_durability_protocol` (extended): seeds a cache entry containing the forgotten value via the production writer, asserts the entry genuinely held the value (no vacuous pass), then asserts after `forget` that the dir survives, zero `*.json` entries remain, and no file under `.chunk-cache` contains the value — re-checked as step 11 after all background jobs. Failed before the change (seeded entry survived the forget).
- `test_forget_purges_chunk_cache` (new): forget empties the cache, keeps the dir, and prints `purged 1 cached chunk`. Failed before (entry survived, no report line).
- `test_forget_cache_purge_failure_warns_but_still_succeeds` (new): with `purge_chunk_cache` raising, forget still exits 0, the item is still removed, and the output carries `cache purge failed: <reason>`. Failed before (`purge_chunk_cache` did not exist).
- Full suite from `plugin/` after `uv sync --all-extras`: **2186 passed, 2 skipped**.
