### PR TITLE
fix(serializer): quote verification no longer accepts daimon's own injected text as witness

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1573,8 +1573,14 @@ def _cmd_audit_quotes(args) -> int:
         if tpath is not None:
             try:
                 msgs = transcript.from_file(tpath)
-                haystack = serializer._render_transcript(msgs)
-                texts_by_id = serializer.message_texts_by_id(msgs)
+                # #440: the same stripped haystacks verify_quotes used at
+                # serialize time. Audit re-blesses stored items, so reading
+                # the raw render here would certify exactly the echo
+                # verification rejected — and do it with the CLI's authority.
+                haystack = serializer.stripped_transcript(msgs)
+                texts_by_id = {
+                    mid: serializer.strip_injected(text) for mid, text
+                    in serializer.message_texts_by_id(msgs).items()}
             except (OSError, FileNotFoundError):
                 haystack = None
         if haystack is None:

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -822,6 +822,82 @@ def quote_matches(quote, haystack) -> bool:
     return True
 
 
+# ---- #440: daimon's own injected output is not a witness ----
+#
+# The recall hook (`daimon recall: prior work — ...`) and the SessionStart
+# briefing (`DAIMON BRIEFING ...`) print INTO the host's transcript, and
+# transcript.py flattens hook stdout byte-identically into the user turn that
+# carried it — under the SAME message id as the user's own prose (whole-turn
+# granularity, #358). A quote copied out of that echo used to pass
+# verification and store as trust="verbatim", quote_verified: true: a PRIOR
+# session's item laundered as freshly witnessed in THIS one.
+#
+# The strip is applied to the verification haystacks ONLY. `_render_transcript`
+# deliberately keeps feeding the extractor the raw text: the brief legitimately
+# informs the model, and #48 chunk-cache keys derive from the chunk text, so
+# stripping there would invalidate every cached extraction on every install.
+# The laundering happens at verification, so it is fixed at verification.
+
+# Injected scaffolding rides inside user turns wrapped in <system-reminder>.
+# Quoting it back is daimon vouching for its own output (the self-reference
+# loop, parked 07-15); `pin_imperatives` (#369) has always stripped it for its
+# own scan, and this is that same strip promoted to shared use.
+_SYSTEM_REMINDER_RE = re.compile(r"<system-reminder>.*?</system-reminder>",
+                                 re.DOTALL | re.IGNORECASE)
+# Line-scoped: a recall injection is exactly one line and never spans a
+# newline, so a genuine user sentence on the next line keeps its witness.
+_RECALL_LINE_RE = re.compile(r"daimon recall: prior work —[^\n]*")
+# Message-scoped: the briefing is a multi-line render with no terminator, so
+# everything from its first marker to the end of the MESSAGE goes. Either
+# marker fires on its own — a host that swallows the hook's `DAIMON BRIEFING`
+# header still emits the render's own first line. A deliberate
+# over-approximation: over-stripping costs a downgrade to inferred,
+# under-stripping mints a false `verbatim`, and only one of those is a
+# security bug.
+_BRIEF_HEAD_RE = re.compile(
+    r"(?:DAIMON BRIEFING |While you were away — here['’]s where we left off\.).*",
+    re.DOTALL)
+
+# Code-owned, absent-never-False (#292 discipline, same as `grounded`): set
+# only where verify_quotes proves the quote lives in injected output and
+# nowhere else, so `verification_rejections` can ledger it under its own
+# reason code and the echo rate becomes an endogenous measurement.
+ECHO_ONLY_KEY = "quote_echo_only"
+
+
+def strip_injected(text: str) -> str:
+    """`text` minus daimon's own injected spans — ONE message's text.
+
+    The briefing rule truncates to end of string, which is end of MESSAGE by
+    contract: every caller hands this a single message body. The
+    whole-transcript haystack goes through `stripped_transcript`, which strips
+    per message and re-renders, so a briefing never swallows the turns after
+    it. Non-str input yields "" — an unusable haystack fails closed."""
+    if not isinstance(text, str):
+        return ""
+    text = _SYSTEM_REMINDER_RE.sub(" ", text)
+    text = _RECALL_LINE_RE.sub("", text)
+    return _BRIEF_HEAD_RE.sub("", text)
+
+
+def stripped_transcript(messages) -> str:
+    """`_render_transcript`'s text with every message's injected spans removed
+    — the whole-transcript VERIFICATION haystack (#440).
+
+    Renders shallow message copies whose flattened text has been stripped, so
+    markers, role labels and joins stay byte-identical to the haystack
+    verification read before this fix: only the injected bytes go missing."""
+    stripped = []
+    for m in messages or []:
+        if not isinstance(m, dict):
+            stripped.append(m)
+            continue
+        copy = dict(m)
+        copy["content"] = strip_injected(_message_text(m))
+        stripped.append(copy)
+    return _render_transcript(stripped)
+
+
 def verify_quotes(checkpoint, transcript_text: str, messages=None) -> int:
     """Verify every verbatim item's quote against the rendered transcript, in
     place (#125). On a hit the item gets `quote_verified: true` AND a
@@ -855,13 +931,30 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None) -> int:
     (serialize_strict, itself not now-aware), and datetime.now(...) inline
     matches store.append_event's own stamping idiom (store.py) rather than
     threading a new param through a call chain that has no other use for
-    it."""
-    texts_by_id = message_texts_by_id(messages) if messages else {}
+    it.
+
+    #440: both haystacks are stripped of daimon's OWN injected output first
+    (see strip_injected) — a quote copied out of a recall line or a briefing
+    block is an echo, not a witness, and must never earn `verbatim`. A miss
+    is re-checked against the unstripped text so an echoed quote is ledgered
+    under `echo-only` rather than the generic absent-quote reason."""
+    # #440: the RAW pair survives alongside the stripped haystacks, read on
+    # the failure path only — to tell an echoed quote from an absent one.
+    raw_texts_by_id = message_texts_by_id(messages) if messages else {}
+    texts_by_id = {mid: strip_injected(text)
+                   for mid, text in raw_texts_by_id.items()}
+    haystack = (stripped_transcript(messages) if messages
+                else strip_injected(transcript_text))
     # #359: signal pointers (tool-result ids) are outcome evidence, not
     # quote-source claims — they never scope the quote check, and a scoped
     # MISS must not execute them for the quote-id's crime.
     signals = signal_message_ids(messages) if messages else set()
-    downgraded = 0
+    downgraded = echoed = 0
+    # The model never gets a vote on the echo verdict (#292 discipline, same
+    # as `grounded`/`pinned`): any model-emitted value is dropped before the
+    # checker re-derives it.
+    for item in iter_items(checkpoint):
+        item.pop(ECHO_ONLY_KEY, None)
     for item in iter_items(checkpoint):
         if item.get("trust") != "verbatim":
             continue
@@ -873,7 +966,7 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None) -> int:
             item["quote_verified"] = True
             item["last_verified"] = datetime.now(timezone.utc).strftime(
                 "%Y-%m-%dT%H:%M:%SZ")
-        elif quote_matches(quote, transcript_text):
+        elif quote_matches(quote, haystack):
             if scoped is not None:
                 # Resolved AND mismatched: the quote is real but not in its
                 # cited message — drop the disproven QUOTE binding (signal
@@ -891,6 +984,16 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None) -> int:
             item["last_verified"] = datetime.now(timezone.utc).strftime(
                 "%Y-%m-%dT%H:%M:%SZ")
         else:
+            # #440: a second pass over the UNSTRIPPED text separates "present
+            # only in daimon's own injected output" from "absent entirely".
+            # Same downgrade either way — an echo is not a witness — but the
+            # distinct reason code turns the echo rate into something the
+            # rejection ledger can count.
+            raw_scoped = scoped_haystack(item, raw_texts_by_id, exclude=signals)
+            if ((raw_scoped is not None and quote_matches(quote, raw_scoped))
+                    or quote_matches(quote, transcript_text)):
+                item[ECHO_ONLY_KEY] = True
+                echoed += 1
             item["trust"] = "inferred"
             item["quote_verified"] = False
             # A downgraded quote is not evidence; a binding for it is noise.
@@ -902,11 +1005,16 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None) -> int:
             # (#194): this line is the only surviving record of the downgrade —
             # the CLI routes it to serialize.log, which holds full result lines.
             logged, _ = redact.redact_text(item.get("text") or "")
-            log.warning("quote verification: downgraded verbatim->inferred: %s",
-                        logged)
+            if item.get(ECHO_ONLY_KEY):
+                log.warning("quote verification: downgraded verbatim->inferred "
+                            "(echo-only: quote appears only in daimon's own "
+                            "injected output): %s", logged)
+            else:
+                log.warning("quote verification: downgraded verbatim->inferred: %s",
+                            logged)
     if downgraded:
-        log.info("quote verification: %d verbatim item(s) downgraded to inferred",
-                 downgraded)
+        log.info("quote verification: %d verbatim item(s) downgraded to inferred"
+                 " (%d echo-only)", downgraded, echoed)
     return downgraded
 
 
@@ -1013,8 +1121,13 @@ def verification_rejections(checkpoint) -> list:
         if not isinstance(ref, str) or not ref:
             continue
         if item.get("quote_verified") is False:
+            # #440: the two ways a quote fails are worth telling apart —
+            # "nowhere in the session" is a fabrication signal, "only inside
+            # daimon's own injected output" is the echo rate.
             out.append({"item_ref": ref, "check": "quote",
-                        "reason": "quote-not-in-transcript"})
+                        "reason": ("echo-only"
+                                   if item.get(ECHO_ONLY_KEY) is True
+                                   else "quote-not-in-transcript")})
         if item.get(GROUNDED_KEY) is False:
             out.append({"item_ref": ref, "check": "outcome",
                         "reason": "no-signal-cited"})
@@ -1101,9 +1214,9 @@ _IMPERATIVE_RE = re.compile(
 
 # Injected scaffolding (briefings, hook output) rides inside user turns
 # wrapped in <system-reminder> — pinning it would quote daimon's own output
-# back as a user constraint (the self-reference loop, parked 07-15).
-_SYSTEM_REMINDER_RE = re.compile(r"<system-reminder>.*?</system-reminder>",
-                                 re.DOTALL | re.IGNORECASE)
+# back as a user constraint (the self-reference loop, parked 07-15). The
+# pattern itself now lives with the #440 strip family above, which generalized
+# this guard from the auto-pin scan to the verification haystacks.
 
 
 def _constraint_sentences(text: str):

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -886,12 +886,15 @@ def stripped_transcript(messages) -> str:
 
     Renders shallow message copies whose flattened text has been stripped, so
     markers, role labels and joins stay byte-identical to the haystack
-    verification read before this fix: only the injected bytes go missing."""
+    verification read before this fix: only the injected bytes go missing.
+
+    No non-dict guard on purpose: `serialize_strict` renders the SAME list
+    through `_render_transcript` before verification runs, and that raises on
+    any non-dict row — so a message list that reaches here has already proven
+    itself dict-shaped. A guard would only move a crash that already
+    happened."""
     stripped = []
     for m in messages or []:
-        if not isinstance(m, dict):
-            stripped.append(m)
-            continue
         copy = dict(m)
         copy["content"] = strip_injected(_message_text(m))
         stripped.append(copy)

--- a/plugin/tests/test_quote_verification.py
+++ b/plugin/tests/test_quote_verification.py
@@ -859,6 +859,22 @@ def test_strip_injected_leaves_ordinary_text_byte_identical():
     assert serializer.strip_injected(text) == text
 
 
+def test_a_contentless_row_does_not_break_verification():
+    """A host row whose `content` is null flattens to None, not "" — so the
+    strip runs on a non-str and must fail closed (empty haystack) instead of
+    raising. Verification of the OTHER messages has to survive it: one
+    malformed row must never cost the whole capture its quotes."""
+    msgs = _msgs(("user", "we adopt the D-007 prompt for the serializer", "u-1"))
+    msgs.append({"role": "assistant", "content": None, "id": "a-2"})
+    cp = _decision(text="a real decision",
+                   quote="adopt the D-007 prompt for the serializer")
+    n = serializer.verify_quotes(cp, serializer._render_transcript(msgs), msgs)
+    item = _only_decision(cp)
+    assert n == 0
+    assert item["trust"] == "verbatim"
+    assert item["quote_verified"] is True
+
+
 # verify_quotes: an echo never earns quote_verified
 
 def test_quote_only_in_a_recall_line_downgrades_to_inferred():

--- a/plugin/tests/test_quote_verification.py
+++ b/plugin/tests/test_quote_verification.py
@@ -786,3 +786,199 @@ def test_audit_quotes_stale_id_falls_back_to_whole_scan(
     assert "id-resolved: 0" in out
     assert "verified: 1" in out
     assert "failed: 0" in out
+
+
+# ---- Unit G (#440): daimon's own injected output is not a witness ----
+#
+# The recall hook and the SessionStart briefing print INTO the transcript, and
+# transcript.py flattens hook stdout byte-identically into the user turn that
+# carried it. Verification therefore used to accept a quote copied out of
+# daimon's own echo as though this session had witnessed it — a prior
+# session's item laundered as freshly verbatim, bound to a real user turn.
+# The verification haystacks (and ONLY those — the extraction prompt and the
+# chunk cache keep seeing the raw text) drop injected spans first.
+
+_ECHOED = "we agreed to freeze the verbatim pin on reconsolidation"
+_RECALL = ('daimon recall: prior work — decision from S0 (2h ago): '
+           f'"{_ECHOED}" [verbatim]. More: daimon recall "freeze verbatim pin"')
+_BRIEF = ("DAIMON BRIEFING (checkpoint: S0, written 2h ago)\n"
+          "While you were away — here's where we left off.\n"
+          f"decisions:\n- {_ECHOED}")
+_REMINDER = f"<system-reminder>\n{_BRIEF}\n</system-reminder>"
+
+
+def _msgs(*turns):
+    """(role, content, id) turns shaped like transcript.py's Claude Code rows."""
+    return [{"role": r, "content": c, "id": i} for r, c, i in turns]
+
+
+def _decision(**over):
+    item = {"text": "freeze the pin", "trust": "verbatim", "quote": _ECHOED}
+    item.update(over)
+    return _cp_with({("working_context", "recent_decisions"): [item]})
+
+
+def _only_decision(cp):
+    return cp["working_context"]["recent_decisions"][0]
+
+
+# strip_injected: the shared strip, unit-level
+
+def test_strip_injected_removes_a_system_reminder_span():
+    out = serializer.strip_injected(f"genuine before\n{_REMINDER}\ngenuine after")
+    assert _ECHOED not in out
+    assert "genuine before" in out
+    assert "genuine after" in out
+
+
+def test_strip_injected_removes_a_recall_line_but_keeps_its_neighbours():
+    out = serializer.strip_injected(
+        f"my own words here\n{_RECALL}\nand more of mine")
+    assert _ECHOED not in out
+    assert "my own words here" in out
+    assert "and more of mine" in out
+
+
+def test_strip_injected_truncates_from_an_unwrapped_briefing_prefix():
+    out = serializer.strip_injected(f"please review the plan\n{_BRIEF}")
+    assert _ECHOED not in out
+    assert "please review the plan" in out
+
+
+def test_strip_injected_truncates_from_the_bare_briefing_header():
+    # A host that swallows the DAIMON BRIEFING line still emits the render's
+    # own header, so the header alone must be enough to fire the strip.
+    out = serializer.strip_injected(
+        f"ok\nWhile you were away — here's where we left off.\n- {_ECHOED}")
+    assert _ECHOED not in out
+    assert "ok" in out
+
+
+def test_strip_injected_leaves_ordinary_text_byte_identical():
+    text = "we decided to adopt the D-007 prompt\n- and to ship it on Friday"
+    assert serializer.strip_injected(text) == text
+
+
+# verify_quotes: an echo never earns quote_verified
+
+def test_quote_only_in_a_recall_line_downgrades_to_inferred():
+    msgs = _msgs(("user", f"{_RECALL}\nwhat did we settle on?", "u-1"))
+    cp = _decision()
+    n = serializer.verify_quotes(cp, serializer._render_transcript(msgs), msgs)
+    item = _only_decision(cp)
+    assert n == 1
+    assert item["trust"] == "inferred"
+    assert item["quote_verified"] is False
+    assert item["quote_echo_only"] is True
+
+
+def test_quote_only_in_a_system_reminder_brief_downgrades_to_inferred():
+    msgs = _msgs(("user", f"{_REMINDER}\ncarry on please", "u-1"))
+    cp = _decision()
+    n = serializer.verify_quotes(cp, serializer._render_transcript(msgs), msgs)
+    item = _only_decision(cp)
+    assert n == 1
+    assert item["trust"] == "inferred"
+    assert item["quote_verified"] is False
+    assert item["quote_echo_only"] is True
+
+
+def test_quote_only_in_an_unwrapped_briefing_block_downgrades_to_inferred():
+    # The context-emitting hosts' path: hook stdout lands raw, no wrapper.
+    msgs = _msgs(("user", _BRIEF, "u-1"),
+                 ("user", "so where were we?", "u-2"))
+    cp = _decision()
+    n = serializer.verify_quotes(cp, serializer._render_transcript(msgs), msgs)
+    item = _only_decision(cp)
+    assert n == 1
+    assert item["quote_verified"] is False
+    assert item["quote_echo_only"] is True
+
+
+def test_genuine_text_adjacent_to_an_injected_line_still_verifies():
+    genuine = "let us cut the release once the write guard lands"
+    msgs = _msgs(("user", f"{_RECALL}\n{genuine}", "u-1"))
+    cp = _decision(text="cut the release", quote=genuine)
+    n = serializer.verify_quotes(cp, serializer._render_transcript(msgs), msgs)
+    item = _only_decision(cp)
+    assert n == 0
+    assert item["trust"] == "verbatim"
+    assert item["quote_verified"] is True
+    assert "quote_echo_only" not in item
+
+
+def test_echo_quote_bound_to_the_injected_turn_loses_its_binding():
+    # Whole-turn id granularity is exactly what made the laundering possible:
+    # the injected span and the user's own prose share one message id.
+    msgs = _msgs(("user", f"{_RECALL}\nplease continue", "u-1"),
+                 ("assistant", "on it", "a-2"))
+    cp = _decision(source_message_ids=["u-1"])
+    serializer.verify_quotes(cp, serializer._render_transcript(msgs), msgs)
+    item = _only_decision(cp)
+    assert item["quote_verified"] is False
+    assert item["quote_echo_only"] is True
+    assert "source_message_ids" not in item
+
+
+def test_quote_absent_entirely_is_not_flagged_echo_only():
+    msgs = _msgs(("user", "nothing related here at all", "u-1"))
+    cp = _decision(quote="this sentence is nowhere in the source transcript")
+    serializer.verify_quotes(cp, serializer._render_transcript(msgs), msgs)
+    item = _only_decision(cp)
+    assert item["quote_verified"] is False
+    assert "quote_echo_only" not in item
+
+
+def test_echo_flag_is_code_owned_and_model_values_are_stripped():
+    cp = _decision(quote="adopt the D-007 prompt", quote_echo_only=True)
+    serializer.verify_quotes(cp, "assistant: adopt the D-007 prompt today")
+    item = _only_decision(cp)
+    assert item["quote_verified"] is True
+    assert "quote_echo_only" not in item
+
+
+def test_legacy_two_arg_call_still_strips_a_reminder_span():
+    cp = _decision()
+    n = serializer.verify_quotes(cp, f"user: {_REMINDER}")
+    assert n == 1
+    assert _only_decision(cp)["quote_echo_only"] is True
+
+
+# the rejection ledger carries the distinct reason code
+
+def test_capture_writes_the_echo_only_reason_to_the_rejection_ledger(
+    tmp_checkpoint_dir, fake_chat_factory
+):
+    from daimon_briefing import capture
+    chat = fake_chat_factory(_script([
+        {"text": "freeze the pin", "trust": "verbatim", "quote": _ECHOED}]))
+    msgs = _msgs(("user", f"{_RECALL}\nwhat did we settle on?", "u-1"))
+    msgs += [dict(m, id=f"m-{i}") for i, m in enumerate(make_messages(12))]
+    capture.run("S1", msgs, project="/p/E", chat=chat, deadline=None)
+    slug = store.project_slug("/p/E")
+    rows = [json.loads(line) for line in
+            (tmp_checkpoint_dir / slug / "verification.jsonl")
+            .read_text(encoding="utf-8").splitlines()]
+    assert [r["reason"] for r in rows] == ["echo-only"]
+    assert rows[0]["check"] == "quote"
+
+
+# `daimon audit` reads the same stripped haystack
+
+def test_audit_quotes_does_not_verify_an_echoed_quote(
+    tmp_checkpoint_dir, _projects_dir, capsys
+):
+    slug = store.project_slug("/p/A")
+    _write_transcript(_projects_dir, slug, "SA", [
+        ("user", f"{_RECALL}\nwhat did we settle on?"),
+        ("assistant", "let me look"),
+    ])
+    store.write_checkpoint("SA", _stored_checkpoint("SA", slug, [
+        {"text": "freeze the pin", "trust": "verbatim", "quote": _ECHOED,
+         "id": "d-echo"}]), project_dir="/p/A")
+
+    rc = cli.main(["audit-quotes", "--project", "/p/A"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "verified: 0" in out
+    assert "failed: 1" in out

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -2413,6 +2413,16 @@ def test_rejections_derives_quote_downgrade():
         {"item_ref": "a", "check": "quote", "reason": "quote-not-in-transcript"}]
 
 
+def test_rejections_derives_echo_only_quote_downgrade():
+    """#440: a quote whose only support was daimon's own injected output gets
+    its own reason code, so the echo rate is measurable rather than hidden
+    inside the generic quote-not-in-transcript bucket."""
+    ck = _ck([{"id": "a", "trust": "inferred", "quote_verified": False,
+               "quote_echo_only": True}])
+    assert serializer.verification_rejections(ck) == [
+        {"item_ref": "a", "check": "quote", "reason": "echo-only"}]
+
+
 def test_rejections_derives_outcome_downgrade():
     ck = _ck([{"id": "b", "trust": "inferred", "grounded": False}])
     assert serializer.verification_rejections(ck) == [


### PR DESCRIPTION
Closes #440

## What

`verify_quotes` and `daimon audit` now check verbatim quotes against a transcript with daimon's **own injected output removed**. A new shared `serializer.strip_injected(text)` drops the three injection surfaces:

- `<system-reminder>…</system-reminder>` spans — the existing `_SYSTEM_REMINDER_RE` promoted from its single `pin_imperatives` (#369) use to shared use
- `daimon recall: prior work — …` lines (line-scoped, so a genuine sentence on the next line keeps its witness)
- a `DAIMON BRIEFING ` prefix or the `While you were away — here's where we left off.` header, to end of message

`stripped_transcript(messages)` applies it per message and re-renders through `_render_transcript`, so the "to end of message" over-approximation can never swallow the turns *after* a briefing. `verify_quotes` uses it when `messages` is available (the only production path); the legacy two-arg call falls back to `strip_injected(transcript_text)`.

On a verification failure the quote is re-checked against the **unstripped** text. A hit there means the quote lives only in daimon's own output: the item still downgrades to `inferred`, but carries the code-owned `quote_echo_only` flag, and `verification_rejections` ledgers it under the distinct reason code `echo-only` instead of `quote-not-in-transcript`.

## Why

The recall hook and the SessionStart briefing print *into* the host's transcript, and `transcript.py` flattens hook stdout byte-identically into the user turn that carried it — under the **same message id** as the user's own prose (whole-turn granularity, #358). So a quote copied out of that echo passed verification and stored as `trust: "verbatim"`, `quote_verified: true`, `source_message_ids` bound to a real turn in *this* session: a prior session's item laundered as freshly witnessed. `daimon audit` re-blessed it through the same unstripped haystack, with the CLI's authority behind it.

Scope was kept deliberately narrow. `_render_transcript` still feeds the extractor raw text: the brief legitimately informs the model, and #48 chunk-cache keys derive from the chunk text, so stripping there would invalidate every cached extraction on every install. The laundering happens at verification, so it is fixed at verification.

**Expected observable:** the measured verbatim share of captured items drops, because part of today's rate is echo counted as fresh capture. That drop is the correction, not a regression — the #364 re-read should be annotated accordingly. The `echo-only` reason code is what makes the size of that share measurable.

Refs #268 (hard prerequisite for its "echo does not self-corroborate" guarantee), #292, #361.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/serializer.py` | New `strip_injected` / `stripped_transcript` + `ECHO_ONLY_KEY`; `_SYSTEM_REMINDER_RE` moved up to the shared block; `verify_quotes` matches against stripped haystacks and re-checks misses against the raw text; `verification_rejections` emits `echo-only` |
| `plugin/daimon_briefing/cli.py` | `daimon audit` builds both haystacks through the strip |
| `plugin/tests/test_quote_verification.py` | New "Unit G (#440)" section — 15 tests |
| `plugin/tests/test_serializer.py` | `echo-only` rejection-row derivation, next to the existing #376 group |

## Tests

Strict TDD — all 16 tests were written first and observed failing (13 + 1 on the first run, plus 2 regression guards that passed from the start by design: adjacent genuine text and absent-entirely quotes must keep behaving exactly as before).

- **`2238 passed, 2 skipped`** (baseline `2222` + 16 new). `ruff check` clean; `mypy` adds no new errors.
- Acceptance criteria, one test each: quote only in a `daimon recall:` line → `inferred` / `quote_verified: false` / `echo-only`; same for a `<system-reminder>`-wrapped brief and an unwrapped `DAIMON BRIEFING` block; genuine user text on a line adjacent to an injected line still verifies; `daimon audit` reports `verified: 0  failed: 1` on an echoed quote; the rejection ledger on disk carries `echo-only` after a real `capture.run`.
- Also covered: an echo quote bound to the injected turn loses its `source_message_ids` binding; an absent-entirely quote is **not** flagged `echo-only`; the flag is code-owned (a model-emitted value is stripped before the checker re-derives it); the legacy two-arg call still strips.

## Design notes

Two calls worth flagging for review:

1. **`strip_injected` is documented as single-message semantics.** Applying the briefing rule's end-of-string truncation to a whole rendered transcript would delete everything after the first briefing — in practice the entire haystack, since the brief lands in the first turn. Stripping per message and re-rendering keeps the over-approximation bounded to the message that actually carries the injection, and keeps markers, role labels and joins byte-identical to the haystack verification read before this change.
2. **The recall-line pattern is not anchored to line start.** In a rendered transcript the line is prefixed with `[mN] user: `, so anchoring would miss it on the legacy two-arg path. Matching marker-to-end-of-line strips the whole injected span either way, and leaves anything preceding it on the line intact — the conservative direction for genuine content.
