### PR TITLE
feat(research): run-attributed merge-fidelity instrument

### DIFF
--- a/research/experiments/merge-fidelity-536/.gitignore
+++ b/research/experiments/merge-fidelity-536/.gitignore
@@ -1,0 +1,2 @@
+run-output.local.json
+__pycache__/

--- a/research/experiments/merge-fidelity-536/classify.py
+++ b/research/experiments/merge-fidelity-536/classify.py
@@ -1,0 +1,171 @@
+"""#536 frozen classification rubric — pure functions, zero I/O.
+
+Implements, verbatim, the pre-registered protocol on issue #536:
+normalization is casefold + whitespace collapse; fuzzy is
+difflib.SequenceMatcher ratio at threshold 0.55 with greedy pairing in
+deterministic (sorted) order; native items classify in fixed pass order
+survived -> reworded -> freeze-explained -> emitted-new; union items
+left without a descendant are true-lost. The containment check and the
+cross-chunk twin rate are diagnostics, not decision-bearing.
+
+The thresholds are frozen. Nothing here may grow a tuning knob.
+"""
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+
+FUZZY_THRESHOLD = 0.55
+CONTAINMENT_SLICE = 60
+
+
+@dataclass(frozen=True)
+class UnionItem:
+    text: str
+    chunk: int
+    trust: str = "untagged"
+
+
+@dataclass(frozen=True)
+class NativeItem:
+    text: str
+    trust: str = "untagged"
+
+
+@dataclass
+class Result:
+    survived: int = 0
+    reworded: int = 0
+    freeze_explained: int = 0
+    emitted_new: int = 0
+    true_lost: int = 0
+    union_total: int = 0
+    native_total: int = 0
+    emitted_new_by_trust: dict = field(default_factory=dict)
+    true_lost_by_trust: dict = field(default_factory=dict)
+    containment_flags: int = 0
+    twin_items: int = 0
+    lost_texts: list = field(default_factory=list)
+    emitted_new_texts: list = field(default_factory=list)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.casefold().split())
+
+
+def _ratio(a: str, b: str) -> float:
+    return SequenceMatcher(None, a, b).ratio()
+
+
+def _bump(d: dict, key: str) -> None:
+    d[key] = d.get(key, 0) + 1
+
+
+def wilson(k: int, n: int, z: float = 1.96):
+    """Wilson 95% score interval for k successes in n trials."""
+    if n == 0:
+        return (0.0, 0.0)
+    p = k / n
+    denom = 1 + z * z / n
+    centre = (p + z * z / (2 * n)) / denom
+    half = (z / denom) * ((p * (1 - p) / n + z * z / (4 * n * n)) ** 0.5)
+    return (max(0.0, centre - half), min(1.0, centre + half))
+
+
+def classify(native, union, prev_verbatim) -> Result:
+    """Classify one join. `native`: NativeItem list (non-carried items of
+    the checkpoint). `union`: UnionItem list (all chunk-partial items of
+    the producing run). `prev_verbatim`: normalized-or-raw text list of
+    the PREVIOUS checkpoint's verbatim items (freeze-explanation pool)."""
+    r = Result(native_total=len(native), union_total=len(union))
+
+    # deterministic order everywhere: sort by normalized text
+    natives = sorted(native, key=lambda i: normalize(i.text))
+    unions = sorted(union, key=lambda i: normalize(i.text))
+    union_free = {id(u): u for u in unions}
+    prev_pool = sorted(normalize(t) for t in prev_verbatim)
+    prev_free = list(prev_pool)
+
+    unmatched_native = []
+
+    # pass 1: survived (exact normalized match, one-to-one)
+    for n in natives:
+        nn = normalize(n.text)
+        hit = next((u for u in unions
+                    if id(u) in union_free and normalize(u.text) == nn), None)
+        if hit is not None:
+            r.survived += 1
+            del union_free[id(hit)]
+        else:
+            unmatched_native.append(n)
+
+    # pass 2: reworded (best fuzzy pair >= threshold, greedy in sorted order)
+    still_unmatched = []
+    for n in unmatched_native:
+        nn = normalize(n.text)
+        best, best_ratio = None, FUZZY_THRESHOLD
+        for u in unions:
+            if id(u) not in union_free:
+                continue
+            score = _ratio(nn, normalize(u.text))
+            if score > best_ratio or (score == best_ratio and best is None
+                                      and score >= FUZZY_THRESHOLD):
+                best, best_ratio = u, score
+        if best is not None and best_ratio >= FUZZY_THRESHOLD:
+            r.reworded += 1
+            del union_free[id(best)]
+        else:
+            still_unmatched.append(n)
+
+    # pass 3: freeze-explained (exact or fuzzy vs previous checkpoint's
+    # verbatim items; carry's reconsolidation freeze rewrites native twins)
+    for n in still_unmatched:
+        nn = normalize(n.text)
+        hit_idx = None
+        for i, p in enumerate(prev_free):
+            if p == nn or _ratio(nn, p) >= FUZZY_THRESHOLD:
+                hit_idx = i
+                break
+        if hit_idx is not None:
+            r.freeze_explained += 1
+            prev_free.pop(hit_idx)
+        else:
+            # pass 4: emitted-new
+            r.emitted_new += 1
+            _bump(r.emitted_new_by_trust, n.trust)
+            r.emitted_new_texts.append(n.text)
+
+    # union items with no descendant after passes 1-2: true-lost
+    for u in unions:
+        if id(u) in union_free:
+            r.true_lost += 1
+            _bump(r.true_lost_by_trust, u.trust)
+            r.lost_texts.append(u.text)
+
+    # diagnostic: containment (split/combine artifacts one-to-one miscounts).
+    # Checked over unpaired natives x unpaired unions only.
+    unpaired_native_texts = [normalize(n.text) for n in still_unmatched]
+    for u in unions:
+        if id(u) not in union_free:
+            continue
+        un = normalize(u.text)
+        for nn in unpaired_native_texts:
+            short, long_ = (un, nn) if len(un) <= len(nn) else (nn, un)
+            if len(short) >= CONTAINMENT_SLICE and (
+                    short[:CONTAINMENT_SLICE] in long_
+                    or short[-CONTAINMENT_SLICE:] in long_):
+                r.containment_flags += 1
+                break
+
+    # diagnostic: cross-chunk twin rate input (items with a fuzzy twin in a
+    # DIFFERENT chunk of the same run — the merge's genuine dedup workload)
+    twins = set()
+    for i, a in enumerate(unions):
+        na = normalize(a.text)
+        for b in unions[i + 1:]:
+            if a.chunk == b.chunk:
+                continue
+            if _ratio(na, normalize(b.text)) >= FUZZY_THRESHOLD:
+                twins.add(id(a))
+                twins.add(id(b))
+    r.twin_items = len(twins)
+
+    return r

