### PR TITLE
feat(policy): bind item origin at write time (#268 slice 1)

### DIFF
--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -318,6 +318,18 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                 # recorded against the old id still binds after re-extraction.
                 if item.get("id"):
                     twin.setdefault("id", item["id"])
+                # Origin (#268) rides that same rail, and the twin path is the
+                # ONLY place it needs a line: plain carry deep-copies the whole
+                # prev item, binding included. A reworded twin is not a copy —
+                # without this it would reach write_checkpoint unbound and
+                # bind_origin would name THIS session as the first writer, so
+                # every rewording would mint a fresh witness and a claim
+                # restated across N sessions would read as N independent
+                # agreements. Absent on a pre-#268 prev item -> left unbound
+                # here (write_checkpoint binds it), never an empty stamp.
+                for field in ("origin_session", "origin_author"):
+                    if item.get(field):
+                        twin.setdefault(field, item[field])
                 continue
             if item.get("id") in resolved:
                 continue  # world closed this loop (#102) — stop carrying it

--- a/plugin/daimon_briefing/policy.py
+++ b/plugin/daimon_briefing/policy.py
@@ -9,8 +9,11 @@ order is load-bearing and must not change:
 2. drop_forgotten — the value-keyed forget gate (#402) compares against the
    STORED (post-redaction) text the forget command keyed its tombstone on —
    a raw re-extraction of a redacted-then-forgotten sentence only folds to
-   the tombstoned key because redaction already ran; and
-3. stamp_item_ids — ids (#102) are stamped LAST, so they hash redacted text
+   the tombstoned key because redaction already ran;
+3. bind_origin — write-time origin binding (#268) runs after the forget gate
+   for the same reason id-stamping does: a dropped item is never bound to an
+   origin it will not reach disk under; and
+4. stamp_item_ids — ids (#102) are stamped LAST, so they hash redacted text
    and a dropped item is never minted an id at all.
 
 Like the helpers it absorbed, every function mutates its checkpoint argument
@@ -156,13 +159,70 @@ def stamp_item_ids(checkpoint: dict) -> None:
             seen.add(cand)
 
 
+def bind_origin(checkpoint: dict) -> None:
+    """Write-time origin binding (#268 slice 1): stamp each item with the
+    session and author that FIRST wrote it.
+
+    `carried_from` cannot answer this. It names the session an item was
+    copied from on its LAST hop, and on the twin path (a session restating a
+    carried claim in its own words) it is not even that — the reworded native
+    is not a copy, so the next carry stamps it with the restating session.
+    Corroboration counting needs the first writer: two checkpoints agreeing
+    because one copied the other are one witness, not two, and without a
+    first-writer stamp a claim re-asserted across N sessions looks like N
+    independent agreements. That is the manufactured-corroboration failure
+    mode, so origin must be bound where the claim is born, not derived later
+    from a chain that has already lost the answer.
+
+    setdefault semantics, the rail `id` and `first_seen` already ride: a
+    carried copy arrives bound and is never re-bound, so re-writes
+    (anchor --attach's read-mutate-write), rotation, and re-serialization
+    are all idempotent. The corollary is that a value present here is
+    honored forever — which is why the serialize boundary strips any
+    model-emitted binding before this ever runs (serializer's
+    _CODE_OWNED_ITEM_KEYS), the same discipline as `grounded`/`pinned`.
+
+    Only non-empty string fields bind. An empty origin would read as a real
+    witness with an unnameable source; absent = unknown is the project
+    convention (project_slug, git_branch). Walks _ITEM_LISTS, so
+    active_topic is excluded for the same reason stamp_item_ids excludes it:
+    it is per-session by definition and never carries (#33)."""
+    session = checkpoint.get("session_id")
+    author = checkpoint.get("author")
+    stamps = [(key, val) for key, val in (("origin_session", session),
+                                          ("origin_author", author))
+              if isinstance(val, str) and val.strip()]
+    if not stamps:
+        return
+    for section, key in _ITEM_LISTS:
+        block = checkpoint.get(section)
+        if not isinstance(block, dict):
+            continue  # torn/legacy blob — drop_forgotten's tolerance, not
+            #           redact_checkpoint's `or {}`, which trips on a str
+        items = block.get(key)
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            for field, val in stamps:
+                item.setdefault(field, val)
+
+
 def admit_checkpoint(checkpoint: dict, forgotten_keys: set) -> list:
     """Run the full admission pipeline, in the only valid order (module
-    docstring): redact, then the forget gate, then id-stamping. Mutates
-    `checkpoint` in place; returns the forget-dropped items for the caller's
-    hit accounting (#404)."""
+    docstring): redact, then the forget gate, then origin binding, then
+    id-stamping. Mutates `checkpoint` in place; returns the forget-dropped
+    items for the caller's hit accounting (#404).
+
+    bind_origin (#268) sits AFTER the forget gate so a dropped item is never
+    bound to an origin it will not reach disk under — the same reason ids are
+    stamped after it. Its position relative to stamp_item_ids is free (they
+    touch disjoint fields and neither reads the other's output); it runs
+    first only so id-stamping keeps its documented place as the LAST gate."""
     redact_checkpoint(checkpoint)
     dropped = drop_forgotten(checkpoint, forgotten_keys)
+    bind_origin(checkpoint)
     stamp_item_ids(checkpoint)
     return dropped
 

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -1605,11 +1605,24 @@ def _merge_partials(chat, session_id: str, partials: list, deadline,
 _CODE_OWNED_KEYS = (
     "format_version", "created", "author",
     "transcript_hash", "project_slug", "git_branch", "receipts",
+    # #268: origin binding is asserted by policy.bind_origin at the write
+    # boundary. No code path reads a top-level copy, but a model naming the
+    # key must not leave one lying beside the real per-item stamps.
+    "origin_session", "origin_author",
 )
+
+# The same discipline one level down: origin binds per ITEM (#268 S1), and
+# policy.bind_origin uses setdefault so a carried item's binding survives a
+# re-write. That makes any value already on an item authoritative forever —
+# so a model-emitted one is a self-issued witness that corroboration counting
+# would then treat as an independent session. Stripped from freshly authored
+# model output only, exactly like `grounded`/`pinned` (#292 discipline).
+_CODE_OWNED_ITEM_KEYS = ("origin_session", "origin_author")
 
 
 def strip_code_owned_keys(checkpoint: dict) -> None:
-    """Discard any code-owned key a model emitted in its own output.
+    """Discard any code-owned key a model emitted in its own output, at the
+    checkpoint level (_CODE_OWNED_KEYS) and per item (_CODE_OWNED_ITEM_KEYS).
 
     Public: called both here (after every fresh _produce() parse) and by
     cli's `_cmd_write_checkpoint`, the other place a model authors a
@@ -1631,6 +1644,10 @@ def strip_code_owned_keys(checkpoint: dict) -> None:
         if key in checkpoint:
             log.info("serialize: discarding model-supplied code-owned key %r", key)
             del checkpoint[key]
+    for item in iter_items(checkpoint):
+        for key in _CODE_OWNED_ITEM_KEYS:
+            if item.pop(key, None) is not None:
+                log.info("serialize: discarding model-supplied item key %r", key)
 
 
 def _stamp_llm_provenance(checkpoint: dict) -> None:

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -367,6 +367,63 @@ def test_twin_inherits_prev_id():
     assert qs[0]["id"] == "o-aaa111"
 
 
+def test_twin_inherits_prev_origin_binding():
+    """#268 S1: origin rides the same rail as id/first_seen. A reworded native
+    twin is the SAME claim, so the session that first wrote it stays its
+    origin — otherwise every rewording would mint a fresh witness and two
+    sessions restating one claim would corroborate each other."""
+    prev = _cp("S-prev", 1, questions=[
+        _item("cache guard holds", id="o-aaa111",
+              origin_session="S-origin", origin_author="ada")])
+    new = _cp("S-new", 0, questions=[
+        _item("the cache guard is holding", days=0)])
+    out = carry.merge(new, prev, NOW)
+    twin = out["working_context"]["open_questions"][0]
+    assert twin["origin_session"] == "S-origin"
+    assert twin["origin_author"] == "ada"
+
+
+def test_twin_keeps_its_own_origin_over_prev():
+    """setdefault, not overwrite — a twin already bound (a re-merge, or a
+    native that was itself carried in) keeps the binding it arrived with."""
+    prev = _cp("S-prev", 1, questions=[
+        _item("cache guard holds", origin_session="S-prev-origin",
+              origin_author="grace")])
+    new = _cp("S-new", 0, questions=[
+        _item("the cache guard is holding", days=0,
+              origin_session="S-own", origin_author="ada")])
+    out = carry.merge(new, prev, NOW)
+    twin = out["working_context"]["open_questions"][0]
+    assert twin["origin_session"] == "S-own"
+    assert twin["origin_author"] == "ada"
+
+
+def test_twin_without_prev_origin_is_left_unbound():
+    """A pre-#268 prev checkpoint has no origin to give. The twin must stay
+    absent (write_checkpoint's bind_origin then binds it to THIS session) —
+    never an empty string, which would read as a nameless witness."""
+    prev = _cp("S-prev", 1, questions=[_item("cache guard holds")])
+    new = _cp("S-new", 0, questions=[
+        _item("the cache guard is holding", days=0)])
+    out = carry.merge(new, prev, NOW)
+    twin = out["working_context"]["open_questions"][0]
+    assert "origin_session" not in twin
+    assert "origin_author" not in twin
+
+
+def test_plain_carry_copy_keeps_its_origin():
+    """The non-twin path needs no propagation line — carried items are
+    deep-copied whole — but the guarantee is load-bearing, so pin it."""
+    prev = _cp("S-prev", 1, questions=[
+        _item("zephyr ledger drop unresolved",
+              origin_session="S-origin", origin_author="ada")])
+    out = carry.merge(_cp("S-new"), prev, NOW)
+    carried = out["working_context"]["open_questions"][0]
+    assert carried["carried_from"] == "S-prev"     # one hop back
+    assert carried["origin_session"] == "S-origin"  # all the way back
+    assert carried["origin_author"] == "ada"
+
+
 def test_resolved_prev_item_does_not_carry():
     prev = _cp("S-prev", 1, questions=[
         _item("dead loop no longer relevant", id="o-dead01"),

--- a/plugin/tests/test_policy.py
+++ b/plugin/tests/test_policy.py
@@ -329,3 +329,171 @@ def test_admit_row_uses_injected_redact_fn_and_skips_non_strings():
     assert out["item_text"] is None    # non-string passes through
     assert out["n"] == 3               # non-string passes through
     assert "absent" not in out         # named-but-missing field not created
+
+
+# ---- #268 S1: bind_origin — write-time origin binding ----
+#
+# `carried_from` names the session an item was copied FROM on its last hop,
+# which is the PREVIOUS session, not the session that first wrote the claim.
+# Corroboration counting needs the latter: two checkpoints agreeing because one
+# copied the other is one witness, not two. bind_origin stamps the writing
+# session/author once, at the write boundary, and never rewrites it.
+
+
+def _origin_cp(sid="S-A", author="ada"):
+    return {
+        "session_id": sid,
+        "author": author,
+        "working_context": {
+            "active_topic": {"text": "the ingest path", "trust": "inferred"},
+            "open_questions": [{"text": "should we shard?", "trust": "inferred"}],
+            "recent_decisions": [{"text": _S, "trust": "inferred"}],
+        },
+        "epistemic_snapshot": {
+            "strong_beliefs": [{"text": "sqlite is enough", "trust": "inferred"}],
+            "uncertainties": [{"text": "write volume unknown", "trust": "inferred"}],
+            "contradictions_flagged": [{"text": "we also said postgres",
+                                        "trust": "inferred"}],
+        },
+    }
+
+
+def _list_items(cp):
+    from daimon_briefing import schema
+
+    return [item
+            for section, key in schema.ITEM_LISTS
+            for item in (cp.get(section) or {}).get(key) or []
+            if isinstance(item, dict)]
+
+
+def test_bind_origin_stamps_session_and_author_on_every_list_item():
+    from daimon_briefing import policy
+
+    cp = _origin_cp()
+    policy.bind_origin(cp)
+
+    items = _list_items(cp)
+    assert len(items) == 5  # every list section, not just recent_decisions
+    for item in items:
+        assert item["origin_session"] == "S-A"
+        assert item["origin_author"] == "ada"
+
+
+def test_bind_origin_never_overwrites_an_existing_origin():
+    """setdefault semantics — the same rail `id`/`first_seen` ride. A carried
+    copy arrives already bound to the session that FIRST wrote it, and the
+    session re-writing it must never restamp itself as the origin."""
+    from daimon_briefing import policy
+
+    cp = _origin_cp(sid="S-B", author="grace")
+    carried = cp["working_context"]["recent_decisions"][0]
+    carried["origin_session"] = "S-A"
+    carried["origin_author"] = "ada"
+
+    policy.bind_origin(cp)
+    policy.bind_origin(cp)  # re-admission (anchor --attach rewrite) is idempotent
+
+    assert carried["origin_session"] == "S-A"
+    assert carried["origin_author"] == "ada"
+    # a native item written this session still binds to this session
+    native = cp["working_context"]["open_questions"][0]
+    assert native["origin_session"] == "S-B"
+
+
+def test_bind_origin_skips_absent_or_empty_checkpoint_fields():
+    """An empty origin is worse than none: it would read as a real witness
+    with an unnameable source. Absent field = unknown, the project convention."""
+    from daimon_briefing import policy
+
+    cp = _origin_cp(sid="", author="   ")
+    policy.bind_origin(cp)
+    for item in _list_items(cp):
+        assert "origin_session" not in item
+        assert "origin_author" not in item
+
+    cp = _origin_cp()
+    del cp["author"]
+    policy.bind_origin(cp)
+    for item in _list_items(cp):
+        assert item["origin_session"] == "S-A"   # the known half still binds
+        assert "origin_author" not in item
+
+
+def test_bind_origin_tolerates_malformed_checkpoints():
+    from daimon_briefing import policy
+
+    cp = {"session_id": "S-A", "author": "ada",
+          "working_context": {"recent_decisions": ["bare string", 7, None],
+                              "open_questions": "not-a-list"},
+          "epistemic_snapshot": "not-a-dict"}
+    policy.bind_origin(cp)  # must not raise
+    assert cp["working_context"]["recent_decisions"] == ["bare string", 7, None]
+
+
+def test_admit_checkpoint_binds_origin_and_never_binds_a_dropped_item():
+    """Through the pipeline: the forget gate runs first, so an item the gate
+    dropped is never bound to an origin it will not reach disk under."""
+    from daimon_briefing import policy
+
+    cp = _origin_cp()
+    cp["working_context"]["recent_decisions"].append({"text": _T, "trust": "inferred"})
+    dropped = policy.admit_checkpoint(cp, {normalize.content_key(_S)})
+
+    assert len(dropped) == 1
+    assert "origin_session" not in dropped[0]
+    kept = cp["working_context"]["recent_decisions"]
+    assert [d["text"] for d in kept] == [_T]
+    assert kept[0]["origin_session"] == "S-A"
+    assert kept[0]["origin_author"] == "ada"
+    assert kept[0]["id"]  # id-stamping still runs
+
+
+# ---- #268 S1: origin binding end-to-end through the write boundary ----
+
+
+def test_write_checkpoint_binds_origin_to_the_writing_session_and_author(
+        tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", _A)
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S1", _cp("S1", "2026-07-01T00:00:00Z", [_S]),
+                           project_dir=_A)
+    item = store.read_latest(project_dir=_A,
+                             fallback=False)["working_context"]["recent_decisions"][0]
+    assert item["origin_session"] == "S1"
+    assert item["origin_author"] == "ada"
+
+
+def test_origin_survives_two_carry_hops_while_carried_from_only_names_the_last(
+        tmp_checkpoint_dir, monkeypatch):
+    """A -> B -> C, with B re-discussing the claim in its own words (the twin
+    path). `carried_from` on C's copy names B — one hop back — so it cannot
+    answer "who first wrote this". `origin_session` still says A."""
+    from daimon_briefing import carry, config, store as _store
+
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", _A)
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+
+    _store.write_checkpoint("S-A", _cp("S-A", "2026-07-01T00:00:00Z", [_S]),
+                            project_dir=_A)
+
+    def _write_with_carry(sid, created, texts):
+        cp = _cp(sid, created, texts)
+        prev = _store.read_latest(project_dir=_A, fallback=False)
+        cp = carry.merge(cp, prev, _store._created_epoch(created),
+                         floor=config.carry_floor(), cap=config.carry_max(),
+                         resolved=frozenset())
+        _store.write_checkpoint(sid, cp, project_dir=_A)
+        return cp
+
+    # B restates A's decision in its own wording -> native twin, not a copy.
+    _write_with_carry("S-B", "2026-07-02T00:00:00Z",
+                      ["adopt sqlite for the recall index cache layer"])
+    _write_with_carry("S-C", "2026-07-03T00:00:00Z", [_T])
+
+    latest = _store.read_latest(project_dir=_A, fallback=False)
+    sqlite_item = next(d for d in latest["working_context"]["recent_decisions"]
+                       if "sqlite" in d["text"])
+    assert sqlite_item.get("carried_from") in ("S-B", "S-C")
+    assert sqlite_item["origin_session"] == "S-A"
+    assert sqlite_item["origin_author"] == "ada"

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -1254,6 +1254,11 @@ def test_serialize_prompt_has_external_artifact_identifier_rule():
     ("project_slug", "some-other-project"),
     ("git_branch", "not-the-real-branch"),
     ("receipts", "not-a-real-receipt-marker"),
+    # #268 S1: origin binding is an assertion about WHO first wrote a claim —
+    # the input to corroboration counting. A model that can name it can
+    # manufacture a second witness for its own output.
+    ("origin_session", "S-someone-elses-session"),
+    ("origin_author", "not-the-real-author"),
 ])
 def test_serialize_strips_model_supplied_code_owned_key(fake_chat_factory, key, spoofed):
     spoofed_ckpt = json.loads(_valid_checkpoint_json("S1"))
@@ -1262,6 +1267,44 @@ def test_serialize_strips_model_supplied_code_owned_key(fake_chat_factory, key, 
     ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
     assert ckpt is not None
     assert key not in ckpt  # stripped, not carried through as the model's value
+
+
+def test_serialize_strips_model_supplied_origin_binding_off_items(fake_chat_factory):
+    """#268 S1: origin lives on ITEMS, so the top-level strip is not enough.
+    policy.bind_origin uses setdefault (a carried item's origin must survive
+    a re-write), which means a model-emitted item-level binding would be
+    honored forever — a self-issued witness. Strip it at the same boundary
+    `grounded`/`pinned` are stripped: the freshly parsed model output."""
+    spoofed = json.loads(_valid_checkpoint_json("S1"))
+    for item in [spoofed["working_context"]["active_topic"],
+                 spoofed["working_context"]["open_questions"][0],
+                 spoofed["working_context"]["recent_decisions"][0]]:
+        item["origin_session"] = "S-someone-elses-session"
+        item["origin_author"] = "not-the-real-author"
+    chat = fake_chat_factory(json.dumps(spoofed))
+
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+
+    assert ckpt is not None
+    for item in serializer.iter_items(ckpt):
+        assert "origin_session" not in item
+        assert "origin_author" not in item
+
+
+def test_strip_code_owned_keys_clears_item_origin_on_the_introspection_path():
+    """`daimon write-checkpoint` takes a dict a live model authored directly —
+    the same spoofing surface, one level down (cli calls this function for
+    exactly that reason)."""
+    ckpt = json.loads(_valid_checkpoint_json("S1"))
+    ckpt["working_context"]["open_questions"][0]["origin_session"] = "S-forged"
+    ckpt["working_context"]["open_questions"][0]["origin_author"] = "forger"
+
+    serializer.strip_code_owned_keys(ckpt)
+
+    item = ckpt["working_context"]["open_questions"][0]
+    assert "origin_session" not in item
+    assert "origin_author" not in item
+    assert item["text"] == "q"  # nothing else disturbed
 
 
 def test_serialize_strip_survives_the_validation_retry_pass(fake_chat_factory):


### PR DESCRIPTION
Refs #268

## Summary
- New pure `policy.bind_origin(checkpoint)`: stamps `origin_session`/`origin_author` on every item at admission, setdefault semantics on the `id`/`first_seen` rail — the first writer survives arbitrarily many carry hops, which single-hop `carried_from` cannot answer (and answers wrongly on the reworded-twin path).
- Forgery refusal at the serialize boundary: both keys are code-owned, including a new item-level strip (`_CODE_OWNED_ITEM_KEYS`) — without it a model-emitted origin inside an item would be honored forever by setdefault, a self-issued witness.
- Carry twin block propagates the prev item's binding onto a reworded native twin.

Slice 1 of the origin-bound corroboration design (prerequisite #440 merged as #441). Items without a bound origin remain permanently ineligible for corroboration — never guessed from `carried_from`.

## Changes
| File | Change |
|------|--------|
| `plugin/daimon_briefing/policy.py` | `bind_origin` + wired into `admit_checkpoint` (order documented: after forget gate, before id-stamping) |
| `plugin/daimon_briefing/serializer.py` | `origin_session`/`origin_author` code-owned at top level AND per item |
| `plugin/daimon_briefing/carry.py` | twin block propagates prev origin on the `id`/`first_seen` rail |
| `plugin/tests/` | 15 new cases (policy 7, carry 4, serializer 4) |

## Test plan
- [x] Strict TDD — each case observed red before implementation
- [x] Full suite: 2254 passed, 2 skipped (baseline 2239)
- [x] ruff clean; mypy no new errors (63 = main baseline)
- [x] Zero uncovered added lines (term-missing intersect added-lines = none)
- [x] Purity AST guard, write-audit guard, capture-parity guard all green

## Notes
- `bind_origin` uses `isinstance(block, dict)` tolerance (drop_forgotten's shape) rather than the `or {}` idiom — the latter raises on torn/legacy string sections; siblings carry that latent nit, deliberately not touched here.