### PR TITLE
fix(scoring): soft-clip the trust ceiling so it bounds order instead of erasing it

### DIFF
--- a/plugin/daimon_briefing/scoring.py
+++ b/plugin/daimon_briefing/scoring.py
@@ -132,9 +132,11 @@ def _soft_clip(weight: float, ceiling: float) -> float:
     - C1-continuous at the knee: f(K) = K and f'(K+) = 1.
     - identity below K, so the great majority of items are untouched and the
       carry_floor comparisons that sit far below the knee cannot move.
+
+    A zero ceiling needs no special case: K collapses to 0, the gap term
+    vanishes, and every weight maps to 0.0 — so a trust class with no
+    authority silences its items by arithmetic rather than by a guard.
     """
-    if ceiling <= 0.0:
-        return 0.0
     knee = ceiling * (1.0 - _SOFT_CLIP_DELTA)
     if weight <= knee:
         return weight

--- a/plugin/daimon_briefing/scoring.py
+++ b/plugin/daimon_briefing/scoring.py
@@ -106,6 +106,42 @@ def _age_days(item, now: float) -> float | None:
     return max(0.0, (now - epoch) / 86400.0)
 
 
+_SOFT_CLIP_DELTA = 0.1   # knee at C*(1-delta): below it, nothing changes
+
+
+def _soft_clip(weight: float, ceiling: float) -> float:
+    """Saturate `weight` toward `ceiling` without ever reaching it, preserving
+    order (#488).
+
+    #408 applied the lid with min(), which caps correctly and is not injective
+    on [C, inf): every accumulation at or above the ceiling collapsed onto the
+    same number, so importance stopped separating exactly the items the lid was
+    protecting. Measured on the real corpus, fresh inferred items at importance
+    8, 9 and 10 all scored 0.700, leaving briefing._by_weight's stable sort to
+    fall back on serializer emission order.
+
+    The invariant #408 states is sup(w) <= C. It never required collapsing the
+    domain. With K = C(1-delta):
+
+        f(w) = w                              for w <= K
+        f(w) = C - (C-K)^2 / (w - 2K + C)     for w > K
+
+    - bounded, strictly: w > K => w-2K+C > C-K > 0, so f(w) < C, approaching C
+      from below. Tighter than min(), which ATTAINS C.
+    - strictly increasing: f'(w) = (C-K)^2 / (w-2K+C)^2 > 0. Order-preserving.
+    - C1-continuous at the knee: f(K) = K and f'(K+) = 1.
+    - identity below K, so the great majority of items are untouched and the
+      carry_floor comparisons that sit far below the knee cannot move.
+    """
+    if ceiling <= 0.0:
+        return 0.0
+    knee = ceiling * (1.0 - _SOFT_CLIP_DELTA)
+    if weight <= knee:
+        return weight
+    gap = ceiling - knee
+    return ceiling - (gap * gap) / (weight - 2.0 * knee + ceiling)
+
+
 def effective_weight(item, item_type: str, now: float) -> float:
     """Ordering key for one checkpoint item. Tolerant of everything a legacy or
     torn checkpoint can throw: missing/malformed first_seen -> neutral recency,
@@ -122,8 +158,8 @@ def effective_weight(item, item_type: str, now: float) -> float:
     ceiling = trust_ceiling(item.get("trust"))
     age = _age_days(item, now)
     if age is None:
-        return min(base * _NEUTRAL_RECENCY, ceiling)
+        return _soft_clip(base * _NEUTRAL_RECENCY, ceiling)
     weight = base * recency_weight(age) * _type_decay(age, rules)
     if rules["auto_escalation"] and age > rules["expected_lifespan"]:
         weight *= _overdue_boost(age - rules["expected_lifespan"])
-    return min(weight, ceiling)
+    return _soft_clip(weight, ceiling)

--- a/plugin/tests/test_scoring.py
+++ b/plugin/tests/test_scoring.py
@@ -230,3 +230,16 @@ def test_soft_clip_preserves_the_cross_class_band():
     verbatim = scoring.effective_weight(
         {**shape, "trust": "verbatim"}, "open_question", _NOW)
     assert inferred < scoring.trust_ceiling("inferred") < verbatim
+
+
+def test_soft_clip_at_a_zero_ceiling_silences_without_a_special_case():
+    # A trust class with no authority is expressible in the table (nothing
+    # forbids a 0.0 lid). The closed form handles it: the knee collapses to 0,
+    # the gap term vanishes, and every weight maps to 0.0 — so no guard branch
+    # is needed, and none exists to rot untested.
+    for w in (0.0, 0.5, 1.0, 3.0):
+        assert scoring._soft_clip(w, 0.0) == 0.0, w
+    # and the live table has no non-positive lid, which is why the above is a
+    # statement about the formula rather than about production behavior.
+    assert all(v > 0 for v in scoring.TRUST_CEILING.values())
+    assert scoring._DEFAULT_CEILING > 0

--- a/plugin/tests/test_scoring.py
+++ b/plugin/tests/test_scoring.py
@@ -174,3 +174,59 @@ def test_verbatim_keeps_full_escalation_range():
     # escalation cap, so a verbatim open loop keeps every bit of overdue boost.
     v_ceiling = scoring.trust_ceiling("verbatim")
     assert v_ceiling >= scoring._ESCALATION_CAP
+
+
+# ---- #488: the ceiling must BOUND the order, not erase it ----
+
+
+def test_clamped_items_keep_distinct_weights_by_importance():
+    # #408's min() caps correctly and destroys injectivity on [C, inf): every
+    # fresh inferred item at importance 8/9/10 evaluated to exactly 0.700, so
+    # among the HIGHEST-importance items in a briefing the tiebreak fell to
+    # whatever order the serializer happened to emit (briefing._by_weight is a
+    # stable sort). The lid was only ever asked to bound the score.
+    ws = [scoring.effective_weight(
+        {"trust": "inferred", "first_seen": _iso(0), "importance": imp},
+        "open_question", _NOW) for imp in (7, 8, 9, 10)]
+    assert len(set(ws)) == len(ws), f"importance ordering collapsed: {ws}"
+    assert ws == sorted(ws), f"not monotone in importance: {ws}"
+
+
+def test_soft_clip_never_attains_the_ceiling():
+    # Strictly tighter than min(), which ATTAINS the lid. Drive the same
+    # adversarial cross-product shape as the #408 guard and assert strict
+    # inequality, not <=.
+    ceiling = scoring.trust_ceiling("inferred")
+    for imp in (8, 9, 10):
+        for age in (0, 1, 2):
+            w = scoring.effective_weight(
+                {"trust": "inferred", "first_seen": _iso(age),
+                 "importance": imp}, "open_question", _NOW)
+            assert w < ceiling, (imp, age, w, ceiling)
+
+
+def test_soft_clip_is_a_noop_below_the_knee():
+    # The change must touch ONLY the degenerate region. Anything whose raw
+    # accumulation lands below the knee scores exactly what it scored before.
+    ceiling = scoring.trust_ceiling("inferred")
+    knee = ceiling * (1 - scoring._SOFT_CLIP_DELTA)
+    for age, imp in ((30, 5), (60, 3), (90, 7), (200, 2)):
+        item = {"trust": "inferred", "first_seen": _iso(age),
+                "importance": imp}
+        w = scoring.effective_weight(item, "recent_decision", _NOW)
+        if w < knee:                      # only assert on the untouched region
+            raw = (imp / 10.0) * scoring.recency_weight(age) * scoring._type_decay(
+                age, scoring.TYPE_RULES["recent_decision"])
+            assert abs(w - raw) < 1e-12, (age, imp, w, raw)
+
+
+def test_soft_clip_preserves_the_cross_class_band():
+    # #408's load-bearing property: no inferred item reaches the band a
+    # verbatim item of the same shape occupies. The soft clip must not leak
+    # across it while it is busy separating ties.
+    shape = {"first_seen": _iso(0), "importance": 10}
+    inferred = scoring.effective_weight(
+        {**shape, "trust": "inferred"}, "open_question", _NOW)
+    verbatim = scoring.effective_weight(
+        {**shape, "trust": "verbatim"}, "open_question", _NOW)
+    assert inferred < scoring.trust_ceiling("inferred") < verbatim


### PR DESCRIPTION
Closes #488

## What

`effective_weight` applies the #408 trust lid with a soft clip instead of `min()`. With `K = C(1 - 0.1)`:

    f(w) = w                              for w <= K
    f(w) = C - (C-K)^2 / (w - 2K + C)     for w > K

## Why

`min()` caps correctly and is **not injective** on `[C, inf)`. Every accumulation at or above the ceiling collapsed onto the same value, so importance stopped separating exactly the items the lid was protecting. Measured against the module, fresh `inferred` items at importance 6 through 10:

    0.5997, 0.6997, 0.700, 0.700, 0.700

`briefing._by_weight` sorts with a stable `sorted()`, so for the top three the tiebreak was whatever order the serializer happened to emit — a property of the extraction model, not of the record.

The invariant #408 states is `sup(w) <= C`. It never required collapsing the domain; `min()` did both, and only the first was asked for.

Properties, all provable from the closed form and pinned by tests:

- **Bounded, strictly.** For `w > K`, `w - 2K + C > C - K > 0`, so `f(w) < C`, approaching it from below. Strictly tighter than `min()`, which *attains* `C`.
- **Strictly increasing.** `f'(w) = (C-K)^2 / (w - 2K + C)^2 > 0`. Order-preserving.
- **C1-continuous at the knee.** `f(K) = K`, `f'(K+) = 1`.
- **Identity below the knee**, so items far from the lid are untouched and the `carry_floor` comparisons cannot move.
- **Cross-class band preserved.** `sup(inferred) < 0.7 <` the values fresh verbatim items reach, which is the property #408 exists for.

## Corpus effect, stated in full

    items scored:                12628
    value changed by soft clip:    950 = 7.52%
    previously AT the ceiling:     547 = 4.33%
    in a tie group BEFORE:       10138 = 80.28%
    in a tie group AFTER:         9940 = 78.71%

Two things worth being explicit about rather than quoting the flattering number only:

**More items change than were clamped.** Everything above the knee compresses, not just what sat at the lid. That is the design — a hard corner at `C` is what produced the collapse — but it means ~7.5% of items shift slightly, all of them in the top band and all order-preserving.

**Most remaining ties are genuine.** The residual 78.7% are items of equal importance in the same age band, which no clamp caused and this change does not claim to fix.

**This is a correctness change, not a ranking improvement**, and the issue's own pre-registered bar says so: 4.63% of items sat in a clamped tie group against a 5% threshold set in advance. It did not clear it. Shipping on the proof, not on a precision claim.

## Tests

Four new, all failing before the change:

- `test_clamped_items_keep_distinct_weights_by_importance` — the collapse itself: importance 7/8/9/10 must be distinct and monotone
- `test_soft_clip_never_attains_the_ceiling` — strict inequality, where the #408 guard only asserts `<=`
- `test_soft_clip_is_a_noop_below_the_knee` — the untouched region really is untouched
- `test_soft_clip_preserves_the_cross_class_band` — no leak across the band while separating ties

The existing #408 guards are unchanged and still green, including the adversarial cross-product (`test_no_input_lifts_effective_weight_above_trust_ceiling`) that drives every type, age and out-of-range importance against every trust class.

Full suite: 2634 passed, 2 skipped.