### PR TITLE
fix(stats): say when no rescue path exists, instead of reporting it as unused

### DIFF
--- a/.scars/candidates/config-env-file-shadows-cleared-process-env.md
+++ b/.scars/candidates/config-env-file-shadows-cleared-process-env.md
@@ -1,0 +1,48 @@
+---
+id: 0
+type: landmine
+title: Clearing os.environ does NOT unset a daimon config value — config._get falls back to ~/.daimon/env on disk
+severity: high
+confidence: 0.95
+created: 2026-07-31
+authors: ["claude-code"]
+anchors:
+  - path: plugin/daimon_briefing/config.py
+  - pattern: "os\.environ\.pop|monkeypatch\.delenv"
+evidence:
+  - note: "daimon#475 part 2 review. An exhaustive parity harness compared the old inline rescue_gap formula against rescue_posture() across 40 backend/key/fallback/command combinations. Every 'no API key' row was produced with os.environ.pop('DAIMON_LLM_API_KEY') + pop('LITELLM_API_KEY'). The harness reported rows where config.llm_api_key() was truthy despite the pops, and the first run's conclusions were wrong in BOTH directions: it hid the real defect (2 rows) and invented 2 fake ones. Caught only because a row was internally inconsistent (OLD=True is impossible when the formula requires a truthy key). Re-run with the accessors patched directly, the true answer was 3 changed rows, one of which was a genuine design defect."
+expires:
+  condition: "config._get stops falling back to the env file, or an official test helper lands that neutralises both sources at once"
+  review_after: 2027-01-31
+status: candidate
+---
+
+`config._get()` is `process env, then env file`:
+
+```python
+val = os.environ.get(name)
+if val is not None:
+    return val
+return _file_values().get(name)      # ~/.daimon/env
+```
+
+So `os.environ.pop("DAIMON_LLM_API_KEY")` / `monkeypatch.delenv(...)` does **not**
+simulate "this operator has no API key" on any machine where daimon is actually
+installed. The developer's own `~/.daimon/env` silently supplies the value, and
+the test or diagnostic quietly measures the wrong configuration. Nothing errors.
+The numbers just come back confident and wrong.
+
+This is worst in **ad-hoc analysis scripts**, which have no conftest protecting
+them. It produced a parity table whose "no key" column was entirely fictional
+and which pointed at two non-existent defects while concealing a real one.
+
+To genuinely simulate an absent value, do ONE of:
+
+- patch the accessor: `monkeypatch.setattr(config, "llm_api_key", lambda: None)`
+  (preferred — states the intent, immune to both sources), or
+- point the file lookup at nothing: set `DAIMON_ENV_FILE` to a path that does
+  not exist, which makes `_file_values()` return `{}` via its `OSError` guard.
+
+Deleting the process-env var alone is never sufficient. If a config-dependent
+result looks surprising, verify the input you *think* you set is the input the
+code actually read before trusting any conclusion drawn from it.

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1591,14 +1591,24 @@ def _status_world(project_arg=None) -> dict:
     # One-line pointer only when installed hook copies have drifted (#266);
     # silent on a clean machine. Cheap: hashes a handful of small files.
     hook_drift = _hook_drift_present()
-    # #341: a remote-gateway primary with no resolvable command backend has
-    # zero rescue coverage — surface it here, not in a post-mortem.
-    rescue_gap = bool(
-        config.llm_backend() in ("litellm", "auto")
-        and config.llm_api_key()
-        and config.llm_fallback()
-        and llm._resolve_command() is None
-    )
+    # #341/#475 part 2: whether a rescue path exists for the CURRENTLY
+    # CONFIGURED primary. llm.rescue_posture() is the single resolver (it
+    # calls resolve_backend(), the same decision chat() dispatches on) —
+    # rescue_gap is re-expressed through it rather than re-implementing the
+    # "auto" cascade inline a second time (two copies of one decision drift
+    # the moment either changes). rescue_gap keeps its EXACT existing
+    # meaning (posture == "gap") for JSON back-compat; rescue_posture is the
+    # richer value new consumers get.
+    rescue_posture = llm.rescue_posture()
+    rescue_gap = rescue_posture == "gap"
+    # #475 part 2: the "none" warning below is gated on real errors, not on
+    # posture alone (the #349/#477 false-positive shape) — an operator who
+    # pinned a `command` backend deliberately must not see a permanent
+    # warning about a permanent property of their own choice. The 14-day
+    # capture window _stats_capture() already computes is the same window
+    # `daimon stats` reports, so "no errors yet" here means the same thing
+    # it means there.
+    rescue_window_errors = _stats_capture()["window"]["errors"]
     health = _status_health(proj, glob, outstanding, siblings, now=now,
                             disabled=disabled)
     # ONE objective team line (#113), only when a team remote exists — the #84
@@ -1627,6 +1637,7 @@ def _status_world(project_arg=None) -> dict:
         "recall_error": recall_error, "recall_index": recall_index,
         "receipts": receipts_line, "capture_alarm": capture_alarm,
         "hook_drift": hook_drift, "rescue_gap": rescue_gap,
