### PR TITLE
fix(stats): stop mixing host populations in the retention ratio

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -59,7 +59,7 @@ from .ledger import (
     _parse_serialize_log,
     _parse_stamp,
     _session_ledger,
-    _spawns_in_window,
+    _spawns_in_window,  # noqa: F401 — re-exported for compat
     _spawns_in_window_count,
     _stats_capture,
 )
@@ -2221,24 +2221,59 @@ _RETENTION_WINDOW_DAYS = 14
 
 
 def _stats_retention(now=None) -> dict:
-    """usage.log -> hook-driven briefings (`brief:auto`) vs deliberate
-    re-reads, over the last _RETENTION_WINDOW_DAYS. Re-reads are memory
-    reads only (`brief`, `recall`); `status` is ops polling and counts
-    apart, outside the total and the ratio (#232 — a debugging session
-    must not read as retention). Plain `brief` lines stamped before the
-    first `brief:auto` ever logged predate the flag and are reported as
-    untagged — ambiguous, never guessed (#54 honesty rule).
+    """usage.log -> briefings delivered vs deliberate re-reads, over the last
+    _RETENTION_WINDOW_DAYS. `status` is ops polling and counts apart, outside
+    the total and the ratio (#232 — a debugging session must not read as
+    retention).
+
+    A briefing reaches the agent by one of two paths, and which one is
+    available is a permanent property of the host (#349): hosts with a
+    session-start event log `brief:auto`, and hosts without one (Cascade,
+    Codex) have the skill invoke `daimon brief` instead. usage.log carries no
+    host, so a plain `brief` line is only readable against the hosts that
+    actually spawned captures in the same window (#477):
+
+    - `hook`/`none` — no hookless spawns contradict it, so `brief` is a
+      deliberate re-read, as it always was.
+    - `skill` — hookless spawns only. `brief` IS the briefing being delivered;
+      counting it as a re-read made the only working delivery path on that
+      host invisible. The pre-`--auto` untagged rule is off here too: a host
+      that can never log `brief:auto` has no upgrade marker to sit before.
+    - `mixed` — both. A plain `brief` is neither confidently delivery nor
+      re-read, so it is reported as `ambiguous_briefs` and the ratio is
+      withheld rather than guessed (#54). This is the defect #477 filed: one
+      stray auto-capable session in the denominator against a fortnight of
+      hookless reads in the numerator rendered as a confident headline number.
+
+    Plain `brief` lines stamped before the first `brief:auto` ever logged
+    predate the flag and are reported as untagged — ambiguous, never guessed.
     stale_hook_warning: sessions were captured in the window but zero
     auto-briefings were logged — the SessionStart hook likely predates
     --auto."""
     now = now or datetime.now(timezone.utc)
     cutoff = now - timedelta(days=_RETENTION_WINDOW_DAYS)
     out = {"window_days": _RETENTION_WINDOW_DAYS, "hook_briefs": 0,
+           "skill_briefs": 0, "ambiguous_briefs": 0, "briefings_total": 0,
+           "delivery_mode": "none",
            # status is ops polling (serializer health, pending counts), not a
            # memory read (#232): counted apart, never in the total or ratio.
            "rereads": {"brief": 0, "recall": 0}, "status_checks": 0,
-           "rereads_total": 0, "rereads_per_hook_brief": None,
+           "rereads_total": 0, "rereads_per_briefing": None,
            "untagged_briefs": 0, "stale_hook_warning": False}
+    # Host population is read from the SAME window as the counters, so a stale
+    # spawn from a host retired months ago cannot reclassify this fortnight.
+    auto_spawns = _spawns_in_window_count(cutoff, hosts=AUTO_BRIEF_HOSTS)
+    total_spawns = _spawns_in_window_count(cutoff)
+    hookless_spawns = total_spawns - auto_spawns
+    if hookless_spawns and auto_spawns:
+        mode = "mixed"
+    elif hookless_spawns:
+        mode = "skill"
+    elif auto_spawns:
+        mode = "hook"
+    else:
+        mode = "none"
+    out["delivery_mode"] = mode
     try:
         lines = (config.log_dir() / "usage.log").read_text(encoding="utf-8").splitlines()
     except OSError:
@@ -2253,7 +2288,8 @@ def _stats_retention(now=None) -> dict:
             events.append((stamp, parts[1]))
     first_auto = min((s for s, cmd in events if cmd == "brief:auto"), default=None)
     for stamp, cmd in events:
-        if cmd == "brief" and (first_auto is None or stamp < first_auto):
+        if (cmd == "brief" and mode != "skill"
+                and (first_auto is None or stamp < first_auto)):
             out["untagged_briefs"] += 1
             continue
         if stamp < cutoff:
@@ -2262,17 +2298,25 @@ def _stats_retention(now=None) -> dict:
             out["hook_briefs"] += 1
         elif cmd == "status":
             out["status_checks"] += 1
+        elif cmd == "brief":
+            if mode == "skill":
+                out["skill_briefs"] += 1
+            elif mode == "mixed":
+                out["ambiguous_briefs"] += 1
+            else:
+                out["rereads"]["brief"] += 1
         elif cmd in out["rereads"]:
             out["rereads"][cmd] += 1
     out["rereads_total"] = sum(out["rereads"].values())
-    if out["hook_briefs"]:
-        out["rereads_per_hook_brief"] = round(
-            out["rereads_total"] / out["hook_briefs"], 2)
+    out["briefings_total"] = out["hook_briefs"] + out["skill_briefs"]
+    # Withheld on `mixed`: the numerator spans hosts the denominator does not.
+    if mode != "mixed" and out["briefings_total"]:
+        out["rereads_per_briefing"] = round(
+            out["rereads_total"] / out["briefings_total"], 2)
     # #349: only spawns from auto-brief-capable hosts count — a Windsurf- or
     # Codex-only machine can never log brief:auto, and warning it to re-run
     # `hooks install` is a permanent false positive.
-    if out["hook_briefs"] == 0 and _spawns_in_window(
-            cutoff, hosts=AUTO_BRIEF_HOSTS):
+    if out["hook_briefs"] == 0 and auto_spawns:
         out["stale_hook_warning"] = True
     return out
 

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -39,6 +39,18 @@ def supports_rich() -> bool:
 
 _TRUST_STYLE = {"verbatim": "bold green", "inferred": "yellow", "untagged": "dim"}
 
+# A withheld retention ratio travels with its reason (#54, #477): a caveat
+# documented elsewhere does not survive a pasted stats table.
+_RATIO_WITHHELD = {
+    "mixed": ("n/a (mixed hosts — a plain `brief` here is either a "
+              "skill-delivered briefing or a re-read, and usage.log cannot "
+              "tell them apart)"),
+}
+
+
+def _ratio_na(mode: str) -> str:
+    return _RATIO_WITHHELD.get(mode, "n/a")
+
 
 @contextmanager
 def working(message: str):
@@ -928,14 +940,18 @@ def _plain_stats(data: dict) -> None:
     r = data.get("retention")
     if r:
         print(f"retention (last {r['window_days']}d):")
-        print(f"  hook briefings: {r['hook_briefs']}")
+        print(f"  briefings delivered: hook {r['hook_briefs']}, "
+              f"skill-invoked {r['skill_briefs']}  "
+              f"(total {r['briefings_total']})")
         rr = r["rereads"]
         print(f"  deliberate re-reads: brief {rr['brief']}, "
               f"recall {rr['recall']}  (total {r['rereads_total']})")
         print(f"  status checks: {r['status_checks']}  (ops, not counted)")
-        ratio = r["rereads_per_hook_brief"]
-        print(f"  re-reads per hook briefing: "
-              f"{ratio if ratio is not None else 'n/a'}")
+        ratio = r["rereads_per_briefing"]
+        shown = _ratio_na(r["delivery_mode"]) if ratio is None else ratio
+        print(f"  re-reads per briefing: {shown}")
+        if r["ambiguous_briefs"]:
+            print(f"  unclassified `brief` invocations: {r['ambiguous_briefs']}")
         if r["untagged_briefs"]:
             print(f"  untagged brief lines (pre --auto): {r['untagged_briefs']}")
         if r["stale_hook_warning"]:
@@ -1002,16 +1018,23 @@ def _rich_stats(data: dict) -> None:
                           header_style="bold")
         ret_table.add_column("metric")
         ret_table.add_column("value", justify="right")
-        ret_table.add_row("hook briefings", str(r["hook_briefs"]))
+        ret_table.add_row("briefings delivered",
+                          f"hook {r['hook_briefs']}, "
+                          f"skill-invoked {r['skill_briefs']} "
+                          f"(total {r['briefings_total']})")
         rr = r["rereads"]
         ret_table.add_row("deliberate re-reads",
                           f"brief {rr['brief']}, "
                           f"recall {rr['recall']} (total {r['rereads_total']})")
         ret_table.add_row("status checks (ops, not counted)",
                           str(r["status_checks"]))
-        ratio = r["rereads_per_hook_brief"]
-        ret_table.add_row("re-reads per hook briefing",
-                          "n/a" if ratio is None else str(ratio))
+        ratio = r["rereads_per_briefing"]
+        ret_table.add_row("re-reads per briefing",
+                          _ratio_na(r["delivery_mode"]) if ratio is None
+                          else str(ratio))
+        if r["ambiguous_briefs"]:
+            ret_table.add_row("unclassified `brief` invocations",
+                              str(r["ambiguous_briefs"]))
         if r["untagged_briefs"]:
             ret_table.add_row("untagged brief lines (pre --auto)",
                               str(r["untagged_briefs"]))

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -5631,7 +5631,7 @@ def test_retention_counts_hook_briefs_and_rereads_in_window(tmp_log_dir):
     assert r["rereads"] == {"brief": 1, "recall": 1}
     assert r["status_checks"] == 1
     assert r["rereads_total"] == 2
-    assert r["rereads_per_hook_brief"] == 1.0
+    assert r["rereads_per_briefing"] == 1.0
     assert r["untagged_briefs"] == 1
     assert r["stale_hook_warning"] is False
 
@@ -5642,7 +5642,7 @@ def test_retention_zero_hook_briefs_ratio_is_none(tmp_log_dir):
     (tmp_log_dir / "usage.log").write_text(_usage_line(1, "status", now))
     r = cli._stats_retention(now=now)
     assert r["hook_briefs"] == 0
-    assert r["rereads_per_hook_brief"] is None
+    assert r["rereads_per_briefing"] is None
 
 
 def test_retention_status_alone_never_moves_the_value_signal(tmp_log_dir):
@@ -5659,7 +5659,7 @@ def test_retention_status_alone_never_moves_the_value_signal(tmp_log_dir):
     r = cli._stats_retention(now=now)
     assert r["status_checks"] == 3
     assert r["rereads_total"] == 0
-    assert r["rereads_per_hook_brief"] == 0.0
+    assert r["rereads_per_briefing"] == 0.0
 
 
 def test_retention_all_briefs_untagged_when_no_auto_ever(tmp_log_dir):
@@ -5713,6 +5713,137 @@ def test_retention_stale_warning_still_fires_on_mixed_hosts(tmp_log_dir):
         f"{stamp} session-end: spawned serialize for S1 (pid 2)\n")
     r = cli._stats_retention(now=now)
     assert r["stale_hook_warning"] is True
+
+
+# ---- #477: the ratio must not mix host populations ----
+
+
+def _host_spawn_line(days_ago, host, sid, now):
+    stamp = (now - timedelta(days=days_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return f"{stamp} {host}: spawned serialize for {sid} (pid 1)\n"
+
+
+def test_retention_no_spawn_log_keeps_hook_semantics(tmp_log_dir):
+    """No serialize.log at all: nothing contradicts the hook reading, so plain
+    `brief` stays a deliberate re-read and the ratio is computed as before."""
+    now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "usage.log").write_text(
+        _usage_line(5, "brief:auto", now) + _usage_line(4, "brief", now))
+    r = cli._stats_retention(now=now)
+    assert r["delivery_mode"] == "none"
+    assert r["briefings_total"] == 1
+    assert r["rereads"]["brief"] == 1
+    assert r["rereads_per_briefing"] == 1.0
+
+
+def test_retention_hook_only_machine_counts_briefs_as_rereads(tmp_log_dir):
+    now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "serialize.log").write_text(
+        _host_spawn_line(2, "session-end", "S1", now))
+    (tmp_log_dir / "usage.log").write_text(
+        _usage_line(5, "brief:auto", now)
+        + _usage_line(4, "brief", now)
+        + _usage_line(3, "recall", now))
+    r = cli._stats_retention(now=now)
+    assert r["delivery_mode"] == "hook"
+    assert r["hook_briefs"] == 1
+    assert r["skill_briefs"] == 0
+    assert r["briefings_total"] == 1
+    assert r["rereads"] == {"brief": 1, "recall": 1}
+    assert r["rereads_per_briefing"] == 2.0
+
+
+def test_retention_hookless_machine_reports_skill_delivered_briefings(tmp_log_dir):
+    """#477 / #349: Cascade has no session-start event, so `daimon brief` run by
+    the skill IS the briefing being delivered. Counting it as a deliberate
+    re-read made the only working delivery path on that host invisible."""
+    now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "serialize.log").write_text(
+        _host_spawn_line(2, "windsurf-cascade", "W1", now)
+        + _host_spawn_line(1, "codex-stop", "C1", now))
+    (tmp_log_dir / "usage.log").write_text(
+        _usage_line(5, "brief", now)
+        + _usage_line(4, "brief", now)
+        + _usage_line(3, "recall", now))
+    r = cli._stats_retention(now=now)
+    assert r["delivery_mode"] == "skill"
+    assert r["hook_briefs"] == 0
+    assert r["skill_briefs"] == 2
+    assert r["briefings_total"] == 2
+    # a hookless host can never log brief:auto, so the pre-auto "untagged"
+    # rule must not swallow its briefings.
+    assert r["untagged_briefs"] == 0
+    assert r["rereads"] == {"brief": 0, "recall": 1}
+    assert r["rereads_total"] == 1
+    assert r["rereads_per_briefing"] == 0.5
+
+
+def test_retention_mixed_hosts_withhold_the_ratio(tmp_log_dir):
+    """The #477 defect itself: one stray auto-capable session puts 1 in the
+    denominator while a fortnight of hookless `brief`/`recall` accumulates in
+    the numerator. That rendered as a confident `8.0`. Withhold instead (#54)."""
+    now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "serialize.log").write_text(
+        _host_spawn_line(2, "windsurf-cascade", "W1", now)
+        + _host_spawn_line(1, "session-end", "S1", now))
+    (tmp_log_dir / "usage.log").write_text(
+        _usage_line(6, "brief:auto", now)
+        + "".join(_usage_line(5, "brief", now) for _ in range(4))
+        + "".join(_usage_line(4, "recall", now) for _ in range(4)))
+    r = cli._stats_retention(now=now)
+    assert r["delivery_mode"] == "mixed"
+    assert r["hook_briefs"] == 1
+    # the plain `brief` lines are neither confidently delivery nor re-read
+    assert r["ambiguous_briefs"] == 4
+    assert r["rereads"]["brief"] == 0
+    assert r["rereads_per_briefing"] is None
+
+
+def test_retention_mixed_hosts_still_counts_recall(tmp_log_dir):
+    """Ambiguity is confined to `brief`. `recall` is a re-read on every host and
+    must stay visible even when the ratio is withheld."""
+    now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "serialize.log").write_text(
+        _host_spawn_line(2, "windsurf-cascade", "W1", now)
+        + _host_spawn_line(1, "session-end", "S1", now))
+    (tmp_log_dir / "usage.log").write_text(
+        _usage_line(6, "brief:auto", now) + _usage_line(3, "recall", now))
+    r = cli._stats_retention(now=now)
+    assert r["rereads"]["recall"] == 1
+    assert r["rereads_total"] == 1
+    assert r["rereads_per_briefing"] is None
+
+
+def test_retention_skill_mode_with_no_briefs_has_no_ratio(tmp_log_dir):
+    now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "serialize.log").write_text(
+        _host_spawn_line(2, "windsurf-cascade", "W1", now))
+    (tmp_log_dir / "usage.log").write_text(_usage_line(1, "recall", now))
+    r = cli._stats_retention(now=now)
+    assert r["delivery_mode"] == "skill"
+    assert r["briefings_total"] == 0
+    assert r["rereads_per_briefing"] is None
+
+
+def test_retention_stale_spawns_do_not_set_the_delivery_mode(tmp_log_dir):
+    """Host population is read from the same window as the counters. A Windsurf
+    spawn from two months ago must not reclassify this fortnight's briefings."""
+    now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "serialize.log").write_text(
+        _host_spawn_line(60, "windsurf-cascade", "W1", now)
+        + _host_spawn_line(2, "session-end", "S1", now))
+    (tmp_log_dir / "usage.log").write_text(
+        _usage_line(5, "brief:auto", now) + _usage_line(4, "brief", now))
+    r = cli._stats_retention(now=now)
+    assert r["delivery_mode"] == "hook"
+    assert r["rereads_per_briefing"] == 1.0
 
 
 def test_spawns_in_window_skips_garbage_and_stale_spawns(tmp_log_dir):
