### PR TITLE
ci(pr-validation): fail a breaking-change body with no surviving marker

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,10 @@ CI gates on this PR (pr-validation.yml):
 - exactly one type:* label on the PR
 - conventional title — squash-merge makes it the commit subject on main
 - branch named type/description (lowercase)
+- breaking change? put the `!` in the TITLE (`feat!:` / `fix(scope)!:`).
+  Local commit footers do NOT survive the squash; a body that says
+  "breaking change" without a title `!` or a `BREAKING CHANGE:` body
+  footer fails validation (#561, scar 0041)
 -->
 
 ## What

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -75,6 +75,23 @@ jobs:
             exit 1
           fi
 
+      # #561: squash-merge composes main's commit from PR title + body and
+      # discards local commit footers (scar 0041 — it mis-versioned a release
+      # twice). release-please reads exactly two markers: `!` in the subject or
+      # a BREAKING CHANGE: footer line; prose counts for nothing. If the body
+      # DESCRIBES a breaking change, at least one machine-readable marker must
+      # survive the squash — the title `!` is the one a squash cannot eat.
+      - name: Check Breaking-Change Marker
+        run: |
+          body="$(gh pr view "$PR" --repo "$REPO" --json body -q .body)"
+          title="$(gh pr view "$PR" --repo "$REPO" --json title -q .title)"
+          if grep -qiE 'breaking[ -]change' <<<"$body" \
+             && ! grep -qE '^[a-z]+(\([a-z0-9._-]+\))?!: ' <<<"$title" \
+             && ! grep -qiE '^BREAKING[- ]CHANGE: ' <<<"$body"; then
+            echo "::error::PR body mentions a breaking change but the title has no '!' and the body has no 'BREAKING CHANGE:' footer line. Neither marker survives the squash to release-please, so this would ship as an ordinary bump. Add '!' to the title (preferred: a squash cannot eat it), add the footer line, or reword the body if it is not actually breaking."
+            exit 1
+          fi
+
       - name: Check Branch Name
         run: |
           branch="${{ github.head_ref }}"


### PR DESCRIPTION
Closes #561

## What

- New marker-check step in `pr-validation.yml` (see the step name in the diff): fails when a PR body talks about an incompatible change while the title carries no `!` and the body carries no machine-readable footer line for it. Wording of this very description is deliberately indirect: the step greps bodies for the phrase itself, and this PR is not an incompatible change.
- Accepts both footer spellings (space and hyphen variants, case-insensitive), since release-please honors both.
- Pairs a line in `PULL_REQUEST_TEMPLATE.md` next to the existing conventional-title note, so the rule is visible at authoring time.

## Why

Squash-merge composes main's commit from PR title plus body and discards local commit footers, which mis-versioned a release twice in a row (#549 shipped an intended incompatibility as a patch; #551 tried to correct it with a footer that the squash ate too). Scar 0041 records it, but a scar fires on editing anchored code and this trap fires while authoring a PR. Only a check reaches that moment. The title `!` is the marker a squash cannot eat, so the error message steers there first.

## Tests

- Truth-table simulation of the exact grep logic across 7 cases: the #549 incident shape fails; title `!` (scoped and unscoped), either footer spelling, and unrelated bodies pass; a body that merely quotes the phrase without being incompatible fails by design (the tradeoff recorded in the issue).
- `shellcheck` clean on the step body.
- `actionlint` reports only a pre-existing finding on the untouched `Check Branch Name` step.
