### PR TITLE
chore(scars): promote five reviewed candidates to active scars 0026-0030

### DIFF
--- a/.scars/0026-bare-uv-sync-strips-extras-suite-fails-misleadingly.landmine.md
+++ b/.scars/0026-bare-uv-sync-strips-extras-suite-fails-misleadingly.landmine.md
@@ -1,0 +1,29 @@
+---
+id: 26
+type: landmine
+title: Bare `uv sync` in plugin/ strips dev+pretty extras — suite then fails looking like code regressions
+severity: medium
+confidence: 0.9
+created: 2026-07-29
+authors: ["claude-code", "Kibukx"]
+anchors:
+  - path: plugin/pyproject.toml
+evidence:
+  - note: 2026-07-29 session: after `uv sync -q`, pytest binary vanished; after `uv sync --extra dev`, 31 test_render failures (rich missing) read as regressions on an untouched module; `uv sync --extra dev --extra pretty` restored 2037 passed
+  - pr: 424
+  - pr: 425
+  - note: 2026-07-30: recurred TWICE independently — the #418 and #419 fix agents each hit the identical 31-failure test_render shape in fresh git worktrees (`uv sync --extra dev` alone); both recovered only via `uv sync --all-extras`. Two later agents avoided it solely because their prompts pre-warned them. Three independent hits in two days.
+expires:
+  condition: "dev/pretty move from [project.optional-dependencies] to default dependency-groups, or a sync wrapper/Makefile target becomes the documented path"
+  review_after: 2026-10-29
+status: active
+---
+
+Ran `uv sync` in plugin/ to refresh the env after a version bump. It removes
+everything not in default dependencies: pytest disappears, and rich/rich-argparse
+go with it. The trap is the failure shape, not the failure: with only `--extra
+dev` restored, 31 test_render/test_version failures look exactly like code
+regressions in modules nobody touched, inviting a debugging spiral on healthy
+code. Both extras are required for a green suite: `uv sync --extra dev --extra
+pretty`. If the suite suddenly fails wide on render/version tests right after
+an env operation, fix the env first, read the diffs second.

--- a/.scars/0027-write-checkpoint-mutates-its-argument-in-place.landmine.md
+++ b/.scars/0027-write-checkpoint-mutates-its-argument-in-place.landmine.md
@@ -1,28 +1,32 @@
 ---
-id: 0
+id: 27
 type: landmine
 title: store.write_checkpoint mutates its checkpoint argument in place — reading the serialize() output after writing yields the gated/redacted/id-stamped version, not the extraction
 severity: medium
 confidence: 0.9
 created: 2026-07-29
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/store.py
+  - path: plugin/daimon_briefing/policy.py
 evidence:
   - issue: 407
-  - note: "2026-07-29 while writing the deletion-durability protocol test: asserted `_S in serialize()_output[...]` AFTER store.write_checkpoint(sid, cp) and got a red — _drop_forgotten had already removed _S from the same dict object the test held."
+  - note: 2026-07-29 while writing the deletion-durability protocol test: asserted `_S in serialize()_output[...]` AFTER store.write_checkpoint(sid, cp) and got a red — _drop_forgotten had already removed _S from the same dict object the test held.
+  - pr: 428
+  - note: 2026-07-30, PR #428: the admission pipeline moved into policy.admit_checkpoint, which deliberately KEPT the in-place mutation contract (callers rely on reading the gated dict back); the trap now spans both modules.
 expires:
   condition: "write_checkpoint deep-copies its argument before mutating (redaction/_drop_forgotten/_stamp_item_ids operate on a copy), or its docstring documents the in-place contract"
   review_after: 2026-12-31
-status: candidate
+status: active
 ---
 
 `store.write_checkpoint(session_id, checkpoint, ...)` does NOT treat
-`checkpoint` as read-only. It mutates the SAME dict object in place, in this
-order: `_redact_checkpoint`, `_drop_forgotten` (the #402 value-keyed forget
-gate — removes items), `_stamp_item_ids`, plus several `setdefault`s
-(`format_version`, `created`, `author`, `project_slug`, `git_branch`,
-`first_seen`, `receipts`).
+`checkpoint` as read-only. It mutates the SAME dict object in place — since
+PR #428 via `policy.admit_checkpoint` (redact → `drop_forgotten`, the #402
+value-keyed forget gate that removes items → id stamping), plus store-side
+`setdefault`s (`format_version`, `created`, `author`, `project_slug`,
+`git_branch`, `first_seen`, `receipts`). `policy.py` keeps the in-place
+contract deliberately — callers read the gated dict back after the write.
 
 The trap for test (and caller) authors: `serializer.serialize(...)` returns a
 checkpoint dict; if you then call `write_checkpoint(sid, cp)` and later read

--- a/.scars/0028-trust-ceiling-only-bites-fresh-high-importance.landmine.md
+++ b/.scars/0028-trust-ceiling-only-bites-fresh-high-importance.landmine.md
@@ -1,20 +1,21 @@
 ---
-id: 0
+id: 28
 type: landmine
 title: The #408 trust ceiling only clips FRESH, high-importance items — stale ceiling tests tie misleadingly
 severity: medium
 confidence: 0.9
 created: 2026-07-29
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/scoring.py
   - pattern: "trust_ceiling|TRUST_CEILING"
 evidence:
   - pr: 408
