### PR TITLE
feat(status): report Claude Code plugin staleness

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1897,6 +1897,11 @@ def _status_world(project_arg=None) -> dict:
     # One-line pointer only when installed hook copies have drifted (#266);
     # silent on a clean machine. Cheap: hashes a handful of small files.
     hook_drift = _hook_drift_present()
+    # #554: the same pointer for the one host `hooks status` cannot audit —
+    # Claude Code's hooks ship inside the plugin, which updates on its own
+    # schedule. None on a machine with no plugin, so non-plugin users stay
+    # silent.
+    plugin_drift = _plugin_drift_present()
     # #341/#475 part 2: whether a rescue path exists for the CURRENTLY
     # CONFIGURED primary. llm.rescue_posture() is the single resolver (it
     # calls resolve_backend(), the same decision chat() dispatches on) —
@@ -1942,7 +1947,8 @@ def _status_world(project_arg=None) -> dict:
         "disabled": disabled, "skipped_recent": skipped_recent,
         "recall_error": recall_error, "recall_index": recall_index,
         "receipts": receipts_line, "capture_alarm": capture_alarm,
-        "hook_drift": hook_drift, "rescue_gap": rescue_gap,
+        "hook_drift": hook_drift, "plugin_drift": plugin_drift,
+        "rescue_gap": rescue_gap,
         "rescue_posture": rescue_posture, "rescue_window_errors": rescue_window_errors,
         "forget_hits": forget_hits, "rc": rc,
     }
@@ -1960,7 +1966,8 @@ def status_payload(project_arg=None) -> tuple:
         "disabled": w["disabled"], "skipped_recent": w["skipped_recent"],
         "recall_error": w["recall_error"], "recall_index": w["recall_index"],
         "receipts": w["receipts"], "capture_alarm": w["capture_alarm"],
-        "hook_drift": w["hook_drift"], "rescue_gap": w["rescue_gap"],
+        "hook_drift": w["hook_drift"], "plugin_drift": w.get("plugin_drift"),
+        "rescue_gap": w["rescue_gap"],
         "rescue_posture": w["rescue_posture"],
         "forget_hits": w["forget_hits"],
     }
@@ -1983,7 +1990,8 @@ def _cmd_status(args) -> int:
         "crash": w["crash"], "skipped_recent": w["skipped_recent"],
         "recall_error": w["recall_error"], "recall_index": w["recall_index"],
         "receipts": w["receipts"], "capture_alarm": w["capture_alarm"],
-        "hook_drift": w["hook_drift"], "rescue_gap": w["rescue_gap"],
+        "hook_drift": w["hook_drift"], "plugin_drift": w.get("plugin_drift"),
+        "rescue_gap": w["rescue_gap"],
         "rescue_posture": w["rescue_posture"],
         "rescue_window_errors": w["rescue_window_errors"],
         "forget_hits": w["forget_hits"],
@@ -3013,6 +3021,80 @@ def _hooks_status_report(home: Path) -> list[dict]:
     pkg = resources.files("daimon_briefing._hooks")
     return [_host_status_entry(host, spec, pkg, home)
             for host, spec in sorted(_HOOK_HOSTS.items())]
