### PR TITLE
fix(serializer): verify the chunk-cache producer — served-model envelope, replay attribution

### DIFF
--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -202,6 +202,23 @@ def reset_served_models() -> None:
     del _served_models[:]
 
 
+def note_served(name) -> None:
+    """Record a served-model observation that did not come off this process's
+    wire — today only #465's chunk-cache replay.
+
+    A replayed cached chunk's recorded producer is a genuine observation of
+    "a model whose output is in this checkpoint": the content joins the
+    serialize exactly like a live call's would. Folding it into the same
+    collector makes the EXISTING mixed-run detection (the serializer's
+    substitution WARNING + `serialize:model-substituted` counter +
+    `llm_model_served` stamp) cover replay-then-live-substitution with no new
+    stamp logic. Same append-under-GIL contract as _chat_litellm's record; same
+    honest-absence rule — a non-string or blank name records NOTHING rather
+    than guessing (scar 0032)."""
+    if isinstance(name, str) and name.strip():
+        _served_models.append(name.strip())
+
+
 def chat(messages, model=None, temperature=None, timeout=None, retries=3, deadline=None):
     """Dispatch to the configured backend. litellm (default) falls back to a
     command backend on ChatError when fallback is enabled and one resolves."""

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -1444,6 +1444,26 @@ def _plan_waves(n_chunks: int, workers: int, k: int) -> int:
 # files are written 0600. Same sensitivity and root as checkpoints.
 # Everything here is best-effort: a broken cache must never break a
 # serialize — worst case is re-paying the chunk call.
+#
+# #465 producer verification (the same hole #343 closed in the bench cache,
+# tests/bench/cache.py — this mirrors that contract). The `model` dimension in
+# the key above is the CONFIGURED alias: routing config, not provenance (scar
+# 0032). When the gateway silently substitutes, the client-side fallback flag
+# stays False, so the substitute's extraction would land under the alias key
+# and replay for chunk_cache_days. The served model can never join the key —
+# it is unknowable before the call that produces it (chicken-egg) — so entries
+# instead carry it in an envelope `{"served_model": ..., "partial": {...}}`
+# and reads verify it against the run's #458 receipts (llm.served_models()):
+#   - recorded producer disagrees with the run's single receipt -> MISS
+#   - recorded null (command backend, honest absence — never the alias copied
+#     in) replays ONLY into a run that is itself receiptless
+#   - the run is already mixed -> MISS (fail toward re-serialize)
+#   - the run has no receipts yet -> ADOPT the recorded producer via
+#     llm.note_served, so a later live substitution trips both this check and
+#     the existing _stamp_llm_provenance WARNING/counter
+# Writes hold the poison gate (scar 0015): a mixed-producer run caches nothing.
+# Pre-#465 entries are raw partials with no receipt — unattributable, so they
+# are a counted miss and re-warm once.
 
 
 def _chunk_cache_dir():
@@ -1481,7 +1501,54 @@ def _load_chunk_cache(key: str):
             (_chunk_cache_dir() / f"{key}.json").read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
-    return obj if isinstance(obj, dict) else None
+    if not isinstance(obj, dict):
+        return None
+    if "partial" not in obj:
+        # Pre-#465 entry: a raw partial with no producer receipt, exactly the
+        # unattributable shape a silently-substituted run leaves behind. Never
+        # replayed; the cost is a one-time re-warm after upgrading, after
+        # which every entry carries its receipt.
+        _note_chunk_cache_miss("serialize:chunk-cache-legacy-miss")
+        return None
+    partial = obj.get("partial")
+    if not isinstance(partial, dict):
+        return None
+    recorded = obj.get("served_model")
+    if recorded is not None and not isinstance(recorded, str):
+        return None  # corrupt receipt: unverifiable, so not replayable
+    observed = llm.served_models()
+    if recorded is None:
+        # Receiptless entry (command backend): replayable only into a run that
+        # is itself receiptless — a receipted run must not fold in content no
+        # receipt can attribute.
+        if observed:
+            _note_chunk_cache_miss("serialize:chunk-cache-model-mismatch")
+            return None
+    elif len(observed) > 1:
+        # Already mixed: nothing can be verified against a single producer, so
+        # fail toward re-serialize rather than replay into the mess.
+        _note_chunk_cache_miss("serialize:chunk-cache-model-mismatch")
+        return None
+    elif not observed:
+        # First read before any live call — adopt the entry's producer as this
+        # run's first receipt (#465; mirrors the bench cache's pin adoption).
+        llm.note_served(recorded)
+    elif recorded != observed[0]:
+        _note_chunk_cache_miss("serialize:chunk-cache-model-mismatch")
+        return None
+    return partial
+
+
+def _note_chunk_cache_miss(counter: str) -> None:
+    # Counted through the SAME local usage-counter mechanism the cli commands
+    # use (#54), so a producer-verification miss is never silently
+    # indistinguishable from a cold cache. Lazy import keeps the module graph
+    # acyclic (cli imports this module); best-effort keeps the read fail-open.
+    try:
+        from . import cli
+        cli._note_usage(counter)
+    except Exception:
+        pass
 
 
 def _save_chunk_cache(key: str, partial: dict) -> None:
