### PR TITLE
feat(worldcheck): render confirmed items as ground, not only contradicted ones as quicksand

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -158,6 +158,13 @@ def _line(item, degraded: bool = False, briefable: bool = False) -> str:
         # inferred; state both facts — claimed verbatim, unverifiable here.
         base += f" {FOREIGN_VERBATIM_NOTE}"
     base += corroboration_badge(item)
+    if item.get("_worldcheck_confirmed") and not item.get("_worldcheck"):
+        # #525: trusted ground — worldcheck agreed with this claim during
+        # THIS brief. A separate axis from the trust class (how it was
+        # captured) and from corroboration (how many sessions witnessed it):
+        # this says the world itself just agreed. A contradiction on any
+        # other axis suppresses it — quicksand outranks ground.
+        base += " [✓ world-checked]"
     if quote:
         base += f'  — "{quote}"'
     base += _handle_suffix(item, briefable)

--- a/plugin/daimon_briefing/worldcheck.py
+++ b/plugin/daimon_briefing/worldcheck.py
@@ -802,6 +802,11 @@ def check(checkpoint, project_dir) -> dict:
             outcome = "skipped"
         elif _satisfied(cls, claim, value):
             outcome = "confirmed"
+            # #525: the quiet inverse of the contradiction stamp — transient,
+            # in-memory, same lifecycle as `_worldcheck`. The render marks
+            # solid ground with it; a contradiction on ANY axis outranks it
+            # at render time, so stamping here stays unconditional.
+            item.setdefault("_worldcheck_confirmed", True)
         else:
             outcome = "contradicted"
             note, status = _flag(cls, claim, value)

--- a/plugin/tests/test_briefing.py
+++ b/plugin/tests/test_briefing.py
@@ -473,6 +473,30 @@ def test_line_marks_carried_items():
     assert "[carried]" not in briefing._line(native)
 
 
+def test_line_renders_world_checked_badge():
+    # #525: trusted ground — the world agreed with this item moments ago.
+    item = {"text": "PR #60 awaiting review", "trust": "inferred",
+            "carried_from": "S-old", "_worldcheck_confirmed": True}
+    assert "[✓ world-checked]" in briefing._line(item)
+
+
+def test_line_no_badge_without_confirmation():
+    item = {"text": "PR #60 awaiting review", "trust": "inferred",
+            "carried_from": "S-old"}
+    assert "world-checked" not in briefing._line(item)
+
+
+def test_line_contradiction_suppresses_the_ground_badge():
+    # An item confirmed on one axis and contradicted on another is NOT
+    # ground — the contradiction is the louder, truer surface.
+    item = {"text": "PR #60 awaiting review", "trust": "inferred",
+            "carried_from": "S-old", "_worldcheck_confirmed": True,
+            "_worldcheck": {"note": "#60 merged", "status": "merged"}}
+    line = briefing._line(item)
+    assert "world-checked" not in line
+    assert "#60 merged" in line
+
+
 def test_line_carried_marker_precedes_quote():
     item = {"text": "old decision", "trust": "verbatim",
             "quote": "the exact words", "carried_from": "S-0"}

--- a/plugin/tests/test_worldcheck.py
+++ b/plugin/tests/test_worldcheck.py
@@ -166,7 +166,9 @@ def test_claim_explicit_kind_wins_over_state_heuristic():
 # ---- check(): probes, budget, stamping --------------------------------------
 
 
-def test_check_confirmed_leaves_item_untouched(monkeypatch, fake_gh, proj):
+def test_check_confirmed_stamps_ground_not_contradiction(monkeypatch, fake_gh, proj):
+    # #525: a confirmation earns a quiet transient stamp so the render can
+    # mark solid ground; the contradiction surface stays absent.
     gh, log = fake_gh("echo '{\"state\":\"OPEN\"}'")
     _enable_probes(monkeypatch, gh)
     cp = _cp(["PR #60 awaiting review"])
@@ -175,7 +177,17 @@ def test_check_confirmed_leaves_item_untouched(monkeypatch, fake_gh, proj):
                      "pr-state:confirmed": 1}
     item = cp["working_context"]["open_questions"][0]
     assert "_worldcheck" not in item
+    assert item["_worldcheck_confirmed"] is True
     assert len(_calls(log)) == 1
+
+
+def test_check_contradicted_never_stamps_ground(monkeypatch, fake_gh, proj):
+    gh, _log = fake_gh("echo '{\"state\":\"MERGED\",\"mergedAt\":\"2026-07-20T00:00:00Z\"}'")
+    _enable_probes(monkeypatch, gh)
+    cp = _cp(["PR #60 awaiting review"])
+    worldcheck.check(cp, proj)
+    item = cp["working_context"]["open_questions"][0]
+    assert "_worldcheck_confirmed" not in item
 
 
 def test_check_contradicted_stamps_item(monkeypatch, fake_gh, proj):


### PR DESCRIPTION
Closes #525

## What

- `worldcheck.check` stamps confirmed items with a transient `_worldcheck_confirmed` — exact parallel of the existing `_worldcheck` contradiction stamp: in-place, in-memory, never persisted.
- `briefing._line` appends `[✓ world-checked]` for items carrying it. A separate axis from the trust class (how the claim was captured) and the corroboration badge (how many sessions witnessed it): this one says the world itself agreed, during this brief.
- A contradiction on any axis suppresses the badge — quicksand outranks ground. An item confirmed on its text claim but failing receipt validity still renders as contradicted, nothing else.

## Why

The briefing flags quicksand and never marks solid ground. Worldcheck already verifies carried claims at brief time, but only contradictions surface — a confirmed item rendered identically to an unchecked one, so readers re-verify claims the code verified seconds earlier. 121 lifetime confirmations on one machine, zero ever visible. This surfaces work already done; no new claim, no new probe.

## Tests

Two watched failing first (confirmed stamps ground; badge renders), three boundary pins passing from the start (contradicted never stamps ground; no badge without confirmation; contradiction suppresses the badge). The old `confirmed_leaves_item_untouched` test is renamed to the new contract with its stats assertion intact. Full suite: 2730 passed, 2 skipped.
