### PR TITLE
fix(cli): origin cooldown is a budget, not a session-wide ban

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1187,32 +1187,96 @@ def _seen_path(session: str):
     return config.recall_seen_dir() / f"{session}.json"
 
 
-def _load_seen(path) -> tuple[set, set]:
-    """(origin session ids, content keys) already injected this host session.
+# Sentinel for "argument not supplied", where None is itself a meaningful
+# value: an unknown age (never gate) and a disabled origin cooldown both use
+# None deliberately, so neither can double as "use the default".
+_UNSET = object()
 
-    Two on-disk shapes are read. The pre-#451 file is a flat JSON list of
-    origin ids; it loads as origins with NO content keys, so an in-flight
-    session keeps every suppression it had and simply starts collecting
-    content keys from its next injection. The current shape is
-    {"origins": [...], "content_keys": [...]}. Anything else — corrupt,
-    truncated, a bare scalar — is state we cannot trust, and cooldown is
-    best-effort: fall open to an empty set and pay one extra suggestion."""
+# Rows ONE prior session may supply across a host session (not per prompt —
+# _INJECT_BUDGET already caps that at 2). Was effectively 1: injecting a row
+# retired its whole origin.
+#
+# Measured on the replay corpus, the rows that ban was suppressing are the
+# GOOD ones: lifting it to 3 restores 138 injections of which 40 are <=1d and
+# only 3 are older than a week — an age mix whose calibrated relevance is ~39%
+# against a ~20% baseline. The ban was spending its suppression on the freshest
+# material in the store.
+#
+# 3 is a judgement bounded by evidence, not a measured optimum: 2 and "no cap"
+# are both defensible (they recover 116 and 160 rows at 37% and 43%). The cap
+# exists for the concern the ban encoded — one dense prior session must not
+# crowd out everything else — and unlimited lets a single origin supply 7 rows
+# in one working session. Crowding harm itself is UNMEASURED, so the cap is
+# deliberately conservative rather than tuned.
+_ORIGIN_BUDGET = 3
+
+
+def cooled_origins(origin_counts: dict, budget=_UNSET) -> set:
+    """Origins that have spent their budget and must not be offered again.
+
+    ONE definition, called by the injection path and by the replay harness —
+    the same reason #491 extracted the age gate. A hand-copied cooldown drifts,
+    and a harness enforcing last week's cooldown reports confident numbers
+    about a system that no longer exists.
+
+    #500: this used to be a session-wide BAN. Injecting a single row retired
+    its whole origin, so a decision about one row silently cost every other row
+    that session could supply — and any change upstream reshuffled which
+    sessions got burned. Measured while shipping #491, 12 injections <=7d old
+    vanished that way, including a 1-day-old exact-match decision that appeared
+    nowhere else in the run. The age gate cannot have touched them.
+
+    A budget keeps the intent the ban encoded — one dense prior session must
+    not crowd out everything else — at the granularity the decision is actually
+    made at. `budget=None` disables origin cooldown entirely (the measurement
+    arm); `budget=1` is the pre-#500 ban, kept exactly reachable so the change
+    is provably behaviour-preserving at the old default.
+    """
+    # Resolved at CALL time, not bound as a def-time default: a default
+    # argument freezes the module constant at import and silently ignores any
+    # later change, which makes the knob untunable and every sweep over it a
+    # measurement of the same arm.
+    if budget is _UNSET:
+        budget = _ORIGIN_BUDGET
+    if budget is None:
+        return set()
+    return {sid for sid, n in origin_counts.items() if n >= budget}
+
+
+def _load_seen(path) -> tuple[dict, set]:
+    """(origin session id -> injected count, content keys) for this host
+    session.
+
+    Three on-disk shapes are read. The pre-#451 file is a flat JSON list of
+    origin ids; the pre-#500 file is {"origins": [...], "content_keys": [...]}.
+    Neither records a per-origin COUNT, so both load as EXHAUSTED (budget
+    reached) rather than as one: guessing low would hand an in-flight session
+    extra slots it may already have spent, and an upgrade must never loosen
+    suppression a session already earned. The current shape carries
+    {"origins": {sid: count}, ...}.
+
+    Anything else — corrupt, truncated, a bare scalar — is state we cannot
+    trust, and cooldown is best-effort: fall open and pay one extra
+    suggestion."""
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
         if isinstance(raw, list):
-            return {str(s) for s in raw}, set()
-        return ({str(s) for s in raw["origins"]},
-                {str(k) for k in raw["content_keys"]})
-    except (OSError, json.JSONDecodeError, TypeError, KeyError):
-        return set(), set()
+            return {str(s): _ORIGIN_BUDGET for s in raw}, set()
+        origins = raw["origins"]
+        keys = {str(k) for k in raw["content_keys"]}
+        if isinstance(origins, dict):
+            return ({str(s): int(n) for s, n in origins.items()}, keys)
+        return ({str(s): _ORIGIN_BUDGET for s in origins}, keys)
+    except (OSError, json.JSONDecodeError, TypeError, KeyError, ValueError):
+        return {}, set()
 
 
-def _save_seen(path, origins: set, content_keys: set) -> None:
+def _save_seen(path, origin_counts: dict, content_keys: set) -> None:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps({"origins": sorted(origins),
-                                    "content_keys": sorted(content_keys)}),
-                        encoding="utf-8")
+        path.write_text(json.dumps(
+            {"origins": {s: origin_counts[s] for s in sorted(origin_counts)},
+             "content_keys": sorted(content_keys)}), encoding="utf-8")
         # Opportunistic prune: cooldown state for long-dead sessions.
         cutoff = time.time() - _SEEN_PRUNE_SECONDS
         for p in path.parent.iterdir():
@@ -1223,9 +1287,6 @@ def _save_seen(path, origins: set, content_keys: set) -> None:
                 pass
     except OSError:
         pass  # cooldown is best-effort; losing it means one extra suggestion
-
-
-_UNSET = object()   # "compute it yourself"; None is a MEANINGFUL age here
 
 
 def _row_age_days(m, now: float):
@@ -1340,11 +1401,12 @@ def _cmd_recall_inject(args) -> int:
             if sid:
                 exclude.add(str(sid))
         seen_file = _seen_path(session)
-        seen_origins, seen_keys = (_load_seen(seen_file) if seen_file
-                                   else (set(), set()))
+        origin_counts, seen_keys = (_load_seen(seen_file) if seen_file
+                                    else ({}, set()))
         matches = recall.suggest(prompt, project_dir=project,
                                  current_session=session,
-                                 exclude_sessions=exclude | seen_origins,
+                                 exclude_sessions=(
+                                     exclude | cooled_origins(origin_counts)),
                                  limit=_INJECT_FETCH)
         # #451: an origin id is not a content identity. The same claim carried
         # by two checkpoints (sibling-id copies — the read-side twin of the
@@ -1402,9 +1464,14 @@ def _cmd_recall_inject(args) -> int:
         for m in chosen:
             print(_suggest_line(m, terms, now))
         if seen_file:
-            _save_seen(seen_file,
-                       seen_origins | {str(m["session_id"]) for m in chosen},
-                       seen_keys | chosen_keys)
+            # #500: count what each origin supplied instead of retiring it
+            # outright, so a later, stronger row from the same session stays
+            # reachable until that session has had its share.
+            spent = dict(origin_counts)
+            for m in chosen:
+                sid = str(m["session_id"])
+                spent[sid] = spent.get(sid, 0) + 1
+            _save_seen(seen_file, spent, seen_keys | chosen_keys)
     except Exception:  # noqa: BLE001 — see docstring: fail-open, always rc 0
         pass
     return 0

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3237,7 +3237,10 @@ def test_recall_inject_origin_cooldown_survives_content_keying(
 def test_recall_inject_reads_legacy_flat_list_seen_file_and_upgrades_it(
         tmp_checkpoint_dir, capsys, monkeypatch):
     # Pre-#451 state on disk is a flat JSON list of origin ids. It must be read
-    # as origins (suppression preserved) and rewritten in the new shape.
+    # as origins (suppression preserved) and rewritten in the new shape. #500
+    # made that shape a per-origin COUNT; a legacy entry carries no count, so
+    # it loads EXHAUSTED — an upgrade must never hand a session slots it may
+    # already have spent.
     from daimon_briefing import config, normalize
 
     _seed_item("S-dup-hi", _CK_DUP, 10)
@@ -3252,7 +3255,8 @@ def test_recall_inject_reads_legacy_flat_list_seen_file_and_upgrades_it(
     assert _CK_DUP not in out  # legacy origin entry still suppresses
     assert _CK_DISTINCT_A in out
     upgraded = json.loads(seen.read_text(encoding="utf-8"))
-    assert upgraded["origins"] == ["S-distinct-a", "S-dup-hi"]
+    assert upgraded["origins"] == {"S-dup-hi": cli._ORIGIN_BUDGET,
+                                   "S-distinct-a": 1}
     assert upgraded["content_keys"] == [normalize.content_key(_CK_DISTINCT_A)]
 
 
@@ -3592,10 +3596,10 @@ def test_save_seen_prunes_week_old_cooldown_files(tmp_checkpoint_dir):
     old = time.time() - (8 * 86400)
     os.utime(stale, (old, old))
 
-    cli_mod._save_seen(seen_dir / "S-fresh.json", {"S-o"}, {"deadbeef"})
+    cli_mod._save_seen(seen_dir / "S-fresh.json", {"S-o": 1}, {"deadbeef"})
     assert not stale.exists()
     assert json.loads((seen_dir / "S-fresh.json").read_text()) == {
-        "origins": ["S-o"], "content_keys": ["deadbeef"]}
+        "origins": {"S-o": 1}, "content_keys": ["deadbeef"]}
 
 
 # ---- #33 Phase 2: deterministic carry wired into the serialize path ----
@@ -8209,3 +8213,74 @@ def test_age_gate_accepts_a_precomputed_age_and_agrees_with_itself():
             cli.age_gate_blocks(row, _GATE_NOW, age_days=computed)
     # an explicit None age is "unknown", not "compute it for me"
     assert cli.age_gate_blocks(_row(), _GATE_NOW, age_days=None) is False
+
+
+# ---- #500: origin cooldown is a BUDGET, not a session-wide ban ----
+# Injecting one row used to ban its entire origin session for the rest of the
+# host session, so a gate decision about ONE row silently cost every other row
+# that session could supply. Measured while shipping #491: 12 injections <=7d
+# old disappeared, including a 1-day-old exact-match decision that appeared
+# nowhere else in the run — collateral the age gate cannot have caused.
+
+
+def test_cooled_origins_at_budget_one_reproduces_the_old_ban(tmp_path):
+    # budget=1 IS the pre-#500 policy: one injection retires the origin. Pinned
+    # so the refactor is provably behaviour-preserving at the old default.
+    counts = {"S-a": 1, "S-b": 2, "S-c": 0}
+    assert cli.cooled_origins(counts, budget=1) == {"S-a", "S-b"}
+
+
+def test_cooled_origins_lets_a_second_row_through_at_budget_two():
+    counts = {"S-a": 1, "S-b": 2, "S-c": 3}
+    assert cli.cooled_origins(counts, budget=2) == {"S-b", "S-c"}
+
+
+def test_cooled_origins_with_no_budget_never_excludes():
+    # budget=None is "no origin cooldown at all" — the measurement arm, and
+    # the shape the content-key cooldown (#451) would carry alone.
+    assert cli.cooled_origins({"S-a": 9}, budget=None) == set()
+
+
+def test_seen_state_round_trips_origin_counts(tmp_path):
+    p = tmp_path / "sess.json"
+    cli._save_seen(p, {"S-a": 1, "S-b": 3}, {"k1", "k2"})
+    counts, keys = cli._load_seen(p)
+    assert counts == {"S-a": 1, "S-b": 3}
+    assert keys == {"k1", "k2"}
+
+
+def test_seen_state_reads_the_pre_500_shape_as_exhausted(tmp_path):
+    # A file written before this change stored a SET, so the per-origin count
+    # is unknowable. Load it as exhausted rather than as one: guessing low
+    # would hand an in-flight session extra slots it may already have spent.
+    p = tmp_path / "sess.json"
+    p.write_text(json.dumps({"origins": ["S-a", "S-b"],
+                             "content_keys": ["k1"]}), encoding="utf-8")
+    counts, keys = cli._load_seen(p)
+    assert cli.cooled_origins(counts) == {"S-a", "S-b"}
+    assert keys == {"k1"}
+
+
+def test_seen_state_reads_the_pre_451_list_as_exhausted(tmp_path):
+    p = tmp_path / "sess.json"
+    p.write_text(json.dumps(["S-a"]), encoding="utf-8")
+    counts, keys = cli._load_seen(p)
+    assert cli.cooled_origins(counts) == {"S-a"}
+    assert keys == set()
+
+
+def test_seen_state_falls_open_on_unreadable_state(tmp_path):
+    p = tmp_path / "sess.json"
+    p.write_text("{not json", encoding="utf-8")
+    assert cli._load_seen(p) == ({}, set())
+
+
+def test_cooled_origins_reads_the_budget_at_call_time(monkeypatch):
+    # A def-time default would freeze _ORIGIN_BUDGET at import, making the knob
+    # untunable — and silently turning any sweep over it into four runs of the
+    # same arm. Found exactly that way.
+    counts = {"S-a": 1}
+    monkeypatch.setattr(cli, "_ORIGIN_BUDGET", 1)
+    assert cli.cooled_origins(counts) == {"S-a"}
+    monkeypatch.setattr(cli, "_ORIGIN_BUDGET", 2)
+    assert cli.cooled_origins(counts) == set()

--- a/research/experiments/recall-replay-ab/replay_ab.py
+++ b/research/experiments/recall-replay-ab/replay_ab.py
@@ -326,8 +326,8 @@ def run(dataset_path, daimon_home, sweep_tokens, out_dir,
                 flags = {}
                 for label, param in arms_spec:  # fixed order: A then each B
                     state = (seen_state[label].setdefault(
-                        row["session"], {"origins": set(), "keys": set()})
-                        if seen_ok else {"origins": set(), "keys": set()})
+                        row["session"], {"origins": {}, "keys": set()})
+                        if seen_ok else {"origins": {}, "keys": set()})
 
                     def _call(_state=state, **override):
                         """The shipped call for this prompt/arm. A variant
@@ -336,7 +336,11 @@ def run(dataset_path, daimon_home, sweep_tokens, out_dir,
                         kw = dict(
                             prompt=row["prompt"], project_dir=row["project"],
                             current_session=row["session"],
-                            exclude_sessions=exclude | _state["origins"],
+                            # #500: the cooldown rule is cli's, not a copy
+                            # — same reason the age gate is shared.
+                            exclude_sessions=(
+                                exclude | cli.cooled_origins(
+                                    _state["origins"])),
                             limit=cli._INJECT_FETCH, now=row["ts"])
                         kw.update(override)
                         return recall.suggest(**kw)
@@ -353,8 +357,10 @@ def run(dataset_path, daimon_home, sweep_tokens, out_dir,
                     chosen, chosen_keys, suppressed, age_gated = _postfilter(
                         matches, state["keys"], row["ts"])
                     if seen_ok and chosen:  # cli saves only when it injected
-                        state["origins"] |= {str(m["session_id"])
-                                             for m in chosen}
+                        for m in chosen:
+                            sid = str(m["session_id"])
+                            state["origins"][sid] = (
+                                state["origins"].get(sid, 0) + 1)
                         state["keys"] |= chosen_keys
                     arms[label] = [{
                         "session_id": str(m["session_id"]),


### PR DESCRIPTION
Closes #500

## What

Seen-state records a per-origin **count** instead of a set, and the exclusion becomes a budget (`_ORIGIN_BUDGET = 3`) rather than a ban. The rule lives in `cli.cooled_origins`, which the replay harness now calls instead of keeping its own copy — the same seam #491 established for the age gate.

`budget=1` is exactly the old policy and stays reachable, so the refactor is provably behaviour-preserving at the old default. `budget=None` disables origin cooldown entirely (the measurement arm).

## Why

Injecting one row retired its **entire origin session** for the rest of the host session. A decision about one row silently cost every other row that session could supply, and any upstream change reshuffled which sessions got burned.

**The pre-registered check failed, and that is reported rather than buried.** The issue predicted the sub-7d collateral seen while shipping #491 would vanish once origin cooldown was relaxed. It does not:

```
budget      inj  gate_lost  of_that<=7d  max/origin
1 (today)   274       80         12         1
2           320       50          6         2
3           332       47          7         3
None        349       38          7         7
```

With origin cooldown **fully disabled**, 7 of the 12 persist. The ban explains at most about five; the rest come from content-key cooldown shifting on the same path-dependent state. That half of the causal story is refuted and the issue's framing was too narrow — the seen-state is path-dependent as a whole, not just its origin half.

**What the sweep found instead is bigger than the collateral.** The rows the ban was suppressing are the freshest material in the store:

| budget | rows restored | age mix | calibrated relevance |
|---|---|---|---|
| 2 | 116 | 29 x `<=1d`, 84 x `2-7d`, 3 x `>7d` | 37% |
| **3** | **138** | **40 x `<=1d`, 95 x `2-7d`, 3 x `>7d`** | **39%** |
| None | 160 | 57 x `<=1d`, 100 x `2-7d`, 3 x `>7d` | 43% |

Baseline injection precision is ~20%. The ban was suppressing rows at roughly **double** the average quality, and only 3 of them are stale. It was spending its suppression on the best material it had.

This is a legitimate use of the age proxy: describing a population's age mix against a calibrated band, **not** comparing two policies. (Per the harness README, the proxy cannot do the latter — a policy sweep through it is an age-histogram tautology.)

## Why 3

A judgement bounded by evidence, not a measured optimum, and the docstring says so. 2 and "no cap" are both defensible. The cap exists for the concern the ban encoded — one dense prior session must not crowd out everything else — and unlimited lets a single origin supply 7 rows in one working session. **Crowding harm is unmeasured**, so the cap stays conservative rather than tuned to this corpus.

Note the scope: this is per *host session*, not per prompt. `_INJECT_BUDGET` already caps a single prompt at 2.

## Migration

Legacy files carry no per-origin count, so **both** older shapes (the pre-#451 flat list and the pre-#500 `{"origins": [...]}`) load as **exhausted**. Guessing low would hand an in-flight session extra slots it may already have spent; an upgrade must never loosen suppression a session already earned.

## A trap worth recording

The budget was first written as a def-time default argument (`budget=_ORIGIN_BUDGET`). That freezes the constant at import, so reassigning it does nothing — and it silently turned my four-value sweep into **four runs of the same arm**, all reporting identical numbers. Caught because four different budgets produced byte-identical results, which is not a plausible outcome. Now resolved at call time, with a test pinning it.

## Tests

11 new, all failing before the change:

- `cooled_origins` at budget 1 reproduces the old ban / lets a second row through at 2 / never excludes at `None`
- budget is read at **call time**, pinning the def-time-default trap
- seen-state round-trips counts; both legacy shapes load exhausted; unreadable state falls open to `{}`

Two existing tests were updated for the counted on-disk shape (`test_recall_inject_reads_legacy_flat_list_seen_file_and_upgrades_it`, `test_save_seen_prunes_week_old_cooldown_files`) — shape change, same contract.

Full suite: 2668 passed, 2 skipped. Harness `--verify`: PASS.