### PR TITLE
feat(cli): daimon handoff — an authored baton that leads the next briefing

### DIFF
--- a/.scars/0025-append-event-any-kind-resolves-the-item.landmine.md
+++ b/.scars/0025-append-event-any-kind-resolves-the-item.landmine.md
@@ -14,9 +14,10 @@ anchors:
   - path: plugin/daimon_briefing/briefing.py
   - path: plugin/tests/
   - pattern: "append_event[(][^)]{0,200}kind="
-violation: "append_event\([^)]{0,200}kind=(?!["'](tombstone|corroboration)["']|args\.kind)"
+violation: "append_event\([^)]{0,200}kind=(?!["'](tombstone|corroboration|handoff)["']|args\.kind)"
 evidence:
   - note: 2026-07-28 probe while designing #376: append_event(ref, 'quote-verification-failed', kind='verification') then resolutions() then is_resolved() returned True — the item would vanish from briefing, recall and carry
+  - note: "2026-08-02 whitelist amendment (#523): kind='handoff' added — the baton is REF-LESS by contract (item_ref always \"\"), and the resolutions fold ignores ref-less lines, so a handoff event cannot resolve anything; guarded by test_handoff_event_never_resolves_an_item in test_store.py"
 expires:
   condition: "resolutions() filters by kind (or the ledger moves to its own stream) AND is_resolved() no longer treats unknown statuses as resolved"
   review_after: 2027-07-28

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -550,7 +550,14 @@ def _render_briefing_body(checkpoint, route, *, drift_project, teammates,
     # for v1 (degrades safely); origin-project gating is future work (#60 follow-up).
     drift = (anchor.drifted(checkpoint, drift_project)
              if checkpoint and drift_project else [])
-    render.render_brief(checkpoint, drift=drift, teammates=teammates)
+    # #523: the baton leads the briefing. Fail-open like withhold — a broken
+    # events file must never take the briefing down.
+    try:
+        handoff = store.active_handoff(route)
+    except Exception:
+        handoff = None
+    render.render_brief(checkpoint, drift=drift, teammates=teammates,
+                        handoff=handoff)
     if withheld:
         render.render_brief_note([
             f"{len(withheld)} resolved item(s) withheld — "
@@ -1129,6 +1136,49 @@ def _cmd_loops(args) -> int:
         return 0
     for item_id, key, text, mark in rows:
         print(f"  {item_id}  [{key}] [{mark}] {text}")
+    return 0
+
+
+# #523: a baton is small on purpose — "do X first, beware Y", not a second
+# checkpoint. Over-cap input is REFUSED, never silently truncated: it is an
+# authored artifact and the author trims it.
+_HANDOFF_MAX_CHARS = 2000
+
+
+def _cmd_handoff(args) -> int:
+    """Leave (or retract) the project's baton (#523). Ref-less by contract —
+    scar 0025: an event kind carrying an item_ref silently resolves that
+    item, so a handoff must never name one. The resolutions fold ignores
+    ref-less lines (guarded by test_handoff_event_never_resolves_an_item)."""
+    _note_usage("handoff")
+    project = _resolve_project(args.project)
+    if args.clear:
+        if args.text:
+            print("error: --clear takes no text", file=sys.stderr)
+            return 1
+        if not store.append_event("", "cleared", note="", kind="handoff",
+                                  project_dir=project):
+            print("error: handoff not recorded (daimon disabled or project "
+                  "unknown)", file=sys.stderr)
+            return 1
+        print("handoff cleared")
+        return 0
+    text = (args.text or "").strip()
+    if not text:
+        print("error: nothing to hand off — pass the baton text or --clear",
+              file=sys.stderr)
+        return 1
+    if len(text) > _HANDOFF_MAX_CHARS:
+        print(f"error: baton exceeds {_HANDOFF_MAX_CHARS} chars "
+              f"({len(text)}) — a handoff is \"do X first, beware Y\", not a "
+              "second checkpoint; trim it", file=sys.stderr)
+        return 1
+    if not store.append_event("", "active", note=text, kind="handoff",
+                              project_dir=project):
+        print("error: handoff not recorded (daimon disabled or project "
+              "unknown)", file=sys.stderr)
+        return 1
+    print("handoff recorded — will lead the next briefing for this project.")
     return 0
 
 
@@ -3242,6 +3292,20 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_loops.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
     p_loops.set_defaults(func=_cmd_loops)
+
+    p_handoff = sub.add_parser(
+        "handoff",
+        help="leave an authored baton for the next session — renders above "
+             "everything in its next briefing (#523)",
+    )
+    p_handoff.add_argument("text", nargs="?", default=None,
+                           help="the baton: imperative, small — what to do "
+                                "first and what to beware")
+    p_handoff.add_argument("--clear", action="store_true",
+                           help="retract the active baton")
+    p_handoff.add_argument("--project", help="project directory (default: "
+                           "DAIMON_PROJECT_DIR, then cwd)")
+    p_handoff.set_defaults(func=_cmd_handoff)
 
     p_log = sub.add_parser(
         "log", help="append a freeform timeline event (zero-LLM) to this project's event log (#102)",

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -121,7 +121,21 @@ def _print_version_note(checkpoint) -> None:
               f"schema changed; some sections may render partially.")
 
 
-def render_brief(checkpoint, drift=None, teammates=None) -> None:
+def _print_handoff(handoff) -> None:
+    """The baton block (#523): authored, imperative, rendered ABOVE every
+    briefing section on both render paths — it must never lose position to
+    ambient sections. Multi-line batons keep one arrow per line."""
+    if not handoff:
+        return
+    print(f"HANDOFF (left deliberately by previous session, {handoff['ts']}):")
+    for line in str(handoff["note"]).splitlines():
+        if line.strip():
+            print(f"→ {line.strip()}")
+    print("")
+
+
+def render_brief(checkpoint, drift=None, teammates=None, handoff=None) -> None:
+    _print_handoff(handoff)
     b = briefing.build(checkpoint)
     if b is None:
         # Point at the real flow (#29): checkpoints come from the hooks; bare

--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -115,6 +115,11 @@ withheld early. Never use this for a loop you merely SUSPECT is stale —
 that is `reverify`/worldcheck territory, not a resolve claim. `forget`
 stays human-only.
 
+## Handing off
+
+A checkpoint holds what HAPPENED, not what you INTENDED. Before ending with
+unfinished work: `daimon handoff "Do X. Beware: Y."` — leads the next briefing.
+
 ## Context switching (other projects)
 
 Memory is per-project. To deliberately read another project's memory:

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -972,7 +972,9 @@ def active_handoff(project_dir=None) -> dict | None:
         d = config.checkpoint_dir() / slug
         try:
             entries = list(d.iterdir())
-        except OSError:
+        except OSError:  # pragma: no cover — TOCTOU only: the events file
+            # was just read from this dir, so it exists; the guard is for a
+            # bucket deleted mid-call, and the fail-open promise must hold.
             entries = []
         for p in entries:
             if not _POINTER_RE.match(p.name):

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -925,6 +925,71 @@ def _events_path(project_dir=None):
     return config.checkpoint_dir() / slug / "events.jsonl"
 
 
+def active_handoff(project_dir=None) -> dict | None:
+    """The project's active baton (#523), or None.
+
+    A handoff is an AUTHORED, ref-less `handoff` event — never a cognitive
+    item, so it cannot enter ranking, dedup, carry or budget trimming, and
+    (scar 0025) it must never name an `item_ref`: the resolutions fold
+    ignores ref-less lines, so a baton can never resolve an item. Latest
+    handoff-kind event wins; `status: cleared` (or an empty note) retracts.
+
+    Consumption: the baton stays active until TWO distinct non-introspection
+    sessions have serialized after its write — the first post-write
+    checkpoint is the writer's own session end, the second belongs to the
+    session that was briefed with it. A crashed session on either side never
+    serializes, so it never eats the baton; under same-project concurrency
+    the baton can over-survive one session, which is the safe direction for
+    a baton. Introspection checkpoints are excluded: a /daimon-end
+    provisional plus its superseding reconstruction would otherwise count
+    one session twice and kill the baton before any consumer saw it.
+    Fail-open: unreadable files read as "no baton", never an exception."""
+    path = _events_path(project_dir)
+    if path is None or not path.exists():
+        return None
+    latest = None
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            try:
+                evt = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if (not isinstance(evt, dict) or evt.get("kind") != "handoff"
+                    or evt.get("item_ref")):
+                continue
+            if latest is None or (str(evt.get("ts") or "")
+                                  >= str(latest.get("ts") or "")):
+                latest = evt
+    except OSError:
+        return None
+    if (latest is None or latest.get("status") == "cleared"
+            or not str(latest.get("note") or "").strip()):
+        return None
+    ts = str(latest.get("ts") or "")
+    slug = project_slug(project_dir)
+    consumers = set()
+    if slug:
+        d = config.checkpoint_dir() / slug
+        try:
+            entries = list(d.iterdir())
+        except OSError:
+            entries = []
+        for p in entries:
+            if not _POINTER_RE.match(p.name):
+                continue
+            try:
+                ck = json.loads(p.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(ck, dict) or ck.get("source") == "introspection":
+                continue
+            if str(ck.get("created") or "") > ts and ck.get("session_id"):
+                consumers.add(str(ck["session_id"]))
+    if len(consumers) >= 2:
+        return None
+    return {"ts": ts, "note": str(latest["note"])}
+
+
 def _ledger_path(project_dir=None):
     slug = project_slug(project_dir)
     if not slug:

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1665,6 +1665,55 @@ def test_stats_store_counts_version_generations(tmp_checkpoint_dir):
     assert s["extraction_versions"]["unknown"] == 1
 
 
+# ---- #523: daimon handoff — the baton verb ----
+
+
+def test_cli_handoff_records_event_and_confirms(tmp_checkpoint_dir, capsys):
+    from daimon_briefing import store
+
+    rc = cli.main(["handoff", "Build the MCP server next. Gotcha: cd plugin first.",
+                   "--project", "/p/A"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "handoff recorded" in out
+    h = store.active_handoff("/p/A")
+    assert h["note"] == "Build the MCP server next. Gotcha: cd plugin first."
+
+
+def test_cli_handoff_refuses_over_cap(tmp_checkpoint_dir, capsys):
+    from daimon_briefing import store
+
+    rc = cli.main(["handoff", "x" * 2001, "--project", "/p/A"])
+    assert rc != 0
+    assert "2000" in capsys.readouterr().err
+    assert store.active_handoff("/p/A") is None
+
+
+def test_cli_handoff_clear_retracts(tmp_checkpoint_dir, capsys):
+    from daimon_briefing import store
+
+    assert cli.main(["handoff", "do X", "--project", "/p/A"]) == 0
+    assert cli.main(["handoff", "--clear", "--project", "/p/A"]) == 0
+    assert store.active_handoff("/p/A") is None
+
+
+def test_cli_brief_renders_handoff_above_everything(
+        tmp_checkpoint_dir, sample_checkpoint, monkeypatch, capsys):
+    from daimon_briefing import store
+
+    monkeypatch.chdir("/")
+    store.write_checkpoint("S-prev", sample_checkpoint, project_dir="/p/A")
+    assert cli.main(["handoff", "Ship the baton first.", "--project", "/p/A"]) == 0
+    capsys.readouterr()
+    rc = cli.main(["brief", "--project", "/p/A"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "HANDOFF" in out
+    assert "Ship the baton first." in out
+    # above everything: the baton block precedes the briefing header
+    assert out.index("Ship the baton first.") < out.index("left off")
+
+
 def test_top_level_help_has_examples(capsys):
     with pytest.raises(SystemExit) as exc:
         cli.main(["--help"])

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1697,6 +1697,44 @@ def test_cli_handoff_clear_retracts(tmp_checkpoint_dir, capsys):
     assert store.active_handoff("/p/A") is None
 
 
+def test_cli_handoff_clear_refuses_text(tmp_checkpoint_dir, capsys):
+    rc = cli.main(["handoff", "some text", "--clear", "--project", "/p/A"])
+    assert rc != 0
+    assert "--clear takes no text" in capsys.readouterr().err
+
+
+def test_cli_handoff_empty_text_refused(tmp_checkpoint_dir, capsys):
+    rc = cli.main(["handoff", "   ", "--project", "/p/A"])
+    assert rc != 0
+    assert "nothing to hand off" in capsys.readouterr().err
+
+
+def test_cli_handoff_reports_disabled(tmp_checkpoint_dir, monkeypatch, capsys):
+    monkeypatch.setenv("DAIMON_DISABLE", "1")
+    rc = cli.main(["handoff", "do X", "--project", "/p/A"])
+    assert rc != 0
+    assert "not recorded" in capsys.readouterr().err
+    rc = cli.main(["handoff", "--clear", "--project", "/p/A"])
+    assert rc != 0
+    assert "not recorded" in capsys.readouterr().err
+
+
+def test_cli_brief_survives_broken_handoff_read(
+        tmp_checkpoint_dir, sample_checkpoint, monkeypatch, capsys):
+    # Fail-open: a broken events read must never take the briefing down.
+    from daimon_briefing import store
+
+    monkeypatch.chdir("/")
+    store.write_checkpoint("S-prev", sample_checkpoint, project_dir="/p/A")
+    monkeypatch.setattr(cli.store, "active_handoff",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("boom")))
+    rc = cli.main(["brief", "--project", "/p/A"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "HANDOFF" not in out
+    assert "left off" in out
+
+
 def test_cli_brief_renders_handoff_above_everything(
         tmp_checkpoint_dir, sample_checkpoint, monkeypatch, capsys):
     from daimon_briefing import store

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1389,6 +1389,49 @@ def test_active_handoff_same_session_counts_once(tmp_checkpoint_dir):
     assert store.active_handoff("/p/A") is not None
 
 
+def test_active_handoff_fail_open_on_unreadable_events(tmp_checkpoint_dir):
+    # events.jsonl replaced by a directory: the read raises OSError and the
+    # accessor answers "no baton", never an exception.
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    d = tmp_checkpoint_dir / slug
+    (d / "events.jsonl").mkdir(parents=True)
+    assert store.active_handoff("/p/A") is None
+
+
+def test_active_handoff_skips_malformed_and_reffed_lines(tmp_checkpoint_dir):
+    # Garbage lines are skipped; a handoff-kind line CARRYING a ref is
+    # ignored by contract (scar 0025) — only ref-less batons count.
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    d = tmp_checkpoint_dir / slug
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "events.jsonl").write_text(
+        "not json at all\n"
+        + json.dumps({"ts": "2026-08-02T12:00:00Z", "kind": "handoff",
+                      "item_ref": "o-abc123", "status": "active",
+                      "note": "reffed baton must not count"}) + "\n"
+        + _handoff_line("2026-08-02T10:00:00Z", note="real baton"))
+    h = store.active_handoff("/p/A")
+    assert h["note"] == "real baton"
+
+
+def test_active_handoff_unknown_project_is_none(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    assert store.active_handoff(None) is None
+
+
+def test_active_handoff_survives_unreadable_bucket_pointer(tmp_checkpoint_dir):
+    # A torn pointer file is skipped by the consumption count, not fatal.
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    d = tmp_checkpoint_dir / slug
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "events.jsonl").write_text(_handoff_line("2026-08-02T10:00:00Z"))
+    (d / "latest.json").write_text("{torn")
+    assert store.active_handoff("/p/A") is not None
+
+
 def test_handoff_event_never_resolves_an_item(tmp_checkpoint_dir):
     # Belt for scar 0025: the baton is REF-LESS by contract, so the
     # resolutions fold must not see it and no item may vanish because a

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1288,6 +1288,118 @@ def test_append_event_respects_kill_switch(tmp_checkpoint_dir, monkeypatch):
     assert not (tmp_checkpoint_dir / slug / "events.jsonl").exists()
 
 
+# ---- #523: the handoff baton — authored, ref-less, above ranking ----
+
+
+def _handoff_line(ts, status="active", note="do X first"):
+    return json.dumps({"ts": ts, "kind": "handoff", "item_ref": "",
+                       "status": status, "note": note, "source": "cli"}) + "\n"
+
+
+def _bucket_ckpt(tmp_checkpoint_dir, slug, name, created, session_id,
+                 source=None):
+    d = tmp_checkpoint_dir / slug
+    d.mkdir(parents=True, exist_ok=True)
+    ck = {"session_id": session_id, "created": created,
+          "working_context": {}, "epistemic_snapshot": {}}
+    if source:
+        ck["source"] = source
+    (d / name).write_text(json.dumps(ck))
+
+
+def test_active_handoff_none_without_events(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    assert store.active_handoff("/p/A") is None
+
+
+def test_active_handoff_returns_latest_baton(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    d = tmp_checkpoint_dir / slug
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "events.jsonl").write_text(
+        _handoff_line("2026-08-02T10:00:00Z", note="old baton")
+        + _handoff_line("2026-08-02T11:00:00Z", note="new baton"))
+    h = store.active_handoff("/p/A")
+    assert h["note"] == "new baton"
+    assert h["ts"] == "2026-08-02T11:00:00Z"
+
+
+def test_active_handoff_cleared_is_none(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    d = tmp_checkpoint_dir / slug
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "events.jsonl").write_text(
+        _handoff_line("2026-08-02T10:00:00Z")
+        + _handoff_line("2026-08-02T11:00:00Z", status="cleared", note=""))
+    assert store.active_handoff("/p/A") is None
+
+
+def test_active_handoff_survives_one_serialize_dies_after_two(tmp_checkpoint_dir):
+    # Consumption rule (#523): the FIRST post-write checkpoint is the writer's
+    # own session-end serialize; the SECOND belongs to the consuming session.
+    # A crashed session on either side never serializes, so it never eats the
+    # baton.
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    d = tmp_checkpoint_dir / slug
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "events.jsonl").write_text(_handoff_line("2026-08-02T10:00:00Z"))
+    # writer's own serialize
+    _bucket_ckpt(tmp_checkpoint_dir, slug, "latest.json",
+                 "2026-08-02T10:05:00Z", "S-writer")
+    assert store.active_handoff("/p/A") is not None
+    # consuming session's serialize rotates writer to prev-1
+    _bucket_ckpt(tmp_checkpoint_dir, slug, "prev-1.json",
+                 "2026-08-02T10:05:00Z", "S-writer")
+    _bucket_ckpt(tmp_checkpoint_dir, slug, "latest.json",
+                 "2026-08-02T12:00:00Z", "S-consumer")
+    assert store.active_handoff("/p/A") is None
+
+
+def test_active_handoff_ignores_introspection_checkpoints(tmp_checkpoint_dir):
+    # A /daimon-end provisional checkpoint is not a session end — counting it
+    # would let one session's intro+reconstruction pair eat the baton before
+    # any consumer ever saw it.
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    d = tmp_checkpoint_dir / slug
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "events.jsonl").write_text(_handoff_line("2026-08-02T10:00:00Z"))
+    _bucket_ckpt(tmp_checkpoint_dir, slug, "prev-1.json",
+                 "2026-08-02T10:03:00Z", "intro-x", source="introspection")
+    _bucket_ckpt(tmp_checkpoint_dir, slug, "latest.json",
+                 "2026-08-02T10:05:00Z", "S-writer")
+    assert store.active_handoff("/p/A") is not None
+
+
+def test_active_handoff_same_session_counts_once(tmp_checkpoint_dir):
+    # Rotation keeps multiple pointers from ONE session (re-serialize, heal):
+    # distinct session ids, not pointer files, are the consumption unit.
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    d = tmp_checkpoint_dir / slug
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "events.jsonl").write_text(_handoff_line("2026-08-02T10:00:00Z"))
+    _bucket_ckpt(tmp_checkpoint_dir, slug, "prev-1.json",
+                 "2026-08-02T10:05:00Z", "S-writer")
+    _bucket_ckpt(tmp_checkpoint_dir, slug, "latest.json",
+                 "2026-08-02T10:06:00Z", "S-writer")
+    assert store.active_handoff("/p/A") is not None
+
+
+def test_handoff_event_never_resolves_an_item(tmp_checkpoint_dir):
+    # Belt for scar 0025: the baton is REF-LESS by contract, so the
+    # resolutions fold must not see it and no item may vanish because a
+    # handoff was recorded.
+    from daimon_briefing import store
+    assert store.append_event("", "active", note="baton", kind="handoff",
+                              project_dir="/p/A") is True
+    res = store.resolutions(project_dir="/p/A")
+    assert res == {}
+
+
 def test_resolutions_latest_wins_by_timestamp_not_line_order(tmp_checkpoint_dir):
     from daimon_briefing import store
     slug = store.project_slug("/p/A")

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -394,6 +394,12 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
     def r_log():
         run(["log", "--text", "cut the release"], 0)
 
+    def r_handoff():
+        # #523: the baton writes a ref-less handoff event; append_event's
+        # policy.admit_row is the frame. Clear writes a second event.
+        run(["handoff", "ship the baton first"], 0)
+        run(["handoff", "--clear"], 0)
+
     def r_loops():
         # #480 slice 1: pure read — lists open, briefable loop items with ids.
         # No write path of its own, but drive it anyway so a future regression
@@ -482,6 +488,7 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
         ("reverify",): r_reverify,
         ("forget",): r_forget,
         ("log",): r_log,
+        ("handoff",): r_handoff,
         ("loops",): r_loops,
         ("recall-inject",): r_recall_inject,
         ("status",): r_status,


### PR DESCRIPTION
Closes #523

## What

`daimon handoff "<imperative text>"` records an authored baton as a ref-less `handoff` event; the next briefing renders it above every section on both render paths. `--clear` retracts; a new baton supersedes the old (event trail retains history). 2000-char cap, refused rather than silently truncated — a baton is "do X first, beware Y", not a second checkpoint.

| piece | behavior |
|---|---|
| `store.active_handoff` | latest ref-less handoff event wins; `cleared`/empty retracts; fail-open on unreadable files |
| consumption | baton stays active until **two distinct non-introspection sessions** serialize after its write — the writer's own session end, then the consuming session's. A crashed session on either side never eats it; introspection checkpoints are excluded so a provisional + its reconstruction cannot count one session twice. Under same-project concurrency it can over-survive one session — the safe direction |
| render | leads the briefing, both plain and rich paths, one arrow per line |
| redaction / audit | rides `append_event`'s existing redact + admit frame; drive recipe added to the write-audit guard |
| skill | teaches the verb, inside the 150-line budget |

## Why

Checkpoints are reconstructive — extracted, ranked, budget-trimmed, competing for slots. Deliberate handoff has different semantics: intentional, small, imperative, must never lose rank to ambient noise. The demand signal is a workaround that has outlived three releases: agents hand-write next-session notes into host memory files because nothing in daimon held this shape.

## Scar 0025, honored rather than routed around

The landmine (any event kind carrying an `item_ref` silently resolves that item) is real and stays armed. The baton is **ref-less by contract** — the resolutions fold ignores ref-less lines, so a handoff can never resolve anything, guarded by `test_handoff_event_never_resolves_an_item`. The scar's violation whitelist gains `kind="handoff"` with the justification recorded in its evidence block, in this reviewed diff — not a regex dodge via variable indirection.

## Tests

Ten new tests watched failing first (store fold: none/latest/cleared/consumption/introspection-exclusion/same-session-once; CLI: record/cap-refusal/clear/renders-first) plus the scar belt (passed from the start, stays as the guard). Full suite: 2718 passed, 2 skipped. Live-verified: a real baton recorded on this repo renders at the top of `daimon brief`.
