### PR TITLE
fix(recall): skip machine prompts in the recall-inject hook — 37.9% of injections fired at prompts no human wrote

### DIFF
--- a/docs/hosts/claude-code.md
+++ b/docs/hosts/claude-code.md
@@ -84,8 +84,9 @@ registers them:
   `daimon recall-inject` on stdin, and injects a one-line pointer when the
   prompt overlaps a prior open loop. Because it fires per-prompt, failures
   are silent (exit 0, no output) — the only thing it ever prints is a real
-  suggestion — and slash commands (host directives, not work statements)
-  never match.
+  suggestion. Prompts that are not a person asking for work never match:
+  slash commands (host directives) and host-emitted machine blocks —
+  background-task notifications, teammate/agent messages, command output.
 
 These two capture/inject scripts are wired in one of two mutually exclusive
 ways — pick ONE (both at once double-fires every session: two briefing

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1086,6 +1086,20 @@ def _cmd_recall_inject(args) -> int:
     _note_usage("recall-inject")
     try:
         prompt = sys.stdin.read()
+        # #450: host-emitted blocks (task notifications, teammate/agent
+        # messages, command output) arrive here as prompts but are nobody
+        # asking for anything — 37.9% of measured injections landed on them.
+        # Its own try: a classifier failure must cost nothing, so it falls back
+        # to today's behavior (suggest) rather than to the outer silent return.
+        try:
+            machine = recall.is_machine_prompt(prompt)
+        except Exception:  # noqa: BLE001 — fail toward suggesting, never skip on a bug
+            machine = False
+        if machine:
+            # Counted apart from `recall-inject`, which still counts every fire:
+            # the pair is the before/after measure of the noise removed (#450).
+            _note_usage("recall-inject:skip-machine")
+            return 0
         project = _resolve_project(args.project)
         session = str(args.session or "")
         # Never re-suggest what the SessionStart briefing already carried: the

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -828,6 +828,51 @@ def salient_terms(prompt: str) -> list[str]:
     return out if len(out) >= _MIN_TERMS else []
 
 
+# #450: literal openings of the host-emitted blocks that reach the prompt hook
+# as if they were user input — background-task notifications, teammate/agent
+# messages, slash-command output. Measured on the maintainer's transcripts,
+# 37.9% of injections landed on these, at the same rate as on real prompts:
+# nothing consumes those suggestions, so they are pure token cost. Literal and
+# case-sensitive on purpose — the hosts emit exactly one casing, and loosening
+# the match only buys false skips.
+_MACHINE_MARKERS = (
+    "[SYSTEM NOTIFICATION",
+    "<task-notification>",
+    "<teammate-message",
+    "<agent-message",
+    "<local-command-stdout>",
+)
+
+_MACHINE_SCAN_CHARS = 400   # opening region only — see is_machine_prompt
+
+
+def is_machine_prompt(prompt: str) -> bool:
+    """True when the prompt is structurally a host-emitted block rather than a
+    person asking for work (#450). Deliberately conservative: a missed skip is
+    the status quo, a wrong skip costs one suggestion.
+
+    Boundary — a marker counts only when it OPENS A LINE inside the first
+    _MACHINE_SCAN_CHARS characters (after leading whitespace):
+
+      - Line-start, because a machine block's marker is the block's opening;
+        a human quoting one does it mid-sentence ("why does the hook fire on
+        <task-notification> blocks?"). A plain substring scan would silence
+        recall on exactly the prompts that discuss recall. Indented markers
+        (a pasted code sample) are left ambiguous and still get suggestions.
+      - Windowed, because a genuine prompt may paste a whole block far below
+        its own question; only the opening region can carry the block that IS
+        the prompt. Observed shape: the notification wrapper opens with
+        `[SYSTEM NOTIFICATION` at offset 0 and carries `<task-notification>`
+        ~490 chars in, past this window — the marker list is redundant for
+        that reason, so the window never has to be widened to catch it.
+
+    Truncation at the window can only split a marker, i.e. only ever miss a
+    skip, which is the safe direction.
+    """
+    head = prompt.lstrip()[:_MACHINE_SCAN_CHARS]
+    return any(line.startswith(_MACHINE_MARKERS) for line in head.split("\n"))
+
+
 def suggest(prompt: str, project_dir=None, current_session=None,
             exclude_sessions=(), limit: int = 2, now=None) -> list[dict]:
     """Proactive matches for a user prompt, or [] — silence is the default and

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3006,6 +3006,95 @@ def test_recall_inject_never_fails(tmp_checkpoint_dir, capsys, monkeypatch):
     assert rc == 0
 
 
+# ---- #450: machine prompts (notifications, teammate/agent messages, command
+# ---- output) are not work statements — the hook must stay silent on them.
+
+_MACHINE_MARKERS = ("[SYSTEM NOTIFICATION", "<task-notification>",
+                    "<teammate-message", "<agent-message",
+                    "<local-command-stdout>")
+
+# Matches the seeded history hard: the ONLY reason these prompts stay silent
+# must be the machine classifier, never a missing match.
+_MATCHING_TEXT = "debugging the litellm gateway cache pinning again"
+
+
+@pytest.mark.parametrize("marker", _MACHINE_MARKERS)
+def test_recall_inject_skips_machine_prompt(
+        marker, tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    _seed_recall_history()
+    rc, out = _inject(monkeypatch, capsys, f"{marker} x>\n{_MATCHING_TEXT}\n")
+    assert rc == 0
+    assert out == ""
+    tags = [line.split()[1]
+            for line in (tmp_log_dir / "usage.log").read_text().splitlines()]
+    assert "recall-inject:skip-machine" in tags
+
+
+def test_recall_inject_control_same_text_without_marker_suggests(
+        tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    # Fixture pair for the skip above: identical body, no machine wrapper.
+    _seed_recall_history()
+    rc, out = _inject(monkeypatch, capsys, _MATCHING_TEXT)
+    assert rc == 0 and "S-old" in out
+    tags = [line.split()[1]
+            for line in (tmp_log_dir / "usage.log").read_text().splitlines()]
+    assert tags == ["recall-inject"]  # no skip tag on a genuine prompt
+
+
+def test_recall_inject_suggests_when_prompt_quotes_a_marker_beyond_the_window(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # A real question that pastes a notification below it: the block marker is
+    # outside the opening region, so this keeps its suggestions.
+    _seed_recall_history()
+    prompt = (_MATCHING_TEXT + "\n"
+              + "context line about that same gateway seam\n" * 20
+              + "<task-notification>\n<task-id>t1</task-id>\n")
+    rc, out = _inject(monkeypatch, capsys, prompt)
+    assert rc == 0
+    assert "S-old" in out
+
+
+def test_recall_inject_suggests_when_prompt_mentions_a_marker_inline(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    _seed_recall_history()
+    rc, out = _inject(
+        monkeypatch, capsys,
+        f"why does <teammate-message> matter while {_MATCHING_TEXT}?")
+    assert rc == 0
+    assert "S-old" in out
+
+
+def test_recall_inject_classifier_error_falls_open_to_todays_behavior(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # The classifier sits on the per-prompt critical path: if it raises, the
+    # command must behave exactly as it did before #450 — suggestions, rc 0.
+    from daimon_briefing import recall
+
+    _seed_recall_history()
+
+    def boom(_prompt):
+        raise RuntimeError("classifier exploded")
+
+    monkeypatch.setattr(recall, "is_machine_prompt", boom)
+    rc, out = _inject(monkeypatch, capsys, _MATCHING_TEXT)
+    assert rc == 0
+    assert "S-old" in out
+
+
+def test_stats_surfaces_machine_skip_apart_from_recall_inject(
+        tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    # The acceptance criterion: the effect is measurable from `daimon stats`
+    # alone — skips counted separately, total fires still counted.
+    _seed_recall_history()
+    _inject(monkeypatch, capsys, "<task-notification>\n" + _MATCHING_TEXT)
+    _inject(monkeypatch, capsys, _MATCHING_TEXT, session="S-two")
+    capsys.readouterr()
+    assert cli.main(["stats", "--json"]) == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["usage"]["recall-inject:skip-machine"] == 1
+    assert data["usage"]["recall-inject"] == 2  # denominator keeps every fire
+
+
 # ---- #33 Phase 2: deterministic carry wired into the serialize path ----
 
 

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -1697,3 +1697,61 @@ def test_rebuild_env_grant_admits_single_clone_path(tmp_checkpoint_dir, monkeypa
         logical="core/x")
     recall.rebuild()
     assert len(recall.search("flamingo", all_projects=True)) == 1
+
+
+# ---- #450: machine-prompt classifier — the recall hook must not fire on
+# ---- notifications, teammate/agent messages, or command output.
+
+
+MACHINE_MARKERS = ("[SYSTEM NOTIFICATION", "<task-notification>",
+                   "<teammate-message", "<agent-message",
+                   "<local-command-stdout>")
+
+
+@pytest.mark.parametrize("marker", MACHINE_MARKERS)
+def test_machine_marker_opening_the_prompt_is_machine(marker):
+    prompt = f'{marker} id="a1">\nthe agent finished its batch\n'
+    assert recall.is_machine_prompt(prompt) is True
+
+
+@pytest.mark.parametrize("marker", MACHINE_MARKERS)
+def test_machine_marker_after_leading_blank_lines_is_machine(marker):
+    # Hosts vary on trailing/leading whitespace around the block; the block is
+    # still the whole prompt.
+    assert recall.is_machine_prompt(f"\n\n  {marker} rest of the block") is True
+
+
+@pytest.mark.parametrize("marker", MACHINE_MARKERS)
+def test_marker_quoted_inline_in_a_human_sentence_is_not_machine(marker):
+    # The maintainer's own prompts about this feature quote the markers. A
+    # mid-line mention is prose, never a block opening.
+    prompt = (f"why does the recall hook still fire on {marker} blocks when "
+              "the session already briefed that work?")
+    assert recall.is_machine_prompt(prompt) is False
+
+
+@pytest.mark.parametrize("marker", MACHINE_MARKERS)
+def test_marker_beyond_the_scan_window_is_not_machine(marker):
+    # A genuine prompt that pastes a block far below its own question keeps its
+    # suggestions: only the opening region can carry a block marker.
+    prompt = ("here is the failing gateway trace I want to talk about\n"
+              + "padding line about the gateway seam\n" * 20
+              + f"{marker} pasted for reference")
+    assert len(prompt) > recall._MACHINE_SCAN_CHARS
+    assert recall.is_machine_prompt(prompt) is False
+
+
+def test_indented_marker_is_not_machine():
+    # An indented code block quoting a marker is a human pasting an example.
+    assert recall.is_machine_prompt("look at this:\n\n    <task-notification>\n") is False
+
+
+def test_ordinary_prompt_is_not_machine():
+    assert recall.is_machine_prompt("finish the gateway seam refactor") is False
+    assert recall.is_machine_prompt("") is False
+
+
+def test_lowercased_marker_is_not_machine():
+    # Literal and case-sensitive on purpose: the hosts emit exactly one casing,
+    # and loosening it only buys false skips.
+    assert recall.is_machine_prompt("[system notification] all done") is False

--- a/website/docs/hosts/claude-code.md
+++ b/website/docs/hosts/claude-code.md
@@ -85,8 +85,9 @@ registers them:
   `daimon recall-inject` on stdin, and injects a one-line pointer when the
   prompt overlaps a prior open loop. Because it fires per-prompt, failures
   are silent (exit 0, no output) — the only thing it ever prints is a real
-  suggestion — and slash commands (host directives, not work statements)
-  never match.
+  suggestion. Prompts that are not a person asking for work never match:
+  slash commands (host directives) and host-emitted machine blocks —
+  background-task notifications, teammate/agent messages, command output.
 
 These two capture/inject scripts are wired in one of two mutually exclusive
 ways — pick ONE (both at once double-fires every session: two briefing

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/claude-code.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/claude-code.md
@@ -88,8 +88,10 @@ instalación que los registre:
   `daimon recall-inject` por stdin, e inyecta un puntero de una línea cuando
   el prompt se solapa con un pendiente previo. Como se dispara por prompt,
   las fallas son silenciosas (exit 0, sin salida) — lo único que imprime es
-  una sugerencia real — y los comandos slash (directivas del host, no
-  enunciados de trabajo) nunca coinciden.
+  una sugerencia real. Los prompts que no son una persona pidiendo trabajo
+  nunca coinciden: los comandos slash (directivas del host) y los bloques
+  emitidos por el host — notificaciones de tareas en segundo plano, mensajes
+  de agentes o compañeros de equipo, salida de comandos.
 
 Estos dos scripts de captura/inyección se cablean de una de dos maneras
 mutuamente excluyentes — elige UNA (ambas a la vez disparan todo dos veces


### PR DESCRIPTION
Closes #450

## Summary
- `recall.is_machine_prompt`: a confident machine marker (`[SYSTEM NOTIFICATION`, `<task-notification>`, `<teammate-message`, `<agent-message`, `<local-command-stdout>`) counts only when it **opens a line within the first 400 chars** — line-start, not substring, so a prompt that merely discusses a notification (quoting a marker mid-sentence) keeps its suggestions. Ambiguous shapes (indented, lowercased, past the window) still suggest.
- `_cmd_recall_inject` classifies right after the stdin read; on machine: silent, rc 0, counted as `recall-inject:skip-machine` **alongside** the unconditional `recall-inject` key (historical denominator preserved — the 37.9% is re-measurable).
- Fail-open inner-scoped: a classifier error falls back to *suggesting* (today's behavior), never to silence.
- Host docs (en + es) updated — the never-matches list explicitly enumerated skip conditions and would have gone stale.

## Test plan
- [x] Strict TDD, red first; 33 tests added (2352 → 2385, 2 skipped)
- [x] All five markers parametrized at both unit and behavioral level; fixture-pair control (same body, no wrapper → suggests, no skip logged); quoted-inline, past-window, indented, lowercased all still suggest; classifier-raises → suggests
- [x] Both usage keys assert through `stats --json`
- [x] ruff clean; mypy 63 = origin/main baseline (measured on throwaway baseline worktree)
- [x] Zero uncovered added lines (programmatic diff∩missing = ∅ both source files)

## Notes
- The hook script still spawns the subprocess for machine prompts by design — the CLI is the single source of truth for matching; duplicating the marker list in the hook is a drift surface for milliseconds of gain. Follow-up on request.