### PR TITLE
feat(llm): stream litellm-backend responses so the timeout guards the connection, not the completion length

### DIFF
--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -530,6 +530,16 @@ def llm_no_cache() -> bool:
     return _flag("DAIMON_LLM_NO_CACHE")
 
 
+def llm_stream() -> bool:
+    """#531: request streamed responses from the litellm backend. Default ON —
+    a non-streaming request emits zero bytes until the whole completion is
+    done, which turns DAIMON_TIMEOUT into a hard ceiling on total generation
+    time; merge-sized completions cross it at normal throughput and get
+    killed healthy. Set 0 for strict upstreams that reject `stream` or
+    `stream_options` (restores the exact pre-#531 body)."""
+    return (_get("DAIMON_LLM_STREAM") or "1").strip() in ("1", "true", "yes", "on")
+
+
 def llm_base_url() -> str:
     return (
         _get("DAIMON_LLM_BASE_URL")

--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -69,6 +69,65 @@ def _read_within_deadline(r, deadline, attempt, last):
     return b"".join(chunks)
 
 
+def _looks_like_sse(raw: bytes) -> bool:
+    """True when a response body is an SSE stream rather than one JSON object.
+
+    Sniffs the first non-blank line for the two things a stream can open with:
+    a `data:` field or a `:` comment (gateways send `: ping` keep-alives).
+    Sniffing the body instead of trusting a Content-Type header keeps the
+    fake-response test seam (io.BytesIO, no headers) and misbehaving gateways
+    on the same honest path."""
+    for line in raw.split(b"\n"):
+        s = line.strip()
+        if not s:
+            continue
+        return s.startswith(b"data:") or s.startswith(b":")
+    return False
+
+
+def _parse_sse(raw: bytes):
+    """Fold an OpenAI-style SSE body into (content, served_model, usage).
+
+    `content` is the concatenated `choices[0].delta.content` across frames,
+    or None when no frame carried any (distinct from "" — callers must treat
+    a content-free stream as an error, not an answer). `served_model` is the
+    first frame's `model` field; `usage` the last frame that carried one
+    (stream_options.include_usage delivers it in a trailing frame with no
+    choices). Torn or non-JSON frames are skipped — one bad frame must not
+    sink a call whose remaining frames carry the completion."""
+    parts = []
+    served = None
+    usage = {}
+    saw_content = False
+    for line in raw.decode("utf-8", errors="replace").split("\n"):
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue  # blank separators and `:` comment lines
+        payload = line[len("data:"):].strip()
+        if payload == "[DONE]":
+            break
+        try:
+            frame = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(frame, dict):
+            continue
+        if served is None:
+            m = frame.get("model")
+            if isinstance(m, str) and m.strip():
+                served = m
+        if frame.get("usage"):
+            usage = frame["usage"]
+        choices = frame.get("choices") or []
+        if choices:
+            delta = choices[0].get("delta") or {}
+            piece = delta.get("content")
+            if isinstance(piece, str):
+                parts.append(piece)
+                saw_content = True
+    return ("".join(parts) if saw_content else None), served, usage
+
+
 def _chat_litellm(messages, model=None, temperature=None, timeout=None, retries=3, deadline=None):
     """POST /v1/chat/completions. Returns the assistant message content (str).
 
@@ -108,6 +167,17 @@ def _chat_litellm(messages, model=None, temperature=None, timeout=None, retries=
         # LiteLLM per-request cache bypass. Opt-in only: strict upstreams may
         # reject unknown fields, so the default body must stay unchanged.
         payload["cache"] = {"no-cache": True}
+    if config.llm_stream():
+        # #531: without streaming the server emits zero bytes until the whole
+        # completion is done, so urlopen's socket timeout becomes a hard
+        # ceiling on total generation time — merge-sized completions cross it
+        # at normal throughput and get killed healthy. Streamed, the socket
+        # timeout bounds the inter-frame gap (measured max 0.31s on a live
+        # gateway) and guards what it was always meant to: a dead connection.
+        # stream_options keeps the usage block arriving (in a trailing
+        # frame), so the per-call spend log line below stays lit.
+        payload["stream"] = True
+        payload["stream_options"] = {"include_usage": True}
     body = json.dumps(payload).encode()
     last = None
     for attempt in range(retries):
@@ -124,23 +194,34 @@ def _chat_litellm(messages, model=None, temperature=None, timeout=None, retries=
         )
         try:
             with urllib.request.urlopen(req, timeout=attempt_timeout) as r:
-                data = json.loads(_read_within_deadline(r, deadline, attempt, last))
+                raw = _read_within_deadline(r, deadline, attempt, last)
+            if _looks_like_sse(raw):
+                content, served, usage = _parse_sse(raw)
+                if content is None:
+                    # A stream that closed having delivered no content is the
+                    # SSE twin of an empty HTTP 200 body — never return "".
+                    raise ChatError("LLM stream closed with no content (body suppressed)")
+            else:
+                # Plain JSON — either streaming is off, or the gateway ignored
+                # `stream: true` and answered with one object. Serve it.
+                data = json.loads(raw)
+                content = data["choices"][0]["message"]["content"]
+                served = data.get("model")
+                usage = data.get("usage") or {}
             # #458 / scar 0032: record the model the response SAYS served this
             # call — the requested `mdl` is a gateway alias and proves nothing.
             # list.append is atomic under the GIL, so concurrent chunk threads
             # record safely; served_models() dedupes/sorts on read. Absent or
             # non-string field -> record nothing (honest absence, no guessing).
-            served = data.get("model")
             if isinstance(served, str) and served.strip():
                 _served_models.append(served.strip())
             # Surface token cost — the serializer discards the rest of the
             # response, so this log line is the only record of per-call spend.
-            usage = data.get("usage") or {}
             if usage:
                 log.info("LLM usage model=%s served=%s total_tokens=%s prompt=%s completion=%s",
                          mdl, served, usage.get("total_tokens"),
                          usage.get("prompt_tokens"), usage.get("completion_tokens"))
-            return data["choices"][0]["message"]["content"]
+            return content
         except urllib.error.HTTPError as e:
             if 500 <= e.code < 600 and attempt < retries - 1:
                 last = f"HTTP {e.code}"

--- a/plugin/tests/test_config.py
+++ b/plugin/tests/test_config.py
@@ -606,3 +606,13 @@ def test_chunk_cache_days_default_override_and_bad_value(monkeypatch):
     assert config.chunk_cache_days() == 7
     monkeypatch.setenv("DAIMON_CHUNK_CACHE_DAYS", "not-a-number")
     assert config.chunk_cache_days() == 3
+
+
+def test_llm_stream_default_on_with_opt_out(monkeypatch):
+    # #531: streaming default ON (the timeout-cliff fix must not require
+    # config), DAIMON_LLM_STREAM=0 restores the pre-streaming body for strict
+    # upstreams.
+    monkeypatch.delenv("DAIMON_LLM_STREAM", raising=False)
+    assert config.llm_stream() is True
+    monkeypatch.setenv("DAIMON_LLM_STREAM", "0")
+    assert config.llm_stream() is False

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -1291,3 +1291,137 @@ def test_command_backend_records_no_served_model(monkeypatch):
                         lambda argv, stdin_text, timeout, env, cwd: (0, "OK", ""))
     assert llm.chat([{"role": "user", "content": "hi"}]) == "OK"
     assert llm.served_models() == []
+
+
+# ---- #531: streaming. Non-streaming requests emit zero bytes until the whole
+# completion is done, which turns DAIMON_TIMEOUT into a hard ceiling on total
+# server-side generation time — merge calls emitting 30-40k completion tokens
+# cross the default 420s at normal throughput and get killed healthy. With
+# streaming, urlopen's socket timeout bounds the INTER-FRAME gap instead, and
+# no healthy gap approaches the timeout.
+
+
+def _sse_response(frames):
+    """An OpenAI-style SSE body: one `data:` line per frame, blank-line
+    separated, closed by `data: [DONE]`."""
+    lines = []
+    for f in frames:
+        payload = f if isinstance(f, str) else json.dumps(f)
+        lines.append(f"data: {payload}")
+        lines.append("")
+    lines.append("data: [DONE]")
+    lines.append("")
+    return io.BytesIO("\n".join(lines).encode())
+
+
+def test_chat_payload_requests_streaming_by_default(llm_env, monkeypatch):
+    monkeypatch.delenv("DAIMON_LLM_STREAM", raising=False)
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["body"] = json.loads(req.data)
+        return _ok_response("ok")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    llm.chat([{"role": "user", "content": "hi"}])
+    assert captured["body"]["stream"] is True
+    # Without stream_options the usage block never arrives on a stream, and
+    # the usage log line (the only per-call spend record) goes dark.
+    assert captured["body"]["stream_options"] == {"include_usage": True}
+
+
+def test_chat_stream_opt_out_keeps_body_unchanged(llm_env, monkeypatch):
+    # Strict upstreams may reject unknown fields (the llm_no_cache precedent):
+    # DAIMON_LLM_STREAM=0 must restore the exact pre-#531 body shape.
+    monkeypatch.setenv("DAIMON_LLM_STREAM", "0")
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["body"] = json.loads(req.data)
+        return _ok_response("ok")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    llm.chat([{"role": "user", "content": "hi"}])
+    assert "stream" not in captured["body"]
+    assert "stream_options" not in captured["body"]
+
+
+def test_chat_parses_sse_streamed_response(llm_env, monkeypatch):
+    def fake_urlopen(req, timeout=None):
+        return _sse_response([
+            {"choices": [{"delta": {"role": "assistant"}}], "model": "served-x"},
+            {"choices": [{"delta": {"content": "Hel"}}], "model": "served-x"},
+            {"choices": [{"delta": {"content": "lo"}}], "model": "served-x"},
+        ])
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert llm.chat([{"role": "user", "content": "hi"}]) == "Hello"
+
+
+def test_chat_sse_records_served_model(llm_env, monkeypatch):
+    llm.reset_served_models()
+
+    def fake_urlopen(req, timeout=None):
+        return _sse_response([
+            {"choices": [{"delta": {"content": "ok"}}], "model": "served-y"},
+            {"choices": [{"delta": {"content": "!"}}], "model": "served-y"},
+        ])
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    llm.chat([{"role": "user", "content": "hi"}])
+    assert llm.served_models() == ["served-y"]
+
+
+def test_chat_sse_logs_usage_from_final_frame(llm_env, monkeypatch, caplog):
+    # stream_options.include_usage delivers usage in a trailing frame that has
+    # no choices — the spend log line must survive the streaming switch.
+    def fake_urlopen(req, timeout=None):
+        return _sse_response([
+            {"choices": [{"delta": {"content": "ok"}}], "model": "served-z"},
+            {"choices": [], "usage": {"total_tokens": 42, "prompt_tokens": 30,
+                                      "completion_tokens": 12}},
+        ])
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    with caplog.at_level(logging.INFO, logger="daimon_briefing.llm"):
+        assert llm.chat([{"role": "user", "content": "hi"}]) == "ok"
+    assert any("total_tokens=42" in r.getMessage() for r in caplog.records)
+
+
+def test_chat_sse_skips_comments_and_garbled_frames(llm_env, monkeypatch):
+    # Gateways interleave `: ping` comment lines, and a torn frame must skip,
+    # not sink the call.
+    body = (
+        ": ping\n\n"
+        'data: {"choices":[{"delta":{"content":"a"}}]}\n\n'
+        "data: {torn json\n\n"
+        'data: {"choices":[{"delta":{"content":"b"}}]}\n\n'
+        "data: [DONE]\n\n"
+    )
+
+    def fake_urlopen(req, timeout=None):
+        return io.BytesIO(body.encode())
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert llm.chat([{"role": "user", "content": "hi"}]) == "ab"
+
+
+def test_chat_plain_json_answer_to_a_stream_request_still_parses(llm_env, monkeypatch):
+    # A gateway may ignore `stream: true` and answer with one JSON object —
+    # the client must serve it, not die on an SSE parse.
+    def fake_urlopen(req, timeout=None):
+        return _ok_response_with_usage("plain", {"total_tokens": 7})
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert llm.chat([{"role": "user", "content": "hi"}]) == "plain"
+
+
+def test_chat_sse_empty_content_raises_chat_error(llm_env, monkeypatch):
+    # A stream that closes having delivered no content is the SSE twin of an
+    # empty HTTP 200 body — surface it as ChatError, never return "".
+    def fake_urlopen(req, timeout=None):
+        return _sse_response([{"choices": [{"delta": {}}], "model": "m"}])
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    with pytest.raises(llm.ChatError):
+        llm.chat([{"role": "user", "content": "hi"}])

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -1425,3 +1425,42 @@ def test_chat_sse_empty_content_raises_chat_error(llm_env, monkeypatch):
     monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
     with pytest.raises(llm.ChatError):
         llm.chat([{"role": "user", "content": "hi"}])
+
+
+def test_chat_sse_detection_skips_leading_blank_lines(llm_env, monkeypatch):
+    # Keep-alive newlines before the first frame must not defeat detection.
+    body = '\n\n\ndata: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n'
+
+    def fake_urlopen(req, timeout=None):
+        return io.BytesIO(body.encode())
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert llm.chat([{"role": "user", "content": "hi"}]) == "ok"
+
+
+def test_chat_all_blank_body_is_not_sse_and_surfaces_as_chat_error(llm_env, monkeypatch):
+    # A body of pure whitespace is neither a stream nor JSON — it must fail
+    # loud as a ChatError-family parse failure, never be mistaken for SSE.
+    def fake_urlopen(req, timeout=None):
+        return io.BytesIO(b"\n\n  \n")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    with pytest.raises(Exception) as exc:
+        llm.chat([{"role": "user", "content": "hi"}])
+    assert not isinstance(exc.value, AssertionError)
+
+
+def test_chat_sse_non_dict_frame_is_skipped(llm_env, monkeypatch):
+    # A frame that parses as JSON but is not an object (e.g. a bare array)
+    # has no fields to read — skip it, keep the stream's real content.
+    body = (
+        'data: [1, 2, 3]\n\n'
+        'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+        "data: [DONE]\n"
+    )
+
+    def fake_urlopen(req, timeout=None):
+        return io.BytesIO(body.encode())
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert llm.chat([{"role": "user", "content": "hi"}]) == "ok"


### PR DESCRIPTION
Closes #531

## PR Type
- [x] New feature

## Summary
- Request `stream: true` + `stream_options: {include_usage: true}` on the litellm backend by default, so urlopen's socket timeout bounds the inter-frame gap instead of total server-side generation time. Merge-sized completions no longer get killed healthy at the DAIMON_TIMEOUT cliff.
- Parse SSE frames into content / served-model / usage. Torn frames skip; a content-free stream raises ChatError; a plain-JSON answer to a stream request (gateway ignoring `stream`) still parses.
- `DAIMON_LLM_STREAM=0` opt-out restores the exact pre-change request body for strict upstreams (the `llm_no_cache` precedent).

## Changes
| File | Change |
|------|--------|
| `plugin/daimon_briefing/llm.py` | streaming payload fields, `_looks_like_sse` sniff, `_parse_sse` fold, response handling split (SSE vs plain JSON) |
| `plugin/daimon_briefing/config.py` | `llm_stream()` (default ON, opt-out) |
| `plugin/tests/test_llm.py` | 8 tests: payload shape, opt-out body identity, SSE parse, served-model, trailing-frame usage, comment/torn-frame tolerance, plain-JSON fallback, empty-stream ChatError |
| `plugin/tests/test_config.py` | `llm_stream` default/opt-out |

## Test Plan
- [x] TDD: all 8 new tests watched failing before implementation
- [x] Full suite: 2746 passed, 2 skipped
- [x] Live call through a real OpenAI-compatible gateway: streamed, content parsed, served-model recorded, usage logged from the trailing frame

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one type:* label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers