### PR TITLE
fix(forget): reach every plaintext surface the project owns

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -944,18 +944,31 @@ def _cmd_forget(args) -> int:
     if not isinstance(checkpoint, dict):
         print("no checkpoint for this project yet — nothing to forget")
         return 1
+    # Every surface this project holds, not just the live checkpoint (#419
+    # scope): a value that had been superseded still sits in prev-N and in its
+    # session file, and resolving only against `latest` made forget answer "no
+    # item matches" about plaintext that was demonstrably on disk.
+    seen_ids: set[str] = set()
     items = []
-    for section, key in store._ITEM_LISTS:
-        for item in ((checkpoint.get(section) or {}).get(key) or []):
-            if isinstance(item, dict) and item.get("id"):
-                items.append((section, key, item))
+    for _path, section, key, item in store.items_for_project(project):
+        if item["id"] in seen_ids:
+            continue          # one item, several surfaces — not several items
+        seen_ids.add(item["id"])
+        items.append((section, key, item))
     target = next((it for _, _, it in items if it["id"] == args.target), None)
     if target is None:
         texts = [str(it.get("text") or "") for _, _, it in items]
         generic = carry._generic_terms(texts)
         hits = [(s, k, it) for s, k, it in items
                 if carry._same_item(args.target, str(it.get("text") or ""), generic)]
-        if len(hits) == 1:
+        # Ambiguity is about distinct VALUES, not hit count. The same sentence
+        # carried by sibling ids or held on several surfaces is one thing to
+        # forget; #418 already splices sibling ids from a single key. Only
+        # genuinely different values leave the user a choice to make, and there
+        # never-guess still refuses.
+        distinct = {normalize.content_key(str(it.get("text") or ""))
+                    for _, _, it in hits}
+        if len(distinct) == 1:
             target = hits[0][2]
         else:
             _note_usage("forget:no-match" if not hits else "forget:ambiguous")

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1007,8 +1007,16 @@ def _cmd_forget(args) -> int:
                                    == content_hash))]
     # allow_disabled (#421): the ONE write_checkpoint call that may run under
     # the kill switch — the rewrite that makes the deletion real on disk.
+    # rotate=False: rotation copies the CURRENT latest into prev-1 before
+    # writing, and the current latest is the PRE-forget bytes. Rotating here
+    # made the deletion manufacture a fresh copy of the value it was asked to
+    # remove, in a file that did not exist when the user ran the command.
     store.write_checkpoint(sid, checkpoint, project_dir=project,
-                           allow_disabled=True)
+                           allow_disabled=True, rotate=False)
+    # The live checkpoint is one surface of several. prev-N and superseded
+    # session files hold the same plaintext and were never in the contract
+    # (#419: plaintext is what puts a file inside it, not its role).
+    store.scrub_content_key(content_hash, project_dir=project)
     # #422: the serializer chunk cache holds PRE-redaction extraction output
     # (quote verification forbids redacting before caching, #125), keyed by
     # chunk text — the forgotten value cannot be located selectively, so the

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -263,6 +263,56 @@ def _plaintext_surfaces(d: Path) -> list[Path]:
     return out
 
 
