### PR TITLE
feat(worldcheck): receipt-validity spot-check class — sampled vitni verification of origin receipts

### DIFF
--- a/.scars/candidates/popen-manual-stdin-close-breaks-communicate.md
+++ b/.scars/candidates/popen-manual-stdin-close-breaks-communicate.md
@@ -1,0 +1,30 @@
+---
+id: 0
+type: landmine
+title: Manually closing a Popen stdin pipe makes communicate() raise — and fail-open reapers turn that into silent skips
+severity: medium
+confidence: 0.9
+created: 2026-07-31
+authors: ["claude-code"]
+anchors:
+  - path: plugin/daimon_briefing/worldcheck.py
+evidence:
+  - note: "#439 implementation session 2026-07-31: every stdin-bearing vitni probe skipped silently; answer was on stdout the whole time"
+expires:
+  condition: "worldcheck._run_probes stops writing probe stdin manually (e.g. moves to communicate(input=...) with its own timeout discipline)"
+  review_after: 2026-10-31
+---
+
+`subprocess.Popen(stdin=PIPE)` + a manual `proc.stdin.write(...); proc.stdin.close()`
+(needed when you poll under a shared deadline instead of blocking in
+`communicate(input=...)`) leaves a closed pipe object on the Popen. A later
+`proc.communicate()` flushes `self.stdin` UNCONDITIONALLY and raises
+`ValueError: I/O operation on closed file`. Inside a fail-open reaper
+(`except Exception: continue`, the worldcheck contract) that ValueError reads
+as "probe failed" — every stdin-bearing probe becomes a silent skip while the
+correct answer sits on stdout. The failure mode is silence, not an error;
+gauges read green. Fix that must be preserved: set `proc.stdin = None`
+immediately after the manual close (worldcheck._run_probes does this — do not
+"clean it up"). Sibling trap: do not swap the runner for `receipts._run_cli`;
+its blocking `subprocess.run(timeout=10)` is 12× worldcheck's whole 0.8s
+budget.

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -504,8 +504,10 @@ def _render_briefing_body(checkpoint, route, *, drift_project, teammates,
                 checkpoint, store.corroborations(project_dir=route))
         except Exception:
             pass
-    # Worldcheck (#365): opt-in, budget-bounded, read-only `gh` spot-check of
-    # carried PR/issue-state claims — stamps contradicted items on the
+    # Worldcheck (#365/#397/#439): opt-in, budget-bounded, read-only
+    # spot-check of carried claims — repo state via `gh`, on-disk state via
+    # the filesystem, and the origin checkpoint's signed receipt via the vitni
+    # CLI. Stamps contradicted items on the
     # IN-MEMORY checkpoint before render (transient, like withhold's
     # candidate stamps; never persisted). Fail-open like withhold above: a
     # briefing must never block or die on the network. Counters ride the
