### PR TITLE
fix(brief): say when a serialize is in flight instead of silently briefing one session behind

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -30,7 +30,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from . import anchor, briefing, capture, carry, config, configure, harvest, llm, normalize, recall, receipts, redact, render, schema, serializer, store, teamsync, transcript, worldcheck
+from . import anchor, briefing, capture, carry, config, configure, harvest, ledger, llm, normalize, recall, receipts, redact, render, schema, serializer, store, teamsync, transcript, worldcheck
 from . import __version__
 
 # The serialize.log ledger subsystem lives in ledger.py (#147 + #162, pure
@@ -273,6 +273,13 @@ def _run_serialize(transcript_path: Path, project: str | None,
     # none at all, so a manual `daimon serialize` had no bound even in
     # principle while the SessionEnd hook did (#298).
     deadline = start + config.timeout_seconds()
+    # #534: one slug-stamped entry touch attributes this run's whole
+    # heartbeat trail to its project (step touches preserve the content), so
+    # a brief in another shell can say "a serialize for THIS project is in
+    # flight". Before the pipeline so the stamp exists for the entire run;
+    # a too-short skip writes its result line immediately, which ends the
+    # session's classification exactly as before.
+    ledger.touch_heartbeat(session_id, project_slug=store.project_slug(project))
     try:
         # THE shared pipeline (#432): serialize -> stamps -> carry+fold ->
         # bind_links -> supersede emission -> write -> rejection ledger.
@@ -644,6 +651,16 @@ def _cmd_brief(args) -> int:
     if fallback_used:
         render.render_brief_note(["⚠ no checkpoint for this project — showing the global "
                                   "checkpoint (fallback), possibly another project's."])
+    # #534: a LIVE serialize for this project means a fresher checkpoint is
+    # being written right now — say so instead of silently briefing one
+    # session behind (measured at 10% of runs on one field machine). Keyed on
+    # the ledger's liveness bar, never heartbeat existence: a stuck or
+    # crashed serialize is heal's case, and a permanent false staleness line
+    # would be worse than the silence this fixes.
+    if ledger.serialize_in_flight(store.project_slug(project) or ""):
+        render.render_brief_note([
+            "⏳ a serialize is in flight — this briefing may be one session "
+            "behind; re-run `daimon brief` in a few minutes for the fresh one."])
     # --team (#111): fan in teammates for THIS project. Empty team → None → the
     # renderer emits no Teammates section, byte-identical to a non-team briefing.
     teammates = _team_briefings(project) if getattr(args, "team", False) else None

--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -351,16 +351,27 @@ def _heartbeat_dir() -> Path:
     return config.log_dir() / "heartbeats"
 
 
-def touch_heartbeat(session_id: str) -> None:
+def touch_heartbeat(session_id: str, project_slug: str | None = None) -> None:
     """Stamp liveness for a running serialize (#342). Best-effort: a full
     disk or unwritable dir must never break the serialize doing the
     touching. Old stamps are reaped opportunistically here — result lines
     end a session's classification, so a leftover file is disk hygiene,
-    never a liveness signal."""
+    never a liveness signal.
+
+    `project_slug` (#534): the serialize entry point stamps which project
+    the run belongs to as the file's CONTENT, so the briefing can answer
+    "is a serialize in flight for THIS project" without a session->project
+    map. Step touches omit it — Path.touch() updates mtime and preserves
+    content, so one stamped entry touch attributes the whole trail. A
+    pre-#534 stamp has empty content and stays unattributable on purpose."""
     try:
         d = _heartbeat_dir()
         d.mkdir(parents=True, exist_ok=True)
-        (d / Path(session_id).name).touch()
+        p = d / Path(session_id).name
+        if project_slug is not None:
+            p.write_text(str(project_slug), encoding="utf-8")
+        else:
+            p.touch()
         now = time.time()
         for p in d.iterdir():
             try:
@@ -381,6 +392,37 @@ def heartbeat_age(session_id: str, now: float | None = None) -> float | None:
     except OSError:
         return None
     return max(0.0, (now if now is not None else time.time()) - mtime)
+
+
+def serialize_in_flight(project_slug: str, now: float | None = None) -> bool:
+    """#534: is a serialize LIVE for this project right now? True only for a
+    heartbeat whose content matches `project_slug` and whose age is inside
+    the hung ceiling — the same liveness bar heal uses, so brief and heal
+    never disagree about what "alive" means.
+
+    Every other shape answers False on purpose: a stale stamp is a stuck or
+    crashed serialize (heal's case, and a permanent false "one session
+    behind" line would be worse than the silence this exists to fix), an
+    empty stamp is a pre-#534 trail nothing can attribute, and a missing
+    dir is simply no activity."""
+    slug = str(project_slug or "").strip()
+    if not slug:
+        return False
+    ceiling = config.hung_after_seconds()
+    t = now if now is not None else time.time()
+    try:
+        entries = list(_heartbeat_dir().iterdir())
+    except OSError:
+        return False
+    for p in entries:
+        try:
+            if t - p.stat().st_mtime > ceiling:
+                continue
+            if p.read_text(encoding="utf-8").strip() == slug:
+                return True
+        except OSError:
+            continue
+    return False
 
 
 # Host prefix on a spawn line, for per-host capture counts. Deliberately the

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -8553,3 +8553,20 @@ def test_brief_silent_when_no_serialize_in_flight(tmp_checkpoint_dir,
     rc = cli.main(["brief"])
     assert rc == 0
     assert "one session behind" not in capsys.readouterr().out
+
+
+def test_serialize_in_flight_blank_slug_is_false(tmp_log_dir):
+    from daimon_briefing import ledger
+    ledger.touch_heartbeat("S-p", project_slug="-p-A")
+    assert ledger.serialize_in_flight("") is False
+    assert ledger.serialize_in_flight("   ") is False
+
+
+def test_serialize_in_flight_skips_unreadable_entry(tmp_log_dir):
+    from daimon_briefing import ledger
+    # A directory inside heartbeats/ stats fine but fails read_text with an
+    # OSError — the scan must skip it and still find the real stamp.
+    (tmp_log_dir / "heartbeats").mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "heartbeats" / "not-a-file").mkdir()
+    ledger.touch_heartbeat("S-p", project_slug="-p-A")
+    assert ledger.serialize_in_flight("-p-A") is True

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -8570,3 +8570,14 @@ def test_serialize_in_flight_skips_unreadable_entry(tmp_log_dir):
     (tmp_log_dir / "heartbeats" / "not-a-file").mkdir()
     ledger.touch_heartbeat("S-p", project_slug="-p-A")
     assert ledger.serialize_in_flight("-p-A") is True
+
+
+def test_serialize_in_flight_unreadable_only_entry_is_false(tmp_log_dir):
+    from daimon_briefing import ledger
+    # The unreadable entry is the ONLY candidate, so the OSError-skip path
+    # MUST execute regardless of iterdir() order (the two-entry variant above
+    # can return True off the real stamp first on filesystems that iterate
+    # it earlier — this one cannot).
+    (tmp_log_dir / "heartbeats").mkdir(parents=True, exist_ok=True)
+    (tmp_log_dir / "heartbeats" / "only-a-dir").mkdir()
+    assert ledger.serialize_in_flight("-p-A") is False

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -8482,3 +8482,74 @@ def test_cooled_origins_reads_the_budget_at_call_time(monkeypatch):
     assert cli.cooled_origins(counts) == {"S-a"}
     monkeypatch.setattr(cli, "_ORIGIN_BUDGET", 2)
     assert cli.cooled_origins(counts) == set()
+
+
+# ---- #534: a serialize in flight means the briefing is one session behind —
+# say so, keyed on liveness (a crashed serialize must never pin a permanent
+# false staleness line; live -> one line, stuck or absent -> silence).
+
+
+def test_heartbeat_slug_stamp_and_preserve(tmp_log_dir):
+    from daimon_briefing import ledger
+    ledger.touch_heartbeat("S-p", project_slug="-p-A")
+    f = tmp_log_dir / "heartbeats" / "S-p"
+    assert f.read_text() == "-p-A"
+    ledger.touch_heartbeat("S-p")  # step touches carry no slug
+    assert f.read_text() == "-p-A", "plain touch must preserve the slug stamp"
+
+
+def test_serialize_in_flight_true_for_fresh_matching_slug(tmp_log_dir):
+    from daimon_briefing import ledger
+    ledger.touch_heartbeat("S-p", project_slug="-p-A")
+    assert ledger.serialize_in_flight("-p-A") is True
+
+
+def test_serialize_in_flight_false_for_other_project(tmp_log_dir):
+    from daimon_briefing import ledger
+    ledger.touch_heartbeat("S-p", project_slug="-p-B")
+    assert ledger.serialize_in_flight("-p-A") is False
+
+
+def test_serialize_in_flight_false_when_stale(tmp_log_dir):
+    from daimon_briefing import ledger, config
+    ledger.touch_heartbeat("S-p", project_slug="-p-A")
+    f = tmp_log_dir / "heartbeats" / "S-p"
+    old = time.time() - config.hung_after_seconds() - 60
+    os.utime(f, (old, old))
+    assert ledger.serialize_in_flight("-p-A") is False, \
+        "a stuck serialize must not pin a permanent staleness line"
+
+
+def test_serialize_in_flight_false_for_legacy_empty_stamp(tmp_log_dir):
+    from daimon_briefing import ledger
+    ledger.touch_heartbeat("S-legacy")  # no slug content, pre-#534 shape
+    assert ledger.serialize_in_flight("-p-A") is False, \
+        "an unattributable stamp fails toward silence, never cross-project noise"
+
+
+def test_serialize_in_flight_false_with_no_heartbeat_dir(tmp_log_dir):
+    from daimon_briefing import ledger
+    assert ledger.serialize_in_flight("-p-A") is False
+
+
+def test_brief_notes_in_flight_serialize(tmp_checkpoint_dir, sample_checkpoint,
+                                         capsys, monkeypatch):
+    from daimon_briefing import store, ledger
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    store.write_checkpoint("S-prev", sample_checkpoint, project_dir="/p/A")
+    monkeypatch.setattr(ledger, "serialize_in_flight", lambda slug, now=None: True)
+    rc = cli.main(["brief"])
+    assert rc == 0
+    assert "one session behind" in capsys.readouterr().out
+
+
+def test_brief_silent_when_no_serialize_in_flight(tmp_checkpoint_dir,
+                                                  sample_checkpoint, capsys,
+                                                  monkeypatch):
+    from daimon_briefing import store, ledger
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    store.write_checkpoint("S-prev", sample_checkpoint, project_dir="/p/A")
+    monkeypatch.setattr(ledger, "serialize_in_flight", lambda slug, now=None: False)
+    rc = cli.main(["brief"])
+    assert rc == 0
+    assert "one session behind" not in capsys.readouterr().out


### PR DESCRIPTION
Closes #534

## PR Type
- [x] Bug fix

## Summary
- Serialize entry stamps its project slug as the heartbeat file's content (step touches preserve it); `ledger.serialize_in_flight(slug)` answers true only for a fresh-within-the-hung-ceiling stamp matching this project.
- `daimon brief` renders one ⏳ line when true. Stale, empty (legacy), and foreign-project stamps stay silent — the approval condition: a crashed serialize must never pin a permanent false staleness line. Liveness bar is the same ceiling heal uses.

## Changes
| File | Change |
|------|--------|
| `plugin/daimon_briefing/ledger.py` | `touch_heartbeat` slug content param, `serialize_in_flight` |
| `plugin/daimon_briefing/cli.py` | ledger import, stamped entry touch in `_run_serialize`, brief line |
| `plugin/tests/test_cli.py` | 8 tests: stamp/preserve, match, foreign-slug, stale, legacy-empty, no-dir, line shown, line silent |

## Test Plan
- [x] TDD: all watched failing first
- [x] Full suite: 2765 passed

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one type:* label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers