### PR TITLE
chore(scars): promote four reviewed candidates to 0036-0039

### DIFF
--- a/.scars/0036-config-env-file-shadows-cleared-process-env.landmine.md
+++ b/.scars/0036-config-env-file-shadows-cleared-process-env.landmine.md
@@ -1,20 +1,20 @@
 ---
-id: 0
+id: 36
 type: landmine
 title: Clearing os.environ does NOT unset a daimon config value — config._get falls back to ~/.daimon/env on disk
 severity: high
 confidence: 0.95
 created: 2026-07-31
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/config.py
   - pattern: "os\.environ\.pop|monkeypatch\.delenv"
 evidence:
-  - note: "daimon#475 part 2 review. An exhaustive parity harness compared the old inline rescue_gap formula against rescue_posture() across 40 backend/key/fallback/command combinations. Every 'no API key' row was produced with os.environ.pop('DAIMON_LLM_API_KEY') + pop('LITELLM_API_KEY'). The harness reported rows where config.llm_api_key() was truthy despite the pops, and the first run's conclusions were wrong in BOTH directions: it hid the real defect (2 rows) and invented 2 fake ones. Caught only because a row was internally inconsistent (OLD=True is impossible when the formula requires a truthy key). Re-run with the accessors patched directly, the true answer was 3 changed rows, one of which was a genuine design defect."
+  - note: daimon#475 part 2 review. An exhaustive parity harness compared the old inline rescue_gap formula against rescue_posture() across 40 backend/key/fallback/command combinations. Every 'no API key' row was produced with os.environ.pop('DAIMON_LLM_API_KEY') + pop('LITELLM_API_KEY'). The harness reported rows where config.llm_api_key() was truthy despite the pops, and the first run's conclusions were wrong in BOTH directions: it hid the real defect (2 rows) and invented 2 fake ones. Caught only because a row was internally inconsistent (OLD=True is impossible when the formula requires a truthy key). Re-run with the accessors patched directly, the true answer was 3 changed rows, one of which was a genuine design defect.
 expires:
   condition: "config._get stops falling back to the env file, or an official test helper lands that neutralises both sources at once"
   review_after: 2027-01-31
-status: candidate
+status: active
 ---
 
 `config._get()` is `process env, then env file`:

--- a/.scars/0037-prompt-stance-does-not-predict-recall-relevance.deadend.md
+++ b/.scars/0037-prompt-stance-does-not-predict-recall-relevance.deadend.md
@@ -1,21 +1,21 @@
 ---
