### PR TITLE
fix(bench): verify the served model — run-pinned receipts, producer-verified cache

### DIFF
--- a/plugin/tests/bench/adapter.py
+++ b/plugin/tests/bench/adapter.py
@@ -37,7 +37,7 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-from daimon_briefing import carry, config, recall, serializer, store
+from daimon_briefing import carry, config, llm, recall, serializer, store
 
 from tests.bench import cache as cache_mod
 from tests.bench import dataset, metrics
@@ -135,6 +135,9 @@ def serialize_question(question: dict, *, chat, cache: cache_mod.CheckpointCache
                     with carry on, a carried copy maps to `carried_from` (the
                     session that first produced it — chains preserve the origin
                     because carry.merge stamps carried_from with setdefault).
+
+    Raises cache_mod.ServedModelMismatch (#343) when any wire receipt names a
+    served model other than the run's pin — the caller records an error row.
     """
     sessions = dataset.sessions_of(question)
     cache_lock = threading.Lock()
@@ -158,13 +161,39 @@ def serialize_question(question: dict, *, chat, cache: cache_mod.CheckpointCache
             return index, sid, None, "failed"
         except Exception:
             return index, sid, None, "failed"
+        # #343: verify the wire receipts BEFORE the cache write. served is the
+        # run-unit's distinct receipt set (llm.served_models(), reset by run.py
+        # per question) — this serialize's own receipts are guaranteed in it
+        # (chat() appends before returning), plus possibly concurrent workers'.
+        # Any receipt disagreeing with the run pin means a gateway substituted
+        # a model (scar 0032) and per-call attribution is lost, so NOTHING is
+        # cached (scar 0015: the write gate is the only poison gate) and the
+        # question fails loudly below. Deliberately conservative: a pin-served
+        # checkpoint racing a substituted one is re-paid next run, never risked.
+        served = llm.served_models()
         with cache_lock:
-            cache.put(key, checkpoint)
+            offender = cache.check_served(served)
+            if offender is None:
+                # Record the producer: the pin (== the single consistent
+                # receipt) when receipts exist, else honest absence (command
+                # backend exposes no served model — never the alias).
+                cache.put(key, checkpoint,
+                          served_model=cache.pinned_served if served else None)
+        if offender is not None:
+            return index, sid, None, "model_mismatch"
         return index, sid, checkpoint, "serialized"
 
     workers = max(1, min(workers, len(sessions) or 1))
     with ThreadPoolExecutor(max_workers=workers) as pool:
         produced = list(pool.map(_produce, enumerate(sessions)))
+
+    # #343: a served-model mismatch fails the WHOLE question loudly — an error
+    # row upstream, never a partial score over sessions a substitute model
+    # serialized. Raised after the pool so concurrent workers finish cleanly
+    # (their results are discarded with the question; none were cached).
+    if any(r[3] == "model_mismatch" for r in produced):
+        observed = sorted(set(llm.served_models()) - {cache.pinned_served})
+        raise cache_mod.ServedModelMismatch(cache.pinned_served, observed)
 
     tally = {"serialized": 0, "cached": 0, "too_short": 0, "failed": 0, "indexed": 0}
     attribution: dict[tuple[str, str], str] = {}

--- a/plugin/tests/bench/cache.py
+++ b/plugin/tests/bench/cache.py
@@ -9,6 +9,12 @@ purpose: a cached checkpoint from a different pipeline is a different measuremen
 
 The cache stores the RAW `serialize_strict` output (pre-store mutation). Callers
 deep-copy on write, so a cached checkpoint is never mutated in place by the store.
+
+#343: entries additionally record the SERVED model that produced them (the
+wire's `response.model`, #458) and are verified against the run's pinned served
+model on read — see CheckpointCache. The served model is deliberately NOT part
+of `cache_key`: it is unknowable before the call is made (chicken-egg), so the
+verify-on-read envelope is the mechanism, never the key.
 """
 
 from __future__ import annotations
@@ -17,6 +23,26 @@ import copy
 import hashlib
 import json
 from pathlib import Path
+
+
+class ServedModelMismatch(RuntimeError):
+    """#343: a wire receipt named a served model other than the run's pin.
+
+    Raised by the adapter when a question's serialize was (or may have been)
+    produced by a model different from the one this run is pinned to — a
+    gateway silently substituting under quota/error (scar 0032). The question
+    carrying it must be recorded as an error row and never scored; nothing it
+    produced may enter the cache (scar 0015: caches replay whatever they were
+    fed, so the gate sits at write time)."""
+
+    def __init__(self, pinned: str | None, observed: list):
+        self.pinned = pinned
+        self.observed = sorted(observed)
+        super().__init__(
+            f"served model(s) {', '.join(self.observed) or '<none>'} != run pin "
+            f"'{pinned}' — a gateway substituted the model mid-run (#343); this "
+            "question fails loudly (error row, not scored) and its checkpoints "
+            "are not cached")
 
 
 def cache_key(messages: list[dict], *, backend: str, model: str,
@@ -41,6 +67,11 @@ def cache_key(messages: list[dict], *, backend: str, model: str,
     flag changes the serialize prompt itself, so a scene-on run reusing a
     scene-off entry would measure the cache, not the flag. Scene-off keys are
     byte-identical to pre-#319 keys, same preservation rule as carry.
+
+    `model` here is the CONFIGURED gateway alias — routing config, not
+    provenance (scar 0032). The model that actually served is unknowable
+    until after the call, so it can never be part of the key; #343 records
+    it in the entry envelope instead and verifies it on read.
     """
     h = hashlib.sha256()
     h.update(f"v1\x00{backend}\x00{model}\x00{prompt_version}\x00".encode())
@@ -63,13 +94,47 @@ class CheckpointCache:
 
     Best-effort by design: a corrupt or unreadable entry is a miss, never a
     crash — a re-serialize is always safe, only slower.
+
+    #343 provenance contract. The run holds ONE served-model pin
+    (`pinned_served`): the explicit expectation when given (`expected_served`,
+    from --expect-served / BENCH_EXPECT_SERVED), otherwise the first served
+    receipt observed — from a live serialize (`check_served`) or from a
+    replayed entry's recorded producer (`get`), whichever comes first; a
+    replayed checkpoint's content joins this run's scores exactly like a live
+    one, so its receipt is an observation too, and adopting it makes a warm
+    cache holding MIXED producers fail loudly instead of replaying both.
+    On disk each entry is an envelope `{"served_model": ..., "checkpoint":
+    {...}}` — `served_model` is the wire's `response.model` receipt, or null
+    when no receipt existed (command backend: honest absence, never the
+    configured alias copied in — scar 0032). Reads verify the envelope against
+    the pin; any disagreement, either direction, is a counted miss.
     """
 
-    def __init__(self, cache_dir: Path):
+    def __init__(self, cache_dir: Path, expected_served: str | None = None):
         self.dir = Path(cache_dir)
         self.dir.mkdir(parents=True, exist_ok=True)
         self.hits = 0
         self.misses = 0
+        self.expected_served = expected_served
+        self.pinned_served = expected_served
+        # #343 miss reasons, surfaced in the run report's cost block so a
+        # producer-verification miss is never silently indistinguishable
+        # from a cold cache.
+        self.model_mismatch_misses = 0
+        self.legacy_misses = 0
+
+    def check_served(self, served: list) -> str | None:
+        """Fold live wire receipts into the pin; return the first offender.
+
+        First receipt with no pin set → becomes the pin. Any receipt that
+        disagrees with the pin → returned (the caller must fail the question
+        loudly and skip the cache write). None → all receipts consistent."""
+        for name in served:
+            if self.pinned_served is None:
+                self.pinned_served = name
+            elif name != self.pinned_served:
+                return name
+        return None
 
     def _path(self, key: str) -> Path:
         # keys are hex digests (or test literals) — no separators to contain.
@@ -78,21 +143,56 @@ class CheckpointCache:
     def get(self, key: str) -> dict | None:
         p = self._path(key)
         try:
-            checkpoint = json.loads(p.read_text(encoding="utf-8"))
+            entry = json.loads(p.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             self.misses += 1
             return None
+        if not isinstance(entry, dict):
+            self.misses += 1
+            return None
+        if "checkpoint" not in entry:
+            # Pre-#343 entry: a raw checkpoint dict with no producer receipt —
+            # exactly the unattributable shape the poisoning incident left
+            # behind (~250 entries purgeable only by mtime), so it can never
+            # be replayed. Poisoning-safe default; the cost is a one-time
+            # cache re-warm after upgrading (each entry re-pays its LLM call
+            # once, then carries a receipt forever).
+            self.legacy_misses += 1
+            self.misses += 1
+            return None
+        checkpoint = entry.get("checkpoint")
         if not isinstance(checkpoint, dict):
+            self.misses += 1
+            return None
+        recorded = entry.get("served_model")
+        if recorded is None:
+            # Receiptless entry (command backend). Replayable only into a run
+            # that is itself receiptless — a pinned run must not score
+            # unattributable content (#343).
+            if self.pinned_served is not None:
+                self.model_mismatch_misses += 1
+                self.misses += 1
+                return None
+        elif self.pinned_served is None:
+            self.pinned_served = recorded  # first observation of the run
+        elif recorded != self.pinned_served:
+            # Producer disagrees with the run's pin: the entry was made by a
+            # different served model — a MISS, never replayed (#343).
+            self.model_mismatch_misses += 1
             self.misses += 1
             return None
         self.hits += 1
         # Copy out: the store mutates checkpoints in place (redaction, id stamps).
         return copy.deepcopy(checkpoint)
 
-    def put(self, key: str, checkpoint: dict) -> None:
+    def put(self, key: str, checkpoint: dict,
+            served_model: str | None = None) -> None:
+        # #343 envelope: record the producer alongside the payload. None is
+        # honest absence (no wire receipt), never a default to the alias.
+        entry = {"served_model": served_model, "checkpoint": checkpoint}
         try:
             self._path(key).write_text(
-                json.dumps(checkpoint, ensure_ascii=False), encoding="utf-8"
+                json.dumps(entry, ensure_ascii=False), encoding="utf-8"
             )
         except OSError:
             pass  # an uncacheable checkpoint just re-serializes next run

--- a/plugin/tests/bench/metrics.py
+++ b/plugin/tests/bench/metrics.py
@@ -190,8 +190,16 @@ def aggregate(per_question: list[dict], k: int) -> dict:
     Retrieval means (recall@k, hit@k, mrr) are taken over SCORED questions only
     (abstention rows excluded). The token average is over ALL questions — it is
     the efficiency of the whole run, abstentions included.
+
+    Error rows (#343: `error` set — e.g. a served-model mismatch failed the
+    question loudly) are excluded from every mean AND counted explicitly in
+    `questions_error`, so a run that hit failures carries them in its
+    aggregate forever — a mixed-model run can never present itself as a
+    clean score.
     """
-    scored = [q for q in per_question if not q.get("abstention")]
+    errors = [q for q in per_question if q.get("error")]
+    scored = [q for q in per_question
+              if not q.get("abstention") and not q.get("error")]
     recalls = [q["recall_at_5"] for q in scored if q.get("recall_at_5") is not None]
     hits = [1.0 if q["hit_at_5"] else 0.0 for q in scored
             if q.get("hit_at_5") is not None]
@@ -218,7 +226,8 @@ def aggregate(per_question: list[dict], k: int) -> dict:
         "k": k,
         "questions_total": len(per_question),
         "questions_scored": len(scored),
-        "questions_abstention": len(per_question) - len(scored),
+        "questions_abstention": len(per_question) - len(scored) - len(errors),
+        "questions_error": len(errors),
         "recall_at_5": _mean(recalls),
         "hit_at_5": _mean(hits),
         "mrr": _mean(rrs),

--- a/plugin/tests/bench/run.py
+++ b/plugin/tests/bench/run.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 import time
@@ -110,6 +111,11 @@ def _build_config_stamp(args, dataset_path: Path) -> dict:
         # changes the serialize prompt, so the mode is stamped and cache-keyed.
         "scene": "on" if args.scene else "off",
         "workers": args.workers,
+        # #343: the explicit served-model expectation (--expect-served /
+        # BENCH_EXPECT_SERVED), or null when the run pins on first observation.
+        # Recorded so a number can be read knowing whether provenance was
+        # asserted up front or adopted from the wire.
+        "expected_served": args.expect_served,
         "dataset_file": dataset_path.name,
         "dataset_sha256": dataset.sha256_of(dataset_path),
     }
@@ -136,11 +142,11 @@ def _stamp_served_models(stamp: dict, agg: dict, served: list) -> None:
 def run(args) -> dict:
     dataset_path = _resolve_dataset(args)
     questions = dataset.sample(dataset.load(dataset_path), args.sample, args.seed)
-    cache = cache_mod.CheckpointCache(Path(args.cache_dir))
+    # #343: the cache verifies every entry's recorded producer against the
+    # run's served-model pin (explicit --expect-served, else first observed).
+    cache = cache_mod.CheckpointCache(Path(args.cache_dir),
+                                      expected_served=args.expect_served)
     chat = llm.chat
-    # #458: collect served-model receipts for THIS run only — the collector
-    # is module-sticky (same lifecycle as llm's #28 fallback flag).
-    llm.reset_served_models()
 
     stamp = _build_config_stamp(args, dataset_path)
     print(f"suite={args.suite} sample={len(questions)} backend={stamp['backend']} "
@@ -148,30 +154,61 @@ def run(args) -> dict:
           f"scene={stamp['scene']}")
 
     per_question: list[dict] = []
+    run_served: set = set()
     t0 = time.monotonic()
     for i, q in enumerate(questions, 1):
         qt0 = time.monotonic()
-        result = adapter.run_question(
-            q, chat=chat, cache=cache, backend=stamp["backend"],
-            model=stamp["model"] or "unknown", root=Path(args.work_dir),
-            k=args.k, depth=args.depth, min_messages=args.min_messages,
-            workers=args.workers, carry_on=args.carry, scene_on=args.scene,
-        )
+        # #343: question-scoped receipts. Resetting the #458 collector per
+        # question attributes a substitution to the question that observed it
+        # — and lets a run keep scoring after the gateway heals (the cumulative
+        # set would taint every later question with a model seen once).
+        # `run_served` re-accumulates everything for the run-level #458 stamp,
+        # INCLUDING receipts from questions that errored: the foreign model's
+        # serve happened and stays on the record.
+        llm.reset_served_models()
+        try:
+            result = adapter.run_question(
+                q, chat=chat, cache=cache, backend=stamp["backend"],
+                model=stamp["model"] or "unknown", root=Path(args.work_dir),
+                k=args.k, depth=args.depth, min_messages=args.min_messages,
+                workers=args.workers, carry_on=args.carry, scene_on=args.scene,
+            )
+            print(f"[{i}/{len(questions)}] {result['question_id']} "
+                  f"hit@{args.k}={result['hit_at_5']} "
+                  f"r@{args.k}={result['recall_at_5']} "
+                  f"indexed={result['serialize']['indexed']}/{result['n_haystack']} "
+                  f"({time.monotonic() - qt0:.0f}s)")
+        except cache_mod.ServedModelMismatch as e:
+            # #343: fail-loud, not fail-run. The question becomes an error row
+            # (never scored, aggregate carries `questions_error`), the run
+            # continues — later questions served by the pin still score.
+            result = {
+                "question_id": q["question_id"],
+                "question_type": q.get("question_type"),
+                "error": "served_model_mismatch",
+                "error_detail": str(e),
+                "model_pinned": e.pinned,
+                "model_observed": e.observed,
+            }
+            print(f"[{i}/{len(questions)}] {q['question_id']} "
+                  f"ERROR served-model mismatch (#343): {e}")
+        run_served.update(llm.served_models())
         per_question.append(result)
-        print(f"[{i}/{len(questions)}] {result['question_id']} "
-              f"hit@{args.k}={result['hit_at_5']} r@{args.k}={result['recall_at_5']} "
-              f"indexed={result['serialize']['indexed']}/{result['n_haystack']} "
-              f"({time.monotonic() - qt0:.0f}s)")
 
     agg = metrics.aggregate(per_question, args.k)
-    # #458: stamp what actually served (reset ran before the loop, so these
-    # are exactly this run's receipts). A mixed run is flagged loudly in the
+    # #458: stamp what actually served across the whole run (accumulated over
+    # the per-question resets above). A mixed run is flagged loudly in the
     # aggregate block AND on stdout — never aggregated silently.
-    _stamp_served_models(stamp, agg, llm.served_models())
+    _stamp_served_models(stamp, agg, sorted(run_served))
     if agg.get("mixed_models"):
         print(f"WARNING: mixed served models in this run ({stamp['model_served']}) "
               "— do not attribute this number to a single model (#458)")
-    total_serialized = sum(r["serialize"]["serialized"] for r in per_question)
+    if agg.get("questions_error"):
+        print(f"WARNING: {agg['questions_error']} question(s) failed loudly on "
+              f"served-model mismatch (#343) — recorded as error rows, not "
+              f"scored; run pin={cache.pinned_served!r}")
+    total_serialized = sum(r["serialize"]["serialized"] for r in per_question
+                           if "serialize" in r)
     report = {
         "config": stamp,
         "metrics": agg,
@@ -179,6 +216,11 @@ def run(args) -> dict:
             "llm_serialize_calls": total_serialized,
             "cache_hits": cache.hits,
             "cache_misses": cache.misses,
+            # #343: verification misses broken out of the total so a producer
+            # rejection is never mistaken for a cold cache. legacy = pre-#343
+            # entries with no recorded producer (one-time re-warm cost).
+            "cache_model_mismatch_misses": cache.model_mismatch_misses,
+            "cache_legacy_misses": cache.legacy_misses,
             "wall_seconds": round(time.monotonic() - t0, 1),
         },
         "per_question": per_question,
@@ -230,6 +272,15 @@ def build_parser() -> argparse.ArgumentParser:
                    help="fold prior checkpoints forward (cross-session carry, "
                         "#274) — a separate retrieval axis; recorded in the "
                         "config stamp and cached under separate keys")
+    p.add_argument("--expect-served",
+                   default=os.environ.get("BENCH_EXPECT_SERVED"),
+                   help="expected served model for the whole run (#343), as "
+                        "the wire reports it (response.model) — NOT the "
+                        "configured gateway alias, which never matches (scar "
+                        "0032). Env: BENCH_EXPECT_SERVED. When set, every "
+                        "receipt (including the first) is checked against it; "
+                        "when unset, the run pins the first observed serve. "
+                        "Any other served model fails that question loudly")
     p.add_argument("--min-messages", default=adapter.BENCH_MIN_MESSAGES,
                    help="serialize floor for the benchmark (product default is 10)")
     p.add_argument("--dataset-path", help="use a local dataset file (skip download)")

--- a/plugin/tests/test_bench_cache.py
+++ b/plugin/tests/test_bench_cache.py
@@ -70,7 +70,10 @@ class TestCacheRoundTrip:
         assert c.misses == 1
 
     def test_put_writes_valid_json(self, tmp_path):
+        # #343: on disk an entry is an envelope recording its producer; a put
+        # without a receipt records null (honest absence), never the alias.
         c = cache.CheckpointCache(tmp_path)
         c.put("k", {"session_id": "s1"})
         stored = json.loads((tmp_path / "k.json").read_text(encoding="utf-8"))
-        assert stored["session_id"] == "s1"
+        assert stored["checkpoint"]["session_id"] == "s1"
+        assert stored["served_model"] is None

--- a/plugin/tests/test_bench_model_pin.py
+++ b/plugin/tests/test_bench_model_pin.py
@@ -1,0 +1,263 @@
+"""#343: run-pinned served model + producer-verified checkpoint cache.
+
+The bench's configured `model` is a gateway ALIAS (scar 0032) — it never
+literally equals the wire's `response.model`, so the honest contract is not
+"served == configured" but:
+
+  - the run PINS the first observed served model (or an explicit expectation,
+    BENCH_EXPECT_SERVED / --expect-served) and any question that observes a
+    DIFFERENT served model fails loudly: an error row, never a silent score,
+    and nothing it produced enters the cache (scar 0015: a cache replays
+    whatever it was fed, so the poison gate must sit at write time);
+  - every cache entry records the served model that produced it, and a read
+    whose recorded producer differs from the run's pin is a MISS — verified on
+    read because the served model is unknowable before the call (chicken-egg),
+    so it can never live in the key.
+
+The fakes below append to llm's served-model collector exactly where
+llm._chat_litellm records the wire receipt (#458), so the pipeline under test
+is the real one minus the HTTP call.
+"""
+
+import json
+
+import pytest
+
+from daimon_briefing import llm
+
+from tests.bench import adapter, cache as cache_mod, metrics
+
+
+class ServingChat:
+    """EchoChat (test_bench_adapter) plus a wire receipt: records `served` in
+    llm's #458 collector before returning, exactly as _chat_litellm does when
+    the response body names the model that actually ran."""
+
+    def __init__(self, served):
+        self.served = served
+        self.calls = 0
+
+    def __call__(self, messages, **kwargs):
+        self.calls += 1
+        # Simulate the response.model receipt (llm.py, #458 / scar 0032).
+        llm._served_models.append(self.served)
+        blob = " ".join(str(m.get("content") or "") for m in messages)
+        marker = next((w for w in blob.split() if w.endswith("marker")), "nomarker")
+        return json.dumps({
+            "session_id": "ignored",
+            "working_context": {
+                "active_topic": {"text": f"session about {marker}", "trust": "inferred"},
+                "open_questions": [],
+                "recent_decisions": [],
+            },
+            "epistemic_snapshot": {
+                "strong_beliefs": [], "uncertainties": [], "contradictions_flagged": [],
+            },
+            "worker_queue": [],
+        })
+
+
+def _turns(marker):
+    return [
+        {"role": "user", "content": f"let us discuss {marker} today please"},
+        {"role": "assistant", "content": f"sure, {marker} is interesting"},
+        {"role": "user", "content": f"tell me more about {marker}"},
+        {"role": "assistant", "content": f"here is more on {marker}"},
+    ]
+
+
+def _question(qid="q_pin_1", marker="thinkpadmarker"):
+    return {
+        "question_id": qid,
+        "question_type": "single-session-user",
+        "question": f"what about {marker} did we conclude",
+        "answer": "x",
+        "haystack_session_ids": [f"{qid}_hello", f"{qid}_gold"],
+        "haystack_sessions": [_turns(f"hello{marker}"), _turns(marker)],
+        "answer_session_ids": [f"{qid}_gold"],
+    }
+
+
+def _run_q(question, chat, cache, root):
+    return adapter.run_question(
+        question, chat=chat, cache=cache, backend="fake", model="alias",
+        root=root, k=5, depth=20, workers=1,
+    )
+
+
+# ---- run-pinned served model: fail loud, never cache the foreign model ------
+
+
+def test_second_question_different_served_model_fails_loudly_not_cached(tmp_path):
+    cache = cache_mod.CheckpointCache(tmp_path / "c")
+    # Question 1 pins the run to the first observed served model.
+    result = _run_q(_question("q_a", "alphamarker"), ServingChat("model-a"),
+                    cache, tmp_path / "r1")
+    assert result["serialize"]["serialized"] == 2
+    entries_after_q1 = sorted((tmp_path / "c").glob("*.json"))
+    assert entries_after_q1
+
+    # Question 2 observes a DIFFERENT served model: fail loudly, name both
+    # models, and cache NOTHING from it.
+    llm.reset_served_models()  # mirrors run.py's per-question reset
+    with pytest.raises(cache_mod.ServedModelMismatch) as err:
+        _run_q(_question("q_b", "betamarker"), ServingChat("model-b"),
+               cache, tmp_path / "r2")
+    assert "model-a" in str(err.value)
+    assert "model-b" in str(err.value)
+    assert sorted((tmp_path / "c").glob("*.json")) == entries_after_q1
+
+
+def test_uniform_run_scores_normally(tmp_path):
+    cache = cache_mod.CheckpointCache(tmp_path / "c")
+    r1 = _run_q(_question("q_a", "alphamarker"), ServingChat("model-a"),
+                cache, tmp_path / "r1")
+    llm.reset_served_models()
+    r2 = _run_q(_question("q_b", "betamarker"), ServingChat("model-a"),
+                cache, tmp_path / "r2")
+    assert r1["recall_at_5"] == 1.0
+    assert r2["recall_at_5"] == 1.0
+    assert cache.pinned_served == "model-a"
+
+
+def test_expected_served_knob_rejects_first_observed_mismatch(tmp_path):
+    # Explicit pin up front (#343 knob): the FIRST observed serve is checked
+    # against it too — no free first observation.
+    cache = cache_mod.CheckpointCache(tmp_path / "c", expected_served="model-a")
+    with pytest.raises(cache_mod.ServedModelMismatch) as err:
+        _run_q(_question("q_a", "alphamarker"), ServingChat("model-b"),
+               cache, tmp_path / "r1")
+    assert "model-a" in str(err.value)
+    assert "model-b" in str(err.value)
+    assert not sorted((tmp_path / "c").glob("*.json"))
+
+
+def test_expected_served_knob_accepts_matching_serve(tmp_path):
+    cache = cache_mod.CheckpointCache(tmp_path / "c", expected_served="model-a")
+    result = _run_q(_question("q_a", "alphamarker"), ServingChat("model-a"),
+                    cache, tmp_path / "r1")
+    assert result["serialize"]["serialized"] == 2
+
+
+# ---- cache entries record their producer; verified on READ ------------------
+
+
+def test_cache_entry_records_its_producer(tmp_path):
+    c = cache_mod.CheckpointCache(tmp_path)
+    c.put("k", {"session_id": "s1"}, served_model="model-a")
+    raw = json.loads((tmp_path / "k.json").read_text(encoding="utf-8"))
+    assert raw["served_model"] == "model-a"
+    assert raw["checkpoint"] == {"session_id": "s1"}
+
+
+def test_read_side_producer_mismatch_is_a_counted_miss(tmp_path):
+    cache_mod.CheckpointCache(tmp_path).put(
+        "k", {"session_id": "s1"}, served_model="model-a")
+    c = cache_mod.CheckpointCache(tmp_path, expected_served="model-b")
+    assert c.get("k") is None
+    assert c.model_mismatch_misses == 1
+    assert c.misses == 1
+    assert c.hits == 0
+
+
+def test_read_matching_producer_is_a_hit(tmp_path):
+    cache_mod.CheckpointCache(tmp_path).put(
+        "k", {"session_id": "s1"}, served_model="model-a")
+    c = cache_mod.CheckpointCache(tmp_path, expected_served="model-a")
+    assert c.get("k") == {"session_id": "s1"}
+    assert c.hits == 1
+
+
+def test_unpinned_run_adopts_the_entry_producer_as_pin(tmp_path):
+    # A replayed entry's content joins this run's scores, so its recorded
+    # producer is an observation too: adopting it as the pin makes a warm
+    # cache with MIXED producers fail loudly instead of replaying both.
+    cache_mod.CheckpointCache(tmp_path).put(
+        "k", {"session_id": "s1"}, served_model="model-a")
+    c = cache_mod.CheckpointCache(tmp_path)
+    assert c.get("k") == {"session_id": "s1"}
+    assert c.pinned_served == "model-a"
+
+
+def test_legacy_entry_without_producer_field_is_a_counted_miss(tmp_path):
+    # Pre-#343 entries are raw checkpoint dicts with no producer receipt —
+    # exactly the shape the poisoning incident left behind, so they can never
+    # be replayed (one-time cache-warm cost, accepted).
+    (tmp_path / "k.json").write_text(
+        json.dumps({"session_id": "s1", "working_context": {}}), encoding="utf-8")
+    c = cache_mod.CheckpointCache(tmp_path)
+    assert c.get("k") is None
+    assert c.legacy_misses == 1
+    assert c.misses == 1
+
+
+def test_receiptless_entry_hits_only_a_receiptless_run(tmp_path):
+    # served_model=None is honest absence (command backend, no wire receipt).
+    cache_mod.CheckpointCache(tmp_path).put(
+        "k", {"session_id": "s1"}, served_model=None)
+    # A pinned run must not replay unattributable content.
+    pinned = cache_mod.CheckpointCache(tmp_path, expected_served="model-a")
+    assert pinned.get("k") is None
+    assert pinned.model_mismatch_misses == 1
+    # A run with no receipts on either side may.
+    free = cache_mod.CheckpointCache(tmp_path)
+    assert free.get("k") == {"session_id": "s1"}
+
+
+# ---- aggregate carries the fail-loud outcome --------------------------------
+
+
+def test_aggregate_carries_error_rows_never_silent_scores():
+    scored_row = {
+        "question_id": "q_ok", "abstention": False, "recall_at_5": 1.0,
+        "hit_at_5": True, "mrr": 1.0, "injected_tokens": 10,
+    }
+    error_row = {
+        "question_id": "q_bad", "error": "served_model_mismatch",
+        "model_pinned": "model-a", "model_observed": ["model-b"],
+    }
+    agg = metrics.aggregate([scored_row, error_row], 5)
+    assert agg["questions_total"] == 2
+    assert agg["questions_error"] == 1
+    assert agg["questions_scored"] == 1
+    assert agg["questions_abstention"] == 0
+    assert agg["recall_at_5"] == 1.0  # the error row never dilutes the mean
+
+
+# ---- run loop: mixed run records the error row and the mixed stamp ----------
+
+
+def test_run_records_error_row_and_mixed_stamp(tmp_path, monkeypatch):
+    from tests.bench import run as bench_run
+
+    questions = [_question("q_a", "alphamarker"), _question("q_b", "betamarker")]
+    monkeypatch.setattr(bench_run, "_resolve_dataset",
+                        lambda args: tmp_path / "ds.json")
+    monkeypatch.setattr(bench_run.dataset, "load", lambda path: questions)
+    monkeypatch.setattr(bench_run.dataset, "sample", lambda qs, n, seed: qs)
+    monkeypatch.setattr(bench_run.dataset, "sha256_of", lambda path: "0" * 64)
+
+    serves = iter(["model-a", "model-a", "model-b", "model-b"])
+
+    def chat(messages, **kwargs):
+        return ServingChat(next(serves))(messages, **kwargs)
+
+    monkeypatch.setattr(bench_run.llm, "chat", chat)
+    args = bench_run.build_parser().parse_args([
+        "--sample", "2", "--workers", "1",
+        "--cache-dir", str(tmp_path / "cache"),
+        "--work-dir", str(tmp_path / "work"),
+        "--out", str(tmp_path / "result.json"),
+    ])
+    report = bench_run.run(args)
+
+    rows = report["per_question"]
+    assert rows[0]["recall_at_5"] == 1.0
+    assert rows[1]["error"] == "served_model_mismatch"
+    assert rows[1]["model_pinned"] == "model-a"
+    assert "model-b" in rows[1]["model_observed"]
+    assert report["metrics"]["questions_error"] == 1
+    # #458 stamp still sees BOTH serves: the mixed run is flagged, and the
+    # foreign model's receipt is on the record even though its row errored.
+    assert report["config"]["model_served"] == ["model-a", "model-b"]
+    assert report["metrics"]["mixed_models"] is True


### PR DESCRIPTION
Closes #343.

## What
- Run pins the first served-model receipt (`--expect-served` / `BENCH_EXPECT_SERVED` for an explicit pin); any disagreeing receipt fails the question loudly — error row naming both models, never scored, nothing cached (write gate = the only poison gate, scar 0015).
- Cache entries are envelopes recording their producer (`served_model`, null = honest absence); read-side mismatch and legacy no-producer entries are counted misses (`cache_model_mismatch_misses` / `cache_legacy_misses` in the cost block). Replayed entries' recorded producers adopt/check the pin too — a warm mixed cache fails loudly.
- `aggregate` excludes error rows from every mean and reports `questions_error`; a mixed-model run can never present a clean score.
- Served model deliberately NOT in the cache key (unknowable pre-call); verify-on-read is the mechanism.

Note: the issue's literal ask (compare served vs configured) is impossible — the configured name is an alias and never literally equals a served id (#458 arc). The run-pin is the honest implementable contract.

## Confirmed follow-up (report-only here)
The serializer's own chunk cache shares the exposure: key hashes the alias (serializer.py `_chunk_cache_key`), the write gate only checks client-side fallback (`llm.fallback_used()`), so a gateway-side substitute IS cached and replayed for up to `chunk_cache_days`. Issue to follow.

## Tests
Strict TDD, 12 new tests RED-confirmed. Full suite 2441 passed, 2 skipped; ruff clean.