### PR TITLE
feat(teamsync): gate inbound team content — scope, redaction, forget, and trust now apply on read

### DIFF
--- a/docs/team.md
+++ b/docs/team.md
@@ -170,6 +170,13 @@ in the machine-local mirror (`<team_dir>/local/`) — withheld from the remote,
 never lost. Without this gate, one enabled remote would receive every project
 on the machine, including personal ones.
 
+The same allowlist gates **reads** too: `brief --team` and the recall index
+only admit a synced remote's content when the scope check passes. A remote
+this project was never granted to contributes nothing to this project's
+briefing or search index — the files stay untouched in the sidecar clone,
+they just don't enter local surfaces. The machine-local mirror
+(`<team_dir>/local/`, your own withheld writes) needs no grant.
+
 A project is in scope for a remote when any of these holds:
 
 1. Its origin URL is listed under the sidecar's top-level `[scope]` table:
@@ -212,11 +219,32 @@ Teammates' checkpoints are shown within a read-time age window controlled by
 is a read filter only — no file is ever physically deleted from the append-only
 shared branch.
 
+### The inbound gate
+
+Every policy daimon enforces on your own checkpoints on the way out is
+re-asserted on a teammate's checkpoint on the way in, at read/index time
+(in-memory — sidecar files and git history are never rewritten):
+
+- **Scope** — content from a remote that doesn't pass the scope check above
+  never reaches the briefing or the recall index.
+- **Redaction** — your local secret patterns re-scrub incoming text before it
+  is shown or indexed. A teammate on an older daimon with fewer patterns
+  can't seed a durable cleartext copy on your machine.
+- **Forget** — values you tombstoned with `daimon forget` are dropped from
+  incoming checkpoints too: a teammate's copy can't re-surface something you
+  deleted locally.
+- **Trust** — a teammate's `verbatim` item is stored and scored as
+  `inferred`, because its receipt can only be verified on the machine that
+  captured it. In the Teammates section it renders with a visible label —
+  `[teammate claims verbatim — unverifiable here]` — stating both facts:
+  the claim, and that it can't be checked locally. Your own items are
+  unaffected.
+
 ## Environment reference
 
 | Variable | Default | What it does |
 |---|---|---|
-| `DAIMON_TEAM` | unset (off) | Set to `1` to mirror your checkpoints into the team dir. Gates writes only; reads are always on. |
+| `DAIMON_TEAM` | unset (off) | Set to `1` to mirror your checkpoints into the team dir. Gates the outbound mirror; reads are on regardless, but pass the per-remote scope gate above. |
 | `DAIMON_AUTHOR` | `git config user.name` → OS username → `unknown` | The author name your checkpoints are filed under. |
 | `DAIMON_TEAM_DIR` | `~/.daimon/team` | Root of the local team mirror (one subdirectory per sidecar clone). |
 | `DAIMON_TEAM_PROJECT` | unset | Explicit logical project path (e.g. `core/api-gateway`) for this machine's sessions. Beats the `daimon-team.toml` mapping and the origin-derived fallback. |

--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -36,6 +36,10 @@ DEGRADE_NOTE = (
     "⚠ RECEIPT UNVERIFIED — this checkpoint claims signed provenance, but its "
     "receipt is missing or no longer matches the stored bytes. The 'verbatim' "
     "quotes below are shown UNVERIFIED (run `daimon verify-receipt`).")
+# #423: a teammate's `verbatim` claim cannot be verified on this machine —
+# receipts resolve against the LOCAL checkpoint dir — so the inbound gate
+# clamps it to inferred and marks it; render states BOTH facts visibly.
+FOREIGN_VERBATIM_NOTE = "[teammate claims verbatim — unverifiable here]"
 
 
 def receipt_degraded(checkpoint) -> bool:
@@ -71,6 +75,10 @@ def _line(item, degraded: bool = False) -> str:
         # Epistemic honesty, same philosophy as trust marks: a loop carried
         # from an older session must not read as fresh context (#33 Phase 2).
         base += " [carried]"
+    if item.get("foreign_verbatim_claim"):
+        # #423: the inbound gate clamped a teammate's verbatim claim to
+        # inferred; state both facts — claimed verbatim, unverifiable here.
+        base += f" {FOREIGN_VERBATIM_NOTE}"
     if quote:
         base += f'  — "{quote}"'
     candidate = item.get("_supersede_candidate")

--- a/plugin/daimon_briefing/policy.py
+++ b/plugin/daimon_briefing/policy.py
@@ -15,6 +15,12 @@ order is load-bearing and must not change:
 
 Like the helpers it absorbed, every function mutates its checkpoint argument
 IN PLACE (the established store.py contract — callers rely on it).
