### PR TITLE
fix(llm): PATH presence is not consent — name the CLI that receives the transcript

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -171,7 +171,7 @@ The URL, key, and model each fall back to a `LITELLM_*` variable if the
 
 | Variable | Default | What it does |
 |---|---|---|
-| `DAIMON_LLM_BACKEND` | `auto` | Transport: `auto` (litellm if credentials exist, else a command CLI if one resolves), `litellm`, `command`, or `claude-cli`. |
+| `DAIMON_LLM_BACKEND` | `auto` | Transport: `auto` (litellm if credentials exist, else a named command CLI if one resolves), `litellm`, `command`, or `claude-cli`. `claude-cli` is the zero-config option: it runs a `claude` found on PATH with a built-in preset and needs nothing else set. `command` requires `DAIMON_LLM_COMMAND`. |
 | `DAIMON_LLM_BASE_URL` | `http://localhost:4000` | OpenAI-compatible endpoint URL (trailing slash trimmed). Falls back to `LITELLM_BASE_URL`. |
 | `DAIMON_LLM_API_KEY` | unset | API key for the endpoint. Falls back to `LITELLM_API_KEY`. |
 | `DAIMON_LLM_MODEL` | unset | Model name to send. Falls back to `LITELLM_MODEL`. |
@@ -181,7 +181,15 @@ The URL, key, and model each fall back to a `LITELLM_*` variable if the
 | `DAIMON_LLM_STREAM` | on | Stream the litellm response so the socket timeout bounds the inter-frame gap rather than the whole completion. Without it, a long completion trips the timeout and retries from scratch. Set to `0` to disable. |
 | `DAIMON_LLM_NO_CACHE` | off | When truthy, bypass gateway response caching per request — needed when a cached bad response pins a failure or runs must be statistically independent. |
 | `DAIMON_LLM_BRIEFING` | off | When truthy, render the briefing via the LLM instead of the deterministic template. |
-| `DAIMON_LLM_COMMAND` | unset | Full CLI invocation for the `command` backend (binary + model + flags). |
+| `DAIMON_LLM_COMMAND` | unset | Full CLI invocation for the `command` backend (binary + model + flags). Required for `command`, and required for a `claude` on PATH to be used by any backend other than `claude-cli`. |
+
+:::note Which process receives your transcript
+
+A `claude` binary merely present on PATH is **not** adopted automatically. Serializing sends the full session transcript to whichever CLI is configured, so that CLI has to be named: either `DAIMON_LLM_COMMAND`, or `DAIMON_LLM_BACKEND=claude-cli` to opt into the built-in preset.
+
+Previously an unset `DAIMON_LLM_COMMAND` plus a `claude` anywhere on PATH was enough for `auto` installs and for the litellm rescue path. If you relied on that, set one of the two variables above. `daimon configure` and `daimon doctor` name the resolved binary and its path so you can see exactly which one is in use.
+
+:::
 | `DAIMON_LLM_COMMAND_OUTPUT` | unset | How to extract assistant text from the command's stdout: `text` (raw stdout) or `json:<key>` (parse JSON, read `<key>`). |
 | `DAIMON_LLM_COMMAND_INPUT` | `stdin` | How the prompt reaches the command backend: `stdin` (piped), `arg` (appended as the final argv element), or `file:<flag>` (written to a tempfile, then `<flag> <path>` appended). An unrecognized value logs a warning and falls back to `stdin`. |
 | `DAIMON_LLM_COMMAND_FALLBACK` | unset | The one rescue CLI, used when the primary backend fails. Works for both a litellm primary and a `command` primary, which previously had no rescue direction at all. One fallback, never a chain: if the primary and this both fail the cause is almost always environmental, and a third CLI spends budget reaching the same error while making the install look better protected than it is. When unset, a litellm primary still falls back to `DAIMON_LLM_COMMAND` as before. |

--- a/plugin/daimon_briefing/configure.py
+++ b/plugin/daimon_briefing/configure.py
@@ -46,6 +46,13 @@ def status() -> dict:
             "explicit" if config.llm_command()
             else ("claude-cli" if cmd else None)
         ),
