### PR TITLE
fix(transcript): recognise daimon invoked through a shell wrapper

### DIFF
--- a/plugin/daimon_briefing/transcript.py
+++ b/plugin/daimon_briefing/transcript.py
@@ -92,6 +92,12 @@ _TOOL_RESULT_MAX_CHARS = 500
 _DAIMON_CMD_RE = re.compile(
     r"(?:^|[|;&(`]|\&\&|\|\|)\s*"
     r"(?:\S+=\S+\s+)*(?:sudo\s+)?"
+    # #585: a shell wrapper puts a QUOTE immediately before the command, and
+    # quotes are deliberately absent from the delimiter class above — adding
+    # them there would match `rg "daimon" cli.py`, which greps ABOUT daimon and
+    # whose output is a genuine witness. Recognise the wrapper explicitly
+    # instead, the same way `uv run` is handled below.
+    r"(?:(?:\S*/)?(?:ba|z|da|k)?sh\s+-[a-z]*c\s+['\"]?)?"
     r"(?:uv\s+run\s+(?:--?[\w-]+(?:[= ]\S+)?\s+)*(?:python\s+-m\s+)?)?"
     r"(?:\S*/)?daimon(?:\s|$)", re.MULTILINE)
 

--- a/plugin/tests/test_echo_invocation_recognition.py
+++ b/plugin/tests/test_echo_invocation_recognition.py
@@ -1,0 +1,84 @@
+"""The echo defense holds only as far as invocation recognition does (#585).
+
+Daimon's own output is flagged by resolving a tool result back to the tool_use
+that produced it and deciding whether that invocation was daimon. Keying on the
+invocation rather than the output shape is the right call: it covers every
+subcommand without enumerating render formats.
+
+The cost is that a recognition miss is silent. Output that daimon produced but
+whose invocation was not recognised reaches the extractor as ordinary
+transcript content, which is the hole #512 and #577 exist to close.
+
+A shell wrapper defeated the matcher: in `sh -c 'daimon ...'` the character
+before `daimon` is a quote, and quotes are not in the delimiter class.
+
+Widening that class is the wrong fix and is pinned against below. `rg "daimon"
+cli.py` greps ABOUT daimon, and its output is a genuine witness; a blanket
+tool-row strip was measured at 9.5% of the corpus's verifiable quotes against
+0.06% for the invocation-scoped rule. Wrappers are therefore recognised
+explicitly, the way `uv run` already is.
+"""
+import pytest
+
+from daimon_briefing import transcript
+
+
+def _use(cmd):
+    return {"type": "tool_use", "id": "TU-1", "name": "Bash",
+            "input": {"command": cmd}}
+
+
+RECOGNISED = [
+    # Already covered, kept so a regex change cannot quietly drop them.
+    "daimon brief",
+    "uv run --project plugin daimon loops",
+    "cd /repo && daimon brief",
+    "DAIMON_ENV_FILE=/tmp/e daimon status --suppressed",
+    "/usr/local/bin/daimon recall --json foo | head",
+    # The gap this closes.
+    "sh -c 'daimon refute guard x'",
+    'sh -c "daimon brief"',
+    "bash -c 'daimon status'",
+    "zsh -c 'daimon recall foo'",
+    "/bin/sh -c 'daimon brief'",
+    "bash -lc 'daimon brief'",
+]
+
+NOT_RECOGNISED = [
+    # Talking ABOUT daimon. These outputs are legitimate witnesses and must
+    # keep their evidentiary value.
+    "rg daimon cli.py",
+    'rg "daimon" cli.py',
+    "rg 'daimon' cli.py",
+    "grep -r daimon .",
+    "echo daimon",
+    "cat daimon.log",
+    "ls ~/.daimon",
+]
+
+
+@pytest.mark.parametrize("cmd", RECOGNISED)
+def test_daimon_invocations_are_recognised(cmd):
+    assert transcript._is_daimon_tool_use(_use(cmd)), (
+        f"unrecognised invocation reaches the extractor unflagged: {cmd!r}")
+
+
+@pytest.mark.parametrize("cmd", NOT_RECOGNISED)
+def test_commands_about_daimon_stay_witnesses(cmd):
+    assert not transcript._is_daimon_tool_use(_use(cmd)), (
+        f"over-broad match destroys a legitimate witness: {cmd!r}")
+
+
+def test_mcp_tool_names_still_match():
+    assert transcript._is_daimon_tool_use(
+        {"type": "tool_use", "id": "x", "name": "mcp__daimon__brief", "input": {}})
+
+
+def test_the_recognised_set_is_enumerated_not_sampled():
+    # #585's point: the recognised set is a hand-maintained list of idioms, so
+    # it has to be visible in one place rather than discovered by whoever hits
+    # the next gap. This list IS that enumeration.
+    assert len(RECOGNISED) >= 10
+    assert any("sh -c" in c for c in RECOGNISED)
+    assert any("uv run" in c for c in RECOGNISED)
+    assert any("&&" in c for c in RECOGNISED)


### PR DESCRIPTION
Closes #585

## What

Recognises daimon invoked through a shell wrapper, so its output is flagged as
daimon's own rather than treated as ordinary transcript content.

Adds an optional wrapper prefix to `_DAIMON_CMD_RE`: `sh -c`, `bash -lc`,
`zsh -c`, `/bin/sh -c`, with an optional path and an optional opening quote.

## Why

The echo defense flags daimon output by resolving a tool result back to the
`tool_use` that produced it. Keying on the invocation rather than the output
shape is the right design, because it covers every subcommand without
enumerating render formats. The cost is that a recognition miss is silent: the
output keeps its evidentiary value and nothing reports that it should not have.

`sh -c 'daimon refute guard x'` was such a miss. The matcher requires a
delimiter from ``[|;&(`]`` immediately before the command, and a shell wrapper
puts a quote there instead.

## Why not just add quotes to the delimiter class

Because it would reintroduce the cost the invocation-scoped rule exists to
avoid. `rg "daimon" cli.py` greps ABOUT daimon, and its output is a genuine
witness. The comment above that regex records the measurement: a blanket
tool-row strip costs 9.5% of the corpus's verifiable quotes, against 0.06% for
the invocation-scoped rule.

Seven commands that mention daimon without invoking it are now pinned as
must-not-match, so a future widening of that class fails loudly.

## Scope, stated precisely

This fixes recognition. On `main` today that means `stripped_transcript` blanks
the row and quote verification refuses daimon as a witness for its own claim,
which is the `#512` guarantee.

It does not change what the extractor reads, because the extractor-side blanking
is `#582` and is not on `main` yet. Verified rather than assumed: a transcript
whose `tool_use` runs `sh -c 'daimon refute guard x'` now yields
`daimon_output_ids` of size 1, and `serializer.extraction_messages` does not
exist on this branch.

## Tests

`plugin/tests/test_echo_invocation_recognition.py`, 20 tests. The six wrapper
forms failed before the change; the rest are the regression surface.

The recognised set is enumerated in one place rather than sampled, which is the
issue's second ask: 11 invocation forms that must match, including the idioms
already covered so a future regex change cannot quietly drop them, and 7
commands about daimon that must keep their evidentiary value.

Suite: 2898 passed, 4 skipped. `ruff` clean.

## Left open deliberately

Whether output that cannot be attributed to a recognised invocation should be
treated as unattributed rather than as safe. That is a real behaviour change
with a real cost, and the issue raises it as a tradeoff needing measurement
rather than a proposal.
