### PR TITLE
fix(status): show why a serialize failed, and stop the backend log erasing itself

### DIFF
--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -12,6 +12,7 @@ import tempfile
 import time
 import urllib.error
 import urllib.request
+from datetime import datetime, timezone
 
 from . import config, redact
 
@@ -395,12 +396,28 @@ def _apply_input_spec(argv, prompt_text, input_spec, cwd):
     return argv, prompt_text
 
 
+# #474 reverses #56's truncate-per-run rule on field evidence: 143 lifetime
+# errors left exactly ONE line, and a question about them stayed open nine days
+# while every new failure erased the evidence for the last. The log is now a
+# BOUNDED APPEND — a byte cap trimmed oldest-first, chosen over rotation
+# because rotation is more machinery (numbering, N-file cleanup, a second path
+# every reader has to know about) for the same "cannot grow without limit"
+# guarantee. 512 KiB is thousands of entries and rounding error next to one
+# transcript.
+_STDERR_LOG_MAX_BYTES = 512 * 1024
+
+
 def _log_backend_stderr(argv0, err, header, out=None) -> str:
-    """Write redacted command-backend diagnostics to backend-stderr.log
-    (truncate-per-run — the log is "the last failure", not an archive, #56)
-    and return a hint embeddable in a ChatError message: the log path on
-    success, "stderr suppressed" on any OSError — logging must never mask the
-    real failure (fail-open on the logging seam, #225).
+    """Append redacted command-backend diagnostics to backend-stderr.log and
+    return a hint embeddable in a ChatError message: the log path on success,
+    "stderr suppressed" on any OSError — logging must never mask the real
+    failure (fail-open on the logging seam, #225).
+
+    The log is an ARCHIVE bounded to the last _STDERR_LOG_MAX_BYTES, each entry
+    UTC-stamped so it correlates with serialize.log and checkpoint ages. It was
+    truncate-per-run — "the last failure", not an archive — until the field
+    showed a repeating failure destroying its own history exactly when the
+    repetition IS the diagnosis (#56, reversed on evidence by #474).
 
     `out` is the backend's stdout, appended under a label AFTER stderr:
     agent-style CLIs (claude among them) report errors on stdout with an
@@ -415,11 +432,23 @@ def _log_backend_stderr(argv0, err, header, out=None) -> str:
         # CLI backends can echo prompt fragments (transcript text) into
         # either stream — scrub before it persists (#141).
         err_logged, _ = redact.redact_text(err or "")
-        body = f"{header}\n{err_logged}\n"
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        body = f"--- {stamp} ---\n{header}\n{err_logged}\n"
         if out is not None:
             out_logged, _ = redact.redact_text(out)
             body += f"--- stdout ---\n{out_logged}\n"
-        p.write_text(body, encoding="utf-8")
+        try:
+            prior = p.read_bytes()
+        except OSError:
+            prior = b""  # absent (first failure) or unreadable: still log this one
+        raw = prior + body.encode("utf-8")
+        if len(raw) > _STDERR_LOG_MAX_BYTES:
+            raw = raw[-_STDERR_LOG_MAX_BYTES:]
+            # The tail slice can land mid-character; dropping through the first
+            # newline discards those bytes with the half entry they belong to.
+            nl = raw.find(b"\n")
+            raw = raw[nl + 1:] if nl != -1 else b""
+        p.write_bytes(raw)
         hint = f"stderr: {p}"
     except OSError:
         pass
@@ -457,8 +486,8 @@ def _chat_command(messages, deadline):
             # stderr stays OFF every wire, but the user's own disk is the same
             # trust domain as the transcript being serialized — discarding it
             # locally turned every backend failure into guesswork (#56, exit
-            # 101 in the field with zero diagnostics). Truncate-per-run: the
-            # log is "the last failure", not an archive.
+            # 101 in the field with zero diagnostics). Bounded append: a
+            # repeating failure must not erase its own history (#474).
             hint = _log_backend_stderr(
                 argv[0], err, f"command backend exit {rc} (argv0: {argv[0]})",
                 out=out)

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -7,10 +7,11 @@ which is non-TTY — always renders plain.
 """
 
 import os
+import re
 import sys
 from contextlib import contextmanager
 
-from . import briefing, config, schema, serializer
+from . import briefing, config, redact, schema, serializer
 
 _TRUTHY = ("1", "true", "yes", "on")
 
@@ -427,6 +428,42 @@ def _recall_index_line(att) -> str | None:
     return f"recall index: {att['items']} items"
 
 
+# The bookkeeping tail of a ledger error line (ledger.py:132-134) — the
+# transcript path is already reachable from the record, and `after Ns` is a
+# duration, not a cause. Anchored at the end so a message that merely mentions
+# a transcript mid-sentence keeps it.
+_CAUSE_TAIL_RE = re.compile(r"\s*\(transcript: .+?\)(?: after \d+s)?\s*$")
+# Status is a diagnostic surface, not a pager: a backend can put kilobytes into
+# an exception message. 160 chars is one wrapped line on an 80-column terminal
+# and comfortably fits the shapes that actually occur ("command backend exited
+# 1 (stderr: <path>)", "LLM unreachable/timeout after 3 tries at <base>").
+_CAUSE_MAX_CHARS = 160
+
+
+def _failure_cause(line) -> str | None:
+    """The human-meaningful half of a ledger error line (#474): everything
+    between the `error: ` prefix and the transcript/duration bookkeeping,
+    flattened to one bounded line. None for anything that is not an error line
+    — hung records carry `line: None` by construction, and status must degrade
+    to its pre-#474 output rather than print a dangling label.
+
+    Redacted here because result lines are NOT scrubbed at write time
+    (_append_serialize_log and hooks._ledger_capture_failure both write
+    `str(exc)` raw) — same #141 rule the backend-stderr log applies."""
+    if not isinstance(line, str):
+        return None
+    text = " ".join(line.split())
+    if not text.startswith("error: "):
+        return None
+    text = _CAUSE_TAIL_RE.sub("", text[len("error: "):]).strip()
+    if not text:
+        return None
+    text, _ = redact.redact_text(text)
+    if len(text) > _CAUSE_MAX_CHARS:
+        text = text[:_CAUSE_MAX_CHARS].rstrip() + "…"
+    return text
+
+
 def _outstanding_lines(outstanding) -> list:
     """Human lines for lost sessions; empty list when nothing is outstanding."""
     lines = []
@@ -456,6 +493,12 @@ def _outstanding_lines(outstanding) -> list:
             lines.append(f"  - {f['sid']}  error {age} ago — transcript unavailable, cannot auto-heal")
         else:
             lines.append(f"  - {f['sid']}  error {age} ago — run `daimon heal`")
+        # #474: the cause has always been in the record and was never read.
+        # A continuation line keeps the class-specific hint (the actionable
+        # part) at the end of the first line where operators already look.
+        cause = _failure_cause(f.get("line"))
+        if cause:
+            lines.append(f"    cause: {cause}")
     return lines
 
 

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -527,6 +527,29 @@ def test_cli_status_lists_buried_failure(tmp_checkpoint_dir, tmp_log_dir, capsys
     assert "run `daimon heal`" in out
 
 
+def test_cli_status_surfaces_the_failure_cause(
+    tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch
+):
+    # #474 end to end: the cause has been in the ledger record since the
+    # per-session fold landed, and `status` never printed it — a field install
+    # burned ~23 hours and 3 sessions rediscovering it from a log file by hand.
+    transcript_a = FIXTURES / "sample_transcript.md"
+    _write_log(
+        tmp_log_dir,
+        [
+            "2026-06-10T12:00:00Z session-end: spawned serialize for sample_transcript "
+            "(reason: exit, project: /p/A)",
+            "error: command backend exited 1 (stderr: /l/backend-stderr.log) "
+            f"(transcript: {transcript_a}) after 1s",
+        ],
+    )
+    monkeypatch.setenv("DAIMON_PLAIN", "1")
+    cli.main(["status"])
+    out = capsys.readouterr().out
+    assert "cause: command backend exited 1 (stderr: /l/backend-stderr.log)" in out
+    assert "run `daimon heal`" in out  # the actionable hint survives
+
+
 def test_cli_status_log_success_line(tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
     monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
     _write_log(

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -3,6 +3,7 @@ import io
 import json
 import logging
 import os
+import re
 import threading
 import time
 import urllib.error
@@ -675,7 +676,10 @@ def test_command_backend_stderr_log_redacts_secret(monkeypatch, tmp_path):
     assert "[redacted:aws-key]" in text
 
 
-def test_command_backend_stderr_log_truncates_per_run(monkeypatch, tmp_path):
+def test_command_backend_stderr_log_appends_across_runs(monkeypatch, tmp_path):
+    # #474 REVERSES the #56 truncate-per-run rule: on a field install 143
+    # lifetime errors left exactly one line, so a diagnostic question stayed
+    # open for nine days while every failure erased the evidence for the last.
     monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
     monkeypatch.setenv("DAIMON_LLM_COMMAND", "failing-cli")
     monkeypatch.setenv("DAIMON_LOG_DIR", str(tmp_path / "logs"))
@@ -686,7 +690,61 @@ def test_command_backend_stderr_log_truncates_per_run(monkeypatch, tmp_path):
     with pytest.raises(llm.ChatError):
         llm.chat([{"role": "user", "content": "x"}])
     text = (tmp_path / "logs" / "backend-stderr.log").read_text()
-    assert "second" in text and "first" not in text
+    assert "first" in text and "second" in text
+    assert text.index("first") < text.index("second")  # chronological
+
+
+def test_command_backend_stderr_log_entries_are_utc_stamped(monkeypatch, tmp_path):
+    # #474: entries have to be correlatable with serialize.log and checkpoint
+    # ages, which are UTC `%Y-%m-%dT%H:%M:%SZ`.
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "failing-cli")
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setattr(llm, "_run_command", lambda *a, **k: (1, "", "boom"))
+    with pytest.raises(llm.ChatError):
+        llm.chat([{"role": "user", "content": "x"}])
+    text = (tmp_path / "logs" / "backend-stderr.log").read_text()
+    assert re.search(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", text)
+
+
+def test_command_backend_stderr_log_is_size_bounded(monkeypatch, tmp_path):
+    # An append-only failure log on an install failing 78% of the time is a
+    # disk-filler unless it is bounded. Oldest entries go first.
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "failing-cli")
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(tmp_path / "logs"))
+    log = tmp_path / "logs" / "backend-stderr.log"
+    log.parent.mkdir(parents=True)
+    log.write_text("ANCIENT-MARKER\n" + ("filler line\n" * 60000))
+    assert log.stat().st_size > llm._STDERR_LOG_MAX_BYTES
+    monkeypatch.setattr(llm, "_run_command", lambda *a, **k: (1, "", "newest"))
+    with pytest.raises(llm.ChatError):
+        llm.chat([{"role": "user", "content": "x"}])
+    assert log.stat().st_size <= llm._STDERR_LOG_MAX_BYTES
+    text = log.read_text()
+    assert "newest" in text          # the run that just failed survives
+    assert "ANCIENT-MARKER" not in text  # the oldest entry is what gets dropped
+
+
+def test_command_backend_stderr_log_read_failure_still_logs(monkeypatch, tmp_path):
+    # #225 fail-open, extended to the read seam the append introduced: a prior
+    # log that cannot be read back must not cost the current entry.
+    from pathlib import Path
+
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "failing-cli")
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(tmp_path / "logs"))
+    log = tmp_path / "logs" / "backend-stderr.log"
+    log.parent.mkdir(parents=True)
+    log.write_text("prior entry\n")
+    monkeypatch.setattr(Path, "read_bytes",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("EIO")))
+    monkeypatch.setattr(llm, "_run_command", lambda *a, **k: (1, "", "newest"))
+    with pytest.raises(llm.ChatError) as exc:
+        llm.chat([{"role": "user", "content": "x"}])
+    assert "backend-stderr.log" in str(exc.value)
+    assert "suppressed" not in str(exc.value)
+    assert "newest" in log.read_text()
 
 
 # ---- #225: rc=0 + empty stdout gets the same local diagnostics as a non-zero

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -337,6 +337,110 @@ def test_render_status_outstanding_rich_smoke(monkeypatch, capsys):
     assert "heal" in out
 
 
+# ---- #474: the ledger already carried the cause; status never read it ----
+
+
+def _one_error(line):
+    return [{"sid": "S-A", "kind": "error", "class": "healable", "age": 180,
+             "age_str": "3m", "transcript": "/t/S-A.jsonl", "project": "/p/A",
+             "spawned": True, "line": line}]
+
+
+def test_render_status_outstanding_shows_failure_cause(capsys):
+    # A field install ran 78% capture errors for 14 days with the cause one
+    # dict field away from the operator. The class-specific hint must survive.
+    data = _status_data()
+    data["outstanding"] = _one_error(
+        "error: command backend exited 1 (stderr: /l/backend-stderr.log) "
+        "(transcript: /t/S-A.jsonl) after 3s")
+    render.render_status(data)
+    out = capsys.readouterr().out
+    assert "  - S-A  error 3m ago — run `daimon heal`\n" in out
+    assert ("    cause: command backend exited 1 "
+            "(stderr: /l/backend-stderr.log)\n") in out
+    # the bookkeeping tail is the operator's noise, not the cause
+    assert "(transcript:" not in out
+    assert "after 3s" not in out
+
+
+def test_render_status_outstanding_cause_on_every_error_class(capsys):
+    for cls, hint in (("retry-exhausted", "heal --force"),
+                      ("unrecoverable", "cannot auto-heal")):
+        data = _status_data()
+        f = _one_error("error: boom (transcript: /t/S-A.jsonl) after 3s")[0]
+        f["class"] = cls
+        data["outstanding"] = [f]
+        render.render_status(data)
+        out = capsys.readouterr().out
+        assert "    cause: boom\n" in out
+        assert hint in out
+
+
+def test_render_status_outstanding_without_line_degrades_to_prior_output(capsys):
+    # hung records always carry line=None; an error record can too when the
+    # ledger fold never saw a result line. Neither may print a dangling label.
+    data = _status_data()
+    f = _one_error(None)[0]
+    data["outstanding"] = [f, _outstanding_sample()[1]]
+    render.render_status(data)
+    out = capsys.readouterr().out
+    assert "  - S-A  error 3m ago — run `daimon heal`\n" in out
+    assert "  - S-C  spawned 40m ago, no result (hung/killed; transcript unavailable)\n" in out
+    assert "cause" not in out
+
+
+@pytest.mark.parametrize("line", [
+    "wrote checkpoint: /c/x.json (took 1s)",   # wrong prefix entirely
+    "error: ",                                 # prefix with nothing after it
+    "error: (transcript: /t/S-A.jsonl) after 3s",  # bookkeeping only
+    42,                                        # not a string at all
+])
+def test_render_status_outstanding_malformed_line_prints_no_cause(capsys, line):
+    data = _status_data()
+    data["outstanding"] = _one_error(line)
+    render.render_status(data)
+    out = capsys.readouterr().out
+    assert "  - S-A  error 3m ago — run `daimon heal`\n" in out
+    assert "cause" not in out
+
+
+def test_render_status_outstanding_cause_is_truncated(capsys):
+    # A backend can dump kilobytes into the exception message; status is a
+    # diagnostic surface, not a pager.
+    data = _status_data()
+    data["outstanding"] = _one_error(
+        "error: " + ("boom " * 2000) + "(transcript: /t/S-A.jsonl) after 3s")
+    render.render_status(data)
+    out = capsys.readouterr().out
+    cause = [ln for ln in out.splitlines() if ln.strip().startswith("cause:")]
+    assert len(cause) == 1
+    assert len(cause[0]) <= render._CAUSE_MAX_CHARS + 16
+
+
+def test_render_status_outstanding_cause_is_single_line(capsys):
+    data = _status_data()
+    data["outstanding"] = _one_error(
+        "error: traceback\n  File \"x.py\", line 1\nRuntimeError: nope "
+        "(transcript: /t/S-A.jsonl) after 3s")
+    render.render_status(data)
+    out = capsys.readouterr().out
+    assert "    cause: traceback File \"x.py\", line 1 RuntimeError: nope\n" in out
+
+
+def test_render_status_outstanding_cause_is_redacted(capsys):
+    # #141: result lines are NOT scrubbed at write time (_append_serialize_log
+    # and hooks._ledger_capture_failure both write str(exc) raw), so the
+    # display seam is where the scrub has to happen.
+    secret = "AKIAIOSFODNN7EXAMPLE"
+    data = _status_data()
+    data["outstanding"] = _one_error(
+        f"error: backend said key {secret} (transcript: /t/S-A.jsonl) after 3s")
+    render.render_status(data)
+    out = capsys.readouterr().out
+    assert secret not in out
+    assert "[redacted:aws-key]" in out
+
+
 def _cfg_ready():
     return {"ready": True, "resolved_backend": "command", "command_source": "claude-cli",
             "command": "claude", "has_api_key": False, "has_model": False,


### PR DESCRIPTION
Closes #474

## PR Type

- [x] Bug fix (`type:fix`)

## Summary

- `daimon status` now prints **why** a serialize failed, not just that one did. The cause was already in the status payload — `ledger.py` puts the full result line into every outstanding-error record and `render.py` never read it.
- `backend-stderr.log` becomes a bounded append instead of truncating on every run, reversing the #56 decision on field evidence.

## The failure this fixes

A field install ran a **78% capture error rate over 14 days** — 99 failed serializes — while `status` reported only:

```
- <sid>  error 3h ago — retry attempted, still failing (re-run with `daimon heal --force`)
```

`heal --force` re-entered the same deterministic backend failure and failed identically. Diagnosis took roughly 23 hours and cost 3 sessions, and only arrived by opening a log file whose path the operator had to already know existed.

After this change the same failure reads:

```
- <sid>  error 3h ago — retry attempted, still failing (re-run with `daimon heal --force`)
    cause: EmptyOutputError: command backend returned empty output
```

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/render.py` | `_failure_cause()` extracts the message from the recorded result line — strips the `error:` prefix and the trailing `(transcript: …) after Ns` bookkeeping via an end-anchored pattern, flattens whitespace, redacts, truncates at 160 chars. `_outstanding_lines()` emits it as a `cause:` continuation so the existing class-specific guidance stays byte-identical. |
| `plugin/daimon_briefing/llm.py` | `_log_backend_stderr` appends UTC-stamped entries under a 512 KB cap, trimmed oldest-first at an entry boundary. Docstring records that #56 was reversed by #474 rather than forgotten. |
| `plugin/tests/test_render.py` | 8 tests: cause rendered across all three error classes, `None` line, four malformed shapes, truncation, newline flattening, redaction. |
| `plugin/tests/test_llm.py` | The truncate-per-run test is **replaced** by an append test — that test was the codification of the decision this PR reverses. UTC stamp, size bound, and read-seam fail-open added. |
| `plugin/tests/test_cli.py` | End-to-end `status` test proving the cause reaches the screen. |

## Design notes

**Redaction happens at the display seam.** Result lines are *not* scrubbed at write time — verified in both writers (`ledger.py` and `hooks.py` write the string raw). The established #141 convention is to scrub anything derived from backend output, so the display is the correct and only place. Double-redaction is not a risk regardless: `redact_text` is documented idempotent.

**Missing cause degrades to today's output exactly.** `hung` records always carry `line: None`, and a malformed or bookkeeping-only line returns `None`. `status` is a diagnostic surface — it must not become the second thing that fails.

**Byte cap over rotation.** Rotation is more machinery (numbering, cleanup, a second path every reader must learn) for the same "cannot grow without limit" guarantee. The prior-read has its own `OSError` handler so a first-ever write cannot regress the #225 fail-open.

**JSON payload unchanged.** `ledger.py` untouched; records already expose the raw `line`, which is strictly more informative than a derived field.

## Test Plan

- [x] Full suite green: `2500 passed, 2 skipped` (2499 before)
- [x] `ruff check daimon_briefing tests` clean
- [x] Manually rendered the real field failure shape and confirmed the cause line appears, and that a `hung` record with `line: None` is byte-identical to prior output
- [x] Manually confirmed two successive backend failures both survive in the log with distinct UTC stamps
- [x] Scars checked: 0015 and 0032 are path-anchored to `llm.py`; neither concerns diagnostics logging. 0009 (last-of-kind masking) complied with — no new last-of-kind heuristic; the cause comes from an already per-session-attributed record.

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No shell scripts modified (shellcheck n/a)
- [x] Docstring updated where behaviour changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
