### PR TITLE
chore(scars): promote 0041, squash-merge discards local commit footers

### DIFF
--- a/.scars/0041-squash-merge-discards-local-commit-footers.landmine.md
+++ b/.scars/0041-squash-merge-discards-local-commit-footers.landmine.md
@@ -1,22 +1,22 @@
 ---
-id: 0
+id: 41
 type: landmine
 title: Squash-merge replaces the local commit body with the PR body, so conventional-commits footers must live in the PR
-severity: medium
+severity: high
 confidence: 0.95
 created: 2026-08-04
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: release-please-config.json
   - path: .github/workflows/pr-validation.yml
   - path: .github/workflows/release.yml
 evidence:
-  - note: "PR #551 was authored specifically to add a BREAKING CHANGE footer. Its local commit carried the footer; the squashed commit on main (0d3d1a8) carries the PR body instead, with no footer. The Release workflow ran green and left the release PR at 0.24.1."
-  - note: ".github/workflows/pr-validation.yml:70 states the rule for the subject line: 'squash-merge makes the PR title the commit subject on main'. The same substitution applies to the body, which is the half that is easy to miss."
+  - note: PR #551 was authored specifically to add a BREAKING CHANGE footer. Its local commit carried the footer; the squashed commit on main (0d3d1a8) carries the PR body instead, with no footer. The Release workflow ran green and left the release PR at 0.24.1.
+  - note: .github/workflows/pr-validation.yml:70 states the rule for the subject line: 'squash-merge makes the PR title the commit subject on main'. The same substitution applies to the body, which is the half that is easy to miss.
 expires:
   condition: "the repository stops squash-merging, or release-please starts reading PR bodies/labels for breaking-change markers instead of commit footers"
   review_after: 2027-02-04
-status: candidate
+status: active
 ---
 
 This repository squash-merges. GitHub composes the squashed commit message from
@@ -51,4 +51,16 @@ Do not rely on prose. A `## Breaking change` heading in a PR body is invisible
 to release-please; only `!` in the subject and a `BREAKING CHANGE:` footer are
 parsed. Related: `bump-minor-pre-major` must be true in
 `release-please-config.json` for a 0.x breaking change to bump the minor rather
-than jumping to 1.0.0.
+than jumping to 1.0.0. That key is set as of `0d3d1a8`.
+
+A note on this scar's own reach. Scars fire before you edit anchored code, but
+this trap fires while AUTHORING A PR, which touches no file. The anchors below
+catch someone editing release configuration, which is adjacent but not the
+moment of danger, so this scar cannot be relied on to fire when it matters.
+
+Two things would close that reach gap, neither shipped at the time of writing:
+a reminder in `.github/PULL_REQUEST_TEMPLATE.md` beside the conventional-title
+rule, since that is what an author actually has in front of them, and the real
+fix, which is mechanical rather than documentary: a PR-convention check that
+fails when a body carries breaking-change prose while the title carries no `!`.
+That check is the thing to build. This scar is the record of why.


### PR DESCRIPTION
## What

Promotes the reviewed candidate to `.scars/0041-squash-merge-discards-local-commit-footers.landmine.md` via `scar promote`, with two review amendments.

**Severity raised from medium to high.** The other `high` scars record traps that cost analysis time. This one shipped a capture-stopping change across a patch boundary, which `uv tool upgrade` takes without prompting, so the blast radius reaches users rather than the author.

**The scar now records its own reach gap.** Scars fire before you edit anchored code, but this trap fires while authoring a PR, which touches no file. Anchored to release configuration it catches an adjacent action, not the moment of danger. Saying so in the scar is better than implying a guard that does not exist.

## Why

The evidence was re-verified against main before promoting, not taken on faith:

- `0d3d1a8`'s commit body on main is verbatim the PR body, carrying no `BREAKING CHANGE:` footer, exactly as the candidate claims. The footer was authored locally and eaten by the squash.
- `.github/workflows/pr-validation.yml:70` documents the subject half of the same substitution, which is what makes the body half easy to miss.
- The evidence cites a main SHA rather than a branch SHA, so it will not rot into `evidence-unreachable` when branches are deleted.

No existing scar among the other 40 covers squash-merge, so this is not a duplicate.

## Tests

`scar lint`: 41 files, 0 errors, 0 orphans, 0 partial-rot, 0 unreachable-evidence. The single warning is pre-existing on `0016` and untouched here.

Scars-only PR, so the issue gates do not apply per the detector at `pr-validation.yml:28`.

## Follow-up, deliberately not in this PR

The real fix is mechanical: a PR-convention check that fails when a body carries breaking-change prose while the title carries no `!`. A reminder in the PR template is the cheaper interim guard. Both are filed separately rather than bundled here, because including a non-scar file would have voided this PR's scars-only exemption.
