### PR TITLE
docs(blog): origin-bound corroboration ship story, en + es

### DIFF
--- a/website/blog/2026-07-30-origin-bound-corroboration.md
+++ b/website/blog/2026-07-30-origin-bound-corroboration.md
@@ -1,0 +1,116 @@
+---
+slug: origin-bound-corroboration
+title: "Agreement is not evidence: shipping origin-bound corroboration"
+authors: [daimon]
+tags: [concepts, trust-classes, corroboration, release]
+---
+
+Here is a trap every agent memory system walks toward sooner or later: an item
+that keeps showing up starts to feel true. Five sessions all "remember" the
+same fact, so the fact must be solid. Promote it. Trust it more.
+
+We wanted that feature. Independent re-observation *should* strengthen a
+memory — that is how evidence works everywhere else. But before building it we
+went looking for the ways it breaks, and what we found changed the design, the
+release, and one security assumption we had been living with. All of it
+shipped today in v0.22.0.
+
+{/* truncate */}
+
+## The echo in our own house
+
+Daimon injects prior memory into new sessions: a briefing at session start, a
+`daimon recall:` line when a prompt matches past work. That injected text
+becomes part of the new session's transcript. The serializer then reads that
+transcript to extract what the session learned.
+
+See the loop? An item from session A gets injected into session B's
+transcript, and session B's extraction can "observe" it there — not because
+the fact was re-derived from real work, but because daimon quoted itself. On
+our own corpus, thirteen transcripts carry injected prior items. A naive
+corroboration counter ("different session saw it again") would count daimon's
+own echoes as independent witnesses, and the items recalled most often would
+accumulate the most confidence. Recall frequency would become truth.
+
+It got worse before it got better. While mapping the injection surfaces we
+found that our quote verifier checked verbatim quotes against the *unstripped*
+transcript. A quote copied from daimon's own injected line passed verification
+and was stored as `verbatim`, `quote_verified: true` — a prior session's item
+laundered as freshly witnessed. That hole did not wait for the corroboration
+feature; it shipped as a standalone security fix the same day it was found,
+and verification now refuses any quote whose only support lies inside
+daimon's own output. Failed echoes get their own rejection reason
+(`echo-only`), so the echo rate is now measurable instead of invisible.
+
+## The proof that says the naive version cannot be patched
+
+This is not just our bug. A recent paper — [*Securing LLM-Agent Long-Term
+Memory Against Poisoning: Non-Malleable, Origin-Bound Authority with
+Machine-Checked Guarantees*](https://arxiv.org/abs/2606.24322) — proves, with
+machine-checked TLA+ theorems, that defenses based on a memory item's content
+or its derivation history are unsound. Attackers launder untrusted origins
+through three channels: the agent's own summarization, trusted-tool echoes,
+and **manufactured corroboration** — planting agreeing sources so that
+agreement reads as verification.
+
+That third channel is exactly the self-reference loop above, named as an
+attack primitive with an impossibility result behind it. The paper's repair:
+write-time origin binding is *necessary*, and origin-bound authority with
+Sybil-resistant corroboration-gated elevation is *sufficient*. In plain
+words: fix where a claim came from at the moment it is written, and only
+count agreement when independence can be proven from those origins — never
+assumed from the agreement itself.
+
+## What v0.22.0 ships
+
+Our implementation of that prescription, in a local-first CLI:
+
+- **Origin bound at write.** Every item is stamped with the session and
+  author that first wrote it, at the admission boundary, on the same
+  never-rewritten rail as its identity. A model that emits its own origin
+  fields gets them stripped — a memory cannot issue itself a witness.
+- **Independence proven from origins.** A re-observation counts only when the
+  original writer is a *different* session, the new observation is locally
+  verbatim with a verified quote (which, after the echo fix, structurally
+  excludes daimon's own output), the match is strong enough to certify rather
+  than merely deduplicate, and the two observations do not share transcript
+  message bindings.
+- **An auditable count, never a stored score.** Corroborations are events in
+  the append-only log, one per independent witness. The count is derived at
+  read time. Contradiction outranks: a superseded or world-checked item loses
+  its badge, and reopening it does not restore counts earned before the
+  contradiction.
+- **A separate axis, not a trust promotion.** Items independently seen twice
+  render as `[≈ corroborated ×2]` beside their trust tag. The trust class
+  itself never moves on recurrence — that still takes re-verification
+  evidence or an explicit human decision.
+- **Wired into nothing, on purpose.** The badge affects no ranking and no
+  recall scoring, and a test enforces that scoring code cannot even import
+  the corroboration reader. The self-reinforcing loop — promotion raises
+  salience, salience raises injection, injection manufactures the next
+  corroboration — closes exactly where a counter feeds ranking, so that wire
+  stays cut until field data says otherwise. We ship the measurement before
+  anything acts on the measurement.
+
+## What it does not do
+
+Honesty section, as always. Corroboration only accrues on items written from
+v0.22.0 forward — origins are never guessed retroactively, because a wrong
+guess would make dependent observations look independent. A resumed session
+that replays the same conversation under a new id is refused where hosts
+preserve message ids, but a host that mints fresh ids can make one
+conversation look like two. An attacker who controls the content of two
+separate sessions can still manufacture two origins — the design raises the
+cost of fake agreement from one recall line to two compromised sessions; it
+does not make fake agreement impossible. And teammate checkpoints do not
+corroborate in this version: a synced copy of a claim is still one witness,
+and the gates that would make cross-author counting Sybil-resistant are
+designed but deliberately not enabled yet.
+
+The full release also carries the write-gateway hardening this work sat on
+top of: value-keyed deletion end to end, a write-audit guard over every
+command, and inbound team content passing the same scope, redaction, forget,
+and trust gates as local writes.
+
+If your agent's memory tells you something twice, ask it who told it first.
+[daimon](https://github.com/Daily-Nerd/daimon) can now answer.

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-07-30-origin-bound-corroboration.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-07-30-origin-bound-corroboration.md
@@ -1,0 +1,128 @@
+---
+slug: origin-bound-corroboration
+title: "Que dos memorias coincidan no es evidencia: corroboración ligada al origen"
+authors: [daimon]
+tags: [concepts, trust-classes, corroboration, release]
+---
+
+Hay una trampa hacia la que camina todo sistema de memoria para agentes,
+tarde o temprano: un ítem que aparece una y otra vez empieza a *sentirse*
+verdadero. Cinco sesiones "recuerdan" el mismo hecho, así que el hecho debe
+ser sólido. Promuévelo. Confía más en él.
+
+Queríamos esa funcionalidad. La re-observación independiente *debería*
+fortalecer una memoria — así funciona la evidencia en todos lados. Pero antes
+de construirla salimos a buscar las formas en que se rompe, y lo que
+encontramos cambió el diseño, el release y una suposición de seguridad con la
+que veníamos conviviendo. Todo eso salió hoy en v0.22.0.
+
+{/* truncate */}
+
+## El eco en nuestra propia casa
+
+Daimon inyecta memoria previa en las sesiones nuevas: un briefing al inicio y
+una línea `daimon recall:` cuando un prompt coincide con trabajo pasado. Ese
+texto inyectado pasa a formar parte de la transcripción de la sesión nueva. El
+serializador después lee esa transcripción para extraer lo que la sesión
+aprendió.
+
+¿Ves el bucle? Un ítem de la sesión A se inyecta en la transcripción de la
+sesión B, y la extracción de B puede "observarlo" ahí — no porque el hecho se
+haya re-derivado de trabajo real, sino porque daimon se citó a sí mismo. En
+nuestro propio corpus, trece transcripciones cargan ítems previos inyectados.
+Un contador ingenuo de corroboración ("otra sesión lo vio de nuevo") contaría
+los ecos de daimon como testigos independientes, y los ítems más recordados
+acumularían la mayor confianza. La frecuencia de recall se volvería verdad.
+
+Se puso peor antes de mejorar. Mapeando las superficies de inyección
+encontramos que nuestro verificador de citas comparaba las citas verbatim
+contra la transcripción *sin filtrar*. Una cita copiada de una línea inyectada
+por el propio daimon pasaba la verificación y se guardaba como `verbatim`,
+`quote_verified: true` — un ítem de una sesión anterior lavado como si fuera
+testimonio fresco. Ese agujero no esperó a la funcionalidad de corroboración:
+salió como fix de seguridad independiente el mismo día en que se encontró, y
+la verificación ahora rechaza cualquier cita cuyo único soporte esté dentro de
+la salida del propio daimon. Los ecos rechazados tienen su propia razón en el
+ledger (`echo-only`), así que la tasa de eco ahora se puede medir en vez de
+ser invisible.
+
+## La prueba de que la versión ingenua no se puede parchar
+
+Esto no es solo un bug nuestro. Un paper reciente — [*Securing LLM-Agent
+Long-Term Memory Against Poisoning: Non-Malleable, Origin-Bound Authority
+with Machine-Checked Guarantees*](https://arxiv.org/abs/2606.24322) —
+demuestra, con teoremas TLA+ verificados por máquina, que las defensas
+basadas en el contenido de un ítem o en su historial de derivación no son
+sólidas. Los atacantes lavan orígenes no confiables por tres canales: el
+propio resumen del agente, los ecos de herramientas confiables y la
+**corroboración fabricada** — plantar fuentes que coinciden para que la
+coincidencia se lea como verificación.
+
+Ese tercer canal es exactamente el bucle de auto-referencia de arriba, con
+nombre de primitiva de ataque y un resultado de imposibilidad detrás. La
+reparación que prescribe el paper: ligar el origen al momento de escritura es
+*necesario*, y la autoridad ligada al origen con elevación por corroboración
+resistente a Sybil es *suficiente*. En corto: fija de dónde vino una
+afirmación en el momento en que se escribe, y cuenta la coincidencia solo
+cuando la independencia se pueda probar desde esos orígenes — nunca asumirla
+desde la coincidencia misma.
+
+## Qué trae v0.22.0
+
+Nuestra implementación de esa prescripción, en una CLI local-first:
+
+- **Origen ligado al escribir.** Cada ítem queda estampado con la sesión y el
+  autor que lo escribió por primera vez, en la frontera de admisión, sobre el
+  mismo riel que nunca se reescribe donde vive su identidad. Si un modelo
+  emite sus propios campos de origen, se le quitan — una memoria no puede
+  emitirse un testigo a sí misma.
+- **Independencia probada desde los orígenes.** Una re-observación cuenta
+  solo cuando el escritor original es una sesión *distinta*, la observación
+  nueva es verbatim local con cita verificada (lo que, después del fix del
+  eco, excluye estructuralmente la salida del propio daimon), la coincidencia
+  es lo bastante fuerte para certificar y no solo deduplicar, y las dos
+  observaciones no comparten anclajes de mensajes de transcripción.
+- **Un conteo auditable, nunca un puntaje guardado.** Las corroboraciones son
+  eventos en el log append-only, uno por testigo independiente. El conteo se
+  deriva al leer. La contradicción manda: un ítem superseded o contradicho
+  por el world-check pierde su insignia, y reabrirlo no restaura conteos
+  ganados antes de la contradicción.
+- **Un eje aparte, no una promoción de confianza.** Los ítems vistos
+  independientemente dos veces se muestran como `[≈ corroborated ×2]` al lado
+  de su clase de confianza. La clase en sí nunca sube por recurrencia — eso
+  sigue exigiendo evidencia de re-verificación o una decisión humana
+  explícita.
+- **Conectado a nada, a propósito.** La insignia no afecta ningún ranking ni
+  el scoring de recall, y un test impone que el código de scoring ni siquiera
+  pueda importar el lector de corroboraciones. El bucle auto-reforzante —
+  la promoción sube la saliencia, la saliencia sube la inyección, la
+  inyección fabrica la próxima corroboración — se cierra exactamente donde un
+  contador alimenta el ranking, así que ese cable queda cortado hasta que los
+  datos de campo digan otra cosa. Publicamos la medición antes de que nada
+  actúe sobre la medición.
+
+## Qué no hace
+
+Sección de honestidad, como siempre. La corroboración solo se acumula sobre
+ítems escritos desde v0.22.0 en adelante — los orígenes nunca se adivinan
+retroactivamente, porque una adivinanza errada haría parecer independientes a
+observaciones dependientes. Una sesión reanudada que repite la misma
+conversación bajo otro id se rechaza donde el host preserva los ids de
+mensaje, pero un host que emite ids frescos puede hacer que una conversación
+parezca dos. Un atacante que controla el contenido de dos sesiones separadas
+todavía puede fabricar dos orígenes — el diseño sube el costo del acuerdo
+falso de una línea de recall a dos sesiones comprometidas; no lo vuelve
+imposible. Y los checkpoints de compañeros de equipo no corroboran en esta
+versión: una copia sincronizada de una afirmación sigue siendo un solo
+testigo, y las compuertas que harían el conteo entre autores resistente a
+Sybil están diseñadas pero deliberadamente apagadas por ahora.
+
+El release completo también trae el endurecimiento del gateway de escritura
+sobre el que se apoyó este trabajo: borrado por valor de punta a punta, un
+guard de auditoría de escritura sobre cada comando, y contenido entrante de
+equipo pasando por las mismas compuertas de scope, redacción, forget y
+confianza que las escrituras locales.
+
+Si la memoria de tu agente te dice algo dos veces, pregúntale quién se lo
+dijo primero. [daimon](https://github.com/Daily-Nerd/daimon) ahora puede
+responder.


### PR DESCRIPTION
Closes #447

## Summary
- v0.22.0 ship story, published same-day per the ship-log cadence: the self-corroboration trap, the echo-laundering hole found and fixed the same day, arXiv 2606.24322's impossibility result and prescription, what shipped, and an explicit what-it-does-not-do section.
- en + es (tuteo register matched to existing posts), slug `origin-bound-corroboration`, dated 2026-07-30.

## Gates
- [x] Citation verified against the raw arXiv abstract (title, three laundering channels, T1-T3 wording) — not a summarizer
- [x] rg privacy scan clean on both files (identifiers + process vocab)
- [x] Honest numbers: no benchmark samples, no efficacy claims, no first/only claims; the one corpus number (thirteen transcripts) is already public in #268
- [x] Limits section: retroactive origins never guessed, resume-fork residual, two-session attack cost-raised-not-eliminated, team deferred

## Changes
| File | Change |
|------|--------|
| `website/blog/2026-07-30-origin-bound-corroboration.md` | new post (en) |
| `website/i18n/es/.../2026-07-30-origin-bound-corroboration.md` | new post (es) |