### PR TITLE
feat(serializer): decisions carry their because — stated reasoning rides the item

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -158,6 +158,11 @@ def _line(item, degraded: bool = False, briefable: bool = False) -> str:
         # inferred; state both facts — claimed verbatim, unverifiable here.
         base += f" {FOREIGN_VERBATIM_NOTE}"
     base += corroboration_badge(item)
+    because = str(item.get("because") or "").strip()
+    if because:
+        # F4 (#527): the decision travels with its stated reasoning — a
+        # decision whose why got compacted away invites re-litigation.
+        base += f" — because {because}"
     if item.get("_worldcheck_confirmed") and not item.get("_worldcheck"):
         # #525: trusted ground — worldcheck agreed with this claim during
         # THIS brief. A separate axis from the trust class (how it was

--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -407,6 +407,14 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                 # killed the #128 overdue boost) — keep the older birth stamp.
                 if item.get("trust") == "verbatim":
                     twin["text"] = item["text"]
+                    # F4 (#527): `because` explains ITS text. The freeze
+                    # restores prev's wording, so prev's reasoning rides
+                    # along and the twin's own — written for a sentence that
+                    # no longer renders — must not survive attached to it.
+                    if item.get("because"):
+                        twin["because"] = item["because"]
+                    else:
+                        twin.pop("because", None)
                     if item.get("quote"):
                         twin["quote"] = item["quote"]
                         # source_message_ids travel WITH the quote (#358),

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -51,7 +51,7 @@ log = logging.getLogger(__name__)
 # Checkpoints are only comparable across runs sharing this version (scar
 # landmine #4); pre-bump checkpoints firing the #93 format_version mismatch
 # warning is desired, not a bug.
-PROMPT_VERSION = "D-017"
+PROMPT_VERSION = "D-018"
 
 # #367: the chunk-cache rotation lever, deliberately SEPARATE from
 # PROMPT_VERSION. Bump ONLY when extraction semantics change — the output
@@ -64,7 +64,11 @@ PROMPT_VERSION = "D-017"
 # chunk pass extracts, so the cache must rotate. Serving a pre-#416 cached
 # extraction that dropped the date would poison the later citable-date
 # re-measurement the whole change exists to make honest.
-EXTRACTION_VERSION = 2
+# 2 -> 3 (#527): rule 22 adds the `because` field to decisions — a new
+# extraction target, so a cached pre-#527 chunk would silently produce
+# because-less decisions forever. First bump since the #514 checkpoint
+# stamp shipped, so the corpus generation split is finally visible.
+EXTRACTION_VERSION = 3
 
 
 class SerializeError(Exception):
@@ -214,13 +218,20 @@ RULES — follow every one exactly; this is the point of the exercise:
     transcript does not state. Add nothing when no temporal detail is present; this rule only
     stops you from discarding one that is.
 
+22. THE BECAUSE CLAUSE (D-018): when the transcript STATES the reasoning behind a decision
+    ("chose X because Y", "X — the alternative would have Z"), put ONE short clause of that
+    stated reasoning in the decision's `because` field. Reasoning only, not a restatement of
+    the decision. If the transcript states no reasoning, OMIT the field entirely — a decision
+    without a stated why must arrive without one, never with an invented one. Same honesty
+    bar as rule 1.
+
 Schema shape:
 {
   "session_id": "<id>",
   "working_context": {
     "active_topic": {"text": "", "trust": "", "quote": "", "importance": 0},
     "open_questions": [{"text": "", "trust": "", "quote": "", "external_state": false, "importance": 0}],
-    "recent_decisions": [{"text": "", "trust": "", "quote": "", "importance": 0, "links": [{"type": "", "target": ""}]}]
+    "recent_decisions": [{"text": "", "trust": "", "quote": "", "because": "", "importance": 0, "links": [{"type": "", "target": ""}]}]
   },
   "epistemic_snapshot": {
     "strong_beliefs": [{"text": "", "trust": "", "quote": "", "importance": 0}],
@@ -341,13 +352,17 @@ MERGE RULES — follow every one exactly:
     is the more specific quote. Never invent, alter, or normalize a date while merging; this
     rule only prevents dropping a temporal detail a chunk already captured.
 
+- BECAUSE clauses (D-018): when partial checkpoints hold the same decision and one carries a
+  `because`, keep it. Never merge two reasons into a new sentence and never invent one for a
+  decision that arrived without.
+
 Schema shape:
 {
   "session_id": "<id>",
   "working_context": {
     "active_topic": {"text": "", "trust": "", "quote": "", "importance": 0},
     "open_questions": [{"text": "", "trust": "", "quote": "", "external_state": false, "importance": 0}],
-    "recent_decisions": [{"text": "", "trust": "", "quote": "", "importance": 0, "links": [{"type": "", "target": ""}]}]
+    "recent_decisions": [{"text": "", "trust": "", "quote": "", "because": "", "importance": 0, "links": [{"type": "", "target": ""}]}]
   },
   "epistemic_snapshot": {
     "strong_beliefs": [{"text": "", "trust": "", "quote": "", "importance": 0}],
@@ -552,6 +567,11 @@ def _valid_item(item) -> bool:
         # D-006: a verbatim claim without a real quote is an unpinned claim.
         if not isinstance(quote, str) or not quote.strip():
             return False
+    because = item.get("because")
+    if because is not None and not isinstance(because, str):
+        # F4 (#527), same #134 lesson as text: present-but-non-str would
+        # reach disk and crash a later render — reject at the boundary.
+        return False
     anchor = item.get("anchored_to")
     if anchor is not None:
         if not isinstance(anchor, dict):

--- a/plugin/tests/test_briefing.py
+++ b/plugin/tests/test_briefing.py
@@ -473,6 +473,20 @@ def test_line_marks_carried_items():
     assert "[carried]" not in briefing._line(native)
 
 
+def test_line_renders_because_clause():
+    # F4: the decision travels WITH its reasoning — a decision whose why got
+    # compacted away invites re-litigation.
+    item = {"text": "soft-clip over hard clamp", "trust": "inferred",
+            "because": "the clamp erased ordering in tied groups"}
+    line = briefing._line(item)
+    assert "— because the clamp erased ordering in tied groups" in line
+
+
+def test_line_no_because_renders_clean():
+    item = {"text": "soft-clip over hard clamp", "trust": "inferred"}
+    assert "because" not in briefing._line(item)
+
+
 def test_line_renders_world_checked_badge():
     # #525: trusted ground — the world agreed with this item moments ago.
     item = {"text": "PR #60 awaiting review", "trust": "inferred",

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -309,6 +309,32 @@ def test_verbatim_freeze_pops_twin_ids_when_prev_has_none():
     assert "source_message_ids" not in qs[0]
 
 
+def test_verbatim_freeze_because_travels_with_frozen_text():
+    # F4: `because` explains ITS text. When the freeze restores prev's
+    # original wording, the twin's own reasoning would explain a sentence
+    # that no longer renders — prev's because replaces it, absent pops.
+    prev = _cp("S-prev", 1, questions=[_item(
+        _VERB_ORIG, trust="verbatim", quote=_VERB_QUOTE, days=45,
+        because="the clamp erased ordering")])
+    new = _cp("S-new", 0, questions=[_item(
+        _VERB_TWIN, days=0, because="a reworded reason for reworded text")])
+    out = carry.merge(new, prev, NOW)
+    qs = out["working_context"]["open_questions"]
+    assert len(qs) == 1
+    assert qs[0]["because"] == "the clamp erased ordering"
+
+
+def test_verbatim_freeze_pops_twin_because_when_prev_has_none():
+    prev = _cp("S-prev", 1, questions=[_item(
+        _VERB_ORIG, trust="verbatim", quote=_VERB_QUOTE, days=45)])
+    new = _cp("S-new", 0, questions=[_item(
+        _VERB_TWIN, days=0, because="reasoning for text the freeze replaces")])
+    out = carry.merge(new, prev, NOW)
+    qs = out["working_context"]["open_questions"]
+    assert len(qs) == 1
+    assert "because" not in qs[0]
+
+
 def test_verbatim_freeze_inherits_older_first_seen():
     # first_seen birth-stamp inheritance still works on the freeze path: the
     # native twin has a NEWER stamp; the older prev original stamp must win,

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -756,7 +756,7 @@ def test_validation_retry_note_restates_copy_paste_contract(
     assert "elisions marked with `...`" in second
 
 
-def test_prompt_version_is_d017():
+def test_prompt_version_history_and_current_pin():
     # D-008 -> D-010 (#101: emotional_valence dropped from the schema).
     # D-009 is taken by the host-adapter decision. D-010 -> D-011 (#126:
     # per-item importance added to the emitted schema). D-011 -> D-012 (#5:
@@ -767,9 +767,14 @@ def test_prompt_version_is_d017():
     # claims ground in tool-result signals). D-016 -> D-017 (#416: prefer a
     # quote span that preserves a temporal span the transcript states —
     # data-gathering for the deferred bi-temporal design, no new schema).
+    # D-017 -> D-018 (#527: decisions carry a `because` clause of stated
+    # reasoning — new schema field AND new extraction target, so
+    # EXTRACTION_VERSION bumped alongside for the first time since the
+    # #514 stamp made a lone bump visible).
     # Pre-bump checkpoints firing the format_version mismatch warning (#93)
     # is DESIRED behavior.
-    assert serializer.PROMPT_VERSION == "D-017"
+    assert serializer.PROMPT_VERSION == "D-018"
+    assert serializer.EXTRACTION_VERSION == 3
 
 
 def test_serialize_prompt_prefers_temporal_span_preserving_quote():
@@ -1305,6 +1310,30 @@ def test_strip_code_owned_keys_clears_item_origin_on_the_introspection_path():
     assert "origin_session" not in item
     assert "origin_author" not in item
     assert item["text"] == "q"  # nothing else disturbed
+
+
+def test_validate_accepts_decision_with_because():
+    """#525 follow-on (F4): decisions may carry a `because` clause — the
+    stated reasoning, extracted only when the transcript states it."""
+    ckpt = json.loads(_valid_checkpoint_json("S1"))
+    ckpt["working_context"]["recent_decisions"][0]["because"] = (
+        "the hard clamp erased ordering in tied groups")
+    assert serializer.validate(ckpt)
+
+
+def test_validate_rejects_non_str_because():
+    # #134 lesson: presence != usable value — a null/list `because` must be
+    # rejected at the boundary, not crash a later render.
+    ckpt = json.loads(_valid_checkpoint_json("S1"))
+    ckpt["working_context"]["recent_decisions"][0]["because"] = ["not", "str"]
+    assert not serializer.validate(ckpt)
+
+
+def test_serialize_prompt_extracts_because():
+    # The prompt must name the field and the schema template must carry it,
+    # or the extractor can never emit one.
+    assert '"because"' in serializer.SERIALIZE_SYS
+    assert "because" in serializer.SERIALIZE_SYS.lower()
 
 
 def test_strip_code_owned_keys_clears_model_claimed_verification_stamps():


### PR DESCRIPTION
Closes #527

## What

- Optional `because` field on items: extraction rule 22 takes ONE short clause of **stated** reasoning — absent when the transcript states none, never invented (rule 1's honesty bar applies). The merge prompt keeps an arriving `because` and never synthesizes one from two.
- `validate()` rejects a present-but-non-str value — the null-text lesson at the boundary.
- Render: `decided X — because Y`, placed before the quote suffix.
- Carry: the verbatim freeze moves `because` **with** the frozen text. A reworded twin's reasoning must not survive attached to a sentence that no longer renders; prev's rides along, absent pops, and inferred twins (new wording wins) keep their own.
- `PROMPT_VERSION` D-017 → D-018 **and** `EXTRACTION_VERSION` 2 → 3, together: this is both a schema change and a new extraction target, so the chunk cache must rotate — a cached pre-bump chunk would silently produce because-less decisions forever. The version pin test carries the history note.

## Why

A decision serialized without its why invites the next session to re-litigate it — re-derive the rationale, or reverse a settled call. The observed workaround: sessions maintaining hand-written "why we chose X / do not rebuild" notes outside the tool, because checkpoints carried only the what.

## Deterministic vs live verification

Everything deterministic is TDD'd (7 new tests watched failing first: validation both directions, prompt/template presence, render both directions, freeze rides + pops). The extraction quality itself is LLM-driven and cannot be unit-proven — the honest smoke test is the next real serialize, whose checkpoint will also be the first to stamp `extraction_version: 3` and light up the generations line in `stats`.

Full suite: 2737 passed, 2 skipped.