+def project_surfaces(project_dir=None) -> list[Path]:
+    """`_plaintext_surfaces` narrowed to ONE project.
+
+    forget is project-scoped — its tombstone lands in one project's ledger — so
+    every surface it reads or rewrites must belong to that project. The flat
+    dir is shared: `latest.json` there is the GLOBAL pointer and may hold any
+    project's session, and session files sit side by side regardless of origin.
+    Membership is therefore decided by the payload's own `project_slug`, never
+    by the file's location.
+
+    A file whose slug cannot be read is EXCLUDED. Deleting from a surface whose
+    ownership is unknown is the failure this function exists to prevent."""
+    slug = project_slug(project_dir)
+    if not slug:
+        return []
+    out: list[Path] = []
+    for path in _plaintext_surfaces(config.checkpoint_dir()):
+        if path.parent.name == slug:
+            out.append(path)
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if isinstance(payload, dict) and payload.get("project_slug") == slug:
+            out.append(path)
+    return out
+
+
+def items_for_project(project_dir=None) -> list[tuple[Path, str, str, dict]]:
+    """Every identified item this project holds on ANY surface, live or not.
+
+    forget resolved targets against the live checkpoint alone, so a value that
+    had been superseded was reported as "no item matches" while its plaintext
+    sat in prev-N. Resolution has to see what deletion has to reach."""
+    found: list[tuple[Path, str, str, dict]] = []
+    for path in project_surfaces(project_dir):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        for section, key in _ITEM_LISTS:
+            for item in ((payload.get(section) or {}).get(key) or []):
+                if isinstance(item, dict) and item.get("id"):
+                    found.append((path, section, key, item))
+    return found
+
+
 def scrub_content_key(content_hash: str, project_dir=None) -> list[str]:
     """Remove every item folding to `content_hash` from all plaintext surfaces.
 
@@ -274,9 +324,8 @@ def scrub_content_key(content_hash: str, project_dir=None) -> list[str]:
     """
     if not content_hash:
         return []
-    d = config.checkpoint_dir()
     rewritten: list[str] = []
-    for path in _plaintext_surfaces(d):
+    for path in project_surfaces(project_dir):
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, ValueError):

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -235,6 +235,77 @@ def _session_files(d: Path) -> list[Path]:
     ]
 
 
+def _plaintext_surfaces(d: Path) -> list[Path]:
+    """Every file under the store that holds checkpoint items as PLAINTEXT:
+    per-session checkpoints and the rotation pointers, in the flat dir and in
+    every per-project bucket.
+
+    This list is the deletion contract's surface set. #419 settled that holding
+    plaintext — not being append-only, not being "history" — is what puts a file
+    inside it. `forget` previously reasoned only about the LIVE checkpoint, so
+    prev-N and superseded session files kept the value after a successful
+    deletion. Anything added here later must be added to this walk, or it
+    silently inherits the same hole."""
+    out: list[Path] = []
+    try:
+        entries = list(d.iterdir())
+    except OSError:
+        return out
+    for entry in entries:
+        try:
+            if entry.is_file() and entry.suffix == ".json":
+                out.append(entry)
+            elif entry.is_dir():
+                out.extend(p for p in entry.iterdir()
+                           if p.is_file() and p.suffix == ".json")
+        except OSError:
+            continue
+    return out
+
+
+def scrub_content_key(content_hash: str, project_dir=None) -> list[str]:
+    """Remove every item folding to `content_hash` from all plaintext surfaces.
+
+    Returns the paths rewritten, so the caller can report what deletion
+    actually reached instead of asserting it. Best-effort per file: one
+    unreadable or unwritable surface must not abort the rest of the scrub, and
+    a file that cannot be parsed is left byte-identical rather than truncated —
+    the same posture the ledger rewrite takes toward rows it cannot interpret.
+    """
+    if not content_hash:
+        return []
+    d = config.checkpoint_dir()
+    rewritten: list[str] = []
+    for path in _plaintext_surfaces(d):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        changed = False
+        for section, key in _ITEM_LISTS:
+            lst = (payload.get(section) or {}).get(key)
+            if not isinstance(lst, list):
+                continue
+            kept = [i for i in lst
+                    if not (isinstance(i, dict)
+                            and normalize.content_key(i.get("text") or "")
+                            == content_hash)]
+            if len(kept) != len(lst):
+                lst[:] = kept
+                changed = True
+        if not changed:
+            continue
+        try:
+            _atomic_write(path, json.dumps(payload, indent=2,
+                                           ensure_ascii=False) + "\n")
+        except OSError:
+            continue
+        rewritten.append(str(path))
+    return rewritten
+
+
 def checkpoints_written_since(cutoff: float) -> int:
     """How many per-session checkpoints were WRITTEN since `cutoff` (epoch
     seconds), counted by file mtime — the write-side signal for the silent-
@@ -398,7 +469,8 @@ _stamp_item_ids = policy.stamp_item_ids
 
 
 def write_checkpoint(session_id: str, checkpoint: dict, project_dir=None,
-                     allow_disabled: bool = False) -> Path | None:
+                     allow_disabled: bool = False,
+                     rotate: bool = True) -> Path | None:
     """Write the session checkpoint + the global latest pointer, and — when the
     project is known — the per-project latest pointer too. The global pointer is
     kept for backward compatibility (pre-routing consumers and the fallback).
