### PR TITLE
docs(site): CLI reference page and the undocumented briefing annotations

### DIFF
--- a/website/docs/concepts/lifecycle.md
+++ b/website/docs/concepts/lifecycle.md
@@ -124,6 +124,44 @@ command, and the `chunk_cache_days` reaper (default 3 days) remains the
 independent upper bound for anything written after a forget. The claim is
 scoped to this machine: the cache never syncs anywhere.
 
+## `daimon handoff` — the baton
+
+Checkpoints are reconstructive: extracted from the transcript, ranked,
+budget-trimmed, competing for slots. The moment of deliberate handoff —
+"next session: do THIS first, watch out for THAT" — has different semantics:
+intentional, small, imperative, and it must never lose rank to ambient noise.
+
+```sh
+daimon handoff "Ship the release first. Beware: the cache key rotated."
+daimon handoff --clear
+```
+
+The baton leads the next briefing, above every section:
+
+```text
+HANDOFF (left deliberately by previous session, 2026-08-03T03:43:58Z):
+→ Ship the release first. Beware: the cache key rotated.
+```
+
+It is stored as an event, never as a cognitive item — so it cannot enter
+ranking, dedup, or carry scoring, and it cannot resolve anything. One baton
+per project; a new one supersedes the old (the event trail keeps history).
+It stays active until the session that read it ends and serializes — a
+crashed session never consumes it. Capped small on purpose: a baton is
+"do X, beware Y", not a second checkpoint.
+
+## Decisions carry their because
+
+A decision without its reasoning invites the next session to re-litigate it.
+When the transcript *states* the why, capture keeps one short clause of it:
+
+```text
+- [✓ verbatim] soft-clip over hard clamp — because the clamp erased ordering in tied groups
+```
+
+The honesty bar matches everything else: stated reasoning only, never
+invented — a decision whose why was never said arrives without one.
+
 ## The redaction boundary, stated exactly
 
 "A quoted secret never reaches disk" is easily heard as "secrets never leave

--- a/website/docs/concepts/trust-classes.md
+++ b/website/docs/concepts/trust-classes.md
@@ -151,3 +151,22 @@ The intended reading protocol, for humans and agents alike:
 
 A briefing is context, not instructions — it never overrides what the user is
 asking for now.
+
+## Ground, not only quicksand
+
+The inverse marker exists too. At brief time daimon spot-checks carried
+claim-bearing items against reality — PR states, branch and file existence,
+receipt validity. A contradiction replaces the item's render with what
+actually changed. A *confirmation* used to render nothing at all, which made
+a just-verified claim indistinguishable from an unchecked one; now it earns a
+quiet suffix:
+
+```text
+- [~ inferred] PR #60 awaiting review [carried] [✓ world-checked]
+```
+
+`[✓ world-checked]` means the world itself agreed with this claim during this
+brief — a separate axis from the trust class (how the claim was captured) and
+from corroboration (how many sessions witnessed it). You can lean on these
+without re-verifying. One asymmetry is deliberate: a contradiction on any
+axis suppresses the badge — quicksand always outranks ground.

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -126,8 +126,21 @@ If the last serialize failed or a session was never captured, a failed capture
 self-heals on the next session start — or run `daimon heal` to retry
 immediately.
 
+## Before you end a session
+
+If you are leaving work unfinished, pass the baton — one imperative line the
+next session sees above everything else in its briefing:
+
+```sh
+daimon handoff "Finish the migration first. Beware: the staging DB is stale."
+```
+
+A checkpoint reconstructs what happened; the baton carries what you intended
+next. Full story in [the item lifecycle](../concepts/lifecycle.md).
+
 ## Where to next
 
+- [CLI reference](../reference/cli.md) — every verb, one page.
 - [Configuration](./configuration.md) — every environment variable, including
   the `DAIMON_DISABLE` kill switch.
 - [Hosts](../hosts/index.md) — per-host setup detail and known limitations.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 1
+---
+
+# CLI reference
+
+Every daimon verb, grouped by what you are trying to do. Each command's
+`--help` carries the full flag surface; this page is the map.
+
+## The daily loop
+
+| command | what it does |
+| --- | --- |
+| `daimon brief` | Render the briefing from the latest checkpoint — where you left off, trust-tagged. `--team` adds teammates' latest; `--slug <s>` reads another project's bucket explicitly. |
+| `daimon recall "query"` | Full-text search across local + team checkpoint history. `--json` for rows, `--all-projects` to widen. |
+| `daimon handoff "Do X first. Beware: Y."` | Leave an authored baton for the next session — it renders above every briefing section and never competes with ranked items. `--clear` retracts; a new baton supersedes the old. |
+| `daimon loops` | List open, addressable loop items with their ids — the read counterpart to `resolve`'s write path. |
+| `daimon status` | Checkpoint presence and age, last serialize outcome, health warnings. `--suppressed` lists withheld resolved items. |
+
+## Closing and correcting
+
+| command | what it does |
+| --- | --- |
+| `daimon resolve <id or text>` | Mark an item resolved — append-only event; the item stops carrying. `--dry-run` previews the match; `--by agent --evidence "<quote>"` claims a close that is byte-checked at session end. |
+| `daimon reverify <id>` | Assert a carried item is still true — evidence-gated, resets its staleness clock. Also the reject half of a supersession candidate. |
+| `daimon forget <id or text>` | Remove one item's content from disk and index, leaving a hash-only tombstone. The deletion survives re-serialization of the original transcript. |
+| `daimon log --text "…"` | Append a freeform timeline event to the project's event log — zero-LLM, audit-trail only. |
+
+## Trust and audit
+
+| command | what it does |
+| --- | --- |
+| `daimon verify-receipt` | Verify a checkpoint's signed provenance receipt (full cryptographic check via the vitni CLI). |
+| `daimon audit-quotes` | Re-check every stored verbatim quote against its source transcript and report mismatches. Read-only — it never rewrites trust tags. |
+| `daimon anchor <file> <symbol>` | Bind a cognitive item to a code symbol; briefings then warn when the anchored code drifts. |
+
+## Setup and operations
+
+| command | what it does |
+| --- | --- |
+| `daimon configure` | Detect the resolved LLM backend and fill gaps in `~/.daimon/env`. `--test` runs a live round-trip. |
+| `daimon hooks install <host>` | Ship the host hook scripts (Windsurf, Codex) from the package. `list` / `status` inspect. |
+| `daimon skill install <host>` | Install the daimon agent skill into a host's skill directory. Re-run after upgrades. |
+| `daimon team init\|sync\|status` | Shared team memory via a sidecar repo — default-closed routing, shape-redacted before anything syncs. |
+| `daimon stats` | Local usage and capture aggregates — nothing is transmitted; sharing the output is a deliberate paste. `--json` for machines. |
+| `daimon heal` | Re-serialize the most recent failed session when it is safe to do so. |
+| `daimon projects` | List every project daimon holds a checkpoint for, with topic teasers. |
+
+## Internals (invoked by hooks, documented for completeness)
+
+| command | what it does |
+| --- | --- |
+| `daimon serialize <transcript>` | Turn a transcript file into a checkpoint — the SessionEnd hooks call this; running it by hand backfills one. |
+| `daimon write-checkpoint` | Store a checkpoint supplied as JSON on stdin — the in-session introspection path. Trust is code-clamped: nothing on this path can claim `verbatim`, because there is no transcript to verify against. |
+| `daimon recall-inject` | The per-prompt suggestion backend behind the recall hook: prompt on stdin, zero to two prior-work lines out, exit 0 always. |
+| `daimon mcp serve` | Serve the daimon tools over MCP (stdio). |
+
+## Briefing annotations, decoded
+
+The briefing marks every line; the full trust story lives in
+[trust classes](../concepts/trust-classes.md). Quick key:
+
+- `[✓ verbatim]` / `[~ inferred]` / `[? untagged]` — how the item was captured.
+- `[carried]` — inherited from an earlier session, not fresh context.
+- `[≈ corroborated ×N]` — N independent sessions witnessed the claim.
+- `[✓ world-checked]` — a live probe agreed with this claim during this brief.
+- `HANDOFF (…)` — an authored baton from the previous session; it outranks everything below it.
+- `— because …` — the decision's stated reasoning, captured only when the transcript states it.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/lifecycle.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/lifecycle.md
@@ -134,6 +134,46 @@ superior independiente para todo lo escrito después de un forget. La
 afirmación se limita a esta máquina: la caché nunca se sincroniza a ningún
 lado.
 
+## `daimon handoff` — el batón
+
+Los checkpoints son reconstructivos: extraídos de la transcripción,
+rankeados, recortados por presupuesto, compitiendo por lugares. El momento
+del traspaso deliberado — "próxima sesión: hacé ESTO primero, ojo con
+AQUELLO" — tiene otra semántica: intencional, chico, imperativo, y no debe
+perder rango jamás frente al ruido ambiente.
+
+```sh
+daimon handoff "Cortá el release primero. Ojo: la clave de caché rotó."
+daimon handoff --clear
+```
+
+El batón encabeza el próximo briefing, arriba de todas las secciones:
+
+```text
+HANDOFF (left deliberately by previous session, 2026-08-03T03:43:58Z):
+→ Cortá el release primero. Ojo: la clave de caché rotó.
+```
+
+Se guarda como evento, nunca como ítem cognitivo — no puede entrar al
+ranking, al dedup ni al scoring de carry, y no puede resolver nada. Un batón
+por proyecto; uno nuevo reemplaza al anterior (el rastro de eventos guarda la
+historia). Sigue activo hasta que la sesión que lo leyó termina y serializa —
+una sesión que crashea nunca lo consume. Acotado chico a propósito: un batón
+es "hacé X, ojo con Y", no un segundo checkpoint.
+
+## Las decisiones llevan su porqué
+
+Una decisión sin su razonamiento invita a la próxima sesión a re-litigarla.
+Cuando la transcripción *declara* el porqué, la captura conserva una cláusula
+corta:
+
+```text
+- [✓ verbatim] soft-clip over hard clamp — because the clamp erased ordering in tied groups
+```
+
+La vara de honestidad es la misma de siempre: solo razonamiento declarado,
+nunca inventado — una decisión cuyo porqué nunca se dijo llega sin él.
+
 ## El límite de la redacción, dicho con exactitud
 
 "Un secreto citado nunca llega al disco" se escucha fácil como "los secretos

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/trust-classes.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/trust-classes.md
@@ -163,3 +163,24 @@ por igual:
 
 Un briefing es contexto, no instrucciones — nunca prevalece sobre lo que el
 usuario pide ahora.
+
+## Suelo firme, no solo arena movediza
+
+El marcador inverso también existe. Al momento del brief, daimon verifica por
+muestreo los ítems arrastrados con afirmaciones comprobables contra la
+realidad — estado de PRs, existencia de ramas y archivos, validez de recibos.
+Una contradicción reemplaza el render del ítem con lo que cambió. Una
+*confirmación* antes no renderizaba nada, lo que hacía indistinguible una
+afirmación recién verificada de una nunca revisada; ahora gana un sufijo
+discreto:
+
+```text
+- [~ inferred] PR #60 awaiting review [carried] [✓ world-checked]
+```
+
+`[✓ world-checked]` significa que el mundo mismo coincidió con esta
+afirmación durante este brief — un eje separado de la clase de confianza
+(cómo se capturó) y de la corroboración (cuántas sesiones la atestiguaron).
+Sobre estas podés apoyarte sin re-verificar. Una asimetría es deliberada: una
+contradicción en cualquier eje suprime la insignia — la arena movediza
+siempre le gana al suelo firme.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
@@ -131,8 +131,21 @@ Si la última serialización falló o una sesión nunca se capturó, una captura
 fallida se auto-repara al inicio de la siguiente sesión — o ejecuta
 `daimon heal` para reintentar de inmediato.
 
+## Antes de terminar una sesión
+
+Si dejás trabajo sin terminar, pasá el batón — una línea imperativa que la
+próxima sesión ve arriba de todo en su briefing:
+
+```sh
+daimon handoff "Terminá la migración primero. Ojo: la DB de staging está vieja."
+```
+
+Un checkpoint reconstruye lo que pasó; el batón lleva lo que pensabas hacer
+después. Historia completa en [el ciclo de vida](../concepts/lifecycle.md).
+
 ## Adónde seguir
 
