### PR TITLE
fix(serializer): stop feeding daimon's own output to the extractor

### DIFF
--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -951,6 +951,42 @@ def daimon_output_ids(messages) -> set:
             and (mid := _message_id(m)) is not None}
 
 
+def extraction_messages(messages):
+    """Messages as the EXTRACTOR should see them: daimon's own tool output
+    blanked (#577).
+
+    Until this existed the two halves disagreed. `stripped_transcript` blanked
+    a `daimon_output` row so quote verification could not accept daimon as a
+    witness for its own claim, while the extractor kept reading the same rows
+    raw. Verification is quote-scoped, so an item could carry a real assistant
+    sentence in `quote` and daimon's own output in `text`/`because`/`scene`,
+    and arrive at `verbatim` with content the defense was built to keep out.
+    Measured on #575's guard: one derived belief was correctly downgraded to
+    `inferred`, one derived decision landed `verbatim`.
+
+    Blanked, never dropped: `[mN]` markers are positional over the full list,
+    so removing a row would renumber every later citation.
+
+    What this costs, measured rather than assumed. Chunk-cache keys derive from
+    chunk text (#48), so blanking shifts chunk boundaries and invalidates
+    entries: 28.6% of chunks over 1,166 real transcripts, against a cache that
+    reaps itself every `chunk_cache_days` (3). It is a one-time re-extraction
+    of a store that fully rotates twice a week.
+
+    What it does NOT cost: content. Of 616 items across 12 checkpoint chains,
+    156 had text appearing verbatim in the brief rendered from their own prior
+    checkpoint, and 156 of 156 were already stored in that bucket. Nothing here
+    is the only copy of anything. Carry works off checkpoint data, not off the
+    extractor's input, so carried items are untouched either way.
+
+    Open and deliberately not claimed: whether the brief as CONTEXT helps the
+    extractor interpret the session's own content. Substring matching cannot
+    see reworded reuse, and no retrospective can measure a context effect.
+    """
+    return [dict(m, content="") if isinstance(m, dict) and m.get("daimon_output")
+            else m for m in (messages or [])]
+
+
 def stripped_transcript(messages) -> str:
     """`_render_transcript`'s text with every message's injected spans removed
     — the whole-transcript VERIFICATION haystack (#440).
@@ -2020,7 +2056,11 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
     if deadline is not None and deadline - time.monotonic() <= 0:
         raise LLMCallError("deadline exhausted before the first LLM call")
 
-    transcript_text = _render_transcript(messages)
+    # #577: the extractor reads daimon's own tool output blanked, the same way
+    # verification already refuses to read it as a witness. `messages` stays
+    # unblanked below — verification, grounding and the [mN] markers all key on
+    # the original list.
+    transcript_text = _render_transcript(extraction_messages(messages))
     chunks = chunk_transcript(transcript_text, config.chunk_lines(), config.chunk_overlap())
 
     # #314: DAIMON_TIMEOUT is the field-derived floor for ONE slow call (#284,

--- a/plugin/tests/test_extraction_echo.py
+++ b/plugin/tests/test_extraction_echo.py
@@ -1,0 +1,72 @@
+"""#577: daimon's own tool output must not reach the extractor.
+
+The echo defense (#440/#441/#512) was quote-scoped. `stripped_transcript`
+blanked a `daimon_output` row so verification could not accept daimon as a
+witness for its own claim, but the extractor kept reading the same rows raw.
+An extracted item carries `text`, `quote`, `because` and `scene`, and only
+`quote` is verified, so daimon's output could ride in through the other three
+and inherit `verbatim` from an unrelated real sentence.
+
+Measured on a real serialize of guard output: the derived belief was correctly
+downgraded to `inferred` with `quote_echo_only`, and the derived decision
+landed `verbatim` with `because` holding the guard verdict word for word.
+"""
+from daimon_briefing import serializer
+
+
+def _msgs():
+    return [
+        {"role": "user", "content": "should we add a cache here?", "id": "m1"},
+        {"role": "tool", "content": "REFUTED: caching was rolled back in March",
+         "id": "m2", "tool_result": True, "daimon_output": True},
+        {"role": "assistant", "content": "No, that route is already refuted.",
+         "id": "m3"},
+    ]
+
+
+def test_extractor_never_receives_daimon_output():
+    rendered = serializer._render_transcript(
+        serializer.extraction_messages(_msgs()))
+    assert "rolled back in March" not in rendered
+    # Everything else survives untouched.
+    assert "should we add a cache here?" in rendered
+    assert "No, that route is already refuted." in rendered
+
+
+def test_blanking_preserves_message_positions():
+    # [mN] markers are positional over the full list (#358). Dropping a row
+    # instead of blanking it would renumber every later citation, silently
+    # repointing quotes that were already verified against the old numbering.
+    before = serializer._render_transcript(_msgs())
+    after = serializer._render_transcript(
+        serializer.extraction_messages(_msgs()))
+    assert before.count("[m") == after.count("[m")
+    for marker in ("[m1]", "[m2]", "[m3]"):
+        assert (marker in before) == (marker in after)
+
+
+def test_extraction_messages_does_not_mutate_its_input():
+    messages = _msgs()
+    serializer.extraction_messages(messages)
+    assert messages[1]["content"] == "REFUTED: caching was rolled back in March"
+
+
+def test_verification_haystack_is_unchanged_by_this_fix():
+    # The two halves now agree, and the verification side must still blank the
+    # same row it always did. A regression here would re-open #512.
+    haystack = serializer.stripped_transcript(_msgs())
+    assert "rolled back in March" not in haystack
+    assert "No, that route is already refuted." in haystack
+
+
+def test_rows_without_the_flag_are_passed_through_by_identity():
+    # Provenance, never shape (deadend 0020). An ordinary tool row that merely
+    # looks like daimon output is not daimon output.
+    messages = [{"role": "tool", "content": "REFUTED: something", "id": "m1",
+                 "tool_result": True}]
+    assert serializer.extraction_messages(messages)[0] is messages[0]
+
+
+def test_non_dict_rows_survive():
+    assert serializer.extraction_messages([None, "x"]) == [None, "x"]
+    assert serializer.extraction_messages(None) == []


### PR DESCRIPTION
## What changed

- Blank daimon's own tool output before the extractor sees it, via a new `extraction_messages` helper applied at the extraction boundary only.
- `_render_transcript` stays a pure renderer, so the verification path and every existing caller are untouched.

## Why

The echo defense (#440/#441/#512) turned out to be **quote-scoped**. `stripped_transcript` blanked a `daimon_output` row so quote verification could not accept daimon as a witness for its own claim, while the extractor kept reading the same rows raw. That asymmetry was deliberate and documented, on the grounds that chunk-cache keys derive from chunk text.

An extracted item carries `text`, `quote`, `because` and `scene`, and only `quote` is verified. So daimon's output could ride in through the other three and inherit `verbatim` from an unrelated real sentence.

## Measured, before and after

A fixture session containing one `daimon refute guard` hit, serialized end to end.

Before, two items derived from the guard output:

```
strong_beliefs    inferred   quote_echo_only: true      <- defense worked
recent_decisions  verbatim   quote_verified: true       <- defense did not reach it
  quote:   "The memoization route is already refuted, so I will not propose it."
  because: "<the guard's verdict line, word for word>"
```

After, zero. The refutation id, the measurement id and the verdict wording are all absent from the checkpoint. What survives is one belief recording that the approach was already refuted, which traces to the agent's own sentence in the transcript rather than to daimon's output. That is what a checkpoint should record.

Fixture shape matters here and is easy to get wrong. A markdown transcript carries no provenance at all, and JSONL without a row `uuid` never reaches the branch that sets `daimon_output`. Assert `daimon_output_ids(messages)` is non-empty before spending a serialize on any echo measurement. Recorded as scar 0043.

## The cost, measured rather than assumed

Chunk-cache keys derive from chunk text, so blanking shifts chunk boundaries and invalidates entries. Over 1,166 real transcripts on one machine:

| | |
| --- | --- |
| transcripts holding daimon output | 17.0% |
| chunks containing daimon text | 22.6% |
| chunk keys that change | 28.6% |

The gap between the last two rows is the interesting part: about a quarter of the invalidated chunks contain no daimon text at all and change purely because earlier lines disappeared and the windows shifted. That cache reaps itself every `chunk_cache_days` (default 3) and currently holds 35 entries with nothing older than the window, so the cost is a one-time re-extraction of a store that fully rotates twice a week.

## What it does not cost

Content. Across 12 checkpoint chains, 156 of 616 items had text appearing verbatim in the brief rendered from their own prior checkpoint, and **156 of 156 were already stored in that bucket**. Nothing reachable only through the extractor's view of daimon output. Carry works off checkpoint data rather than the extractor's input, so carried items are unaffected either way.

## Not claimed

Whether the brief as **context** helps the extractor interpret the session's own content. Substring matching cannot see reworded reuse, and no retrospective can measure a context effect. A proper A/B would need a blind paired judge that survives four documented failure modes in this repo, and only 22 local transcripts contain brief output, which cannot carry that conclusion. Left as a named open question rather than a silent assumption.

## Validation

- Full plugin test suite passes with 2,859 tests and two skips.
- Six new tests: the extractor never receives daimon output, positions are preserved, the input is not mutated, the verification haystack is unchanged, rows are matched by provenance rather than shape, and non-dict rows survive.
- Ruff and the hook mirror check pass.
- End-to-end fixture re-run through the working tree, not the installed CLI.

Closes #577


## Scope of the blanking, by output class

`_daimon_tool_use_ids` (`transcript.py:109`) keys on the daimon **invocation** rather than on the shape of its output. That is deliberate: it covers every subcommand, current and future, without enumerating render formats. `test_transcript.py:348` pins it across four real invocation idioms, including wrappers and `&&` chains.

The consequence is that this change blanks every daimon subcommand, while the content measurement above covered brief-derived text only. Closing that gap by class:

| Output class | Content unique to it? | Evidence-ineligible | Context-ineligible |
| --- | --- | --- | --- |
| `recall`, `recall-inject` | No. Output is by construction a query over the checkpoint store | yes | not required |
| `status`, `doctor`, `loops` | No. Metrics, not memory content | yes | not required |
| `why` | No. Provenance about items already stored | yes | not required |
| `refute list/show/guard` | **Yes.** The ledger is a separate store the checkpoint never held | yes | yes |

Only the last row holds content with no copy in the extractor's target, and it is the class this change exists for. The other three are safe to blank for the same reason the 156 of 156 result gives for `brief`: blanking removes nothing that is not already stored.

Stated plainly, because the two questions are different and this change currently answers both the same way: a message can be invalid as **evidence** and still useful as **context**. Global blanking says no to both. That is defensible here only because three of the four classes carry no unique content and the fourth is the one being defended against.

## Positions and associations after the shift

Blanking preserves the row scaffold rather than removing the row. A blanked row renders as its marker and role with empty content, so neighbouring messages never become adjacent:

```
[m1] user: should we add a cache here?

[m2] tool:

[m3] assistant: No, that route is already refuted.
```

`message_id_map` is identical before and after, so marker to host id resolution is untouched. Chunk windows do shift, which is the 28.6% above, but what a shifted window brings together is genuine adjacent content in genuine order. The change is to which evidence a chunk contains, not to whether that evidence is real.

Known limitation, not fixed here. `transcript.py:164` renders a tool call that genuinely produced nothing as `(no output)`. A blanked daimon row renders as empty instead, so the two are distinguishable, but an empty row still presents a daimon call as though it did nothing rather than as though its output was withheld. A constant marker would be equally evidence-ineligible and more honest about what happened. One end-to-end run produced no item making that mistake, which is a sample of one.

## Route to structured provenance

This is a mitigation at the correct seam, not the final contract. The durable version is a per-message provenance envelope carrying `origin` (user, agent, tool, daimon, system) with separate `evidence_eligible` and `context_eligible` flags, so the extractor can read context it may not cite, and trust rules can reject daimon as an independent witness by policy rather than by blanking text. Filed as #591.

The open question above is the one that decides whether the envelope is worth its migration cost, and it is answerable: run each transcript that holds daimon output three ways (raw, blanked, context-visible but evidence-ineligible) and have a blind judge score omissions, false derivations and causal comprehension, with criteria registered before the run.

## Interaction with #590

Rebased onto `main` after #590, which taught the invocation matcher to recognise
daimon run through a shell wrapper. The two compose: #590 decides what counts as
daimon's own output, this change decides what the extractor sees of it.

Verified together on the rebased branch:

| tool_use command | flagged | reaches extractor |
| --- | --- | --- |
| `daimon refute guard x` | 1 | no |
| `sh -c 'daimon refute guard x'` | 1 | no |
| `rg "daimon" cli.py` | 0 | yes |

The last row is the control. A command that talks about daimon rather than
invoking it keeps its evidentiary value, which is the property the
invocation-scoped rule exists to protect.