+
+#423 adds the INBOUND twin: admit_foreign runs where a teammate's synced
+checkpoint enters local surfaces (read_team, the recall scan) — scope, local
+re-redaction, the local forget gate, and the foreign verbatim->inferred
+trust clamp. Same purity contract: membership, the forgotten set, and the
+redact function are all injected by the caller.
 """
 
 import hashlib
@@ -28,7 +34,7 @@ from . import normalize, redact, schema
 _ITEM_LISTS = schema.ITEM_LISTS
 
 
-def redact_checkpoint(checkpoint: dict) -> None:
+def redact_checkpoint(checkpoint: dict, redact_fn=None) -> None:
     """Capture-time secret redaction (#104): runs before this module's own
     stamp_item_ids call below, so ids stamped HERE hash redacted text. On
     the serialize path the cli stamps ids earlier (before bind_links, #14),
@@ -37,12 +43,16 @@ def redact_checkpoint(checkpoint: dict) -> None:
     secret-bearing items differs between the two paths.
     Covers text AND quote on every list item plus active_topic — verbatim
     quotes are the likeliest secret carriers. Stamps a visible
-    checkpoint["redactions"] counter only when something was scrubbed."""
+    checkpoint["redactions"] counter only when something was scrubbed.
+    `redact_fn` (#423) lets the inbound gate inject the scrub function;
+    the write path keeps the module-level default."""
     counts: dict = {}
+    if redact_fn is None:
+        redact_fn = redact.redact_text
 
     def _scrub(d: dict, field: str) -> None:
         val = d.get(field)
-        red, c = redact.redact_text(val)
+        red, c = redact_fn(val)
         if c:
             d[field] = red
             for k, n in c.items():
@@ -155,3 +165,61 @@ def admit_checkpoint(checkpoint: dict, forgotten_keys: set) -> list:
     dropped = drop_forgotten(checkpoint, forgotten_keys)
     stamp_item_ids(checkpoint)
     return dropped
+
+
+def clamp_foreign_trust(checkpoint: dict) -> None:
+    """#423: a foreign `verbatim` claim is structurally unverifiable on this
+    machine — receipt verification resolves against the LOCAL checkpoint dir —
+    so repeated foreign assertion must never read as verified capture (the
+    manufactured-corroboration failure mode). Clamp the trust class to
+    `inferred` (also the #413 authority ceiling the recall index scores by)
+    and stamp `foreign_verbatim_claim` so the Teammates render can state both
+    facts visibly: claimed verbatim, unverifiable here. Items that never
+    claimed verbatim are left untouched — no marker they never earned."""
+    def _clamp(item) -> None:
+        if isinstance(item, dict) and item.get("trust") == "verbatim":
+            item["trust"] = "inferred"
+            item["foreign_verbatim_claim"] = True
+
+    for section, key in _ITEM_LISTS:
+        items = (checkpoint.get(section) or {}).get(key)
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            _clamp(item)
+    _clamp((checkpoint.get("working_context") or {}).get("active_topic"))
+
+
+def admit_foreign(checkpoint, *, member: bool, forgotten_keys: set,
+                  redact_fn):
+    """#423 inbound gate: the read/index-time twin of admit_checkpoint, run
+    where FOREIGN content (a synced teammate's checkpoint) enters local
+    surfaces. In-memory only — sidecar files and the git layer are never
+    rewritten. Order mirrors the write pipeline where it overlaps:
+
+    1. scope    — `member` is the caller's teamproject.in_scope answer for
+                  the sidecar this checkpoint came from; not a member -> None
+                  (caller skips the checkpoint entirely, default closed);
+    2. redact   — the injected local redact_fn re-scrubs text/quote/scene
+                  (+ active_topic): a teammate on an older daimon with fewer
+                  secret patterns must not seed a durable cleartext copy here;
+    3. forget   — items whose canonicalized text hashes into the injected
+                  LOCAL forgotten set are dropped, so a teammate's checkpoint
+                  cannot re-assert a value forgotten on this machine
+                  (redaction first, same load-bearing order as the write side);
+    4. trust    — clamp_foreign_trust above.
+
+    Pure by the module contract: the caller injects membership, the forgotten
+    set, and the redact function. Mutates `checkpoint` in place and returns
+    it, or None when the checkpoint must not be admitted. Tolerant of
+    legacy/malformed foreign blobs (missing sections, junk items) — the only
+    hard rejection is a non-dict, which fails CLOSED rather than admit what
+    the gate cannot inspect."""
+    if not member:
+        return None
+    if not isinstance(checkpoint, dict):
+        return None  # cannot inspect it -> cannot vouch for it
+    redact_checkpoint(checkpoint, redact_fn)
+    drop_forgotten(checkpoint, forgotten_keys)
+    clamp_foreign_trust(checkpoint)
+    return checkpoint

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -45,7 +45,7 @@ import unicodedata
 from datetime import datetime, timezone
 from pathlib import Path
 
-from . import config, schema, scoring, store
+from . import config, policy, redact, schema, scoring, store, teamproject
 
 log = logging.getLogger("daimon.recall")
 
@@ -183,15 +183,39 @@ def _scan_sources():
     has aged out, #120). An aged-out team file is skipped WITHOUT entering
     `seen`, so a dual-written copy of your OWN session still indexes from the
     local scan below — retention is a team-view concept, never a cap on your
-    own searchable history."""
+    own searchable history.
+
+    Inbound gate (#423): foreign content (a synced remote's files, other
+    authors) passes policy.admit_foreign before a row can exist — the index
+    is the durable local copy, so scope, local re-redaction, the local forget
+    tombstones and the foreign verbatim->inferred clamp all apply HERE, not
+    at query time. The index is machine-global (no project dir in hand), so
+    remote membership is judged by what the sidecar's own toml vouches for
+    (teamproject.granted_paths) against the checkpoint's stamped logical
+    path; flat-era foreign blobs carry no toml-checkable identity and fail
+    CLOSED. A gated-out file is skipped WITHOUT entering `seen` — same
+    posture as retention. The 'local' mirror (this machine's own writes) and
+    this author's own synced-back copies stay ungated."""
     seen: set[tuple[str, str]] = set()
     root = config.team_dir()
     cutoff = store.team_retention_cutoff()
+    self_author = store.project_slug(config.author())
+    forgotten = store.all_forgotten_content_keys()
     try:
         remotes = list(root.iterdir())
     except OSError:
         remotes = []
+    # Mirror of _team_write_slugs / read_team (#423): the env grant is
+    # explicit machine intent with a single synced clone, unroutable noise
+    # with several.
+    clones = [r for r in remotes if r.is_dir()
+              and r.name != store._TEAM_LOCAL_REMOTE
+              and (r / ".git").exists()]
+    honor_env = len(clones) <= 1
     for remote in remotes:
+        foreign = remote.name != store._TEAM_LOCAL_REMOTE
+        granted = (teamproject.granted_paths(remote, honor_env=honor_env)
+                   if foreign else None)
         # Both layout eras (#200): legacy flat authors/* plus nested
         # projects/**/authors/* — same walker read_team's fan-in rests on.
         author_dirs = store._team_author_dirs(remote)
@@ -210,6 +234,16 @@ def _scan_sources():
                     continue
                 sid = str(cp.get("session_id") or p.stem)
                 author = str(cp.get("author") or adir.name)
+                if foreign and store.project_slug(author) != self_author:
+                    stamp = cp.get("team_project")
+                    segs = (teamproject.logical_segments(stamp)
+                            if isinstance(stamp, str) else ())
+                    cp = policy.admit_foreign(
+                        cp, member=bool(segs) and segs in granted,
+                        forgotten_keys=forgotten,
+                        redact_fn=redact.redact_text)
+                    if cp is None:
+                        continue  # not admitted; never enters `seen`
                 key = (author, sid)
                 if key in seen:
                     continue

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -250,7 +250,12 @@ def _plain_teammates(teammates) -> None:
         print(f"[{author}]")
         active = b.get("active_topic")
         if active:
-            print(f"  Active topic: {active.get('text', '').strip()}")
+            line = f"  Active topic: {active.get('text', '').strip()}"
+            if active.get("foreign_verbatim_claim"):
+                # #423: decisions get this via briefing._line; the topic line
+                # is built here, so the label has to be repeated.
+                line += f" {briefing.FOREIGN_VERBATIM_NOTE}"
+            print(line)
         decisions = b.get("decisions") or []
         if decisions:
             print("  Decisions made:")
@@ -272,12 +277,20 @@ def _rich_teammates(teammates) -> None:
         active = b.get("active_topic")
         if active:
             body.append(f"Active topic: {active.get('text', '').strip()}\n", style="white")
+            if active.get("foreign_verbatim_claim"):
+                body.append(f"    {briefing.FOREIGN_VERBATIM_NOTE}\n", style="yellow")
         decisions = b.get("decisions") or []
         if decisions:
             body.append("Decisions made:\n", style="bold")
             for i in decisions:
                 trust = _trust_key(i)
                 body.append(f"• {i.get('text', '').strip()}\n", style=_TRUST_STYLE[trust])
+                if i.get("foreign_verbatim_claim"):
+                    # #423: parity with briefing._line's plain-path label —
+                    # this panel builds its own Text body, so the label is
+                    # repeated here (same reasoning as the #14 flag above).
+                    body.append(f"    {briefing.FOREIGN_VERBATIM_NOTE}\n",
+                                style="yellow")
             note = briefing._overflow_note(b.get("decisions_overflow", 0))
             if note:
                 body.append(f"{note}\n", style="dim")

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -829,15 +829,27 @@ def read_team(project_dir=None) -> list[tuple[str, dict]]:
     only — NO physical deletes, ever: the shared branch is append-only and
     deletes race appends (spike verdict).
 
+    Inbound gate (#423): content from a synced remote passes
+    policy.admit_foreign before it can reach the result — scope membership
+    (the same teamproject.in_scope answer the outbound router uses, default
+    closed), local re-redaction, the local forget tombstones, and the foreign
+    verbatim->inferred trust clamp. In-memory only: sidecar files are never
+    rewritten. The machine-local mirror ('local') is this machine's own
+    writes and stays ungated, as do this author's own dual-written copies
+    synced back through a clone (their verbatim claims ARE locally
+    verifiable).
+
     Pure file-ops, never raises — a missing/broken/torn team dir yields []."""
     root = config.team_dir()
     want_slug = project_slug(project_dir)
     cutoff = team_retention_cutoff()
     candidates = teamproject.read_candidates(project_dir)
+    forgotten = forgotten_content_keys(project_dir)
+    self_author = project_slug(config.author())
     # author-slug (dir identity, one per author) -> (recency, author, checkpoint)
     best: dict[str, tuple[float, str, dict]] = {}
 
-    def _consider(adir: Path, check_stamp: bool) -> None:
+    def _consider(adir: Path, check_stamp: bool, member) -> None:
         try:
             files = [p for p in adir.iterdir()
                      if p.is_file() and p.suffix == ".json"]
@@ -856,6 +868,14 @@ def read_team(project_dir=None) -> list[tuple[str, dict]]:
             rec = _file_recency(p)
             if cutoff is not None and rec < cutoff:
                 continue  # aged out of the read window; file stays on disk
+            if member is not None \
+                    and project_slug(str(cp.get("author") or adir.name)) \
+                    != self_author:
+                cp = policy.admit_foreign(
+                    cp, member=member, forgotten_keys=forgotten,
+                    redact_fn=redact.redact_text)
+                if cp is None:
+                    continue  # not admitted; the file stays on disk untouched
             key = adir.name
             if key not in best or rec > best[key][0]:
                 best[key] = (rec, cp.get("author") or adir.name, cp)
@@ -864,14 +884,24 @@ def read_team(project_dir=None) -> list[tuple[str, dict]]:
         remotes = list(root.iterdir())
     except OSError:
         return []
+    # #423 scope, mirroring _team_write_slugs: with a single synced clone the
+    # DAIMON_TEAM_PROJECT env grant counts as explicit intent; with several it
+    # cannot say which remote it means, so only each sidecar's toml answers.
+    clones = [r for r in remotes if r.is_dir()
+              and r.name != _TEAM_LOCAL_REMOTE and (r / ".git").exists()]
+    honor_env = len(clones) <= 1
     for remote in remotes:
+        # member=None -> the machine-local mirror, ungated; any other dir is
+        # foreign-shaped and must earn admission (default closed, like #279).
+        member = None if remote.name == _TEAM_LOCAL_REMOTE else \
+            teamproject.in_scope(project_dir, remote, honor_env=honor_env)
         # Nested era (#200): only THIS project's subtrees — every candidate
         # path (winner + prior-tier locations); the paths filter.
         for segs in candidates:
             nested = remote.joinpath("projects", *segs, "authors")
             try:
                 for adir in nested.iterdir():
-                    _consider(adir, check_stamp=False)
+                    _consider(adir, check_stamp=False, member=member)
             except OSError:
                 pass  # no such subtree in this remote (yet)
         # Legacy flat era: stamp-filtered, readable forever.
@@ -880,7 +910,7 @@ def read_team(project_dir=None) -> list[tuple[str, dict]]:
         except OSError:
             continue  # not a remote-shaped dir; skip
         for adir in author_dirs:
-            _consider(adir, check_stamp=True)
+            _consider(adir, check_stamp=True, member=member)
     ordered = sorted(best.values(), key=lambda t: t[0], reverse=True)
     return [(author, cp) for _rec, author, cp in ordered]
 
@@ -1190,6 +1220,27 @@ def forgotten_content_keys(project_dir=None) -> set[str]:
             key = status[len(_FORGOTTEN_PREFIX):].strip()
             if key:
                 keys.add(key)
+    return keys
+
+
+def all_forgotten_content_keys() -> set[str]:
+    """Union of EVERY local project's forget tombstones (#423). The recall
+    index is machine-global and a foreign checkpoint cannot name the local
+    project dir its content corresponds to, so the inbound forget gate
+    suppresses a value forgotten in ANY local project. Over-suppression is
+    the fail-safe direction (drop_forgotten's documented posture) — a
+    forgotten value re-surfacing via a teammate is the worse failure.
+    Never raises; degrades to the empty set."""
+    keys: set[str] = set()
+    try:
+        children = list(config.checkpoint_dir().iterdir())
+    except OSError:
+        return keys
+    for child in children:
+        # Bucket dirs are named by slug; project_slug is idempotent on slugs,
+        # so the name rides through the project_dir-shaped ledger API.
+        if child.is_dir():
+            keys |= forgotten_content_keys(child.name)
     return keys
 
 

--- a/plugin/daimon_briefing/teamproject.py
+++ b/plugin/daimon_briefing/teamproject.py
@@ -269,6 +269,42 @@ def in_scope(project_dir, sidecar, honor_env=True) -> bool:
         return False
 
 
+def granted_paths(sidecar, honor_env=True) -> set[tuple[str, ...]]:
+    """The logical project paths ONE sidecar's daimon-team.toml vouches for —
+    the inbound mirror of in_scope for readers that hold NO local project dir
+    (the machine-global recall index, #423). A path is granted when it is:
+
+      - a [projects.*] mapped path, or
+      - the tier-3 origin-derived path of any granted repo ([scope] or a
+        [projects.*] repos list) — pre-mapping history lives there, the same
+        reason read_candidates keeps the derived path as a read candidate, or
+      - (honor_env, single-remote setups only — the same #387 rule the
+        outbound router applies) the machine's DAIMON_TEAM_PROJECT intent.
+
+    Default CLOSED like in_scope: no config, broken config, or a resolver
+    bug all grant nothing. Never raises."""
+    out: set[tuple[str, ...]] = set()
+    try:
+        entries, scope, _err = _parse_config(Path(sidecar) / CONFIG_NAME)
+        repos = set(scope)
+        for segs, mapped in entries:
+            out.add(segs)
+            repos |= mapped
+        for repo in repos:
+            derived = logical_segments("/".join(repo.split("/")[1:]))
+            if derived:
+                out.add(derived)
+        if honor_env:
+            env = config.team_project()
+            if env:
+                segs = logical_segments(env)
+                if segs:
+                    out.add(segs)
+    except Exception:  # membership bugs must deny, never admit
+        return set()
+    return out
+
+
 def scope_entries(sidecar) -> list[str]:
     """Sorted normalized repo allowlist for `daimon team status` — the one
     place a human can see which projects a remote accepts. Never raises."""

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2650,6 +2650,50 @@ def test_cli_brief_team_respects_decision_cap(tmp_checkpoint_dir, sample_checkpo
     assert "earlier decision" in out  # overflow marker: cap dropped 1 of grace's 2
 
 
+def test_cli_brief_team_labels_foreign_verbatim_claim(tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch, tmp_path):
+    """#423: a teammate's `verbatim` claim renders as a CLAIM — clamped to the
+    inferred mark plus a visible 'unverifiable here' label — while the user's
+    OWN verbatim items keep the full verbatim mark (control)."""
+    import json as _json
+
+    from daimon_briefing import config, store
+
+    proj = str((tmp_path / "proj").resolve())
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("a-1", sample_checkpoint, project_dir=proj)
+
+    # A single synced clone; the env grant is this machine's explicit intent.
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/x")
+    remote = config.team_dir() / "team-a"
+    (remote / ".git").mkdir(parents=True, exist_ok=True)
+    d = remote / "projects" / "core" / "x" / "authors" / "grace"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "S-g.json").write_text(_json.dumps({
+        "session_id": "S-g",
+        "author": "grace",
+        "team_project": "core/x",
+        "working_context": {
+            "active_topic": {"text": "Hardening the ingest gate", "trust": "inferred"},
+            "open_questions": [],
+            "recent_decisions": [
+                {"text": "Ship the ingest gate tomorrow", "trust": "verbatim",
+                 "quote": "ship it tomorrow"},
+            ],
+        },
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []},
+    }), encoding="utf-8")
+
+    rc = cli.main(["brief", "--team", "--project", proj])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "✓ verbatim" in out  # control: OWN verbatim rendering unchanged
+    line = next(ln for ln in out.splitlines() if "Ship the ingest gate" in ln)
+    assert "~ inferred" in line          # the claim renders clamped…
+    assert "✓ verbatim" not in line
+    assert "unverifiable here" in line   # …with both facts stated visibly
+    assert "verbatim" in line            # (claimed verbatim + unverifiable)
+
+
 # ---- recall: FTS search over local + team checkpoint history (#112) ----
 
 

--- a/plugin/tests/test_policy.py
+++ b/plugin/tests/test_policy.py
@@ -200,3 +200,103 @@ def test_policy_module_is_pure():
     for token in ("open(", ".write_text", ".read_text", ".write_bytes",
                   ".read_bytes", ".mkdir", "os.environ", "getenv"):
         assert token not in src, f"policy.py contains I/O-shaped token {token!r}"
+
+
+# ---- #423: inbound gate — admit_foreign (scope, redact, forget, trust clamp) ----
+
+
+def _foreign_cp():
+    return {
+        "session_id": "S-f",
+        "author": "grace",
+        "working_context": {
+            "active_topic": {"text": "tuning the ingest path", "trust": "inferred"},
+            "open_questions": [],
+            "recent_decisions": [
+                {"text": _S, "trust": "verbatim", "quote": "we adopt sqlite"},
+                {"text": _T, "trust": "inferred"},
+            ],
+        },
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []},
+    }
+
+
+def test_admit_foreign_out_of_scope_returns_none():
+    from daimon_briefing import policy
+
+    cp = _foreign_cp()
+    assert policy.admit_foreign(
+        cp, member=False, forgotten_keys=set(),
+        redact_fn=redact.redact_text) is None
+
+
+def test_admit_foreign_redacts_with_injected_fn():
+    from daimon_briefing import policy
+
+    cp = _foreign_cp()
+    cp["working_context"]["recent_decisions"][0]["text"] = _SECRET_RAW
+    out = policy.admit_foreign(
+        cp, member=True, forgotten_keys=set(), redact_fn=redact.redact_text)
+    assert out is cp  # in-place mutation, the established module contract
+    text = out["working_context"]["recent_decisions"][0]["text"]
+    assert "AKIA" not in text
+    assert "[redacted:" in text
+    assert out.get("redactions")  # visible counter, same as the write path
+
+
+def test_admit_foreign_drops_locally_forgotten_value():
+    from daimon_briefing import policy
+
+    out = policy.admit_foreign(
+        _foreign_cp(), member=True,
+        forgotten_keys={normalize.content_key(_S)},
+        redact_fn=redact.redact_text)
+    kept = [d["text"] for d in out["working_context"]["recent_decisions"]]
+    assert _S not in kept
+    assert _T in kept
+
+
+def test_admit_foreign_forget_gate_sees_redacted_text():
+    """Order mirror of admit_checkpoint: redaction runs BEFORE the forget
+    gate, so a foreign re-assertion of a redacted-then-forgotten sentence
+    folds to the tombstoned (post-redaction) key and stays gone."""
+    from daimon_briefing import policy
+
+    redacted, counts = redact.redact_text(_SECRET_RAW)
+    assert counts  # the fixture really is secret-shaped
+    cp = _foreign_cp()
+    cp["working_context"]["recent_decisions"][0]["text"] = _SECRET_RAW
+    out = policy.admit_foreign(
+        cp, member=True, forgotten_keys={normalize.content_key(redacted)},
+        redact_fn=redact.redact_text)
+    kept = [d["text"] for d in out["working_context"]["recent_decisions"]]
+    assert kept == [_T]
+
+
+def test_admit_foreign_clamps_verbatim_and_marks_claim():
+    from daimon_briefing import policy
+
+    out = policy.admit_foreign(
+        _foreign_cp(), member=True, forgotten_keys=set(),
+        redact_fn=redact.redact_text)
+    first, second = out["working_context"]["recent_decisions"]
+    assert first["trust"] == "inferred"
+    assert first["foreign_verbatim_claim"] is True
+    assert second["trust"] == "inferred"
+    assert "foreign_verbatim_claim" not in second  # never claimed — unmarked
+
+
+def test_admit_foreign_tolerates_malformed_checkpoints():
+    from daimon_briefing import policy
+
+    # A non-dict blob fails CLOSED (dropped), never raises.
+    assert policy.admit_foreign(
+        [1, 2], member=True, forgotten_keys=set(),
+        redact_fn=redact.redact_text) is None
+    # Junk items / missing sections ride through without raising.
+    cp = {"working_context": {"recent_decisions": ["bare string", 7, None],
+                              "active_topic": "not-a-dict"}}
+    out = policy.admit_foreign(
+        cp, member=True, forgotten_keys={normalize.content_key(_S)},
+        redact_fn=redact.redact_text)
+    assert out is cp

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -1534,3 +1534,121 @@ def test_rebuild_drops_forgotten_items_from_index(tmp_checkpoint_dir, monkeypatc
     recall.rebuild()
     hits = recall.search("sqlite", all_projects=True)
     assert not any("recall index" in h["text"] for h in hits)
+
+
+# ---- #423: inbound gate — foreign content passes admit_foreign before indexing ----
+# The index is machine-global (no project dir in hand), so remote membership is
+# judged by what the sidecar's own daimon-team.toml vouches for: content under
+# a granted logical path indexes; everything else from a synced remote is
+# dropped BEFORE a row exists. The "local" mirror is this machine's own writes
+# and stays ungated.
+
+
+def _clone_remote(name="team-a", toml_text=None):
+    d = config.team_dir() / name
+    (d / ".git").mkdir(parents=True, exist_ok=True)
+    if toml_text is not None:
+        (d / "daimon-team.toml").write_text(toml_text, encoding="utf-8")
+    return d
+
+
+def _write_clone_team_file(remote, author, sid, cp, logical=None):
+    blob = {**cp, "author": author}
+    if logical:
+        d = remote.joinpath("projects", *logical.split("/"), "authors", author)
+        blob["team_project"] = logical
+    else:
+        d = remote / "authors" / author
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{sid}.json").write_text(json.dumps(blob), encoding="utf-8")
+
+
+_GRANT_X = '[projects."core/x"]\nrepos = ["https://github.com/org/x"]\n'
+
+
+def test_rebuild_skips_out_of_scope_remote_content(tmp_checkpoint_dir, monkeypatch):
+    remote = _clone_remote(toml_text=_GRANT_X)
+    # Nested under a path the sidecar never granted + a flat-era blob: neither
+    # may reach the index (default closed, mirror of #279).
+    _write_clone_team_file(
+        remote, "grace", "S-g1",
+        _cp("S-g1", beliefs=[{"text": "Zoneless flamingo pipelines are stable",
+                              "trust": "inferred"}]),
+        logical="other/thing")
+    _write_clone_team_file(
+        remote, "grace", "S-g2",
+        _cp("S-g2", beliefs=[{"text": "Quantum pelican caching works",
+                              "trust": "inferred"}]))
+    recall.rebuild()
+    assert recall.search("flamingo", all_projects=True) == []
+    assert recall.search("pelican", all_projects=True) == []
+
+
+def test_rebuild_admits_granted_path_and_redacts(tmp_checkpoint_dir, monkeypatch):
+    remote = _clone_remote(toml_text=_GRANT_X)
+    _write_clone_team_file(
+        remote, "grace", "S-g",
+        _cp("S-g", decisions=[{"text": "rotate the flamingo key "
+                                       "AKIAABCDEFGHIJKLMNOP soon",
+                               "trust": "inferred"}]),
+        logical="core/x")
+    recall.rebuild()
+    hits = recall.search("flamingo", all_projects=True)
+    assert len(hits) == 1  # granted path DOES index
+    assert "AKIA" not in hits[0]["text"]  # …but only after local re-redaction
+    assert "[redacted:" in hits[0]["text"]
+
+
+def test_rebuild_drops_locally_forgotten_value_from_foreign(tmp_checkpoint_dir, monkeypatch):
+    from daimon_briefing import normalize
+
+    forgotten_text = "Adopt the flamingo cache for ingest"
+    store.append_event(
+        "d-dead02", f"forgotten:{normalize.content_key(forgotten_text)}",
+        kind="tombstone", project_dir="/repo/x")
+    remote = _clone_remote(toml_text=_GRANT_X)
+    _write_clone_team_file(
+        remote, "grace", "S-g",
+        _cp("S-g", decisions=[{"text": forgotten_text, "trust": "inferred"},
+                              {"text": "Keep the pelican path", "trust": "inferred"}]),
+        logical="core/x")
+    recall.rebuild()
+    assert recall.search("flamingo", all_projects=True) == []
+    assert len(recall.search("pelican", all_projects=True)) == 1  # others kept
+
+
+def test_rebuild_clamps_foreign_verbatim_to_inferred(tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    # Own local verbatim row: the control — must stay verbatim.
+    store.write_checkpoint(
+        "S1",
+        _cp("S1", decisions=[{"text": "Adopt pelican caching locally",
+                              "trust": "verbatim", "quote": "adopt it"}]),
+        project_dir="/repo/x")
+    remote = _clone_remote(toml_text=_GRANT_X)
+    _write_clone_team_file(
+        remote, "grace", "S-g",
+        _cp("S-g", decisions=[{"text": "Adopt flamingo caching remotely",
+                               "trust": "verbatim", "quote": "trust me"}]),
+        logical="core/x")
+    recall.rebuild()
+    foreign = recall.search("flamingo", all_projects=True)
+    assert len(foreign) == 1
+    assert foreign[0]["trust"] == "inferred"  # claim clamped at the boundary
+    own = recall.search("pelican", all_projects=True)
+    assert len(own) == 1
+    assert own[0]["trust"] == "verbatim"  # own claim untouched
+
+
+def test_rebuild_env_grant_admits_single_clone_path(tmp_checkpoint_dir, monkeypatch):
+    # DAIMON_TEAM_PROJECT is explicit machine intent; with a SINGLE clone it
+    # grants that logical path inbound too (mirror of _team_write_slugs).
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/x")
+    remote = _clone_remote()  # no toml at all
+    _write_clone_team_file(
+        remote, "grace", "S-g",
+        _cp("S-g", beliefs=[{"text": "Flamingo pipelines hold under load",
+                             "trust": "inferred"}]),
+        logical="core/x")
+    recall.rebuild()
+    assert len(recall.search("flamingo", all_projects=True)) == 1

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -1113,3 +1113,43 @@ def test_rich_stats_omits_verification_when_nothing_rejected(monkeypatch):
     render.render_stats(_stats_payload({"total": 0, "by_check": {}}))
     titles = [getattr(o, "title", None) for o in printed]
     assert "verification (this project)" not in titles
+
+
+# ---- #423: foreign-verbatim label in the Teammates section, both paths ----
+
+
+def _marked_teammates():
+    """One teammate whose active topic AND decision both carry the inbound
+    gate's foreign_verbatim_claim marker (trust already clamped)."""
+    return [("grace", {
+        "active_topic": {"text": "Hardening the ingest gate",
+                         "trust": "inferred", "foreign_verbatim_claim": True},
+        "decisions": [
+            {"text": "Ship the ingest gate tomorrow", "trust": "inferred",
+             "foreign_verbatim_claim": True},
+            {"text": "Keep the pelican path", "trust": "inferred"},
+        ],
+        "decisions_overflow": 0,
+    })]
+
+
+def test_plain_teammates_labels_foreign_verbatim_claim(monkeypatch, capsys):
+    monkeypatch.setenv("DAIMON_PLAIN", "1")
+    render.render_teammates(_marked_teammates())
+    out = capsys.readouterr().out
+    topic_line = next(ln for ln in out.splitlines() if "Active topic" in ln)
+    assert "unverifiable here" in topic_line  # label rides the topic line too
+    dec_line = next(ln for ln in out.splitlines() if "Ship the ingest" in ln)
+    assert "unverifiable here" in dec_line
+    unmarked = next(ln for ln in out.splitlines() if "pelican" in ln)
+    assert "unverifiable here" not in unmarked  # never claimed — no label
+
+
+def test_rich_teammates_labels_foreign_verbatim_claim(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_teammates(_marked_teammates())
+    out = capsys.readouterr().out
+    assert "Teammate" in out and "grace" in out
+    # Both the marked topic and the marked decision carry the label; the
+    # unmarked decision does not (2 labels exactly).
+    assert out.count("unverifiable here") == 2

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -3,7 +3,7 @@ import re
 import time as _time
 from pathlib import Path
 
-from daimon_briefing import config, serializer, store
+from daimon_briefing import config, normalize, serializer, store
 
 _ISO_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 
@@ -870,6 +870,138 @@ def test_read_team_nested_retention_applies(tmp_checkpoint_dir, sample_checkpoin
     assert [a for a, _ in team] == ["grace"]  # ada aged out of the READ window
     # NO physical deletes — the nested era is append-only too.
     assert (_nested_author_dir("core/api", "ada") / "a-old.json").exists()
+
+
+# ---- #423: inbound gate — scope, redaction, forget, and trust apply on READ ----
+# Foreign content (a synced remote's files) passes policy.admit_foreign before
+# it reaches read_team output; the machine-local mirror ("local") is this
+# machine's own writes and stays ungated.
+
+
+def _clone_remote(name="team-a", toml_text=None):
+    """A dir the store treats as a real synced remote (.git present)."""
+    d = config.team_dir() / name
+    (d / ".git").mkdir(parents=True, exist_ok=True)
+    if toml_text is not None:
+        (d / "daimon-team.toml").write_text(toml_text, encoding="utf-8")
+    return d
+
+
+def _foreign_file(remote, author, sid, cp, logical=None, project_dir=None):
+    """Lay down a teammate's checkpoint inside a remote, either era."""
+    blob = {**cp, "author": cp.get("author") or author}
+    if logical:
+        d = remote.joinpath("projects", *logical.split("/"), "authors", author)
+        blob["team_project"] = logical
+    else:
+        d = remote / "authors" / author
+    if project_dir is not None:
+        blob["project_slug"] = store.project_slug(project_dir)
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{sid}.json").write_text(json.dumps(blob), encoding="utf-8")
+
+
+def test_read_team_drops_out_of_scope_remote(tmp_checkpoint_dir, sample_checkpoint):
+    # The clone grants membership to org/alpha only; /repo/x has no origin and
+    # no env grant — default CLOSED, exactly like the write path (#279).
+    remote = _clone_remote(
+        toml_text='[scope]\nrepos = ["https://github.com/org/alpha"]\n')
+    _foreign_file(remote, "grace", "S-g", _stamped(sample_checkpoint, "S-g", 1),
+                  project_dir="/repo/x")
+    assert store.read_team(project_dir="/repo/x") == []
+
+
+def test_read_team_local_mirror_needs_no_grant(tmp_checkpoint_dir, sample_checkpoint):
+    # Control for the scope gate: the machine-local mirror is this machine's
+    # own withheld writes — always readable, no membership required, ungated
+    # (verbatim stays verbatim; no foreign marker).
+    d = _team_author_dir("grace")
+    d.mkdir(parents=True, exist_ok=True)
+    blob = {**_stamped(sample_checkpoint, "S-g", 1), "author": "grace",
+            "project_slug": store.project_slug("/repo/x")}
+    (d / "S-g.json").write_text(json.dumps(blob), encoding="utf-8")
+    team = store.read_team(project_dir="/repo/x")
+    assert [a for a, _ in team] == ["grace"]
+    first = team[0][1]["working_context"]["recent_decisions"][0]
+    assert first["trust"] == "verbatim"
+    assert "foreign_verbatim_claim" not in first
+
+
+def test_read_team_multi_remote_env_grant_ignored(tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
+    # Two clones: the machine-global env grant cannot say WHICH remote it
+    # means — same #387 rule the outbound router applies (honor_env=False).
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/x")
+    a = _clone_remote("team-a")
+    _clone_remote("team-b")
+    _foreign_file(a, "grace", "S-g", _stamped(sample_checkpoint, "S-g", 1),
+                  logical="core/x")
+    assert store.read_team(project_dir="/repo/x") == []
+
+
+def test_read_team_in_scope_foreign_arrives_redacted(tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
+    # Single clone honors the env grant (mirror of _team_write_slugs). The
+    # teammate's older daimon missed a secret shape; the local read side
+    # re-scrubs before the text reaches any surface.
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/x")
+    remote = _clone_remote()
+    cp = _stamped(sample_checkpoint, "S-g", 1)
+    cp = json.loads(json.dumps(cp))  # deep copy before nested mutation
+    cp["working_context"]["recent_decisions"].append(
+        {"text": "rotate the key AKIAABCDEFGHIJKLMNOP soon", "trust": "inferred"})
+    _foreign_file(remote, "grace", "S-g", cp, logical="core/x")
+    team = store.read_team(project_dir="/repo/x")
+    assert [a for a, _ in team] == ["grace"]
+    texts = [i["text"] for i in team[0][1]["working_context"]["recent_decisions"]]
+    assert all("AKIA" not in t for t in texts)
+    assert any("[redacted:" in t for t in texts)
+
+
+def test_read_team_foreign_cannot_reassert_forgotten_value(tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/x")
+    forgotten_text = "Adopt the D-007 prompt for the serializer"
+    store.append_event(
+        "d-dead01", f"forgotten:{normalize.content_key(forgotten_text)}",
+        kind="tombstone", project_dir="/repo/x")
+    remote = _clone_remote()
+    _foreign_file(remote, "grace", "S-g", _stamped(sample_checkpoint, "S-g", 1),
+                  logical="core/x")
+    team = store.read_team(project_dir="/repo/x")
+    assert [a for a, _ in team] == ["grace"]
+    texts = [i["text"] for i in team[0][1]["working_context"]["recent_decisions"]]
+    assert forgotten_text not in texts
+    assert "Single-pass for Slice 1, chunking is Slice 2" in texts  # others kept
+
+
+def test_read_team_foreign_verbatim_clamped_with_marker(tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
+    # A foreign `verbatim` claim is locally unverifiable (receipts resolve
+    # against the LOCAL checkpoint dir) — indexed/returned as inferred, with a
+    # marker so render can label the claim.
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/x")
+    remote = _clone_remote()
+    _foreign_file(remote, "grace", "S-g", _stamped(sample_checkpoint, "S-g", 1),
+                  logical="core/x")
+    team = store.read_team(project_dir="/repo/x")
+    first = team[0][1]["working_context"]["recent_decisions"][0]
+    assert first["trust"] == "inferred"
+    assert first["foreign_verbatim_claim"] is True
+    inferred = team[0][1]["working_context"]["recent_decisions"][1]
+    assert "foreign_verbatim_claim" not in inferred  # never claimed — unmarked
+
+
+def test_read_team_own_synced_copy_not_clamped(tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
+    # Your OWN dual-written copy synced back through a clone is not foreign —
+    # its verbatim claims ARE locally verifiable, so the clamp must not touch
+    # it (control for #423 trust handling).
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/x")
+    remote = _clone_remote()
+    _foreign_file(remote, "ada", "S-a", _stamped(sample_checkpoint, "S-a", 1),
+                  logical="core/x")
+    team = store.read_team(project_dir="/repo/x")
+    assert [a for a, _ in team] == ["ada"]
+    first = team[0][1]["working_context"]["recent_decisions"][0]
+    assert first["trust"] == "verbatim"
+    assert "foreign_verbatim_claim" not in first
 
 
 # ---- latest-pointer regression guard: heal of an old session must not steal

--- a/plugin/tests/test_teamproject.py
+++ b/plugin/tests/test_teamproject.py
@@ -733,3 +733,38 @@ def test_dual_write_single_remote_env_grant_still_honored(
     _remote_clone("team-a")
     store._dual_write_team("S1", sample_checkpoint, str(repo))
     assert list((config.team_dir() / "team-a").rglob("S1.json"))
+
+
+# ---- #423: granted_paths — the inbound scope mirror for project-less readers ----
+
+
+def test_granted_paths_covers_mapped_and_derived_and_scope():
+    sidecar = _remote_clone()
+    _write_config(
+        '[scope]\nrepos = ["git@github.com:Org/Zeta.git"]\n'
+        '[projects."core/beta"]\nrepos = ["https://github.com/org/beta"]\n',
+        remote="team-mem")
+    granted = teamproject.granted_paths(sidecar)
+    assert ("core", "beta") in granted        # the mapped path
+    assert ("org", "beta") in granted         # its tier-3 derived path
+    assert ("org", "zeta") in granted         # scope repo's derived path
+
+
+def test_granted_paths_default_closed_without_config():
+    assert teamproject.granted_paths(_remote_clone()) == set()
+
+
+def test_granted_paths_env_honored_only_when_asked(monkeypatch):
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/gamma")
+    sidecar = _remote_clone()  # no toml at all
+    assert ("core", "gamma") in teamproject.granted_paths(sidecar)
+    assert teamproject.granted_paths(sidecar, honor_env=False) == set()
+
+
+def test_granted_paths_resolver_bug_denies(monkeypatch):
+    # Fail CLOSED, mirror of in_scope: a membership bug must deny, never admit.
+    def _boom(_path):
+        raise RuntimeError("resolver bug")
+
+    monkeypatch.setattr(teamproject, "_parse_config", _boom)
+    assert teamproject.granted_paths(_remote_clone()) == set()


### PR DESCRIPTION
Closes #423

## What

An inbound gate at read/index time: `policy.admit_foreign` — the pure twin of `admit_checkpoint` — runs wherever a teammate's synced checkpoint enters local surfaces, wired into both `store.read_team` and `recall._scan_sources`. In-memory only: sidecar files and the git layer are never rewritten.

Pipeline (order mirrors the write side where it overlaps):

1. **Scope** — content from a synced remote must pass membership before it reaches `brief --team` or the recall index (default closed, the #279 semantics mirrored inbound). `read_team` asks `teamproject.in_scope(project_dir, remote)` directly; the env grant is honored only with a single clone, exactly like `_team_write_slugs`.
2. **Redaction** — the injected local `redact_text` re-scrubs incoming text/quote/scene (+ active topic), so a teammate on an older daimon with fewer secret patterns can't seed a durable cleartext copy here.
3. **Forget** — items whose canonicalized text hashes into the local forget tombstones are dropped; a teammate's checkpoint can't re-assert a locally forgotten value.
4. **Trust clamp** — foreign `verbatim` → stored/indexed as `inferred` plus a `foreign_verbatim_claim` marker; the Teammates section (plain + rich) renders it with a visible label stating both facts: `[teammate claims verbatim — unverifiable here]`. Own checkpoints and own synced-back copies are untouched (their receipts ARE locally resolvable).

The machine-local mirror (`local/`) stays ungated — it holds only this machine's own already-admitted writes.

## Why

Every policy was outbound-only (#423): `teamproject.in_scope` had zero inbound callers, `read_team` and the recall scan ingested every remote and author dir unfiltered, foreign text was never re-redacted, forget tombstones didn't suppress foreign re-assertion, and a foreign `verbatim` claim rendered with the full verbatim mark although receipt verification resolves local-only — the manufactured-corroboration failure mode the verifiable-memory positioning argues against. Redact-pattern skew and never-granted-remote read-in bite cooperating teammates, not just attackers.

## Design decisions taken under the "conservative / fail closed" rule

The ratified decisions didn't pin down two points; both resolved toward drop-rather-than-admit:

- **Recall scope has no local project dir in hand** (the index is machine-global), so `in_scope(project_dir, remote)` cannot be evaluated there. The inbound mirror used instead: `teamproject.granted_paths(remote)` — the logical paths the sidecar's own toml vouches for (`[projects.*]` paths, each granted repo's tier-3 derived path, and the env grant in single-clone setups). A foreign checkpoint indexes only when its stamped `team_project` path is granted. **Flat-era foreign blobs carry no toml-checkable identity and fail closed** for the index; `brief --team` still serves them when the local project passes `in_scope`, so legacy flat sidecars degrade only on the recall surface.
- **Own synced-back copies are exempt from the gate** (matched by author slug, same self-identification `_team_briefings` uses). Without this, the recall scan's team-dir-first dedupe would clamp your own verbatim history to `inferred` whenever your own dual-written copy is scanned before the local file. Cooperating-team threat model, consistent with `docs/team.md`'s stated scope.
- The recall forget gate uses the **union of every local project's tombstones** (`store.all_forgotten_content_keys`) — a foreign checkpoint can't name the local project its content maps to, and over-suppression is `drop_forgotten`'s documented fail-safe direction.

## Tests

Strict TDD — all of these failed before the change (confirmed red for the right reasons: gate absent, foreign content admitted raw):

- `test_admit_foreign_out_of_scope_returns_none`, `_redacts_with_injected_fn`, `_drops_locally_forgotten_value`, `_forget_gate_sees_redacted_text`, `_clamps_verbatim_and_marks_claim`, `_tolerates_malformed_checkpoints` (policy unit; purity AST guard still green)
- `test_read_team_drops_out_of_scope_remote`, `_multi_remote_env_grant_ignored`, `_in_scope_foreign_arrives_redacted`, `_foreign_cannot_reassert_forgotten_value`, `_foreign_verbatim_clamped_with_marker` + controls `_local_mirror_needs_no_grant`, `_own_synced_copy_not_clamped` (store)
- `test_rebuild_skips_out_of_scope_remote_content`, `_admits_granted_path_and_redacts`, `_drops_locally_forgotten_value_from_foreign`, `_clamps_foreign_verbatim_to_inferred` (own row stays `verbatim` as control), `_env_grant_admits_single_clone_path` (recall)
- `test_cli_brief_team_labels_foreign_verbatim_claim` — teammate line renders `~ inferred` + the unverifiable-here label; own `✓ verbatim` rendering unchanged in the same brief (cli e2e, plain path)
- `test_plain_teammates_labels_foreign_verbatim_claim` / `test_rich_teammates_labels_foreign_verbatim_claim` — the label on marked topic + decision, absent on unmarked items, in BOTH render paths (render)
- `test_granted_paths_covers_mapped_and_derived_and_scope`, `_default_closed_without_config`, `_env_honored_only_when_asked`, `_resolver_bug_denies` (teamproject)

Full suite: `uv sync --all-extras && uv run pytest` from `plugin/` — **2209 passed, 2 skipped**. `ruff check` clean; mypy adds no new errors over the pre-existing baseline.

Docs: `docs/team.md` — scope section now states the allowlist gates reads too; new "The inbound gate" subsection; corrected the `DAIMON_TEAM` env-table line ("gates writes only; reads are always on" was wrong).