--- a/research/experiments/merge-fidelity-536/join.py
+++ b/research/experiments/merge-fidelity-536/join.py
@@ -1,0 +1,339 @@
+"""#536 join half — walks serialize.log, re-chunks transcripts, loads
+cached chunk partials, and feeds airtight joins to the frozen rubric in
+classify.py.
+
+Attribution rules (pre-registered on issue #536; a session enters the
+population only if ALL hold, failures are counted and excluded, never
+partially joined):
+  1. exactly one spawn and one successful write in serialize.log
+  2. every re-derived chunk has a cached partial; cached count == the
+     log's chunk count for that run
+  3. every partial's producer receipt matches the checkpoint's
+     served-model stamp; checkpoint extraction version matches the
+     cache generation
+  4. the carry source (previous checkpoint) is on disk when carried
+     items exist
+
+Cache keys are reconstructed from the PRODUCING checkpoint's own stamps
+(llm_backend, llm_model, extraction_version), never from live config —
+the box flipped backends on 08-04 and live-config keys silently drop
+7 of 12 joins.
+
+Zero LLM calls. Reads only. The committed artifact is aggregates-only:
+chunk partials are pre-redaction by design, so item texts never leave
+this process except into the uncommitted local report.
+"""
+import hashlib
+import json
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import classify
+
+DAIMON_ROOT = Path.home() / ".daimon"
+LOG_PATH = DAIMON_ROOT / "logs" / "serialize.log"
+CHECKPOINT_DIR = DAIMON_ROOT / "checkpoints"
+CACHE_DIR = CHECKPOINT_DIR / ".chunk-cache"
+
+_SPAWN_RE = re.compile(
+    r"^\S+ [\w-]+: (?:spawned|retry) serialize for (?P<sid>[0-9a-f-]{8,})"
+    r".*?(?:\(transcript: (?P<transcript>[^)]+)\))?\s*$")
+_WROTE_RE = re.compile(
+    r"^wrote checkpoint: (?P<path>\S+?/(?P<sid>[0-9a-f-]{8,})\.json)"
+    r"(?: \(took \d+s\))?\s*$")
+_CHUNKED_RE = re.compile(
+    r"chunked serialize: (?P<n>\d+) chunks from \d+ lines")
+_ERROR_RE = re.compile(
+    r"^error: .*\(transcript: (?P<path>[^)]*?(?P<sid>[0-9a-f-]{8,})"
+    r"\.jsonl?)\)")
+
+
+@dataclass
+class RunRecord:
+    sid: str
+    spawns: int = 0
+    writes: int = 0
+    chunk_counts: list = field(default_factory=list)
+    transcript_path: str = None
+    _window_open: bool = False
+    _ambiguous: bool = False
+
+    def eligible(self):
+        return (self.spawns == 1 and self.writes == 1
+                and len(self.chunk_counts) == 1 and not self._ambiguous)
+
+
+def attribute_log(lines):
+    """Fold serialize.log lines into per-session RunRecords.
+
+    Chunk-count lines carry no session id; they attribute to the single
+    session whose spawn->write window is open. Overlapping windows (two
+    concurrent serializes) make attribution ambiguous for every window
+    open at that moment — those runs are excluded, never guessed.
+
+    Window hygiene, because a poisoned window poisons everything after:
+    an `error:` line closes its window (sid recovered from the
+    transcript path), and a window still open when a LATER-spawned run
+    completes a full spawn->write cycle is a zombie (the serialize died
+    silently) and is reaped. Chunk lines emit within seconds of spawn —
+    before any LLM wait — so a genuinely live long run has already
+    claimed its count by the time a later cycle could reap it."""
+    runs = {}
+    open_windows = {}  # sid -> spawn order index
+    spawn_seq = 0
+    for line in lines:
+        m = _SPAWN_RE.match(line)
+        if m:
+            sid = m.group("sid")
+            r = runs.setdefault(sid, RunRecord(sid=sid))
+            r.spawns += 1
+            if m.group("transcript"):
+                r.transcript_path = m.group("transcript")
+            spawn_seq += 1
+            open_windows[sid] = spawn_seq
+            continue
+        m = _WROTE_RE.match(line)
+        if m:
+            sid = m.group("sid")
+            r = runs.setdefault(sid, RunRecord(sid=sid))
+            r.writes += 1
+            born = open_windows.pop(sid, None)
+            if born is not None:
+                # reap zombies: windows spawned before this completed
+                # run that never wrote are dead processes
+                for other, other_born in list(open_windows.items()):
+                    if other_born < born:
+                        del open_windows[other]
+            continue
+        m = _ERROR_RE.match(line)
+        if m:
+            open_windows.pop(m.group("sid"), None)
+            continue
+        m = _CHUNKED_RE.search(line)
+        if m:
+            if len(open_windows) == 1:
+                r = runs[next(iter(open_windows))]
+                r.chunk_counts.append(int(m.group("n")))
+                if len(r.chunk_counts) > 1:
+                    r._ambiguous = True
+            else:
+                # zero or multiple candidate runs: attribute to nobody,
+                # and poison every open window — the count cannot be
+                # trusted for any of them
+                for sid in open_windows:
+                    runs[sid]._ambiguous = True
+    return runs
+
+
+def cache_key_for(chunk_text, backend, model, temperature,
+                  extraction_version, scene, lane="default"):
+    """Reconstruct serializer._chunk_cache_key with explicit stamp inputs
+    (serializer.py:1613 — v2 stamp, NUL-separated), so keys come from the
+    producing checkpoint's fields, not this process's config."""
+    scene_s = "scene" if scene else ""
+    stamp = (f"v2\x00{backend}\x00{model or ''}"
+             f"\x00{temperature}\x00{extraction_version}"
+             f"\x00{scene_s}\x00{lane}\x00")
+    return hashlib.sha256(
+        stamp.encode("utf-8") + chunk_text.encode("utf-8")).hexdigest()[:32]
+
+
+def checkpoint_extraction_version(cp):
+    """Absent extraction_version means pre-#514 stamp era; the cache
+    generation that hits for those checkpoints is 2 (pre-#527)."""
+    return cp.get("extraction_version", 2)
+
+
+def served_model_ok(envelope_model, checkpoint_served):
+    """Rule 3: producer receipt vs the checkpoint's llm_model_served.
+    Both-null is the honest-absence command-backend case (scar 0032);
+    any one-sided null is unattributable."""
+    return envelope_model == checkpoint_served
+
+
+_SECTIONS = (("working_context", ("open_questions", "recent_decisions")),
+             ("epistemic_snapshot", ("strong_beliefs", "uncertainties",
+                                     "contradictions_flagged")))
+
+
+def _iter_items(cp):
+    for section, kinds in _SECTIONS:
+        for kind in kinds:
+            for item in (cp.get(section) or {}).get(kind, []) or []:
+                if isinstance(item, dict) and item.get("text"):
+                    yield item
+
+
+def native_items(cp):
+    return [classify.NativeItem(text=i["text"],
+                                trust=i.get("trust", "untagged"))
+            for i in _iter_items(cp) if not i.get("carried_from")]
+
+
+def union_items(partials):
+    out = []
+    for idx, p in enumerate(partials):
+        for i in _iter_items(p):
+            out.append(classify.UnionItem(text=i["text"], chunk=idx,
+                                          trust=i.get("trust", "untagged")))
+    return out
+
+
+def prev_verbatim_pool(prev_cp):
+    return [i["text"] for i in _iter_items(prev_cp)
+            if i.get("trust") == "verbatim"]
+
+
+def predecessor_id(cp):
+    hops = Counter(i["carried_from"] for i in _iter_items(cp)
+                   if i.get("carried_from"))
+    if not hops:
+        return None
+    return hops.most_common(1)[0][0]
+
+
+# ---- disk walking (thin, untested — the run itself is the test) ----------
+
+def _load_json(path):
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def join_session(sid, run, config, serializer, transcript_mod):
+    """Attempt one airtight join. Returns ("joined", payload) or
+    ("excluded:<rule>", detail)."""
+    cp = _load_json(CHECKPOINT_DIR / f"{sid}.json")
+    if cp is None:
+        return "excluded:no-flat-checkpoint", sid
+    if not run.eligible():
+        if run.spawns != 1:
+            reason = "excluded:rule1-multi-spawn"
+        elif run.writes != 1:
+            reason = "excluded:rule1-no-write"
+        elif run._ambiguous:
+            reason = "excluded:rule1-ambiguous-window"
+        else:
+            # no chunked-serialize line: single-pass run, out of scope
+            # (no merge happened) — reported apart from log failures
+            reason = "excluded:single-pass"
+        return reason, (run.spawns, run.writes, run.chunk_counts)
+
+    tpath = run.transcript_path
+    if not tpath or not Path(tpath).exists():
+        hits = list(Path.home().glob(f".claude/projects/*/{sid}.jsonl"))
+        if len(hits) != 1:
+            return "excluded:no-transcript", sid
+        tpath = str(hits[0])
+    if transcript_mod.file_sha256(tpath) != cp.get("transcript_hash"):
+        return "excluded:transcript-mutated", sid
+
+    messages = transcript_mod.from_file(tpath)
+    text = serializer._render_transcript(messages)
+    chunks = serializer.chunk_transcript(text, config.chunk_lines(),
+                                         config.chunk_overlap())
+    if len(chunks) != run.chunk_counts[0]:
+        return "excluded:rule2-chunk-count", (len(chunks),
+                                              run.chunk_counts[0])
+
+    partials = []
+    for chunk in chunks:
+        key = cache_key_for(
+            chunk_text=chunk,
+            backend=cp.get("llm_backend", "unknown"),
+            model=cp.get("llm_model"),
+            temperature=config.llm_temperature(),
+            extraction_version=checkpoint_extraction_version(cp),
+            scene=config.scene_traces_enabled())
+        entry = _load_json(CACHE_DIR / f"{key}.json")
+        if entry is None or "partial" not in entry:
+            return "excluded:rule2-cache-miss", sid
+        if not served_model_ok(entry.get("served_model"),
+                               cp.get("llm_model_served")):
+            return "excluded:rule3-producer", (entry.get("served_model"),
+                                               cp.get("llm_model_served"))
+        partials.append(entry["partial"])
+
+    prev_sid = predecessor_id(cp)
+    prev_pool = []
+    if prev_sid is not None:
+        prev_cp = _load_json(CHECKPOINT_DIR / f"{prev_sid}.json")
+        if prev_cp is None:
+            return "excluded:rule4-no-predecessor", prev_sid
+        prev_pool = prev_verbatim_pool(prev_cp)
+
+    result = classify.classify(native=native_items(cp),
+                               union=union_items(partials),
+                               prev_verbatim=prev_pool)
+    return "joined", (cp, result)
+
+
+def main():
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]
+                           / "plugin"))
+    from daimon_briefing import config, serializer, transcript as transcript_mod
+
+    runs = attribute_log(LOG_PATH.read_text(encoding="utf-8").splitlines())
+    exclusions = Counter()
+    joins = []
+    for sid, run in sorted(runs.items()):
+        status, payload = join_session(sid, run, config, serializer,
+                                       transcript_mod)
+        if status == "joined":
+            joins.append((sid, *payload))
+        else:
+            exclusions[status] += 1
+        print(f"{sid[:8]}  {status}")
+
+    print(f"\njoined: {len(joins)}   excluded: {dict(exclusions)}")
+
+    # pooled rates
+    tot = Counter()
+    per_session = []
+    for sid, cp, r in joins:
+        tot.update(survived=r.survived, reworded=r.reworded,
+                   freeze_explained=r.freeze_explained,
+                   emitted_new=r.emitted_new, true_lost=r.true_lost,
+                   union=r.union_total, native=r.native_total,
+                   twin_items=r.twin_items,
+                   containment_flags=r.containment_flags)
+        for k, v in r.true_lost_by_trust.items():
+            tot[f"lost_trust_{k}"] += v
+        for k, v in r.emitted_new_by_trust.items():
+            tot[f"new_trust_{k}"] += v
+        per_session.append({
+            "session": sid[:8],
+            "native": r.native_total, "union": r.union_total,
+            "survived": r.survived, "reworded": r.reworded,
+            "freeze_explained": r.freeze_explained,
+            "emitted_new": r.emitted_new, "true_lost": r.true_lost,
+            "twin_items": r.twin_items,
+            "containment_flags": r.containment_flags,
+        })
+
+    n_union = tot["union"]
+    lost_ci = classify.wilson(tot["true_lost"], n_union)
+    twin_ci = classify.wilson(tot["twin_items"], n_union)
+    summary = {
+        "joined_sessions": len(joins),
+        "exclusions": dict(exclusions),
+        "pooled": dict(tot),
+        "true_lost_rate": tot["true_lost"] / n_union if n_union else None,
+        "true_lost_wilson95": lost_ci,
+        "twin_rate": tot["twin_items"] / n_union if n_union else None,
+        "twin_wilson95": twin_ci,
+        "per_session": per_session,
+    }
+    out = Path(__file__).parent / "run-output.local.json"
+    out.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    print(json.dumps({k: v for k, v in summary.items()
+                      if k != "per_session"}, indent=2))
+    print(f"\nfull per-session detail: {out} (LOCAL ONLY, not committed)")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/experiments/merge-fidelity-536/measurements.json
+++ b/research/experiments/merge-fidelity-536/measurements.json
@@ -1,0 +1,69 @@
+{
+  "issue": 536,
+  "claim": "run-attributed merge-fidelity measurement; pre-registration frozen in the issue #536 comment before any data was read",
+  "privacy": "AGGREGATES ONLY. Chunk partials are pre-redaction by design and item texts never leave the measuring process; run-output.local.json (counts per session) stays uncommitted.",
+  "status": {
+    "joined_sessions": 2,
+    "pre_registered_minimum_for_rates": 5,
+    "verdict": "BELOW MINIMUM — counts reported, no rate claim, decision rule NOT evaluated. The chunk cache reaps at 3 days, so the joinable population accrues forward; re-run as clean serializes accumulate.",
+    "measured": "2026-08-04, single machine"
+  },
+  "population": {
+    "sessions_in_log": 172,
+    "exclusions": {
+      "no-flat-checkpoint": 36,
+      "single-pass (no merge ran, out of scope)": 37,
+      "rule1-multi-spawn (retry present)": 22,
+      "rule1-no-write (failed or skipped serialize)": 50,
+      "rule1-ambiguous-window (concurrent serializes)": 11,
+      "rule2-cache-miss (3-day reap or key drift)": 11,
+      "rule2-chunk-count-mismatch": 3
+    },
+    "note": "exclusions are counted, never partially joined, per the pre-registration"
+  },
+  "pooled_counts": {
+    "union_items": 177,
+    "native_items": 154,
+    "survived": 73,
+    "reworded": 70,
+    "freeze_explained": 0,
+    "emitted_new": 11,
+    "true_lost": 34,
+    "true_lost_by_trust": {"verbatim": 11, "inferred": 23},
+    "emitted_new_by_trust": {"verbatim": 10, "inferred": 1},
+    "cross_chunk_twin_items": 7,
+    "containment_flags": 1
+  },
+  "if_rates_were_claimable_they_are_not": {
+    "true_lost_over_union_pct": 19.2,
+    "wilson_95_ci_pct": [14.1, 25.6],
+    "twin_rate_pct": 4.0,
+    "twin_wilson_95_ci_pct": [1.9, 7.9],
+    "interpretation": "directionally consistent with the n=1 specimen that motivated the issue (23.6% loss), and the twin rate sits near the 5% boundary that separates the two redesign forks — exactly why the 5-join minimum must be honored before any decision fires"
+  },
+  "per_session_counts": [
+    {"session": "3aaaf828", "chunks": 2, "native": 74, "union": 74, "survived": 33, "reworded": 30, "freeze_explained": 0, "emitted_new": 11, "true_lost": 11, "twin_items": 0},
+    {"session": "ff27204a", "chunks": 5, "native": 80, "union": 103, "survived": 40, "reworded": 40, "freeze_explained": 0, "emitted_new": 0, "true_lost": 23, "twin_items": 7}
+  ],
+  "observations_not_decision_bearing": {
+    "emitted_new_verbatim": "10 of 11 emitted-new items carry trust=verbatim — the merge emitting verbatim-tagged items with no chunk ancestor is the invention shape the trust model exists to prevent; worth its own eyeball pass once n grows",
+    "freeze_explained_zero": "pass 3 never fired on these two joins; the freeze-artifact control has not yet been exercised on real data"
+  },
+  "not_measured": {
+    "rewording_quality": "a fuzzy pair says the text changed, not whether it got worse",
+    "importance_trust_mutations": "field-level drift through the merge is not compared",
+    "corpus_scope": "single machine, single user, 3-day cache window",
+    "silence_costs_discovered": [
+      "pre-#565-era `wrote checkpoint:` lines lack the `(took Ns)` suffix; a strict parser silently never closes those windows and poisons all later attribution",
+      "silently-killed serializes leave zombie log windows; reaped only when a later spawn->write cycle completes",
+      "the 08-04 kill-test's concurrent serializes made 11 windows genuinely ambiguous — correct exclusions, but a reminder that rapid-close bursts blind this instrument",
+      "cache keys must be reconstructed from the producing checkpoint's own stamps (llm_backend, extraction_version); live-config keys silently dropped 7 of 12 candidate joins after the 08-04 backend flip"
+    ]
+  },
+  "artifacts": {
+    "rubric": "classify.py (frozen thresholds, pure functions)",
+    "join": "join.py (attribution + key reconstruction + disk walk)",
+    "tests": "test_classify.py (17), test_join.py (21)",
+    "local_only": "run-output.local.json"
+  }
+}

