### PR TITLE
chore(scars): promote three candidates and repair 0003's status

### DIFF
--- a/.scars/0001-llm-judge-grounding-reference.deadend.md
+++ b/.scars/0001-llm-judge-grounding-reference.deadend.md
@@ -5,7 +5,7 @@ title: LLM-judge grounding must reference the transcript, never the answer key
 severity: high
 confidence: 0.95
 created: 2026-06-09
-authors: [claude, kibukx]
+authors: [claude, Kibukx]
 anchors:
   - path: research/experiments/track-a/probe_d007.py
   - pattern: "GROUNDING_JUDGE_SYS"

--- a/.scars/0002-probe-concurrent-runs.landmine.md
+++ b/.scars/0002-probe-concurrent-runs.landmine.md
@@ -5,7 +5,7 @@ title: Concurrent probe_d007.py runs race on runs/ — no locking
 severity: medium
 confidence: 0.9
 created: 2026-06-09
-authors: [claude, kibukx]
+authors: [claude, Kibukx]
 anchors:
   - path: research/experiments/track-a/probe_d007.py
   - pattern: "score.json"

--- a/.scars/0003-uv-tool-install-cached-wheel.landmine.md
+++ b/.scars/0003-uv-tool-install-cached-wheel.landmine.md
@@ -5,7 +5,7 @@ title: uv tool install --force reuses cached wheel when version is unchanged
 severity: low
 confidence: 0.9
 created: 2026-06-10
-authors: [claude]
+authors: ["claude", "kibukx"]
 anchors:
   - path: plugin/pyproject.toml
   - pattern: "uv tool install"
@@ -14,7 +14,7 @@ evidence:
 expires:
   condition: "plugin adopts per-change version bumps, or install docs/scripts always pass --reinstall"
   review_after: 2027-06-10
-status: candidate
+status: active
 ---
 
 `uv tool install --force <local-dir>` resolves against the cached wheel for an

--- a/.scars/0003-uv-tool-install-cached-wheel.landmine.md
+++ b/.scars/0003-uv-tool-install-cached-wheel.landmine.md
@@ -5,7 +5,7 @@ title: uv tool install --force reuses cached wheel when version is unchanged
 severity: low
 confidence: 0.9
 created: 2026-06-10
-authors: ["claude", "kibukx"]
+authors: ["claude", "Kibukx"]
 anchors:
   - path: plugin/pyproject.toml
   - pattern: "uv tool install"

--- a/.scars/0004-llm-judge-grounding-noise.landmine.md
+++ b/.scars/0004-llm-judge-grounding-noise.landmine.md
@@ -5,7 +5,7 @@ title: LLM judge per-claim grounding is noise-dominated without forced verificat
 severity: high
 confidence: 0.85
 created: 2026-06-10
-authors: ["claude-code", kibukx]
+authors: ["claude-code", Kibukx]
 anchors:
   - path: research/experiments/track-a/
   - pattern: "grounded|FMR|judge.{0,40}claim"

--- a/.scars/0005-uv-run-daimon-resolves-stale-global-tool.landmine.md
+++ b/.scars/0005-uv-run-daimon-resolves-stale-global-tool.landmine.md
@@ -5,7 +5,7 @@ title: uv run daimon from repo root runs the stale GLOBAL tool, not the working 
 severity: medium
 confidence: 0.95
 created: 2026-07-02
-authors: [claude, kibukx]
+authors: [claude, Kibukx]
 anchors:
   - path: plugin/
   - path: README.md

--- a/.scars/0006-briefing-cap-assumes-chronological-decisions.landmine.md
+++ b/.scars/0006-briefing-cap-assumes-chronological-decisions.landmine.md
@@ -5,7 +5,7 @@ title: Briefing decision-cap keeps the TAIL of recent_decisions — it silently 
 severity: medium
 confidence: 0.9
 created: 2026-06-30