+        "rescue_posture": rescue_posture, "rescue_window_errors": rescue_window_errors,
         "forget_hits": forget_hits, "rc": rc,
     }
 
@@ -1644,6 +1655,7 @@ def status_payload(project_arg=None) -> tuple:
         "recall_error": w["recall_error"], "recall_index": w["recall_index"],
         "receipts": w["receipts"], "capture_alarm": w["capture_alarm"],
         "hook_drift": w["hook_drift"], "rescue_gap": w["rescue_gap"],
+        "rescue_posture": w["rescue_posture"],
         "forget_hits": w["forget_hits"],
     }
     return payload, w["rc"]
@@ -1666,6 +1678,8 @@ def _cmd_status(args) -> int:
         "recall_error": w["recall_error"], "recall_index": w["recall_index"],
         "receipts": w["receipts"], "capture_alarm": w["capture_alarm"],
         "hook_drift": w["hook_drift"], "rescue_gap": w["rescue_gap"],
+        "rescue_posture": w["rescue_posture"],
+        "rescue_window_errors": w["rescue_window_errors"],
         "forget_hits": w["forget_hits"],
     })
     return w["rc"]
@@ -2361,7 +2375,10 @@ def _cmd_stats(args) -> int:
     data = {"usage": _stats_usage(), "capture": _stats_capture(),
             "store": _stats_store(), "retention": _stats_retention(),
             "events": _stats_events(_resolve_project(None)),
-            "verification": _stats_verification(_resolve_project(None))}
+            "verification": _stats_verification(_resolve_project(None)),
+            # #475 part 2: current-configuration posture, rendered next to
+            # (never merged into) the historical fallback counts above.
+            "rescue_posture": llm.rescue_posture()}
     if args.json:
         print(json.dumps(data, indent=2))
         return 0

--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -220,18 +220,44 @@ def note_served(name) -> None:
         _served_models.append(name.strip())
 
 
+def resolve_backend() -> dict:
+    """The single source of truth for which backend serves a chat() call.
+
+    {"backend": "litellm"|"command"|"claude-cli",
+     "source": "explicit"|"auto-key"|"auto-command"|"auto-none"}
+
+    chat() calls this instead of re-deriving the "auto" cascade inline —
+    daimon#475's rescue-posture code calls it too, and any other caller must,
+    rather than re-implementing the decision a second time (two copies of
+    one decision drift the moment either changes).
+
+    Mirrors chat()'s dispatch exactly:
+    - config.llm_backend() returns an explicit value ("litellm", "command",
+      "claude-cli") -> that backend, source "explicit".
+    - "auto" + config.llm_api_key() truthy -> "litellm", source "auto-key".
+    - "auto" + no key + _resolve_command() resolves -> "command", source
+      "auto-command".
+    - "auto" + no key + nothing resolves -> "litellm", source "auto-none".
+      This is the branch where litellm is picked ONLY so _chat_litellm
+      raises its helpful no-key error — `source` is what lets callers tell
+      this apart from a real litellm install, and is the whole reason
+      `source` exists. Do not collapse it.
+    """
+    backend = config.llm_backend()
+    if backend != "auto":
+        return {"backend": backend, "source": "explicit"}
+    if config.llm_api_key():
+        return {"backend": "litellm", "source": "auto-key"}
+    if _resolve_command() is not None:
+        return {"backend": "command", "source": "auto-command"}
+    return {"backend": "litellm", "source": "auto-none"}
+
+
 def chat(messages, model=None, temperature=None, timeout=None, retries=3, deadline=None):
     """Dispatch to the configured backend. litellm (default) falls back to a
     command backend on ChatError when fallback is enabled and one resolves."""
     global _fallback_used
-    backend = config.llm_backend()
-    if backend == "auto":
-        if config.llm_api_key():
-            backend = "litellm"
-        elif _resolve_command() is not None:
-            backend = "command"
-        else:
-            backend = "litellm"   # let _chat_litellm raise the helpful no-key error
+    backend = resolve_backend()["backend"]
     if backend in ("command", "claude-cli"):
         return _chat_command(messages, deadline)
     try:

--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -253,6 +253,59 @@ def resolve_backend() -> dict:
     return {"backend": "litellm", "source": "auto-none"}
 
 