--- a/research/experiments/merge-fidelity-536/test_classify.py
+++ b/research/experiments/merge-fidelity-536/test_classify.py
@@ -1,0 +1,149 @@
+"""Tests for the #536 frozen classification rubric.
+
+Every rule here restates the pre-registration comment on issue #536
+verbatim; if a test wants a different behaviour, the protocol — not the
+test — wins, and the mismatch is a protocol failure to report.
+"""
+import classify
+
+
+def U(text, chunk=0, trust="inferred"):
+    return classify.UnionItem(text=text, chunk=chunk, trust=trust)
+
+
+def N(text, trust="inferred"):
+    return classify.NativeItem(text=text, trust=trust)
+
+
+class TestNormalize:
+    def test_casefold_and_whitespace_collapse(self):
+        assert classify.normalize("  Foo\tBAR\n baz ") == "foo bar baz"
+
+    def test_empty(self):
+        assert classify.normalize("") == ""
+
+
+class TestSurvived:
+    def test_exact_normalized_match_is_survived(self):
+        r = classify.classify(
+            native=[N("Merge kept THIS  item")],
+            union=[U("merge kept this item")],
+            prev_verbatim=[])
+        assert r.survived == 1 and r.reworded == 0
+
+    def test_one_to_one_no_double_spend(self):
+        # two identical natives, one union ancestor: only one survives
+        r = classify.classify(
+            native=[N("same text"), N("same text")],
+            union=[U("same text")],
+            prev_verbatim=[])
+        assert r.survived == 1
+        assert r.emitted_new == 1
+
+
+class TestReworded:
+    def test_fuzzy_above_threshold_is_reworded(self):
+        r = classify.classify(
+            native=[N("the deadline bug makes resample unrecoverable")],
+            union=[U("deadline bug leaves the resample unrecoverable by construction")],
+            prev_verbatim=[])
+        assert r.reworded == 1 and r.survived == 0
+
+    def test_below_threshold_is_not_reworded(self):
+        r = classify.classify(
+            native=[N("completely unrelated statement about apples")],
+            union=[U("kubernetes volume detached during failover")],
+            prev_verbatim=[])
+        assert r.reworded == 0
+        assert r.emitted_new == 1
+        assert r.true_lost == 1
+
+
+class TestFreezeExplained:
+    def test_prev_verbatim_match_is_freeze_explained_not_new(self):
+        r = classify.classify(
+            native=[N("frozen wording from the carry path")],
+            union=[U("something else entirely different topic")],
+            prev_verbatim=["frozen wording from the carry path"])
+        assert r.freeze_explained == 1
+        assert r.emitted_new == 0
+
+    def test_freeze_pass_runs_after_union_passes(self):
+        # a native matching BOTH union and prev-verbatim counts as survived
+        r = classify.classify(
+            native=[N("appears in both places")],
+            union=[U("appears in both places")],
+            prev_verbatim=["appears in both places"])
+        assert r.survived == 1 and r.freeze_explained == 0
+
+
+class TestEmittedNewAndTrueLost:
+    def test_no_ancestor_is_emitted_new_with_trust_breakdown(self):
+        r = classify.classify(
+            native=[N("invented by the merge", trust="verbatim")],
+            union=[],
+            prev_verbatim=[])
+        assert r.emitted_new == 1
+        assert r.emitted_new_by_trust == {"verbatim": 1}
+
+    def test_union_without_descendant_is_true_lost_with_trust_breakdown(self):
+        r = classify.classify(
+            native=[],
+            union=[U("dropped on the floor", trust="verbatim")],
+            prev_verbatim=[])
+        assert r.true_lost == 1
+        assert r.true_lost_by_trust == {"verbatim": 1}
+
+    def test_deterministic_under_input_order(self):
+        native = [N("alpha item one"), N("beta item two")]
+        union = [U("beta item two"), U("alpha item one")]
+        a = classify.classify(native=native, union=union, prev_verbatim=[])
+        b = classify.classify(native=list(reversed(native)),
+                              union=list(reversed(union)), prev_verbatim=[])
+        assert (a.survived, a.reworded, a.true_lost) == \
+               (b.survived, b.reworded, b.true_lost) == (2, 0, 0)
+
+
+class TestContainment:
+    def test_sixty_char_slice_containment_flagged(self):
+        long = "x" * 30 + " the load bearing sixty character slice payload " + "y" * 30
+        r = classify.classify(
+            native=[N(long + " plus a merged-in tail from another item making fuzzy fail entirely different words appended here to push ratio down " + "z" * 200)],
+            union=[U(long)],
+            prev_verbatim=[])
+        assert r.containment_flags >= 1
+
+    def test_short_items_do_not_flag_containment(self):
+        r = classify.classify(
+            native=[N("short")],
+            union=[U("other")],
+            prev_verbatim=[])
+        assert r.containment_flags == 0
+
+
+class TestCrossChunkTwins:
+    def test_twin_in_different_chunk_counts(self):
+        r = classify.classify(
+            native=[],
+            union=[U("the same discovery stated twice", chunk=0),
+                   U("the same discovery stated twice again", chunk=1)],
+            prev_verbatim=[])
+        assert r.twin_items == 2
+
+    def test_twin_in_same_chunk_does_not_count(self):
+        r = classify.classify(
+            native=[],
+            union=[U("the same discovery stated twice", chunk=0),
+                   U("the same discovery stated twice again", chunk=0)],
+            prev_verbatim=[])
+        assert r.twin_items == 0
+
+
+class TestWilson:
+    def test_wilson_interval_known_value(self):
+        lo, hi = classify.wilson(3, 30)
+        assert 0.03 < lo < 0.05
+        assert 0.25 < hi < 0.27
+
+    def test_wilson_zero_denominator(self):
+        assert classify.wilson(0, 0) == (0.0, 0.0)