+
+
+def _version_tuple(v: str) -> tuple:
+    """Loose numeric compare, stdlib only (no packaging dependency). Trailing
+    non-digits in a component are ignored, so '1.0.0rc1' sorts as (1, 0, 0)."""
+    out = []
+    for chunk in str(v).split("."):
+        digits = ""
+        for ch in chunk:
+            if not ch.isdigit():
+                break
+            digits += ch
+        out.append(int(digits) if digits else 0)
+    return tuple(out)
+
+
+def _plugin_drift(home: Path, cli_version: str) -> dict | None:
+    """The installed Claude Code plugin's version vs this CLI's, or None when
+    they agree or no plugin is installed (#554).
+
+    Claude Code's hooks ship INSIDE the plugin rather than through
+    `hooks install`, so #266's byte-hash audit never sees them: the host with
+    the most users was the only one whose drift nothing reported. The two
+    halves also move under different commands (`uv tool upgrade` for the CLI,
+    the host's own plugin update for the hooks), and neither notices the other.
+
+    The version comes from daimon's OWN manifest inside the installed tree.
+    That file ships with the code that will actually execute; the host's record
+    only says what it meant to install, and the two can disagree.
+    """
+    state = home / ".claude" / "plugins" / "installed_plugins.json"
+    try:
+        data = json.loads(state.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    plugins = data.get("plugins") if isinstance(data, dict) else None
+    if not isinstance(plugins, dict):
+        return None
+    installed = None
+    for key, entries in plugins.items():
+        if key.split("@")[0] != "daimon" or not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            installed = _plugin_manifest_version(entry.get("installPath")) \
+                or entry.get("version")
+            if installed:
+                break
+        if installed:
+            break
+    if not installed or installed == cli_version:
+        return None
+    return {"installed": installed, "cli": cli_version,
+            "behind": _version_tuple(installed) < _version_tuple(cli_version)}
+
+
+def _plugin_manifest_version(install_path) -> str | None:
+    if not install_path:
+        return None
+    manifest = Path(install_path) / ".claude-plugin" / "plugin.json"
+    try:
+        return json.loads(manifest.read_text(encoding="utf-8")).get("version")
+    except (OSError, ValueError, AttributeError):
+        return None
+
+
+def _plugin_drift_present() -> dict | None:
+    """Same swallow-everything contract as _hook_drift_present: status must
+    never crash on another tool's file format."""
+    try:
+        return _plugin_drift(Path.home(), __version__)
+    except Exception:
+        return None
 
 
 def _hook_drift_present() -> bool:

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -601,6 +601,22 @@ def _forget_hits_line(data: dict) -> str | None:
             f"re-assertion{'s' if n != 1 else ''}, most recent {ts}")
 
 
+def _plugin_drift_line(pd: dict) -> str:
+    """#554: name BOTH versions and the command that moves the stale half.
+    "out of date" alone does not say which half, and the two are updated by
+    different tools. The restart is part of the fix, not a footnote: hooks
+    resolve at session start, so an updated plugin changes nothing until then.
+    """
+    if pd.get("behind"):
+        fix = ("run /plugin in Claude Code and update daimon, then restart the "
+               "session — hooks resolve at session start")
+    else:
+        fix = ("upgrade the CLI with `uv tool upgrade daimon-briefing`, then "
+               "restart the session — hooks resolve at session start")
+    return (f"⚠ Claude Code plugin is {pd['installed']} but the daimon CLI is "
+            f"{pd['cli']} — {fix}")
+
+
 def _plain_status(data: dict) -> None:
     alarm = data.get("capture_alarm")
     if alarm:
@@ -616,6 +632,8 @@ def _plain_status(data: dict) -> None:
             print(f"  ⚠ {w}")
     if data.get("hook_drift"):
         print("⚠ installed hooks out of date — run daimon hooks status")
+    if data.get("plugin_drift"):
+        print(_plugin_drift_line(data["plugin_drift"]))
     if data.get("rescue_gap"):
         print("⚠ primary is a remote gateway and no fallback backend resolves "
               "— gateway failures won't be rescued (install claude or set "
@@ -707,6 +725,8 @@ def _rich_status(data: dict) -> None:
     if data.get("hook_drift"):
         console.print("[red]⚠ installed hooks out of date — "
                       "run daimon hooks status[/red]")
+    if data.get("plugin_drift"):
+        console.print(f"[red]{_plugin_drift_line(data['plugin_drift'])}[/red]")
     if data.get("rescue_gap"):
         console.print("[yellow]⚠ primary is a remote gateway and no fallback "
                       "backend resolves — gateway failures won't be rescued "

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -701,7 +701,9 @@ def test_cli_status_json_shape(
                          "siblings", "health", "team", "crash", "disabled",
                          "skipped_recent", "recall_error", "recall_index",
                          "receipts", "capture_alarm", "hook_drift",
-                         "rescue_gap", "rescue_posture", "forget_hits"}
+                         "plugin_drift", "rescue_gap", "rescue_posture",
+                         "forget_hits"}
+    assert data["plugin_drift"] is None  # #554 no plugin installed -> null
     assert data["capture_alarm"] is None  # #265 FAIL-only probe silent by default
     assert data["forget_hits"]["count"] == 0  # #404 nothing suppressed yet
     assert data["team"] is None  # no team remote configured -> explicit null (#113)

--- a/plugin/tests/test_plugin_drift.py
+++ b/plugin/tests/test_plugin_drift.py
@@ -1,0 +1,188 @@
+"""#554: `daimon hooks status` audits the hook copies daimon itself installs,
+but Claude Code's hooks ship inside the plugin, so its drift was the one host
+nothing reported. The CLI and the plugin update through different commands and
+neither notices the other. Fixtures build a fake ~/.claude/plugins tree.
+"""
+
+import json
+from pathlib import Path
+
+from daimon_briefing import cli, render
+
+
+def _install_plugin(home: Path, version: str, recorded: str | None = None,
+                    marketplace: str = "daimon") -> Path:
+    """Mimic a marketplace install: a versioned cache dir holding daimon's own
+    manifest, plus the host's record of what it installed."""
+    root = home / ".claude" / "plugins" / "cache" / marketplace / "daimon" / version
+    (root / ".claude-plugin").mkdir(parents=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "daimon", "version": version}), encoding="utf-8")
+    state = home / ".claude" / "plugins" / "installed_plugins.json"
+    state.parent.mkdir(parents=True, exist_ok=True)
+    state.write_text(json.dumps({"version": 2, "plugins": {
+        f"daimon@{marketplace}": [
+            {"scope": "user", "installPath": str(root),
+             "version": recorded or version},
+        ]}}), encoding="utf-8")
+    return root
+
+
+def test_no_plugin_installed_is_not_drift(tmp_path):
+    # A Codex-only or CLI-only install is not broken, it is simply not a plugin
+    # user. Nagging it would be noise on every status.
+    assert cli._plugin_drift(tmp_path, "0.25.0") is None
+
+
+def test_matching_versions_are_not_drift(tmp_path):
+    _install_plugin(tmp_path, "0.25.0")
+    assert cli._plugin_drift(tmp_path, "0.25.0") is None
+
+
+def test_plugin_behind_the_cli_is_drift(tmp_path):
+    # The field case: `uv tool install` moved the CLI, the plugin cache did not.
+    _install_plugin(tmp_path, "0.17.0")
+    assert cli._plugin_drift(tmp_path, "0.25.0") == {
+        "installed": "0.17.0", "cli": "0.25.0", "behind": True,
+    }
+
+
+def test_plugin_ahead_of_the_cli_is_drift_too(tmp_path):
+    # Same split, other direction: the plugin updated and the CLI did not. Still
+    # a mismatch worth reporting, but the fix is the opposite command.
+    _install_plugin(tmp_path, "0.26.0")
+    assert cli._plugin_drift(tmp_path, "0.25.0") == {
+        "installed": "0.26.0", "cli": "0.25.0", "behind": False,
+    }
+
+
+def test_version_comes_from_daimons_own_manifest_not_the_host_record(tmp_path):
+    # Two sources disagree. daimon's manifest ships with the code being run, so
+    # it is the one that describes the hooks that will actually execute.
+    _install_plugin(tmp_path, "0.17.0", recorded="0.25.0")
+    drift = cli._plugin_drift(tmp_path, "0.25.0")
+    assert drift is not None and drift["installed"] == "0.17.0"
+
+
+def test_prerelease_versions_compare_without_a_packaging_dependency():
+    # The kernel is stdlib-only, so version compare is hand-rolled. A component
+    # with a non-numeric suffix must not crash or sort wrong.
+    assert cli._version_tuple("1.0.0rc1") == (1, 0, 0)
+    assert cli._version_tuple("0.25.0") < cli._version_tuple("0.26.0")
+
+
+def test_plugins_key_of_the_wrong_shape_is_not_drift(tmp_path):
+    state = tmp_path / ".claude" / "plugins" / "installed_plugins.json"
+    state.parent.mkdir(parents=True)
+    state.write_text(json.dumps({"version": 2, "plugins": []}), encoding="utf-8")
+    assert cli._plugin_drift(tmp_path, "0.25.0") is None
+
+
+def test_non_dict_entries_are_skipped(tmp_path):
+    state = tmp_path / ".claude" / "plugins" / "installed_plugins.json"
+    state.parent.mkdir(parents=True)
+    state.write_text(json.dumps({"plugins": {"daimon@daimon": ["junk"]}}),
+                     encoding="utf-8")
+    assert cli._plugin_drift(tmp_path, "0.25.0") is None
+
+
+def test_entry_without_an_install_path_falls_back_to_the_recorded_version(tmp_path):
+    # No path to read daimon's manifest from, so the host's record is all there
+    # is. Better than reporting nothing.
+    state = tmp_path / ".claude" / "plugins" / "installed_plugins.json"
+    state.parent.mkdir(parents=True)
+    state.write_text(json.dumps({"plugins": {
+        "daimon@daimon": [{"scope": "user", "version": "0.17.0"}]}}),
+        encoding="utf-8")
+    drift = cli._plugin_drift(tmp_path, "0.25.0")
+    assert drift is not None and drift["installed"] == "0.17.0"
+
+
+def test_corrupt_manifest_falls_back_to_the_recorded_version(tmp_path):
+    root = _install_plugin(tmp_path, "0.17.0")
+    (root / ".claude-plugin" / "plugin.json").write_text("{not json",
+                                                         encoding="utf-8")
+    drift = cli._plugin_drift(tmp_path, "0.25.0")
+    assert drift is not None and drift["installed"] == "0.17.0"
+
+
+def test_drift_probe_swallows_an_exploding_home(monkeypatch):
+    # Same contract as _hook_drift_present: status never crashes on a probe.
+    monkeypatch.setattr(cli.Path, "home", staticmethod(
+        lambda: (_ for _ in ()).throw(RuntimeError("no home"))))
+    assert cli._plugin_drift_present() is None
+
+
+# ---- the daimon status pointer -----------------------------------------------
+
+
+def test_status_names_both_versions_and_the_restart(capsys):
+    # Naming both versions is the point: "out of date" alone sent me to the
+    # wrong host once already. The restart matters because hooks resolve at
+    # session start, so updating the plugin mid-session changes nothing.
+    render.render_status({
+        "project": "/p/A",
+        "proj": {"exists": False},
+        "glob": {"exists": False},
+        "last": None,
+        "plugin_drift": {"installed": "0.17.0", "cli": "0.25.0", "behind": True},
+    })
+    out = capsys.readouterr().out
+    assert "0.17.0" in out and "0.25.0" in out
+    assert "/plugin" in out
+    assert "restart" in out
+
+
+def test_status_tells_a_plugin_ahead_user_to_upgrade_the_cli(capsys):
+    render.render_status({
+        "project": "/p/A",
+        "proj": {"exists": False},
+        "glob": {"exists": False},
+        "last": None,
+        "plugin_drift": {"installed": "0.26.0", "cli": "0.25.0", "behind": False},
+    })
+    out = capsys.readouterr().out
+    assert "uv tool upgrade" in out
+
+
+def test_rich_status_renders_the_same_warning(capsys, monkeypatch):
+    # Both renderers carry the warning or half the users never see it. The rich
+    # path is chosen by supports_rich(), so force it rather than depend on
+    # whether the pretty extra happens to be installed here.
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_status({
+        "project": "/p/A",
+        "proj": {"exists": False},
+        "glob": {"exists": False},
+        "last": None,
+        "plugin_drift": {"installed": "0.17.0", "cli": "0.25.0", "behind": True},
+    })
+    out = capsys.readouterr().out
+    assert "0.17.0" in out and "0.25.0" in out
+
+
+def test_status_silent_when_versions_agree(capsys):
+    render.render_status({
+        "project": "/p/A",
+        "proj": {"exists": False},
+        "glob": {"exists": False},
+        "last": None,
+        "plugin_drift": None,
+    })
+    assert "plugin" not in capsys.readouterr().out
+
+
+def test_cmd_status_surfaces_a_stale_plugin_end_to_end(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _install_plugin(tmp_path, "0.0.1")  # any version the running CLI is not
+    capsys.readouterr()
+    cli.main(["status"])
+    assert "0.0.1" in capsys.readouterr().out
+
+
+def test_unreadable_plugin_state_is_not_drift(tmp_path):
+    # status must never crash on someone else's file format.
+    state = tmp_path / ".claude" / "plugins" / "installed_plugins.json"
+    state.parent.mkdir(parents=True)
+    state.write_text("{not json", encoding="utf-8")
+    assert cli._plugin_drift(tmp_path, "0.25.0") is None


### PR DESCRIPTION
Closes #554

## What

`daimon status` now reports when the installed Claude Code plugin and the CLI are
different versions:

```
⚠ Claude Code plugin is 0.17.0 but the daimon CLI is 0.25.0, run /plugin in Claude Code and update daimon, then restart the session, hooks resolve at session start
```

Drift is reported in both directions. A plugin ahead of the CLI gets the opposite
fix line (`uv tool upgrade daimon-briefing`), because the stale half is the other
one.

Silent when no plugin is installed, so a Codex-only or CLI-only machine is never
nagged. `plugin_drift` also joins the `status --json` shape as `null` or the
`{installed, cli, behind}` object, so the check is scriptable.

## Why

#266 audits the hook copies daimon installs by byte hash, but Claude Code's hooks
ship inside the plugin and `hooks install` deliberately rejects `claude` as a host.
The result was that the host with the most users was the only one whose hook
staleness nothing reported.

The two halves move under different commands. `uv tool upgrade` moves the CLI. The
host's plugin update moves the hooks. Neither notices the other, and a machine can
sit for weeks running a CLI several minor versions ahead of the hooks that actually
execute, with every local signal reading clean.

The restart is part of the fix rather than a footnote. Hooks resolve at session
start, so an updated plugin changes nothing until the session restarts, and
reloading skills is not enough. That is easy to assume and wrong.

## Design notes

The version is read from daimon's own `.claude-plugin/plugin.json` inside the
installed tree, not from the host's record of what it installed. That file ships
with the code that will actually run, and there is a test for the case where the
two disagree.

The host's `installed_plugins.json` is still used to locate the install, since it
is the only authoritative pointer, but every read of it is defensive: a wrong
shape, a non-dict entry, a corrupt manifest, or an unreadable file all resolve to
"no drift" rather than an error. `status` must never crash on another tool's file
format, which is the same contract `_hook_drift_present` already keeps.

Version comparison is hand-rolled against the stdlib-only kernel policy, so
`1.0.0rc1` sorts as `(1, 0, 0)` instead of pulling in `packaging`.

## Tests

`plugin/tests/test_plugin_drift.py`, 17 cases, each watched failing first:

- no plugin, matching versions, plugin behind, plugin ahead
- daimon's manifest wins over the host's record when they disagree
- unreadable state, wrong-shaped `plugins` key, non-dict entry, missing
  `installPath`, corrupt manifest, and an exploding `Path.home()`
- prerelease version comparison
- both renderers carry the warning, the rich path forced rather than left to
  whether the pretty extra is installed
- end to end through `cli.main(["status"])`

Full suite: 2837 passed, 2 skipped.

`test_cli_status_json_shape` pins the exact `status --json` key set on purpose, so
adding `plugin_drift` had to update it. That is the deliberate contract change this
PR makes, and the key is additive: consumers reading named fields are unaffected.
`hook_drift` and `rescue_posture` are already exposed the same way.

Ruff clean. mypy reports 38 pre-existing errors across the two touched files, the
same 38 as on main. No new ones.
