### PR TITLE
fix(serializer): tool output of daimon's own commands is not a witness

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1361,10 +1361,16 @@ def age_gate_blocks(m, now: float, age_days=_UNSET) -> bool:
 
 
 def _suggest_line(r: dict, terms, now: float) -> str:
-    """One compact, attributed, trust-preserving injection line (#125)."""
+    """One compact, attributed, trust-preserving injection line (#125).
+
+    ONE line is a contract, not a hope (#512): the echo strip that removes
+    this line from the verification haystack is line-scoped, so item text
+    carrying a newline would leave its tail behind as a fake witness.
+    Internal whitespace collapses here, at the emitter."""
     age = _format_age(now - r["created"]) if r.get("created") else "?"
     trust = r.get("trust") or "untagged"
-    text = r["text"] if len(r["text"]) <= 160 else r["text"][:157] + "..."
+    text = " ".join(str(r["text"]).split())
+    text = text if len(text) <= 160 else text[:157] + "..."
     # v3 (#234): the flag is item-level evidence — a typed supersedes link
     # or a logged resolution — not the old whole-checkpoint recency.
     sup = r.get("superseded_by")
@@ -1944,11 +1950,13 @@ def _load_audit_transcript(tpath):
     # #440: the same stripped haystacks verify_quotes used at serialize time.
     # Audit re-blesses stored items, so reading the raw render here would
     # certify exactly the echo verification rejected — and do it with the
-    # CLI's authority.
+    # CLI's authority. #512: daimon-output tool rows blank here too, for the
+    # same reason and by the same rule.
     haystack = serializer.stripped_transcript(msgs)
+    daimon_ids = serializer.daimon_output_ids(msgs)
     texts_by_id = {
-        mid: serializer.strip_injected(text) for mid, text
-        in serializer.message_texts_by_id(msgs).items()}
+        mid: "" if mid in daimon_ids else serializer.strip_injected(text)
+        for mid, text in serializer.message_texts_by_id(msgs).items()}
     return haystack, texts_by_id
 
 

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -887,6 +887,18 @@ def strip_injected(text: str) -> str:
     return _BRIEF_HEAD_RE.sub("", text)
 
 
+def daimon_output_ids(messages) -> set:
+    """Ids of rows transcript.py flagged as daimon's own tool output (#512):
+    a tool result born from a daimon invocation (CLI or MCP), resolved by
+    provenance at parse time. Verification must never read these as
+    witnesses — same principle as strip_injected, keyed on the invocation
+    instead of the render shape, so every daimon subcommand present or
+    future is covered without pattern enumeration."""
+    return {mid for m in (messages or [])
+            if isinstance(m, dict) and m.get("daimon_output")
+            and (mid := _message_id(m)) is not None}
+
+
 def stripped_transcript(messages) -> str:
     """`_render_transcript`'s text with every message's injected spans removed
     — the whole-transcript VERIFICATION haystack (#440).
@@ -894,6 +906,9 @@ def stripped_transcript(messages) -> str:
     Renders shallow message copies whose flattened text has been stripped, so
     markers, role labels and joins stay byte-identical to the haystack
     verification read before this fix: only the injected bytes go missing.
+    #512: a daimon-output tool row is BLANKED, never dropped — [mN] markers
+    are positional over the full list and a dropped row would renumber every
+    later citation.
 
     No non-dict guard on purpose: `serialize_strict` renders the SAME list
     through `_render_transcript` before verification runs, and that raises on
@@ -903,7 +918,8 @@ def stripped_transcript(messages) -> str:
     stripped = []
     for m in messages or []:
         copy = dict(m)
-        copy["content"] = strip_injected(_message_text(m))
+        copy["content"] = ("" if m.get("daimon_output")
+                           else strip_injected(_message_text(m)))
         stripped.append(copy)
     return _render_transcript(stripped)
 
@@ -950,8 +966,12 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None) -> int:
     under `echo-only` rather than the generic absent-quote reason."""
     # #440: the RAW pair survives alongside the stripped haystacks, read on
     # the failure path only — to tell an echoed quote from an absent one.
+    # #512: daimon-output tool rows are blanked in the STRIPPED map (their
+    # bytes are daimon's own, not a witness) but kept raw, so a quote living
+    # only there downgrades under the honest `echo-only` reason code.
     raw_texts_by_id = message_texts_by_id(messages) if messages else {}
-    texts_by_id = {mid: strip_injected(text)
+    daimon_ids = daimon_output_ids(messages) if messages else set()
+    texts_by_id = {mid: "" if mid in daimon_ids else strip_injected(text)
                    for mid, text in raw_texts_by_id.items()}
     haystack = (stripped_transcript(messages) if messages
                 else strip_injected(transcript_text))

--- a/plugin/daimon_briefing/transcript.py
+++ b/plugin/daimon_briefing/transcript.py
@@ -83,6 +83,64 @@ def _text_of(content) -> str:
 _TOOL_RESULT_MAX_CHARS = 500
 
 
+# #512: `daimon` as the INVOKED binary — start of command or after a shell
+# separator / substitution, tolerating env-var prefixes, sudo, uv run (with
+# flags), python -m, and path prefixes. Deliberately NOT a bare substring:
+# `rg daimon cli.py` greps ABOUT daimon and its output is a genuine witness
+# (measured: a blanket tool-row strip costs 9.5% of the corpus's verifiable
+# quotes; this invocation-scoped rule costs 0.06%).
+_DAIMON_CMD_RE = re.compile(
+    r"(?:^|[|;&(`]|\&\&|\|\|)\s*"
+    r"(?:\S+=\S+\s+)*(?:sudo\s+)?"
+    r"(?:uv\s+run\s+(?:--?[\w-]+(?:[= ]\S+)?\s+)*(?:python\s+-m\s+)?)?"
+    r"(?:\S*/)?daimon(?:\s|$)", re.MULTILINE)
+
+
+def _is_daimon_tool_use(block: dict) -> bool:
+    """True when a tool_use block invokes daimon: an MCP tool whose name
+    carries `daimon`, or a shell command with daimon in command position."""
+    if "daimon" in str(block.get("name") or "").lower():
+        return True
+    inp = block.get("input")
+    cmd = inp.get("command") if isinstance(inp, dict) else None
+    return isinstance(cmd, str) and bool(_DAIMON_CMD_RE.search(cmd))
+
+
+def _daimon_tool_use_ids(objects: list[dict]) -> set[str]:
+    """ids of every tool_use block that invokes daimon, across the file —
+    the prepass that lets a tool_result row know its own provenance (#512).
+    A tool result born from a daimon invocation is daimon's own output
+    echoed back through the transcript; quote verification must never treat
+    it as a witness, and keying on the INVOCATION (not the output shape)
+    means every daimon subcommand — current or future — is covered without
+    enumerating render formats."""
+    ids: set[str] = set()
+    for obj in objects:
+        msg = obj.get("message")
+        content = msg.get("content") if isinstance(msg, dict) else None
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if (isinstance(block, dict) and block.get("type") == "tool_use"
+                    and _is_daimon_tool_use(block)):
+                bid = str(block.get("id") or "").strip()
+                if bid:
+                    ids.add(bid)
+    return ids
+
+
+def _tool_use_ids_of(obj: dict) -> set[str]:
+    """The tool_use ids a tool_result row answers, tolerant of absent ids."""
+    msg = obj.get("message")
+    content = msg.get("content") if isinstance(msg, dict) else None
+    if not isinstance(content, list):
+        return set()
+    return {str(b.get("tool_use_id") or "").strip()
+            for b in content
+            if isinstance(b, dict) and b.get("type") == "tool_result"
+            and str(b.get("tool_use_id") or "").strip()}
+
+
 def _tool_result_of(obj: dict) -> tuple[str, bool] | None:
     """(flattened text, is_error) for a row whose payload is tool_result
     blocks, or None when the row carries none. `content` inside a block can be
@@ -186,6 +244,7 @@ def _from_jsonl(text: str) -> list[dict]:
         return windsurf_messages
 
     messages: list[dict] = []
+    daimon_uses = _daimon_tool_use_ids(objects)  # #512 provenance prepass
     for obj in objects:
         if obj.get("isSidechain") or obj.get("isMeta"):
             continue
@@ -224,6 +283,11 @@ def _from_jsonl(text: str) -> list[dict]:
                                   "tool_result": True}
                 if is_error:
                     tool_msg["tool_error"] = True
+                # #512: provenance flag, resolved via the tool_use pairing.
+                # Discriminating FIELD again (deadend #20) — downstream strips
+                # key on this, never on the rendered shape.
+                if _tool_use_ids_of(obj) & daimon_uses:
+                    tool_msg["daimon_output"] = True
                 messages.append(tool_msg)
     return messages
 

--- a/plugin/daimon_briefing/transcript.py
+++ b/plugin/daimon_briefing/transcript.py
@@ -129,28 +129,19 @@ def _daimon_tool_use_ids(objects: list[dict]) -> set[str]:
     return ids
 
 
-def _tool_use_ids_of(obj: dict) -> set[str]:
-    """The tool_use ids a tool_result row answers, tolerant of absent ids."""
-    msg = obj.get("message")
-    content = msg.get("content") if isinstance(msg, dict) else None
-    if not isinstance(content, list):
-        return set()
-    return {str(b.get("tool_use_id") or "").strip()
-            for b in content
-            if isinstance(b, dict) and b.get("type") == "tool_result"
-            and str(b.get("tool_use_id") or "").strip()}
-
-
-def _tool_result_of(obj: dict) -> tuple[str, bool] | None:
-    """(flattened text, is_error) for a row whose payload is tool_result
-    blocks, or None when the row carries none. `content` inside a block can be
-    a plain string or a nested block list — both flatten. Empty output is
-    still a signal ("ran, said nothing"), kept via a placeholder."""
+def _tool_result_of(obj: dict) -> tuple[str, bool, set[str]] | None:
+    """(flattened text, is_error, answered tool_use ids) for a row whose
+    payload is tool_result blocks, or None when the row carries none.
+    `content` inside a block can be a plain string or a nested block list —
+    both flatten. Empty output is still a signal ("ran, said nothing"), kept
+    via a placeholder. The ids ride along from the same block walk (#512) so
+    the caller can resolve the row's provenance without a second pass."""
     msg = obj.get("message")
     content = msg.get("content") if isinstance(msg, dict) else None
     if not isinstance(content, list):
         return None
     parts: list[str] = []
+    use_ids: set[str] = set()
     is_error = False
     found = False
     for block in content:
@@ -159,6 +150,9 @@ def _tool_result_of(obj: dict) -> tuple[str, bool] | None:
         found = True
         if block.get("is_error"):
             is_error = True
+        use_id = str(block.get("tool_use_id") or "").strip()
+        if use_id:
+            use_ids.add(use_id)
         inner = block.get("content")
         if isinstance(inner, str):
             parts.append(inner.strip())
@@ -167,7 +161,7 @@ def _tool_result_of(obj: dict) -> tuple[str, bool] | None:
     if not found:
         return None
     text = "\n".join(p for p in parts if p).strip()[:_TOOL_RESULT_MAX_CHARS]
-    return (text or "(no output)", is_error)
+    return (text or "(no output)", is_error, use_ids)
 
 
 def _from_jsonl(text: str) -> list[dict]:
@@ -278,7 +272,7 @@ def _from_jsonl(text: str) -> list[dict]:
         if mid is not None:
             tool = _tool_result_of(obj)
             if tool is not None:
-                text, is_error = tool
+                text, is_error, use_ids = tool
                 tool_msg: dict = {"role": "tool", "content": text, "id": mid,
                                   "tool_result": True}
                 if is_error:
@@ -286,7 +280,7 @@ def _from_jsonl(text: str) -> list[dict]:
                 # #512: provenance flag, resolved via the tool_use pairing.
                 # Discriminating FIELD again (deadend #20) — downstream strips
                 # key on this, never on the rendered shape.
-                if _tool_use_ids_of(obj) & daimon_uses:
+                if use_ids & daimon_uses:
                     tool_msg["daimon_output"] = True
                 messages.append(tool_msg)
     return messages

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1581,6 +1581,18 @@ def test_cli_write_checkpoint_strips_model_claimed_grounded(
     assert "grounded" not in dec
 
 
+def test_suggest_line_collapses_multiline_item_text():
+    # #512: the injection line's echo strip is line-scoped (`[^\n]*`), so item
+    # text carrying a newline would leave its tail in the verification
+    # haystack. The emitter owns the one-line contract: internal whitespace
+    # collapses to single spaces.
+    r = {"kind": "decision", "session_id": "S-1", "created": 1000.0,
+         "trust": "verbatim", "text": "first clause\nsecond clause\n\tthird"}
+    line = cli._suggest_line(r, ["clause"], 2000.0)
+    assert "\n" not in line
+    assert "first clause second clause third" in line
+
+
 def test_cli_write_checkpoint_downgrades_unverifiable_verbatim(
         tmp_checkpoint_dir, monkeypatch):
     # #511: the introspection path has NO transcript, so `verify_quotes`

--- a/plugin/tests/test_quote_verification.py
+++ b/plugin/tests/test_quote_verification.py
@@ -1317,6 +1317,77 @@ def test_quote_absent_entirely_is_not_flagged_echo_only():
     assert "quote_echo_only" not in item
 
 
+# ---- #512: tool results born from daimon invocations are not witnesses ----
+#
+# `daimon recall`, `daimon loops`, MCP daimon_recall (and every other daimon
+# subcommand, current or future) print prior-session item text into the
+# transcript as TOOL RESULTS. Coverage is keyed on the row's provenance flag
+# (transcript.py pairs tool_result -> tool_use invocation), never on output
+# shape — a new emitter cannot escape by changing its render format.
+
+
+def _daimon_tool_row(content, mid):
+    return {"role": "tool", "content": content, "id": mid,
+            "tool_result": True, "daimon_output": True}
+
+
+def test_quote_only_in_daimon_tool_output_downgrades_as_echo():
+    msgs = _msgs(("user", "what did we decide about the pin?", "u-1"))
+    msgs.append(_daimon_tool_row(f"[me] [verbatim] [decision] {_ECHOED} "
+                                 "(S-old, 3d ago)", "t-2"))
+    cp = _decision()
+    n = serializer.verify_quotes(cp, serializer._render_transcript(msgs), msgs)
+    item = _only_decision(cp)
+    assert n == 1
+    assert item["trust"] == "inferred"
+    assert item["quote_verified"] is False
+    assert item["quote_echo_only"] is True
+
+
+def test_quote_in_ordinary_tool_output_still_verifies():
+    # The measured reason this is provenance-scoped, not a blanket tool-row
+    # strip: 9.5% of the corpus's verifiable quotes live only in genuine tool
+    # output (test summaries, error lines, file reads) and must keep verifying.
+    genuine = "FAILED tests/test_auth.py - expired token accepted by refresh"
+    msgs = _msgs(("user", "run the auth suite", "u-1"))
+    msgs.append({"role": "tool", "content": genuine, "id": "t-2",
+                 "tool_result": True})
+    cp = _decision(text="auth suite is red", quote=genuine)
+    n = serializer.verify_quotes(cp, serializer._render_transcript(msgs), msgs)
+    item = _only_decision(cp)
+    assert n == 0
+    assert item["trust"] == "verbatim"
+    assert item["quote_verified"] is True
+
+
+def test_daimon_tool_row_does_not_shift_marker_numbering():
+    # The strip BLANKS a daimon row's content; it never drops the row, because
+    # [mN] markers are positional over the full message list and a dropped row
+    # would renumber every later citation.
+    genuine = "let us cut the release once the write guard lands"
+    msgs = _msgs(("user", "where were we?", "u-1"))
+    msgs.append(_daimon_tool_row(f"[me] [verbatim] [decision] {_ECHOED}", "t-2"))
+    msgs.append({"role": "user", "content": genuine, "id": "u-3"})
+    cp = _decision(text="cut the release", quote=genuine,
+                   source_message_ids=["u-3"])
+    n = serializer.verify_quotes(cp, serializer._render_transcript(msgs), msgs)
+    item = _only_decision(cp)
+    assert n == 0
+    assert item["quote_verified"] is True
+    assert item["source_message_ids"] == ["u-3"]
+
+
+def test_daimon_tool_quote_bound_to_the_tool_row_loses_its_binding():
+    msgs = _msgs(("user", "carry on", "u-1"))
+    msgs.append(_daimon_tool_row(f"[me] [verbatim] [decision] {_ECHOED}", "t-2"))
+    cp = _decision(source_message_ids=["t-2"])
+    serializer.verify_quotes(cp, serializer._render_transcript(msgs), msgs)
+    item = _only_decision(cp)
+    assert item["quote_verified"] is False
+    assert item["quote_echo_only"] is True
+    assert "source_message_ids" not in item
+
+
 def test_a_corroboration_badge_quoted_out_of_a_brief_is_echo_only():
     # #268 slice 4 x #440: the badge is daimon's own render, so a quote that
     # copies a badged briefing line back out of the transcript is an echo of

--- a/plugin/tests/test_transcript.py
+++ b/plugin/tests/test_transcript.py
@@ -287,6 +287,85 @@ def test_from_file_tool_result_error_rows_carry_the_error_flag(tmp_path):
     ]
 
 
+def test_from_file_flags_tool_results_of_daimon_invocations(tmp_path):
+    # #512: a tool result born from a `daimon` invocation is daimon's own
+    # output echoed back through the transcript — verification must never
+    # treat it as a witness. The flag is provenance (tool_use pairing), not
+    # output shape, so every daimon subcommand — current or future — is
+    # covered without enumerating render formats.
+    p = _write_jsonl(tmp_path / "session.jsonl", [
+        {"type": "assistant", "uuid": "a-1",
+         "message": {"role": "assistant", "content": [
+             {"type": "tool_use", "id": "TU-1", "name": "Bash",
+              "input": {"command": "daimon recall \"auth pin\""}}]}},
+        {"type": "user", "uuid": "t-2",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "TU-1",
+              "content": "[me] [verbatim] [decision] freeze the pin (S-1, 3d ago)"}]}},
+    ])
+    assert transcript.from_file(p) == [
+        {"role": "tool",
+         "content": "[me] [verbatim] [decision] freeze the pin (S-1, 3d ago)",
+         "id": "t-2", "tool_result": True, "daimon_output": True},
+    ]
+
+
+def test_from_file_does_not_flag_ordinary_tool_results(tmp_path):
+    # pytest output and a grep ABOUT daimon are genuine witnesses — `daimon`
+    # as an argument is not `daimon` as the invoked command.
+    p = _write_jsonl(tmp_path / "session.jsonl", [
+        {"type": "assistant", "uuid": "a-1",
+         "message": {"role": "assistant", "content": [
+             {"type": "tool_use", "id": "TU-1", "name": "Bash",
+              "input": {"command": "rg -n daimon cli.py"}}]}},
+        {"type": "user", "uuid": "t-2",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "TU-1",
+              "content": "12: daimon recall wiring"}]}},
+    ])
+    assert transcript.from_file(p) == [
+        {"role": "tool", "content": "12: daimon recall wiring", "id": "t-2",
+         "tool_result": True},
+    ]
+
+
+def test_from_file_flags_daimon_mcp_tool_results(tmp_path):
+    p = _write_jsonl(tmp_path / "session.jsonl", [
+        {"type": "assistant", "uuid": "a-1",
+         "message": {"role": "assistant", "content": [
+             {"type": "tool_use", "id": "TU-9",
+              "name": "mcp__daimon__daimon_recall",
+              "input": {"query": "auth"}}]}},
+        {"type": "user", "uuid": "t-2",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "TU-9",
+              "content": "[{\"text\": \"freeze the pin\"}]"}]}},
+    ])
+    rows = transcript.from_file(p)
+    assert rows[-1]["daimon_output"] is True
+
+
+def test_from_file_flags_daimon_behind_wrappers_and_chains(tmp_path):
+    # The invocation idioms real sessions use: uv run, env prefixes, `&&`
+    # chains, absolute paths. All are daimon as the invoked binary.
+    for cmd in ("uv run --project plugin daimon loops",
+                "cd /repo && daimon brief",
+                "DAIMON_ENV_FILE=/tmp/e daimon status --suppressed",
+                "/usr/local/bin/daimon recall --json foo | head"):
+        p = _write_jsonl(tmp_path / "session.jsonl", [
+            {"type": "assistant", "uuid": "a-1",
+             "message": {"role": "assistant", "content": [
+                 {"type": "tool_use", "id": "TU-1", "name": "Bash",
+                  "input": {"command": cmd}}]}},
+            {"type": "user", "uuid": "t-2",
+             "message": {"role": "user", "content": [
+                 {"type": "tool_result", "tool_use_id": "TU-1",
+                  "content": "output"}]}},
+        ])
+        rows = transcript.from_file(p)
+        assert rows[-1].get("daimon_output") is True, cmd
+
+
 def test_from_file_tool_result_rows_without_uuid_stay_dropped(tmp_path):
     # No uuid means no [mN] marker and no way to cite the row — grounding is
     # pointer-based, so an id-less tool result stays dropped: byte-identical


### PR DESCRIPTION
Closes #512

## What

- `transcript.py` pairs every `tool_result` row to its `tool_use` invocation and flags rows born from a daimon invocation (`daimon` in shell command position, tolerating `uv run`/env prefixes/paths/chains, or an MCP tool named `daimon*`) with a `daimon_output: True` field. Provenance, not output shape: a new daimon subcommand is covered by construction, with nothing to register.
- Verification blanks flagged rows in the stripped haystacks: `stripped_transcript` (inherited by `verify_quotes`' fallback, the agent-evidence checks, and `audit-quotes`), the scoped `texts_by_id` map in `verify_quotes`, and the audit loader. The raw pair is kept, so a quote living only in daimon output downgrades under the existing `echo-only` reason code instead of the generic absent-quote one. Rows are blanked, never dropped — `[mN]` markers are positional and a dropped row would renumber every later citation.
- `_suggest_line` collapses internal whitespace. The injection line's echo strip is line-scoped, so item text carrying a newline previously left its tail in the haystack as a fake witness. The emitter now owns the one-line contract.

## Why

The #440 echo defense strips three render-format literals. The issue names three uncovered emitters; a review sweep for this fix found fourteen surfaces that print prior-checkpoint item text into the transcript as tool results, including `recall --json` and the MCP tool, which leak the stored `quote` field byte-for-byte. Keying the defense on render shapes means every new emitter silently escapes — that is the failure mode observed, so the fix must not be more shapes.

Measured on the real corpus before choosing the mechanism (3376 verifiable verbatim quotes across 70 transcript-resolvable sessions):

| rule | verifiable quotes lost |
|---|---|
| blanket "no tool row is a witness" | 320 (9.5%) — overwhelmingly genuine: test output, error lines, file reads |
| provenance rule (this PR) | 2 (0.06%) — the same carried quote twice, existing only inside daimon output: a true echo, correctly dying |

463 tool rows flag corpus-wide. The shipped implementation reproduces the measurement exactly.

## Honest scope

- An agent that restates recall output in its own assistant prose still verifies — no strip can distinguish restatement from genuine speech. This PR closes the direct-copy laundering path; the restatement path is the known self-reference loop and is not claimed here.
- Hosts whose transcripts carry no `tool_use` pairing (Windsurf, Codex, Gemini context paths) are byte-identical to before.
- The corroboration axis: a flagged-row quote can no longer earn `quote_verified`, so the G3 cross-session laundering variant through this door closes with it.

## Tests

Six new tests watched failing first (transcript flagging for plain/wrapped/chained/MCP invocations, echo downgrade with `quote_echo_only`, binding drop, `_suggest_line` collapse), plus two boundary pins that passed from the start and stay as guards (ordinary tool output keeps verifying; marker numbering unmoved). Full suite: 2697 passed, 2 skipped.