@@ -498,14 +570,16 @@ def write_checkpoint(session_id: str, checkpoint: dict, project_dir=None,
     # sequence proceeds unguarded (pre-lock behavior, fail-open).
     with _pointer_lock(d):
         if not _pointer_regresses(d, new_epoch):
-            _rotate_pointers(d, history)
+            if rotate:
+                _rotate_pointers(d, history)
             _atomic_write(d / _LATEST, blob)
     if slug:
         pdir = d / slug
         pdir.mkdir(parents=True, exist_ok=True)
         with _pointer_lock(pdir):
             if not _pointer_regresses(pdir, new_epoch):
-                _rotate_pointers(pdir, history)
+                if rotate:
+                    _rotate_pointers(pdir, history)
                 _atomic_write(pdir / _LATEST, blob)
     # Mint the receipt now that the checkpoint file is durably on disk (#204):
     # outputs_hash covers those exact bytes. Best-effort and self-contained —

--- a/plugin/tests/test_forget_pointer_history.py
+++ b/plugin/tests/test_forget_pointer_history.py
@@ -1,0 +1,118 @@
+"""`daimon forget` must not leave the value behind in pointer history.
+
+Two defects, one visible only with a byte scan of the whole store:
+
+1. `forget` rewrites the checkpoint through `write_checkpoint`, which rotates
+   `latest.json` into `prev-1.json` BEFORE writing. The pre-forget bytes are
+   the ones rotated, so the deletion manufactures a fresh copy of the value it
+   was asked to remove — in a file that did not exist when the user asked.
+2. `prev-N` written by ordinary earlier serializes was never scrubbed at all,
+   so any value that was ever superseded survived every `forget` regardless.
+
+#419 settled the house rule: a surface holding PLAINTEXT is inside the deletion
+contract, and being an append-only or historical file is not an exemption.
+`prev-N` is neither append-only nor hashed. It was simply missed.
+"""
+import json
+
+import pytest
+
+from daimon_briefing import cli, store
+
+
+PROJECT = "/p/forget-pointers"
+CANARY = "zqxcanary7788 the account migration in a single pass"
+KEEPER = "an unrelated decision that must survive the deletion"
+
+
+def _write(session_id, *texts, project_dir=PROJECT):
+    store.write_checkpoint(session_id, {
+        "session_id": session_id,
+        "created": f"2026-07-0{session_id[-1]}T00:00:00Z",
+        "working_context": {
+            "recent_decisions": [{"text": t, "trust": "inferred"} for t in texts]},
+    }, project_dir=project_dir)
+
+
+def _files(root):
+    return {str(p.relative_to(root)) for p in root.rglob("*") if p.is_file()}
+
+
+def _holding(root, needle):
+    return sorted(str(p.relative_to(root)) for p in root.rglob("*")
+                  if p.is_file() and needle.encode() in p.read_bytes())
+
+
+def test_forget_leaves_no_plaintext_in_pointer_history(tmp_checkpoint_dir):
+    # Both sessions carry the canary, so it is present in the LATEST checkpoint
+    # and target resolution finds it. What this pins is the scrub: prev-1 and
+    # the older session file hold the same value and are equally plaintext.
+    #
+    # The harder case — a value present ONLY in superseded state, which forget
+    # currently reports as "no item matches" while it sits on disk — is stage 2
+    # and is pinned separately below.
+    _write("S1", CANARY, KEEPER)
+    _write("S2", CANARY, KEEPER)
+    assert len(_holding(tmp_checkpoint_dir, CANARY)) > 2, "fixture is too weak"
+
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+
+    assert _holding(tmp_checkpoint_dir, CANARY) == [], (
+        "forget reported success while the value survived on disk")
+
+
+@pytest.mark.xfail(reason="stage 2: target resolution cannot see superseded "
+                          "state, so forget denies a value that is on disk",
+                   strict=True)
+def test_forget_reaches_a_value_only_in_superseded_state(tmp_checkpoint_dir):
+    _write("S1", CANARY, KEEPER)
+    _write("S2", KEEPER)
+    assert _holding(tmp_checkpoint_dir, CANARY), "fixture did not plant residue"
+
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+    assert _holding(tmp_checkpoint_dir, CANARY) == []
+
+
+def test_forget_does_not_create_new_files_holding_the_value(tmp_checkpoint_dir):
+    # The sharper half: whatever forget fails to clean, it must at least not
+    # MANUFACTURE. A deletion that writes a fresh copy of its own target is
+    # worse than one that misses an old file.
+    _write("S1", CANARY, KEEPER)
+    before = _files(tmp_checkpoint_dir)
+
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+
+    created = _files(tmp_checkpoint_dir) - before
+    holding = set(_holding(tmp_checkpoint_dir, CANARY))
+    assert not (created & holding), (
+        f"forget created new files holding the forgotten value: "
+        f"{sorted(created & holding)}")
+
+
+def test_forget_preserves_unrelated_items_in_pointer_history(tmp_checkpoint_dir):
+    # Scrubbing history must be surgical. #418's contract is content removal of
+    # the targeted value, never truncation of the surfaces that held it.
+    _write("S1", CANARY, KEEPER)
+    _write("S2", CANARY, KEEPER)
+
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+
+    survivors = _holding(tmp_checkpoint_dir, KEEPER)
+    assert survivors, "forget destroyed unrelated history it did not target"
+    for rel in survivors:
+        payload = json.loads((tmp_checkpoint_dir / rel).read_text())
+        assert isinstance(payload, dict), f"{rel} is no longer a valid pointer"
+
+
+@pytest.mark.parametrize("pointer", ["latest.json", "prev-1.json"])
+def test_pointer_files_stay_readable_after_a_scrub(tmp_checkpoint_dir, pointer):
+    _write("S1", CANARY, KEEPER)
+    _write("S2", CANARY, KEEPER)
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+
+    slug = store.project_slug(PROJECT)
+    path = tmp_checkpoint_dir / slug / pointer
+    if not path.exists():
+        pytest.skip(f"{pointer} not present in this layout")
+    payload = json.loads(path.read_text())
+    assert payload.get("session_id"), f"{pointer} lost its session_id"

--- a/plugin/tests/test_forget_pointer_history.py
+++ b/plugin/tests/test_forget_pointer_history.py
@@ -61,9 +61,6 @@ def test_forget_leaves_no_plaintext_in_pointer_history(tmp_checkpoint_dir):
         "forget reported success while the value survived on disk")
 
 
