### PR TITLE
feat(carry): corroboration predicate — origin-proven independence, pure (#268 slice 2)

### DIFF
--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -27,6 +27,11 @@ _CARRIED_KINDS = schema.CARRIED_KINDS
 
 _MIN_SHARED = 3     # shared salient terms for same-item
 _MIN_RATIO = 0.6    # or this fraction of the shorter term list
+# Which rail a same-item match came in on (#268). Dedup treats them alike;
+# corroboration does not — see _match_path and _record_corroboration's G4.
+_MATCH_EXACT = "exact"
+_MATCH_ABSOLUTE = "absolute"
+_MATCH_RATIO = "ratio"
 _GENERIC_DF = 3     # a term shared by >=3 items of one kind is that kind's
                     # vocabulary, not an item's identity. Filtering it out of
                     # dedup stops generic overlap (data/field/validation, the
@@ -124,8 +129,13 @@ def _generic_terms(texts, k: int = _GENERIC_DF) -> frozenset:
     return frozenset(term for term, n in df.items() if n >= k)
 
 
-def _same_item(a_text: str, b_text: str, generic=frozenset()) -> bool:
-    """Term-overlap identity: the serializer rewords constantly (run-01), so
+def _match_path(a_text: str, b_text: str, generic=frozenset()) -> str:
+    """WHICH rail two texts matched on: `_MATCH_ABSOLUTE`, `_MATCH_RATIO`, or
+    "" for no match. `_same_item` is this function's boolean face; the path
+    itself matters only to corroboration (#268), which trusts the absolute
+    rail and refuses the ratio one.
+
+    Term-overlap identity: the serializer rewords constantly (run-01), so
     exact text misses twins. Shared >=3 salient terms, or >=60% of the shorter
     list, means same item — but only AFTER subtracting `generic` (the kind's
     document-frequent vocabulary), so overlap on common words can't merge
@@ -141,15 +151,29 @@ def _same_item(a_text: str, b_text: str, generic=frozenset()) -> bool:
     Quantity-conflict guard (#173) runs FIRST and short-circuits term overlap
     entirely: two texts stating different numbers are structurally distinct
     even when they share enough subject vocabulary to clear the thresholds
-    below (an UPDATE's shared frame, not a reworded twin)."""
+    below (an UPDATE's shared frame, not a reworded twin).
+
+    Absolute beats ratio when both hold: a pair clearing >=_MIN_SHARED is
+    reported as absolute regardless of the fraction it also happens to pass."""
     if _quantity_conflict(a_text, b_text):
-        return False
+        return ""
     a = set(recall.salient_terms(a_text)) - generic
     b = set(recall.salient_terms(b_text)) - generic
     if len(a) < 2 or len(b) < 2:
-        return False
+        return ""
     shared = len(a & b)
-    return shared >= _MIN_SHARED or shared / min(len(a), len(b)) >= _MIN_RATIO
+    if shared >= _MIN_SHARED:
+        return _MATCH_ABSOLUTE
+    if shared / min(len(a), len(b)) >= _MIN_RATIO:
+        return _MATCH_RATIO
+    return ""
+
+
+def _same_item(a_text: str, b_text: str, generic=frozenset()) -> bool:
+    """Same-item verdict for dedup/twinning — any `_match_path` rail counts.
+    See that function for the thresholds and the don't-merge bias behind
+    them."""
+    return bool(_match_path(a_text, b_text, generic))
 
 
 def _is_reversal_of(native_item: dict, prev_text: str, prev_id,
@@ -186,9 +210,81 @@ def _is_reversal_of(native_item: dict, prev_text: str, prev_id,
     return False
 
 
+def _message_ids(item: dict) -> frozenset:
+    """The item's bound transcript-message ids as a set, tolerating the shapes
+    a hand-edited or pre-#358 checkpoint can hold (absent, non-list, non-str
+    entries) — same read-side tolerance as serializer.scoped_haystack."""
+    ids = item.get("source_message_ids")
+    if not isinstance(ids, list):
+        return frozenset()
+    return frozenset(i for i in ids if isinstance(i, str) and i)
+
+
+def _record_corroboration(observed: list, prev_item: dict, native_item: dict,
+                          match_path: str, out_sid: str) -> None:
+    """Append `(item_id, origin_session, origin_author)` to `observed` when
+    this prev/native pair is INDEPENDENT corroboration — and append nothing
+    at all otherwise (#268 slice 2). Pure: decides, records, emits nothing.
+
+    Corroboration is the one signal that RAISES trust, so every guard below
+    refuses in the same direction: a missed observation costs a boost, a
+    forged one costs the axis. Two checkpoints agreeing because one copied
+    the other are ONE witness (manufactured corroboration, arXiv 2606.24322).
+
+      G1 bound origin  — prev names its first writer (#268 S1). Never guessed
+        from `carried_from`: that names the LAST hop, and on the twin path not
+        even that. Unbound stays permanently ineligible.
+      G2 different origin — the first writer is not the session doing the
+        observing. Both sides required: a checkpoint with no session_id cannot
+        prove somebody ELSE wrote the claim, and unprovable is not corroborated.
+      G3 witnessed, not echoed — the NATIVE item is this session's own verified
+        verbatim. `trust` alone is a claim; `quote_verified is True` is the
+        check (and #441 is what stops daimon's own injected briefing text from
+        passing it). Read PRE-freeze: the #22 verbatim freeze overwrites the
+        native's trust/quote_verified with prev's, so afterwards this reads the
+        wrong item entirely.
+      G4 strong match only — identical text, or >=_MIN_SHARED shared salient
+        terms. The ratio rail exists so short rewordings still MERGE; two
+        shared terms out of three is nowhere near evidence of two independent
+        statements.
+      G5 not a reversal — inherited: reversal pairs never reach the twin block
+        (#167). A contradiction is not agreement.
+      G6 disjoint message binding — both sides citing the same transcript turn
+        is one utterance read twice (a re-serialize, a duplicated transcript).
+        Only fires when BOTH carry ids; absent bindings prove nothing either way.
+
+    G7 (the origin session still exists on disk) is deliberately NOT here —
+    it needs I/O, so it belongs to the emitter (S3), never to this module.
+
+    The recorded id is the one the pair ENDS UP under: the native's own when
+    it has one, else the prev id it inherits on the setdefault rail below (and
+    on the exact-text branch the two are equal anyway — ids are sha1 of
+    kind:text). Neither side having an id means nothing to attribute the
+    observation to, so nothing is recorded. `origin_author` is optional
+    (hosts that name no author): absent becomes "", never a fabricated name."""
+    origin = str(prev_item.get("origin_session") or "")
+    if not origin:
+        return                                                          # G1
+    if not out_sid or origin == out_sid:
+        return                                                          # G2
+    if (native_item.get("trust") != "verbatim"
+            or native_item.get("quote_verified") is not True):
+        return                                                          # G3
+    if match_path not in (_MATCH_EXACT, _MATCH_ABSOLUTE):
+        return                                                          # G4
+    prev_msgs, native_msgs = _message_ids(prev_item), _message_ids(native_item)
+    if prev_msgs & native_msgs:
+        return                                                          # G6
+    item_id = str(native_item.get("id") or prev_item.get("id") or "")
+    if not item_id:
+        return  # no identity to attribute the observation to
+    observed.append((item_id, origin, str(prev_item.get("origin_author") or "")))
+
+
 def merge(new_cp: dict, prev_cp: dict | None, now: float,
           floor: float = 0.05, cap: int = 8,
-          resolved: frozenset = frozenset()) -> dict:
+          resolved: frozenset = frozenset(),
+          observed: list | None = None) -> dict:
     """Fold prev_cp's carry-eligible items into a COPY of new_cp.
 
     Native items are never dropped or reordered — carry only appends, and (on
@@ -205,6 +301,15 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
     and the native item itself is never dropped — only the render layer, not
     carry, decides what to do with a resolved-but-still-mentioned item.
 
+    `observed` (#268 slice 2): an optional list merge APPENDS corroboration
+    observations to — `(item_id, origin_session, origin_author)` per prev/
+    native pair that clears `_record_corroboration`'s guards. Out-parameter
+    rather than a second return value so no existing caller changes; default
+    None skips the predicate entirely, so behaviour is byte-identical to
+    before for everyone who doesn't ask. Observation only: this module still
+    writes no ledger, emits no event and renders nothing (that is S3/S4), and
+    the merged checkpoint is the same either way.
+
     No-op paths (non-dict inputs, anachronism guard) return new_cp UNCHANGED,
     not a copy — callers reassign the result immediately, so a defensive
     deepcopy there would just be wasted work."""
@@ -217,6 +322,11 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
 
     out = copy.deepcopy(new_cp)
     prev_sid = str(prev_cp.get("session_id") or "")
+    # The OBSERVING session — who is agreeing, for the corroboration predicate's
+    # G2. Read off the checkpoint being merged into (it is stamped at
+    # serialize, long before this runs); absent means G2 is unprovable and
+    # every observation refuses.
+    out_sid = str(out.get("session_id") or "")
     for section, key, item_type in _CARRIED_KINDS:
         native = (out.get(section) or {}).get(key)
         if not isinstance(native, list):
@@ -235,6 +345,20 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                 continue
             text = item["text"]
             if text in native_texts:
+                # #268: this branch returns before the twin block, so the
+                # STRONGEST pair there is — a later session restating the
+                # identical sentence — would never be seen. Match against the
+                # natives only: `native_texts` also holds texts carried in
+                # THIS call, and a prev item agreeing with another prev item
+                # is not a witness. The reversal check the twin block gets by
+                # construction (#167) has to be explicit here.
+                if observed is not None:
+                    exact = next((n for n in native if isinstance(n, dict)
+                                  and n.get("text") == text), None)
+                    if exact is not None and not _is_reversal_of(
+                            exact, text, item.get("id"), generic):
+                        _record_corroboration(observed, item, exact,
+                                              _MATCH_EXACT, out_sid)
                 continue  # exact twin already present (idempotency)
             # Reversal guard (#167): a native that supersedes THIS prev item
             # (own verified quote + aimed link) is excluded from twin candidacy
@@ -247,6 +371,16 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                                                  generic)),
                         None)
             if twin is not None:
+                # #268: the corroboration verdict runs FIRST — BEFORE the
+                # freeze below, which overwrites the native twin's trust and
+                # drops its quote_verified, i.e. destroys exactly the evidence
+                # G3 asks for (did THIS session witness the claim, or merely
+                # reword what it was handed?).
+                if observed is not None:
+                    _record_corroboration(
+                        observed, item, twin,
+                        _match_path(text, str(twin.get("text") or ""), generic),
+                        out_sid)
                 # Session re-discussed it. Split by the PREV item's trust class
                 # (#22, two-path recall):
                 #   - verbatim -> FREEZE. A verbatim item carries an immutable

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -1168,3 +1168,236 @@ def test_carry_preserves_scene(monkeypatch):
     carried = merged["working_context"]["open_questions"]
     assert any(i.get("scene") == "asked right after the gateway pinned a bad response"
                for i in carried)
+
+
+# --- #268 S2: the corroboration PREDICATE (observed sink) --------------------
+# merge() gains an optional out-parameter: a list it appends
+# (item_id, origin_session, origin_author) to for every prev/native pair that
+# survives every guard. Pure observation — no ledger, no events, no render
+# change (those are S3/S4), and with the default `observed=None` merge behaves
+# exactly as before.
+#
+# The bar is deliberately brutal, because corroboration is the one signal that
+# RAISES trust: two checkpoints agreeing because one copied the other are one
+# witness, not two (manufactured corroboration, arXiv 2606.24322). Every guard
+# below refuses in the same direction — a missed corroboration costs a boost,
+# a forged one costs the axis.
+
+_COR_PREV = "the quorint ledger reconciliation drops entries on feed pauses"
+_COR_NATIVE = "quorint ledger reconciliation still dropping entries when the feed pauses"
+
+
+def _witness(text=_COR_NATIVE, **kw):
+    """A native item that satisfies G3: THIS session's own verified verbatim."""
+    return _item(text, days=0, **{"trust": "verbatim", "quote": "q-native",
+                                  "quote_verified": True, **kw})
+
+
+def _bound(text=_COR_PREV, **kw):
+    """A prev item bound to a DIFFERENT origin session (G1 + G2 satisfied)."""
+    return _item(text, days=1, **{"id": "o-a1d001",
+                                  "origin_session": "S-origin",
+                                  "origin_author": "ada", **kw})
+
+
+def _observe(prev_items, native_items, sid="S-new"):
+    """Merge with the sink attached; return (observed, merged questions)."""
+    observed: list = []
+    out = carry.merge(_cp(sid, 0, questions=list(native_items)),
+                      _cp("S-prev", 1, questions=list(prev_items)), NOW,
+                      observed=observed)
+    return observed, out["working_context"]["open_questions"]
+
+
+def test_observed_records_reworded_twin_from_a_different_origin():
+    observed, qs = _observe([_bound()], [_witness()])
+    assert observed == [("o-a1d001", "S-origin", "ada")]
+    assert len(qs) == 1  # merge behaviour unchanged: still one twin
+
+
+def test_observed_refuses_when_prev_origin_is_unbound():
+    # G1: a pre-#268 item has no first writer on record. Never guessed from
+    # carried_from — that names the LAST hop, and on the twin path not even
+    # that.
+    observed, _ = _observe([_bound(origin_session=None, carried_from="S-x")],
+                           [_witness()])
+    assert observed == []
+
+
+def test_observed_refuses_when_origin_is_this_same_session():
+    # G2: a session cannot corroborate itself. This is the whole attack — a
+    # claim re-asserted across N re-serializes of ONE session's own writing
+    # would otherwise read as N independent agreements.
+    observed, _ = _observe([_bound(origin_session="S-new")], [_witness()])
+    assert observed == []
+
+
+def test_observed_refuses_when_the_observing_session_is_unnameable():
+    # G2 needs BOTH sides. A checkpoint with no session_id cannot prove the
+    # origin is somebody else's, and unprovable never means corroborated.
+    observed: list = []
+    new = _cp("S-new", 0, questions=[_witness()])
+    del new["session_id"]
+    carry.merge(new, _cp("S-prev", 1, questions=[_bound()]), NOW,
+                observed=observed)
+    assert observed == []
+
+
+def test_observed_refuses_an_inferred_native():
+    # G3: only a WITNESS corroborates. An inferred restatement is the model
+    # agreeing with its own earlier reading, not the world speaking twice.
+    observed, _ = _observe([_bound()], [_item(_COR_NATIVE, days=0)])
+    assert observed == []
+
+
+def test_observed_refuses_a_verbatim_native_whose_quote_never_verified():
+    # G3, second leg: verbatim is a CLAIM, quote_verified is the check. #441
+    # already stopped daimon's own injected briefing text from passing that
+    # check — corroboration rides the verified verdict, nothing weaker.
+    observed, _ = _observe([_bound()], [_witness(quote_verified=False)])
+    assert observed == []
+    observed, _ = _observe([_bound()], [_witness(quote_verified=None)])
+    assert observed == []
+
+
+def test_observed_refuses_a_ratio_only_match():
+    # G4: the ratio path (>=60% of the shorter term list) exists so short
+    # rewordings still MERGE. It is far too loose to certify two independent
+    # statements of the same claim — two shared terms out of three.
+    observed, qs = _observe(
+        [_bound("zephyr ledger drop")],
+        [_witness("zephyr ledger stall")])
+    assert len(qs) == 1      # still twinned — merge behaviour untouched
+    assert observed == []    # but never corroborated
+
+
+def test_observed_records_an_absolute_overlap_match():
+    # Control for the case above: >=3 shared salient terms is the strong path.
+    observed, _ = _observe([_bound()], [_witness()])
+    assert observed == [("o-a1d001", "S-origin", "ada")]
+
+
+def test_observed_refuses_a_reversal_pair():
+    # G5, inherited: a native that SUPERSEDES the prev item is excluded from
+    # twin candidacy entirely (#167), so it never reaches the predicate. A
+    # contradiction must never be counted as agreement.
+    observed: list = []
+    prev, new = _reversal_cps()
+    prev["working_context"]["recent_decisions"][0].update(
+        origin_session="S-origin", origin_author="ada")
+    out = carry.merge(new, prev, NOW, observed=observed)
+    assert observed == []
+    assert len(out["working_context"]["recent_decisions"]) == 2  # unchanged
+
+
+def test_observed_refuses_when_both_sides_cite_the_same_message():
+    # G6: two items bound to the SAME transcript turn are one utterance read
+    # twice (a re-serialize, a duplicated transcript), not two witnesses.
+    observed, _ = _observe(
+        [_bound(source_message_ids=["m-7", "m-9"])],
+        [_witness(source_message_ids=["m-9"])])
+    assert observed == []
+
+
+def test_observed_records_when_message_bindings_are_disjoint():
+    # The other side of G6: different turns is exactly what corroboration is.
+    observed, _ = _observe(
+        [_bound(source_message_ids=["m-7"])],
+        [_witness(source_message_ids=["m-9"])])
+    assert observed == [("o-a1d001", "S-origin", "ada")]
+
+
+def test_observed_refuses_a_quantity_conflict_pair():
+    # Inherited from _same_item (#173): different numbers are structurally
+    # distinct items, so they never twin and never corroborate.
+    observed, qs = _observe(
+        [_bound("the quorint ledger dropped 10 entries over 6 feed pauses")],
+        [_witness("the quorint ledger dropped 3 entries over 6 feed pauses")])
+    assert len(qs) == 2   # two distinct items, no twinning
+    assert observed == []
+
+
+def test_observed_refuses_generic_term_only_overlap():
+    # Inherited (#13 live specimen): the two unrelated items that matched on
+    # exactly {data, field, validation}. Generic vocabulary is not identity,
+    # so there is no twin and nothing to corroborate.
+    observed, qs = _observe(
+        [_bound(_SPEC_A), _bound(_SPEC_SIB, id="o-a1d002")],
+        [_witness(_SPEC_B)])
+    assert observed == []
+    assert len(qs) == 3
+
+
+def test_observed_records_an_exact_text_restatement():
+    # The exact-text short-circuit (idempotency guard) returns BEFORE the twin
+    # block. A later session stating the identical sentence, with its own
+    # verified quote, is the strongest corroboration there is — recording it
+    # has to happen on that branch too or it is lost.
+    observed, _ = _observe([_bound()], [_witness(_COR_PREV)])
+    assert observed == [("o-a1d001", "S-origin", "ada")]
+
+
+def test_observed_exact_text_records_an_empty_author_when_unnamed():
+    # origin_author is optional (hosts that name no author). Absent stays
+    # absent — an empty string in the tuple, never a fabricated name.
+    observed, _ = _observe([_bound(origin_author=None)], [_witness(_COR_PREV)])
+    assert observed == [("o-a1d001", "S-origin", "")]
+
+
+def test_observed_exact_text_refuses_an_inferred_native():
+    # G3 applies identically on the short-circuit branch.
+    observed, _ = _observe([_bound()], [_item(_COR_PREV, days=0)])
+    assert observed == []
+
+
+def test_observed_exact_text_refuses_a_reversal_native():
+    # The twin block drops reversals before the predicate; the short-circuit
+    # branch has no such filter, so it needs the check explicitly. A native
+    # that restates the prev text WHILE superseding it is contradicting
+    # itself — ambiguity refuses, same bias as everywhere else here.
+    observed, _ = _observe(
+        [_bound()],
+        [_witness(_COR_PREV, links=[{"type": "supersedes",
+                                     "target": "o-a1d001"}])])
+    assert observed == []
+
+
+def test_observed_exact_text_match_against_a_carried_sibling_is_not_a_witness():
+    # Two prev items with identical text: the first carries, the second hits
+    # the short-circuit against THAT CARRIED COPY, not against anything this
+    # session wrote. No native, no witness.
+    observed, _ = _observe(
+        [_bound(), _bound(id="o-a1d002")], [_item("unrelated plimsol topic")])
+    assert observed == []
+
+
+def test_observed_refuses_a_pair_with_no_item_id_to_attribute():
+    # The tuple's first field is the id the twin ENDS UP carrying. When
+    # neither side has one there is nothing to attribute the observation to.
+    observed, _ = _observe([_bound(id=None)], [_witness()])
+    assert observed == []
+
+
+def test_observed_records_before_the_verbatim_freeze_destroys_the_evidence():
+    # ORDER PIN. The #22 freeze overwrites the native twin's trust/quote and
+    # DROPS its quote_verified (it attested a quote that no longer exists) —
+    # so a predicate evaluated after the freeze would read the frozen prev's
+    # values and G3 would answer about the wrong item.
+    observed, qs = _observe(
+        [_bound(trust="verbatim", quote="q-prev")], [_witness()])
+    assert observed == [("o-a1d001", "S-origin", "ada")]
+    assert qs[0]["quote"] == "q-prev"              # freeze happened
+    assert "quote_verified" not in qs[0]           # and destroyed the evidence
+
+
+def test_observed_default_none_leaves_merge_byte_identical():
+    # The sink is additive: no caller changes, no behaviour change.
+    prev = _cp("S-prev", 1, questions=[_bound(), _bound("plimsol retry loop",
+                                                        id="o-a1d002")])
+    new = _cp("S-new", 0, questions=[_witness()])
+    plain = carry.merge(copy.deepcopy(new), copy.deepcopy(prev), NOW)
+    observed: list = []
+    sunk = carry.merge(copy.deepcopy(new), copy.deepcopy(prev), NOW,
+                       observed=observed)
+    assert plain == sunk
+    assert observed == [("o-a1d001", "S-origin", "ada")]


### PR DESCRIPTION
Refs #268

## Summary
- `carry.merge()` gains an optional `observed` sink: pairs passing ALL independence guards are recorded as corroboration candidates — `(item_id, origin_session, origin_author)`.
- Guards G1–G6 from the ratified design: bound origin, different origin (also refusing an unnamed observer — independence must never be vacuously true), locally-verbatim + quote-verified native (read PRE-freeze, the #22 freeze destroys the evidence one block later), absolute-overlap/exact-text match only (ratio-only merges but never corroborates), reversal refusal on both paths, disjoint `source_message_ids` (resume-fork defense).
- Pure slice: no ledger writes, no events, no render (S3/S4). `observed=None` leaves merge byte-identical (pinned by test). G7 (origin-exists-on-disk) deferred to the S3 emitter where I/O lives.

## Changes
| File | Change |
|------|--------|
| `plugin/daimon_briefing/carry.py` | `_match_path` (absolute/ratio/""), `_record_corroboration` guard chain, two call sites: twin block pre-freeze + exact-text short-circuit |
| `plugin/tests/test_carry.py` | 21 cases: one per guard, both G6 directions, inherited refusals (#13 specimen, quantity conflict, reversal), exact-text branch, freeze-order pin, observed=None byte-identity pin |

## Test plan
- [x] Strict TDD — every case observed red first
- [x] Full suite: 2275 passed, 2 skipped (baseline 2254 + 21)
- [x] ruff clean; mypy 63 = main baseline, no new errors
- [x] Zero uncovered added lines (141 added lines ∩ uncovered = ∅, verified programmatically)
- [x] carry.py stays I/O-free; architecture guards green

## Notes
- Exact-text branch searches `native`, not `native_texts` (the latter accumulates carried texts mid-call — matching against a carried sibling would be self-corroboration).