### PR TITLE
fix(recall): content-key the injection dedup — cross-origin duplicates were 15.5% of injections

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1029,27 +1029,49 @@ def _cmd_log(args) -> int:
 
 _SEEN_PRUNE_SECONDS = 7 * 86400  # cooldown files for week-old sessions are dead
 
+_INJECT_BUDGET = 2   # slots per prompt (#125 noise budget)
+_INJECT_FETCH = 8    # candidates asked of `suggest`, i.e. budget + headroom:
+                     # content dedup below must be able to PROMOTE the next
+                     # distinct candidate, and it can only promote from
+                     # candidates it was given (#451)
+
 
 def _seen_path(session: str):
     """Cooldown-state file for one session, or None when the id is unusable
-    (empty, or path-hostile — the id becomes a filename)."""
+    (empty, or path-hostile — the id becomes a filename). Origin ids are not
+    all uuids: a Codex session id is `rollout-<timestamp>-<hex>`, which is a
+    fine filename and must keep working."""
     if not session or "/" in session or "\\" in session or ".." in session:
         return None
     return config.recall_seen_dir() / f"{session}.json"
 
 
-def _load_seen(path) -> set:
+def _load_seen(path) -> tuple[set, set]:
+    """(origin session ids, content keys) already injected this host session.
+
+    Two on-disk shapes are read. The pre-#451 file is a flat JSON list of
+    origin ids; it loads as origins with NO content keys, so an in-flight
+    session keeps every suppression it had and simply starts collecting
+    content keys from its next injection. The current shape is
+    {"origins": [...], "content_keys": [...]}. Anything else — corrupt,
+    truncated, a bare scalar — is state we cannot trust, and cooldown is
+    best-effort: fall open to an empty set and pay one extra suggestion."""
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
-        return {str(s) for s in raw} if isinstance(raw, list) else set()
-    except (OSError, json.JSONDecodeError):
-        return set()
+        if isinstance(raw, list):
+            return {str(s) for s in raw}, set()
+        return ({str(s) for s in raw["origins"]},
+                {str(k) for k in raw["content_keys"]})
+    except (OSError, json.JSONDecodeError, TypeError, KeyError):
+        return set(), set()
 
 
-def _save_seen(path, seen: set) -> None:
+def _save_seen(path, origins: set, content_keys: set) -> None:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(sorted(seen)), encoding="utf-8")
+        path.write_text(json.dumps({"origins": sorted(origins),
+                                    "content_keys": sorted(content_keys)}),
+                        encoding="utf-8")
         # Opportunistic prune: cooldown state for long-dead sessions.
         cutoff = time.time() - _SEEN_PRUNE_SECONDS
         for p in path.parent.iterdir():
@@ -1110,18 +1132,47 @@ def _cmd_recall_inject(args) -> int:
             if sid:
                 exclude.add(str(sid))
         seen_file = _seen_path(session)
-        seen = _load_seen(seen_file) if seen_file else set()
+        seen_origins, seen_keys = (_load_seen(seen_file) if seen_file
+                                   else (set(), set()))
         matches = recall.suggest(prompt, project_dir=project,
                                  current_session=session,
-                                 exclude_sessions=exclude | seen)
-        if not matches:
+                                 exclude_sessions=exclude | seen_origins,
+                                 limit=_INJECT_FETCH)
+        # #451: an origin id is not a content identity. The same claim carried
+        # by two checkpoints (sibling-id copies — the read-side twin of the
+        # value-keyed forget arc, #424/#435) passes the origin cooldown and
+        # re-injects as if it were new: 15.5% of measured injections repeated
+        # text the session had already seen, every repeated group cross-origin.
+        # So the budget is spent on distinct content keys, within one injection
+        # AND across the session, and a suppressed candidate yields its slot to
+        # the next distinct one instead of shrinking the injection.
+        chosen: list[dict] = []
+        chosen_keys: set[str] = set()
+        suppressed = False
+        for m in matches:
+            key = normalize.content_key(m.get("text") or "")
+            if key in seen_keys or key in chosen_keys:
+                suppressed = True
+                continue
+            chosen_keys.add(key)
+            chosen.append(m)
+            if len(chosen) >= _INJECT_BUDGET:
+                break
+        if suppressed:
+            # Counted apart from `recall-inject`, which still counts every fire:
+            # the issue's claim is a RATE, so the pair has to be readable from
+            # `daimon stats` the way #450's machine skip is.
+            _note_usage("recall-inject:dedup-content")
+        if not chosen:
             return 0
         now = time.time()
         terms = recall.salient_terms(prompt)
-        for m in matches:
+        for m in chosen:
             print(_suggest_line(m, terms, now))
         if seen_file:
-            _save_seen(seen_file, seen | {str(m["session_id"]) for m in matches})
+            _save_seen(seen_file,
+                       seen_origins | {str(m["session_id"]) for m in chosen},
+                       seen_keys | chosen_keys)
     except Exception:  # noqa: BLE001 — see docstring: fail-open, always rc 0
         pass
     return 0

--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -229,8 +229,11 @@ def brief_max_tokens() -> int:
 
 def recall_seen_dir() -> Path:
     """Per-session suggestion-cooldown state for recall-inject (#125): one small
-    JSON per session listing the checkpoints already suggested, so a repeated
-    topic never re-injects. Disposable like the recall db — deleting it only
+    JSON per session, {"origins": [...], "content_keys": [...]} — the
+    checkpoints already suggested AND the content keys already injected, so
+    neither a repeated topic nor the same claim carried by a second checkpoint
+    re-injects (#451). Pre-#451 files are a flat list of origins and still read
+    (see cli._load_seen). Disposable like the recall db — deleting it only
     resets cooldowns. DAIMON_RECALL_SEEN_DIR overrides (tests -> tmp)."""
     raw = _get("DAIMON_RECALL_SEEN_DIR")
     if raw:

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3095,6 +3095,236 @@ def test_stats_surfaces_machine_skip_apart_from_recall_inject(
     assert data["usage"]["recall-inject"] == 2  # denominator keeps every fire
 
 
+# ---- #451: injection dedup is content-keyed, not only origin-keyed. Measured
+# ---- on the maintainer's corpus: 15.5% of injections repeated text already
+# ---- injected that session, and every repeated group was CROSS-origin.
+
+# All four texts share the same four prompt terms and the same word count, so
+# FTS5 bm25 is effectively flat across them and #78 importance is the ranking
+# lever the fixtures actually steer with.
+_CK_DUP = "litellm gateway cache pinning stalls the release"
+_CK_DISTINCT_A = "litellm gateway cache warmup skips the release"
+_CK_DISTINCT_B = "litellm gateway cache purge blocks the release"
+_CK_PROMPT = "litellm gateway cache release trouble again"
+
+
+def _seed_item(session, text, importance, project="/repo/x",
+               created="2026-06-20T00:00:00Z"):
+    """One checkpoint carrying one open question. The active topic is
+    deliberately term-disjoint from `_CK_PROMPT` so it can never become the
+    row `suggest` returns for the session."""
+    from daimon_briefing import store
+
+    store.write_checkpoint(
+        session,
+        {"session_id": session, "created": created,
+         "working_context": {
+             "active_topic": {"text": f"scratch notes {session}",
+                              "trust": "inferred"},
+             "open_questions": [{
+                 "text": text, "trust": "verbatim", "quote": text,
+                 "importance": importance, "first_seen": created}],
+             "recent_decisions": []},
+         "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": [],
+                                "contradictions_flagged": []}},
+        project_dir=project,
+    )
+
+
+def _seed_latest_decoy(project="/repo/x"):
+    """Written LAST so the briefing-already-covered exclusion (project latest +
+    global latest) lands on a checkpoint no fixture prompt matches."""
+    _seed_item("S-latest", "unrelated newer topiary work", 1, project=project,
+               created="2026-06-28T00:00:00Z")
+
+
+def _quoted_texts(out: str) -> list[str]:
+    """The injected item texts only — not the trailing `daimon recall "..."`
+    deep-dive hint, which quotes the prompt's salient terms."""
+    return re.findall(r'ago\): "(.*?)" \[', out)
+
+
+def test_recall_inject_does_not_repeat_content_from_another_origin(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # Two distinct candidates outrank the dup copies, so the first prompt spends
+    # its budget on them; the second prompt is where the surviving dup copy
+    # would re-inject text the session already saw, from a different origin.
+    _seed_item("S-dup-hi", _CK_DUP, 10)
+    _seed_item("S-dup-lo", _CK_DUP, 3)
+    _seed_item("S-distinct-a", _CK_DISTINCT_A, 9)
+    _seed_item("S-distinct-b", _CK_DISTINCT_B, 8)
+    _seed_latest_decoy()
+
+    _rc1, out1 = _inject(monkeypatch, capsys, _CK_PROMPT)
+    assert _CK_DUP in out1  # the dup text IS injected once — that is fine
+    rc2, out2 = _inject(monkeypatch, capsys, _CK_PROMPT)
+    assert rc2 == 0
+    assert _CK_DUP not in out2  # same text, different origin -> suppressed
+    assert out2 != ""  # ... and the remaining distinct candidate takes its slot
+
+
+def test_recall_inject_never_spends_both_slots_on_one_content_key(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # The worst measured shape: a whole 2-slot budget on two copies of one rule
+    # from two origins. Here both dup copies outrank the distinct candidate.
+    _seed_item("S-dup-hi", _CK_DUP, 10)
+    _seed_item("S-dup-lo", _CK_DUP, 9)
+    _seed_item("S-distinct-a", _CK_DISTINCT_A, 8)
+    _seed_latest_decoy()
+
+    rc, out = _inject(monkeypatch, capsys, _CK_PROMPT)
+    assert rc == 0
+    texts = _quoted_texts(out)
+    assert len(texts) == 2  # suppression promotes, it never shrinks the budget
+    assert len(set(texts)) == 2
+
+
+def test_recall_inject_content_key_folds_case_and_whitespace_variants(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # normalize.content_key is normalized identity, not similarity: casing,
+    # collapsed whitespace and unicode confusables fold; different WORDS do not.
+    noisy = "  LiteLLM   Gateway  Cache  Pinning  Stalls  The  Release  "
+    _seed_item("S-dup-hi", _CK_DUP, 10)
+    _seed_item("S-dup-lo", noisy, 9)
+    _seed_item("S-distinct-a", _CK_DISTINCT_A, 8)
+    _seed_latest_decoy()
+
+    rc, out = _inject(monkeypatch, capsys, _CK_PROMPT)
+    assert rc == 0
+    assert _CK_DISTINCT_A in out  # the case/space variant was folded away
+    assert noisy.strip() not in out
+
+
+def test_recall_inject_origin_cooldown_survives_content_keying(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # The measured 0 same-origin repeats must stay 0: re-suggesting the SAME
+    # checkpoint is still blocked, whatever its content key.
+    _seed_recall_history()
+    _rc1, out1 = _inject(monkeypatch, capsys,
+                         "debugging the litellm gateway cache pinning again")
+    rc2, out2 = _inject(monkeypatch, capsys,
+                        "still stuck on that litellm gateway cache pinning")
+    assert out1 != ""
+    assert rc2 == 0 and out2 == ""
+
+
+def test_recall_inject_reads_legacy_flat_list_seen_file_and_upgrades_it(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # Pre-#451 state on disk is a flat JSON list of origin ids. It must be read
+    # as origins (suppression preserved) and rewritten in the new shape.
+    from daimon_briefing import config, normalize
+
+    _seed_item("S-dup-hi", _CK_DUP, 10)
+    _seed_item("S-distinct-a", _CK_DISTINCT_A, 9)
+    _seed_latest_decoy()
+    seen = config.recall_seen_dir() / "S-now.json"
+    seen.parent.mkdir(parents=True, exist_ok=True)
+    seen.write_text(json.dumps(["S-dup-hi"]), encoding="utf-8")
+
+    rc, out = _inject(monkeypatch, capsys, _CK_PROMPT)
+    assert rc == 0
+    assert _CK_DUP not in out  # legacy origin entry still suppresses
+    assert _CK_DISTINCT_A in out
+    upgraded = json.loads(seen.read_text(encoding="utf-8"))
+    assert upgraded["origins"] == ["S-distinct-a", "S-dup-hi"]
+    assert upgraded["content_keys"] == [normalize.content_key(_CK_DISTINCT_A)]
+
+
+def test_recall_inject_handles_codex_format_origin_id(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # Origin ids are not all uuids — Codex sessions carry rollout-<timestamp>-…
+    codex = "rollout-2026-07-11T19-04-27-0f3c9a11"
+    _seed_item(codex, _CK_DUP, 10)
+    _seed_item("S-dup-lo", _CK_DUP, 9)
+    _seed_item("S-distinct-a", _CK_DISTINCT_A, 8)
+    _seed_latest_decoy()
+
+    rc, out = _inject(monkeypatch, capsys, _CK_PROMPT)
+    assert rc == 0 and codex in out
+    texts = _quoted_texts(out)
+    assert len(texts) == 2 and len(set(texts)) == 2
+
+
+def test_recall_inject_unreadable_seen_state_falls_open_to_suggesting(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # Cooldown state is best-effort: a corrupt or unreadable file costs one
+    # extra suggestion, never a swallowed one and never a non-zero rc.
+    from daimon_briefing import config
+
+    _seed_item("S-dup-hi", _CK_DUP, 10)
+    _seed_latest_decoy()
+    seen = config.recall_seen_dir() / "S-now.json"
+    seen.parent.mkdir(parents=True, exist_ok=True)
+    seen.write_text("{not json at all", encoding="utf-8")
+
+    rc, out = _inject(monkeypatch, capsys, _CK_PROMPT)
+    assert rc == 0 and _CK_DUP in out
+
+
+@pytest.mark.parametrize("payload", ['{"origins": 5}', '{"content_keys": []}',
+                                     '"a bare string"'])
+def test_recall_inject_malformed_seen_shapes_fall_open(
+        payload, tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import config
+
+    _seed_item("S-dup-hi", _CK_DUP, 10)
+    _seed_latest_decoy()
+    seen = config.recall_seen_dir() / "S-now.json"
+    seen.parent.mkdir(parents=True, exist_ok=True)
+    seen.write_text(payload, encoding="utf-8")
+
+    rc, out = _inject(monkeypatch, capsys, _CK_PROMPT)
+    assert rc == 0 and _CK_DUP in out
+
+
+def test_recall_inject_unwritable_seen_state_still_suggests_rc_zero(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import cli as cli_mod
+
+    _seed_item("S-dup-hi", _CK_DUP, 10)
+    _seed_latest_decoy()
+
+    def boom(_path, _origins, _keys):
+        raise AssertionError("_save_seen must swallow its own IO trouble")
+
+    monkeypatch.setattr(cli_mod, "_save_seen", boom)
+    rc, out = _inject(monkeypatch, capsys, _CK_PROMPT)
+    assert rc == 0 and _CK_DUP in out
+
+
+def test_recall_inject_content_dedup_is_counted_for_measurement(
+        tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    # The issue's expected effect is a rate, so the suppression has to be
+    # readable from `daimon stats` the way #450's machine skip is.
+    _seed_item("S-dup-hi", _CK_DUP, 10)
+    _seed_item("S-dup-lo", _CK_DUP, 9)
+    _seed_item("S-distinct-a", _CK_DISTINCT_A, 8)
+    _seed_latest_decoy()
+
+    _inject(monkeypatch, capsys, _CK_PROMPT)
+    capsys.readouterr()
+    assert cli.main(["stats", "--json"]) == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["usage"]["recall-inject:dedup-content"] == 1
+    assert data["usage"]["recall-inject"] == 1
+
+
+def test_save_seen_prunes_week_old_cooldown_files(tmp_checkpoint_dir):
+    from daimon_briefing import config, cli as cli_mod
+
+    seen_dir = config.recall_seen_dir()
+    seen_dir.mkdir(parents=True, exist_ok=True)
+    stale = seen_dir / "S-ancient.json"
+    stale.write_text("[]", encoding="utf-8")
+    old = time.time() - (8 * 86400)
+    os.utime(stale, (old, old))
+
+    cli_mod._save_seen(seen_dir / "S-fresh.json", {"S-o"}, {"deadbeef"})
+    assert not stale.exists()
+    assert json.loads((seen_dir / "S-fresh.json").read_text()) == {
+        "origins": ["S-o"], "content_keys": ["deadbeef"]}
+
+
 # ---- #33 Phase 2: deterministic carry wired into the serialize path ----
 
 


### PR DESCRIPTION
Closes #451

## Summary
- `recall_seen` cooldown gains content identity: `{"origins": [...], "content_keys": [...]}` with a legacy flat-list fallback reader (in-flight sessions keep their suppressions; first write upgrades). Origin keying untouched — the measured 0 same-origin repeats stays 0.
- Injection now fetches up to 8 ranked candidates and picks the first 2 with **distinct, unseen content keys** — suppression promotes the next distinct candidate instead of shrinking the budget. The measured worst shape (both slots on one rule from two origins) is now impossible, pinned by a test that was RED on main with exactly that shape.
- Codex-format (non-uuid) origin ids handled; corrupt/malformed seen files fall open to suggesting (cooldown is best-effort — the cost of falling open is one extra suggestion, never a swallowed one).
- `recall-inject:dedup-content` counter (mirrors #450's key) makes the effect readable from `daimon stats`.

## Honest limit
`normalize.content_key` is normalized identity (NFKC, whitespace, casefold, confusables), not similarity — two different phrasings of the same rule still pass. carry's salient-terms matcher needs a DF vocabulary that 8 candidates cannot supply, and its own docstring warns a false merge is worse than a false non-merge; here a false merge would silently withhold a distinct finding. Similarity folding = follow-up issue, not a smuggled heuristic.

## Test plan
- [x] Strict TDD, red first; 13 cases (2385 → 2398, 2 skipped)
- [x] Cross-origin identical text suppressed + distinct candidate promoted; both-slots-same-key impossible; origin cooldown preserved; legacy file migration; Codex id; corrupt/malformed/save-failure all fail open rc 0; counter reaches stats; week-old prune intact
- [x] ruff clean; mypy 63 = baseline (throwaway-worktree measured)
- [x] Zero uncovered added lines (programmatic diff∩missing = ∅ both source files)