### PR TITLE
chore(capture): converge hook and CLI capture pipelines behind one parity-tested path

### DIFF
--- a/plugin/daimon_briefing/capture.py
+++ b/plugin/daimon_briefing/capture.py
@@ -1,0 +1,188 @@
+"""The ONE capture pipeline (#432): serialize -> stamp -> carry+fold ->
+bind_links -> supersede emission -> write -> rejection ledger.
+
+Both capture entry points — `cli._run_serialize` and `hooks.on_session_end` —
+call `run`. They had drifted: the hook wrote checkpoints that skipped the
+CLI-layer steps (created/transcript_hash stamps, carry.merge with the
+resolved fold, bind_links, supersede-candidate emission with its #425
+forgotten-filter, and the #376 rejection ledger), so what a checkpoint
+contained depended on which door the session left through.
+`tests/test_capture_parity.py` is the standing guard: any re-divergence
+fails CI.
+
+Error posture stays at the CALLER: this module raises `serializer`'s
+TooShortError / SerializeError (and anything the store raises) upward —
+the hook wraps everything in its never-raise contract, the CLI prints and
+exits. The advisory sub-steps (carry, rejection ledger) fail open HERE,
+identically for both doors, because a broken advisory feature must never
+cost the checkpoint itself.
+
+Intended per-door differences are explicit parameters, nothing else:
+  - `escalate` (#360): only `daimon heal` may pass True — escalation cost
+    scales with failure, not usage. The hook and plain `serialize` never do.
+  - `transcript_path=None`: some hosts hand the hook no transcript FILE
+    (messages arrive via transcript.from_session), so the session-end
+    `created` stamp (#123) has no source and store.write_checkpoint's
+    setdefault-now covers it. A host constraint, not pipeline drift —
+    whenever a path exists, both doors stamp identically.
+"""
+
+import time
+from pathlib import Path
+
+from . import carry, config, normalize, serializer, store, transcript
+
+
+def run(session_id: str, messages, *, project, chat, deadline,
+        transcript_path=None, transcript_sha=None,
+        escalate: bool = False) -> Path | None:
+    """Serialize `messages` into a checkpoint routed to `project` (used AS-IS;
+    None => global pointer only — the caller decides routing, same contract
+    as the old cli._run_serialize).
+
+    Returns store.write_checkpoint's result: the checkpoint path, or None
+    when the write boundary refused (kill switch, #421) — each caller renders
+    its own skip/success line. Serializer failures propagate."""
+    checkpoint = serializer.serialize_strict(
+        session_id, messages, chat=chat, deadline=deadline, escalate=escalate)
+    # `created` = when the SESSION ended, not when this write happens (#123).
+    # Stamped here — not left to store's setdefault-now — so a heal/re-serialize
+    # of an old transcript carries its true age and store's pointer guard can
+    # keep it from stealing `latest` from a newer session. Needs a transcript
+    # FILE; a hook host that provides none falls through to setdefault-now.
+    if transcript_path is not None:
+        checkpoint["created"] = _session_end_stamp(transcript_path)
+    # Bind the checkpoint to its exact source content (#125). The sha is
+    # computed by the caller at read time, before any LLM work; absent
+    # (unreadable file / no file) means no stamp — readers tolerate that.
+    if transcript_sha:
+        checkpoint["transcript_hash"] = transcript_sha
+    if config.carry_enabled():
+        # Deterministic carry (#33 Phase 2): fold the previous checkpoint's
+        # unresolved items in BEFORE the write rotates it away. Clock = this
+        # checkpoint's own stamp (scar: never default to wall clock when a
+        # stamp exists), wall time only as fallback for stampless paths.
+        # Advisory feature — a raise here must never cost us the checkpoint
+        # itself (a briefing missing carried items is strictly better than
+        # no briefing at all; same idiom as the rejection-ledger swallow below).
+        try:
+            # fallback=False (#94): on a project's first serialize there is no
+            # per-project pointer, and the global pointer is another project's
+            # checkpoint — carrying from it would write foreign items into
+            # this project's bucket permanently. No prev -> no carry.
+            prev = store.read_latest(project, fallback=False)
+            now = store._created_epoch(checkpoint.get("created")) or time.time()
+            events = store.resolutions(project_dir=project)
+            resolved = frozenset(ref for ref, evt in events.items()
+                                 if store.is_resolved(evt))
+            checkpoint = carry.merge(checkpoint, prev, now,
+                                     floor=config.carry_floor(),
+                                     cap=config.carry_max(),
+                                     resolved=resolved)
+            # #14: text-target supersession links bound to prev-item ids ->
+            # candidate events, gated so a human verdict is never overridden
+            # (see _emit_supersede_candidates). Same fail-open try as merge
+            # itself — a broken emission must never cost the checkpoint.
+            # Stamp ids BEFORE binding: fresh natives are only stamped inside
+            # write_checkpoint (after this block), so without this every new
+            # item binds with new_id="" and the event carries no target.
+            # Setdefault-idempotent — write_checkpoint's re-stamp no-ops.
+            store._stamp_item_ids(checkpoint)
+            pairs = carry.bind_links(checkpoint, prev)
+            _emit_supersede_candidates(pairs, events, project)
+        except Exception:  # keep the unmerged checkpoint, proceed to write
+            pass
+    out = store.write_checkpoint(session_id, checkpoint, project_dir=project)
+    if out is None:
+        # #421: the write boundary refused (kill switch) — nothing landed, so
+        # there is nothing to ledger rejections against either.
+        return None
+    # #376: record what the checkers REJECTED, after write_checkpoint because
+    # that is where item ids are guaranteed stamped (the merge branch above
+    # only stamps when it runs). Its own append-only stream, never events.jsonl
+    # — a rejection folded on item_ref would resolve the item and hide exactly
+    # what it describes. Fail-open: an advisory counter never costs a capture.
+    try:
+        for row in serializer.verification_rejections(checkpoint):
+            store.append_verification(row["item_ref"], row["check"],
+                                      row["reason"], project_dir=project)
+    except Exception:
+        pass
+    return out
+
+
+def _emit_supersede_candidates(pairs, events: dict, project) -> int:
+    """Turn `carry.bind_links` triples into `supersede-candidate:*` events,
+    gated so a machine SUGGESTION never overrides a human verdict (#14,
+    human-speaks-once).
+
+    `events` is the SAME `store.resolutions` fold the serialize block already
+    fetched for `resolved` — reused, not re-read, so this stays consistent
+    with the resolved set computed moments earlier in the same call.
+
+    Gate per (old_id, new_id, old_text) triple:
+    (a) prior = events.get(old_id) — the latest lifecycle fact for old_id.
+    (b) prior exists and its source isn't "serializer" -> a HUMAN spoke
+        (confirmed via superseded-by, rejected via reopened, or anything
+        else typed by a person) -> skip, forever. The gate itself is why a
+        latest-event check is enough for permanence: machine events only
+        ever land through this function, and this function refuses to
+        write over a non-serializer prior, so once a human event is latest
+        no future serialize run can dethrone it — there is no path back to
+        a machine-authored latest.
+    (c) prior exists, is a serializer-authored candidate, and already points
+        at this same new_id -> idempotent, skip (re-running serialize on an
+        unchanged pair must not spam the log).
+    (d) otherwise -> append. Covers both the fresh case (no prior) and the
+        candidate-changed case (prior candidate names a DIFFERENT new_id —
+        the carry target moved, so a fresh candidate replaces it as latest).
+
+    Forget gate (#419): `old_text` is a PREV item's raw text, and this runs
+    BEFORE write_checkpoint's forget gate — so a forgotten value surviving in
+    the prev checkpoint under a never-tombstoned id (sibling-id shape, #418)
+    would land as plaintext `item_text` in append-only events.jsonl, forever.
+    A pair whose old_text canonicalizes into the forgotten set (the same
+    normalize.content_key keying store._drop_forgotten uses) is skipped
+    entirely. Fail-safe direction: if the forgotten-keys read raises, emit
+    NOTHING — a missed suggestion costs a candidate event; a leaked value
+    costs the deletion guarantee.
+
+    Returns the number of events actually appended."""
+    appended = 0
+    try:
+        forgotten = store.forgotten_content_keys(project_dir=project)
+    except Exception:
+        return 0  # can't prove a value isn't forgotten -> emit nothing
+    for old_id, new_id, old_text in pairs:
+        if not new_id:
+            continue  # defense-in-depth: never write a candidate with no
+                      # target ("supersede-candidate:") — the wiring stamps
+                      # ids before binding, but a caller that skips that
+                      # step must not corrupt the event log
+        if forgotten and normalize.content_key(old_text or "") in forgotten:
+            continue  # #419: tombstoned VALUE — its text must never reach
+                      # the append-only audit trail
+        prior = events.get(old_id)
+        if prior and str(prior.get("source") or "") != "serializer":
+            continue  # human spoke — machine stays silent forever
+        if prior and prior.get("status") == f"supersede-candidate:{new_id}":
+            continue  # idempotent — same candidate already latest
+        if store.append_event(old_id, f"supersede-candidate:{new_id}",
+                              source="serializer", item_text=old_text,
+                              project_dir=project):
+            appended += 1
+    return appended
+
+
+def _session_end_stamp(path) -> str:
+    """When the session in `path` ended, in checkpoint `created` format (#123):
+    the transcript's last message timestamp, falling back to the file mtime
+    (markdown/plain transcripts carry no per-row stamps), then to now."""
+    stamp = transcript.last_timestamp(path)
+    if stamp:
+        return stamp
+    try:
+        mtime = Path(path).stat().st_mtime
+    except OSError:
+        mtime = time.time()
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(mtime))

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -30,7 +30,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from . import anchor, briefing, carry, config, configure, harvest, llm, normalize, recall, receipts, render, schema, serializer, store, teamsync, transcript, worldcheck
+from . import anchor, briefing, capture, carry, config, configure, harvest, llm, normalize, recall, receipts, render, schema, serializer, store, teamsync, transcript, worldcheck
 from . import __version__
 
 # The serialize.log ledger subsystem lives in ledger.py (#147 + #162, pure
