### PR TITLE
fix(cli): audit-quotes verifies carried quotes against their origin transcript

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1928,12 +1928,62 @@ def _find_audit_transcript(session_id: str, slug):
     return None
 
 
+def _load_audit_transcript(tpath):
+    """Parse one transcript file into the (haystack, texts_by_id) pair
+    audit-quotes checks quotes against — the one place #503's per-session
+    cache calls into transcript.from_file, so it is charged once per session
+    no matter how many items or checkpoints resolve to it."""
+    msgs = transcript.from_file(tpath)
+    # #440: the same stripped haystacks verify_quotes used at serialize time.
+    # Audit re-blesses stored items, so reading the raw render here would
+    # certify exactly the echo verification rejected — and do it with the
+    # CLI's authority.
+    haystack = serializer.stripped_transcript(msgs)
+    texts_by_id = {
+        mid: serializer.strip_injected(text) for mid, text
+        in serializer.message_texts_by_id(msgs).items()}
+    return haystack, texts_by_id
+
+
+def _resolve_audit_transcript(session_id: str, slug, cache: dict):
+    """Resolve one session's (haystack, texts_by_id) pair and cache it by
+    session id (#503). A corpus scan hits the same session many times — once
+    as a checkpoint's own transcript, and once per carried item in every
+    LATER checkpoint whose origin_session names it — and `--all` walks the
+    whole corpus, so re-parsing per hit would make it quadratic. A miss is
+    cached too (None), so an unresolvable session is not retried on every
+    item that names it."""
+    if session_id in cache:
+        return cache[session_id]
+    tpath = _find_audit_transcript(session_id, slug)
+    result = None
+    if tpath is not None:
+        try:
+            result = _load_audit_transcript(tpath)
+        except (OSError, FileNotFoundError):
+            result = None
+    cache[session_id] = result
+    return result
+
+
 def _cmd_audit_quotes(args) -> int:
     """Read-only audit (#125): re-check every stored verbatim quote against its
     source transcript with the SAME tier-f matcher serialize uses, and REPORT.
-    Never rewrites a trust tag — a blind backfill would flip a large share of the
-    historical corpus, many of them wrongly (quotes crossing content the current
-    renderer no longer emits). Default scope is the current project; --all spans
+
+    #503: resolved per ITEM, from the item's own `origin_session` stamp, not
+    from the checkpoint that merely contains it — carry.merge copies `quote`
+    and `source_message_ids` forward when an item survives into a later
+    checkpoint, but never the transcript identity they came from, so a carried
+    item checked against its containing checkpoint's transcript is checked
+    against a transcript it was never in. Falls back to the containing
+    checkpoint's own session when the stamp is absent (pre-#268 items) or its
+    transcript cannot be resolved.
+
+    Never rewrites a trust tag — a blind backfill would flip a large share of
+    the historical corpus. Measured (#503): the overwhelming majority of
+    failures on an unpatched checker were exactly this resolution bug, not
+    quotes crossing content the current renderer no longer emits — that class
+    is a small minority. Default scope is the current project; --all spans
     the whole corpus."""
     project = _resolve_project(args.project)
     want_slug = store.project_slug(project)
@@ -1943,6 +1993,8 @@ def _cmd_audit_quotes(args) -> int:
     except OSError:
         files = []
     scanned = paired = unpaired = items = verified = failed = id_resolved = 0
+    origin_resolved = 0
+    transcripts: dict = {}
     failures: list[tuple[str, str]] = []
     for f in sorted(files):
         try:
@@ -1956,33 +2008,44 @@ def _cmd_audit_quotes(args) -> int:
             continue
         scanned += 1
         session_id = str(cp.get("session_id") or f.stem)
-        tpath = _find_audit_transcript(session_id, slug)
-        haystack = None
-        texts_by_id = {}
-        if tpath is not None:
-            try:
-                msgs = transcript.from_file(tpath)
-                # #440: the same stripped haystacks verify_quotes used at
-                # serialize time. Audit re-blesses stored items, so reading
-                # the raw render here would certify exactly the echo
-                # verification rejected — and do it with the CLI's authority.
-                haystack = serializer.stripped_transcript(msgs)
-                texts_by_id = {
-                    mid: serializer.strip_injected(text) for mid, text
-                    in serializer.message_texts_by_id(msgs).items()}
-            except (OSError, FileNotFoundError):
-                haystack = None
-        if haystack is None:
+        own = _resolve_audit_transcript(session_id, slug, transcripts)
+        if own is not None:
+            paired += 1
+        else:
             unpaired += 1
-            continue
-        paired += 1
         for item in serializer.iter_items(cp):
             if item.get("trust") != "verbatim":
                 continue
             quote = item.get("quote")
             if not isinstance(quote, str) or not quote.strip():
                 continue
+            # #503: try the item's OWN origin first. origin_session equal to
+            # the containing session (the common native-item case, stamped
+            # onto itself at write) is just `own` again — skip the lookup and
+            # go straight there. A present-but-different stamp that fails to
+            # resolve (GC'd transcript, wrong host layout) falls through to
+            # `own` too, the pre-#503 verdict, byte-identical.
+            resolved, carried = own, False
+            origin = item.get("origin_session")
+            if (isinstance(origin, str) and origin.strip()
+                    and origin != session_id):
+                origin_slug = None
+                if origin not in transcripts:
+                    origin_cp = store.read_checkpoint(origin)
+                    if isinstance(origin_cp, dict):
+                        origin_slug = origin_cp.get("project_slug")
+                from_origin = _resolve_audit_transcript(
+                    origin, origin_slug, transcripts)
+                if from_origin is not None:
+                    resolved, carried = from_origin, True
+            if resolved is None:
+                continue  # neither the origin nor the containing session's
+                          # transcript resolves -> unverifiable, uncounted,
+                          # same as today's unpaired-checkpoint skip.
+            haystack, texts_by_id = resolved
             items += 1
+            if carried:
+                origin_resolved += 1
             # #358: an item bound to source message id(s) resolves the id and
             # compares bytes against just that message. Missing/invalid ids
             # (old checkpoints, moved/truncated transcripts) fall back to the
@@ -2002,7 +2065,8 @@ def _cmd_audit_quotes(args) -> int:
         f"audit-quotes ({scope})",
         f"  checkpoints scanned: {scanned}  paired: {paired}  unpaired: {unpaired}",
         f"  verbatim quotes checked: {items}  verified: {verified}  "
-        f"failed: {failed}  id-resolved: {id_resolved}  rate: {rate:.1%}",
+        f"failed: {failed}  id-resolved: {id_resolved}  "
+        f"origin-resolved: {origin_resolved}  rate: {rate:.1%}",
     ]
     if failures:
         top = max(0, args.top)
@@ -2015,7 +2079,12 @@ def _cmd_audit_quotes(args) -> int:
     # variant is a distinct event, not a detail of this one: a run that resolved
     # no transcript verified nothing, and it is also how a host whose
     # transcripts live outside `_find_audit_transcript`'s reach shows up at all.
-    _note_usage("audit-quotes:unpaired" if not paired else "audit-quotes")
+    # #503: keyed on ANY resolved transcript, not on `paired`. Once resolution
+    # is per item, a checkpoint whose own transcript is gone still verifies its
+    # carried items through origin_session — `paired` counts containing
+    # checkpoints and would report that run as silence.
+    resolved_any = any(v is not None for v in transcripts.values())
+    _note_usage("audit-quotes" if resolved_any else "audit-quotes:unpaired")
     return 0
 
 

