### PR TITLE
test(harness): add a null-control arm and state what the corpus resolves

### DIFF
--- a/research/experiments/recall-replay-ab/README.md
+++ b/research/experiments/recall-replay-ab/README.md
@@ -108,6 +108,46 @@ bug, not a finding.
 - `run-meta.json` — runtime/wall-clock (kept out of `summary.json` so the
   determinism self-check can byte-compare every analytical artifact).
 
+## Before you pre-register: can this corpus answer the question?
+
+A pre-registered decision rule is worthless if the run could never satisfy it.
+Every `summary.json` arm now carries a `resolution` block:
+
+    "resolution": {
+      "baseline_assumed_pct": 20.0, "power": 0.8, "alpha": 0.05,
+      "mde_pp": 9.2, "detectable_b_precision_pct": 29.2,
+      "n_per_arm_for_5pp": 1092
+    }
+
+Read it FIRST. On the 07-30 dataset (344 injections per arm) the minimum
+detectable effect is **9.2pp** — arm B has to reach ~29% precision against a
+20% control before the difference is readable, and resolving 5pp would need
+~1092 injections per arm. A hypothesis that perturbs a few percent of volume
+cannot be settled here at any grading budget, and knowing that *before* the
+run is the difference between an answer and a month of confident noise.
+
+Note the asymmetry: **comparing two arms is expensive; characterising one
+class is cheap.** Blind-grading "how relevant is the class this gate admits?"
+is a one-sample question that lands inside a useful interval at n≈30. Prefer
+it when the goal is to indict a rule rather than rank two of them.
+
+## The null control: `--variant placebo`
+
+    --variant placebo --sweep "0.12"                      # uniform rate
+    --variant placebo --sweep "<=1d:0,2-7d:0.07,>7d:0.11" # matched to a
+                                                          # treatment's drops
+
+The placebo suppresses rows at random (deterministically, hashed per row) at a
+per-age-band rate. It exists because **any scoring proxy keyed on item age is
+a function of the age histogram of the rows a rule drops, and of nothing
+else** — so every rule dropping the same profile scores identically, including
+random ones. A hypothesis that does not beat a placebo matched to its own drop
+histogram has measured the histogram, not the hypothesis. This is not
+hypothetical: it invalidated a gate sweep that appeared to move precision
+20.6% → 21.8%, where the age-matched placebo scored the same to two decimals.
+
+Run it for any variant that suppresses. It costs one extra arm.
+
 ## The method: pre-register before you run
 
 This is the part worth reusing. **Write the criteria down, in the issue,

--- a/research/experiments/recall-replay-ab/replay_ab.py
+++ b/research/experiments/recall-replay-ab/replay_ab.py
@@ -26,6 +26,7 @@ are executable via `--verify` (see verify.py).
 import argparse
 import hashlib
 import json
+import math
 import os
 import random
 import shutil
@@ -392,6 +393,43 @@ def _inj_ids(injs) -> set:
     return {(i["session_id"], i["content_key"]) for i in injs}
 
 
+# #495: what this corpus can RESOLVE. A delta smaller than the minimum
+# detectable effect is unreadable however confidently it is reported, and that
+# has to be visible in the artifact people share — a pre-registered decision
+# rule is worthless if the run could never satisfy it.
+#
+# Arcsine (Cohen's h): 2*asin(sqrt(p)) has variance 1/n, so the difference of
+# two arms has variance 1/n_a + 1/n_b. Stdlib only, no scipy: the two z values
+# are the fixed 5% two-sided / 80% power constants.
+_Z_SUM = 1.959964 + 0.841621   # z(alpha/2=0.025) + z(power=0.80)
+_RESOLUTION_BASELINE = 0.20    # assumed control precision; stated, not hidden
+
+
+def _phi(p: float) -> float:
+    return 2.0 * math.asin(math.sqrt(p))
+
+
+def _resolution(n_a: int, n_b: int, baseline: float = _RESOLUTION_BASELINE):
+    """Smallest arm-B precision this run could distinguish from `baseline`,
+    and the per-arm n a 5pp difference would actually need."""
+    if n_a <= 0 or n_b <= 0:
+        return None
+    h_detectable = _Z_SUM * math.sqrt(1.0 / n_a + 1.0 / n_b)
+    p2 = math.sin(min(math.pi / 2, _phi(baseline) / 2 + h_detectable / 2)) ** 2
+    h_5pp = _phi(min(1.0, baseline + 0.05)) - _phi(baseline)
+    return {
+        "baseline_assumed_pct": round(100 * baseline, 1),
+        "power": 0.80,
+        "alpha": 0.05,
+        "mde_pp": round(100 * (p2 - baseline), 1),
+        "detectable_b_precision_pct": round(100 * p2, 1),
+        "n_per_arm_for_5pp": math.ceil(2 * (_Z_SUM / h_5pp) ** 2),
+        "note": ("a delta below mde_pp is not readable from this corpus; "
+                 "compare any suppressing arm against the `placebo` variant "
+                 "before attributing a difference to the hypothesis"),
+    }
+
+
 def _build_outputs(prompts, b_labels, counters, snap, n_rebuilds,
                    seed, holdout_min, variant_name, sweep_tokens,
                    out: Path) -> dict:
@@ -428,6 +466,8 @@ def _build_outputs(prompts, b_labels, counters, snap, n_rebuilds,
             agg["b_dedup_prompts"] += int(p["flags"][label]["dedup"])
             agg["a_agegate_prompts"] += int(p["flags"]["A"]["age_gate"])
             agg["b_agegate_prompts"] += int(p["flags"][label]["age_gate"])
+        agg["resolution"] = _resolution(agg["a_injections"],
+                                        agg["b_injections"])
         arm_aggs[label] = agg
 
     # ---- diffs.jsonl (private: carries prompt text) ----

--- a/research/experiments/recall-replay-ab/variants.py
+++ b/research/experiments/recall-replay-ab/variants.py
@@ -44,10 +44,13 @@ Registering a hypothesis: add a function here and name it in `BUILTIN`, or
 keep it out of the repo entirely and pass `--variant mymodule:myfunc`.
 """
 
+import hashlib
 import importlib
 import re
 import sys
 from pathlib import Path
+
+from daimon_briefing import store
 
 # ---------------------------------------------------------------------------
 # stance_gate (#483): does the prompt APPROACH the memory's territory (needs
@@ -164,7 +167,87 @@ def none(ctx, suggest):
     return suggest()
 
 
-BUILTIN = {"none": none, "stance_gate": stance_gate}
+# ---------------------------------------------------------------------------
+# placebo (#495): the NULL CONTROL. Suppresses rows at random, optionally at a
+# different rate per age band, so a real hypothesis can be compared against
+# "drop this many rows of this age and nothing else".
+#
+# It exists because a scoring proxy keyed on item age — the cheap way to score
+# a policy without blind grading — is a function of the age HISTOGRAM of the
+# rows a rule drops, and of nothing else. Every rule dropping the same profile
+# scores identically, including this one. A hypothesis that does not beat its
+# own placebo has measured the histogram, not the hypothesis.
+# ---------------------------------------------------------------------------
+
+_BANDS = ("<=1d", "2-7d", ">7d", "unknown")
+
+
+def _age_band(row, now) -> str:
+    epoch = store._created_epoch(row.get("first_seen"))
+    if epoch is None or epoch > now:
+        return "unknown"
+    age = (now - epoch) / 86400.0
+    return "<=1d" if age <= 1 else "2-7d" if age <= 7 else ">7d"
+
+
+def _placebo_rates(param):
+    """`param` is either a bare probability applied to every band ("0.15"), or
+    comma-separated per-band rates ("<=1d:0,2-7d:0.07,>7d:0.11") so a placebo
+    can be matched to a treatment arm's observed drop histogram. Unnamed bands
+    default to 0 — a placebo must never suppress more than it was asked to."""
+    if param is None:
+        return {}
+    token = str(param).strip()
+    if not token:
+        return {}
+    if ":" not in token:
+        try:
+            rate = float(token)
+        except ValueError:
+            raise SystemExit(
+                f"replay-ab: placebo param {param!r} is neither a probability "
+                f"nor band:rate pairs")
+        return {b: rate for b in _BANDS}
+    rates = {}
+    for piece in token.split(","):
+        band, _, value = piece.partition(":")
+        band = band.strip()
+        if band not in _BANDS:
+            raise SystemExit(
+                f"replay-ab: placebo band {band!r} unknown; expected "
+                f"{list(_BANDS)}")
+        rates[band] = float(value)
+    return rates
+
+
+def placebo(ctx, suggest):
+    """Null control: suppress rows at random, per-band, deterministically.
+
+    The draw is a hash of (prompt, row text, param) rather than a PRNG, so it
+    is stable under replay and re-entry — verify.py byte-compares two runs of
+    every artifact, and a stateful generator would drift the moment the arm
+    order or the prompt set changed. Rows are only ever REMOVED: like every
+    gate, the placebo can decline what `suggest()` returned and can never
+    invent a row it did not.
+    """
+    rows = suggest()
+    rates = _placebo_rates(ctx.get("param"))
+    if not rates or not rows:
+        return rows
+    kept = []
+    for row in rows:
+        rate = rates.get(_age_band(row, ctx["ts"]), 0.0)
+        if rate <= 0.0:
+            kept.append(row)
+            continue
+        seed = f"{ctx['prompt']}\x00{row.get('text') or ''}\x00{ctx['param']}"
+        draw = int(hashlib.sha1(seed.encode("utf-8")).hexdigest()[:8], 16)
+        if draw / 0xFFFFFFFF >= rate:
+            kept.append(row)
+    return kept
+
+
+BUILTIN = {"none": none, "stance_gate": stance_gate, "placebo": placebo}
 
 
 def resolve(spec: str):

--- a/research/experiments/recall-replay-ab/verify.py
+++ b/research/experiments/recall-replay-ab/verify.py
@@ -217,6 +217,58 @@ def main() -> int:
             id_arm["a_injections"] > 0,
             f"a={id_arm['a_injections']}")
 
+        # 2b. #495: the rig must state what it can RESOLVE. A delta smaller
+        #     than the minimum detectable effect is unreadable no matter how
+        #     confidently it is reported, and that has to be visible in the
+        #     artifact people share rather than rediscovered afterwards.
+        res_block = id_arm.get("resolution")
+        ok &= _check(
+            "resolution: summary.json states the minimum detectable effect",
+            isinstance(res_block, dict)
+            and isinstance(res_block.get("mde_pp"), (int, float))
+            and res_block["mde_pp"] > 0,
+            f"block={res_block}")
+        ok &= _check(
+            "resolution: states n required to resolve 5pp, and it exceeds n",
+            isinstance(res_block, dict)
+            and isinstance(res_block.get("n_per_arm_for_5pp"), int)
+            and res_block["n_per_arm_for_5pp"] > 0
+            and res_block["n_per_arm_for_5pp"] > id_arm["a_injections"],
+            f"need={(res_block or {}).get('n_per_arm_for_5pp')} "
+            f"have={id_arm['a_injections']}")
+
+        # 2c. #495: the null control. A placebo suppressing nothing must be
+        #     the identity; a placebo suppressing rows must only ever REMOVE
+        #     (it cannot invent a row suggest() did not return).
+        res_p0 = replay_ab.run(dataset, home, ["0.0"], root / "out-p0",
+                               seed=470, variant=variants.placebo,
+                               variant_name="placebo")
+        p0 = res_p0["summary"]["arms"]["B@0.0"]
+        ok &= _check(
+            "placebo at p=0 is the identity: B == A",
+            p0["diff_prompts"] == 0 and p0["a_only"] == 0
+            and p0["b_only"] == 0,
+            f"a={p0['a_injections']} b={p0['b_injections']}")
+
+        res_p1 = replay_ab.run(dataset, home, ["1.0"], root / "out-p1",
+                               seed=470, variant=variants.placebo,
+                               variant_name="placebo")
+        p1 = res_p1["summary"]["arms"]["B@1.0"]
+        ok &= _check(
+            "placebo at p=1 suppresses everything and adds nothing",
+            p1["b_injections"] == 0 and p1["b_only"] == 0
+            and p1["a_injections"] > 0,
+            f"a={p1['a_injections']} b={p1['b_injections']} "
+            f"b_only={p1['b_only']}")
+
+        res_p1b = replay_ab.run(dataset, home, ["1.0"], root / "out-p1b",
+                                seed=470, variant=variants.placebo,
+                                variant_name="placebo")
+        ok &= _check(
+            "placebo is deterministic for a given (seed, param)",
+            (root / "out-p1" / "summary.json").read_bytes()
+            == (root / "out-p1b" / "summary.json").read_bytes())
+
         prompts = {p["idx"]: p for p in res1["prompts"]}
         summ = res1["summary"]
         arms = summ["arms"]


### PR DESCRIPTION
Closes #495

## What

Two additions to the replay A/B harness. Neither changes any arm's semantics.

**`placebo` builtin variant.** Suppresses rows at random at a per-age-band rate:

    --variant placebo --sweep "0.12"                       # uniform
    --variant placebo --sweep "<=1d:0,2-7d:0.07,>7d:0.11"  # matched to a treatment's drops

The draw is a hash of (prompt, row text, param) rather than a PRNG, so it is stable under replay and re-entry — `--verify` byte-compares two runs of every artifact, and a stateful generator would drift the moment arm order or the prompt set changed. Like every gate it can only remove rows, never invent them.

**`resolution` block in `summary.json`**, per arm:

    "resolution": {
      "baseline_assumed_pct": 20.0, "power": 0.8, "alpha": 0.05,
      "mde_pp": 9.2, "detectable_b_precision_pct": 29.2,
      "n_per_arm_for_5pp": 1092
    }

Arcsine (Cohen's h), stdlib `math` only — no new dependency. The baseline is an assumption, so it is stated in the block rather than buried.

## Why

The harness could report that B differs from A. It could not report whether that difference exceeded a randomly perturbed arm, and it never said what effect size the corpus was capable of resolving. Each gap produced a wrong reading.

**No null control.** A gate sweep scored with an age-band relevance proxy appeared to move precision 20.6% → 21.8%. An age-matched random control scored **identically to two decimals**. That is not coincidence: any proxy keyed on item age is a deterministic function of the age histogram of the rows a rule drops, so every rule dropping the same profile scores the same. The sweep measured "which rule drops more old rows", not the hypothesis. A placebo arm exposes that in one run.

**No stated resolution.** Separately, a matcher A/B perturbed 7.3% of injection volume; at 25 discordant units its minimum detectable effect required the variant to reach ~59% precision. The decision rule was pre-registered; the power was never checked; the run could not have satisfied its own rule. On the real corpus the MDE is **9.2pp at n=344**, which retroactively condemns several deltas that were read as findings.

Both failures are the measuring device declining to describe its own limits. Fixing the instrument is cheaper than being careful with the next hypothesis.

The README gains the two sections that make this operational, including the asymmetry worth knowing: **comparing two arms is expensive, characterising one class is cheap.** "How relevant is the class this gate admits?" is a one-sample question that lands inside a useful interval at n≈30 — prefer it when the goal is to indict a rule rather than rank two of them.

## Tests

Five new executable checks in `verify.py`, all failing before the change:

- `resolution: summary.json states the minimum detectable effect`
- `resolution: states n required to resolve 5pp, and it exceeds n` — on the fixture, 1092 needed against 3 available
- `placebo at p=0 is the identity: B == A`
- `placebo at p=1 suppresses everything and adds nothing` — pins the never-invents-a-row half of the variant contract
- `placebo is deterministic for a given (seed, param)`

The first two failed with `block=None`, the rest with `module 'variants' has no attribute 'placebo'`.

`--verify` PASS (all 31 checks, including the pre-existing determinism, snapshot, cooldown and stance-gate suites). Plugin suite untouched and green: 2630 passed, 2 skipped.