### PR TITLE
chore(scars): arm violation tripwires on machine-checkable scars

### DIFF
--- a/.scars/0016-simulated-clock-must-thread-into-every-now-consumer.landmine.md
+++ b/.scars/0016-simulated-clock-must-thread-into-every-now-consumer.landmine.md
@@ -9,6 +9,7 @@ authors: ["claude-code", "kibukx"]
 anchors:
   - path: research/experiments/multicycle/
   - pattern: "briefing\.build\b"
+violation: "briefing\.build\((?![^)]{0,300}now=)"
 evidence:
   - note: "lab commit 510787d (pre-public-history archive; fix squashed into lab PR #134)"
   - note: live run-01 killed 2026-07-02 — 6 cycles of spend invalidated

--- a/.scars/0025-append-event-any-kind-resolves-the-item.landmine.md
+++ b/.scars/0025-append-event-any-kind-resolves-the-item.landmine.md
@@ -8,7 +8,13 @@ created: 2026-07-28
 authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/store.py
+  - path: plugin/daimon_briefing/capture.py
+  - path: plugin/daimon_briefing/cli.py
+  - path: plugin/daimon_briefing/recall.py
+  - path: plugin/daimon_briefing/briefing.py
+  - path: plugin/tests/
   - pattern: "append_event[(][^)]{0,200}kind="
+violation: "append_event\([^)]{0,200}kind=(?!["'](tombstone|corroboration)["']|args\.kind)"
 evidence:
   - note: 2026-07-28 probe while designing #376: append_event(ref, 'quote-verification-failed', kind='verification') then resolutions() then is_resolved() returned True — the item would vanish from briefing, recall and carry
 expires:

--- a/.scars/0026-bare-uv-sync-strips-extras-suite-fails-misleadingly.landmine.md
+++ b/.scars/0026-bare-uv-sync-strips-extras-suite-fails-misleadingly.landmine.md
@@ -8,6 +8,11 @@ created: 2026-07-29
 authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/pyproject.toml
+  - path: scripts/
+  - path: .github/workflows/
+  - path: CONTRIBUTING.md
+  - path: docs/
+violation: "uv sync(?!.*--all-extras)(?!.*--extra[= ].*--extra[= ])"
 evidence:
   - note: 2026-07-29 session: after `uv sync -q`, pytest binary vanished; after `uv sync --extra dev`, 31 test_render failures (rich missing) read as regressions on an untouched module; `uv sync --extra dev --extra pretty` restored 2037 passed
   - pr: 424

--- a/.scars/0031-global-only-gpgsign-silent-unsigned.landmine.md
+++ b/.scars/0031-global-only-gpgsign-silent-unsigned.landmine.md
@@ -8,6 +8,8 @@ created: 2026-07-30
 authors: ["claude-code", "Kibukx"]
 anchors:
   - pattern: "git commit"
+  - path: scripts/
+  - path: .github/
 violation: "--no-gpg-sign"
 evidence:
   - pr: 441


### PR DESCRIPTION
Closes #438.

## Armed/advisory split (the coverage statement)
**9 armed / 23 advisory — 28% of active scars now measurable.** Newly armed: 0016 (`briefing\.build\((?![^)]{0,300}now=)`, scoped to the multicycle experiment dir), 0025 (`append_event` with a `kind=` outside the audited-safe set {tombstone, corroboration, args.kind}), 0026 (`uv sync` lacking both `--all-extras` and the two-extra spelling). Pre-existing verified: 0005, 0019, 0020, 0021, 0022. Repaired: 0031.

## Two structural findings
1. **Violation candidacy is path-proximity only** (scar-cli `match.py`): a `pattern:` anchor never qualifies a file for violation checking — an armed regex on a pattern-only scar is theater.
2. **0031's tripwire was dead** on exactly that: proven pre-fix (guilty `--no-gpg-sign` diff fired the injection, returned zero violations), repaired with path anchors, proven both ways post-fix.

Every armed tripwire proven with `scar check --diff` on a guilty diff (fires) AND an innocent diff (silent). All 23 advisory decisions carry recorded reasons — no theater tripwires per the authoring rule.

## Also flagged (not changed — promotion authority is human)
0003 carries `status: candidate` while living in `.scars/` root, so it never fires or injects. Follow-up needed: either `scar promote`-style status fix or investigation of how it landed.

`scar lint`: 33 files, 0 errors, 0 partial-rot. `.scars/` only — no code or tests touched.