@@ -5860,9 +5991,11 @@ def test_stats_json_includes_retention(tmp_checkpoint_dir, tmp_log_dir,
     assert cli.main(["stats", "--json"]) == 0
     data = json.loads(capsys.readouterr().out)
     assert "retention" in data
-    assert set(data["retention"]) >= {"window_days", "hook_briefs", "rereads",
-                                      "status_checks", "rereads_total",
-                                      "rereads_per_hook_brief",
+    assert set(data["retention"]) >= {"window_days", "hook_briefs",
+                                      "skill_briefs", "ambiguous_briefs",
+                                      "briefings_total", "delivery_mode",
+                                      "rereads", "status_checks",
+                                      "rereads_total", "rereads_per_briefing",
                                       "untagged_briefs", "stale_hook_warning"}
 
 
@@ -5878,10 +6011,10 @@ def test_stats_plain_renders_retention_section(tmp_checkpoint_dir, tmp_log_dir,
     assert cli.main(["stats"]) == 0
     out = capsys.readouterr().out
     assert "retention (last 14d):" in out
-    assert "hook briefings: 1" in out
+    assert "briefings delivered: hook 1, skill-invoked 0  (total 1)" in out
     # the lone status poll is ops, not retention (#232)
     assert "status checks: 1  (ops, not counted)" in out
-    assert "re-reads per hook briefing: 0.0" in out
+    assert "re-reads per briefing: 0.0" in out
 
 
 def test_stats_rich_renders_retention_section(tmp_checkpoint_dir, tmp_log_dir,
@@ -5897,9 +6030,30 @@ def test_stats_rich_renders_retention_section(tmp_checkpoint_dir, tmp_log_dir,
     assert cli.main(["stats"]) == 0
     out = capsys.readouterr().out
     assert "retention (last 14d)" in out
-    assert "hook briefings" in out
+    assert "briefings delivered" in out
     assert "status checks (ops, not counted)" in out
     assert "0.0" in out  # ratio: the status poll counts apart (#232)
+
+
+def test_stats_plain_says_why_the_ratio_is_withheld_on_mixed_hosts(
+        tmp_checkpoint_dir, tmp_log_dir, sample_checkpoint, capsys, monkeypatch):
+    """#54 honesty rule: a withheld number must travel with its reason, because
+    a caveat documented elsewhere does not survive a pasted stats table."""
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PLAIN", "1")
+    store.write_checkpoint("S1", sample_checkpoint)
+    now = datetime.now(timezone.utc)
+    tmp_log_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "serialize.log").write_text(
+        _host_spawn_line(2, "windsurf-cascade", "W1", now)
+        + _host_spawn_line(1, "session-end", "S1", now))
+    (tmp_log_dir / "usage.log").write_text(_usage_line(3, "brief:auto", now)
+                                           + _usage_line(2, "brief", now))
+    assert cli.main(["stats"]) == 0
+    out = capsys.readouterr().out
+    assert "re-reads per briefing: n/a" in out
+    assert "mixed hosts" in out
+    assert "unclassified `brief` invocations: 1" in out
 
 
 def test_stats_plain_warns_on_stale_hook(tmp_checkpoint_dir, tmp_log_dir,


### PR DESCRIPTION
Closes #477

## What

Takes option 2 from the issue: report the two delivery paths separately instead of patching the ratio.

`usage.log` lines carry no host, so a plain `brief` is classified against the hosts that actually spawned captures in the same window (`_spawns_in_window_count`, the helper #349 already introduced). `delivery_mode` is one of:

| mode | window shows | plain `brief` reads as | ratio |
|---|---|---|---|
| `hook` / `none` | auto-capable spawns only, or none | deliberate re-read (unchanged) | `rereads_total / hook_briefs` |
| `skill` | hookless spawns only | the briefing being delivered → `skill_briefs` | `rereads_total / skill_briefs` |
| `mixed` | both | neither, confidently → `ambiguous_briefs` | withheld, with the reason attached |

Two consequences worth calling out:

- **The hookless path becomes visible.** On a host with no session-start event, skill-invoked `brief` *is* the delivery mechanism working as designed. It now has its own counter and its own denominator, so those machines get a real retention figure instead of `n/a`.
- **The pre-`--auto` untagged rule is off in `skill` mode.** A host that can never log `brief:auto` has no upgrade marker for its `brief` lines to sit before, so the rule was classifying every single one as untagged — the reason the path read as absent rather than merely mis-attributed.

Per #54, the withheld ratio carries its reason inline rather than deferring to a doc, because a caveat elsewhere does not survive a pasted stats table:

```
re-reads per briefing: n/a (mixed hosts — a plain `brief` here is either a
skill-delivered briefing or a re-read, and usage.log cannot tell them apart)
```

Renames the JSON key `rereads_per_hook_brief` → `rereads_per_briefing`; the denominator is no longer hook-specific. Nothing outside the CLI read the old key.

## Why

Retention is the number used to judge whether the briefing loop delivers anything, and on any machine without a session-start event it was either absent or inflated by construction. A single auto-capable session put `1` in the denominator while a fortnight of hookless `brief`/`recall` accumulated in the numerator, so the headline figure described nothing while looking like excellent retention.

Host population is read from the same window as the counters, so a spawn from a host retired months ago cannot reclassify the current fortnight.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/cli.py` | `_stats_retention` classifies `brief` by delivery mode; adds `skill_briefs`, `ambiguous_briefs`, `briefings_total`, `delivery_mode`; renames the ratio key; `stale_hook_warning` reuses the counted spawns instead of a second scan |
| `plugin/daimon_briefing/render.py` | plain + rich retention sections render the delivery split, the unclassified count, and the withheld-ratio reason |
| `plugin/tests/test_cli.py` | 8 new tests covering all four modes, the stale-spawn boundary, and the rendered reason; existing tests updated for the key rename |

## Tests

- [x] `uv run pytest -q` → **2508 passed, 2 skipped**
- [x] `uv run ruff check daimon_briefing tests` → clean
- [x] All 8 new tests fail against the pre-change code (the mixed-host case asserts `None` where it previously produced a number)
- [x] Rendered against a real local `usage.log` on a hook-mode machine: split reports `hook 25, skill-invoked 0`, ratio unchanged in shape and value
