### PR TITLE
feat(cli): warn when handoff supersedes an unconsumed baton

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1196,6 +1196,17 @@ def _cmd_handoff(args) -> int:
               f"({len(text)}) — a handoff is \"do X first, beware Y\", not a "
               "second checkpoint; trim it", file=sys.stderr)
         return 1
+    # #571: latest-wins stays the contract, but replacing a baton no session
+    # has consumed yet must not be silent — the superseded text never
+    # surfaces again (ref-less events sit outside ranking/recall/carry).
+    # active_handoff already encodes "unconsumed" (None after two distinct
+    # non-introspection serializes) and is fail-open, so a broken read warns
+    # about nothing rather than blocking the write.
+    prior = store.active_handoff(project)
+    if prior:
+        print("warning: superseding an unconsumed baton — its text below "
+              "never surfaces again; fold anything still relevant into the "
+              f"new baton:\n  {prior['note']}", file=sys.stderr)
     if not store.append_event("", "active", note=text, kind="handoff",
                               project_dir=project):
         print("error: handoff not recorded (daimon disabled or project "

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1690,6 +1690,61 @@ def test_cli_handoff_records_event_and_confirms(tmp_checkpoint_dir, capsys):
     assert h["note"] == "Build the MCP server next. Gotcha: cd plugin first."
 
 
+def test_cli_handoff_warns_when_superseding_unconsumed_baton(
+        tmp_checkpoint_dir, capsys):
+    # #571: latest-wins is the contract, but replacing a baton no session has
+    # consumed yet must SAY so — the superseded text never surfaces again
+    # (batons are ref-less events, outside ranking/recall/carry).
+    assert cli.main(["handoff", "Finish the adapter. Beware: flaky test.",
+                     "--project", "/p/A"]) == 0
+    capsys.readouterr()
+    rc = cli.main(["handoff", "Ship the release next.", "--project", "/p/A"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "supersed" in captured.err
+    assert "Finish the adapter. Beware: flaky test." in captured.err
+    assert "handoff recorded" in captured.out
+    from daimon_briefing import store
+    assert store.active_handoff("/p/A")["note"] == "Ship the release next."
+
+
+def test_cli_handoff_no_warning_on_first_baton(tmp_checkpoint_dir, capsys):
+    assert cli.main(["handoff", "do X", "--project", "/p/A"]) == 0
+    assert capsys.readouterr().err == ""
+
+
+def test_cli_handoff_no_warning_after_baton_consumed(
+        tmp_checkpoint_dir, capsys):
+    # Consumed = two distinct non-introspection sessions serialized after the
+    # write (store.active_handoff's own rule) — a consumed baton did its job,
+    # replacing it is not a supersede.
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    d = tmp_checkpoint_dir / slug
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "events.jsonl").write_text(json.dumps(
+        {"ts": "2026-08-02T10:00:00Z", "kind": "handoff", "item_ref": "",
+         "status": "active", "note": "old consumed baton",
+         "source": "cli"}) + "\n")
+    for name, created, sid in (("prev-1.json", "2026-08-02T10:05:00Z",
+                                "S-writer"),
+                               ("latest.json", "2026-08-02T12:00:00Z",
+                                "S-consumer")):
+        (d / name).write_text(json.dumps(
+            {"session_id": sid, "created": created,
+             "working_context": {}, "epistemic_snapshot": {}}))
+    assert store.active_handoff("/p/A") is None
+    assert cli.main(["handoff", "fresh baton", "--project", "/p/A"]) == 0
+    assert capsys.readouterr().err == ""
+
+
+def test_cli_handoff_clear_never_warns(tmp_checkpoint_dir, capsys):
+    # --clear is explicit retraction intent; warning would be noise.
+    assert cli.main(["handoff", "do X", "--project", "/p/A"]) == 0
+    assert cli.main(["handoff", "--clear", "--project", "/p/A"]) == 0
+    assert capsys.readouterr().err == ""
+
+
 def test_cli_handoff_refuses_over_cap(tmp_checkpoint_dir, capsys):
     from daimon_briefing import store
 


### PR DESCRIPTION
Closes #571

## What

`daimon handoff` now prints a stderr warning when the new baton replaces one that no session has consumed yet, quoting the superseded text so the author can fold anything still relevant into the new baton. The write itself is unchanged: latest-wins stays the contract, `--clear` stays silent, consumed or absent batons produce no notice.

## Why

Batons are ref-less events — outside ranking, recall, and carry — so a superseded baton's text never surfaces again anywhere. Replacing an unconsumed one silently loses instructions the writer believed would travel. Detection reuses `store.active_handoff`, which already encodes both "unconsumed" (None after two distinct non-introspection serializes) and fail-open reads, so a broken events file warns about nothing rather than blocking the write.

## Tests

- `test_cli_handoff_warns_when_superseding_unconsumed_baton` — failed before the change, passes after; asserts the warning quotes the old text and the new baton still wins.
- `test_cli_handoff_no_warning_on_first_baton`, `test_cli_handoff_no_warning_after_baton_consumed`, `test_cli_handoff_clear_never_warns` — pin the three silence cases.
- Full suite: 2853 passed, 2 skipped.
