### PR TITLE
feat(research): stance-gate recall variant — #483 measured and refuted

### DIFF
--- a/.scars/candidates/prompt-stance-does-not-predict-recall-relevance.md
+++ b/.scars/candidates/prompt-stance-does-not-predict-recall-relevance.md
@@ -1,0 +1,32 @@
+---
+id: 0
+type: deadend
+title: Prompt-stance surface markers do not predict recall relevance — gating injection on question-vs-statement shape refuted (#483)
+severity: medium
+confidence: 0.9
+created: 2026-08-01
+authors: ["claude-code"]
+anchors:
+  - path: research/experiments/recall-replay-ab/variants.py
+  - path: plugin/daimon_briefing/recall.py
+  - pattern: "classify_stance|question.?shaped|statement.?shaped"
+evidence:
+  - note: "#483 pre-registered run (run-04-stance-gate, 2026-08-01, same 342-prompt corpus as #470's run-03; arm A reproduced run-03's 344 injections exactly). Holdout blind judging: relevant rate in rows the gate DROPPED = 38.5%, vs 39.9% in arm A's full pool and 39.4% in what the gate kept — statistically indistinguishable. Both pre-registered ship clauses failed; kill condition met. Classifier itself was reliable (spot-checked); the markers simply do not carry relevance signal."
+expires:
+  condition: "a stance signal richer than surface markers (e.g. trained intent classification) is tested and shows the dropped-row relevant rate materially below the kept-row rate"
+  review_after: 2027-02-01
+status: candidate
+---
+
+Hypothesis (#483, from the remnant collision-detector critique): overlap
+measures shared vocabulary, not epistemic stance, so gating recall injection
+on question-shaped vs statement-shaped prompts should cut fresh-tangential
+noise. Built as a deterministic surface classifier (interrogative openers,
+help phrases, trailing "?"), run on the #472 replay instrument, blind-judged
+on the holdout split. REFUTED: relevance in suppressed rows equaled relevance
+in kept rows — statement-shaped prompts need memories exactly as often as
+question-shaped ones. Do not rebuild this as a surface-marker gate; the
+mechanism claim ("approaching vs mentioning") may still be true, but surface
+stance is not a usable proxy for it. Second consecutive selection-shaping
+refutation after #470 (rarity); both died on the same lesson: judge what the
+gate removes, not what it keeps.

--- a/.scars/candidates/sd-multiline-mutation-silently-noops.md
+++ b/.scars/candidates/sd-multiline-mutation-silently-noops.md
@@ -1,0 +1,28 @@
+---
+id: 0
+type: deadend
+title: sd with multiline/complex regex silently no-ops — mutation tests then "pass" against unmutated code
+severity: high
+confidence: 0.9
+created: 2026-08-01
+authors: ["claude-code"]
+anchors:
+  - path: plugin/
+  - pattern: "sd '[^']*\n"
+evidence:
+  - note: "2026-08-01 session, twice in one day. (1) #475 review: sd pattern spanning 'backend = resolve_backend()...' lines did not match; the 'restored' file still held the mutant and the full suite ran 2 failures that were misread as new-test signal. (2) #480 slice-2 review: sd multiline pattern on _tie_rank did not match, tie-break test 'passed' against UNMUTATED code and the pass was nearly reported as mutation-proof. Both caught only by re-grepping for the MUTANT marker / the expected changed line before trusting the run."
+expires:
+  condition: "mutation edits move to a dedicated tool that fails loudly on zero replacements"
+  review_after: 2027-02-01
+status: candidate
+---
+
+Tried using `sd 'pattern' 'replacement' file` for quick mutation-testing edits
+where the pattern spanned multiple lines or contained parens/newlines. `sd`
+exits 0 whether or not anything matched, so a non-matching pattern is
+indistinguishable from a successful edit — and the follow-up test run then
+"verifies" code that was never mutated. A passing mutation test is evidence
+ONLY if you first confirm the mutant is present (`rg MUTANT <file>` or grep
+for the changed line). Abandoned sd for this use: make mutation edits with
+the Edit tool (fails loudly on no-match), tag them with a `MUTANT` comment,
+and grep for the tag before running the suite; grep again after restore.

--- a/.scars/candidates/suppressing-variants-drift-session-seen-state.md
+++ b/.scars/candidates/suppressing-variants-drift-session-seen-state.md
@@ -1,0 +1,30 @@
+---
+id: 0
+type: landmine
+title: Any suppressing replay variant drifts session seen-state — later prompts in the same session no longer compare A-vs-B cleanly
+severity: medium
+confidence: 0.85
+created: 2026-08-01
+authors: ["claude-code"]
+anchors:
+  - path: research/experiments/recall-replay-ab/
+  - pattern: "return \[\]"
+evidence:
+  - note: "#483 run-04: 38 of 166 diff prompts carried b_only injections that arm A never produced — impossible for a pure prompt gate whose pass-through arm is 'identical to A'. Traced (prompt_idx 214): when arm B suppresses an earlier prompt's injections, it never marks the origin session as seen, so a later pass-through prompt in the same session faces a larger candidate pool than arm A's. Session-cooldown-layer analog of #470's slot-promotion trap."
+expires:
+  condition: "the replay rig gains a mode that replays arm B against arm A's seen-state (or documents per-arm seen-state as the intended semantics in README)"
+  review_after: 2027-02-01
+status: candidate
+---
+
+The replay rig maintains per-arm seen/cooldown state. A variant that returns
+fewer rows than arm A (any suppressor) therefore accumulates DIFFERENT
+seen-state, and every later prompt in the same session diverges from arm A
+for reasons unrelated to the hypothesis — b_only rows appear on prompts the
+variant claims to pass through unchanged. This is not a bug in the rig (per-
+arm state is arguably the honest simulation of shipping the variant), but it
+breaks the naive reading "diff rows = the gate's direct effect." When
+interpreting a suppressing variant's diff: partition b_only rows by whether
+an earlier same-session prompt was suppressed, before attributing them to
+the hypothesis. #483's b_only rows judged ~equal quality (32% relevant) so
+the verdict survived; a closer call would not.

--- a/research/experiments/recall-replay-ab/variants.py
+++ b/research/experiments/recall-replay-ab/variants.py
@@ -45,8 +45,111 @@ keep it out of the repo entirely and pass `--variant mymodule:myfunc`.
 """
 
 import importlib
+import re
 import sys
 from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# stance_gate (#483): does the prompt APPROACH the memory's territory (needs
+# it) or REPORT from inside it (already has it)? Overlap-based matching
+# cannot tell the two apart — both share the vocabulary. This is a
+# deterministic SURFACE classifier of epistemic stance: no LLM, no new deps.
+# ---------------------------------------------------------------------------
+
+# Sentence-initial interrogative forms named in #483's pre-registration.
+_QUESTION_OPENERS = frozenset({
+    "how", "why", "what", "when", "where", "which", "who",
+    "can", "could", "should", "does", "is",
+})
+# Phrase markers named in #483's pre-registration: "trying to", "can't get",
+# "doesn't work", "need to figure", plus imperative help-requests.
+_QUESTION_PHRASES = (
+    "trying to", "can't get", "doesn't work", "need to figure",
+    "help me", "figure out",
+)
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+_LEAD_WORD_RE = re.compile(r"^[\s\"'(*_-]*([a-zA-Z']+)")
+
+
+def classify_stance(prompt: str) -> str:
+    """Deterministic surface classification of a prompt's epistemic stance.
+
+    Returns ``"question"`` for prompts that show question-shaped surface
+    markers, else ``"statement"`` (completed-work reports and declarations —
+    the default when no marker fires). Case-insensitive. The trailing '?'
+    check looks at the whole prompt; opener/phrase markers look at the
+    first ~2 sentences only, so a late aside inside a long statement-shaped
+    report doesn't flip the whole prompt.
+
+    Markers (per #483's pre-registration):
+      - trailing '?' anywhere in the prompt
+      - sentence-initial interrogative: how/why/what/when/where/which/who/
+        can/could/should/does/is (covers "is it ...")
+      - phrase markers: "trying to", "can't get", "doesn't work",
+        "need to figure"
+      - imperative help-requests: "help me", "figure out"
+
+    >>> classify_stance("How do I handle network timeouts?")
+    'question'
+    >>> classify_stance("Why does the retry loop spin forever")
+    'question'
+    >>> classify_stance("I implemented idempotent retry with exponential backoff")
+    'statement'
+    >>> classify_stance("Shipped the retry logic and closed the ticket.")
+    'statement'
+    >>> classify_stance("trying to get the retry logic working")
+    'question'
+    >>> classify_stance("The deploy doesn't work on the staging box")
+    'question'
+    >>> classify_stance("Deployed the staging box, all green.")
+    'statement'
+    >>> classify_stance("need to figure out why the index rebuild is slow")
+    'question'
+    >>> classify_stance("help me debug this stack trace")
+    'question'
+    >>> classify_stance("Merged #470, refuted and closed.")
+    'statement'
+    >>> classify_stance("Is it safe to rerun the migration")
+    'question'
+    >>> classify_stance("")
+    'statement'
+    """
+    text = (prompt or "").strip()
+    if not text:
+        return "statement"
+    if "?" in text:
+        return "question"
+    sentences = _SENTENCE_SPLIT_RE.split(text)[:2]
+    lead = " ".join(sentences).lower()
+    if any(p in lead for p in _QUESTION_PHRASES):
+        return "question"
+    for sentence in sentences:
+        m = _LEAD_WORD_RE.match(sentence)
+        if m and m.group(1).lower() in _QUESTION_OPENERS:
+            return "question"
+    return "statement"
+
+
+def stance_gate(ctx, suggest):
+    """H (#483): gate injection on the prompt's epistemic stance.
+
+    Question-shaped prompts pass through unchanged — arm B is arm A for
+    that prompt. Statement-shaped prompts suppress injection entirely (the
+    pre-registered PRIMARY form; downweighting is a follow-up hypothesis,
+    not this variant).
+
+    Prompt-level gate — but NOT leak-free, the run proved (#483, run-04):
+    when arm B suppresses an earlier statement-shaped prompt, it never marks
+    that origin session "seen", so a LATER question-shaped prompt in the
+    same session faces a different candidate pool than arm A's — 38 of 166
+    diff prompts carried b_only injections through exactly this seen-state
+    drift. Session-cooldown-layer analog of #470's slot-promotion trap: any
+    suppressing variant inherits it, and "pass-through prompts are
+    identical to arm A" is only true until a session runs long enough.
+    """
+    if classify_stance(ctx["prompt"]) == "question":
+        return suggest()
+    return []
 
 
 def none(ctx, suggest):
@@ -61,7 +164,7 @@ def none(ctx, suggest):
     return suggest()
 
 
-BUILTIN = {"none": none}
+BUILTIN = {"none": none, "stance_gate": stance_gate}
 
 
 def resolve(spec: str):

--- a/research/experiments/recall-replay-ab/verify.py
+++ b/research/experiments/recall-replay-ab/verify.py
@@ -28,6 +28,7 @@ This substitutes for plugin-suite tests: the harness is research code, but
 its correctness claims must be executable.
 """
 
+import doctest
 import json
 import sys
 import tempfile
@@ -129,6 +130,42 @@ def build_fixture_home(root: Path) -> tuple[Path, Path]:
          "ts": T0 + 7 * DAY, "session": "sess-machine", "project": PROJ},
     ]
     dataset = root / "dataset.jsonl"
+    dataset.write_text("".join(json.dumps(r) + "\n" for r in rows),
+                       encoding="utf-8")
+    return home, dataset
+
+
+def build_stance_fixture(root: Path) -> tuple[Path, Path]:
+    """Synthetic flat store + dataset for the #483 `stance_gate` variant
+    (variants.py): one checkpoint recent enough to be injectable, replayed
+    against two prompts that share ITS vocabulary but differ only in
+    grammatical stance — question-shaped vs statement-shaped — so any
+    difference between arm A and the stance_gate arm is attributable to the
+    gate, not to term overlap."""
+    home = root / "stance-home"
+    with replay_ab._pinned_env(home, author="fixture"):
+        filler = [{"text": f"deploy pipeline filler{i:02d} note",
+                   "trust": "inferred"} for i in range(40)]
+        store.write_checkpoint(
+            "T-hist", _cp("T-hist", T0 + 1 * DAY, filler), project_dir=PROJ)
+        store.write_checkpoint(
+            "T-src", _cp("T-src", T0 + 2 * DAY,
+                         [{"text": "widget calibration procedure documented",
+                           "trust": "inferred"}]), project_dir=PROJ)
+        store.write_checkpoint(
+            "T-pad", _cp("T-pad", T0 + 3 * DAY,
+                         [{"text": "unrelated aardvark bookkeeping entry",
+                           "trust": "inferred"}]), project_dir=PROJ)
+    rows = [
+        # idx 0: question-shaped — must pass through unchanged (B == A).
+        {"prompt": "how do I run the widget calibration procedure?",
+         "ts": T0 + 4 * DAY, "session": "sess-stance-q", "project": PROJ},
+        # idx 1: statement-shaped — must be fully suppressed (B == []).
+        {"prompt": "ran the widget calibration procedure and it passed",
+         "ts": T0 + 4 * DAY + 3600, "session": "sess-stance-s",
+         "project": PROJ},
+    ]
+    dataset = root / "stance-dataset.jsonl"
     dataset.write_text("".join(json.dumps(r) + "\n" for r in rows),
                        encoding="utf-8")
     return home, dataset
@@ -262,6 +299,64 @@ def main() -> int:
             "machine prompt skipped",
             summ["corpus"]["n_machine_skipped"] == 1
             and prompts[4]["machine"])
+
+        # 9. classify_stance's own doctests (variants.py) — the classifier's
+        #    worked examples must pass as executable claims, not just prose.
+        dt = doctest.testmod(variants, verbose=False)
+        ok &= _check(
+            "classify_stance: doctests pass",
+            dt.attempted > 0 and dt.failed == 0,
+            f"attempted={dt.attempted} failed={dt.failed}")
+
+        # 10. classify_stance edge cases beyond the doctests: case
+        #     insensitivity and the "first ~2 sentences only" opener/phrase
+        #     boundary (the trailing '?' check alone is whole-prompt).
+        ok &= _check(
+            "classify_stance: case-insensitive opener",
+            variants.classify_stance("HOW DO I FIX THIS") == "question")
+        ok &= _check(
+            "classify_stance: opener beyond first 2 sentences does not "
+            "count",
+            variants.classify_stance(
+                "Shipped the fix. Tests are green. How about that.")
+            == "statement")
+        ok &= _check(
+            "classify_stance: phrase marker beyond first 2 sentences does "
+            "not count",
+            variants.classify_stance(
+                "Shipped the fix. Tests are green. Still trying to land "
+                "the follow-up.") == "statement")
+
+        # 11. stance_gate variant (#483), exercised end to end through the
+        #     real harness on a synthetic fixture — same pattern as the
+        #     marker_silencer checks above, for the real hypothesis instead
+        #     of a fixture-only stand-in.
+        print("verify: stance-gate fixture built, running replay ...")
+        stance_home, stance_dataset = build_stance_fixture(root)
+        res_stance = replay_ab.run(
+            stance_dataset, stance_home, [None], root / "out-stance",
+            seed=470, variant=variants.stance_gate, variant_name="stance_gate")
+        sp = {p["idx"]: p for p in res_stance["prompts"]}
+        pq, ps = sp[0], sp[1]
+        ok &= _check(
+            "stance_gate fixture: prompts classify as intended",
+            variants.classify_stance(pq["prompt"]) == "question"
+            and variants.classify_stance(ps["prompt"]) == "statement")
+        ok &= _check(
+            "stance_gate: question-shaped prompt passes through, B == A",
+            len(pq["arms"]["A"]) >= 1 and pq["arms"]["B"] == pq["arms"]["A"],
+            f"A={len(pq['arms']['A'])} B={len(pq['arms']['B'])}")
+        ok &= _check(
+            "stance_gate: statement-shaped prompt fully suppressed, "
+            "B == []",
+            len(ps["arms"]["A"]) >= 1 and ps["arms"]["B"] == [],
+            f"A={len(ps['arms']['A'])} B={len(ps['arms']['B'])}")
+        stance_agg = res_stance["summary"]["arms"]["B"]
+        ok &= _check(
+            "stance_gate: aggregate a_only > 0 (the suppression), "
+            "b_only == 0 (gate never adds a row suggest() didn't return)",
+            stance_agg["a_only"] > 0 and stance_agg["b_only"] == 0,
+            f"a_only={stance_agg['a_only']} b_only={stance_agg['b_only']}")
 
     print("VERIFY " + ("PASS" if ok else "FAIL"))
     return 0 if ok else 1


### PR DESCRIPTION
Closes #483 — the pre-registered experiment ran; this PR banks the negative result.

## What ran

`stance_gate` variant on the #472 replay instrument: deterministic surface classification of each prompt (question-shaped → pass through; statement-shaped → suppress injection), no LLM. Same 342-prompt corpus as #470's run; **arm A reproduced run-03's 344 injections exactly**, so the refutations are directly comparable. Rig self-check 22/22 including four new stance fixtures.

## Verdict: REFUTED (pre-registered kill condition met)

Holdout blind judging, per the rig's protocol:

| pool | n judged | relevant |
|---|---|---|
| rows the gate **dropped** (a-only) | 130 | **38.5%** |
| arm A full pool | 138 | 39.9% |
| rows the gate **kept** (arm B) | 33 | 39.4% |

The gate discarded relevant injections at the same rate as everything else — statement-shaped prompts need memories exactly as often as question-shaped ones. The classifier itself was reliable on spot-checks; the surface markers simply carry no relevance signal. Both ship clauses failed; kill condition met exactly as written in the issue.

## Second finding: the run falsified the variant's own safety claim

The docstring claimed a prompt-level gate has nothing to backfill "by construction." Measured: 38/166 diff prompts carried b_only injections on pass-through prompts — a suppressing arm B accumulates different **session seen-state**, so later same-session prompts face a different candidate pool. Session-cooldown-layer analog of #470's slot-promotion trap; any suppressing variant inherits it. Docstring corrected to state the measured reality.

## Changes

| file | change |
|---|---|
| `research/experiments/recall-replay-ab/variants.py` | `classify_stance` (12 doctests) + `stance_gate`, docstring stating the measured drift |
| `research/experiments/recall-replay-ab/verify.py` | stance fixture + boundary checks (22/22) |
| `.scars/candidates/prompt-stance-does-not-predict-recall-relevance.md` | the refuted gate, with numbers |
| `.scars/candidates/suppressing-variants-drift-session-seen-state.md` | the interpretation trap for future suppressing variants |
| `.scars/candidates/sd-multiline-mutation-silently-noops.md` | unrelated candidate riding along (mutation-testing workflow trap, banked earlier today) |

Run artifacts stay local per the rig's privacy rules (they carry raw prompt text); everything quotable is aggregated above.

## Tests

- [x] Rig `--verify`: 22/22 (was 18 before the variant fixtures)
- [x] `scar lint`: 38 files, 0 errors
- [x] No plugin code touched; plugin suite unaffected