### PR TITLE
docs(research): correct the linearity reading and the subject-rail zero

### DIFF
--- a/research/experiments/refutation-573/.gitignore
+++ b/research/experiments/refutation-573/.gitignore
@@ -1,0 +1,6 @@
+corpus.local.jsonl
+contexts.local.jsonl
+survival.local.json
+classifier-output.local.json
+labels.local.json
+results.local.json

--- a/research/experiments/refutation-573/DESIGN.md
+++ b/research/experiments/refutation-573/DESIGN.md
@@ -1,0 +1,311 @@
+# Revised refutation design: negative knowledge as an evidence ledger
+
+Status: design proposal informed by the #573 retrospective. No production
+implementation is included in this directory.
+
+## Design position
+
+A refutation is not a checkpoint item that happens to receive a stronger
+weight. It is a project-level, evidence-bearing lifecycle record.
+
+Checkpoints answer “what matters in this session?” Refutations answer “what
+approach has already lost, in what scope, and what evidence would justify
+trying it again?” Mixing those concerns makes permanence compete with an
+attention budget and makes semantic state look like ranking metadata.
+
+V1 should provide:
+
+1. a dedicated append-only `refutations.jsonl` stream per project;
+2. authored proposals and human-ratified activation, each carrying cited
+   evidence (#576: cited, not verified — daimon shape-checks a source string
+   and never resolves the referent or judges entailment);
+3. explicit query and distinct rendering;
+4. exact-anchor guards for direct matches;
+5. a deliberation check over approaches an agent is about to recommend;
+6. explicit revise and overturn events;
+7. instrumentation before any broader automatic injection.
+
+V1 should not provide:
+
+- a new checkpoint `ITEM_FIELDS` member;
+- carry caps, decay exceptions, or ordinary recall-slot priority;
+- automatic extraction writes;
+- a hard command veto;
+- a single scalar “trust score.”
+
+## Why a separate stream
+
+The stream belongs under the existing project bucket:
+
+```text
+~/.daimon/checkpoints/<project-slug>/refutations.jsonl
+```
+
+It must not reuse `events.jsonl`. Current `resolutions()` folds rows by
+`item_ref` without filtering `kind`, and `is_resolved()` treats unknown
+statuses as resolved. Scar 0025 documents that attaching a new event kind to
+an item can silently remove that item from briefing, carry, and recall.
+
+A separate stream costs another small fold and index path. In return it keeps
+resolution semantics untouched, allows a purpose-built schema, and makes the
+negative ledger auditable without pretending it is checkpoint state.
+
+The stream is append-only. Current state is a deterministic fold; no command
+rewrites or deletes historical assertions.
+
+## Record and event model
+
+One JSONL row is one lifecycle fact:
+
+```json
+{
+  "version": 1,
+  "ts": "2026-08-05T03:00:00Z",
+  "event": "asserted",
+  "refutation_id": "r-a81f4c2d",
+  "subject": "original #502 receipt verdict tiers",
+  "verdict": "whole-file hashes cannot substantiate span-level claims",
+  "scope": "the original daimon why design for carried items",
+  "anchors": ["issue:573", "issue:502", "command:daimon why"],
+  "revisit_when": "the receipt binds and verifies the originating message span",
+  "evidence": [
+    {
+      "kind": "measurement",
+      "session_id": "source-session",
+      "message_ids": ["source-message"],
+      "claim": "566 of 623 carried items failed origin resolution"
+    }
+  ],
+  "origin": {
+    "author": "agent",
+    "host": "agent-host",
+    "requested_model": "requested-model",
+    "served_model": "served-model"
+  }
+}
+```
+
+Lifecycle events:
+
+- `asserted` creates a candidate and fixes its subject, verdict, scope,
+  anchors, revisit condition, and evidence references.
+- `ratified` records explicit human acceptance of the scoped verdict.
+- `activated` records a mechanically checked outcome from a named verifier.
+- `revised` creates a new version and names the prior version; it never edits
+  the old assertion in place.
+- `overturned` deactivates the record with new evidence and preserves both
+  sides of the audit trail.
+
+Derived states:
+
+- `candidate`: asserted but not yet load-bearing;
+- `active`: human-ratified or mechanically activated;
+- `revised`: replaced by a newer scoped version;
+- `overturned`: retained for history, excluded from guards.
+
+Same-second ties must resolve from event content, not line order, following the
+existing event-fold concurrency lesson.
+
+## Trust is multidimensional
+
+`[refuted]` describes semantic state. It does not answer who said it, whether
+the source bytes exist, whether the evidence entails the verdict, or whether a
+human accepted the scope.
+
+Render those dimensions separately:
+
+```text
+[✗ refuted · human-ratified · measured]
+#502 original receipt design
+Whole-file hashes cannot substantiate span-level claims.
+Scope: carried-item receipts in the original `daimon why` design.
+Evidence: 566/623 origin-resolution misses.
+Revisit when: receipts bind and verify the originating message span.
+```
+
+Required signals:
+
+- provenance: origin author, host, session, and requested/served model where
+  available;
+- grounding: verbatim source, deterministic artifact, or measured outcome;
+- authority: agent-proposed, mechanically activated, or human-ratified;
+- lifecycle: active, revised, or overturned.
+
+Byte-valid evidence proves provenance, not entailment. An agent-authored
+claim with a matching quote remains a candidate unless a deterministic
+verifier establishes the typed outcome or a human ratifies the interpretation.
+This prevents a true quote attached to an unsupported generalization from
+becoming a permanent veto.
+
+## Authoring surface
+
+Conceptual CLI:
+
+```text
+daimon refute add \
+  --subject "original #502 receipt verdict tiers" \
+  --verdict "whole-file hashes cannot substantiate span-level claims" \
+  --scope "carried-item receipts in the original design" \
+  --anchor issue:502 \
+  --revisit-when "receipts bind and verify the origin message span" \
+  --evidence message:<id>
+
+daimon refute ratify r-a81f4c2d
+daimon refute revise r-a81f4c2d ...
+daimon refute overturn r-a81f4c2d --evidence message:<id>
+daimon refute show r-a81f4c2d
+daimon refute search "receipt verification"
+```
+
+`add` performs redaction and evidence-pointer validation before append. An
+agent invocation creates a candidate by default. A human-authored invocation
+may ratify explicitly; authorship alone must never be guessed from prose.
+
+Extraction is a later proposal source only:
+
+```text
+raw transcript -> candidate extractor -> review queue -> human/mechanical gate
+                                               |
+                                               +-> never directly active
+```
+
+## Read and protection paths
+
+### 1. Explicit query
+
+`refute search/show/list` is the complete, auditable pull surface. Search does
+not decay active records. Overturned records appear only when history is
+requested.
+
+### 2. Exact-anchor prompt guard
+
+When a prompt names a strong anchor such as `issue:502`, a command, experiment
+identifier, or exact subject alias, emit at most one active refutation in a
+dedicated guard lane. It consumes no ordinary recall slot.
+
+The lane is advisory, not a hard veto: “known negative result in this scope”
+rather than “operation forbidden.” The human remains the decision maker.
+
+Fuzzy topic matches may suggest an explicit lookup, but should not inject a
+blocking verdict until false-veto evidence exists. Scope mismatch is the most
+dangerous error direction.
+
+### 3. Deliberation guard
+
+Broad prompts such as “rank our open issues” do not contain the subject that
+will appear in the answer. Prompt hooks cannot guard what has not been
+proposed yet.
+
+Before presenting recommendations, the agent-facing integration should batch
+the candidate approaches and their anchors through a refutation lookup:
+
+```text
+human request
+    -> agent develops candidate actions
+    -> refutation lookup(candidate subjects + anchors)
+    -> reconcile scope / revisit condition
+    -> present recommendation with any warning
+```
+
+This is the primary prevention surface for the one observed historical
+re-arm. It should produce a receipt recording which candidate was checked,
+which refutation matched, and whether the agent withdrew, qualified, or kept
+the recommendation because scope had changed.
+
+### 4. Session briefing
+
+Do not dump the permanent ledger into every briefing. Render a compact count
+and only records connected to an explicit active topic or handoff anchor.
+Until topic linkage is reliable, silence is better than a permanent wall of
+warnings.
+
+## Matching and false-veto posture
+
+Match strength is ordered:
+
+1. exact stable anchor;
+2. exact normalized subject alias;
+3. multiple salient-term overlap plus compatible scope;
+4. semantic similarity, later and optional.
+
+Only the first two may proactively emit in v1. Lower-confidence matches go to
+explicit search or review. A `revisit_when` condition satisfied by current
+evidence converts the interaction into reconsideration; it does not silently
+overturn the old record.
+
+Guards must record:
+
+- match rail and matched anchors;
+- whether scope was compatible;
+- whether `revisit_when` appeared satisfied;
+- disposition: prevented, qualified, legitimate reconsideration, false veto,
+  or ignored.
+
+## Instrumentation and expansion gates
+
+V1 earns broader automation only with field evidence.
+
+Measure separately:
+
+- authored candidates and activation rate;
+- explicit searches and useful-hit rate;
+- exact-anchor guard fires;
+- deliberation checks and prevented re-arms;
+- legitimate reconsiderations;
+- false vetoes;
+- overturned records and time to overturn;
+- records never read after creation.
+
+Expansion gates:
+
+- Prompt guard expansion requires at least one prevented re-arm and zero
+  unresolved false vetoes in the observed set.
+- Fuzzy proactive matching requires a pre-registered graded corpus and a
+  false-veto upper bound chosen before implementation.
+- Extraction may propose candidates only after an independent 40-span run
+  reaches at least 80% precision with Wilson lower bound at least 60%.
+- Extraction never activates a record, regardless of classifier score.
+
+## Alternatives and tradeoffs
+
+### Checkpoint refutation item
+
+Reuses schema, rendering, and recall machinery, but couples permanence to
+session attention, inherits carry/dedup behavior, and cannot protect broad
+deliberation. Rejected for v1.
+
+### Generic pinned item
+
+Cheap, but “remember this” is not “this approach lost under these conditions.”
+It lacks verdict scope, revisit semantics, and explicit overturn. Rejected.
+
+### Existing `events.jsonl`
+
+Avoids a new file, but violates scar 0025 under current resolution folding and
+couples two lifecycle domains. Rejected unless the event architecture is
+redesigned first—a much larger change than #573 warrants.
+
+### Repository scars
+
+Excellent for code-anchored hazards and edit-time enforcement. Refuted
+experiments often have no surviving file or symbol and must surface during
+deliberation. Complementary, not interchangeable.
+
+### Host-curated memory
+
+Immediately available but host-locked, free-form, and unaudited. It is the
+failure source #573 exists to bridge.
+
+## Recommended delivery slices
+
+1. **Ledger kernel:** schema validation, append/fold, redaction, evidence
+   pointers, lifecycle, and explicit CLI query. No proactive behavior.
+2. **Human surface:** distinct rendering, ratify/revise/overturn workflows,
+   and audit receipts.
+3. **Exact-anchor guard:** one dedicated advisory result plus measurements.
+4. **Deliberation integration:** batch-check proposed issue/experiment anchors
+   before recommendations are emitted.
+5. **Only after evidence:** candidate extraction and fuzzy proactive matching.
+
+Each slice is independently useful and keeps the dangerous direction—wrongly
+blocking a good idea—fail-open and visible.

--- a/research/experiments/refutation-573/README.md
+++ b/research/experiments/refutation-573/README.md
@@ -1,0 +1,182 @@
+# Refutation class study — issue #573
+
+Pre-design retrospective for deciding whether Daimon needs a protected
+negative-knowledge primitive and, if so, which read/write mechanics it earns.
+No production code is changed by this experiment.
+
+Results: [`RESULTS.md`](RESULTS.md). Revised design:
+[`DESIGN.md`](DESIGN.md). Machine-readable aggregates:
+[`measurements.json`](measurements.json).
+
+## Corpus and cutoff
+
+- Project: `Daily-Nerd/daimon`
+- Project bucket: the local bucket derived from the repository root
+- Durable source: top-level per-session checkpoints in the local Daimon store
+- Transcript source: matching top-level JSONL sessions from the local agent host
+- Cutoff: `2026-08-05T02:06:37Z`, the checkpoint that first recorded #573
+- Subagent transcripts are excluded from the primary analysis. They may be
+  reported separately, never mixed into the denominator: a delegated model
+  sees different context and is a different recurrence opportunity.
+
+The audit is read-only. Local rows contain private transcript text and are
+gitignored. Only aggregate measurements and redacted case descriptions may be
+committed.
+
+## Prior exploration — disclosed before the formal runs
+
+The formal studies are not blind to these observations:
+
+1. The local project corpus contains 55 checkpoints before the cutoff.
+2. A deliberately broad lexical scan produced 323 unique negative-shaped
+   items; a stricter scan left 51 and still included obvious false positives
+   (ordinary preferences, rejected alternatives, and generic invariants).
+3. At least three recurrence-shaped cases are already known from the recorded
+   graveyard: self-assigned identity was rejected twice, one secret-scan method
+   was invalid twice, and the abandoned ACB architecture was re-mined after a
+   do-not-re-mine instruction.
+
+Those observations establish neither classifier precision nor a re-arm rate.
+They do establish that the motivating event is not literally impossible. The
+studies below measure the shape and cost honestly instead of rediscovering it.
+
+## Vocabulary
+
+### Logical refutation
+
+One claim or approach whose applicability was narrowed or rejected by evidence.
+Repeated checkpoint copies and later summaries are one logical record.
+
+A refutation must name all of:
+
+- **subject** — the approach or claim being rejected;
+- **verdict** — what no longer holds;
+- **basis** — measurement, deterministic code/world evidence, or explicit
+  human ratification;
+- **scope** — where the verdict applies.
+
+An ordinary preference, temporary deferral, unsupported opinion, implementation
+invariant, or failed command is not a refutation.
+
+### Opportunity
+
+A later human or agent message that discusses the same subject closely enough
+that the stored verdict could have changed the next action. Pure history,
+quoted/injected Daimon output, tool output, and compliant statements such as
+"do not rerun X" are not opportunities.
+
+### Re-arm
+
+An opportunity that crosses one of these ordered severities:
+
+1. `re_proposed` — presents the rejected approach as available without noting
+   the verdict;
+2. `re_run` — repeats the rejected experiment;
+3. `rebuilt` — implements or ships the rejected approach.
+
+A changed scope or a satisfied `revisit_when` condition is not a re-arm; it is
+legitimate reconsideration and must be recorded separately.
+
+## Study 1 — historical trap re-arm
+
+### Procedure
+
+1. Harvest negative-shaped checkpoint items at or before the cutoff.
+2. Human-grade them into `refutation`, `not_refutation`, or `uncertain` using
+   only the item, quote, and named artifact.
+3. Deduplicate accepted rows into logical refutations before reading later
+   transcripts.
+4. For each logical refutation, inspect later main-session messages for the
+   same subject and grade every opportunity using the categories above.
+5. Report both denominators:
+   - all accepted logical refutations;
+   - opportunity-bearing logical refutations.
+6. Report Wilson 95% intervals. Never count repeated checkpoint copies as
+   independent trials.
+
+A secondary, explicitly non-pooled stratum uses the 22 curated graveyard
+entries recited at the cutoff. Those entries expose exactly the cross-host gap
+#573 is about: several lived in host memory rather than as independently
+searchable checkpoint items. They are inspected with the same opportunity and
+re-arm rubric, but their recurrence rate is reported separately because a
+curated graveyard is selected on consequence and recurrence by construction.
+
+### Decision rule
+
+- The motivating claim **fires** if at least two independent logical
+  refutations re-arm, or if one reaches `re_run`/`rebuilt` severity.
+- It is **not observed at useful scale** if at least 15 logical refutations have
+  later opportunities and none re-arms.
+- Fewer than 10 opportunity-bearing refutations with no severe event is
+  **inconclusive**, not permission to claim the trap absent.
+
+## Study 2 — protection counterfactual
+
+This is not one generic ranking comparison. Current code has four different
+surfaces: deterministic carry, the session briefing, explicit FTS recall, and
+prompt-time proactive recall. Explicit recall has no age-decay ranking, while
+the other surfaces have different caps and ordering rules.
+
+### Procedure
+
+For every accepted logical refutation and each later opportunity:
+
+1. Determine whether the verdict was present in the latest checkpoint that
+   would have briefed that session.
+2. Determine whether ordinary proactive recall would have selected it.
+3. Replay a **separate guard lane**: topic-match active refutations, then emit
+   at most one compact guard without consuming either ordinary recall slot.
+4. Grade whether the guard would have been:
+   - `preventive` — would have warned before a re-arm;
+   - `relevant_nonpreventive` — useful context but no mistake pending;
+   - `false_veto` — same vocabulary, materially different approach/scope;
+   - `silent` — no match.
+5. Carry and briefing survival are reported separately from prompt-time guard
+   coverage. A search-index row is not counted as an injection.
+
+### Decision rule
+
+- A protected read path **earns its place** if it would prevent at least one
+  observed re-arm and produces zero false vetoes in the graded opportunity
+  set.
+- A dedicated lane is rejected if it prevents none, or if any false veto is
+  not eliminated by adding an explicit scope/revisit condition.
+- `no decay` applies only to active records. Candidates may expire; overturned
+  records remain audit history but never enter the guard lane.
+
+## Study 3 — extraction-side candidate precision
+
+### Procedure
+
+1. Draw 40 candidate spans from raw main-session transcript messages, one
+   candidate per logical subject, stratified across measured-result language,
+   deterministic diagnoses, rejections/deferrals, and normative language.
+2. A candidate generator sees the raw span and may output a proposed
+   `{subject, verdict, basis, scope}` record or `none`.
+3. A judge grades only the proposed record plus its source span, without seeing
+   the generator rule or the other candidates.
+4. Primary metric: precision among proposed candidates. Secondary diagnostics:
+   missing subject, unsupported generalization, absent scope, opinion mistaken
+   for evidence, and duplicate logical records.
+
+### Decision rule
+
+- Precision >=80% with Wilson lower bound >=60%: extraction may propose
+  reviewable candidates.
+- Otherwise: authored command only.
+- Extraction never activates a refutation. Activation requires either
+  mechanically grounded outcome evidence or explicit human ratification,
+  regardless of measured classifier precision.
+
+## Architecture hypotheses held until results
+
+These are design hypotheses, not conclusions smuggled into the studies:
+
+- A refutation is a project-level evidence record, not a forever-carried
+  checkpoint item.
+- `[refuted]` is semantic state, orthogonal to trust class, outcome grounding,
+  authorship, and human ratification.
+- Append-only lifecycle events should assert, ratify, revise, and overturn a
+  refutation; no update silently rewrites history.
+- Prompt-time protection should use a bounded guard lane rather than steal an
+  ordinary recall slot.