@@ -270,9 +270,14 @@ def _run_serialize(transcript_path: Path, project: str | None,
     # principle while the SessionEnd hook did (#298).
     deadline = start + config.timeout_seconds()
     try:
-        checkpoint = serializer.serialize_strict(
-            session_id, messages, chat=_chat, deadline=deadline,
-            escalate=escalate)
+        # THE shared pipeline (#432): serialize -> stamps -> carry+fold ->
+        # bind_links -> supersede emission -> write -> rejection ledger.
+        # Identical for both capture doors — hooks.on_session_end calls the
+        # same function; tests/test_capture_parity.py guards the parity.
+        # Error POSTURE stays here: capture raises, this door prints/exits.
+        out = capture.run(session_id, messages, project=project, chat=_chat,
+                          deadline=deadline, transcript_path=path,
+                          transcript_sha=transcript_sha, escalate=escalate)
     except serializer.TooShortError as exc:
         msg = f"skipped serialize for {session_id}: {exc}"
         print(msg)
@@ -284,49 +289,6 @@ def _run_serialize(transcript_path: Path, project: str | None,
         print(msg, file=sys.stderr)
         _append_serialize_log(msg)
         return 1
-    # `created` = when the SESSION ended, not when this write happens (#123).
-    # Stamped here — not left to store's setdefault-now — so a heal/re-serialize
-    # of an old transcript carries its true age and store's pointer guard can
-    # keep it from stealing `latest` from a newer session.
-    checkpoint["created"] = _session_end_stamp(path)
-    if transcript_sha:
-        checkpoint["transcript_hash"] = transcript_sha
-    if config.carry_enabled():
-        # Deterministic carry (#33 Phase 2): fold the previous checkpoint's
-        # unresolved items in BEFORE the write rotates it away. Clock = this
-        # checkpoint's own stamp (scar: never default to wall clock when a
-        # stamp exists), wall time only as fallback for stampless paths.
-        # Advisory feature — a raise here must never cost us the checkpoint
-        # itself (a briefing missing carried items is strictly better than
-        # no briefing at all; same idiom as harvest.run's swallow below).
-        try:
-            # fallback=False (#94): on a project's first serialize there is no
-            # per-project pointer, and the global pointer is another project's
-            # checkpoint — carrying from it would write foreign items into
-            # this project's bucket permanently. No prev -> no carry.
-            prev = store.read_latest(project, fallback=False)
-            now = store._created_epoch(checkpoint.get("created")) or time.time()
-            events = store.resolutions(project_dir=project)
-            resolved = frozenset(ref for ref, evt in events.items()
-                                 if store.is_resolved(evt))
-            checkpoint = carry.merge(checkpoint, prev, now,
-                                     floor=config.carry_floor(),
-                                     cap=config.carry_max(),
-                                     resolved=resolved)
-            # #14: text-target supersession links bound to prev-item ids ->
-            # candidate events, gated so a human verdict is never overridden
-            # (see _emit_supersede_candidates). Same fail-open try as merge
-            # itself — a broken emission must never cost the checkpoint.
-            # Stamp ids BEFORE binding: fresh natives are only stamped inside
-            # write_checkpoint (after this block), so without this every new
-            # item binds with new_id="" and the event carries no target.
-            # Setdefault-idempotent — write_checkpoint's re-stamp no-ops.
-            store._stamp_item_ids(checkpoint)
-            pairs = carry.bind_links(checkpoint, prev)
-            _emit_supersede_candidates(pairs, events, project)
-        except Exception:  # keep the unmerged checkpoint, proceed to write
-            pass
-    out = store.write_checkpoint(session_id, checkpoint, project_dir=project)
     if out is None:
         # #421: the write boundary refused (kill switch). Same "skipped" shape
         # as the hash-match short-circuit above — matches neither _RESULT_OK_RE
@@ -336,17 +298,6 @@ def _run_serialize(transcript_path: Path, project: str | None,
         print(msg)
         _append_serialize_log(msg)
         return 0
-    # #376: record what the checkers REJECTED, after write_checkpoint because
-    # that is where item ids are guaranteed stamped (the merge branch above
-    # only stamps when it runs). Its own append-only stream, never events.jsonl
-    # — a rejection folded on item_ref would resolve the item and hide exactly
-    # what it describes. Fail-open: an advisory counter never costs a capture.
-    try:
-        for row in serializer.verification_rejections(checkpoint):
-            store.append_verification(row["item_ref"], row["check"],
-                                      row["reason"], project_dir=project)
-    except Exception:
-        pass
     elapsed = int(time.monotonic() - start)
     msg = f"wrote checkpoint: {out} (took {elapsed}s)"
     if llm.fallback_used():
@@ -376,81 +327,10 @@ def _run_serialize(transcript_path: Path, project: str | None,
     return 0
 
 
-def _emit_supersede_candidates(pairs, events: dict, project) -> int:
-    """Turn `carry.bind_links` triples into `supersede-candidate:*` events,
-    gated so a machine SUGGESTION never overrides a human verdict (#14,
-    human-speaks-once).
-
-    `events` is the SAME `store.resolutions` fold the serialize block already
-    fetched for `resolved` — reused, not re-read, so this stays consistent
-    with the resolved set computed moments earlier in the same call.
-
-    Gate per (old_id, new_id, old_text) triple:
-    (a) prior = events.get(old_id) — the latest lifecycle fact for old_id.
-    (b) prior exists and its source isn't "serializer" -> a HUMAN spoke
-        (confirmed via superseded-by, rejected via reopened, or anything
-        else typed by a person) -> skip, forever. The gate itself is why a
-        latest-event check is enough for permanence: machine events only
-        ever land through this function, and this function refuses to
-        write over a non-serializer prior, so once a human event is latest
-        no future serialize run can dethrone it — there is no path back to
-        a machine-authored latest.
-    (c) prior exists, is a serializer-authored candidate, and already points
-        at this same new_id -> idempotent, skip (re-running serialize on an
-        unchanged pair must not spam the log).
-    (d) otherwise -> append. Covers both the fresh case (no prior) and the
-        candidate-changed case (prior candidate names a DIFFERENT new_id —
-        the carry target moved, so a fresh candidate replaces it as latest).
-
-    Forget gate (#419): `old_text` is a PREV item's raw text, and this runs
-    BEFORE write_checkpoint's forget gate — so a forgotten value surviving in
-    the prev checkpoint under a never-tombstoned id (sibling-id shape, #418)
-    would land as plaintext `item_text` in append-only events.jsonl, forever.
-    A pair whose old_text canonicalizes into the forgotten set (the same
-    normalize.content_key keying store._drop_forgotten uses) is skipped
-    entirely. Fail-safe direction: if the forgotten-keys read raises, emit
-    NOTHING — a missed suggestion costs a candidate event; a leaked value
-    costs the deletion guarantee.
-
-    Returns the number of events actually appended."""
-    appended = 0
-    try:
-        forgotten = store.forgotten_content_keys(project_dir=project)
-    except Exception:
-        return 0  # can't prove a value isn't forgotten -> emit nothing
-    for old_id, new_id, old_text in pairs:
-        if not new_id:
-            continue  # defense-in-depth: never write a candidate with no
-                      # target ("supersede-candidate:") — the wiring stamps
-                      # ids before binding, but a caller that skips that
-                      # step must not corrupt the event log
-        if forgotten and normalize.content_key(old_text or "") in forgotten:
-            continue  # #419: tombstoned VALUE — its text must never reach
-                      # the append-only audit trail
-        prior = events.get(old_id)
-        if prior and str(prior.get("source") or "") != "serializer":
-            continue  # human spoke — machine stays silent forever
-        if prior and prior.get("status") == f"supersede-candidate:{new_id}":
-            continue  # idempotent — same candidate already latest
-        if store.append_event(old_id, f"supersede-candidate:{new_id}",
-                              source="serializer", item_text=old_text,
-                              project_dir=project):
-            appended += 1
-    return appended
-
-
-def _session_end_stamp(path) -> str:
-    """When the session in `path` ended, in checkpoint `created` format (#123):
-    the transcript's last message timestamp, falling back to the file mtime
-    (markdown/plain transcripts carry no per-row stamps), then to now."""
-    stamp = transcript.last_timestamp(path)
-    if stamp:
-        return stamp
-    try:
-        mtime = Path(path).stat().st_mtime
-    except OSError:
-        mtime = time.time()
-    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(mtime))
+# Moved to capture.py (#432) with the rest of the shared pipeline; re-exported
+# because `cli.<name>` is a stable seam — tests and callers resolve them here.
+_emit_supersede_candidates = capture._emit_supersede_candidates
+_session_end_stamp = capture._session_end_stamp
 
 
 def _cmd_serialize(args) -> int:

--- a/plugin/daimon_briefing/hooks.py
+++ b/plugin/daimon_briefing/hooks.py
@@ -13,7 +13,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-from . import briefing, config, harvest, llm, recall, serializer, store, transcript
+from . import briefing, capture, config, harvest, llm, recall, serializer, store, transcript
 
 log = logging.getLogger("daimon_briefing")
 
@@ -79,6 +79,7 @@ def on_session_end(session_id, completed=None, interrupted=None, model=None, pla
         # reproducing a byte-identical checkpoint. No transcript_path -> can't
         # hash -> proceeds exactly as before #185 (fail-open).
         transcript_path = kwargs.get("transcript_path")
+        transcript_sha = None
         if transcript_path:
             transcript_sha = transcript.file_sha256(transcript_path)
             if store.transcript_unchanged(session_id, transcript_sha):
@@ -91,18 +92,38 @@ def on_session_end(session_id, completed=None, interrupted=None, model=None, pla
         messages = transcript.from_session(session_id)
         if not messages or len(messages) < config.min_messages():
             return
+        root = config.resolve_project_root(config.project_dir())
         try:
-            # serialize_strict, NOT the never-raise serialize(): a swallowed
+            # THE shared pipeline (#432): serialize -> stamps -> carry+fold ->
+            # bind_links -> supersede emission -> write -> rejection ledger —
+            # the SAME function cli._run_serialize calls, so a checkpoint's
+            # contents no longer depend on which door the session left through
+            # (tests/test_capture_parity.py guards this). Inside it,
+            # serialize_strict — NOT the never-raise serialize(): a swallowed
             # LLM/schema failure would exit through the old "skip" branch and
             # never reach the ledger — only a too-short session is a true skip.
-            checkpoint = serializer.serialize_strict(
-                session_id, messages, chat=_chat, deadline=deadline
+            # No `escalate` here ever (#360): escalation is heal-only, so its
+            # cost scales with failure, not usage. transcript_path/sha may be
+            # None — this host reads messages via transcript.from_session, not
+            # always a file — in which case the created stamp falls back to
+            # the store's setdefault-now, exactly as before.
+            out = capture.run(
+                session_id, messages, project=root, chat=_chat,
+                deadline=deadline, transcript_path=transcript_path,
+                transcript_sha=transcript_sha,
             )
         except serializer.TooShortError:
             log.info("daimon: no checkpoint produced for session %s (skip)", session_id)
             return
-        root = config.resolve_project_root(config.project_dir())
-        store.write_checkpoint(session_id, checkpoint, project_dir=root)
+        if out is None:
+            # #421: the write boundary refused (kill switch flipped since the
+            # hook-start check). Nothing landed — a skip, never a lying success.
+            log.info(
+                "daimon: skipped checkpoint write for session %s: daimon "
+                "disabled (DAIMON_DISABLE)",
+                session_id,
+            )
+            return
         log.info(
             "daimon: wrote checkpoint for session %s (took %ds)",
             session_id,

--- a/plugin/tests/test_capture_parity.py
+++ b/plugin/tests/test_capture_parity.py
@@ -1,0 +1,167 @@
+"""#432 standing parity guard: the hook and CLI capture entry points must
+produce IDENTICAL checkpoints — and emit the same ledger events — from
+identical input.
+
+The two doors (`hooks.on_session_end`, `cli._run_serialize`) had drifted:
+the hook skipped the CLI-layer pipeline (created stamp from the transcript
+end, transcript_hash, carry.merge + resolved fold, bind_links, supersede
+emission with its #425 forgotten-filter, and the #376 rejection ledger).
+Both must call the ONE shared pipeline; this test fails CI on any future
+re-divergence.
+
+Fixed-clock conventions (scar 0016): all time that lands on disk is threaded
+from the transcript's own row stamps (`created` -> carry `now` -> first_seen);
+the transcript file's mtime is pinned via os.utime so the mtime fallback can
+never smuggle wall clock in. The ONE nondeterministic field per ledger row is
+the append-time `ts` wall stamp — popped before comparison and listed as the
+intended difference.
+"""
+
+import copy
+import json
+import os
+
+from daimon_briefing import cli, hooks, store, transcript
+
+PROJECT = "/p/parity"
+SESSION = "S-parity"
+
+# Previous checkpoint, seeded IDENTICALLY into both stores: one open question
+# for carry to fold, one decision for bind_links to target.
+_PREV = {
+    "session_id": "S-prev",
+    "created": "2026-06-25T08:00:00Z",
+    "working_context": {
+        "active_topic": {"text": "prior topic", "trust": "inferred"},
+        "open_questions": [
+            {"text": "quorint reconciliation loop unresolved", "trust": "inferred",
+             "importance": 7, "first_seen": "2026-06-20T00:00:00Z"},
+        ],
+        "recent_decisions": [
+            {"text": "use gateway A for serialize", "trust": "inferred"},
+        ],
+    },
+    "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": [],
+                           "contradictions_flagged": []},
+}
+
+# The extraction both fake LLMs return. Exercises every drifted step:
+# - a supersedes link with a free-text target that uniquely matches the prev
+#   decision -> bind_links pair -> supersede-candidate event in events.jsonl;
+# - a verbatim item whose quote is NOT in the transcript -> quote_verified
+#   False -> a #376 rejection row in verification.jsonl. (Deliberately no
+#   verbatim item whose quote WOULD verify: a hit stamps wall-clock
+#   `last_verified`, which would be flaky noise here, not signal.)
+_NEW_CP = json.dumps({
+    "session_id": SESSION,
+    "working_context": {
+        "active_topic": {"text": "t", "trust": "inferred"},
+        "open_questions": [
+            {"text": "PR #6 state", "trust": "verbatim",
+             "quote": "this quote appears nowhere in the transcript"},
+        ],
+        "recent_decisions": [
+            {"text": "postgres replaces the old lookup store",
+             "trust": "inferred",
+             "links": [{"type": "supersedes",
+                        "target": "gateway A serialize choice"}]},
+        ],
+    },
+    "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []},
+})
+
+_STAMPS = ["2026-07-01T10:00:00Z", "2026-07-01T10:01:00Z", "2026-07-01T10:02:00Z"]
+
+
+def _write_transcript(tmp_path):
+    rows = []
+    for i, ts in enumerate(_STAMPS):
+        role = "user" if i % 2 == 0 else "assistant"
+        rows.append({"type": role,
+                     "message": {"role": role, "content": f"turn {i}"},
+                     "timestamp": ts})
+    p = tmp_path / f"{SESSION}.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in rows), encoding="utf-8")
+    # Pin mtime (scar 0016): if either door ever falls back to mtime for the
+    # session-end stamp, it still reads a fixed clock, not test wall time.
+    os.utime(p, (1782000000, 1782000000))
+    return p
+
+
+def _seed_home(monkeypatch, home):
+    """Point the store at `home` and seed the identical prev checkpoint."""
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(home / "checkpoints"))
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(home / "logs"))
+    # deepcopy: write_checkpoint mutates its argument in place (scar 0027) —
+    # both homes must be seeded from the same pristine dict.
+    store.write_checkpoint("S-prev", copy.deepcopy(_PREV), project_dir=PROJECT)
+
+
+def _rows_minus_ts(path):
+    """Ledger rows with the append-time wall stamp popped — `ts` is the ONE
+    intended per-run difference (append happens at two different instants)."""
+    if not path.exists():
+        return []
+    rows = [json.loads(line) for line in
+            path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    for r in rows:
+        r.pop("ts", None)
+    return rows
+
+
+def test_hook_and_cli_capture_produce_identical_checkpoints(
+        tmp_path, fake_chat_factory, monkeypatch):
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    tpath = _write_transcript(tmp_path)
+    slug = store.project_slug(PROJECT)
+
+    # ---- door 1: the CLI (`daimon serialize`) ----
+    home_cli = tmp_path / "home-cli"
+    _seed_home(monkeypatch, home_cli)
+    monkeypatch.setattr(cli, "_chat", fake_chat_factory(_NEW_CP))
+    assert cli.main(["serialize", str(tpath)]) == 0
+
+    # ---- door 2: the in-process SessionEnd hook ----
+    home_hook = tmp_path / "home-hook"
+    _seed_home(monkeypatch, home_hook)
+    monkeypatch.setattr(hooks, "_chat", fake_chat_factory(_NEW_CP))
+    monkeypatch.setattr(transcript, "from_session",
+                        lambda sid: transcript.from_file(tpath))
+    hooks.on_session_end(session_id=SESSION, completed=True, interrupted=False,
+                         model="m", platform="cli",
+                         transcript_path=str(tpath))
+
+    cli_cp = json.loads(
+        (home_cli / "checkpoints" / f"{SESSION}.json").read_text(encoding="utf-8"))
+    hook_path = home_hook / "checkpoints" / f"{SESSION}.json"
+    assert hook_path.exists(), "hook door wrote no checkpoint at all"
+    hook_cp = json.loads(hook_path.read_text(encoding="utf-8"))
+
+    # THE contract: byte-equal checkpoint content. No excluded fields — every
+    # stamp is threaded from the transcript's fixed clock, so any diff here is
+    # real pipeline drift.
+    assert hook_cp == cli_cp
+
+    # Liveness: the scenario actually exercised the drifted steps on the CLI
+    # side — a vacuously-equal empty run would guard nothing.
+    carried = [q for q in cli_cp["working_context"]["open_questions"]
+               if q.get("text") == "quorint reconciliation loop unresolved"]
+    assert carried and carried[0]["carried_from"] == "S-prev"
+    assert cli_cp["transcript_hash"] == transcript.file_sha256(tpath)
+    assert cli_cp["created"] == _STAMPS[-1]
+
+    # Same events emitted through both doors (supersede-candidate emission),
+    # minus the append-time `ts` wall stamp.
+    cli_events = _rows_minus_ts(home_cli / "checkpoints" / slug / "events.jsonl")
+    hook_events = _rows_minus_ts(home_hook / "checkpoints" / slug / "events.jsonl")
+    assert cli_events, "scenario failed to produce a supersede-candidate event"
+    assert any(str(e.get("status") or "").startswith("supersede-candidate:")
+               for e in cli_events)
+    assert hook_events == cli_events
+
+    # Same rejection-ledger rows (#376), minus `ts`.
+    cli_rej = _rows_minus_ts(home_cli / "checkpoints" / slug / "verification.jsonl")
+    hook_rej = _rows_minus_ts(home_hook / "checkpoints" / slug / "verification.jsonl")
+    assert cli_rej, "scenario failed to produce a quote-rejection row"
+    assert hook_rej == cli_rej


### PR DESCRIPTION
Closes #432

## What

Extracts the shared capture pipeline — serialize → created/transcript_hash stamps → carry.merge (+resolved fold) → bind_links → supersede-candidate emission (with the #425 forgotten-filter) → write_checkpoint → #376 rejection ledger — into one function, `capture.run`, and makes both capture doors (`cli._run_serialize` and `hooks.on_session_end`) call it. Adds a standing parity test asserting both doors produce identical checkpoints and ledger rows from identical input, so future drift fails CI instead of accumulating.

- `daimon_briefing/capture.py` (new): `run` plus `_emit_supersede_candidates` / `_session_end_stamp`, moved verbatim from cli.py (re-exported there — `cli.<name>` is a stable seam tests resolve).
- `cli._run_serialize`: keeps its own guard/preflight/result-line/rc contract; the pipeline body is now one `capture.run` call. The #421 kill-switch `None` return still prints the ledger-neutral "skipped … daimon disabled" line.
- `hooks.on_session_end`: same `capture.run` call inside the existing never-raise contract; TooShortError stays a logged skip, any other failure still lands in serialize.log via `_ledger_failure`. New: a mid-flight kill-switch refusal now logs a skip instead of a lying "wrote checkpoint".

**Error posture stays at the callers** (hook never-fatal, CLI prints/exits); the advisory sub-steps (carry, rejection ledger) fail open inside the shared pipeline, identically for both doors.

**Intended differences — explicit parameters only** (investigated per the slice-7 design; git history shows no deliberate exclusion of the hook path — carry/#33, #14, #123, #125, #376 were wired into cli only, classic two-doors drift):

- `escalate` (#360): heal-only, so escalation cost scales with failure, not usage. Hook and plain `serialize` never pass it.
- `transcript_path=None`: some hosts hand the hook no transcript file (messages arrive via `transcript.from_session`), so the #123 session-end `created` stamp has no source and `store.write_checkpoint`'s setdefault-now covers it — a host constraint, not drift. Whenever a path exists, both doors stamp identically.

## Why

Same store-boundary gates, different checkpoint contents depending on which door a session left through — and every new pipeline step had to be remembered twice or silently applied to only one path. Rejected alternative (documenting the divergence) left both costs in place; see the issue.

## Tests

- `tests/test_capture_parity.py::test_hook_and_cli_capture_produce_identical_checkpoints` — RED on main before the change, showing the real divergence from one identical input (same transcript, same prev checkpoint, fixed clock threaded per scar 0016): hook checkpoint had wall-clock `created` and `first_seen` (vs transcript-end stamps), no `transcript_hash`, both carried items missing (`carried_from: S-prev` open question and prev decision), the `supersedes` link target left as free text instead of bound to the prev item id, no `supersede-candidate` event in events.jsonl, and no quote-rejection row in verification.jsonl. GREEN after: dict-equal checkpoints (no excluded fields) and identical ledger rows; the ONE intended nondeterminism is each ledger row's append-time `ts`, popped before comparison.
- Full suite from `plugin/`: 2222 passed, 2 skipped (was 2221/2 on main — the parity test is the +1). The #436 write-audit ratchet guard passes — hook-path writes still route through `write_checkpoint`/`append_event`/`append_verification`, so every write carries its admit frame.
