### PR TITLE
fix(recall): resolve forgotten tombstones by content key so sibling-id copies in historical sessions cannot survive rebuild

### DIFF
--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -45,7 +45,8 @@ import unicodedata
 from datetime import datetime, timezone
 from pathlib import Path
 
-from . import config, policy, redact, schema, scoring, store, teamproject
+from . import (config, normalize, policy, redact, schema, scoring, store,
+               teamproject)
 
 log = logging.getLogger("daimon.recall")
 
@@ -434,6 +435,7 @@ def _apply_event_resolutions(conn: sqlite3.Connection) -> None:
         # The bucket dir NAME is the slug, and slug munging is idempotent
         # (guarded by test_project_slug_is_idempotent_on_slugs), so it routes
         # store.resolutions exactly like a project dir.
+        forgotten_ids: set[str] = set()
         for ref, evt in store.resolutions(project_dir=bucket.name).items():
             if not store.is_resolved(evt):
                 continue
@@ -443,20 +445,7 @@ def _apply_event_resolutions(conn: sqlite3.Connection) -> None:
             # Prefix-match like every other status reader; only the LATEST
             # event counts (a later reopen un-hides history by design).
             if status.lower().startswith("forgotten"):
-                rows = conn.execute(
-                    "SELECT id, text, quote, scene FROM items"
-                    " WHERE item_id = ? AND project_slug IS ?",
-                    (ref, bucket.name)).fetchall()
-                for rowid, text, quote, scene in rows:
-                    # contentless fts5: deletion is the special 'delete'
-                    # INSERT and must repeat the original column values
-                    conn.execute(
-                        "INSERT INTO items_fts(items_fts, rowid, text, quote, scene)"
-                        " VALUES('delete', ?, ?, ?, ?)",
-                        (rowid, text, quote, scene))
-                conn.execute(
-                    "DELETE FROM items WHERE item_id = ? AND project_slug IS ?",
-                    (ref, bucket.name))
+                forgotten_ids.add(ref)
                 continue
             value = "resolved"
             if status.lower().startswith("superseded-by:"):
@@ -466,6 +455,36 @@ def _apply_event_resolutions(conn: sqlite3.Connection) -> None:
                 " WHERE item_id = ? AND project_slug IS ?",
                 (value, ref, bucket.name),
             )
+        if not forgotten_ids:
+            continue
+        # #427: the scrub is VALUE-keyed, not only id-keyed. One value can
+        # live under sibling ids (same sentence in two sections, widened hash
+        # within one — store._stamp_item_ids), and forget rewrites only the
+        # LATEST session file: an older per-session checkpoint still holds the
+        # value under an id the ledger never tombstoned, and rebuild indexes
+        # it. The tombstone status embeds the canonical content key
+        # (`forgotten:<content_key>`, same ledger the write gate reads), so
+        # any row whose text canonicalizes into the forgotten set goes too.
+        # The id-keyed delete stays: it covers rows whose stored text was
+        # redacted into a different key at capture. Canonicalization runs only
+        # when a tombstone exists for the bucket (rows are scanned here, not
+        # per-event, so the common no-forget rebuild pays nothing).
+        forgotten_keys = store.forgotten_content_keys(project_dir=bucket.name)
+        rows = conn.execute(
+            "SELECT id, text, quote, scene, item_id FROM items"
+            " WHERE project_slug IS ?", (bucket.name,)).fetchall()
+        for rowid, text, quote, scene, item_id in rows:
+            if item_id not in forgotten_ids and not (
+                    forgotten_keys
+                    and normalize.content_key(text or "") in forgotten_keys):
+                continue
+            # contentless fts5: deletion is the special 'delete'
+            # INSERT and must repeat the original column values
+            conn.execute(
+                "INSERT INTO items_fts(items_fts, rowid, text, quote, scene)"
+                " VALUES('delete', ?, ?, ?, ?)",
+                (rowid, text, quote, scene))
+            conn.execute("DELETE FROM items WHERE id = ?", (rowid,))
 
 
 def rebuild() -> int:

--- a/plugin/tests/test_carry_forget_adversarial.py
+++ b/plugin/tests/test_carry_forget_adversarial.py
@@ -181,23 +181,6 @@ def _brief_decisions(cp):
     return [d["text"] for d in (b["decisions"] if b else [])]
 
 
-def _drop_prev_remnants():
-    """Unlink the on-disk remnants of the armed prev (its flat session file and
-    the rotated prev-N pointers) before the recall rebuild. They still contain
-    S BY CONSTRUCTION — the tombstone here never rewrote any file — and
-    recall's forgotten-scrub is id-keyed (it deletes rows by the event ref),
-    so rows indexed from those historical files would surface S regardless of
-    the write gate. #420 pins the WRITE boundary: the question for recall is
-    whether the NEW write fed S to the index. Runs strictly AFTER the raw-disk
-    assertions on the new checkpoint, so a gate failure is caught before any
-    evidence is removed (latest.json and the new session file are never
-    touched)."""
-    keep = {"latest.json", f"{_NEW_SID}.json"}
-    for p in config.checkpoint_dir().rglob("*.json"):
-        if p.name not in keep and _S in p.read_text(encoding="utf-8"):
-            p.unlink()
-
-
 def _recall_texts():
     recall.rebuild()
     return [h["text"] for h in recall.search(_HOT, project_dir=_P)]
@@ -254,9 +237,13 @@ def test_ungated_prev_cannot_resurrect_forgotten_value_through_carry(
     assert _S not in bd
     assert _T in bd and _PROBE in bd
 
-    # 3) Recall after a full index rebuild (prev remnants removed first — see
-    # _drop_prev_remnants; the raw-disk assertions above already ran).
-    _drop_prev_remnants()
+    # 3) Recall after a full index rebuild. The armed prev's remnants (flat
+    # session file, rotated prev-N pointers) still contain S on disk BY
+    # CONSTRUCTION — the tombstone here never rewrote any file. Pre-#427 the
+    # index's forgotten-scrub was id-keyed and this test had to unlink those
+    # remnants to isolate the write boundary; post-#427 the scrub is
+    # value-keyed, so the assertion holds against the FULL on-disk history:
+    # neither the new write nor any historical sibling-id row may surface S.
     texts = _recall_texts()
     assert _S not in texts
     assert _T in texts

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -1640,6 +1640,51 @@ def test_rebuild_clamps_foreign_verbatim_to_inferred(tmp_checkpoint_dir, monkeyp
     assert own[0]["trust"] == "verbatim"  # own claim untouched
 
 
+def test_rebuild_scrubs_forgotten_value_sibling_id_in_older_session(
+        tmp_checkpoint_dir, monkeypatch):
+    # #427: the forgotten scrub must be VALUE-keyed, not only id-keyed. The
+    # same sentence in two sections mints two item ids (store._stamp_item_ids
+    # hashes f"{key}:{text}"), and forget rewrites only the LATEST session
+    # file — an older per-session checkpoint holding the value under a sibling
+    # id is never rewritten, and rebuild indexes it. Pre-fix that sibling row
+    # survived the id-keyed delete and resurfaced the forgotten value.
+    from daimon_briefing import cli
+
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/repo/x")
+    s = "Adopt sqlite for the recall index cache"
+    t = "Adopt postgres for the analytics warehouse"
+    store.write_checkpoint(
+        "S1",
+        _cp("S1", decisions=[{"text": s, "trust": "inferred"},
+                             {"text": t, "trust": "inferred"}],
+            created="2026-07-30T00:00:00Z"),
+        project_dir="/repo/x")
+    store.write_checkpoint(
+        "S2",
+        _cp("S2", questions=[{"text": s, "trust": "inferred"}],
+            created="2026-07-31T00:00:00Z"),
+        project_dir="/repo/x")
+    latest = store.read_latest(project_dir="/repo/x", fallback=False)
+    q_id = next(i["id"] for i in latest["working_context"]["open_questions"]
+                if i["text"] == s)
+    old_file = config.checkpoint_dir() / "S1.json"
+    old = json.loads(old_file.read_text(encoding="utf-8"))
+    d_id = next(i["id"] for i in old["working_context"]["recent_decisions"]
+                if i["text"] == s)
+    assert d_id != q_id  # sibling ids: one value, two sections
+
+    assert cli.main(["forget", q_id]) == 0  # the real path, latest session
+    # forget rewrote only the latest session; the older checkpoint still holds
+    # the value verbatim under the sibling id — exactly what rebuild re-indexes.
+    assert s in old_file.read_text(encoding="utf-8")
+
+    recall.rebuild()
+    texts = [h["text"] for h in recall.search("adopt", all_projects=True)]
+    assert s not in texts  # forgotten value gone under EVERY id, any session
+    assert t in texts      # liveness control: the never-forgotten twin stays
+
+
 def test_rebuild_env_grant_admits_single_clone_path(tmp_checkpoint_dir, monkeypatch):
     # DAIMON_TEAM_PROJECT is explicit machine intent; with a SINGLE clone it
     # grants that logical path inbound too (mirror of _team_write_slugs).


### PR DESCRIPTION
Closes #427

## What

Makes the recall index's rebuild-time forgotten scrub **value-keyed** in addition to id-keyed. `_apply_event_resolutions` now collects each bucket's `forgotten:` tombstone refs, derives the bucket's forgotten content-key set via `store.forgotten_content_keys` (the same ledger the write gate reads), and deletes every row whose stored text canonicalizes (`normalize.content_key`) into that set — alongside the existing id-keyed delete, which stays because it covers rows whose stored text was redacted into a different key at capture. The contentless-FTS5 `'delete'` insert is preserved for every removed row exactly as before, and canonicalization only runs for buckets that actually hold a tombstone (a no-forget rebuild pays nothing).

Also removes `test_carry_forget_adversarial._drop_prev_remnants`: that helper existed solely to isolate around this bug (its own comment said so). Post-fix the test passes against the full on-disk history, so the recall assertion now holds the stronger reality — neither the new write nor any historical sibling-id row may surface the forgotten value.

## Why

One value can live under multiple item ids — the same sentence in two sections mints two ids, and same-section duplicates get a widened hash (`store._stamp_item_ids`). `forget` rewrites only the **latest** session file; older per-session checkpoints are never rewritten, and rebuild indexes them all. The scrub deleted rows `WHERE item_id = <event ref>`, so a sibling-id copy of a forgotten value in an older session file survived and resurfaced in `daimon recall`. This is the read/index-side twin of #418 (write-side sibling-id survival, fixed in #424): the write boundary was value-keyed, the index scrub was not.

## Tests

- New: `test_rebuild_scrubs_forgotten_value_sibling_id_in_older_session` (tests/test_recall.py) — two sessions hold the same sentence under different section ids; forget runs via the real CLI path in the latest session; after rebuild the value yields zero hits under every id while the never-forgotten twin still hits. Confirmed RED before the fix for exactly the issue's reason: the older session's sibling-id row surfaced the value.
- Tightened: `test_ungated_prev_cannot_resurrect_forgotten_value_through_carry` no longer unlinks prev remnants before the rebuild — the recall assertion now runs against the untouched on-disk history.
- Full suite from plugin/: **2214 passed, 2 skipped**.
