### PR TITLE
feat(serializer): report which predicate rejected a checkpoint

### DIFF
--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -549,39 +549,49 @@ def signal_message_ids(messages) -> set[str]:
     return out
 
 
-def _valid_item(item) -> bool:
+def _item_reason(item) -> str | None:
+    """None when the item is valid, else WHICH predicate rejected it (#555).
+
+    Names the predicate only. Never the item's text, quote, or trust value —
+    the reason is logged verbatim and the payload is exactly what the boundary
+    is refusing to vouch for.
+    """
     if not isinstance(item, dict):
-        return False
+        return "not a dict"
     if "text" not in item or "trust" not in item:
-        return False
+        return "missing text or trust"
     # #134: presence != a usable value. A present-but-null (or non-str) text
     # passed this check, reached disk, then crashed briefing.render on the next
     # session. Reject at the boundary. Empty str stays valid — active_topic MAY
     # carry empty text (test_validate_allows_empty_active_topic_text).
     if not isinstance(item["text"], str):
-        return False
+        return "text is not a str"
     if item["trust"] not in _TRUST_CLASSES:
-        return False
+        return "trust is not a known trust class"
     if item["trust"] == "verbatim":
         quote = item.get("quote")
         # D-006: a verbatim claim without a real quote is an unpinned claim.
         if not isinstance(quote, str) or not quote.strip():
-            return False
+            return "trust=verbatim item has no quote"
     because = item.get("because")
     if because is not None and not isinstance(because, str):
         # F4 (#527), same #134 lesson as text: present-but-non-str would
         # reach disk and crash a later render — reject at the boundary.
-        return False
+        return "because is not a str"
     anchor = item.get("anchored_to")
     if anchor is not None:
         if not isinstance(anchor, dict):
-            return False
+            return "anchored_to is not a dict"
         if not all(
             isinstance(anchor.get(k), str) and anchor.get(k)
             for k in ("file", "symbol", "body_hash")
         ):
-            return False
-    return True
+            return "anchored_to is missing file, symbol, or body_hash"
+    return None
+
+
+def _valid_item(item) -> bool:
+    return _item_reason(item) is None
 
 
 def iter_items(checkpoint):
@@ -637,37 +647,59 @@ def sanitize_scene(checkpoint) -> None:
             del item["scene"]
 
 
-def validate(checkpoint) -> bool:
-    """Light validation: required keys + trust-class integrity (D-006).
+def validation_reason(checkpoint) -> str | None:
+    """None when the checkpoint is valid, else WHICH predicate rejected it.
 
-    Not full JSON-schema validation — just enough to refuse garbage before storing.
+    Light validation: required keys + trust-class integrity (D-006). Not full
+    JSON-schema validation — just enough to refuse garbage before storing.
 
     Contract: active_topic MAY have empty text (sessions without a single clear
     topic); briefing.render() skips the empty section. Trust rules still apply.
+
+    #555: the bool this used to return threw away the one fact a failure is
+    diagnosed by. The causes are not equivalent — a bad trust class means the
+    model ignored an instruction, a verbatim item with no quote means D-006
+    caught a genuinely unpinned claim (the machinery working), a non-str text
+    means junk arrived from upstream. Predicate order is unchanged, so the
+    accept/reject verdict is byte-identical to the bool version.
     """
     if not isinstance(checkpoint, dict):
-        return False
+        return "checkpoint is not a dict"
     if "session_id" not in checkpoint:
-        return False
+        return "missing session_id"
     wc = checkpoint.get("working_context")
     es = checkpoint.get("epistemic_snapshot")
-    if not isinstance(wc, dict) or not isinstance(es, dict):
-        return False
+    if not isinstance(wc, dict):
+        return "working_context is not a dict"
+    if not isinstance(es, dict):
+        return "epistemic_snapshot is not a dict"
     if "active_topic" not in wc:
-        return False
+        return "missing working_context.active_topic"
     for key in ("open_questions", "recent_decisions"):
         items = wc.get(key)
         if not isinstance(items, list):
-            return False
-        if not all(_valid_item(i) for i in items):
-            return False
-    if not _valid_item(wc["active_topic"]):
-        return False
+            return f"working_context.{key} is not a list"
+        for i, item in enumerate(items):
+            reason = _item_reason(item)
+            if reason is not None:
+                return f"working_context.{key}[{i}]: {reason}"
+    reason = _item_reason(wc["active_topic"])
+    if reason is not None:
+        return f"working_context.active_topic: {reason}"
     for key in ("strong_beliefs", "uncertainties"):
         items = es.get(key, [])
-        if not isinstance(items, list) or not all(_valid_item(i) for i in items):
-            return False
-    return True
+        if not isinstance(items, list):
+            return f"epistemic_snapshot.{key} is not a list"
+        for i, item in enumerate(items):
+            reason = _item_reason(item)
+            if reason is not None:
+                return f"epistemic_snapshot.{key}[{i}]: {reason}"
+    return None
+
+
+def validate(checkpoint) -> bool:
+    """True when the checkpoint passes validation_reason()'s predicates."""
+    return validation_reason(checkpoint) is None
 
 
 # ---- #358: verbatim items bind to transcript message ids ----
@@ -2136,8 +2168,10 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
     checkpoint = _produce("")
     strip_code_owned_keys(checkpoint)
     checkpoint["session_id"] = session_id
-    if not validate(checkpoint):
-        log.info("checkpoint failed validation — one resample with attempt nonce (#118)")
+    first_reason = validation_reason(checkpoint)
+    if first_reason is not None:
+        log.info("checkpoint failed validation: %s — one resample with attempt "
+                 "nonce (#118)", first_reason)
         # #553: the rejected attempt has already spent the budget the resample
         # is about to need, so guarantee it one call's worth. max(), never
         # assignment — a caller who granted more keeps it. _produce reads
@@ -2152,10 +2186,14 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
         checkpoint = _produce(_RETRY_NOTE)
         strip_code_owned_keys(checkpoint)
         checkpoint["session_id"] = session_id