+def rescue_posture() -> str:
+    """Whether a rescue path exists for the CURRENTLY CONFIGURED primary
+    (daimon#475 part 2) — derived from resolve_backend(), never re-derived.
+
+    Field evidence: a `command`-backend install ran a 78% capture error rate
+    for 14 days while `daimon stats` showed `attempted 0, succeeded 0` —
+    indistinguishable from "a rescue existed and was never needed". Posture
+    is the missing fact: `chat()` returns from `_chat_command` at the top of
+    its dispatch, before the litellm/fallback try block even exists, so a
+    `command` primary has NO rescue direction by construction — no flag can
+    conjure one.
+
+    Five states, checked in this order (order matters):
+    - "none": the resolved backend is "command" or "claude-cli" — both
+      dispatch through _chat_command, which has no fallback branch at all.
+      Checked FIRST because a command backend needs no credentials, so the
+      no-backend test below must not claim it. An unknown backend string
+      (config.llm_backend() is free text) is NOT "command" or "claude-cli",
+      so it falls through to the litellm-family checks below — mirroring
+      chat()'s own dispatch, which treats any other string as the litellm
+      branch. Same rule, same edge case, same answer: no crash, no sixth
+      state.
+    - "no-backend": litellm family with neither credentials nor a resolvable
+      command — nothing can serve a call, so there is no rescue question to
+      answer and this must NOT nag about a missing fallback.
+
+      This deliberately does NOT key on resolve_backend()'s "auto-none"
+      source, which covers only the `auto` route to that state. Explicit
+      `DAIMON_LLM_BACKEND=litellm` with no key reaches the identical reality
+      by a different route, and keying on the source alone reported it as
+      "gap" — advising the operator to install a fallback when what they
+      actually lack is an API key. Verified against every backend/key/
+      fallback/command combination: the source-only test changed
+      rescue_gap's answer on real configurations, this one does not.
+    - "disabled": litellm family, but config.llm_fallback() is off — the
+      operator turned rescue off deliberately.
+    - "covered": litellm family, fallback on, and a command backend
+      resolves — a rescue path exists.
+    - "gap": litellm family, fallback on, nothing resolves — the #341
+      warning case.
+    """
+    resolved = resolve_backend()
+    if resolved["backend"] in ("command", "claude-cli"):
+        return "none"
+    if not config.llm_api_key() and _resolve_command() is None:
+        return "no-backend"
+    if not config.llm_fallback():
+        return "disabled"
+    if _resolve_command() is not None:
+        return "covered"
+    return "gap"
+
+
 def chat(messages, model=None, temperature=None, timeout=None, retries=3, deadline=None):
     """Dispatch to the configured backend. litellm (default) falls back to a
     command backend on ChatError when fallback is enabled and one resolves."""

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -530,6 +530,20 @@ def _capture_alarm_lines(alarm: dict) -> list[str]:
     ]
 
 