-  - note: "recall ceiling test tied verbatim vs inferred at 39d overdue (raw ~0.30 < 0.7 lid) until now was aligned to first_seen so raw ~1.0 clipped the inferred item"
+  - note: recall ceiling test tied verbatim vs inferred at 39d overdue (raw ~0.30 < 0.7 lid) until now was aligned to first_seen so raw ~1.0 clipped the inferred item
 expires:
   condition: "TYPE_RULES reshaped so overdue-escalated inferred items can exceed the inferred ceiling, or the ceiling becomes a multiplicative discount instead of a min() clamp"
   review_after: 2026-12-01
+status: active
 ---
 
 effective_weight applies the trust ceiling as `min(weight, ceiling)`. The lid

--- a/.scars/0029-local-coverage-lies-across-crypto-libs.landmine.md
+++ b/.scars/0029-local-coverage-lies-across-crypto-libs.landmine.md
@@ -1,21 +1,21 @@
 ---
-id: 0
+id: 29
 type: landmine
 title: Local patch-coverage green does NOT mean codecov green when a branch depends on LibreSSL-vs-OpenSSL behavior
 severity: medium
 confidence: 0.9
 created: 2026-07-10
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/receipts.py
 evidence:
   - pr: 205
   - pr: 207
-  - note: "three catch-up commits across two PRs: 71feff7/efa57aa (#205), post-review sweep (#207) — each time local intersect said 0 missing, codecov said otherwise"
+  - note: three catch-up commits across two PRs: 71feff7/efa57aa (#205), post-review sweep (#207) — each time local intersect said 0 missing, codecov said otherwise
 expires:
   condition: "openssl subprocess path removed from receipts.py (vitni keygen becomes the only derivation), or CI adds a macOS/LibreSSL coverage job"
   review_after: 2026-10-01
-status: candidate
+status: active
 ---
 
 receipts.py's key derivation branches on what the host crypto CLI can do:

--- a/.scars/0030-echochat-marker-is-contaminated-by-serializer-prompt.landmine.md
+++ b/.scars/0030-echochat-marker-is-contaminated-by-serializer-prompt.landmine.md
@@ -1,20 +1,21 @@
 ---
-id: 0
+id: 30
 type: landmine
 title: The bench EchoChat fake echoes bare "marker", not the per-session token — its topic text does NOT discriminate sessions by content
 severity: medium
 confidence: 0.85
 created: 2026-07-29
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/tests/test_bench_adapter.py
   - pattern: "endswith.*marker"
 evidence:
   - commit: 5e0f6b2
-  - note: "#405 forbidden-hit cases: assumed the gold checkpoint's topic would contain the per-session marker token (e.g. thinkpadmarker); it contained the bare word 'marker' instead, so a forbidden string keyed on the token matched nothing"
+  - note: #405 forbidden-hit cases: assumed the gold checkpoint's topic would contain the per-session marker token (e.g. thinkpadmarker); it contained the bare word 'marker' instead, so a forbidden string keyed on the token matched nothing
 expires:
   condition: "EchoChat is changed to emit a token that cannot collide with the serializer prompt (e.g. a UUID-shaped marker), or serialize_strict stops prepending prompt text to the transcript blob the fake inspects"
   review_after: 2026-12-01
+status: active
 ---
 
 EchoChat (test_bench_adapter.py) picks its marker with

--- a/.scars/candidates/prompt-version-bump-does-not-rotate-chunk-cache.md
+++ b/.scars/candidates/prompt-version-bump-does-not-rotate-chunk-cache.md
@@ -15,6 +15,7 @@ evidence:
 expires:
   condition: "the outdated 'rotates the #48 chunk-cache key' phrasing is removed from every pre-#367 comment block above PROMPT_VERSION, or the cache key is re-keyed on PROMPT_VERSION"
   review_after: 2026-12-01
+status: candidate
 ---
 
 When you add an extraction-behavior change (a new numbered rule that changes


### PR DESCRIPTION
Closes #433

## What

Promotes five reviewed scar candidates to active scars 0026–0030 (all landmines) and completes the frontmatter of the one candidate deliberately held back.

- `0026` bare `uv sync` strips dev+pretty extras — suite fails looking like code regressions
- `0027` `write_checkpoint` mutates its argument in place — refreshed post-#428, anchors both `store.py` and `policy.py`
- `0028` trust ceiling only bites fresh high-importance items — stale ceiling tests tie misleadingly
- `0029` local patch-coverage green ≠ codecov green on LibreSSL/OpenSSL-conditional branches
- `0030` bench EchoChat fake echoes bare "marker" — its output is not session-distinct

`prompt-version-bump-does-not-rotate-chunk-cache` stays in candidates: its root cause is a stale comment in `serializer.py` that should be deleted instead of scarred around.

## Why

Maintainer review of the accumulated candidate set. Recurrence evidence updated where it changed: 0026 recurred twice more on 2026-07-30 during the #418/#419 fix work; 0027's mutation pipeline moved into `policy.admit_checkpoint` in #428 and the scar now covers both modules.

## Tests

`scar lint`: 31 files, 0 errors, 0 orphans, 0 partial-rot, 0 unreachable evidence. Content-only change under `.scars/` — no runtime code touched; scar lint CI job is the relevant gate.
