### PR TITLE
feat(serializer): stamp extraction_version on checkpoints and surface generations in stats

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -2511,7 +2511,7 @@ def _stats_store() -> dict:
     Reuses recall's section map so a new cognitive kind shows up here for free."""
     out = {"checkpoints": 0, "project_buckets": 0, "items_by_kind": {},
            "items_verbatim": 0, "items_inferred": 0, "items_untagged": 0,
-           "items_carried": 0}
+           "items_carried": 0, "format_versions": {}, "extraction_versions": {}}
     d = config.checkpoint_dir()
     try:
         out["project_buckets"] = sum(1 for p in d.iterdir() if p.is_dir())
@@ -2526,6 +2526,13 @@ def _stats_store() -> dict:
         if not isinstance(cp, dict):
             continue
         out["checkpoints"] += 1
+        # #514: corpus generation composition — absent stamps count as
+        # "unknown" (pre-stamp checkpoints cannot be retroactively dated),
+        # so a mixed-generation corpus is visible instead of assumed uniform.
+        for field, bucket in (("format_version", "format_versions"),
+                              ("extraction_version", "extraction_versions")):
+            key = str(cp.get(field)) if cp.get(field) is not None else "unknown"
+            out[bucket][key] = out[bucket].get(key, 0) + 1
         for section, key, kind in recall._KIND_SOURCES:
             block = cp.get(section)
             raw = block.get(key) if isinstance(block, dict) else None

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -1002,6 +1002,22 @@ def _rescue_suffix(posture, fallback_attempts: int) -> str | None:
     return _RESCUE_SUFFIXES.get(posture)
 
 
+def _generation_lines(s: dict) -> list[str]:
+    """#514: corpus generation composition, shared by the plain and rich
+    stats renderers. Shown only when MORE than one generation coexists —
+    a uniform corpus is the healthy default and needs no line; "unknown"
+    buckets (pre-stamp checkpoints) count as their own generation, because
+    unknown-vs-current is exactly the mix worth surfacing."""
+    lines = []
+    for label, key in (("format versions", "format_versions"),
+                       ("extraction versions", "extraction_versions")):
+        counts = s.get(key) or {}
+        if len(counts) > 1:
+            lines.append(f"{label}: " + ", ".join(
+                f"{v}: {n}" for v, n in sorted(counts.items())))
+    return lines
+
+
 def _plain_stats(data: dict) -> None:
     u, c, s = data["usage"], data["capture"], data["store"]
     print("usage (local, never transmitted):")
@@ -1049,6 +1065,8 @@ def _plain_stats(data: dict) -> None:
               f"avg {c['total_serialize_seconds'] // c['success']}")
     print("store:")
     print(f"  checkpoints: {s['checkpoints']}  project buckets: {s['project_buckets']}")
+    for line in _generation_lines(s):
+        print(f"  {line}")
     if s["items_by_kind"]:
         print("  items by kind: " + ", ".join(
             f"{k}: {n}" for k, n in sorted(s["items_by_kind"].items())))
@@ -1168,6 +1186,9 @@ def _rich_stats(data: dict) -> None:
     store_table.add_column("value")
     store_table.add_row("checkpoints", str(s["checkpoints"]))
     store_table.add_row("project buckets", str(s["project_buckets"]))
+    for line in _generation_lines(s):
+        label, _, rest = line.partition(": ")
+        store_table.add_row(label, rest)
     if s["items_by_kind"]:
         store_table.add_row("items by kind", ", ".join(
             f"{k}: {n}" for k, n in sorted(s["items_by_kind"].items())))

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -1759,6 +1759,9 @@ def _merge_partials(chat, session_id: str, partials: list, deadline,
 _CODE_OWNED_KEYS = (
     "format_version", "created", "author",
     "transcript_hash", "project_slug", "git_branch", "receipts",
+    # #514: the extractor dates its own run at serialize time; a model never
+    # gets to claim one (and the introspection path stays absent = unknown).
+    "extraction_version",
     # #268: origin binding is asserted by policy.bind_origin at the write
     # boundary. No code path reads a top-level copy, but a model naming the
     # key must not leave one lying beside the real per-item stamps.
@@ -2153,6 +2156,13 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
     # after validation/verification so it can never influence either, and
     # last so nothing downstream re-derives or clobbers it.
     _stamp_llm_provenance(checkpoint)
+    # #514: date the extraction. PROMPT_VERSION and EXTRACTION_VERSION are two
+    # independent levers; without this stamp a lone EXTRACTION_VERSION bump
+    # would leave extraction-incomparable checkpoints whose only visible
+    # version field (format_version) looks identical. Stamped HERE, not in
+    # store.write_checkpoint: only a path that actually ran the extractor may
+    # claim its version — introspection checkpoints stay absent = unknown.
+    checkpoint["extraction_version"] = EXTRACTION_VERSION
     # #48: success does NOT consume the chunk cache — persistence across
     # successful serializes is the feature (grown transcripts and resume
     # forks reuse their prefix chunks). Age-based reaping bounds the store.

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1625,6 +1625,46 @@ def test_cli_write_checkpoint_downgrades_unverifiable_verbatim(
     assert q["trust"] == "inferred"
 
 
+def test_cli_write_checkpoint_does_not_stamp_extraction_version(
+        tmp_checkpoint_dir, monkeypatch):
+    # #514: no extraction ran on the introspection path, so no extractor
+    # version may be claimed — absent means unknown, same posture as the
+    # missing hashes. A model-emitted value is code-owned and stripped.
+    from daimon_briefing import store
+
+    cp = json.loads(_valid_json("S-intro"))
+    cp["extraction_version"] = 999
+    _stdin(monkeypatch, json.dumps(cp))
+    rc = cli.main(["write-checkpoint", "--project", "/p/A"])
+    assert rc == 0
+    ck = store.read_latest(project_dir="/p/A")
+    assert "extraction_version" not in ck
+
+
+def test_stats_store_counts_version_generations(tmp_checkpoint_dir):
+    # #514: a mixed-generation corpus must be visible, not assumed uniform.
+    # One modern checkpoint (both stamps), one legacy file (neither) — the
+    # absent buckets render as "unknown" rather than vanishing.
+    import json as _json
+
+    from daimon_briefing import config, store
+
+    modern = _json.loads(_valid_json("S-new"))
+    modern["format_version"] = "D-017"
+    modern["extraction_version"] = 2
+    store.write_checkpoint("S-new", modern, project_dir="/p/A")
+    legacy_dir = config.checkpoint_dir()
+    (legacy_dir / "S-old.json").write_text(_json.dumps(
+        {"session_id": "S-old", "working_context": {}, "epistemic_snapshot": {}}))
+
+    s = cli._stats_store()
+
+    assert s["format_versions"]["D-017"] == 1
+    assert s["format_versions"]["unknown"] == 1
+    assert s["extraction_versions"]["2"] == 1
+    assert s["extraction_versions"]["unknown"] == 1
+
+
 def test_top_level_help_has_examples(capsys):
     with pytest.raises(SystemExit) as exc:
         cli.main(["--help"])

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -908,6 +908,11 @@ def _stats_sample():
             "items_by_kind": {"decision": 2, "belief": 1},
             "items_verbatim": 2, "items_inferred": 1, "items_untagged": 0,
             "items_carried": 1,
+            # #514: mixed on purpose — the generation lines render only when
+            # more than one generation coexists, and this fixture must drive
+            # them in BOTH the plain and rich paths.
+            "format_versions": {"D-017": 2, "unknown": 1},
+            "extraction_versions": {"2": 2, "unknown": 1},
         },
     }
 
@@ -937,6 +942,8 @@ def test_render_stats_plain_exact_format(capsys):
         "  serialize seconds: max 42, avg 25\n"
         "store:\n"
         "  checkpoints: 3  project buckets: 2\n"
+        "  format versions: D-017: 2, unknown: 1\n"
+        "  extraction versions: 2: 2, unknown: 1\n"
         "  items by kind: belief: 1, decision: 2\n"
         "  trust: verbatim 2, inferred 1, untagged 0  (carried: 1)\n"
     )
@@ -963,6 +970,10 @@ def test_render_stats_rich_smoke(monkeypatch, capsys):
     assert "usage" in out.lower()
     assert "brief" in out
     assert "verbatim" in out
+    # #514: the mixed-generation fixture must drive the generation rows in
+    # the rich table too, not only the plain path.
+    assert "format versions" in out
+    assert "extraction versions" in out
 
 
 def test_render_stats_plain_events_section(capsys):

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -1344,6 +1344,28 @@ def test_downgrade_unverifiable_verbatim_reclasses_every_verbatim_item():
     assert ckpt["epistemic_snapshot"]["strong_beliefs"][0]["trust"] == "inferred"
 
 
+def test_serialize_stamps_extraction_version(fake_chat_factory):
+    """#514: EXTRACTION_VERSION rotates the chunk cache but was written to
+    ZERO checkpoints, so a bump without a coincident PROMPT_VERSION bump
+    would leave two extraction-incomparable populations looking identical.
+    Stamped at serialize (not in store): only a real extraction may claim
+    an extractor version — the introspection path stays absent = unknown."""
+    chat = fake_chat_factory(_valid_checkpoint_json("S1"))
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+    assert ckpt["extraction_version"] == serializer.EXTRACTION_VERSION
+
+
+def test_strip_code_owned_keys_clears_model_claimed_extraction_version():
+    """#514: same #292 discipline as format_version — the model never gets
+    to date its own extraction."""
+    ckpt = json.loads(_valid_checkpoint_json("S1"))
+    ckpt["extraction_version"] = 999
+
+    serializer.strip_code_owned_keys(ckpt)
+
+    assert "extraction_version" not in ckpt
+
+
 def test_serialize_strip_survives_the_validation_retry_pass(fake_chat_factory):
     # A spoofed format_version alongside output that FAILS validation forces
     # the #118 resample retry — the strip must apply to the retried output


### PR DESCRIPTION
Closes #514

## What

- `serialize_strict` stamps `extraction_version` onto the checkpoint, next to the llm provenance stamp. Deliberately not in `store.write_checkpoint`: only a path that actually ran the extractor may claim its version, so introspection checkpoints stay absent = unknown — the same posture used elsewhere for missing hashes. No backfill, as the issue itself concluded: existing checkpoints cannot be retroactively dated.
- `extraction_version` joins `_CODE_OWNED_KEYS`, so a model-emitted value is stripped on both authoring paths. The model never dates its own extraction.
- `stats` counts checkpoints by `format_version` and `extraction_version` (absent = `unknown` bucket, its own generation on purpose — unknown-vs-current is exactly the mix worth seeing). The plain and rich renders share one helper and show the composition only when more than one generation coexists; `--json` always carries both maps.

## Why

`EXTRACTION_VERSION` is documented as an independent rotation lever but was used only in the chunk-cache key and written to zero checkpoints (0 of 38 live ones). A bump without a coincident `PROMPT_VERSION` bump would leave extraction-incomparable populations looking identical, and nothing would surface it. This is the missing plumbing, not a demonstrated bug.

## Tests

Four new tests watched failing first: serialize stamps the version; `strip_code_owned_keys` drops a model-claimed one; `write-checkpoint` stores none (absent = unknown); `_stats_store` buckets a mixed corpus including the `unknown` generation. Full suite: 2706 passed, 2 skipped.