@@ -1491,6 +1558,13 @@ def _save_chunk_cache(key: str, partial: dict) -> None:
         # #28/#343 lesson: once the weaker fallback backend has fired in this
         # process, nothing from this run may be cached under the primary
         # backend's key — that is exactly how caches get poisoned.
+        return
+    served = llm.served_models()
+    if len(served) > 1:
+        # #465: distinct producers observed in this process — no chunk is
+        # attributable to a single model, and caching any of it under the
+        # alias key is exactly how caches get poisoned (scar 0015). The write
+        # gate stays THE gate.
         return
     d = _chunk_cache_dir()
     try:
@@ -1503,8 +1577,13 @@ def _save_chunk_cache(key: str, partial: dict) -> None:
                     stale.unlink()
             except OSError:
                 continue
+        # #465 envelope: the producer rides alongside the payload. Exactly one
+        # receipt names it; none is honest absence (null), never a default to
+        # the configured alias (scar 0032).
+        entry = {"served_model": served[0] if served else None,
+                 "partial": partial}
         tmp = d / f".{key}.{uuid.uuid4().hex[:8]}.tmp"
-        tmp.write_text(json.dumps(partial, ensure_ascii=False), encoding="utf-8")
+        tmp.write_text(json.dumps(entry, ensure_ascii=False), encoding="utf-8")
         tmp.chmod(0o600)
         tmp.replace(d / f"{key}.json")
     except OSError:

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -1001,6 +1001,26 @@ def test_served_models_distinct_sorted_and_resettable(llm_env, monkeypatch):
     assert llm.served_models() == []
 
 
