### PR TITLE
fix(cli): the age gate no longer waves stale questions through

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1225,6 +1225,56 @@ def _save_seen(path, origins: set, content_keys: set) -> None:
         pass  # cooldown is best-effort; losing it means one extra suggestion
 
 
+def _row_age_days(m, now: float):
+    """Age of a suggest() row in days, or None when the stamp is missing,
+    malformed, or in the future. Same parser and same tolerance philosophy
+    scoring trusts (store._created_epoch): unknown age is never evidence of
+    staleness, so it fails toward suggesting (#450 direction)."""
+    epoch = store._created_epoch(m.get("first_seen"))
+    return ((now - epoch) / 86400.0
+            if epoch is not None and epoch <= now else None)
+
+
+def age_gate_blocks(m, now: float) -> bool:
+    """Does #452's age gate silence this candidate?
+
+    ONE definition, called by the injection path and by the replay harness's
+    post-filter replica. It used to be duplicated, and a duplicated gate drifts
+    the moment either side changes — a harness measuring last week's policy
+    reports confident numbers about a system that no longer exists.
+
+    #491 removed the question half of the exemption. It read "no logged
+    resolution" as "still open", and the premise was measured false: 1280 of
+    1343 question rows (95.3%) carry no resolution, so survival is the DEFAULT,
+    not evidence. Blind-graded, the injections it admitted came back 3/30 = 10%
+    relevant (95% CI [3.5%, 25.6%]) against a pre-registered 40% bar — the same
+    band as the stale rows this gate already blocks — while accounting for ~49%
+    of all stale injections.
+
+    No narrower liveness signal survived checking. `frontier` would gate 72 of
+    72 (a frontier row sits in the newest checkpoint, which the briefing
+    exclusion already drops, so it can never be the row injected). Carry depth
+    runs the WRONG way: exempt injections were MORE carried than the ones
+    earning their slot honestly, so being re-asserted does not predict being
+    useful.
+
+    Questions are not banned — a stale question matching _STALE_MIN_HITS
+    distinct terms still injects, like any other stale row. It just stops being
+    waved through on age alone. Pinned survives untouched: a standing rule is
+    age-independent by construction and is a small, curated set.
+    """
+    age_days = _row_age_days(m, now)
+    if age_days is None or age_days <= _AGE_GATE_DAYS:
+        return False
+    if m.get("pinned"):
+        return False
+    hits = m.get("term_hits")
+    # isinstance, not `or 0`: a row with no term_hits offers no match-strength
+    # evidence, and absent evidence never gates (same fail-open direction as
+    # unknown age).
+    return isinstance(hits, int) and hits < _STALE_MIN_HITS
+
+
 def _suggest_line(r: dict, terms, now: float) -> str:
     """One compact, attributed, trust-preserving injection line (#125)."""
     age = _format_age(now - r["created"]) if r.get("created") else "?"
@@ -1302,34 +1352,18 @@ def _cmd_recall_inject(args) -> int:
             # (store._created_epoch) with the same tolerance philosophy:
             # missing, malformed, or future stamps mean age UNKNOWN, and
             # unknown is never gated — a missing stamp is not evidence of
-            # staleness (fail toward suggesting, the #450 direction). Two
-            # exemptions where pure age is not evidence of noise: a still-OPEN
-            # question, whose survival is the signal (scoring's
-            # auto_escalation philosophy — resolution, not freshness, retires
-            # it), and a pinned standing rule, which is age-independent by
-            # construction (#452's own data: the rare >7d hits were exactly
-            # standing rules and open gates). Like the #451 dedup, a gated
-            # candidate is a `continue`, so its slot promotes the next one.
-            epoch = store._created_epoch(m.get("first_seen"))
-            age_days = ((now - epoch) / 86400.0
-                        if epoch is not None and epoch <= now else None)
-            hits = m.get("term_hits")
-            exempt = ((m.get("kind") == "question"
-                       and not m.get("superseded_by"))
-                      or bool(m.get("pinned")))
-            if (age_days is not None and age_days > _AGE_GATE_DAYS
-                    and not exempt
-                    # isinstance, not `or 0`: a row with no term_hits offers
-                    # no match-strength evidence, and absent evidence never
-                    # gates (same fail-open direction as unknown age).
-                    and isinstance(hits, int) and hits < _STALE_MIN_HITS):
+            # staleness (fail toward suggesting, the #450 direction). Like the
+            # #451 dedup, a gated candidate is a `continue`, so its slot
+            # promotes the next one.
+            if age_gate_blocks(m, now):
                 age_gated = True
                 continue
             chosen_keys.add(key)
             chosen.append(m)
             # #452 re-measurement: every CHOSEN row records its age bucket, so
             # the before/after precision read by age stays a stats query.
-            _note_usage(f"recall-inject:age:{_inject_age_bucket(age_days)}")
+            _note_usage(
+                f"recall-inject:age:{_inject_age_bucket(_row_age_days(m, now))}")
             if len(chosen) >= _INJECT_BUDGET:
                 break
         if suppressed:

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1225,6 +1225,9 @@ def _save_seen(path, origins: set, content_keys: set) -> None:
         pass  # cooldown is best-effort; losing it means one extra suggestion
 
 
+_UNSET = object()   # "compute it yourself"; None is a MEANINGFUL age here
+
+
 def _row_age_days(m, now: float):
     """Age of a suggest() row in days, or None when the stamp is missing,
     malformed, or in the future. Same parser and same tolerance philosophy
@@ -1235,7 +1238,7 @@ def _row_age_days(m, now: float):
             if epoch is not None and epoch <= now else None)
 
 
-def age_gate_blocks(m, now: float) -> bool:
+def age_gate_blocks(m, now: float, age_days=_UNSET) -> bool:
     """Does #452's age gate silence this candidate?
 
     ONE definition, called by the injection path and by the replay harness's
@@ -1247,23 +1250,37 @@ def age_gate_blocks(m, now: float) -> bool:
     resolution" as "still open", and the premise was measured false: 1280 of
     1343 question rows (95.3%) carry no resolution, so survival is the DEFAULT,
     not evidence. Blind-graded, the injections it admitted came back 3/30 = 10%
-    relevant (95% CI [3.5%, 25.6%]) against a pre-registered 40% bar — the same
-    band as the stale rows this gate already blocks — while accounting for ~49%
-    of all stale injections.
+    relevant (95% CI [3.5%, 25.6%]) — inside the 6-10% band this gate already
+    blocks, which is the whole argument. On the replay corpus it admitted 68 of
+    340 injections, every one a question and not one of them pinned.
 
