### PR TITLE
fix(recall): age-gate stale injections — >7d items need a 3-term match to fire

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1035,6 +1035,33 @@ _INJECT_FETCH = 8    # candidates asked of `suggest`, i.e. budget + headroom:
                      # distinct candidate, and it can only promote from
                      # candidates it was given (#451)
 
+# #452: age dominates injection precision. Measured per-slot relevance by item
+# age on the maintainer's corpus: <=1d = 78%, 2-7d ~ 24%, >7d = 6-10% — a
+# week-old item riding an ordinary 2-term match is near-certain noise, so past
+# the knee it must EARN its slot with a substantially stronger match. The
+# thresholds are the measured knee and one term above suggest's session floor
+# (_MIN_OVERLAP = 2): 3 distinct hits on one ITEM is specific prior work, not
+# vocabulary coincidence.
+_AGE_GATE_DAYS = 7   # past this, a candidate needs _STALE_MIN_HITS
+_STALE_MIN_HITS = 3  # distinct salient-term hits that buy a stale slot back
+
+
+def _inject_age_bucket(age_days: float | None) -> str:
+    """Stats bucket for a CHOSEN candidate's age — the bands of #452's
+    measured relevance table, so the before/after read by age is a `daimon
+    stats` query. `unknown` = no usable first_seen stamp."""
+    if age_days is None:
+        return "unknown"
+    if age_days <= 1:
+        return "<=1d"
+    if age_days <= 3:
+        return "2-3d"
+    if age_days <= 7:
+        return "4-7d"
+    if age_days <= 14:
+        return "8-14d"
+    return ">14d"
+
 
 def _seen_path(session: str):
     """Cooldown-state file for one session, or None when the id is unusable
@@ -1146,16 +1173,49 @@ def _cmd_recall_inject(args) -> int:
         # So the budget is spent on distinct content keys, within one injection
         # AND across the session, and a suppressed candidate yields its slot to
         # the next distinct one instead of shrinking the injection.
+        now = time.time()
         chosen: list[dict] = []
         chosen_keys: set[str] = set()
         suppressed = False
+        age_gated = False
         for m in matches:
             key = normalize.content_key(m.get("text") or "")
             if key in seen_keys or key in chosen_keys:
                 suppressed = True
                 continue
+            # #452: stale items must show a stronger match. Age comes from the
+            # row's first_seen through the same parser scoring trusts
+            # (store._created_epoch) with the same tolerance philosophy:
+            # missing, malformed, or future stamps mean age UNKNOWN, and
+            # unknown is never gated — a missing stamp is not evidence of
+            # staleness (fail toward suggesting, the #450 direction). Two
+            # exemptions where pure age is not evidence of noise: a still-OPEN
+            # question, whose survival is the signal (scoring's
+            # auto_escalation philosophy — resolution, not freshness, retires
+            # it), and a pinned standing rule, which is age-independent by
+            # construction (#452's own data: the rare >7d hits were exactly
+            # standing rules and open gates). Like the #451 dedup, a gated
+            # candidate is a `continue`, so its slot promotes the next one.
+            epoch = store._created_epoch(m.get("first_seen"))
+            age_days = ((now - epoch) / 86400.0
+                        if epoch is not None and epoch <= now else None)
+            hits = m.get("term_hits")
+            exempt = ((m.get("kind") == "question"
+                       and not m.get("superseded_by"))
+                      or bool(m.get("pinned")))
+            if (age_days is not None and age_days > _AGE_GATE_DAYS
+                    and not exempt
+                    # isinstance, not `or 0`: a row with no term_hits offers
+                    # no match-strength evidence, and absent evidence never
+                    # gates (same fail-open direction as unknown age).
+                    and isinstance(hits, int) and hits < _STALE_MIN_HITS):
+                age_gated = True
+                continue
             chosen_keys.add(key)
             chosen.append(m)
+            # #452 re-measurement: every CHOSEN row records its age bucket, so
+            # the before/after precision read by age stays a stats query.
+            _note_usage(f"recall-inject:age:{_inject_age_bucket(age_days)}")
             if len(chosen) >= _INJECT_BUDGET:
                 break
         if suppressed:
@@ -1163,9 +1223,12 @@ def _cmd_recall_inject(args) -> int:
             # the issue's claim is a RATE, so the pair has to be readable from
             # `daimon stats` the way #450's machine skip is.
             _note_usage("recall-inject:dedup-content")
+        if age_gated:
+            # Same convention as dedup-content above: once per injection run
+            # where >=1 candidate was age-gated (#452) — a rate, not a tally.
+            _note_usage("recall-inject:age-gate")
         if not chosen:
             return 0
-        now = time.time()
         terms = recall.salient_terms(prompt)
         for m in chosen:
             print(_suggest_line(m, terms, now))

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -75,7 +75,10 @@ def _note_error(where: str, exc: BaseException) -> None:
 # v4 (#317): items + items_fts grew a scene column (episodic context traces);
 # an old db queried with the new column list would OperationalError, so the
 # bump forces the rebuild instead.
-_SCHEMA_VERSION = "4"
+# v5 (#452): items grew pinned — the cli age gate exempts pinned standing
+# rules, so suggest()'s SELECT names the column and a v4 db would
+# OperationalError on it; the bump funnels that into the rebuild too.
+_SCHEMA_VERSION = "5"
 
 _FTS5_MISSING_MSG = (
     "sqlite3 has no FTS5 module — `daimon recall` needs an FTS5-enabled "
@@ -103,12 +106,15 @@ def _load(path: Path) -> dict | None:
 
 def _items(cp: dict):
     """Yield (kind, text, trust, quote, scene, importance, first_seen, item_id,
-    supersede_targets) for every cognitive item in a checkpoint. Tolerant of
-    shape drift: bare strings become text-only items; anything without usable
-    text is skipped (an index row with no text matches nothing). importance/
-    first_seen/item_id are None on pre-D-011 items; scene is "" on items
-    without one (#317). supersede_targets is the item's `supersedes` link
-    target strings (#234) — usually empty."""
+    pinned, supersede_targets) for every cognitive item in a checkpoint.
+    Tolerant of shape drift: bare strings become text-only items; anything
+    without usable text is skipped (an index row with no text matches
+    nothing). importance/first_seen/item_id are None on pre-D-011 items;
+    scene is "" on items without one (#317). pinned is 0/1 — the #369
+    force-pinned standing-rule flag, carried so the #452 age gate can read it
+    without re-opening checkpoints (any truthy value counts; absent = 0).
+    supersede_targets is the item's `supersedes` link target strings (#234) —
+    usually empty."""
     for section, key, kind in _KIND_SOURCES:
         block = cp.get(section)
         if not isinstance(block, dict):
@@ -146,7 +152,7 @@ def _items(cp: dict):
                         targets.append(link["target"].strip())
             yield (kind, text, str(item.get("trust") or ""),
                    str(item.get("quote") or ""), str(item.get("scene") or ""),
-                   imp, fs, item_id, targets)
+                   imp, fs, item_id, 1 if item.get("pinned") else 0, targets)
 
 
 def _bucket_slugs(d: Path) -> dict[str, str]:
@@ -345,6 +351,7 @@ def _init_schema(conn: sqlite3.Connection) -> None:
                 importance INTEGER,
                 first_seen TEXT,
                 item_id TEXT,
+                pinned INTEGER NOT NULL DEFAULT 0,
                 frontier INTEGER NOT NULL DEFAULT 0
             );
             CREATE VIRTUAL TABLE items_fts USING fts5(text, quote, scene, content='');
@@ -524,14 +531,15 @@ def rebuild() -> int:
                 if key not in newest or (stamped, recency, sid) > newest[key]:
                     newest[key] = (stamped, recency, sid)
             for (kind, text, trust, quote, scene, importance, first_seen,
-                 item_id, targets) in _items(cp):
+                 item_id, pinned, targets) in _items(cp):
                 cur = conn.execute(
                     "INSERT INTO items"
                     " (text, quote, scene, trust, kind, author, project_slug,"
-                    "  session_id, created, importance, first_seen, item_id)"
-                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "  session_id, created, importance, first_seen, item_id,"
+                    "  pinned)"
+                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (text, quote, scene, trust, kind, author, slug, sid, recency,
-                     importance, first_seen, item_id),
+                     importance, first_seen, item_id, pinned),
                 )
                 conn.execute(
                     "INSERT INTO items_fts(rowid, text, quote, scene)"
@@ -894,6 +902,10 @@ def suggest(prompt: str, project_dir=None, current_session=None,
     flag means item-level evidence (a typed supersedes link or a logged
     resolution, #234), so it is rare and load-bearing; it still never hides
     a result (an overturned decision is still evidence, #112).
+
+    Each returned row also carries `term_hits` (its own distinct-term match
+    count) and `pinned` (the #369 standing-rule flag) — inputs to the cli
+    age gate (#452), not rank inputs here.
     """
     slug = store.project_slug(project_dir)
     if slug is None:
@@ -915,6 +927,9 @@ def suggest(prompt: str, project_dir=None, current_session=None,
     sql = (
         "SELECT i.text, i.quote, i.trust, i.kind, i.author, i.project_slug,"
         " i.session_id, i.created, i.importance, i.first_seen, i.superseded_by,"
+        # pinned rides out for the #452 age gate (standing rules are
+        # age-independent); it is NOT a rank input here.
+        " i.pinned,"
         " bm25(items_fts) AS rank"
         " FROM items_fts JOIN items i ON i.id = items_fts.rowid"
         # Best-ranked candidates first (#31 item 4): without ORDER BY the LIMIT
@@ -957,6 +972,12 @@ def suggest(prompt: str, project_dir=None, current_session=None,
     for r, hit in matched:
         if len(coverage[r["session_id"]]) < _MIN_OVERLAP:
             continue
+        # #452: the per-ITEM distinct-term count rides out with the row (the
+        # session-level coverage above is the gate; this is the row's own
+        # match strength). Purely additive — cli's age gate reads it to demand
+        # a stronger match from stale items; nothing here ranks on it beyond
+        # the existing len(hit) tiebreak below.
+        r["term_hits"] = len(hit)
         relevance = max(0.0, -float(r["rank"]))  # FTS5 bm25(): smaller = better
         weight = scoring.effective_weight(
             {"importance": r["importance"], "first_seen": r["first_seen"],

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3517,6 +3517,22 @@ def test_recall_inject_age_bucket_counted_per_chosen_row(
     assert data["usage"]["recall-inject:age:8-14d"] == 1
 
 
+def test_inject_age_bucket_boundaries_match_the_452_bands():
+    # The bands ARE the #452 measurement table — a drifted boundary would file
+    # future re-measurement rows against the wrong measured baseline. Pinned
+    # at both edges of every band, boundaries inclusive-left per the table.
+    assert cli._inject_age_bucket(None) == "unknown"
+    assert cli._inject_age_bucket(0.0) == "<=1d"
+    assert cli._inject_age_bucket(1.0) == "<=1d"
+    assert cli._inject_age_bucket(1.5) == "2-3d"
+    assert cli._inject_age_bucket(3.0) == "2-3d"
+    assert cli._inject_age_bucket(3.5) == "4-7d"
+    assert cli._inject_age_bucket(7.0) == "4-7d"
+    assert cli._inject_age_bucket(7.5) == "8-14d"
+    assert cli._inject_age_bucket(14.0) == "8-14d"
+    assert cli._inject_age_bucket(14.5) == ">14d"
+
+
 def test_save_seen_prunes_week_old_cooldown_files(tmp_checkpoint_dir):
     from daimon_briefing import config, cli as cli_mod
 

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3038,7 +3038,10 @@ def test_recall_inject_control_same_text_without_marker_suggests(
     assert rc == 0 and "S-old" in out
     tags = [line.split()[1]
             for line in (tmp_log_dir / "usage.log").read_text().splitlines()]
-    assert tags == ["recall-inject"]  # no skip tag on a genuine prompt
+    assert tags[0] == "recall-inject"  # denominator fires first
+    # No skip tag on a genuine prompt (#452 later added per-chosen age-bucket
+    # counters to this same log, so the list is no longer exactly one tag).
+    assert "recall-inject:skip-machine" not in tags
 
 
 def test_recall_inject_suggests_when_prompt_quotes_a_marker_beyond_the_window(
@@ -3307,6 +3310,211 @@ def test_recall_inject_content_dedup_is_counted_for_measurement(
     data = json.loads(capsys.readouterr().out)
     assert data["usage"]["recall-inject:dedup-content"] == 1
     assert data["usage"]["recall-inject"] == 1
+
+
+# ---- #452: stale items need a stronger match. Measured per-slot relevance by
+# ---- item age: <=1d = 78%, 2-7d ~ 24%, >7d = 6-10% — age dominates every
+# ---- other precision axis, so a >7d item must EARN its slot with more
+# ---- distinct term hits, while still-open questions and pinned standing
+# ---- rules stay age-independent (the rare >7d hits were exactly those).
+
+# Prompt terms: ocelot / pipeline / cache / deploy. WEAK shares exactly two
+# of them (the suggest floor), STRONG shares three (the stale bar) — chosen so
+# no term is a substring of another word in any fixture text.
+_AGE_PROMPT = "ocelot pipeline cache deploy"
+_AGE_WEAK = "ocelot pipeline rollback stalls staging"
+_AGE_WEAK_B = "ocelot pipeline retry loops staging"
+_AGE_STRONG = "ocelot pipeline cache warmup staging"
+_AGE_FRESH_A = "ocelot pipeline warmup skips staging"
+_AGE_FRESH_B = "ocelot pipeline purge blocks staging"
+
+
+def _iso_days_ago(days: float) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ",
+                         time.gmtime(time.time() - days * 86400))
+
+
+def _seed_aged(session, text, importance, *, days_old, kind="decision",
+               pinned=False, item_id=None, first_seen=None, project="/repo/x"):
+    """One checkpoint carrying one aged item of the given kind. `created` and
+    `first_seen` share the stamp (unless overridden) so the item's age is
+    unambiguous; the active topic is term-disjoint from `_AGE_PROMPT` so it can
+    never become the row suggest returns for the session."""
+    from daimon_briefing import store
+
+    stamp = _iso_days_ago(days_old)
+    item = {"text": text, "trust": "verbatim", "quote": text,
+            "importance": importance,
+            "first_seen": first_seen if first_seen is not None else stamp}
+    if pinned:
+        item["pinned"] = True
+    if item_id:
+        item["id"] = item_id
+    questions, decisions, beliefs = [], [], []
+    if kind == "question":
+        questions = [item]
+    elif kind == "belief":
+        beliefs = [item]
+    else:
+        decisions = [item]
+    store.write_checkpoint(
+        session,
+        {"session_id": session, "created": stamp,
+         "working_context": {
+             "active_topic": {"text": f"scratch notes {session}",
+                              "trust": "inferred"},
+             "open_questions": questions, "recent_decisions": decisions},
+         "epistemic_snapshot": {"strong_beliefs": beliefs, "uncertainties": [],
+                                "contradictions_flagged": []}},
+        project_dir=project,
+    )
+
+
+def _seed_age_decoy(project="/repo/x"):
+    """Written LAST with the newest stamp so the briefing-already-covered
+    exclusion lands on a checkpoint no #452 fixture prompt matches."""
+    _seed_aged("S-age-latest", "unrelated topiary sculpture notes", 1,
+               days_old=0, project=project)
+
+
+def _usage_tags(tmp_log_dir):
+    return [line.split()[1]
+            for line in (tmp_log_dir / "usage.log").read_text().splitlines()]
+
+
+def test_recall_inject_gates_stale_low_hit_candidate(
+        tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    # >7d old, only two term hits: the pure-age precision band is 6-10%, so
+    # the slot is not worth it — silence.
+    _seed_aged("S-stale", _AGE_WEAK, 9, days_old=30)
+    _seed_age_decoy()
+    rc, out = _inject(monkeypatch, capsys, _AGE_PROMPT)
+    assert rc == 0 and out == ""
+    assert "recall-inject:age-gate" in _usage_tags(tmp_log_dir)
+
+
+def test_recall_inject_fresh_copy_of_same_text_still_injects(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # Control for the gate above: the IDENTICAL candidate, merely fresh,
+    # keeps its slot — the gate is age-conditioned, never a new match bar.
+    _seed_aged("S-fresh", _AGE_WEAK, 9, days_old=0)
+    _seed_age_decoy()
+    rc, out = _inject(monkeypatch, capsys, _AGE_PROMPT)
+    assert rc == 0 and _AGE_WEAK in out
+
+
+def test_recall_inject_stale_strong_match_injects(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # >7d but three distinct term hits: a substantially stronger match buys
+    # the slot back.
+    _seed_aged("S-stale", _AGE_STRONG, 9, days_old=30)
+    _seed_age_decoy()
+    rc, out = _inject(monkeypatch, capsys, _AGE_PROMPT)
+    assert rc == 0 and _AGE_STRONG in out
+
+
+def test_recall_inject_open_question_survives_age_gate(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # A still-open question's survival is evidence (scoring's auto_escalation
+    # philosophy): the pure-age penalty never applies to it.
+    _seed_aged("S-q", _AGE_WEAK, 9, days_old=30, kind="question")
+    _seed_age_decoy()
+    rc, out = _inject(monkeypatch, capsys, _AGE_PROMPT)
+    assert rc == 0 and _AGE_WEAK in out
+
+
+def test_recall_inject_superseded_question_is_age_gated(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # ...but a RESOLVED question lost that evidence: the exemption reads the
+    # row's superseded_by, so it gates like any other stale low-hit item.
+    from daimon_briefing import config, store
+
+    _seed_aged("S-q", _AGE_WEAK, 9, days_old=30, kind="question",
+               item_id="o-452aaa")
+    _seed_age_decoy()
+    slug = store.project_slug("/repo/x")
+    ev = config.checkpoint_dir() / slug / "events.jsonl"
+    ev.parent.mkdir(parents=True, exist_ok=True)
+    ev.write_text(
+        json.dumps({"ts": _iso_days_ago(0), "kind": "resolution",
+                    "item_ref": "o-452aaa", "status": "resolved",
+                    "source": "cli"}) + "\n", encoding="utf-8")
+    rc, out = _inject(monkeypatch, capsys, _AGE_PROMPT)
+    assert rc == 0 and out == ""
+
+
+def test_recall_inject_pinned_item_survives_age_gate(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # Standing rules are age-independent — the issue's own data: the rare >7d
+    # hits were pinned rules or open gates.
+    _seed_aged("S-pin", _AGE_WEAK, 9, days_old=30, kind="belief", pinned=True)
+    _seed_age_decoy()
+    rc, out = _inject(monkeypatch, capsys, _AGE_PROMPT)
+    assert rc == 0 and _AGE_WEAK in out
+
+
+@pytest.mark.parametrize("shape", ["malformed", "future"])
+def test_recall_inject_unknown_age_is_never_gated(
+        shape, tmp_checkpoint_dir, capsys, monkeypatch):
+    # A missing/unreadable/future stamp is not evidence of staleness — same
+    # fail-open direction as #450's classifier failure.
+    stamp = "sometime-last-quarter" if shape == "malformed" \
+        else _iso_days_ago(-30)
+    _seed_aged("S-unknown", _AGE_WEAK, 9, days_old=30, first_seen=stamp)
+    _seed_age_decoy()
+    rc, out = _inject(monkeypatch, capsys, _AGE_PROMPT)
+    assert rc == 0 and _AGE_WEAK in out
+
+
+def test_recall_inject_gated_candidate_yields_slot_to_next(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # The gate is a `continue`, not a budget spend: with budget 2 and
+    # candidates [stale-low-hit, fresh, fresh], both fresh ones inject. The
+    # importances put the STALE candidate first in rank (at 20d: 1.0 base x
+    # 0.7 recency x 0.6 decay = 0.42 beats the fresh 0.2s; all three share
+    # the same two prompt terms so bm25 is flat) — the yielded slot is real,
+    # not a ranking accident.
+    _seed_aged("S-stale", _AGE_WEAK, 10, days_old=20)
+    _seed_aged("S-fresh-a", _AGE_FRESH_A, 2, days_old=0)
+    _seed_aged("S-fresh-b", _AGE_FRESH_B, 2, days_old=0)
+    _seed_age_decoy()
+    rc, out = _inject(monkeypatch, capsys, _AGE_PROMPT)
+    assert rc == 0
+    texts = _quoted_texts(out)
+    assert len(texts) == 2
+    assert _AGE_WEAK not in texts
+    assert set(texts) == {_AGE_FRESH_A, _AGE_FRESH_B}
+
+
+def test_recall_inject_age_gate_counted_once_for_measurement(
+        tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    # Mirrors #451's dedup-content convention: one count per injection run
+    # where gating occurred, however many candidates were gated — the stats
+    # pair (age-gate / recall-inject) is a RATE.
+    _seed_aged("S-stale-a", _AGE_WEAK, 10, days_old=30)
+    _seed_aged("S-stale-b", _AGE_WEAK_B, 9, days_old=30)
+    _seed_age_decoy()
+    _inject(monkeypatch, capsys, _AGE_PROMPT)
+    capsys.readouterr()
+    assert cli.main(["stats", "--json"]) == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["usage"]["recall-inject:age-gate"] == 1
+    assert data["usage"]["recall-inject"] == 1
+
+
+def test_recall_inject_age_bucket_counted_per_chosen_row(
+        tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    # Re-measurement counters: every CHOSEN row records its age bucket so the
+    # before/after read by age is a `daimon stats` query, not a log dig.
+    _seed_aged("S-fresh-a", _AGE_FRESH_A, 9, days_old=0)
+    _seed_aged("S-mid", _AGE_STRONG, 8, days_old=10)
+    _seed_age_decoy()
+    _inject(monkeypatch, capsys, _AGE_PROMPT)
+    capsys.readouterr()
+    assert cli.main(["stats", "--json"]) == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["usage"]["recall-inject:age:<=1d"] == 1
+    assert data["usage"]["recall-inject:age:8-14d"] == 1
 
 
 def test_save_seen_prunes_week_old_cooldown_files(tmp_checkpoint_dir):

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -1056,6 +1056,68 @@ def test_suggest_rich_prompt_terms_beyond_twelve_still_match(tmp_checkpoint_dir,
     assert out and out[0]["session_id"] == "S-old"
 
 
+# ---- #452: suggest's side of the age-aware injection gate — rows carry the
+# ---- per-item match strength (term_hits) and the standing-rule flag (pinned)
+# ---- so the cli gate can judge stale candidates without recomputing either.
+
+
+def test_suggest_rows_carry_term_hits(tmp_checkpoint_dir, monkeypatch):
+    _seed_history()
+    out = recall.suggest("debugging the litellm gateway cache pinning again",
+                         project_dir="/repo/x", current_session="S-now")
+    assert out
+    # text+quote share exactly litellm/gateway/cache with the prompt ("pins"
+    # never contains "pinning"; "debugging" appears nowhere in the item).
+    assert out[0]["term_hits"] == 3
+
+
+def test_rebuild_indexes_pinned_flag_and_suggest_returns_it(
+        tmp_checkpoint_dir, monkeypatch):
+    store.write_checkpoint(
+        "S-old", _cp(
+            "S-old",
+            beliefs=[{"text": "ocelot cache flushes forbidden in prod",
+                      "trust": "verbatim",
+                      "quote": "ocelot cache flushes forbidden in prod",
+                      "pinned": True, "importance": 9,
+                      "first_seen": "2026-06-20T00:00:00Z"}],
+            decisions=[{"text": "ocelot cache warmup adopted for staging",
+                        "trust": "inferred", "importance": 5,
+                        "first_seen": "2026-06-20T00:00:00Z"}],
+            created="2026-06-20T00:00:00Z"),
+        project_dir="/repo/x")
+    recall.rebuild()
+    conn = sqlite3.connect(str(config.recall_db()))
+    try:
+        by_text = dict(conn.execute("SELECT text, pinned FROM items").fetchall())
+    finally:
+        conn.close()
+    assert by_text["ocelot cache flushes forbidden in prod"] == 1
+    assert by_text["ocelot cache warmup adopted for staging"] == 0
+    out = recall.suggest("ocelot cache flushes prod",
+                         project_dir="/repo/x", current_session="S-now")
+    assert out and out[0]["pinned"] == 1
+
+
+def test_pre_452_schema_db_rebuilds_instead_of_erroring(
+        tmp_checkpoint_dir, monkeypatch):
+    # An existing v4 db has no `pinned` column — suggest's SELECT would
+    # OperationalError on it. The schema bump must funnel that into the
+    # standard silent rebuild, never a swallowed-empty answer.
+    _seed_history()
+    recall.rebuild()
+    conn = sqlite3.connect(str(config.recall_db()))
+    try:
+        conn.execute("ALTER TABLE items DROP COLUMN pinned")
+        conn.execute("UPDATE meta SET value='4' WHERE key='schema_version'")
+        conn.commit()
+    finally:
+        conn.close()
+    out = recall.suggest("debugging the litellm gateway cache pinning again",
+                         project_dir="/repo/x", current_session="S-now")
+    assert out and out[0]["session_id"] == "S-old"
+
+
 def test_unattributed_sessions_never_supersede_each_other(tmp_checkpoint_dir, monkeypatch):
     # #31 item 6: all NULL-slug (unattributed) sessions shared one supersession
     # bucket — the newest unattributed session superseded unrelated


### PR DESCRIPTION
Closes #452.

## What
Injection-side age gate: candidates older than 7 days need 3 distinct per-item salient-term hits to take a slot (fresh items keep today's bar). Exemptions where pure age is not evidence of noise: still-open questions and pinned standing rules. Unknown age / missing match evidence never gates (fail toward suggesting, #450 direction). Gated candidates yield their slot to the next distinct candidate (#451 pattern).

## Why
Rubric-scored measurement (#452): per-slot relevance <=1d = 78%, 2-7d ~24%, >7d = 6-10%. Age dominates every other precision axis.

## Re-measurement path
- `recall-inject:age-gate` — runs where the gate fired (rate pair with `recall-inject`, same convention as #450/#451)
- `recall-inject:age:<=1d|2-3d|4-7d|8-14d|>14d|unknown` — every chosen row records its bucket

## Architecture
- `scoring.py` untouched: #413/#408 trust-ceiling fences green by construction (test_scoring + test_corroboration: 90 passed)
- `recall.suggest()` rows gain `term_hits` + `pinned` — inputs to the cli gate, not rank inputs
- recall index schema v5 (adds `pinned`); v4 dbs funnel into the existing any-doubt-rebuild path, covered by test

## Tests
Strict TDD, RED-confirmed first on all behavior tests. Full suite 2412 passed, 2 skipped. One #450 test amended (exact-tag-list assertion could not coexist with per-chosen bucket counters; relaxed with comment).