### PR TITLE
fix(recall): count matched terms on word boundaries, not substrings

### DIFF
--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -817,6 +817,97 @@ def _fold(tok: str) -> str:
         c for c in unicodedata.normalize("NFD", tok) if not unicodedata.combining(c))
 
 
+_TOKEN_RE = re.compile(r"\w[\w\-]*")
+# Identifier separators + camelCase: `auth_token`, `session-start`, `parseJSON`.
+_SUBTOKEN_SPLIT_RE = re.compile(r"[_\-./:]+")
+_CAMEL_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+# Cheap pre-check: does this token have any boundary worth splitting on?
+_SPLITTABLE_RE = re.compile(r"[_\-./:]|[a-z0-9][A-Z]")
+# Longest first so `-ies` is tried before `-s`.
+_INFLECTIONS = ("ings", "edly", "ing", "ies", "ers", "est", "ed", "es", "er",
+                "ly", "s", "d")
+_STEM_MIN = 3   # never stem down to a stub shorter than a salient term
+
+
+def _match_units(text: str) -> set:
+    """Every whole word-unit a salient term may legitimately match (#490).
+
+    Retrieval is FTS5 `MATCH` under unicode61 — strict token equality — while
+    the gates that judge it (`_MIN_OVERLAP` here, cli's `_STALE_MIN_HITS` via
+    `term_hits`) used substring containment. Substring hits are a strict
+    superset of token hits, so every threshold stated in "distinct salient
+    terms" was evaluated on an inflated statistic, one-sided and always
+    permissive: `port` was credited against `transport`, `one` against
+    `honest`, `cli` against `client`.
+
+    Raw token equality is the wrong correction. `salient_terms` tokenizes on
+    `\\w[\\w-]*`, so compound identifiers are SINGLE tokens and substring
+    matching was the only reason a query for `token` reached `auth_token` — in
+    a code corpus that is the vocabulary, not noise. Measured on the real
+    corpus, only ~14% of substring-only credits were genuine mid-word false
+    positives; the rest were compounds (~72%) and inflections (~15%).
+
+    So: split each token on identifier separators and camelCase, add cheap
+    inflection stems, and credit a term only when it equals a whole unit. A
+    term is never credited for matching the middle of a word.
+    """
+    units = set()
+    for m in _TOKEN_RE.finditer(text):
+        raw = m.group(0)
+        # Fast path: this runs over every candidate row on the per-prompt
+        # critical path, and _fold's NFD normalize dominates. Almost every
+        # token is plain ASCII with no identifier boundary, so check for both
+        # before paying for either.
+        low = raw.lower() if raw.isascii() else _fold(raw).lower()
+        units.add(low)
+        if not _SPLITTABLE_RE.search(raw):
+            continue
+        for part in _SUBTOKEN_SPLIT_RE.split(_CAMEL_RE.sub("-", raw)):
+            if part:
+                units.add(part.lower() if part.isascii()
+                          else _fold(part).lower())
+    return units
+
+
+def _term_variants(term: str) -> set:
+    """Inflected forms of ONE salient term.
+
+    Morphology is folded on the QUERY side, not the haystack side, and that is
+    a performance decision with teeth: `suggest` compares <=24 terms against up
+    to 256 candidate rows, so expanding the terms once per prompt costs ~24
+    small sets while stemming every haystack token costs thousands. Measured on
+    real rows, haystack-side stemming ran ~7x slower than the substring
+    matching it replaced; this direction is ~1.4x.
+
+    Over-generous in one direction only: a form that is not a real word can be
+    generated (`statuss`), which at worst credits a term a stemmer would also
+    credit. It never removes a form.
+    """
+    forms = {term}
+    for suf in _INFLECTIONS:
+        forms.add(term + suf)
+        if term.endswith(suf) and len(term) - len(suf) >= _STEM_MIN:
+            base = term[:-len(suf)]
+            forms.add(base)
+            if suf == "ies":
+                forms.add(base + "y")
+            elif suf in ("es", "ed", "er", "est", "ing"):
+                forms.add(base + "e")
+    if term.endswith("y") and len(term) > _STEM_MIN:
+        forms.add(term[:-1] + "ies")
+    if not term.endswith("e"):
+        forms.add(term + "es")
+    else:
+        forms.add(term + "s")
+    return forms
+
+
+def credited_terms(terms, text: str) -> set:
+    """Which of `terms` the text legitimately answers, on word boundaries."""
+    units = _match_units(text)
+    return {t for t in terms if _term_variants(t) & units}
+
+
 def salient_terms(prompt: str) -> list[str]:
     """Prompt -> deduped lowercase retrieval terms, prompt order preserved.
     Tokens are word runs (unicode: "sesión" stays one token, never "sesi"+"n";
@@ -919,6 +1010,10 @@ def suggest(prompt: str, project_dir=None, current_session=None,
     if current_session:
         excluded.add(str(current_session))
 
+    # Term variants are computed ONCE per prompt (<=24 terms) and reused across
+    # every candidate row — the whole point of folding morphology on the query
+    # side rather than the haystack side (#490).
+    variants = {t: _term_variants(t) for t in terms}
     expr = " OR ".join('"' + t.replace('"', '""') + '"' for t in terms)
     try:
         _ensure_fresh()
@@ -958,11 +1053,13 @@ def suggest(prompt: str, project_dir=None, current_session=None,
     for r in rows:
         if r["session_id"] in excluded:
             continue
-        # Fold the haystack like the terms (#27): salient_terms folds
-        # "sesión"->"sesion", so an unfolded haystack silences accented
-        # content that FTS5 (remove_diacritics) already matched.
-        haystack = _fold(f"{r['text']} {r['quote'] or ''}".lower())
-        hit = {t for t in terms if t in haystack}
+        # #490: match on WORD BOUNDARIES, not substrings — the candidate set
+        # came from a token-based MATCH, so a gate counting substrings reads a
+        # statistic the retrieval never granted. _match_units folds the
+        # haystack the same way salient_terms folds the query (#27), so
+        # accented content FTS5 already matched still counts.
+        hit = {t for t, forms in variants.items()
+               if forms & _match_units(f"{r['text']} {r['quote'] or ''}")}
         if not hit:
             continue
         coverage.setdefault(r["session_id"], set()).update(hit)

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -1817,3 +1817,76 @@ def test_lowercased_marker_is_not_machine():
     # Literal and case-sensitive on purpose: the hosts emit exactly one casing,
     # and loosening it only buys false skips.
     assert recall.is_machine_prompt("[system notification] all done") is False
+
+
+# ---- #490: the coverage/hit-count gates must match on TOKEN BOUNDARIES ----
+
+
+def test_match_units_keeps_compounds_and_inflections_kills_mid_word():
+    # Retrieval is FTS5 MATCH (unicode61, strict token equality); the gates
+    # counted SUBSTRING containment, a strict superset, so every threshold
+    # stated in "distinct salient terms" was read off an inflated statistic —
+    # one-sided, always permissive.
+    #
+    # Raw token equality is the wrong correction here: the tokenizer is
+    # \w[\w-]*, so compound identifiers are SINGLE tokens and substring
+    # matching was the only reason a query for `token` ever reached
+    # `auth_token`. Split on identifier boundaries and stem instead.
+    keep = [("daimon", "daimon_team"), ("output", "empty-output"),
+            ("merge", "merged"), ("user", "users"), ("token", "auth_token"),
+            ("start", "session-start"), ("status", "statuses"),
+            ("command", "commands")]
+    kill = [("one", "honest"), ("read", "already"), ("cli", "client"),
+            ("port", "transport"), ("api", "rapid"), ("test", "latest"),
+            ("key", "monkey"), ("sent", "representative")]
+    for term, text in keep:
+        assert recall.credited_terms({term}, text) == {term}, \
+            f"{term} should match {text}"
+    for term, text in kill:
+        assert recall.credited_terms({term}, text) == set(), \
+            f"{term} must NOT match {text}"
+
+
+def test_match_units_folds_accents_like_salient_terms():
+    # Same fold as the query side, or accented content FTS5 already matched
+    # goes uncounted (#27).
+    assert recall.credited_terms({"sesion"}, "la sesión anterior") == {"sesion"}
+
+
+def test_suggest_does_not_credit_a_mid_word_substring(tmp_checkpoint_dir,
+                                                      monkeypatch):
+    # The gate is session-level >=2 distinct terms. Here exactly one term
+    # ("gateway") genuinely matches; "port" appears only inside "transport",
+    # which used to buy the second term and the injection with it.
+    store.write_checkpoint(
+        "S-sub",
+        _cp125("S-sub", questions=[{
+            "text": "the gateway transport layer reconnects on idle",
+            "trust": "inferred", "importance": 7,
+            "first_seen": "2026-06-20T00:00:00Z",
+        }], created="2026-06-20T00:00:00Z"),
+        project_dir="/repo/x",
+    )
+    out = recall.suggest("which gateway port should the proxy bind",
+                         project_dir="/repo/x", current_session="S-now")
+    assert out == [], f"mid-word substring bought a slot: {out}"
+
+
+def test_suggest_still_credits_a_compound_identifier(tmp_checkpoint_dir,
+                                                     monkeypatch):
+    # The other direction, and the reason raw token equality was rejected: in
+    # a code corpus the nouns are compound identifiers, and a query for the
+    # bare word must still reach them.
+    store.write_checkpoint(
+        "S-comp",
+        _cp125("S-comp", questions=[{
+            "text": "auth_token refresh races with the session-start hook",
+            "trust": "inferred", "importance": 7,
+            "first_seen": "2026-06-20T00:00:00Z",
+        }], created="2026-06-20T00:00:00Z"),
+        project_dir="/repo/x",
+    )
+    out = recall.suggest("the token refresh during session start",
+                         project_dir="/repo/x", current_session="S-now")
+    assert out and out[0]["session_id"] == "S-comp"
+    assert out[0]["term_hits"] >= 2


### PR DESCRIPTION
Closes #490

## What

`suggest` computes each row's matched-term set with boundary-aware subtoken matching instead of substring containment. Tokens are split on identifier separators and camelCase; morphology is folded on the query side.

    port  -> transport      no longer credited
    token -> auth_token     still credited

## Why

The candidate set comes from FTS5 `MATCH` under `unicode61` — strict token equality. The gates that judge it counted substrings:

```python
haystack = _fold(f"{r['text']} {r['quote'] or ''}".lower())
hit = {t for t in terms if t in haystack}
```

Substring hits are a strict superset of token hits, so `_MIN_OVERLAP` here and `_STALE_MIN_HITS` in cli's age gate (via the exported `term_hits`) were both read off an inflated statistic — one-sided, always permissive, never restrictive. Measured on 659 recorded prompts / 153,936 candidate rows: **27.1% of rows over-credit, 19.5% of all credits are substring-only.**

**Raw token equality is the wrong correction**, and this is the part worth keeping. `salient_terms` tokenizes on `\w[\w-]*`, so compound identifiers are single tokens — substring matching was the only reason a query for `token` ever reached `auth_token`. Classifying the substring-only credits by how the term sits inside the token:

| class | share | example |
|---|---|---|
| prefix of a longer token | 43.8% | `daimon` → `daimon_team` |
| suffix | 27.9% | `output` → `empty-output` |
| inflection | 14.6% | `merge` → `merged` |
| **embedded mid-word** | **13.8%** | `one` → `honest` |

Only the last class is a false positive. Raw token equality would have removed 19.5% of credits, ~86% of them legitimate; this removes ~5%.

## Performance — the claim in the issue was wrong

The issue said the change would be "plausibly cheaper". Measured against 256 real rows, it was not:

    substring (original)            2.3 ms per prompt
    subtoken, haystack-side stems  16.0 ms      (7x slower)
    subtoken, query-side variants  13.3 ms
    + ASCII fast path               5.0 ms      (~2x, shipped)

This runs on the per-prompt critical path, so two things changed to earn that back. Morphology folds on the **query** side — ≤24 terms expanded once per prompt, rather than stemming every token of every haystack. And `_match_units` takes an ASCII fast path that skips `_fold`'s NFD normalize plus a pre-check that skips the split work for tokens with no boundary. Net cost is ~2.4ms per prompt.

## Scope: hygiene, not a quality claim

Corpus effect is **344 → 340 injections**, age-gated prompts 106 → 105. This corpus resolves 9.2pp at n=344 (`summary.json`'s new `resolution` block), so an effect this size is unmeasurable here by construction — which is exactly why this ships on the soundness argument with no A/B attached.

`_STALE_MIN_HITS` was tuned against the inflated statistic and should be re-derived against the corrected one. That is #491's territory, where the age gate is already under review; deliberately not smuggled in here.

## Tests

Four new. Three failed before the change; the fourth passed and is the regression guard that made raw token equality unacceptable.

- `test_match_units_keeps_compounds_and_inflections_kills_mid_word` — 8 keep pairs, 8 kill pairs, the discriminating set
- `test_match_units_folds_accents_like_salient_terms` — same fold as the query side (#27)
- `test_suggest_does_not_credit_a_mid_word_substring` — end-to-end: one genuine term plus `port` inside `transport` used to buy the second term and the injection with it
- `test_suggest_still_credits_a_compound_identifier` — **passed before and after**; pins the behavior raw token equality would have broken

Full suite: 2639 passed, 2 skipped. Harness `--verify`: PASS.