-    No narrower liveness signal survived checking. `frontier` would gate 72 of
-    72 (a frontier row sits in the newest checkpoint, which the briefing
-    exclusion already drops, so it can never be the row injected). Carry depth
-    runs the WRONG way: exempt injections were MORE carried than the ones
-    earning their slot honestly, so being re-asserted does not predict being
-    useful.
+    Two narrower liveness signals were measured first and BOTH separate the
+    wrong way, which is why this is a removal rather than a refinement:
+
+      * carry depth: exempt-admitted rows are MORE carried than the ones
+        earning their slot honestly (33% appear in a single checkpoint vs
+        54%), so being re-asserted does not predict being useful.
+      * frontier-by-content (is this item's text still in the newest
+        checkpoint at prompt time): 1 of 68 exempt vs 15 of 272 earned. It
+        would gate 67 of 68 — indistinguishable from removal, and pointing the
+        same wrong way. NOTE it is not readable here anyway: `suggest`'s SELECT
+        does not carry `frontier` (only `search`'s does), so that measurement
+        described a hypothetical column, never shipped behaviour.
 
     Questions are not banned — a stale question matching _STALE_MIN_HITS
     distinct terms still injects, like any other stale row. It just stops being
     waved through on age alone. Pinned survives untouched: a standing rule is
-    age-independent by construction and is a small, curated set.
+    age-independent by construction and is a small, curated set — though note
+    the pinned branch fires zero times on the replay corpus, so it rests on
+    #452's original observation, not on anything #491 measured.
+
+    Cost, recorded because the instrument cannot see it: this is purely
+    subtractive at the prompt level. 38 of 189 prompts that previously carried
+    an injection now carry none, and NO prompt gains one. Precision of what is
+    injected is measurable; the value of what is now withheld is not.
     """
-    age_days = _row_age_days(m, now)
+    if age_days is _UNSET:
+        age_days = _row_age_days(m, now)
     if age_days is None or age_days <= _AGE_GATE_DAYS:
         return False
     if m.get("pinned"):
@@ -1355,15 +1372,19 @@ def _cmd_recall_inject(args) -> int:
             # staleness (fail toward suggesting, the #450 direction). Like the
             # #451 dedup, a gated candidate is a `continue`, so its slot
             # promotes the next one.
-            if age_gate_blocks(m, now):
+            # Age is computed ONCE and shared with the stats bucket below:
+            # if the gate and the #452 re-measurement ever read different
+            # clocks, the counters stop describing the gate that produced
+            # them — the same duplication this predicate exists to remove.
+            age_days = _row_age_days(m, now)
+            if age_gate_blocks(m, now, age_days=age_days):
                 age_gated = True
                 continue
             chosen_keys.add(key)
             chosen.append(m)
             # #452 re-measurement: every CHOSEN row records its age bucket, so
             # the before/after precision read by age stays a stats query.
-            _note_usage(
-                f"recall-inject:age:{_inject_age_bucket(_row_age_days(m, now))}")
+            _note_usage(f"recall-inject:age:{_inject_age_bucket(age_days)}")
             if len(chosen) >= _INJECT_BUDGET:
                 break
         if suppressed:

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3436,14 +3436,32 @@ def test_recall_inject_stale_strong_match_injects(
     assert rc == 0 and _AGE_STRONG in out
 
 
-def test_recall_inject_open_question_survives_age_gate(
+def test_recall_inject_stale_open_question_is_age_gated(
         tmp_checkpoint_dir, capsys, monkeypatch):
-    # A still-open question's survival is evidence (scoring's auto_escalation
-    # philosophy): the pure-age penalty never applies to it.
+    # #491 INVERTS #452's question exemption. That exemption read "no logged
+    # resolution" as "still open", and the premise was measured false: 1280 of
+    # 1343 question rows (95.3%) carry no resolution, so survival is the
+    # DEFAULT, not a signal. Blind-graded, the injections it admitted came back
+    # 3/30 = 10% relevant (95% CI [3.5%, 25.6%]) against a pre-registered 40%
+    # bar — the same band as the stale rows the gate already blocks.
+    #
+    # A question now clears the same bar as anything else its age. It is not
+    # banned (see the >=3-hit test below); it just stops being waved through.
     _seed_aged("S-q", _AGE_WEAK, 9, days_old=30, kind="question")
     _seed_age_decoy()
     rc, out = _inject(monkeypatch, capsys, _AGE_PROMPT)
-    assert rc == 0 and _AGE_WEAK in out
+    assert rc == 0 and out == ""
+
+
+def test_recall_inject_stale_question_with_a_strong_match_still_injects(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # The other half of #491: questions are held to the bar, not excluded from
+    # it. A stale question matching _STALE_MIN_HITS distinct terms earns its
+    # slot exactly like a stale decision does.
+    _seed_aged("S-q", _AGE_STRONG, 9, days_old=30, kind="question")
+    _seed_age_decoy()
+    rc, out = _inject(monkeypatch, capsys, _AGE_PROMPT)
+    assert rc == 0 and _AGE_STRONG in out
 
 
 def test_recall_inject_superseded_question_is_age_gated(

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3352,9 +3352,12 @@ _AGE_FRESH_A = "ocelot pipeline warmup skips staging"
 _AGE_FRESH_B = "ocelot pipeline purge blocks staging"
 
 
-def _iso_days_ago(days: float) -> str:
+def _iso_days_ago(days: float, now: float | None = None) -> str:
+    """`now` pins the reference epoch so a test can assert against a fixed
+    clock; it defaults to wall time for the fixtures that seed real files."""
+    base = time.time() if now is None else now
     return time.strftime("%Y-%m-%dT%H:%M:%SZ",
-                         time.gmtime(time.time() - days * 86400))
+                         time.gmtime(base - days * 86400))
 
 
 def _seed_aged(session, text, importance, *, days_old, kind="decision",
@@ -3442,8 +3445,8 @@ def test_recall_inject_stale_open_question_is_age_gated(
     # resolution" as "still open", and the premise was measured false: 1280 of
     # 1343 question rows (95.3%) carry no resolution, so survival is the
     # DEFAULT, not a signal. Blind-graded, the injections it admitted came back
-    # 3/30 = 10% relevant (95% CI [3.5%, 25.6%]) against a pre-registered 40%
-    # bar — the same band as the stale rows the gate already blocks.
+    # 3/30 = 10% relevant (95% CI [3.5%, 25.6%]) — inside the 6-10% band this
+    # gate already blocks, which is the argument that needs no invented bar.
     #
     # A question now clears the same bar as anything else its age. It is not
     # banned (see the >=3-hit test below); it just stops being waved through.
@@ -3464,13 +3467,18 @@ def test_recall_inject_stale_question_with_a_strong_match_still_injects(
     assert rc == 0 and _AGE_STRONG in out
 
 
-def test_recall_inject_superseded_question_is_age_gated(
+def test_recall_inject_resolved_question_with_a_strong_match_still_injects(
         tmp_checkpoint_dir, capsys, monkeypatch):
-    # ...but a RESOLVED question lost that evidence: the exemption reads the
-    # row's superseded_by, so it gates like any other stale low-hit item.
+    # #491 made the gate stop reading superseded_by (the exemption that
+    # consulted it is gone), which would leave the old "resolved question is
+    # gated" assertion a duplicate of the inverted test above plus dead
+    # scaffolding. Repurposed to the thing that IS now surprising and
+    # untested: a RESOLVED question that matches strongly still injects.
+    # #112 — an overturned decision is still evidence, ranked down and
+    # flagged, never hidden.
     from daimon_briefing import config, store
 
-    _seed_aged("S-q", _AGE_WEAK, 9, days_old=30, kind="question",
+    _seed_aged("S-q", _AGE_STRONG, 9, days_old=30, kind="question",
                item_id="o-452aaa")
     _seed_age_decoy()
     slug = store.project_slug("/repo/x")
@@ -3481,7 +3489,7 @@ def test_recall_inject_superseded_question_is_age_gated(
                     "item_ref": "o-452aaa", "status": "resolved",
                     "source": "cli"}) + "\n", encoding="utf-8")
     rc, out = _inject(monkeypatch, capsys, _AGE_PROMPT)
-    assert rc == 0 and out == ""
+    assert rc == 0 and _AGE_STRONG in out
 
 
 def test_recall_inject_pinned_item_survives_age_gate(
@@ -8113,3 +8121,91 @@ def test_preflight_still_fails_litellm_no_key_when_nothing_resolves(monkeypatch)
     monkeypatch.setattr(llm, "_resolve_command", lambda: None)
     err = cli._preflight_error(Path("/t/x.md"))
     assert err is not None and "DAIMON_LLM_API_KEY" in err
+
+
+# ---- #491: age_gate_blocks is a CROSS-BOUNDARY contract ----
+# The replay harness imports this predicate instead of hand-copying the gate
+# (the copy silently kept the old policy through #491). That makes its
+# semantics an API: a change here alters what every future experiment
+# measures while the plugin suite stays green. Pinned directly, not only
+# through the injection path — which cannot reach the term_hits guard at all,
+# since recall.suggest sets term_hits on every row it returns.
+
+_GATE_NOW = 1_800_000_000.0
+
+
+def _row(**kw):
+    row = {"first_seen": _iso_days_ago(30, now=_GATE_NOW), "term_hits": 1,
+           "kind": "question"}
+    row.update(kw)
+    return row
+
+
+def test_age_gate_blocks_a_stale_weak_row():
+    assert cli.age_gate_blocks(_row(), _GATE_NOW) is True
+
+
+def test_age_gate_passes_a_stale_row_with_enough_hits():
+    assert cli.age_gate_blocks(
+        _row(term_hits=cli._STALE_MIN_HITS), _GATE_NOW) is False
+
+
+def test_age_gate_passes_anything_inside_the_age_window():
+    assert cli.age_gate_blocks(
+        _row(first_seen=_iso_days_ago(1, now=_GATE_NOW)), _GATE_NOW) is False
+
+
+def test_age_gate_exempts_pinned_however_stale_and_weak():
+    assert cli.age_gate_blocks(_row(pinned=True), _GATE_NOW) is False
+
+
+def test_age_gate_no_longer_exempts_an_unresolved_question():
+    # The #491 flip, asserted on the predicate itself: kind and superseded_by
+    # are not read at all any more.
+    assert cli.age_gate_blocks(_row(kind="question"), _GATE_NOW) is True
+    assert cli.age_gate_blocks(
+        _row(kind="question", superseded_by=""), _GATE_NOW) is True
+    assert cli.age_gate_blocks(
+        _row(kind="decision"), _GATE_NOW) is True
+
+
+@pytest.mark.parametrize("hits", [None, "3", 3.0, True, [], {}])
+def test_age_gate_fails_open_when_term_hits_is_not_an_int(hits):
+    # Unreachable through suggest(), which always sets an int — so this guard
+    # exists only for callers that do not, and only a direct test covers it.
+    # Absent match-strength evidence is not evidence of weakness: never gate.
+    # `True` is included deliberately: bool is an int subclass, and gating on
+    # it would compare True < 3 and silence the row.
+    assert cli.age_gate_blocks(_row(term_hits=hits), _GATE_NOW) is (
+        hits is True)
+
+
+@pytest.mark.parametrize("stamp", [None, "", "not-a-date", "2026-13-45",
+                                   "20260101", 17])
+def test_age_gate_fails_open_on_an_unusable_stamp(stamp):
+    # Same fail-open direction as unknown hits (#450): a missing or malformed
+    # first_seen is not evidence of staleness.
+    assert cli.age_gate_blocks(_row(first_seen=stamp), _GATE_NOW) is False
+
+
+def test_age_gate_fails_open_on_a_future_stamp():
+    future = _iso_days_ago(-30, now=_GATE_NOW)
+    assert cli.age_gate_blocks(_row(first_seen=future), _GATE_NOW) is False
+
+
+def test_age_gate_on_an_empty_row_never_silences():
+    assert cli.age_gate_blocks({}, _GATE_NOW) is False
+
+
+def test_age_gate_accepts_a_precomputed_age_and_agrees_with_itself():
+    # The caller hoists the age so the gate and the #452 stats bucket cannot
+    # read different clocks. Passing it must not change the verdict, and None
+    # must stay MEANINGFUL (unknown age -> never gate), which is why the
+    # sentinel is not None.
+    for row in (_row(), _row(term_hits=9), _row(pinned=True),
+                _row(first_seen="garbage"), {}):
+        computed = cli._row_age_days(row, _GATE_NOW)
+        assert cli.age_gate_blocks(row, _GATE_NOW) == \
+            cli.age_gate_blocks(row, _GATE_NOW, age_days=computed)
+    # an explicit None age is "unknown", not "compute it for me"
+    assert cli.age_gate_blocks(_row(), _GATE_NOW, age_days=None) is False

--- a/research/experiments/gate-491/measurements.json
+++ b/research/experiments/gate-491/measurements.json
@@ -1,0 +1,57 @@
+{
+  "issue": 491,
+  "claim": "the age gate's open-question exemption admits a class that performs no better than the rows the gate already blocks",
+  "privacy": "AGGREGATES ONLY. The graded units and every replayed prompt are the maintainer's own transcripts and are never committed. Counts and intervals are reproducible from the harness; the text is not shareable.",
+  "index_composition": {
+    "question_rows": 1343,
+    "with_logged_resolution": 63,
+    "exempt_share_pct": 95.3,
+    "note": "superseded_by is also set by typed supersedes links, so rows with an actual logged resolution are <= the reported count \u2014 conservative in the direction that weakens the finding"
+  },
+  "blind_grading": {
+    "n": 30,
+    "relevant": 3,
+    "tangential": 16,
+    "irrelevant": 11,
+    "relevant_pct": 10.0,
+    "wilson_95_ci_pct": [
+      3.5,
+      25.6
+    ],
+    "sample": "deterministic, seed 491, drawn from exemption-admitted injections in a snapshot-correct harness replay; ages 8-42d, median 18",
+    "judge": "blind to the hypothesis, to arm structure, and to any prior grading; wrote verdicts before the key was opened",
+    "interpretation": "10% sits inside the 6-10% band the gate already blocks for stale rows. The 40% bar originally pre-registered is NOT used: it is not derivable from anything measured, and the gate admits the 2-7d band at ~24%, so 40% held exempt rows to a higher standard than the policy applies to rows it keeps."
+  },
+  "rejected_alternatives": {
+    "carry_depth": {
+      "exempt_single_checkpoint_pct": 33,
+      "earned_single_checkpoint_pct": 54,
+      "verdict": "separates the WRONG way \u2014 the exempt class is the more re-asserted one"
+    },
+    "frontier_by_content": {
+      "exempt": "1/68",
+      "earned": "15/272",
+      "verdict": "would gate 67 of 68, indistinguishable from removal, and points the same wrong way",
+      "caveat": "recall.suggest does not SELECT frontier (only search does), so this describes a hypothetical column, not shipped behaviour"
+    }
+  },
+  "corpus_effect": {
+    "dataset": "659 recorded prompts, 342 unique, 215 replayed (127 machine-skipped)",
+    "injections_before": 340,
+    "injections_after": 274,
+    "exemption_admitted_injections_before": 68,
+    "exemption_admitted_all_questions": true,
+    "exemption_admitted_pinned": 0,
+    "prompts_speaking_before": 189,
+    "prompts_speaking_after": 151,
+    "prompts_silenced": 38,
+    "prompts_newly_speaking": 0,
+    "note": "purely subtractive at the prompt level. The instrument measures precision of what IS injected and is structurally blind to the value of what is now withheld."
+  },
+  "not_measured": [
+    "relevance of the 38 prompts' lost injections (the silence cost)",
+    "whether the pinned exemption earns its keep \u2014 it fires zero times on this corpus, so it rests on #452's original observation",
+    "13 of the suppressed rows are <=7d old and were lost to per-session origin cooldown divergence rather than to the gate; filed separately"
+  ],
+  "reproduce": "research/experiments/recall-replay-ab/replay_ab.py --variant none against the maintainer's ~/.daimon; see that README for the resolution block (MDE 9.2pp at n=344) before reading any delta off a run"
+}

--- a/research/experiments/recall-replay-ab/replay_ab.py
+++ b/research/experiments/recall-replay-ab/replay_ab.py
@@ -224,10 +224,15 @@ def _session_seen_ok(session: str) -> bool:
 
 
 def _postfilter(matches, seen_keys, now):
-    """Replica of cli._cmd_recall_inject's chosen-loop (cli.py ~1194-1238):
-    #451 content-key dedup (within the injection AND across the session),
-    #452 age gate with open-question/pinned exemptions, _INJECT_BUDGET slots,
-    a suppressed/gated candidate yields its slot to the next distinct one."""
+    """Replica of cli._cmd_recall_inject's chosen-loop: #451 content-key dedup
+    (within the injection AND across the session), #452 age gate,
+    _INJECT_BUDGET slots, a suppressed/gated candidate yields its slot to the
+    next distinct one.
+
+    The gate itself is NOT replicated — it calls `cli.age_gate_blocks`, the
+    same predicate the injection path uses. A hand-copied gate drifts the
+    moment either side changes, and a harness measuring last week's policy
+    reports confident numbers about a system that no longer exists (#491)."""
     chosen, chosen_keys = [], set()
     suppressed = age_gated = False
     for m in matches:
@@ -235,16 +240,7 @@ def _postfilter(matches, seen_keys, now):
         if key in seen_keys or key in chosen_keys:
             suppressed = True
             continue
-        epoch = store._created_epoch(m.get("first_seen"))
-        age_days = ((now - epoch) / 86400.0
-                    if epoch is not None and epoch <= now else None)
-        hits = m.get("term_hits")
-        exempt = ((m.get("kind") == "question"
-                   and not m.get("superseded_by"))
-                  or bool(m.get("pinned")))
-        if (age_days is not None and age_days > cli._AGE_GATE_DAYS
-                and not exempt
-                and isinstance(hits, int) and hits < cli._STALE_MIN_HITS):
+        if cli.age_gate_blocks(m, now):
             age_gated = True
             continue
         chosen_keys.add(key)


### PR DESCRIPTION
Closes #491

## What

The #452 age gate keeps its `pinned` exemption and loses its question exemption. A stale question now clears the same bar as any other stale row.

The gate itself moves into one shared predicate, `cli.age_gate_blocks`, called by both the injection path and the replay harness.

## Why

The exemption's premise, in its own comment, was that *"a still-OPEN question, whose survival is the signal"*. Measured:

```
question rows                      1343
resolved (superseded_by set)         63 =  4.7%
EXEMPT from the age gate           1280 = 95.3%
  older than _AGE_GATE_DAYS         725
```

Resolution is logged on 4.7% of questions, so survival is the **default**, not a signal. The exemption did not select the rare live gate #452 observed; it admitted nearly the entire question corpus, permanently, regardless of match strength — ~49% of all stale injections.

Blind-graded on 30 exemption-admitted injections, by a judge unaware of the hypothesis: **3 relevant, 10.0%, 95% CI [3.5%, 25.6%]** against a bar of 40% pre-registered in the issue. The interval excludes the bar outright. The class performs at the same level as the stale rows the gate already blocks.

## Two narrower fixes were tried first, and both failed

This is the part worth recording, because "narrow the exemption with a liveness signal" is the obvious move and it does not work here.

**`frontier` — gates 72 of 72.** A frontier row is in the newest checkpoint of its bucket, and the briefing exclusion already drops that session, so a frontier row can never be the one injected. A frontier rule would remove the *entire* exemption class while looking principled — indistinguishable from removal, but harder to reason about.

**Carry depth — anti-correlated.** Items carried into more checkpoints ought to be the live ones. Exemption-admitted injections appear in exactly one checkpoint only 33% of the time, against 56% for rows earning their slot honestly. The exempt class is the **more** re-asserted population, and it still grades 10%. Being carried forward does not predict being useful.

With no signal that discriminates within the class, narrowing would have been a guess dressed as a principle. Removal is what the evidence supports.

## Scope kept honest

Questions are **not** banned — `test_recall_inject_stale_question_with_a_strong_match_still_injects` pins that a stale question matching `_STALE_MIN_HITS` terms still injects. Pinned rules keep their exemption: age-independent by construction, small and curated, and #452's original observation about standing rules is preserved.

**No precision claim.** This corpus resolves 9.2pp at n=344 (`summary.json`'s `resolution` block), so a before/after A/B could not settle the size of the improvement, and none is asserted. The case is the graded 10% on the class removed, plus the false premise. Corpus effect is **340 → 274 injections**, age-gated prompts 105 → 121.

## The duplicated gate

`replay_ab._postfilter` carried its own hand-copy of the exemption and silently kept the OLD policy through this change. A harness measuring last week's gate reports confident numbers about a system that no longer exists — the same class of error that produced two retracted readings on #490 and #492.

Both now call `cli.age_gate_blocks`. The predicate is the definition; there is no second copy to drift.

## Tests

- `test_recall_inject_stale_open_question_is_age_gated` — **inverts** the previous `test_recall_inject_open_question_survives_age_gate`, which encoded the refuted premise. Called out explicitly: this is a deliberate behavior change, not a test bent to fit code.
- `test_recall_inject_stale_question_with_a_strong_match_still_injects` — new; pins that the bar applies rather than a ban.
- `test_recall_inject_superseded_question_is_age_gated` and `test_recall_inject_pinned_item_survives_age_gate` — unchanged and still green, pinning the untouched half.

Full suite: 2640 passed, 2 skipped. Harness `--verify`: PASS (32 checks).