### PR TITLE
feat(hooks): make Codex SessionEnd the primary capture event

### DIFF
--- a/docs/hosts/codex.md
+++ b/docs/hosts/codex.md
@@ -51,7 +51,7 @@ python3 hook/codex-hooks.py status
   project checkpoint and returns Codex `additionalContext` JSON, so the
   briefing is injected as developer context.
 - **`daimon-codex-stop.py`** — `Stop` hook. Codex exposes `Stop` at turn
-  scope, not as a clean session-end event, so this hook serializes
+  scope. `SessionEnd` covers the graceful end of a session, so this hook serializes
   opportunistically and is throttled by `DAIMON_CODEX_MIN_SERIALIZE_INTERVAL`
   (default `300` seconds per session). Set it to `0` to serialize every turn,
   or set `DAIMON_CODEX_SERIALIZE_ON_STOP=0` to disable Codex capture while

--- a/hook/CODEX.md
+++ b/hook/CODEX.md
@@ -6,7 +6,8 @@ Adds Daimon's capture -> inject loop to Codex.
   project checkpoint and returns Codex `additionalContext` JSON, so the briefing
   is injected as developer context.
 - `daimon-codex-stop.py` — `Stop` hook. Codex exposes `Stop` at turn scope, not
-  as a clean session-end event, so this hook serializes opportunistically and is
+  as a clean session-end event. `SessionEnd` now covers the graceful end, so
+  this hook serializes opportunistically as crash insurance and is
   throttled by `DAIMON_CODEX_MIN_SERIALIZE_INTERVAL` (default `300` seconds per
   session). Set it to `0` to serialize every turn, or set
   `DAIMON_CODEX_SERIALIZE_ON_STOP=0` to disable Codex capture while leaving

--- a/hook/codex-hooks.py
+++ b/hook/codex-hooks.py
@@ -40,6 +40,21 @@ HOOKS = [
         },
     },
     {
+        "script": "daimon-codex-session-end.py",
+        "event": "SessionEnd",
+        "entry": {
+            "hooks": [{
+                "type": "command",
+                "command": "python3 ~/.codex/hooks/daimon-codex-session-end.py",
+                # Codex clamps a timeout above 3 with a user-visible warning,
+                # and omitting it silently yields 1, which a cold interpreter
+                # start on a loaded machine can exceed. Set it explicitly.
+                "timeout": 3,
+                "statusMessage": "Checkpointing session...",
+            }],
+        },
+    },
+    {
         "script": "daimon-codex-stop.py",
         "event": "Stop",
         "entry": {

--- a/hook/daimon-codex-session-end.py
+++ b/hook/daimon-codex-session-end.py
@@ -1,16 +1,23 @@
 #!/usr/bin/env python3
-"""Codex Stop hook: checkpoint the current transcript opportunistically.
+"""Codex SessionEnd hook: checkpoint the true end of a session.
 
-Codex exposes `Stop` at turn scope. `SessionEnd` is the clean end-of-session
-event and is handled by daimon-codex-session-end.py; this hook remains as
-crash insurance, because SessionEnd cannot fire on a crash or SIGKILL.
-Serializing after every turn would be expensive, so this hook is throttled by
-DAIMON_CODEX_MIN_SERIALIZE_INTERVAL (default: 300 seconds per session). Set it
-to 0 to serialize on every Stop, or DAIMON_CODEX_SERIALIZE_ON_STOP=0 to disable
-this hook while keeping SessionStart briefing injection.
+`Stop` fires at turn scope and is throttled, so the final tail of a session is
+whatever the throttle happened to allow rather than the real end state. This
+hook is the event the Stop hook has been apologising for not having: it fires
+once, on graceful teardown, with the complete transcript.
 
-The LLM work runs detached via `daimon serialize <transcript_path>` so
-the hook returns immediately. Diagnostics land in ~/.daimon/logs/serialize.log.
+It does NOT replace the Stop hook. `run_session_end_hooks` is the last statement
+in graceful teardown, so a crash, a SIGKILL or a closed terminal window means it
+never runs. Stop stays as crash insurance for exactly that case.
+
+Deliberately unthrottled: this is the real end, not a heartbeat. It still writes
+the Stop hook's marker, so a Stop arriving moments earlier or later does not
+serialize the same transcript twice.
+
+Set DAIMON_CODEX_SERIALIZE_ON_SESSION_END=0 to disable. The LLM work runs
+detached via `daimon serialize <transcript_path>`, so the hook returns
+immediately against Codex's 3 second cap. Diagnostics land in
+~/.daimon/logs/serialize.log.
 """
 
 import json
@@ -30,6 +37,7 @@ except Exception:  # noqa: BLE001 — missing/corrupt lib must never crash the h
     lib = None
 
 STATE_DIR = Path.home() / ".daimon" / "codex"
+TAG = "codex-session-end"
 
 
 def _fallback_log(line: str) -> None:
@@ -49,54 +57,32 @@ def _fallback_log(line: str) -> None:
 def _enabled() -> bool:
     if lib.disabled():
         return False
-    val = os.environ.get("DAIMON_CODEX_SERIALIZE_ON_STOP", "1").strip().lower()
+    val = os.environ.get("DAIMON_CODEX_SERIALIZE_ON_SESSION_END", "1").strip().lower()
     return val not in ("0", "false", "no", "off")
-
-
-def _interval_seconds() -> int:
-    raw = os.environ.get("DAIMON_CODEX_MIN_SERIALIZE_INTERVAL", "300").strip()
-    try:
-        return max(0, int(raw))
-    except ValueError:
-        return 300
 
 
 def _safe_name(session_id: str) -> str:
     return session_id.replace("/", "_").replace("\\", "_").replace("..", "_")
 
 
-def _marker_path(session_id: str) -> Path:
-    return STATE_DIR / f"{_safe_name(session_id)}.last-stop"
-
-
-def _should_spawn(session_id: str) -> bool:
-    interval = _interval_seconds()
-    if interval <= 0:
-        return True
-    try:
-        STATE_DIR.mkdir(parents=True, exist_ok=True)
-        marker = _marker_path(session_id)
-        now = time.time()
-        if marker.exists() and now - marker.stat().st_mtime < interval:
-            return False
-        return True
-    except OSError:
-        return True
-
-
 def _mark_spawned(session_id: str) -> None:
-    if _interval_seconds() <= 0:
-        return
+    """Write the marker the Stop hook throttles against.
+
+    Unconditional, unlike the Stop hook's own version, which skips the write
+    when the interval is 0. The point here is not throttling this hook but
+    suppressing a redundant Stop for the same transcript, and that suppression
+    has to hold regardless of how the interval is configured."""
     try:
         STATE_DIR.mkdir(parents=True, exist_ok=True)
-        _marker_path(session_id).write_text(str(int(time.time())), encoding="utf-8")
+        marker = STATE_DIR / f"{_safe_name(session_id)}.last-stop"
+        marker.write_text(str(int(time.time())), encoding="utf-8")
     except OSError:
         pass
 
 
 def main() -> int:
     if lib is None:
-        _fallback_log("codex-stop: hook library missing (_daimon_hook_lib.py) - skipped")
+        _fallback_log(f"{TAG}: hook library missing (_daimon_hook_lib.py) - skipped")
         return 0
     if not _enabled():
         return 0
@@ -104,22 +90,19 @@ def main() -> int:
     try:
         payload = json.load(sys.stdin)
     except (json.JSONDecodeError, ValueError):
-        lib.log("codex-stop: unparseable stdin payload - skipped")
+        lib.log(f"{TAG}: unparseable stdin payload - skipped")
         return 0
 
     transcript_path = payload.get("transcript_path", "")
     if not transcript_path or not Path(transcript_path).exists():
-        lib.log(f"codex-stop: transcript not found ({transcript_path!r}) - skipped")
+        lib.log(f"{TAG}: transcript not found ({transcript_path!r}) - skipped")
         return 0
 
     session_id = str(payload.get("session_id") or Path(transcript_path).stem)
-    if not _should_spawn(session_id):
-        lib.log(f"codex-stop: skipped serialize for {session_id} (throttled)")
-        return 0
 
     cli = lib.resolve_cli()
     if cli is None:
-        lib.log("codex-stop: `daimon` CLI not found - checkpoint skipped")
+        lib.log(f"{TAG}: `daimon` CLI not found - checkpoint skipped")
         return 0
 
     cwd = str(payload.get("cwd") or "").strip()
@@ -127,10 +110,10 @@ def main() -> int:
     try:
         lib.spawn_serialize(cli, transcript_path, child_env)
         _mark_spawned(session_id)
-        lib.log(f"codex-stop: spawned serialize for {session_id} "
+        lib.log(f"{TAG}: spawned serialize for {session_id} "
                 f"(project: {cwd or '?'}) (transcript: {transcript_path})")
     except OSError as exc:
-        lib.log(f"codex-stop: spawn failed ({type(exc).__name__}: {exc})")
+        lib.log(f"{TAG}: spawn failed ({type(exc).__name__}: {exc})")
     return 0
 
 
@@ -139,7 +122,7 @@ if __name__ == "__main__":
         sys.exit(main())
     except Exception as exc:
         if lib is not None:
-            lib.log(f"codex-stop: hook error ({type(exc).__name__}: {exc})")
+            lib.log(f"{TAG}: hook error ({type(exc).__name__}: {exc})")
         else:
-            _fallback_log(f"codex-stop: hook error ({type(exc).__name__}: {exc})")
+            _fallback_log(f"{TAG}: hook error ({type(exc).__name__}: {exc})")
         sys.exit(0)

--- a/plugin/daimon_briefing/_hooks/daimon-codex-session-end.py
+++ b/plugin/daimon_briefing/_hooks/daimon-codex-session-end.py
@@ -1,16 +1,23 @@
 #!/usr/bin/env python3
-"""Codex Stop hook: checkpoint the current transcript opportunistically.
+"""Codex SessionEnd hook: checkpoint the true end of a session.
 
-Codex exposes `Stop` at turn scope. `SessionEnd` is the clean end-of-session
-event and is handled by daimon-codex-session-end.py; this hook remains as
-crash insurance, because SessionEnd cannot fire on a crash or SIGKILL.
-Serializing after every turn would be expensive, so this hook is throttled by
-DAIMON_CODEX_MIN_SERIALIZE_INTERVAL (default: 300 seconds per session). Set it
-to 0 to serialize on every Stop, or DAIMON_CODEX_SERIALIZE_ON_STOP=0 to disable
-this hook while keeping SessionStart briefing injection.
+`Stop` fires at turn scope and is throttled, so the final tail of a session is
+whatever the throttle happened to allow rather than the real end state. This
+hook is the event the Stop hook has been apologising for not having: it fires
+once, on graceful teardown, with the complete transcript.
 
-The LLM work runs detached via `daimon serialize <transcript_path>` so
-the hook returns immediately. Diagnostics land in ~/.daimon/logs/serialize.log.
+It does NOT replace the Stop hook. `run_session_end_hooks` is the last statement
+in graceful teardown, so a crash, a SIGKILL or a closed terminal window means it
+never runs. Stop stays as crash insurance for exactly that case.
+
+Deliberately unthrottled: this is the real end, not a heartbeat. It still writes
+the Stop hook's marker, so a Stop arriving moments earlier or later does not
+serialize the same transcript twice.
+
+Set DAIMON_CODEX_SERIALIZE_ON_SESSION_END=0 to disable. The LLM work runs
+detached via `daimon serialize <transcript_path>`, so the hook returns
+immediately against Codex's 3 second cap. Diagnostics land in
+~/.daimon/logs/serialize.log.
 """
 
 import json
@@ -30,6 +37,7 @@ except Exception:  # noqa: BLE001 — missing/corrupt lib must never crash the h
     lib = None
 
 STATE_DIR = Path.home() / ".daimon" / "codex"
+TAG = "codex-session-end"
 
 
 def _fallback_log(line: str) -> None:
@@ -49,54 +57,32 @@ def _fallback_log(line: str) -> None:
 def _enabled() -> bool:
     if lib.disabled():
         return False
-    val = os.environ.get("DAIMON_CODEX_SERIALIZE_ON_STOP", "1").strip().lower()
+    val = os.environ.get("DAIMON_CODEX_SERIALIZE_ON_SESSION_END", "1").strip().lower()
     return val not in ("0", "false", "no", "off")
-
-
-def _interval_seconds() -> int:
-    raw = os.environ.get("DAIMON_CODEX_MIN_SERIALIZE_INTERVAL", "300").strip()
-    try:
-        return max(0, int(raw))
-    except ValueError:
-        return 300
 
 
 def _safe_name(session_id: str) -> str:
     return session_id.replace("/", "_").replace("\\", "_").replace("..", "_")
 
 
-def _marker_path(session_id: str) -> Path:
-    return STATE_DIR / f"{_safe_name(session_id)}.last-stop"
-
-
-def _should_spawn(session_id: str) -> bool:
-    interval = _interval_seconds()
-    if interval <= 0:
-        return True
-    try:
-        STATE_DIR.mkdir(parents=True, exist_ok=True)
-        marker = _marker_path(session_id)
-        now = time.time()
-        if marker.exists() and now - marker.stat().st_mtime < interval:
-            return False
-        return True
-    except OSError:
-        return True
-
-
 def _mark_spawned(session_id: str) -> None:
-    if _interval_seconds() <= 0:
-        return
+    """Write the marker the Stop hook throttles against.
+
+    Unconditional, unlike the Stop hook's own version, which skips the write
+    when the interval is 0. The point here is not throttling this hook but
+    suppressing a redundant Stop for the same transcript, and that suppression
+    has to hold regardless of how the interval is configured."""
     try:
         STATE_DIR.mkdir(parents=True, exist_ok=True)
-        _marker_path(session_id).write_text(str(int(time.time())), encoding="utf-8")
+        marker = STATE_DIR / f"{_safe_name(session_id)}.last-stop"
+        marker.write_text(str(int(time.time())), encoding="utf-8")
     except OSError:
         pass
 
 
 def main() -> int:
     if lib is None:
-        _fallback_log("codex-stop: hook library missing (_daimon_hook_lib.py) - skipped")
+        _fallback_log(f"{TAG}: hook library missing (_daimon_hook_lib.py) - skipped")
         return 0
     if not _enabled():
         return 0
@@ -104,22 +90,19 @@ def main() -> int:
     try:
         payload = json.load(sys.stdin)
     except (json.JSONDecodeError, ValueError):
-        lib.log("codex-stop: unparseable stdin payload - skipped")
+        lib.log(f"{TAG}: unparseable stdin payload - skipped")
         return 0
 
     transcript_path = payload.get("transcript_path", "")
     if not transcript_path or not Path(transcript_path).exists():
-        lib.log(f"codex-stop: transcript not found ({transcript_path!r}) - skipped")
+        lib.log(f"{TAG}: transcript not found ({transcript_path!r}) - skipped")
         return 0
 
     session_id = str(payload.get("session_id") or Path(transcript_path).stem)
-    if not _should_spawn(session_id):
-        lib.log(f"codex-stop: skipped serialize for {session_id} (throttled)")
-        return 0
 
     cli = lib.resolve_cli()
     if cli is None:
-        lib.log("codex-stop: `daimon` CLI not found - checkpoint skipped")
+        lib.log(f"{TAG}: `daimon` CLI not found - checkpoint skipped")
         return 0
 
     cwd = str(payload.get("cwd") or "").strip()
@@ -127,10 +110,10 @@ def main() -> int:
     try:
         lib.spawn_serialize(cli, transcript_path, child_env)
         _mark_spawned(session_id)
-        lib.log(f"codex-stop: spawned serialize for {session_id} "
+        lib.log(f"{TAG}: spawned serialize for {session_id} "
                 f"(project: {cwd or '?'}) (transcript: {transcript_path})")
     except OSError as exc:
-        lib.log(f"codex-stop: spawn failed ({type(exc).__name__}: {exc})")
+        lib.log(f"{TAG}: spawn failed ({type(exc).__name__}: {exc})")
     return 0
 
 
@@ -139,7 +122,7 @@ if __name__ == "__main__":
         sys.exit(main())
     except Exception as exc:
         if lib is not None:
-            lib.log(f"codex-stop: hook error ({type(exc).__name__}: {exc})")
+            lib.log(f"{TAG}: hook error ({type(exc).__name__}: {exc})")
         else:
-            _fallback_log(f"codex-stop: hook error ({type(exc).__name__}: {exc})")
+            _fallback_log(f"{TAG}: hook error ({type(exc).__name__}: {exc})")
         sys.exit(0)

--- a/plugin/daimon_briefing/_hooks/daimon-codex-stop.py
+++ b/plugin/daimon_briefing/_hooks/daimon-codex-stop.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 """Codex Stop hook: checkpoint the current transcript opportunistically.
 
-Codex currently exposes `Stop` at turn scope, not a clean session-end event.
+Codex exposes `Stop` at turn scope. `SessionEnd` is the clean end-of-session
+event and is handled by daimon-codex-session-end.py; this hook remains as
+crash insurance, because SessionEnd cannot fire on a crash or SIGKILL.
 Serializing after every turn would be expensive, so this hook is throttled by
 DAIMON_CODEX_MIN_SERIALIZE_INTERVAL (default: 300 seconds per session). Set it
 to 0 to serialize on every Stop, or DAIMON_CODEX_SERIALIZE_ON_STOP=0 to disable

--- a/plugin/daimon_briefing/codex_hooks.py
+++ b/plugin/daimon_briefing/codex_hooks.py
@@ -40,6 +40,21 @@ HOOKS = (
         },
     },
     {
+        "script": "daimon-codex-session-end.py",
+        "event": "SessionEnd",
+        "entry": {
+            "hooks": [{
+                "type": "command",
+                "command": "python3 ~/.codex/hooks/daimon-codex-session-end.py",
+                # Codex clamps a timeout above 3 with a user-visible warning,
+                # and omitting it silently yields 1, which a cold interpreter
+                # start on a loaded machine can exceed. Set it explicitly.
+                "timeout": 3,
+                "statusMessage": "Checkpointing session...",
+            }],
+        },
+    },
+    {
         "script": "daimon-codex-stop.py",
         "event": "Stop",
         "entry": {

--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -69,7 +69,8 @@ def _append_retry_log(session_id: str, prior: str) -> None:
 # host and the verb are alternations. A new host adapter MUST add its prefix
 # here or its serializes are invisible to status/hung detection/heal.
 _SPAWN_RE = re.compile(
-    r"^(\S+) (?:gemini-session-end|session-end|codex-stop|windsurf-cascade|"
+    r"^(\S+) (?:gemini-session-end|codex-session-end|session-end|codex-stop|"
+    r"windsurf-cascade|"
     r"windsurf-finalizer|session-start): "
     r"(?:spawned|retry) serialize for (\S+)"
 )
@@ -440,7 +441,8 @@ def serialize_in_flight(project_slug: str, now: float | None = None) -> bool:
 # Host prefix on a spawn line, for per-host capture counts. Deliberately the
 # same alternation as _SPAWN_RE (a new host adapter updates both).
 _STATS_HOST_RE = re.compile(
-    r"^\S+ (gemini-session-end|session-end|codex-stop|windsurf-cascade|"
+    r"^\S+ (gemini-session-end|codex-session-end|session-end|codex-stop|"
+    r"windsurf-cascade|"
     r"windsurf-finalizer): "
     r"spawned serialize for "
 )

--- a/plugin/tests/test_codex_session_end.py
+++ b/plugin/tests/test_codex_session_end.py
@@ -1,0 +1,104 @@
+"""Codex SessionEnd is the primary capture event; Stop stays as crash insurance.
+
+`Stop` fires at turn scope and is throttled, so the final tail of a session is
+whatever the throttle happened to allow rather than the true end state.
+`SessionEnd` fires once on graceful teardown with the complete transcript.
+
+It cannot replace `Stop`. `run_session_end_hooks` is the last statement in
+graceful teardown, so a crash, a SIGKILL or a closed terminal means it never
+runs. Keeping both trades an unbounded worst case for a bounded one.
+
+Adding the entry is safe on older builds: in `hook_config.rs` at
+`rust-v0.142.0`, `deny_unknown_fields` sits on `HooksFile` and NOT on
+`HookEventsToml`, the struct holding the event map, so serde skips an
+unrecognised key instead of failing the file.
+"""
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parents[2]
+TAG = "codex-session-end"
+
+
+def _load(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _hooks(rel):
+    return {h["event"]: h for h in _load(REPO / rel, f"m_{abs(hash(rel))}").HOOKS}
+
+
+@pytest.mark.parametrize("rel", [
+    "hook/codex-hooks.py",
+    "plugin/daimon_briefing/codex_hooks.py",
+])
+def test_session_end_is_registered_with_an_explicit_timeout(rel):
+    entry = _hooks(rel).get("SessionEnd")
+    assert entry is not None, f"{rel} does not register SessionEnd"
+    cmd = entry["entry"]["hooks"][0]
+    # Codex clamps above 3 with a user-visible warning, and omitting the field
+    # silently yields 1, which a cold interpreter start can exceed.
+    assert cmd["timeout"] == 3, "SessionEnd timeout must be set explicitly to 3"
+    assert entry["script"] == "daimon-codex-session-end.py"
+
+
+def test_both_hook_manifests_agree():
+    # The standalone manager runs in whatever interpreter Codex invokes and
+    # cannot import the package, so the shape lives in two files by necessity.
+    assert _hooks("hook/codex-hooks.py") == _hooks(
+        "plugin/daimon_briefing/codex_hooks.py")
+
+
+def test_stop_is_still_registered():
+    # SessionEnd cannot cover ungraceful exit. Losing Stop would trade a
+    # bounded worst case for total loss on a crash.
+    assert "Stop" in _hooks("hook/codex-hooks.py")
+
+
+def test_the_new_script_is_in_the_sync_manifest():
+    sync = _load(REPO / "scripts/sync_hooks.py", "sync_hooks")
+    pairs = {src for src, _dst in sync.SYNC_PAIRS}
+    assert "hook/daimon-codex-session-end.py" in pairs, (
+        "a hand-copied hook outside SYNC_PAIRS drifts silently")
+
+
+def test_ledger_attributes_the_new_tag_without_breaking_codex_stop():
+    from daimon_briefing import ledger
+    ts = "2026-08-05T23:00:00Z"
+    new = f"{ts} {TAG}: spawned serialize for S-1 (transcript.jsonl)"
+    old = f"{ts} codex-stop: spawned serialize for S-2 (transcript.jsonl)"
+
+    assert ledger._SPAWN_RE.match(new), "new tag is invisible to spawn parsing"
+    assert ledger._SPAWN_RE.match(old), "existing codex-stop lines must keep parsing"
+    assert ledger._SPAWN_RE.match(new).group(2) == "S-1"
+
+    assert ledger._STATS_HOST_RE.match(new).group(1) == TAG
+    assert ledger._STATS_HOST_RE.match(old).group(1) == "codex-stop"
+
+
+def test_the_tag_is_distinct_from_the_claude_code_session_end_tag():
+    # `session-end` is already taken by the Claude Code adapter. Reusing it
+    # would make per-host freshness unattributable, which is the measurement
+    # this change exists to enable.
+    from daimon_briefing import ledger
+    line = "2026-08-05T23:00:00Z session-end: spawned serialize for S-3 (t.jsonl)"
+    assert ledger._STATS_HOST_RE.match(line).group(1) == "session-end"
+    assert TAG != "session-end"
+
+
+def test_session_end_script_exists_and_bypasses_the_throttle():
+    src = (REPO / "hook/daimon-codex-session-end.py").read_text(encoding="utf-8")
+    assert "DAIMON_CODEX_MIN_SERIALIZE_INTERVAL" not in src, (
+        "SessionEnd is the real end, not a heartbeat; it must not be throttled")
+    assert TAG in src, "log lines must carry the distinct tag"
+    # Fail-open: an advisory hook that raises is surfaced to the user as a hook
+    # failure, so the top level has to swallow.
+    assert re.search(r"except\s+(BaseException|Exception)", src), (
+        "hook must not propagate an exception to Codex")

--- a/scripts/sync_hooks.py
+++ b/scripts/sync_hooks.py
@@ -27,6 +27,7 @@ SYNC_PAIRS = (
     ("hook/daimon-windsurf-hooks.py", "plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py"),
     ("hook/daimon-codex-session-start.py", "plugin/daimon_briefing/_hooks/daimon-codex-session-start.py"),
     ("hook/daimon-codex-stop.py", "plugin/daimon_briefing/_hooks/daimon-codex-stop.py"),
+    ("hook/daimon-codex-session-end.py", "plugin/daimon_briefing/_hooks/daimon-codex-session-end.py"),
     ("hook/_daimon_hook_lib.py", "plugin/daimon_briefing/_hooks/_daimon_hook_lib.py"),
 )
 

--- a/website/docs/hosts/codex.md
+++ b/website/docs/hosts/codex.md
@@ -51,7 +51,7 @@ python3 hook/codex-hooks.py status
   project checkpoint and returns Codex `additionalContext` JSON, so the
   briefing is injected as developer context.
 - **`daimon-codex-stop.py`** — `Stop` hook. Codex exposes `Stop` at turn
-  scope, not as a clean session-end event, so this hook serializes
+  scope. `SessionEnd` covers the graceful end of a session, so this hook serializes
   opportunistically and is throttled by `DAIMON_CODEX_MIN_SERIALIZE_INTERVAL`
   (default `300` seconds per session). Set it to `0` to serialize every turn,
   or set `DAIMON_CODEX_SERIALIZE_ON_STOP=0` to disable Codex capture while


### PR DESCRIPTION
Refs #580

## What

Adds `SessionEnd` as the primary Codex capture event and keeps `Stop` as crash
insurance.

- New `hook/daimon-codex-session-end.py` and its synced mirror, registered in
  `SYNC_PAIRS` so the hand-copied pair cannot drift.
- Registered in both `HOOKS` manifests with `"timeout": 3` set explicitly.
- Distinct `codex-session-end` log tag, taught to `_SPAWN_RE` and
  `_STATS_HOST_RE` together.
- Docs corrected in three files plus the Stop hook's own docstring.

`Refs` rather than `Closes`: the issue also asks for the throttle retune and the
tail-freshness measurement, and both want field data from this being live first.

## Why

`Stop` fires at turn scope and is throttled, so the final tail of a session is
whatever the throttle allowed rather than the true end state. `SessionEnd` fires
once on graceful teardown with the complete transcript.

Stop is kept rather than replaced. `run_session_end_hooks` is the last statement
in graceful teardown, so a crash, a SIGKILL or a closed terminal means
`SessionEnd` never runs. Replacing Stop would trade a bounded five minute worst
case for total loss on an ungraceful exit.

The issue's blocking gate is resolved, from source rather than release dates. In
`codex-rs/config/src/hook_config.rs` at tag `rust-v0.142.0`,
`deny_unknown_fields` appears exactly once and sits on `HooksFile`, whose fields
are `description` and `hooks`. `HookEventsToml`, the struct holding the event
map, carries no such attribute, so serde skips an unrecognised key rather than
failing the file. `SessionStart` and `Stop` keep registering on builds that
predate the event. Detail in the issue comment.

## Design notes

The new hook is unthrottled, since it is the real end rather than a heartbeat.
It still writes the marker `Stop` throttles against, so a `Stop` arriving
moments away does not serialize the same transcript twice. That write is
unconditional, unlike Stop's own version which skips when the interval is 0: the
job here is suppressing a redundant Stop, and that has to hold however the
interval is configured.

`timeout` is explicit because Codex clamps a higher value with a user-visible
warning, and omitting the field silently yields 1, which a cold interpreter
start on a loaded machine can exceed.

The tag is kept distinct from the Claude Code adapter's `session-end`. Reusing
it would make per-host freshness unattributable, which is the measurement this
change exists to enable.

## Tests

`plugin/tests/test_codex_session_end.py`, 8 tests, written before the
implementation and failing against it:

- `SessionEnd` registered in both manifests with an explicit timeout of 3
- the two manifests agree, since the shape necessarily lives in two files
- `Stop` is still registered
- the new script is in the sync manifest
- the ledger attributes the new tag and still parses `codex-stop`
- the tag is distinct from the Claude Code `session-end` tag
- the script is unthrottled and cannot propagate an exception to Codex

Suite: 2878 passed, 4 skipped. `ruff` clean, hook mirror drift check passes.

## Upgrade note

Existing installs read PARTIAL until `daimon hooks install codex` is re-run. The
installer is idempotent and merge-preserving, so the upgrade is one command.