+        # #546: when the preset resolved, the operator named the BACKEND but
+        # not the binary — PATH chose that. Naming the resolved path is what
+        # turns "zero-config" from opaque into auditable.
+        "command_path": (
+            shutil.which("claude")
+            if (cmd and not config.llm_command()) else None
+        ),
         # #475: the rescue is a second binary now. The doctor showed only the
         # primary, so a misconfigured fallback was invisible on the one
         # surface built to catch misconfiguration before a detached hook

--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -534,14 +534,27 @@ def _resolve_command():
     """Resolve the command backend (command_str, output_spec, input_spec) or
     None.
 
-    Order: explicit DAIMON_LLM_COMMAND, else claude-cli preset if claude is
-    on PATH, else None (no fallback possible). The claude-cli preset always
+    Order: explicit DAIMON_LLM_COMMAND, else the claude-cli preset ONLY when
+    the operator asked for that backend by name, else None. The preset always
     stays on stdin — `claude -p` reads the prompt from stdin, so the input
-    axis (#58) only matters for explicit commands."""
+    axis (#58) only matters for explicit commands.
+
+    #546: the preset used to resolve on PATH presence alone, which handed the
+    full transcript to whichever `claude` happened to be first on PATH with no
+    opt-in anywhere. The asymmetry gave it away: how the prompt is delivered
+    (DAIMON_LLM_COMMAND_INPUT) and how output is read
+    (DAIMON_LLM_COMMAND_OUTPUT) both require explicit configuration, while the
+    identity of the process RECEIVING the transcript did not.
+
+    DAIMON_LLM_BACKEND=claude-cli is a named, deliberate choice, so it keeps
+    the zero-config preset — that backend has no other implementation, and the
+    consent is the naming. `auto` and the litellm rescue are not choices at
+    all (PATH picked, not the operator), so they now require naming a
+    command."""
     cmd = config.llm_command()
     if cmd:
         return cmd, (config.llm_command_output() or "text"), config.llm_command_input()
-    if shutil.which("claude"):
+    if config.llm_backend().strip() == "claude-cli" and shutil.which("claude"):
         return (*_CLAUDE_PRESET, "stdin")
     return None
 
@@ -710,7 +723,11 @@ def _chat_command(messages, deadline, resolved=None):
     if resolved is None:
         resolved = _resolve_command()
     if not resolved:
-        raise ChatError("No command backend (set DAIMON_LLM_COMMAND or install claude).")
+        raise ChatError(
+            "No command backend: set DAIMON_LLM_COMMAND to the CLI that should "
+            "receive the transcript, or set DAIMON_LLM_BACKEND=claude-cli to use "
+            "the zero-config claude preset. Since #546 a claude on PATH is no "
+            "longer adopted implicitly.")
     command, output_spec, input_spec = resolved
     argv = shlex.split(command)
     prompt_text = _flatten_messages(messages)

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -367,7 +367,12 @@ def _explain(st: dict) -> str:
         if st["ready"]:
             src = st["command_source"]
             if src == "claude-cli":
-                return f"backend: {rb} (claude CLI, zero-config)"
+                # #546: name the binary PATH resolved. "zero-config" is a
+                # feature, but the operator should be able to see WHICH claude
+                # is about to receive the transcript without running `which`.
+                path = st.get("command_path")
+                where = f" from PATH: {path}" if path else ""
+                return f"backend: {rb} (claude CLI{where}, zero-config)"
             base = f"backend: {rb} ({st['command']})"
             # #58: only note the input spec when it's not the stdin default —
             # keeps the common case's one-liner unchanged.

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1282,18 +1282,26 @@ def _set_claude(monkeypatch, present):
 def test_cli_configure_claude_zero_config_writes_nothing(
     capsys, monkeypatch, tmp_path
 ):
-    # claude on PATH, no API key -> zero-config ready; nothing must be written.
+    # claude-cli NAMED, claude on PATH, no API key -> zero-config ready;
+    # nothing must be written.
+    #
+    # #546: this used to leave the backend at `auto` and rely on PATH alone to
+    # produce a command backend. That path no longer exists, and the loose
+    # substring assertions below kept passing against an unrelated
+    # "missing: api_key, model" line — a test whose name had stopped matching
+    # what it exercised. Naming the backend restores the intent.
     env_file = tmp_path / "env"
     monkeypatch.setenv("DAIMON_ENV_FILE", str(env_file))
     _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "claude-cli")
     _set_claude(monkeypatch, True)
 
     rc = cli.main(["configure"])
     assert rc == 0
-    out = capsys.readouterr().out.lower()
-    assert "ready" in out
-    assert "command" in out  # the resolved backend is named
-    assert not env_file.exists()  # zero-config writes nothing
+    out = capsys.readouterr().out
+    assert "claude CLI" in out          # the zero-config preset is what resolved
+    assert "missing:" not in out        # genuinely ready, not a degraded read
+    assert not env_file.exists()        # zero-config writes nothing
 
 
 def test_cli_configure_litellm_flags_write_env(capsys, monkeypatch, tmp_path):

--- a/plugin/tests/test_configure.py
+++ b/plugin/tests/test_configure.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from daimon_briefing import configure, llm
+from daimon_briefing import configure, llm, render
 
 
 _LLM_VARS = (
@@ -35,15 +35,31 @@ def _set_claude(monkeypatch, present):
 # ---- resolved_backend / status detection matrix (mirrors llm.chat() `auto`) ----
 
 
-def test_claude_on_path_no_key_resolves_command(clean_llm_env):
+def test_named_claude_cli_backend_resolves_the_zero_config_preset(clean_llm_env):
+    # #546: naming the backend IS the consent, so claude-cli keeps resolving
+    # the preset off PATH with no further configuration.
+    clean_llm_env.setenv("DAIMON_LLM_BACKEND", "claude-cli")
     _set_claude(clean_llm_env, True)
-    assert configure.resolved_backend() == "command"
+    assert configure.resolved_backend() == "claude-cli"
     st = configure.status()
-    assert st["resolved_backend"] == "command"
+    assert st["resolved_backend"] == "claude-cli"
     assert st["ready"] is True
     assert st["claude_on_path"] is True
     assert st["command_source"] == "claude-cli"
     assert st["command"] == llm._CLAUDE_PRESET[0]
+
+
+def test_claude_on_path_alone_no_longer_resolves_a_command_backend(clean_llm_env):
+    # #546: the (b) population. `auto` with no key and a claude on PATH used
+    # to become a command backend nobody chose. It now reports the real
+    # problem — no credentials — instead of silently adopting a binary.
+    _set_claude(clean_llm_env, True)
+    assert configure.resolved_backend() == "litellm"
+    st = configure.status()
+    assert st["ready"] is False
+    assert st["claude_on_path"] is True      # still REPORTED, just not adopted
+    assert st["command"] is None
+    assert st["command_source"] is None
 
 
 def test_api_key_and_model_no_claude_resolves_litellm(clean_llm_env):
@@ -104,7 +120,31 @@ def test_explicit_command_source(clean_llm_env):
 # ---- #58: DAIMON_LLM_COMMAND_INPUT surfaced in status() ----
 
 
+def test_status_names_the_path_resolved_binary(clean_llm_env):
+    # #546 surfacing half: naming the backend is consent, but the operator
+    # still never chose WHICH claude. Report the resolved path so "zero-config"
+    # is auditable without shelling out to `which`.
+    clean_llm_env.setenv("DAIMON_LLM_BACKEND", "claude-cli")
+    _set_claude(clean_llm_env, True)
+    st = configure.status()
+    assert st["command_path"] == "/usr/bin/claude"
+    assert "/usr/bin/claude" in render._explain(st)
+    assert "zero-config" in render._explain(st)
+
+
+def test_status_command_path_absent_for_an_explicit_command(clean_llm_env):
+    # An explicitly named command needs no PATH provenance — the operator
+    # wrote the string themselves.
+    clean_llm_env.setenv("DAIMON_LLM_BACKEND", "command")
+    clean_llm_env.setenv("DAIMON_LLM_COMMAND", "mycli -p")
+    _set_claude(clean_llm_env, True)
+    st = configure.status()
+    assert st["command_path"] is None
+    assert "from PATH" not in render._explain(st)
+
+
 def test_status_input_defaults_to_stdin_for_claude_cli(clean_llm_env):
+    clean_llm_env.setenv("DAIMON_LLM_BACKEND", "claude-cli")  # #546: named intent
     _set_claude(clean_llm_env, True)
     st = configure.status()
     assert st["input"] == "stdin"

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -358,11 +358,94 @@ def test_resolve_command_prefers_explicit(monkeypatch):
 
 
 def test_resolve_command_claude_preset(monkeypatch):
+    # #546: the preset is the IMPLEMENTATION of the claude-cli backend, so it
+    # resolves when the operator named that backend.
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "claude-cli")
     monkeypatch.delenv("DAIMON_LLM_COMMAND", raising=False)
     monkeypatch.setattr(llm.shutil, "which", lambda b: "/usr/bin/claude")
     cmd, out, inp = llm._resolve_command()
     assert cmd.startswith("claude -p") and out == "json:result"
     assert inp == "stdin"  # #58: the claude-cli preset never changes off stdin
+
+
+# ---- #546: PATH presence is not consent.
+#
+# _resolve_command() handed the full transcript to whatever `claude` happened
+# to be first on PATH, with no opt-in — while the sibling axes (how the prompt
+# is delivered, how output is parsed) both REQUIRE explicit configuration. The
+# asymmetry was the tell: everything about the command was configurable except
+# WHICH BINARY RECEIVES THE TRANSCRIPT.
+#
+# The split: DAIMON_LLM_BACKEND=claude-cli is a named, deliberate choice and
+# keeps its zero-config preset. `auto` and the litellm rescue are not choices
+# at all — PATH picked for the operator — and now require naming the command.
+
+
+def test_resolve_command_auto_backend_does_not_adopt_a_path_claude(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "auto")
+    monkeypatch.delenv("DAIMON_LLM_COMMAND", raising=False)
+    monkeypatch.setattr(llm.shutil, "which", lambda b: "/usr/bin/claude")
+    assert llm._resolve_command() is None
+
+
+def test_resolve_command_command_backend_requires_naming_the_command(monkeypatch):
+    # Picking `command` without saying which command is under-specified; the
+    # wizard asks for it. claude-cli is the zero-config alias for that intent.
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.delenv("DAIMON_LLM_COMMAND", raising=False)
+    monkeypatch.setattr(llm.shutil, "which", lambda b: "/usr/bin/claude")
+    assert llm._resolve_command() is None
+
+
+def test_resolve_command_explicit_command_still_wins_on_any_backend(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "auto")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "mycli")
+    monkeypatch.delenv("DAIMON_LLM_COMMAND_OUTPUT", raising=False)
+    monkeypatch.delenv("DAIMON_LLM_COMMAND_INPUT", raising=False)
+    assert llm._resolve_command() == ("mycli", "text", "stdin")
+
+
+def test_auto_cascade_no_longer_resolves_to_command_via_path_alone(monkeypatch):
+    # The (b) population: `auto`, no key, a claude on PATH. Previously this
+    # silently became a command backend. Now it reaches litellm's own
+    # helpful no-key error instead of a binary nobody named.
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "auto")
+    monkeypatch.delenv("DAIMON_LLM_COMMAND", raising=False)
+    monkeypatch.setattr(config, "llm_api_key", lambda: None)
+    monkeypatch.setattr(llm.shutil, "which", lambda b: "/usr/bin/claude")
+    assert llm.resolve_backend() == {"backend": "litellm", "source": "auto-none"}
+
+
+def test_litellm_rescue_no_longer_adopts_a_path_claude(monkeypatch):
+    # The (c) population: a gateway primary quietly rescued by whatever claude
+    # was on PATH. The rescue must now be named.
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.delenv("DAIMON_LLM_COMMAND", raising=False)
+    monkeypatch.delenv("DAIMON_LLM_COMMAND_FALLBACK", raising=False)
+    monkeypatch.setattr(llm.shutil, "which", lambda b: "/usr/bin/claude")
+    assert llm._resolve_fallback_command() is None
+
+
+def test_claude_cli_backend_keeps_its_zero_config_rescue_shim(monkeypatch):
+    # claude-cli is a named choice, so a litellm primary explicitly rescued by
+    # DAIMON_LLM_COMMAND still works — the shim is unaffected by #546.
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "legacycli")
+    monkeypatch.delenv("DAIMON_LLM_COMMAND_FALLBACK", raising=False)
+    assert llm._resolve_fallback_command() == ("legacycli", "text", "stdin")
+
+
+def test_chat_command_error_names_the_consent_fix(monkeypatch):
+    # The (b) break must be loud and actionable, never a silent stop.
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.delenv("DAIMON_LLM_COMMAND", raising=False)
+    monkeypatch.setattr(llm.shutil, "which", lambda b: "/usr/bin/claude")
+    with pytest.raises(llm.ChatError) as e:
+        llm._chat_command([{"role": "user", "content": "x"}], deadline=None)
+    msg = str(e.value)
+    assert "DAIMON_LLM_COMMAND" in msg
+    assert "claude-cli" in msg  # names the zero-config route too
 
 
 def test_resolve_command_none(monkeypatch):

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -143,7 +143,7 @@ the `DAIMON_*` form is unset.
 
 | Variable | Default | What it does |
 |---|---|---|
-| `DAIMON_LLM_BACKEND` | `auto` | Transport: `auto` (litellm if credentials exist, else a command CLI if one resolves), `litellm`, `command`, or `claude-cli`. |
+| `DAIMON_LLM_BACKEND` | `auto` | Transport: `auto` (litellm if credentials exist, else a named command CLI if one resolves), `litellm`, `command`, or `claude-cli`. `claude-cli` is the zero-config option: it runs a `claude` found on PATH with a built-in preset and needs nothing else set. `command` requires `DAIMON_LLM_COMMAND`. |
 | `DAIMON_LLM_BASE_URL` | `http://localhost:4000` | OpenAI-compatible endpoint URL (trailing slash trimmed). Falls back to `LITELLM_BASE_URL`. |
 | `DAIMON_LLM_API_KEY` | unset | API key for the endpoint. Falls back to `LITELLM_API_KEY`. |
 | `DAIMON_LLM_MODEL` | unset | Model name to send. Falls back to `LITELLM_MODEL`. |
@@ -153,7 +153,15 @@ the `DAIMON_*` form is unset.
 | `DAIMON_LLM_STREAM` | on | Stream the litellm response so the socket timeout bounds the inter-frame gap rather than the whole completion. Without it, a long completion trips the timeout and retries from scratch. Set to `0` to disable. |
 | `DAIMON_LLM_NO_CACHE` | off | When truthy, bypass gateway response caching per request — needed when a cached bad response pins a failure or runs must be statistically independent. |
 | `DAIMON_LLM_BRIEFING` | off | When truthy, render the briefing via the LLM instead of the deterministic template. |
-| `DAIMON_LLM_COMMAND` | unset | Full CLI invocation for the `command` backend (binary + model + flags). |
+| `DAIMON_LLM_COMMAND` | unset | Full CLI invocation for the `command` backend (binary + model + flags). Required for `command`, and required for a `claude` on PATH to be used by any backend other than `claude-cli`. |
+
+:::note Which process receives your transcript
+
+A `claude` binary merely present on PATH is **not** adopted automatically. Serializing sends the full session transcript to whichever CLI is configured, so that CLI has to be named: either `DAIMON_LLM_COMMAND`, or `DAIMON_LLM_BACKEND=claude-cli` to opt into the built-in preset.
+
+Previously an unset `DAIMON_LLM_COMMAND` plus a `claude` anywhere on PATH was enough for `auto` installs and for the litellm rescue path. If you relied on that, set one of the two variables above. `daimon configure` and `daimon doctor` name the resolved binary and its path so you can see exactly which one is in use.
+
+:::
 | `DAIMON_LLM_COMMAND_OUTPUT` | unset | How to extract assistant text from the command's stdout: `text` (raw stdout) or `json:<key>` (parse JSON, read `<key>`). |
 | `DAIMON_LLM_COMMAND_INPUT` | `stdin` | How the prompt reaches the command backend: `stdin` (piped), `arg` (appended as the final argv element), or `file:<flag>` (written to a tempfile, then `<flag> <path>` appended). An unrecognized value logs a warning and falls back to `stdin`. |
 | `DAIMON_LLM_COMMAND_FALLBACK` | unset | The one rescue CLI, used when the primary backend fails. Works for both a litellm primary and a `command` primary, which previously had no rescue direction at all. One fallback, never a chain: if the primary and this both fail the cause is almost always environmental, and a third CLI spends budget reaching the same error while making the install look better protected than it is. When unset, a litellm primary still falls back to `DAIMON_LLM_COMMAND` as before. |

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
@@ -150,7 +150,7 @@ uno a una variable `LITELLM_*` si la forma `DAIMON_*` no está definida.
 
 | Variable | Default | Qué hace |
 |---|---|---|
-| `DAIMON_LLM_BACKEND` | `auto` | Transporte: `auto` (litellm si hay credenciales, si no un CLI de comando si alguno resuelve), `litellm`, `command` o `claude-cli`. |
+| `DAIMON_LLM_BACKEND` | `auto` | Transporte: `auto` (litellm si hay credenciales, si no un CLI de comando **nombrado** si alguno resuelve), `litellm`, `command` o `claude-cli`. `claude-cli` es la opción sin configuración: ejecuta un `claude` encontrado en el PATH con un preset incorporado y no necesita nada más. `command` requiere `DAIMON_LLM_COMMAND`. |
 | `DAIMON_LLM_BASE_URL` | `http://localhost:4000` | URL del endpoint compatible con OpenAI (se recorta la barra final). Cae a `LITELLM_BASE_URL`. |
 | `DAIMON_LLM_API_KEY` | sin definir | API key del endpoint. Cae a `LITELLM_API_KEY`. |
 | `DAIMON_LLM_MODEL` | sin definir | Nombre de modelo a enviar. Cae a `LITELLM_MODEL`. |
@@ -160,7 +160,15 @@ uno a una variable `LITELLM_*` si la forma `DAIMON_*` no está definida.
 | `DAIMON_LLM_STREAM` | on | Transmite la respuesta de litellm para que el timeout del socket acote el intervalo entre frames y no la longitud total de la respuesta. Sin esto, una respuesta larga dispara el timeout y reintenta desde cero. Ponlo en `0` para desactivarlo. |
 | `DAIMON_LLM_NO_CACHE` | off | Cuando es verdadero, evita el cache de respuestas del gateway por request — necesario cuando una respuesta mala cacheada fija una falla o cuando las corridas deben ser estadísticamente independientes. |
 | `DAIMON_LLM_BRIEFING` | off | Cuando es verdadero, renderiza el briefing vía LLM en lugar de la plantilla determinista. |
-| `DAIMON_LLM_COMMAND` | sin definir | Invocación completa del CLI para el backend `command` (binario + modelo + flags). |
+| `DAIMON_LLM_COMMAND` | sin definir | Invocación completa del CLI para el backend `command` (binario + modelo + flags). Obligatoria para `command`, y obligatoria para que un `claude` en el PATH sea usado por cualquier backend que no sea `claude-cli`. |
+
+:::note Qué proceso recibe tu transcripción
+
+Un binario `claude` que simplemente esté en el PATH **no** se adopta automáticamente. Serializar envía la transcripción completa de la sesión al CLI configurado, así que ese CLI debe nombrarse: o `DAIMON_LLM_COMMAND`, o `DAIMON_LLM_BACKEND=claude-cli` para optar por el preset incorporado.
+
+Antes bastaba con dejar `DAIMON_LLM_COMMAND` sin definir y tener un `claude` en cualquier parte del PATH, tanto para instalaciones en `auto` como para la ruta de rescate de litellm. Si dependías de eso, definí una de las dos variables de arriba. `daimon configure` y `daimon doctor` nombran el binario resuelto y su ruta para que puedas ver exactamente cuál está en uso.
+
+:::
 | `DAIMON_LLM_COMMAND_OUTPUT` | sin definir | Cómo extraer el texto del asistente del stdout del comando: `text` (stdout crudo) o `json:<key>` (parsear JSON, leer `<key>`). |
 | `DAIMON_LLM_COMMAND_INPUT` | `stdin` | Cómo llega el prompt al backend de comando: `stdin` (por tubería), `arg` (anexado como último elemento de argv) o `file:<flag>` (escrito a un archivo temporal, luego se anexa `<flag> <path>`). Un valor no reconocido registra una advertencia y cae a `stdin`. |
 | `DAIMON_LLM_COMMAND_FALLBACK` | sin definir | El único CLI de rescate, usado cuando el backend primario falla. Sirve tanto para un primario litellm como para uno `command`, que antes no tenía ninguna dirección de rescate. Un solo fallback, nunca una cadena: si el primario y este fallan, la causa casi siempre es del entorno, y un tercer CLI gasta presupuesto para llegar al mismo error mientras hace que la instalación parezca más protegida de lo que está. Si no se define, un primario litellm sigue cayendo a `DAIMON_LLM_COMMAND` como antes. |


### PR DESCRIPTION
Closes #546

## What

`_resolve_command()` no longer adopts a `claude` binary merely because it is on PATH.

| File | Change |
|------|--------|
| `llm.py` | preset gated on `DAIMON_LLM_BACKEND=claude-cli`; the no-backend error names both fixes |
| `configure.py` | `status()` gains `command_path` |
| `render.py` | the doctor line reports the resolved binary's path |
| docs (x3) | backend and command rows, plus an explicit note on what to set instead |
| `tests/` | 8 new, 4 updated |

## Why

Serializing sends the full session transcript to the configured CLI. Which binary that is was the one thing about the command backend that required no configuration: `DAIMON_LLM_COMMAND_INPUT` (how the prompt is delivered) and `DAIMON_LLM_COMMAND_OUTPUT` (how output is parsed) both had to be set explicitly, while the identity of the receiving process came from PATH order.

The auto-select was serving two populations, and separating them is the whole fix:

**`DAIMON_LLM_BACKEND=claude-cli`** is a named choice, offered by the `configure` wizard, whose only implementation IS the PATH preset. The naming is the consent, so it keeps working unchanged and keeps its zero-config property. Nothing here degrades it.

**`auto` with no key, and the litellm rescue path**, were not choices. PATH picked for the operator. These now require naming a command, and the error names both routes:

```
No command backend: set DAIMON_LLM_COMMAND to the CLI that should receive the
transcript, or set DAIMON_LLM_BACKEND=claude-cli to use the zero-config claude
preset. Since #546 a claude on PATH is no longer adopted implicitly.
```

## Surfacing, folded in

Naming the backend is consent to the mechanism. It was never consent to a specific binary, so `claude-cli` installs still get told which one resolved:

```
backend: claude-cli (claude CLI from PATH: /usr/local/bin/claude, zero-config)
```

`configure.status()` carries `command_path` for the JSON consumers. Absent for an explicitly configured command, where the operator wrote the string themselves and needs no provenance.

## Breaking change

Installs that relied on PATH alone will stop serializing until they set one of the two variables. That is deliberate: the fix is precisely that this configuration was never chosen. The failure is loud and names the remedy, and all three configuration tables carry a note.

There is no field evidence of harm from the old behavior. The argument for changing it anyway is that "a binary you did not name received your transcript because it was on PATH" is the finding that most directly contradicts what this project claims to be, and it is cheaper to fix before someone else writes it up than after.

## Tests

`uv run --extra dev --extra pretty pytest -q` from `plugin/`: **2795 passed, 2 skipped**. `ruff check daimon_briefing tests ../scripts`: clean. `scar lint`: 0 errors.

Six behavioral tests watched failing first: `auto` does not adopt a PATH claude, `command` requires naming the command, the auto cascade no longer resolves to a command backend via PATH alone, the litellm rescue no longer adopts one, an explicit command still wins on any backend, and the error names the consent fix. Two surfacing tests (`command_path` present for the preset, absent for an explicit command) were written after their implementation rather than before.

Four existing tests updated. Three now name the backend, which is the behavior change. The fourth is worth flagging: `test_cli_configure_claude_zero_config_writes_nothing` left the backend at `auto`, so after this change it no longer exercised zero-config at all — it kept passing because `"ready" in out` and `"command" in out` both matched an unrelated `missing: api_key, model` line. Retargeted at `claude-cli` with assertions that fail if the preset is not what resolved.

## Note

`scar lint` reports `evidence-unreachable` on scar `0040` from this branch. That is fixed in #548 (repointing a pre-squash SHA) and is a warning, not an error, so CI is unaffected. It resolves when #548 merges.
