### PR TITLE
feat(provenance): stamp the served model from the LLM response

### DIFF
--- a/benchmark/results/longmemeval-s-baseline.json
+++ b/benchmark/results/longmemeval-s-baseline.json
@@ -7,6 +7,7 @@
     "backend": "litellm",
     "backend_configured": "auto",
     "model": "claude-haiku-4-5-via-meridian",
+    "model_note": "`model` is the requested gateway alias, not a served-model receipt: the operator's gateway had silent fallback chains active on run day, so per-call served-model purity is unverifiable for this run; served-model stamping (`model_served`) was added later (#458) and does not cover it",
     "prompt_version": "D-013",
     "seed": 0,
     "sample": 5,

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -264,6 +264,10 @@ def _run_serialize(transcript_path: Path, project: str | None,
     # Elapsed time lands in serialize.log — checkpoint generation runs 4-25 min
     # in production and was invisible before this.
     llm.reset_fallback()  # #28: detect a silent backend downgrade during THIS run
+    # #458: same unit-of-work contract for the served-model collector — the
+    # provenance stamp must report what the wire said during THIS serialize,
+    # not receipts left over from an earlier run in a long-lived process.
+    llm.reset_served_models()
     start = time.monotonic()
     # Same total budget as the hook path (hooks.py:73) — this entry point had
     # none at all, so a manual `daimon serialize` had no bound even in

--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -124,12 +124,20 @@ def _chat_litellm(messages, model=None, temperature=None, timeout=None, retries=
         try:
             with urllib.request.urlopen(req, timeout=attempt_timeout) as r:
                 data = json.loads(_read_within_deadline(r, deadline, attempt, last))
+            # #458 / scar 0032: record the model the response SAYS served this
+            # call — the requested `mdl` is a gateway alias and proves nothing.
+            # list.append is atomic under the GIL, so concurrent chunk threads
+            # record safely; served_models() dedupes/sorts on read. Absent or
+            # non-string field -> record nothing (honest absence, no guessing).
+            served = data.get("model")
+            if isinstance(served, str) and served.strip():
+                _served_models.append(served.strip())
             # Surface token cost — the serializer discards the rest of the
             # response, so this log line is the only record of per-call spend.
             usage = data.get("usage") or {}
             if usage:
-                log.info("LLM usage model=%s total_tokens=%s prompt=%s completion=%s",
-                         mdl, usage.get("total_tokens"),
+                log.info("LLM usage model=%s served=%s total_tokens=%s prompt=%s completion=%s",
+                         mdl, served, usage.get("total_tokens"),
                          usage.get("prompt_tokens"), usage.get("completion_tokens"))
             return data["choices"][0]["message"]["content"]
         except urllib.error.HTTPError as e:
@@ -166,6 +174,32 @@ def fallback_used() -> bool:
 def reset_fallback() -> None:
     global _fallback_used
     _fallback_used = False
+
+
+# #458 / scar 0032: the requested model name is ROUTING CONFIG, not provenance.
+# Behind an OpenAI-compatible gateway it is an alias, and gateways run silent
+# fallback chains — the call succeeds, a different model serves it, no error
+# is raised (2026-07-30 live: the configured alias was served by a local
+# Qwen3-30B; the response's own `model` field said so). That field is the only
+# per-call truth, so _chat_litellm records it below. Module-sticky accessors
+# deliberately mirror the #28 fallback pattern above: chat()'s `-> str`
+# contract is consumed by every injectable-chat seam (serializer, cli, bench,
+# test fakes) and must not change shape. reset_served_models() at the start of
+# a unit of work; served_models() when stamping. The command backend exposes
+# NO served-model info and records nothing — honest absence, never the
+# requested name copied into the served slot.
+_served_models: list = []
+
+
+def served_models() -> list:
+    """Distinct served-model names observed since the last reset, sorted —
+    deterministic stamp order regardless of chunk-thread completion order."""
+    return sorted(set(_served_models))
+
+
+def reset_served_models() -> None:
+    # Clear in place: concurrent chunk threads hold the same list object.
+    del _served_models[:]
 
 
 def chat(messages, model=None, temperature=None, timeout=None, retries=3, deadline=None):

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -1675,10 +1675,30 @@ def _stamp_llm_provenance(checkpoint: dict) -> None:
         assignment always stomps any model-authored value with the
         resolved truth.
 
+    `llm_model_served` (#458 / scar 0032): `llm_model` is the REQUESTED
+    alias — routing config. Behind a gateway with silent fallback chains a
+    different model can serve the call with no error, so the response body's
+    own `model` field is the only per-call truth; llm.py collects the
+    distinct names across this process's calls (chunks + merge) and this
+    stamp records them: one distinct name -> string, more than one -> sorted
+    list AND the substitution-during-run signal (WARNING + the
+    `serialize:model-substituted` usage counter). Mixed-within-a-run is the
+    ONLY detectable mismatch: alias->served-name mapping is unknowable
+    client-side (the served id is provider-prefixed or fully qualified, so a
+    raw requested != served compare would always fire). The command backend
+    exposes no served-model info and records nothing, so its checkpoints
+    carry NO key — honest absence, never the requested name copied over.
+
     Fail-open: called right before the checkpoint is handed off to
     store/write, so a resolver exception must never fail an otherwise-
     successful serialize. Both fields are simply left absent.
     """
+    # #458: a model-authored `llm_model_served` in the extracted JSON is a
+    # self-issued receipt — pop unconditionally BEFORE any fail-open early
+    # return, so even a stamp that bails leaves honest absence, not a spoof
+    # (same discipline as strip_code_owned_keys, #292, but local: this key's
+    # legitimate value is only ever computed right here).
+    checkpoint.pop("llm_model_served", None)
     try:
         backend = configure.resolved_backend()
     except Exception:
@@ -1692,6 +1712,31 @@ def _stamp_llm_provenance(checkpoint: dict) -> None:
         model = None
     if model:
         checkpoint["llm_model"] = model
+    try:
+        served = llm.served_models()
+    except Exception:
+        served = []
+    if not served:
+        return
+    checkpoint["llm_model_served"] = served[0] if len(served) == 1 else served
+    if len(served) > 1:
+        log.warning(
+            "serialize: model substitution during run — %d distinct served "
+            "models %s behind requested %r; every item in this checkpoint "
+            "was extracted by at least one model that is not the configured "
+            "one (#458)",
+            len(served), served, model)
+        # Count through the SAME local usage-counter mechanism the cli
+        # commands use (#54) — mcp_tools.py already records via
+        # cli._note_usage from outside cli, so this matches the existing
+        # architecture rather than inventing a counter subsystem. Lazy
+        # import keeps the module graph acyclic (cli imports this module);
+        # best-effort keeps the stamp fail-open.
+        try:
+            from . import cli
+            cli._note_usage("serialize:model-substituted")
+        except Exception:
+            pass
 
 
 def serialize_strict(session_id: str, messages, chat=None, deadline=None,

--- a/plugin/tests/bench/run.py
+++ b/plugin/tests/bench/run.py
@@ -115,11 +115,32 @@ def _build_config_stamp(args, dataset_path: Path) -> dict:
     }
 
 
+def _stamp_served_models(stamp: dict, agg: dict, served: list) -> None:
+    """#458 / scar 0032: `stamp['model']` is the REQUESTED gateway alias —
+    routing config, not provenance (gateways run silent fallback chains, so
+    the alias proves nothing about which model ran). `served` is what the
+    response bodies actually said across the run (llm.served_models()). One
+    distinct name -> `model_served` string; several -> the sorted list AND an
+    explicit `mixed_models: true` on the aggregate block, so a mixed run can
+    never be attributed to a single model silently. Empty (command backend,
+    or an all-cache run that made no LLM call) -> no key at all: honest
+    absence, never the alias copied into the served slot."""
+    distinct = sorted(set(served))
+    if not distinct:
+        return
+    stamp["model_served"] = distinct[0] if len(distinct) == 1 else distinct
+    if len(distinct) > 1:
+        agg["mixed_models"] = True
+
+
 def run(args) -> dict:
     dataset_path = _resolve_dataset(args)
     questions = dataset.sample(dataset.load(dataset_path), args.sample, args.seed)
     cache = cache_mod.CheckpointCache(Path(args.cache_dir))
     chat = llm.chat
+    # #458: collect served-model receipts for THIS run only — the collector
+    # is module-sticky (same lifecycle as llm's #28 fallback flag).
+    llm.reset_served_models()
 
     stamp = _build_config_stamp(args, dataset_path)
     print(f"suite={args.suite} sample={len(questions)} backend={stamp['backend']} "
@@ -143,6 +164,13 @@ def run(args) -> dict:
               f"({time.monotonic() - qt0:.0f}s)")
 
     agg = metrics.aggregate(per_question, args.k)
+    # #458: stamp what actually served (reset ran before the loop, so these
+    # are exactly this run's receipts). A mixed run is flagged loudly in the
+    # aggregate block AND on stdout — never aggregated silently.
+    _stamp_served_models(stamp, agg, llm.served_models())
+    if agg.get("mixed_models"):
+        print(f"WARNING: mixed served models in this run ({stamp['model_served']}) "
+              "— do not attribute this number to a single model (#458)")
     total_serialized = sum(r["serialize"]["serialized"] for r in per_question)
     report = {
         "config": stamp,

--- a/plugin/tests/conftest.py
+++ b/plugin/tests/conftest.py
@@ -41,6 +41,15 @@ def _isolate_daimon_home(tmp_path, monkeypatch):
     return home
 
 
+@pytest.fixture(autouse=True)
+def _reset_served_models():
+    """#458: the served-model collector is module-sticky (same shape as #28's
+    fallback flag) — clear it per test so one test's canned response bodies
+    can never stamp phantom served models onto another test's checkpoints."""
+    from daimon_briefing import llm
+    llm.reset_served_models()
+
+
 @pytest.fixture
 def tmp_checkpoint_dir(tmp_path):
     # The autouse fixture already points DAIMON_CHECKPOINT_DIR here; expose the path.

--- a/plugin/tests/test_bench_smoke.py
+++ b/plugin/tests/test_bench_smoke.py
@@ -49,3 +49,63 @@ def test_real_backend_serialize_and_recall(tmp_path):
     )
     assert result["serialize"]["indexed"] >= 1
     assert result["n_retrieved_sessions"] >= 1
+
+
+# ---- #458 / scar 0032: served-model stamp in the bench report ----
+#
+# The config stamp's `model` is the REQUESTED gateway alias — routing config,
+# not provenance. `model_served` records what the wire said across the run;
+# a run that saw more than one served model gets an explicit `mixed_models`
+# flag in the aggregate block so a number is never attributed to one model
+# when several actually ran. No LLM needed: pure stamp-shaping helper.
+
+
+def test_stamp_served_models_single(tmp_path):
+    stamp, agg = {}, {}
+    bench_run._stamp_served_models(stamp, agg, ["provider/only-model"])
+    assert stamp["model_served"] == "provider/only-model"
+    assert "mixed_models" not in agg
+
+
+def test_stamp_served_models_mixed_flags_never_silent(tmp_path):
+    stamp, agg = {}, {}
+    bench_run._stamp_served_models(stamp, agg, ["z-model", "a-model"])
+    assert stamp["model_served"] == ["a-model", "z-model"]
+    assert agg["mixed_models"] is True
+
+
+def test_stamp_served_models_absent_records_nothing(tmp_path):
+    # Command backend / all-cache runs have no wire receipt: honest absence,
+    # never the alias copied over.
+    stamp, agg = {}, {}
+    bench_run._stamp_served_models(stamp, agg, [])
+    assert "model_served" not in stamp
+    assert "mixed_models" not in agg
+
+
+def test_committed_baseline_is_annotated_and_metrics_untouched():
+    # #458 acceptance: the 5-question baseline's `model` is a gateway alias
+    # recorded while fallback chains were live — the config block must SAY so
+    # (model_note, mirroring interim-317-baseline-first54.json), and the
+    # annotation must not touch a single metric value.
+    import json
+    from pathlib import Path
+
+    baseline = Path(__file__).resolve().parents[2] / \
+        "benchmark/results/longmemeval-s-baseline.json"
+    report = json.loads(baseline.read_text(encoding="utf-8"))
+    note = report["config"]["model_note"]
+    assert "alias" in note
+    assert "#458" in note
+    assert "unverifiable" in note
+    assert report["config"]["model"] == "claude-haiku-4-5-via-meridian"
+    assert report["metrics"] == {
+        "k": 5,
+        "questions_total": 5,
+        "questions_scored": 5,
+        "questions_abstention": 0,
+        "recall_at_5": 0.8,
+        "hit_at_5": 1.0,
+        "mrr": 0.85,
+        "avg_injected_tokens": 149.6,
+    }

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -936,3 +936,81 @@ def test_chat_fallback_no_deadline_stays_none(monkeypatch):
     monkeypatch.setattr(llm, "_chat_command", fake_command)
     assert llm.chat([{"role": "user", "content": "x"}]) == "OK"
     assert seen["deadline"] is None
+
+
+# ---- #458 / scar 0032: the served model comes from the wire, not the config ----
+#
+# A gateway alias is routing config; gateways run silent fallback chains, so the
+# response body's `model` field is the only per-call truth about which model
+# actually served. llm must capture it per call and expose it to the stamping
+# caller (module-sticky accessor, mirroring the #28 fallback_used pattern —
+# chat()'s `-> str` contract is consumed by every injectable-chat seam and
+# must not change shape).
+
+
+def _ok_response_with_model(content, served_model):
+    body = json.dumps({
+        "model": served_model,
+        "choices": [{"message": {"content": content}}],
+    }).encode()
+    return io.BytesIO(body)
+
+
+def test_chat_records_served_model_from_response_body(llm_env, monkeypatch):
+    # The live incident (2026-07-30): request named the gateway alias, the
+    # response's own `model` field named the local fallback that actually ran.
+    llm.reset_served_models()
+
+    def fake_urlopen(req, timeout=None):
+        return _ok_response_with_model(
+            "ok", "unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert llm.chat([{"role": "user", "content": "hi"}]) == "ok"
+    assert llm.served_models() == ["unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF"]
+
+
+def test_chat_without_model_field_records_honest_absence(llm_env, monkeypatch):
+    # No `model` in the response body -> nothing recorded. Never copy the
+    # requested alias into the served slot — that would re-create the exact
+    # lie #458 exists to kill.
+    llm.reset_served_models()
+
+    def fake_urlopen(req, timeout=None):
+        return _ok_response("ok")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert llm.chat([{"role": "user", "content": "hi"}]) == "ok"
+    assert llm.served_models() == []
+
+
+def test_served_models_distinct_sorted_and_resettable(llm_env, monkeypatch):
+    # Multiple calls in one process (a chunked serialize) accumulate; the
+    # accessor reports DISTINCT names, sorted, so the stamp is deterministic.
+    llm.reset_served_models()
+    served = iter(["z-model", "a-model", "z-model"])
+
+    def fake_urlopen(req, timeout=None):
+        return _ok_response_with_model("ok", next(served))
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    for _ in range(3):
+        assert llm.chat([{"role": "user", "content": "hi"}]) == "ok"
+    assert llm.served_models() == ["a-model", "z-model"]
+    llm.reset_served_models()
+    assert llm.served_models() == []
+
+
+def test_command_backend_records_no_served_model(monkeypatch):
+    # The claude-CLI/command backend exposes no served-model info at all —
+    # honest absence, never a guess (scar 0032: measurements attributed
+    # without a served-model receipt must say so by carrying nothing).
+    llm.reset_served_models()
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "mycli")
+    monkeypatch.delenv("DAIMON_LLM_COMMAND_OUTPUT", raising=False)
+    monkeypatch.delenv("DAIMON_LLM_COMMAND_INPUT", raising=False)
+    monkeypatch.setattr(llm, "_run_command",
+                        lambda argv, stdin_text, timeout, env, cwd: (0, "OK", ""))
+    assert llm.chat([{"role": "user", "content": "hi"}]) == "OK"
+    assert llm.served_models() == []

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -2661,3 +2661,116 @@ def test_chunked_serialize_touches_heartbeat_per_chunk(fake_chat_factory,
     assert serializer.serialize("S-long", messages, chat=chat) is not None
     # entry + per-chunk + merge: strictly more touches than chunks
     assert len([c for c in calls if c == "S-long"]) > n_chunks
+
+
+# ---- #458 / scar 0032: llm_model_served — the wire's truth beside the alias ----
+#
+# `llm_model` stays the REQUESTED alias (routing config, #230 semantics
+# untouched). `llm_model_served` is stamped from what the response bodies
+# actually said across the serialize's calls: one distinct name -> string;
+# more than one -> sorted list AND the substitution-during-run signal (a
+# gateway swapped models mid-serialize — the only mismatch we can detect
+# honestly, since alias->served-name mapping is unknowable client-side).
+
+
+def _serve(monkeypatch, names):
+    from daimon_briefing import llm
+    monkeypatch.setattr(llm, "served_models", lambda: list(names))
+
+
+def test_serialize_stamps_served_model_string_when_single(fake_chat_factory, monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_API_KEY", "sk-test")
+    monkeypatch.setenv("DAIMON_LLM_MODEL", "gateway-alias")
+    _serve(monkeypatch, ["provider/real-model-served"])
+    chat = fake_chat_factory(_valid_checkpoint_json("S1"))
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+    assert ckpt is not None
+    assert ckpt["llm_model"] == "gateway-alias"          # requested, unchanged
+    assert ckpt["llm_model_served"] == "provider/real-model-served"
+
+
+def test_serialize_stamps_sorted_list_and_flags_substitution_when_mixed(
+        fake_chat_factory, monkeypatch, caplog):
+    import logging
+
+    from daimon_briefing import cli
+    monkeypatch.setenv("DAIMON_LLM_API_KEY", "sk-test")
+    monkeypatch.setenv("DAIMON_LLM_MODEL", "gateway-alias")
+    _serve(monkeypatch, ["a-model", "z-model"])
+    noted = []
+    monkeypatch.setattr(cli, "_note_usage", noted.append)
+    chat = fake_chat_factory(_valid_checkpoint_json("S1"))
+    with caplog.at_level(logging.WARNING, logger="daimon_briefing.serializer"):
+        ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+    assert ckpt is not None
+    assert ckpt["llm_model_served"] == ["a-model", "z-model"]
+    assert any("model" in r.getMessage() and "substitut" in r.getMessage()
+               for r in caplog.records), \
+        "mixed served models must surface as a WARNING, never silently"
+    assert "serialize:model-substituted" in noted
+
+
+def test_serialize_uniform_served_does_not_warn_or_count(
+        fake_chat_factory, monkeypatch, caplog):
+    import logging
+
+    from daimon_briefing import cli
+    monkeypatch.setenv("DAIMON_LLM_API_KEY", "sk-test")
+    monkeypatch.setenv("DAIMON_LLM_MODEL", "gateway-alias")
+    _serve(monkeypatch, ["one-model"])
+    noted = []
+    monkeypatch.setattr(cli, "_note_usage", noted.append)
+    chat = fake_chat_factory(_valid_checkpoint_json("S1"))
+    with caplog.at_level(logging.WARNING, logger="daimon_briefing.serializer"):
+        ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+    assert ckpt is not None
+    assert not any("substitut" in r.getMessage() for r in caplog.records)
+    assert "serialize:model-substituted" not in noted
+
+
+def test_serialize_absent_served_leaves_key_absent_and_strips_spoof(
+        fake_chat_factory, monkeypatch):
+    # No wire receipt -> no key. And a model-authored `llm_model_served` in
+    # the extracted JSON must never survive as provenance (same discipline
+    # as #292's code-owned keys: the model proposes nothing about its own
+    # identity — a spoofable served-stamp is worse than none).
+    monkeypatch.setenv("DAIMON_LLM_API_KEY", "sk-test")
+    monkeypatch.setenv("DAIMON_LLM_MODEL", "gateway-alias")
+    _serve(monkeypatch, [])
+    spoofed = json.loads(_valid_checkpoint_json("S1"))
+    spoofed["llm_model_served"] = "model-invented-provenance"
+    chat = fake_chat_factory(json.dumps(spoofed))
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+    assert ckpt is not None
+    assert "llm_model_served" not in ckpt
+
+
+def test_serialize_command_backend_leaves_served_absent(fake_chat_factory, monkeypatch):
+    # The command backend records no served-model info (llm.py exposes none
+    # for it — honest absence). Real accessor, not a monkeypatch: proves the
+    # end-to-end default is "no receipt, no key".
+    from daimon_briefing import llm
+    llm.reset_served_models()
+    monkeypatch.delenv("DAIMON_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("DAIMON_LLM_MODEL", raising=False)
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "echo hi")
+    chat = fake_chat_factory(_valid_checkpoint_json("S1"))
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+    assert ckpt is not None
+    assert ckpt["llm_backend"] == "command"
+    assert "llm_model_served" not in ckpt
+
+
+def test_validate_tolerates_served_field_presence_and_absence(fake_chat_factory):
+    # Schema tolerance both ways (green-by-design guard): legacy checkpoints
+    # without `llm_model_served` must keep validating, and new ones carrying
+    # it must not be rejected — validate() is required-keys-only and this
+    # test pins that contract for the new field.
+    legacy = json.loads(_valid_checkpoint_json("S-legacy"))
+    assert serializer.validate(legacy)
+    stamped = json.loads(_valid_checkpoint_json("S-new"))
+    stamped["llm_model_served"] = "provider/real-model-served"
+    assert serializer.validate(stamped)
+    mixed = json.loads(_valid_checkpoint_json("S-mixed"))
+    mixed["llm_model_served"] = ["a-model", "z-model"]
+    assert serializer.validate(mixed)

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -2710,6 +2710,43 @@ def test_serialize_stamps_sorted_list_and_flags_substitution_when_mixed(
     assert "serialize:model-substituted" in noted
 
 
+def test_serialize_served_collector_raising_leaves_key_absent(
+        fake_chat_factory, monkeypatch):
+    # Fail-open contract: the stamp runs right before store/write, so a
+    # broken collector must never fail an otherwise-successful serialize —
+    # and must leave honest absence, not a partial stamp (#458).
+    from daimon_briefing import llm
+
+    monkeypatch.setenv("DAIMON_LLM_API_KEY", "sk-test")
+    monkeypatch.setenv("DAIMON_LLM_MODEL", "gateway-alias")
+    monkeypatch.setattr(llm, "served_models",
+                        lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    chat = fake_chat_factory(_valid_checkpoint_json("S1"))
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+    assert ckpt is not None
+    assert "llm_model_served" not in ckpt
+
+
+def test_serialize_substitution_counter_failure_never_fails_serialize(
+        fake_chat_factory, monkeypatch, caplog):
+    # The counter is telemetry: a broken usage log must cost nothing. The
+    # WARNING and the stamp itself still land (#458).
+    import logging
+
+    from daimon_briefing import cli
+    monkeypatch.setenv("DAIMON_LLM_API_KEY", "sk-test")
+    monkeypatch.setenv("DAIMON_LLM_MODEL", "gateway-alias")
+    _serve(monkeypatch, ["a-model", "z-model"])
+    monkeypatch.setattr(cli, "_note_usage",
+                        lambda _: (_ for _ in ()).throw(OSError("disk")))
+    chat = fake_chat_factory(_valid_checkpoint_json("S1"))
+    with caplog.at_level(logging.WARNING, logger="daimon_briefing.serializer"):
+        ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+    assert ckpt is not None
+    assert ckpt["llm_model_served"] == ["a-model", "z-model"]
+    assert any("substitut" in r.getMessage() for r in caplog.records)
+
+
 def test_serialize_uniform_served_does_not_warn_or_count(
         fake_chat_factory, monkeypatch, caplog):
     import logging


### PR DESCRIPTION
Closes #458.

## What
- litellm backend records `response.model` per call (module-sticky collector mirroring the #28 `fallback_used` pattern — `chat()`'s `-> str` contract untouched); command backend records nothing (honest absence).
- `_stamp_llm_provenance` stamps `llm_model_served` (string, or sorted list when mixed); mixed-within-a-run is the only honest mismatch signal (alias→served mapping is unknowable client-side) and triggers a WARNING + `serialize:model-substituted` counter via the same out-of-cli counter path mcp_tools uses.
- Model-authored `llm_model_served` is popped BEFORE any fail-open return — a bailing stamp leaves honest absence, never a self-issued receipt (#292 discipline).
- Bench harness stamps `model_served` and flags `mixed_models: true` in the aggregate; never silent.
- Committed 5q baseline annotated with `model_note` (alias-not-receipt, purity unverifiable); metrics byte-identical, +1 line diff.

## Why
Live incident 2026-07-30: the configured extraction alias was served by a local Qwen3-30B via the gateway's silent fallback chain; every checkpoint stamped that day names a model that never ran. Scar 0032 records the landmine; this PR meets its expiry condition.

## Tests
Strict TDD, RED-confirmed (14 new tests across test_llm/test_serializer/test_bench_smoke). Full suite 2427 passed, 2 skipped; ruff clean.

## Note
Pre-existing unrelated flake found (test_llm + test_serializer as a pair leak `_fallback_used` into chunk-cache tests; verified pre-existing on HEAD via stash) — follow-up issue to come, out of scope here.