+def _rescue_none_warns(data: dict) -> bool:
+    """#475 part 2: the "none" posture warning ("`command` backend has no
+    rescue path") fires ONLY when there is a real failure to point at.
+
+    Gated on posture == "none" AND the 14-day capture window has errors > 0
+    — same shape as the #349 false positive removed and the #477 fix that
+    just landed: an operator who pinned `command` deliberately must not see
+    a permanent warning about a permanent property of their own choice.
+    `covered` / `disabled` / `no-backend` never warn at all (#84: no line,
+    no false alarms)."""
+    return (data.get("rescue_posture") == "none"
+            and (data.get("rescue_window_errors") or 0) > 0)
+
+
 def _forget_hits_line(data: dict) -> str | None:
     """#404: one line when the value-keyed tombstone has caught a re-assertion
     on this install; silent otherwise (same 'quiet by default' rule as the team
@@ -565,6 +579,10 @@ def _plain_status(data: dict) -> None:
         print("⚠ primary is a remote gateway and no fallback backend resolves "
               "— gateway failures won't be rescued (install claude or set "
               "DAIMON_LLM_COMMAND)")
+    if _rescue_none_warns(data):
+        print("⚠ the `command` backend has no rescue path — a failing "
+              "command is not retried or substituted. Run `daimon status` "
+              "for the recorded failure cause.")
     if data.get("team"):
         print(data["team"])  # one objective line; absent when team unused (#113)
     if data.get("receipts"):
@@ -651,6 +669,10 @@ def _rich_status(data: dict) -> None:
         console.print("[yellow]⚠ primary is a remote gateway and no fallback "
                       "backend resolves — gateway failures won't be rescued "
                       "(install claude or set DAIMON_LLM_COMMAND)[/yellow]")
+    if _rescue_none_warns(data):
+        console.print("[yellow]⚠ the `command` backend has no rescue path — "
+                      "a failing command is not retried or substituted. Run "
+                      "`daimon status` for the recorded failure cause.[/yellow]")
     if data.get("team"):
         console.print(data["team"])  # one objective line; absent when team unused (#113)
     if data.get("receipts"):
@@ -929,6 +951,35 @@ def _capture_window_lines(c: dict) -> list[str]:
     return lines
 
 
+# #475 part 2: `fallback: attempted 0, succeeded 0` reads identically whether
+# a rescue existed and was never needed OR no rescue path can exist for this
+# backend at all — the counter isn't wrong, it's unreadable. This suffix adds
+# the missing fact (current-configuration posture) next to the historical
+# counts, never merged into them.
+_RESCUE_SUFFIXES = {
+    "covered": "rescue available, not needed",
+    "disabled": "fallback disabled by config",
+    "gap": "no fallback resolves — gateway failures won't be rescued",
+    "none": "no rescue path — a `command` backend has no fallback direction",
+}
+
+
+def _rescue_suffix(posture, fallback_attempts: int) -> str | None:
+    """The `(...)` parenthetical for the stats fallback line, or None for a
+    posture with nothing to add (e.g. "no-backend", where there is no LLM
+    configured at all).
+
+    History-versus-config disagreement wins over the plain "none" text: an
+    install that ran on litellm and later pinned `command` shows historical
+    attempts under a current no-rescue posture. Same shape as #477 — do not
+    infer which config produced the counts, state both facts and let them
+    disagree visibly."""
+    if posture == "none" and fallback_attempts > 0:
+        return ("counts are historical; the current `command` backend has "
+                "no rescue path")
+    return _RESCUE_SUFFIXES.get(posture)
+
+
 def _plain_stats(data: dict) -> None:
     u, c, s = data["usage"], data["capture"], data["store"]
     print("usage (local, never transmitted):")
@@ -959,10 +1010,13 @@ def _plain_stats(data: dict) -> None:
                   "SessionStart hook may predate --auto; re-run `daimon hooks "
                   "install` (or update the plugin)")
     print("capture:")
+    fallback_attempts = c.get("fallback_attempts", 0)
+    suffix = _rescue_suffix(data.get("rescue_posture"), fallback_attempts)
     print(f"  serialized: {c['success']}  skipped: {c['skipped']}  "
           f"errors: {c['errors']}  fallback: "
-          f"attempted {c.get('fallback_attempts', 0)}, "
-          f"succeeded {c['fallback_serializes']}")
+          f"attempted {fallback_attempts}, "
+          f"succeeded {c['fallback_serializes']}"
+          + (f"  ({suffix})" if suffix else ""))
     for line in _capture_window_lines(c):
         print(f"  {line}")
     if c["hosts"]:
@@ -1051,8 +1105,11 @@ def _rich_stats(data: dict) -> None:
     capture_table.add_row("serialized", str(c["success"]))
     capture_table.add_row("skipped", str(c["skipped"]))
     capture_table.add_row("errors", str(c["errors"]))
-    capture_table.add_row("fallback", f"attempted {c.get('fallback_attempts', 0)}, "
-                                      f"succeeded {c['fallback_serializes']}")
+    fallback_attempts = c.get("fallback_attempts", 0)
+    suffix = _rescue_suffix(data.get("rescue_posture"), fallback_attempts)
+    capture_table.add_row("fallback", f"attempted {fallback_attempts}, "
+                                      f"succeeded {c['fallback_serializes']}"
+                                      + (f"  ({suffix})" if suffix else ""))
     window_lines = _capture_window_lines(c)
     if window_lines:
         # first line is `last Nd: <values>` — split it into the two columns

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -701,7 +701,7 @@ def test_cli_status_json_shape(
                          "siblings", "health", "team", "crash", "disabled",
                          "skipped_recent", "recall_error", "recall_index",
                          "receipts", "capture_alarm", "hook_drift",
-                         "rescue_gap", "forget_hits"}
+                         "rescue_gap", "rescue_posture", "forget_hits"}
     assert data["capture_alarm"] is None  # #265 FAIL-only probe silent by default
     assert data["forget_hits"]["count"] == 0  # #404 nothing suppressed yet
     assert data["team"] is None  # no team remote configured -> explicit null (#113)
@@ -5129,6 +5129,187 @@ def test_status_no_rescue_warning_when_command_resolves(tmp_checkpoint_dir,
     cli.main(["status"])   # rc reflects checkpoint health, not this warning
     out = capsys.readouterr().out
     assert "no fallback backend resolves" not in out
+
+
+# ---- #475 part 2: rescue posture — the fact missing from the fallback
+# counter is whether a rescue was ever POSSIBLE, not just whether it fired.
+
+
+@pytest.mark.parametrize(
+    "backend, fallback, api_key, command, expected_posture",
+    [
+        ("auto", "1", None, None, "no-backend"),
+        ("command", "1", "k", ("claude -p", "text", "stdin"), "none"),
+        ("claude-cli", "1", "k", ("claude -p", "text", "stdin"), "none"),
+        ("litellm", "0", "k", ("claude -p", "text", "stdin"), "disabled"),
+        ("litellm", "1", "k", ("claude -p", "text", "stdin"), "covered"),
+        ("litellm", "1", "k", None, "gap"),
+    ],
+    ids=["no-backend", "none-command", "none-claude-cli", "disabled",
+         "covered", "gap"],
+)
+def test_cli_status_rescue_gap_matches_posture_across_all_rows(
+        tmp_checkpoint_dir, monkeypatch, backend, fallback, api_key, command,
+        expected_posture):
+    # Design test 7: rescue_gap must stay JSON-back-compatible across every
+    # posture row — it is exactly `posture == "gap"`, never anything else.
+    from daimon_briefing import config, llm
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", backend)
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", fallback)
+    monkeypatch.setattr(config, "llm_api_key", lambda: api_key)
+    monkeypatch.setattr(llm, "_resolve_command", lambda: command)
+    payload, _ = cli.status_payload(None)
+    assert payload["rescue_posture"] == expected_posture
+    assert payload["rescue_gap"] == (expected_posture == "gap")
+
+
+def test_status_none_warning_silent_when_no_window_errors(
+        tmp_checkpoint_dir, tmp_log_dir, monkeypatch, capsys):
+    # #349/#477 shape: an operator who pinned `command` deliberately must not
+    # see a permanent warning about a permanent property of their own
+    # choice. No in-window errors -> no line at all (#84 rule).
+    from daimon_briefing import llm
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("claude -p", "text", "stdin"))
+    # Anchor the state FIRST. Asserting only the absence of a string passes
+    # vacuously — it would still pass if the posture never reached "none", if
+    # the window were not actually error-free, or if the warning did not exist
+    # at all. Pin both halves of the gate's input before testing its output.
+    payload, _ = cli.status_payload()
+    assert payload["rescue_posture"] == "none"
+    assert cli._stats_capture()["window"]["errors"] == 0
+    cli.main(["status"])
+    out = capsys.readouterr().out
+    assert "no rescue path" not in out
+
+
+def test_status_none_warning_fires_when_window_has_errors(
+        tmp_checkpoint_dir, tmp_log_dir, monkeypatch, capsys):
+    from daimon_briefing import llm
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("claude -p", "text", "stdin"))
+    now = datetime.now(timezone.utc)
+    _write_log(tmp_log_dir, [
+        f"{_iso(now - timedelta(days=1))} session-end: spawned serialize for A "
+        "(project: /p/A)",
+        "error: boom (transcript: /t/A.jsonl) after 3s",
+    ])
+    cli.main(["status"])
+    out = capsys.readouterr().out
+    assert "⚠ the `command` backend has no rescue path" in out
+    assert "Run `daimon status` for the recorded failure cause." in out
+
+
+def test_status_covered_disabled_no_backend_stay_silent(
+        tmp_checkpoint_dir, tmp_log_dir, monkeypatch, capsys):
+    # covered / disabled / no-backend never warn, even with in-window errors
+    # (#84: "no line, no false alarms" — these are not rescue-gap states).
+    from daimon_briefing import config, llm
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setattr(config, "llm_api_key", lambda: "k")
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("claude -p", "text", "stdin"))
+    now = datetime.now(timezone.utc)
+    _write_log(tmp_log_dir, [
+        f"{_iso(now - timedelta(days=1))} session-end: spawned serialize for A "
+        "(project: /p/A)",
+        "error: boom (transcript: /t/A.jsonl) after 3s",
+    ])
+    # Anchor the state: errors ARE present in the window, so silence here is
+    # the posture's doing and not an empty fixture. Without this the assertion
+    # below passes vacuously.
+    payload, _ = cli.status_payload()
+    assert payload["rescue_posture"] == "covered"
+    assert cli._stats_capture()["window"]["errors"] > 0
+    cli.main(["status"])
+    out = capsys.readouterr().out
+    assert "no rescue path" not in out
+
+
+def test_stats_plain_fallback_line_suffix_covered(
+        tmp_checkpoint_dir, tmp_log_dir, sample_checkpoint, capsys, monkeypatch):
+    from daimon_briefing import config, llm, store
+    monkeypatch.setenv("DAIMON_PLAIN", "1")
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setattr(config, "llm_api_key", lambda: "k")
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("claude -p", "text", "stdin"))
+    store.write_checkpoint("S1", sample_checkpoint)
+    assert cli.main(["stats"]) == 0
+    out = capsys.readouterr().out
+    assert "fallback: attempted 0, succeeded 0  (rescue available, not needed)" in out
+
+
+def test_stats_rich_fallback_line_suffix_covered(
+        tmp_checkpoint_dir, tmp_log_dir, sample_checkpoint, capsys, monkeypatch):
+    from daimon_briefing import config, llm, store
+    monkeypatch.setattr("daimon_briefing.render.supports_rich", lambda: True)
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setattr(config, "llm_api_key", lambda: "k")
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("claude -p", "text", "stdin"))
+    store.write_checkpoint("S1", sample_checkpoint)
+    assert cli.main(["stats"]) == 0
+    out = capsys.readouterr().out
+    assert "rescue available, not needed" in out
+
+
+def test_stats_plain_fallback_line_suffix_none(
+        tmp_checkpoint_dir, tmp_log_dir, sample_checkpoint, capsys, monkeypatch):
+    from daimon_briefing import llm, store
+    monkeypatch.setenv("DAIMON_PLAIN", "1")
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("claude -p", "text", "stdin"))
+    store.write_checkpoint("S1", sample_checkpoint)
+    assert cli.main(["stats"]) == 0
+    out = capsys.readouterr().out
+    assert ("fallback: attempted 0, succeeded 0  (no rescue path — a "
+            "`command` backend has no fallback direction)") in out
+
+
+def test_stats_rich_fallback_line_suffix_none(
+        tmp_checkpoint_dir, tmp_log_dir, sample_checkpoint, capsys, monkeypatch):
+    from daimon_briefing import llm, store
+    monkeypatch.setattr("daimon_briefing.render.supports_rich", lambda: True)
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("claude -p", "text", "stdin"))
+    store.write_checkpoint("S1", sample_checkpoint)
+    assert cli.main(["stats"]) == 0
+    out = capsys.readouterr().out
+    # Rich wraps the table cell at column width, so the phrase can land on
+    # two lines — assert the halves rather than one brittle exact substring
+    # (the file's own convention for rich output: content, not format).
+    assert "no rescue path" in out
+    assert "no fallback direction" in out
+
+
+def test_stats_plain_fallback_line_historical_disclaimer_when_posture_none(
+        tmp_checkpoint_dir, tmp_log_dir, sample_checkpoint, capsys, monkeypatch):
+    # The history/config trap (#477 shape): an install that ran on litellm
+    # and then switched to `command` shows historical attempts under a
+    # current no-rescue posture. Do not infer which config produced them —
+    # render both facts and let them disagree visibly.
+    from daimon_briefing import llm, store
+    monkeypatch.setenv("DAIMON_PLAIN", "1")
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("claude -p", "text", "stdin"))
+    store.write_checkpoint("S1", sample_checkpoint)
+    now = datetime.now(timezone.utc)
+    lines = []
+    for i in range(30):
+        lines.append(f"{_iso(now - timedelta(days=1))} WARNING daimon_briefing.llm: "
+                     "llm.fallback backend=command (litellm failed)")
+        if i < 6:
+            lines.append(f"wrote checkpoint: /c/{i}.json (took 9s) [fallback backend]")
+    _write_log(tmp_log_dir, lines)
+    assert cli.main(["stats"]) == 0
+    out = capsys.readouterr().out
+    assert "fallback: attempted 30, succeeded 6" in out
+    assert ("counts are historical; the current `command` backend has no "
+            "rescue path") in out
+    # The plain "no rescue path" suffix must NOT also appear standalone —
+    # the historical disclaimer replaces it, it doesn't sit alongside it.
+    assert out.count("no rescue path") == 1
 
 
 def test_stats_capture_does_not_dedupe_spawn_lines(tmp_log_dir):

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -616,6 +616,104 @@ def test_chat_auto_falls_to_litellm_when_nothing(monkeypatch):
         llm.chat([{"role": "user", "content": "x"}])
 
 
+# ---- #475 slice 1: resolve_backend() — single source of truth for dispatch.
+# chat() re-implemented the "auto" cascade inline; rescue-posture code (slice
+# 2) needs the same decision. Two copies of one decision drift the moment
+# either changes — extract it once, make chat() USE it, and pin the agreement
+# with a test that can never let them diverge again.
+
+
+def test_resolve_backend_explicit_command(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    assert llm.resolve_backend() == {"backend": "command", "source": "explicit"}
+
+
+def test_resolve_backend_explicit_claude_cli(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "claude-cli")
+    assert llm.resolve_backend() == {"backend": "claude-cli", "source": "explicit"}
+
+
+def test_resolve_backend_explicit_litellm(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    assert llm.resolve_backend() == {"backend": "litellm", "source": "explicit"}
+
+
+def test_resolve_backend_auto_key_present(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "auto")
+    monkeypatch.setattr(config, "llm_api_key", lambda: "sk-key")
+    assert llm.resolve_backend() == {"backend": "litellm", "source": "auto-key"}
+
+
+def test_resolve_backend_auto_no_key_command_resolves(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "auto")
+    monkeypatch.setattr(config, "llm_api_key", lambda: None)
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text", "stdin"))
+    assert llm.resolve_backend() == {"backend": "command", "source": "auto-command"}
+
+
+def test_resolve_backend_auto_no_key_no_command(monkeypatch):
+    # The "auto-none" branch: chat() still picks litellm here (so
+    # _chat_litellm raises its helpful no-key error), but `source` marks it
+    # distinctly from a real litellm install — do not collapse it.
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "auto")
+    monkeypatch.setattr(config, "llm_api_key", lambda: None)
+    monkeypatch.setattr(llm, "_resolve_command", lambda: None)
+    assert llm.resolve_backend() == {"backend": "litellm", "source": "auto-none"}
+
+
+def _dispatch_family(backend: str) -> str:
+    """chat() branches on `backend in ("command", "claude-cli")`, sending
+    both onto the SAME function (_chat_command) — the drift test below can
+    only observe which underlying function actually ran, not the distinct
+    label, so it buckets resolve_backend()'s output the same way chat() does
+    before comparing."""
+    return "command" if backend in ("command", "claude-cli") else "litellm"
+
+
+@pytest.mark.parametrize(
+    "backend_env, api_key, command_resolves",
+    [
+        ("command", None, None),
+        ("claude-cli", None, None),
+        ("litellm", "sk-test", None),
+        ("auto", "sk-key", None),
+        ("auto", None, ("mycli", "text", "stdin")),
+        ("auto", None, None),
+    ],
+    ids=[
+        "explicit-command", "explicit-claude-cli", "explicit-litellm",
+        "auto-key", "auto-command", "auto-none",
+    ],
+)
+def test_resolve_backend_agrees_with_chat_dispatch(
+    monkeypatch, backend_env, api_key, command_resolves
+):
+    """The agreement test (#475 design doc, test 8): chat()'s real dispatch
+    must never disagree with resolve_backend(). Stub both backend
+    implementations to record which one chat() actually invokes, then assert
+    it matches resolve_backend() — this is what makes the two-copies-drift
+    class structurally untestable-to-break."""
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", backend_env)
+    monkeypatch.setattr(config, "llm_api_key", lambda: api_key)
+    monkeypatch.setattr(llm, "_resolve_command", lambda: command_resolves)
+    invoked = {"backend": None}
+
+    def fake_litellm(*a, **k):
+        invoked["backend"] = "litellm"
+        return "FROM_LITELLM"
+
+    def fake_command(m, deadline):
+        invoked["backend"] = "command"
+        return "FROM_CMD"
+
+    monkeypatch.setattr(llm, "_chat_litellm", fake_litellm)
+    monkeypatch.setattr(llm, "_chat_command", fake_command)
+
+    llm.chat([{"role": "user", "content": "x"}])
+
+    assert invoked["backend"] == _dispatch_family(llm.resolve_backend()["backend"])
+
+
 # ---- #28 S6: fallback must be observable, not just logged to a dead-drop ----
 
 

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -714,6 +714,107 @@ def test_resolve_backend_agrees_with_chat_dispatch(
     assert invoked["backend"] == _dispatch_family(llm.resolve_backend()["backend"])
 
 
+# ---- #475 slice 2: rescue_posture() — whether a rescue path exists for the
+# CURRENT configuration, derived from resolve_backend() (never re-derived).
+
+
+def test_rescue_posture_no_backend(monkeypatch):
+    # resolve_backend()'s auto-none branch: nothing resolves at all. Must read
+    # as "no-backend", never "gap" — a machine with no LLM configured at all
+    # should not nag about a missing fallback.
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "auto")
+    monkeypatch.setattr(config, "llm_api_key", lambda: None)
+    monkeypatch.setattr(llm, "_resolve_command", lambda: None)
+    assert llm.rescue_posture() == "no-backend"
+
+
+def test_rescue_posture_no_backend_for_explicit_litellm_without_a_key(monkeypatch):
+    # The SAME reality as the auto-none case, reached by a different route.
+    # Keying "no-backend" on resolve_backend()'s source alone reported this
+    # config as "gap" — telling an operator to install a fallback when what
+    # they actually lack is an API key, and flipping rescue_gap's answer on a
+    # real configuration. The condition is "no credentials AND no command",
+    # not "how did we get here".
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setattr(config, "llm_api_key", lambda: None)
+    monkeypatch.setattr(llm, "_resolve_command", lambda: None)
+    assert llm.rescue_posture() == "no-backend"
+
+
+def test_rescue_posture_keyless_litellm_with_a_command_is_covered(monkeypatch):
+    # No key, but a command resolves and fallback is on: every call fails over
+    # to the command and succeeds. That is a rescue path, not an absent
+    # backend — the no-backend test must require BOTH halves to be missing.
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setattr(config, "llm_api_key", lambda: None)
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text", "stdin"))
+    assert llm.rescue_posture() == "covered"
+
+
+def test_rescue_posture_none_for_explicit_command_backend(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    assert llm.rescue_posture() == "none"
+
+
+def test_rescue_posture_none_for_explicit_claude_cli_backend(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "claude-cli")
+    assert llm.rescue_posture() == "none"
+
+
+def test_rescue_posture_command_primary_stays_none_even_with_fallback_and_key(monkeypatch):
+    # Test 3 of the design's plan: flags cannot conjure a rescue direction
+    # that does not exist. A `command` primary has no fallback direction by
+    # construction, regardless of DAIMON_LLM_FALLBACK or an available litellm
+    # key.
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setattr(config, "llm_api_key", lambda: "sk-key")
+    assert llm.rescue_posture() == "none"
+
+
+def test_rescue_posture_disabled(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setattr(config, "llm_api_key", lambda: "sk-key")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "0")
+    assert llm.rescue_posture() == "disabled"
+
+
+def test_rescue_posture_covered(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setattr(config, "llm_api_key", lambda: "sk-key")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text", "stdin"))
+    assert llm.rescue_posture() == "covered"
+
+
+def test_rescue_posture_gap(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setattr(config, "llm_api_key", lambda: "sk-key")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setattr(llm, "_resolve_command", lambda: None)
+    assert llm.rescue_posture() == "gap"
+
+
+def test_rescue_posture_unknown_backend_string_joins_litellm_family(monkeypatch):
+    # chat() treats anything not in ("command", "claude-cli") as the litellm
+    # branch (config.llm_backend() is free text) — posture must mirror that
+    # exactly: no crash, no sixth state, same litellm-family resolution.
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "bogus")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    # A key must be present to exercise the FAMILY question. Without one the
+    # honest answer is "no-backend" regardless of which family the string
+    # joins, and this test would be asking two questions at once.
+    monkeypatch.setattr(config, "llm_api_key", lambda: "sk-key")
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text", "stdin"))
+    assert llm.rescue_posture() == "covered"
+    monkeypatch.setattr(llm, "_resolve_command", lambda: None)
+    assert llm.rescue_posture() == "gap"
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "0")
+    assert llm.rescue_posture() == "disabled"
+
+
 # ---- #28 S6: fallback must be observable, not just logged to a dead-drop ----
 
 


### PR DESCRIPTION
Refs #475

Part 2 only. Part 1 — whether a command-backend install should gain a rescue path, and whether transcript text may leave the machine to get one — is a policy decision and stays open. Using `Refs` so merging does not close the issue.

## What

`fallback: attempted 0, succeeded 0` was rendered identically in two situations that are nothing alike: a rescue path existed and was never needed, or **no rescue path could exist at all**. `chat()` returns from `_chat_command` above the `try` block, so a `command` primary has no fallback direction by construction and no flag can conjure one.

Adds `rescue_posture()` — derived from `resolve_backend()` (extracted in the first commit) so it can never disagree with what `chat()` actually dispatches:

| posture | meaning | warns? |
|---|---|---|
| `covered` | rescue path exists | no |
| `gap` | rescuable in principle, nothing resolves | yes — existing #341 warning, unchanged |
| `disabled` | operator turned fallback off | no |
| `none` | no rescue direction exists, by construction | only when the window has errors |
| `no-backend` | nothing can serve a call | no |

`stats` suffixes the existing counts; `status` gains the `none` warning.

**The warning is error-gated.** An operator who pinned `command` deliberately must not see a permanent warning about a permanent property of their own choice — the same false positive #349 removed and #477 just finished cleaning up. No errors in the window, no line.

**History and configuration are kept apart.** `serialize.log` records fallback entry and success but never which primary served each line, so history cannot be attributed to a config. When the counts disagree with the current posture, both facts are printed:

```
fallback: attempted 30, succeeded 6  (counts are historical; the current `command` backend has no rescue path)
```

## Two corrections found in review

**1. `no-backend` was under-specified.** It keyed on `resolve_backend()`'s `auto-none` source, which covers only the `auto` route to that state. Explicit `DAIMON_LLM_BACKEND=litellm` with no key reaches the identical reality by a different route, and was reported as `gap` — advising the operator to install a fallback when what they actually lack is an API key. The condition is now "no credentials **and** no command resolves".

Verified by enumerating all 40 backend/key/fallback/command combinations against the pre-refactor formula. The source-keyed version changed `rescue_gap`'s answer on 3 rows; this one changes it on 1.

**2. That surviving row is intentional.** Unknown backend string with a key present. The old formula required `llm_backend()` to be exactly `"litellm"` or `"auto"`, so a typo in an unrelated field silently suppressed a real gap warning. `chat()` treats any unknown string as the litellm branch, so the gap is real and it now warns.

## Test quality

Two tests asserted only the *absence* of a string and passed vacuously — they never verified the state under test was reached. Both now anchor the posture and the error window before asserting. Confirmed by mutation: forcing `rescue_posture()` to never return `none` fails the anchor, where previously it passed green.

The backend resolver's agreement test was also mutation-checked — re-inlining the old `auto` cascade into `chat()` fails it.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/llm.py` | `resolve_backend()` (single source of truth for dispatch) + `rescue_posture()` |
| `plugin/daimon_briefing/cli.py` | `rescue_gap` re-expressed as `posture == "gap"`, replacing the hand-duplicated inline formula; `rescue_posture` added to the `status --json` payload |
| `plugin/daimon_briefing/render.py` | posture suffix on the stats fallback line (plain + rich), the historical-disagreement override, and the error-gated `none` warning |
| `plugin/tests/test_llm.py` | resolver rows, the agreement/drift test, posture rows, the keyless-litellm cases |
| `plugin/tests/test_cli.py` | `rescue_gap`/posture consistency across all rows, warning-gate tests, stats suffix + disclaimer tests |
| `.scars/candidates/` | landmine: clearing `os.environ` does not unset a daimon config value |

`rescue_gap` keeps its exact meaning and its place in the JSON payload; `rescue_posture` is added alongside it, not in place of it.

## Tests

- [x] `uv run pytest -q` → **2544 passed, 2 skipped** (baseline 2508 before this branch)
- [x] `uv run ruff check daimon_briefing tests` → clean
- [x] `scar lint` → 36 files, 0 errors
- [x] Mutation-verified: the drift test and the hardened gate anchor both fail on a real break
- [x] Exhaustive parity check across all 40 config combinations for `rescue_gap` back-compat
