### PR TITLE
fix(serializer): treat a redaction marker as a fragment boundary, not as text to delete

### DIFF
--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -800,17 +800,24 @@ def quote_matches(quote, haystack) -> bool:
     span), drops fragments shorter than _MIN_FRAGMENT chars after normalization,
     and requires every surviving fragment to appear IN ORDER — each searched
     from the previous fragment's match end. A quote left with no usable fragment
-    is unverifiable and returns False (conservative: never auto-pass). Redaction
-    placeholders are stripped from fragments first, so a stored quote already
-    carrying a `[redacted:...]` marker still matches."""
+    is unverifiable and returns False (conservative: never auto-pass).
+
+    A `[redacted:...]` marker is a fragment boundary, exactly like an ellipsis
+    (#505). Stored quotes are redacted at capture while the transcript still
+    holds the real secret, so the marker stands where bytes we cannot reproduce
+    used to be — the same situation as an elided span. DELETING it instead
+    (the pre-#505 behavior) joined two spans that are not adjacent in the
+    source, so any quote with a secret in the MIDDLE could never match: the
+    contract the docstring described was only ever met at the quote's edges."""
     if not isinstance(quote, str) or not isinstance(haystack, str):
         return False
     hay = _normalize_for_match(haystack)
     fragments = []
     for raw in _ELLIPSIS_RE.split(quote):
-        frag = _normalize_for_match(_REDACTED_RE.sub("", raw))
-        if len(frag) >= _MIN_FRAGMENT:
-            fragments.append(frag)
+        for piece in _REDACTED_RE.split(raw):
+            frag = _normalize_for_match(piece)
+            if len(frag) >= _MIN_FRAGMENT:
+                fragments.append(frag)
     if not fragments:
         return False
     pos = 0

--- a/plugin/tests/test_quote_verification.py
+++ b/plugin/tests/test_quote_verification.py
@@ -51,6 +51,45 @@ def test_redacted_placeholder_stripped_from_fragment():
     assert serializer.quote_matches("set the staging token [redacted:api-key]", hay)
 
 
+def test_redacted_placeholder_mid_quote_still_matches():
+    # #505: the marker sits BETWEEN real text on both sides. Deleting it joined
+    # two spans that are not adjacent in the source ("...token for prod" vs
+    # "...token sk-... for prod"), so the quote could never match. Treating the
+    # marker as a fragment boundary — the same way ellipsis is treated — is what
+    # the docstring always promised.
+    hay = "assistant: please set the staging token sk_live_abc123def for prod now"
+    assert serializer.quote_matches(
+        "set the staging token [redacted:api-key] for prod", hay)
+
+
+def test_redacted_placeholder_at_quote_start_still_matches():
+    hay = "assistant: the value sk_live_abc123def was rotated yesterday"
+    assert serializer.quote_matches("[redacted:api-key] was rotated yesterday", hay)
+
+
+def test_redacted_fragments_must_appear_in_order():
+    # A redaction boundary must not weaken the precision guard: the surviving
+    # fragments still have to appear in the source IN ORDER.
+    hay = "assistant: please set the staging token sk_live_abc123def for prod now"
+    assert not serializer.quote_matches(
+        "for prod now [redacted:api-key] set the staging token", hay)
+
+
+def test_marker_only_quote_is_unverifiable():
+    # Nothing survives the split -> no usable fragment -> conservative False.
+    # A quote that is ENTIRELY a redacted secret carries no evidence at all.
+    assert not serializer.quote_matches(
+        "[redacted:api-key]", "assistant: sk_live_abc123def is the token")
+
+
+def test_multiple_redactions_in_one_quote_match():
+    hay = ("assistant: use api_key=sk_live_abc123def and "
+           "password=hunter2secret for the staging box")
+    assert serializer.quote_matches(
+        "use api_key=[redacted:api-key] and password=[redacted:api-key] "
+        "for the staging box", hay)
+
+
 def test_ellipsis_split_in_order_passes():
     hay = ("assistant: first we rotate the pointer chain, then much later "
            "we write the new latest atomically")


### PR DESCRIPTION
Closes #505

## What

A `[redacted:...]` marker now splits a quote into ordered fragments, exactly the way an ellipsis already does, instead of being deleted from the fragment text.

## Why

`quote_matches` documented a tolerance it did not implement:

> Redaction placeholders are stripped from fragments first, so a stored quote already carrying a `[redacted:...]` marker still matches.

The stripping was one-sided. `_REDACTED_RE.sub("", raw)` removed the marker from the quote; nothing corresponding happened to the haystack. So a quote stored as `abc[redacted:key]def` normalized to `abcdef` and was searched for in a haystack still containing `abcSECRETdef`. Deleting the marker **joined two spans that are not adjacent in the source**, and the search could not succeed.

Only a redaction at the very start or end of a quote survived, because there the deletion trimmed rather than joined. That is why the claim looked true — the one existing test placed the marker at the end.

Treating it as a boundary is the honest reading of what the marker means: stored quotes are redacted at capture while the transcript still holds the real secret, so the marker stands exactly where bytes we cannot reproduce used to be. That is what an elided span already is.

## Precision is unchanged

The surviving fragments must still appear **in order**, each searched from the previous match's end:

- a quote reordered across a redaction still fails (`test_redacted_fragments_must_appear_in_order`)
- a quote that is nothing but a marker leaves no usable fragment and stays unverifiable (`test_marker_only_quote_is_unverifiable`)
- fragments below `_MIN_FRAGMENT` are still dropped, so a redaction surrounded by scraps does not auto-pass

## Measured

Real corpus, 130 checkpoints, same 2733 quotes checked in both runs:

| | verified | failed | rate |
|---|---|---|---|
| before | 1818 | 915 | 66.5% |
| after | 1825 | 908 | **66.8%** |

7 quotes recovered, +0.3pp. Small, and worth stating plainly rather than rounding up: the issue estimated ~13 affected items from a sample, the measured figure is 7.

The direction of the old bug was honest — it under-reported verification rather than certifying anything wrongly — which is why it survived this long without being noticed.

## Tests

`uv run pytest` — **2676 passed, 2 skipped** (2671 baseline + 5 new). Two of the five failed before the change:

| test | before |
|---|---|
| `test_redacted_placeholder_mid_quote_still_matches` | **failed** — the bug |
| `test_multiple_redactions_in_one_quote_match` | **failed** — two markers in one quote |
| `test_redacted_placeholder_at_quote_start_still_matches` | passed — documents the edge case that did work |
| `test_redacted_fragments_must_appear_in_order` | passed — pins the precision guard against the change |
| `test_marker_only_quote_is_unverifiable` | passed — pins fail-closed behavior |

The three that already passed are there deliberately: they pin the behavior this change must **not** alter.

| File | Change |
|------|--------|
| `plugin/daimon_briefing/serializer.py` | split on `_REDACTED_RE` inside the ellipsis split; docstring corrected to describe what the code does |
| `plugin/tests/test_quote_verification.py` | five tests |