-authors: ["claude-code", "kibukx"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/briefing.py
   - path: plugin/daimon_briefing/serializer.py

--- a/.scars/0007-from-session-returns-raw-block-array-content.landmine.md
+++ b/.scars/0007-from-session-returns-raw-block-array-content.landmine.md
@@ -5,7 +5,7 @@ title: transcript.from_session returns RAW hermes messages (block-array content)
 severity: high
 confidence: 0.95
 created: 2026-06-30
-authors: ["claude-code", "kibukx"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/transcript.py
   - path: plugin/daimon_briefing/harvest.py

--- a/.scars/0008-merge-call-count-is-hierarchical.landmine.md
+++ b/.scars/0008-merge-call-count-is-hierarchical.landmine.md
@@ -5,7 +5,7 @@ title: serializer merge-call count is hierarchical (chunks × merge_group_size) 
 severity: medium
 confidence: 0.85
 created: 2026-06-30
-authors: ["claude-code", "kibukx"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/serializer.py
   - pattern: "MERGE_SYS"

--- a/.scars/0009-serialize-log-last-of-kind-masks-failures.landmine.md
+++ b/.scars/0009-serialize-log-last-of-kind-masks-failures.landmine.md
@@ -5,7 +5,7 @@ title: Reasoning over serialize.log with last-of-kind logic masks per-session bu
 severity: high
 confidence: 0.9
 created: 2026-06-30
-authors: ["claude-code", "kibukx"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - pattern: "_parse_serialize_log|last[_ ]?result"
 evidence:

--- a/.scars/0010-judge-grades-wrong-dimension.landmine.md
+++ b/.scars/0010-judge-grades-wrong-dimension.landmine.md
@@ -5,7 +5,7 @@ title: LLM judges silently grade the wrong dimension — grep-verify catches abs
 severity: high
 confidence: 0.8
 created: 2026-06-12
-authors: ["claude-code", "kibukx"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: research/experiments/track-a/
   - pattern: "stale|staleness|adversarial.{0,40}verif|overturn"

--- a/.scars/0011-grounding-skeptic-strictness-is-correct.fence.md
+++ b/.scars/0011-grounding-skeptic-strictness-is-correct.fence.md
@@ -5,7 +5,7 @@ title: The strict grounding skeptic looks over-strict (low rescue rate) but is c
 severity: high
 confidence: 0.85
 created: 2026-06-29
-authors: ["claude-code", "kibukx"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: research/experiments/track-a/scoring/grounding_skeptic.py
   - path: research/experiments/track-a/scoring/grounding_fixture.json

--- a/.scars/0012-scale-grading-penalizes-verbose-history.landmine.md
+++ b/.scars/0012-scale-grading-penalizes-verbose-history.landmine.md
@@ -5,7 +5,7 @@ title: state-benchmark stale-substring grader fakes a "prose loses" signal — a
 severity: high
 confidence: 0.85
 created: 2026-06-27
-authors: ["claude-code", "kibukx"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: research/memory-backend/benchmark/state/grade.py
   - pattern: "ANSWER_PROMPT|asserts_stale|is_override"

--- a/.scars/0013-two-llm-clients-share-hang-shape.landmine.md
+++ b/.scars/0013-two-llm-clients-share-hang-shape.landmine.md
@@ -5,7 +5,7 @@ title: Two independent LLM clients (lib/llm.py + evaluate.py) share the stall-ha
 severity: high
 confidence: 0.9
 created: 2026-06-30
-authors: ["claude-code", "kibukx"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: research/experiments/lib/llm.py
   - path: research/memory-backend/benchmark/evaluate.py

--- a/.scars/0014-haiku-timeout-floor.fence.md
+++ b/.scars/0014-haiku-timeout-floor.fence.md
@@ -5,7 +5,7 @@ title: DAIMON_TIMEOUT must stay >=420 — haiku real serialize/merge calls run 8
 severity: medium
 confidence: 0.85
 created: 2026-06-13
-authors: ["claude-code", "kibukx"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/config.py
   - pattern: "DAIMON_TIMEOUT"

--- a/.scars/0015-gateway-response-cache-pins-bad-responses.landmine.md
+++ b/.scars/0015-gateway-response-cache-pins-bad-responses.landmine.md
@@ -5,7 +5,7 @@ title: Gateway exact-match response cache pins transient bad LLM responses; iden
 severity: high
 confidence: 0.9
 created: 2026-06-12
-authors: ["claude-code", "kibukx"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/llm.py
   - path: research/experiments/track-a/rerun.py

--- a/.scars/0016-simulated-clock-must-thread-into-every-now-consumer.landmine.md
+++ b/.scars/0016-simulated-clock-must-thread-into-every-now-consumer.landmine.md
@@ -5,7 +5,7 @@ title: Simulated-time stamps freeze decay math unless the clock is threaded into
 severity: high
 confidence: 0.9
 created: 2026-07-02
-authors: ["claude-code", "kibukx"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: research/experiments/multicycle/
   - pattern: "briefing\.build\b"

--- a/.scars/0017-gateway-815s-request-ceiling.landmine.md
+++ b/.scars/0017-gateway-815s-request-ceiling.landmine.md
@@ -5,7 +5,7 @@ title: Gateway kills LLM requests at ~815s; dense K=3 merges on kimi exceed it a
 severity: high
 confidence: 0.85
 created: 2026-06-12
-authors: ["claude-code", "kibukx"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/serializer.py
   - path: plugin/daimon_briefing/config.py

--- a/.scars/0018-grounding-screen-droplist-safety.landmine.md
+++ b/.scars/0018-grounding-screen-droplist-safety.landmine.md
@@ -5,7 +5,7 @@ title: grounding screen's safety invariant depends on the salient_tokens drop-li
 severity: medium
 confidence: 0.8
 created: 2026-06-29
-authors: ["claude-code", "kibukx"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: research/experiments/track-a/scoring/grounding_screen.py
   - pattern: "STOPWORDS|salient_tokens|screen_negative"

--- a/.scars/0019-scar-pattern-anchors-are-a-three-layer-escape-trap.landmine.md
+++ b/.scars/0019-scar-pattern-anchors-are-a-three-layer-escape-trap.landmine.md
@@ -5,7 +5,7 @@ title: Scar pattern anchors are NOT YAML — quotes stripped, escapes untouched,
 severity: medium
 confidence: 0.9
 created: 2026-07-02
-authors: ["claude-code", "kibukx"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: .scars/
 violation: "pattern:.*\\\\"

--- a/.scars/0033-idf-rarity-weighting-refuted.deadend.md
+++ b/.scars/0033-idf-rarity-weighting-refuted.deadend.md
@@ -5,7 +5,7 @@ title: Rarity/IDF weighting of recall matches is anti-correlated with relevance 
 severity: high
 confidence: 0.9
 created: 2026-07-31
-authors: ["claude-code", "kibukx"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/recall.py
   - path: research/experiments/recall-replay-ab/

--- a/.scars/0033-idf-rarity-weighting-refuted.deadend.md
+++ b/.scars/0033-idf-rarity-weighting-refuted.deadend.md
@@ -1,22 +1,22 @@
 ---
-id: 0
+id: 33
 type: deadend
 title: Rarity/IDF weighting of recall matches is anti-correlated with relevance — measured and refuted, do not rebuild it
 severity: high
 confidence: 0.9
 created: 2026-07-31
-authors: ["claude-code"]
+authors: ["claude-code", "kibukx"]
 anchors:
   - path: plugin/daimon_briefing/recall.py
   - path: research/experiments/recall-replay-ab/
 evidence:
-  - note: "#470 pre-registered offline replay A/B, 237 blind-judged injection pairs from the maintainer's real prompt corpus. On the pre-registered HOLDOUT split arm B's per-slot precision was WORSE than arm A at every threshold: 17.3% / 16.9% / 15.9% / 12.3% at thresholds 6/8/10/12 vs A's 18.8%. The pre-registered zero-loss guard (no judged-relevant A injection lost) FAILED at every threshold."
-  - note: "Diagnostic: the gate drops judged-relevant items at a HIGHER rate than the items it keeps. At threshold 12, 26.0% of dropped injections were judged relevant vs 17.0% of kept ones. Summed term rarity is slightly ANTI-correlated with relevance in this corpus."
-  - note: "Earlier in-selection variant: over 215 replayed real prompts arm A injected 344 rows and arm B 374 at threshold 10 — the noise gate ADDED 30 injections — and 86 of the 123 B-only injections were open questions, i.e. the gate's own exempt class."
+  - note: #470 pre-registered offline replay A/B, 237 blind-judged injection pairs from the maintainer's real prompt corpus. On the pre-registered HOLDOUT split arm B's per-slot precision was WORSE than arm A at every threshold: 17.3% / 16.9% / 15.9% / 12.3% at thresholds 6/8/10/12 vs A's 18.8%. The pre-registered zero-loss guard (no judged-relevant A injection lost) FAILED at every threshold.
+  - note: Diagnostic: the gate drops judged-relevant items at a HIGHER rate than the items it keeps. At threshold 12, 26.0% of dropped injections were judged relevant vs 17.0% of kept ones. Summed term rarity is slightly ANTI-correlated with relevance in this corpus.
+  - note: Earlier in-selection variant: over 215 replayed real prompts arm A injected 344 rows and arm B 374 at threshold 10 — the noise gate ADDED 30 injections — and 86 of the 123 B-only injections were open questions, i.e. the gate's own exempt class.
 expires:
   condition: "a replay A/B run on a materially different corpus (different author, different project mix, or >10x the item count) shows summed-rarity weighting positively correlated with judged relevance under the same pre-registered criteria"
   review_after: 2027-02-01
-status: candidate
+status: active
 ---
 
 Do not add IDF / rarity / TF-IDF weighting to recall selection. It was built,

--- a/.scars/0034-popen-manual-stdin-close-breaks-communicate.landmine.md
+++ b/.scars/0034-popen-manual-stdin-close-breaks-communicate.landmine.md
@@ -5,7 +5,7 @@ title: Manually closing a Popen stdin pipe makes communicate() raise — and fai
 severity: medium
 confidence: 0.9
 created: 2026-07-31
-authors: ["claude-code", "kibukx"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/worldcheck.py
 evidence:

--- a/.scars/0034-popen-manual-stdin-close-breaks-communicate.landmine.md
+++ b/.scars/0034-popen-manual-stdin-close-breaks-communicate.landmine.md
@@ -1,18 +1,19 @@
 ---
-id: 0
+id: 34
 type: landmine
 title: Manually closing a Popen stdin pipe makes communicate() raise — and fail-open reapers turn that into silent skips
 severity: medium
 confidence: 0.9
 created: 2026-07-31
-authors: ["claude-code"]
+authors: ["claude-code", "kibukx"]
 anchors:
   - path: plugin/daimon_briefing/worldcheck.py
 evidence:
-  - note: "#439 implementation session 2026-07-31: every stdin-bearing vitni probe skipped silently; answer was on stdout the whole time"
+  - note: #439 implementation session 2026-07-31: every stdin-bearing vitni probe skipped silently; answer was on stdout the whole time
 expires:
   condition: "worldcheck._run_probes stops writing probe stdin manually (e.g. moves to communicate(input=...) with its own timeout discipline)"
   review_after: 2026-10-31
+status: active
 ---
 
 `subprocess.Popen(stdin=PIPE)` + a manual `proc.stdin.write(...); proc.stdin.close()`

--- a/.scars/0035-prompt-version-bump-does-not-rotate-chunk-cache.landmine.md
+++ b/.scars/0035-prompt-version-bump-does-not-rotate-chunk-cache.landmine.md
@@ -5,7 +5,7 @@ title: A PROMPT_VERSION bump does NOT rotate the #48 chunk cache — its own his
 severity: medium
 confidence: 0.9
 created: 2026-07-29
-authors: ["claude-code", "kibukx"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/serializer.py
 evidence:

--- a/.scars/0035-prompt-version-bump-does-not-rotate-chunk-cache.landmine.md
+++ b/.scars/0035-prompt-version-bump-does-not-rotate-chunk-cache.landmine.md
@@ -1,21 +1,20 @@
 ---
-id: 0
+id: 35
 type: landmine
 title: A PROMPT_VERSION bump does NOT rotate the #48 chunk cache — its own historical comment says it does, but the cache key is EXTRACTION_VERSION
 severity: medium
 confidence: 0.9
 created: 2026-07-29
-authors: ["claude-code"]
+authors: ["claude-code", "kibukx"]
 anchors:
   - path: plugin/daimon_briefing/serializer.py
-    pattern: "rotates the #48 chunk-cache key"
 evidence:
-  - commit: "#416"
-  - note: "#416 added extraction rule 21 (prefer a quote span that keeps a temporal span). The pre-#367 D-015/D-016 comment blocks claim the PROMPT_VERSION bump 'rotates the #48 chunk-cache key' — but since #367 the cache key (_chunk_cache_key) hashes EXTRACTION_VERSION, not PROMPT_VERSION. Bumping only PROMPT_VERSION would have served stale date-dropping cached extractions for up to chunk_cache_days (default 3), silently poisoning the citable-date re-measurement the change exists to make honest."
+  - commit: #416
+  - note: #416 added extraction rule 21 (prefer a quote span that keeps a temporal span). The pre-#367 D-015/D-016 comment blocks claim the PROMPT_VERSION bump 'rotates the #48 chunk-cache key' — but since #367 the cache key (_chunk_cache_key) hashes EXTRACTION_VERSION, not PROMPT_VERSION. Bumping only PROMPT_VERSION would have served stale date-dropping cached extractions for up to chunk_cache_days (default 3), silently poisoning the citable-date re-measurement the change exists to make honest.
 expires:
   condition: "the outdated 'rotates the #48 chunk-cache key' phrasing is removed from every pre-#367 comment block above PROMPT_VERSION, or the cache key is re-keyed on PROMPT_VERSION"
   review_after: 2026-12-01
-status: candidate
+status: active
 ---
 
 When you add an extraction-behavior change (a new numbered rule that changes


### PR DESCRIPTION
Closes #471

## PR Type

- [x] Maintenance/tooling (`type:chore`)

## Summary

- Repairs scar 0003, which sat in the active directory carrying `status: candidate` — so its tripwire never fired and the scar protected nothing despite looking present in the tree.
- Promotes the three reviewed candidates, emptying the candidate queue.

## Changes

| File | Change |
|------|--------|
| `.scars/0003-uv-tool-install-cached-wheel.landmine.md` | `status: candidate` → `active`; reviewing human added to `authors`, matching what `scar promote` writes on the normal path |
| `.scars/0033-idf-rarity-weighting-refuted.deadend.md` | Promoted. Records that rarity/IDF weighting of recall matches is anti-correlated with relevance (#470, measured and refuted), and that any such gate applied during candidate *selection* recruits the exempt class through slot promotion |
| `.scars/0034-popen-manual-stdin-close-breaks-communicate.landmine.md` | Promoted |
| `.scars/0035-prompt-version-bump-does-not-rotate-chunk-cache.landmine.md` | Promoted |

## Test Plan

- [x] `scar lint`: 35 files, 0 errors, 0 orphans, 0 partial-rot, 0 unreachable-evidence
- [x] `scar status`: 35 active, 0 candidates pending review
- [x] 0003 now reports as active rather than sitting inert in the active directory
- [x] No shell scripts modified (shellcheck n/a)

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No code behavior changed — negative-knowledge records only
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
