### PR TITLE
fix(serializer): guarantee the validation resample a minimum budget

### DIFF
--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -594,6 +594,24 @@ def fallback_min_seconds() -> int:
     return timeout_seconds()
 
 
+def resample_min_seconds() -> int:
+    """#553: minimum budget the #118 validation resample is guaranteed on
+    entry. Exactly the failure #341 fixed for the command fallback, one path
+    over: the shared deadline is drained by the attempt whose output just got
+    rejected, so handing the resample the remainder made it dead on arrival
+    (field case: 262s left against a merge that had taken 371s). Defaults to
+    timeout_seconds() for the same reason fallback_min_seconds() does — the
+    operator has already declared how long one backend call may take.
+    Override with DAIMON_RESAMPLE_MIN_SECONDS."""
+    raw = _get("DAIMON_RESAMPLE_MIN_SECONDS")
+    if raw:
+        try:
+            return int(raw)
+        except ValueError:
+            pass
+    return timeout_seconds()
+
+
 def llm_command() -> str | None:
     """Full CLI invocation for the command backend (binary + model + flags).
     How the prompt reaches it is controlled separately by

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -2138,6 +2138,17 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
     checkpoint["session_id"] = session_id
     if not validate(checkpoint):
         log.info("checkpoint failed validation — one resample with attempt nonce (#118)")
+        # #553: the rejected attempt has already spent the budget the resample
+        # is about to need, so guarantee it one call's worth. max(), never
+        # assignment — a caller who granted more keeps it. _produce reads
+        # `deadline` from this scope at call time, so rebinding here is what
+        # every call underneath it sees.
+        if deadline is not None:
+            floor = time.monotonic() + config.resample_min_seconds()
+            if floor > deadline:
+                log.info("resample budget re-armed to %ds (#553)",
+                         config.resample_min_seconds())
+                deadline = floor
         checkpoint = _produce(_RETRY_NOTE)
         strip_code_owned_keys(checkpoint)
         checkpoint["session_id"] = session_id

--- a/plugin/tests/test_config.py
+++ b/plugin/tests/test_config.py
@@ -599,6 +599,29 @@ def test_fallback_min_seconds_bad_value_falls_back_to_timeout(monkeypatch):
     assert config.fallback_min_seconds() == 222
 
 
+# ---- #553: DAIMON_RESAMPLE_MIN_SECONDS ---------------------------------------
+
+
+def test_resample_min_seconds_defaults_to_timeout(monkeypatch):
+    # Same inheritance as the #341 fallback floor: DAIMON_TIMEOUT is already
+    # the operator's answer to "how long may one backend call take".
+    monkeypatch.delenv("DAIMON_RESAMPLE_MIN_SECONDS", raising=False)
+    monkeypatch.setenv("DAIMON_TIMEOUT", "111")
+    assert config.resample_min_seconds() == 111
+
+
+def test_resample_min_seconds_env_override(monkeypatch):
+    monkeypatch.setenv("DAIMON_TIMEOUT", "111")
+    monkeypatch.setenv("DAIMON_RESAMPLE_MIN_SECONDS", "77")
+    assert config.resample_min_seconds() == 77
+
+
+def test_resample_min_seconds_bad_value_falls_back_to_timeout(monkeypatch):
+    monkeypatch.setenv("DAIMON_TIMEOUT", "222")
+    monkeypatch.setenv("DAIMON_RESAMPLE_MIN_SECONDS", "not-a-number")
+    assert config.resample_min_seconds() == 222
+
+
 def test_chunk_cache_days_default_override_and_bad_value(monkeypatch):
     monkeypatch.delenv("DAIMON_CHUNK_CACHE_DAYS", raising=False)
     assert config.chunk_cache_days() == 3

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -1,4 +1,5 @@
 import json
+import time
 from pathlib import Path
 
 import pytest
@@ -987,6 +988,39 @@ def test_validation_failure_retries_once_with_nonce(fake_chat_factory, monkeypat
     assert first != second  # never byte-identical — gateway caches replay garbage
     assert "attempt 2" in second
     assert "quote" in second  # the reminder names the observed failure mode
+
+
+def test_validation_resample_is_guaranteed_a_minimum_budget(fake_chat_factory, monkeypatch):
+    # #553: the resample reused the SAME deadline the first attempt had already
+    # drained, so a validation failure late in the budget died of arithmetic
+    # before its socket opened (field case: 262s left against a 371s merge).
+    # Same lesson #341 learned for the rescue path (fallback_min_seconds).
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    monkeypatch.setenv("DAIMON_TIMEOUT", "420")
+    chat = fake_chat_factory([_invalid_checkpoint_json(), _valid_checkpoint_json("S1")])
+    # The shape that failed in the field: budget all but spent when validation
+    # rejects the first attempt.
+    serializer.serialize_strict("S1", make_messages(6), chat=chat,
+                                deadline=time.monotonic() + 5)
+    assert len(chat.calls) == 2
+    # Guard: the FIRST attempt really did run on the drained budget, so this
+    # test exercises the starved state rather than a fresh one.
+    assert chat.calls[0]["kwargs"]["deadline"] - time.monotonic() <= 5
+    remaining = chat.calls[1]["kwargs"]["deadline"] - time.monotonic()
+    assert remaining >= 419, f"resample got {remaining:.0f}s, needs a full call budget"
+
+
+def test_validation_resample_never_shortens_a_healthy_deadline(fake_chat_factory,
+                                                               monkeypatch):
+    # The floor is a guarantee, not an assignment: a caller who already granted
+    # more than one call's worth keeps it.
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    monkeypatch.setenv("DAIMON_TIMEOUT", "420")
+    chat = fake_chat_factory([_invalid_checkpoint_json(), _valid_checkpoint_json("S1")])
+    serializer.serialize_strict("S1", make_messages(6), chat=chat,
+                                deadline=time.monotonic() + 5000)
+    remaining = chat.calls[1]["kwargs"]["deadline"] - time.monotonic()
+    assert remaining >= 4990, f"resample budget shrank to {remaining:.0f}s"
 
 
 def test_validation_failure_twice_raises(fake_chat_factory, monkeypatch):


### PR DESCRIPTION
Closes #553

## What

`validate()` rejects a checkpoint, the #118 resample fires, and it runs on the
same deadline object the attempt that just failed had already drained. This adds
a floor: on entry the resample is guaranteed one call's worth of budget.

`config.resample_min_seconds()` defaults to `timeout_seconds()`, override with
`DAIMON_RESAMPLE_MIN_SECONDS`. The re-arm is a `max()`, never an assignment, so a
caller who granted more keeps it.

`_produce` reads `deadline` from the enclosing scope at call time, so rebinding it
before the retry call is what every call underneath it sees. No signature changes.

## Why

The field failure that produced the issue:

```
T+0s     spawn, deadline = 420s base + 420s wave extension (#314) = 840s
T+567s   merge level 1, group 1/1 done in 371s
T+567s   checkpoint failed validation, one resample with attempt nonce
T+840s   DeadlineExhausted
```

273s of budget against a merge that had just taken 371s. Dead by arithmetic before
the socket opened, and the reported error was a read timeout, which points at the
network rather than at the budget.

This is not a new diagnosis. `fallback_min_seconds()` (#341) fixed the identical
arithmetic for the command fallback, and its docstring already records what the
un-floored version cost: "handing the fallback the remainder made it dead on
arrival (field data: entered 6+ times, rescued 0)." The validation resample was
the same shape one path over, and never got the same guarantee. This change copies
that mechanism rather than inventing a second one, so there is one idea in the
codebase instead of two.

## Tests

`plugin/tests/test_serializer.py`

- `test_validation_resample_is_guaranteed_a_minimum_budget` reproduces the field
  shape (budget all but spent when validation rejects attempt 1) and asserts the
  resample's deadline. Failed before the change with `resample got 5s, needs a
  full call budget`, which is the bug exactly. It also asserts attempt 1 really
  ran on the drained budget, so the test cannot silently stop exercising the
  starved state.
- `test_validation_resample_never_shortens_a_healthy_deadline` verifies a generous caller
  budget survives. Guards against a fix that assigns instead of taking `max()`.

`plugin/tests/test_config.py` covers default, env override, and unparseable value for
the new knob, mirroring the #341 block.

Full suite: 2805 passed, 2 skipped. 2802 before, plus the 3 new config cases.

## Not in scope

Why `validate()` rejected a parseable merge in the first place is still not
recorded anywhere, and the rejected checkpoint is never written to disk, so there
is no artifact to inspect after the fact. That is #555 and it is what would have
made the original diagnosis possible.