+- [Referencia CLI](../reference/cli.md) — todos los verbos, una página.
 - [Configuración](./configuration) — todas las variables de entorno,
   incluido el interruptor de apagado `DAIMON_DISABLE`.
 - [Hosts](../hosts/) — detalle de configuración por host y

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 1
+---
+
+# Referencia CLI
+
+Cada verbo de daimon, agrupado por lo que querés hacer. El `--help` de cada
+comando trae la superficie completa de flags; esta página es el mapa.
+
+## El ciclo diario
+
+| comando | qué hace |
+| --- | --- |
+| `daimon brief` | Renderiza el briefing del último checkpoint — dónde quedaste, con etiquetas de confianza. `--team` suma lo último del equipo; `--slug <s>` lee el bucket de otro proyecto explícitamente. |
+| `daimon recall "consulta"` | Búsqueda full-text sobre el historial local + de equipo. `--json` para filas, `--all-projects` para ampliar. |
+| `daimon handoff "Hacé X primero. Ojo con Y."` | Deja un batón autoral para la próxima sesión — se renderiza arriba de todas las secciones del briefing y nunca compite con ítems rankeados. `--clear` lo retira; uno nuevo reemplaza al anterior. |
+| `daimon loops` | Lista los loops abiertos direccionables con sus ids — la contraparte de lectura del camino de escritura de `resolve`. |
+| `daimon status` | Presencia y edad del checkpoint, resultado del último serialize, avisos de salud. `--suppressed` lista los ítems resueltos retenidos. |
+
+## Cerrar y corregir
+
+| comando | qué hace |
+| --- | --- |
+| `daimon resolve <id o texto>` | Marca un ítem como resuelto — evento append-only; el ítem deja de arrastrarse. `--dry-run` previsualiza el match; `--by agent --evidence "<cita>"` reclama un cierre que se verifica byte a byte al final de la sesión. |
+| `daimon reverify <id>` | Afirma que un ítem arrastrado sigue siendo cierto — exige evidencia y reinicia su reloj de vencimiento. También es la mitad de rechazo de un candidato a supersesión. |
+| `daimon forget <id o texto>` | Elimina el contenido de un ítem del disco y del índice, dejando una lápida de solo-hash. La eliminación sobrevive a re-serializar la transcripción original. |
+| `daimon log --text "…"` | Agrega un evento libre a la línea de tiempo del proyecto — cero LLM, solo rastro de auditoría. |
+
+## Confianza y auditoría
+
+| comando | qué hace |
+| --- | --- |
+| `daimon verify-receipt` | Verifica el recibo firmado de procedencia de un checkpoint (chequeo criptográfico completo vía el CLI de vitni). |
+| `daimon audit-quotes` | Re-verifica cada cita verbatim almacenada contra su transcripción de origen y reporta discrepancias. Solo lectura — nunca reescribe etiquetas. |
+| `daimon anchor <archivo> <símbolo>` | Ancla un ítem cognitivo a un símbolo de código; los briefings avisan cuando el código anclado cambió. |
+
+## Setup y operación
+
+| comando | qué hace |
+| --- | --- |
+| `daimon configure` | Detecta el backend LLM resuelto y completa los huecos en `~/.daimon/env`. `--test` corre un round-trip real. |
+| `daimon hooks install <host>` | Instala los hook scripts del host (Windsurf, Codex) desde el paquete. `list` / `status` inspeccionan. |
+| `daimon skill install <host>` | Instala la skill de agente de daimon en el directorio de skills del host. Volvé a correrlo después de cada upgrade. |
+| `daimon team init\|sync\|status` | Memoria de equipo compartida vía repo sidecar — ruteo cerrado por defecto, redacción por forma antes de sincronizar nada. |
+| `daimon stats` | Agregados locales de uso y captura — nada se transmite; compartir la salida es un pegado deliberado. `--json` para máquinas. |
+| `daimon heal` | Re-serializa la última sesión fallida cuando es seguro hacerlo. |
+| `daimon projects` | Lista cada proyecto con checkpoint, con un adelanto del tema. |
+
+## Internos (los invocan los hooks; documentados por completitud)
+
+| comando | qué hace |
+| --- | --- |
+| `daimon serialize <transcripción>` | Convierte un archivo de transcripción en checkpoint — lo llaman los hooks de fin de sesión; a mano, rellena uno. |
+| `daimon write-checkpoint` | Almacena un checkpoint recibido como JSON por stdin — el camino de introspección en sesión. La confianza la fija el código: nada en este camino puede reclamar `verbatim`, porque no hay transcripción contra la cual verificar. |
+| `daimon recall-inject` | El backend de sugerencias por prompt detrás del hook de recall: prompt por stdin, de cero a dos líneas de trabajo previo, exit 0 siempre. |
+| `daimon mcp serve` | Sirve las herramientas de daimon por MCP (stdio). |
+
+## Anotaciones del briefing, decodificadas
+
+El briefing marca cada línea; la historia completa de confianza vive en
+[clases de confianza](../concepts/trust-classes.md). Clave rápida:
+
+- `[✓ verbatim]` / `[~ inferred]` / `[? untagged]` — cómo se capturó el ítem.
+- `[carried]` — heredado de una sesión anterior, no contexto fresco.
+- `[≈ corroborated ×N]` — N sesiones independientes atestiguaron la afirmación.
+- `[✓ world-checked]` — una sonda en vivo coincidió con esta afirmación durante este brief.
+- `HANDOFF (…)` — un batón autoral de la sesión anterior; va arriba de todo.
+- `— because …` — el razonamiento declarado de la decisión, capturado solo cuando la transcripción lo declara.


### PR DESCRIPTION
Closes #529

New `reference/cli.md` (every verb grouped by purpose + a key decoding every briefing annotation), the world-checked badge lands in trust-classes ('Ground, not only quicksand'), the baton and because clause join the lifecycle page, and quickstart teaches the baton before session end. Full ES mirror; both locales build clean (`npm run build`).