### PR TITLE
fix(redact): route status log tails through redact_text and contain anchor paths

### DIFF
--- a/plugin/daimon_briefing/anchor.py
+++ b/plugin/daimon_briefing/anchor.py
@@ -48,9 +48,20 @@ def body_hash_of(source: str, symbol: str) -> str | None:
 
 
 def resolve(project_root, file: str, symbol: str) -> dict | None:
-    """Snapshot an anchor for (file, symbol), or None if it can't be resolved."""
+    """Snapshot an anchor for (file, symbol), or None if it can't be resolved.
+
+    #513: `file` must stay INSIDE project_root. Pathlib join semantics make
+    `root / "/abs/path"` the absolute path itself, so an absolute (or
+    `../`-traversing) --file would escape the root and the leaked path would
+    land in `anchored_to` — which syncs verbatim to the team remote.
+    Containment refuses instead; symlink escapes fall to the same resolve().
+    """
     try:
-        source = (Path(project_root) / file).read_text(encoding="utf-8")
+        root = Path(project_root).resolve()
+        target = (root / file).resolve()
+        if not target.is_relative_to(root):
+            return None
+        source = target.read_text(encoding="utf-8")
     except OSError:
         return None
     h = body_hash_of(source, symbol)

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -30,7 +30,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from . import anchor, briefing, capture, carry, config, configure, harvest, llm, normalize, recall, receipts, render, schema, serializer, store, teamsync, transcript, worldcheck
+from . import anchor, briefing, capture, carry, config, configure, harvest, llm, normalize, recall, receipts, redact, render, schema, serializer, store, teamsync, transcript, worldcheck
 from . import __version__
 
 # The serialize.log ledger subsystem lives in ledger.py (#147 + #162, pure
@@ -1628,7 +1628,11 @@ def _tail_log_info(path: Path, now: float) -> dict | None:
     if not lines:
         return None
     age = int(now - st.st_mtime)
-    return {"last_line": lines[-1], "age_seconds": age,
+    # #513: raw disk bytes reach stdout via status — the one display path
+    # that never passed redact_text. Redacted at construction so the plain,
+    # rich, and --json renders all inherit it.
+    logged, _ = redact.redact_text(lines[-1])
+    return {"last_line": logged, "age_seconds": age,
             "age": _format_age(age), "path": str(path)}
 
 
@@ -1678,7 +1682,11 @@ def _crash_log_info(path: Path, now: float) -> dict | None:
             pass  # unstamped/foreign header: fall back to file mtime
     if age is None:
         age = int(now - st.st_mtime)
-    return {"last_line": last_line, "age_seconds": age,
+    # #513: same rule as _tail_log_info — the traceback's exception line is
+    # raw child stderr and can embed a credential (requests errors echo URLs,
+    # config errors echo the offending value).
+    logged, _ = redact.redact_text(last_line)
+    return {"last_line": logged, "age_seconds": age,
             "age": _format_age(age), "path": str(path)}
 
 

--- a/plugin/tests/test_anchor.py
+++ b/plugin/tests/test_anchor.py
@@ -37,6 +37,33 @@ def test_resolve_missing_symbol_returns_none(tmp_path):
     assert anchor.resolve(tmp_path, "m.py", "nope") is None
 
 
+def test_resolve_rejects_an_absolute_file_outside_the_project(tmp_path):
+    # #513: pathlib join semantics make `root / "/abs/path"` resolve to the
+    # absolute path itself, so an absolute --file escaped the project root
+    # and the leaked path landed in anchored_to, which syncs to the team
+    # remote. Containment refuses instead.
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    _write(outside, "secret.py", _SRC)
+    project = tmp_path / "project"
+    project.mkdir()
+    assert anchor.resolve(project, str(outside / "secret.py"), "foo") is None
+
+
+def test_resolve_rejects_parent_traversal(tmp_path):
+    _write(tmp_path, "escape.py", _SRC)
+    project = tmp_path / "project"
+    project.mkdir()
+    assert anchor.resolve(project, "../escape.py", "foo") is None
+
+
+def test_resolve_still_accepts_nested_relative_paths(tmp_path):
+    _write(tmp_path, "pkg/mod.py", _SRC)
+    a = anchor.resolve(tmp_path, "pkg/mod.py", "foo")
+    assert a is not None
+    assert a["qualified_name"] == "pkg/mod.py::foo"
+
+
 def test_check_live_when_unchanged(tmp_path):
     _write(tmp_path, "m.py", _SRC)
     a = anchor.resolve(tmp_path, "m.py", "foo")

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -4542,6 +4542,33 @@ def test_crash_log_info_reports_last_line_and_header_age(tmp_path):
     assert info["path"] == str(p)
 
 
+def test_crash_log_info_redacts_secrets_in_the_exception_line(tmp_path):
+    # #513: the crash log holds raw child stderr, and status prints its
+    # exception line — the one disk-read-to-display path that never passed
+    # redact_text. An exception message can embed a live credential
+    # (requests errors echo URLs, config errors echo the offending value).
+    p = tmp_path / "serialize-crash.log"
+    p.write_text(
+        "--- crash 2026-07-09T00:00:00Z pid=123 cmd=serialize ---\n"
+        "Traceback (most recent call last):\n"
+        '  File "x.py", line 1, in <module>\n'
+        "ValueError: bad credential AKIA1234567890ABCDEF rejected\n"
+    )
+    info = cli._crash_log_info(p, now=0.0)
+    assert "AKIA1234567890ABCDEF" not in info["last_line"]
+    assert "[redacted:aws-key]" in info["last_line"]
+
+
+def test_tail_log_info_redacts_secrets_in_the_error_line(tmp_path):
+    # #513: same rule for recall-error.log's breadcrumb tail.
+    p = tmp_path / "recall-error.log"
+    p.write_text("2026-07-09T00:00:00Z rebuild failed: "
+                 "token xoxb-1234567890-abcdefghij leaked into the error\n")
+    info = cli._tail_log_info(p, now=0.0)
+    assert "xoxb-1234567890-abcdefghij" not in info["last_line"]
+    assert "[redacted:slack-token]" in info["last_line"]
+
+
 def test_crash_log_info_warnings_only_is_none(tmp_path):
     # #194: pre-fix, lastResort dumped serializer WARNINGs into this file and
     # status misreported them as a crash. No `--- crash ` header -> no crash.

--- a/website/docs/concepts/lifecycle.md
+++ b/website/docs/concepts/lifecycle.md
@@ -124,6 +124,28 @@ command, and the `chunk_cache_days` reaper (default 3 days) remains the
 independent upper bound for anything written after a forget. The claim is
 scoped to this machine: the cache never syncs anywhere.
 
+## The redaction boundary, stated exactly
+
+"A quoted secret never reaches disk" is easily heard as "secrets never leave
+the machine". Those are different claims, and only the first is made:
+
+- Redaction is a **disk boundary**. It runs where bytes are persisted or
+  displayed from disk — checkpoint writes, the team dual-write, event notes,
+  and the status lines read back from crash/error logs.
+- It is **not a network boundary**. The serialize call ships the **raw
+  session transcript** to whatever LLM backend you configured — a local
+  backend sees everything, and so does a hosted one. Pick the backend with
+  that in mind.
+- It catches **secret shapes, not sensitive meaning**. The pattern list is
+  deliberately narrow (see [team sharing](../team/team.md) for the exact
+  inventory): filesystem paths, usernames, hostnames, and emails are not
+  secret shapes, and a stored quote is arbitrary transcript bytes that syncs
+  verbatim to a team remote. `forget` is the tool for content the patterns
+  cannot know about.
+- The one bounded exception on disk is the pre-redaction **chunk cache**
+  described above: local-only, mode 0600, age-reaped, purged wholesale by
+  `forget`.
+
 ## Supersession candidates
 
 When a newer session contradicts a carried item, the briefing presents a

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/lifecycle.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/lifecycle.md
@@ -134,6 +134,31 @@ superior independiente para todo lo escrito después de un forget. La
 afirmación se limita a esta máquina: la caché nunca se sincroniza a ningún
 lado.
 
+## El límite de la redacción, dicho con exactitud
+
+"Un secreto citado nunca llega al disco" se escucha fácil como "los secretos
+nunca salen de la máquina". Son afirmaciones distintas, y solo la primera se
+hace:
+
+- La redacción es un **límite de disco**. Corre donde los bytes se persisten
+  o se muestran desde disco — escrituras de checkpoint, el dual-write de
+  equipo, notas de eventos, y las líneas de estado leídas de los logs de
+  crash/error.
+- **No es un límite de red.** La llamada de serialización envía la
+  **transcripción cruda de la sesión** al backend LLM que hayas configurado —
+  un backend local lo ve todo, y uno hospedado también. Elegí el backend con
+  eso en mente.
+- Atrapa **formas de secreto, no significado sensible**. La lista de patrones
+  es deliberadamente estrecha (mirá [compartir en equipo](../team/team.md)
+  para el inventario exacto): rutas de archivos, nombres de usuario, hosts y
+  correos no son formas de secreto, y una cita almacenada son bytes
+  arbitrarios de transcripción que se sincronizan literales a un remoto de
+  equipo. `forget` es la herramienta para contenido que los patrones no
+  pueden conocer.
+- La única excepción acotada en disco es la **caché de chunks**
+  pre-redacción descrita arriba: solo local, modo 0600, cosechada por edad,
+  purgada por completo por `forget`.
+
 ## Candidatos a supersesión
 
 Cuando una sesión nueva contradice un ítem arrastrado, el briefing presenta


### PR DESCRIPTION
Closes #513

## What

Three of the issue's five findings, following its own smallest-first split:

- **`status` log tails redact at construction.** `_tail_log_info` and `_crash_log_info` pass `last_line` through `redact_text` before returning, so the plain, rich, and `--json` renders all inherit it. These were the only disk-read-to-display paths that never redacted; an exception message can embed a live credential (requests errors echo URLs, config errors echo the offending value).
- **`anchor.resolve` contains its file argument.** Pathlib join semantics make `root / "/abs/path"` the absolute path itself, so an absolute or `../`-traversing `--file` escaped the project root and the leaked path landed in `anchored_to`, which syncs verbatim to the team remote. Resolution now refuses anything outside the resolved root; symlink escapes fall to the same `resolve()`.
- **The redaction boundary is stated exactly, where users read.** New section in `concepts/lifecycle` (EN + ES): redaction is a disk boundary, not a network boundary (the serialize call ships the raw transcript to the configured backend); it catches secret shapes, not sensitive meaning; the pre-redaction chunk cache is the one bounded on-disk exception. Cross-links the team-sharing page, which already carries the exact pattern inventory.

## Deferred, per the issue's own framing

- Identifier patterns (filesystem paths, usernames, hostnames, emails) are "a separate piece of work and should be measured before being claimed" — not smuggled in here.
- The chunk cache's pre-redaction window is already honestly documented and covered by the deletion-durability protocol (purged wholesale on `forget`, age-reaped at `chunk_cache_days`).

## Tests

Five new tests, four watched failing first (crash-line redaction, error-tail redaction, absolute-path refusal, `../` refusal); the fifth (nested relative paths keep resolving) passed from the start and stays as the boundary pin. Full suite: 2702 passed, 2 skipped.