@@ -513,7 +515,13 @@ def _render_briefing_body(checkpoint, route, *, drift_project, teammates,
     # the fires-true rate with zero extra machinery.
     if checkpoint and worldcheck_project and config.worldcheck_enabled():
         try:
-            wc_stats = worldcheck.check(checkpoint, worldcheck_project)
+            wc_stats = dict(worldcheck.check(checkpoint, worldcheck_project))
+            # #439: the receipt-validity class returns its FAILURES alongside
+            # the counters, under a reserved key. worldcheck writes nothing to
+            # disk by contract, so the rejection-ledger append happens HERE,
+            # where the project route is already resolved. Popped first: the
+            # counter loop below must see an all-ints dict.
+            ledger_rows = wc_stats.pop(worldcheck.LEDGER_KEY, ())
             # #397: the dict carries the aggregate outcomes AND a
             # "<class>:<outcome>" key per class, so one pass emits both the
             # slice-1 counters (unchanged meaning) and the per-class
@@ -521,6 +529,12 @@ def _render_briefing_body(checkpoint, route, *, drift_project, teammates,
             for counter, count in sorted(wc_stats.items()):
                 for _ in range(int(count)):
                     _note_usage(f"worldcheck:{counter}")
+            # A POINTER and a REASON CODE, never the item's text (#376) — the
+            # same second stream capture writes, for the same reason: folded
+            # into events.jsonl a rejection would HIDE the item it describes.
+            for item_ref, check, reason in ledger_rows:
+                store.append_verification(item_ref, check, reason,
+                                          project_dir=route)
         except Exception:
             pass
     # NOTE: drift is checked against the resolved project root. If read_latest fell

--- a/plugin/daimon_briefing/worldcheck.py
+++ b/plugin/daimon_briefing/worldcheck.py
@@ -47,6 +47,19 @@ aggregate three keep their slice-1 meaning, so the fires-true rate is
 readable per class before any further expansion. Content-hash — the strongest
 form — is deliberately NOT here: it would have to capture a hash at serialize
 time, which changes the serializer contract, so it is its own issue.
+
+#439 slice 3 adds RECEIPT-VALIDITY, the first class whose subject is daimon's
+own artifact rather than the world around it. Slices 1-2 ask "is what this item
+says still true"; this one asks "is the session that FIRST said it still
+provably the session that said it". The briefing's existing check is only a
+cheap byte match (receipts.verbatim_degraded); here the carried item's ORIGIN
+checkpoint (#268's write-time binding) gets the FULL vitni verification —
+signature, canonical structure, policy binding — sampled at one origin per day
+and run under this module's own deadline, never `receipts._run_cli`'s blocking
+10s timeout. A failed verification flags the item like any other failed check
+AND feeds the #376 rejection ledger, which is the one thing worldcheck cannot
+do itself: nothing here writes to disk, so `check()` RETURNS the failures and
+the CLI appends them.
 """
 
 import json
@@ -57,7 +70,7 @@ import time
 from collections import namedtuple
 from pathlib import Path
 
-from . import serializer
+from . import config, receipts, serializer, store
 
 # Aggregate wall-clock budget for ALL probes together (sub-second by
 # contract). Probes run in parallel, so this bounds the render delay, not a
@@ -78,6 +91,13 @@ BRANCH_STATE = "branch-state"
 FILE_EXISTS = "file-exists"
 DEPENDENCY_VERSION = "dependency-version"
 
+# #439. Deliberately NOT in claim_for's priority list: that list is
+# text-derived and first-match-wins, so a receipt class inside it would either
+# steal an item's PR-state reading or be starved by it. Receipt claims come
+# from the item's `origin_session` stamp, not from its text, so they are
+# collected in their own pass and an item may legitimately carry BOTH.
+RECEIPT_VALIDITY = "receipt-validity"
+
 # Classes answered from disk alone — no subprocess, no network.
 _LOCAL_CLASSES = frozenset({BRANCH_STATE, FILE_EXISTS, DEPENDENCY_VERSION})
 
@@ -85,6 +105,37 @@ Claim = namedtuple("Claim", "num kind expected")
 PathClaim = namedtuple("PathClaim", "path expected")
 BranchClaim = namedtuple("BranchClaim", "name expected")
 DepClaim = namedtuple("DepClaim", "name version")
+# No `expected` field: a receipt claim is implicit — carrying an item asserts
+# its origin's provenance still holds, and only "VALID" satisfies that.
+ReceiptClaim = namedtuple("ReceiptClaim", "session")
+
+# One receipt probe per brief, no matter how many origins a checkpoint carries:
+# it is the only class that spawns a CRYPTO subprocess, and the point is a
+# spot-check, not an audit (`daimon verify-receipt` is the audit).
+MAX_RECEIPT_PROBES = 1
+
+# The three answers a receipt probe can produce. Same bounded-vocabulary rule
+# as _KNOWN_STATES: these are the only values that reach _flag.
+_VALID = "VALID"            # vitni verified signature + structure + binding
+_INVALID = "INVALID"        # vitni REJECTED it — a real provenance failure
+_TAMPERED = "TAMPERED"      # bytes no longer match the signed outputs_hash
+
+# `check()`'s return is a counter dict the CLI turns into usage counters. This
+# reserved key (underscore, same convention as the transient `_worldcheck`
+# stamp) carries the receipt FAILURES out to a caller that may write them to
+# the #376 rejection ledger — worldcheck itself writes nothing to disk, which
+# is the whole reason the rows travel rather than land here. Present only when
+# something actually failed, so the happy-path dict stays all-ints.
+LEDGER_KEY = "_ledger"
+_LEDGER_CHECK = "receipt"
+_LEDGER_REASONS = {_TAMPERED: "receipt-tampered", _INVALID: "receipt-invalid"}
+
+# A probe: how to spawn it, what to feed its stdin, and how to read its answer.
+# The parser rides PER PROBE because the classes speak different dialects
+# (`gh` answers {"state": ...}, vitni answers {"valid": ...}) while sharing ONE
+# parallel fan-out — separate runners would let one class's slow probe
+# serialize behind the other's entire budget.
+Probe = namedtuple("Probe", "argv stdin parse")
 
 # Repo-LOCAL ref: "#N" optionally preceded by an explicit "PR"/"pull
 # request"/"issue" kind word. The lookbehind rejects any word char (or
@@ -271,7 +322,57 @@ def _target(cls, claim):
         return f"{claim.kind}/{claim.num}"
     if cls == FILE_EXISTS:
         return claim.path
+    if cls == RECEIPT_VALIDITY:
+        return claim.session
     return claim.name
+
+
+def _day_bucket() -> int:
+    """Days since the epoch — the rotation counter, and a test seam."""
+    return int(time.time() // 86400)
+
+
+def _receipt_targets(carried, project, deadline) -> set:
+    """The origin session(s) whose signed receipt THIS brief verifies (#439).
+
+    Eligibility mirrors `capture._origin_on_disk`: an origin whose checkpoint
+    is absent, unreadable, GC'd or belongs to another project is not a witness
+    anybody can produce, so it makes no claim at all — the same bar a bare
+    "#48" mention fails. That is a normal skip, never a contradiction: the
+    store keeps a BOUNDED number of per-session files, so an old origin being
+    gone says nothing about the claim it once carried.
+
+    Sampling is a day-bucket ROTATION over the eligible list, not a
+    hash-modulo gate. A `sha1(origin) % N` scheme is stable, which is exactly
+    what makes it wrong here: the origins it excludes are excluded FOREVER —
+    permanent blind spots, and a tampered checkpoint sitting in one would
+    never be probed on any day. Rotation reaches every origin over
+    consecutive days instead, at the same one-probe-per-brief cost.
+
+    Reads one small checkpoint per DISTINCT origin, which is why it takes the
+    shared deadline: collection work the budget does not cover is work the
+    briefing can still be blocked by."""
+    if not config.receipts_enabled():
+        return set()
+    slug = store.project_slug(project)
+    if not slug:
+        return set()
+    eligible, seen = [], set()
+    for item in carried:
+        origin = item.get("origin_session")
+        if not isinstance(origin, str) or not origin or origin in seen:
+            continue
+        seen.add(origin)
+        if time.monotonic() >= deadline:
+            break
+        cp = store.read_checkpoint(origin)  # total — swallows torn/bad paths
+        if isinstance(cp, dict) and cp.get("project_slug") == slug:
+            eligible.append(origin)
+    if not eligible:
+        return set()
+    start = _day_bucket() % len(eligible)
+    return {eligible[(start + i) % len(eligible)]
+            for i in range(min(MAX_RECEIPT_PROBES, len(eligible)))}
 
 
 def _gh_path():
@@ -423,11 +524,34 @@ def _run_local(plan: dict, project, deadline) -> dict:
     return out
 
 
-def _run_gh(plan: dict, project, deadline) -> dict:
-    """Slice 1's read-only `gh` probes, now sharing the aggregate deadline and
-    cap with the on-disk classes. The `gh`/GitHub-remote gate is per CLASS:
-    a missing `gh` skips the PR/issue claims ONLY, and a checkpoint with no
-    PR/issue claim never shells out at all."""
+def _parse_gh_state(out):
+    """Slice 1's `gh` reading, unchanged: the state word, and ONLY when it is
+    one this module is willing to put in front of a user."""
+    try:
+        state = str(json.loads(out).get("state") or "").strip().upper()
+    except Exception:
+        return None
+    return state if state in _KNOWN_STATES else None
+
+
+def _parse_vitni_valid(out):
+    """vitni's verify answer: {"valid": true|false}. Anything else — garbage,
+    a missing field, an {"error"} payload — is UNANSWERED, not a rejection: a
+    broken verifier must never read as "this receipt is bad" (the same
+    don't-guess bias as slice 1's ambiguous-vocabulary refusal)."""
+    try:
+        valid = json.loads(out).get("valid")
+    except Exception:
+        return None
+    if valid is True:
+        return _VALID
+    return _INVALID if valid is False else None
+
+
+def _gh_probes(plan: dict, project) -> dict:
+    """Slice 1's read-only `gh` probes as probe specs. The `gh`/GitHub-remote
+    gate is per CLASS: a missing `gh` skips the PR/issue claims ONLY, and a
+    checkpoint with no PR/issue claim never shells out at all."""
     wanted = {key: claim for key, claim in plan.items() if key[0] == PR_STATE}
     if not wanted:
         return {}
@@ -437,26 +561,118 @@ def _run_gh(plan: dict, project, deadline) -> dict:
     probes = {}
     for key, claim in wanted.items():
         if claim.kind == "pr":
-            probes[key] = [gh, "pr", "view", claim.num, "--json", "state,mergedAt"]
+            argv = [gh, "pr", "view", claim.num, "--json", "state,mergedAt"]
         else:
-            probes[key] = [gh, "issue", "view", claim.num, "--json", "state"]
-    return _run_probes(probes, cwd=project, deadline=deadline)
+            argv = [gh, "issue", "view", claim.num, "--json", "state"]
+        probes[key] = Probe(argv=argv, stdin=None, parse=_parse_gh_state)
+    return probes
+
+
+def _verify_probe(session):
+    """The vitni `verify` invocation for one origin session, or None when the
+    verification cannot be attempted (no CLI, no sidecar, no local public key,
+    corrupt sidecar) — all silent skips.
+
+    Replicates `receipts._verify_receipt`'s CLI contract EXACTLY (same
+    subcommand, same stdin object, same policy fields); only the RUNNER
+    differs. It cannot call that function, or `receipts._run_cli` beneath it,
+    because those block on `subprocess.run` with `_CLI_TIMEOUT` = 10s — twelve
+    times this module's entire budget."""
+    cli = receipts._resolve_cli()
+    if cli is None:
+        return None
+    cp_file = receipts._checkpoint_file(session)
+    try:
+        sidecar = json.loads(
+            receipts._sidecar_path(cp_file).read_text(encoding="utf-8"))
+        jws = sidecar["jws"]
+        receipt = sidecar["receipt"]
+    except (OSError, json.JSONDecodeError, KeyError, TypeError):
+        return None  # no sidecar at all = a pre-receipt origin: nothing to do
+    performer = sidecar.get("performer_id") or receipt.get("performer_id")
+    pubkey = receipts._load_pubkey(config.keys_dir())
+    if not jws or not performer or pubkey is None:
+        return None
+    payload = json.dumps({
+        "signed_receipt": jws,
+        "keys": {performer: {sidecar.get("kid") or receipts.KID: pubkey}},
+        "policy": {"expected_binding": receipts._BINDING,
+                   "expected_method": receipts.METHOD},
+    })
+    return Probe(argv=[cli, "verify"], stdin=payload, parse=_parse_vitni_valid)
+
+
+def _receipt_probes(plan: dict, out: dict) -> dict:
+    """Phase (a) of the receipt check, plus the phase (b) probe specs (#439).
+
+    Phase (a) is FREE — sidecar-exists + outputs_hash byte match, exactly the
+    check the briefing already runs (`receipts.verbatim_degraded`), no
+    subprocess. A byte mismatch is already terminal, so it answers TAMPERED
+    straight into `out` and NO CLI is ever spawned for it. Only an origin that
+    survives phase (a) earns phase (b), the full signature/structure/binding
+    verification — which is the point of the class: the byte match alone
+    cannot tell a re-signed forgery from the real thing.
+
+    Mutates `out` (the results dict) for the phase-(a) answers and returns
+    only what still needs spawning. Never raises: any failure is a skip."""
+    probes = {}
+    for key, claim in plan.items():
+        if key[0] != RECEIPT_VALIDITY:
+            continue
+        try:
+            cp = store.read_checkpoint(claim.session)
+            if not isinstance(cp, dict):
+                continue  # vanished between collection and probe -> skip
+            if receipts.verbatim_degraded(cp):
+                out[key] = _TAMPERED
+                continue
+            probe = _verify_probe(claim.session)
+        except Exception:
+            continue
+        if probe is not None:
+            probes[key] = probe
+    return probes
 
 
 def _run_probes(probes: dict, cwd, deadline) -> dict:
     """Run every probe in parallel under the SHARED aggregate deadline.
-    `probes` is {key: argv}; returns {key: STATE | None} — None for anything
+    `probes` is {key: Probe}; returns {key: value | None} — None for anything
     killed at the deadline, failed, or unparseable. Never raises: a probe
-    error is a skip, not a briefing failure."""
+    error is a skip, not a briefing failure.
+
+    ONE fan-out for every subprocess class: separate runners would make the
+    aggregate budget a fiction, since the second runner could only start after
+    the first had waited out its whole deadline."""
+    if not probes:
+        return {}
     procs: dict = {}
     results: dict = {key: None for key in probes}
-    for key, argv in probes.items():
+    for key, probe in probes.items():
         try:
-            procs[key] = subprocess.Popen(
-                argv, cwd=str(cwd), stdin=subprocess.DEVNULL,
+            proc = subprocess.Popen(
+                probe.argv, cwd=str(cwd),
+                stdin=subprocess.PIPE if probe.stdin else subprocess.DEVNULL,
                 stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True)
         except Exception:
             continue  # spawn failure (gh vanished mid-flight) -> skip
+        if probe.stdin and proc.stdin is not None:
+            # Written and closed IMMEDIATELY: a stdin-reading child otherwise
+            # blocks forever and burns the whole budget. Safe without a writer
+            # thread ONLY because the payload is one small JSON object (a JWS
+            # plus one public key, far under the 64 KiB pipe buffer) — a
+            # bigger payload would deadlock here and needs a different shape.
+            try:
+                proc.stdin.write(probe.stdin)
+                proc.stdin.close()
+            except Exception:
+                pass  # child already gone — its rc/output decides the skip
+            # MUST drop the handle: `communicate()` below flushes `self.stdin`
+            # unconditionally and raises ValueError("I/O operation on closed
+            # file") on a pipe WE closed. Caught by the reaper's except, it
+            # turned every stdin-bearing probe into a silent skip — the answer
+            # was on stdout the whole time.
+            proc.stdin = None
+        procs[key] = proc
     while (any(p.poll() is None for p in procs.values())
            and time.monotonic() < deadline):
         time.sleep(0.02)
@@ -476,11 +692,9 @@ def _run_probes(probes: dict, cwd, deadline) -> dict:
         if p.returncode != 0:
             continue
         try:
-            state = str(json.loads(out).get("state") or "").strip().upper()
+            results[key] = probes[key].parse(out)
         except Exception:
             continue
-        if state in _KNOWN_STATES:
-            results[key] = state
     return results
 
 
@@ -490,6 +704,10 @@ def _satisfied(cls, claim, value) -> bool:
     coarser claim is not a false one — every other class is set membership."""
     if cls == DEPENDENCY_VERSION:
         return value == claim.version or value.startswith(claim.version + ".")
+    if cls == RECEIPT_VALIDITY:
+        # The claim is implicit and absolute: carrying an item asserts its
+        # origin's provenance still holds, and only a full VALID says so.
+        return value == _VALID
     return value in claim.expected
 
 
@@ -505,6 +723,15 @@ def _flag(cls, claim, value):
     if cls == BRANCH_STATE:
         word = "gone" if value == "MISSING" else "exists"
         return f"branch {claim.name} {word}", word
+    if cls == RECEIPT_VALIDITY:
+        # Two failure flavors worth telling apart — an edited artifact and a
+        # receipt the verifier rejected are different incidents. Both notes
+        # are FIXED literals: the only variable in scope is a session id, and
+        # this text rides into briefing output and the hook-injected LLM
+        # context, where a raw session id has no business being.
+        note = ("signed receipt no longer matches checkpoint bytes"
+                if value == _TAMPERED else "signed receipt failed verification")
+        return note, "unverified"
     return f"{claim.name} {value} not {claim.version}", "changed"
 
 
@@ -520,23 +747,44 @@ def check(checkpoint, project_dir) -> dict:
     rate per claim class while the aggregate three keep their slice-1
     meaning. Zero-claim checkpoints return all-zeros and cost one iteration,
     no probe of any kind. Confirmed items are untouched: only a contradiction
-    earns any surface at all."""
-    stats = {"confirmed": 0, "contradicted": 0, "skipped": 0}
+    earns any surface at all.
+
+    #439 adds ONE non-counter key, `LEDGER_KEY`, present only when a receipt
+    verification actually failed: [(item_ref, check, reason)] rows for the
+    caller to append to the rejection ledger. A caller that ignores it loses
+    the ledger row and nothing else — the counters and the flags are whole on
+    their own. A caller that iterates the dict blindly must pop it first."""
+    # dict, not dict[str, int]: LEDGER_KEY carries list rows (#439).
+    stats: dict = {"confirmed": 0, "contradicted": 0, "skipped": 0}
     if not isinstance(checkpoint, dict) or not project_dir:
         return stats
-    claims = []
-    for item in serializer.iter_items(checkpoint):
-        if not item.get("carried_from"):
-            continue  # native items were just re-extracted — not in question
-        found = claim_for(item.get("text"))
-        if found is not None:
-            claims.append((item, found[0], found[1]))
-    if not claims:
+    # Native items were just re-extracted — not in question, for any class.
+    carried = [item for item in serializer.iter_items(checkpoint)
+               if item.get("carried_from")]
+    if not carried:
         return stats
     # ONE deadline for every class. Allocation of the shared cap follows
     # checkpoint order so no class is privileged when it binds; execution
     # then runs local-before-network so the cheap classes cannot be starved.
+    # Armed BEFORE collection (#439): receipt-validity's eligibility scan
+    # reads origin checkpoints off disk, and collection work the budget does
+    # not cover is work the briefing can still be blocked by.
     deadline = time.monotonic() + BUDGET_SECONDS
+    origins = _receipt_targets(carried, project_dir, deadline)
+    claims = []
+    for item in carried:
+        found = claim_for(item.get("text"))
+        if found is not None:
+            claims.append((item, found[0], found[1]))
+        # Second pass, interleaved per item so the cap still allocates in
+        # CHECKPOINT order — appending all receipt claims at the end would
+        # starve them on any claim-heavy checkpoint. The text claim goes
+        # first, which is also what decides the stamp collision below.
+        if item.get("origin_session") in origins:
+            claims.append(
+                (item, RECEIPT_VALIDITY, ReceiptClaim(session=item["origin_session"])))
+    if not claims:
+        return stats
     plan: dict = {}
     for _item, cls, claim in claims:
         key = (cls, _target(cls, claim))
@@ -544,7 +792,10 @@ def check(checkpoint, project_dir) -> dict:
             continue
         plan[key] = claim
     results = _run_local(plan, project_dir, deadline)
-    results.update(_run_gh(plan, project_dir, deadline))
+    probes = _receipt_probes(plan, results)  # phase (a) answers into results
+    probes.update(_gh_probes(plan, project_dir))
+    results.update(_run_probes(probes, cwd=project_dir, deadline=deadline))
+    ledger = []
     for item, cls, claim in claims:
         value = results.get((cls, _target(cls, claim)))
         if value is None:
@@ -554,7 +805,20 @@ def check(checkpoint, project_dir) -> dict:
         else:
             outcome = "contradicted"
             note, status = _flag(cls, claim, value)
-            item["_worldcheck"] = {"note": note, "status": status}
+            # FIRST stamp wins, and text claims are emitted first per item
+            # above — so when an item is contradicted on both axes the text
+            # flag survives. It is the more actionable one: it names what
+            # changed and drives a real `daimon resolve --status`, while the
+            # receipt flag would replace it with a status of "unverified".
+            # The receipt outcome still counts and still reaches the ledger.
+            item.setdefault("_worldcheck", {"note": note, "status": status})
+            ref = item.get("id")
+            if cls == RECEIPT_VALIDITY and isinstance(ref, str) and ref:
+                # An id-less item yields no row: a ledger entry nobody can
+                # trace back is noise (serializer.verification_rejections).
+                ledger.append((ref, _LEDGER_CHECK, _LEDGER_REASONS[value]))
         stats[outcome] += 1
         stats[f"{cls}:{outcome}"] = stats.get(f"{cls}:{outcome}", 0) + 1
+    if ledger:
+        stats[LEDGER_KEY] = ledger
     return stats

--- a/plugin/tests/conftest.py
+++ b/plugin/tests/conftest.py
@@ -55,6 +55,93 @@ def _reset_llm_module_state():
     llm.reset_served_models()
 
 
+# ---- fake vitni CLI (#204 receipts, #439 worldcheck receipt-validity) -------
+#
+# CI has NO node and NO vitni CLI, so every test that needs the signer/verifier
+# stubs it with this fake executable (a python script echoing canned JSON and
+# capturing the stdin it received, so the input contract can be asserted).
+# Lifted here from test_receipts.py when #439 gave worldcheck a second consumer
+# — the CLI contract is ONE contract, and two divergent copies of the fake
+# would let the two call sites drift apart silently.
+
+_FAKE_CLI_SRC = r'''#!/usr/bin/env python3
+import sys, json, os
+cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+raw = sys.stdin.read()
+cap = os.environ.get("FAKE_VITNI_CAPTURE")
+if cap:
+    with open(cap, "a") as f:
+        f.write(json.dumps({"cmd": cmd, "stdin": raw}) + "\n")
+mode = os.environ.get("FAKE_VITNI_MODE", "ok")
+if mode == "garbage":
+    sys.stdout.write("not json at all")
+    sys.exit(0)
+if mode == "rc1":
+    sys.stderr.write("boom")
+    sys.exit(1)
+if mode == "hang":
+    import time
+    time.sleep(30)
+try:
+    data = json.loads(raw)
+except ValueError:
+    print(json.dumps({"error": "invalid_json"})); sys.exit(0)
+if cmd == "sign":
+    print(json.dumps({"signed_receipt": os.environ.get("FAKE_VITNI_JWS", "aaa.bbb.ccc")}))
+elif cmd == "verify":
+    verdict = os.environ.get("FAKE_VITNI_VERDICT", "ok")
+    if verdict == "ok":
+        print(json.dumps({"valid": True, "reason": "ok"}))
+    else:
+        print(json.dumps({"valid": False, "reason": verdict}))
+elif cmd == "keygen":
+    kmode = os.environ.get("FAKE_VITNI_KEYGEN_MODE", "ok")
+    if kmode == "unknown":          # simulate an old CLI without keygen
+        print(json.dumps({"error": "unknown_command"})); sys.exit(0)
+    if kmode == "error":            # {"error"} on exit 0 — never rc
+        print(json.dumps({"error": "invalid_seed"})); sys.exit(0)
+    if kmode == "nojwk":            # malformed output shape
+        print(json.dumps({"private_key_b64": data.get("seed_b64", "")})); sys.exit(0)
+    seed = data.get("seed_b64")
+    if seed == "":                 # present-but-empty != absent -> invalid_seed
+        print(json.dumps({"error": "invalid_seed"})); sys.exit(0)
+    PROBE = "nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A="
+    PROBE_X = "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+    if seed == PROBE:
+        x = os.environ.get("FAKE_VITNI_PROBE_X", PROBE_X)
+    else:
+        x = os.environ.get("FAKE_VITNI_KEYGEN_X",
+                           "Kg2fakeKEYGENxKg2fakeKEYGENxKg2fakeKEYGENxK")
+    print(json.dumps({"jwk": {"alg": "EdDSA", "crv": "Ed25519", "kty": "OKP",
+                              "status": "active", "x": x},
+                      "private_key_b64": seed}))
+else:
+    print(json.dumps({"error": "unknown_command"}))
+sys.exit(0)
+'''
+
+
+@pytest.fixture
+def fake_cli_src():
+    """The fake CLI's source, for tests that need to install it themselves
+    (e.g. two distinct binaries to prove a per-binary cache)."""
+    return _FAKE_CLI_SRC
+
+
+@pytest.fixture
+def fake_cli(tmp_path, monkeypatch):
+    """Install a fake vitni CLI on DAIMON_VITNI_CLI + capture file. Returns the
+    capture-path so a test can assert what daimon actually sent on stdin (and,
+    by its absence, that the CLI was never invoked at all)."""
+    script = tmp_path / "fake-vitni"
+    script.write_text(_FAKE_CLI_SRC)
+    script.chmod(0o755)
+    capture = tmp_path / "vitni-capture.jsonl"
+    monkeypatch.setenv("DAIMON_VITNI_CLI", str(script))
+    monkeypatch.setenv("FAKE_VITNI_CAPTURE", str(capture))
+    return capture
+
+
 @pytest.fixture
 def tmp_checkpoint_dir(tmp_path):
     # The autouse fixture already points DAIMON_CHECKPOINT_DIR here; expose the path.

--- a/plugin/tests/test_receipts.py
+++ b/plugin/tests/test_receipts.py
@@ -47,75 +47,10 @@ _TSCRIPT_HEX = hashlib.sha256(b"hello transcript").hexdigest()
 
 
 # ---- fake vitni CLI --------------------------------------------------------
-
-_FAKE_CLI_SRC = r'''#!/usr/bin/env python3
-import sys, json, os
-cmd = sys.argv[1] if len(sys.argv) > 1 else ""
-raw = sys.stdin.read()
-cap = os.environ.get("FAKE_VITNI_CAPTURE")
-if cap:
-    with open(cap, "a") as f:
-        f.write(json.dumps({"cmd": cmd, "stdin": raw}) + "\n")
-mode = os.environ.get("FAKE_VITNI_MODE", "ok")
-if mode == "garbage":
-    sys.stdout.write("not json at all")
-    sys.exit(0)
-if mode == "rc1":
-    sys.stderr.write("boom")
-    sys.exit(1)
-if mode == "hang":
-    import time
-    time.sleep(30)
-try:
-    data = json.loads(raw)
-except ValueError:
-    print(json.dumps({"error": "invalid_json"})); sys.exit(0)
-if cmd == "sign":
-    print(json.dumps({"signed_receipt": os.environ.get("FAKE_VITNI_JWS", "aaa.bbb.ccc")}))
-elif cmd == "verify":
-    verdict = os.environ.get("FAKE_VITNI_VERDICT", "ok")
-    if verdict == "ok":
-        print(json.dumps({"valid": True, "reason": "ok"}))
-    else:
-        print(json.dumps({"valid": False, "reason": verdict}))
-elif cmd == "keygen":
-    kmode = os.environ.get("FAKE_VITNI_KEYGEN_MODE", "ok")
-    if kmode == "unknown":          # simulate an old CLI without keygen
-        print(json.dumps({"error": "unknown_command"})); sys.exit(0)
-    if kmode == "error":            # {"error"} on exit 0 — never rc
-        print(json.dumps({"error": "invalid_seed"})); sys.exit(0)
-    if kmode == "nojwk":            # malformed output shape
-        print(json.dumps({"private_key_b64": data.get("seed_b64", "")})); sys.exit(0)
-    seed = data.get("seed_b64")
-    if seed == "":                 # present-but-empty != absent -> invalid_seed
-        print(json.dumps({"error": "invalid_seed"})); sys.exit(0)
-    PROBE = "nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A="
-    PROBE_X = "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
-    if seed == PROBE:
-        x = os.environ.get("FAKE_VITNI_PROBE_X", PROBE_X)
-    else:
-        x = os.environ.get("FAKE_VITNI_KEYGEN_X",
-                           "Kg2fakeKEYGENxKg2fakeKEYGENxKg2fakeKEYGENxK")
-    print(json.dumps({"jwk": {"alg": "EdDSA", "crv": "Ed25519", "kty": "OKP",
-                              "status": "active", "x": x},
-                      "private_key_b64": seed}))
-else:
-    print(json.dumps({"error": "unknown_command"}))
-sys.exit(0)
-'''
-
-
-@pytest.fixture
-def fake_cli(tmp_path, monkeypatch):
-    """Install a fake vitni CLI on DAIMON_VITNI_CLI + capture file. Returns the
-    capture-path so a test can assert what daimon actually sent on stdin."""
-    script = tmp_path / "fake-vitni"
-    script.write_text(_FAKE_CLI_SRC)
-    script.chmod(0o755)
-    capture = tmp_path / "vitni-capture.jsonl"
-    monkeypatch.setenv("DAIMON_VITNI_CLI", str(script))
-    monkeypatch.setenv("FAKE_VITNI_CAPTURE", str(capture))
-    return capture
+#
+# `_FAKE_CLI_SRC` and the `fake_cli` fixture live in tests/conftest.py: #439
+# gave the same CLI contract a second consumer (worldcheck's receipt-validity
+# class), and two divergent copies of the fake would let the call sites drift.
 
 
 @pytest.fixture
@@ -1020,15 +955,16 @@ def test_probe_runs_once_per_process(keys_seed_only, fake_cli, monkeypatch):
     assert len(probe_calls) == 1  # cached after first probe
 
 
-def test_probe_cache_is_per_cli_binary(tmp_path, keys_seed_only, monkeypatch):
+def test_probe_cache_is_per_cli_binary(tmp_path, keys_seed_only, monkeypatch,
+                                       fake_cli_src):
     # A verdict belongs to the binary that earned it: after CLI A passes the
     # probe, repointing DAIMON_VITNI_CLI at binary B must re-probe B — a bad B
     # must NOT inherit A's pass and be trusted with the real seed.
     good = tmp_path / "cli-good"
-    good.write_text(_FAKE_CLI_SRC)
+    good.write_text(fake_cli_src)
     good.chmod(0o755)
     bad = tmp_path / "cli-bad"
-    bad.write_text(_FAKE_CLI_SRC)
+    bad.write_text(fake_cli_src)
     bad.chmod(0o755)
     capture = tmp_path / "cap.jsonl"
     monkeypatch.setenv("FAKE_VITNI_CAPTURE", str(capture))

--- a/plugin/tests/test_worldcheck.py
+++ b/plugin/tests/test_worldcheck.py
@@ -22,8 +22,17 @@ Contract pinned here:
   cross-project (--slug) and global-fallback briefs never probe, and outcomes
   land in usage.log as worldcheck:<outcome> AND worldcheck:<class>:<outcome>.
 
+#439 slice 3 adds receipt-validity, the first class whose subject is daimon's
+OWN artifact: a carried item's ORIGIN checkpoint verified through the vitni CLI
+(full signature + structure + binding, not the cheap byte match the briefing
+already does). It samples ONE origin per day by rotation, and a FAILED
+verification both flags the item and feeds the #376 rejection ledger — written
+by the CLI, never by worldcheck, which still writes nothing to disk.
+
 All gh probes in this suite hit a fake `gh` script on disk — zero network.
 Slice 2's probes touch only tmp_path trees — zero network, zero subprocess.
+Slice 3's probes hit the shared fake vitni CLI (tests/conftest.py) — a local
+subprocess, still zero network.
 """
 
 import json
@@ -32,7 +41,7 @@ import time
 
 import pytest
 
-from daimon_briefing import briefing, cli, config, store, worldcheck
+from daimon_briefing import briefing, cli, config, receipts, store, worldcheck
 
 
 # ---- helpers ----------------------------------------------------------------
@@ -1036,3 +1045,408 @@ def test_stats_surfaces_worldcheck_counters(monkeypatch, tmp_path, capsys):
     usage = data.get("usage") or {}
     assert usage.get("worldcheck:contradicted") == 1
     assert usage.get("worldcheck:confirmed") == 2
+
+
+# ---- #439 slice 3: receipt-validity -----------------------------------------
+#
+# The first class whose subject is daimon's OWN artifact rather than the world
+# around it: a carried item's ORIGIN checkpoint is verified through the vitni
+# CLI (full signature + structure + binding, not just the cheap byte match the
+# briefing already does). Everything the slice-1 contract promised still holds
+# — one aggregate budget, one shared probe cap, silent skip on any failure,
+# nothing written to disk from inside worldcheck.
+
+
+def _cp_origins(origins, texts=None):
+    """Checkpoint whose carried open_questions each name an origin session.
+    `texts` defaults to a non-claim text per item, so the only claim available
+    is the receipt one (the classes stay independently observable)."""
+    texts = texts or [f"note {i}" for i in range(len(origins))]
+    cp = _cp(texts)
+    for item, origin in zip(cp["working_context"]["open_questions"], origins):
+        if origin is not None:
+            item["origin_session"] = origin
+    return cp
+
+
+def _pubkey_dir(tmp_path, monkeypatch):
+    """A keys dir holding only the cached PUBLIC key — worldcheck verifies, it
+    never signs, so the seed is deliberately absent."""
+    kdir = tmp_path / "keys"
+    kdir.mkdir(exist_ok=True)
+    (kdir / "signing.pub.json").write_text(json.dumps(
+        {"kty": "OKP", "crv": "Ed25519", "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
+         "alg": "EdDSA", "status": "active"}))
+    monkeypatch.setenv("DAIMON_KEYS_DIR", str(kdir))
+    return kdir
+
+
+def _signed_origin(session, project, *, sidecar=True, tamper=False,
+                   receipts_era=True, slug=None):
+    """Write a receipt-era origin checkpoint (+ its `.receipt` sidecar) exactly
+    where store/receipts expect them. `tamper=True` signs OTHER bytes, which is
+    what an edited-after-signing artifact looks like from brief time."""
+    cp = {"session_id": session,
+          "project_slug": slug if slug is not None else store.project_slug(project),
+          "working_context": {}, "epistemic_snapshot": {}}
+    if receipts_era:
+        cp["receipts"] = True
+    path = config.checkpoint_dir() / f"{session}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(cp, indent=2), encoding="utf-8")
+    if sidecar:
+        signed = b"other bytes entirely" if tamper else path.read_bytes()
+        # The JWS is session-derived so a test can tell WHICH origin was
+        # verified from the CLI capture alone.
+        path.with_suffix(".receipt").write_text(json.dumps({
+            "jws": f"{session}.bbb.ccc",
+            "receipt": {"outputs_hash": receipts._multibase_sha256(signed)},
+            "kid": "daimon-1", "performer_id": "tester"}))
+    return path
+
+
+@pytest.fixture
+def receipts_on(tmp_path, monkeypatch, fake_cli):
+    """Receipt-validity fully armed: feature flag on, a fake vitni CLI on
+    DAIMON_VITNI_CLI, a cached public key. Returns the CLI capture path — its
+    NON-existence is how a test proves no subprocess ever ran."""
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    _pubkey_dir(tmp_path, monkeypatch)
+    return fake_cli
+
+
+def _vitni_calls(capture):
+    if not capture.exists():
+        return []
+    return [json.loads(x) for x in capture.read_text().splitlines() if x.strip()]
+
+
+def test_receipt_valid_confirms_and_leaves_item_untouched(receipts_on, proj):
+    _signed_origin("S-origin", proj)
+    cp = _cp_origins(["S-origin"])
+    stats = worldcheck.check(cp, proj)
+    assert stats == {"confirmed": 1, "contradicted": 0, "skipped": 0,
+                     "receipt-validity:confirmed": 1}
+    assert "_worldcheck" not in cp["working_context"]["open_questions"][0]
+    calls = _vitni_calls(receipts_on)
+    assert [c["cmd"] for c in calls] == ["verify"]
+
+
+def test_receipt_cli_verify_payload_matches_the_receipts_contract(receipts_on, proj):
+    # Same subcommand and same stdin shape `receipts._verify_receipt` builds —
+    # only the runner differs (Popen under worldcheck's deadline instead of a
+    # blocking subprocess.run with a 10s timeout).
+    _signed_origin("S-origin", proj)
+    worldcheck.check(_cp_origins(["S-origin"]), proj)
+    sent = json.loads(_vitni_calls(receipts_on)[0]["stdin"])
+    assert sent["signed_receipt"] == "S-origin.bbb.ccc"
+    assert sent["policy"] == {"expected_binding": "local",
+                              "expected_method": receipts.METHOD}
+    assert list(sent["keys"]) == ["tester"]
+    assert list(sent["keys"]["tester"]) == ["daimon-1"]
+
+
+def test_receipt_cli_rejection_stamps_and_feeds_the_ledger(
+    receipts_on, proj, monkeypatch
+):
+    monkeypatch.setenv("FAKE_VITNI_VERDICT", "signature_invalid")
+    cp = _cp_origins(["S-origin"])
+    _signed_origin("S-origin", proj)
+    stats = worldcheck.check(cp, proj)
+    assert stats["contradicted"] == 1
+    assert stats["receipt-validity:contradicted"] == 1
+    item = cp["working_context"]["open_questions"][0]
+    # Bounded literals only: the note rides into briefing output and the
+    # hook-injected LLM context, so no session id and no CLI text may reach it.
+    assert item["_worldcheck"] == {
+        "note": "signed receipt failed verification", "status": "unverified"}
+    assert "S-origin" not in item["_worldcheck"]["note"]
+    assert stats[worldcheck.LEDGER_KEY] == [("o-000001", "receipt", "receipt-invalid")]
+
+
+def test_receipt_tampered_bytes_flag_without_any_subprocess(receipts_on, proj):
+    # Phase (a) is FREE (sidecar + sha256, no exec). A byte mismatch is already
+    # a terminal answer, so the CLI must never be spawned for it.
+    _signed_origin("S-origin", proj, tamper=True)
+    cp = _cp_origins(["S-origin"])
+    stats = worldcheck.check(cp, proj)
+    assert stats["receipt-validity:contradicted"] == 1
+    assert cp["working_context"]["open_questions"][0]["_worldcheck"] == {
+        "note": "signed receipt no longer matches checkpoint bytes",
+        "status": "unverified"}
+    assert stats[worldcheck.LEDGER_KEY] == [("o-000001", "receipt", "receipt-tampered")]
+    assert _vitni_calls(receipts_on) == []
+
+
+def test_receipt_era_origin_with_no_sidecar_is_tampered(receipts_on, proj):
+    # Marked receipt-era but the receipt is gone: removed or lost, and
+    # provenance cannot be confirmed — the same verdict verify-receipt gives.
+    _signed_origin("S-origin", proj, sidecar=False)
+    stats = worldcheck.check(_cp_origins(["S-origin"]), proj)
+    assert stats["receipt-validity:contradicted"] == 1
+    assert _vitni_calls(receipts_on) == []
+
+
+def test_receipt_pre_receipt_origin_skips_silently(receipts_on, proj):
+    # An origin written before receipts existed has nothing to verify. It is a
+    # SKIP, not a contradiction — no retroactive downgrades (#204).
+    _signed_origin("S-origin", proj, sidecar=False, receipts_era=False)
+    cp = _cp_origins(["S-origin"])
+    stats = worldcheck.check(cp, proj)
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "receipt-validity:skipped": 1}
+    assert "_worldcheck" not in cp["working_context"]["open_questions"][0]
+    assert _vitni_calls(receipts_on) == []
+
+
+def test_receipt_item_without_origin_session_makes_no_claim(receipts_on, proj):
+    # Pre-#268 carried items carry no origin binding — nothing to check, and
+    # nothing to count either (the same bar a bare "#48" mention meets).
+    stats = worldcheck.check(_cp_origins([None]), proj)
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 0}
+    assert _vitni_calls(receipts_on) == []
+
+
+def test_receipt_feature_off_makes_no_claim(receipts_on, proj, monkeypatch):
+    monkeypatch.delenv("DAIMON_RECEIPTS", raising=False)
+    _signed_origin("S-origin", proj)
+    stats = worldcheck.check(_cp_origins(["S-origin"]), proj)
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 0}
+    assert _vitni_calls(receipts_on) == []
+
+
+def test_receipt_gc_d_origin_makes_no_claim(receipts_on, proj):
+    # A GC'd origin is a NORMAL skip: the store keeps a bounded number of
+    # per-session files, so an old origin being gone says nothing about the
+    # claim. Never a contradiction.
+    stats = worldcheck.check(_cp_origins(["S-gone"]), proj)
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 0}
+    assert _vitni_calls(receipts_on) == []
+
+
+def test_receipt_foreign_project_origin_makes_no_claim(receipts_on, proj):
+    # A checkpoint that exists but belongs elsewhere cannot vouch for a claim
+    # here — capture._origin_on_disk's rule, reused verbatim.
+    _signed_origin("S-origin", proj, slug="some-other-project")
+    stats = worldcheck.check(_cp_origins(["S-origin"]), proj)
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 0}
+    assert _vitni_calls(receipts_on) == []
+
+
+def test_receipt_missing_cli_skips_silently(receipts_on, proj, monkeypatch):
+    monkeypatch.setenv("DAIMON_VITNI_CLI", "vitni-verify-that-does-not-exist")
+    _signed_origin("S-origin", proj)
+    cp = _cp_origins(["S-origin"])
+    stats = worldcheck.check(cp, proj)
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "receipt-validity:skipped": 1}
+    assert "_worldcheck" not in cp["working_context"]["open_questions"][0]
+
+
+def test_receipt_missing_pubkey_skips_silently(receipts_on, proj, tmp_path,
+                                               monkeypatch):
+    monkeypatch.setenv("DAIMON_KEYS_DIR", str(tmp_path / "no-keys-here"))
+    _signed_origin("S-origin", proj)
+    stats = worldcheck.check(_cp_origins(["S-origin"]), proj)
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "receipt-validity:skipped": 1}
+    assert _vitni_calls(receipts_on) == []
+
+
+def test_receipt_garbage_cli_output_skips(receipts_on, proj, monkeypatch):
+    # Unparseable output is not a rejection: a broken verifier must never be
+    # read as "this receipt is bad" (don't-guess bias, the module's stance).
+    monkeypatch.setenv("FAKE_VITNI_MODE", "garbage")
+    _signed_origin("S-origin", proj)
+    cp = _cp_origins(["S-origin"])
+    stats = worldcheck.check(cp, proj)
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "receipt-validity:skipped": 1}
+    assert "_worldcheck" not in cp["working_context"]["open_questions"][0]
+
+
+def test_receipt_nonzero_rc_skips(receipts_on, proj, monkeypatch):
+    monkeypatch.setenv("FAKE_VITNI_MODE", "rc1")
+    _signed_origin("S-origin", proj)
+    stats = worldcheck.check(_cp_origins(["S-origin"]), proj)
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "receipt-validity:skipped": 1}
+
+
+def test_receipt_hanging_cli_is_killed_at_the_deadline(receipts_on, proj,
+                                                       monkeypatch):
+    # receipts._run_cli would wait _CLI_TIMEOUT=10s — twelve times the WHOLE
+    # worldcheck budget. Under worldcheck's own deadline machinery it is killed
+    # and skipped, and the render is never blocked.
+    monkeypatch.setenv("FAKE_VITNI_MODE", "hang")
+    monkeypatch.setattr(worldcheck, "BUDGET_SECONDS", 0.3)
+    _signed_origin("S-origin", proj)
+    start = time.monotonic()
+    stats = worldcheck.check(_cp_origins(["S-origin"]), proj)
+    assert time.monotonic() - start < 3.0
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "receipt-validity:skipped": 1}
+
+
+def test_receipt_probes_one_origin_per_day_by_rotation(receipts_on, proj,
+                                                       monkeypatch):
+    # Day-bucket ROTATION, not a hash-modulo gate: a sha1(origin) % N scheme
+    # leaves some origins deterministically never sampled (permanent blind
+    # spots), while rotation covers every origin over consecutive days.
+    _signed_origin("S-a", proj)
+    _signed_origin("S-b", proj)
+    monkeypatch.setattr(worldcheck, "_day_bucket", lambda: 4)  # 4 % 2 == 0
+    worldcheck.check(_cp_origins(["S-a", "S-b"]), proj)
+    assert len(_vitni_calls(receipts_on)) == 1
+    monkeypatch.setattr(worldcheck, "_day_bucket", lambda: 5)  # 5 % 2 == 1
+    stats = worldcheck.check(_cp_origins(["S-a", "S-b"]), proj)
+    assert len(_vitni_calls(receipts_on)) == 2
+    # One probe per brief either way: the other origin makes no claim at all.
+    assert stats == {"confirmed": 1, "contradicted": 0, "skipped": 0,
+                     "receipt-validity:confirmed": 1}
+
+
+def test_receipt_rotation_reaches_every_origin_over_days(receipts_on, proj,
+                                                         monkeypatch):
+    _signed_origin("S-a", proj)
+    _signed_origin("S-b", proj)
+    _signed_origin("S-c", proj)
+    for day in range(3):
+        monkeypatch.setattr(worldcheck, "_day_bucket", lambda d=day: d)
+        stats = worldcheck.check(_cp_origins(["S-a", "S-b", "S-c"]), proj)
+        assert stats["receipt-validity:confirmed"] == 1  # exactly one per day
+    # Three consecutive days, three distinct origins verified: no origin is
+    # left permanently unsampled, which is the whole point of rotation.
+    sent = {json.loads(c["stdin"])["signed_receipt"] for c in
+            _vitni_calls(receipts_on)}
+    assert sent == {"S-a.bbb.ccc", "S-b.bbb.ccc", "S-c.bbb.ccc"}
+
+
+def test_receipt_one_probe_stamps_every_item_sharing_that_origin(
+    receipts_on, proj, monkeypatch
+):
+    # Dedup by origin, same as slice 1 dedups by ref: ONE probe, every claim
+    # naming that target scored against it.
+    monkeypatch.setenv("FAKE_VITNI_VERDICT", "signature_invalid")
+    _signed_origin("S-origin", proj)
+    cp = _cp_origins(["S-origin", "S-origin"])
+    stats = worldcheck.check(cp, proj)
+    assert len(_vitni_calls(receipts_on)) == 1
+    assert stats["receipt-validity:contradicted"] == 2
+    assert len(stats[worldcheck.LEDGER_KEY]) == 2
+    for item in cp["working_context"]["open_questions"]:
+        assert item["_worldcheck"]["status"] == "unverified"
+
+
+def test_receipt_never_overwrites_a_text_class_stamp(receipts_on, proj,
+                                                     monkeypatch, fake_gh):
+    # An item can carry BOTH a text claim and a receipt claim. The text stamp
+    # is the more actionable one (it names what changed and drives a `daimon
+    # resolve --status`), so it WINS — but the receipt outcome still counts and
+    # still reaches the rejection ledger.
+    monkeypatch.setenv("FAKE_VITNI_VERDICT", "signature_invalid")
+    gh, _log = fake_gh("echo '{\"state\":\"MERGED\"}'")
+    _enable_probes(monkeypatch, gh)
+    _signed_origin("S-origin", proj)
+    cp = _cp_origins(["S-origin"], texts=["PR #60 awaiting review"])
+    stats = worldcheck.check(cp, proj)
+    item = cp["working_context"]["open_questions"][0]
+    assert item["_worldcheck"] == {"note": "#60 merged", "status": "merged"}
+    assert stats["pr-state:contradicted"] == 1
+    assert stats["receipt-validity:contradicted"] == 1
+    assert stats[worldcheck.LEDGER_KEY] == [("o-000001", "receipt", "receipt-invalid")]
+
+
+def test_receipt_claims_are_carried_only(receipts_on, proj):
+    _signed_origin("S-origin", proj)
+    cp = _cp_origins(["S-origin"])
+    for item in cp["working_context"]["open_questions"]:
+        item.pop("carried_from")
+    stats = worldcheck.check(cp, proj)
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 0}
+    assert _vitni_calls(receipts_on) == []
+
+
+def test_receipt_ledger_key_absent_when_nothing_failed(receipts_on, proj):
+    # The reserved key only appears when there is something to write — the
+    # counter dict the CLI iterates stays all-ints on the happy path.
+    _signed_origin("S-origin", proj)
+    stats = worldcheck.check(_cp_origins(["S-origin"]), proj)
+    assert worldcheck.LEDGER_KEY not in stats
+
+
+def test_receipt_idless_item_yields_no_ledger_row(receipts_on, proj, monkeypatch):
+    # A ledger entry nobody can trace back is noise (serializer's rule).
+    monkeypatch.setenv("FAKE_VITNI_VERDICT", "signature_invalid")
+    _signed_origin("S-origin", proj)
+    cp = _cp_origins(["S-origin"])
+    cp["working_context"]["open_questions"][0].pop("id")
+    stats = worldcheck.check(cp, proj)
+    assert stats["receipt-validity:contradicted"] == 1
+    assert worldcheck.LEDGER_KEY not in stats
+
+
+def test_receipt_check_writes_nothing_to_disk(receipts_on, proj, monkeypatch):
+    # worldcheck's hardest constraint: transient stamps only. The ledger write
+    # is the CLI's job, precisely so this stays true.
+    monkeypatch.setenv("FAKE_VITNI_VERDICT", "signature_invalid")
+    _signed_origin("S-origin", proj)
+
+    def _boom(*a, **k):
+        raise AssertionError("worldcheck must never write to the ledger itself")
+
+    monkeypatch.setattr(store, "append_verification", _boom)
+    stats = worldcheck.check(_cp_origins(["S-origin"]), proj)
+    assert stats["receipt-validity:contradicted"] == 1
+
+
+# ---- #439 CLI wiring --------------------------------------------------------
+
+
+def _verification_rows(project):
+    path = config.checkpoint_dir() / store.project_slug(project) / "verification.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(x) for x in path.read_text().splitlines() if x.strip()]
+
+
+def test_cli_brief_receipt_failure_appends_a_verification_row(
+    monkeypatch, tmp_path, capsys, receipts_on, proj
+):
+    monkeypatch.setenv("FAKE_VITNI_VERDICT", "signature_invalid")
+    _signed_origin("S-origin", proj)
+    cp = _cp_origins(["S-origin"])
+    store.write_checkpoint("S-now", cp, project_dir=proj)
+    monkeypatch.setenv("DAIMON_WORLDCHECK", "1")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", proj)
+    rc = cli.main(["brief"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "⚠ state changed since capture: signed receipt failed verification" in out
+    rows = _verification_rows(proj)
+    assert len(rows) == 1
+    assert rows[0]["check"] == "receipt"
+    assert rows[0]["reason"] == "receipt-invalid"
+    assert rows[0]["item_ref"] == "o-000001"
+    # A POINTER and a REASON CODE, never the item's text (#376).
+    assert "note 0" not in json.dumps(rows[0])
+    usage = _usage_lines(tmp_path)
+    assert sum(
+        1 for ln in usage if ln.endswith(" worldcheck:receipt-validity:contradicted")) == 1
+    assert sum(1 for ln in usage if ln.endswith(" worldcheck:contradicted")) == 1
+
+
+def test_cli_brief_receipt_confirmed_writes_no_verification_row(
+    monkeypatch, tmp_path, capsys, receipts_on, proj
+):
+    _signed_origin("S-origin", proj)
+    store.write_checkpoint("S-now", _cp_origins(["S-origin"]), project_dir=proj)
+    monkeypatch.setenv("DAIMON_WORLDCHECK", "1")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", proj)
+    assert cli.main(["brief"]) == 0
+    capsys.readouterr()
+    assert _verification_rows(proj) == []
+    usage = _usage_lines(tmp_path)
+    assert sum(
+        1 for ln in usage if ln.endswith(" worldcheck:receipt-validity:confirmed")) == 1

--- a/plugin/tests/test_worldcheck.py
+++ b/plugin/tests/test_worldcheck.py
@@ -1401,6 +1401,125 @@ def test_receipt_check_writes_nothing_to_disk(receipts_on, proj, monkeypatch):
     assert stats["receipt-validity:contradicted"] == 1
 
 
+# ---- #439 fail-open branches ------------------------------------------------
+#
+# Every branch below is a SILENT SKIP by contract, which is exactly why each
+# needs its own test: a fail-open `except` that quietly returns the wrong
+# answer looks identical to one that works. The assertions pin the OUTCOME
+# (all-zeros or a skipped counter, never a stamp, never a raise), not merely
+# that nothing escaped.
+
+
+def test_receipt_unknown_project_slug_makes_no_claim(receipts_on):
+    # An unnameable project cannot be compared against an origin's
+    # `project_slug`, so eligibility is unanswerable and nothing is claimed.
+    # store.project_slug answers None for a blank dir — the same "unknown
+    # project" the ledger and event writers refuse to write for.
+    cp = _cp_origins(["S-origin"])
+    stats = worldcheck.check(cp, "   ")
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 0}
+    assert "_worldcheck" not in cp["working_context"]["open_questions"][0]
+    assert _vitni_calls(receipts_on) == []
+
+
+def test_receipt_eligibility_scan_stops_at_an_exhausted_budget(
+    receipts_on, proj, monkeypatch
+):
+    # The scan reads one checkpoint per DISTINCT origin, so it runs UNDER the
+    # aggregate deadline like every probe. An already-spent budget must stop
+    # it before the first read, not merely discard the result afterwards.
+    _signed_origin("S-a", proj)
+    _signed_origin("S-b", proj)
+    monkeypatch.setattr(worldcheck, "BUDGET_SECONDS", -1.0)
+
+    def _boom(*a, **k):
+        raise AssertionError("an exhausted budget must stop the scan cold")
+
+    monkeypatch.setattr(store, "read_checkpoint", _boom)
+    cp = _cp_origins(["S-a", "S-b"])
+    stats = worldcheck.check(cp, proj)
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 0}
+    assert "_worldcheck" not in cp["working_context"]["open_questions"][0]
+    assert _vitni_calls(receipts_on) == []
+
+
+def test_receipt_origin_gc_d_between_collection_and_probe_skips(
+    receipts_on, proj, monkeypatch
+):
+    # Eligibility and the probe are two separate reads, and GC runs on its own
+    # schedule between them. A checkpoint that was there at collection and
+    # gone at probe time is a SKIP: its absence says nothing about the claim.
+    _signed_origin("S-origin", proj)
+    real = store.read_checkpoint
+    calls = []
+
+    def _vanishing(session_id):
+        calls.append(session_id)
+        return real(session_id) if len(calls) == 1 else None
+
+    monkeypatch.setattr(store, "read_checkpoint", _vanishing)
+    cp = _cp_origins(["S-origin"])
+    stats = worldcheck.check(cp, proj)
+    assert len(calls) == 2  # once for eligibility, once at probe time
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "receipt-validity:skipped": 1}
+    assert "_worldcheck" not in cp["working_context"]["open_questions"][0]
+    assert _vitni_calls(receipts_on) == []
+
+
+def test_receipt_phase_a_failure_skips_without_spawning(receipts_on, proj,
+                                                        monkeypatch):
+    # Phase (a) is a file read plus a sha256, and either can fail on a torn
+    # store. A raise there must not be read as tampering and must not fall
+    # through to the CLI — an unanswerable check is a skip, not a verdict.
+    _signed_origin("S-origin", proj)
+
+    def _boom(_checkpoint):
+        raise OSError("store went away mid-read")
+
+    monkeypatch.setattr(receipts, "verbatim_degraded", _boom)
+    cp = _cp_origins(["S-origin"])
+    stats = worldcheck.check(cp, proj)
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "receipt-validity:skipped": 1}
+    assert "_worldcheck" not in cp["working_context"]["open_questions"][0]
+    assert _vitni_calls(receipts_on) == []
+
+
+def test_receipt_unwritable_stdin_skips_without_leaking_the_payload(
+    receipts_on, proj, monkeypatch
+):
+    # The child can die between spawn and write (a killed verifier, a full
+    # pipe on a wedged host). The write raises, the probe answers nothing, and
+    # the briefing renders — the payload simply never arrives.
+    _signed_origin("S-origin", proj)
+    real_popen = worldcheck.subprocess.Popen
+
+    class _DeadStdin:
+        def write(self, _payload):
+            raise BrokenPipeError("child already gone")
+
+        def close(self):
+            raise AssertionError("close is unreachable once write raised")
+
+    def _popen(*args, **kwargs):
+        proc = real_popen(*args, **kwargs)
+        if proc.stdin is not None:
+            proc.stdin.close()  # hand the child EOF; the fake replaces the handle
+            proc.stdin = _DeadStdin()
+        return proc
+
+    monkeypatch.setattr(worldcheck.subprocess, "Popen", _popen)
+    cp = _cp_origins(["S-origin"])
+    stats = worldcheck.check(cp, proj)
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 1,
+                     "receipt-validity:skipped": 1}
+    assert "_worldcheck" not in cp["working_context"]["open_questions"][0]
+    # The CLI ran but received NOTHING — proof the failure was the write, not
+    # a rejection the verifier actually reached a conclusion about.
+    assert [c["stdin"] for c in _vitni_calls(receipts_on)] == [""]
+
+
 # ---- #439 CLI wiring --------------------------------------------------------
 
 


### PR DESCRIPTION
Closes #439

## What

Adds `receipt-validity` as worldcheck's fifth spot-check claim class — the first whose subject is daimon's own artifact rather than the world around it. At brief time, one carried item's ORIGIN checkpoint (per #268's write-time `origin_session` binding) gets its signed receipt sidecar verified through the vitni CLI — full signature + structure + policy binding, not just the existing byte match — sampled, budgeted, fail-open.

- **Collection**: second pass over carried items, interleaved per item — NOT routed through `claim_for`, which is text-derived and first-match-wins (a receipt class in its priority list would either steal an item's PR-state reading or be starved by it). An item may carry both claims; on double contradiction the text stamp wins (more actionable), the receipt outcome still counts and reaches the ledger.
- **Sampling**: day-bucket rotation over eligible origins, `MAX_RECEIPT_PROBES = 1` CLI exec per brief. Hash-modulo was rejected: its excluded origins are excluded *forever* — permanent blind spots.
- **Two-phase probe**: phase (a) free — `receipts.verbatim_degraded` byte match answers `TAMPERED` with zero subprocess; phase (b) only on a clean sidecar — vitni `verify` spawned through worldcheck's own Popen-under-shared-deadline fan-out. Never `receipts._run_cli`: its blocking 10s timeout is 12× the entire 0.8s budget.
- **Runner generalization**: `_run_gh` → `_gh_probes` specs + one shared `_run_probes` fan-out with a per-probe parser (`gh` speaks `{"state"}`, vitni speaks `{"valid"}`). Separate runners would make the aggregate budget a fiction. gh behavior byte-identical — every pre-existing worldcheck test passes untouched.
- **Failure surfacing**: bounded-literal notes (never a session id — note text rides into LLM context), `worldcheck:receipt-validity:{confirmed,contradicted,skipped}` counters for free, and failures travel out of `check()` under a reserved key so the CLI can append `receipt-tampered` / `receipt-invalid` rows to the #376 rejection ledger — worldcheck itself still writes nothing to disk.
- **Skip taxonomy**: ineligible origins (no binding, GC'd, foreign project, receipts off) produce *no claim* — counting them as skips would poison the fires-true denominator the counters exist to measure. Probe-time failures (no CLI, deadline kill, garbage output) count as skipped.

## Why

Receipts are minted daily (41+ sidecars) but only cheap-tamper-checked at brief time; `daimon verify-receipt` exists and nobody runs it. A receipt never adversarially read is a log line with extra steps — a rotated seed, corrupted sidecar, or vitni regression would surface never. Worldcheck already runs ambiently; this makes the wire earn its keep at spot-check cost. The latest checkpoint is already byte-checked at render — the marginal value here is precisely the carried items' origin checkpoints, which nothing verifies today.

## Tests

- 25 new tests in `test_worldcheck.py` (88 → 113), written first (strict TDD): valid → confirmed; CLI-rejected → stamped + ledger row; tampered → `TAMPERED` with zero CLI invocations (capture-file asserted); the full silent-skip taxonomy; hang killed at deadline without blocking render; day rotation picks `day % len(eligible)` and rotates; stamp collision preserves the text flag; CLI wiring appends `verification.jsonl` rows (pointer + reason code, no text); flag-off never calls worldcheck.
- Fake vitni CLI fixture lifted from `test_receipts.py` to `conftest.py`; `test_receipts.py` consumes it unchanged (85 tests, no behavior change).
- Full suite: 2456 → **2481 passed, 2 skipped** (verified by orchestrator run, 157s). Ruff clean; mypy introduces zero new errors on touched files.
- Scar candidate filed: `popen-manual-stdin-close-breaks-communicate` (fail-open reaper turned a `communicate()` ValueError into silent probe skips — the class of bug fail-open code hides).