### PR TITLE
fix(llm)!: a claude on PATH is no longer adopted implicitly as the command backend

### DIFF
--- a/.scars/candidates/squash-merge-discards-local-commit-footers.md
+++ b/.scars/candidates/squash-merge-discards-local-commit-footers.md
@@ -1,0 +1,54 @@
+---
+id: 0
+type: landmine
+title: Squash-merge replaces the local commit body with the PR body, so conventional-commits footers must live in the PR
+severity: medium
+confidence: 0.95
+created: 2026-08-04
+authors: ["claude-code"]
+anchors:
+  - path: release-please-config.json
+  - path: .github/workflows/pr-validation.yml
+  - path: .github/workflows/release.yml
+evidence:
+  - note: "PR #551 was authored specifically to add a BREAKING CHANGE footer. Its local commit carried the footer; the squashed commit on main (0d3d1a8) carries the PR body instead, with no footer. The Release workflow ran green and left the release PR at 0.24.1."
+  - note: ".github/workflows/pr-validation.yml:70 states the rule for the subject line: 'squash-merge makes the PR title the commit subject on main'. The same substitution applies to the body, which is the half that is easy to miss."
+expires:
+  condition: "the repository stops squash-merging, or release-please starts reading PR bodies/labels for breaking-change markers instead of commit footers"
+  review_after: 2027-02-04
+status: candidate
+---
+
+This repository squash-merges. GitHub composes the squashed commit message from
+the PR TITLE and PR BODY, discarding whatever the local commits said. The
+subject half of this is already documented at
+`.github/workflows/pr-validation.yml:70`. The body half is not, and it is the
+one that silently breaks releases.
+
+Consequence: any conventional-commits FOOTER that release-please must parse has
+to be written into the PR body, not into the local commit message. A
+`BREAKING CHANGE:` footer authored locally never reaches `main` and never
+reaches release-please, which then computes an ordinary patch bump for a
+change that breaks users.
+
+This is not hypothetical. #549 changed `_resolve_command()` so a `claude` on
+PATH is no longer adopted implicitly, which stops capture on installs that
+relied on it. It was queued to ship as `0.24.1`. #551 was authored to correct
+exactly that by adding the missing footer, and #551's own footer was eaten the
+same way. The Release workflow reported success both times, because nothing in
+the pipeline compares "this PR describes a breaking change" against "this
+commit is marked as one".
+
+What to do instead, in order of reliability:
+
+1. Put `!` in the PR TITLE (`fix(scope)!: ...`). The title becomes the commit
+   subject verbatim, and `pr-validation.yml`'s regex already permits `!`. This
+   is the only marker that cannot be lost by the merge.
+2. Additionally place the `BREAKING CHANGE:` footer as the LAST paragraph of
+   the PR body, so the rendered changelog entry carries the remedy.
+
+Do not rely on prose. A `## Breaking change` heading in a PR body is invisible
+to release-please; only `!` in the subject and a `BREAKING CHANGE:` footer are
+parsed. Related: `bump-minor-pre-major` must be true in
+`release-please-config.json` for a 0.x breaking change to bump the minor rather
+than jumping to 1.0.0.


### PR DESCRIPTION
Refs #550

Retroactively marks the behavior change from #549 as breaking, so the pending release computes a minor bump instead of a patch. Also records why the previous attempt failed.

#551 merged and the Release workflow ran green, but the release PR stayed at `chore(main): release 0.24.1`. The cause is that this repository squash-merges: GitHub composes the squashed commit message from the PR title and PR body and discards the local commit message. The `BREAKING CHANGE:` footer was written into the local commit, so it never reached `main`, and release-please never saw it.

`.github/workflows/pr-validation.yml:70` documents the subject half of that rule. The body half is the one that bites, and it is now recorded as a scar candidate in this PR.

So this PR carries the marker in the PR TITLE, where `!` becomes the commit subject verbatim and cannot be lost. The title regex at `pr-validation.yml:73` already permits it. The footer below is belt and braces, and this time it is in the body, which is what actually lands.

The half of #551 that did land is still correct and still required: `bump-minor-pre-major: true` in `release-please-config.json`, without which a 0.x breaking change would jump to `1.0.0` rather than to `0.25.0`.

Diff is a single scar candidate; the versioning work is done by the title and footer.

## Verification

After merge, `chore(main): release 0.24.1` should recompute to `chore(main): release 0.25.0` with a breaking-changes section. If it does not, the marker was lost again and the release should not be tagged until it is understood.

BREAKING CHANGE: a `claude` binary present on PATH is no longer adopted implicitly as the command backend. Serializing sends the full session transcript to the configured CLI, so that CLI must now be named: set `DAIMON_LLM_COMMAND` to the invocation that should receive it, or set `DAIMON_LLM_BACKEND=claude-cli` to opt into the built-in zero-config preset. Installs that already set either variable are unaffected. The two configurations that previously resolved a command from PATH alone were `auto` installs with no API key and the litellm rescue path; both now fail with an error naming the remedy instead of using a binary nobody chose.