-@pytest.mark.xfail(reason="stage 2: target resolution cannot see superseded "
-                          "state, so forget denies a value that is on disk",
-                   strict=True)
 def test_forget_reaches_a_value_only_in_superseded_state(tmp_checkpoint_dir):
     _write("S1", CANARY, KEEPER)
     _write("S2", KEEPER)
@@ -116,3 +113,61 @@ def test_pointer_files_stay_readable_after_a_scrub(tmp_checkpoint_dir, pointer):
         pytest.skip(f"{pointer} not present in this layout")
     payload = json.loads(path.read_text())
     assert payload.get("session_id"), f"{pointer} lost its session_id"
+
+
+OTHER = "zqxcanary7788 a different sentence that also mentions migration"
+
+
+def test_one_value_across_two_surfaces_is_not_ambiguous(tmp_checkpoint_dir):
+    # The hazard of widening the candidate pool. The SAME value in latest and
+    # in prev-1 is one value in two places, not two candidates to choose
+    # between. Counting hits would turn the ordinary case into a refusal.
+    _write("S1", CANARY, KEEPER)
+    _write("S2", CANARY, KEEPER)
+
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+    assert _holding(tmp_checkpoint_dir, CANARY) == []
+
+
+def test_two_distinct_values_across_surfaces_still_refuse(tmp_checkpoint_dir):
+    # never-guess (#418) has to survive the wider pool: distinct VALUES that
+    # both match the query are still ambiguous, and forget must refuse rather
+    # than pick one.
+    _write("S1", CANARY, KEEPER)
+    _write("S2", OTHER, KEEPER)
+
+    rc = cli.main(["forget", "zqxcanary7788", "--project", PROJECT])
+
+    assert rc == 1
+    assert _holding(tmp_checkpoint_dir, CANARY), "refusal must change nothing"
+    assert _holding(tmp_checkpoint_dir, OTHER), "refusal must change nothing"
+
+
+def test_exact_id_resolves_from_a_superseded_surface(tmp_checkpoint_dir):
+    import json as _json
+    _write("S1", CANARY, KEEPER)
+    _write("S2", KEEPER)
+    old = _json.loads((tmp_checkpoint_dir / "S1.json").read_text())
+    target = next(i["id"] for i in old["working_context"]["recent_decisions"]
+                  if i["text"] == CANARY)
+
+    assert cli.main(["forget", target, "--project", PROJECT]) == 0
+    assert _holding(tmp_checkpoint_dir, CANARY) == []
+
+
+OTHER_PROJECT = "/p/forget-pointers-neighbour"
+
+
+def test_scrub_never_crosses_a_project_boundary(tmp_checkpoint_dir):
+    # forget is project-scoped: the tombstone is written to one project's
+    # ledger. A scrub that walked the whole store would delete an identical
+    # sentence out of an unrelated project that never asked for it.
+    _write("S1", CANARY, KEEPER)
+    _write("N1", CANARY, KEEPER, project_dir=OTHER_PROJECT)
+
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+
+    neighbour = tmp_checkpoint_dir / store.project_slug(OTHER_PROJECT)
+    survived = [p for p in neighbour.rglob("*")
+                if p.is_file() and CANARY.encode() in p.read_bytes()]
+    assert survived, "forget deleted an unrelated project's data"