+def test_note_served_folds_a_replayed_producer_into_the_collector():
+    # #465: a replayed cached chunk's recorded producer is an observation of
+    # "a model whose output is in this checkpoint" — folding it in makes the
+    # EXISTING mixed-run detection cover replay-then-live-substitution.
+    llm.reset_served_models()
+    llm.note_served("provider/real-model")
+    assert llm.served_models() == ["provider/real-model"]
+    llm.note_served("  z-model  ")            # stripped like the wire path
+    llm.note_served("provider/real-model")    # dedupe still happens on read
+    assert llm.served_models() == ["provider/real-model", "z-model"]
+
+
+def test_note_served_ignores_empty_input():
+    # Honest absence: nothing to record beats recording a blank (scar 0032).
+    llm.reset_served_models()
+    for junk in (None, "", "   ", 42, ["a-model"]):
+        llm.note_served(junk)
+    assert llm.served_models() == []
+
+
 def test_command_backend_records_no_served_model(monkeypatch):
     # The claude-CLI/command backend exposes no served-model info at all —
     # honest absence, never a guess (scar 0032: measurements attributed

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -1725,6 +1725,165 @@ def test_chunk_cache_files_written_0600(
         assert _stat.S_IMODE(p.stat().st_mode) == 0o600
 
 
+# ---- #465: chunk-cache producer verification (mirrors bench cache.py, #343) ----
+
+
+def _chunk_entry(tmp_checkpoint_dir, key):
+    return json.loads(
+        (tmp_checkpoint_dir / ".chunk-cache" / f"{key}.json").read_text(
+            encoding="utf-8"))
+
+
+def test_save_chunk_cache_records_the_single_served_producer(tmp_checkpoint_dir):
+    # #465: the entry carries the model that ACTUALLY served (the #458 wire
+    # receipt), never the configured alias (scar 0032).
+    from daimon_briefing import llm
+    llm.note_served("provider/real-model")
+    serializer._save_chunk_cache("k1", {"working_context": {"a": 1}})
+    assert _chunk_entry(tmp_checkpoint_dir, "k1") == {
+        "served_model": "provider/real-model",
+        "partial": {"working_context": {"a": 1}},
+    }
+
+
+def test_save_chunk_cache_refuses_a_mixed_producer_run(tmp_checkpoint_dir):
+    # Two distinct receipts in one process: no chunk is attributable to a
+    # single producer, so nothing from this run may be cached — the write
+    # gate is THE poison gate (scar 0015).
+    from daimon_briefing import llm
+    llm.note_served("a-model")
+    llm.note_served("z-model")
+    serializer._save_chunk_cache("k1", {"working_context": {"a": 1}})
+    assert not (tmp_checkpoint_dir / ".chunk-cache" / "k1.json").exists()
+
+
+def test_save_chunk_cache_records_honest_absence_without_receipts(
+        tmp_checkpoint_dir):
+    # Command backend exposes no receipts: null, never the alias copied in.
+    serializer._save_chunk_cache("k1", {"working_context": {"a": 1}})
+    assert _chunk_entry(tmp_checkpoint_dir, "k1")["served_model"] is None
+
+
+def test_save_chunk_cache_still_refuses_after_a_fallback_fired(
+        monkeypatch, tmp_checkpoint_dir):
+    # #28/#343 gate untouched by the #465 envelope work.
+    from daimon_briefing import llm
+    monkeypatch.setattr(llm, "fallback_used", lambda: True)
+    serializer._save_chunk_cache("k1", {"working_context": {"a": 1}})
+    assert not (tmp_checkpoint_dir / ".chunk-cache").exists()
+
+
+def test_load_chunk_cache_rejects_a_legacy_receiptless_entry(
+        monkeypatch, tmp_checkpoint_dir):
+    # Pre-#465 raw partial: unattributable content, exactly the shape a
+    # poisoned cache leaves behind — a counted MISS, never replayed.
+    from daimon_briefing import cli
+    d = tmp_checkpoint_dir / ".chunk-cache"
+    d.mkdir(parents=True)
+    (d / "k1.json").write_text(json.dumps({"working_context": {"a": 1}}),
+                               encoding="utf-8")
+    noted = []
+    monkeypatch.setattr(cli, "_note_usage", noted.append)
+    assert serializer._load_chunk_cache("k1") is None
+    assert "serialize:chunk-cache-legacy-miss" in noted
+
+
+def test_load_chunk_cache_returns_the_partial_when_producer_matches(
+        tmp_checkpoint_dir):
+    from daimon_briefing import llm
+    llm.note_served("provider/real-model")
+    serializer._save_chunk_cache("k1", {"working_context": {"a": 1}})
+    assert serializer._load_chunk_cache("k1") == {"working_context": {"a": 1}}
+
+
+def test_load_chunk_cache_rejects_a_different_producer(
+        monkeypatch, tmp_checkpoint_dir):
+    # The #465 hole itself: an entry written when the gateway silently served
+    # a substitute must not be replayed into a run served by another model.
+    from daimon_briefing import cli, llm
+    llm.note_served("substitute-model")
+    serializer._save_chunk_cache("k1", {"working_context": {"a": 1}})
+    llm.reset_served_models()
+    llm.note_served("provider/real-model")
+    noted = []
+    monkeypatch.setattr(cli, "_note_usage", noted.append)
+    assert serializer._load_chunk_cache("k1") is None
+    assert "serialize:chunk-cache-model-mismatch" in noted
+
+
+def test_load_chunk_cache_rejects_a_receiptless_entry_in_a_receipted_run(
+        monkeypatch, tmp_checkpoint_dir):
+    # A run that HAS receipts must not replay unattributable content.
+    from daimon_briefing import cli, llm
+    serializer._save_chunk_cache("k1", {"working_context": {"a": 1}})
+    llm.note_served("provider/real-model")
+    noted = []
+    monkeypatch.setattr(cli, "_note_usage", noted.append)
+    assert serializer._load_chunk_cache("k1") is None
+    assert "serialize:chunk-cache-model-mismatch" in noted
+
+
+def test_load_chunk_cache_rejects_everything_once_the_run_is_mixed(
+        monkeypatch, tmp_checkpoint_dir):
+    from daimon_briefing import cli, llm
+    llm.note_served("provider/real-model")
+    serializer._save_chunk_cache("k1", {"working_context": {"a": 1}})
+    llm.note_served("substitute-model")
+    noted = []
+    monkeypatch.setattr(cli, "_note_usage", noted.append)
+    assert serializer._load_chunk_cache("k1") is None
+    assert "serialize:chunk-cache-model-mismatch" in noted
+
+
+def test_load_chunk_cache_adopts_the_recorded_producer_when_run_has_none(
+        tmp_checkpoint_dir):
+    # First read before any live call: the replayed producer IS an observation
+    # of "a model whose output is in this checkpoint", so it joins the run's
+    # receipts — a later live substitution then trips both the read
+    # verification above and the existing mixed-run stamp/WARNING (#458).
+    from daimon_briefing import llm
+    llm.note_served("provider/real-model")
+    serializer._save_chunk_cache("k1", {"working_context": {"a": 1}})
+    llm.reset_served_models()
+    assert serializer._load_chunk_cache("k1") == {"working_context": {"a": 1}}
+    assert llm.served_models() == ["provider/real-model"]
+
+
+def test_load_chunk_cache_rejects_an_envelope_with_a_non_dict_partial(
+        tmp_checkpoint_dir):
+    d = tmp_checkpoint_dir / ".chunk-cache"
+    d.mkdir(parents=True)
+    (d / "k1.json").write_text(
+        json.dumps({"served_model": None, "partial": "not a dict"}),
+        encoding="utf-8")
+    assert serializer._load_chunk_cache("k1") is None
+
+
+def test_load_chunk_cache_rejects_a_non_string_recorded_producer(
+        tmp_checkpoint_dir):
+    # A corrupt receipt is unverifiable, so it is not replayable — the same
+    # rule as a missing one, never a silent pass-through.
+    d = tmp_checkpoint_dir / ".chunk-cache"
+    d.mkdir(parents=True)
+    (d / "k1.json").write_text(
+        json.dumps({"served_model": 42, "partial": {"working_context": {}}}),
+        encoding="utf-8")
+    assert serializer._load_chunk_cache("k1") is None
+
+
+def test_chunk_cache_verification_counters_never_break_a_serialize(
+        monkeypatch, tmp_checkpoint_dir):
+    # Telemetry only: a broken usage log must cost nothing but the counter.
+    from daimon_briefing import cli, llm
+    llm.note_served("substitute-model")
+    serializer._save_chunk_cache("k1", {"working_context": {"a": 1}})
+    llm.reset_served_models()
+    llm.note_served("provider/real-model")
+    monkeypatch.setattr(cli, "_note_usage",
+                        lambda _: (_ for _ in ()).throw(OSError("disk")))
+    assert serializer._load_chunk_cache("k1") is None  # must not raise
+
+
 # ---- #317: scene traces (encode-time episodic context, bench-gated experiment) ----
 
 


### PR DESCRIPTION
Closes #465

## What

Mirrors #343's bench-cache producer-verification contract at serializer scale:

- Chunk-cache entries are now envelopes `{"served_model": ..., "partial": {...}}` recording their producer — the wire's `response.model` receipt (#458). None = honest absence (command backend), never the configured alias copied in (scar 0032).
- Reads verify the recorded producer against the run's receipt set (`llm.served_models()`): producer disagreement, receiptless-entry-into-receipted-run, and mixed-run reads are counted misses (`serialize:chunk-cache-model-mismatch`); pre-#465 raw entries are counted legacy misses (`serialize:chunk-cache-legacy-miss`) and re-warm once.
- A first read before any live call ADOPTS the entry's producer via new `llm.note_served()`, folding it into the existing collector — so the shipped mixed-run WARNING + `serialize:model-substituted` counter + `llm_model_served` stamp cover replay-then-live-substitution with zero new stamp logic.
- Write gate stays THE poison gate (scar 0015): fallback runs (existing) and mixed-producer runs (new) cache nothing.

## Why

Confirmed during #343 (report-only there): the cache key hashes the CONFIGURED alias — routing config, not provenance — and the write gate only checks daimon's client-side fallback flag. A gateway-side silent substitution leaves that flag False, so the substitute model's extraction is cached under the alias key and replayed for up to `chunk_cache_days` (default 3) after the gateway heals. Live relevance: the operator's gateway is currently degraded to its local fallback lane, so poisoned entries are accumulating right now.

## Tests

- 15 new tests (13 serializer, 2 llm), written first and observed failing before implementation (strict TDD): envelope write with single/zero receipts, mixed-run write gate, legacy miss + counter, mismatch miss + counter, receiptless-into-receipted miss, match hit, adoption folds producer into `served_models()`, corrupt (non-string) receipt rejected, fallback gate regression guard, `note_served` contract.
- Full suite: 2441 → **2456 passed, 2 skipped** (verified by orchestrator run, 157s).
- Existing chunk-cache/forget/deletion-durability tests unchanged and green — envelope keeps pre-redaction content in the same file, so the deletion leak check stays meaningful.