### PR TITLE
feat(cli): loop handles — ids inline and a daimon loops listing

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -94,7 +94,39 @@ def corroboration_badge(item) -> str:
     return f" [≈ corroborated ×{n}]"
 
 
-def _line(item, degraded: bool = False) -> str:
+# ---- #480 slice 1: resolve handles on open-loop-class items ----
+
+# build()'s section keys that render a resolve handle — the single source of
+# truth both render paths (plain _line below, rich render._rich_brief) and
+# `daimon loops` key off of. Decisions/beliefs/contradictions are valid
+# `daimon resolve` targets too (resolve accepts any item id), but are not
+# loop-shaped: stamping a handle there would invite resolving settled facts,
+# which is out of this slice's scope.
+BRIEFABLE_SECTIONS = frozenset({"external", "open_loops", "uncertainties"})
+
+# The raw checkpoint field keys underlying BRIEFABLE_SECTIONS above — build()
+# splits ONE field (open_questions) into "external"/"open_loops" by the
+# external_state flag, so the raw-checkpoint view collapses back to two keys.
+# `daimon loops` walks store._ITEM_LISTS (raw section/key pairs), not the
+# built briefing dict, so it needs this mapping rather than BRIEFABLE_SECTIONS
+# itself.
+BRIEFABLE_ITEM_KEYS = frozenset({"open_questions", "uncertainties"})
+
+
+def _handle_suffix(item, briefable: bool) -> str:
+    """The compact ` [id]` handle appended to a briefable item's rendered
+    line — the read side of the #480 write path: an agent (or a human via
+    `daimon loops`) needs something to pass to `daimon resolve`. A legacy
+    item with no id renders unchanged (empty string), and a non-briefable
+    item (decision/belief/contradiction) never earns one in this slice
+    regardless of whether it happens to carry an id."""
+    if not briefable:
+        return ""
+    item_id = item.get("id")
+    return f" [{item_id}]" if item_id else ""
+
+
+def _line(item, degraded: bool = False, briefable: bool = False) -> str:
     # #134: dict.get returns the stored None for a present-but-null key (the
     # default only fires for an ABSENT key), so a torn/legacy checkpoint could
     # crash the whole render here. Use the codebase's str(x or "") idiom
@@ -113,6 +145,7 @@ def _line(item, degraded: bool = False) -> str:
     base += corroboration_badge(item)
     if quote:
         base += f'  — "{quote}"'
+    base += _handle_suffix(item, briefable)
     candidate = item.get("_supersede_candidate")
     if candidate:
         # #14: a machine-suggested (unconfirmed) supersession — never
@@ -573,7 +606,8 @@ def _render_parts(b: dict, trimmed: dict, degraded: bool = False) -> str:
             return
         parts.append("")
         parts.append(header)
-        parts.extend(_line(i, degraded) for i in items)
+        briefable = key in BRIEFABLE_SECTIONS
+        parts.extend(_line(i, degraded, briefable) for i in items)
         if key == "decisions":
             overflow = _overflow_note(b.get("decisions_overflow", 0))
             if overflow:
@@ -584,7 +618,7 @@ def _render_parts(b: dict, trimmed: dict, degraded: bool = False) -> str:
     if b["external"]:
         parts.append("")
         parts.append("VERIFY BEFORE TRUSTING (state may have changed outside this session):")
-        parts.extend(_line(i, degraded) for i in b["external"])
+        parts.extend(_line(i, degraded, "external" in BRIEFABLE_SECTIONS) for i in b["external"])
 
     _section("Open loops:", "open_loops")
     _section("Decisions made:", "decisions")

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1029,6 +1029,54 @@ def _cmd_reverify(args) -> int:
     return 0
 
 
+def _cmd_loops(args) -> int:
+    """`daimon loops` (#480 slice 1): list open, briefable loop items with
+    ids for this project — the read-only counterpart to the id handles
+    briefing._line now renders inline (an agent, or a human, needs something
+    to pass to `daimon resolve`).
+
+    Reuses the SAME item walk `_cmd_resolve` builds (store._ITEM_LISTS over
+    the latest checkpoint) and the SAME withhold classification `daimon
+    status --suppressed` uses (briefing.withhold over store.resolutions) —
+    the resolved/live split must stay in exactly one place, or this listing
+    could show an item the briefing itself would withhold (an agent would
+    then "resolve" a ghost).
+
+    Briefable = briefing.BRIEFABLE_ITEM_KEYS (open_questions — external and
+    non-external both — plus uncertainties). Decisions/beliefs/
+    contradictions are valid `daimon resolve` targets too, but are not
+    loop-shaped; listing them here would invite resolving settled facts
+    (#480 scope guard, mirrors briefing._line's new suffix)."""
+    _note_usage("loops")
+    project = _resolve_project(args.project)
+    checkpoint = store.read_latest(project_dir=project, fallback=False)
+    if not isinstance(checkpoint, dict):
+        print("no checkpoint for this project yet — nothing to list")
+        return 0
+    try:
+        events = store.resolutions(project_dir=project)
+        checkpoint, _, _ = briefing.withhold(checkpoint, events)
+    except Exception:
+        pass  # fail-open, same stance as _print_suppressed
+    rows = []
+    for section, key in store._ITEM_LISTS:
+        if key not in briefing.BRIEFABLE_ITEM_KEYS:
+            continue
+        for item in ((checkpoint.get(section) or {}).get(key) or []):
+            if not isinstance(item, dict) or not item.get("id"):
+                continue
+            text = str(item.get("text") or "").strip()
+            if not text:
+                continue
+            rows.append((item["id"], key, text, briefing._mark(item)))
+    if not rows:
+        print("no open loops")
+        return 0
+    for item_id, key, text, mark in rows:
+        print(f"  {item_id}  [{key}] [{mark}] {text}")
+    return 0
+
+
 def _cmd_log(args) -> int:
     """Freeform zero-LLM event append (#102): a timeline fact worth keeping
     that is not tied to one item. The fold ignores ref-less lines; readers
@@ -2838,6 +2886,14 @@ def build_parser() -> argparse.ArgumentParser:
     p_reverify.add_argument("--evidence", help="why this claim can be trusted again")
     p_reverify.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
     p_reverify.set_defaults(func=_cmd_reverify)
+
+    p_loops = sub.add_parser(
+        "loops", help="list open, briefable loop items with ids for this "
+        "project (#480) — the read counterpart to daimon resolve's write path",
+        epilog="Examples:\n  daimon loops\n  daimon loops --project .\n",
+    )
+    p_loops.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    p_loops.set_defaults(func=_cmd_loops)
 
     p_log = sub.add_parser(
         "log", help="append a freeform timeline event (zero-LLM) to this project's event log (#102)",

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -196,6 +196,10 @@ def _rich_brief(b: dict, degraded: bool = False) -> None:
         if not items:
             continue
         body = Text()
+        # #480 slice 1: whether THIS section's items earn a resolve handle —
+        # same set briefing._line's plain path keys off of, so the two
+        # renders agree on which items are actionable.
+        briefable = key in briefing.BRIEFABLE_SECTIONS
         for i in items:
             trust = _trust_key(i)
             # Degrade a verbatim item's confident green — its integrity is
@@ -207,7 +211,13 @@ def _rich_brief(b: dict, degraded: bool = False) -> None:
             # before the quote) — one shared literal, so the two renders state
             # the witness count in identical bytes.
             body.append(f"• {i.get('text', '').strip()}"
-                        f"{briefing.corroboration_badge(i)}\n", style=item_style)
+                        f"{briefing.corroboration_badge(i)}", style=item_style)
+            # #480 slice 1: the id handle, dim like the quote below — it is
+            # a supplementary resolve target, not part of the claim itself.
+            handle = briefing._handle_suffix(i, briefable)
+            if handle:
+                body.append(handle, style="dim")
+            body.append("\n", style=item_style)
             quote = i.get("quote", "").strip()
             if quote:
                 body.append(f'    "{quote}"\n', style="dim italic")

--- a/plugin/tests/test_briefing.py
+++ b/plugin/tests/test_briefing.py
@@ -455,6 +455,75 @@ def test_line_carried_marker_precedes_quote():
     assert line.index("[carried]") < line.index("the exact words")
 
 
+# ---- #480 slice 1: resolve handles on open-loop-class items ----
+
+
+def test_line_renders_id_suffix_when_briefable():
+    item = {"text": "chunk threshold unclear", "trust": "inferred", "id": "o-3f2a9c"}
+    assert "[o-3f2a9c]" in briefing._line(item, briefable=True)
+
+
+def test_line_omits_id_suffix_when_not_briefable():
+    item = {"text": "adopt the D-007 prompt", "trust": "verbatim", "id": "r-aa11bb"}
+    assert "[r-aa11bb]" not in briefing._line(item, briefable=False)
+
+
+def test_line_legacy_item_without_id_unaffected_by_briefable_flag():
+    # A legacy item (no id yet) must render identically whether or not its
+    # section is briefable — no suffix, no crash.
+    item = {"text": "old loop, no id yet", "trust": "inferred"}
+    assert briefing._line(item, briefable=True) == briefing._line(item, briefable=False)
+
+
+def test_render_plain_shows_handle_for_open_loop_item():
+    cp = {"working_context": {"open_questions": [
+              {"text": "chunk threshold unclear", "trust": "inferred", "id": "o-3f2a9c"}]},
+          "epistemic_snapshot": {}}
+    out = briefing.render_plain(briefing.build(cp))
+    assert "[o-3f2a9c]" in out
+
+
+def test_render_plain_shows_handle_for_uncertainty_item():
+    cp = {"working_context": {}, "epistemic_snapshot": {"uncertainties": [
+              {"text": "not sure retries are safe", "trust": "inferred", "id": "u-11aa22"}]}}
+    out = briefing.render_plain(briefing.build(cp))
+    assert "[u-11aa22]" in out
+
+
+def test_render_plain_shows_handle_for_external_item():
+    cp = {"working_context": {"open_questions": [
+              {"text": "PR #6 state", "trust": "verbatim", "quote": "I'll merge it",
+               "external_state": True, "id": "o-77bb88"}]},
+          "epistemic_snapshot": {}}
+    out = briefing.render_plain(briefing.build(cp))
+    assert "[o-77bb88]" in out
+
+
+def test_render_plain_never_suffixes_decisions_with_id():
+    cp = {"working_context": {"recent_decisions": [
+              {"text": "adopt D-007 prompt", "trust": "verbatim", "id": "r-abc123"}]},
+          "epistemic_snapshot": {}}
+    out = briefing.render_plain(briefing.build(cp))
+    assert "[r-abc123]" not in out
+
+
+def test_render_plain_never_suffixes_beliefs_with_id():
+    cp = {"working_context": {}, "epistemic_snapshot": {"strong_beliefs": [
+              {"text": "extractive pinning prevents fact loss", "trust": "inferred",
+               "id": "s-99aa88"}]}}
+    out = briefing.render_plain(briefing.build(cp))
+    assert "[s-99aa88]" not in out
+
+
+def test_render_plain_legacy_open_loop_without_id_renders_unchanged():
+    cp = {"working_context": {"open_questions": [
+              {"text": "chunk threshold unclear", "trust": "inferred"}]},
+          "epistemic_snapshot": {}}
+    out = briefing.render_plain(briefing.build(cp))
+    lines = out.splitlines()
+    assert "- [~ inferred] chunk threshold unclear" in lines
+
+
 # ---- #134: null text/quote must render, not crash (torn/legacy checkpoint) ----
 
 

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -6561,6 +6561,77 @@ def test_log_appends_freeform_event(tmp_checkpoint_dir, capsys, monkeypatch):
     assert line["item_ref"] == ""
 
 
+# ---- #480 slice 1: daimon loops — the resolve-handle listing ----
+
+
+def test_loops_lists_open_loop_items_with_ids(tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    assert cli.main(["loops"]) == 0
+    out = capsys.readouterr().out
+    for item in cp["working_context"]["open_questions"]:
+        assert item["id"] in out
+        assert item["text"] in out
+
+
+def test_loops_excludes_item_withheld_by_resolution(tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    resolved_id = cp["working_context"]["open_questions"][0]["id"]
+    live_id = cp["working_context"]["open_questions"][1]["id"]
+    assert cli.main(["resolve", resolved_id]) == 0
+    capsys.readouterr()  # discard resolve's own output
+    assert cli.main(["loops"]) == 0
+    out = capsys.readouterr().out
+    assert resolved_id not in out
+    assert live_id in out
+
+
+def test_loops_no_checkpoint_exits_0_with_friendly_message(tmp_checkpoint_dir, capsys, monkeypatch):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    assert cli.main(["loops"]) == 0
+    out = capsys.readouterr().out
+    assert "no checkpoint" in out.lower()
+
+
+def test_loops_no_open_loops_exits_0_with_friendly_message(tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = {"working_context": {"recent_decisions": [
+        {"text": "adopt D-007 prompt", "trust": "verbatim"}]}}
+    store.write_checkpoint("S1", cp, project_dir="/p/A")
+    assert cli.main(["loops"]) == 0
+    out = capsys.readouterr().out
+    assert "no open loops" in out.lower()
+
+
+def test_loops_excludes_decisions_scope_guard(tmp_checkpoint_dir, capsys, monkeypatch):
+    # #480 slice 1 scope guard: decisions are valid `daimon resolve` targets
+    # too, but are not loop-shaped — `daimon loops` must not list them.
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = {"working_context": {
+        "open_questions": [{"text": "chunk threshold unclear", "trust": "inferred"}],
+        "recent_decisions": [{"text": "adopt D-007 prompt", "trust": "verbatim"}],
+    }}
+    store.write_checkpoint("S1", cp, project_dir="/p/A")
+    assert cli.main(["loops"]) == 0
+    out = capsys.readouterr().out
+    assert "chunk threshold unclear" in out
+    assert "adopt D-007 prompt" not in out
+
+
+def test_loops_records_usage_event(tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    _write_cp_with_ids(store)
+    assert cli.main(["loops"]) == 0
+    lines = (tmp_log_dir / "usage.log").read_text().splitlines()
+    assert lines[0].split()[1] == "loops"
+
+
 # ---- #103: daimon reverify — evidence-gated reopen ----
 
 

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -6596,6 +6596,45 @@ def test_loops_no_checkpoint_exits_0_with_friendly_message(tmp_checkpoint_dir, c
     assert "no checkpoint" in out.lower()
 
 
+def test_loops_skips_idless_and_empty_text_items(tmp_checkpoint_dir, capsys, monkeypatch):
+    # A legacy item with no id has no handle to print; an id-bearing item with
+    # blank text would render as a bare handle. Both skip, neither crashes.
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = {"session_id": "S1", "working_context": {"open_questions": [
+        {"text": "legacy loop without an id", "trust": "inferred"},
+        {"text": "live loop with an id", "trust": "inferred"},
+    ]}}
+    store.write_checkpoint("S1", cp, project_dir="/p/A")
+    # Strip the id write_checkpoint stamped on the first item, blank the text
+    # path via a raw edit of the stored checkpoint.
+    stored = store.read_latest(project_dir="/p/A", fallback=False)
+    items = stored["working_context"]["open_questions"]
+    items[0].pop("id", None)
+    items[1]["text"] = "   "
+    import json
+    p = store.project_latest_path("/p/A")
+    p.write_text(json.dumps(stored), encoding="utf-8")
+    assert cli.main(["loops"]) == 0
+    out = capsys.readouterr().out
+    assert "no open loops" in out
+    assert "legacy loop" not in out
+
+
+def test_loops_fails_open_when_resolutions_fold_raises(tmp_checkpoint_dir, capsys, monkeypatch):
+    # Same stance as _print_suppressed: a broken events.jsonl must not take
+    # the listing down with it — the loops still print, unfiltered.
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    def boom(project_dir=None):
+        raise RuntimeError("corrupt events log")
+    monkeypatch.setattr(store, "resolutions", boom)
+    assert cli.main(["loops"]) == 0
+    out = capsys.readouterr().out
+    assert cp["working_context"]["open_questions"][0]["id"] in out
+
+
 def test_loops_no_open_loops_exits_0_with_friendly_message(tmp_checkpoint_dir, capsys, monkeypatch):
     from daimon_briefing import store
     monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -614,6 +614,43 @@ def test_rich_brief_shows_contradictions_section(capsys):
     assert "cache cold vs warm" in out
 
 
+# ---- #480 slice 1: rich path renders the same id handle as the plain path ----
+
+
+def test_rich_brief_shows_handle_for_open_loop(capsys):
+    import pytest
+    pytest.importorskip("rich")
+    from daimon_briefing import render
+
+    b = {
+        "external": [],
+        "open_loops": [{"text": "chunk threshold unclear", "trust": "inferred",
+                        "id": "o-3f2a9c"}],
+        "decisions": [], "decisions_overflow": 0,
+        "active_topic": None, "beliefs": [], "uncertainties": [],
+    }
+    render._rich_brief(b)
+    out = capsys.readouterr().out
+    assert "o-3f2a9c" in out
+
+
+def test_rich_brief_does_not_show_handle_for_decisions(capsys):
+    import pytest
+    pytest.importorskip("rich")
+    from daimon_briefing import render
+
+    b = {
+        "external": [], "open_loops": [],
+        "decisions": [{"text": "adopt D-007 prompt", "trust": "verbatim",
+                       "id": "r-abc123"}],
+        "decisions_overflow": 0,
+        "active_topic": None, "beliefs": [], "uncertainties": [],
+    }
+    render._rich_brief(b)
+    out = capsys.readouterr().out
+    assert "r-abc123" not in out
+
+
 def _identity_status_data(identity, health):
     return {
         "project": identity["git_root"],

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -394,6 +394,12 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
     def r_log():
         run(["log", "--text", "cut the release"], 0)
 
+    def r_loops():
+        # #480 slice 1: pure read — lists open, briefable loop items with ids.
+        # No write path of its own, but drive it anyway so a future regression
+        # (e.g. it starts writing) trips this guard immediately.
+        run(["loops"], 0)
+
     def r_recall_inject():
         run(["recall-inject", "--session", "S-live"], 0,
             stdin="anything about the gateway seam?")
@@ -476,6 +482,7 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
         ("reverify",): r_reverify,
         ("forget",): r_forget,
         ("log",): r_log,
+        ("loops",): r_loops,
         ("recall-inject",): r_recall_inject,
         ("status",): r_status,
         ("verify-receipt",): r_verify_receipt,


### PR DESCRIPTION
Refs #480 — first stage of a multi-PR issue; `Refs` so merging does not close it.

## What

- Briefed open-loop-class items (external / open loops / uncertainties) render a compact ` [id]` handle, plain + rich paths, via one shared `BRIEFABLE_SECTIONS` source of truth. Legacy id-less items render byte-identically.
- `daimon loops` lists open briefable items with ids — the designed surface for what previously only leaked through `resolve`'s ambiguous-refusal error path.
- Decisions/beliefs get NO handle: valid resolve targets, but loop-shaped they are not — handles there would invite resolving settled facts (scope guard, tested).
- The listing runs the same `store.resolutions` → `briefing.withhold` fold the briefing uses, so it cannot list an item the briefing would suppress (resolving a ghost = the #13 silent-suppression shape).

## Why

#480's write path (agent-initiated resolve) is useless without handles: an agent cannot close what it cannot name. This stage is pure observability and is worth having even if the write path is later vetoed.

## Tests

- [x] 17 new tests (briefing plain, rich, CLI), all observed failing before implementation
- [x] Full suite: **2561 passed, 2 skipped** (baseline 2544), ruff clean
- [x] Mutation-verified: removing the withhold consult fails `test_loops_excludes_item_withheld_by_resolution`
- [x] Live smoke on a real checkpoint: loops render with ids, resolved items absent