### PR TITLE
test(policy): write-side architecture guard — every command's writes must carry an admit frame, with a bypass ratchet

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -2545,8 +2545,11 @@ def _crash_stamp_excepthook(exc_type, exc, tb) -> None:
     sys.__excepthook__(exc_type, exc, tb)
 
 
-def main(argv=None) -> int:
-    sys.excepthook = _crash_stamp_excepthook  # #92: stamp uncaught crashes
+def build_parser() -> argparse.ArgumentParser:
+    """The full daimon parser tree, extracted from main (#431) so tests can
+    walk the subparser registry mechanically — the write-audit architecture
+    guard enumerates every command argparse knows about, so a NEW subcommand
+    is enumerated (and audited) automatically the moment it is registered."""
     # #68: one formatter selection for the WHOLE parser tree. argparse does not
     # propagate formatter_class from parent to subparser, so every add_parser
     # call below must receive it — done here by patching add_parser on each
@@ -2955,6 +2958,12 @@ def main(argv=None) -> int:
         help="serve MCP over stdio until EOF — reads only, never writes; "
              "register in your host's MCP config (see the docs site)")
     pm_serve.set_defaults(func=_cmd_mcp_serve)
+    return parser
+
+
+def main(argv=None) -> int:
+    sys.excepthook = _crash_stamp_excepthook  # #92: stamp uncaught crashes
+    parser = build_parser()
 
     # Slugs are munged absolute paths, so they START with "-" ("/Users/x" ->
     # "-Users-x") — argparse reads `--slug -Users-x` as a missing argument and

--- a/plugin/daimon_briefing/policy.py
+++ b/plugin/daimon_briefing/policy.py
@@ -167,6 +167,27 @@ def admit_checkpoint(checkpoint: dict, forgotten_keys: set) -> list:
     return dropped
 
 
