### PR TITLE
fix(brief): clear serialize heartbeat when the run ends

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -300,6 +300,12 @@ def _run_serialize(transcript_path: Path, project: str | None,
         print(msg, file=sys.stderr)
         _append_serialize_log(msg)
         return 1
+    finally:
+        # #564: the pipeline is over on every path out of this try — success
+        # (checkpoint already on disk), skip, error, or an unexpected raise —
+        # so the liveness stamp must go with it. Leaving it made every brief
+        # inside the hung ceiling claim a finished serialize was in flight.
+        ledger.clear_heartbeat(session_id)
     if out is None:
         # #421: the write boundary refused (kill switch). Same "skipped" shape
         # as the hash-match short-circuit above — matches neither _RESULT_OK_RE

--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -383,6 +383,18 @@ def touch_heartbeat(session_id: str, project_slug: str | None = None) -> None:
         pass
 
 
+def clear_heartbeat(session_id: str) -> None:
+    """#564: a run's result ends its liveness — the serialize door clears the
+    stamp alongside writing its result line, so a completed run can never read
+    as in-flight for the rest of the hung ceiling. Best-effort like the touch:
+    a leftover stamp (kill -9 before the clear) is still bounded by the
+    ceiling, and heal's spawn-no-result classification never needed it."""
+    try:
+        (_heartbeat_dir() / Path(session_id).name).unlink()
+    except OSError:
+        pass
+
+
 def heartbeat_age(session_id: str, now: float | None = None) -> float | None:
     """Seconds since this session's serialize last proved liveness, or None
     when it never has (no stamp — pre-#342 host hook or a child that died

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -8738,3 +8738,39 @@ def test_serialize_in_flight_unreadable_only_entry_is_false(tmp_log_dir):
     (tmp_log_dir / "heartbeats").mkdir(parents=True, exist_ok=True)
     (tmp_log_dir / "heartbeats" / "only-a-dir").mkdir()
     assert ledger.serialize_in_flight("-p-A") is False
+
+
+# ---- #564: a COMPLETED serialize must not read as in-flight — the run clears
+# its heartbeat with its result, so brief never tells the reader to wait for a
+# checkpoint that already landed (false positive lasted the full hung ceiling).
+
+
+def test_run_serialize_success_clears_heartbeat(
+    tmp_checkpoint_dir, tmp_log_dir, fake_chat_factory, monkeypatch, capsys
+):
+    from daimon_briefing import ledger
+    monkeypatch.setattr(cli, "_chat", fake_chat_factory(_valid_json()))
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    rc = cli._run_serialize(FIXTURES / "sample_transcript.md", "/p")
+    assert rc == 0
+    assert not (tmp_log_dir / "heartbeats" / "sample_transcript").exists(), \
+        "a finished serialize must not leave its heartbeat behind"
+    assert ledger.serialize_in_flight("-p") is False, \
+        "success already wrote the checkpoint — nothing is in flight"
+
+
+def test_run_serialize_error_clears_heartbeat(
+    tmp_checkpoint_dir, tmp_log_dir, fake_chat_factory, monkeypatch, capsys
+):
+    from daimon_briefing import ledger
+    monkeypatch.setattr(cli, "_chat", fake_chat_factory("prose, not JSON"))
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    rc = cli._run_serialize(FIXTURES / "sample_transcript.md", "/p")
+    assert rc != 0
+    assert ledger.serialize_in_flight("-p") is False, \
+        "a failed serialize is heal's case, not an in-flight one"
+
+
+def test_clear_heartbeat_missing_file_is_noop(tmp_log_dir):
+    from daimon_briefing import ledger
+    ledger.clear_heartbeat("S-never-stamped")  # must not raise


### PR DESCRIPTION
Closes #564

## What

- `ledger.clear_heartbeat(session_id)`: best-effort unlink of a session's liveness stamp.
- `cli._run_serialize`: a `finally` on the pipeline try clears the stamp on every path out of the run: success (checkpoint already on disk by then), skip, error, and an unexpected raise.
- Two regression tests (success and error paths) plus a no-op test for a never-stamped session.

## Why

`serialize_in_flight` answers True from heartbeat freshness alone, and nothing removed the stamp when a run completed. The last touch lands at the end of the run, so after every successful serialize `daimon brief` carried the "a serialize is in flight" line for up to the hung ceiling (default 1800s), telling the reader to wait for a checkpoint that had already landed.

The write-side clear keeps `serialize_in_flight` untouched and honors the contract already stated on `touch_heartbeat`: a leftover file is disk hygiene, never a liveness signal. A stamp orphaned by a hard kill still exists for `status`/`heal` stuck diagnostics and stays bounded by the ceiling, exactly as before. A heal retry stamps again at entry, so a live retry still reads as in flight.

## Tests

- `test_run_serialize_success_clears_heartbeat`: failed before the change (stamp survived a successful run and `serialize_in_flight` stayed True), passes after.
- `test_run_serialize_error_clears_heartbeat`: a failed run is heal's case, not an in-flight one.
- `test_clear_heartbeat_missing_file_is_noop`: clearing a never-stamped session must not raise.
- Full plugin suite: 2847 passed, 2 skipped.