--- a/research/experiments/merge-fidelity-536/test_join.py
+++ b/research/experiments/merge-fidelity-536/test_join.py
@@ -1,0 +1,197 @@
+"""Tests for the #536 join half — log attribution, key reconstruction,
+predecessor selection. Pure-function pieces only; disk walking stays thin
+and untested here (the run itself exercises it)."""
+import hashlib
+
+import join
+
+
+SPAWN = ("2026-08-04T20:40:16Z session-end: spawned serialize for aaaa1111-2222-3333-4444-555566667777 "
+         "(reason: prompt_input_exit, project: /Users/x/proj) "
+         "(transcript: /Users/x/.claude/projects/-x-proj/aaaa1111-2222-3333-4444-555566667777.jsonl)")
+CHUNKED = ("2026-08-04T20:40:17Z INFO daimon_briefing.serializer: "
+           "chunked serialize: 2 chunks from 1256 lines")
+WROTE = "wrote checkpoint: /Users/kibukx/.daimon/checkpoints/aaaa1111-2222-3333-4444-555566667777.json (took 237s)"
+RETRY = ("2026-08-04T20:43:04Z session-start: retry serialize for aaaa1111-2222-3333-4444-555566667777 "
+         "(prior: error: unparseable model output on chunk 1 of 2)")
+
+
+class TestLogAttribution:
+    def test_single_spawn_single_write_passes(self):
+        runs = join.attribute_log([SPAWN, CHUNKED, WROTE])
+        r = runs["aaaa1111-2222-3333-4444-555566667777"]
+        assert r.spawns == 1 and r.writes == 1
+        assert r.chunk_counts == [2]
+        assert r.transcript_path == "/Users/x/.claude/projects/-x-proj/aaaa1111-2222-3333-4444-555566667777.jsonl"
+        assert r.eligible()
+
+    def test_retry_spawn_disqualifies(self):
+        runs = join.attribute_log([SPAWN, CHUNKED, RETRY, CHUNKED, WROTE])
+        r = runs["aaaa1111-2222-3333-4444-555566667777"]
+        assert r.spawns == 2
+        assert not r.eligible()
+
+    def test_chunk_line_outside_spawn_write_window_ignored(self):
+        # chunk line after the write belongs to some other run
+        runs = join.attribute_log([SPAWN, WROTE, CHUNKED])
+        assert runs["aaaa1111-2222-3333-4444-555566667777"].chunk_counts == []
+
+    def test_two_chunk_lines_in_window_ambiguous(self):
+        runs = join.attribute_log([SPAWN, CHUNKED, CHUNKED, WROTE])
+        r = runs["aaaa1111-2222-3333-4444-555566667777"]
+        assert not r.eligible()
+
+    def test_single_pass_run_has_no_chunk_line(self):
+        single = ("2026-08-04T20:40:17Z INFO daimon_briefing.serializer: "
+                  "single-pass serialize: 300 lines")
+        runs = join.attribute_log([SPAWN, single, WROTE])
+        r = runs["aaaa1111-2222-3333-4444-555566667777"]
+        assert r.chunk_counts == []
+        assert not r.eligible()  # no chunked run -> nothing to measure
+
+    def test_other_host_spawn_prefixes_count(self):
+        codex = ("2026-08-04T10:00:00Z codex-stop: spawned serialize for bbbb1111-2222-3333-4444-555566667777 "
+                 "(reason: stop, project: /Users/x/p2) "
+                 "(transcript: /t/bbbb1111-2222-3333-4444-555566667777.jsonl)")
+        wrote_b = "wrote checkpoint: /Users/kibukx/.daimon/checkpoints/bbbb1111-2222-3333-4444-555566667777.json (took 10s)"
+        runs = join.attribute_log([codex, CHUNKED.replace("2 chunks", "3 chunks"), wrote_b])
+        assert runs["bbbb1111-2222-3333-4444-555566667777"].spawns == 1
+        assert runs["bbbb1111-2222-3333-4444-555566667777"].chunk_counts == [3]
+
+
+class TestLogHygiene:
+    SID_A = "aaaa1111-2222-3333-4444-555566667777"
+    SID_B = "bbbb1111-2222-3333-4444-555566667777"
+
+    def test_old_wrote_line_without_took_suffix_closes_window(self):
+        old_wrote = ("wrote checkpoint: /Users/kibukx/.daimon/checkpoints/"
+                     f"{self.SID_A}.json")
+        runs = join.attribute_log([SPAWN, CHUNKED, old_wrote])
+        r = runs[self.SID_A]
+        assert r.writes == 1
+        assert r.eligible()
+
+    def test_error_line_closes_window_via_transcript_stem(self):
+        err = (f"error: backend timeout (transcript: /t/{self.SID_A}.jsonl) "
+               "after 420s")
+        spawn_b = SPAWN.replace(self.SID_A, self.SID_B)
+        chunk3 = CHUNKED.replace("2 chunks", "3 chunks")
+        wrote_b = ("wrote checkpoint: /Users/kibukx/.daimon/checkpoints/"
+                   f"{self.SID_B}.json (took 10s)")
+        # A spawns, errors out; B then runs alone — B's chunk line must
+        # attribute cleanly, not be poisoned by A's dead window
+        runs = join.attribute_log([SPAWN, err, spawn_b, chunk3, wrote_b])
+        assert runs[self.SID_B].chunk_counts == [3]
+        assert runs[self.SID_B].eligible()
+
+    def test_zombie_window_reaped_after_full_later_cycle(self):
+        # A spawns and dies silently (no write, no error). B runs a full
+        # spawn->write cycle. C's chunk line after that must attribute to
+        # C alone: A's zombie window is reaped by B's completed cycle.
+        sid_c = "cccc1111-2222-3333-4444-555566667777"
+        spawn_b = SPAWN.replace(self.SID_A, self.SID_B)
+        wrote_b = ("wrote checkpoint: /Users/kibukx/.daimon/checkpoints/"
+                   f"{self.SID_B}.json (took 5s)")
+        spawn_c = SPAWN.replace(self.SID_A, sid_c)
+        chunk4 = CHUNKED.replace("2 chunks", "4 chunks")
+        wrote_c = ("wrote checkpoint: /Users/kibukx/.daimon/checkpoints/"
+                   f"{sid_c}.json (took 5s)")
+        runs = join.attribute_log(
+            [SPAWN, spawn_b, wrote_b, spawn_c, chunk4, wrote_c])
+        assert runs[sid_c].chunk_counts == [4]
+        assert runs[sid_c].eligible()
+
+    def test_true_overlap_still_poisons(self):
+        # A and B both open when the chunk line appears: no guess
+        spawn_b = SPAWN.replace(self.SID_A, self.SID_B)
+        wrote_a = ("wrote checkpoint: /Users/kibukx/.daimon/checkpoints/"
+                   f"{self.SID_A}.json (took 5s)")
+        wrote_b = ("wrote checkpoint: /Users/kibukx/.daimon/checkpoints/"
+                   f"{self.SID_B}.json (took 5s)")
+        runs = join.attribute_log([SPAWN, spawn_b, CHUNKED, wrote_a, wrote_b])
+        assert not runs[self.SID_A].eligible()
+        assert not runs[self.SID_B].eligible()
+
+
+class TestKeyReconstruction:
+    def test_stamp_uses_checkpoint_fields_not_live_config(self):
+        key = join.cache_key_for(
+            chunk_text="hello world",
+            backend="litellm", model="claude-haiku-4-5", temperature=0.0,
+            extraction_version=2, scene=True, lane="default")
+        stamp = ("v2\x00litellm\x00claude-haiku-4-5\x000.0\x002"
+                 "\x00scene\x00default\x00")
+        expected = hashlib.sha256(
+            stamp.encode("utf-8") + b"hello world").hexdigest()[:32]
+        assert key == expected
+
+    def test_missing_extraction_version_defaults_to_2(self):
+        assert join.checkpoint_extraction_version({}) == 2
+        assert join.checkpoint_extraction_version({"extraction_version": 3}) == 3
+
+
+class TestServedModelRule:
+    def test_both_null_matches(self):
+        assert join.served_model_ok(None, None)
+
+    def test_named_must_equal(self):
+        assert join.served_model_ok("m1", "m1")
+        assert not join.served_model_ok("m1", "m2")
+
+    def test_null_envelope_into_stamped_checkpoint_fails(self):
+        assert not join.served_model_ok(None, "m1")
+        assert not join.served_model_ok("m1", None)
+
+
+class TestPredecessor:
+    def test_prev_selected_by_carried_from(self):
+        cp = {"session_id": "B",
+              "working_context": {"recent_decisions": [
+                  {"text": "x", "carried_from": "A"}]},
+              "epistemic_snapshot": {}}
+        assert join.predecessor_id(cp) == "A"
+
+    def test_no_carried_items_means_no_predecessor_required(self):
+        cp = {"session_id": "B",
+              "working_context": {"recent_decisions": [{"text": "x"}]},
+              "epistemic_snapshot": {}}
+        assert join.predecessor_id(cp) is None
+
+    def test_mixed_hops_takes_majority(self):
+        cp = {"session_id": "C",
+              "working_context": {"recent_decisions": [
+                  {"text": "1", "carried_from": "B"},
+                  {"text": "2", "carried_from": "B"},
+                  {"text": "3", "carried_from": "A"}]},
+              "epistemic_snapshot": {}}
+        assert join.predecessor_id(cp) == "B"
+
+
+class TestItemPools:
+    def test_native_pool_excludes_carried(self):
+        cp = {"working_context": {
+                  "open_questions": [{"text": "q1", "trust": "verbatim"}],
+                  "recent_decisions": [{"text": "d1", "carried_from": "A"}]},
+              "epistemic_snapshot": {
+                  "strong_beliefs": [{"text": "b1", "trust": "inferred"}]}}
+        pool = join.native_items(cp)
+        assert sorted(i.text for i in pool) == ["b1", "q1"]
+
+    def test_union_pool_tags_chunk_index(self):
+        partials = [
+            {"working_context": {"open_questions": [{"text": "u1"}]},
+             "epistemic_snapshot": {}},
+            {"working_context": {},
+             "epistemic_snapshot": {"uncertainties": [{"text": "u2",
+                                                       "trust": "verbatim"}]}},
+        ]
+        pool = join.union_items(partials)
+        assert {(i.text, i.chunk) for i in pool} == {("u1", 0), ("u2", 1)}
+
+    def test_prev_verbatim_pool_only_verbatim(self):
+        prev = {"working_context": {
+                    "recent_decisions": [
+                        {"text": "keep", "trust": "verbatim"},
+                        {"text": "drop", "trust": "inferred"}]},
+                "epistemic_snapshot": {}}
+        assert join.prev_verbatim_pool(prev) == ["keep"]