+def admit_row(row: dict, redact_fields: tuple = (), redact_fn=None) -> dict:
+    """#431: the ledger-row admission gate — the seam an append-only
+    belief-bearing row (events.jsonl, verification.jsonl) passes through
+    before store appends it. Scrubs the named free-text fields with the
+    injected redact function (default redact.redact_text — same #141
+    defence-in-depth the appenders applied inline before this seam
+    existed), IN PLACE, and returns the SAME dict: callers must write the
+    returned object, so the write-audit architecture guard
+    (tests/test_write_audit_guard.py) can correlate the row that landed on
+    disk with this admission. Pure by the module contract: no I/O, no
+    clock — `ts` is stamped by the caller."""
+    if redact_fn is None:
+        redact_fn = redact.redact_text
+    for field in redact_fields:
+        val = row.get(field)
+        if isinstance(val, str) and val:
+            scrubbed, _ = redact_fn(val)
+            row[field] = scrubbed
+    return row
+
+
 def clamp_foreign_trust(checkpoint: dict) -> None:
     """#423: a foreign `verbatim` claim is structurally unverifiable on this
     machine — receipt verification resolves against the LOCAL checkpoint dir —

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -958,11 +958,14 @@ def append_verification(item_ref: str, check: str, reason: str,
     if path is None:
         return False
     try:
-        check, _ = redact.redact_text(check)
-        reason, _ = redact.redact_text(reason)
+        # #431: the scrub runs through policy.admit_row — same redaction as
+        # before, but mounted on the policy seam so the write-audit guard can
+        # correlate the row on disk with its admission.
+        row = policy.admit_row(
+            {"ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+             "check": check, "item_ref": item_ref, "reason": reason},
+            redact_fields=("check", "reason"))
         path.parent.mkdir(parents=True, exist_ok=True)
-        row = {"ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-               "check": check, "item_ref": item_ref, "reason": reason}
         with path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(row, ensure_ascii=False) + "\n")
         return True
@@ -1092,19 +1095,22 @@ def append_event(item_ref: str, status: str, note: str = "",
     if path is None:
         return False
     try:
-        note, _ = redact.redact_text(note)
-        item_text, _ = redact.redact_text(item_text)
-        # status is free-form by design (readers prefix-match, never enum) —
-        # so it can carry a secret-shaped value and must be scrubbed too (#141).
-        status, _ = redact.redact_text(status)
+        # #431: the scrub runs through policy.admit_row — same redaction as
+        # before (status is free-form by design, readers prefix-match, so it
+        # can carry a secret-shaped value and is scrubbed too, #141), but
+        # mounted on the policy seam so the write-audit guard can correlate
+        # the row on disk with its admission.
+        evt = policy.admit_row(
+            {"ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+             "kind": kind, "item_ref": item_ref, "status": status,
+             "source": source, "note": note, "item_text": item_text},
+            redact_fields=("status", "note", "item_text"))
+        # Empty optional fields never land on the row — unchanged shape.
+        if not evt["note"]:
+            del evt["note"]
+        if not evt["item_text"]:
+            del evt["item_text"]
         path.parent.mkdir(parents=True, exist_ok=True)
-        evt = {"ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-               "kind": kind, "item_ref": item_ref, "status": status,
-               "source": source}
-        if note:
-            evt["note"] = note
-        if item_text:
-            evt["item_text"] = item_text
         with path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(evt, ensure_ascii=False) + "\n")
         return True

--- a/plugin/tests/test_policy.py
+++ b/plugin/tests/test_policy.py
@@ -300,3 +300,32 @@ def test_admit_foreign_tolerates_malformed_checkpoints():
         cp, member=True, forgotten_keys={normalize.content_key(_S)},
         redact_fn=redact.redact_text)
     assert out is cp
+
+
+# ---- #431: admit_row — the ledger-row admission seam ----
+
+
+def test_admit_row_scrubs_named_fields_in_place():
+    from daimon_briefing import policy
+
+    row = {"ts": "2026-07-29T00:00:00Z", "item_ref": "o-1",
+           "status": "resolved", "note": f"key is {_SECRET_RAW}"}
+    out = policy.admit_row(row, redact_fields=("status", "note"))
+    assert out is row  # same object back — the correlation contract
+    assert "AKIA" not in out["note"]
+    assert "[redacted:" in out["note"]
+    assert out["status"] == "resolved"          # clean field untouched
+    assert out["item_ref"] == "o-1"             # unnamed field never scrubbed
+
+
+def test_admit_row_uses_injected_redact_fn_and_skips_non_strings():
+    from daimon_briefing import policy
+
+    row = {"note": "hello", "item_text": None, "n": 3}
+    out = policy.admit_row(
+        row, redact_fields=("note", "item_text", "n", "absent"),
+        redact_fn=lambda s: ("SCRUBBED", {"x": 1}))
+    assert out["note"] == "SCRUBBED"   # injected fn used
+    assert out["item_text"] is None    # non-string passes through
+    assert out["n"] == 3               # non-string passes through
+    assert "absent" not in out         # named-but-missing field not created

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -1,0 +1,601 @@
+"""#431: the write-side architecture guard — no CLI command may write
+checkpoint/team bytes without passing through the policy seam.
+
+The read side has its structural guard (test_scoring.py: no scoring input can
+lift effective weight above the trust ceiling). This is the write-side twin:
+a runtime write-audit that drives EVERY command `cli.build_parser()` knows
+about and asserts each audited write is attributable to a `policy.admit_*`
+admission, with an explicit two-directional ratchet (KNOWN_BYPASSES) for the
+writes that are deliberately outside the seam.
+
+Mechanism
+---------
+The `write_audit` fixture patches `store._atomic_write` AND
+`pathlib.Path.open` (write/append/create modes), recording every write that
+lands under `config.checkpoint_dir()` or `config.team_dir()` (the conftest
+isolation makes those tmp-rooted, so the audit is total for Python-level file
+I/O). It also wraps `policy.admit_checkpoint` and `policy.admit_row` to
+register the exact objects they admitted. A recorded write is GOVERNED when:
+
+- a `daimon_briefing.policy.admit_*` frame is live on the stack, or
+- some `daimon_briefing.*` frame on the stack holds a local whose identity
+  was registered by an admit call — the correlation the issue prescribes,
+  because `write_checkpoint`'s pointer/mirror writes (and the ledger appends)
+  happen AFTER their admit call returned. `store.write_checkpoint` still
+  holds the admitted checkpoint dict, and `store.append_event` /
+  `store.append_verification` write the very dict `policy.admit_row`
+  returned, so the bytes on disk are the bytes that were admitted.
+
+Ratchet semantics (both directions)
+-----------------------------------
+`observed_bypasses == KNOWN_BYPASSES` exactly: an ungoverned write not in the
+set fails (a new ungoverned write path landed), AND a listed entry that is no
+longer observed fails (stale entry — the ratchet must shrink truthfully when
+a bypass is closed). Sensitivity is proven, not assumed: companion tests stub
+`policy.admit_checkpoint` / `policy.admit_row` out (the #426/#420 mutation-
+check precedent, test_carry_forget_adversarial.py) and show the guard trips.
+
+Documented limitations (honest absences, not covered by this audit)
+-------------------------------------------------------------------
+- recall's sqlite index (DAIMON_RECALL_DB): sqlite writes happen in C, below
+  Python file I/O, so they cannot be recorded by these patches, and patching
+  the sqlite3 module to intercept them would test the mock, not the seam.
+  The db is a DERIVED index — rebuilt at any time from checkpoint files that
+  themselves passed the seam — and it lives outside the audited roots.
+- git subprocess writes (team sidecar clone/commit/fetch in teamsync) happen
+  in a child process, invisible to in-process patches. The sidecar's PYTHON-
+  side writes (scaffolding on `team init`, the dual-write mirror) ARE audited
+  — the mirror is governed, the scaffolding is ratcheted below.
+- builtin open() is not routed through pathlib.Path.open; the only such
+  writer under the roots is store._pointer_lock's flock sidecar dotfile,
+  which carries no content (opened "a+", never written).
+- the serializer chunk cache is only written on CHUNKED serializes; the
+  serialize recipe forces chunking (DAIMON_CHUNK_LINES) precisely so that
+  write is observed and ratcheted rather than silently uncovered.
+- correlation blind spot: a hypothetical rogue write inside a daimon_briefing
+  frame that still holds a reference to some previously admitted object would
+  read as governed. The admitted registry is per-test and the sensitivity
+  tests bound the risk; a frame-exact taint system is not worth its weight.
+"""
+
+import argparse
+import inspect  # noqa: F401  (documented API of the recorded stacks)
+import io
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from daimon_briefing import cli, config, policy, store, teamsync
+from tests.conftest import FIXTURES, FakeChat
+
+# ---------------------------------------------------------------------------
+# The ratchet. Every entry is (command, path pattern) with its justification.
+# Delete entries as their bypass is closed — the stale-entry direction of the
+# guard forces that deletion.
+# ---------------------------------------------------------------------------
+KNOWN_BYPASSES = frozenset({
+    # serializer._save_chunk_cache: the #48 content-addressed chunk cache is
+    # PRE-redaction by design (quote verification must see raw text, #125) and
+    # written before store.write_checkpoint ever runs — deliberately outside
+    # the admission pipeline. Its exposure is bounded elsewhere: 0600 files,
+    # age reaper (chunk_cache_days), and `daimon forget` purges it wholesale
+    # (#422, incl. the pre-redaction window, #429).
+    ("serialize", "checkpoints/.chunk-cache/*"),
+    # teamsync.init scaffolding on an EMPTY remote: a stub README and the #279
+    # scope-seed daimon-team.toml. Repo furniture, not belief bytes — no
+    # checkpoint content can reach either file.
+    ("team init", "team/{remote}/README.md"),
+    ("team init", "team/{remote}/daimon-team.toml"),
+})
+
+# Commands that genuinely cannot be driven headless would be named here with
+# a reason — the guard fails on any command lacking BOTH a recipe and a
+# SKIPPED entry, so a skip can never be silent. Currently every command runs.
+SKIPPED: dict = {}
+
+# Pure log sinks, allowlisted BY FILENAME if one ever lands under an audited
+# root. Today they all live under config.log_dir() (outside the roots), so
+# this is insurance against a future move, not an active exemption.
+# Belief-bearing files — checkpoints, latest/prev pointers, events.jsonl,
+# verification.jsonl, forget-hits.jsonl, receipts sidecars, the team mirror —
+# are deliberately NOT here.
+LOG_SINKS = frozenset({
+    "usage.log", "serialize.log", "serialize-crash.log", "recall-error.log",
+})
+
+_HEX = re.compile(r"^\.?[0-9a-f]{16,}")
+
+
+class WriteAudit:
+    """Recorder for every Python-level write under the audited roots."""
+
+    def __init__(self):
+        self.command = "<fixture>"
+        self.records = []       # (command, root_label, rel Path, governed, frames)
+        self.placeholders = {}  # literal path part -> "{placeholder}"
+        self._roots = []        # (label, absolute base) — raw + resolved forms
+        self._admitted_ids = set()
+        self._admitted_refs = []   # strong refs pin id()s against reuse
+        self._local = threading.local()
+
+    def add_root(self, label, base: Path):
+        for form in {Path(os.path.abspath(base)), Path(os.path.abspath(base)).resolve()}:
+            self._roots.append((label, form))
+
+    def admit(self, obj):
+        self._admitted_refs.append(obj)
+        self._admitted_ids.add(id(obj))
+
+    # -- recording ---------------------------------------------------------
+
+    def _under_roots(self, path):
+        for p in {Path(os.path.abspath(path)), Path(os.path.abspath(path)).resolve()}:
+            for label, base in self._roots:
+                try:
+                    return label, p.relative_to(base)
+                except ValueError:
+                    continue
+        return None
+
+    def record(self, path):
+        hit = self._under_roots(path)
+        if hit is None:
+            return
+        label, rel = hit
+        governed = False
+        frames = []
+        fr = sys._getframe(1)
+        while fr is not None:
+            mod = fr.f_globals.get("__name__", "")
+            name = fr.f_code.co_name
+            frames.append(f"{mod}.{name}")
+            if mod == "daimon_briefing.policy" and name.startswith("admit_"):
+                governed = True
+            elif not governed and mod.startswith("daimon_briefing"):
+                try:
+                    if any(id(v) in self._admitted_ids
+                           for v in fr.f_locals.values()):
+                        governed = True
+                except Exception:
+                    pass
+            fr = fr.f_back
+        self.records.append((self.command, label, rel, governed, tuple(frames)))
+
+    # -- classification ----------------------------------------------------
+
+    def pattern(self, label, rel: Path) -> str:
+        parts = rel.parts
+        if label == "checkpoints" and parts and parts[0] == ".chunk-cache":
+            return "checkpoints/.chunk-cache/*"
+        normed = [self.placeholders.get(p, "{hash}" if _HEX.match(p) else p)
+                  for p in parts]
+        return "/".join([label] + normed)
+
+    def bypasses(self) -> set:
+        return {(cmd, self.pattern(label, rel))
+                for cmd, label, rel, governed, _ in self.records
+                if not governed and rel.name not in LOG_SINKS}
+
+    def governed(self):
+        return [(cmd, label, rel) for cmd, label, rel, governed, _
+                in self.records if governed]
+
+
+@pytest.fixture
+def write_audit(monkeypatch):
+    """Install the write audit: record every write under the checkpoint/team
+    roots, and register every object the policy seam admits."""
+    audit = WriteAudit()
+    audit.add_root("checkpoints", config.checkpoint_dir())
+    audit.add_root("team", config.team_dir())
+
+    orig_atomic = store._atomic_write
+
+    def rec_atomic(path, blob):
+        audit.record(path)
+        audit._local.in_atomic = True    # its inner write_text re-opens the
+        try:                             # .tmp twin — one write, one record
+            return orig_atomic(path, blob)
+        finally:
+            audit._local.in_atomic = False
+
+    monkeypatch.setattr(store, "_atomic_write", rec_atomic)
+
+    orig_open = Path.open
+
+    def rec_open(self, mode="r", *args, **kwargs):
+        if (any(c in mode for c in "wax+")
+                and not getattr(audit._local, "in_atomic", False)):
+            audit.record(self)
+        return orig_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", rec_open)
+
+    orig_admit_checkpoint = policy.admit_checkpoint
+
+    def rec_admit_checkpoint(checkpoint, forgotten_keys):
+        audit.admit(checkpoint)
+        return orig_admit_checkpoint(checkpoint, forgotten_keys)
+
+    monkeypatch.setattr(policy, "admit_checkpoint", rec_admit_checkpoint)
+
+    orig_admit_row = policy.admit_row
+
+    def rec_admit_row(row, redact_fields=(), redact_fn=None):
+        audit.admit(row)
+        return orig_admit_row(row, redact_fields=redact_fields,
+                              redact_fn=redact_fn)
+
+    monkeypatch.setattr(policy, "admit_row", rec_admit_row)
+    return audit
+
+
+# ---------------------------------------------------------------------------
+# Command enumeration + drive recipes
+# ---------------------------------------------------------------------------
+
+def _iter_commands(parser, prefix=()):
+    """Every leaf command tuple the parser tree registers."""
+    subs = [a for a in parser._actions
+            if isinstance(a, argparse._SubParsersAction)]
+    if not subs:
+        yield prefix
+        return
+    for action in subs:
+        for name, sub in action.choices.items():
+            yield from _iter_commands(sub, prefix + (name,))
+
+
+def _assert_ratchet(observed: set):
+    new = observed - KNOWN_BYPASSES
+    stale = KNOWN_BYPASSES - observed
+    assert not new, (
+        "UNGOVERNED WRITE(S) outside the ratchet — a write path reached "
+        "checkpoint/team bytes without a policy.admit_* admission. Route it "
+        f"through the seam (or, if deliberate, ratchet it): {sorted(new)}")
+    assert not stale, (
+        "stale KNOWN_BYPASSES entries — these bypasses were not observed, so "
+        "either the bypass was closed (delete the entry: the ratchet must "
+        "shrink truthfully) or the recipe stopped exercising its write path "
+        f"(fix the recipe): {sorted(stale)}")
+
+
+# Item texts the recipes key on.
+_T_GATEWAY = "Adopt the gateway seam for all writes"
+_T_FORGET = "Retire the legacy uploader path"
+_T_KEEP = "Keep the ratchet honest in tests"
+_T_SER = "Serialize goes through the gateway too"
+_T_HEAL = "Heal rejoins the governed store"
+_Q1 = "Which commands still bypass the seam"
+_B1 = "The seam sees every governed write"
+
+
+def _cp_json(session_id, decisions, questions=(_Q1,)):
+    return json.dumps({
+        "session_id": session_id,
+        "working_context": {
+            "active_topic": {"text": "Write-audit guard drive", "trust": "inferred"},
+            "open_questions": [{"text": q, "trust": "inferred"} for q in questions],
+            "recent_decisions": [{"text": d, "trust": "inferred"} for d in decisions],
+        },
+        "epistemic_snapshot": {
+            "strong_beliefs": [{"text": _B1, "trust": "inferred"}],
+            "uncertainties": [],
+        },
+    })
+
+
+def _setup_env(tmp_path, monkeypatch):
+    """Project + HOME isolation for the drive. conftest already isolates every
+    DAIMON_* path; HOME covers hooks/skill installs (they write under ~)."""
+    proj = tmp_path / "proj"
+    proj.mkdir(exist_ok=True)
+    (proj / "mod.py").write_text("def fn():\n    return 1\n", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", str(proj))
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    return proj
+
+
+def _ids_by_text(proj):
+    cp = store.read_latest(project_dir=str(proj), fallback=False)
+    out = {}
+    for section, key in store._ITEM_LISTS:
+        for item in ((cp or {}).get(section) or {}).get(key) or []:
+            if isinstance(item, dict) and item.get("id"):
+                out[str(item.get("text") or "")] = item["id"]
+    return out
+
+
+def _transcript_copy(tmp_path, name):
+    dst = tmp_path / name
+    dst.write_text((FIXTURES / "sample_transcript.md").read_text(encoding="utf-8"),
+                   encoding="utf-8")
+    return dst
+
+
+def _drive_all(audit, tmp_path, monkeypatch, proj):
+    """Drive every command with minimal valid args, in dependency order.
+    Each recipe asserts its rc so a broken drive can never silently stop
+    exercising a write path."""
+    ctx = {}
+
+    def run(argv, want_rc, stdin=None, env=(), chat=None):
+        with monkeypatch.context() as m:
+            for k, v in env:
+                m.setenv(k, v)
+            if stdin is not None:
+                m.setattr(sys, "stdin", io.StringIO(stdin))
+            if chat is not None:
+                m.setattr(cli, "_chat", chat)
+            rc = cli.main(argv)
+        assert rc == want_rc, f"{argv} -> rc {rc}, wanted {want_rc}"
+
+    def r_write_checkpoint():
+        run(["write-checkpoint"], 0,
+            stdin=_cp_json("S-seed", [_T_GATEWAY, _T_FORGET, _T_KEEP]))
+        ctx["ids"] = _ids_by_text(proj)
+
+    def r_team_init():
+        if shutil.which("git") is None:  # matches test_teamsync's requirement
+            pytest.skip("git not on PATH — team recipes need it")
+        bare = tmp_path / "origin" / "team-mem.git"
+        bare.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["git", "init", "--bare", "-b", "main", str(bare)],
+                       check=True, capture_output=True, timeout=30)
+        remote = teamsync.remote_slug(str(bare))
+        audit.placeholders[remote] = "{remote}"
+        run(["team", "init", str(bare)], 0)
+        # Team mirroring ON for the rest of the drive, so write_checkpoint's
+        # dual-write path into team_dir is exercised (and must be governed).
+        monkeypatch.setenv("DAIMON_TEAM", "1")
+
+    def r_serialize():
+        ts = _transcript_copy(tmp_path, "guard-serialize.md")
+        # Force the CHUNKED path so the pre-admission chunk cache write is
+        # observed (and ratcheted) instead of silently uncovered.
+        run(["serialize", str(ts)], 0,
+            env=(("DAIMON_CHUNK_LINES", "3"), ("DAIMON_CHUNK_OVERLAP", "0"),
+                 ("DAIMON_CHUNK_CONCURRENCY", "1")),
+            chat=FakeChat(_cp_json("x", [_T_GATEWAY, _T_FORGET, _T_KEEP, _T_SER])))
+        ctx["ids"] = _ids_by_text(proj)
+
+    def r_brief():
+        run(["brief"], 0)
+
+    def r_anchor():
+        run(["anchor", "mod.py", "fn", "--attach", "gateway seam"], 0)
+
+    def r_recall():
+        run(["recall", "gateway"], 0)
+
+    def r_projects():
+        run(["projects"], 0)
+
+    def r_resolve():
+        run(["resolve", ctx["ids"][_T_KEEP], "--note", "shipped"], 0)
+
+    def r_forget():
+        run(["forget", ctx["ids"][_T_FORGET], "--reason", "stale"], 0)
+
+    def r_reverify():
+        run(["reverify", ctx["ids"][_T_KEEP], "--evidence",
+             "checked the release page"], 0)
+
+    def r_log():
+        run(["log", "--text", "cut the release"], 0)
+
+    def r_recall_inject():
+        run(["recall-inject", "--session", "S-live"], 0,
+            stdin="anything about the gateway seam?")
+
+    def r_status():
+        run(["status"], 0)
+
+    def r_verify_receipt():
+        run(["verify-receipt"], 2)  # rc 2 = unable (receipts off — no sidecar)
+
+    def r_audit_quotes():
+        run(["audit-quotes"], 0)
+
+    def r_heal():
+        # Seed a FAILED session with the ledger's own documented line shapes
+        # (spawn + error result), then heal re-serializes it for real. The
+        # canned checkpoint re-asserts the forgotten value, so the forget gate
+        # drops it inside write_checkpoint and the forget-hits sink is
+        # exercised under audit.
+        heal_md = _transcript_copy(tmp_path, "guard-heal.md")
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        log_dir = config.log_dir()
+        log_dir.mkdir(parents=True, exist_ok=True)
+        with (log_dir / "serialize.log").open("a", encoding="utf-8") as f:
+            f.write(f"{stamp} session-end: spawned serialize for guard-heal "
+                    f"(reason: exit, project: {proj}) (transcript: {heal_md})\n")
+            f.write(f"error: canned failure (transcript: {heal_md}) after 1s\n")
+        run(["heal"], 0, chat=FakeChat(_cp_json("x", [_T_HEAL, _T_FORGET])))
+        stored = store.read_checkpoint("guard-heal")
+        texts = json.dumps(stored)
+        assert _T_HEAL in texts
+        assert _T_FORGET not in texts  # forget gate dropped the re-assertion
+
+    def r_team_sync():
+        run(["team", "sync"], 0)
+
+    def r_team_status():
+        run(["team", "status"], 0)
+
+    def r_configure():
+        run(["configure", "--backend", "command", "--command", "true",
+             "--output", "text"], 0)
+
+    def r_stats():
+        run(["stats"], 0)
+
+    def r_hooks_list():
+        run(["hooks", "list"], 0)
+
+    def r_hooks_install():
+        run(["hooks", "install", "windsurf"], 0)  # HOME is tmp-isolated
+
+    def r_hooks_status():
+        run(["hooks", "status"], 0)
+
+    def r_skill_list():
+        run(["skill", "list"], 0)
+
+    def r_skill_show():
+        run(["skill", "show"], 0)
+
+    def r_skill_install():
+        run(["skill", "install", "claude"], 0)
+
+    def r_skill_uninstall():
+        run(["skill", "uninstall", "claude"], 0)
+
+    def r_mcp_serve():
+        run(["mcp", "serve"], 0, stdin="")
+
+    recipes = {
+        ("write-checkpoint",): r_write_checkpoint,
+        ("team", "init"): r_team_init,
+        ("serialize",): r_serialize,
+        ("brief",): r_brief,
+        ("anchor",): r_anchor,
+        ("recall",): r_recall,
+        ("projects",): r_projects,
+        ("resolve",): r_resolve,
+        ("reverify",): r_reverify,
+        ("forget",): r_forget,
+        ("log",): r_log,
+        ("recall-inject",): r_recall_inject,
+        ("status",): r_status,
+        ("verify-receipt",): r_verify_receipt,
+        ("audit-quotes",): r_audit_quotes,
+        ("heal",): r_heal,
+        ("team", "sync"): r_team_sync,
+        ("team", "status"): r_team_status,
+        ("configure",): r_configure,
+        ("stats",): r_stats,
+        ("hooks", "list"): r_hooks_list,
+        ("hooks", "install"): r_hooks_install,
+        ("hooks", "status"): r_hooks_status,
+        ("skill", "list"): r_skill_list,
+        ("skill", "show"): r_skill_show,
+        ("skill", "install"): r_skill_install,
+        ("skill", "uninstall"): r_skill_uninstall,
+        ("mcp", "serve"): r_mcp_serve,
+    }
+
+    # No silent skips: every registered command has a recipe or a named SKIPPED
+    # entry — a new subcommand fails here until it is covered.
+    registered = set(_iter_commands(cli.build_parser()))
+    covered = set(recipes) | set(SKIPPED)
+    assert covered == registered and not (set(recipes) & set(SKIPPED)), (
+        f"command registry / recipe drift — uncovered: "
+        f"{sorted(registered - covered)}; phantom recipes: "
+        f"{sorted(covered - registered)}")
+
+    for cmd, recipe in recipes.items():
+        audit.command = " ".join(cmd)
+        recipe()
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# THE GUARD
+# ---------------------------------------------------------------------------
+
+def test_every_command_write_carries_an_admit_frame(
+        write_audit, tmp_path, monkeypatch, capsys):
+    proj = _setup_env(tmp_path, monkeypatch)
+    _drive_all(write_audit, tmp_path, monkeypatch, proj)
+
+    _assert_ratchet(write_audit.bypasses())
+
+    # Anti-vacuity: the audit must have SEEN the belief-bearing writes it
+    # exists to govern — a fixture that recorded nothing would pass the
+    # ratchet trivially.
+    governed = write_audit.governed()
+
+    def saw(command, name, label=None):
+        return any(cmd == command and rel.name == name
+                   and (label is None or lbl == label)
+                   for cmd, lbl, rel in governed)
+
+    assert saw("write-checkpoint", "latest.json")   # pointer writes
+    assert saw("serialize", "latest.json")          # serialize's store path
+    assert saw("serialize", "guard-serialize.json", "team")  # team dual-write
+    assert saw("resolve", "events.jsonl")           # admit_row on the ledger
+    assert saw("forget", "events.jsonl")            # tombstone append
+    assert saw("heal", "forget-hits.jsonl")         # capture-time forget drop
+    assert saw("anchor", "latest.json")             # --attach rewrite
+
+
+# ---------------------------------------------------------------------------
+# SENSITIVITY — the guard must FAIL when the seam is removed (the #420/#426
+# mutation-check precedent: prove the alarm rings, don't assume it).
+# ---------------------------------------------------------------------------
+
+def test_guard_trips_when_admit_checkpoint_is_stubbed_out(
+        write_audit, tmp_path, monkeypatch, capsys):
+    _setup_env(tmp_path, monkeypatch)
+    # The mutation: the write boundary loses its admission pipeline entirely
+    # (no gates run, nothing is registered as admitted).
+    monkeypatch.setattr(policy, "admit_checkpoint",
+                        lambda checkpoint, forgotten_keys: [])
+    write_audit.command = "write-checkpoint"
+    monkeypatch.setattr(sys, "stdin", io.StringIO(_cp_json("S-mut", [_T_GATEWAY])))
+    assert cli.main(["write-checkpoint"]) == 0
+
+    stray = write_audit.bypasses() - KNOWN_BYPASSES
+    assert stray, "guard is blind: an unadmitted checkpoint write passed"
+    assert any(pat.endswith(".json") for _, pat in stray)  # checkpoint bytes
+
+
+def test_guard_trips_when_admit_row_is_stubbed_out(
+        write_audit, tmp_path, monkeypatch, capsys):
+    proj = _setup_env(tmp_path, monkeypatch)
+    # Seed through the intact seam first, so the ledger append has a target.
+    write_audit.command = "<fixture>"
+    monkeypatch.setattr(sys, "stdin", io.StringIO(_cp_json("S-seed", [_T_KEEP])))
+    assert cli.main(["write-checkpoint"]) == 0
+    item_id = _ids_by_text(proj)[_T_KEEP]
+
+    # The mutation: ledger rows stop passing through the admission seam.
+    monkeypatch.setattr(policy, "admit_row",
+                        lambda row, redact_fields=(), redact_fn=None: row)
+    write_audit.command = "resolve"
+    assert cli.main(["resolve", item_id, "--note", "done"]) == 0
+
+    stray = write_audit.bypasses() - KNOWN_BYPASSES
+    assert ("resolve", f"checkpoints/{store.project_slug(str(proj))}/events.jsonl") \
+        in stray or any(pat.endswith("events.jsonl") for _, pat in stray), \
+        "guard is blind: an unadmitted ledger append passed"
+
+
+def test_guard_trips_on_a_synthetic_ungoverned_write(write_audit):
+    write_audit.command = "rogue"
+    p = config.checkpoint_dir() / "some-slug" / "events.jsonl"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("a", encoding="utf-8") as f:
+        f.write("{}\n")
+    assert ("rogue", "checkpoints/some-slug/events.jsonl") in \
+        write_audit.bypasses() - KNOWN_BYPASSES
+
+
+def test_ratchet_fails_in_both_directions():
+    # New bypass -> fails.
+    with pytest.raises(AssertionError, match="UNGOVERNED"):
+        _assert_ratchet(set(KNOWN_BYPASSES) | {("rogue", "checkpoints/x.json")})
+    # Stale entry -> fails (KNOWN_BYPASSES is non-empty by construction).
+    with pytest.raises(AssertionError, match="stale"):
+        _assert_ratchet(set())


### PR DESCRIPTION
Closes #431

## What

The write-side structural guard (gateway design, slice 2 — the read side's twin of test_scoring.py's trust-ceiling guard), in three parts:

1. **`build_parser()` extracted from `cli.main`** — pure refactor, the subparser tree moves verbatim so tests can walk the command registry mechanically. Behavior identical; every pre-existing test green unchanged.
2. **`policy.admit_row`** — the ledger-row admission seam. `append_event` / `append_verification` applied their #141 redaction inline; the same scrub now runs through policy (byte-identical rows), and the appender writes the SAME dict the seam returned, so a row on disk is correlatable with its admission. `record_forget_hits` deliberately stays inline: its rows are `{ts, content-hash}` only — a fieldless admit_row frame would be a vacuous pass (#404 forbids content in that sink), and its appends are governed anyway (they run inside the admitting `write_checkpoint` invocation).
3. **The guard** (`tests/test_write_audit_guard.py`): a `write_audit` fixture patches `store._atomic_write` + `pathlib.Path.open` (write/append modes), recording every write under `checkpoint_dir()`/`team_dir()`, and wraps `policy.admit_checkpoint`/`policy.admit_row` to register the admitted objects. The guard drives EVERY command `build_parser()` registers (28 leaves; coverage assertion — no silent skips, `SKIPPED` is currently empty) and asserts each audited write is attributable to an admission: a live `admit_*` frame, or a `daimon_briefing` frame holding the exact admitted object (pointer/mirror writes land after `admit_checkpoint` returns — the correlation the issue prescribes).

**Ratchet — set equality in BOTH directions.** An observed bypass not in `KNOWN_BYPASSES` fails (new ungoverned write); a listed bypass no longer observed fails (stale entry — the set must shrink truthfully). Final residents, all observed live:

- `("serialize", "checkpoints/.chunk-cache/*")` — the #48 pre-redaction chunk cache, deliberately pre-seam (quote verification needs raw text); bounded by 0600 + age reaper + the #422/#429 forget purge. The serialize recipe forces chunking so this write is observed and ratcheted, never silently uncovered.
- `("team init", "team/{remote}/README.md")` and `("team init", "team/{remote}/daimon-team.toml")` — empty-remote scaffolding; repo furniture, no belief bytes.

## Why

The gateway now exists (#421/#428/#430) and each rule is individually tested, but nothing asserted the structural claim: no mutation path skips the seam. A future command or refactor writing checkpoint/team bytes around `policy.admit_*` would land silently. This makes that a red test — and the auto-discovered command table means a NEW subcommand is enumerated (and audited) the moment it is registered.

## Tests

- `uv sync --all-extras && uv run pytest` from `plugin/`: **2220 passed, 2 skipped** (2213 baseline + 2 `admit_row` unit tests + 5 guard tests).
- **Sensitivity proven, not assumed** (the #420/#426 mutation-check precedent): with `policy.admit_checkpoint` stubbed out, the checkpoint writes classify ungoverned and the guard trips; with `policy.admit_row` stubbed out, the `events.jsonl` append trips it; a synthetic rogue append under the checkpoint root trips it; and the ratchet helper fails on both a fabricated new bypass and a fabricated stale entry.
- Anti-vacuity assertions: the audit must have SEEN the governed belief writes (latest pointers, team dual-write mirror, resolve/forget ledger appends, the forget-hits row from a re-asserted forgotten value on the heal path, the anchor --attach rewrite) — an audit that recorded nothing cannot pass.

**Documented honest absences** (in the module docstring, not gamed): recall's sqlite index (C-level writes below Python file I/O; derived data rebuilt from checkpoints that themselves pass the seam), git subprocess writes (child process; the Python-side sidecar writes ARE audited), and the builtin-open flock sidecar (no content).