### PR TITLE
chore(llm): log provider-usage-field presence so model substitution is detectable

### DIFF
--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -135,6 +135,27 @@ def _parse_sse(raw: bytes):
     return ("".join(parts) if saw_content else None), served, usage
 
 
+def _provider_field_flags(usage: dict) -> str:
+    """#535: name which provider-specific usage fields the response carried.
+
+    The served-model stamp is a gateway alias and proves nothing (scar 0032);
+    Anthropic-served responses carry usage fields typical local
+    OpenAI-compatible servers do not. Logging their PRESENCE (never their
+    values — presence is the discriminator) makes a silent model substitution
+    catchable from the log with one grep: an alias claiming an Anthropic
+    model whose calls all say `provider_fields=none` was not served by one.
+    Absence must be stated explicitly ("none") — the signal cannot be
+    expressed by omission."""
+    present = []
+    if "cache_creation_input_tokens" in usage:
+        present.append("cache_creation")
+    if "cache_read_input_tokens" in usage:
+        present.append("cache_read")
+    if "reasoning_tokens" in (usage.get("completion_tokens_details") or {}):
+        present.append("reasoning")
+    return ",".join(present) if present else "none"
+
+
 def _chat_litellm(messages, model=None, temperature=None, timeout=None, retries=3, deadline=None):
     """POST /v1/chat/completions. Returns the assistant message content (str).
 
@@ -225,9 +246,10 @@ def _chat_litellm(messages, model=None, temperature=None, timeout=None, retries=
             # Surface token cost — the serializer discards the rest of the
             # response, so this log line is the only record of per-call spend.
             if usage:
-                log.info("LLM usage model=%s served=%s total_tokens=%s prompt=%s completion=%s",
+                log.info("LLM usage model=%s served=%s total_tokens=%s prompt=%s completion=%s provider_fields=%s",
                          mdl, served, usage.get("total_tokens"),
-                         usage.get("prompt_tokens"), usage.get("completion_tokens"))
+                         usage.get("prompt_tokens"), usage.get("completion_tokens"),
+                         _provider_field_flags(usage))
             return content
         except urllib.error.HTTPError as e:
             if 500 <= e.code < 600 and attempt < retries - 1:

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -1523,3 +1523,55 @@ def test_command_backend_deadline_exhausted_raises_the_subclass(monkeypatch):
     with pytest.raises(llm.DeadlineExhausted):
         llm._chat_command([{"role": "user", "content": "x"}],
                           deadline=time.monotonic() - 1)
+# ---- #535: the served-model stamp is a gateway alias (scar 0032) — log the
+# presence of provider-specific usage fields so a silent model substitution
+# is detectable from the log, permanently, going forward.
+
+
+def test_usage_log_names_present_provider_fields(llm_env, monkeypatch, caplog):
+    def fake_urlopen(req, timeout=None):
+        return _ok_response_with_usage("ok", {
+            "total_tokens": 10, "prompt_tokens": 5, "completion_tokens": 5,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "completion_tokens_details": {"reasoning_tokens": 0},
+        })
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    with caplog.at_level(logging.INFO, logger="daimon_briefing.llm"):
+        llm.chat([{"role": "user", "content": "hi"}])
+    msgs = [r.getMessage() for r in caplog.records if "LLM usage" in r.getMessage()]
+    assert msgs, "usage log line missing"
+    line = msgs[0]
+    assert "provider_fields=cache_creation,cache_read,reasoning" in line
+
+
+def test_usage_log_says_none_when_provider_fields_absent(llm_env, monkeypatch, caplog):
+    # A typical local OpenAI-compatible server carries none of the fields —
+    # the log must say so explicitly (absence is the discriminator's signal,
+    # so it cannot be expressed by omission).
+    def fake_urlopen(req, timeout=None):
+        return _ok_response_with_usage("ok", {
+            "total_tokens": 10, "prompt_tokens": 5, "completion_tokens": 5,
+        })
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    with caplog.at_level(logging.INFO, logger="daimon_briefing.llm"):
+        llm.chat([{"role": "user", "content": "hi"}])
+    msgs = [r.getMessage() for r in caplog.records if "LLM usage" in r.getMessage()]
+    assert msgs and "provider_fields=none" in msgs[0]
+
+
+def test_usage_log_partial_provider_fields(llm_env, monkeypatch, caplog):
+    # Only what is actually present gets named — never inferred to a full set.
+    def fake_urlopen(req, timeout=None):
+        return _ok_response_with_usage("ok", {
+            "total_tokens": 10,
+            "cache_read_input_tokens": 3,
+        })
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    with caplog.at_level(logging.INFO, logger="daimon_briefing.llm"):
+        llm.chat([{"role": "user", "content": "hi"}])
+    msgs = [r.getMessage() for r in caplog.records if "LLM usage" in r.getMessage()]
+    assert msgs and "provider_fields=cache_read" in msgs[0]


### PR DESCRIPTION
Closes #535

## PR Type
- [x] Maintenance/tooling

## Summary
- `provider_fields=<names|none>` appended to the existing LLM usage log line: presence flags for `cache_creation_input_tokens`, `cache_read_input_tokens`, `completion_tokens_details.reasoning_tokens`. Presence only, never values.
- Works for both plain-JSON and streamed (trailing-frame) usage blocks — the flags are computed from the same usage dict either path produces.

## Changes
| File | Change |
|------|--------|
| `plugin/daimon_briefing/llm.py` | `_provider_field_flags` + one log-line field |
| `plugin/tests/test_llm.py` | 3 tests: full set named, explicit none, partial set |

## Test Plan
- [x] TDD: all 3 watched failing first
- [x] Full suite: 2752 passed
- [x] Field shapes probe-validated against a live gateway earlier today (Anthropic fields survive intact)

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one type:* label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers