### PR TITLE
feat(cli): agent-initiated resolve — evidence-gated claim that never withholds

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -797,7 +797,38 @@ def _cmd_resolve(args) -> int:
     across checkpoints; resolve: carry._same_item over this checkpoint
     only), and a preview that disagrees with the writer is worse than none.
     Ambiguous/no-match refusals return before this point either way, so
-    their output is identical with or without the flag."""
+    their output is identical with or without the flag.
+
+    #480 slice 2 — the agent write path: `--by agent --evidence "<quote>"`
+    appends a `resolving-candidate` event, `source="agent"`, instead of the
+    human path's immediate `resolved`/`source="cli"`. Evidence is mandatory
+    with `--by agent` (mirrors #103 reverify's evidence gate on the reopen
+    side) — a call without it is refused before any checkpoint I/O, nothing
+    written, logged as `resolve:no-evidence` (extends #303). `--evidence`
+    without `--by agent` is rejected too: it is not a `--note` synonym on
+    the human path. The bind (exact id, unique fuzzy match, ambiguous/
+    no-match refusal, --dry-run) is identical on both paths — only what gets
+    written at the end differs. `resolving-candidate` is deliberately NOT
+    'resolved': store.is_resolved/_tie_rank exempt it exactly as they exempt
+    #14's supersede-candidate, so an agent's claim never withholds the item
+    on its own (the #13 false-merge lesson) until slice 3's serializer
+    verifies the quote or a human confirms."""
+    by_agent = getattr(args, "by", None) == "agent"
+    raw_evidence = getattr(args, "evidence", None)
+    if raw_evidence is not None and not by_agent:
+        print("--evidence requires --by agent — the human path vouches by "
+              "calling resolve directly, no evidence needed")
+        return 1
+    evidence = (raw_evidence or "").strip()
+    if by_agent and not evidence:
+        # Same #303 stance as the ambiguous/no-match refusals below: a
+        # refused attempt must leave its own trace, so "no agent ever tried"
+        # and "an agent tried and was refused for lacking evidence" stay
+        # distinguishable in `daimon stats`.
+        _note_usage("resolve:no-evidence")
+        print("--by agent requires --evidence \"<verbatim transcript quote>\" "
+              "— refused, nothing written")
+        return 1
     project = _resolve_project(args.project)
     checkpoint = store.read_latest(project_dir=project, fallback=False)
     if not isinstance(checkpoint, dict):
@@ -829,6 +860,10 @@ def _cmd_resolve(args) -> int:
                 print(f"  {it['id']}  [{key}] {it.get('text', '')}")
             print("resolve by exact id: daimon resolve <id>")
             return 1
+    # #480 slice 2: the agent path writes a candidate status, credited to
+    # source="agent" — NOT args.status/"cli", which stay exactly what the
+    # human path has always written (byte-identical human behavior).
+    effective_status = "resolving-candidate" if by_agent else args.status
     if getattr(args, "dry_run", False):
         # A distinct tag, not "resolve": nothing was written, so folding this
         # into the success counter would inflate it with attempts that never
@@ -836,13 +871,21 @@ def _cmd_resolve(args) -> int:
         # exists to expose. Not silent either: the tag still shows up in
         # `daimon stats` usage counts, just apart from resolve/resolve:*.
         _note_usage("resolve:dry-run")
-        print(f"would resolve {target['id']}: {target.get('text', '')} [{args.status}]")
+        print(f"would resolve {target['id']}: {target.get('text', '')} [{effective_status}]")
         return 0
-    ok = store.append_event(target["id"], args.status, note=args.note or "",
-                            project_dir=project, item_text=str(target.get("text") or ""))
+    ok = store.append_event(
+        target["id"], effective_status,
+        note=(evidence if by_agent else (args.note or "")),
+        source=("agent" if by_agent else "cli"),
+        project_dir=project, item_text=str(target.get("text") or ""))
     if not ok:
         print("event not written (daimon disabled or project unknown)")
         return 1
+    if by_agent:
+        _note_usage("resolve:agent")
+        print(f"claim recorded {target['id']}: {target.get('text', '')} "
+              "— pending verification at session end")
+        return 0
     _note_usage("resolve")
     print(f"resolved {target['id']}: {target.get('text', '')} [{args.status}]")
     return 0
@@ -2853,6 +2896,14 @@ def build_parser() -> argparse.ArgumentParser:
                            help="free-form lifecycle status (default: resolved; "
                                 "a status starting with 'reopen' revives the item)")
     p_resolve.add_argument("--note", help="optional context recorded on the event")
+    p_resolve.add_argument(
+        "--by", choices=["agent"],
+        help="declare an agent-initiated claim (requires --evidence); "
+             "omit for the human path (default)")
+    p_resolve.add_argument(
+        "--evidence",
+        help="verbatim transcript quote proving the claim — required with "
+             "--by agent, rejected without it")
     p_resolve.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
     p_resolve.add_argument(
         "--dry-run", action="store_true",

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -1121,11 +1121,12 @@ def append_event(item_ref: str, status: str, note: str = "",
 def _tie_rank(evt: dict) -> int:
     """Same-second precedence (#143), from event content only. reopen beats
     resolving: when order is unknowable the item stays visible — hiding a
-    live item costs more than showing a resolved one. supersede-candidate
-    loses to everything: a machine SUGGESTION must never shadow a same-second
-    definitive statement (mirrors is_resolved's no-suppression rule)."""
+    live item costs more than showing a resolved one. supersede-candidate and
+    resolving-candidate (#480 slice 2) lose to everything: a machine
+    SUGGESTION must never shadow a same-second definitive statement (mirrors
+    is_resolved's no-suppression rule)."""
     status = str(evt.get("status") or "").lower()
-    if status.startswith("supersede-candidate"):
+    if status.startswith(("supersede-candidate", "resolving-candidate")):
         return 0
     if status.startswith("reopen"):
         return 2
@@ -1187,15 +1188,15 @@ def resolutions(project_dir=None) -> dict:
 
 def is_resolved(event) -> bool:
     """Liveness rule (#102, #14): latest event wins; three states — a status
-    starting with 'reopen' returns the item to live; 'supersede-candidate'
-    and 'corroborat*' are non-resolving by construction (see below);
-    anything else means resolved. Status is free-form text by design — never
-    an enum, so unknown statuses resolve (the writer bothered to record a
-    lifecycle fact) rather than vanish."""
+    starting with 'reopen' returns the item to live; 'supersede-candidate',
+    'corroborat*', and 'resolving-candidate' (#480 slice 2) are non-resolving
+    by construction (see below); anything else means resolved. Status is
+    free-form text by design — never an enum, so unknown statuses resolve
+    (the writer bothered to record a lifecycle fact) rather than vanish."""
     if not isinstance(event, dict):
         return False
     status = str(event.get("status") or "").lower()
-    if status.startswith(("supersede-candidate", "corroborat")):
+    if status.startswith(("supersede-candidate", "corroborat", "resolving-candidate")):
         return False  # a machine SUGGESTION is live by construction (#14):
                       # every consumer (carry, withhold, future) inherits
                       # no-suppression without knowing candidates exist.
@@ -1206,6 +1207,10 @@ def is_resolved(event) -> bool:
                       # can equal, so this branch is the belt to that brace —
                       # scar 0025 (any event kind on a bare ref hides its
                       # item) is too expensive a failure to guard once.
+                      # #480 slice 2: resolving-candidate is the SAME shape —
+                      # an agent's unverified claim — one status further; it
+                      # withholds only once slice 3's serialize-time
+                      # verification (or a human) writes the next event.
     return not status.startswith("reopen")
 
 

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -6671,6 +6671,162 @@ def test_loops_records_usage_event(tmp_checkpoint_dir, tmp_log_dir, capsys, monk
     assert lines[0].split()[1] == "loops"
 
 
+# ---- #480 slice 2: daimon resolve --by agent --evidence — the agent write path ----
+
+
+def test_resolve_by_agent_without_evidence_refuses_and_writes_nothing(
+        tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    assert cli.main(["resolve", iid, "--by", "agent"]) == 1
+    assert store.resolutions(project_dir="/p/A") == {}
+    lines = (tmp_log_dir / "usage.log").read_text().splitlines()
+    assert lines[0].split()[1] == "resolve:no-evidence"
+
+
+def test_resolve_by_agent_with_whitespace_evidence_refuses(
+        tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    assert cli.main(["resolve", iid, "--by", "agent", "--evidence", "   "]) == 1
+    assert store.resolutions(project_dir="/p/A") == {}
+    lines = (tmp_log_dir / "usage.log").read_text().splitlines()
+    assert lines[0].split()[1] == "resolve:no-evidence"
+
+
+def test_resolve_by_agent_with_evidence_appends_candidate_event(
+        tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    rc = cli.main(["resolve", iid, "--by", "agent",
+                   "--evidence", "we shipped the manual approval step in 0.9"])
+    assert rc == 0
+    evt = store.resolutions(project_dir="/p/A")[iid]
+    assert evt["source"] == "agent"
+    assert evt["note"] == "we shipped the manual approval step in 0.9"
+    lines = (tmp_log_dir / "usage.log").read_text().splitlines()
+    assert lines[0].split()[1] == "resolve:agent"
+
+
+def test_resolve_by_agent_candidate_never_withholds_human_resolve_still_does(
+        tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
+    # #480 slice 2 core safety property: an agent candidate must not shadow
+    # the item from brief/loops — the same "never withheld" guarantee #14
+    # supersede-candidates already have. A human `resolve` on the SAME KIND
+    # of item withholds exactly as it always has.
+    from daimon_briefing import store
+    store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+    written = store.read_latest(project_dir="/repo/x")
+    agent_item = written["working_context"]["open_questions"][0]
+    human_item = written["working_context"]["open_questions"][1]
+
+    rc = cli.main(["resolve", agent_item["id"], "--by", "agent",
+                   "--evidence", "the user merged PR #6 from the GitHub UI",
+                   "--project", "/repo/x"])
+    assert rc == 0
+
+    rc = cli.main(["brief", "--project", "/repo/x"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert agent_item["text"] in out  # agent candidate: still shown, unverified
+
+    rc = cli.main(["loops", "--project", "/repo/x"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert agent_item["id"] in out  # loops: still listed
+
+    rc = cli.main(["resolve", human_item["id"], "--project", "/repo/x"])
+    assert rc == 0
+    capsys.readouterr()
+    rc = cli.main(["brief", "--project", "/repo/x"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert human_item["text"] not in out  # human resolve: withheld as always
+
+
+def test_resolve_human_path_unchanged_source_status_and_message(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # Regression: the human path must remain byte-identical after the #480
+    # slice 2 agent branch is added.
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    rc = cli.main(["resolve", iid])
+    assert rc == 0
+    out = capsys.readouterr().out
+    text = cp["working_context"]["open_questions"][0]["text"]
+    assert out == f"resolved {iid}: {text} [resolved]\n"
+    evt = store.resolutions(project_dir="/p/A")[iid]
+    assert evt["source"] == "cli"
+    assert evt["status"] == "resolved"
+    assert store.is_resolved(evt)
+
+
+def test_resolve_evidence_without_by_agent_is_rejected(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    rc = cli.main(["resolve", iid, "--evidence", "some quote"])
+    assert rc == 1
+    assert store.resolutions(project_dir="/p/A") == {}
+
+
+def test_resolve_by_agent_evidence_dry_run_writes_nothing(
+        tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    rc = cli.main(["resolve", iid, "--by", "agent", "--evidence", "quote",
+                   "--dry-run"])
+    assert rc == 0
+    assert store.resolutions(project_dir="/p/A") == {}
+    lines = (tmp_log_dir / "usage.log").read_text().splitlines()
+    assert lines[0].split()[1] == "resolve:dry-run"
+
+
+def test_resolve_by_agent_fuzzy_target_binds_uniquely(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    rc = cli.main(["resolve", "release pipeline manual approval", "--by", "agent",
+                   "--evidence", "shipped the approval step"])
+    assert rc == 0
+    evt = store.resolutions(project_dir="/p/A")[iid]
+    assert evt["source"] == "agent"
+
+
+def test_resolve_by_agent_ambiguous_target_still_refuses_with_candidates(
+        tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    cp = {"working_context": {"open_questions": [
+        {"text": "gateway retry budget for serializer chunks"},
+        {"text": "serializer chunk retry budget unclear"},
+    ]}}
+    store.write_checkpoint("S1", cp, project_dir="/p/A")
+    rc = cli.main(["resolve", "serializer chunk retry budget", "--by", "agent",
+                   "--evidence", "quote"])
+    assert rc == 1
+    out = capsys.readouterr().out
+    for item in cp["working_context"]["open_questions"]:
+        assert item["id"] in out
+    assert store.resolutions(project_dir="/p/A") == {}
+    lines = (tmp_log_dir / "usage.log").read_text().splitlines()
+    assert lines[0].split()[1] == "resolve:ambiguous"
+
+
 # ---- #103: daimon reverify — evidence-gated reopen ----
 
 

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1539,6 +1539,46 @@ def test_is_resolved_supersede_candidate_is_live():
     assert store.is_resolved({"status": "REOPENED"}) is False                 # regression
 
 
+def test_is_resolved_agent_resolving_candidate_is_live():
+    # #480 slice 2: an agent's unverified claim is a machine SUGGESTION, same
+    # shape as #14's supersede-candidate — it must never withhold on its own,
+    # only after serialize-time verification or a human confirm.
+    from daimon_briefing import store
+    assert store.is_resolved({"status": "resolving-candidate", "source": "agent"}) is False
+    assert store.is_resolved({"status": "RESOLVING-CANDIDATE"}) is False  # case-insensitive
+
+
+def test_resolutions_equal_timestamp_agent_candidate_loses_both_orders(tmp_checkpoint_dir):
+    # An agent's resolving-candidate is a machine SUGGESTION too — it must
+    # not shadow a same-second definitive statement, mirroring the
+    # supersede-candidate tie-break directly above (#480 slice 2).
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    d = tmp_checkpoint_dir / slug
+    d.mkdir(parents=True, exist_ok=True)
+    # The note fields are load-bearing: an agent candidate always carries a
+    # non-empty evidence quote while a human resolve may carry note "". At
+    # equal _tie_rank the fold falls to canonical-JSON, where the non-empty
+    # note sorts ABOVE the empty one — so without the rank-0 exemption the
+    # candidate would win this tie and shadow the human's real resolution.
+    # A fixture without notes passes vacuously (source "agent" < "cli"
+    # happens to favor the right outcome for the wrong reason).
+    cand = ('{"ts": "2026-07-07T10:00:00Z", "item_ref": "o-a",'
+            ' "note": "verbatim evidence quote here",'
+            ' "status": "resolving-candidate", "source": "agent"}\n')
+    reopen = ('{"ts": "2026-07-07T10:00:00Z", "item_ref": "o-a",'
+              ' "note": "", "status": "reopened", "source": "cli"}\n')
+    resolve = ('{"ts": "2026-07-07T10:00:00Z", "item_ref": "o-a",'
+               ' "note": "", "status": "resolved", "source": "cli"}\n')
+
+    for log in (cand + reopen, reopen + cand):
+        (d / "events.jsonl").write_text(log)
+        assert store.resolutions(project_dir="/p/A")["o-a"]["status"] == "reopened"
+    for log in (cand + resolve, resolve + cand):
+        (d / "events.jsonl").write_text(log)
+        assert store.resolutions(project_dir="/p/A")["o-a"]["status"] == "resolved"
+
+
 def test_redact_scrubs_link_targets(tmp_checkpoint_dir):
     from daimon_briefing import store
     cp = {"working_context": {"recent_decisions": [


### PR DESCRIPTION
Refs #480 — second stage (stage 1 = #481). `Refs` so merging does not close the issue.

## What

- `daimon resolve <target> --by agent --evidence "<verbatim quote>"` → `resolving-candidate` event, `source="agent"`, note = the evidence quote.
- No evidence (or whitespace) → refused before any I/O, exit 1, logged `resolve:no-evidence` (extends #303's refusal vocabulary).
- `--evidence` without `--by agent` → rejected; the human path is byte-identical to before (`source="cli"`, immediate withhold, same output).
- Bind logic (exact id / unique fuzzy / ambiguous refusal / `--dry-run`) shared between both paths, unchanged.

## The safety property, and the trap under it

**A candidate never withholds** — same guarantee as #14's supersede-candidate: an agent's unverified claim costs nothing; the item stays in briefings and `daimon loops` until serialize-time verification (next stage) or a human writes the following event.

Two central-fold fixes were required to make the design's own status literal honor that:

1. `store.is_resolved` exempted only `supersede-candidate`/`corroborat*`; `resolving-candidate` fell through to *resolved* — the first agent claim would have silently vanished from the next briefing, the exact #13 failure this design exists to prevent. One-line exemption at the single choke point; briefing/carry/recall inherit it. **Mutation-verified**: reverting the exemption fails the end-to-end never-withholds test.
2. `_tie_rank` ranks the candidate 0 alongside supersede-candidate. Real exposure, not belt-and-braces: an agent candidate always carries a non-empty evidence note, a human resolve may carry `note: ""`, and at equal rank the canonical-JSON tie-break sorts the non-empty note first — the candidate would shadow a same-second human resolution. The tie test carries notes for exactly this reason; supervision found the note-less version passed vacuously (`source "agent" < "cli"` favored the right outcome by accident) and hardened it. **Mutation-verified** after hardening.

## Tests

- [x] 11 new tests (refusals, event shape, never-withholds end-to-end through real brief+loops paths, human-path byte-regression, dry-run composition, fuzzy bind, tie-break both orders)
- [x] Full suite **2574 passed, 2 skipped** (baseline 2563), ruff clean
- [x] Both central-fold fixes mutation-verified