### PR TITLE
fix(hooks): the orphan sweep must not spawn a serialize that is already running

### DIFF
--- a/.scars/0040-fallback-used-flag-gates-the-chunk-cache.landmine.md
+++ b/.scars/0040-fallback-used-flag-gates-the-chunk-cache.landmine.md
@@ -13,7 +13,7 @@ anchors:
 evidence:
   - note: serializer.py:1652 refuses every chunk-cache write once fallback_used() is true, citing the #28/#343 poisoning lesson inline.
   - note: serializer.py:1577 builds the cache key from configure.resolved_backend() — the CONFIGURED backend, which is not the backend that served the call when a fallback fired.
-  - commit: 792b115
+  - commit: 856cc9c
 expires:
   condition: "_chunk_cache_key stamps the backend that actually SERVED the call (e.g. from llm.served_models()) instead of the configured one, making the key self-distinguishing"
   review_after: 2027-02-04

--- a/hook/_daimon_hook_lib.py
+++ b/hook/_daimon_hook_lib.py
@@ -244,6 +244,64 @@ _LOG_RESULT_ERR_RE = re.compile(r"^error: .*?(?: after (\d+)s)?$")
 _LOG_ERR_TRANSCRIPT_RE = re.compile(r"\(transcript: (.+?)\)(?: after \d+s|$)")
 
 
+def hung_after_seconds() -> int:
+    """Age (seconds) past which a serialize heartbeat is treated as hung or
+    killed rather than still-running. A second copy of
+    daimon_briefing.config.hung_after_seconds(), because hooks cannot import
+    the package; tests lock the two to behavioral equality.
+
+    Reads the PROCESS env only. The package form also consults ~/.daimon/env,
+    so a DAIMON_HUNG_AFTER set only in that file is invisible here — the same
+    documented boundary as LOG_DIR, which the hooks hardcode while the CLI
+    honors DAIMON_LOG_DIR. A disagreement costs at most a delayed or an extra
+    sweep, never a lost transcript."""
+    try:
+        return int(os.environ.get("DAIMON_HUNG_AFTER") or "1800")
+    except ValueError:
+        return 1800
+
+
+def _in_flight_stems() -> set:
+    """Transcript stems (session ids) with a LIVE serialize right now (#545).
+
+    A serialize stamps a heartbeat named for its session (ledger.touch_heartbeat)
+    and only writes its checkpoint at the very end, so between those two moments
+    the transcript looks exactly like a never-captured orphan: no checkpoint on
+    disk, nothing in the failure ledger. sweep_orphans then spawned a SECOND
+    full serialize of the same transcript, and whichever finished last
+    overwrote the other — last-writer-wins, uncorrelated with quality (field
+    case: the surviving checkpoint had 28 decisions against the discarded
+    one's 32).
+
+    sweep_orphans' own idempotency argument does not cover this: the #185
+    identical-bytes guard compares against an EXISTING checkpoint, and an
+    unfinished serialize has not written one yet, so the guard cannot fire.
+
+    A STALE stamp is deliberately not in-flight — that is a crashed serialize
+    and heal's territory, and treating it as live would make the transcript
+    permanently unsweepable, strictly worse than the double-spawn this
+    prevents. Same liveness bar as ledger.serialize_in_flight, but keyed
+    per-session (the stamp's filename) rather than per-project (its content),
+    so a live serialize for one session never starves an orphaned sibling.
+
+    Fails open to an empty set on any read error, matching
+    _failed_session_stems: a missing heartbeat dir must never block the
+    genuine #185/#188 recovery sweep."""
+    stems = set()
+    try:
+        ceiling = hung_after_seconds()
+        now = time.time()
+        for p in (LOG_DIR / "heartbeats").iterdir():
+            try:
+                if now - p.stat().st_mtime <= ceiling:
+                    stems.add(p.name)
+            except OSError:
+                continue
+    except OSError:
+        return set()
+    return stems
+
+
 def _failed_session_stems() -> set:
     """Transcript stems (session ids) whose LATEST serialize.log outcome is a
     recorded failure — a lightweight, read-only echo of
@@ -320,6 +378,7 @@ def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
         cutoff = time.time() - _ORPHAN_MAX_AGE_SECONDS
         ckpt_dir = checkpoint_dir()
         failed_stems = _failed_session_stems()
+        in_flight_stems = _in_flight_stems()
         best_path = None
         best_mtime = None
         for candidate in directory.glob("*.jsonl"):
@@ -333,6 +392,8 @@ def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
                 continue  # outside the bounded scan window
             if candidate.stem in failed_stems:
                 continue  # attempted and failed -> heal's job, not an orphan (#299)
+            if candidate.stem in in_flight_stems:
+                continue  # serialize RUNNING right now -> not an orphan yet (#545)
             ckpt_path = ckpt_dir / f"{candidate.stem}.json"
             try:
                 if ckpt_path.stat().st_mtime >= mtime:

--- a/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
+++ b/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
@@ -244,6 +244,64 @@ _LOG_RESULT_ERR_RE = re.compile(r"^error: .*?(?: after (\d+)s)?$")
 _LOG_ERR_TRANSCRIPT_RE = re.compile(r"\(transcript: (.+?)\)(?: after \d+s|$)")
 
 
+def hung_after_seconds() -> int:
+    """Age (seconds) past which a serialize heartbeat is treated as hung or
+    killed rather than still-running. A second copy of
+    daimon_briefing.config.hung_after_seconds(), because hooks cannot import
+    the package; tests lock the two to behavioral equality.
+
+    Reads the PROCESS env only. The package form also consults ~/.daimon/env,
+    so a DAIMON_HUNG_AFTER set only in that file is invisible here — the same
+    documented boundary as LOG_DIR, which the hooks hardcode while the CLI
+    honors DAIMON_LOG_DIR. A disagreement costs at most a delayed or an extra
+    sweep, never a lost transcript."""
+    try:
+        return int(os.environ.get("DAIMON_HUNG_AFTER") or "1800")
+    except ValueError:
+        return 1800
+
+
+def _in_flight_stems() -> set:
+    """Transcript stems (session ids) with a LIVE serialize right now (#545).
+
+    A serialize stamps a heartbeat named for its session (ledger.touch_heartbeat)
+    and only writes its checkpoint at the very end, so between those two moments
+    the transcript looks exactly like a never-captured orphan: no checkpoint on
+    disk, nothing in the failure ledger. sweep_orphans then spawned a SECOND
+    full serialize of the same transcript, and whichever finished last
+    overwrote the other — last-writer-wins, uncorrelated with quality (field
+    case: the surviving checkpoint had 28 decisions against the discarded
+    one's 32).
+
+    sweep_orphans' own idempotency argument does not cover this: the #185
+    identical-bytes guard compares against an EXISTING checkpoint, and an
+    unfinished serialize has not written one yet, so the guard cannot fire.
+
+    A STALE stamp is deliberately not in-flight — that is a crashed serialize
+    and heal's territory, and treating it as live would make the transcript
+    permanently unsweepable, strictly worse than the double-spawn this
+    prevents. Same liveness bar as ledger.serialize_in_flight, but keyed
+    per-session (the stamp's filename) rather than per-project (its content),
+    so a live serialize for one session never starves an orphaned sibling.
+
+    Fails open to an empty set on any read error, matching
+    _failed_session_stems: a missing heartbeat dir must never block the
+    genuine #185/#188 recovery sweep."""
+    stems = set()
+    try:
+        ceiling = hung_after_seconds()
+        now = time.time()
+        for p in (LOG_DIR / "heartbeats").iterdir():
+            try:
+                if now - p.stat().st_mtime <= ceiling:
+                    stems.add(p.name)
+            except OSError:
+                continue
+    except OSError:
+        return set()
+    return stems
+
+
 def _failed_session_stems() -> set:
     """Transcript stems (session ids) whose LATEST serialize.log outcome is a
     recorded failure — a lightweight, read-only echo of
@@ -320,6 +378,7 @@ def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
         cutoff = time.time() - _ORPHAN_MAX_AGE_SECONDS
         ckpt_dir = checkpoint_dir()
         failed_stems = _failed_session_stems()
+        in_flight_stems = _in_flight_stems()
         best_path = None
         best_mtime = None
         for candidate in directory.glob("*.jsonl"):
@@ -333,6 +392,8 @@ def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
                 continue  # outside the bounded scan window
             if candidate.stem in failed_stems:
                 continue  # attempted and failed -> heal's job, not an orphan (#299)
+            if candidate.stem in in_flight_stems:
+                continue  # serialize RUNNING right now -> not an orphan yet (#545)
             ckpt_path = ckpt_dir / f"{candidate.stem}.json"
             try:
                 if ckpt_path.stat().st_mtime >= mtime:

--- a/plugin/tests/test_claude_hooks.py
+++ b/plugin/tests/test_claude_hooks.py
@@ -459,6 +459,127 @@ def test_sweep_orphans_spawns_for_uncaptured_transcript(tmp_path, monkeypatch):
     assert calls == [str(orphan)]
 
 
+def test_sweep_orphans_skips_a_transcript_whose_serialize_is_in_flight(tmp_path, monkeypatch):
+    # #545: the sweep classified an IN-FLIGHT serialize as an orphan. Its
+    # idempotency argument ("the spawned serialize hits the #185
+    # identical-bytes guard and no-ops if the transcript actually WAS
+    # captured") compares against an EXISTING checkpoint — an unfinished
+    # serialize has not written one yet, so the guard cannot fire. The second
+    # run then overwrote the first's checkpoint with a worse one.
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
+    monkeypatch.setattr(lib, "LOG_DIR", tmp_path / "logs")
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+    orphan = transcripts / "S-orphan.jsonl"
+    orphan.write_text("{}\n")
+    _age(orphan, 3600)
+
+    beats = tmp_path / "logs" / "heartbeats"
+    beats.mkdir(parents=True)
+    (beats / "S-orphan").write_text("some-project-slug")  # fresh: serialize live
+
+    calls = []
+    monkeypatch.setattr(lib, "spawn_serialize", lambda cli, path, env: calls.append(path))
+    lib.sweep_orphans("daimon", "/p/A", "S-new", str(current))
+    assert calls == []
+
+
+def test_sweep_orphans_still_spawns_when_the_heartbeat_is_stale(tmp_path, monkeypatch):
+    # A crashed serialize leaves its stamp behind forever. Treating a stale
+    # stamp as "in flight" would make the transcript permanently unsweepable —
+    # strictly worse than the double-spawn this fixes. Same liveness bar the
+    # package uses.
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
+    monkeypatch.setattr(lib, "LOG_DIR", tmp_path / "logs")
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+    orphan = transcripts / "S-orphan.jsonl"
+    orphan.write_text("{}\n")
+    _age(orphan, 3600)
+
+    beats = tmp_path / "logs" / "heartbeats"
+    beats.mkdir(parents=True)
+    stamp = beats / "S-orphan"
+    stamp.write_text("some-project-slug")
+    _age(stamp, 4000)  # past the 1800s hung ceiling
+
+    calls = []
+    monkeypatch.setattr(lib, "spawn_serialize", lambda cli, path, env: calls.append(path))
+    lib.sweep_orphans("daimon", "/p/A", "S-new", str(current))
+    assert calls == [str(orphan)]
+
+
+def test_sweep_orphans_in_flight_check_is_per_session_not_per_project(tmp_path, monkeypatch):
+    # A live serialize for ONE session must not starve a genuinely orphaned
+    # sibling. The heartbeat FILENAME is the session id, so the filter is
+    # per-candidate rather than the project-level question `daimon brief` asks.
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
+    monkeypatch.setattr(lib, "LOG_DIR", tmp_path / "logs")
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+    busy = transcripts / "S-busy.jsonl"
+    busy.write_text("{}\n")
+    _age(busy, 1800)          # newer candidate, but its serialize is running
+    orphan = transcripts / "S-orphan.jsonl"
+    orphan.write_text("{}\n")
+    _age(orphan, 3600)
+
+    beats = tmp_path / "logs" / "heartbeats"
+    beats.mkdir(parents=True)
+    (beats / "S-busy").write_text("some-project-slug")
+
+    calls = []
+    monkeypatch.setattr(lib, "spawn_serialize", lambda cli, path, env: calls.append(path))
+    lib.sweep_orphans("daimon", "/p/A", "S-new", str(current))
+    assert calls == [str(orphan)]
+
+
+def test_sweep_orphans_survives_a_missing_heartbeat_dir(tmp_path, monkeypatch):
+    # Fail-open, same rule as _failed_session_stems: no heartbeat dir must
+    # never block the genuine #185/#188 recovery sweep.
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
+    monkeypatch.setattr(lib, "LOG_DIR", tmp_path / "logs")
+    transcripts = tmp_path / "proj"
+    transcripts.mkdir()
+    current = transcripts / "S-new.jsonl"
+    current.write_text("{}\n")
+    orphan = transcripts / "S-orphan.jsonl"
+    orphan.write_text("{}\n")
+    _age(orphan, 3600)
+
+    calls = []
+    monkeypatch.setattr(lib, "spawn_serialize", lambda cli, path, env: calls.append(path))
+    lib.sweep_orphans("daimon", "/p/A", "S-new", str(current))
+    assert calls == [str(orphan)]
+
+
+def test_hook_lib_hung_ceiling_stays_in_sync_with_config():
+    # Same drift-lock treatment as the #521 slug/created_epoch pair. The hook
+    # lib cannot import daimon_briefing, so the ceiling is a second copy; if
+    # the two disagree, the sweep and `daimon status` disagree about what
+    # "still running" means and the #545 double-spawn returns silently.
+    # Behavioral equality over inputs chosen to discriminate plausible drifts.
+    from daimon_briefing import config
+
+    # Locks the PROCESS-env axis, which is the only one the hook lib reads:
+    # config also consults ~/.daimon/env, a documented boundary stated in
+    # lib.hung_after_seconds' own docstring.
+    for raw in (None, "", "   ", "1800", "60", "0", "-5", "not-an-int", "12.5"):
+        os.environ.pop("DAIMON_HUNG_AFTER", None)
+        if raw is not None:
+            os.environ["DAIMON_HUNG_AFTER"] = raw
+        try:
+            assert lib.hung_after_seconds() == config.hung_after_seconds(), raw
+        finally:
+            os.environ.pop("DAIMON_HUNG_AFTER", None)
+
+
 def test_sweep_orphans_spawns_only_the_newest_candidate(tmp_path, monkeypatch):
     monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
     monkeypatch.setattr(lib, "LOG_DIR", tmp_path / "logs")  # a spawn also logs a breadcrumb


### PR DESCRIPTION
Closes #545

## What

`sweep_orphans` gets a per-candidate in-flight filter, alongside the `#299` failed-stems one.

| File | Change |
|------|--------|
| `hook/_daimon_hook_lib.py` | `hung_after_seconds()` and `_in_flight_stems()`; one new `continue` in the candidate loop |
| `plugin/daimon_briefing/_hooks/_daimon_hook_lib.py` | generated mirror, synced |
| `plugin/tests/test_claude_hooks.py` | 5 tests |
| `.scars/0040-...landmine.md` | evidence repointed, see below |

## Why

The sweep classified an in-flight serialize as a never-captured orphan and spawned a second full serialize of the same transcript. Whichever finished last overwrote the other. That is last-writer-wins, uncorrelated with quality: in the captured case the surviving checkpoint had 28 decisions and 89% `because` coverage against the discarded one's 32 and 100%.

The function's own idempotency argument does not reach this case. It says:

> the spawned serialize hits the #185 identical-bytes guard and no-ops if the transcript actually WAS captured

That guard compares the transcript hash against the hash stamped on an **existing** checkpoint. An unfinished serialize has not written one, so the guard cannot fire and the transcript still looks uncaptured.

Same shape as `#299`, which fixed the neighbouring case where a **failed** serialize also left no checkpoint. `_failed_session_stems()` cannot cover an in-flight run, because it is not failing, it simply has not finished yet.

Three decisions worth review attention:

**Per-session, not per-project.** `ledger.serialize_in_flight()` answers a project-level question, which is right for the `brief` line it was built for. Here the heartbeat's **filename** is the session id, so the filter keys on that. A live serialize for one session therefore never starves a genuinely orphaned sibling, which a project-level check would.

**A stale stamp is deliberately not in-flight.** A crashed serialize leaves its heartbeat behind forever. Treating that as live would make the transcript permanently unsweepable, which is strictly worse than the double-spawn being fixed. Same liveness bar the package uses.

**The ceiling is a second copy, and that is load-bearing.** Hooks are stdlib-only and cannot import `daimon_briefing`, so `hung_after_seconds()` duplicates `config.hung_after_seconds()`. A test locks the two to behavioral equality over inputs chosen to discriminate plausible drifts, the same treatment `#521` gave `slug` and `created_epoch`. If they disagree, the sweep and `daimon status` disagree about what "still running" means and this bug returns silently.

Stated limit: the hook copy reads the process env only, while the package form also consults `~/.daimon/env`. That is the same boundary `LOG_DIR` already sits on (the hooks hardcode it, the CLI honors `DAIMON_LOG_DIR`), it is stated in the docstring, and the drift-lock test says which axis it locks. A disagreement costs at most a delayed or an extra sweep, never a lost transcript.

## Tests

`uv run --extra dev --extra pretty pytest -q` from `plugin/`: **2790 passed, 2 skipped**. `ruff check daimon_briefing tests ../scripts`: clean. `scar lint`: 0 errors. `scripts/sync_hooks.py --check`: in sync.

5 new tests, the three behavioral ones watched failing first:

- skips a transcript whose serialize is in flight (the bug)
- still spawns when the heartbeat is stale (crashed serialize stays sweepable)
- the filter is per-session, not per-project (a busy sibling does not starve an orphan)
- survives a missing heartbeat dir (fail-open, matching `_failed_session_stems`)
- ceiling stays in sync with `config.hung_after_seconds()` (drift lock)

## Note on the scar edit

`scar lint` flagged `evidence-unreachable` on scar `0040`: it cited `792b115`, a branch commit that `#547`'s squash-merge removed from history. Repointed at `856cc9c`, the commit that actually exists on main. Worth knowing as a general trap, since any scar citing a pre-squash SHA will rot the moment its PR merges.
