### PR TITLE
fix(stats): say when agent credit became recordable

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -2767,6 +2767,15 @@ def _stats_verification(project_dir) -> dict:
     return {"total": sum(by_check.values()), "by_check": by_check}
 
 
+def _earlier(current: str | None, ts: str) -> str | None:
+    """Earliest of two event stamps, ignoring empties. Stamps are written by
+    one helper in a single UTC format, so lexicographic order is chronological
+    (#562)."""
+    if not ts:
+        return current
+    return ts if current is None or ts < current else current
+
+
 def _stats_resolutions(project_dir, usage: dict) -> dict:
     """Resolution credit, by source (#480 slice 5) — who is closing loops,
     and whether their receipts hold. Two populations, kept honestly apart
@@ -2799,7 +2808,21 @@ def _stats_resolutions(project_dir, usage: dict) -> dict:
 
     Fails open to zeroes on a broken/missing/unknown-project log, same
     stance as every other stats instrument here."""
-    out = {"human": 0, "agent_verified": 0, "agent_pending": 0, "refused": 0}
+    # #562: the lifetime fold spans the arrival of agent credit, so a store
+    # older than the agent write path reports its whole history as human
+    # credit. Before the first agent-attributable event the absence of agent
+    # credit is UNFALSIFIABLE — the path may simply not have existed — so the
+    # counter reports where that line falls instead of implying a comparison
+    # across it. Derived from the events themselves rather than a hardcoded
+    # release, so it generalizes to the next credit source added.
+    #
+    # Counters stay plain locals and the result dict is built once at the end:
+    # a literal mixing ints with a nullable stamp types the whole mapping as
+    # optional, and every `+= 1` below then reads as arithmetic on None.
+    human = 0
+    agent_verified = 0
+    agent_since: str | None = None
+    human_stamps: list[str] = []
     path = store._events_path(project_dir)
     if path is not None:
         try:
@@ -2816,17 +2839,33 @@ def _stats_resolutions(project_dir, usage: dict) -> dict:
             source = str(evt.get("source") or "")
             status = str(evt.get("status") or "")
             kind = str(evt.get("kind") or "")
+            ts = str(evt.get("ts") or "")
             if source == "cli" and kind == "resolution" and store.is_resolved(evt):
-                out["human"] += 1
+                human += 1
+                human_stamps.append(ts)
             elif source == "serializer" and status == capture.AGENT_VERIFIED_STATUS:
-                out["agent_verified"] += 1
+                agent_verified += 1
+                agent_since = _earlier(agent_since, ts)
+            elif source == "agent" and kind == "resolution":
+                # A claim the serializer has not verified yet is still proof
+                # the path existed, which is the only question here.
+                agent_since = _earlier(agent_since, ts)
+    # No agent event at all: the whole human population predates any agent
+    # credit, because there is none to have predated.
+    human_before_agent = (human if agent_since is None
+                          else sum(1 for t in human_stamps
+                                   if t and t < agent_since))
+    agent_pending = 0
     try:
