### PR TITLE
fix(cli): write-checkpoint downgrades unverifiable verbatim to inferred

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -381,6 +381,13 @@ def _cmd_write_checkpoint(args) -> int:
     # there are no signals, so a model-claimed verdict is stripped (empty
     # signal set = strip-only, no downgrade).
     serializer.ground_outcomes(checkpoint, set())
+    # #511, the last field of the same discipline: with no transcript,
+    # verify_quotes never runs here — a model-claimed `verbatim` is a
+    # byte-check this path cannot perform, and carry's #22 freeze would
+    # prefer it over genuinely extracted content. Unconditional (not keyed
+    # to --source): the path never has a transcript regardless of what the
+    # caller claims the checkpoint is.
+    serializer.downgrade_unverifiable_verbatim(checkpoint)
     checkpoint["source"] = args.source  # provenance: introspection vs reconstruction
     session_id = str(checkpoint["session_id"])
     out = store.write_checkpoint(session_id, checkpoint, project_dir=_resolve_project(args.project))

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -1751,7 +1751,13 @@ _CODE_OWNED_KEYS = (
 # so a model-emitted one is a self-issued witness that corroboration counting
 # would then treat as an independent session. Stripped from freshly authored
 # model output only, exactly like `grounded`/`pinned` (#292 discipline).
-_CODE_OWNED_ITEM_KEYS = ("origin_session", "origin_author")
+# #511: `quote_verified`/`last_verified` are verify_quotes' verdicts — on the
+# serialize path they are re-derived AFTER this strip, and on the introspection
+# path (no transcript, verify_quotes never runs) nothing may hold either stamp.
+# Safe to strip on both paths because carry.merge folds prev items in AFTER
+# serialize_strict returns — a carried item's genuine stamps never pass here.
+_CODE_OWNED_ITEM_KEYS = ("origin_session", "origin_author",
+                         "quote_verified", "last_verified")
 
 
 def strip_code_owned_keys(checkpoint: dict) -> None:
@@ -1782,6 +1788,32 @@ def strip_code_owned_keys(checkpoint: dict) -> None:
         for key in _CODE_OWNED_ITEM_KEYS:
             if item.pop(key, None) is not None:
                 log.info("serialize: discarding model-supplied item key %r", key)
+
+
+def downgrade_unverifiable_verbatim(checkpoint) -> int:
+    """Downgrade every `trust: "verbatim"` item to `inferred`, in place, and
+    return the count (#511). For paths with NO transcript (cli's
+    `write-checkpoint` introspection path) — nothing there can byte-check a
+    quote, so `verbatim` is a trust class the code cannot justify. Without
+    this the item stores indistinguishable from a #125-verified capture,
+    `briefing._mark` renders it verbatim, `scoring.trust_ceiling` grants the
+    full escalation band, and carry's #22 freeze prefers it over a genuinely
+    extracted twin at the next rotation.
+
+    The quote itself survives as a claim, exactly like the item's text — it
+    just buys nothing until a real serialize re-extracts and verifies it.
+    Never call this on the serialize path: there verify_quotes IS the gate,
+    and it downgrades misses individually instead of wholesale.
+    """
+    downgraded = 0
+    for item in iter_items(checkpoint):
+        if item.get("trust") == "verbatim":
+            item["trust"] = "inferred"
+            downgraded += 1
+    if downgraded:
+        log.info("introspection path: %d unverifiable verbatim item(s) "
+                 "downgraded to inferred (#511)", downgraded)
+    return downgraded
 
 
 def _stamp_llm_provenance(checkpoint: dict) -> None:

--- a/plugin/skills/daimon-end/SKILL.md
+++ b/plugin/skills/daimon-end/SKILL.md
@@ -47,9 +47,15 @@ this as a `prev` pointer). So it does not need to be perfect to be useful, and i
 2. **HONESTY RULE (load-bearing).** Mark `trust: "verbatim"` and include a `quote`
    ONLY if you can reproduce the EXACT transcript text. Anything from an earlier,
    **compacted/summarized** part of the session you can no longer quote verbatim →
-   `trust: "inferred"`, no `quote`. Do not fabricate quotes. (This is the known
-   weakness of introspection vs the full-transcript reconstruction — be honest and
-   the merge/supersession handles the rest.)
+   `trust: "inferred"`, no `quote`. Do not fabricate quotes.
+
+   Know what the code does with it (#511): this path has no transcript to check
+   your quote against, so the CLI **records every item as `inferred`** regardless
+   of the trust you claim — the quote is kept as a claim, it just earns no
+   verbatim mark. Byte-verified `verbatim` comes only from the automatic
+   full-transcript reconstruction that supersedes this checkpoint. Still follow
+   the rule above: an honest quote helps the later merge; a fabricated one is
+   noise either way.
 
 3. **Write it** via the CLI (reads JSON on stdin, validates the schema, routes to
    this project + global + a per-session file, atomically, with rotation). Write

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1581,6 +1581,38 @@ def test_cli_write_checkpoint_strips_model_claimed_grounded(
     assert "grounded" not in dec
 
 
+def test_cli_write_checkpoint_downgrades_unverifiable_verbatim(
+        tmp_checkpoint_dir, monkeypatch):
+    # #511: the introspection path has NO transcript, so `verify_quotes`
+    # never runs here — a model-claimed `trust: "verbatim"` is a byte-check
+    # this path cannot perform. Without a downgrade the item stores
+    # indistinguishable from a #125-verified capture, briefing._mark renders
+    # it verbatim, and carry's #22 freeze prefers it over a genuinely
+    # extracted twin. Same discipline as #358 (source ids) and #359
+    # (grounded), one field further: verbatim -> inferred, and the
+    # model-claimed verification stamps are stripped as code-owned.
+    from daimon_briefing import store
+
+    cp = json.loads(_valid_json("S-intro"))
+    cp["working_context"]["recent_decisions"] = [{
+        "text": "d", "trust": "verbatim", "quote": "fabricated exact words",
+        "quote_verified": True, "last_verified": "2026-01-01T00:00:00Z",
+    }]
+    _stdin(monkeypatch, json.dumps(cp))
+    rc = cli.main(["write-checkpoint", "--project", "/p/A"])
+    assert rc == 0
+    ck = store.read_latest(project_dir="/p/A")
+    dec = ck["working_context"]["recent_decisions"][0]
+    assert dec["trust"] == "inferred"
+    assert "quote_verified" not in dec
+    assert "last_verified" not in dec
+    assert dec["quote"] == "fabricated exact words"  # claim kept, not trusted
+    # _valid_json's own verbatim open question gets the same downgrade —
+    # the rule is unconditional on this path, not keyed to spoofed stamps.
+    q = ck["working_context"]["open_questions"][0]
+    assert q["trust"] == "inferred"
+
+
 def test_top_level_help_has_examples(capsys):
     with pytest.raises(SystemExit) as exc:
         cli.main(["--help"])

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -1307,6 +1307,43 @@ def test_strip_code_owned_keys_clears_item_origin_on_the_introspection_path():
     assert item["text"] == "q"  # nothing else disturbed
 
 
+def test_strip_code_owned_keys_clears_model_claimed_verification_stamps():
+    """#511: `quote_verified`/`last_verified` are verify_quotes' verdicts —
+    code-derived attestations, same class as `origin_*`. A model emitting
+    them must never persist: on the serialize path verify_quotes re-derives
+    both AFTER this strip; on the introspection path there is no transcript,
+    so nothing may hold either stamp at all."""
+    ckpt = json.loads(_valid_checkpoint_json("S1"))
+    item = ckpt["working_context"]["recent_decisions"][0]
+    item["quote_verified"] = True
+    item["last_verified"] = "2026-01-01T00:00:00Z"
+
+    serializer.strip_code_owned_keys(ckpt)
+
+    assert "quote_verified" not in item
+    assert "last_verified" not in item
+    assert item["text"] == "d"  # nothing else disturbed
+
+
+def test_downgrade_unverifiable_verbatim_reclasses_every_verbatim_item():
+    """#511: a path with no transcript cannot byte-check any quote, so a
+    model-claimed `verbatim` is a trust class the code cannot justify —
+    downgraded to inferred. The quote itself survives as a claim (same as
+    any other model-authored text), it just buys nothing."""
+    ckpt = json.loads(_valid_checkpoint_json("S1"))
+    ckpt["epistemic_snapshot"]["strong_beliefs"] = [
+        {"text": "b", "trust": "inferred"}]
+
+    downgraded = serializer.downgrade_unverifiable_verbatim(ckpt)
+
+    assert downgraded == 1
+    dec = ckpt["working_context"]["recent_decisions"][0]
+    assert dec["trust"] == "inferred"
+    assert dec["quote"] == "line 3 from assistant"  # claim kept, not trusted
+    # untouched non-verbatim items keep their class
+    assert ckpt["epistemic_snapshot"]["strong_beliefs"][0]["trust"] == "inferred"
+
+
 def test_serialize_strip_survives_the_validation_retry_pass(fake_chat_factory):
     # A spoofed format_version alongside output that FAILS validation forces
     # the #118 resample retry — the strip must apply to the retried output


### PR DESCRIPTION
Closes #511

## What

- `quote_verified` and `last_verified` join `_CODE_OWNED_ITEM_KEYS`: `strip_code_owned_keys` now drops model-emitted values for both, on both model-authoring paths. Safe on the serialize path because `verify_quotes` re-derives both after the strip, and safe for carried items because `carry.merge` folds prev items in after `serialize_strict` returns, so genuine carried stamps never pass the strip.
- New `serializer.downgrade_unverifiable_verbatim`: every `trust: "verbatim"` item is reclassed to `inferred`, in place, with the quote kept as a claim. `_cmd_write_checkpoint` calls it unconditionally: the path never has a transcript regardless of what `--source` claims, so no verbatim claim is checkable there.
- `skills/daimon-end/SKILL.md` documents the recorded behavior, so the honesty rule and the code now say the same thing.

## Why

`write-checkpoint` accepted `trust: "verbatim"` on faith. With no transcript on that path, `verify_quotes` never runs, and the stored item was indistinguishable from a verified capture: `briefing._mark` rendered the verbatim mark, `scoring.trust_ceiling` granted the full escalation band, and carry's #22 freeze preferred the unverified item over a genuinely extracted twin at the next rotation. Same fix direction as the existing strips in the same function (#358 source ids, #359 grounded): a claim the code cannot check must not persist as if it had been checked.

Out of scope, but measured while here: the issue's independent note that `_mark` should read `quote_verified` rather than `trust` alone. On a local corpus, 3034 of 6395 verbatim items (47.4%) legitimately lack the stamp (carry pops `False`, carried copies lose stamps per #209, items predating #125 never had one), so keying the render on it would demote roughly half of all verbatim renders. That change needs its own issue and its own measurement, not a rider here.

## Tests

Three new tests, each watched failing before the change:

- `test_cli_write_checkpoint_downgrades_unverifiable_verbatim`: end to end through the CLI; asserts trust downgrade, stamp strip, and quote survival, including the template's own verbatim item (rule is unconditional, not keyed to spoofed stamps).
- `test_strip_code_owned_keys_clears_model_claimed_verification_stamps`: unit; model-emitted `quote_verified`/`last_verified` dropped per item.
- `test_downgrade_unverifiable_verbatim_reclasses_every_verbatim_item`: unit; count returned, non-verbatim items untouched, quote kept.

Full suite: 2688 passed, 2 skipped, 0 regressions (the serialize-path verify tests pin that re-derivation still lands after the widened strip).