--- a/plugin/tests/test_forget_pointer_history.py
+++ b/plugin/tests/test_forget_pointer_history.py
@@ -171,3 +171,101 @@ def test_scrub_never_crosses_a_project_boundary(tmp_checkpoint_dir):
     survived = [p for p in neighbour.rglob("*")
                 if p.is_file() and CANARY.encode() in p.read_bytes()]
     assert survived, "forget deleted an unrelated project's data"
+
+
+# --- failure paths -----------------------------------------------------------
+# The scrub is best-effort per file BY DESIGN: one unreadable surface must not
+# abort the deletion of the rest, and a surface this version cannot parse is
+# left byte-identical rather than truncated. Those branches decide whether a
+# partial failure corrupts data, so they are asserted rather than assumed.
+
+
+def test_unparseable_surface_is_left_byte_identical(tmp_checkpoint_dir):
+    _write("S1", CANARY, KEEPER)
+    junk = tmp_checkpoint_dir / store.project_slug(PROJECT) / "prev-1.json"
+    junk.write_text("{ this is not json", encoding="utf-8")
+    before = junk.read_bytes()
+
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+
+    assert junk.read_bytes() == before, "a file we cannot parse was rewritten"
+
+
+def test_non_dict_payload_is_skipped_not_rewritten(tmp_checkpoint_dir):
+    _write("S1", CANARY, KEEPER)
+    odd = tmp_checkpoint_dir / store.project_slug(PROJECT) / "prev-2.json"
+    odd.write_text('["a list, not a checkpoint"]', encoding="utf-8")
+
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+
+    assert odd.read_text(encoding="utf-8") == '["a list, not a checkpoint"]'
+
+
+def test_one_unwritable_surface_does_not_abort_the_rest(
+        tmp_checkpoint_dir, monkeypatch):
+    _write("S1", CANARY, KEEPER)
+    _write("S2", CANARY, KEEPER)
+    real = store._atomic_write
+    failed = {"n": 0}
+
+    def flaky(path, blob):
+        if path.name == "prev-1.json" and failed["n"] == 0:
+            failed["n"] += 1
+            raise OSError("read-only surface")
+        return real(path, blob)
+
+    monkeypatch.setattr(store, "_atomic_write", flaky)
+    store.scrub_content_key(
+        __import__("daimon_briefing.normalize", fromlist=["x"]).content_key(CANARY),
+        project_dir=PROJECT)
+
+    assert failed["n"] == 1, "the failure path was never exercised"
+
+
+def test_scrub_is_a_noop_without_a_content_key(tmp_checkpoint_dir):
+    _write("S1", CANARY, KEEPER)
+    assert store.scrub_content_key("", project_dir=PROJECT) == []
+    assert _holding(tmp_checkpoint_dir, CANARY), "empty key must delete nothing"
+
+
+def test_surfaces_are_empty_when_the_project_is_unknown(tmp_checkpoint_dir):
+    assert store.project_surfaces(None) == []
+    assert store.items_for_project(None) == []
+
+
+def test_unreadable_directory_yields_no_surfaces(tmp_checkpoint_dir, monkeypatch):
+    def boom(*_a, **_k):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(store.Path, "iterdir", boom)
+    assert store._plaintext_surfaces(tmp_checkpoint_dir) == []
+
+
+def test_unreadable_flat_file_is_not_claimed_by_this_project(tmp_checkpoint_dir):
+    # Ownership in the flat dir is decided by reading `project_slug` out of the
+    # payload. A file we cannot read has UNKNOWN ownership, and the safe answer
+    # is to exclude it: deleting from a surface that might belong to another
+    # project is the failure this walk exists to prevent.
+    _write("S1", CANARY, KEEPER)
+    opaque = tmp_checkpoint_dir / "not-json.json"
+    opaque.write_text("{ broken", encoding="utf-8")
+
+    assert opaque not in store.project_surfaces(PROJECT)
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+    assert opaque.read_text(encoding="utf-8") == "{ broken"
+
+
+def test_a_subdirectory_we_cannot_list_is_skipped(tmp_checkpoint_dir, monkeypatch):
+    _write("S1", CANARY, KEEPER)
+    real = store.Path.iterdir
+
+    def selective(self):
+        if self.name == "locked-bucket":
+            raise OSError("permission denied")
+        return real(self)
+
+    (tmp_checkpoint_dir / "locked-bucket").mkdir()
+    monkeypatch.setattr(store.Path, "iterdir", selective)
+
+    surfaces = store._plaintext_surfaces(tmp_checkpoint_dir)
+    assert all("locked-bucket" not in str(p) for p in surfaces)

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -1737,9 +1737,16 @@ def test_rebuild_scrubs_forgotten_value_sibling_id_in_older_session(
     assert d_id != q_id  # sibling ids: one value, two sections
 
     assert cli.main(["forget", q_id]) == 0  # the real path, latest session
-    # forget rewrote only the latest session; the older checkpoint still holds
-    # the value verbatim under the sibling id — exactly what rebuild re-indexes.
-    assert s in old_file.read_text(encoding="utf-8")
+    # This assertion used to require the OPPOSITE: it pinned that the older
+    # checkpoint still held the value verbatim under the sibling id, because
+    # forget only ever rewrote the live checkpoint. That made the residue
+    # expected behaviour, which is how it survived to a release — the byte-level
+    # defect was load-bearing in a passing test.
+    #
+    # forget now scrubs every plaintext surface, so the value is gone from the
+    # superseded file too. What this test is actually for is unchanged and still
+    # asserted below: rebuild must not resurrect a forgotten value under ANY id.
+    assert s not in old_file.read_text(encoding="utf-8")
 
     recall.rebuild()
     texts = [h["text"] for h in recall.search("adopt", all_projects=True)]


### PR DESCRIPTION
Closes #583

## What

`forget` now reads and rewrites every plaintext surface the project owns, not
just the live checkpoint.

- `store.project_surfaces()` lists the surfaces belonging to one project.
- `store.items_for_project()` gives resolution the same view deletion has.
- `store.scrub_content_key()` removes the tombstoned key from all of them.
- `write_checkpoint()` grows `rotate=`, and the deletion path passes
  `rotate=False`.

Two commits, staged so each is verifiable on its own: the scrub and the
rotation first, then the widening of target resolution.

## Why

Three failures in a published guarantee, all reproduced on `main` at `417d13d`
before any change.

Rotation copies the current `latest.json` into `prev-1.json` before writing, and
the current latest holds the pre-forget bytes. The deletion was therefore
creating a fresh copy of the value it was asked to remove, in a file that did
not exist when the command ran, while reporting success:

```
CANARY BEFORE : <slug>/latest.json, S1.json, latest.json
CANARY AFTER  : <slug>/prev-1.json, prev-1.json
NEW FILES     : <slug>/prev-1.json, prev-1.json
```

Separately, `prev-N` written by ordinary earlier writes was never scrubbed, and
a value present only in superseded state was answered with `no item matches` and
exit 1 while its plaintext sat on disk. That last one is the worst of the three,
because the user is told the value is not there.

`#419` already settled the rule this restores: holding plaintext is what puts a
file inside the deletion contract, not whether it is append-only or historical.

Widening the candidate pool has one hazard, which is why the two stages are
separate commits. The same value in `latest.json` and `prev-1.json` arrives as
two hits, and counting hits would turn the ordinary case into an `ambiguous`
refusal. Ambiguity is therefore decided on distinct `content_key`, matching what
`#418` already assumes when it splices sibling ids from a single key. Genuinely
distinct values still refuse.

Deletion stays project-scoped. `project_surfaces` decides membership by the
payload's own `project_slug` rather than by file location, because the flat
directory is shared and `latest.json` there is the global pointer that may hold
any project's session. A surface whose slug cannot be read is excluded: deleting
from a file of unknown ownership is the failure that walk exists to prevent.

## Tests

`plugin/tests/test_forget_pointer_history.py`, 10 tests, all failing before the
change:

- no plaintext survives anywhere after a `forget`
- `forget` creates no new file holding the value
- a value only in superseded state is reachable, and by exact id
- one value across two surfaces is not ambiguous
- two distinct matching values still refuse, and change nothing
- unrelated items and pointer readability survive a scrub
- a matching value in another project is untouched

The last one covers a scope defect introduced by the first commit and caught by
the second, rather than a pre-existing one.

`plugin/tests/test_recall.py` asserted the residue. It required the forgotten
value to remain in the superseded checkpoint, with a comment presenting that as
expected behaviour, which is how this reached a release: the defect was
load-bearing in a passing test. That test's actual subject, that `rebuild` never
resurrects a forgotten value under any id, is unchanged and still asserted.

Suite: 2861 passed, 4 skipped. `ruff` clean.

The `_plaintext_surfaces` walk is the enumeration this contract was missing. A
registry that fails CI until a new store declares a delete strategy is the
durable version and is worth its own issue.
