### PR TITLE
fix(briefing): cut inside the sections when they overflow the budget

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -575,17 +575,24 @@ def estimate_tokens(text: str) -> int:
 
 def truncate_preserving_sections(text: str, max_chars: int) -> str:
     """Cut `text` to max_chars, keeping **Label:** sections over filler: if the
-    labeled sections alone fit, they ARE the truncation; only a section-less
-    text falls back to a blind head-cut. Always appends a visible marker —
-    silent truncation reads as 'this is everything' when it isn't."""
+    labeled sections alone fit, they ARE the truncation; when they do not fit
+    the cut still lands INSIDE them, and only a section-less text falls back to
+    a blind head-cut of the raw text. Always appends a visible marker — silent
+    truncation reads as 'this is everything' when it isn't.
+
+    #489: the over-budget case used to fall through to the raw head-cut, which
+    returned unlabeled preamble and dropped every section it had just found —
+    the inverse of the contract, and worst on the longest, most structured
+    items. Cutting the joined sections degrades predictably instead: the
+    leading label survives, and what is lost is the tail rather than all of it.
+    """
     if len(text) <= max_chars:
         return text
     parts = _SECTION_RE.findall(text)
-    if parts:
-        key = "\n".join(parts)
-        if len(key) + len(_TRUNCATION_MARKER) <= max_chars:
-            return key + _TRUNCATION_MARKER
-    return text[:max(0, max_chars - len(_TRUNCATION_MARKER))] + _TRUNCATION_MARKER
+    body = "\n".join(parts) if parts else text
+    if parts and len(body) + len(_TRUNCATION_MARKER) <= max_chars:
+        return body + _TRUNCATION_MARKER
+    return body[:max(0, max_chars - len(_TRUNCATION_MARKER))] + _TRUNCATION_MARKER
 
 
 def _trim_note(dropped: int) -> str:

--- a/plugin/tests/test_briefing.py
+++ b/plugin/tests/test_briefing.py
@@ -383,6 +383,31 @@ def test_truncate_without_sections_head_cuts_with_marker():
     assert "…" in out or "..." in out or "truncated" in out
 
 
+def test_truncate_cuts_sections_not_preamble_when_sections_overflow():
+    # #489: the blind head-cut is documented as the SECTION-LESS fallback, but
+    # it also fired whenever the sections were found and did not fit — handing
+    # back raw preamble and dropping every label. That is the inverse of the
+    # contract, and it bites hardest on the longest, most structured items.
+    preamble = "unlabeled preamble filler " * 20
+    text = (preamble
+            + "\n**Problem:** the serializer drops the tail\n"
+            + "problem detail " * 20
+            + "\n**Root Cause:** the throttle window closes early\n"
+            + "cause detail " * 20
+            + "\n**Fix:** flush before the window closes\n")
+    budget = 400
+    # Precondition: the sections alone are over budget, so the fit-branch
+    # cannot fire and the fallback is what is under test.
+    sections = "\n".join(briefing._SECTION_RE.findall(text))
+    assert len(sections) + len(briefing._TRUNCATION_MARKER) > budget
+
+    out = briefing.truncate_preserving_sections(text, budget)
+    assert len(out) <= budget
+    assert "**Problem:**" in out
+    assert not out.startswith("unlabeled preamble")
+    assert "…" in out or "..." in out or "truncated" in out
+
+
 def _fat_checkpoint(n_beliefs=40, n_loops=6):
     def item(i, imp, kind):
         return {"text": f"{kind} number {i} " + "padding words " * 30,


### PR DESCRIPTION
Closes #489

## What

`truncate_preserving_sections` fell through to a blind head-cut of the **raw** text whenever the labeled sections were found but did not fit the budget, discarding the sections it had just extracted.

Now the sections are joined first and the cut lands inside them. Raw text is head-cut only when there are no sections at all, which is what the docstring always claimed.

## Why

The docstring promised "only a section-less text falls back to a blind head-cut". The code took that branch in two cases, not one, and the second is the case the function exists to handle: a long structured item under budget pressure.

Concretely, at the `_ITEM_TRUNCATE_CHARS = 400` budget this is called with, an item carrying ~500 chars of unlabeled preamble followed by `**Problem:**` / `**Root Cause:**` / `**Fix:**` rendered as ~360 chars of pure preamble and zero labels. The larger and better structured the item, the more certain the loss.

This is on the #79 budget path, so it fires precisely on the briefings that are already over budget and have the least room to spend on filler.

## Tests

`test_truncate_cuts_sections_not_preamble_when_sections_overflow` — asserts the label survives and the output does not start with the preamble. It carries an explicit precondition assert that the sections are over budget, so it is exercising the fallback branch rather than the fit branch.

Fails before the change with the bug verbatim:

    AssertionError: assert '**Problem:**' in 'unlabeled preamble filler unlabeled preamble
    filler ... …[truncated — full text in checkpoint]'

Passes after. The two existing truncation tests (sections that fit; no sections at all) are unchanged and still green, pinning both untouched branches.

Full suite: 2624 passed, 2 skipped.