### PR TITLE
feat(cli): record audit-quotes usage

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -2010,6 +2010,12 @@ def _cmd_audit_quotes(args) -> int:
         for sid, text in failures[:top]:
             lines.append(f"    [{sid}] {text[:80]}")
     print("\n".join(lines))
+    # #504: the only read-side verification verb recorded nothing, so there was
+    # no evidence either way about whether anyone reaches for it. The unpaired
+    # variant is a distinct event, not a detail of this one: a run that resolved
+    # no transcript verified nothing, and it is also how a host whose
+    # transcripts live outside `_find_audit_transcript`'s reach shows up at all.
+    _note_usage("audit-quotes:unpaired" if not paired else "audit-quotes")
     return 0
 
 

--- a/plugin/tests/test_quote_verification.py
+++ b/plugin/tests/test_quote_verification.py
@@ -700,6 +700,69 @@ def test_audit_quotes_counts_unpaired_when_transcript_missing(
     assert "unpaired" in out
 
 
+@pytest.fixture
+def _log_dir(tmp_path):
+    # The autouse fixture already points DAIMON_LOG_DIR here; expose the path.
+    return tmp_path / ".daimon" / "logs"
+
+
+def test_audit_quotes_records_usage(
+    tmp_checkpoint_dir, _projects_dir, _log_dir, capsys
+):
+    """#504: the only read-side verification verb recorded nothing, so there was
+    no evidence either way about whether anyone reaches for it."""
+    slug = store.project_slug("/p/A")
+    _write_transcript(_projects_dir, slug, "SA",
+                      [("user", "alpha decision text that is quoted exactly")])
+    cp = _stored_checkpoint("SA", slug, [
+        {"text": "d", "trust": "verbatim",
+         "quote": "alpha decision text that is quoted exactly", "id": "d-a"},
+    ])
+    store.write_checkpoint("SA", cp, project_dir="/p/A")
+
+    assert cli.main(["audit-quotes", "--project", "/p/A"]) == 0
+    usage = (_log_dir / "usage.log").read_text(encoding="utf-8")
+    assert "audit-quotes" in usage
+    # A run that paired a transcript is NOT the unpaired variant.
+    assert "audit-quotes:unpaired" not in usage
+
+
+def test_audit_quotes_records_unpaired_variant_when_nothing_pairs(
+    tmp_checkpoint_dir, _projects_dir, _log_dir, capsys
+):
+    """A run that resolved no transcript at all is a materially different event
+    from one that verified a corpus — and doubles as passive detection for a
+    host whose transcripts live somewhere the resolver does not look."""
+    slug = store.project_slug("/p/A")
+    # No transcript written -> nothing pairs.
+    cp = _stored_checkpoint("SNO", slug, [
+        {"text": "d", "trust": "verbatim", "quote": "some quoted text here", "id": "d-c"},
+    ])
+    store.write_checkpoint("SNO", cp, project_dir="/p/A")
+
+    assert cli.main(["audit-quotes", "--project", "/p/A"]) == 0
+    usage = (_log_dir / "usage.log").read_text(encoding="utf-8")
+    assert "audit-quotes:unpaired" in usage
+
+
+def test_audit_quotes_usage_respects_kill_switch(
+    tmp_checkpoint_dir, _projects_dir, _log_dir, capsys, monkeypatch
+):
+    """Disabled means daimon writes nothing — the audit verb is no exception."""
+    slug = store.project_slug("/p/A")
+    _write_transcript(_projects_dir, slug, "SA",
+                      [("user", "alpha decision text that is quoted exactly")])
+    cp = _stored_checkpoint("SA", slug, [
+        {"text": "d", "trust": "verbatim",
+         "quote": "alpha decision text that is quoted exactly", "id": "d-a"},
+    ])
+    store.write_checkpoint("SA", cp, project_dir="/p/A")
+    monkeypatch.setenv("DAIMON_DISABLE", "1")
+
+    cli.main(["audit-quotes", "--project", "/p/A"])
+    assert not (_log_dir / "usage.log").exists()
+
+
 def test_audit_quotes_all_flag_spans_projects(
     tmp_checkpoint_dir, _projects_dir, capsys
 ):


### PR DESCRIPTION
Closes #504

## What

`_cmd_audit_quotes` now records a usage line, with a distinct counter for a run that paired nothing:

- `audit-quotes` — the run happened and at least one transcript resolved
- `audit-quotes:unpaired` — ran, but no transcript could be resolved for any checkpoint

## Why

`audit-quotes` was the only read-side verification verb recording nothing about being used. Every other verb calls `_note_usage` — `brief`, `recall`, `resolve`, `forget`, `loops`, `projects`, `status`, `verify-receipt`, and the recall-inject gate counters — so there was no evidence either way about whether on-demand verification is something anyone reaches for.

That gap is load-bearing right now. The one comparable instrumented verb, `verify-receipt`, reports 5 lifetime invocations against 63 for `recall` and 42 for `resolve`. If read-side verification is genuinely unused, that is worth knowing before more is built on top of it; if it is used, the counter is stronger evidence than any symmetry argument. Neither answer was available.

The unpaired variant is a separate event rather than a detail of the main one. A run that resolved no transcript verified nothing, so folding the two together would report activity where none happened. It also doubles as passive detection for the host-coverage gap: `_find_audit_transcript` knows one host's transcript layout, and a user on any other host currently shows up as silence rather than as "ran, found nothing to check".

`daimon stats` aggregates `usage.log` generically (`render.py:1009`, `render.py:1096` both iterate the dict), so both counters surface with no further wiring.

## Tests

`uv run pytest` — 2671 passed, 2 skipped.

Three new tests in `tests/test_quote_verification.py`, all of which failed before the change:

| test | proves |
|---|---|
| `test_audit_quotes_records_usage` | a paired run writes `audit-quotes` and *not* the unpaired variant |
| `test_audit_quotes_records_unpaired_variant_when_nothing_pairs` | a run with no resolvable transcript writes `audit-quotes:unpaired` |
| `test_audit_quotes_usage_respects_kill_switch` | `DAIMON_DISABLE=1` writes no `usage.log` at all |

Red before, green after — the first two failed with `FileNotFoundError` on `usage.log`, which is the honest failure for "nothing was recorded".

| File | Change |
|------|--------|
| `plugin/daimon_briefing/cli.py` | `_note_usage` call at the end of `_cmd_audit_quotes`, variant chosen on `paired` |
| `plugin/tests/test_quote_verification.py` | three tests + a local `_log_dir` fixture |