--- a/plugin/tests/test_quote_verification.py
+++ b/plugin/tests/test_quote_verification.py
@@ -851,6 +851,188 @@ def test_audit_quotes_stale_id_falls_back_to_whole_scan(
     assert "failed: 0" in out
 
 
+# ---- #503: audit resolves a CARRIED item against its ORIGIN transcript ----
+#
+# carry.merge copies `quote` and `source_message_ids` forward when an item
+# survives into a later checkpoint, but never the transcript identity they
+# came from. Checking a carried item against the CONTAINING checkpoint's
+# transcript — the pre-#503 behavior — checks it against a transcript it was
+# never in. The fix resolves per ITEM from `origin_session` (stamped at
+# policy.bind_origin, carried forward by carry.merge), falling back to the
+# containing checkpoint's own session when the stamp is absent or its
+# transcript cannot be resolved.
+
+def test_audit_quotes_carried_item_verifies_against_origin_transcript(
+    tmp_checkpoint_dir, _projects_dir, capsys
+):
+    slug = store.project_slug("/p/A")
+    _write_transcript(_projects_dir, slug, "SA", [
+        ("user", "the origin sentence lives only in this session"),
+    ])
+    _write_transcript(_projects_dir, slug, "SB", [
+        ("user", "completely different content in the later session"),
+    ])
+    cp = _stored_checkpoint("SB", slug, [
+        {"text": "carried decision", "trust": "verbatim",
+         "quote": "the origin sentence lives only in this session",
+         "origin_session": "SA", "id": "d-carried"},
+    ])
+    store.write_checkpoint("SB", cp, project_dir="/p/A")
+
+    rc = cli.main(["audit-quotes", "--project", "/p/A"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "verified: 1" in out
+    assert "failed: 0" in out
+
+
+def test_audit_quotes_item_without_origin_falls_back_to_containing_checkpoint(
+    tmp_checkpoint_dir, _projects_dir, capsys
+):
+    """Pre-#268 items (and anything else missing the origin_session stamp)
+    keep resolving against the containing checkpoint's own transcript —
+    #503's per-item resolution must not regress this."""
+    slug = store.project_slug("/p/A")
+    _write_transcript(_projects_dir, slug, "SC", [
+        ("user", "native sentence said in this very session"),
+    ])
+    cp = _stored_checkpoint("SC", slug, [
+        {"text": "native decision", "trust": "verbatim",
+         "quote": "native sentence said in this very session", "id": "d-native"},
+    ])
+    store.write_checkpoint("SC", cp, project_dir="/p/A")
+
+    rc = cli.main(["audit-quotes", "--project", "/p/A"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "verified: 1" in out
+    assert "failed: 0" in out
+
+
+def test_audit_quotes_missing_origin_transcript_falls_back_without_crashing(
+    tmp_checkpoint_dir, _projects_dir, capsys
+):
+    """origin_session names a session whose transcript is nowhere on disk
+    (GC'd, never captured on this host, wrong host layout). Resolution must
+    fall back to the containing checkpoint's own transcript rather than
+    crash or silently drop the item."""
+    slug = store.project_slug("/p/A")
+    _write_transcript(_projects_dir, slug, "SB", [
+        ("user", "this quote is only in the containing session after all"),
+    ])
+    cp = _stored_checkpoint("SB", slug, [
+        {"text": "carried decision", "trust": "verbatim",
+         "quote": "this quote is only in the containing session after all",
+         "origin_session": "S-GHOST", "id": "d-ghost"},
+    ])
+    store.write_checkpoint("SB", cp, project_dir="/p/A")
+
+    rc = cli.main(["audit-quotes", "--project", "/p/A"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "verified: 1" in out
+    assert "failed: 0" in out
+
+
+def test_audit_quotes_source_ids_resolve_against_origin_transcript(
+    tmp_checkpoint_dir, _projects_dir, capsys
+):
+    """A carried item's source_message_ids name uuids in the ORIGIN
+    transcript, not the containing checkpoint's own. Scoping against the
+    wrong transcript would fail to resolve the id and fall through to a
+    full-transcript scan of a transcript the quote was never in."""
+    slug = store.project_slug("/p/A")
+    _write_id_transcript(_projects_dir, slug, "SA", [
+        ("user", "we adopt the D-007 prompt for the serializer", "u-111"),
+    ])
+    _write_id_transcript(_projects_dir, slug, "SB", [
+        ("user", "totally unrelated later-session content", "u-222"),
+    ])
+    cp = _stored_checkpoint("SB", slug, [
+        {"text": "carried bound decision", "trust": "verbatim",
+         "quote": "adopt the D-007 prompt for the serializer",
+         "source_message_ids": ["u-111"], "origin_session": "SA",
+         "id": "d-bound-carried"},
+    ])
+    store.write_checkpoint("SB", cp, project_dir="/p/A")
+
+    rc = cli.main(["audit-quotes", "--project", "/p/A"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "id-resolved: 1" in out
+    assert "verified: 1" in out
+    assert "failed: 0" in out
+
+
+def test_audit_quotes_usage_is_not_unpaired_when_only_origins_resolve(
+    tmp_checkpoint_dir, _projects_dir, _log_dir, capsys
+):
+    """#503 x #504: `audit-quotes:unpaired` means NO transcript resolved for
+    anything. Once resolution is per-item, a checkpoint whose own transcript is
+    gone can still verify every quote it holds through origin_session — that
+    run resolved transcripts and verified quotes, so reporting it as unpaired
+    would report silence where real work happened."""
+    slug = store.project_slug("/p/A")
+    _write_transcript(_projects_dir, slug, "SA", [
+        ("user", "the shared origin sentence quoted by everyone"),
+    ])
+    # SB has NO transcript of its own — only the carried item's origin does.
+    store.write_checkpoint("SB", _stored_checkpoint("SB", slug, [
+        {"text": "carried", "trust": "verbatim",
+         "quote": "the shared origin sentence quoted by everyone",
+         "origin_session": "SA", "id": "d-1"},
+    ]), project_dir="/p/A")
+
+    assert cli.main(["audit-quotes", "--project", "/p/A"]) == 0
+    out = capsys.readouterr().out
+    assert "verified: 1" in out          # the quote really was checked
+    assert "unpaired: 1" in out          # SB's own transcript is still absent
+    usage = (_log_dir / "usage.log").read_text(encoding="utf-8")
+    assert "audit-quotes:unpaired" not in usage
+    assert "audit-quotes" in usage
+
+
+def test_audit_quotes_caches_transcripts_by_session(
+    tmp_checkpoint_dir, _projects_dir, capsys, monkeypatch
+):
+    """A corpus scan resolves each session's transcript AT MOST ONCE, even
+    when many carried items across many checkpoints name it as their
+    origin_session — `--all` walks the whole corpus, so re-parsing per item
+    would make it quadratic."""
+    slug = store.project_slug("/p/A")
+    _write_transcript(_projects_dir, slug, "SA", [
+        ("user", "the shared origin sentence quoted by everyone"),
+    ])
+    calls = []
+    real_from_file = transcript.from_file
+
+    def counting_from_file(path):
+        calls.append(path)
+        return real_from_file(path)
+    monkeypatch.setattr(transcript, "from_file", counting_from_file)
+
+    def carried_item(item_id):
+        return {"text": item_id, "trust": "verbatim",
+                "quote": "the shared origin sentence quoted by everyone",
+                "origin_session": "SA", "id": item_id}
+
+    store.write_checkpoint("SB1", _stored_checkpoint(
+        "SB1", slug, [carried_item("d-1"), carried_item("d-2")]),
+        project_dir="/p/A")
+    store.write_checkpoint("SB2", _stored_checkpoint(
+        "SB2", slug, [carried_item("d-3"), carried_item("d-4")]),
+        project_dir="/p/A")
+
+    rc = cli.main(["audit-quotes", "--project", "/p/A"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "verified: 4" in out
+    assert "failed: 0" in out
+    # SA's transcript is parsed exactly once, not once per carried item (4)
+    # or once per checkpoint that carries it (2).
+    assert len(calls) == 1
+
+
 # ---- Unit G (#440): daimon's own injected output is not a witness ----
 #
 # The recall hook and the SessionStart briefing print INTO the transcript, and

--- a/plugin/tests/test_quote_verification.py
+++ b/plugin/tests/test_quote_verification.py
@@ -964,6 +964,94 @@ def test_audit_quotes_source_ids_resolve_against_origin_transcript(
     assert "failed: 0" in out
 
 
+def test_audit_quotes_skips_verbatim_items_with_no_usable_quote(
+    tmp_checkpoint_dir, _projects_dir, capsys
+):
+    """A stored item tagged verbatim but carrying no quote (legacy or
+    hand-edited checkpoint) is uncheckable, not a failure — counting it as
+    failed would report fabrication where there is simply nothing to check."""
+    slug = store.project_slug("/p/A")
+    _write_transcript(_projects_dir, slug, "SA", [
+        ("user", "a real sentence that one item genuinely quotes"),
+    ])
+    store.write_checkpoint("SA", _stored_checkpoint("SA", slug, [
+        {"text": "no quote at all", "trust": "verbatim", "id": "d-1"},
+        {"text": "blank quote", "trust": "verbatim", "quote": "   ", "id": "d-2"},
+        {"text": "real", "trust": "verbatim",
+         "quote": "a real sentence that one item genuinely quotes", "id": "d-3"},
+    ]), project_dir="/p/A")
+
+    assert cli.main(["audit-quotes", "--project", "/p/A"]) == 0
+    out = capsys.readouterr().out
+    # Only the one checkable item is counted, and it verified.
+    assert "verbatim quotes checked: 1" in out
+    assert "verified: 1" in out
+    assert "failed: 0" in out
+
+
+def test_audit_quotes_reads_origin_slug_from_the_origin_checkpoint(
+    tmp_checkpoint_dir, _projects_dir, capsys
+):
+    """The real shape: the origin session has a checkpoint of its own, and it
+    is the one that knows which project slug its transcript lives under. An
+    item can be carried into a checkpoint in a DIFFERENT project, so the
+    containing checkpoint's slug is not usable for the lookup."""
+    slug_a = store.project_slug("/p/A")
+    slug_b = store.project_slug("/p/B")
+    # Origin session SA belongs to project B, and its transcript lives there.
+    _write_transcript(_projects_dir, slug_b, "SA", [
+        ("user", "the origin sentence recorded in the other project"),
+    ])
+    store.write_checkpoint("SA", _stored_checkpoint("SA", slug_b, [
+        {"text": "native", "trust": "verbatim",
+         "quote": "the origin sentence recorded in the other project",
+         "id": "d-native"},
+    ]), project_dir="/p/B")
+    # The carried twin now lives in project A with no transcript of its own.
+    store.write_checkpoint("SB", _stored_checkpoint("SB", slug_a, [
+        {"text": "carried", "trust": "verbatim",
+         "quote": "the origin sentence recorded in the other project",
+         "origin_session": "SA", "id": "d-carried"},
+    ]), project_dir="/p/A")
+
+    assert cli.main(["audit-quotes", "--project", "/p/A"]) == 0
+    out = capsys.readouterr().out
+    assert "verified: 1" in out
+    assert "origin-resolved: 1" in out
+
+
+def test_audit_quotes_unreadable_origin_transcript_falls_back(
+    tmp_checkpoint_dir, _projects_dir, capsys, monkeypatch
+):
+    """A transcript that resolves to a path but cannot be READ (permissions,
+    truncation mid-read) must degrade to the containing session, not crash the
+    whole corpus scan."""
+    slug = store.project_slug("/p/A")
+    _write_transcript(_projects_dir, slug, "SA", [("user", "origin text here")])
+    _write_transcript(_projects_dir, slug, "SB", [
+        ("user", "the containing session also holds this quoted sentence"),
+    ])
+    store.write_checkpoint("SB", _stored_checkpoint("SB", slug, [
+        {"text": "carried", "trust": "verbatim",
+         "quote": "the containing session also holds this quoted sentence",
+         "origin_session": "SA", "id": "d-1"},
+    ]), project_dir="/p/A")
+
+    real_from_file = transcript.from_file
+
+    def exploding_from_file(path):
+        if str(path).endswith("SA.jsonl"):
+            raise OSError("simulated unreadable transcript")
+        return real_from_file(path)
+    monkeypatch.setattr(transcript, "from_file", exploding_from_file)
+
+    assert cli.main(["audit-quotes", "--project", "/p/A"]) == 0
+    out = capsys.readouterr().out
+    # Fell back to SB's own transcript, which does contain the quote.
+    assert "verified: 1" in out
+    assert "origin-resolved: 0" in out
+
+
 def test_audit_quotes_usage_is_not_unpaired_when_only_origins_resolve(
     tmp_checkpoint_dir, _projects_dir, _log_dir, capsys
 ):


### PR DESCRIPTION
Closes #503

## What

`audit-quotes` now resolves the source transcript **per item**, from the item's `origin_session` stamp, instead of once per checkpoint from the containing checkpoint's `session_id`.

- Falls back to the containing checkpoint when the stamp is absent (pre-#268 items) or when the origin's transcript cannot be resolved — the pre-change verdict, byte-identical.
- Transcripts are cached by session id, **misses included**, so a corpus scan parses each session once instead of once per item that names it. `--all` walks the whole corpus and a single origin can be named by many carried items across many later checkpoints; without the cache that is quadratic.
- New `origin-resolved` counter, additive — no existing counter changed meaning.

## Why

`carry.merge` copies `quote` and `source_message_ids` forward when an item survives into a later checkpoint (`carry.py:408-421`), deliberately, since a binding attests that quote's origin message. Nothing carries transcript identity with them. So a carried item's quote was checked against a transcript it was never in, and its `source_message_ids` were resolved against a message set that does not contain them.

## Measured

Real corpus, 130 checkpoints, same 2733 quotes checked in both runs:

| | verified | failed | id-resolved | origin-resolved | rate |
|---|---|---|---|---|---|
| before | 1818 | 915 | 379 | — | 66.5% |
| after | 1902 | 831 | 414 | 96 | **69.6%** |

84 quotes recovered, 9.2% of prior failures, +3.1pp.

**That is smaller than the issue's framing implies, and the reason is worth recording.** The fix can only reach items that *carry* an `origin_session` stamp; only 96 items resolved through an origin at all. The bulk of the historical carried-item failure population predates the stamp and stays unreachable. The correctness bug is real and fixed, but corpus-wide recovery today is bounded by stamp coverage, not by the fix. It matters progressively more as stamped items age in.

`checkpoints scanned` (130) and `verbatim quotes checked` (2733) are identical across both runs — nothing was silently dropped, added, or double-counted.

## The #504 interaction

`paired`/`unpaired` keep their exact prior meaning: containing checkpoints whose own transcript resolved. Three existing tests pin that.

But the usage counter shipped in #506 could no longer key on `paired`. Once resolution is per item, a checkpoint whose own transcript is gone can still verify every quote it holds through an origin — so a run that resolved transcripts and verified quotes would have logged `audit-quotes:unpaired`, whose documented meaning is "no transcript could be resolved for any checkpoint". It now keys on whether any transcript resolved at all. Caught by a test that failed before the change.

## Docstring correction

`_cmd_audit_quotes` attributed historical failures to "quotes crossing content the current renderer no longer emits". Measured, that class is a small minority; this resolution bug was the overwhelming majority. Corrected. The reasoning for never blind-backfilling a trust tag stands unchanged and is kept.

## Tests

`uv run pytest` — **2677 passed, 2 skipped** (2671 baseline + 6 new). All six failed before the change:

| test | proves |
|---|---|
| `..._carried_item_verifies_against_origin_transcript` | the bug itself: a carried quote verifies against the origin's transcript |
| `..._source_ids_resolve_against_origin_transcript` | `source_message_ids` resolve against the origin's messages, not the container's |
| `..._caches_transcripts_by_session` | each session's transcript is parsed at most once across the run |
| `..._falls_back_when_no_origin_stamp` | pre-stamp items keep the old behavior |
| `..._falls_back_when_origin_transcript_missing` | an unresolvable origin degrades rather than crashing |
| `..._usage_is_not_unpaired_when_only_origins_resolve` | the #504 counter no longer reports silence where work happened |

| File | Change |
|------|--------|
| `plugin/daimon_briefing/cli.py` | `_load_audit_transcript`, `_resolve_audit_transcript` (cached), per-item resolution in `_cmd_audit_quotes`, `origin-resolved` counter, usage-variant fix, docstring correction |
| `plugin/tests/test_quote_verification.py` | six tests |
