### PR TITLE
feat(briefing): render the corroboration badge — separate axis, never a trust class (#268 slice 4)

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -63,6 +63,37 @@ def _mark(item, degraded: bool = False) -> str:
     return _UNTAGGED_MARK
 
 
+# #268: how many independent sightings a claim needs before the render says
+# so. The origin of record is the first, so ONE corroborating session clears
+# the bar — and a lone unwitnessed claim stays silent rather than announcing
+# "×1", which would read as evidence where there is none.
+CORROBORATION_MIN = 2
+
+
+def corroboration_badge(item) -> str:
+    """The ` [≈ corroborated ×N]` annotation for an item, or "" (#268 slice 4).
+
+    A SEPARATE axis from the trust class — `_mark` says what KIND of evidence
+    backs the claim, this says how many independent sessions have witnessed
+    it. A corroborated inferred item is still inferred.
+
+    Two suppressions, same rule: a contradiction never co-renders with a
+    well-witnessed badge. An item flagged as likely superseded (#14) or
+    contradicted by the world (#365) shows the contradiction ALONE — a witness
+    count printed beside "this is probably wrong" reads as support for the
+    claim, inverting the very signal corroboration exists to carry. Silence
+    costs a boost; the inversion costs the axis.
+
+    One literal, shared by the plain path (_line) and the rich panel
+    (render._rich_brief), so the two can never drift."""
+    n = item.get("_corroborated")
+    if not isinstance(n, int) or n < CORROBORATION_MIN:
+        return ""
+    if item.get("_supersede_candidate") or item.get("_worldcheck"):
+        return ""
+    return f" [≈ corroborated ×{n}]"
+
+
 def _line(item, degraded: bool = False) -> str:
     # #134: dict.get returns the stored None for a present-but-null key (the
     # default only fires for an ABSENT key), so a torn/legacy checkpoint could
@@ -79,6 +110,7 @@ def _line(item, degraded: bool = False) -> str:
         # #423: the inbound gate clamped a teammate's verbatim claim to
         # inferred; state both facts — claimed verbatim, unverifiable here.
         base += f" {FOREIGN_VERBATIM_NOTE}"
+    base += corroboration_badge(item)
     if quote:
         base += f'  — "{quote}"'
     candidate = item.get("_supersede_candidate")
@@ -316,6 +348,58 @@ def withhold(checkpoint, resolutions: dict) -> tuple[dict, list, list]:
         items[:] = kept
 
     return out, withheld, candidates
+
+
+# ---- #268: corroboration — independent sightings, stamped for the render ----
+
+
+def mark_corroborated(checkpoint, corroborations: dict):
+    """Stamp corroborated items with a transient `_corroborated = N` count and
+    return the result; pure, no I/O — the caller does the read, exactly as
+    `withhold` takes `store.resolutions()`'s output (#268 slice 4).
+
+    `corroborations` is `store.corroborations()`'s shape, keyed by bare item
+    id. N = 1 + the EFFECTIVE origins: the origin of record is the claim's
+    first sighting, and every session in `origins` is one more. `recorded` is
+    deliberately not counted — a witness discounted by a later contradiction
+    stays on the record without paying, and re-deriving that verdict here
+    would be a second opinion about a question the fold already answered.
+    Below `CORROBORATION_MIN` nothing is stamped at all, so an uncorroborated
+    item is byte-identical to its pre-#268 render.
+
+    Transient like withhold's candidate stamps and worldcheck's flags: the
+    count lives in events.jsonl, and a `_corroborated` key on a stored
+    checkpoint would be a second, forgeable copy of it. Nothing here writes.
+
+    No corroborations, or a non-dict checkpoint -> the input UNCHANGED, same
+    no-op idiom as withhold/carry.merge: no copy unless something is actually
+    stamped, so the common case (nothing witnessed yet) costs nothing."""
+    if not isinstance(checkpoint, dict) or not corroborations:
+        return checkpoint
+
+    # Dry run over the ORIGINAL, then one deepcopy — withhold's shape exactly.
+    to_stamp = []  # [(section, key, index, n)]
+    for section, key in store._ITEM_LISTS:
+        items = (checkpoint.get(section) or {}).get(key)
+        if not isinstance(items, list):
+            continue
+        for idx, item in enumerate(items):
+            if not isinstance(item, dict):
+                continue
+            entry = corroborations.get(item.get("id"))
+            if not isinstance(entry, dict):
+                continue
+            n = 1 + len(entry.get("origins") or ())
+            if n >= CORROBORATION_MIN:
+                to_stamp.append((section, key, idx, n))
+
+    if not to_stamp:
+        return checkpoint
+
+    out = copy.deepcopy(checkpoint)
+    for section, key, idx, n in to_stamp:
+        out[section][key][idx]["_corroborated"] = n
+    return out
 
 
 # ---- #215: staleness budget — carried items nobody has world-checked ----

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -489,6 +489,17 @@ def _render_briefing_body(checkpoint, route, *, drift_project, teammates,
         except Exception:
             withheld = []
             events = {}
+        # Corroboration (#268): a SEPARATE axis from the trust class — how many
+        # independent sessions have witnessed the claim, never what kind of
+        # evidence it is. Its own try: a failure here must cost the badge
+        # only, not the withheld list `events` still owes to stale_carried
+        # below. Transient stamps on the in-memory checkpoint, same posture as
+        # the candidate flags above and the worldcheck flags below.
+        try:
+            checkpoint = briefing.mark_corroborated(
+                checkpoint, store.corroborations(project_dir=route))
+        except Exception:
+            pass
     # Worldcheck (#365): opt-in, budget-bounded, read-only `gh` spot-check of
     # carried PR/issue-state claims — stamps contradicted items on the
     # IN-MEMORY checkpoint before render (transient, like withhold's

--- a/plugin/daimon_briefing/hooks.py
+++ b/plugin/daimon_briefing/hooks.py
@@ -172,6 +172,12 @@ def pre_llm_call(session_id=None, user_message=None, conversation_history=None,
         try:
             events = store.resolutions(project_dir=project)
             checkpoint, _withheld, _candidates = briefing.withhold(checkpoint, events)
+            # #268: the witness count is a reason to weight a claim, so the
+            # injected context states it exactly as the human brief does.
+            # Rides the same fail-open try — the badge is advisory, and no
+            # annotation is worth losing the injection over.
+            checkpoint = briefing.mark_corroborated(
+                checkpoint, store.corroborations(project_dir=project))
         except Exception:
             pass
         text = briefing.render(checkpoint)

--- a/plugin/daimon_briefing/mcp_tools.py
+++ b/plugin/daimon_briefing/mcp_tools.py
@@ -72,6 +72,11 @@ def _brief(arguments: dict) -> str:
         return f"no checkpoint for this project. {hint}"
     filtered, _withheld, _candidates = briefing.withhold(
         checkpoint, store.resolutions(project_dir=target))
+    # #268: the witness count rides the same strictly-scoped target as the
+    # withhold fold — an agent consumer reads the corroboration axis the human
+    # brief shows, from this project's ledger and no other.
+    filtered = briefing.mark_corroborated(
+        filtered, store.corroborations(project_dir=target))
     b = briefing.build(filtered)
     if b is None:
         return "checkpoint exists but has nothing worth surfacing."

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -189,7 +189,12 @@ def _rich_brief(b: dict, degraded: bool = False) -> None:
             # unverified (#204). Inferred/untagged never claimed it, so untouched.
             item_style = "bold red" if (degraded and trust == "verbatim") \
                 else _TRUST_STYLE[trust]
-            body.append(f"• {i.get('text', '').strip()}\n", style=item_style)
+            # #268: the corroboration badge rides the text line here, the same
+            # position it holds on the plain path (after the annotations,
+            # before the quote) — one shared literal, so the two renders state
+            # the witness count in identical bytes.
+            body.append(f"• {i.get('text', '').strip()}"
+                        f"{briefing.corroboration_badge(i)}\n", style=item_style)
             quote = i.get("quote", "").strip()
             if quote:
                 body.append(f'    "{quote}"\n', style="dim italic")

--- a/plugin/tests/test_corroboration.py
+++ b/plugin/tests/test_corroboration.py
@@ -32,8 +32,8 @@ import time
 
 import pytest
 
-from daimon_briefing import (briefing, capture, cli, hooks, normalize, recall,
-                             store, transcript)
+from daimon_briefing import (briefing, capture, cli, hooks, mcp_tools,
+                             normalize, recall, render, store, transcript)
 
 PROJECT = "/p/corroborate"
 ITEM = "o-a1d001"
@@ -703,3 +703,208 @@ def test_carry_merge_still_runs_when_corroboration_emission_explodes(
     assert written["session_id"] == session
     texts = [q["text"] for q in written["working_context"]["open_questions"]]
     assert "an unrelated prior loop about zephyr batching" in texts
+
+
+# ---------------------------------------------------------------------------
+# Slice 4: the RENDER — the corroboration badge.
+#
+# The badge is a SEPARATE axis from the trust class, and the separation is the
+# whole point: `verbatim` says what KIND of evidence backs a claim, the badge
+# says HOW MANY independent sessions have witnessed it. A corroborated
+# inferred item is still inferred. `_mark` is therefore untouched.
+#
+# Two rules do the load-bearing work here:
+#
+#   N = 1 + effective origins. The origin of record is the first sighting, so
+#   one corroborating session makes two — the ratified threshold. A witness
+#   whose row predates the item's latest contradiction is not effective and
+#   does not count (store.corroborations already separates `origins` from
+#   `recorded`; the render trusts that split rather than re-deriving it).
+#
+#   A contradiction never co-renders with a well-witnessed badge. An item
+#   flagged as likely superseded (#14) or contradicted by the world (#365)
+#   shows the contradiction alone: "three sessions agreed" next to "this is
+#   probably wrong" reads as evidence FOR the claim, which is precisely the
+#   inversion corroboration must never produce.
+# ---------------------------------------------------------------------------
+
+BADGE_2 = "[≈ corroborated ×2]"
+
+
+def _entry(origins, recorded=None, demoted=None):
+    """One store.corroborations row, hand-built — the reader's exact shape."""
+    return {"origins": set(origins),
+            "recorded": set(origins if recorded is None else recorded),
+            "latest_demotion_ts": demoted}
+
+
+def _render_checkpoint(text=_TEXT, item_id=ITEM, **over):
+    item = {"id": item_id, "text": text, "trust": "inferred"}
+    item.update(over)
+    return {"session_id": "S-render",
+            "created": "2026-06-25T08:00:00Z",
+            "working_context": {
+                "active_topic": {"text": "seed", "trust": "inferred"},
+                "open_questions": [item],
+                "recent_decisions": []},
+            "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []}}
+
+
+def _rendered(checkpoint, corroborations):
+    marked = briefing.mark_corroborated(checkpoint, corroborations)
+    return briefing.render_plain(briefing.build(marked))
+
+
+def test_two_total_sightings_render_the_badge():
+    # One corroborating origin + the origin of record = two independent
+    # sightings, the ratified threshold. Placement is pinned: after the trust
+    # mark and the item text, before the quote — an ANNOTATION on the line,
+    # never a replacement for the mark.
+    out = _rendered(_render_checkpoint(), {ITEM: _entry({OBSERVER})})
+    assert f"[~ inferred] {_TEXT} {BADGE_2}" in out
+
+
+def test_an_item_with_no_corroboration_row_gets_no_badge():
+    # Zero rows is the overwhelmingly common case and must cost nothing and
+    # say nothing — silence, not "×1".
+    assert "corroborated" not in _rendered(_render_checkpoint(), {})
+
+
+def test_a_single_sighting_stays_below_the_threshold():
+    # A demotion zeroed the only witness: `recorded` remembers it, `origins`
+    # no longer counts it, so the item is back to one sighting — its own.
+    out = _rendered(_render_checkpoint(),
+                    {ITEM: _entry(set(), recorded={OBSERVER},
+                                  demoted="2026-07-11T10:00:00Z")})
+    assert "corroborated" not in out
+
+
+def test_the_count_uses_effective_origins_not_recorded_witnesses():
+    # Two sessions ever wrote a row; one of them was discounted by a later
+    # contradiction. Counting `recorded` here would let a demoted witness keep
+    # paying — the render must read the same number the fold already decided.
+    out = _rendered(_render_checkpoint(),
+                    {ITEM: _entry({"S-b"}, recorded={"S-a", "S-b"},
+                                  demoted="2026-07-11T10:00:00Z")})
+    assert BADGE_2 in out
+    assert "×3" not in out
+
+
+def test_three_effective_origins_render_as_four_sightings():
+    out = _rendered(_render_checkpoint(),
+                    {ITEM: _entry({"S-a", "S-b", "S-c"})})
+    assert "[≈ corroborated ×4]" in out
+
+
+def test_a_supersede_candidate_suppresses_the_badge():
+    # The #14 flag and the badge point in opposite directions. The
+    # contradiction wins outright; it is not softened by a witness count.
+    out = _rendered(_render_checkpoint(_supersede_candidate="o-b2c003"),
+                    {ITEM: _entry({OBSERVER, "S-b"})})
+    assert "corroborated" not in out
+    assert "likely superseded by o-b2c003" in out
+
+
+def test_a_worldcheck_contradiction_suppresses_the_badge():
+    # Same rule for the #365 flag: the world moved, so agreement about the
+    # stale claim is not evidence the claim holds.
+    out = _rendered(
+        _render_checkpoint(_worldcheck={"note": "#60 merged", "status": "merged"}),
+        {ITEM: _entry({OBSERVER, "S-b"})})
+    assert "corroborated" not in out
+    assert "state changed since capture: #60 merged" in out
+
+
+def test_the_stamp_is_transient_and_never_reaches_disk(tmp_checkpoint_dir):
+    # The badge is derived at render time from events.jsonl, exactly like
+    # withhold's candidate stamps. A `_corroborated` key on a stored
+    # checkpoint would be a second, forgeable copy of a count the ledger
+    # already owns. Scar 0027: the on-disk state is asserted through
+    # store.read_latest, never through the in-memory dict that was written.
+    item_id, stored = _corroborated_checkpoint()
+    marked = briefing.mark_corroborated(
+        stored, store.corroborations(project_dir=PROJECT))
+
+    assert marked["working_context"]["open_questions"][0]["_corroborated"] == 2
+    # Pure: the caller's own dict is untouched, and so is the file.
+    assert "_corroborated" not in stored["working_context"]["open_questions"][0]
+    fresh = store.read_latest(project_dir=PROJECT, fallback=False)
+    assert "_corroborated" not in fresh["working_context"]["open_questions"][0]
+
+
+def test_plain_and_rich_render_the_same_badge(monkeypatch, capsys):
+    # The rich panel builds its own body rather than routing through
+    # briefing._line, so parity is a real risk, not a formality (the #14 and
+    # #365 flags each had to be repeated there). Byte-comparable badge text.
+    marked = briefing.mark_corroborated(
+        _render_checkpoint(text="the feed pauses drop entries"),
+        {ITEM: _entry({OBSERVER})})
+    render.render_brief(marked)
+    plain = capsys.readouterr().out
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_brief(marked)
+    rich_out = capsys.readouterr().out
+    assert BADGE_2 in plain
+    assert BADGE_2 in rich_out
+
+
+# ---- the three read paths that fold events ---------------------------------
+
+
+def test_the_brief_command_surfaces_the_badge(tmp_checkpoint_dir, monkeypatch,
+                                              capsys):
+    _corroborated_checkpoint()
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    assert cli.main(["brief"]) == 0
+    assert BADGE_2 in capsys.readouterr().out
+
+
+def test_pre_llm_call_injects_the_badge(tmp_checkpoint_dir, monkeypatch):
+    # The hook path renders into the model's context, where the count is a
+    # reason to weight the claim — the same fact the human brief states.
+    _corroborated_checkpoint()
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    out = hooks.pre_llm_call(session_id="S-new", user_message="hi",
+                             conversation_history=[], is_first_turn=True,
+                             model="m", platform="cli")
+    assert BADGE_2 in out["context"]
+
+
+def test_the_mcp_brief_surfaces_the_badge(tmp_checkpoint_dir):
+    _corroborated_checkpoint()
+    out = mcp_tools.HANDLERS["daimon_brief"]({"slug": store.project_slug(PROJECT)})
+    assert BADGE_2 in out
+
+
+def test_the_brief_survives_an_unreadable_corroboration_fold(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    # Same fail-open posture as withhold and worldcheck: the badge is an
+    # advisory annotation, and a briefing must never die over one.
+    _corroborated_checkpoint()
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("events.jsonl is a smoking crater")
+
+    monkeypatch.setattr(store, "corroborations", _boom)
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    assert cli.main(["brief"]) == 0
+    out = capsys.readouterr().out
+    assert _TEXT in out            # the item still briefs
+    assert "corroborated" not in out
+
+
+def test_a_torn_item_row_never_costs_its_neighbour_a_badge():
+    # #134 posture, same as every other reader here: a legacy/torn checkpoint
+    # can hold a null where an item belongs. Skip it, keep going — one bad row
+    # must not silently strip the axis off the rest of the section.
+    cp = _render_checkpoint()
+    cp["working_context"]["open_questions"].insert(0, None)
+    out = _rendered(cp, {ITEM: _entry({OBSERVER})})
+    assert f"{_TEXT} {BADGE_2}" in out
+
+
+def test_a_malformed_corroboration_entry_stamps_nothing():
+    # The fold's shape is a contract, not a promise: anything that is not the
+    # reader's dict earns no badge rather than a crash or an invented count.
+    assert "corroborated" not in _rendered(_render_checkpoint(),
+                                           {ITEM: "corroborated-by:S-witness"})

--- a/plugin/tests/test_quote_verification.py
+++ b/plugin/tests/test_quote_verification.py
@@ -945,6 +945,39 @@ def test_quote_absent_entirely_is_not_flagged_echo_only():
     assert "quote_echo_only" not in item
 
 
+def test_a_corroboration_badge_quoted_out_of_a_brief_is_echo_only():
+    # #268 slice 4 x #440: the badge is daimon's own render, so a quote that
+    # copies a badged briefing line back out of the transcript is an echo of
+    # daimon agreeing with itself — the exact self-corroboration loop the
+    # namespaced ledger exists to prevent, arriving by a different door. The
+    # briefing strip already swallows it; this pins that the new annotation
+    # rides inside the stripped span rather than surviving as a witness.
+    from daimon_briefing import briefing
+
+    badged = briefing.mark_corroborated(
+        {"working_context": {
+            "active_topic": None,
+            "open_questions": [],
+            "recent_decisions": [{"id": "d-a1d001", "text": _ECHOED,
+                                  "trust": "inferred"}]},
+         "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []}},
+        {"d-a1d001": {"origins": {"S-a"}, "recorded": {"S-a"},
+                      "latest_demotion_ts": None}})
+    rendered = briefing.render(badged)
+    line = next(ln for ln in rendered.splitlines() if "corroborated" in ln)
+    assert "[≈ corroborated ×2]" in line
+
+    msgs = _msgs(("user", f"DAIMON BRIEFING (checkpoint: S0)\n{rendered}", "u-1"),
+                 ("user", "so where were we?", "u-2"))
+    cp = _decision(quote=line.strip())
+    n = serializer.verify_quotes(cp, serializer._render_transcript(msgs), msgs)
+    item = _only_decision(cp)
+    assert n == 1
+    assert item["trust"] == "inferred"
+    assert item["quote_verified"] is False
+    assert item["quote_echo_only"] is True
+
+
 def test_echo_flag_is_code_owned_and_model_values_are_stripped():
     cp = _decision(quote="adopt the D-007 prompt", quote_echo_only=True)
     serializer.verify_quotes(cp, "assistant: adopt the D-007 prompt today")


### PR DESCRIPTION
Refs #268

## Summary
- `[≈ corroborated ×N]` renders at N ≥ 2 total independent sightings (origin of record + **effective** origins — demotion-zeroed origins never count), after `[carried]`/foreign annotations, before the quote.
- Separate axis: `_mark()` untouched; the trust-raise invariant (evidence-gated reverify or human action only) intact.
- Contradiction suppression at **render time** (order-independent — worldcheck stamps after the corroboration read at the CLI site): supersede-candidate or worldcheck note → no badge.
- `mark_corroborated` pure + transient (withhold's shape; nothing ever hits disk, pinned via `store.read_latest`). Wired at brief CLI / `pre_llm_call` / MCP brief; CLI read in its own fail-open try so a badge failure never costs `stale_carried` its events. Rich path byte-identical.
- Echo interplay pinned: a badged briefing line quoted from a later transcript downgrades to inferred (`quote_echo_only`) via the #440 strip — the badge cannot mint a verbatim.

## Changes
| File | Change |
|------|--------|
| `plugin/daimon_briefing/briefing.py` | `CORROBORATION_MIN=2`, `corroboration_badge`, `mark_corroborated`, one line in `_line` |
| `plugin/daimon_briefing/render.py` | rich body appends the same badge |
| `plugin/daimon_briefing/cli.py` | wiring + isolated fail-open try |
| `plugin/daimon_briefing/hooks.py` | wiring inside existing try |
| `plugin/daimon_briefing/mcp_tools.py` | wiring at `_brief` |
| `plugin/tests/` | 16 cases: threshold/count 5, suppression 2, transience 3, parity 1, wiring 4 (incl. fail-open), echo interplay 1 |

## Test plan
- [x] Strict TDD, red first
- [x] Full suite: 2332 passed, 2 skipped (baseline 2316 + 16)
- [x] ruff clean; mypy 63 = baseline (normalized error-set diff empty)
- [x] Zero uncovered added lines (programmatic diff∩missing = ∅, all 5 source files)
- [x] No scoring/recall change (S5 fences that structurally)