-        out["agent_pending"] = len(capture._pending_agent_candidates(
+        agent_pending = len(capture._pending_agent_candidates(
             store.resolutions(project_dir=project_dir)))
     except Exception:
         pass
-    out["refused"] = usage.get("resolve:no-evidence", 0)
-    return out
+    return {"human": human, "agent_verified": agent_verified,
+            "agent_pending": agent_pending,
+            "refused": usage.get("resolve:no-evidence", 0),
+            "agent_since": agent_since,
+            "human_before_agent": human_before_agent}
 
 
 def _cmd_stats(args) -> int:

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -1137,6 +1137,16 @@ def _plain_stats(data: dict) -> None:
         print("resolutions (this project, lifetime):")
         print(f"  human: {res['human']}  agent-verified: {res['agent_verified']}  "
               f"agent-pending: {res['agent_pending']}")
+        # #562: the counters above are a lifetime fold. Human credit recorded
+        # before agent credit could exist is not evidence that humans out-close
+        # agents — the comparison had no other side. Say so, and only while it
+        # is true; the line disappears on its own once both populations overlap.
+        pre = res.get("human_before_agent") or 0
+        if pre:
+            since = res.get("agent_since")
+            when = f", first seen {since[:10]}" if since else ""
+            print(f"  note: {pre} of those predate any agent-recorded "
+                  f"resolution{when} — not a human-vs-agent ratio")
         # #477 lesson: refused comes from usage.log, a DIFFERENT (per-machine)
         # population than the three counters above (per-project) — labeled
         # apart, on its own line, never summed with them.
@@ -1282,3 +1292,11 @@ def _rich_stats(data: dict) -> None:
         res_table.add_row("agent-pending", str(res["agent_pending"]))
         res_table.add_row("refused (this machine)", str(res["refused"]))
         console.print(res_table)
+        # #562: same caveat as the plain renderer, same disappearing condition.
+        pre = res.get("human_before_agent") or 0
+        if pre:
+            since = res.get("agent_since")
+            when = f", first seen {since[:10]}" if since else ""
+            console.print(f"[yellow]note: {pre} of those predate any "
+                          f"agent-recorded resolution{when} — not a "
+                          f"human-vs-agent ratio[/yellow]")

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -6038,14 +6038,18 @@ def test_stats_json_resolutions_key_present_existing_keys_untouched(
     assert set(data) >= {"usage", "capture", "store", "retention", "events",
                          "verification", "rescue_posture", "resolutions"}
     assert set(data["resolutions"]) == {"human", "agent_verified",
-                                        "agent_pending", "refused"}
+                                        "agent_pending", "refused",
+                                        "agent_since", "human_before_agent"}
 
 
 def test_stats_resolutions_empty_world_is_all_zeroes(tmp_checkpoint_dir, capsys):
     rc = cli.main(["stats", "--json"])
     assert rc == 0
     res = json.loads(capsys.readouterr().out)["resolutions"]
-    assert res == {"human": 0, "agent_verified": 0, "agent_pending": 0, "refused": 0}
+    assert res == {"human": 0, "agent_verified": 0, "agent_pending": 0,
+                   "refused": 0, "agent_since": None,
+                   # nothing recorded, so nothing predates anything (#562)
+                   "human_before_agent": 0}
 
 
 def test_stats_resolutions_counts_all_four_states(
@@ -6083,6 +6087,144 @@ def test_stats_resolutions_counts_all_four_states(
     assert res["agent_verified"] == 1
     assert res["agent_pending"] == 1
     assert res["refused"] == 1
+
+
+def _write_events(tmp_checkpoint_dir, project, rows):
+    """Append raw event rows with controlled timestamps (#562 needs ordering)."""
+    from daimon_briefing import store
+    slug = store.project_slug(project)
+    path = tmp_checkpoint_dir / slug / "events.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+
+def _res(capsys, monkeypatch, project):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", project)
+    capsys.readouterr()
+    assert cli.main(["stats", "--json"]) == 0
+    return json.loads(capsys.readouterr().out)["resolutions"]
+
+
+def test_stats_resolutions_reports_when_agent_credit_became_possible(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # #562: a lifetime fold spanning the agent path's arrival reads as human
+    # credit. Absence of agent credit BEFORE the first agent-attributable
+    # event is unfalsifiable, so the counter has to say where that line is.
+    _write_events(tmp_checkpoint_dir, "/p/562a", [
+        {"item_ref": "a", "kind": "resolution", "status": "resolved",
+         "source": "cli", "ts": "2026-07-10T00:00:00Z"},
+        {"item_ref": "b", "kind": "resolution", "status": "resolved",
+         "source": "cli", "ts": "2026-07-20T00:00:00Z"},
+        {"item_ref": "c", "kind": "resolution", "status": "resolving-candidate",
+         "source": "agent", "ts": "2026-08-01T00:00:00Z"},
+        {"item_ref": "d", "kind": "resolution", "status": "resolved",
+         "source": "cli", "ts": "2026-08-02T00:00:00Z"},
+    ])
+    res = _res(capsys, monkeypatch, "/p/562a")
+    assert res["human"] == 3  # unchanged: lifetime still counts every one
+    assert res["agent_since"] == "2026-08-01T00:00:00Z"
+    assert res["human_before_agent"] == 2  # only the two that predate it
+
+
+def test_stats_resolutions_agent_since_is_none_when_no_agent_event_exists(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # The whole population predates any agent credit, so EVERY human count is
+    # uncomparable — the render layer needs to be able to say exactly that.
+    _write_events(tmp_checkpoint_dir, "/p/562b", [
+        {"item_ref": "a", "kind": "resolution", "status": "resolved",
+         "source": "cli", "ts": "2026-07-10T00:00:00Z"},
+    ])
+    res = _res(capsys, monkeypatch, "/p/562b")
+    assert res["agent_since"] is None
+    assert res["human_before_agent"] == 1
+
+
+def test_stats_resolutions_agent_since_counts_a_verified_stamp_too(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # An agent claim can be pruned while its serializer verification stamp
+    # survives; that stamp is equally proof the path existed.
+    from daimon_briefing import capture
+    _write_events(tmp_checkpoint_dir, "/p/562c", [
+        {"item_ref": "a", "kind": "resolution", "status": "resolved",
+         "source": "cli", "ts": "2026-07-10T00:00:00Z"},
+        {"item_ref": "b", "kind": "resolution",
+         "status": capture.AGENT_VERIFIED_STATUS,
+         "source": "serializer", "ts": "2026-07-25T00:00:00Z"},
+    ])
+    res = _res(capsys, monkeypatch, "/p/562c")
+    assert res["agent_since"] == "2026-07-25T00:00:00Z"
+    assert res["human_before_agent"] == 1
+
+
+def test_stats_render_flags_human_credit_that_predates_agent_capability(capsys):
+    # #562: the number itself is not wrong, the missing context is. A reader
+    # must not be able to take "human 36 / agent 2" as a ratio when most of
+    # the 36 landed before agent credit could be recorded at all.
+    from daimon_briefing import render
+    render.render_stats({"usage": {}, "store": {"items_by_kind": {}, "checkpoints": 0,
+                                   "project_buckets": 0, "items_verbatim": 0,
+                                   "items_inferred": 0, "items_untagged": 0,
+                                   "items_carried": 0},
+                         "capture": {"success": 0, "skipped": 0, "errors": 0,
+                                     "fallback_serializes": 0, "hosts": {}},
+                         "resolutions": {
+        "human": 36, "agent_verified": 2, "agent_pending": 0, "refused": 0,
+        "agent_since": "2026-07-31T00:00:00Z", "human_before_agent": 36}})
+    out = capsys.readouterr().out
+    assert "36" in out
+    assert "2026-07-31" in out
+    assert "predate" in out
+
+
+def test_stats_render_says_nothing_extra_once_the_populations_overlap(capsys):
+    # Once human credit accrues after the agent path exists, the comparison is
+    # legitimate and the caveat must disappear rather than nag forever.
+    from daimon_briefing import render
+    render.render_stats({"usage": {}, "store": {"items_by_kind": {}, "checkpoints": 0,
+                                   "project_buckets": 0, "items_verbatim": 0,
+                                   "items_inferred": 0, "items_untagged": 0,
+                                   "items_carried": 0},
+                         "capture": {"success": 0, "skipped": 0, "errors": 0,
+                                     "fallback_serializes": 0, "hosts": {}},
+                         "resolutions": {
+        "human": 36, "agent_verified": 2, "agent_pending": 0, "refused": 0,
+        "agent_since": "2026-07-31T00:00:00Z", "human_before_agent": 0}})
+    assert "predate" not in capsys.readouterr().out
+
+
+def test_stats_resolutions_agent_event_without_a_stamp_does_not_set_the_line(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    # events.jsonl is append-only and older writers may have omitted ts. An
+    # undated agent event still proves the path exists, but it cannot date it,
+    # so the boundary stays unknown rather than being guessed as "the epoch".
+    _write_events(tmp_checkpoint_dir, "/p/562d", [
+        {"item_ref": "a", "kind": "resolution", "status": "resolved",
+         "source": "cli", "ts": "2026-07-10T00:00:00Z"},
+        {"item_ref": "b", "kind": "resolution",
+         "status": "resolving-candidate", "source": "agent"},  # no ts
+    ])
+    res = _res(capsys, monkeypatch, "/p/562d")
+    assert res["agent_since"] is None
+    assert res["human_before_agent"] == 1
+
+
+def test_rich_stats_renders_the_same_predate_note(capsys, monkeypatch):
+    # Both renderers carry the caveat or half the readers never see it.
+    from daimon_briefing import render
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_stats({"usage": {}, "store": {"items_by_kind": {},
+                         "checkpoints": 0, "project_buckets": 0,
+                         "items_verbatim": 0, "items_inferred": 0,
+                         "items_untagged": 0, "items_carried": 0},
+                         "capture": {"success": 0, "skipped": 0, "errors": 0,
+                                     "fallback_serializes": 0, "hosts": {}},
+                         "resolutions": {
+        "human": 36, "agent_verified": 2, "agent_pending": 0, "refused": 0,
+        "agent_since": "2026-07-31T00:00:00Z", "human_before_agent": 36}})
+    out = capsys.readouterr().out
+    assert "predate" in out and "2026-07-31" in out
 
 
 def test_stats_resolutions_human_counts_events_not_refs(


### PR DESCRIPTION
Closes #562

## What

`_stats_resolutions` gains two derived fields:

- `agent_since`: timestamp of the earliest agent-attributable event, or `null`
- `human_before_agent`: how many human resolutions predate it

Both renderers print one line while it matters, and stop once it does not:

```
human: 36  agent-verified: 2  agent-pending: 0
note: 36 of those predate any agent-recorded resolution, first seen 2026-08-02, not a human-vs-agent ratio
```

The four existing counters are untouched. This adds context, it does not restate
the numbers.

## Why

Before the first agent-attributable event, the absence of agent credit is
unfalsifiable: the path may simply not have existed. Reporting a lifetime
`human` beside a lifetime `agent_verified` invites a ratio whose denominator
spans that boundary.

The issue proposed a rolling window, following #364. I did not take that, and the
reason is worth recording: a 14-day window does not fix this **today**. On a store
where the agent path arrived on 2026-07-31, a fortnight back from now still spans
the boundary, so the mixed comparison survives and only self-heals later. It would
look like a fix while still being wrong.

Deriving the boundary from the events avoids that. It is correct immediately, needs
no knowledge of which release shipped which capability, and generalizes to the next
credit source added rather than special-casing this one.

An unverified agent claim counts as proof the path existed, the same as a verified
one. The question is whether agent credit was recordable, not whether it was upheld.

## Tests

Six new cases in `plugin/tests/test_cli.py`, each watched failing first:

- human events split correctly across the boundary
- `agent_since` is `null` when no agent event exists, and every human event is then
  marked as predating
- a serializer verification stamp sets the boundary even with no surviving claim
- an agent event with no `ts` proves the path existed but cannot date it, so the
  boundary stays unknown rather than being guessed
- both renderers carry the note, with the rich path forced rather than left to
  whether the pretty extra is installed
- the note disappears once human credit accrues after the boundary

Verified against this repo's own store, where the derived date matches the events:

```
note: 36 of those predate any agent-recorded resolution, first seen 2026-08-02, not a human-vs-agent ratio
```

Full suite: 2844 passed, 2 skipped.

Two shape-pinning tests needed updating, deliberately: `stats --json`'s resolution
key set is asserted exactly, which is what makes an additive field a conscious
decision rather than a silent one.

## Note on typing

The first draft put `agent_since` into the result dict literal, which widened the
mapping to optional and made every `+= 1` read as arithmetic on `None`, adding six
mypy errors. Counters are now plain locals with the dict built once at the end.
mypy is back to the same 38 pre-existing errors as main across both touched files,
verified by running it on both. Ruff clean.
