### PR TITLE
feat(trust): add durable quote provenance

### DIFF
--- a/hook/_daimon_hook_lib.py
+++ b/hook/_daimon_hook_lib.py
@@ -156,10 +156,16 @@ def age_line(latest: Path) -> str:
     return f"(checkpoint: {session_id}, written {age} ago)"
 
 
-def project_env(cwd):
-    """Child env with DAIMON_PROJECT_DIR set to `cwd`, or None to inherit the
-    parent env unchanged (pre-routing behavior when no cwd is known)."""
-    return {**os.environ, "DAIMON_PROJECT_DIR": cwd} if cwd else None
+def project_env(cwd, host=None):
+    """Child env with code-owned project/host capture hints when known."""
+    if not cwd and not host:
+        return None
+    env = dict(os.environ)
+    if cwd:
+        env["DAIMON_PROJECT_DIR"] = cwd
+    if host:
+        env["DAIMON_CAPTURE_HOST"] = host
+    return env
 
 
 def log(line: str) -> None:

--- a/hook/daimon-codex-session-end.py
+++ b/hook/daimon-codex-session-end.py
@@ -106,7 +106,7 @@ def main() -> int:
         return 0
 
     cwd = str(payload.get("cwd") or "").strip()
-    child_env = lib.project_env(cwd)
+    child_env = lib.project_env(cwd, "codex")
     try:
         lib.spawn_serialize(cli, transcript_path, child_env)
         _mark_spawned(session_id)

--- a/hook/daimon-codex-stop.py
+++ b/hook/daimon-codex-stop.py
@@ -123,7 +123,7 @@ def main() -> int:
         return 0
 
     cwd = str(payload.get("cwd") or "").strip()
-    child_env = lib.project_env(cwd)
+    child_env = lib.project_env(cwd, "codex")
     try:
         lib.spawn_serialize(cli, transcript_path, child_env)
         _mark_spawned(session_id)

--- a/hook/daimon-gemini-session-end.py
+++ b/hook/daimon-gemini-session-end.py
@@ -84,7 +84,7 @@ def main() -> int:
     # Per-project routing: hand the session's working directory to the child so
     # the serializer writes this project's latest pointer (plus the global one).
     cwd = str(payload.get("cwd") or "").strip()
-    child_env = lib.project_env(cwd)
+    child_env = lib.project_env(cwd, "gemini")
     try:
         lib.spawn_serialize(cli, transcript_path, child_env)
         lib.log(

--- a/hook/daimon-session-end.py
+++ b/hook/daimon-session-end.py
@@ -74,7 +74,7 @@ def main() -> int:
     # the serializer writes this project's latest pointer (plus the global one).
     # No cwd in the payload -> child env untouched -> pre-routing behavior.
     cwd = str(payload.get("cwd") or "").strip()
-    child_env = lib.project_env(cwd)
+    child_env = lib.project_env(cwd, "claude-code")
     try:
         lib.spawn_serialize(cli, transcript_path, child_env)
         # Trailing (transcript: ...) group (#28): if the child crashes before

--- a/hook/daimon-windsurf-hooks.py
+++ b/hook/daimon-windsurf-hooks.py
@@ -348,7 +348,8 @@ def _spawn_serialize_for(trajectory_id: str, transcript_path, detail: str) -> No
         return
     cwd = _project_cwd()
     try:
-        lib.spawn_serialize(cli, str(transcript_path), lib.project_env(cwd))
+        lib.spawn_serialize(
+            cli, str(transcript_path), lib.project_env(cwd, "windsurf"))
         _mark_spawned(trajectory_id)
         lib.log(f"windsurf-cascade: spawned serialize for {trajectory_id} "
                 f"(project: {cwd or '?'}) ({detail})")
@@ -437,7 +438,8 @@ def _finalize(trajectory_id: str, transcript_path: str, armed_mtime_ns: str) -> 
         return 0
     cwd = _project_cwd()
     try:
-        lib.spawn_serialize(cli, transcript_path, lib.project_env(cwd))
+        lib.spawn_serialize(
+            cli, transcript_path, lib.project_env(cwd, "windsurf"))
         # Logged at FIRE time, not arm time: an arm-time spawn line would sit
         # unresolved for the whole quiet period and read as hung to the ledger.
         lib.log(f"windsurf-finalizer: spawned serialize for {trajectory_id} "

--- a/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
+++ b/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
@@ -156,10 +156,16 @@ def age_line(latest: Path) -> str:
     return f"(checkpoint: {session_id}, written {age} ago)"
 
 
-def project_env(cwd):
-    """Child env with DAIMON_PROJECT_DIR set to `cwd`, or None to inherit the
-    parent env unchanged (pre-routing behavior when no cwd is known)."""
-    return {**os.environ, "DAIMON_PROJECT_DIR": cwd} if cwd else None
+def project_env(cwd, host=None):
+    """Child env with code-owned project/host capture hints when known."""
+    if not cwd and not host:
+        return None
+    env = dict(os.environ)
+    if cwd:
+        env["DAIMON_PROJECT_DIR"] = cwd
+    if host:
+        env["DAIMON_CAPTURE_HOST"] = host
+    return env
 
 
 def log(line: str) -> None:

--- a/plugin/daimon_briefing/_hooks/daimon-codex-session-end.py
+++ b/plugin/daimon_briefing/_hooks/daimon-codex-session-end.py
@@ -106,7 +106,7 @@ def main() -> int:
         return 0
 
     cwd = str(payload.get("cwd") or "").strip()
-    child_env = lib.project_env(cwd)
+    child_env = lib.project_env(cwd, "codex")
     try:
         lib.spawn_serialize(cli, transcript_path, child_env)
         _mark_spawned(session_id)

--- a/plugin/daimon_briefing/_hooks/daimon-codex-stop.py
+++ b/plugin/daimon_briefing/_hooks/daimon-codex-stop.py
@@ -123,7 +123,7 @@ def main() -> int:
         return 0
 
     cwd = str(payload.get("cwd") or "").strip()
-    child_env = lib.project_env(cwd)
+    child_env = lib.project_env(cwd, "codex")
     try:
         lib.spawn_serialize(cli, transcript_path, child_env)
         _mark_spawned(session_id)

--- a/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
+++ b/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
@@ -348,7 +348,8 @@ def _spawn_serialize_for(trajectory_id: str, transcript_path, detail: str) -> No
         return
     cwd = _project_cwd()
     try:
-        lib.spawn_serialize(cli, str(transcript_path), lib.project_env(cwd))
+        lib.spawn_serialize(
+            cli, str(transcript_path), lib.project_env(cwd, "windsurf"))
         _mark_spawned(trajectory_id)
         lib.log(f"windsurf-cascade: spawned serialize for {trajectory_id} "
                 f"(project: {cwd or '?'}) ({detail})")
@@ -437,7 +438,8 @@ def _finalize(trajectory_id: str, transcript_path: str, armed_mtime_ns: str) -> 
         return 0
     cwd = _project_cwd()
     try:
-        lib.spawn_serialize(cli, transcript_path, lib.project_env(cwd))
+        lib.spawn_serialize(
+            cli, transcript_path, lib.project_env(cwd, "windsurf"))
         # Logged at FIRE time, not arm time: an arm-time spawn line would sit
         # unresolved for the whole quiet period and read as hung to the ledger.
         lib.log(f"windsurf-finalizer: spawned serialize for {trajectory_id} "

--- a/plugin/daimon_briefing/capture.py
+++ b/plugin/daimon_briefing/capture.py
@@ -32,14 +32,14 @@ import logging
 import time
 from pathlib import Path
 
-from . import carry, config, normalize, serializer, store, transcript
+from . import carry, config, normalize, provenance, serializer, store, transcript
 
 log = logging.getLogger(__name__)
 
 
 def run(session_id: str, messages, *, project, chat, deadline,
         transcript_path=None, transcript_sha=None,
-        escalate: bool = False) -> Path | None:
+        escalate: bool = False, capture_host=None) -> Path | None:
     """Serialize `messages` into a checkpoint routed to `project` (used AS-IS;
     None => global pointer only — the caller decides routing, same contract
     as the old cli._run_serialize).
@@ -47,8 +47,13 @@ def run(session_id: str, messages, *, project, chat, deadline,
     Returns store.write_checkpoint's result: the checkpoint path, or None
     when the write boundary refused (kill switch, #421) — each caller renders
     its own skip/success line. Serializer failures propagate."""
+    source_ref = provenance.capture_source_ref(
+        session_id, transcript_path, author=config.author(),
+        host_hint=capture_host or config.capture_host(),
+        claude_projects=config.claude_projects_dir())
     checkpoint = serializer.serialize_strict(
-        session_id, messages, chat=chat, deadline=deadline, escalate=escalate)
+        session_id, messages, chat=chat, deadline=deadline, escalate=escalate,
+        source_ref=source_ref, transcript_hash=transcript_sha)
     # `created` = when the SESSION ended, not when this write happens (#123).
     # Stamped here — not left to store's setdefault-now — so a heal/re-serialize
     # of an old transcript carries its true age and store's pointer guard can
@@ -61,6 +66,8 @@ def run(session_id: str, messages, *, project, chat, deadline,
     # (unreadable file / no file) means no stamp — readers tolerate that.
     if transcript_sha:
         checkpoint["transcript_hash"] = transcript_sha
+    if source_ref is not None:
+        checkpoint["source_ref"] = source_ref
     if config.carry_enabled():
         # Deterministic carry (#33 Phase 2): fold the previous checkpoint's
         # unresolved items in BEFORE the write rotates it away. Clock = this

--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -12,7 +12,7 @@ import copy
 import re
 from collections import Counter
 
-from . import recall, schema, scoring, store
+from . import provenance, recall, schema, scoring, store
 
 # An item id already looks like this (store._stamp_item_ids: kind-initial +
 # >=6 hex chars, optional -N collision suffix) — never treat it as free text
@@ -190,7 +190,7 @@ def _is_reversal_of(native_item: dict, prev_text: str, prev_id,
     — freeze stays the safe default), and the link must aim at the prev item
     (id-equal when already bound, `_same_item` on free text otherwise) so an
     unrelated supersedes link can't defeat the freeze."""
-    if native_item.get("quote_verified") is not True:
+    if not _capture_verified(native_item):
         return False
     links = native_item.get("links")
     if not isinstance(links, list):
@@ -210,10 +210,21 @@ def _is_reversal_of(native_item: dict, prev_text: str, prev_id,
     return False
 
 
+def _capture_verified(item: dict) -> bool:
+    """Receipt outcome is authoritative; flat stamp is legacy fallback."""
+    receipt = item.get("quote_provenance")
+    if provenance.valid_quote_receipt(receipt):
+        return receipt["outcome"] == "verified"
+    return item.get("quote_verified") is True
+
+
 def _message_ids(item: dict) -> frozenset:
     """The item's bound transcript-message ids as a set, tolerating the shapes
     a hand-edited or pre-#358 checkpoint can hold (absent, non-list, non-str
     entries) — same read-side tolerance as serializer.scoped_haystack."""
+    receipt = item.get("quote_provenance")
+    if provenance.valid_quote_receipt(receipt):
+        return frozenset(provenance.binding_message_ids(receipt))
     ids = item.get("source_message_ids")
     if not isinstance(ids, list):
         return frozenset()
@@ -238,11 +249,11 @@ def _record_corroboration(observed: list, prev_item: dict, native_item: dict,
         observing. Both sides required: a checkpoint with no session_id cannot
         prove somebody ELSE wrote the claim, and unprovable is not corroborated.
       G3 witnessed, not echoed — the NATIVE item is this session's own verified
-        verbatim. `trust` alone is a claim; `quote_verified is True` is the
-        check (and #441 is what stops daimon's own injected briefing text from
-        passing it). Read PRE-freeze: the #22 verbatim freeze overwrites the
-        native's trust/quote_verified with prev's, so afterwards this reads the
-        wrong item entirely.
+        verbatim. `trust` alone is a claim; the receipt outcome (flat
+        `quote_verified` only for legacy items) is the check, and #441 is what
+        stops daimon's own injected briefing text from passing it. Read
+        PRE-freeze: the #22 verbatim freeze overwrites the native evidence with
+        prev's, so afterwards this reads the wrong item entirely.
       G4 strong match only — identical text, or >=_MIN_SHARED shared salient
         terms. The ratio rail exists so short rewordings still MERGE; two
         shared terms out of three is nowhere near evidence of two independent
@@ -268,7 +279,7 @@ def _record_corroboration(observed: list, prev_item: dict, native_item: dict,
     if not out_sid or origin == out_sid:
         return                                                          # G2
     if (native_item.get("trust") != "verbatim"
-            or native_item.get("quote_verified") is not True):
+            or not _capture_verified(native_item)):
         return                                                          # G3
     if match_path not in (_MATCH_EXACT, _MATCH_ABSOLUTE):
         return                                                          # G4
@@ -417,6 +428,16 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                         twin.pop("because", None)
                     if item.get("quote"):
                         twin["quote"] = item["quote"]
+                        # #594: the quote and its complete deterministic
+                        # receipt are one atomic value. The native receipt
+                        # describes the now-replaced native quote and must not
+                        # survive. Legacy/partial prev evidence degrades to no
+                        # receipt instead of mixing fields across checks.
+                        receipt = item.get("quote_provenance")
+                        if provenance.valid_quote_receipt(receipt):
+                            twin["quote_provenance"] = copy.deepcopy(receipt)
+                        else:
+                            twin.pop("quote_provenance", None)
                         # source_message_ids travel WITH the quote (#358),
                         # same rail as quote_verified below: a binding
                         # attests THIS quote's origin message. The twin's
@@ -441,6 +462,15 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                             twin["quote_verified"] = True
                         else:
                             twin.pop("quote_verified", None)
+                    else:
+                        # A legacy verbatim item without a quote has no quote
+                        # evidence to freeze. Do not leave the native twin's
+                        # quote or any part of its receipt attached to the
+                        # restored previous wording.
+                        twin.pop("quote", None)
+                        twin.pop("quote_provenance", None)
+                        twin.pop("source_message_ids", None)
+                        twin.pop("quote_verified", None)
                     twin["trust"] = "verbatim"
                 if item.get("first_seen") and not twin.get("first_seen"):
                     twin["first_seen"] = item["first_seen"]

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -30,7 +30,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from . import anchor, briefing, capture, carry, config, configure, harvest, ledger, llm, normalize, recall, receipts, redact, render, schema, serializer, store, teamsync, transcript, worldcheck
+from . import anchor, briefing, capture, carry, config, configure, harvest, ledger, llm, normalize, provenance, recall, receipts, redact, render, schema, serializer, store, teamsync, transcript, worldcheck
 from . import __version__
 
 # The serialize.log ledger subsystem lives in ledger.py (#147 + #162, pure
@@ -2044,24 +2044,6 @@ def _cmd_mcp_serve(args) -> int:
     return mcp_server.serve()
 
 
-def _find_audit_transcript(session_id: str, slug):
-    """Locate a stored checkpoint's source transcript for the #125 audit:
-    <claude_projects>/<slug>/<session_id>.jsonl, with a glob fallback across
-    buckets (a session's project may have moved or forked its bucket). Returns
-    the Path or None when nothing matches."""
-    base = config.claude_projects_dir()
-    if slug:
-        direct = base / slug / f"{session_id}.jsonl"
-        if direct.exists():
-            return direct
-    try:
-        for cand in base.glob(f"*/{session_id}.jsonl"):
-            return cand
-    except OSError:
-        pass
-    return None
-
-
 def _load_audit_transcript(tpath):
     """Parse one transcript file into the (haystack, texts_by_id) pair
     audit-quotes checks quotes against — the one place #503's per-session
@@ -2081,24 +2063,52 @@ def _load_audit_transcript(tpath):
     return haystack, texts_by_id
 
 
-def _resolve_audit_transcript(session_id: str, slug, cache: dict):
-    """Resolve one session's (haystack, texts_by_id) pair and cache it by
-    session id (#503). A corpus scan hits the same session many times — once
-    as a checkpoint's own transcript, and once per carried item in every
-    LATER checkpoint whose origin_session names it — and `--all` walks the
-    whole corpus, so re-parsing per hit would make it quadratic. A miss is
-    cached too (None), so an unresolvable session is not retried on every
-    item that names it."""
-    if session_id in cache:
-        return cache[session_id]
-    tpath = _find_audit_transcript(session_id, slug)
+def _legacy_audit_source(session_id, author=None):
+    """Explicitly inferred pre-#594 Claude candidate, never a bound receipt."""
+    if not provenance.valid_session_id(session_id):
+        return None
+    source = {
+        "version": provenance.SOURCE_REF_VERSION,
+        "host": "claude-code",
+        "session_id": session_id,
+        "locator": "managed",
+    }
+    if isinstance(author, str) and author.strip():
+        source["author"] = author.strip()
+    return source
+
+
+def _audit_item_source(item):
+    """Return (source, receipt) without containing-checkpoint fallback."""
+    receipt = item.get("quote_provenance")
+    if provenance.valid_quote_receipt(receipt):
+        return receipt["source"], receipt
+    origin = item.get("origin_session")
+    if not provenance.valid_session_id(origin):
+        return None, None
+    origin_cp = store.read_checkpoint(origin)
+    if isinstance(origin_cp, dict):
+        source = origin_cp.get("source_ref")
+        if provenance.valid_source_ref(source):
+            return source, None
+    return _legacy_audit_source(origin, item.get("origin_author")), None
+
+
+def _resolve_audit_source(source, resolver, cache: dict):
+    """Resolve and parse one strict source once per complete source identity."""
+    if not provenance.valid_source_ref(source):
+        return None
+    key = json.dumps(source, sort_keys=True, separators=(",", ":"))
+    if key in cache:
+        return cache[key]
     result = None
-    if tpath is not None:
+    resolved = resolver.resolve(source)
+    if resolved.state == "resolved" and resolved.path is not None:
         try:
-            result = _load_audit_transcript(tpath)
+            result = _load_audit_transcript(resolved.path)
         except (OSError, FileNotFoundError):
             result = None
-    cache[session_id] = result
+    cache[key] = result
     return result
 
 
@@ -2106,14 +2116,11 @@ def _cmd_audit_quotes(args) -> int:
     """Read-only audit (#125): re-check every stored verbatim quote against its
     source transcript with the SAME tier-f matcher serialize uses, and REPORT.
 
-    #503: resolved per ITEM, from the item's own `origin_session` stamp, not
-    from the checkpoint that merely contains it — carry.merge copies `quote`
-    and `source_message_ids` forward when an item survives into a later
-    checkpoint, but never the transcript identity they came from, so a carried
-    item checked against its containing checkpoint's transcript is checked
-    against a transcript it was never in. Falls back to the containing
-    checkpoint's own session when the stamp is absent (pre-#268 items) or its
-    transcript cannot be resolved.
+    #594: a valid item receipt is authoritative for source identity and message
+    binding. Legacy origin_session may form an explicitly inferred Claude
+    candidate, but an absent/unresolved source NEVER falls back to the
+    containing checkpoint: exact-text carry proves origin, quote evidence, and
+    containing session can be three different facts.
 
     Never rewrites a trust tag — a blind backfill would flip a large share of
     the historical corpus. Measured (#503): the overwhelming majority of
@@ -2131,6 +2138,9 @@ def _cmd_audit_quotes(args) -> int:
     scanned = paired = unpaired = items = verified = failed = id_resolved = 0
     origin_resolved = 0
     transcripts: dict = {}
+    resolver = provenance.SourceResolver(
+        claude_projects=config.claude_projects_dir(),
+        current_author=config.author())
     failures: list[tuple[str, str]] = []
     for f in sorted(files):
         try:
@@ -2144,7 +2154,10 @@ def _cmd_audit_quotes(args) -> int:
             continue
         scanned += 1
         session_id = str(cp.get("session_id") or f.stem)
-        own = _resolve_audit_transcript(session_id, slug, transcripts)
+        own_source = cp.get("source_ref")
+        if not provenance.valid_source_ref(own_source):
+            own_source = _legacy_audit_source(session_id, cp.get("author"))
+        own = _resolve_audit_source(own_source, resolver, transcripts)
         if own is not None:
             paired += 1
         else:
@@ -2155,38 +2168,27 @@ def _cmd_audit_quotes(args) -> int:
             quote = item.get("quote")
             if not isinstance(quote, str) or not quote.strip():
                 continue
-            # #503: try the item's OWN origin first. origin_session equal to
-            # the containing session (the common native-item case, stamped
-            # onto itself at write) is just `own` again — skip the lookup and
-            # go straight there. A present-but-different stamp that fails to
-            # resolve (GC'd transcript, wrong host layout) falls through to
-            # `own` too, the pre-#503 verdict, byte-identical.
-            resolved, carried = own, False
-            origin = item.get("origin_session")
-            if (isinstance(origin, str) and origin.strip()
-                    and origin != session_id):
-                origin_slug = None
-                if origin not in transcripts:
-                    origin_cp = store.read_checkpoint(origin)
-                    if isinstance(origin_cp, dict):
-                        origin_slug = origin_cp.get("project_slug")
-                from_origin = _resolve_audit_transcript(
-                    origin, origin_slug, transcripts)
-                if from_origin is not None:
-                    resolved, carried = from_origin, True
+            source, receipt = _audit_item_source(item)
+            resolved = _resolve_audit_source(source, resolver, transcripts)
             if resolved is None:
-                continue  # neither the origin nor the containing session's
-                          # transcript resolves -> unverifiable, uncounted,
-                          # same as today's unpaired-checkpoint skip.
+                continue
             haystack, texts_by_id = resolved
             items += 1
-            if carried:
+            if source.get("session_id") != session_id:
                 origin_resolved += 1
             # #358: an item bound to source message id(s) resolves the id and
             # compares bytes against just that message. Missing/invalid ids
             # (old checkpoints, moved/truncated transcripts) fall back to the
             # whole-transcript scan — the pre-#358 verdict, byte-identical.
-            scoped = serializer.scoped_haystack(item, texts_by_id)
+            checked_item = item
+            if receipt is not None:
+                checked_item = dict(item)
+                ids = provenance.binding_message_ids(receipt)
+                if ids:
+                    checked_item[serializer.SOURCE_IDS_KEY] = ids
+                else:
+                    checked_item.pop(serializer.SOURCE_IDS_KEY, None)
+            scoped = serializer.scoped_haystack(checked_item, texts_by_id)
             if scoped is not None and serializer.quote_matches(quote, scoped):
                 verified += 1
                 id_resolved += 1
@@ -2214,7 +2216,7 @@ def _cmd_audit_quotes(args) -> int:
     # no evidence either way about whether anyone reaches for it. The unpaired
     # variant is a distinct event, not a detail of this one: a run that resolved
     # no transcript verified nothing, and it is also how a host whose
-    # transcripts live outside `_find_audit_transcript`'s reach shows up at all.
+    # transcripts live outside the registered resolver's reach shows up at all.
     # #503: keyed on ANY resolved transcript, not on `paired`. Once resolution
     # is per item, a checkpoint whose own transcript is gone still verifies its
     # carried items through origin_session — `paired` counts containing

--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -342,6 +342,11 @@ def project_dir() -> str | None:
     return _get("DAIMON_PROJECT_DIR") or None
 
 
+def capture_host() -> str | None:
+    """Trusted host hint forwarded by installed capture hooks (#594)."""
+    return _get("DAIMON_CAPTURE_HOST") or None
+
+
 def claude_projects_dir() -> Path:
     """Where host transcripts live: ~/.claude/projects/<slug>/<session>.jsonl.
     The #125 audit reads (never writes) these to re-check stored quotes against

--- a/plugin/daimon_briefing/hooks.py
+++ b/plugin/daimon_briefing/hooks.py
@@ -110,7 +110,7 @@ def on_session_end(session_id, completed=None, interrupted=None, model=None, pla
             out = capture.run(
                 session_id, messages, project=root, chat=_chat,
                 deadline=deadline, transcript_path=transcript_path,
-                transcript_sha=transcript_sha,
+                transcript_sha=transcript_sha, capture_host=platform,
             )
         except serializer.TooShortError:
             log.info("daimon: no checkpoint produced for session %s (skip)", session_id)

--- a/plugin/daimon_briefing/provenance.py
+++ b/plugin/daimon_briefing/provenance.py
@@ -1,0 +1,335 @@
+"""Durable quote provenance and strict transcript source resolution (#594).
+
+Checkpoint ``source_ref`` describes the source captured by that checkpoint.
+Item ``quote_provenance`` snapshots the complete evidence receipt so carried
+items do not depend on their original checkpoint surviving retention GC.
+
+This module deliberately knows nothing about checkpoint or transcript parsing.
+It validates/stamps plain data and resolves a source to at most one local path;
+callers own parsing and quote matching.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+
+SOURCE_REF_VERSION = 1
+QUOTE_PROVENANCE_VERSION = 1
+QUOTE_VERIFIER_ID = "tier-f"
+QUOTE_VERIFIER_VERSION = 1
+
+_HOSTS = frozenset((
+    "claude-code", "codex", "windsurf", "gemini", "hermes", "manual"))
+_LOCATORS = frozenset(("managed", "host-api", "unsupported"))
+_OUTCOMES = frozenset(("verified", "not-verified"))
+_BINDING_MODES = frozenset(("message-ids", "transcript-scan"))
+_DIGEST_SCOPES = frozenset(("raw-file", "rendered-transcript"))
+_SESSION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True)
+class SourceResolution:
+    """One strict resolver decision. ``path`` is internal and never rendered."""
+
+    state: str
+    path: Path | None = None
+
+
+def valid_session_id(value) -> bool:
+    """Bounded, glob/path-safe host session identifier."""
+    return isinstance(value, str) and _SESSION_RE.fullmatch(value) is not None
+
+
+def _under(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.expanduser().resolve())
+        return True
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def _codex_home() -> Path:
+    raw = os.environ.get("CODEX_HOME")
+    return Path(raw).expanduser() if raw else Path.home() / ".codex"
+
+
+def infer_host(transcript_path, *, home=None, codex_home=None,
+               claude_projects=None) -> tuple[str, str]:
+    """Infer a supported host only from registered transcript roots."""
+    if transcript_path is None:
+        return "manual", "unsupported"
+    path = Path(transcript_path).expanduser()
+    home = Path(home).expanduser() if home is not None else Path.home()
+    claude_root = (Path(claude_projects).expanduser()
+                    if claude_projects is not None
+                    else home / ".claude" / "projects")
+    if _under(path, claude_root):
+        return "claude-code", "managed"
+    codex_home = (Path(codex_home).expanduser() if codex_home is not None
+                  else _codex_home())
+    if (_under(path, codex_home / "sessions")
+            or _under(path, codex_home / "archived_sessions")):
+        return "codex", "managed"
+    if (_under(path, home / ".windsurf" / "transcripts")
+            or _under(path, home / ".daimon" / "windsurf" / "transcripts")):
+        return "windsurf", "managed"
+    return "manual", "unsupported"
+
+
+def normalize_host(value) -> str | None:
+    """Normalize trusted hook hints to the public host enum."""
+    if not isinstance(value, str):
+        return None
+    raw = value.strip().lower().replace("_", "-")
+    aliases = {
+        "claude": "claude-code",
+        "claude-code": "claude-code",
+        "codex": "codex",
+        "windsurf": "windsurf",
+        "windsurf-cascade": "windsurf",
+        "gemini": "gemini",
+        "gemini-cli": "gemini",
+        "hermes": "hermes",
+        "manual": "manual",
+    }
+    return aliases.get(raw)
+
+
+def capture_source_ref(session_id: str, transcript_path=None, *, author=None,
+                       host_hint=None, home=None, codex_home=None,
+                       claude_projects=None) -> dict | None:
+    """Create code-owned capture metadata, or None for an unsafe session id."""
+    if not valid_session_id(session_id):
+        return None
+    inferred_host, locator = infer_host(
+        transcript_path, home=home, codex_home=codex_home,
+        claude_projects=claude_projects)
+    hinted = normalize_host(host_hint)
+    host = hinted or inferred_host
+    if transcript_path is None and host == "hermes":
+        locator = "host-api"
+    elif inferred_host == "manual":
+        # A hint identifies the producer, but an arbitrary path is not a
+        # registered locator and must never be presented as resolvable.
+        locator = "unsupported"
+    source = {
+        "version": SOURCE_REF_VERSION,
+        "host": host,
+        "session_id": session_id,
+        "locator": locator,
+    }
+    if isinstance(author, str) and author.strip():
+        source["author"] = author.strip()
+    return source
+
+
+def valid_source_ref(value) -> bool:
+    if not isinstance(value, dict) or value.get("version") != SOURCE_REF_VERSION:
+        return False
+    if value.get("host") not in _HOSTS or value.get("locator") not in _LOCATORS:
+        return False
+    if not valid_session_id(value.get("session_id")):
+        return False
+    author = value.get("author")
+    return author is None or (isinstance(author, str) and bool(author.strip()))
+
+
+def source_digest(transcript_hash, rendered_transcript: str) -> dict:
+    """Prefer the raw-file digest; otherwise bind the verified render bytes."""
+    if isinstance(transcript_hash, str):
+        raw = transcript_hash.strip().lower()
+        if _SHA256_RE.fullmatch(raw):
+            return {"algorithm": "sha256", "scope": "raw-file", "value": raw}
+    rendered = rendered_transcript.encode("utf-8")
+    return {
+        "algorithm": "sha256",
+        "scope": "rendered-transcript",
+        "value": hashlib.sha256(rendered).hexdigest(),
+    }
+
+
+def quote_receipt(source_ref, digest, *, outcome: str, checked_at: str,
+                  binding_mode: str, message_ids=()) -> dict | None:
+    """Build a complete item receipt from code-derived inputs."""
+    if not valid_source_ref(source_ref) or outcome not in _OUTCOMES:
+        return None
+    if binding_mode not in _BINDING_MODES:
+        return None
+    ids = []
+    if binding_mode == "message-ids":
+        for value in message_ids or ():
+            if isinstance(value, str) and value and value not in ids:
+                ids.append(value)
+    receipt = {
+        "version": QUOTE_PROVENANCE_VERSION,
+        "source": dict(source_ref),
+        "digest": dict(digest),
+        "verifier": {
+            "id": QUOTE_VERIFIER_ID,
+            "version": QUOTE_VERIFIER_VERSION,
+        },
+        "outcome": outcome,
+        "checked_at": checked_at,
+        "binding": {"mode": binding_mode, "message_ids": ids},
+    }
+    return receipt if valid_quote_receipt(receipt) else None
+
+
+def valid_quote_receipt(value) -> bool:
+    if not isinstance(value, dict) or value.get("version") != QUOTE_PROVENANCE_VERSION:
+        return False
+    if not valid_source_ref(value.get("source")):
+        return False
+    digest = value.get("digest")
+    if not isinstance(digest, dict):
+        return False
+    if (digest.get("algorithm") != "sha256"
+            or digest.get("scope") not in _DIGEST_SCOPES
+            or not isinstance(digest.get("value"), str)
+            or _SHA256_RE.fullmatch(digest["value"]) is None):
+        return False
+    verifier = value.get("verifier")
+    if not isinstance(verifier, dict):
+        return False
+    if (verifier.get("id") != QUOTE_VERIFIER_ID
+            or not isinstance(verifier.get("version"), int)
+            or isinstance(verifier.get("version"), bool)
+            or verifier["version"] < 1):
+        return False
+    if value.get("outcome") not in _OUTCOMES:
+        return False
+    checked = value.get("checked_at")
+    if not isinstance(checked, str):
+        return False
+    try:
+        datetime.strptime(checked, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        return False
+    binding = value.get("binding")
+    if not isinstance(binding, dict) or binding.get("mode") not in _BINDING_MODES:
+        return False
+    ids = binding.get("message_ids")
+    if (not isinstance(ids, list) or len(ids) > 64
+            or any(not isinstance(v, str) or not v or len(v) > 256 for v in ids)):
+        return False
+    if len(ids) != len(set(ids)):
+        return False
+    return binding["mode"] != "transcript-scan" or not ids
+
+
+def binding_message_ids(receipt) -> list[str]:
+    """Authoritative message binding from a valid receipt."""
+    if not valid_quote_receipt(receipt):
+        return []
+    binding = receipt["binding"]
+    return list(binding["message_ids"]) if binding["mode"] == "message-ids" else []
+
+
+class SourceResolver:
+    """Strict resolver over registered host roots; never guesses or falls back."""
+
+    def __init__(self, *, home=None, codex_home=None, claude_projects=None,
+                 current_author=None):
+        self.home = Path(home).expanduser() if home is not None else Path.home()
+        self.codex_home = (Path(codex_home).expanduser() if codex_home is not None
+                           else _codex_home())
+        self.claude_projects = (
+            Path(claude_projects).expanduser() if claude_projects is not None
+            else self.home / ".claude" / "projects")
+        self.current_author = current_author
+        self._indexes: dict[str, dict[str, list[Path]]] = {}
+
+    def _roots(self, host: str) -> tuple[Path, ...] | None:
+        if host == "claude-code":
+            return (self.claude_projects,)
+        if host == "codex":
+            return (self.codex_home / "sessions",
+                    self.codex_home / "archived_sessions")
+        if host == "windsurf":
+            return (self.home / ".windsurf" / "transcripts",
+                    self.home / ".daimon" / "windsurf" / "transcripts")
+        return None
+
+    def _candidates(self, source: dict) -> list[Path] | None:
+        host = source["host"]
+        sid = source["session_id"]
+        try:
+            if host == "claude-code":
+                if host not in self._indexes:
+                    self._indexes[host] = self._build_index(
+                        self.claude_projects.glob("*/*.jsonl"))
+                return list(self._indexes[host].get(sid, ()))
+            if host == "codex":
+                if host not in self._indexes:
+                    paths = []
+                    for root in self._roots(host) or ():
+                        if root.exists():
+                            paths.extend(root.rglob("*.jsonl"))
+                    self._indexes[host] = self._build_index(paths)
+                return list(self._indexes[host].get(sid, ()))
+            if host == "windsurf":
+                return [
+                    self.home / ".windsurf" / "transcripts" / f"{sid}.jsonl",
+                    self.home / ".daimon" / "windsurf" / "transcripts" / f"{sid}.md",
+                ]
+        except OSError:
+            return []
+        return None
+
+    @staticmethod
+    def _build_index(paths) -> dict[str, list[Path]]:
+        index: dict[str, list[Path]] = {}
+        for path in paths:
+            index.setdefault(path.stem, []).append(path)
+        return index
+
+    def resolve(self, source) -> SourceResolution:
+        if not valid_source_ref(source):
+            return SourceResolution("unsupported")
+        if source["locator"] != "managed":
+            return SourceResolution("unsupported")
+        candidates = self._candidates(source)
+        if candidates is None:
+            return SourceResolution("unsupported")
+        roots = self._roots(source["host"]) or ()
+        existing = []
+        seen = set()
+        for path in candidates:
+            try:
+                if not path.is_file():
+                    continue
+                resolved_path = path.resolve()
+                if not any(_under(resolved_path, root) for root in roots):
+                    continue
+                key = str(resolved_path)
+            except (OSError, RuntimeError):
+                continue
+            if key not in seen:
+                seen.add(key)
+                existing.append(path)
+        if len(existing) > 1:
+            return SourceResolution("ambiguous")
+        if not existing:
+            author = source.get("author")
+            if (isinstance(author, str) and author.strip()
+                    and author.strip().lower() != "unknown"
+                    and isinstance(self.current_author, str)
+                    and self.current_author.strip()
+                    and self.current_author.strip().lower() != "unknown"
+                    and author.strip() != self.current_author.strip()):
+                return SourceResolution("remote-author")
+            return SourceResolution("absent-local")
+        path = existing[0]
+        try:
+            with path.open("rb") as handle:
+                handle.read(1)
+        except OSError:
+            return SourceResolution("unreadable")
+        return SourceResolution("resolved", path)

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -21,7 +21,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 
-from . import config, configure, ledger, llm, redact, schema
+from . import config, configure, ledger, llm, provenance, redact, schema
 
 # No handlers/basicConfig here — the library stays silent unless the caller
 # configures logging. Multi-hour serialize runs need this heartbeat to be killable.
@@ -1012,7 +1012,8 @@ def stripped_transcript(messages) -> str:
     return _render_transcript(stripped)
 
 
-def verify_quotes(checkpoint, transcript_text: str, messages=None) -> int:
+def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
+                  source_ref=None, transcript_hash=None) -> int:
     """Verify every verbatim item's quote against the rendered transcript, in
     place (#125). On a hit the item gets `quote_verified: true` AND a
     `last_verified` ISO-8601 UTC stamp (#215: the staleness-budget's freshest
@@ -1068,11 +1069,20 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None) -> int:
     # MISS must not execute them for the quote-id's crime.
     signals = signal_message_ids(messages) if messages else set()
     downgraded = echoed = 0
+    digest = provenance.source_digest(transcript_hash, transcript_text)
+
+    def stamp_receipt(item, outcome, checked_at, binding_mode, message_ids=()):
+        receipt = provenance.quote_receipt(
+            source_ref, digest, outcome=outcome, checked_at=checked_at,
+            binding_mode=binding_mode, message_ids=message_ids)
+        if receipt is not None:
+            item["quote_provenance"] = receipt
     # The model never gets a vote on the echo verdict (#292 discipline, same
     # as `grounded`/`pinned`): any model-emitted value is dropped before the
     # checker re-derives it.
     for item in iter_items(checkpoint):
         item.pop(ECHO_ONLY_KEY, None)
+        item.pop("quote_provenance", None)
     for item in iter_items(checkpoint):
         if item.get("trust") != "verbatim":
             continue
@@ -1081,9 +1091,14 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None) -> int:
             continue
         scoped = scoped_haystack(item, texts_by_id, exclude=signals)
         if scoped is not None and quote_matches(quote, scoped):
-            item["quote_verified"] = True
-            item["last_verified"] = datetime.now(timezone.utc).strftime(
+            checked_at = datetime.now(timezone.utc).strftime(
                 "%Y-%m-%dT%H:%M:%SZ")
+            item["quote_verified"] = True
+            item["last_verified"] = checked_at
+            quote_ids = [i for i in item.get(SOURCE_IDS_KEY) or []
+                         if isinstance(i, str) and i not in signals]
+            stamp_receipt(item, "verified", checked_at, "message-ids",
+                          quote_ids)
         elif quote_matches(quote, haystack):
             if scoped is not None:
                 # Resolved AND mismatched: the quote is real but not in its
@@ -1098,9 +1113,11 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None) -> int:
                 log.warning("quote verification: quote not found in its cited "
                             "message(s) — binding dropped, verified via "
                             "whole-transcript scan (#358)")
-            item["quote_verified"] = True
-            item["last_verified"] = datetime.now(timezone.utc).strftime(
+            checked_at = datetime.now(timezone.utc).strftime(
                 "%Y-%m-%dT%H:%M:%SZ")
+            item["quote_verified"] = True
+            item["last_verified"] = checked_at
+            stamp_receipt(item, "verified", checked_at, "transcript-scan")
         else:
             # #440: a second pass over the UNSTRIPPED text separates "present
             # only in daimon's own injected output" from "absent entirely".
@@ -1116,6 +1133,10 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None) -> int:
             item["quote_verified"] = False
             # A downgraded quote is not evidence; a binding for it is noise.
             item.pop(SOURCE_IDS_KEY, None)
+            checked_at = datetime.now(timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ")
+            stamp_receipt(item, "not-verified", checked_at,
+                          "transcript-scan")
             downgraded += 1
             # Log-line-only scrub: item ids are not stamped until store-save,
             # so the text is the only diagnostic handle here. The item itself
@@ -1846,7 +1867,7 @@ def _merge_partials(chat, session_id: str, partials: list, deadline,
 # already stomps a model-supplied value the same way.
 _CODE_OWNED_KEYS = (
     "format_version", "created", "author",
-    "transcript_hash", "project_slug", "git_branch", "receipts",
+    "transcript_hash", "source_ref", "project_slug", "git_branch", "receipts",
     # #514: the extractor dates its own run at serialize time; a model never
     # gets to claim one (and the introspection path stays absent = unknown).
     "extraction_version",
@@ -1868,7 +1889,8 @@ _CODE_OWNED_KEYS = (
 # Safe to strip on both paths because carry.merge folds prev items in AFTER
 # serialize_strict returns — a carried item's genuine stamps never pass here.
 _CODE_OWNED_ITEM_KEYS = ("origin_session", "origin_author",
-                         "quote_verified", "last_verified")
+                         "quote_verified", "last_verified",
+                         "quote_provenance")
 
 
 def strip_code_owned_keys(checkpoint: dict) -> None:
@@ -2017,7 +2039,7 @@ def _stamp_llm_provenance(checkpoint: dict) -> None:
 
 
 def serialize_strict(session_id: str, messages, chat=None, deadline=None,
-                     escalate=False) -> dict:
+                     escalate=False, source_ref=None, transcript_hash=None) -> dict:
     """Transcript -> validated checkpoint, or a named SerializeError.
 
     `chat` is an injectable callable (messages, **kwargs) -> str; defaults to the
@@ -2255,7 +2277,8 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
     # stamp the verdict — the briefing never re-greps. #358: items with a
     # validated binding resolve their id and compare bytes against just that
     # message, whole-transcript scan as fallback.
-    verify_quotes(checkpoint, transcript_text, messages)
+    verify_quotes(checkpoint, transcript_text, messages,
+                  source_ref=source_ref, transcript_hash=transcript_hash)
     # #359: derive the code-owned `grounded` verdict AFTER verification (it
     # must judge the surviving bindings) — outcome claims with a validated
     # signal pointer are marked grounded; unwitnessed verbatim outcome

--- a/plugin/tests/test_capture_parity.py
+++ b/plugin/tests/test_capture_parity.py
@@ -21,7 +21,7 @@ import copy
 import json
 import os
 
-from daimon_briefing import cli, hooks, store, transcript
+from daimon_briefing import cli, hooks, provenance, store, transcript
 
 PROJECT = "/p/parity"
 SESSION = "S-parity"
@@ -150,6 +150,12 @@ def test_hook_and_cli_capture_produce_identical_checkpoints(
     assert carried and carried[0]["carried_from"] == "S-prev"
     assert cli_cp["transcript_hash"] == transcript.file_sha256(tpath)
     assert cli_cp["created"] == _STAMPS[-1]
+    assert provenance.valid_source_ref(cli_cp["source_ref"])
+    rejected = next(
+        q for q in cli_cp["working_context"]["open_questions"]
+        if q.get("text") == "PR #6 state")
+    assert provenance.valid_quote_receipt(rejected["quote_provenance"])
+    assert rejected["quote_provenance"]["outcome"] == "not-verified"
 
     # Same events emitted through both doors (supersede-candidate emission),
     # minus the append-time `ts` wall stamp.

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -3,7 +3,7 @@ unresolved items into the new one by code. Pure function — all clock/config
 injected."""
 import copy
 
-from daimon_briefing import carry
+from daimon_briefing import carry, provenance
 
 NOW = 1_760_000_000.0  # arbitrary fixed epoch
 
@@ -46,6 +46,18 @@ def _cp(sid, created_days_ago=0, questions=(), decisions=(), uncertainties=()):
 def _item(text, imp=7, days=2, **kw):
     return {"text": text, "trust": "inferred", "importance": imp,
             "first_seen": _iso(days), **kw}
+
+
+def _quote_receipt(session_id, checked_at, message_id, outcome="verified"):
+    source = {
+        "version": 1, "host": "claude-code", "session_id": session_id,
+        "locator": "managed", "author": "alice",
+    }
+    return provenance.quote_receipt(
+        source, {"algorithm": "sha256", "scope": "raw-file",
+                 "value": "a" * 64},
+        outcome=outcome, checked_at=checked_at,
+        binding_mode="message-ids", message_ids=[message_id])
 
 
 def test_carries_unresolved_question_with_provenance():
@@ -307,6 +319,64 @@ def test_verbatim_freeze_pops_twin_ids_when_prev_has_none():
     assert len(qs) == 1
     assert qs[0]["quote"] == _VERB_QUOTE
     assert "source_message_ids" not in qs[0]
+
+
+def test_verbatim_freeze_moves_complete_quote_receipt_atomically():
+    prev_receipt = _quote_receipt("S-prev", _iso(44), "u-orig")
+    native_receipt = _quote_receipt("S-new", _iso(0), "u-new")
+    prev = _cp("S-prev", 1, questions=[_item(
+        _VERB_ORIG, trust="verbatim", quote=_VERB_QUOTE, days=45,
+        source_message_ids=["u-orig"], quote_verified=True,
+        last_verified=_iso(44), quote_provenance=prev_receipt)])
+    new = _cp("S-new", 0, questions=[_item(
+        _VERB_TWIN, trust="verbatim", quote="different exact words", days=0,
+        source_message_ids=["u-new"], quote_verified=True,
+        last_verified=_iso(0), quote_provenance=native_receipt)])
+
+    q = carry.merge(new, prev, NOW)["working_context"]["open_questions"][0]
+
+    assert q["quote"] == _VERB_QUOTE
+    assert q["quote_provenance"] == prev_receipt
+    assert q["quote_provenance"]["binding"]["message_ids"] == ["u-orig"]
+    # Flat last_verified remains the fresher world-check compatibility stamp;
+    # only the nested checked_at dates the frozen quote.
+    assert q["last_verified"] == _iso(0)
+    assert q["quote_provenance"]["checked_at"] == _iso(44)
+
+
+def test_exact_native_restatement_keeps_fresh_receipt_and_old_origin():
+    prev_receipt = _quote_receipt("S-origin", _iso(44), "u-orig")
+    native_receipt = _quote_receipt("S-new", _iso(0), "u-new")
+    prev = _cp("S-prev", 1, questions=[_item(
+        _VERB_ORIG, trust="verbatim", quote=_VERB_QUOTE, days=45,
+        origin_session="S-origin", quote_provenance=prev_receipt)])
+    new = _cp("S-new", 0, questions=[_item(
+        _VERB_ORIG, trust="verbatim", quote=_VERB_QUOTE, days=0,
+        source_message_ids=["u-new"], quote_verified=True,
+        last_verified=_iso(0), quote_provenance=native_receipt)])
+
+    q = carry.merge(new, prev, NOW)["working_context"]["open_questions"][0]
+
+    assert q["origin_session"] == "S-origin"
+    assert q["quote_provenance"] == native_receipt
+    assert q["quote_provenance"]["source"]["session_id"] == "S-new"
+
+
+def test_freeze_legacy_prev_without_quote_removes_native_receipt():
+    native_receipt = _quote_receipt("S-new", _iso(0), "u-new")
+    prev = _cp("S-prev", 1, questions=[_item(
+        _VERB_ORIG, trust="verbatim", days=45)])
+    new = _cp("S-new", 0, questions=[_item(
+        _VERB_TWIN, trust="verbatim", quote="native quote", days=0,
+        source_message_ids=["u-new"], quote_verified=True,
+        quote_provenance=native_receipt)])
+
+    q = carry.merge(new, prev, NOW)["working_context"]["open_questions"][0]
+
+    assert "quote" not in q
+    assert "quote_provenance" not in q
+    assert "source_message_ids" not in q
+    assert "quote_verified" not in q
 
 
 def test_verbatim_freeze_because_travels_with_frozen_text():
@@ -1286,6 +1356,21 @@ def test_observed_refuses_a_verbatim_native_whose_quote_never_verified():
     assert observed == []
 
 
+def test_observed_uses_receipt_outcome_before_flat_compatibility_stamp():
+    verified = _quote_receipt("S-new", _iso(0), "m-new")
+    observed, _ = _observe(
+        [_bound()],
+        [_witness(quote_verified=False, quote_provenance=verified)])
+    assert observed == [("o-a1d001", "S-origin", "ada")]
+
+    rejected = _quote_receipt(
+        "S-new", _iso(0), "m-new", outcome="not-verified")
+    observed, _ = _observe(
+        [_bound()],
+        [_witness(quote_verified=True, quote_provenance=rejected)])
+    assert observed == []
+
+
 def test_observed_refuses_a_ratio_only_match():
     # G4: the ratio path (>=60% of the shorter term list) exists so short
     # rewordings still MERGE. It is far too loose to certify two independent
@@ -1330,6 +1415,17 @@ def test_observed_records_when_message_bindings_are_disjoint():
     observed, _ = _observe(
         [_bound(source_message_ids=["m-7"])],
         [_witness(source_message_ids=["m-9"])])
+    assert observed == [("o-a1d001", "S-origin", "ada")]
+
+
+def test_observed_uses_receipt_bindings_before_flat_compatibility_ids():
+    prev_receipt = _quote_receipt("S-origin", _iso(1), "m-prev")
+    native_receipt = _quote_receipt("S-new", _iso(0), "m-new")
+    observed, _ = _observe(
+        [_bound(source_message_ids=["m-stale"],
+                quote_provenance=prev_receipt)],
+        [_witness(source_message_ids=["m-stale"],
+                  quote_provenance=native_receipt)])
     assert observed == [("o-a1d001", "S-origin", "ada")]
 
 

--- a/plugin/tests/test_claude_hooks.py
+++ b/plugin/tests/test_claude_hooks.py
@@ -346,7 +346,8 @@ def _fake_cli(tmp_path) -> tuple[Path, Path]:
     script = fake_bin / "daimon"
     script.write_text(
         "#!/bin/sh\n"
-        f'printf "DAIMON_PROJECT_DIR=%s\\nargs=%s\\n" "$DAIMON_PROJECT_DIR" "$*" > "{capture}"\n'
+        f'printf "DAIMON_PROJECT_DIR=%s\\nDAIMON_CAPTURE_HOST=%s\\nargs=%s\\n" '
+        f'"$DAIMON_PROJECT_DIR" "$DAIMON_CAPTURE_HOST" "$*" > "{capture}"\n'
     )
     script.chmod(script.stat().st_mode | stat.S_IEXEC)
     return fake_bin, capture
@@ -375,6 +376,7 @@ def test_session_end_passes_project_dir_to_child(tmp_path, tmp_checkpoint_dir):
     assert proc.returncode == 0
     captured = _wait_for(capture)
     assert "DAIMON_PROJECT_DIR=/Users/x/projA" in captured
+    assert "DAIMON_CAPTURE_HOST=claude-code" in captured
     assert str(transcript) in captured
 
 
@@ -423,7 +425,9 @@ def test_session_end_does_not_route_child_stdout_into_log(tmp_path, tmp_checkpoi
     assert sentinel not in content
 
 
-def test_session_end_no_cwd_no_project_env(tmp_path, tmp_checkpoint_dir):
+def test_session_end_no_cwd_keeps_project_unset_but_passes_host(
+    tmp_path, tmp_checkpoint_dir
+):
     fake_bin, capture = _fake_cli(tmp_path)
     transcript = tmp_path / "t.jsonl"
     transcript.write_text("{}\n")
@@ -431,7 +435,8 @@ def test_session_end_no_cwd_no_project_env(tmp_path, tmp_checkpoint_dir):
     proc = _run(END_HOOK, payload, tmp_path, extra_env={"PATH": str(fake_bin)})
     assert proc.returncode == 0
     captured = _wait_for(capture)
-    assert "DAIMON_PROJECT_DIR=\n" in captured  # unset for the child, exactly as today
+    assert "DAIMON_PROJECT_DIR=\n" in captured
+    assert "DAIMON_CAPTURE_HOST=claude-code" in captured
 
 
 # ---- sweep_orphans (#185): session-start catch-up sweep, unit-level ----

--- a/plugin/tests/test_codex_session_end.py
+++ b/plugin/tests/test_codex_session_end.py
@@ -98,6 +98,8 @@ def test_session_end_script_exists_and_bypasses_the_throttle():
     assert "DAIMON_CODEX_MIN_SERIALIZE_INTERVAL" not in src, (
         "SessionEnd is the real end, not a heartbeat; it must not be throttled")
     assert TAG in src, "log lines must carry the distinct tag"
+    assert 'project_env(cwd, "codex")' in src, (
+        "serialize child must receive the code-owned capture host hint")
     # Fail-open: an advisory hook that raises is surfaced to the user as a hook
     # failure, so the top level has to swallow.
     assert re.search(r"except\s+(BaseException|Exception)", src), (

--- a/plugin/tests/test_provenance.py
+++ b/plugin/tests/test_provenance.py
@@ -68,6 +68,19 @@ def test_capture_source_ref_rejects_unsafe_session_id(tmp_path):
         assert provenance.capture_source_ref(value, tmp_path / "x") is None
 
 
+def test_capture_source_ref_marks_hermes_host_api_without_transcript():
+    source = provenance.capture_source_ref(
+        "S-hermes", host_hint="hermes", author="alice")
+
+    assert source["host"] == "hermes"
+    assert source["locator"] == "host-api"
+
+
+def test_source_ref_rejects_unknown_host_and_unsafe_session():
+    assert not provenance.valid_source_ref(dict(_source(), host="other"))
+    assert not provenance.valid_source_ref(dict(_source(), session_id="../escape"))
+
+
 def test_quote_receipt_is_complete_valid_and_bounded():
     receipt = _receipt()
     assert provenance.valid_quote_receipt(receipt)
@@ -90,6 +103,41 @@ def test_quote_receipt_rejects_malformed_time_and_unbounded_bindings():
     too_many = json.loads(json.dumps(_receipt()))
     too_many["binding"]["message_ids"] = [f"m-{i}" for i in range(65)]
     assert not provenance.valid_quote_receipt(too_many)
+
+
+def test_quote_receipt_rejects_invalid_constructor_binding_mode():
+    assert provenance.quote_receipt(
+        _source(),
+        {"algorithm": "sha256", "scope": "raw-file", "value": _HASH},
+        outcome="verified", checked_at="2026-08-05T10:00:00Z",
+        binding_mode="other") is None
+
+
+def test_quote_receipt_rejects_every_malformed_evidence_component():
+    mutations = (
+        ("source", None),
+        ("digest", None),
+        ("digest.algorithm", "md5"),
+        ("verifier", None),
+        ("verifier.id", "other"),
+        ("outcome", "unknown"),
+        ("checked_at", None),
+        ("binding", None),
+        ("binding.message_ids", ["msg-1", "msg-1"]),
+    )
+
+    for dotted, value in mutations:
+        receipt = json.loads(json.dumps(_receipt()))
+        target = receipt
+        parts = dotted.split(".")
+        for part in parts[:-1]:
+            target = target[part]
+        target[parts[-1]] = value
+        assert not provenance.valid_quote_receipt(receipt), dotted
+
+
+def test_binding_message_ids_rejects_invalid_receipt():
+    assert provenance.binding_message_ids({}) == []
 
 
 def test_verify_quotes_stamps_receipt_and_compatibility_mirrors():
@@ -189,6 +237,51 @@ def test_resolver_supports_codex_recursive_sessions(tmp_path):
 
     result = resolver.resolve(_source("S-codex", host="codex"))
     assert result.state == "resolved" and result.path == target
+
+
+def test_resolver_supports_windsurf_roots_and_skips_missing_candidate(tmp_path):
+    target = tmp_path / ".windsurf" / "transcripts" / "S-wind.jsonl"
+    target.parent.mkdir(parents=True)
+    target.write_text("{}\n", encoding="utf-8")
+    resolver = provenance.SourceResolver(home=tmp_path)
+
+    result = resolver.resolve(_source("S-wind", host="windsurf"))
+
+    assert result.state == "resolved" and result.path == target
+
+
+def test_resolver_rejects_managed_host_without_registered_roots(tmp_path):
+    resolver = provenance.SourceResolver(home=tmp_path)
+    source = dict(_source("S-gemini", host="gemini"), locator="managed")
+
+    assert resolver._roots("gemini") is None
+    assert resolver.resolve(source).state == "unsupported"
+
+
+def test_resolver_treats_index_scan_oserror_as_absent(tmp_path, monkeypatch):
+    claude = tmp_path / ".claude" / "projects"
+    resolver = provenance.SourceResolver(home=tmp_path, claude_projects=claude)
+
+    def denied_glob(path, pattern):
+        if path == claude:
+            raise OSError("denied")
+        return ()
+
+    monkeypatch.setattr(Path, "glob", denied_glob)
+
+    assert resolver.resolve(_source("S-denied")).state == "absent-local"
+
+
+def test_resolver_skips_candidate_path_runtime_errors(tmp_path, monkeypatch):
+    resolver = provenance.SourceResolver(home=tmp_path)
+
+    def broken_is_file(path):
+        raise RuntimeError(f"cannot inspect {path}")
+
+    monkeypatch.setattr(Path, "is_file", broken_is_file)
+
+    assert resolver.resolve(
+        _source("S-broken", host="windsurf")).state == "absent-local"
 
 
 def test_resolver_reports_unreadable_without_fallback(tmp_path, monkeypatch):

--- a/plugin/tests/test_provenance.py
+++ b/plugin/tests/test_provenance.py
@@ -1,0 +1,255 @@
+"""Durable quote receipts and strict host source resolution (#594)."""
+
+import json
+from pathlib import Path
+
+from daimon_briefing import provenance, serializer, store
+
+
+_HASH = "a" * 64
+
+
+def _source(session="S-origin", *, host="claude-code", author="alice"):
+    return {
+        "version": provenance.SOURCE_REF_VERSION,
+        "host": host,
+        "session_id": session,
+        "locator": "managed",
+        "author": author,
+    }
+
+
+def _receipt(session="S-origin", *, author="alice", checked_at="2026-08-05T10:00:00Z"):
+    return provenance.quote_receipt(
+        _source(session, author=author),
+        {"algorithm": "sha256", "scope": "raw-file", "value": _HASH},
+        outcome="verified", checked_at=checked_at,
+        binding_mode="message-ids", message_ids=["msg-1"])
+
+
+def _checkpoint(session, item, created):
+    return {
+        "session_id": session,
+        "created": created,
+        "working_context": {
+            "active_topic": {"text": "topic", "trust": "inferred"},
+            "open_questions": [item],
+            "recent_decisions": [],
+        },
+        "epistemic_snapshot": {
+            "strong_beliefs": [],
+            "uncertainties": [],
+        },
+    }
+
+
+def test_capture_source_ref_infers_registered_hosts(tmp_path):
+    claude = tmp_path / ".claude" / "projects"
+    codex = tmp_path / ".codex"
+    home = tmp_path
+
+    c = provenance.capture_source_ref(
+        "S-claude", claude / "slug" / "S-claude.jsonl",
+        home=home, codex_home=codex, claude_projects=claude, author="alice")
+    x = provenance.capture_source_ref(
+        "S-codex", codex / "sessions" / "2026" / "S-codex.jsonl",
+        home=home, codex_home=codex, claude_projects=claude, author="alice")
+    w = provenance.capture_source_ref(
+        "S-wind", home / ".windsurf" / "transcripts" / "S-wind.jsonl",
+        home=home, codex_home=codex, claude_projects=claude, author="alice")
+
+    assert (c["host"], c["locator"]) == ("claude-code", "managed")
+    assert (x["host"], x["locator"]) == ("codex", "managed")
+    assert (w["host"], w["locator"]) == ("windsurf", "managed")
+
+
+def test_capture_source_ref_rejects_unsafe_session_id(tmp_path):
+    for value in ("", "../escape", "a/b", "a*b", "a?b", "a[0]", "x" * 201):
+        assert provenance.capture_source_ref(value, tmp_path / "x") is None
+
+
+def test_quote_receipt_is_complete_valid_and_bounded():
+    receipt = _receipt()
+    assert provenance.valid_quote_receipt(receipt)
+    assert receipt["source"]["session_id"] == "S-origin"
+    assert receipt["digest"]["value"] == _HASH
+    assert receipt["verifier"] == {"id": "tier-f", "version": 1}
+    assert receipt["outcome"] == "verified"
+    assert receipt["binding"]["message_ids"] == ["msg-1"]
+    # Representative receipt measured 394 bytes compact / 519 bytes with the
+    # store's indent=2 formatting. Keep a generous compact bound so accidental
+    # growth is reviewed instead of silently multiplying across every item.
+    assert len(json.dumps(receipt, separators=(",", ":"))) < 600
+
+
+def test_quote_receipt_rejects_malformed_time_and_unbounded_bindings():
+    bad_time = json.loads(json.dumps(_receipt()))
+    bad_time["checked_at"] = "sometime-Z"
+    assert not provenance.valid_quote_receipt(bad_time)
+
+    too_many = json.loads(json.dumps(_receipt()))
+    too_many["binding"]["message_ids"] = [f"m-{i}" for i in range(65)]
+    assert not provenance.valid_quote_receipt(too_many)
+
+
+def test_verify_quotes_stamps_receipt_and_compatibility_mirrors():
+    item = {
+        "text": "decision", "trust": "verbatim",
+        "quote": "the durable sentence", "source_message_ids": ["u-1"],
+    }
+    cp = _checkpoint("S-new", item, "2026-08-05T10:00:00Z")
+    messages = [{"role": "user", "content": "the durable sentence", "id": "u-1"}]
+
+    serializer.verify_quotes(
+        cp, "user: the durable sentence", messages,
+        source_ref=_source("S-new"), transcript_hash=_HASH)
+
+    assert item["quote_verified"] is True
+    assert item["last_verified"] == item["quote_provenance"]["checked_at"]
+    assert item["quote_provenance"]["outcome"] == "verified"
+    assert item["quote_provenance"]["binding"] == {
+        "mode": "message-ids", "message_ids": ["u-1"]}
+
+
+def test_verify_quotes_miss_keeps_complete_negative_receipt():
+    item = {"text": "decision", "trust": "verbatim", "quote": "not present"}
+    cp = _checkpoint("S-new", item, "2026-08-05T10:00:00Z")
+
+    serializer.verify_quotes(
+        cp, "user: different text", source_ref=_source("S-new"),
+        transcript_hash=_HASH)
+
+    assert item["trust"] == "inferred"
+    assert item["quote_verified"] is False
+    assert "last_verified" not in item
+    assert item["quote_provenance"]["outcome"] == "not-verified"
+    assert item["quote_provenance"]["binding"] == {
+        "mode": "transcript-scan", "message_ids": []}
+
+
+def test_model_cannot_self_issue_source_or_quote_receipt():
+    receipt = _receipt()
+    item = {"text": "claim", "trust": "inferred", "quote_provenance": receipt}
+    cp = _checkpoint("S-new", item, "2026-08-05T10:00:00Z")
+    cp["source_ref"] = _source("S-new")
+
+    serializer.strip_code_owned_keys(cp)
+
+    assert "source_ref" not in cp
+    assert "quote_provenance" not in item
+
+
+def test_resolver_unique_ambiguous_absent_remote_and_unsupported(tmp_path):
+    claude = tmp_path / ".claude" / "projects"
+    one = claude / "one"
+    one.mkdir(parents=True)
+    target = one / "S-one.jsonl"
+    target.write_text("{}\n", encoding="utf-8")
+    two = claude / "two"
+    two.mkdir()
+    duplicate = two / "S-duplicate.jsonl"
+    duplicate.write_text("{}\n", encoding="utf-8")
+    (one / "S-duplicate.jsonl").write_text("{}\n", encoding="utf-8")
+    resolver = provenance.SourceResolver(
+        home=tmp_path, codex_home=tmp_path / ".codex",
+        claude_projects=claude, current_author="alice")
+
+    found = resolver.resolve(_source("S-one"))
+    assert found.state == "resolved" and found.path == target
+
+    assert resolver.resolve(_source("S-duplicate")).state == "ambiguous"
+
+    assert resolver.resolve(_source("S-none")).state == "absent-local"
+    assert resolver.resolve(_source("S-none", author="bob")).state == "remote-author"
+    assert resolver.resolve(_source("S-none", author="unknown")).state == "absent-local"
+    manual = dict(_source("S-manual"), host="manual", locator="unsupported")
+    assert resolver.resolve(manual).state == "unsupported"
+    assert resolver.resolve({"source": "../../escape"}).state == "unsupported"
+
+
+def test_resolver_local_candidate_wins_over_different_author(tmp_path):
+    claude = tmp_path / ".claude" / "projects" / "slug"
+    claude.mkdir(parents=True)
+    target = claude / "S-team.jsonl"
+    target.write_text("{}\n", encoding="utf-8")
+    resolver = provenance.SourceResolver(
+        home=tmp_path, claude_projects=claude.parent,
+        current_author="alice")
+
+    result = resolver.resolve(_source("S-team", author="bob"))
+    assert result.state == "resolved"
+
+
+def test_resolver_supports_codex_recursive_sessions(tmp_path):
+    codex = tmp_path / ".codex"
+    target = codex / "sessions" / "2026" / "08" / "S-codex.jsonl"
+    target.parent.mkdir(parents=True)
+    target.write_text("{}\n", encoding="utf-8")
+    resolver = provenance.SourceResolver(home=tmp_path, codex_home=codex)
+
+    result = resolver.resolve(_source("S-codex", host="codex"))
+    assert result.state == "resolved" and result.path == target
+
+
+def test_resolver_reports_unreadable_without_fallback(tmp_path, monkeypatch):
+    claude = tmp_path / ".claude" / "projects" / "slug"
+    claude.mkdir(parents=True)
+    target = claude / "S-denied.jsonl"
+    target.write_text("{}\n", encoding="utf-8")
+    real_open = Path.open
+
+    def denied(path, *args, **kwargs):
+        if path == target:
+            raise PermissionError("denied")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", denied)
+    resolver = provenance.SourceResolver(
+        home=tmp_path, claude_projects=claude.parent)
+    assert resolver.resolve(_source("S-denied")).state == "unreadable"
+
+
+def test_resolver_rejects_symlink_escape_from_managed_root(tmp_path):
+    root = tmp_path / ".claude" / "projects"
+    bucket = root / "slug"
+    bucket.mkdir(parents=True)
+    outside = tmp_path / "outside.jsonl"
+    outside.write_text("{}\n", encoding="utf-8")
+    (bucket / "S-link.jsonl").symlink_to(outside)
+    resolver = provenance.SourceResolver(home=tmp_path, claude_projects=root)
+
+    assert resolver.resolve(_source("S-link")).state == "absent-local"
+
+
+def test_carried_receipt_survives_source_checkpoint_gc(
+    tmp_path, tmp_checkpoint_dir, monkeypatch
+):
+    monkeypatch.setenv("DAIMON_CHECKPOINT_KEEP", "1")
+    monkeypatch.setenv("DAIMON_CHECKPOINT_HISTORY", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    claude = tmp_path / ".claude" / "projects" / "slug"
+    claude.mkdir(parents=True)
+    transcript = claude / "S-origin.jsonl"
+    transcript.write_text('{"role":"user","content":"durable quote"}\n',
+                          encoding="utf-8")
+    receipt = _receipt()
+    origin_item = {
+        "text": "durable claim", "trust": "verbatim", "quote": "durable quote",
+        "quote_provenance": receipt,
+    }
+    store.write_checkpoint(
+        "S-origin", _checkpoint("S-origin", origin_item,
+                                "2026-08-05T10:00:00Z"), project_dir="/p/A")
+
+    carried = dict(origin_item, carried_from="S-origin")
+    store.write_checkpoint(
+        "S-current", _checkpoint("S-current", carried,
+                                 "2026-08-05T11:00:00Z"), project_dir="/p/A")
+
+    assert store.read_checkpoint("S-origin") is None
+    current = store.read_checkpoint("S-current")
+    kept = current["working_context"]["open_questions"][0]
+    assert provenance.valid_quote_receipt(kept["quote_provenance"])
+    resolver = provenance.SourceResolver(
+        home=tmp_path, claude_projects=claude.parent, current_author="alice")
+    assert resolver.resolve(kept["quote_provenance"]["source"]).state == "resolved"

--- a/plugin/tests/test_quote_verification.py
+++ b/plugin/tests/test_quote_verification.py
@@ -952,6 +952,25 @@ def test_audit_quotes_resolves_codex_receipt_source(
     assert "origin-resolved: 1" in out
 
 
+def test_audit_source_helpers_reject_unbound_items_and_use_origin_source(
+    monkeypatch,
+):
+    source = {
+        "version": provenance.SOURCE_REF_VERSION,
+        "host": "codex",
+        "session_id": "S-origin",
+        "locator": "managed",
+    }
+    monkeypatch.setattr(
+        store, "read_checkpoint", lambda session_id: {"source_ref": source})
+
+    assert cli._legacy_audit_source("../escape") is None
+    assert cli._audit_item_source({}) == (None, None)
+    assert cli._audit_item_source({"origin_session": "S-origin"}) == (
+        source, None)
+    assert cli._resolve_audit_source({}, object(), {}) is None
+
+
 # ---- #503: audit resolves a CARRIED item against its ORIGIN transcript ----
 #
 # carry.merge copies `quote` and `source_message_ids` forward when an item

--- a/plugin/tests/test_quote_verification.py
+++ b/plugin/tests/test_quote_verification.py
@@ -6,7 +6,7 @@ import logging
 
 import pytest
 
-from daimon_briefing import cli, serializer, store, transcript
+from daimon_briefing import cli, provenance, serializer, store, transcript
 from tests.conftest import FIXTURES, make_messages
 
 
@@ -890,6 +890,68 @@ def test_audit_quotes_stale_id_falls_back_to_whole_scan(
     assert "failed: 0" in out
 
 
+def test_audit_quotes_uses_receipt_binding_not_flat_compatibility_field(
+    tmp_checkpoint_dir, _projects_dir, capsys
+):
+    slug = store.project_slug("/p/A")
+    _write_id_transcript(_projects_dir, slug, "SA", [
+        ("user", "we adopt the durable provenance receipt", "u-right"),
+        ("assistant", "unrelated response", "u-wrong"),
+    ])
+    source = {"version": 1, "host": "claude-code", "session_id": "SA",
+              "locator": "managed", "author": "alice"}
+    receipt = provenance.quote_receipt(
+        source, {"algorithm": "sha256", "scope": "raw-file",
+                 "value": "a" * 64},
+        outcome="verified", checked_at="2026-08-05T10:00:00Z",
+        binding_mode="message-ids", message_ids=["u-right"])
+    cp = _stored_checkpoint("SB", slug, [{
+        "text": "bound decision", "trust": "verbatim",
+        "quote": "adopt the durable provenance receipt",
+        "source_message_ids": ["u-wrong"],  # stale compatibility mirror
+        "quote_provenance": receipt, "id": "d-receipt",
+    }])
+    store.write_checkpoint("SB", cp, project_dir="/p/A")
+
+    assert cli.main(["audit-quotes", "--project", "/p/A"]) == 0
+    out = capsys.readouterr().out
+    assert "id-resolved: 1" in out
+    assert "verified: 1" in out
+
+
+def test_audit_quotes_resolves_codex_receipt_source(
+    tmp_checkpoint_dir, tmp_path, capsys, monkeypatch
+):
+    codex_home = tmp_path / ".codex"
+    path = codex_home / "sessions" / "2026" / "08" / "S-codex.jsonl"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({
+        "type": "event_msg",
+        "payload": {"type": "user_message",
+                    "message": "the codex source supports this quote"},
+    }) + "\n", encoding="utf-8")
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    slug = store.project_slug("/p/A")
+    source = {"version": 1, "host": "codex", "session_id": "S-codex",
+              "locator": "managed", "author": "alice"}
+    receipt = provenance.quote_receipt(
+        source, {"algorithm": "sha256", "scope": "raw-file",
+                 "value": "b" * 64},
+        outcome="verified", checked_at="2026-08-05T10:00:00Z",
+        binding_mode="transcript-scan")
+    cp = _stored_checkpoint("S-containing", slug, [{
+        "text": "codex decision", "trust": "verbatim",
+        "quote": "codex source supports this quote",
+        "quote_provenance": receipt, "id": "d-codex",
+    }])
+    store.write_checkpoint("S-containing", cp, project_dir="/p/A")
+
+    assert cli.main(["audit-quotes", "--project", "/p/A"]) == 0
+    out = capsys.readouterr().out
+    assert "verified: 1" in out
+    assert "origin-resolved: 1" in out
+
+
 # ---- #503: audit resolves a CARRIED item against its ORIGIN transcript ----
 #
 # carry.merge copies `quote` and `source_message_ids` forward when an item
@@ -948,13 +1010,11 @@ def test_audit_quotes_item_without_origin_falls_back_to_containing_checkpoint(
     assert "failed: 0" in out
 
 
-def test_audit_quotes_missing_origin_transcript_falls_back_without_crashing(
+def test_audit_quotes_missing_origin_transcript_never_falls_back(
     tmp_checkpoint_dir, _projects_dir, capsys
 ):
-    """origin_session names a session whose transcript is nowhere on disk
-    (GC'd, never captured on this host, wrong host layout). Resolution must
-    fall back to the containing checkpoint's own transcript rather than
-    crash or silently drop the item."""
+    """An unresolved bound/inferred source stays unresolved. The containing
+    transcript is not provenance and must never rescue the verdict (#594)."""
     slug = store.project_slug("/p/A")
     _write_transcript(_projects_dir, slug, "SB", [
         ("user", "this quote is only in the containing session after all"),
@@ -969,8 +1029,8 @@ def test_audit_quotes_missing_origin_transcript_falls_back_without_crashing(
     rc = cli.main(["audit-quotes", "--project", "/p/A"])
     out = capsys.readouterr().out
     assert rc == 0
-    assert "verified: 1" in out
-    assert "failed: 0" in out
+    assert "verbatim quotes checked: 0" in out
+    assert "verified: 0" in out
 
 
 def test_audit_quotes_source_ids_resolve_against_origin_transcript(
@@ -1059,12 +1119,11 @@ def test_audit_quotes_reads_origin_slug_from_the_origin_checkpoint(
     assert "origin-resolved: 1" in out
 
 
-def test_audit_quotes_unreadable_origin_transcript_falls_back(
+def test_audit_quotes_unreadable_origin_transcript_never_falls_back(
     tmp_checkpoint_dir, _projects_dir, capsys, monkeypatch
 ):
-    """A transcript that resolves to a path but cannot be READ (permissions,
-    truncation mid-read) must degrade to the containing session, not crash the
-    whole corpus scan."""
+    """An unreadable evidence source is uncheckable, even when the containing
+    session happens to repeat the quote. No provenance substitution (#594)."""
     slug = store.project_slug("/p/A")
     _write_transcript(_projects_dir, slug, "SA", [("user", "origin text here")])
     _write_transcript(_projects_dir, slug, "SB", [
@@ -1086,8 +1145,8 @@ def test_audit_quotes_unreadable_origin_transcript_falls_back(
 
     assert cli.main(["audit-quotes", "--project", "/p/A"]) == 0
     out = capsys.readouterr().out
-    # Fell back to SB's own transcript, which does contain the quote.
-    assert "verified: 1" in out
+    assert "verbatim quotes checked: 0" in out
+    assert "verified: 0" in out
     assert "origin-resolved: 0" in out
 
 

--- a/plugin/tests/test_windsurf_hooks.py
+++ b/plugin/tests/test_windsurf_hooks.py
@@ -72,6 +72,11 @@ def _post_payload(response="### Planner Response\n\nDone."):
     }
 
 
+def test_serialize_spawns_tag_the_windsurf_capture_host():
+    src = HOOK.read_text(encoding="utf-8")
+    assert 'project_env(cwd, "windsurf")' in src
+
+
 def _fake_cli(tmp_path):
     """A fake `daimon` on PATH that records its argv."""
     fake_bin = tmp_path / "fakebin"


### PR DESCRIPTION
## Summary

- Attach self-contained quote provenance receipts and code-owned source references to new checkpoints.
- Make carry and freeze behavior atomic, preserving or invalidating receipts according to whether exact quoted text survives.
- Resolve supported host session sources strictly, add capture-host hints, and migrate `audit-quotes` to receipt-first verification.
- Add parity, compatibility, security, and performance regression coverage across hooks and serialization.

## Why

Trust should travel with each quoted item. Flat compatibility metadata and inferred source discovery can become ambiguous after checkpoints are carried or source files move. This makes quote verification explicit, durable, and bounded.

## Impact

New quotes carry compact, verifiable provenance. Legacy checkpoints remain readable and are handled conservatively. Claude, Codex, and Windsurf use managed resolution; Gemini and Hermes report unsupported or hint-based outcomes.

This is the prerequisite implementation for #502.

## Validation

- `uv run --all-extras pytest -q` — 2,940 passed, 2 skipped
- `uv run --all-extras ruff check .`
- `python3 scripts/sync_hooks.py --check`
- `git diff --check`
- No build was run, per repository instructions.

Closes #594
