### PR TITLE
fix(test): reset llm fallback flag per test — file-pair runs leaked _fallback_used

### DIFF
--- a/plugin/tests/conftest.py
+++ b/plugin/tests/conftest.py
@@ -42,11 +42,16 @@ def _isolate_daimon_home(tmp_path, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _reset_served_models():
-    """#458: the served-model collector is module-sticky (same shape as #28's
-    fallback flag) — clear it per test so one test's canned response bodies
-    can never stamp phantom served models onto another test's checkpoints."""
+def _reset_llm_module_state():
+    """#458/#461: llm keeps module-sticky per-unit-of-work state (the #28
+    fallback flag, the #458 served-model collector) — clear both per test.
+    Without the fallback reset, test_llm's fallback tests leak
+    `_fallback_used = True` into any later chunk-cache test in the same
+    process and `_save_chunk_cache` refuses writes: the file-pair run
+    `pytest tests/test_llm.py tests/test_serializer.py` failed 7 tests
+    while the full suite happened to dodge the ordering (#461)."""
     from daimon_briefing import llm
+    llm.reset_fallback()
     llm.reset_served_models()
 
 


### PR DESCRIPTION
Closes #461.

Extends the #458 autouse conftest fixture to clear both pieces of module-sticky llm state (`reset_fallback()` + `reset_served_models()`). Repro before fix: `pytest tests/test_llm.py tests/test_serializer.py` → 7 failed (chunk-cache tests refuse writes under the leaked fallback flag). After: 272 passed on the pair, full suite 2429 passed, 2 skipped.