-id: 0
+id: 37
 type: deadend
 title: Prompt-stance surface markers do not predict recall relevance — gating injection on question-vs-statement shape refuted (#483)
 severity: medium
 confidence: 0.9
 created: 2026-08-01
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: research/experiments/recall-replay-ab/variants.py
   - path: plugin/daimon_briefing/recall.py
   - pattern: "classify_stance|question.?shaped|statement.?shaped"
 evidence:
-  - note: "#483 pre-registered run (run-04-stance-gate, 2026-08-01, same 342-prompt corpus as #470's run-03; arm A reproduced run-03's 344 injections exactly). Holdout blind judging: relevant rate in rows the gate DROPPED = 38.5%, vs 39.9% in arm A's full pool and 39.4% in what the gate kept — statistically indistinguishable. Both pre-registered ship clauses failed; kill condition met. Classifier itself was reliable (spot-checked); the markers simply do not carry relevance signal."
+  - note: #483 pre-registered run (run-04-stance-gate, 2026-08-01, same 342-prompt corpus as #470's run-03; arm A reproduced run-03's 344 injections exactly). Holdout blind judging: relevant rate in rows the gate DROPPED = 38.5%, vs 39.9% in arm A's full pool and 39.4% in what the gate kept — statistically indistinguishable. Both pre-registered ship clauses failed; kill condition met. Classifier itself was reliable (spot-checked); the markers simply do not carry relevance signal.
 expires:
   condition: "a stance signal richer than surface markers (e.g. trained intent classification) is tested and shows the dropped-row relevant rate materially below the kept-row rate"
   review_after: 2027-02-01
-status: candidate
+status: active
 ---
 
 Hypothesis (#483, from the remnant collision-detector critique): overlap

--- a/.scars/0038-sd-multiline-mutation-silently-noops.deadend.md
+++ b/.scars/0038-sd-multiline-mutation-silently-noops.deadend.md
@@ -1,20 +1,20 @@
 ---
-id: 0
+id: 38
 type: deadend
 title: sd with multiline/complex regex silently no-ops — mutation tests then "pass" against unmutated code
 severity: high
 confidence: 0.9
 created: 2026-08-01
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/
-  - pattern: "sd '[^']*\n"
+violation: "sd '[^']*\\n"
 evidence:
-  - note: "2026-08-01 session, twice in one day. (1) #475 review: sd pattern spanning 'backend = resolve_backend()...' lines did not match; the 'restored' file still held the mutant and the full suite ran 2 failures that were misread as new-test signal. (2) #480 slice-2 review: sd multiline pattern on _tie_rank did not match, tie-break test 'passed' against UNMUTATED code and the pass was nearly reported as mutation-proof. Both caught only by re-grepping for the MUTANT marker / the expected changed line before trusting the run."
+  - note: 2026-08-01 session, twice in one day. (1) #475 review: sd pattern spanning 'backend = resolve_backend()...' lines did not match; the 'restored' file still held the mutant and the full suite ran 2 failures that were misread as new-test signal. (2) #480 slice-2 review: sd multiline pattern on _tie_rank did not match, tie-break test 'passed' against UNMUTATED code and the pass was nearly reported as mutation-proof. Both caught only by re-grepping for the MUTANT marker / the expected changed line before trusting the run.
 expires:
   condition: "mutation edits move to a dedicated tool that fails loudly on zero replacements"
   review_after: 2027-02-01
-status: candidate
+status: active
 ---
 
 Tried using `sd 'pattern' 'replacement' file` for quick mutation-testing edits

--- a/.scars/0039-suppressing-variants-drift-session-seen-state.landmine.md
+++ b/.scars/0039-suppressing-variants-drift-session-seen-state.landmine.md
@@ -1,20 +1,20 @@
 ---
-id: 0
+id: 39
 type: landmine
 title: Any suppressing replay variant drifts session seen-state — later prompts in the same session no longer compare A-vs-B cleanly
 severity: medium
 confidence: 0.85
 created: 2026-08-01
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: research/experiments/recall-replay-ab/
   - pattern: "return \[\]"
 evidence:
-  - note: "#483 run-04: 38 of 166 diff prompts carried b_only injections that arm A never produced — impossible for a pure prompt gate whose pass-through arm is 'identical to A'. Traced (prompt_idx 214): when arm B suppresses an earlier prompt's injections, it never marks the origin session as seen, so a later pass-through prompt in the same session faces a larger candidate pool than arm A's. Session-cooldown-layer analog of #470's slot-promotion trap."
+  - note: #483 run-04: 38 of 166 diff prompts carried b_only injections that arm A never produced — impossible for a pure prompt gate whose pass-through arm is 'identical to A'. Traced (prompt_idx 214): when arm B suppresses an earlier prompt's injections, it never marks the origin session as seen, so a later pass-through prompt in the same session faces a larger candidate pool than arm A's. Session-cooldown-layer analog of #470's slot-promotion trap.
 expires:
   condition: "the replay rig gains a mode that replays arm B against arm A's seen-state (or documents per-arm seen-state as the intended semantics in README)"
   review_after: 2027-02-01
-status: candidate
+status: active
 ---
 
 The replay rig maintains per-arm seen/cooldown state. A variant that returns


### PR DESCRIPTION
Closes #543

## PR Type
- [x] Maintenance/tooling

## Summary
- Promotes the four human-reviewed scar candidates via `scar promote` (reviewer stamped from git config).
- One lint-driven fix on 0038: reintroduction-guard regex moved from a dead `pattern:` anchor to `violation:` (the linter's own hint; double-quoted per scar 0021, escaped per scar 0019).

## Changes
| File | Change |
|------|--------|
| `.scars/0036-config-env-file-shadows-cleared-process-env.landmine.md` | promoted |
| `.scars/0037-prompt-stance-does-not-predict-recall-relevance.deadend.md` | promoted |
| `.scars/0038-sd-multiline-mutation-silently-noops.deadend.md` | promoted + violation-field fix |
| `.scars/0039-suppressing-variants-drift-session-seen-state.landmine.md` | promoted |

## Test Plan
- [x] `scar lint`: 39 files, 0 errors, 0 orphans, 0 partial-rot

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one type:* label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers