### PR TITLE
ci(release): create release PRs with a PAT so required checks actually run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,16 @@ jobs:
           # .claude-plugin/plugin.json and marketplace.json in version lock-step.
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # #517: PRs created with the default GITHUB_TOKEN never trigger
+          # other workflows (GitHub suppresses events from that token to
+          # prevent recursion), so the release PR sat at BLOCKED with "no
+          # checks reported" and every release needed an --admin merge. A
+          # fine-grained PAT (contents: write, pull-requests: write on this
+          # repo, stored as RELEASE_PLEASE_TOKEN) makes the release PR
+          # trigger the same six required checks as any human PR. Falls back
+          # to the default token when the secret is absent — behavior then
+          # degrades to the old --admin flow instead of breaking.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN != '' && secrets.RELEASE_PLEASE_TOKEN || github.token }}
 
   publish:
     needs: release-please


### PR DESCRIPTION
Closes #517

## What

`release-please-action` now receives a token input: the `RELEASE_PLEASE_TOKEN` secret when present, the default `github.token` otherwise (graceful degradation to today's `--admin` flow, never a broken release cycle).

## Why — root cause differs from the issue's proposal

The issue proposed a no-op required job on release-please branches. Investigating before building showed that cannot work: CI already triggers on every `pull_request` with no path or branch filter — the checks are missing because **the release PR is created with the default `GITHUB_TOKEN`, and GitHub suppresses workflow triggers on events created by that token** (anti-recursion). A no-op job lives in a workflow that would be suppressed identically.

With a PAT, the release PR triggers the same six required checks as any human PR:

- `PR convention` skips itself on `release-please--` branches by design (a skipped required job satisfies branch protection).
- `codecov/patch` passes a changelog/version-only diff (no coverable lines).
- lint, both pytest jobs, and scar lint run normally against the release branch.

## Action required after merge (repo admin)

Create a fine-grained PAT scoped to this repository with **contents: write** and **pull requests: write**, and store it as the `RELEASE_PLEASE_TOKEN` repository secret. Until the secret exists, behavior is unchanged.

## Tests

Workflow-only change; no test harness covers workflow YAML. Verified: expression syntax against the GitHub expressions grammar, the pr-validation skip condition at `.github/workflows/pr-validation.yml:17`, and the CI trigger block (`pull_request` unfiltered). The real verification is the next release PR reporting six checks.