-    if not validate(checkpoint):
+    reason = validation_reason(checkpoint)
+    if reason is not None:
+        # #555: both attempts, because the FIRST reason is usually the
+        # interesting one — the resample runs against a nonce'd prompt and can
+        # fail a different predicate than the output that triggered it.
         raise SchemaValidationError(
-            "checkpoint failed schema/trust validation (missing keys, bad trust "
-            "class, or verbatim item without a quote)"
+            f"checkpoint failed schema/trust validation twice. "
+            f"attempt 1: {first_reason}; attempt 2: {reason}"
         )
     sanitize_importance(checkpoint)
     sanitize_scene(checkpoint)

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -990,6 +990,31 @@ def test_validation_failure_retries_once_with_nonce(fake_chat_factory, monkeypat
     assert "quote" in second  # the reminder names the observed failure mode
 
 
+# ---- #555: validation reports WHICH predicate rejected the checkpoint ----
+
+
+def test_validation_reason_is_none_for_a_valid_checkpoint():
+    assert serializer.validation_reason(json.loads(_valid_checkpoint_json("S1"))) is None
+
+
+def test_validation_reason_names_the_field_path_and_the_predicate():
+    # The live failure shape: a verbatim item whose quote was inlined into text.
+    # "missing keys, bad trust class, or verbatim item without a quote" cannot
+    # tell an operator which of the three happened; this can.
+    reason = serializer.validation_reason(json.loads(_invalid_checkpoint_json()))
+    assert reason == (
+        "working_context.recent_decisions[0]: trust=verbatim item has no quote"
+    )
+
+
+def test_validation_reason_never_leaks_item_text():
+    # The reason is logged verbatim, so it names the predicate and the path and
+    # nothing from the payload. The fixture's text carries a quoted phrase.
+    bad = json.loads(_invalid_checkpoint_json())
+    bad["working_context"]["recent_decisions"][0]["text"] = "SECRET-abc123"
+    assert "SECRET" not in serializer.validation_reason(bad)
+
+
 def test_validation_resample_is_guaranteed_a_minimum_budget(fake_chat_factory, monkeypatch):
     # #553: the resample reused the SAME deadline the first attempt had already
     # drained, so a validation failure late in the budget died of arithmetic
@@ -1021,6 +1046,35 @@ def test_validation_resample_never_shortens_a_healthy_deadline(fake_chat_factory
                                 deadline=time.monotonic() + 5000)
     remaining = chat.calls[1]["kwargs"]["deadline"] - time.monotonic()
     assert remaining >= 4990, f"resample budget shrank to {remaining:.0f}s"
+
+
+def test_validation_failure_logs_which_predicate_rejected_it(fake_chat_factory,
+                                                             monkeypatch, caplog):
+    # #555: the resample line said only THAT validation failed. Without the
+    # predicate there is nothing to diagnose from afterwards, because the
+    # rejected checkpoint is never written to disk.
+    import logging
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    chat = fake_chat_factory([_invalid_checkpoint_json(), _valid_checkpoint_json("S1")])
+    with caplog.at_level(logging.INFO, logger="daimon_briefing.serializer"):
+        serializer.serialize_strict("S1", make_messages(6), chat=chat)
+    assert "working_context.recent_decisions[0]: trust=verbatim item has no quote" \
+        in caplog.text
+
+
+def test_validation_failure_twice_names_both_reasons(fake_chat_factory, monkeypatch):
+    # When the resample ALSO fails, the first attempt's reason is the
+    # interesting one, so the error carries both rather than only the last.
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    second = json.loads(_invalid_checkpoint_json())
+    second["working_context"]["recent_decisions"] = []
+    second["epistemic_snapshot"]["strong_beliefs"] = [{"text": 5, "trust": "inferred"}]
+    chat = fake_chat_factory([_invalid_checkpoint_json(), json.dumps(second)])
+    with pytest.raises(serializer.SchemaValidationError) as exc:
+        serializer.serialize_strict("S1", make_messages(6), chat=chat)
+    msg = str(exc.value)
+    assert "working_context.recent_decisions[0]: trust=verbatim item has no quote" in msg
+    assert "epistemic_snapshot.strong_beliefs[0]: text is not a str" in msg
 
 
 def test_validation_failure_twice_raises(fake_chat_factory, monkeypatch):

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -1007,6 +1007,46 @@ def test_validation_reason_names_the_field_path_and_the_predicate():
     )
 
 
+def _checkpoint_with(**overrides):
+    cp = json.loads(_valid_checkpoint_json("S1"))
+    cp.update(overrides)
+    return cp
+
+
+@pytest.mark.parametrize("mutate,expected", [
+    (lambda cp: "not a dict at all", "checkpoint is not a dict"),
+    (lambda cp: {k: v for k, v in cp.items() if k != "session_id"},
+     "missing session_id"),
+    (lambda cp: {**cp, "working_context": []}, "working_context is not a dict"),
+    (lambda cp: {**cp, "epistemic_snapshot": []}, "epistemic_snapshot is not a dict"),
+    (lambda cp: {**cp, "working_context": {"open_questions": [],
+                                           "recent_decisions": []}},
+     "missing working_context.active_topic"),
+    (lambda cp: {**cp, "working_context": {**cp["working_context"],
+                                           "open_questions": "nope"}},
+     "working_context.open_questions is not a list"),
+    (lambda cp: {**cp, "epistemic_snapshot": {**cp["epistemic_snapshot"],
+                                              "strong_beliefs": "nope"}},
+     "epistemic_snapshot.strong_beliefs is not a list"),
+    (lambda cp: {**cp, "working_context": {**cp["working_context"],
+                                           "active_topic": "nope"}},
+     "working_context.active_topic: not a dict"),
+    (lambda cp: {**cp, "working_context": {**cp["working_context"],
+                                           "open_questions": [{"text": "t"}]}},
+     "working_context.open_questions[0]: missing text or trust"),
+    (lambda cp: {**cp, "working_context": {
+        **cp["working_context"],
+        "open_questions": [{"text": "t", "trust": "inferred",
+                            "anchored_to": "nope"}]}},
+     "working_context.open_questions[0]: anchored_to is not a dict"),
+])
+def test_validation_reason_covers_every_structural_predicate(mutate, expected):
+    # Each predicate is a separate contract: the whole point of #555 is that
+    # these are NOT interchangeable. They were untested while they returned a
+    # bare False, so they are pinned here now that they say something.
+    assert serializer.validation_reason(mutate(_checkpoint_with())) == expected
+
+
 def test_validation_reason_never_leaks_item_text():
     # The reason is logged verbatim, so it names the predicate and the path and
     # nothing from the payload. The fixture's text carries a quoted phrase.


### PR DESCRIPTION
Closes #555

## What

`validation_reason(checkpoint)` returns the field path and the predicate that
rejected it, or `None` when valid. `validate()` becomes a thin bool wrapper over
it, so every existing caller is untouched. `_valid_item()` gets the same treatment
via `_item_reason()`.

Both consumers now carry the reason:

```
INFO  checkpoint failed validation: working_context.recent_decisions[0]: trust=verbatim item has no quote — one resample with attempt nonce (#118)
```

```
checkpoint failed schema/trust validation twice. attempt 1: working_context.recent_decisions[0]: trust=verbatim item has no quote; attempt 2: epistemic_snapshot.strong_beliefs[0]: text is not a str
```

Predicate order is unchanged, so the accept/reject verdict is identical to the
bool version. This is a reporting change, not a validation change.

## Why

The old message named three candidate causes and committed to none:

```
checkpoint failed schema/trust validation (missing keys, bad trust class, or verbatim item without a quote)
```

Sixteen `return False` sites collapsed into one bool, and the causes are not
equivalent. A bad trust class means the model ignored an instruction. A verbatim
item with no quote means the D-006 boundary caught a genuinely unpinned claim,
which is the machinery working correctly. A non-str `text` means junk arrived from
upstream. Those want three different responses.

There is no recovering the information afterwards, either: a rejected checkpoint is
never written to disk, so nothing survives the failure to inspect. This blocked a
real diagnosis while working on #553, where the resample could be explained exactly
and the original rejection could not be explained at all.

It also makes the failure countable. "How often is validation catching real
unpinned verbatim claims" and "how often is it tripping over a type error" are
opposite signals about model quality, and today they are the same log line.

## Design notes

The reason names the predicate and the path, never the payload. Not the item's
text, quote, or trust value. The reason is logged verbatim and the payload is
exactly what the boundary is refusing to vouch for, so it has no business in a log
line. There is a test asserting this rather than a comment asking for it.

The error carries BOTH attempts because the first reason is usually the interesting
one. The resample runs against a nonce'd prompt and can fail a different predicate
than the output that triggered it, which is precisely the case in the test.

## Tests

`plugin/tests/test_serializer.py`, five new cases, each watched failing first:

- `validation_reason` is `None` for a valid checkpoint
- `validation_reason` names the field path and the predicate, asserted on the live
  failure shape (verbatim item with its quote inlined into `text`)
- `validation_reason` never leaks item text, asserted with a marker string planted
  in the payload
- the resample log line carries the predicate
- a double failure names both attempts' reasons, with the second attempt failing a
  different predicate than the first

The first three failed with `module 'daimon_briefing.serializer' has no attribute
'validation_reason'`. The last two failed against the old three-way guess.

Full suite: 2810 passed, 2 skipped. 2805 before.

Ruff clean. mypy reports one pre-existing `serializer.py` error, present on main at
line 1402 and shifted to 1434 here by the added lines. No new mypy errors.
