### PR TITLE
fix(llm): deadline expiry logs as budget expiry, not backend failure

### DIFF
--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -34,6 +34,13 @@ class ChatError(RuntimeError):
     """A chat call failed after retries. Callers catch this to give up gracefully."""
 
 
+class DeadlineExhausted(ChatError):
+    """The shared serialize budget ran out — daimon's own clock, not a backend
+    failure (#533). A ChatError subclass so every `except ChatError` caller is
+    unaffected; distinguishable so chat()'s fallback branch can log budget
+    expiry as budget expiry instead of blaming a healthy gateway."""
+
+
 class EmptyOutputError(ChatError):
     """The command backend returned rc=0 with empty (or whitespace-only) stdout.
 
@@ -61,7 +68,7 @@ def _read_within_deadline(r, deadline, attempt, last):
     chunks = []
     while True:
         if deadline is not None and time.monotonic() >= deadline:
-            raise ChatError(f"LLM deadline exhausted after {attempt} tries: {last}")
+            raise DeadlineExhausted(f"LLM deadline exhausted after {attempt} tries: {last}")
         chunk = r.read1(_READ_CHUNK_BYTES)
         if not chunk:
             break
@@ -185,7 +192,7 @@ def _chat_litellm(messages, model=None, temperature=None, timeout=None, retries=
         if deadline is not None:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                raise ChatError(f"LLM deadline exhausted after {attempt} tries: {last}")
+                raise DeadlineExhausted(f"LLM deadline exhausted after {attempt} tries: {last}")
             attempt_timeout = min(timeout, remaining)
         req = urllib.request.Request(
             base + "/v1/chat/completions",
@@ -233,7 +240,7 @@ def _chat_litellm(messages, model=None, temperature=None, timeout=None, retries=
                 raise ChatError(f"LLM unreachable/timeout after {retries} tries at {base}: {last}")
         backoff = 3 * (attempt + 1)
         if deadline is not None and time.monotonic() + backoff >= deadline:
-            raise ChatError(f"LLM deadline exhausted after {attempt + 1} tries: {last}")
+            raise DeadlineExhausted(f"LLM deadline exhausted after {attempt + 1} tries: {last}")
         # `last` is "HTTP <code>" or the transport reason — never the response
         # body (it can echo request contents/secrets; see docstring).
         log.warning("LLM %s (attempt %d/%d), backing off %ds",
@@ -397,9 +404,13 @@ def chat(messages, model=None, temperature=None, timeout=None, retries=3, deadli
     try:
         return _chat_litellm(messages, model=model, temperature=temperature,
                              timeout=timeout, retries=retries, deadline=deadline)
-    except ChatError:
+    except ChatError as e:
         if config.llm_fallback() and _resolve_command() is not None:
-            log.warning("llm.fallback backend=command (litellm failed)")
+            # #533: budget expiry is daimon's own clock, not a gateway error —
+            # the label decides which of two very different things gets debugged.
+            reason = ("serialize deadline expired"
+                      if isinstance(e, DeadlineExhausted) else "litellm failed")
+            log.warning("llm.fallback backend=command (%s)", reason)
             _fallback_used = True
             if deadline is not None:
                 # #341: the primary just drained the shared budget retrying
@@ -631,7 +642,7 @@ def _chat_command(messages, deadline):
     if deadline is not None:
         timeout = min(timeout, max(0.0, deadline - time.monotonic()))
         if timeout <= 0:
-            raise ChatError("LLM deadline exhausted before command backend")
+            raise DeadlineExhausted("LLM deadline exhausted before command backend")
     env = {**os.environ, "DAIMON_DISABLE": "1"}
     cwd = tempfile.mkdtemp(prefix="daimon-cli-")
     try:

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -1464,3 +1464,55 @@ def test_chat_sse_non_dict_frame_is_skipped(llm_env, monkeypatch):
 
     monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
     assert llm.chat([{"role": "user", "content": "hi"}]) == "ok"
+
+
+# ---- #533: deadline expiry is daimon's own budget, not a backend failure —
+# the fallback log line must say which one happened, or the reader hunts a
+# gateway problem that does not exist.
+
+
+def test_deadline_exhausted_is_a_chat_error_subclass():
+    # Existing `except ChatError` callers must keep catching it unchanged.
+    assert issubclass(llm.DeadlineExhausted, llm.ChatError)
+
+
+def test_chat_fallback_log_names_deadline_expiry(monkeypatch, caplog):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+
+    def budget_gone(*a, **k):
+        raise llm.DeadlineExhausted("LLM deadline exhausted after 1 tries: x")
+
+    monkeypatch.setattr(llm, "_chat_litellm", budget_gone)
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text"))
+    monkeypatch.setattr(llm, "_chat_command", lambda m, deadline: "FALLBACK")
+    llm.reset_fallback()
+    with caplog.at_level(logging.WARNING, logger="daimon_briefing.llm"):
+        llm.chat([{"role": "user", "content": "x"}])
+    msgs = [r.getMessage() for r in caplog.records if "llm.fallback" in r.getMessage()]
+    assert msgs and "deadline" in msgs[0]
+    assert "litellm failed" not in msgs[0]
+
+
+def test_chat_fallback_log_still_names_backend_failure(monkeypatch, caplog):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+
+    def boom(*a, **k):
+        raise llm.ChatError("gateway down")
+
+    monkeypatch.setattr(llm, "_chat_litellm", boom)
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text"))
+    monkeypatch.setattr(llm, "_chat_command", lambda m, deadline: "FALLBACK")
+    llm.reset_fallback()
+    with caplog.at_level(logging.WARNING, logger="daimon_briefing.llm"):
+        llm.chat([{"role": "user", "content": "x"}])
+    msgs = [r.getMessage() for r in caplog.records if "llm.fallback" in r.getMessage()]
+    assert msgs and "litellm failed" in msgs[0]
+
+
+def test_deadline_exhaustion_sites_raise_the_subclass(llm_env, monkeypatch):
+    # The pre-first-call site: deadline already in the past.
+    with pytest.raises(llm.DeadlineExhausted):
+        llm._chat_litellm([{"role": "user", "content": "x"}],
+                          deadline=time.monotonic() - 1)

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -1516,3 +1516,10 @@ def test_deadline_exhaustion_sites_raise_the_subclass(llm_env, monkeypatch):
     with pytest.raises(llm.DeadlineExhausted):
         llm._chat_litellm([{"role": "user", "content": "x"}],
                           deadline=time.monotonic() - 1)
+
+
+def test_command_backend_deadline_exhausted_raises_the_subclass(monkeypatch):
+    monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text", "stdin"))
+    with pytest.raises(llm.DeadlineExhausted):
+        llm._chat_command([{"role": "user", "content": "x"}],
+                          deadline=time.monotonic() - 1)


### PR DESCRIPTION
Closes #533

## PR Type
- [x] Bug fix

## Summary
- `DeadlineExhausted(ChatError)` subclass marks all four deadline-raise sites (pre-call, mid-read, backoff, pre-command); every `except ChatError` caller is unaffected.
- `chat()`'s fallback branch logs `(serialize deadline expired)` vs `(litellm failed)` depending on which actually happened.

## Changes
| File | Change |
|------|--------|
| `plugin/daimon_briefing/llm.py` | subclass + raise-site retyping + fallback log split |
| `plugin/tests/test_llm.py` | 4 tests: subclass contract, both log labels, raise-site type |

## Test Plan
- [x] TDD: label tests watched failing before the subclass existed
- [x] Full suite: 2750 passed

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one type:* label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers