### PR TITLE
feat(cli): add trust inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ That's it. End a session → a checkpoint is written; start the next → the bri
 ## Beyond the briefing
 
 - **`daimon recall <terms>`** — full-text search over your whole checkpoint history (and your team's, if enabled).
+- **`daimon why <item-id>`** — inspect a recalled item's independent capture, provenance, source, byte-integrity, current-support, verifier, lifecycle, and corroboration evidence. Add `--source` for one bounded redacted source window. See the [Trust Inspector guide](docs/trust-inspector.md).
 - **Context switching** — `daimon projects`, `daimon brief --slug <slug>`: read another project's memory deliberately, provenance-labeled — never automatic.
 - **Proactive recall** — when a new prompt overlaps prior work from an older session, the briefing surfaces it, in English or Spanish.
 - **Code anchors** — `daimon anchor <file> <symbol>` pins a belief to a code symbol; drift is flagged in the next briefing. Offline, stdlib `ast`.
@@ -92,7 +93,7 @@ That's it. End a session → a checkpoint is written; start the next → the bri
 | Surface | State |
 |---------|-------|
 | Claude Code plugin + hooks | live-validated daily |
-| CLI (`brief`, `status`, `recall`, `projects`, `heal`, `anchor`, `forget`, `configure`, `hooks`, `skill`) | stable, on PyPI |
+| CLI (`brief`, `status`, `recall`, `why`, `projects`, `heal`, `anchor`, `forget`, `configure`, `hooks`, `skill`) | stable, on PyPI |
 | Windsurf adapter | live-validated |
 | Codex adapter | shipped, awaiting first live run |
 | Gemini host hooks | blocked upstream (`gemini-cli#14715`) |

--- a/docs/trust-inspector.md
+++ b/docs/trust-inspector.md
@@ -1,0 +1,86 @@
+# Trust Inspector
+
+`daimon why` explains what Daimon can prove about one recalled item without
+collapsing several kinds of evidence into a trust score.
+
+The normal workflow is:
+
+```console
+daimon recall retry policy
+daimon why o-3f8a2c
+daimon resolve o-3f8a2c --dry-run
+daimon resolve o-3f8a2c --note "shipped in 0.27.0"
+```
+
+`recall` prints the exact item ID in brackets. `why` is project-scoped by
+default, just like `recall`; use `--project PATH` or `--slug SLUG` to name a
+different scope explicitly. It never guesses across projects.
+
+## Reading the evidence
+
+The inspector reports independent axes because they can legitimately disagree:
+
+| Axis | Values | Meaning |
+| --- | --- | --- |
+| Capture | `verified`, `not-verified`, `unknown` | The deterministic capture-time quote verdict recorded in a durable receipt. |
+| Provenance | `bound`, `legacy-inferred`, `legacy-unbound` | Whether the quote carries a self-contained source receipt or only older diagnostic metadata. |
+| Locator | `resolved`, `absent-local`, `unsupported`, `ambiguous`, `unreadable`, `remote-author` | Whether the strict host resolver can identify exactly one readable local source. |
+| Bytes | `unchanged`, `changed`, `unknown` | Whether current source bytes reproduce the receipt digest. |
+| Current support | `message-id-match`, `transcript-scan-match`, `not-reproduced`, `not-checked` | Whether the stored quote can be reproduced now. |
+| Verifier | `same-version`, `different-version`, `unknown` | Whether the current deterministic verifier matches the recorded verifier. |
+| Lifecycle | `active`, `resolved`, `forgotten`, `superseded` | The latest append-only lifecycle state. |
+
+Corroboration is shown separately as a count and source-session references. It
+does not modify any evidence axis.
+
+For example, these facts can coexist:
+
+```text
+Now: capture verified; source changed; quote supported by its bound message
+Bytes: changed
+Current support: message-id-match
+```
+
+That does not mean the item is fabricated or invalid. It means the complete
+source file changed while the bound message still supports the quote. The axes
+preserve that distinction instead of inventing one verdict.
+
+## JSON
+
+Use `--json` for automation:
+
+```console
+daimon why o-3f8a2c --json
+```
+
+The V1 document has `schema_version`, stable values under `axes`, item metadata,
+corroboration references, the durable receipt when one exists, and no derived
+`summary` field. Scripts should inspect the axes they actually care about.
+
+Exit codes describe command execution, not epistemic state:
+
+- `0`: the uniquely scoped item was rendered, including degraded evidence states;
+- `1`: the item was not found in that project;
+- `2`: invalid arguments or item-ID shape.
+
+## Source disclosure
+
+Default output is metadata-only and prints no raw transcript excerpt. Add
+`--source` deliberately:
+
+```console
+daimon why o-3f8a2c --source
+```
+
+When validated message bindings are available, Daimon reads the raw source in
+memory, extracts at most three bound messages and 600 collapsed characters,
+then redacts once at the final display boundary. It never persists the excerpt
+or prints an absolute transcript path.
+
+When exact bindings are unavailable, the inspector shows the already-redacted
+stored quote and states that the exact raw message span cannot be reconstructed
+safely. It does not redact stored evidence a second time.
+
+`not-reproduced` is a current observation, not an accusation. Sources can be
+edited, truncated, migrated, or parsed differently by a newer host adapter.
+Use the other axes to understand which condition actually changed.

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -30,7 +30,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from . import anchor, briefing, capture, carry, config, configure, harvest, ledger, llm, normalize, provenance, recall, receipts, redact, render, schema, serializer, store, teamsync, transcript, worldcheck
+from . import anchor, briefing, capture, carry, config, configure, harvest, inspector, ledger, llm, normalize, provenance, recall, receipts, redact, render, schema, serializer, store, teamsync, transcript, worldcheck
 from . import __version__
 
 # The serialize.log ledger subsystem lives in ledger.py (#147 + #162, pure
@@ -750,9 +750,34 @@ def _cmd_recall(args) -> int:
                       else " [resolved]" if sup == "resolved"
                       else f" [superseded by {sup}]")
         trust = r.get("trust") or "untagged"
-        lines.append(f"[{r['author']}] [{trust}] [{r['kind']}] {r['text']} "
+        item_id = f" [{r['item_id']}]" if r.get("item_id") else ""
+        lines.append(f"[{r['author']}] [{trust}] [{r['kind']}]{item_id} {r['text']} "
                      f"({r['session_id']}, {age} ago){superseded}")
     render.render_recall_lines(lines)
+    return 0
+
+
+def _cmd_why(args) -> int:
+    """Render one project-scoped, read-side trust receipt (#502)."""
+    _note_usage("why")
+    if args.slug and args.project:
+        print("error: --slug and --project are two answers to \"which bucket\" "
+              "— pass one", file=sys.stderr)
+        return 2
+    if not inspector.valid_item_id(args.item_id):
+        print("error: invalid item id — expected "
+              "[a-z]-[0-9a-f]{6,40}(-N)?", file=sys.stderr)
+        return 2
+    project = args.slug or _resolve_project(args.project)
+    result = inspector.inspect_item(
+        project, args.item_id, include_source=args.source)
+    if result is None:
+        print(f"no item {args.item_id!r} in this project", file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    else:
+        render.render_recall_lines(inspector.human_lines(result))
     return 0
 
 
@@ -3395,6 +3420,28 @@ def build_parser() -> argparse.ArgumentParser:
         "--limit", type=int, default=20, help="max results (default: 20)"
     )
     p_recall.set_defaults(func=_cmd_recall)
+
+    p_why = sub.add_parser(
+        "why", help="inspect the evidence and lifecycle receipt for one item",
+        epilog="Examples:\n"
+               "  daimon recall retry policy\n"
+               "  daimon why o-3f8a2c\n"
+               "  daimon why o-3f8a2c --source --json\n",
+    )
+    p_why.add_argument(
+        "item_id", help="exact item id shown by `daimon recall` or `daimon loops`")
+    p_why.add_argument(
+        "--source", action="store_true",
+        help="show one bounded, redacted message-level source window")
+    p_why.add_argument(
+        "--json", action="store_true", help="machine-readable evidence axes")
+    p_why.add_argument(
+        "--project",
+        help="project directory to scope to (default: DAIMON_PROJECT_DIR, then cwd)")
+    p_why.add_argument(
+        "--slug", metavar="SLUG",
+        help="scope to a project bucket by its slug (see `daimon projects`)")
+    p_why.set_defaults(func=_cmd_why)
 
     p_projects = sub.add_parser(
         "projects", help="list every project daimon has a checkpoint for",

--- a/plugin/daimon_briefing/inspector.py
+++ b/plugin/daimon_briefing/inspector.py
@@ -1,0 +1,383 @@
+"""Read-side trust inspection for one project-scoped cognitive item (#502).
+
+The inspector keeps evidence axes independent.  It never turns a changed
+source into a failed quote verdict, never treats a missing local transcript as
+an unsupported host, and never promotes legacy origin metadata into a bound
+receipt.  Filesystem paths remain internal to the resolver and are never
+returned to CLI or JSON consumers.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+from . import config, provenance, redact, schema, serializer, store, transcript
+
+
+SCHEMA_VERSION = 1
+_ITEM_ID_RE = re.compile(r"^[a-z]-[0-9a-f]{6,40}(?:-[0-9]+)?$")
+_SOURCE_MESSAGE_LIMIT = 3
+_SOURCE_CHAR_LIMIT = 600
+_WS_RE = re.compile(r"\s+")
+_REDACTION_MARKER_RE = re.compile(r"\[redacted:[^\]\r\n]+\]")
+_KINDS = {(field.section, field.key): field.kind for field in schema.ITEM_FIELDS}
+
+
+def valid_item_id(value) -> bool:
+    """The bounded exact-id contract exposed by ``daimon why``."""
+    return isinstance(value, str) and _ITEM_ID_RE.fullmatch(value) is not None
+
+
+def _read_checkpoint(path: Path) -> dict | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, ValueError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _project_checkpoints(project_dir) -> list[dict]:
+    """One authoritative payload per session, newest first.
+
+    ``project_surfaces`` deliberately includes rotation pointers and flat
+    per-session files.  A session may therefore appear several times.  Prefer
+    its immutable flat session file when it survives GC, otherwise choose one
+    pointer deterministically.  Path identity never leaves this function.
+    """
+    root = config.checkpoint_dir()
+    chosen: dict[str, tuple[tuple[int, str], dict]] = {}
+    for path in store.project_surfaces(project_dir):
+        checkpoint = _read_checkpoint(path)
+        if checkpoint is None:
+            continue
+        session_id = checkpoint.get("session_id")
+        if not isinstance(session_id, str) or not session_id:
+            continue
+        immutable = int(path.parent == root and path.name == f"{session_id}.json")
+        rank = (immutable, str(path))
+        current = chosen.get(session_id)
+        if current is None or rank > current[0]:
+            chosen[session_id] = (rank, checkpoint)
+
+    def recency(checkpoint: dict) -> tuple[float, str]:
+        return (store._created_epoch(checkpoint.get("created")) or 0.0,
+                str(checkpoint.get("session_id") or ""))
+
+    return sorted((entry[1] for entry in chosen.values()),
+                  key=recency, reverse=True)
+
+
+def _item_occurrences(project_dir, item_id: str) -> list[dict]:
+    occurrences = []
+    for checkpoint in _project_checkpoints(project_dir):
+        for section, key in store._ITEM_LISTS:
+            for item in ((checkpoint.get(section) or {}).get(key) or []):
+                if isinstance(item, dict) and item.get("id") == item_id:
+                    occurrences.append({
+                        "checkpoint": checkpoint,
+                        "item": item,
+                        "kind": _KINDS.get((section, key), key),
+                    })
+    return occurrences
+
+
+def _legacy_source(item: dict) -> dict | None:
+    session_id = item.get("origin_session")
+    if not provenance.valid_session_id(session_id):
+        return None
+    origin = store.read_checkpoint(session_id)
+    if isinstance(origin, dict):
+        source = origin.get("source_ref")
+        if provenance.valid_source_ref(source):
+            return source
+    source = {
+        "version": provenance.SOURCE_REF_VERSION,
+        "host": "claude-code",
+        "session_id": session_id,
+        "locator": "managed",
+    }
+    author = item.get("origin_author")
+    if isinstance(author, str) and author.strip():
+        source["author"] = author.strip()
+    return source
+
+
+def _lifecycle(event) -> str:
+    if not isinstance(event, dict):
+        return "active"
+    status = str(event.get("status") or "").lower()
+    if status.startswith("forgotten:"):
+        return "forgotten"
+    if status.startswith("superseded-by:"):
+        return "superseded"
+    return "resolved" if store.is_resolved(event) else "active"
+
+
+def _messages(path: Path) -> list[dict] | None:
+    try:
+        return transcript.from_file(path)
+    except (OSError, UnicodeError, ValueError):
+        return None
+
+
+def _rendered_digest(messages: list[dict]) -> str:
+    rendered = serializer._render_transcript(
+        serializer.extraction_messages(messages))
+    return hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+
+
+def _bytes_axis(receipt, resolution, messages) -> str:
+    if not provenance.valid_quote_receipt(receipt):
+        return "unknown"
+    if resolution.state != "resolved" or resolution.path is None:
+        return "unknown"
+    digest = receipt["digest"]
+    if digest["scope"] == "raw-file":
+        current = transcript.file_sha256(resolution.path)
+    elif messages is not None:
+        current = _rendered_digest(messages)
+    else:
+        current = None
+    if current is None:
+        return "unknown"
+    return "unchanged" if current == digest["value"] else "changed"
+
+
+def _safe_texts_by_id(messages: list[dict]) -> dict[str, str]:
+    raw = serializer.message_texts_by_id(messages)
+    daimon_ids = serializer.daimon_output_ids(messages)
+    return {
+        message_id: "" if message_id in daimon_ids
+        else serializer.strip_injected(text)
+        for message_id, text in raw.items()
+    }
+
+
+def _support_axis(item, receipt, resolution, messages) -> str:
+    quote = item.get("quote") if isinstance(item, dict) else None
+    if (not isinstance(quote, str) or not quote.strip()
+            or resolution.state != "resolved" or messages is None):
+        return "not-checked"
+    texts_by_id = _safe_texts_by_id(messages)
+    message_ids = provenance.binding_message_ids(receipt)
+    if message_ids and all(message_id in texts_by_id for message_id in message_ids):
+        scoped = "\n\n".join(texts_by_id[message_id]
+                              for message_id in message_ids)
+        if serializer.quote_matches(quote, scoped):
+            return "message-id-match"
+    haystack = serializer.stripped_transcript(messages)
+    if serializer.quote_matches(quote, haystack):
+        return "transcript-scan-match"
+    return "not-reproduced"
+
+
+def _message_by_id(messages: list[dict]) -> dict[str, dict]:
+    out = {}
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        message_id = message.get("id")
+        if isinstance(message_id, str) and message_id:
+            out[message_id] = message
+    return out
+
+
+def _cap_disclosed_source(value: str) -> tuple[str, bool]:
+    """Cap display text without splitting a final-boundary redaction marker."""
+    if len(value) <= _SOURCE_CHAR_LIMIT:
+        return value, False
+
+    cut = _SOURCE_CHAR_LIMIT - 1
+    for match in _REDACTION_MARKER_RE.finditer(value):
+        if match.start() < cut < match.end():
+            marker = match.group(0)
+            prefix_limit = _SOURCE_CHAR_LIMIT - len(marker) - 2
+            prefix = value[:prefix_limit].rstrip()
+            return f"{prefix}…{marker}…", True
+    return value[:cut].rstrip() + "…", True
+
+
+def _bounded_source(item, receipt, resolution, messages) -> dict:
+    """Return a display-safe excerpt without persisting or exposing a path."""
+    quote = item.get("quote") if isinstance(item, dict) else None
+    message_ids = provenance.binding_message_ids(receipt)
+    if (resolution.state == "resolved" and messages is not None and message_ids):
+        by_id = _message_by_id(messages)
+        if all(message_id in by_id for message_id in message_ids):
+            parts = []
+            for message_id in message_ids[:_SOURCE_MESSAGE_LIMIT]:
+                message = by_id[message_id]
+                role = str(message.get("role") or "unknown")
+                content = str(message.get("content") or "")
+                parts.append(f"{role}: {content}")
+            raw = _WS_RE.sub(" ", " ".join(parts)).strip()
+            # Redact BEFORE the character cap.  Cutting a credential-shaped
+            # token in half first could stop the detector matching and expose
+            # a real prefix at the boundary.  This remains exactly one pass at
+            # the final display boundary; only the message-count bound is
+            # applied earlier.
+            safe, _counts = redact.redact_text(raw)
+            safe, char_truncated = _cap_disclosed_source(safe)
+            return {
+                "kind": "message-window",
+                "text": safe,
+                "message_ids": message_ids[:_SOURCE_MESSAGE_LIMIT],
+                "truncated": (len(message_ids) > _SOURCE_MESSAGE_LIMIT
+                              or char_truncated),
+            }
+    if isinstance(quote, str) and quote.strip():
+        # Stored quotes already crossed the capture redaction boundary.  Do not
+        # redact twice: a second pass can mutate visible evidence markers.
+        return {
+            "kind": "stored-quote",
+            "text": quote,
+            "message_ids": [],
+            "truncated": False,
+            "note": "exact raw message span is unavailable; showing the stored quote",
+        }
+    return {
+        "kind": "unavailable",
+        "text": None,
+        "message_ids": [],
+        "truncated": False,
+        "note": "no bounded source excerpt is available",
+    }
+
+
+def inspect_item(project_dir, item_id: str, *, include_source: bool = False,
+                 resolver=None) -> dict | None:
+    """Inspect one exact item inside one explicit project scope."""
+    occurrences = _item_occurrences(project_dir, item_id)
+    resolutions = store.resolutions(project_dir=project_dir)
+    event = resolutions.get(item_id)
+    if not occurrences and event is None:
+        return None
+
+    if occurrences:
+        selected = occurrences[0]
+        checkpoint = selected["checkpoint"]
+        item = selected["item"]
+        kind = selected["kind"]
+    else:
+        checkpoint = {}
+        item = {}
+        kind = "unknown"
+
+    receipt = item.get("quote_provenance")
+    bound = provenance.valid_quote_receipt(receipt)
+    if bound:
+        source = receipt["source"]
+        provenance_axis = "bound"
+    else:
+        source = _legacy_source(item)
+        provenance_axis = "legacy-inferred" if source is not None else "legacy-unbound"
+
+    if resolver is None:
+        resolver = provenance.SourceResolver(
+            claude_projects=config.claude_projects_dir(),
+            current_author=config.author())
+    resolution = (resolver.resolve(source) if source is not None
+                  else provenance.SourceResolution("unsupported"))
+    messages = (_messages(resolution.path)
+                if resolution.state == "resolved" and resolution.path is not None
+                else None)
+
+    capture = receipt["outcome"] if bound else "unknown"
+    verifier = "unknown"
+    if bound:
+        current = (provenance.QUOTE_VERIFIER_ID,
+                   provenance.QUOTE_VERIFIER_VERSION)
+        recorded = (receipt["verifier"]["id"],
+                    receipt["verifier"]["version"])
+        verifier = "same-version" if recorded == current else "different-version"
+
+    corroboration = store.corroborations(project_dir=project_dir).get(item_id, {})
+    references = sorted(corroboration.get("origins") or ())
+    result = {
+        "schema_version": SCHEMA_VERSION,
+        "item": {
+            "item_id": item_id,
+            "kind": kind,
+            "text": item.get("text"),
+            "trust": item.get("trust"),
+            "quote": item.get("quote"),
+            "author": checkpoint.get("author"),
+            "project_slug": store.project_slug(project_dir),
+            "session_id": checkpoint.get("session_id"),
+            "origin_session": item.get("origin_session"),
+            "occurrences": len(occurrences),
+        },
+        "axes": {
+            "capture": capture,
+            "provenance": provenance_axis,
+            "locator": resolution.state,
+            "bytes": _bytes_axis(receipt, resolution, messages),
+            "current_support": _support_axis(
+                item, receipt, resolution, messages),
+            "verifier_comparison": verifier,
+            "lifecycle": _lifecycle(event),
+        },
+        "corroboration": {
+            "count": len(references),
+            "references": references,
+        },
+        "receipt": receipt if bound else None,
+        "source": source,
+        "lifecycle_event": ({
+            "status": event.get("status"),
+            "timestamp": event.get("ts"),
+            "source": event.get("source"),
+        } if isinstance(event, dict) else None),
+    }
+    if include_source:
+        result["source_excerpt"] = _bounded_source(
+            item, receipt, resolution, messages)
+    return result
+
+
+def human_lines(result: dict) -> list[str]:
+    """Compact human rendering; JSON intentionally has no derived summary."""
+    item = result["item"]
+    axes = result["axes"]
+    support = {
+        "message-id-match": "quote supported by its bound message",
+        "transcript-scan-match": "quote supported by transcript scan",
+        "not-reproduced": "quote not reproduced",
+        "not-checked": "quote not checked",
+    }[axes["current_support"]]
+    source_state = ({
+        "unchanged": "source unchanged",
+        "changed": "source changed",
+        "unknown": f"source bytes unknown ({axes['locator']})",
+    }[axes["bytes"]])
+    lines = [
+        f"Now: capture {axes['capture']}; {source_state}; {support}",
+        f"Item: [{item['item_id']}] [{item['kind']}] "
+        f"{item.get('text') or '(content unavailable)'}",
+        f"Capture: {axes['capture']}",
+        f"Provenance: {axes['provenance']}",
+        f"Locator: {axes['locator']}",
+        f"Bytes: {axes['bytes']}",
+        f"Current support: {axes['current_support']}",
+        f"Verifier: {axes['verifier_comparison']}",
+        f"Lifecycle: {axes['lifecycle']}",
+    ]
+    corroboration = result["corroboration"]
+    refs = ", ".join(corroboration["references"])
+    lines.append(
+        f"Corroboration: {corroboration['count']}"
+        + (f" ({refs})" if refs else ""))
+    source = result.get("source")
+    if isinstance(source, dict):
+        lines.append(
+            f"Source: {source.get('host', 'unknown')} session "
+            f"{source.get('session_id', 'unknown')}")
+    excerpt = result.get("source_excerpt")
+    if isinstance(excerpt, dict):
+        lines.append(f"Source excerpt: {excerpt.get('text') or '(unavailable)'}")
+        if excerpt.get("note"):
+            lines.append(f"Source note: {excerpt['note']}")
+    return lines

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -702,7 +702,7 @@ def search(query: str, project_dir=None, all_projects: bool = False,
     sql = (
         "SELECT i.text, i.quote, i.trust, i.kind, i.author, i.project_slug,"
         " i.session_id, i.created, i.superseded_by, i.invalidated_by,"
-        " i.importance, i.first_seen, i.frontier,"
+        " i.importance, i.first_seen, i.item_id, i.frontier,"
         " bm25(items_fts) AS rank"
         " FROM items_fts JOIN items i ON i.id = items_fts.rowid"
         " WHERE items_fts MATCH ?"

--- a/plugin/tests/golden/why_bound.json
+++ b/plugin/tests/golden/why_bound.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": 1,
+  "item": {
+    "item_id": "o-abcdef",
+    "kind": "decision",
+    "text": "durable trust decision",
+    "trust": "verbatim",
+    "quote": "durable trust decision",
+    "author": "alice",
+    "project_slug": "-p-A",
+    "session_id": "S-bound",
+    "origin_session": "S-bound",
+    "occurrences": 1
+  },
+  "axes": {
+    "capture": "verified",
+    "provenance": "bound",
+    "locator": "absent-local",
+    "bytes": "unknown",
+    "current_support": "not-checked",
+    "verifier_comparison": "same-version",
+    "lifecycle": "active"
+  },
+  "corroboration": {
+    "count": 0,
+    "references": []
+  },
+  "receipt": {
+    "version": 1,
+    "source": {
+      "version": 1,
+      "host": "claude-code",
+      "session_id": "S-source",
+      "locator": "managed",
+      "author": "alice"
+    },
+    "digest": {
+      "algorithm": "sha256",
+      "scope": "raw-file",
+      "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "verifier": {
+      "id": "tier-f",
+      "version": 1
+    },
+    "outcome": "verified",
+    "checked_at": "2026-08-05T10:00:00Z",
+    "binding": {
+      "mode": "message-ids",
+      "message_ids": [
+        "u-1"
+      ]
+    }
+  },
+  "source": {
+    "version": 1,
+    "host": "claude-code",
+    "session_id": "S-source",
+    "locator": "managed",
+    "author": "alice"
+  },
+  "lifecycle_event": null
+}

--- a/plugin/tests/test_inspector.py
+++ b/plugin/tests/test_inspector.py
@@ -1,0 +1,532 @@
+"""Trust Inspector evidence axes, privacy boundary, and CLI contract (#502)."""
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from daimon_briefing import cli, inspector, provenance, recall, redact, store, transcript
+
+
+_PROJECT = "/p/A"
+_ITEM_ID = "o-abcdef"
+_CHECKED_AT = "2026-08-05T10:00:00Z"
+_GOLDEN = Path(__file__).parent / "golden" / "why_bound.json"
+
+
+def _source(session_id="S-source", *, host="claude-code", locator="managed"):
+    return {
+        "version": provenance.SOURCE_REF_VERSION,
+        "host": host,
+        "session_id": session_id,
+        "locator": locator,
+        "author": "alice",
+    }
+
+
+def _receipt(source, digest, *, outcome="verified", mode="message-ids",
+             message_ids=("u-1",), scope="raw-file"):
+    return provenance.quote_receipt(
+        source,
+        {"algorithm": "sha256", "scope": scope, "value": digest},
+        outcome=outcome,
+        checked_at=_CHECKED_AT,
+        binding_mode=mode,
+        message_ids=message_ids,
+    )
+
+
+def _item(text="durable trust decision", *, item_id=_ITEM_ID,
+          quote="durable trust decision", receipt=None, **extra):
+    value = {
+        "id": item_id,
+        "text": text,
+        "trust": "verbatim" if quote else "inferred",
+    }
+    if quote:
+        value["quote"] = quote
+    if receipt is not None:
+        value["quote_provenance"] = receipt
+        value["quote_verified"] = receipt["outcome"] == "verified"
+    value.update(extra)
+    return value
+
+
+def _checkpoint(session_id, items, created="2026-08-05T10:00:00Z"):
+    return {
+        "session_id": session_id,
+        "created": created,
+        "author": "alice",
+        "working_context": {
+            "active_topic": {"text": "trust inspection", "trust": "inferred"},
+            "open_questions": [],
+            "recent_decisions": items,
+        },
+        "epistemic_snapshot": {
+            "strong_beliefs": [],
+            "uncertainties": [],
+        },
+    }
+
+
+def _write_checkpoint(session_id, items, *, project=_PROJECT,
+                      created="2026-08-05T10:00:00Z"):
+    checkpoint = _checkpoint(session_id, items, created)
+    assert store.write_checkpoint(session_id, checkpoint, project_dir=project)
+    return checkpoint
+
+
+def _write_claude(projects_dir, session_id, messages, *, bucket="bucket"):
+    path = projects_dir / bucket / f"{session_id}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rows = []
+    for role, content, message_id in messages:
+        rows.append(json.dumps({
+            "type": role,
+            "uuid": message_id,
+            "message": {"role": role, "content": content},
+        }))
+    path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+    return path
+
+
+def _resolver(tmp_path, projects_dir):
+    return provenance.SourceResolver(
+        home=tmp_path,
+        codex_home=tmp_path / ".codex",
+        claude_projects=projects_dir,
+        current_author="alice",
+    )
+
+
+@pytest.mark.parametrize("value, expected", [
+    ("o-abcdef", True),
+    ("q-0123456789abcdef-2", True),
+    ("o-abcde", False),
+    ("o-" + "a" * 41, False),
+    ("O-abcdef", False),
+    ("o-abcdeg", False),
+    ("../o-abcdef", False),
+])
+def test_item_id_validation_is_bounded_and_exact(value, expected):
+    assert inspector.valid_item_id(value) is expected
+
+
+def test_bound_receipt_reports_changed_bytes_and_message_support(
+    tmp_checkpoint_dir, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    projects = tmp_path / ".claude" / "projects"
+    path = _write_claude(projects, "S-source", [
+        ("user", "the durable trust decision remains supported", "u-1"),
+    ])
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    receipt = _receipt(_source(), digest)
+    _write_checkpoint("S-containing", [
+        _item(quote="durable trust decision remains supported", receipt=receipt),
+    ])
+    _write_claude(projects, "S-source", [
+        ("user", "the durable trust decision remains supported after editing", "u-1"),
+    ])
+
+    result = inspector.inspect_item(
+        _PROJECT, _ITEM_ID, resolver=_resolver(tmp_path, projects))
+
+    assert result["axes"] == {
+        "capture": "verified",
+        "provenance": "bound",
+        "locator": "resolved",
+        "bytes": "changed",
+        "current_support": "message-id-match",
+        "verifier_comparison": "same-version",
+        "lifecycle": "active",
+    }
+
+
+def test_axes_keep_unchanged_bytes_separate_from_not_reproduced_quote(
+    tmp_checkpoint_dir, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    projects = tmp_path / ".claude" / "projects"
+    path = _write_claude(projects, "S-source", [
+        ("user", "a completely unrelated message", "u-1"),
+    ])
+    receipt = _receipt(
+        _source(), hashlib.sha256(path.read_bytes()).hexdigest())
+    _write_checkpoint("S-containing", [
+        _item(quote="durable trust decision is absent", receipt=receipt),
+    ])
+
+    result = inspector.inspect_item(
+        _PROJECT, _ITEM_ID, resolver=_resolver(tmp_path, projects))
+
+    assert result["axes"]["bytes"] == "unchanged"
+    assert result["axes"]["current_support"] == "not-reproduced"
+    assert "fabricated" not in "\n".join(inspector.human_lines(result)).lower()
+    assert "invalid" not in "\n".join(inspector.human_lines(result)).lower()
+
+
+def test_rendered_digest_and_older_verifier_are_independent_axes(
+    tmp_checkpoint_dir, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    projects = tmp_path / ".claude" / "projects"
+    path = _write_claude(projects, "S-source", [
+        ("user", "durable trust decision", "u-1"),
+    ])
+    digest = inspector._rendered_digest(transcript.from_file(path))
+    receipt = _receipt(_source(), digest, scope="rendered-transcript")
+    receipt["verifier"]["version"] += 1
+    _write_checkpoint("S-containing", [_item(receipt=receipt)])
+
+    result = inspector.inspect_item(
+        _PROJECT, _ITEM_ID, resolver=_resolver(tmp_path, projects))
+
+    assert result["axes"]["bytes"] == "unchanged"
+    assert result["axes"]["current_support"] == "message-id-match"
+    assert result["axes"]["verifier_comparison"] == "different-version"
+
+
+def test_legacy_inferred_and_unbound_items_degrade_explicitly(
+    tmp_checkpoint_dir, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    projects = tmp_path / ".claude" / "projects"
+    _write_claude(projects, "S-legacy", [
+        ("user", "the legacy quote still appears", "u-legacy"),
+    ])
+    legacy_id = "o-aaaaaa"
+    unbound_id = "o-bbbbbb"
+    _write_checkpoint("S-containing", [
+        _item(item_id=legacy_id, quote="legacy quote still appears",
+              origin_session="S-legacy", origin_author="alice"),
+    ])
+    # Pre-origin legacy surface: modern write_checkpoint code-owns and stamps
+    # origin_session, so a true legacy-unbound fixture must predate that gate.
+    unbound_cp = _checkpoint(
+        "S-unbound", [_item(item_id=unbound_id, quote="unbound stored quote")],
+        created="2026-08-05T09:00:00Z")
+    unbound_cp["project_slug"] = store.project_slug(_PROJECT)
+    (tmp_checkpoint_dir / "S-unbound.json").write_text(
+        json.dumps(unbound_cp), encoding="utf-8")
+    resolver = _resolver(tmp_path, projects)
+
+    legacy = inspector.inspect_item(_PROJECT, legacy_id, resolver=resolver)
+    unbound = inspector.inspect_item(_PROJECT, unbound_id, resolver=resolver)
+
+    assert legacy["axes"]["provenance"] == "legacy-inferred"
+    assert legacy["axes"]["capture"] == "unknown"
+    assert legacy["axes"]["locator"] == "resolved"
+    assert legacy["axes"]["current_support"] == "transcript-scan-match"
+    assert unbound["axes"]["provenance"] == "legacy-unbound"
+    assert unbound["axes"]["locator"] == "unsupported"
+    assert unbound["axes"]["current_support"] == "not-checked"
+
+
+def test_legacy_item_prefers_origin_checkpoint_source_ref(
+    tmp_checkpoint_dir, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    projects = tmp_path / ".claude" / "projects"
+    source = _source("S-raw-origin")
+    origin = _checkpoint("S-origin", [])
+    origin["source_ref"] = source
+    assert store.write_checkpoint("S-origin", origin, project_dir=_PROJECT)
+    _write_checkpoint("S-containing", [
+        _item(origin_session="S-origin", origin_author="alice"),
+    ])
+
+    result = inspector.inspect_item(
+        _PROJECT, _ITEM_ID, resolver=_resolver(tmp_path, projects))
+
+    assert result["axes"]["provenance"] == "legacy-inferred"
+    assert result["source"] == source
+    assert result["axes"]["locator"] == "absent-local"
+
+
+def test_locator_states_distinguish_absent_unsupported_and_ambiguous(
+    tmp_checkpoint_dir, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    projects = tmp_path / ".claude" / "projects"
+    absent_id = "o-aaaaaa"
+    unsupported_id = "o-bbbbbb"
+    ambiguous_id = "o-cccccc"
+    digest = "a" * 64
+    _write_checkpoint("S-containing", [
+        _item(item_id=absent_id,
+              receipt=_receipt(_source("S-absent"), digest)),
+        _item(item_id=unsupported_id,
+              receipt=_receipt(_source("S-gemini", host="gemini",
+                                      locator="unsupported"), digest)),
+        _item(item_id=ambiguous_id,
+              receipt=_receipt(_source("S-duplicate"), digest)),
+    ])
+    _write_claude(projects, "S-duplicate", [
+        ("user", "first", "u-1")], bucket="one")
+    _write_claude(projects, "S-duplicate", [
+        ("user", "second", "u-2")], bucket="two")
+    resolver = _resolver(tmp_path, projects)
+
+    assert inspector.inspect_item(
+        _PROJECT, absent_id, resolver=resolver)["axes"]["locator"] == "absent-local"
+    assert inspector.inspect_item(
+        _PROJECT, unsupported_id, resolver=resolver)["axes"]["locator"] == "unsupported"
+    assert inspector.inspect_item(
+        _PROJECT, ambiguous_id, resolver=resolver)["axes"]["locator"] == "ambiguous"
+
+
+def test_lookup_deduplicates_carried_snapshots_and_never_crosses_projects(
+    tmp_checkpoint_dir, monkeypatch
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    item_id = "o-abc123"
+    _write_checkpoint("S-old", [
+        _item("older wording", item_id=item_id, quote=None)],
+        created="2026-08-05T09:00:00Z")
+    _write_checkpoint("S-new", [
+        _item("newest current wording", item_id=item_id, quote=None)],
+        created="2026-08-05T11:00:00Z")
+    _write_checkpoint("S-other", [
+        _item("other project wording", item_id=item_id, quote=None)],
+        project="/p/B", created="2026-08-05T12:00:00Z")
+
+    local = inspector.inspect_item(_PROJECT, item_id)
+    other = inspector.inspect_item("/p/B", item_id)
+
+    assert local["item"]["text"] == "newest current wording"
+    assert local["item"]["occurrences"] == 2
+    assert other["item"]["text"] == "other project wording"
+    assert other["item"]["occurrences"] == 1
+
+
+def test_lifecycle_and_corroboration_fold_without_mutating_evidence(
+    tmp_checkpoint_dir, monkeypatch
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    _write_checkpoint("S-containing", [
+        _item(receipt=_receipt(_source(), "a" * 64)),
+    ])
+    slug = store.project_slug(_PROJECT)
+    events = tmp_checkpoint_dir / slug / "events.jsonl"
+    events.write_text("\n".join(json.dumps(row) for row in (
+        {"ts": "2026-08-05T10:00:00Z", "kind": "resolution",
+         "item_ref": _ITEM_ID, "status": "resolved", "source": "cli"},
+        {"ts": "2026-08-05T10:01:00Z", "kind": "resolution",
+         "item_ref": store.corroboration_ref(_ITEM_ID),
+         "status": "corroborated-by:S-witness-1", "source": "capture"},
+        {"ts": "2026-08-05T10:02:00Z", "kind": "resolution",
+         "item_ref": store.corroboration_ref(_ITEM_ID),
+         "status": "corroborated-by:S-witness-2", "source": "capture"},
+    )) + "\n", encoding="utf-8")
+
+    result = inspector.inspect_item(_PROJECT, _ITEM_ID)
+
+    assert result["axes"]["lifecycle"] == "resolved"
+    assert result["axes"]["capture"] == "verified"
+    assert result["corroboration"] == {
+        "count": 2,
+        "references": ["S-witness-1", "S-witness-2"],
+    }
+
+
+@pytest.mark.parametrize("status, expected", [
+    ("resolved", "resolved"),
+    ("superseded-by:o-fedcba", "superseded"),
+    ("forgotten:abc", "forgotten"),
+    ("reopen", "active"),
+    ("resolving-candidate", "active"),
+])
+def test_lifecycle_axis_values(status, expected):
+    assert inspector._lifecycle({"status": status}) == expected
+
+
+def test_forgotten_event_remains_inspectable_after_plaintext_is_gone(
+    tmp_checkpoint_dir, monkeypatch
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    assert store.append_event(
+        _ITEM_ID, "forgotten:" + "a" * 64,
+        project_dir=_PROJECT, allow_disabled=True)
+
+    result = inspector.inspect_item(_PROJECT, _ITEM_ID)
+
+    assert result["item"]["text"] is None
+    assert result["axes"]["lifecycle"] == "forgotten"
+    assert result["axes"]["provenance"] == "legacy-unbound"
+
+
+def test_source_disclosure_is_bounded_redacted_once_and_path_free(
+    tmp_checkpoint_dir, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    projects = tmp_path / ".claude" / "projects"
+    secret = "sk-proj-" + "A" * 24
+    # Put the credential across the old pre-redaction cutoff. Truncating raw
+    # text first would leave a secret prefix that no longer matches the token
+    # pattern; redacting once before the display cap must remove it whole.
+    content = "opening evidence " + "x" * 560 + " " + secret + " closing evidence"
+    path = _write_claude(projects, "S-source", [
+        ("user", content, "u-1"),
+    ])
+    receipt = _receipt(
+        _source(), hashlib.sha256(path.read_bytes()).hexdigest())
+    _write_checkpoint("S-containing", [
+        _item(quote="opening evidence ... closing evidence", receipt=receipt),
+    ])
+    real_redact = redact.redact_text
+    calls = []
+
+    def counted(value):
+        calls.append(value)
+        return real_redact(value)
+
+    monkeypatch.setattr(redact, "redact_text", counted)
+    resolver = _resolver(tmp_path, projects)
+    default = inspector.inspect_item(_PROJECT, _ITEM_ID, resolver=resolver)
+    disclosed = inspector.inspect_item(
+        _PROJECT, _ITEM_ID, include_source=True, resolver=resolver)
+
+    assert "source_excerpt" not in default
+    assert len(calls) == 1
+    excerpt = disclosed["source_excerpt"]
+    assert excerpt["kind"] == "message-window"
+    assert excerpt["truncated"] is True
+    assert secret not in excerpt["text"]
+    assert "[redacted:openai-key]" in excerpt["text"]
+    assert len(excerpt["text"]) <= inspector._SOURCE_CHAR_LIMIT
+    assert str(tmp_path) not in json.dumps(disclosed)
+
+
+def test_source_disclosure_does_not_redact_stored_quote_twice(
+    tmp_checkpoint_dir, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    projects = tmp_path / ".claude" / "projects"
+    path = _write_claude(projects, "S-source", [
+        ("user", "stored quote evidence", "u-1"),
+    ])
+    receipt = _receipt(
+        _source(), hashlib.sha256(path.read_bytes()).hexdigest(),
+        mode="transcript-scan", message_ids=())
+    _write_checkpoint("S-containing", [
+        _item(quote="stored quote evidence", receipt=receipt),
+    ])
+
+    def must_not_run(_value):
+        raise AssertionError("stored quote crossed redaction twice")
+
+    monkeypatch.setattr(redact, "redact_text", must_not_run)
+    result = inspector.inspect_item(
+        _PROJECT, _ITEM_ID, include_source=True,
+        resolver=_resolver(tmp_path, projects))
+
+    assert result["source_excerpt"]["kind"] == "stored-quote"
+    assert result["source_excerpt"]["text"] == "stored quote evidence"
+
+
+def test_source_disclosure_caps_message_count_and_reports_unavailable(
+    tmp_checkpoint_dir, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    projects = tmp_path / ".claude" / "projects"
+    messages = [("user", f"evidence {n}", f"u-{n}") for n in range(1, 5)]
+    path = _write_claude(projects, "S-source", messages)
+    receipt = _receipt(
+        _source(), hashlib.sha256(path.read_bytes()).hexdigest(),
+        message_ids=tuple(message_id for _, _, message_id in messages))
+    _write_checkpoint("S-containing", [_item(receipt=receipt)])
+
+    disclosed = inspector.inspect_item(
+        _PROJECT, _ITEM_ID, include_source=True,
+        resolver=_resolver(tmp_path, projects))
+
+    assert disclosed["source_excerpt"]["message_ids"] == ["u-1", "u-2", "u-3"]
+    assert disclosed["source_excerpt"]["truncated"] is True
+
+    assert store.append_event(
+        "o-fedcba", "forgotten:" + "a" * 64,
+        project_dir=_PROJECT, allow_disabled=True)
+    unavailable = inspector.inspect_item(
+        _PROJECT, "o-fedcba", include_source=True,
+        resolver=_resolver(tmp_path, projects))
+    assert unavailable["source_excerpt"]["kind"] == "unavailable"
+    human = "\n".join(inspector.human_lines(unavailable))
+    assert "Source excerpt: (unavailable)" in human
+    assert "no bounded source excerpt is available" in human
+
+
+def test_why_json_matches_golden_and_command_is_read_only_except_usage(
+    tmp_checkpoint_dir, tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    monkeypatch.setenv(
+        "DAIMON_CLAUDE_PROJECTS_DIR", str(tmp_path / "no-transcripts"))
+    _write_checkpoint("S-bound", [
+        _item(receipt=_receipt(_source(), "a" * 64)),
+    ])
+    before = {
+        str(path.relative_to(tmp_checkpoint_dir)): path.read_bytes()
+        for path in tmp_checkpoint_dir.rglob("*") if path.is_file()
+    }
+
+    assert cli.main(["why", _ITEM_ID, "--project", _PROJECT, "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    after = {
+        str(path.relative_to(tmp_checkpoint_dir)): path.read_bytes()
+        for path in tmp_checkpoint_dir.rglob("*") if path.is_file()
+    }
+
+    assert payload == json.loads(_GOLDEN.read_text(encoding="utf-8"))
+    assert "summary" not in payload
+    assert before == after
+    usage = (tmp_path / ".daimon" / "logs" / "usage.log").read_text(
+        encoding="utf-8")
+    assert usage.rstrip().endswith(" why")
+
+
+def test_why_exit_codes_and_human_axes(tmp_checkpoint_dir, monkeypatch, capsys):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    _write_checkpoint("S-bound", [
+        _item(receipt=_receipt(_source(), "a" * 64)),
+    ])
+
+    assert cli.main(["why", "bad-id", "--project", _PROJECT]) == 2
+    assert "invalid item id" in capsys.readouterr().err
+    assert cli.main(["why", "o-fedcba", "--project", _PROJECT]) == 1
+    assert "no item" in capsys.readouterr().err
+    assert cli.main(["why", _ITEM_ID, "--project", _PROJECT]) == 0
+    out = capsys.readouterr().out
+    assert "Now: capture verified" in out
+    assert "Capture: verified" in out
+    assert "Provenance: bound" in out
+    assert "Current support: not-checked" in out
+    assert cli.main([
+        "why", _ITEM_ID, "--project", _PROJECT, "--slug", "p-A",
+    ]) == 2
+
+
+def test_recall_exposes_item_id_in_json_and_human_output(
+    tmp_checkpoint_dir, monkeypatch, capsys
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    _write_checkpoint("S-recall", [
+        _item("quorint trust inspector decision", quote=None),
+    ])
+
+    assert cli.main([
+        "recall", "quorint", "--project", _PROJECT, "--json",
+    ]) == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert rows[0]["item_id"] == _ITEM_ID
+
+    assert cli.main(["recall", "quorint", "--project", _PROJECT]) == 0
+    assert f"[{_ITEM_ID}]" in capsys.readouterr().out
+    # The proactive backend has its own SELECT/output contract; adding ids to
+    # deliberate recall must not leak them into injected suggestion rows.
+    suggestions = recall.suggest(
+        "review the quorint trust inspector decision again",
+        project_dir=_PROJECT, current_session="S-now")
+    assert suggestions
+    assert all("item_id" not in row for row in suggestions)

--- a/plugin/tests/test_inspector.py
+++ b/plugin/tests/test_inspector.py
@@ -113,6 +113,26 @@ def test_item_id_validation_is_bounded_and_exact(value, expected):
     assert inspector.valid_item_id(value) is expected
 
 
+def test_checkpoint_scan_skips_corrupt_and_sessionless_surfaces(
+    tmp_checkpoint_dir, monkeypatch
+):
+    tmp_checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    corrupt = tmp_checkpoint_dir / "corrupt.json"
+    corrupt.write_text("{not-json", encoding="utf-8")
+    sessionless = tmp_checkpoint_dir / "sessionless.json"
+    sessionless.write_text(json.dumps({"created": _CHECKED_AT}), encoding="utf-8")
+    valid = tmp_checkpoint_dir / "S-valid.json"
+    valid.write_text(
+        json.dumps(_checkpoint("S-valid", [])), encoding="utf-8")
+    monkeypatch.setattr(
+        store, "project_surfaces",
+        lambda _project: [corrupt, sessionless, valid])
+
+    checkpoints = inspector._project_checkpoints(_PROJECT)
+
+    assert [checkpoint["session_id"] for checkpoint in checkpoints] == ["S-valid"]
+
+
 def test_bound_receipt_reports_changed_bytes_and_message_support(
     tmp_checkpoint_dir, tmp_path, monkeypatch
 ):
@@ -186,6 +206,30 @@ def test_rendered_digest_and_older_verifier_are_independent_axes(
     assert result["axes"]["bytes"] == "unchanged"
     assert result["axes"]["current_support"] == "message-id-match"
     assert result["axes"]["verifier_comparison"] == "different-version"
+
+
+def test_unreadable_rendered_source_degrades_to_unknown(
+    tmp_checkpoint_dir, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    projects = tmp_path / ".claude" / "projects"
+    _write_claude(projects, "S-source", [
+        ("user", "durable trust decision", "u-1"),
+    ])
+    receipt = _receipt(
+        _source(), "a" * 64, scope="rendered-transcript")
+    _write_checkpoint("S-containing", [_item(receipt=receipt)])
+
+    def unreadable(_path):
+        raise ValueError("malformed host transcript")
+
+    monkeypatch.setattr(transcript, "from_file", unreadable)
+    result = inspector.inspect_item(
+        _PROJECT, _ITEM_ID, resolver=_resolver(tmp_path, projects))
+
+    assert result["axes"]["locator"] == "resolved"
+    assert result["axes"]["bytes"] == "unknown"
+    assert result["axes"]["current_support"] == "not-checked"
 
 
 def test_legacy_inferred_and_unbound_items_degrade_explicitly(
@@ -455,6 +499,21 @@ def test_source_disclosure_caps_message_count_and_reports_unavailable(
     human = "\n".join(inspector.human_lines(unavailable))
     assert "Source excerpt: (unavailable)" in human
     assert "no bounded source excerpt is available" in human
+
+
+def test_source_helpers_ignore_malformed_messages_and_cap_plain_text():
+    assert inspector._message_by_id([
+        None,
+        {"id": "u-1", "role": "user", "content": "evidence"},
+    ]) == {
+        "u-1": {"id": "u-1", "role": "user", "content": "evidence"},
+    }
+
+    value = "x" * (inspector._SOURCE_CHAR_LIMIT + 20)
+    capped, truncated = inspector._cap_disclosed_source(value)
+
+    assert truncated is True
+    assert capped == "x" * (inspector._SOURCE_CHAR_LIMIT - 1) + "…"
 
 
 def test_why_json_matches_golden_and_command_is_read_only_except_usage(

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -378,6 +378,10 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
     def r_recall():
         run(["recall", "gateway"], 0)
 
+    def r_why():
+        # #502: trust inspection is read-only apart from usage telemetry.
+        run(["why", ctx["ids"][_T_GATEWAY]], 0)
+
     def r_projects():
         run(["projects"], 0)
 
@@ -483,6 +487,7 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
         ("brief",): r_brief,
         ("anchor",): r_anchor,
         ("recall",): r_recall,
+        ("why",): r_why,
         ("projects",): r_projects,
         ("resolve",): r_resolve,
         ("reverify",): r_reverify,


### PR DESCRIPTION
## Summary

- add `daimon why <item-id>` with independent capture, provenance, locator, byte-integrity, current-support, verifier, lifecycle, and corroboration axes
- expose exact item IDs from deliberate recall while leaving proactive recall injection unchanged
- add bounded, path-free, single-pass-redacted source disclosure with `--source`
- document the recall → why → resolve workflow and the V1 JSON contract
- keep trust inspection in a focused module instead of expanding the existing CLI object

## Why

Users need to understand what Daimon can actually prove about a memory item without collapsing distinct evidence into a single trust score. In particular, changed source bytes and currently supported quote content can both be true; the inspector preserves that distinction.

## Validation

- `uv run --all-extras pytest -q` — 2,977 passed, 2 skipped
- focused inspector suite — 27 passed
- inspector module line coverage — 95%
- `ruff check daimon_briefing tests ../scripts`
- `scripts/sync_hooks.py --check`
- commit-time Ruff and hook-mirror checks

## Follow-up

Post-merge task validation with 3–5 users is tracked separately in #596. It is intentionally not a merge gate for this engineering slice.

Fixes #502