### PR DESCRIPTION
Refs #536

## What

The pre-registered, run-attributed merge-fidelity instrument, plus its first measurement. Zero LLM calls, pure disk reads, aggregates-only committed artifact.

- `classify.py`: the frozen rubric from the pre-registration comment: survived / reworded / freeze-explained / emitted-new for native items, true-lost for union items, difflib ratio at 0.55, greedy sorted pairing, Wilson intervals. Thresholds are frozen; nothing here has a tuning knob.
- `join.py`: the attribution half: full serialize-log fold with window hygiene (old write-line format, error-line closes, zombie reaping, concurrent-window poisoning), transcript-hash verification, re-chunking, and cache-key reconstruction from the producing checkpoint's own stamps rather than live config.
- `measurements.json`: first run, gate-491 style.

## Why

The issue's decision rule needs a trustworthy loss rate before any merge redesign is filed. First run yields 2 airtight joins out of 172 logged sessions: below the pre-registered 5-join minimum, so the artifact reports counts only and the decision rule is explicitly NOT evaluated. The joinable population accrues forward as the 3-day chunk cache refills; the instrument re-runs unchanged. Uses `Refs` rather than a closing keyword because the decision evaluation is the final stage.

Notable in the counts, flagged for the next run rather than concluded on: 10 of 11 emitted-new items carry trust=verbatim, and pooled true-lost sits at 34 of 177 union items: directionally consistent with the specimen that motivated the issue.

Key reconstruction detail: computing cache keys from live config silently dropped 7 of 12 candidate joins after the backend switch on this corpus; keys must come from the producing checkpoint's `llm_backend` and `extraction_version` (absent means the pre-stamp generation, 2).

## Tests

- `test_classify.py` (17): every rubric pass, one-to-one discipline, determinism under input order, trust breakdowns, containment and twin diagnostics, Wilson known-value.
- `test_join.py` (21): log attribution including retry disqualification, ambiguous-window poisoning, old write-line format, error-line window close, zombie reaping, key-stamp reconstruction, served-model rule, predecessor selection, item pools.
- Full run executed end to end on the live corpus; per-session detail stays in the uncommitted local output by design (chunk partials are pre-redaction).