--- a/research/experiments/refutation-573/RESULTS.md
+++ b/research/experiments/refutation-573/RESULTS.md
@@ -1,0 +1,147 @@
+# Refutation study results — issue #573
+
+Cutoff: `2026-08-05T02:06:37Z`. These results describe the local Daimon
+project corpus at that cutoff. Private candidate text, transcript context, and
+manual labels remain in gitignored `*.local.*` files.
+
+## Executive verdict
+
+The problem is real, but the proposed checkpoint item class is not supported
+by the evidence.
+
+- One rejected design genuinely re-armed, at `re_proposed` severity.
+- No rejected design was rerun or rebuilt.
+- The pre-registered re-arm threshold did not fire; the sample is
+  inconclusive rather than negative.
+- Refutation-shaped knowledge has poor independently addressable survival in
+  checkpoints.
+- The observed re-arm would not have been prevented by prompt-time lexical
+  slot priority.
+- Naive extraction is far below the activation bar, and no independent blind
+  classifier run was completed.
+
+The evidence supports an authored, append-only refutation ledger and a
+deliberation-time check. It does not support automatic extraction, permanent
+checkpoint carry, or a prompt-only guard as the primary protection.
+
+## Study 1 — historical re-arm
+
+### Corpus reduction
+
+The audit read 55 canonical main-session checkpoints. A broad negative-shape
+screen produced 64 unique candidate rows. Human review accepted 18 rows,
+which deduplicated to 13 logical refutations.
+
+The accepted set required a subject, verdict, basis, and scope. Preferences,
+temporary deferrals, unsupported negative opinions, failed commands, and
+implementation invariants were rejected.
+
+The later-context scan found 83 lexical hits. Most were history, compliant
+restatements, injected output, or tool output—not genuine opportunities. Three
+logical subjects had a later decision opportunity:
+
+1. Front-selection/backfill was reconsidered through a prompt-level gate with
+   different seen-state mechanics. This was a legitimate scope change.
+2. Echo protection was reconsidered for host-injected memory rather than
+   Daimon-origin output. This was a legitimate provenance-scope change.
+3. The original `#502 daimon why` receipt design was presented again as the
+   only user-facing priority without mentioning its measured rejection. This
+   was a genuine `re_proposed` event.
+
+Rates:
+
+- All accepted logical refutations: 1/13, 7.7%, Wilson 95% [1.4%, 33.3%].
+- Opportunity-bearing refutations: 1/3, 33.3%, Wilson 95% [6.1%, 79.2%].
+- `re_run` or `rebuilt`: 0.
+
+The registered firing rule required two independent re-arms or one
+`re_run`/`rebuilt`. It did not fire. The absence rule required at least 15
+opportunity-bearing refutations with zero re-arms; that did not fire either.
+The correct result is **inconclusive**.
+
+### Curated-graveyard audit
+
+The secondary stratum did not add an independent re-arm:
+
+- “Self-assigned identity rejected twice” conflated two scopes. Scar 0032
+  rejects a requested gateway alias as served-model provenance. The later
+  self-assigned agent UUID proposal was analogous but was the first proposal
+  in that scope.
+- The secret-scan method failed twice inside one continuing investigation; it
+  was not resurrected by a later session lacking the verdict.
+- Revisiting ACB explicitly introduced a new team-memory scope. Under the
+  registered rubric that is legitimate reconsideration, not re-arm.
+
+This corrects the pre-study exploratory wording. The graveyard was useful as
+a lead generator, but it cannot substitute for scoped evidence.
+
+## Study 2 — protection counterfactual
+
+Of the 13 accepted logical refutations:
+
+- 3 were exactly matchable in the next canonical checkpoint;
+- 5 were matchable if Daimon's current fuzzy same-item predicate is allowed;
+- 0 were independently matchable at the cutoff.
+
+The fuzzy figure is an upper bound: one match crossed item kinds through a
+later rewording. Conversely, zero independently matchable records does not
+mean all semantics vanished. The cutoff checkpoint contained a compressed
+graveyard paragraph, but individual verdicts were no longer independently
+addressable, rankable, or lifecycle-managed.
+
+The observed `#502` re-arm is especially diagnostic:
+
+- its strongest verdict was extracted as a belief, a class that never carries;
+- it was absent from the checkpoints that would brief the re-arm session;
+- the re-arm transcript contained no injection of the measured verdict;
+- the triggering user prompt only requested an open-issue ranking and did not
+  mention `#502`, receipts, or carried-item verification.
+
+Therefore a prompt-time lexical guard would have been silent. A permanent
+checkpoint item might have appeared in the briefing, but that spends global
+attention on every session and still depends on an agent connecting a broad
+planning request to the correct record.
+
+The original `no decay + topic slot priority` mechanism does not earn its
+place from this counterfactual. The required protection point is later:
+compare the approaches an agent is about to recommend against the negative
+ledger before presenting the recommendation.
+
+## Study 3 — extraction feasibility
+
+The existing checkpoint extractor plus a broad negative-shape screen is a
+useful baseline, not a dedicated classifier:
+
+- proposed rows: 64;
+- accepted rows: 18;
+- row precision: 28.1%, Wilson 95% [18.6%, 40.1%].
+
+False positives were dominated by ordinary choices between alternatives,
+temporary deferrals, generic “measure first” rules, implementation diagnoses,
+and summaries that duplicated several earlier refutations.
+
+The registered 40-span independent blind-classifier run was not executed. An
+independent judge was not available for this retrospective, and the same agent
+designing, generating, and judging records would not be blind. This limitation
+is not papered over as a score.
+
+Consequently extraction has not earned write authority. V1 must be authored.
+A later independent run can test whether extraction may propose candidates;
+it can never activate them by itself.
+
+## Decision against the issue's original gate
+
+Issue #573 said:
+
+- study 1 fires and study 2 fires → full design;
+- study 1 fires and study 2 does not → rendering only;
+- study 1 does not fire → close with numbers.
+
+The stricter preregistration exposed a fourth state: **insufficient recurrence
+sample, one real failure, and a falsified prevention mechanism**. Closing would
+discard a verified cross-session failure. Approving the full design would
+overstate weak evidence.
+
+The justified move is a smaller, instrumented v1: authored ledger, explicit
+rendering, exact-anchor lookup, and deliberation-time guarding. Its own usage,
+false-veto, and prevention receipts decide whether proactive surfaces expand.

--- a/research/experiments/refutation-573/RESULTS.md
+++ b/research/experiments/refutation-573/RESULTS.md
@@ -129,19 +129,44 @@ Consequently extraction has not earned write authority. V1 must be authored.
 A later independent run can test whether extraction may propose candidates;
 it can never activate them by itself.
 
-## Decision against the issue's original gate
+## Deviation from the registered stop rule
 
-Issue #573 said:
+**This section records a protocol deviation, not a finding.** The rule below was
+registered before the data were seen. It was not followed. What follows is the
+argument for departing from it, offered so a reader can judge the departure
+rather than discover it.
+
+The registered gate, verbatim:
 
 - study 1 fires and study 2 fires → full design;
 - study 1 fires and study 2 does not → rendering only;
 - study 1 does not fire → close with numbers.
 
-The stricter preregistration exposed a fourth state: **insufficient recurrence
-sample, one real failure, and a falsified prevention mechanism**. Closing would
-discard a verified cross-session failure. Approving the full design would
-overstate weak evidence.
+Study 1 did not fire (1/13, 7.7%, Wilson 95% [1.4%, 33.3%]; the rule required
+two independent re-arms or one `re_run`/`rebuilt`). **Under the rule as
+registered, the outcome is "close with numbers."** Shipping a v1 instead is a
+departure decided after the results were known.
 
-The justified move is a smaller, instrumented v1: authored ledger, explicit
-rendering, exact-anchor lookup, and deliberation-time guarding. Its own usage,
-false-veto, and prevention receipts decide whether proactive surfaces expand.
+The argument for departing: the preregistration admitted only three states and
+the observed one is a fourth — insufficient recurrence sample, one real verified
+failure, and a falsified prevention mechanism. Closing would discard a verified
+cross-session failure; approving the full design would overstate weak evidence.
+The chosen move is a smaller, instrumented v1: authored ledger, explicit
+rendering, exact-anchor lookup, and deliberation-time guarding, whose own usage,
+false-veto and prevention receipts decide whether proactive surfaces expand.
+
+That argument may well be right. It is still a post-hoc amendment to a rule
+written to prevent exactly this, and the honest label for the evidence behind v1
+is **permitted by amendment**, not **preregistered**. A reader who wants the
+stricter reading should treat study 1 as closed and v1 as unjustified by it.
+
+Two auditability defects follow from this, both real:
+
+- The gate above is quoted here because it **no longer appears in issue #573**.
+  The only surviving copy of the registered stop rule is inside the document that
+  departs from it, which is precisely the arrangement preregistration exists to
+  prevent. It should be restored to the issue verbatim.
+- A fourth state discovered after unblinding cannot be distinguished, from the
+  outside, from a state constructed to fit the result. Future studies in this
+  repository should register an explicit "none of the above" branch and name in
+  advance who may invoke it.

--- a/research/experiments/refutation-573/audit.py
+++ b/research/experiments/refutation-573/audit.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Read-only corpus builder for Daily-Nerd/daimon#573.
+
+Writes private, gitignored JSONL rows containing checkpoint candidates and
+their source transcript locations. It does not mutate Daimon's checkpoint or
+recall stores.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[3]
+CUTOFF = "2026-08-05T02:06:37Z"
+FIELDS = (
+    ("working_context", "open_questions", "question"),
+    ("working_context", "recent_decisions", "decision"),
+    ("epistemic_snapshot", "strong_beliefs", "belief"),
+    ("epistemic_snapshot", "uncertainties", "uncertainty"),
+    ("epistemic_snapshot", "contradictions_flagged", "contradiction"),
+)
+
+# Candidate generation is intentionally recall-heavy. Study 3 grades its
+# precision; this regex is not a classifier and must never author a record.
+CANDIDATE_RE = re.compile(
+    r"(?ix)\b(?:"
+    r"refut(?:e|ed|ation)|falsif(?:y|ied)|retract(?:ed|ion)?|"
+    r"(?:hypothesis|experiment|approach|variant|gate|design|claim|assumption)"
+    r"\b.{0,100}\b(?:dead|failed|false|wrong|worsen(?:ed)?|rejected|dropped|killed)|"
+    r"(?:worsen(?:ed)?|failed|false|wrong|rejected|dropped|killed)\b.{0,100}"
+    r"\b(?:hypothesis|experiment|approach|variant|gate|design|claim|assumption)|"
+    r"do\s+not\s+(?:rebuild|repeat|rerun|re-run|implement|ship|use|file)|"
+    r"no\s+(?:viable|measurable|statistically\s+significant)\b|"
+    r"negative\s+result|anti-correlated|does\s+not\s+work|did(?:\s+not|n't)\s+work"
+    r")"
+)
+
+
+def _norm(text: str) -> str:
+    return " ".join(text.casefold().split())
+
+
+def _project_slug(project_dir: Path) -> str:
+    return re.sub(r"[^\w-]", "-", str(project_dir.resolve()))
+
+
+def _load_sessions(root: Path, project_slug: str) -> list[tuple[Path, dict]]:
+    sessions: list[tuple[Path, dict]] = []
+    for path in root.glob("*.json"):
+        try:
+            checkpoint = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(checkpoint, dict):
+            continue
+        session_id = str(checkpoint.get("session_id") or "")
+        created = str(checkpoint.get("created") or "")
+        if (checkpoint.get("project_slug") != project_slug
+                or path.stem != session_id
+                or not created or created > CUTOFF):
+            continue
+        sessions.append((path, checkpoint))
+    return sorted(sessions, key=lambda row: (
+        str(row[1].get("created") or ""),
+        str(row[1].get("session_id") or "")))
+
+
+def _items(checkpoint: dict):
+    for section, key, kind in FIELDS:
+        block = checkpoint.get(section)
+        if not isinstance(block, dict):
+            continue
+        items = block.get(key)
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if isinstance(item, str):
+                item = {"text": item}
+            if not isinstance(item, dict):
+                continue
+            text = str(item.get("text") or "").strip()
+            if text:
+                yield section, key, kind, item, text
+
+
+def build_rows(checkpoint_root: Path, transcript_root: Path,
+               project_slug: str) -> list[dict]:
+    rows = []
+    seen = set()
+    for checkpoint_path, checkpoint in _load_sessions(
+            checkpoint_root, project_slug):
+        session_id = str(checkpoint["session_id"])
+        transcript_path = transcript_root / f"{session_id}.jsonl"
+        for section, key, kind, item, text in _items(checkpoint):
+            if not CANDIDATE_RE.search(text):
+                continue
+            logical_key = _norm(text)
+            if logical_key in seen:
+                continue
+            seen.add(logical_key)
+            rows.append({
+                "candidate_id": f"c-{len(rows) + 1:04d}",
+                "created": checkpoint.get("created"),
+                "session_id": session_id,
+                "checkpoint": str(checkpoint_path),
+                "transcript": str(transcript_path) if transcript_path.exists() else None,
+                "section": section,
+                "field": key,
+                "kind": kind,
+                "item_id": item.get("id"),
+                "trust": item.get("trust"),
+                "quote_verified": item.get("quote_verified"),
+                "text": text,
+                "quote": str(item.get("quote") or ""),
+                "source_message_ids": item.get("source_message_ids") or [],
+            })
+    return rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--checkpoint-root", type=Path,
+        default=Path.home() / ".daimon" / "checkpoints")
+    parser.add_argument(
+        "--project-dir", type=Path, default=REPO,
+        help="repository root used to derive the checkpoint project bucket")
+    parser.add_argument(
+        "--transcript-root", type=Path,
+        help="host transcript directory; defaults to the derived project bucket")
+    parser.add_argument(
+        "--out", type=Path,
+        default=Path(__file__).with_name("corpus.local.jsonl"))
+    args = parser.parse_args()
+
+    project_slug = _project_slug(args.project_dir)
+    transcript_root = args.transcript_root or (
+        Path.home() / ".claude" / "projects" / project_slug)
+    rows = build_rows(args.checkpoint_root, transcript_root, project_slug)
+    args.out.write_text(
+        "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows),
+        encoding="utf-8")
+    print(json.dumps({
+        "cutoff": CUTOFF,
+        "candidates": len(rows),
+        "with_transcript": sum(row["transcript"] is not None for row in rows),
+        "out": str(args.out),
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/experiments/refutation-573/contexts.py
+++ b/research/experiments/refutation-573/contexts.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Find later transcript contexts for manually accepted logical refutations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO / "plugin"))
+
+from daimon_briefing import config, serializer, store, transcript  # noqa: E402
+
+
+CUTOFF = "2026-08-05T02:06:37Z"
+
+
+def _snippet(text: str, hit: re.Match, width: int = 500) -> str:
+    start = max(0, hit.start() - width // 2)
+    end = min(len(text), hit.end() + width // 2)
+    body = " ".join(text[start:end].split())
+    return ("…" if start else "") + body + ("…" if end < len(text) else "")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    here = Path(__file__).resolve().parent
+    parser.add_argument("--labels", type=Path,
+                        default=here / "labels.local.json")
+    parser.add_argument(
+        "--project-dir", type=Path, default=REPO,
+        help="repository root used to derive the transcript project bucket")
+    parser.add_argument("--transcript-root", type=Path,
+                        help="host transcript directory; defaults to the derived project bucket")
+    parser.add_argument("--out", type=Path,
+                        default=here / "contexts.local.jsonl")
+    args = parser.parse_args()
+
+    transcript_root = args.transcript_root
+    if transcript_root is None:
+        project_slug = store.project_slug(args.project_dir)
+        transcript_root = config.claude_projects_dir() / project_slug
+
+    labels = json.loads(args.labels.read_text(encoding="utf-8"))
+    sessions = []
+    for path in transcript_root.glob("*.jsonl"):
+        stamp = transcript.last_timestamp(path)
+        if stamp and stamp <= CUTOFF:
+            sessions.append((stamp, path))
+    sessions.sort()
+
+    rows = []
+    for label in labels:
+        patterns = [re.compile(re.escape(p), re.IGNORECASE)
+                    for p in label["patterns"]]
+        for stamp, path in sessions:
+            if (stamp <= label["origin_created"]
+                    or path.stem == label["origin_session"]):
+                continue
+            try:
+                messages = transcript.from_file(path)
+            except OSError:
+                continue
+            for message_index, message in enumerate(messages):
+                if message.get("role") not in ("user", "assistant"):
+                    continue
+                text = serializer.strip_injected(
+                    str(message.get("content") or ""))
+                hit = None
+                for pattern in patterns:
+                    hit = pattern.search(text)
+                    if hit is not None:
+                        break
+                if hit is None:
+                    continue
+                rows.append({
+                    "refutation_id": label["id"],
+                    "subject": label["subject"],
+                    "session_id": path.stem,
+                    "session_end": stamp,
+                    "message_index": message_index,
+                    "role": message.get("role"),
+                    "snippet": _snippet(text, hit),
+                    "grade": None,
+                    "reason": None,
+                })
+
+    args.out.write_text(
+        "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows),
+        encoding="utf-8")
+    print(json.dumps({
+        "logical_refutations": len(labels),
+        "later_contexts": len(rows),
+        "subjects_with_contexts": len({row["refutation_id"] for row in rows}),
+        "out": str(args.out),
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/experiments/refutation-573/measurements.json
+++ b/research/experiments/refutation-573/measurements.json
@@ -1,0 +1,39 @@
+{
+  "cutoff": "2026-08-05T02:06:37Z",
+  "corpus": {
+    "canonical_checkpoints": 55,
+    "negative_shaped_candidate_rows": 64,
+    "accepted_candidate_rows": 18,
+    "accepted_logical_refutations": 13
+  },
+  "study_1": {
+    "later_lexical_contexts_reviewed": 83,
+    "opportunity_bearing_refutations": 3,
+    "legitimate_reconsiderations": 2,
+    "rearmed_refutations": 1,
+    "highest_rearm_severity": "re_proposed",
+    "rerun_or_rebuilt": 0,
+    "all_refutations_rearm_rate": 0.0769,
+    "all_refutations_wilson_95": [0.014, 0.333],
+    "opportunity_rearm_rate": 0.3333,
+    "opportunity_wilson_95": [0.061, 0.792],
+    "decision": "inconclusive"
+  },
+  "study_2": {
+    "independently_matchable_in_next_checkpoint_exact": 3,
+    "independently_matchable_in_next_checkpoint_exact_or_fuzzy": 5,
+    "independently_matchable_at_cutoff": 0,
+    "observed_rearm_present_in_prior_briefing": false,
+    "observed_rearm_present_in_prompt_injection": false,
+    "prompt_only_guard_would_prevent_observed_rearm": false,
+    "decision": "original no-decay plus prompt-slot-priority design not earned"
+  },
+  "study_3": {
+    "screening_baseline_candidate_rows": 64,
+    "screening_baseline_accepted_rows": 18,
+    "screening_baseline_precision": 0.2813,
+    "screening_baseline_wilson_95": [0.186, 0.401],
+    "formal_blind_classifier_run": false,
+    "decision": "authored capture only for v1"
+  }
+}

--- a/research/experiments/refutation-573/survival.py
+++ b/research/experiments/refutation-573/survival.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Measure whether accepted refutations survive into later checkpoints.
+
+This is a read-only retrospective.  Private per-record matches are written to
+the experiment's gitignored local output; committed results contain aggregates
+only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO / "plugin"))
+
+from daimon_briefing import carry, schema, store  # noqa: E402
+
+
+CUTOFF = "2026-08-05T02:06:37Z"
+
+
+def _checkpoint_items(checkpoint: dict):
+    for field in schema.ITEM_FIELDS:
+        block = checkpoint.get(field.section)
+        if not isinstance(block, dict):
+            continue
+        value = block.get(field.key)
+        values = [value] if field.singleton else value
+        if not isinstance(values, list):
+            continue
+        for item in values:
+            if isinstance(item, str):
+                text = item
+                metadata = {}
+            elif isinstance(item, dict):
+                text = item.get("text")
+                metadata = item
+            else:
+                continue
+            if isinstance(text, str) and text.strip():
+                yield field.kind, text.strip(), metadata
+
+
+def _load_checkpoints(root: Path, project_slug: str) -> list[dict]:
+    checkpoints = []
+    for path in root.glob("*.json"):
+        try:
+            checkpoint = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(checkpoint, dict):
+            continue
+        created = checkpoint.get("created")
+        session_id = checkpoint.get("session_id")
+        if (checkpoint.get("project_slug") != project_slug
+                or path.stem != session_id
+                or not isinstance(created, str)
+                or created > CUTOFF):
+            continue
+        checkpoint["_path"] = str(path)
+        checkpoints.append(checkpoint)
+    return sorted(checkpoints, key=lambda cp: (cp["created"], cp["session_id"]))
+
+
+def _match(source_texts: list[str], checkpoint: dict) -> dict | None:
+    for kind, target, metadata in _checkpoint_items(checkpoint):
+        for source in source_texts:
+            if source.casefold() == target.casefold():
+                return {
+                    "match": "exact",
+                    "kind": kind,
+                    "text": target,
+                    "carried_from": metadata.get("carried_from"),
+                    "origin_session": metadata.get("origin_session"),
+                }
+            if carry._same_item(source, target):
+                return {
+                    "match": "fuzzy",
+                    "kind": kind,
+                    "text": target,
+                    "carried_from": metadata.get("carried_from"),
+                    "origin_session": metadata.get("origin_session"),
+                }
+    return None
+
+
+def main() -> int:
+    here = Path(__file__).resolve().parent
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--labels", type=Path,
+                        default=here / "labels.local.json")
+    parser.add_argument("--corpus", type=Path,
+                        default=here / "corpus.local.jsonl")
+    parser.add_argument("--checkpoint-root", type=Path,
+                        default=Path.home() / ".daimon" / "checkpoints")
+    parser.add_argument(
+        "--project-dir", type=Path, default=REPO,
+        help="repository root used to derive the checkpoint project bucket")
+    parser.add_argument("--out", type=Path,
+                        default=here / "survival.local.json")
+    args = parser.parse_args()
+
+    labels = json.loads(args.labels.read_text(encoding="utf-8"))
+    corpus = {
+        row["candidate_id"]: row
+        for row in (
+            json.loads(line)
+            for line in args.corpus.read_text(encoding="utf-8").splitlines()
+        )
+    }
+    project_slug = store.project_slug(args.project_dir)
+    checkpoints = _load_checkpoints(args.checkpoint_root, project_slug)
+
+    rows = []
+    for label in labels:
+        source_texts = [
+            corpus[candidate_id]["text"]
+            for candidate_id in label["candidate_ids"]
+        ]
+        later = [
+            checkpoint for checkpoint in checkpoints
+            if checkpoint["created"] > label["origin_created"]
+            and checkpoint["session_id"] != label["origin_session"]
+        ]
+        timeline = []
+        for checkpoint in later:
+            match = _match(source_texts, checkpoint)
+            timeline.append({
+                "created": checkpoint["created"],
+                "session_id": checkpoint["session_id"],
+                "present": match is not None,
+                "match": match,
+            })
+        rows.append({
+            "refutation_id": label["id"],
+            "origin_created": label["origin_created"],
+            "later_checkpoints": len(timeline),
+            "next_checkpoint_present": (
+                timeline[0]["present"] if timeline else None),
+            "latest_checkpoint_present": (
+                timeline[-1]["present"] if timeline else None),
+            "survived_checkpoints": sum(row["present"] for row in timeline),
+            "timeline": timeline,
+        })
+
+    args.out.write_text(json.dumps(rows, indent=2) + "\n", encoding="utf-8")
+    eligible = [row for row in rows if row["later_checkpoints"]]
+    print(json.dumps({
+        "accepted_refutations": len(rows),
+        "with_later_checkpoint": len(eligible),
+        "present_in_next": sum(bool(row["next_checkpoint_present"])
+                               for row in eligible),
+        "present_at_cutoff": sum(bool(row["latest_checkpoint_present"])
+                                 for row in eligible),
+        "out": str(args.out),
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/experiments/refutation-guard-precision/.gitignore
+++ b/research/experiments/refutation-guard-precision/.gitignore
@@ -1,0 +1,3 @@
+*.local.json
+*.local.jsonl
+results.local.*

--- a/research/experiments/refutation-guard-precision/README.md
+++ b/research/experiments/refutation-guard-precision/README.md
@@ -1,0 +1,85 @@
+# Refutation guard precision — negative-control replay
+
+How often does `daimon refute guard` fire on work that has nothing to do with
+the refuted approach, and how does that rate move as the ledger grows?
+
+Results: [`RESULTS.md`](RESULTS.md). Machine-readable aggregates:
+[`measurements.json`](measurements.json). No production code is changed by this
+experiment.
+
+## Why it matters
+
+An active refutation is permission to interrupt someone's work. A single false
+fire costs attention. Repeated false fires cost something worse: agents learn
+that guard hits are noise, and the one correct fire gets dismissed along with
+the rest. For a memory system whose whole argument is trust, a guard that cries
+wolf argues against itself.
+
+The v1 study that produced the ledger said its own "usage, false-veto, and
+prevention receipts decide whether proactive surfaces expand". This experiment
+supplies the first of those numbers.
+
+## Method
+
+The guard has two rails, both exact by design:
+
+- **anchor** — a canonical anchor such as `issue:502`, which also matches a
+  bare `#502` appearing anywhere in the query.
+- **subject** — the record's subject as a verbatim substring of the query, with
+  an eight-character floor.
+
+Refutations are built from this repository's own refuted work. They are then
+replayed against checkpoint item texts drawn from **other projects** on the same
+machine.
+
+That cross-pairing is the whole design. No unrelated project's session can
+legitimately be reviving a daimon-internal refuted approach, so **every fire is
+a false positive by construction**. There is no labelling step, no judgement
+call, and no way for the experimenter's expectations to influence the count.
+
+Two runs:
+
+1. **fixed** — six refutations on real anchors, including one deliberately
+   short generic subject (`add caching`) to probe the subject rail's floor.
+2. **scaling** — anchors sampled from this repository's issue-number range,
+   evaluated at ledger sizes 6, 20, 60 and 100, over 200 random draws per size
+   (`REPLAY_SEEDS` overrides the count).
+
+Two things about the scaling run are corrections to its first version, and both
+matter more than the numbers they changed.
+
+**A ledger size is created by seeding that many records.** The first version
+seeded all 60 once and filtered hits down to the anchors nominally active at
+each size. That filter passed every *subject*-rail hit through unconditionally,
+so all 60 subject records were live in the size-6 and size-20 conditions too,
+and only the anchor rail actually scaled. It did not corrupt the published
+counts, because the subject rail never fired at all, but the design could not
+have detected it if it had.
+
+**One seed is one draw, and the draw dominates.** A sample that lands on `#3`
+and `#12` measures a different world from one that lands on `#481` and `#522`,
+because the corpus's own `#N` tokens are concentrated at the low end. The first
+version reported a single seed and read its three points as a slope. At 60
+records the spread across draws is roughly sevenfold, larger than the effect the
+three points were being used to establish.
+
+The run therefore also reports a **collision surface**: every `#N` in the corpus,
+counted by magnitude. `guard` promotes each one to an `issue:N` anchor, so those
+tokens are the whole false-positive surface of the anchor rail, and their
+distribution is the mechanism behind the spread rather than a story about it.
+
+## Reproducing
+
+```sh
+cd research/experiments/refutation-guard-precision
+DAIMON_CHECKPOINT_DIR=$(mktemp -d) uv run --project ../../../plugin python replay.py
+```
+
+The scratch `DAIMON_CHECKPOINT_DIR` is required: the script seeds synthetic
+refutations, and they must not land in a real project bucket.
+
+## Privacy
+
+The script reads the local checkpoint store and never emits item text.
+`measurements.json` contains counts only. Local intermediates matching
+`*.local.json` are gitignored.

--- a/research/experiments/refutation-guard-precision/README.md
+++ b/research/experiments/refutation-guard-precision/README.md
@@ -53,8 +53,14 @@ seeded all 60 once and filtered hits down to the anchors nominally active at
 each size. That filter passed every *subject*-rail hit through unconditionally,
 so all 60 subject records were live in the size-6 and size-20 conditions too,
 and only the anchor rail actually scaled. It did not corrupt the published
-counts, because the subject rail never fired at all, but the design could not
-have detected it if it had.
+counts, because no subject-rail hit occurred, but the design could not have
+detected it if one had.
+
+That the subject rail records no hits in the scaling run is a property of how
+the run seeds subjects, not evidence about the rail. See `RESULTS.md`: the run
+has no positive control for the subject rail, and a zero there is not a
+measurement. Adding a subject drawn from the corpus itself, so a zero becomes
+informative, is owed and would require re-running all 200 seeds.
 
 **One seed is one draw, and the draw dominates.** A sample that lands on `#3`
 and `#12` measures a different world from one that lands on `#481` and `#522`,

--- a/research/experiments/refutation-guard-precision/RESULTS.md
+++ b/research/experiments/refutation-guard-precision/RESULTS.md
@@ -15,10 +15,14 @@ one machine. Every fire below is a false positive by construction.
 The single fire came from a refutation anchored `issue:48` matching a bare `#48`
 in an unrelated project's text.
 
-**The subject rail never fired.** That includes the entry deliberately seeded
-with the short generic subject `add caching`. The eight-character floor plus the
-verbatim-substring requirement makes that rail very conservative on real data.
-A false subject hit is constructible by hand, but it did not occur once here.
+**The subject rail did not fire on any of these six probes.** That includes the
+entry deliberately seeded with the short generic subject `add caching`. The
+eight-character floor plus the verbatim-substring requirement makes that rail
+conservative on real data. A false subject hit is constructible by hand, but it
+did not occur here.
+
+Six probes is the whole of the subject-rail evidence in this study. The scaling
+run below cannot add to it, for a reason given there.
 
 ## Scaling with ledger size
 
@@ -32,8 +36,23 @@ received at least one fire.
 | 60 | 1.209% | 1.092% | 0.364–2.427% | 0.121–3.641% |
 | 100 | 2.014% | 2.002% | 0.971–3.519% | 0.728–4.733% |
 
-The subject rail did not fire in any of the 800 runs. Every fire in this table
-is the anchor rail.
+Every fire in this table is the anchor rail.
+
+**The subject rail's silence here carries no information, and an earlier version
+of this document reported it as though it did.** The scaling run seeds subjects
+as `rejected approach number {i} in the daimon serialize path`. The subject rail
+requires the record's whole subject as a verbatim substring of the query, and
+this corpus is by construction drawn from projects other than this repository,
+so that string cannot occur in it. The 800 runs contain zero informative subject
+comparisons, not 800 passing ones. "The subject rail did not fire in any of the
+800 runs" has been removed from this section.
+
+This study also has **no positive control for the subject rail**: nothing in it
+demonstrates that the rail can fire at all, so a silent rail and a broken rail
+are indistinguishable from these results alone. The only evidence the rail works
+is a unit test (`plugin/tests/test_refutations.py`). A future revision should
+seed at least one subject drawn from the corpus itself, so that a zero is a
+measurement rather than a construction.
 
 ### The previous slope is withdrawn
 
@@ -43,10 +62,32 @@ active refutations". That seed sits near the bottom of the distribution: at 60
 records it drew 0.607% against a mean of 1.209%, so the published curve
 understated the rate by about half.
 
-**The linearity survives, and is now much better supported.** Per active
-refutation the mean rate is 0.0188, 0.0204, 0.0202 and 0.0201 percent at the
-four sizes: flat across a sixteenfold range of ledger size. The corrected slope
-is about **two percent per hundred active refutations** on this corpus, not one.
+Per active refutation the mean rate is 0.0188, 0.0204, 0.0202 and 0.0201 percent
+at the four sizes: flat across a sixteenfold range of ledger size. The corrected
+slope is about **two percent per hundred active refutations** on this corpus,
+not one.
+
+**That flatness is not a measurement of the rails, and an earlier version of this
+document read it as one.** The whole table reproduces from a model containing no
+guard code, no ledger and no records, using only "sample k anchors from 1-581,
+do any of them appear in this text's `#N` set": 0.117 / 0.394 / 1.180 / 1.973
+percent against the 0.113 / 0.407 / 1.209 / 2.014 above. For sampling without
+replacement against a fixed target set, the hit rate is approximately
+`k · |S| / 581` while coverage is low, so it is linear **by construction**. The
+flat per-record figures are the sampling design restated, not a property the
+guard was measured to have. The claim "the linearity survives, and is now much
+better supported" is withdrawn.
+
+What the scaling run does establish is the **constant**, roughly 0.0197 percent
+per active refutation on this corpus, and the spread around it. Those are real
+and are what the rest of this document uses.
+
+Where the linear reading dies is computable and was not stated: only 83 of the
+824 texts contain any in-range `#N` at all, so the rate has a **hard ceiling of
+10.073 percent** no ledger size can exceed. Saturation is still mild at the sizes
+discussed below (at 200 records the true mean is 3.810 percent against 4.03 from
+the linear reading), so the extrapolation there survives; by 300 records the gap
+is wider (5.598 percent actual) and past that the linear reading is wrong.
 
 **A point estimate is not usable here.** At 60 records the p05–p95 interval
 spans 0.364% to 2.427%, nearly sevenfold. Which issues a project's refutations
@@ -146,8 +187,14 @@ primary instrument, and this study is not evidence that it works.
   distinct numbers; a handful of new texts referencing a high `#N` would move it.
   Nothing here should be turned into a hard-coded safe range.
 - Sizes 6 through 100 are measured. The two-hundred-record reading above is an
-  extrapolation from a slope that is flat over the measured range, and nothing
-  here establishes that it stays flat.
+  extrapolation. It is checked against the saturating model rather than assumed
+  (3.810 percent actual against 4.03 linear), but it remains an extrapolation.
+- The scaling table measures the **anchor draw**, not the guard. Its shape is
+  fixed by the sampling design, and a model with no guard in it reproduces the
+  table. Only the constant and the spread are results.
+- **Nothing here measures the subject rail.** The scaling run cannot fire it by
+  construction, and there is no positive control. Six probes in the fixed arm are
+  the entire subject-rail evidence.
 
 ## Follow-on
 

--- a/research/experiments/refutation-guard-precision/RESULTS.md
+++ b/research/experiments/refutation-guard-precision/RESULTS.md
@@ -1,0 +1,159 @@
+# Results — refutation guard precision
+
+Corpus: 824 checkpoint item texts from projects other than this repository, on
+one machine. Every fire below is a false positive by construction.
+
+## Fixed ledger, six refutations on real anchors
+
+| Rail | False fires |
+| --- | --- |
+| anchor | 1 |
+| subject | 0 |
+
+1 of 824 texts hit, or 0.12 percent.
+
+The single fire came from a refutation anchored `issue:48` matching a bare `#48`
+in an unrelated project's text.
+
+**The subject rail never fired.** That includes the entry deliberately seeded
+with the short generic subject `add caching`. The eight-character floor plus the
+verbatim-substring requirement makes that rail very conservative on real data.
+A false subject hit is constructible by hand, but it did not occur once here.
+
+## Scaling with ledger size
+
+200 random anchor draws per size. Rate is the share of the 824 corpus texts that
+received at least one fire.
+
+| Active refutations | Mean | Median | p05–p95 | Full range |
+| --- | --- | --- | --- | --- |
+| 6 | 0.113% | 0.000% | 0.000–0.485% | 0.000–1.456% |
+| 20 | 0.407% | 0.243% | 0.000–1.214% | 0.000–1.942% |
+| 60 | 1.209% | 1.092% | 0.364–2.427% | 0.121–3.641% |
+| 100 | 2.014% | 2.002% | 0.971–3.519% | 0.728–4.733% |
+
+The subject rail did not fire in any of the 800 runs. Every fire in this table
+is the anchor rail.
+
+### The previous slope is withdrawn
+
+The first version of this study reported 0.00 / 0.12 / 0.61 percent at sizes
+6 / 20 / 60 from a single seed, and read them as "near one percent per hundred
+active refutations". That seed sits near the bottom of the distribution: at 60
+records it drew 0.607% against a mean of 1.209%, so the published curve
+understated the rate by about half.
+
+**The linearity survives, and is now much better supported.** Per active
+refutation the mean rate is 0.0188, 0.0204, 0.0202 and 0.0201 percent at the
+four sizes: flat across a sixteenfold range of ledger size. The corrected slope
+is about **two percent per hundred active refutations** on this corpus, not one.
+
+**A point estimate is not usable here.** At 60 records the p05–p95 interval
+spans 0.364% to 2.427%, nearly sevenfold. Which issues a project's refutations
+happen to land on matters more than how many there are, over the range measured.
+
+## Where the spread comes from
+
+`guard` promotes every `#N` in a query to an `issue:N` anchor, so the corpus's
+`#N` tokens are the entire false-positive surface of the anchor rail. An anchor
+can only collide with a number some unrelated project already writes down.
+That surface is small and very unevenly distributed:
+
+| Issue band | `#N` tokens in corpus |
+| --- | --- |
+| 1-100 | 45 |
+| 101-200 | 37 |
+| 201-300 | 19 |
+| 301-400 | 0 |
+| 401-500 | 1 |
+| 501-600 | 3 |
+
+(Bands are mechanical hundreds; the repository's issue numbers stop at 581, and
+`measurements.json` omits empty bands rather than writing a zero.)
+
+105 in-range tokens across 824 texts, only **51 distinct values**. 78 percent
+sit below 200. The 301-400 band is empty.
+
+This is the mechanism behind the seed spread, and it is measured rather than
+assumed. A uniform draw from 1-581 puts about a sixth of its anchors below 100,
+where 43 percent of the collisions live; a draw that misses that region scores
+near zero. Same ledger size, sevenfold difference in rate.
+
+**The consequence is that ledger size is the wrong control variable.** A
+refutation anchored `issue:3` is intrinsically noisy and one anchored `issue:573`
+is nearly free, and that is knowable per record at write time, before anything
+is activated. A size threshold treats those two as identical.
+
+**It also means this study is pessimistic about real use, by a knowable amount.**
+It samples anchors uniformly across the whole issue range. Real refutations in
+this repository anchor on recent work, in the 500+ region that contributes 3
+tokens to the entire corpus. The two-percent-per-hundred slope is an upper bound
+on a distribution real usage does not draw from.
+
+The caveat on that: the sparse high region is not permanent. Those other projects
+reference low `#N` because they are younger, and their numbering climbs over
+time. The safety of a high anchor decays as the neighbours mature.
+
+## Reading
+
+The rails are exact and they behave that way. At the sizes an authored ledger
+reaches early, the guard is effectively silent on unrelated work, and the
+alarm-fatigue concern does not bite yet.
+
+It is a growth problem rather than a precision problem, and the corrected slope
+brings the noisy region twice as close. Around two hundred active refutations
+the mean puts a false fire in roughly one deliberation in twenty five, which is
+where a warning starts training its reader to ignore it.
+
+That reframes the open question on mechanical activation. The cost of activating
+records without a human is not mainly per-record trust. It is **growth rate**,
+because activation volume is the input to the curve above. A policy that
+activates more records per unit time reaches the noisy region sooner.
+
+An earlier version of this section concluded that mechanical activation should
+therefore be gated on a ledger-size threshold. **The spread data withdraws that.**
+Size predicts the mean and says almost nothing about a given project: the p05-p95
+interval at a fixed size spans sevenfold, and the band table above shows why. Two
+ledgers of sixty records differ by the anchors they hold, not by their count.
+
+The control that survives is **anchor shape**, and it is strictly better than a
+size threshold in three ways. It is per-record rather than per-ledger, so it
+discriminates where a threshold cannot. It is knowable at write time, before
+activation, rather than after a rate has been observed. And it is cheap: the
+riskiest anchors are low `#N`, which is a property of the anchor string itself.
+
+A size threshold would still be a reasonable backstop. It should not be the
+primary instrument, and this study is not evidence that it works.
+
+## What this cannot carry
+
+- The corpus is checkpoint **item texts**, not raw prompts. The guard is invoked
+  on a proposal an agent is considering, whose phrasing and `#N` density may
+  differ from post-extraction item text.
+- Cross-project pairing is the **easy** case, chosen because it needs no
+  labelling. Same-project collisions would be more frequent, and classifying
+  those requires judgement, which is exactly what this design avoids. It is also
+  not assumption-free: it assumes an unrelated project's text cannot legitimately
+  match, which is true of the refuted *approach* but is carried entirely by the
+  anchor rail's `#N` matching, and `#N` is not project-scoped vocabulary.
+- One machine, one corpus, 824 texts. The spread across seeds is a property of
+  the anchor draw, not a confidence interval for a population.
+- Anchors in the scaling run are sampled uniformly from the issue-number range.
+  Real refutations cluster on recent issues, so the uniform draw overstates the
+  rate. The band table quantifies the direction and rough size of that gap, but
+  it does not substitute for measuring an actual authored ledger.
+- The band table is a property of **this** corpus at **this** moment. It is 51
+  distinct numbers; a handful of new texts referencing a high `#N` would move it.
+  Nothing here should be turned into a hard-coded safe range.
+- Sizes 6 through 100 are measured. The two-hundred-record reading above is an
+  extrapolation from a slope that is flat over the measured range, and nothing
+  here establishes that it stays flat.
+
+## Follow-on
+
+The field metric is now computable. `_cmd_refute_guard` emitted a single
+`refute:guard` usage tag before branching, so a hit and a miss were
+indistinguishable in `daimon stats`. It now splits by outcome and rail
+(`refute:guard:hit:anchor`, `:hit:subject`, `:miss`), mirroring `_cmd_resolve`,
+so the false-veto receipt the v1 study named as its expansion gate can be
+produced from field data rather than from replay.

--- a/research/experiments/refutation-guard-precision/measurements.json
+++ b/research/experiments/refutation-guard-precision/measurements.json
@@ -1,0 +1,83 @@
+{
+  "collision_surface": {
+    "by_band": {
+      "1-100": 45,
+      "101-200": 37,
+      "201-300": 19,
+      "401-500": 1,
+      "501-600": 3
+    },
+    "distinct_in_issue_range": 51,
+    "tokens_in_issue_range": 105,
+    "tokens_total": 111
+  },
+  "corpus_texts": 824,
+  "fixed": {
+    "by_subject": {
+      "two-model merge": 1
+    },
+    "fires": {
+      "anchor": 1,
+      "subject": 0
+    },
+    "rate_pct": 0.121,
+    "refutations": 6,
+    "texts_hit": 1
+  },
+  "scaling": [
+    {
+      "fires_by_rail": {
+        "anchor": 186,
+        "subject": 0
+      },
+      "ledger_size": 6,
+      "max_rate_pct": 1.456,
+      "mean_rate_pct": 0.113,
+      "median_rate_pct": 0.0,
+      "min_rate_pct": 0.0,
+      "p05_rate_pct": 0.0,
+      "p95_rate_pct": 0.485
+    },
+    {
+      "fires_by_rail": {
+        "anchor": 676,
+        "subject": 0
+      },
+      "ledger_size": 20,
+      "max_rate_pct": 1.942,
+      "mean_rate_pct": 0.407,
+      "median_rate_pct": 0.243,
+      "min_rate_pct": 0.0,
+      "p05_rate_pct": 0.0,
+      "p95_rate_pct": 1.214
+    },
+    {
+      "fires_by_rail": {
+        "anchor": 2022,
+        "subject": 0
+      },
+      "ledger_size": 60,
+      "max_rate_pct": 3.641,
+      "mean_rate_pct": 1.209,
+      "median_rate_pct": 1.092,
+      "min_rate_pct": 0.121,
+      "p05_rate_pct": 0.364,
+      "p95_rate_pct": 2.427
+    },
+    {
+      "fires_by_rail": {
+        "anchor": 3429,
+        "subject": 0
+      },
+      "ledger_size": 100,
+      "max_rate_pct": 4.733,
+      "mean_rate_pct": 2.014,
+      "median_rate_pct": 2.002,
+      "min_rate_pct": 0.728,
+      "p05_rate_pct": 0.971,
+      "p95_rate_pct": 3.519
+    }
+  ],
+  "seed": 573,
+  "seeds": 200
+}

--- a/research/experiments/refutation-guard-precision/replay.py
+++ b/research/experiments/refutation-guard-precision/replay.py
@@ -1,0 +1,240 @@
+"""Negative-control replay of the `daimon refute guard` rails.
+
+The guard has two rails: an exact-anchor rail (`issue:N`, which also accepts a
+bare `#N` in the query) and an exact-subject rail (the record's subject as a
+verbatim substring of the query, minimum eight characters). Both are advisory,
+but an active refutation is permission to interrupt work, so a false fire costs
+attention and, repeated, costs trust in every fire.
+
+Design. Refutations are built from this repository's own refuted work and
+replayed against checkpoint item texts drawn from OTHER projects. No unrelated
+project's session can legitimately be reviving a daimon-internal approach, so
+EVERY fire is a false positive by construction. There is no labelling step and
+no judgement call.
+
+Two runs:
+
+  1. fixed    — six refutations on real anchors, to measure the rails as they
+                would behave on a small authored ledger.
+  2. scaling  — anchors sampled from the repository's issue-number range at
+                ledger sizes 6, 20 and 60, to measure how the false-positive
+                rate moves as the ledger grows.
+
+Reads the local checkpoint store. Writes aggregates only: item text never
+leaves this process, and `measurements.json` contains counts alone.
+
+Usage:
+    DAIMON_CHECKPOINT_DIR=<scratch> uv run python replay.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import random
+import re
+import statistics
+import sys
+import tempfile
+
+from daimon_briefing import refutations
+
+SEED = 573
+SEEDS = int(os.environ.get("REPLAY_SEEDS", "200"))
+LEDGER_SIZES = (6, 20, 60, 100)
+ISSUE_RANGE = 582  # exclusive upper bound on this repository's issue numbers
+
+# Real refuted work from this repository's history. The last entry is a short
+# generic phrase, included deliberately to probe the subject rail's floor.
+FIXED = [
+    ("the original 502 receipt design", "receipt tiers", "issue:502"),
+    ("IDF-weighted recall term matching", "recall scoring", "issue:470"),
+    ("substring matching for coverage gates", "recall gates", "issue:490"),
+    ("the merge output cache", "serialize path", "issue:536"),
+    ("two-model merge", "serialize path", "issue:48"),
+    ("add caching", "any layer", "issue:1"),
+]
+
+
+def corpus(exclude: str = "Daily-Nerd-daimon") -> list[str]:
+    """Item texts from every real bucket except this repository's own."""
+    out: list[str] = []
+    root = pathlib.Path.home() / ".daimon" / "checkpoints"
+    if not root.exists():
+        return out
+    for bucket in sorted(root.iterdir()):
+        if not bucket.is_dir() or "pytest" in bucket.name:
+            continue
+        if exclude and exclude in bucket.name:
+            continue
+        latest = bucket / "latest.json"
+        if not latest.exists():
+            continue
+        try:
+            checkpoint = json.loads(latest.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        for section in ("epistemic_snapshot", "working_context", "worker_queue"):
+            block = checkpoint.get(section)
+            if not isinstance(block, dict):
+                continue
+            for value in block.values():
+                if not isinstance(value, list):
+                    continue
+                for entry in value:
+                    if not isinstance(entry, dict):
+                        continue
+                    text = entry.get("text") or entry.get("quote") or ""
+                    if isinstance(text, str) and text.strip():
+                        out.append(text.strip())
+    return out
+
+
+def collision_surface(texts: list[str], band: int = 100) -> dict:
+    """Where the anchor rail's false positives can come from at all.
+
+    `guard` promotes every `#N` it finds in the query to an `issue:N` anchor
+    (refutations.py, `_ISSUE_RE`), so the corpus's `#N` tokens ARE the entire
+    false-positive surface of that rail — an anchor can only collide with a
+    number some unrelated project already writes.  Counting them by magnitude
+    turns "which issues a refutation anchors on" from a hand-waved explanation
+    of the seed spread into a measured property of the corpus.
+
+    Counts only, never the surrounding text.
+    """
+    nums = [int(n) for text in texts
+            for n in re.findall(r"(?:issue:|#)(\d+)\b", text, re.IGNORECASE)]
+    in_range = [n for n in nums if 1 <= n < ISSUE_RANGE]
+    bands: dict[str, int] = {}
+    for n in in_range:
+        low = (n - 1) // band * band + 1
+        bands[f"{low}-{low + band - 1}"] = bands.get(f"{low}-{low + band - 1}", 0) + 1
+    return {
+        "tokens_total": len(nums),
+        "tokens_in_issue_range": len(in_range),
+        "distinct_in_issue_range": len(set(in_range)),
+        "by_band": bands,
+    }
+
+
+def _seed(project: str, records) -> None:
+    for subject, scope, anchor in records:
+        refutations.assert_refutation(
+            subject=subject, verdict="measured and rejected", scope=scope,
+            evidence=["measurement:replay"], anchors=[anchor],
+            authority="human", ratified=True, project_dir=project)
+
+
+def _replay(project: str, texts: list[str]):
+    """Replay every corpus text against whatever is seeded in `project`.
+
+    There is deliberately no post-hoc "active subset" filter here.  The first
+    version of this script seeded all 60 scaling records once and then filtered
+    hits down to the anchors nominally active at each ledger size — but the
+    filter passed every SUBJECT-rail hit through unconditionally, so all 60
+    subject records were live in the size-6 and size-20 conditions too.  Only
+    the anchor rail actually scaled.  It did not corrupt the published numbers,
+    because the subject rail never fired at all, but the design could not have
+    detected it if it had.  Ledger size is now varied by seeding exactly that
+    many records, which is the thing the condition claims to be.
+    """
+    fires = {"anchor": 0, "subject": 0}
+    hit_texts = 0
+    per_subject: dict[str, int] = {}
+    for text in texts:
+        hits = refutations.guard(text[:1900], project_dir=project)
+        if hits:
+            hit_texts += 1
+        for hit in hits:
+            fires[hit["guard_match"]["rail"]] += 1
+            per_subject[hit["subject"]] = per_subject.get(hit["subject"], 0) + 1
+    return fires, hit_texts, per_subject
+
+
+def main() -> None:
+    texts = corpus()
+    if not texts:
+        print("no corpus found in the local checkpoint store", file=sys.stderr)
+        raise SystemExit(1)
+
+    out: dict = {"corpus_texts": len(texts), "seed": SEED,
+                 "collision_surface": collision_surface(texts)}
+
+    with tempfile.TemporaryDirectory() as fixed_project:
+        _seed(fixed_project, FIXED)
+        fires, hit_texts, per_subject = _replay(fixed_project, texts)
+        out["fixed"] = {
+            "refutations": len(FIXED),
+            "fires": fires,
+            "texts_hit": hit_texts,
+            "rate_pct": round(100 * hit_texts / len(texts), 3),
+            "by_subject": per_subject,
+        }
+
+    # One seed is one draw of "which issue numbers did this project's
+    # refutations land on", and that draw dominates the result: low issue
+    # numbers appear as bare `#N` in unrelated prose far more often than high
+    # ones, so a seed that happens to sample #3 and #12 measures a different
+    # world from one that samples #481 and #522.  The first version reported
+    # seed 573 alone and read its three points as a slope.  Report the
+    # distribution instead, and let the spread speak for itself.
+    out["seeds"] = SEEDS
+    out["scaling"] = []
+    for size in LEDGER_SIZES:
+        rates = []
+        rail_totals = {"anchor": 0, "subject": 0}
+        for seed in range(SEEDS):
+            rng = random.Random(SEED + seed)
+            numbers = rng.sample(range(1, ISSUE_RANGE), size)
+            with tempfile.TemporaryDirectory() as scale_project:
+                _seed(scale_project, [
+                    (f"rejected approach number {i} in the daimon serialize path",
+                     f"scope {i}", f"issue:{n}")
+                    for i, n in enumerate(numbers)])
+                fires, hit_texts, _ = _replay(scale_project, texts)
+            rates.append(100 * hit_texts / len(texts))
+            for rail in rail_totals:
+                rail_totals[rail] += fires[rail]
+        rates.sort()
+        out["scaling"].append({
+            "ledger_size": size,
+            "mean_rate_pct": round(statistics.fmean(rates), 3),
+            "median_rate_pct": round(statistics.median(rates), 3),
+            "min_rate_pct": round(rates[0], 3),
+            "max_rate_pct": round(rates[-1], 3),
+            "p05_rate_pct": round(rates[int(0.05 * (len(rates) - 1))], 3),
+            "p95_rate_pct": round(rates[int(0.95 * (len(rates) - 1))], 3),
+            "fires_by_rail": rail_totals,
+        })
+
+    here = pathlib.Path(__file__).parent
+    (here / "measurements.json").write_text(
+        json.dumps(out, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    print(f"corpus (non-daimon projects): {len(texts)} item texts")
+    surface = out["collision_surface"]
+    print(f"anchor-rail collision surface: {surface['tokens_in_issue_range']} "
+          f"in-range #N tokens, {surface['distinct_in_issue_range']} distinct")
+    for band in sorted(surface["by_band"], key=lambda b: int(b.split("-")[0])):
+        print(f"  {band:>9}: {surface['by_band'][band]}")
+    print()
+    fixed = out["fixed"]
+    print(f"fixed ledger ({fixed['refutations']} refutations): "
+          f"{fixed['texts_hit']}/{len(texts)} texts hit "
+          f"({fixed['rate_pct']}%), anchor={fixed['fires']['anchor']} "
+          f"subject={fixed['fires']['subject']}\n")
+    print(f"scaling ({SEEDS} seeds per size):")
+    for row in out["scaling"]:
+        print(f"  ledger {row['ledger_size']:>3}: mean {row['mean_rate_pct']}% "
+              f"median {row['median_rate_pct']}% "
+              f"[{row['min_rate_pct']}–{row['max_rate_pct']}] "
+              f"p05–p95 [{row['p05_rate_pct']}–{row['p95_rate_pct']}] "
+              f"rails={row['fires_by_rail']}")
+
+
+if __name__ == "__main__":
+    if not os.environ.get("DAIMON_CHECKPOINT_DIR"):
+        print("set DAIMON_CHECKPOINT_DIR to a scratch directory first",
+              file=sys.stderr)
+        raise SystemExit(2)
+    main()


### PR DESCRIPTION
Closes #586

## What

Moves the two studies behind the refutation work into their own change, and
corrects them.

Two commits, deliberately separate:

1. The studies exactly as they were written, so the starting point is on the
   record.
2. The corrections, so what changed and why is reviewable on its own rather
   than buried in the initial add.

## Why

Their arithmetic reproduces. The fixed arm gives 1 of 824 texts, or 0.121
percent, matching the published 0.12. The collision surface gives 105 in-range
tokens across 824 texts, 51 distinct, in bands of 45 / 37 / 19 / 0 / 1 / 3,
matching exactly. A 30 seed rerun of the scaling table tracks the checked-in
200 seed run.

Two readings built on that arithmetic do not survive.

The flat per-record rate was read as evidence the guard scales linearly. A
model with no guard, no ledger and no records reproduces the whole table from
"sample k anchors from the issue range, do any appear in this text", giving
0.117 / 0.394 / 1.180 / 1.973 against the published 0.113 / 0.407 / 1.209 /
2.014. Sampling without replacement against a fixed target set is linear by
construction while coverage is low, so the flatness restates the sampling
design rather than describing the rails. The constant and the spread survive.
The hard ceiling of 10.073 percent, which the linear reading hides, is now
stated: only 83 of 824 texts contain an in-range issue reference at all.

The subject rail reporting zero fires across 800 runs is a construction
artifact. That run seeds subjects naming this repository's own serialize path,
the rail needs the whole subject as a verbatim substring, and the corpus is by
design drawn from other projects, so the string cannot occur. Those runs hold
zero informative comparisons rather than 800 passing ones. There is also no
positive control for the rail, so a silent rail and a broken rail cannot be
distinguished from this study.

Study 1's section is retitled to say what it is: a deviation from a registered
stop rule. The rule said close with numbers, study 1 did not fire, and a fourth
state was introduced after unblinding. The argument for departing is kept in
full, and the label on the evidence is corrected to permitted by amendment.

## Tests

No production code is touched. `plugin/` is unchanged by this branch, and the
studies import from it rather than the other way round.

The numbers above were re-derived rather than re-read: the fixed arm and the
collision surface were reproduced exactly, and the scaling table was reproduced
twice, once through the replay script at 30 seeds and once through an
independent model containing no guard code. That second reproduction is the
finding.

Owed and not done here: seeding at least one subject drawn from the corpus
itself, so a zero on that rail becomes a measurement. That requires re-running
the full seed set.
