### PR TITLE
fix(policy): mint item ids at 12 hex, not 6

### DIFF
--- a/plugin/daimon_briefing/policy.py
+++ b/plugin/daimon_briefing/policy.py
@@ -127,12 +127,24 @@ def drop_forgotten(checkpoint: dict, forgotten_keys: set) -> list:
 
 
 def stamp_item_ids(checkpoint: dict) -> None:
-    """Stable per-item ids (#102): sha1 of kind:text, 6 hex chars, prefixed
+    """Stable per-item ids (#102): sha1 of kind:text, 12 hex chars, prefixed
     with the kind's initial. setdefault semantics — an item that already
     carries an id (a carried twin, a re-write) is never re-stamped, so
     identity survives rotation and re-serialization. Collisions within one
     checkpoint widen the slice; identical-text twins fall through to a
-    counter suffix (same text, same kind, still two loops)."""
+    counter suffix (same text, same kind, still two loops).
+
+    #487: the slice is 12 hex, not 6, because the id is a PROJECT-GLOBAL key
+    (store.resolutions folds events by bare ref, briefing.withhold binds on
+    exact equality, recall's rebuild scrub updates bucket-wide) while `seen`
+    below is scoped to ONE checkpoint — so a cross-session collision is
+    undetectable here by construction. At 6 hex that is ~2.4% over ~2k
+    distinct texts per project and grows quadratically; the consequence is a
+    `resolve` or `forget` silently withholding an unrelated live memory, which
+    briefing.withhold's docstring names as the worst failure it can have.
+    Narrowing the hash is free, so the width carries the guarantee instead.
+    Ids already stamped keep their width forever and both shapes coexist:
+    every consumer regex accepts {6,} (briefing's bounds it at {6,40})."""
     seen: set = set()
     for section, key in _ITEM_LISTS:
         items = (checkpoint.get(section) or {}).get(key)
@@ -147,13 +159,18 @@ def stamp_item_ids(checkpoint: dict) -> None:
             digest = hashlib.sha1(
                 f"{key}:{item['text']}".encode("utf-8")).hexdigest()
             cand = ""
-            for width in (6, 8, 12, 40):
+            widths = (12, 16, 24, 40)
+            for width in widths:
                 cand = f"{key[0]}-{digest[:width]}"
                 if cand not in seen:
                     break
             n = 2
             while cand in seen:
-                cand = f"{key[0]}-{digest[:6]}-{n}"
+                # The counter base must be the FIRST rung, not a narrower
+                # slice: a fallback that mints a shorter id would reintroduce
+                # the collision surface the width exists to remove, and it
+                # would do it on the twins path where ids are least distinct.
+                cand = f"{key[0]}-{digest[:widths[0]]}-{n}"
                 n += 1
             item["id"] = cand
             seen.add(cand)

--- a/plugin/tests/test_policy.py
+++ b/plugin/tests/test_policy.py
@@ -11,10 +11,12 @@ promise that outranks "disabled means daimon writes nothing").
 """
 
 import ast
+import hashlib
 import json
 from pathlib import Path
 
-from daimon_briefing import cli, normalize, redact, store
+from daimon_briefing import (briefing, carry, cli, normalize, policy, recall,
+                             redact, store)
 from tests.conftest import FIXTURES
 
 _A = "/repo/policy-A"
@@ -497,3 +499,96 @@ def test_origin_survives_two_carry_hops_while_carried_from_only_names_the_last(
     assert sqlite_item.get("carried_from") in ("S-B", "S-C")
     assert sqlite_item["origin_session"] == "S-A"
     assert sqlite_item["origin_author"] == "ada"
+
+
+# --- #487: minted id width -------------------------------------------------
+# The id is a PROJECT-GLOBAL key (store.resolutions folds events by bare ref,
+# briefing.withhold binds on exact equality, recall's rebuild scrub runs
+# UPDATE ... WHERE item_id = ? bucket-wide) while collision detection is scoped
+# to ONE checkpoint. At 6 hex the birthday probability over ~2k distinct texts
+# per project is ~2.4% and grows quadratically; a collision silently withholds
+# an unrelated live memory, which briefing.withhold's own docstring names as
+# the worst failure this feature can have.
+
+def _stamp_one(text, kind="open_questions"):
+    cp = {"working_context": {kind: [{"text": text}]}}
+    policy.stamp_item_ids(cp)
+    return cp["working_context"][kind][0]["id"]
+
+
+def test_minted_item_id_carries_twelve_hex_chars():
+    item_id = _stamp_one("adopt sqlite for the recall index cache")
+    prefix, _, hexpart = item_id.partition("-")
+    assert prefix == "o"
+    assert len(hexpart) == 12, f"expected a 12-hex slice, got {item_id!r}"
+    assert all(c in "0123456789abcdef" for c in hexpart)
+
+
+def test_minted_id_is_still_a_stable_hash_of_kind_and_text():
+    # Widening must not change WHAT is hashed: same kind+text -> same id, and
+    # the slice must remain a prefix of the same digest.
+    text = "adopt sqlite for the recall index cache"
+    first = _stamp_one(text)
+    assert first == _stamp_one(text)
+    digest = hashlib.sha1(f"open_questions:{text}".encode("utf-8")).hexdigest()
+    assert first == f"o-{digest[:12]}"
+
+
+def test_existing_ids_are_never_restamped_at_the_new_width():
+    # setdefault semantics: a 6-hex id minted by an older version survives
+    # rotation and re-serialization untouched. Both widths coexist forever.
+    legacy = "o-a1b2c3"
+    cp = {"working_context": {"open_questions": [
+        {"text": "an item stamped before the widening", "id": legacy}]}}
+    policy.stamp_item_ids(cp)
+    assert cp["working_context"]["open_questions"][0]["id"] == legacy
+
+
+def test_both_widths_satisfy_every_consumer_id_shape():
+    # carry/recall accept {6,}; briefing's candidate shape accepts {6,40}.
+    # Nothing needed to change for the wider id, and the legacy width must
+    # keep working — assert both rather than trusting the regex by eye.
+    minted = _stamp_one("adopt sqlite for the recall index cache")
+    for ident in (minted, "o-a1b2c3"):
+        assert carry._ID_SHAPE.fullmatch(ident), ident
+        assert recall._ID_SHAPE.fullmatch(ident), ident
+        assert briefing._CANDIDATE_ID_SHAPE.fullmatch(ident), ident
+
+
+def test_identical_text_twins_are_separated_by_the_width_ladder():
+    # Same kind + same text = same digest, so the ladder cannot break the tie
+    # by hashing differently — it breaks it by WIDTH. The twins end up as two
+    # different-length prefixes of one digest (not the counter suffix, which
+    # only fires once every rung is taken). Pinned because the widening
+    # changes which rungs those are.
+    text = "the very same wording"
+    cp = {"working_context": {"open_questions": [{"text": text},
+                                                 {"text": text}]}}
+    policy.stamp_item_ids(cp)
+    ids = [i["id"] for i in cp["working_context"]["open_questions"]]
+    assert len(set(ids)) == 2
+    digest = hashlib.sha1(f"open_questions:{text}".encode("utf-8")).hexdigest()
+    widths = []
+    for ident in ids:
+        hexpart = ident.partition("-")[2]
+        assert digest.startswith(hexpart), ident
+        widths.append(len(hexpart))
+    assert widths[0] < widths[1], f"expected widening, got {ids!r}"
+    assert min(widths) >= 12, f"first rung must be the wide one, got {ids!r}"
+
+
+def test_counter_fallback_never_mints_a_narrow_id():
+    # Five identical texts exhaust the width ladder (12/16/24/40) and force the
+    # counter suffix. That fallback must be based on the FIRST rung: minting a
+    # short slice here would put the collision surface back exactly where ids
+    # are least distinct.
+    text = "one wording repeated past every rung"
+    cp = {"working_context": {"open_questions": [{"text": text}
+                                                 for _ in range(5)]}}
+    policy.stamp_item_ids(cp)
+    ids = [i["id"] for i in cp["working_context"]["open_questions"]]
+    assert len(set(ids)) == 5, ids
+    suffixed = [i for i in ids if i.endswith("-2")]
+    assert suffixed, f"expected the counter to fire, got {ids!r}"
+    hexpart = suffixed[0].partition("-")[2].rpartition("-")[0]
+    assert len(hexpart) >= 12, f"counter minted a narrow id: {suffixed[0]!r}"

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1475,7 +1475,11 @@ def test_item_id_hashes_redacted_text(tmp_checkpoint_dir):
     item = cp["working_context"]["open_questions"][0]
     digest = hashlib.sha1(
         f"open_questions:{item['text']}".encode("utf-8")).hexdigest()
-    assert item["id"] == f"o-{digest[:6]}"  # id derived from REDACTED text
+    # id derived from REDACTED text. Width is #487's 12-hex slice; what this
+    # test is pinning is WHAT is hashed, so it reads the width off the id
+    # rather than restating it and failing on an unrelated change.
+    hexpart = item["id"].partition("-")[2]
+    assert item["id"] == f"o-{digest[:len(hexpart)]}"
 
 
 def test_rewrite_merges_redaction_counts(tmp_checkpoint_dir):


### PR DESCRIPTION
Closes #487

## What

`stamp_item_ids` mints the hash slice at 12 hex instead of 6. The width ladder becomes `(12, 16, 24, 40)`, and the counter-suffix fallback now bases on the first rung rather than a hardcoded 6.

Nothing else changes: same digest, same input, same `setdefault` semantics.

## Why

The id is consumed as a **project-global** key — `store.resolutions` folds events by bare ref, `briefing.withhold` binds on exact equality, `recall`'s rebuild scrub runs `UPDATE items ... WHERE item_id = ?` bucket-wide — while the `seen` set that detects collisions is built per call, over one checkpoint. A collision between two items in different sessions is therefore undetectable at the point of minting, by construction.

At 6 hex (24 bits, partitioned into 5 kind buckets) the birthday probability is ~2.4% at the ~2k distinct texts per project this store already holds, and it grows quadratically: ~5.2% at 3k, ~45% at 10k. At 12 hex it is ~1e-9.

The consequence is the failure mode `briefing.withhold` documents as the worst it can have:

> A fuzzy withhold of an id-bearing item would silently suppress a live memory that merely resembles a closed one — the worst failure mode this feature can have.

The fuzzy path is carefully forbidden for id-bearing items. The id width left the same outcome reachable through the **exact** path, with no user-visible symptom: `daimon resolve` on one loop quietly withholding an unrelated one.

Widening costs nothing at any corpus size, which is most of the argument for doing it regardless of where this particular store sits on the curve.

**No migration.** Existing ids are never re-stamped, and both widths coexist permanently: `carry._ID_SHAPE` and `recall._ID_SHAPE` accept `{6,}`, `briefing._CANDIDATE_ID_SHAPE` accepts `{6,40}`. The visible handle grows by six characters.

## Tests

New, all failing before the change:

- `test_minted_item_id_carries_twelve_hex_chars`
- `test_minted_id_is_still_a_stable_hash_of_kind_and_text` — widening must not change *what* is hashed
- `test_identical_text_twins_are_separated_by_the_width_ladder` — same text means same digest, so the ladder breaks the tie by width, not by hash
- `test_counter_fallback_never_mints_a_narrow_id` — five identical texts exhaust every rung and force the counter; caught a real leftover where the fallback still used `digest[:6]`

Passing before and after (backward compatibility, asserted rather than assumed):

- `test_existing_ids_are_never_restamped_at_the_new_width`
- `test_both_widths_satisfy_every_consumer_id_shape` — checks a minted id and a legacy `o-a1b2c3` against all three consumer regexes

`test_item_id_hashes_redacted_text` restated 6 as a literal; it now reads the width off the id, since what it pins is *what* gets hashed.

Full suite: 2630 passed, 2 skipped.