### PR TITLE
fix(release): version the PATH-consent change as breaking, not as a patch

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bump-minor-pre-major": true,
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
Closes #550

## What

| File | Change |
|------|--------|
| `release-please-config.json` | `"bump-minor-pre-major": true` |
| commit message | a `BREAKING CHANGE:` footer describing #549's behavior change and its remedy |

No code changes. The diff is one config line; the rest of this PR is the commit footer, which is the part that actually does the work.

## Why

The pending release PR computed `0.24.1` for a commit set including `0f1cbd6` (#549), which stops `_resolve_command()` from adopting a `claude` binary found on PATH. Installs relying on that resolution stop serializing until they name a command.

That break is intended and was documented, in the PR body and in all three configuration tables. What it was not is machine-readable. The subject is `fix(llm): ...` with no `!`, and the body carries no `BREAKING CHANGE:` footer. Those two markers are the only things release-please reads, so a `## Breaking change` prose heading counted for nothing and the change was classified as an ordinary fix.

The result: a change that stops capture, queued to cross a patch boundary, where `uv tool upgrade` takes it without a prompt.

**The second half matters as much as the first.** `bump-minor-pre-major` was never set, so it defaulted to `false`. On a `0.x` line that turns any breaking change into a `1.0.0` bump. Marking #549 breaking without this would have swung the release from a patch straight to a major. Setting it to `true` is the conventional pre-1.0 reading of semver, and it is better settled before the first breaking release than during one.

With both in place the pending release recomputes from `0.24.1` to `0.25.0`, and #549 renders under its own changelog heading with the remedy attached.

## Tests

No test changes; this alters release tooling configuration, not runtime behavior.

Verified:

- `release-please-config.json` parses and the key reads back `True`
- pre-commit passed (`ruff` skipped, no Python touched; hook mirror drift check passed)
- the footer follows the conventional-commits form release-please parses (`BREAKING CHANGE:` at the start of a footer paragraph)

The real verification is the release PR itself: after merge, release-please should recompute `chore(main): release 0.24.1` into `chore(main): release 0.25.0` with a breaking-changes section. Worth eyeballing that before merging the release, since the whole point of this PR is that the version number carries the warning.

## Follow-up worth considering separately

A PR-convention check that fails when a PR body contains breaking-change prose while the title carries no `!`. This issue exists because those two disagreed and nothing caught it.
