### PR TITLE
feat(brief): render the HANDOFF baton as a rich panel

### DIFF
--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -124,13 +124,32 @@ def _print_version_note(checkpoint) -> None:
 def _print_handoff(handoff) -> None:
     """The baton block (#523): authored, imperative, rendered ABOVE every
     briefing section on both render paths — it must never lose position to
-    ambient sections. Multi-line batons keep one arrow per line."""
+    ambient sections. Multi-line batons keep one arrow per line.
+
+    #566: on the rich path the baton gets a bordered panel like every ambient
+    section below it — bare stdout above the panels inverted the visual
+    hierarchy for the one block a human wrote deliberately. Magenta border:
+    distinct from red (drift/external warnings) so "read this first" never
+    reads as "something is wrong". The plain path stays byte-identical — it is
+    a compatibility surface for non-TTY hosts and hook briefings."""
     if not handoff:
         return
+    lines = [ln.strip() for ln in str(handoff["note"]).splitlines() if ln.strip()]
+    if supports_rich():
+        from rich.console import Console
+        from rich.panel import Panel
+        from rich.text import Text
+
+        body = Text("\n".join(f"→ {ln}" for ln in lines), style="bold")
+        Console().print(Panel(
+            body,
+            title=f"HANDOFF (left deliberately by previous session, {handoff['ts']})",
+            border_style="magenta", title_align="left",
+        ))
+        return
     print(f"HANDOFF (left deliberately by previous session, {handoff['ts']}):")
-    for line in str(handoff["note"]).splitlines():
-        if line.strip():
-            print(f"→ {line.strip()}")
+    for line in lines:
+        print(f"→ {line}")
     print("")
 
 

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -74,6 +74,36 @@ def test_render_brief_rich_smoke(monkeypatch, sample_checkpoint, capsys):
     assert "PR #6" in out
 
 
+def test_render_brief_rich_handoff_is_a_panel(monkeypatch, sample_checkpoint, capsys):
+    # #566: the baton is the highest-priority block; on the rich path it must
+    # render as a bordered panel like every ambient section, not bare stdout.
+    # Content-only-ish assertion per the rich smoke idiom — except the one
+    # format fact under test: the HANDOFF header sits ON a panel border line.
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    handoff = {"ts": "2026-08-04T18:09:41Z", "note": "merge PR first\nthen review"}
+    render.render_brief(sample_checkpoint, handoff=handoff)
+    out = capsys.readouterr().out
+    header_lines = [ln for ln in out.splitlines() if "HANDOFF" in ln]
+    assert header_lines, "handoff header missing from rich output"
+    assert any("╭" in ln for ln in header_lines), \
+        "HANDOFF must be a panel title, not a bare print above the panels"
+    assert "→ merge PR first" in out
+    assert "→ then review" in out
+
+
+def test_render_brief_plain_handoff_unchanged(monkeypatch, sample_checkpoint, capsys):
+    # #566: the plain path is a compatibility surface (non-TTY hosts, hook
+    # briefings) — byte-identical to the pre-#566 shape.
+    handoff = {"ts": "2026-08-04T18:09:41Z", "note": "merge PR first\nthen review"}
+    render.render_brief(sample_checkpoint, handoff=handoff)
+    out = capsys.readouterr().out
+    assert out.startswith(
+        "HANDOFF (left deliberately by previous session, 2026-08-04T18:09:41Z):\n"
+        "→ merge PR first\n"
+        "→ then review\n"
+    )
+
+
 def test_render_brief_no_content(capsys):
     # #29: the old hint said "Run `serialize` first" — a dead end (serialize
     # needs a transcript path and is hook-internal). Point at the real flow.


### PR DESCRIPTION
Closes #566

## What

- `_print_handoff` renders the baton as a bordered rich panel on the rich path: the HANDOFF header (timestamp included) becomes the panel title, one arrow per line preserved inside, magenta border.
- The plain path stays byte-identical to before, guarded by a new test.

## Why

The baton is the one block a human wrote deliberately, and it rendered as bare stdout above a stack of bordered panels, so the visual hierarchy was inverted: the highest-priority content had the lowest-priority styling. Magenta keeps it distinct from red, which the drift and external-section panels already use for "something is wrong"; the baton means "read this first", not "warning".

Position is untouched on both paths: the baton still renders above every briefing section.

## Tests

- `test_render_brief_rich_handoff_is_a_panel`: failed before the change (HANDOFF was a bare print, no border line), passes after.
- `test_render_brief_plain_handoff_unchanged`: pins the plain output byte-for-byte, since non-TTY hosts and hook briefings consume it.
- Full plugin suite: 2849 passed, 2 skipped.
