### PR TITLE
feat(serializer): verify pending agent resolve claims against the transcript

### DIFF
--- a/plugin/daimon_briefing/capture.py
+++ b/plugin/daimon_briefing/capture.py
@@ -28,10 +28,13 @@ Intended per-door differences are explicit parameters, nothing else:
     whenever a path exists, both doors stamp identically.
 """
 
+import logging
 import time
 from pathlib import Path
 
 from . import carry, config, normalize, serializer, store, transcript
+
+log = logging.getLogger(__name__)
 
 
 def run(session_id: str, messages, *, project, chat, deadline,
@@ -120,6 +123,16 @@ def run(session_id: str, messages, *, project, chat, deadline,
         # #421: the write boundary refused (kill switch) — nothing landed, so
         # there is nothing to ledger rejections against either.
         return None
+    # #480 slice 3: verify pending agent resolve candidates for THIS project
+    # against THIS session's transcript. Independent of config.carry_enabled()
+    # — an agent's claim can be confirmed even on a project's very first
+    # serialize after the candidate landed. Its own try/except (not folded
+    # into the carry block above): a broken verification pass must never cost
+    # the checkpoint OR ride on carry being on.
+    try:
+        _verify_agent_resolutions(project, messages)
+    except Exception:
+        log.warning("agent resolution verification pass failed", exc_info=True)
     # #376: record what the checkers REJECTED, after write_checkpoint because
     # that is where item ids are guaranteed stamped (the merge branch above
     # only stamps when it runs). Its own append-only stream, never events.jsonl
@@ -320,6 +333,84 @@ def _emit_corroborations(observed, events: dict, forgotten_ids: set, project,
                               project_dir=project):
             appended += 1
     return appended
+
+
+# ---- #480 slice 3: serialize-time verification of agent resolve candidates ----
+
+# The confirming event's status. Deliberately does NOT start with
+# "resolving-candidate" or "supersede-candidate" (store.is_resolved's and
+# _tie_rank's exemption prefixes, scar 0025's shape) — a CONFIRMED claim must
+# resolve and withhold like any ordinary human resolution (_tie_rank rank 1),
+# never sit at rank 0 alongside the candidate it replaces. See
+# tests/test_store.py's near-collision guard.
+AGENT_VERIFIED_STATUS = "resolved-agent-verified"
+
+
+def _pending_agent_candidates(events: dict) -> dict:
+    """{item_ref: evidence quote} for every ref whose LATEST lifecycle event
+    (store.resolutions' fold — already latest-by-ts, ties broken by content)
+    is a still-pending agent resolve candidate (#480 slice 2). A ref
+    superseded by ANY later event — a human resolve, a reopen, or this same
+    pass's own prior confirming event — is not pending; the fold already
+    resolves that, this only filters on the folded result. That is what
+    makes both idempotence (a confirmed ref's latest event is no longer
+    'resolving-candidate') and the human-reopen case (a later 'reopened'
+    event is latest) come free, with no extra bookkeeping here."""
+    out: dict = {}
+    for ref, evt in events.items():
+        if not isinstance(evt, dict):
+            continue
+        if str(evt.get("status") or "") != "resolving-candidate":
+            continue
+        if str(evt.get("source") or "") != "agent":
+            continue
+        evidence = evt.get("note")
+        if isinstance(evidence, str) and evidence.strip():
+            out[ref] = evidence
+    return out
+
+
+def _verify_agent_resolutions(project, messages) -> int:
+    """#480 slice 3: byte-check every pending agent resolve candidate's
+    evidence quote against THIS session's transcript — same matching stack
+    verify_quotes already holds verbatim capture claims to (#125), reused,
+    not duplicated: an agent's evidence meets the same bar a capture claim's
+    quote meets.
+
+    Quote found -> a confirming event, source="serializer",
+    status=AGENT_VERIFIED_STATUS, note recording which role (if
+    determinable) carried the quote. From here the item withholds like any
+    ordinary resolution, credited as agent-verified. Quote not found ->
+    nothing written; the candidate stands, exactly as live as before, for a
+    human's resolve/reverify or a future serialize to settle.
+
+    `events` is read fresh, scoped to `project` — store.resolutions reads
+    that project's OWN events.jsonl (store._events_path keys on
+    project_slug), so a candidate belonging to a different project can never
+    be reached from here, let alone confirmed against this transcript (#480
+    cross-project discipline: the store's per-project file layout does the
+    isolating, this function never crosses it).
+
+    Returns the number of confirming events appended. Callers wrap this in
+    their own try/except (capture.run does) — a broken pass here must never
+    fail the serialize itself."""
+    events = store.resolutions(project_dir=project)
+    pending = _pending_agent_candidates(events)
+    if not pending:
+        return 0
+    haystack = serializer.stripped_transcript(messages) if messages else ""
+    confirmed = 0
+    for ref, evidence in pending.items():
+        found, role = serializer.verify_agent_evidence(
+            evidence, messages, haystack=haystack)
+        if not found:
+            continue
+        if store.append_event(
+                ref, AGENT_VERIFIED_STATUS,
+                note=f"verified agent evidence (role: {role})",
+                source="serializer", project_dir=project):
+            confirmed += 1
+    return confirmed
 
 
 def _session_end_stamp(path) -> str:

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -1021,6 +1021,54 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None) -> int:
     return downgraded
 
 
+# ---- #480 slice 3: agent resolve-candidate evidence, verified at serialize ----
+#
+# `daimon resolve --by agent --evidence "<quote>"` (#482, slice 2) appends a
+# `resolving-candidate` event that never withholds anything on its own — the
+# quote is only a CLAIM until this pass byte-checks it against the session's
+# own transcript, at serialize time, the same way verify_quotes byte-checks a
+# verbatim capture claim. Deliberately the SAME matching stack (quote_matches,
+# strip_injected/stripped_transcript) rather than a second one: an agent's
+# evidence meets the identical bar a capture claim's quote meets.
+
+def verify_agent_evidence(evidence, messages, haystack=None) -> tuple:
+    """Byte-check ONE agent resolve-candidate's evidence quote against a
+    transcript. Returns (found, role).
+
+    `found` is whether the quote's bytes are present in the (stripped)
+    transcript, under quote_matches' tier-f normalization. `role` is the
+    `role` of the single message whose own stripped text contains the quote,
+    when exactly that is determinable; "unknown" when the quote isn't found
+    at all, when no single message's text contains it (e.g. real bytes but
+    only found once messages are joined into the whole-transcript haystack),
+    or when the carrying message has no usable role. Per the design doc's
+    self-quotation section: this is labeling, not gating — an assistant-only
+    quote is exactly as trustworthy as any other assistant assertion, and the
+    caller records the role rather than hiding or blocking on it.
+
+    `haystack` lets a caller checking several candidates against the SAME
+    session's transcript build the stripped whole-transcript haystack once
+    (stripped_transcript is O(messages)) instead of once per candidate; omit
+    it to have this function build it.
+
+    Blank/non-str evidence never matches — mirrors verify_quotes' own
+    "no usable quote" guard, conservative by construction."""
+    if not isinstance(evidence, str) or not evidence.strip():
+        return False, "unknown"
+    if haystack is None:
+        haystack = stripped_transcript(messages) if messages else ""
+    if not quote_matches(evidence, haystack):
+        return False, "unknown"
+    for m in messages or []:
+        if not isinstance(m, dict):
+            continue
+        if quote_matches(evidence, strip_injected(_message_text(m))):
+            role = m.get("role")
+            return True, (role.strip()
+                         if isinstance(role, str) and role.strip() else "unknown")
+    return True, "unknown"
+
+
 # ---- #359: outcome claims ground in tool-result signals ----
 #
 # The hard trust-class gap (#185/#194 lineage): the model concludes X, X is

--- a/plugin/tests/test_agent_resolution_verification.py
+++ b/plugin/tests/test_agent_resolution_verification.py
@@ -1,0 +1,261 @@
+"""#480 slice 3: serialize-time verification of pending agent resolve
+candidates.
+
+Slice 2 (#482) gave `daimon resolve --by agent --evidence "<quote>"` a write
+path: a `resolving-candidate` event, `source="agent"`, that never withholds
+anything (the #14 machine-suggestion safety property). This slice closes the
+loop: at serialize time, every pending candidate for the project being
+serialized gets its evidence quote byte-checked against THAT session's
+transcript — reusing `verify_quotes`'s own normalization/matching (#125) —
+and a hit appends a confirming event that DOES withhold, credited to
+source="serializer".
+
+Three properties matter most here, each pinned by its own test:
+  - the candidate never gets touched on a miss (unverified stays live, #14);
+  - a pass here can never fail the serialize itself (best-effort, wrapped);
+  - the pass is scoped to ONE project's events against ONE project's
+    transcript — a candidate from project A must never be confirmed by
+    project B's session.
+"""
+
+import json
+
+from daimon_briefing import capture, cli, store
+from tests.conftest import make_messages
+
+
+def _new_session_json(session_id="S-new", quote=""):
+    """A minimal, schema-valid checkpoint the fake chat returns for a NEW
+    session's own extraction — independent of the pending candidate this
+    module is testing. Optionally carries `quote` as its own verbatim item
+    too, so a single fixture can double as evidence that verify_quotes
+    (#125) and verify_agent_evidence (#480 slice 3) agree on the same
+    transcript."""
+    decisions = []
+    if quote:
+        decisions.append({"text": "recorded via this session's own extraction",
+                          "trust": "verbatim", "quote": quote})
+    return json.dumps({
+        "session_id": session_id,
+        "working_context": {
+            "active_topic": {"text": "this session's own topic", "trust": "inferred"},
+            "open_questions": [],
+            "recent_decisions": decisions,
+        },
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []},
+    })
+
+
+def _agent_candidate(project, sample_checkpoint, quote,
+                     prev_session="S-prev"):
+    """Write a prior checkpoint, then `resolve --by agent --evidence` its
+    first open question — the standard setup every test below shares.
+    Returns the target item dict (with its stable id)."""
+    store.write_checkpoint(prev_session, sample_checkpoint, project_dir=project)
+    written = store.read_latest(project_dir=project)
+    item = written["working_context"]["open_questions"][0]
+    rc = cli.main(["resolve", item["id"], "--by", "agent",
+                   "--evidence", quote, "--project", project])
+    assert rc == 0
+    return item
+
+
+QUOTE = "the user merged PR #6 from the GitHub UI"
+
+
+def test_pending_candidate_confirmed_when_transcript_has_the_quote(
+        tmp_checkpoint_dir, sample_checkpoint, fake_chat_factory, capsys):
+    project = "/repo/slice3-hit"
+    item = _agent_candidate(project, sample_checkpoint, QUOTE)
+    capsys.readouterr()  # discard the "claim recorded" resolve output above
+
+    msgs = make_messages(10)
+    msgs[3] = {"role": "assistant", "content": QUOTE}
+    chat = fake_chat_factory(_new_session_json())
+    out_path = capture.run("S-new", msgs, project=project, chat=chat, deadline=None)
+    assert out_path is not None
+
+    evt = store.resolutions(project_dir=project)[item["id"]]
+    assert evt["status"] == "resolved-agent-verified"
+    assert evt["source"] == "serializer"
+    assert store.is_resolved(evt) is True
+
+    rc = cli.main(["brief", "--project", project])
+    assert rc == 0
+    brief_out = capsys.readouterr().out
+    assert item["text"] not in brief_out  # withheld now
+
+    rc = cli.main(["loops", "--project", project])
+    assert rc == 0
+    loops_out = capsys.readouterr().out
+    assert item["id"] not in loops_out  # absent from the open-loops listing
+
+
+def test_pending_candidate_stands_when_quote_absent_from_transcript(
+        tmp_checkpoint_dir, sample_checkpoint, fake_chat_factory, capsys):
+    project = "/repo/slice3-miss"
+    item = _agent_candidate(project, sample_checkpoint, QUOTE)
+    capsys.readouterr()  # discard the "claim recorded" resolve output above
+
+    msgs = make_messages(10)  # none of these lines carry the evidence quote
+    chat = fake_chat_factory(_new_session_json())
+    capture.run("S-new", msgs, project=project, chat=chat, deadline=None)
+
+    evt = store.resolutions(project_dir=project)[item["id"]]
+    assert evt["status"] == "resolving-candidate"  # untouched
+    assert evt["source"] == "agent"
+    assert store.is_resolved(evt) is False
+
+    rc = cli.main(["brief", "--project", project])
+    assert rc == 0
+    brief_out = capsys.readouterr().out
+    assert item["text"] in brief_out  # still visible, unverified
+
+    rc = cli.main(["loops", "--project", project])
+    assert rc == 0
+    loops_out = capsys.readouterr().out
+    assert item["id"] in loops_out
+
+
+def test_echoed_evidence_via_daimon_injection_never_confirms_end_to_end(
+        tmp_checkpoint_dir, sample_checkpoint, fake_chat_factory, capsys):
+    """The self-reference law, end to end: a still-pending candidate's
+    evidence quote will be RENDERED by daimon itself into future sessions
+    (recall lines today, slice 4's unverified-claim line next) — so a
+    session whose transcript contains the quote ONLY inside daimon-injected
+    spans must not confirm it, or a fabricated quote self-confirms one
+    session later. The unit test covers verify_agent_evidence building its
+    own haystack; THIS test pins the caller — _verify_agent_resolutions
+    precomputes the haystack, and passing the unstripped render there would
+    slip past every unit test while reopening the #440 echo hole."""
+    project = "/repo/slice3-echo"
+    item = _agent_candidate(project, sample_checkpoint, QUOTE)
+    capsys.readouterr()
+
+    msgs = make_messages(10)
+    msgs[2] = {"role": "user", "content":
+               (f'daimon recall: prior work — decision from S-prev (2h ago): '
+                f'"{QUOTE}" [verbatim]\nunrelated genuine user text')}
+    msgs[5] = {"role": "user", "content":
+               f"<system-reminder>\nagent claims resolved: \"{QUOTE}\"\n"
+               f"</system-reminder>\nmore genuine text"}
+    chat = fake_chat_factory(_new_session_json())
+    capture.run("S-new", msgs, project=project, chat=chat, deadline=None)
+
+    evt = store.resolutions(project_dir=project)[item["id"]]
+    assert evt["status"] == "resolving-candidate"  # echo is not a witness
+    assert evt["source"] == "agent"
+
+
+def test_role_recorded_in_confirming_note_when_determinable(
+        tmp_checkpoint_dir, sample_checkpoint, fake_chat_factory):
+    project = "/repo/slice3-role"
+    item = _agent_candidate(project, sample_checkpoint, QUOTE)
+
+    msgs = make_messages(10)
+    msgs[5] = {"role": "user", "content": QUOTE}
+    chat = fake_chat_factory(_new_session_json())
+    capture.run("S-new", msgs, project=project, chat=chat, deadline=None)
+
+    evt = store.resolutions(project_dir=project)[item["id"]]
+    assert evt["note"] == "verified agent evidence (role: user)"
+
+
+def test_role_recorded_as_unknown_when_not_determinable(
+        tmp_checkpoint_dir, sample_checkpoint):
+    # Direct unit call — a message carrying the quote with no usable role
+    # ("unknown" is honest, per the design doc's labeling-not-gating stance).
+    project = "/repo/slice3-role-unknown"
+    item = _agent_candidate(project, sample_checkpoint, QUOTE)
+    n = capture._verify_agent_resolutions(project, [{"content": QUOTE}])
+    assert n == 1
+    evt = store.resolutions(project_dir=project)[item["id"]]
+    assert evt["note"] == "verified agent evidence (role: unknown)"
+
+
+def test_candidate_superseded_by_human_reopen_is_not_touched(
+        tmp_checkpoint_dir, sample_checkpoint, fake_chat_factory):
+    project = "/repo/slice3-reopened"
+    item = _agent_candidate(project, sample_checkpoint, QUOTE)
+
+    rc = cli.main(["reverify", item["id"], "--evidence", "actually still open",
+                   "--project", project])
+    assert rc == 0
+    before = store.resolutions(project_dir=project)[item["id"]]
+    assert before["status"] == "reopened"
+
+    msgs = make_messages(10)
+    msgs[2] = {"role": "assistant", "content": QUOTE}  # quote IS present
+    chat = fake_chat_factory(_new_session_json())
+    capture.run("S-new", msgs, project=project, chat=chat, deadline=None)
+
+    after = store.resolutions(project_dir=project)[item["id"]]
+    assert after == before  # nothing appended — the human reopen stands
+
+
+def test_verify_agent_resolutions_is_idempotent(tmp_checkpoint_dir, sample_checkpoint):
+    project = "/repo/slice3-idempotent"
+    _agent_candidate(project, sample_checkpoint, QUOTE)
+    msgs = [{"role": "assistant", "content": QUOTE}]
+
+    n1 = capture._verify_agent_resolutions(project, msgs)
+    assert n1 == 1
+    n2 = capture._verify_agent_resolutions(project, msgs)
+    assert n2 == 0  # already confirmed — not pending anymore, nothing re-appended
+
+    slug = store.project_slug(project)
+    lines = (tmp_checkpoint_dir / slug / "events.jsonl").read_text().splitlines()
+    confirming = [ln for ln in lines
+                 if json.loads(ln).get("status") == "resolved-agent-verified"]
+    assert len(confirming) == 1
+
+
+def test_verification_pass_exception_does_not_fail_serialize(
+        tmp_checkpoint_dir, sample_checkpoint, fake_chat_factory, monkeypatch):
+    project = "/repo/slice3-exception"
+    _agent_candidate(project, sample_checkpoint, QUOTE)
+
+    def boom(*a, **k):
+        raise RuntimeError("verification pass exploded")
+    monkeypatch.setattr(capture, "_verify_agent_resolutions", boom)
+
+    msgs = make_messages(10)
+    chat = fake_chat_factory(_new_session_json())
+    out_path = capture.run("S-new", msgs, project=project, chat=chat, deadline=None)
+    assert out_path is not None  # serialize still succeeded despite the raise
+
+
+def test_cross_project_candidate_not_confirmed_by_other_project_serialize(
+        tmp_checkpoint_dir, sample_checkpoint, fake_chat_factory):
+    project_a = "/repo/slice3-cross-a"
+    project_b = "/repo/slice3-cross-b"
+    item_a = _agent_candidate(project_a, sample_checkpoint, QUOTE)
+
+    # Project B's own session carries the SAME quote bytes — the pass must
+    # scope to project B's own events.jsonl (empty of candidates) and never
+    # cross into project A's.
+    msgs = make_messages(10)
+    msgs[1] = {"role": "assistant", "content": QUOTE}
+    chat = fake_chat_factory(_new_session_json(session_id="S-b"))
+    capture.run("S-b", msgs, project=project_b, chat=chat, deadline=None)
+
+    evt_a = store.resolutions(project_dir=project_a)[item_a["id"]]
+    assert evt_a["status"] == "resolving-candidate"  # untouched by B's serialize
+    assert store.is_resolved(evt_a) is False
+
+
+def test_pending_agent_candidates_filters_source_and_status():
+    # Unit-level: only status=="resolving-candidate" AND source=="agent"
+    # with a non-empty note count as pending — everything else (a human
+    # resolve, a #14 supersede-candidate, an evidence-less/blank row) is
+    # excluded.
+    events = {
+        "o-a": {"status": "resolving-candidate", "source": "agent", "note": "the quote"},
+        "o-b": {"status": "resolved", "source": "cli", "note": ""},
+        "o-c": {"status": "supersede-candidate:o-x", "source": "serializer"},
+        "o-d": {"status": "resolving-candidate", "source": "agent", "note": "   "},
+        "o-e": {"status": "resolving-candidate", "source": "agent"},  # no note at all
+        "not-a-dict": "garbage",
+    }
+    out = capture._pending_agent_candidates(events)
+    assert out == {"o-a": "the quote"}

--- a/plugin/tests/test_agent_resolution_verification.py
+++ b/plugin/tests/test_agent_resolution_verification.py
@@ -255,6 +255,10 @@ def test_pending_agent_candidates_filters_source_and_status():
         "o-c": {"status": "supersede-candidate:o-x", "source": "serializer"},
         "o-d": {"status": "resolving-candidate", "source": "agent", "note": "   "},
         "o-e": {"status": "resolving-candidate", "source": "agent"},  # no note at all
+        # right status, WRONG source: a hand-written candidate-status event
+        # from the CLI must not enter the serializer's verification set —
+        # only the --by agent path earns the pending classification.
+        "o-f": {"status": "resolving-candidate", "source": "cli", "note": "quote"},
         "not-a-dict": "garbage",
     }
     out = capture._pending_agent_candidates(events)

--- a/plugin/tests/test_quote_verification.py
+++ b/plugin/tests/test_quote_verification.py
@@ -1097,6 +1097,33 @@ def test_verify_agent_evidence_strips_daimon_own_injected_output():
     assert role == "unknown"
 
 
+def test_verify_agent_evidence_skips_non_dict_messages_in_role_scan():
+    # A garbage row must not crash the role scan or steal attribution — the
+    # quote's real carrier still gets the credit. Only reachable with a
+    # caller-precomputed haystack: without one, stripped_transcript raises
+    # on the non-dict row first (serialize_strict's contract), so the loop's
+    # own guard exists precisely for the precomputed-haystack path.
+    good = {"role": "user", "content": "we froze the pin"}
+    haystack = serializer.stripped_transcript([good])
+    found, role = serializer.verify_agent_evidence(
+        "we froze the pin", ["not a dict", good], haystack=haystack)
+    assert found is True
+    assert role == "user"
+
+
+def test_verify_agent_evidence_haystack_hit_without_single_message_is_unknown():
+    # The docstring's third role-unknown case: the quote verifies against
+    # the caller-provided haystack, but no single message's own text carries
+    # it — found stays True (the bytes ARE in the transcript), role is the
+    # honest "unknown" rather than a guessed attribution.
+    found, role = serializer.verify_agent_evidence(
+        "the whole quote lives only in the joined haystack",
+        [{"role": "user", "content": "alpha half"}],
+        haystack="the whole quote lives only in the joined haystack")
+    assert found is True
+    assert role == "unknown"
+
+
 def test_verify_agent_evidence_accepts_a_precomputed_haystack():
     msgs = [{"role": "assistant", "content": "we shipped the manual approval step"}]
     haystack = serializer.stripped_transcript(msgs)

--- a/plugin/tests/test_quote_verification.py
+++ b/plugin/tests/test_quote_verification.py
@@ -1031,3 +1031,76 @@ def test_audit_quotes_does_not_verify_an_echoed_quote(
     assert rc == 0
     assert "verified: 0" in out
     assert "failed: 1" in out
+
+
+# ---- #480 slice 3: verify_agent_evidence reuses verify_quotes' matching ----
+#
+# An agent's `resolve --by agent --evidence "<quote>"` claim is byte-checked
+# at serialize time against the SAME transcript, through the SAME
+# normalization/matching stack (quote_matches, strip_injected) as a verbatim
+# capture claim — these tests exercise that function directly, unit-level,
+# the same way Unit A above exercises quote_matches directly.
+
+def test_verify_agent_evidence_hit_returns_role_of_the_carrying_message():
+    msgs = [
+        {"role": "user", "content": "can you check PR #6?"},
+        {"role": "assistant", "content": "the user merged PR #6 from the GitHub UI"},
+    ]
+    found, role = serializer.verify_agent_evidence(
+        "the user merged PR #6 from the GitHub UI", msgs)
+    assert found is True
+    assert role == "assistant"
+
+
+def test_verify_agent_evidence_miss_returns_false_and_unknown():
+    msgs = [{"role": "user", "content": "totally unrelated content"}]
+    found, role = serializer.verify_agent_evidence(
+        "this exact sentence is nowhere in the transcript at all", msgs)
+    assert found is False
+    assert role == "unknown"
+
+
+def test_verify_agent_evidence_reuses_tier_f_normalization():
+    # Same hyphen/space fold quote_matches already proves (#208) — the
+    # evidence quote meets the identical bar, not a second weaker matcher.
+    msgs = [{"role": "user", "content": "retry windows are 3–5 seconds — measured on the gateway"}]
+    found, role = serializer.verify_agent_evidence(
+        "retry windows are 3-5 seconds - measured on the gateway", msgs)
+    assert found is True
+    assert role == "user"
+
+
+def test_verify_agent_evidence_blank_or_nonstring_is_false():
+    msgs = [{"role": "user", "content": "some real content here"}]
+    assert serializer.verify_agent_evidence("", msgs) == (False, "unknown")
+    assert serializer.verify_agent_evidence("   ", msgs) == (False, "unknown")
+    assert serializer.verify_agent_evidence(None, msgs) == (False, "unknown")
+
+
+def test_verify_agent_evidence_role_unknown_when_message_role_missing():
+    # A hit whose carrying message has no usable role: found True, labeled
+    # honestly as "unknown" rather than guessed (#480 design: labeling, not
+    # gating — see the design doc's self-quotation section).
+    msgs = [{"content": "the deploy succeeded and tests are green"}]
+    found, role = serializer.verify_agent_evidence(
+        "the deploy succeeded and tests are green", msgs)
+    assert found is True
+    assert role == "unknown"
+
+
+def test_verify_agent_evidence_strips_daimon_own_injected_output():
+    # #440: a quote that only appears inside daimon's OWN injected recall/
+    # briefing span is an echo, not a witness — must not verify.
+    msgs = [{"role": "user", "content": f"{_RECALL}\nwhat did we settle on?"}]
+    found, role = serializer.verify_agent_evidence(_ECHOED, msgs)
+    assert found is False
+    assert role == "unknown"
+
+
+def test_verify_agent_evidence_accepts_a_precomputed_haystack():
+    msgs = [{"role": "assistant", "content": "we shipped the manual approval step"}]
+    haystack = serializer.stripped_transcript(msgs)
+    found, role = serializer.verify_agent_evidence(
+        "we shipped the manual approval step", msgs, haystack=haystack)
+    assert found is True
+    assert role == "assistant"

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1933,3 +1933,29 @@ def test_verification_counts_skips_corrupt_and_nondict_rows(tmp_path, monkeypatc
         f.write('["a list, not a row"]\n')
         f.write('{"item_ref": "i2"}\n')          # no check -> not counted
     assert store.verification_counts(project_dir=proj) == {"quote": 1}
+
+
+# ---- #480 slice 3: resolved-agent-verified — the confirming status ----
+
+
+def test_is_resolved_agent_verified_vs_candidate_near_collision():
+    # 'resolved-agent-verified' and 'resolving-candidate' differ by only a
+    # few characters and both start with "resolv" — the trap this slice
+    # names explicitly. Asserted side by side: the confirming status
+    # resolves (withholds), the candidate status it replaces stays live.
+    from daimon_briefing import store
+    assert store.is_resolved({"status": "resolved-agent-verified"}) is True
+    assert store.is_resolved({"status": "resolving-candidate"}) is False
+
+
+def test_tie_rank_resolved_agent_verified_is_ordinary_rank_not_candidate_rank():
+    # The confirming event must rank as a normal resolving event (rank 1),
+    # NEVER rank 0 alongside the candidate it replaces — rank 0 would let a
+    # same-second stray candidate re-tie against its own confirmation and
+    # fall to the (arbitrary) canonical-JSON tie-break instead of a
+    # deterministic win, undermining the "verified beats unverified" story.
+    from daimon_briefing import store
+    assert store._tie_rank({"status": "resolved-agent-verified"}) == 1
+    assert store._tie_rank({"status": "resolving-candidate"}) == 0
+    assert store._tie_rank({"status": "resolved-agent-verified"}) != \
+        store._tie_rank({"status": "resolving-candidate"})


### PR DESCRIPTION
Refs #480 — third stage (#481 handles, #482 write path). `Refs` so the issue stays open for stages 4–5.

## What

At serialize, every pending `resolving-candidate` (source=`agent`) for the project gets its evidence quote byte-checked against that session's transcript, reusing `verify_quotes`'s normalization/matching (#125) — no second matcher. Hit → confirming event (`resolved-agent-verified`, source=`serializer`, role recorded in the note when one message carries the quote). Miss → nothing written, candidate stands.

## The property that matters most

**Echo immunity, end to end.** A pending candidate's quote will be rendered by daimon itself into future sessions (recall lines now, stage 4's unverified-claim line next). The haystack is therefore the **stripped** transcript (#440). Supervision added the end-to-end test pinning the *caller's* haystack choice — the unit test builds its own haystack and would miss a caller regression. Mutation-verified: swapping in the unstripped render fails it, i.e. a fabricated quote would have self-confirmed one session later.

Other pinned properties, each with its own test:
- miss leaves the candidate byte-untouched (still briefed, still in `daimon loops`)
- pass can never fail the serialize (wrapped, logged)
- idempotent across re-serialize/heal (latest-wins fold — a confirmed ref is no longer pending)
- human reopen after a candidate → not pending, not touched
- cross-project: A's candidate can't be confirmed by B's transcript
- `resolved-agent-verified` vs `resolving-candidate` near-collision: is_resolved True/False side by side; `_tie_rank` = ordinary resolution, not candidate rank

## Discrepancy the implementing agent found

The design doc says role attribution comes "via the #358 message binding" — imprecise: #358's binding lives on checkpoint items, not lifecycle events, so there is nothing to read. Implemented as a per-message `quote_matches` scan at verification time; same intent (label the role), honest `unknown` when only the joined transcript matches.

## Tests

- [x] 19 new tests (9 end-to-end incl. the echo test, 7 unit on `verify_agent_evidence`, 2 store near-collision/rank, +1 supervision echo)
- [x] Full suite **2593 passed, 2 skipped** (baseline 2574), ruff clean
- [x] Mutation-verified: unstripped-haystack caller regression caught