### PR TITLE
feat(audit): read-only tombstone residue audit — daimon audit privacy

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -30,7 +30,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from . import anchor, briefing, capture, carry, config, configure, harvest, inspector, ledger, llm, normalize, provenance, recall, receipts, redact, render, schema, serializer, store, teamsync, transcript, worldcheck
+from . import anchor, briefing, capture, carry, config, configure, harvest, inspector, ledger, llm, normalize, privacy, provenance, recall, receipts, redact, render, schema, serializer, store, teamsync, transcript, worldcheck
 from . import __version__
 
 # The serialize.log ledger subsystem lives in ledger.py (#147 + #162, pure
@@ -2137,6 +2137,26 @@ def _resolve_audit_source(source, resolver, cache: dict):
     return result
 
 
+def _cmd_audit_privacy(args) -> int:
+    """Read-only tombstone residue audit — proves forget's contract instead
+    of trusting it (#583: a passing test once asserted the residue). Exit 0
+    proven clean / 1 residue / 3 cannot-prove; 3 exists because "could not
+    check" must never look like "all clean"."""
+    if getattr(args, "all_projects", False):
+        results = privacy.audit_all()
+    else:
+        results = [privacy.audit_project(_resolve_project(args.project))]
+    render.render_privacy_audit(results)
+    code = privacy.exit_code(results)
+    _note_usage("audit-privacy" if code != 3 else "audit-privacy:unproven")
+    return code
+
+
+def _cmd_audit_quotes_deprecated(args) -> int:
+    print("note: 'daimon audit-quotes' is deprecated — use 'daimon audit quotes'")
+    return _cmd_audit_quotes(args)
+
+
 def _cmd_audit_quotes(args) -> int:
     """Read-only audit (#125): re-check every stored verbatim quote against its
     source transcript with the SAME tier-f matcher serialize uses, and REPORT.
@@ -3313,7 +3333,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s {__version__}"
     )
-    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub = parser.add_subparsers(dest="cmd", required=True, metavar="<command>")
     sub.add_parser = functools.partial(sub.add_parser, formatter_class=fmt)
 
     p_ser = sub.add_parser("serialize", help="serialize a transcript file into a checkpoint")
@@ -3586,22 +3606,48 @@ def build_parser() -> argparse.ArgumentParser:
     p_vr.set_defaults(func=_cmd_verify_receipt)
 
     p_audit = sub.add_parser(
-        "audit-quotes",
+        "audit",
+        help="read-only auditors that verify stored guarantees",
+    )
+    audit_sub = p_audit.add_subparsers(dest="audit_cmd", required=True)
+    pa_quotes = audit_sub.add_parser(
+        "quotes",
         help="re-check stored verbatim quotes against their source transcripts "
              "and report mismatches (read-only, never rewrites tags, #125)",
         epilog="Examples:\n"
-               "  daimon audit-quotes\n"
-               "  daimon audit-quotes --all --top 20\n",
+               "  daimon audit quotes\n"
+               "  daimon audit quotes --all --top 20\n",
     )
-    p_audit.add_argument(
+    pa_quotes.add_argument(
         "--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
-    p_audit.add_argument(
+    pa_quotes.add_argument(
         "--all", action="store_true",
         help="audit every project's checkpoints, not just the current one")
-    p_audit.add_argument(
+    pa_quotes.add_argument(
         "--top", type=int, default=10,
         help="how many failing quotes to list (default: 10)")
-    p_audit.set_defaults(func=_cmd_audit_quotes)
+    pa_quotes.set_defaults(func=_cmd_audit_quotes)
+    pa_priv = audit_sub.add_parser(
+        "privacy",
+        help="prove no forgotten value's plaintext survives on any surface "
+             "(read-only; exit 0 clean, 1 residue, 3 cannot-prove)",
+        epilog="Examples:\n"
+               "  daimon audit privacy\n"
+               "  daimon audit privacy --all\n",
+    )
+    pa_priv.add_argument(
+        "--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    pa_priv.add_argument(
+        "--all", action="store_true", dest="all_projects",
+        help="audit every local project, each against its own tombstone set")
+    pa_priv.set_defaults(func=_cmd_audit_privacy)
+    # Deprecated flat alias (#504-era name). metavar on the top-level
+    # subparsers (set below) keeps it out of the usage brace list.
+    p_audit_old = sub.add_parser("audit-quotes")
+    p_audit_old.add_argument("--project")
+    p_audit_old.add_argument("--all", action="store_true")
+    p_audit_old.add_argument("--top", type=int, default=10)
+    p_audit_old.set_defaults(func=_cmd_audit_quotes_deprecated)
 
     p_heal = sub.add_parser(
         "heal",

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -2148,7 +2148,11 @@ def _cmd_audit_privacy(args) -> int:
         results = [privacy.audit_project(_resolve_project(args.project))]
     render.render_privacy_audit(results)
     code = privacy.exit_code(results)
-    _note_usage("audit-privacy" if code != 3 else "audit-privacy:unproven")
+    # One tag per OUTCOME: "the auditor ran" and "the auditor found residue"
+    # answer different questions, and folding them loses the only number that
+    # says whether the deletion contract holds in the field.
+    _note_usage({1: "audit-privacy:residue",
+                 3: "audit-privacy:unproven"}.get(code, "audit-privacy"))
     return code
 
 
@@ -3635,9 +3639,13 @@ def build_parser() -> argparse.ArgumentParser:
                "  daimon audit privacy\n"
                "  daimon audit privacy --all\n",
     )
-    pa_priv.add_argument(
+    # Mutually exclusive: --project scopes to ONE bucket and --all audits every
+    # bucket, so together one of them is silently ignored — and the flag that
+    # loses decides which tombstone sets were checked. Fail loud instead.
+    pa_priv_scope = pa_priv.add_mutually_exclusive_group()
+    pa_priv_scope.add_argument(
         "--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
-    pa_priv.add_argument(
+    pa_priv_scope.add_argument(
         "--all", action="store_true", dest="all_projects",
         help="audit every local project, each against its own tombstone set")
     pa_priv.set_defaults(func=_cmd_audit_privacy)

--- a/plugin/daimon_briefing/privacy.py
+++ b/plugin/daimon_briefing/privacy.py
@@ -270,6 +270,10 @@ def exit_code(results: list[dict]) -> int:
     """0 proven clean / 1 residue / 3 cannot-prove. 2 belongs to argparse and
     the house hard-error convention. Cannot-prove NEVER folds to clean —
     that is scripted false confidence, the exact thing #583 shipped."""
+    # Empty result set means nothing was audited (no buckets, or checkpoint_dir
+    # inaccessible) — cannot distinguish from "clean", so must report cannot-prove.
+    if not results:
+        return 3
     if any(r["findings"] for r in results):
         return 1
     if any(r["unscannable"] or r["zero_surfaces"] for r in results):

--- a/plugin/daimon_briefing/privacy.py
+++ b/plugin/daimon_briefing/privacy.py
@@ -178,6 +178,16 @@ def audit_project(project_dir=None) -> dict:
             result["findings"].extend(findings)
     result["surfaces_scanned"] = members
     result["zero_surfaces"] = members == 0
+    try:
+        team_files = sorted(config.team_dir().rglob("*.json"))
+    except OSError:
+        team_files = []
+    for path in team_files:
+        findings, member = _scan_json_surface(path, slug, keys, "team-copy")
+        if member is None:
+            result["unscannable"].append(str(path))
+        elif member:
+            result["findings"].extend(findings)
     res, info, readable = _scan_recall_db(config.recall_db(), slug, keys)
     if readable is None:
         result["unscannable"].append(str(config.recall_db()))

--- a/plugin/daimon_briefing/privacy.py
+++ b/plugin/daimon_briefing/privacy.py
@@ -5,8 +5,10 @@ wrong surface set, and a passing test asserted the residue. This module
 verifies the contract instead of trusting it: hash every plaintext field
 on every surface and intersect with the forget ledger's tombstone set.
 
-Read-only is load-bearing: sqlite opens use mode=ro URIs (a plain connect
-CREATES a missing db), and the recall public API is never touched
+Read-only is load-bearing: sqlite opens go through URIs (a plain connect
+CREATES a missing db) — mode=ro for the live index, immutable=1 for the dead
+orphan snapshots, because mode=ro alone still lets sqlite write -shm/-wal
+sidecars for a WAL-mode file. The recall public API is never touched
 (_ensure_fresh rebuilds). Findings carry hashes, never the text — audit
 output gets re-serialized into checkpoints, so printing the value would
 re-capture the thing the user deleted.
@@ -16,13 +18,48 @@ import sqlite3
 import time
 from pathlib import Path
 
-from . import config, normalize, store
+from . import config, normalize, store, teamproject
 
 # Plaintext-bearing item fields. forget currently hashes only `text`
 # (cli._cmd_forget, store.scrub_content_key, recall rebuild) — auditing
 # quote/scene as well is deliberate: it detects the residue forget cannot
 # yet reach, which is this tool's reason to exist.
 _FIELDS = ("text", "quote", "scene")
+
+# Free-text fields store.append_event writes to events.jsonl. `note` alone was
+# a third of the surface: `resolve`/`reopen` pass the item's WHOLE text as
+# `item_text` with no forget gate, and `status` is free-form by design (readers
+# prefix-match), so a user's own resolution wording can BE the value. The file
+# is append-only and never rewritten, so forget cannot reach any of the three.
+_EVENT_FIELDS = ("note", "item_text", "status")
+
+_EVENTS_NAME = "events.jsonl"
+
+# Files that live in the checkpoint store and hold NO item plaintext BY
+# CONSTRUCTION. Every exemption is checked against its owning module, because
+# an exemption granted on a hunch is exactly how a plaintext surface goes
+# unreported. Reporting these made exit 0 unreachable on a real install (74
+# `.receipt` sidecars in the flat dir of the machine this was specced on).
+_EXEMPT_NAMES = frozenset({
+    # store._pointer_lock: an empty flock sidecar, opened "a+" and never written.
+    store._LOCK_NAME,
+    # store.append_verification: item_ref + a reason CODE, "never the rejected
+    # text" — quote verification runs pre-redaction, so it must not log text.
+    "verification.jsonl",
+    # store.record_forget_hits: {ts, key} — the canonical hash only, "NEVER the
+    # text or any prefix of it".
+    "forget-hits.jsonl",
+    # macOS Finder metadata: directory listing/positions, never file contents.
+    ".DS_Store",
+})
+# receipts._sidecar_path. The blob is {jws, receipt, kid, performer_id} where
+# the receipt carries inputs/outputs HASHES, method and nonce — it binds to a
+# checkpoint's bytes, it never copies them.
+_EXEMPT_SUFFIX = ".receipt"
+
+
+def _is_plaintext_free(path: Path) -> bool:
+    return path.name in _EXEMPT_NAMES or path.suffix == _EXEMPT_SUFFIX
 
 
 def _hashes(item: dict) -> set[str]:
@@ -34,15 +71,23 @@ def _hashes(item: dict) -> set[str]:
     return out
 
 
-def _checkpoint_candidates() -> tuple[list[Path], list[Path]]:
-    """(json surfaces, unknown files) across the flat dir + bucket dirs.
+def _checkpoint_candidates() -> tuple[list[Path], list[tuple[Path, str | None]]]:
+    """(json surfaces, [(unknown path, owning bucket or None)]).
 
     Unlike store._plaintext_surfaces, files the walk does NOT recognise are
     returned, never dropped: a `latest.json.bak-*` full-checkpoint copy is
-    exactly how plaintext escapes a suffix-filtered walk. `.chunk-cache/` is
-    scanned separately at store level; `events.jsonl` is scanned as a note
-    ledger, not an item surface."""
-    known, unknown = [], []
+    exactly how plaintext escapes a suffix-filtered walk. Sub-directories
+    inside a bucket are reported for the same reason — an undescended dir is
+    unread contents, not an absence of them.
+
+    Unknowns are TAGGED with their bucket: a stray file in project B's bucket
+    is B's blind spot, and an untagged list made every project on the machine
+    unprovable at once. Flat-dir unknowns tag None (= every audit's problem):
+    `latest.json` there is the GLOBAL pointer and its neighbours may hold any
+    project's session. `.chunk-cache/` is reported separately at store level;
+    `events.jsonl` is scanned as the note ledger, not as an item surface."""
+    known: list[Path] = []
+    unknown: list[tuple[Path, str | None]] = []
     d = config.checkpoint_dir()
     try:
         entries = list(d.iterdir())
@@ -53,43 +98,37 @@ def _checkpoint_candidates() -> tuple[list[Path], list[Path]]:
             if entry.is_file():
                 if entry.suffix == ".json":
                     known.append(entry)
-                elif entry.name != ".pointer.lock":
-                    unknown.append(entry)
+                elif not _is_plaintext_free(entry):
+                    unknown.append((entry, None))
             elif entry.is_dir() and entry.name != ".chunk-cache":
                 for p in entry.iterdir():
                     if not p.is_file():
-                        continue
-                    if p.suffix == ".json":
+                        unknown.append((p, entry.name))
+                    elif p.suffix == ".json":
                         known.append(p)
-                    elif p.name not in ("events.jsonl", ".pointer.lock"):
-                        unknown.append(p)
+                    elif p.name != _EVENTS_NAME and not _is_plaintext_free(p):
+                        unknown.append((p, entry.name))
         except OSError:
-            unknown.append(entry)
+            # Could not even list it — tag None, the conservative side: an
+            # entry whose bucket is unknown belongs to nobody in particular.
+            unknown.append((entry, None))
     return known, unknown
 
 
-def _scan_json_surface(path: Path, slug: str, keys: set[str],
-                       surface: str, by_payload_only: bool = False) -> tuple[list[dict], bool | None]:
-    """Findings + membership. None membership = unreadable (unscannable).
+def _load_payload(path: Path) -> dict | None:
+    """The file's JSON object, or None = could not read it as one.
 
-    Membership mirrors store.project_surfaces: bucket location OR payload
-    project_slug — but unreadable files are SURFACED here, not silently
-    excluded, because "could not check" must never fold into "clean".
-
-    When by_payload_only=True, membership is solely by payload project_slug.
-    This prevents author-dir-name collisions from false-matching team files."""
+    UnicodeDecodeError is a ValueError, and that is deliberate in the catch:
+    a non-UTF-8 file must land in `unscannable`, never abort the audit."""
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
-        return [], None
-    if not isinstance(payload, dict):
-        return [], None
-    if by_payload_only:
-        if payload.get("project_slug") != slug:
-            return [], False
-    else:
-        if path.parent.name != slug and payload.get("project_slug") != slug:
-            return [], False
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _payload_findings(payload: dict, path: Path, keys: set[str],
+                      surface: str) -> list[dict]:
     findings: list[dict] = []
     for section, key in store._ITEM_LISTS:
         for item in ((payload.get(section) or {}).get(key) or []):
@@ -100,7 +139,38 @@ def _scan_json_surface(path: Path, slug: str, keys: set[str],
                                  "item_id": item.get("id"),
                                  "content_hash": h,
                                  "surface": surface})
-    return findings, True
+    return findings
+
+
+def _scan_json_surface(path: Path, slug: str, keys: set[str],
+                       surface: str) -> tuple[list[dict], bool | None]:
+    """Findings + membership. None membership = unreadable (unscannable).
+
+    Membership mirrors store.project_surfaces: bucket location OR payload
+    project_slug — but unreadable files are SURFACED here, not silently
+    excluded, because "could not check" must never fold into "clean"."""
+    payload = _load_payload(path)
+    if payload is None:
+        return [], None
+    if path.parent.name != slug and payload.get("project_slug") != slug:
+        return [], False
+    return _payload_findings(payload, path, keys, surface), True
+
+
+def _team_segments(root: Path, path: Path) -> tuple[str, ...] | None:
+    """Logical project segments of a NESTED-era team file, else None.
+
+    store._dual_write_team's nested layout is
+        <team_dir>/<remote>/projects/<seg…>/authors/<author>/<sid>.json
+    and the legacy flat era is <team_dir>/<remote>/authors/<author>/<sid>.json
+    (no segments — that era is stamp-filtered, exactly as read_team does)."""
+    try:
+        parts = path.relative_to(root).parts
+    except ValueError:
+        return None
+    if len(parts) < 6 or parts[1] != "projects" or parts[-3] != "authors":
+        return None
+    return parts[2:-3] or None
 
 
 def _orphan_index_files() -> list[Path]:
@@ -115,19 +185,32 @@ def _orphan_index_files() -> list[Path]:
         return []
 
 
-def _scan_recall_db(db_path: Path, slug: str,
-                    keys: set[str]) -> tuple[list[dict], list[dict], bool | None]:
+def _scan_recall_db(db_path: Path, slug: str, keys: set[str],
+                    immutable: bool = False) -> tuple[list[dict], list[dict], bool | None]:
     """Scan the derived index WITHOUT the recall API (which rebuilds).
 
     A row match is only real residue if the stored fingerprint equals a
     freshly computed one — forget deletes recall rows LAZILY at the next
     rebuild, so a stale index legitimately still holds the value. Classing
-    that as residue would cry wolf after every single forget."""
+    that as residue would cry wolf after every single forget.
+
+    `immutable=1` for the orphan snapshots: `mode=ro` still lets sqlite create
+    `-shm`/`-wal` sidecars for a WAL-mode file, which would make a READ-ONLY
+    auditor write to the store. Orphans are dead files by definition (a
+    crashed rebuild's leftovers), so promising sqlite they cannot change is
+    both true and the only way to guarantee no sidecar appears. The LIVE index
+    keeps `mode=ro` — it is not dead, and a stale snapshot of it would lie."""
     from . import recall  # local import: only _fingerprint (pure read) is used
-    if not db_path.exists():
-        return [], [], True     # absent index holds nothing — vacuously clean
     try:
-        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        if not db_path.exists():
+            return [], [], True  # absent index holds nothing — vacuously clean
+    except OSError:
+        # exists() RAISES on an unreadable parent (EACCES is not in pathlib's
+        # ignored set): cannot even stat it, so it cannot be proven clean.
+        return [], [], None
+    query = "?immutable=1" if immutable else "?mode=ro"
+    try:
+        conn = sqlite3.connect(f"file:{db_path}{query}", uri=True)
         try:
             meta = dict(conn.execute("SELECT key, value FROM meta"))
             rows = conn.execute(
@@ -165,6 +248,49 @@ def _scan_recall_db(db_path: Path, slug: str,
     return residue, informational, True
 
 
+def _scan_team_dir(slug: str, keys: set[str], project_dir,
+                   unscannable: list[str]) -> list[dict]:
+    """Findings in the shared team mirror; appends unreadable files in place.
+
+    Membership by PATH for the nested era, mirroring store.read_team: a
+    teammate's copy of THIS project is stamped with the WRITER's own
+    path-derived `project_slug` (their checkout lives elsewhere), so a
+    payload-only test skips precisely the file this audit exists to catch —
+    the motivating case in the spec. The `projects/<seg…>/` subtree IS the
+    project identity there, so it is the filter.
+
+    A subtree counts as this project's when the logical path resolves to it
+    (teamproject.read_candidates — the same resolver read_team fans across) OR
+    when this machine's own mirror in that subtree is stamped with our slug.
+    The second signal is what keeps `--all` honest: it audits from a bucket
+    slug, not a working dir, so there is no git origin left to probe.
+
+    The payload stamp stays an OR-fallback — it is the whole membership test
+    for the legacy flat era (`<remote>/authors/<author>/<sid>.json`), and it
+    is how our own nested copies identify themselves."""
+    root = config.team_dir()
+    try:
+        files = sorted(root.rglob("*.json"))
+    except OSError:
+        return []
+    loaded: list[tuple[Path, dict, tuple[str, ...] | None]] = []
+    for path in files:
+        payload = _load_payload(path)
+        if payload is None:
+            unscannable.append(str(path))
+            continue
+        loaded.append((path, payload, _team_segments(root, path)))
+    owned = set(teamproject.read_candidates(project_dir))
+    owned |= {segs for _p, payload, segs in loaded
+              if segs and payload.get("project_slug") == slug}
+    findings: list[dict] = []
+    for path, payload, segs in loaded:
+        if (segs in owned if segs else False) \
+                or payload.get("project_slug") == slug:
+            findings.extend(_payload_findings(payload, path, keys, "team-copy"))
+    return findings
+
+
 def audit_project(project_dir=None) -> dict:
     slug = store.project_slug(project_dir)
     keys = store.forgotten_content_keys(project_dir=project_dir)
@@ -176,7 +302,10 @@ def audit_project(project_dir=None) -> dict:
         result["cache"] = {"entries": 0, "oldest_days": None}
         return result
     known, unknown = _checkpoint_candidates()
-    result["unscannable"].extend(str(p) for p in unknown)
+    # Only this project's blind spots: an unknown file in ANOTHER bucket is
+    # that project's audit's problem (None = flat dir = everyone's).
+    result["unscannable"].extend(
+        str(p) for p, bucket in unknown if bucket in (None, slug))
     members = 0
     for path in known:
         findings, member = _scan_json_surface(path, slug, keys, "checkpoint")
@@ -187,17 +316,8 @@ def audit_project(project_dir=None) -> dict:
             result["findings"].extend(findings)
     result["surfaces_scanned"] = members
     result["zero_surfaces"] = members == 0
-    try:
-        team_files = sorted(config.team_dir().rglob("*.json"))
-    except OSError:
-        team_files = []
-    for path in team_files:
-        findings, member = _scan_json_surface(path, slug, keys, "team-copy",
-                                              by_payload_only=True)
-        if member is None:
-            result["unscannable"].append(str(path))
-        elif member:
-            result["findings"].extend(findings)
+    result["findings"].extend(_scan_team_dir(slug, keys, project_dir,
+                                             result["unscannable"]))
     res, info, readable = _scan_recall_db(config.recall_db(), slug, keys)
     if readable is None:
         result["unscannable"].append(str(config.recall_db()))
@@ -205,33 +325,50 @@ def audit_project(project_dir=None) -> dict:
         result["findings"].extend(res)
         result["informational"].extend(info)
     for orphan in _orphan_index_files():
-        res, info, readable = _scan_recall_db(orphan, slug, keys)
+        res, info, readable = _scan_recall_db(orphan, slug, keys,
+                                              immutable=True)
         if readable is None:
             result["unscannable"].append(str(orphan))
             continue
         for f in res + info:
             f["surface"] = "orphan-tmp"
             result["findings"].append(f)
-    # Notes: hashed WHOLE — catches a note that IS the value verbatim; a note
-    # merely containing it is undetectable by hash (stated report limitation).
-    events = config.checkpoint_dir() / slug / "events.jsonl"
-    if events.exists():
+    # Event ledger: every free-text field hashed WHOLE — catches a field that
+    # IS the value verbatim; one merely containing it is undetectable by hash
+    # (stated report limitation). `status` on the tombstone row is
+    # "forgotten:<hash>": hashing that STRING can never equal the key it
+    # names, so it needs no special case. `item_id` is always the row's
+    # item_ref, whichever field matched.
+    events = config.checkpoint_dir() / slug / _EVENTS_NAME
+    try:
+        # Read first, ask later: `events.exists()` RAISES on an unreadable
+        # parent dir (EACCES is not in pathlib's ignored set), which would
+        # crash the auditor on exactly the tree it must report on.
+        # UnicodeDecodeError IS a ValueError: a non-UTF-8 ledger is
+        # cannot-check, not a traceback out of a read-only auditor.
+        lines = events.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        lines = []                  # no ledger written yet — nothing to scan
+    except (OSError, ValueError):
+        lines = []
+        result["unscannable"].append(str(events))
+    for line in lines:
         try:
-            for line in events.read_text(encoding="utf-8").splitlines():
-                try:
-                    evt = json.loads(line)
-                except ValueError:
-                    continue
-                note = evt.get("note") if isinstance(evt, dict) else None
-                if isinstance(note, str) and note.strip():
-                    h = normalize.content_key(note)
-                    if h in keys:
-                        result["findings"].append({
-                            "path": str(events),
-                            "item_id": evt.get("item_ref"),
-                            "content_hash": h, "surface": "events-note"})
-        except OSError:
-            result["unscannable"].append(str(events))
+            evt = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(evt, dict):
+            continue
+        for field in _EVENT_FIELDS:
+            value = evt.get(field)
+            if not (isinstance(value, str) and value.strip()):
+                continue
+            h = normalize.content_key(value)
+            if h in keys:
+                result["findings"].append({
+                    "path": str(events),
+                    "item_id": evt.get("item_ref"),
+                    "content_hash": h, "surface": "events-note"})
     # Chunk cache: value-level detection impossible (cache keyed by chunk
     # text, values are substrings). Store-level honesty: entry count + real
     # oldest age — the reaper runs only on WRITES, so never assert bounded.

--- a/plugin/daimon_briefing/privacy.py
+++ b/plugin/daimon_briefing/privacy.py
@@ -228,7 +228,7 @@ def audit_project(project_dir=None) -> dict:
                     if h in keys:
                         result["findings"].append({
                             "path": str(events),
-                            "item_id": evt.get("item"),
+                            "item_id": evt.get("item_ref"),
                             "content_hash": h, "surface": "events-note"})
         except OSError:
             result["unscannable"].append(str(events))

--- a/plugin/daimon_briefing/privacy.py
+++ b/plugin/daimon_briefing/privacy.py
@@ -247,3 +247,31 @@ def audit_project(project_dir=None) -> dict:
         pass
     result["cache"] = {"entries": entries, "oldest_days": oldest}
     return result
+
+
+def audit_all() -> list[dict]:
+    """One audit per local bucket — each against ITS OWN tombstone set.
+
+    Never the global union for local rows: project B legitimately holding a
+    sentence project A forgot is not residue (shipped deletion is per-bucket,
+    recall.py:479; the union governs only the inbound foreign gate)."""
+    results: list[dict] = []
+    try:
+        buckets = sorted(e.name for e in config.checkpoint_dir().iterdir()
+                         if e.is_dir() and e.name != ".chunk-cache")
+    except OSError:
+        buckets = []
+    for slug in buckets:
+        results.append(audit_project(project_dir=slug))
+    return results
+
+
+def exit_code(results: list[dict]) -> int:
+    """0 proven clean / 1 residue / 3 cannot-prove. 2 belongs to argparse and
+    the house hard-error convention. Cannot-prove NEVER folds to clean —
+    that is scripted false confidence, the exact thing #583 shipped."""
+    if any(r["findings"] for r in results):
+        return 1
+    if any(r["unscannable"] or r["zero_surfaces"] for r in results):
+        return 3
+    return 0

--- a/plugin/daimon_briefing/privacy.py
+++ b/plugin/daimon_briefing/privacy.py
@@ -95,6 +95,18 @@ def _scan_json_surface(path: Path, slug: str, keys: set[str],
     return findings, True
 
 
+def _orphan_index_files() -> list[Path]:
+    """Crashed rebuilds leave `recall.db.<pid>.tmp` (+`-journal`) beside the
+    index — near-complete plaintext snapshots (four live multi-MB examples
+    existed on the dev machine the day this was specced). They are the same
+    sqlite shape, so they get the same scan, not a hand-wave."""
+    db = config.recall_db()
+    try:
+        return sorted(p for p in db.parent.glob(db.name + ".*") if p.is_file())
+    except OSError:
+        return []
+
+
 def _scan_recall_db(db_path: Path, slug: str,
                     keys: set[str]) -> tuple[list[dict], list[dict], bool | None]:
     """Scan the derived index WITHOUT the recall API (which rebuilds).
@@ -172,4 +184,12 @@ def audit_project(project_dir=None) -> dict:
     else:
         result["findings"].extend(res)
         result["informational"].extend(info)
+    for orphan in _orphan_index_files():
+        res, info, readable = _scan_recall_db(orphan, slug, keys)
+        if readable is None:
+            result["unscannable"].append(str(orphan))
+            continue
+        for f in res + info:
+            f["surface"] = "orphan-tmp"
+            result["findings"].append(f)
     return result

--- a/plugin/daimon_briefing/privacy.py
+++ b/plugin/daimon_briefing/privacy.py
@@ -1,0 +1,118 @@
+"""Read-only tombstone residue audit (`daimon audit privacy`).
+
+#583 shipped because forget's deletion contract was written against the
+wrong surface set, and a passing test asserted the residue. This module
+verifies the contract instead of trusting it: hash every plaintext field
+on every surface and intersect with the forget ledger's tombstone set.
+
+Read-only is load-bearing: sqlite opens use mode=ro URIs (a plain connect
+CREATES a missing db), and the recall public API is never touched
+(_ensure_fresh rebuilds). Findings carry hashes, never the text — audit
+output gets re-serialized into checkpoints, so printing the value would
+re-capture the thing the user deleted.
+"""
+import json
+from pathlib import Path
+
+from . import config, normalize, store
+
+# Plaintext-bearing item fields. forget currently hashes only `text`
+# (cli._cmd_forget, store.scrub_content_key, recall rebuild) — auditing
+# quote/scene as well is deliberate: it detects the residue forget cannot
+# yet reach, which is this tool's reason to exist.
+_FIELDS = ("text", "quote", "scene")
+
+
+def _hashes(item: dict) -> set[str]:
+    out: set[str] = set()
+    for field in _FIELDS:
+        value = item.get(field)
+        if isinstance(value, str) and value.strip():
+            out.add(normalize.content_key(value))
+    return out
+
+
+def _checkpoint_candidates() -> tuple[list[Path], list[Path]]:
+    """(json surfaces, unknown files) across the flat dir + bucket dirs.
+
+    Unlike store._plaintext_surfaces, files the walk does NOT recognise are
+    returned, never dropped: a `latest.json.bak-*` full-checkpoint copy is
+    exactly how plaintext escapes a suffix-filtered walk. `.chunk-cache/` is
+    scanned separately at store level; `events.jsonl` is scanned as a note
+    ledger, not an item surface."""
+    known, unknown = [], []
+    d = config.checkpoint_dir()
+    try:
+        entries = list(d.iterdir())
+    except OSError:
+        return [], []
+    for entry in entries:
+        try:
+            if entry.is_file():
+                if entry.suffix == ".json":
+                    known.append(entry)
+                elif entry.name != ".pointer.lock":
+                    unknown.append(entry)
+            elif entry.is_dir() and entry.name != ".chunk-cache":
+                for p in entry.iterdir():
+                    if not p.is_file():
+                        continue
+                    if p.suffix == ".json":
+                        known.append(p)
+                    elif p.name not in ("events.jsonl", ".pointer.lock"):
+                        unknown.append(p)
+        except OSError:
+            unknown.append(entry)
+    return known, unknown
+
+
+def _scan_json_surface(path: Path, slug: str, keys: set[str],
+                       surface: str) -> tuple[list[dict], bool | None]:
+    """Findings + membership. None membership = unreadable (unscannable).
+
+    Membership mirrors store.project_surfaces: bucket location OR payload
+    project_slug — but unreadable files are SURFACED here, not silently
+    excluded, because "could not check" must never fold into "clean"."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return [], None
+    if not isinstance(payload, dict):
+        return [], None
+    if path.parent.name != slug and payload.get("project_slug") != slug:
+        return [], False
+    findings: list[dict] = []
+    for section, key in store._ITEM_LISTS:
+        for item in ((payload.get(section) or {}).get(key) or []):
+            if not isinstance(item, dict):
+                continue
+            for h in _hashes(item) & keys:
+                findings.append({"path": str(path),
+                                 "item_id": item.get("id"),
+                                 "content_hash": h,
+                                 "surface": surface})
+    return findings, True
+
+
+def audit_project(project_dir=None) -> dict:
+    slug = store.project_slug(project_dir)
+    keys = store.forgotten_content_keys(project_dir=project_dir)
+    result = {"slug": slug, "findings": [], "informational": [],
+              "unscannable": [], "surfaces_scanned": 0,
+              "zero_surfaces": False, "cache": {}}
+    if not slug:
+        result["zero_surfaces"] = True
+        return result
+    known, unknown = _checkpoint_candidates()
+    result["unscannable"].extend(str(p) for p in unknown)
+    members = 0
+    for path in known:
+        findings, member = _scan_json_surface(path, slug, keys, "checkpoint")
+        if member is None:
+            result["unscannable"].append(str(path))
+        elif member:
+            members += 1
+            result["findings"].extend(findings)
+    result["surfaces_scanned"] = members
+    result["zero_surfaces"] = members == 0
+    return result

--- a/plugin/daimon_briefing/privacy.py
+++ b/plugin/daimon_briefing/privacy.py
@@ -12,6 +12,7 @@ output gets re-serialized into checkpoints, so printing the value would
 re-capture the thing the user deleted.
 """
 import json
+import sqlite3
 from pathlib import Path
 
 from . import config, normalize, store
@@ -94,6 +95,56 @@ def _scan_json_surface(path: Path, slug: str, keys: set[str],
     return findings, True
 
 
+def _scan_recall_db(db_path: Path, slug: str,
+                    keys: set[str]) -> tuple[list[dict], list[dict], bool | None]:
+    """Scan the derived index WITHOUT the recall API (which rebuilds).
+
+    A row match is only real residue if the stored fingerprint equals a
+    freshly computed one — forget deletes recall rows LAZILY at the next
+    rebuild, so a stale index legitimately still holds the value. Classing
+    that as residue would cry wolf after every single forget."""
+    from . import recall  # local import: only _fingerprint (pure read) is used
+    if not db_path.exists():
+        return [], [], True     # absent index holds nothing — vacuously clean
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            meta = dict(conn.execute("SELECT key, value FROM meta"))
+            rows = conn.execute(
+                "SELECT item_id, text, quote, scene, project_slug, author"
+                " FROM items").fetchall()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return [], [], None
+    current = meta.get("fingerprint") == recall._fingerprint()
+    union = store.all_forgotten_content_keys()
+    self_author = store.project_slug(config.author())
+    residue: list[dict] = []
+    informational: list[dict] = []
+    for item_id, text, quote, scene, row_slug, author in rows:
+        hashes = _hashes({"text": text, "quote": quote, "scene": scene})
+        if row_slug == slug:
+            hit, surface = hashes & keys, "recall-index-residue"
+        elif row_slug is None:
+            hit, surface = hashes & union, "unattributed"
+        elif author and store.project_slug(str(author)) != self_author:
+            # Foreign-author rows answer to the machine-global union — the
+            # shipped inbound gate's semantics (recall.py:244), mirrored.
+            hit, surface = hashes & union, "recall-index-residue"
+        else:
+            continue    # another local project's row — its own audit's job
+        for h in hit:
+            finding = {"path": str(db_path), "item_id": item_id,
+                       "content_hash": h, "surface": surface}
+            if current:
+                residue.append(finding)
+            else:
+                finding["surface"] = "stale-index-pending-rebuild"
+                informational.append(finding)
+    return residue, informational, True
+
+
 def audit_project(project_dir=None) -> dict:
     slug = store.project_slug(project_dir)
     keys = store.forgotten_content_keys(project_dir=project_dir)
@@ -115,4 +166,10 @@ def audit_project(project_dir=None) -> dict:
             result["findings"].extend(findings)
     result["surfaces_scanned"] = members
     result["zero_surfaces"] = members == 0
+    res, info, readable = _scan_recall_db(config.recall_db(), slug, keys)
+    if readable is None:
+        result["unscannable"].append(str(config.recall_db()))
+    else:
+        result["findings"].extend(res)
+        result["informational"].extend(info)
     return result

--- a/plugin/daimon_briefing/privacy.py
+++ b/plugin/daimon_briefing/privacy.py
@@ -68,20 +68,27 @@ def _checkpoint_candidates() -> tuple[list[Path], list[Path]]:
 
 
 def _scan_json_surface(path: Path, slug: str, keys: set[str],
-                       surface: str) -> tuple[list[dict], bool | None]:
+                       surface: str, by_payload_only: bool = False) -> tuple[list[dict], bool | None]:
     """Findings + membership. None membership = unreadable (unscannable).
 
     Membership mirrors store.project_surfaces: bucket location OR payload
     project_slug — but unreadable files are SURFACED here, not silently
-    excluded, because "could not check" must never fold into "clean"."""
+    excluded, because "could not check" must never fold into "clean".
+
+    When by_payload_only=True, membership is solely by payload project_slug.
+    This prevents author-dir-name collisions from false-matching team files."""
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return [], None
     if not isinstance(payload, dict):
         return [], None
-    if path.parent.name != slug and payload.get("project_slug") != slug:
-        return [], False
+    if by_payload_only:
+        if payload.get("project_slug") != slug:
+            return [], False
+    else:
+        if path.parent.name != slug and payload.get("project_slug") != slug:
+            return [], False
     findings: list[dict] = []
     for section, key in store._ITEM_LISTS:
         for item in ((payload.get(section) or {}).get(key) or []):
@@ -183,7 +190,8 @@ def audit_project(project_dir=None) -> dict:
     except OSError:
         team_files = []
     for path in team_files:
-        findings, member = _scan_json_surface(path, slug, keys, "team-copy")
+        findings, member = _scan_json_surface(path, slug, keys, "team-copy",
+                                              by_payload_only=True)
         if member is None:
             result["unscannable"].append(str(path))
         elif member:

--- a/plugin/daimon_briefing/privacy.py
+++ b/plugin/daimon_briefing/privacy.py
@@ -13,6 +13,7 @@ re-capture the thing the user deleted.
 """
 import json
 import sqlite3
+import time
 from pathlib import Path
 
 from . import config, normalize, store
@@ -169,9 +170,10 @@ def audit_project(project_dir=None) -> dict:
     keys = store.forgotten_content_keys(project_dir=project_dir)
     result = {"slug": slug, "findings": [], "informational": [],
               "unscannable": [], "surfaces_scanned": 0,
-              "zero_surfaces": False, "cache": {}}
+              "zero_surfaces": False}
     if not slug:
         result["zero_surfaces"] = True
+        result["cache"] = {"entries": 0, "oldest_days": None}
         return result
     known, unknown = _checkpoint_candidates()
     result["unscannable"].extend(str(p) for p in unknown)
@@ -210,4 +212,38 @@ def audit_project(project_dir=None) -> dict:
         for f in res + info:
             f["surface"] = "orphan-tmp"
             result["findings"].append(f)
+    # Notes: hashed WHOLE — catches a note that IS the value verbatim; a note
+    # merely containing it is undetectable by hash (stated report limitation).
+    events = config.checkpoint_dir() / slug / "events.jsonl"
+    if events.exists():
+        try:
+            for line in events.read_text(encoding="utf-8").splitlines():
+                try:
+                    evt = json.loads(line)
+                except ValueError:
+                    continue
+                note = evt.get("note") if isinstance(evt, dict) else None
+                if isinstance(note, str) and note.strip():
+                    h = normalize.content_key(note)
+                    if h in keys:
+                        result["findings"].append({
+                            "path": str(events),
+                            "item_id": evt.get("item"),
+                            "content_hash": h, "surface": "events-note"})
+        except OSError:
+            result["unscannable"].append(str(events))
+    # Chunk cache: value-level detection impossible (cache keyed by chunk
+    # text, values are substrings). Store-level honesty: entry count + real
+    # oldest age — the reaper runs only on WRITES, so never assert bounded.
+    cache_dir = config.checkpoint_dir() / ".chunk-cache"
+    entries, oldest = 0, None
+    try:
+        for p in cache_dir.iterdir():
+            if p.is_file():
+                entries += 1
+                age = (time.time() - p.stat().st_mtime) / 86400
+                oldest = age if oldest is None else max(oldest, age)
+    except OSError:
+        pass
+    result["cache"] = {"entries": entries, "oldest_days": oldest}
     return result

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -1319,3 +1319,35 @@ def _rich_stats(data: dict) -> None:
             console.print(f"[yellow]note: {pre} of those predate any "
                           f"agent-recorded resolution{when} — not a "
                           f"human-vs-agent ratio[/yellow]")
+
+
+def render_privacy_audit(results: list[dict]) -> None:
+    """Hashes only, never the text: this output gets re-serialized into
+    checkpoints, so printing a forgotten value would re-capture it."""
+    for r in results:
+        slug = r.get("slug") or "(unknown project)"
+        print(f"project {slug}: {r['surfaces_scanned']} surface(s) scanned")
+        if r.get("zero_surfaces"):
+            print("  WARNING: zero surfaces found — cannot distinguish an"
+                  " empty project from a scoping failure (not 'clean')")
+        for f in r["findings"]:
+            print(f"  RESIDUE [{f['surface']}] hash {f['content_hash']}"
+                  f" item {f.get('item_id') or '?'} in {f['path']}")
+            if f["surface"] == "team-copy":
+                print("    note: a team copy may also exist upstream,"
+                      " which no local scrub can reach")
+        for f in r["informational"]:
+            print(f"  stale [{f['surface']}] hash {f['content_hash']}"
+                  f" in {f['path']} (deleted at next index rebuild)")
+        for p in r["unscannable"]:
+            print(f"  UNSCANNABLE {p}")
+        cache = r.get("cache") or {}
+        if cache.get("entries"):
+            print(f"  chunk cache: {cache['entries']} entr(y/ies), oldest"
+                  f" {cache['oldest_days']:.1f}d — value-level scan impossible"
+                  " (substring vs hash); purge is wholesale on forget")
+        if not (r["findings"] or r["informational"] or r["unscannable"]
+                or r.get("zero_surfaces")):
+            print("  clean — no tombstoned value found on any surface")
+    print("note: a free-text event note merely CONTAINING a forgotten value"
+          " is undetectable by hash; only verbatim notes are caught")

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -1342,10 +1342,14 @@ def render_privacy_audit(results: list[dict]) -> None:
         for p in r["unscannable"]:
             print(f"  UNSCANNABLE {p}")
         cache = r.get("cache") or {}
-        if cache.get("entries"):
+        if cache.get("entries") and cache.get("oldest_days") is not None:
             print(f"  chunk cache: {cache['entries']} entr(y/ies), oldest"
                   f" {cache['oldest_days']:.1f}d — value-level scan impossible"
                   " (substring vs hash); purge is wholesale on forget")
+        elif cache.get("entries"):
+            print(f"  chunk cache: {cache['entries']} entr(y/ies) — age unknown,"
+                  " value-level scan impossible (substring vs hash); purge is"
+                  " wholesale on forget")
         if not (r["findings"] or r["informational"] or r["unscannable"]
                 or r.get("zero_surfaces")):
             print("  clean — no tombstoned value found on any surface")

--- a/plugin/tests/test_audit_privacy.py
+++ b/plugin/tests/test_audit_privacy.py
@@ -276,3 +276,61 @@ def test_residue_in_team_copy_detected(tmp_checkpoint_dir):
     result = privacy.audit_project(project_dir=PROJECT)
     assert any(f["surface"] == "team-copy" and f["content_hash"] == key
                for f in result["findings"])
+
+
+def test_team_cross_project_leak_prevented(tmp_checkpoint_dir):
+    """Team file under author dir NAMED the project slug, but different payload slug → not flagged."""
+    _write("S1", KEEPER)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    slug = store.project_slug(PROJECT)
+    other_slug = "different-project-slug"
+    # Author dir named SAME as audited project's slug, but payload is different project
+    team_file = (config.team_dir() / "github-com-example-memories" / "projects"
+                 / "x" / "y" / "authors" / slug / "S9.json")
+    team_file.parent.mkdir(parents=True, exist_ok=True)
+    team_file.write_text(json.dumps({
+        "session_id": "S9", "project_slug": other_slug,
+        "working_context": {"recent_decisions": [
+            {"text": CANARY, "id": "i-t", "trust": "inferred"}]},
+    }), encoding="utf-8")
+    result = privacy.audit_project(project_dir=PROJECT)
+    # Must NOT be in findings (payload slug is different, so team file is not this project's)
+    assert not any(f["surface"] == "team-copy" and f["content_hash"] == key
+                   for f in result["findings"])
+
+
+def test_corrupt_team_file_is_unscannable(tmp_checkpoint_dir):
+    """Malformed JSON in team dir → path in unscannable, not a crash."""
+    _write("S1", KEEPER)
+    corrupt_file = config.team_dir() / "github-com-example-memories" / "projects" / "a" / "b"
+    corrupt_file.mkdir(parents=True, exist_ok=True)
+    (corrupt_file / "corrupt.json").write_text("{this is not valid json", encoding="utf-8")
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert str(corrupt_file / "corrupt.json") in result["unscannable"]
+
+
+def test_team_findings_dont_count_toward_surfaces_scanned(tmp_checkpoint_dir):
+    """Team surfaces don't move surfaces_scanned/zero_surfaces; those are checkpoint-only metrics."""
+    # Project with NO local checkpoints, one matching team file
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    slug = store.project_slug(PROJECT)
+    team_file = (config.team_dir() / "github-com-example-memories" / "projects"
+                 / "x" / "y" / "authors" / "someone" / "S9.json")
+    team_file.parent.mkdir(parents=True, exist_ok=True)
+    team_file.write_text(json.dumps({
+        "session_id": "S9", "project_slug": slug,
+        "working_context": {"recent_decisions": [
+            {"text": CANARY, "id": "i-t", "trust": "inferred"}]},
+    }), encoding="utf-8")
+    result = privacy.audit_project(project_dir=PROJECT)
+    # surfaces_scanned should be 0 (no local checkpoints)
+    assert result["surfaces_scanned"] == 0
+    # zero_surfaces should be True (no local checkpoints)
+    assert result["zero_surfaces"] is True
+    # But team finding should still be present
+    assert any(f["surface"] == "team-copy" and f["content_hash"] == key
+               for f in result["findings"])

--- a/plugin/tests/test_audit_privacy.py
+++ b/plugin/tests/test_audit_privacy.py
@@ -106,7 +106,9 @@ def test_zero_surfaces_is_not_clean(tmp_checkpoint_dir):
 
 
 def _make_recall_db(tmp_path, rows, fingerprint):
-    """Build a minimal real recall.db shape at the isolated test location."""
+    """Build a minimal real recall.db shape at the isolated test location.
+
+    Rows can be 2-tuple (text, slug) or 3-tuple (text, slug, author)."""
     db = config.recall_db()
     db.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(db)
@@ -120,10 +122,15 @@ def _make_recall_db(tmp_path, rows, fingerprint):
         " pinned INTEGER NOT NULL DEFAULT 0,"
         " frontier INTEGER NOT NULL DEFAULT 0);")
     conn.execute("INSERT INTO meta VALUES ('fingerprint', ?)", (fingerprint,))
-    for text, slug in rows:
+    for row in rows:
+        if len(row) == 2:
+            text, slug = row
+            author = None
+        else:
+            text, slug, author = row
         conn.execute(
-            "INSERT INTO items(text, project_slug, item_id) VALUES (?, ?, 'i-r')",
-            (text, slug))
+            "INSERT INTO items(text, project_slug, item_id, author) VALUES (?, ?, 'i-r', ?)",
+            (text, slug, author))
     conn.commit()
     conn.close()
     return db
@@ -174,3 +181,53 @@ def test_missing_recall_db_is_not_created_by_audit(tmp_checkpoint_dir):
     assert not db.exists()
     privacy.audit_project(project_dir=PROJECT)
     assert not db.exists(), "audit must never create the recall db"
+
+
+def test_foreign_author_row_with_matching_tombstone_is_residue(tmp_checkpoint_dir):
+    from daimon_briefing import recall
+    _write("S1", KEEPER)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    # Foreign author (different from self_author project slug)
+    _make_recall_db(tmp_checkpoint_dir, [(CANARY, "other-slug", "foreign@example.com")],
+                    recall._fingerprint())
+    result = privacy.audit_project(project_dir=PROJECT)
+    # Foreign author rows answer to machine-global union, so a global tombstone
+    # creates a finding
+    assert any(f["surface"] == "recall-index-residue"
+               and f["content_hash"] == key for f in result["findings"])
+
+
+def test_different_local_project_row_not_flagged(tmp_checkpoint_dir):
+    from daimon_briefing import recall
+    other = "/p/other-project"
+    _write("S1", KEEPER)
+    _write("S2", KEEPER, project_dir=other)
+    key = normalize.content_key(CANARY)
+    # Tombstone in THIS project
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    # But the row belongs to the OTHER local project with a local author
+    other_slug = store.project_slug(other)
+    local_author = config.author()  # local author
+    _make_recall_db(tmp_checkpoint_dir, [(CANARY, other_slug, local_author)],
+                    recall._fingerprint())
+    result = privacy.audit_project(project_dir=PROJECT)
+    # Other local project's row should not be flagged by this project's audit
+    assert not any(f["content_hash"] == key for f in result["findings"])
+
+
+def test_null_slug_row_with_stale_fingerprint_is_informational(tmp_checkpoint_dir):
+    _write("S1", KEEPER)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    # NULL slug row with stale fingerprint
+    _make_recall_db(tmp_checkpoint_dir, [(CANARY, None)], "stale-fp")
+    result = privacy.audit_project(project_dir=PROJECT)
+    # Should appear in informational, not findings
+    assert not any(f["surface"] == "unattributed" and f["content_hash"] == key
+                   for f in result["findings"])
+    assert any(f["surface"] == "stale-index-pending-rebuild"
+               and f["content_hash"] == key for f in result["informational"])

--- a/plugin/tests/test_audit_privacy.py
+++ b/plugin/tests/test_audit_privacy.py
@@ -421,3 +421,47 @@ def test_render_never_prints_plaintext(tmp_checkpoint_dir, capsys):
     out = capsys.readouterr().out
     assert CANARY not in out
     assert key in out
+
+
+def _daimon_home_snapshot():
+    """(relative_path, bytes) for everything under ~/.daimon except logs/."""
+    home = config.checkpoint_dir().parent
+    out = {}
+    for p in sorted(home.rglob("*")):
+        if p.is_file() and "logs" not in p.relative_to(home).parts:
+            out[str(p.relative_to(home))] = p.read_bytes()
+    return out
+
+
+def test_cli_audit_privacy_runs_and_exits_by_contract(tmp_checkpoint_dir):
+    _write("S1", CANARY)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    assert cli.main(["audit", "privacy", "--project", PROJECT]) == 1
+    # After a REAL forget (which scrubs), audit proves clean.
+    _forget(CANARY)
+    assert cli.main(["audit", "privacy", "--project", PROJECT]) == 0
+
+
+def test_cli_audit_is_read_only_outside_logs(tmp_checkpoint_dir):
+    _write("S1", CANARY)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    before = _daimon_home_snapshot()
+    cli.main(["audit", "privacy", "--project", PROJECT])
+    assert _daimon_home_snapshot() == before
+
+
+def test_audit_quotes_moved_and_alias_deprecated(tmp_checkpoint_dir, capsys):
+    _write("S1", KEEPER)
+    assert cli.main(["audit", "quotes", "--project", PROJECT]) == 0
+    capsys.readouterr()
+    assert cli.main(["audit-quotes", "--project", PROJECT]) == 0
+    assert "deprecated" in capsys.readouterr().out.lower()
+
+
+def test_cli_audit_all_flag(tmp_checkpoint_dir):
+    _write("S1", KEEPER)
+    assert cli.main(["audit", "privacy", "--all"]) in (0, 3)

--- a/plugin/tests/test_audit_privacy.py
+++ b/plugin/tests/test_audit_privacy.py
@@ -5,7 +5,8 @@ tombstoned content key, no plaintext copy may survive on any surface —
 including the `quote`/`scene` fields forget itself does not yet reach,
 and files forget's walk does not recognise.
 """
-from daimon_briefing import cli, normalize, privacy, store
+import sqlite3
+from daimon_briefing import cli, config, normalize, privacy, store
 
 
 PROJECT = "/p/audit-privacy"
@@ -102,3 +103,74 @@ def test_zero_surfaces_is_not_clean(tmp_checkpoint_dir):
     # No checkpoint ever written for this project — scar 0023 class.
     result = privacy.audit_project(project_dir="/p/never-existed")
     assert result["zero_surfaces"] is True
+
+
+def _make_recall_db(tmp_path, rows, fingerprint):
+    """Build a minimal real recall.db shape at the isolated test location."""
+    db = config.recall_db()
+    db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        "CREATE TABLE meta(key TEXT PRIMARY KEY, value TEXT);"
+        "CREATE TABLE items(id INTEGER PRIMARY KEY, text TEXT NOT NULL,"
+        " quote TEXT, scene TEXT, trust TEXT, kind TEXT, author TEXT,"
+        " project_slug TEXT, session_id TEXT, created REAL,"
+        " superseded_by TEXT, invalidated_by TEXT, importance INTEGER,"
+        " first_seen TEXT, item_id TEXT,"
+        " pinned INTEGER NOT NULL DEFAULT 0,"
+        " frontier INTEGER NOT NULL DEFAULT 0);")
+    conn.execute("INSERT INTO meta VALUES ('fingerprint', ?)", (fingerprint,))
+    for text, slug in rows:
+        conn.execute(
+            "INSERT INTO items(text, project_slug, item_id) VALUES (?, ?, 'i-r')",
+            (text, slug))
+    conn.commit()
+    conn.close()
+    return db
+
+
+def test_recall_residue_with_current_fingerprint_is_a_finding(tmp_checkpoint_dir):
+    from daimon_briefing import recall
+    _write("S1", KEEPER)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    slug = store.project_slug(PROJECT)
+    _make_recall_db(tmp_checkpoint_dir, [(CANARY, slug)], recall._fingerprint())
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert any(f["surface"] == "recall-index-residue"
+               and f["content_hash"] == key for f in result["findings"])
+
+
+def test_recall_residue_with_stale_fingerprint_is_informational(tmp_checkpoint_dir):
+    _write("S1", KEEPER)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    slug = store.project_slug(PROJECT)
+    _make_recall_db(tmp_checkpoint_dir, [(CANARY, slug)], "stale-fp")
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert not any(f["surface"] == "recall-index-residue"
+                   for f in result["findings"])
+    assert any(f["surface"] == "stale-index-pending-rebuild"
+               and f["content_hash"] == key for f in result["informational"])
+
+
+def test_null_slug_row_reported_as_unattributed(tmp_checkpoint_dir):
+    from daimon_briefing import recall
+    _write("S1", KEEPER)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    _make_recall_db(tmp_checkpoint_dir, [(CANARY, None)], recall._fingerprint())
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert any(f["surface"] == "unattributed"
+               and f["content_hash"] == key for f in result["findings"])
+
+
+def test_missing_recall_db_is_not_created_by_audit(tmp_checkpoint_dir):
+    _write("S1", KEEPER)
+    db = config.recall_db()
+    assert not db.exists()
+    privacy.audit_project(project_dir=PROJECT)
+    assert not db.exists(), "audit must never create the recall db"

--- a/plugin/tests/test_audit_privacy.py
+++ b/plugin/tests/test_audit_privacy.py
@@ -1,0 +1,104 @@
+"""`daimon audit privacy` — read-only tombstone residue audit.
+
+The audit proves forget's contract instead of trusting it: for every
+tombstoned content key, no plaintext copy may survive on any surface —
+including the `quote`/`scene` fields forget itself does not yet reach,
+and files forget's walk does not recognise.
+"""
+from daimon_briefing import cli, normalize, privacy, store
+
+
+PROJECT = "/p/audit-privacy"
+CANARY = "zqxprivcanary4431 rotate the signing key before the next deploy"
+KEEPER = "an unrelated decision that must not be reported"
+
+
+def _write(session_id, *texts, project_dir=PROJECT):
+    store.write_checkpoint(session_id, {
+        "session_id": session_id,
+        "created": f"2026-08-0{session_id[-1]}T00:00:00Z",
+        "working_context": {
+            "recent_decisions": [{"text": t, "trust": "inferred"} for t in texts]},
+    }, project_dir=project_dir)
+
+
+def _forget(value):
+    assert cli.main(["forget", value, "--project", PROJECT]) == 0
+
+
+def test_hashes_covers_text_quote_and_scene():
+    item = {"text": "a", "quote": "b", "scene": "c", "id": "i-1"}
+    assert privacy._hashes(item) == {
+        normalize.content_key("a"),
+        normalize.content_key("b"),
+        normalize.content_key("c"),
+    }
+
+
+def test_residue_in_prev_n_detected(tmp_checkpoint_dir):
+    _write("S1", CANARY, KEEPER)
+    _write("S2", KEEPER)          # rotation: S1 state now sits in prev-1
+    # Tombstone WITHOUT scrubbing: append the ledger event directly, so the
+    # plaintext demonstrably remains and the audit must find it.
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert any(f["content_hash"] == key for f in result["findings"])
+
+
+def test_residue_in_quote_field_detected(tmp_checkpoint_dir):
+    store.write_checkpoint("S1", {
+        "session_id": "S1", "created": "2026-08-01T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": KEEPER, "quote": CANARY, "trust": "verbatim"}]},
+    }, project_dir=PROJECT)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert any(f["content_hash"] == key for f in result["findings"])
+
+
+def test_clean_tree_reports_nothing(tmp_checkpoint_dir):
+    _write("S1", KEEPER)
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert result["findings"] == []
+    assert result["unscannable"] == []
+    assert result["surfaces_scanned"] > 0
+
+
+def test_reopened_tombstone_not_flagged(tmp_checkpoint_dir):
+    _write("S1", CANARY)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    store.append_event("i-x", "reopened", project_dir=PROJECT)
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert not any(f["content_hash"] == key for f in result["findings"])
+
+
+def test_other_projects_residue_not_flagged(tmp_checkpoint_dir):
+    other = "/p/other-project"
+    _write("S1", CANARY, project_dir=other)
+    _write("S2", KEEPER)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)   # tombstoned HERE, lives THERE
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert not any(f["content_hash"] == key for f in result["findings"])
+
+
+def test_unknown_file_in_bucket_is_unscannable(tmp_checkpoint_dir):
+    _write("S1", KEEPER)
+    slug = store.project_slug(PROJECT)
+    bak = tmp_checkpoint_dir / slug / "latest.json.bak-123"
+    bak.write_text("{}", encoding="utf-8")
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert str(bak) in result["unscannable"]
+
+
+def test_zero_surfaces_is_not_clean(tmp_checkpoint_dir):
+    # No checkpoint ever written for this project — scar 0023 class.
+    result = privacy.audit_project(project_dir="/p/never-existed")
+    assert result["zero_surfaces"] is True

--- a/plugin/tests/test_audit_privacy.py
+++ b/plugin/tests/test_audit_privacy.py
@@ -5,6 +5,7 @@ tombstoned content key, no plaintext copy may survive on any surface —
 including the `quote`/`scene` fields forget itself does not yet reach,
 and files forget's walk does not recognise.
 """
+import json
 import sqlite3
 from daimon_briefing import cli, config, normalize, privacy, store
 
@@ -256,3 +257,22 @@ def test_corrupt_orphan_is_unscannable_not_crash(tmp_checkpoint_dir):
     orphan.write_bytes(b"not a sqlite file")
     result = privacy.audit_project(project_dir=PROJECT)
     assert str(orphan) in result["unscannable"]
+
+
+def test_residue_in_team_copy_detected(tmp_checkpoint_dir):
+    _write("S1", KEEPER)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    slug = store.project_slug(PROJECT)
+    team_file = (config.team_dir() / "github-com-example-memories" / "projects"
+                 / "x" / "y" / "authors" / "someone" / "S9.json")
+    team_file.parent.mkdir(parents=True, exist_ok=True)
+    team_file.write_text(json.dumps({
+        "session_id": "S9", "project_slug": slug,
+        "working_context": {"recent_decisions": [
+            {"text": CANARY, "id": "i-t", "trust": "inferred"}]},
+    }), encoding="utf-8")
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert any(f["surface"] == "team-copy" and f["content_hash"] == key
+               for f in result["findings"])

--- a/plugin/tests/test_audit_privacy.py
+++ b/plugin/tests/test_audit_privacy.py
@@ -7,7 +7,10 @@ and files forget's walk does not recognise.
 """
 import json
 import sqlite3
-from daimon_briefing import cli, config, normalize, privacy, store
+
+import pytest
+
+from daimon_briefing import cli, config, normalize, privacy, render, store
 
 
 PROJECT = "/p/audit-privacy"
@@ -46,7 +49,13 @@ def test_residue_in_prev_n_detected(tmp_checkpoint_dir):
     store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
                        project_dir=PROJECT)
     result = privacy.audit_project(project_dir=PROJECT)
-    assert any(f["content_hash"] == key for f in result["findings"])
+    hits = [f for f in result["findings"] if f["content_hash"] == key]
+    assert hits
+    # Pin the SURFACE, not just the hash: the rotated pointer is the #583 hole
+    # (forget reasoned about the live checkpoint only), so a finding that came
+    # from anywhere else would silently pass this test.
+    assert any(f["path"].endswith("prev-1.json") for f in hits), \
+        f"expected a prev-1.json finding, got {[f['path'] for f in hits]}"
 
 
 def test_residue_in_quote_field_detected(tmp_checkpoint_dir):
@@ -410,7 +419,6 @@ def test_audit_all_uses_per_project_tombstones(tmp_checkpoint_dir):
 
 
 def test_render_never_prints_plaintext(tmp_checkpoint_dir, capsys):
-    from daimon_briefing import render
     _write("S1", CANARY)
     key = normalize.content_key(CANARY)
     store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
@@ -445,13 +453,414 @@ def test_cli_audit_privacy_runs_and_exits_by_contract(tmp_checkpoint_dir):
 
 
 def test_cli_audit_is_read_only_outside_logs(tmp_checkpoint_dir):
+    """Byte-identical AND sidecar-free: every scannable surface shape must be
+    on disk before the snapshot, or the assertion has nothing to bite on. A
+    `mode=ro` open of a WAL-mode sqlite file still CREATES `-shm`/`-wal`, so
+    the orphan snapshots are opened `immutable=1` — asserted here."""
+    from daimon_briefing import recall
     _write("S1", CANARY)
     key = normalize.content_key(CANARY)
     store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
                        project_dir=PROJECT)
+    slug = store.project_slug(PROJECT)
+    db = _make_recall_db(tmp_checkpoint_dir, [(CANARY, slug)],
+                         recall._fingerprint())
+    orphan = db.with_name("recall.db.4242.tmp")
+    orphan.write_bytes(db.read_bytes())      # crashed-rebuild snapshot
+    conn = sqlite3.connect(orphan)           # ...left in WAL mode by the crash
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.commit()
+    conn.close()                             # clean close removes -wal/-shm
+    _team_file(("acme", "backend"), "someone", "S9", slug, CANARY)
     before = _daimon_home_snapshot()
-    cli.main(["audit", "privacy", "--project", PROJECT])
+    assert cli.main(["audit", "privacy", "--project", PROJECT]) == 1, \
+        "fixture must exercise the residue path, not the empty path"
     assert _daimon_home_snapshot() == before
+    for sidecar in ("recall.db-wal", "recall.db-shm",
+                    "recall.db.4242.tmp-wal", "recall.db.4242.tmp-shm"):
+        assert not (db.parent / sidecar).exists(), \
+            f"audit created {sidecar} — the read must leave no sqlite sidecar"
+
+
+# ---- C1: the event ledger carries plaintext in THREE fields, not one ----
+
+
+def test_event_item_text_carrying_value_detected(tmp_checkpoint_dir):
+    """`daimon resolve` / `reopen` pass the item's full text as `item_text`
+    (store.append_event) with no forget gate, and events.jsonl is never
+    rewritten — so resolve-then-forget leaves the value on disk."""
+    _write("S1", KEEPER)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-y", "resolved", item_text=CANARY, project_dir=PROJECT)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    result = privacy.audit_project(project_dir=PROJECT)
+    found = [f for f in result["findings"]
+             if f["surface"] == "events-note" and f["content_hash"] == key]
+    assert found, "item_text residue in the event ledger must be detected"
+    assert found[0]["item_id"] == "i-y"
+
+
+def test_event_status_carrying_value_detected(tmp_checkpoint_dir):
+    """`status` is free-form by design (readers prefix-match), so a user's own
+    resolution wording can BE the forgotten value."""
+    _write("S1", KEEPER)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-y", CANARY, project_dir=PROJECT)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    result = privacy.audit_project(project_dir=PROJECT)
+    found = [f for f in result["findings"]
+             if f["surface"] == "events-note" and f["content_hash"] == key]
+    assert found, "status residue in the event ledger must be detected"
+    assert found[0]["item_id"] == "i-y"
+
+
+def test_tombstone_status_never_self_reports(tmp_checkpoint_dir):
+    """The tombstone's own status is `forgotten:<hash>` — hashing that STRING
+    can never equal the key it names, so no special case is needed and none
+    may be faked into existence either."""
+    _write("S1", KEEPER)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert result["findings"] == []
+    assert privacy.exit_code([result]) == 0
+
+
+def test_non_utf8_events_ledger_is_unscannable(tmp_checkpoint_dir):
+    """A non-UTF-8 ledger raises UnicodeDecodeError (a ValueError) out of
+    read_text — cannot-check, never a crash and never silent-clean."""
+    _write("S1", KEEPER)
+    events = tmp_checkpoint_dir / store.project_slug(PROJECT) / "events.jsonl"
+    events.parent.mkdir(parents=True, exist_ok=True)
+    events.write_bytes(b"\xff\xfe garbage")
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert str(events) in result["unscannable"]
+    assert privacy.exit_code([result]) == 3
+
+
+def test_torn_and_non_dict_event_lines_are_skipped(tmp_checkpoint_dir):
+    """The ledger is append-only and can be torn mid-write. A junk line is a
+    line, not a reason to stop reading the rest of the file."""
+    _write("S1", KEEPER)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    events = tmp_checkpoint_dir / store.project_slug(PROJECT) / "events.jsonl"
+    with events.open("a", encoding="utf-8") as f:
+        f.write('{"kind": "resolution", "item_ref": "i-t\n')   # torn
+        f.write('"a bare string, not a row"\n')                # non-dict
+    store.append_event("i-y", "resolved", note=CANARY, project_dir=PROJECT)
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert any(f["surface"] == "events-note" and f["item_id"] == "i-y"
+               for f in result["findings"])
+    assert str(events) not in result["unscannable"]
+
+
+def test_non_dict_item_in_a_checkpoint_list_is_skipped(tmp_checkpoint_dir):
+    _write("S1", KEEPER)
+    odd = tmp_checkpoint_dir / store.project_slug(PROJECT) / "S9.json"
+    odd.write_text(json.dumps({
+        "session_id": "S9", "project_slug": store.project_slug(PROJECT),
+        "working_context": {"recent_decisions": ["not an item", None]},
+    }), encoding="utf-8")
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert str(odd) not in result["unscannable"]
+    assert result["findings"] == []
+
+
+def test_team_segments_only_reads_the_nested_layout(tmp_path):
+    root = tmp_path / "team"
+    nested = root / "remote" / "projects" / "acme" / "backend" / "authors" / "me" / "S1.json"
+    assert privacy._team_segments(root, nested) == ("acme", "backend")
+    flat = root / "remote" / "authors" / "me" / "S1.json"
+    assert privacy._team_segments(root, flat) is None
+    assert privacy._team_segments(root, tmp_path / "elsewhere" / "S1.json") is None
+
+
+def test_unreadable_index_location_is_unscannable(tmp_path):
+    """`Path.exists()` raises (not returns False) when the parent dir denies
+    access — a stat we cannot do is cannot-prove, never vacuously clean."""
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    (locked / "recall.db").write_bytes(b"x")
+    locked.chmod(0o000)
+    try:
+        _res, _info, readable = privacy._scan_recall_db(
+            locked / "recall.db", "slug", set())
+    finally:
+        locked.chmod(0o755)
+    assert readable is None
+
+
+def test_walks_that_raise_degrade_instead_of_crashing(
+        tmp_checkpoint_dir, monkeypatch):
+    """The orphan glob and the team rglob are best-effort. A filesystem that
+    raises mid-walk must degrade to "nothing found there", never abort the
+    audit — and pathlib's globs swallow EACCES, so the error is injected."""
+    _write("S1", KEEPER)
+
+    def boom(*_a, **_kw):
+        raise OSError("walk exploded")
+
+    monkeypatch.setattr(privacy.Path, "glob", boom)
+    monkeypatch.setattr(privacy.Path, "rglob", boom)
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert result["findings"] == []
+    assert result["surfaces_scanned"] > 0
+
+
+def test_unreadable_bucket_dir_is_unscannable(tmp_checkpoint_dir):
+    _write("S1", KEEPER)
+    bucket = tmp_checkpoint_dir / store.project_slug(PROJECT)
+    bucket.chmod(0o000)
+    try:
+        result = privacy.audit_project(project_dir=PROJECT)
+    finally:
+        bucket.chmod(0o755)
+    assert str(bucket) in result["unscannable"]
+    assert privacy.exit_code([result]) == 3
+
+
+# ---- C2: known plaintext-free sidecars are not "unknown" ----
+
+
+def test_known_sidecar_files_are_not_unscannable(tmp_checkpoint_dir):
+    """Every one of these is plaintext-free BY CONSTRUCTION (receipts hold
+    hashes+JWS, verification.jsonl a pointer+reason code, forget-hits.jsonl
+    {ts,key}, the lock file is empty, .DS_Store is Finder metadata). Reporting
+    them made exit 0 unreachable on a real install."""
+    _write("S1", KEEPER)
+    bucket = tmp_checkpoint_dir / store.project_slug(PROJECT)
+    for d in (bucket, tmp_checkpoint_dir):
+        (d / "S1.receipt").write_text("{}", encoding="utf-8")
+        (d / "verification.jsonl").write_text('{"item_ref": "i-1"}\n',
+                                              encoding="utf-8")
+        (d / "forget-hits.jsonl").write_text('{"key": "h"}\n', encoding="utf-8")
+        (d / ".DS_Store").write_bytes(b"\x00\x01")
+        (d / store._LOCK_NAME).write_text("", encoding="utf-8")
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert result["unscannable"] == []
+    assert privacy.exit_code([result]) == 0
+
+
+# ---- I1: an unknown file belongs to ITS bucket's audit ----
+
+
+def test_unknown_file_in_another_bucket_does_not_taint_this_project(
+        tmp_checkpoint_dir):
+    _write("S1", KEEPER)
+    other = "/p/other-project"
+    _write("S2", KEEPER, project_dir=other)
+    bak = tmp_checkpoint_dir / store.project_slug(other) / "latest.json.bak-9"
+    bak.write_text("{}", encoding="utf-8")
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert str(bak) not in result["unscannable"]
+    assert privacy.exit_code([result]) == 0
+    # ...but it IS that project's problem.
+    other_result = privacy.audit_project(project_dir=other)
+    assert str(bak) in other_result["unscannable"]
+
+
+def test_unknown_file_in_flat_dir_taints_every_project(tmp_checkpoint_dir):
+    """The flat dir is shared — `latest.json` there may hold ANY project's
+    session, so an unrecognised file beside it is every audit's blind spot."""
+    _write("S1", KEEPER)
+    stray = tmp_checkpoint_dir / "latest.json.bak-7"
+    stray.write_text("{}", encoding="utf-8")
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert str(stray) in result["unscannable"]
+
+
+def test_nested_dir_inside_bucket_is_unscannable(tmp_checkpoint_dir):
+    """A directory the walk does not descend into is exactly the `.bak` class:
+    unknown shape, unread contents. Report it, never skip it."""
+    _write("S1", KEEPER)
+    nested = tmp_checkpoint_dir / store.project_slug(PROJECT) / "archive"
+    nested.mkdir(parents=True, exist_ok=True)
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert str(nested) in result["unscannable"]
+
+
+# ---- I2: a teammate's copy is stamped with the WRITER's slug ----
+
+
+def _team_file(segs, author, sid, payload_slug, text, remote="github-com-x"):
+    path = config.team_dir().joinpath(
+        remote, "projects", *segs, "authors", author, f"{sid}.json")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({
+        "session_id": sid, "project_slug": payload_slug,
+        "working_context": {"recent_decisions": [
+            {"text": text, "id": "i-t", "trust": "inferred"}]},
+    }), encoding="utf-8")
+    return path
+
+
+def test_teammate_copy_under_shared_project_path_detected(tmp_checkpoint_dir):
+    """The spec's motivating case. A teammate's mirror of THIS project stamps
+    the writer's own path-derived slug, so payload-slug membership skipped it
+    entirely. The `projects/<segs>/` subtree is the project identity (the same
+    thing store.read_team filters on) — and this machine's own dual-written
+    copy in that subtree is what proves the subtree is ours."""
+    _write("S1", KEEPER)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    slug = store.project_slug(PROJECT)
+    segs = ("acme", "backend")
+    mine = store.project_slug(config.author()) or "me"
+    _team_file(segs, mine, "S1", slug, KEEPER)         # my own mirror
+    theirs = _team_file(segs, "other-author", "S9",
+                        "-home-them-checkouts-backend", CANARY)
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert any(f["surface"] == "team-copy" and f["content_hash"] == key
+               and f["path"] == str(theirs) for f in result["findings"])
+
+
+def test_teammate_copy_under_resolved_team_path_detected(
+        tmp_checkpoint_dir, monkeypatch):
+    """No local mirror in the subtree at all: the logical path resolves from
+    DAIMON_TEAM_PROJECT (teamproject tier 1), exactly as read_team resolves it."""
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "acme/backend")
+    _write("S1", KEEPER)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    theirs = _team_file(("acme", "backend"), "other-author", "S9",
+                        "-home-them-checkouts-backend", CANARY)
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert any(f["surface"] == "team-copy" and f["path"] == str(theirs)
+               for f in result["findings"])
+
+
+# ---- I5: best-effort branches must be proven, not assumed ----
+
+
+def test_residue_in_scene_field_detected(tmp_checkpoint_dir):
+    """`scene` is episodic narrative forget does not reach — the audit does."""
+    store.write_checkpoint("S1", {
+        "session_id": "S1", "created": "2026-08-01T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": KEEPER, "scene": CANARY, "trust": "inferred"}]},
+    }, project_dir=PROJECT)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert any(f["content_hash"] == key and f["surface"] == "checkpoint"
+               for f in result["findings"])
+
+
+def test_non_dict_checkpoint_payload_is_unscannable(tmp_checkpoint_dir):
+    _write("S1", KEEPER)
+    odd = tmp_checkpoint_dir / store.project_slug(PROJECT) / "S9.json"
+    odd.write_text("[1, 2, 3]", encoding="utf-8")
+    assert str(odd) in privacy.audit_project(
+        project_dir=PROJECT)["unscannable"]
+
+
+def test_corrupt_local_checkpoint_is_unscannable(tmp_checkpoint_dir):
+    _write("S1", KEEPER)
+    torn = tmp_checkpoint_dir / store.project_slug(PROJECT) / "S9.json"
+    torn.write_text("{this is not valid json", encoding="utf-8")
+    assert str(torn) in privacy.audit_project(
+        project_dir=PROJECT)["unscannable"]
+
+
+def test_corrupt_recall_db_is_unscannable(tmp_checkpoint_dir):
+    _write("S1", KEEPER)
+    db = config.recall_db()
+    db.parent.mkdir(parents=True, exist_ok=True)
+    db.write_bytes(b"not a sqlite file")
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert str(db) in result["unscannable"]
+    assert privacy.exit_code([result]) == 3
+
+
+def test_audit_all_with_unreadable_checkpoint_dir_is_cannot_prove(
+        tmp_path, monkeypatch):
+    dud = tmp_path / "checkpoints-is-a-file"
+    dud.write_text("not a directory", encoding="utf-8")
+    monkeypatch.setattr(config, "checkpoint_dir", lambda: dud)
+    results = privacy.audit_all()
+    assert results == []
+    assert privacy.exit_code(results) == 3
+
+
+def test_audit_without_a_project_is_cannot_prove(tmp_checkpoint_dir):
+    """No slug = nothing to scope a scan to. Never "clean"."""
+    for no_project in (None, ""):
+        result = privacy.audit_project(project_dir=no_project)
+        assert result["slug"] is None
+        assert result["zero_surfaces"] is True
+        assert result["cache"] == {"entries": 0, "oldest_days": None}
+        assert privacy.exit_code([result]) == 3
+
+
+# ---- render: every line shape, hashes only ----
+
+
+def test_render_covers_every_line_shape(capsys):
+    render.render_privacy_audit([{
+        "slug": None, "surfaces_scanned": 0, "zero_surfaces": True,
+        "findings": [{"path": "/t/S9.json", "item_id": "i-t",
+                      "content_hash": "hteam", "surface": "team-copy"}],
+        "informational": [{"path": "/t/recall.db", "item_id": "i-r",
+                           "content_hash": "hstale",
+                           "surface": "stale-index-pending-rebuild"}],
+        "unscannable": ["/t/latest.json.bak-1"],
+        "cache": {"entries": 2, "oldest_days": 3.0},
+    }])
+    out = capsys.readouterr().out
+    assert "(unknown project)" in out
+    assert "WARNING: zero surfaces" in out
+    assert "RESIDUE [team-copy] hash hteam" in out
+    assert "may also exist upstream" in out
+    assert "stale [stale-index-pending-rebuild] hash hstale" in out
+    assert "UNSCANNABLE /t/latest.json.bak-1" in out
+    assert "chunk cache: 2 entr(y/ies), oldest 3.0d" in out
+
+
+def test_render_cache_age_unknown_line(capsys):
+    render.render_privacy_audit([{
+        "slug": "p", "surfaces_scanned": 1, "zero_surfaces": False,
+        "findings": [], "informational": [], "unscannable": [],
+        "cache": {"entries": 4, "oldest_days": None},
+    }])
+    out = capsys.readouterr().out
+    assert "chunk cache: 4 entr(y/ies) — age unknown" in out
+    assert "clean — no tombstoned value found" in out
+
+
+# ---- CLI surface ----
+
+
+def test_cli_all_and_project_are_mutually_exclusive(tmp_checkpoint_dir):
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["audit", "privacy", "--all", "--project", PROJECT])
+    assert exc.value.code == 2
+
+
+def test_usage_tag_distinguishes_the_three_outcomes(tmp_checkpoint_dir):
+    """`daimon stats` must be able to tell "ran the auditor" from "the auditor
+    found residue" from "the auditor could not prove anything"."""
+    usage = config.log_dir() / "usage.log"
+    _write("S1", CANARY)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    assert cli.main(["audit", "privacy", "--project", PROJECT]) == 1
+    assert usage.read_text(encoding="utf-8").rstrip().endswith(
+        "audit-privacy:residue")
+    assert cli.main(["audit", "privacy", "--project", "/p/never-existed"]) == 3
+    assert usage.read_text(encoding="utf-8").rstrip().endswith(
+        "audit-privacy:unproven")
+    _forget(CANARY)
+    assert cli.main(["audit", "privacy", "--project", PROJECT]) == 0
+    assert usage.read_text(encoding="utf-8").rstrip().endswith("audit-privacy")
 
 
 def test_audit_quotes_moved_and_alias_deprecated(tmp_checkpoint_dir, capsys):
@@ -463,5 +872,8 @@ def test_audit_quotes_moved_and_alias_deprecated(tmp_checkpoint_dir, capsys):
 
 
 def test_cli_audit_all_flag(tmp_checkpoint_dir):
+    # One bucket, one clean checkpoint, nothing unknown on disk: the ONLY
+    # honest answer is 0. `in (0, 3)` would have passed with the auditor
+    # reporting cannot-prove for a tree it fully scanned.
     _write("S1", KEEPER)
-    assert cli.main(["audit", "privacy", "--all"]) in (0, 3)
+    assert cli.main(["audit", "privacy", "--all"]) == 0

--- a/plugin/tests/test_audit_privacy.py
+++ b/plugin/tests/test_audit_privacy.py
@@ -343,8 +343,10 @@ def test_verbatim_note_detected(tmp_checkpoint_dir):
     store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
                        project_dir=PROJECT)
     result = privacy.audit_project(project_dir=PROJECT)
-    assert any(f["surface"] == "events-note" and f["content_hash"] == key
-               for f in result["findings"])
+    found = [f for f in result["findings"]
+             if f["surface"] == "events-note" and f["content_hash"] == key]
+    assert len(found) > 0, "events-note finding not detected"
+    assert found[0]["item_id"] == "i-y", "item_id must match event's item_ref"
 
 
 def test_chunk_cache_reported_at_store_level(tmp_checkpoint_dir):
@@ -355,3 +357,17 @@ def test_chunk_cache_reported_at_store_level(tmp_checkpoint_dir):
     result = privacy.audit_project(project_dir=PROJECT)
     assert result["cache"]["entries"] == 1
     assert result["cache"]["oldest_days"] is not None
+
+
+def test_tombstone_own_note_detected(tmp_checkpoint_dir):
+    """Regression: tombstone's reason field (note) carrying the value must be caught."""
+    _write("S1", KEEPER)
+    key = normalize.content_key(CANARY)
+    # User pasted the value as --reason when forgetting
+    store.append_event("i-x", f"forgotten:{key}", note=CANARY, kind="tombstone",
+                       project_dir=PROJECT)
+    result = privacy.audit_project(project_dir=PROJECT)
+    found = [f for f in result["findings"]
+             if f["surface"] == "events-note" and f["content_hash"] == key]
+    assert len(found) > 0, "tombstone note containing value must be detected"
+    assert found[0]["item_id"] == "i-x", "item_id must match tombstone event's id"

--- a/plugin/tests/test_audit_privacy.py
+++ b/plugin/tests/test_audit_privacy.py
@@ -334,3 +334,24 @@ def test_team_findings_dont_count_toward_surfaces_scanned(tmp_checkpoint_dir):
     # But team finding should still be present
     assert any(f["surface"] == "team-copy" and f["content_hash"] == key
                for f in result["findings"])
+
+
+def test_verbatim_note_detected(tmp_checkpoint_dir):
+    _write("S1", KEEPER)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-y", "resolved", note=CANARY, project_dir=PROJECT)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert any(f["surface"] == "events-note" and f["content_hash"] == key
+               for f in result["findings"])
+
+
+def test_chunk_cache_reported_at_store_level(tmp_checkpoint_dir):
+    _write("S1", KEEPER)
+    cache = tmp_checkpoint_dir / ".chunk-cache"
+    cache.mkdir(parents=True, exist_ok=True)
+    (cache / "abc123.json").write_text("{}", encoding="utf-8")
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert result["cache"]["entries"] == 1
+    assert result["cache"]["oldest_days"] is not None

--- a/plugin/tests/test_audit_privacy.py
+++ b/plugin/tests/test_audit_privacy.py
@@ -381,11 +381,16 @@ def test_exit_code_semantics():
                                      "surface": "checkpoint"}])
     unscan = dict(clean, unscannable=["p"])
     zero = dict(clean, zero_surfaces=True, surfaces_scanned=0)
+    stale_only = dict(clean, informational=[{"path": "p", "item_id": None,
+                                             "content_hash": "h",
+                                             "surface": "stale-index-pending-rebuild"}])
     assert privacy.exit_code([clean]) == 0
     assert privacy.exit_code([residue]) == 1
     assert privacy.exit_code([unscan]) == 3
     assert privacy.exit_code([zero]) == 3
     assert privacy.exit_code([residue, unscan]) == 1   # residue dominates
+    assert privacy.exit_code([]) == 3   # empty set = unaudited = cannot-prove
+    assert privacy.exit_code([stale_only]) == 0   # informational never affects exit code
 
 
 def test_audit_all_uses_per_project_tombstones(tmp_checkpoint_dir):

--- a/plugin/tests/test_audit_privacy.py
+++ b/plugin/tests/test_audit_privacy.py
@@ -371,3 +371,48 @@ def test_tombstone_own_note_detected(tmp_checkpoint_dir):
              if f["surface"] == "events-note" and f["content_hash"] == key]
     assert len(found) > 0, "tombstone note containing value must be detected"
     assert found[0]["item_id"] == "i-x", "item_id must match tombstone event's id"
+
+
+def test_exit_code_semantics():
+    clean = {"findings": [], "informational": [], "unscannable": [],
+             "surfaces_scanned": 3, "zero_surfaces": False, "cache": {}}
+    residue = dict(clean, findings=[{"path": "p", "item_id": None,
+                                     "content_hash": "h",
+                                     "surface": "checkpoint"}])
+    unscan = dict(clean, unscannable=["p"])
+    zero = dict(clean, zero_surfaces=True, surfaces_scanned=0)
+    assert privacy.exit_code([clean]) == 0
+    assert privacy.exit_code([residue]) == 1
+    assert privacy.exit_code([unscan]) == 3
+    assert privacy.exit_code([zero]) == 3
+    assert privacy.exit_code([residue, unscan]) == 1   # residue dominates
+
+
+def test_audit_all_uses_per_project_tombstones(tmp_checkpoint_dir):
+    # CANARY legitimately lives in project B; forgotten only in project A.
+    # A per-bucket audit must NOT read that as B's residue (the global union
+    # would — that is the false positive the reviewer refuted).
+    _write("S1", KEEPER)                       # project A (PROJECT)
+    other = "/p/other-project"
+    _write("S3", CANARY, project_dir=other)    # project B
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    results = privacy.audit_all()
+    b = next(r for r in results
+             if r["slug"] == store.project_slug(other))
+    assert not any(f["content_hash"] == key for f in b["findings"])
+
+
+def test_render_never_prints_plaintext(tmp_checkpoint_dir, capsys):
+    from daimon_briefing import render
+    _write("S1", CANARY)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert result["findings"], "fixture must produce residue"
+    render.render_privacy_audit([result])
+    out = capsys.readouterr().out
+    assert CANARY not in out
+    assert key in out

--- a/plugin/tests/test_audit_privacy.py
+++ b/plugin/tests/test_audit_privacy.py
@@ -231,3 +231,28 @@ def test_null_slug_row_with_stale_fingerprint_is_informational(tmp_checkpoint_di
                    for f in result["findings"])
     assert any(f["surface"] == "stale-index-pending-rebuild"
                and f["content_hash"] == key for f in result["informational"])
+
+
+def test_residue_in_orphan_tmp_detected(tmp_checkpoint_dir):
+    from daimon_briefing import recall
+    _write("S1", KEEPER)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    slug = store.project_slug(PROJECT)
+    db = _make_recall_db(tmp_checkpoint_dir, [(CANARY, slug)],
+                         recall._fingerprint())
+    orphan = db.with_name("recall.db.99999.tmp")
+    db.rename(orphan)          # the crashed-write shape: full snapshot, tmp name
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert any(f["surface"] == "orphan-tmp" and f["content_hash"] == key
+               for f in result["findings"])
+
+
+def test_corrupt_orphan_is_unscannable_not_crash(tmp_checkpoint_dir):
+    _write("S1", KEEPER)
+    orphan = config.recall_db().with_name("recall.db.11111.tmp")
+    orphan.parent.mkdir(parents=True, exist_ok=True)
+    orphan.write_bytes(b"not a sqlite file")
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert str(orphan) in result["unscannable"]

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -423,6 +423,15 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
     def r_audit_quotes():
         run(["audit-quotes"], 0)
 
+    def r_audit_quotes_grouped():
+        # #598: same command, moved under the `audit` group.
+        run(["audit", "quotes"], 0)
+
+    def r_audit_privacy():
+        # #598: read-only tombstone residue audit. r_forget already scrubbed
+        # one item for real by this point in the drive.
+        run(["audit", "privacy"], 0)
+
     def r_heal():
         # Seed a FAILED session with the ledger's own documented line shapes
         # (spawn + error result), then heal re-serializes it for real. The
@@ -499,6 +508,8 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
         ("status",): r_status,
         ("verify-receipt",): r_verify_receipt,
         ("audit-quotes",): r_audit_quotes,
+        ("audit", "quotes"): r_audit_quotes_grouped,
+        ("audit", "privacy"): r_audit_privacy,
         ("heal",): r_heal,
         ("team", "sync"): r_team_sync,
         ("team", "status"): r_team_status,

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -31,8 +31,20 @@ Every daimon verb, grouped by what you are trying to do. Each command's
 | command | what it does |
 | --- | --- |
 | `daimon verify-receipt` | Verify a checkpoint's signed provenance receipt (full cryptographic check via the vitni CLI). |
-| `daimon audit-quotes` | Re-check every stored verbatim quote against its source transcript and report mismatches. Read-only — it never rewrites trust tags. |
+| `daimon audit quotes` | Re-check every stored verbatim quote against its source transcript and report mismatches. Read-only — it never rewrites trust tags. |
+| `daimon audit privacy` | Prove the deletion contract: hash every plaintext field on every surface (checkpoints, rotated pointers, the event ledger, the team mirror, the recall index and its orphan snapshots) and report any forgotten value that survived. Read-only. |
 | `daimon anchor <file> <symbol>` | Bind a cognitive item to a code symbol; briefings then warn when the anchored code drifts. |
+
+The auditors share one exit contract, so a script can act on the answer:
+
+| exit | meaning |
+| --- | --- |
+| `0` | proven clean — every surface was scanned and nothing was found |
+| `1` | residue found; the report names the surface and the hash (never the text) |
+| `3` | cannot prove — a surface could not be read, or nothing was in scope to scan. Never treat this as clean |
+
+`--project <dir>` scopes to one project, `--all` audits every local project
+(each against its own tombstones); the two are mutually exclusive.
 
 ## Setup and operations
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -31,8 +31,21 @@ comando trae la superficie completa de flags; esta página es el mapa.
 | comando | qué hace |
 | --- | --- |
 | `daimon verify-receipt` | Verifica el recibo firmado de procedencia de un checkpoint (chequeo criptográfico completo vía el CLI de vitni). |
-| `daimon audit-quotes` | Re-verifica cada cita verbatim almacenada contra su transcripción de origen y reporta discrepancias. Solo lectura — nunca reescribe etiquetas. |
+| `daimon audit quotes` | Re-verifica cada cita verbatim almacenada contra su transcripción de origen y reporta discrepancias. Solo lectura — nunca reescribe etiquetas. |
+| `daimon audit privacy` | Prueba el contrato de borrado: hashea cada campo con texto plano en cada superficie (checkpoints, punteros rotados, el registro de eventos, el espejo de equipo, el índice de recall y sus snapshots huérfanos) y reporta todo valor olvidado que haya sobrevivido. Solo lectura. |
 | `daimon anchor <archivo> <símbolo>` | Ancla un ítem cognitivo a un símbolo de código; los briefings avisan cuando el código anclado cambió. |
+
+Los auditores comparten un mismo contrato de salida, para que un script pueda
+actuar sobre la respuesta:
+
+| salida | significado |
+| --- | --- |
+| `0` | limpio comprobado — se escaneó cada superficie y no se encontró nada |
+| `1` | hay residuo; el reporte nombra la superficie y el hash (nunca el texto) |
+| `3` | no se puede probar — alguna superficie no se pudo leer, o no había nada en alcance para escanear. Nunca lo trates como limpio |
+
+`--project <dir>` acota a un proyecto, `--all` audita cada proyecto local
+(cada uno contra sus propias lápidas); los dos son mutuamente excluyentes.
 
 ## Setup y operación
 


### PR DESCRIPTION
Closes #598

## What

`daimon audit privacy [--project DIR | --all]` — a read-only auditor that proves `forget`'s contract instead of trusting it: for every tombstoned content key, either no plaintext copy survives on any surface, the exact file holding one is named, or the audit says honestly that a surface could not be proven.

- New `daimon audit` subcommand group; `audit quotes` absorbs `audit-quotes`, which stays as a hidden deprecated alias (one-line notice, hidden via `metavar` on the top-level subparsers).
- All scan logic in a new `plugin/daimon_briefing/privacy.py`; rendering in `render.py`; `cli.py` gets only parser wiring and a thin command func.
- Exit contract: `0` proven clean, `1` residue, `3` cannot-prove. Cannot-prove never folds to clean — an empty audit set, an unscannable surface, or zero surfaces found all refuse to report success (#583's lesson: green is not proof).

Surfaces reached, hashing `text`/`quote`/`scene` on items and `note`/`item_text`/`status` on ledger rows with `normalize.content_key`:

| Surface | Classing |
|---|---|
| checkpoints (latest, prev-N, session files) | `checkpoint` |
| recall.db (read-only `mode=ro` URI, never via the recall API) | `recall-index-residue` when the stored fingerprint is current; `stale-index-pending-rebuild` otherwise — forget deletes index rows lazily at the next rebuild, so a stale match is informational, not residue |
| orphan `recall.db.<pid>.tmp` snapshots from crashed rebuilds (opened `immutable=1`) | `orphan-tmp`, never staleness-excused |
| team mirror (`~/.daimon/team/`), membership by resolved team path identity with payload-slug fallback | `team-copy`, with the note that an upstream copy may exist |
| `events.jsonl` free-text fields (verbatim-only, stated limitation) | `events-note` |
| chunk cache | store-level report (entries + real oldest age; value-level detection impossible for a cache keyed by chunk text) |

Honesty rules baked in: unknown files in scanned directories are `unscannable`, never silently skipped (a `.json`-suffix filter is exactly how a `latest.json.bak-*` full-checkpoint copy escapes); known hash-only sidecars (`.receipt`, `verification.jsonl`, `forget-hits.jsonl`, the pointer lock) are exempted with the justification cited from their owning modules; zero surfaces found is a warning, not "clean"; findings print the content hash, never the plaintext, because audit output itself gets re-serialized.

The audit is deliberately report-only, and it already earns its keep: it detects three shipped gaps it does not fix — `quote`/`scene` fields and `events.jsonl` `item_text` survive forget (#599), and team-mirror copies have no tombstone propagation (#600). The durable end of the hand-maintained surface-list problem is the registry (#601).

## Why

#583 shipped because `forget`'s deletion contract was written against the wrong surface set — and a passing test asserted the residue, so CI could never catch it. #584 fixed deletion; nothing verified the contract kept holding. This command makes the contract continuously checkable, and its first run on a real install immediately surfaced the next three gaps (#599, #600, #601).

## Tests

30 new tests in `plugin/tests/test_audit_privacy.py`; suite 3037 passed, 2 skipped; `ruff` clean; `privacy.py` 223/223 statements covered, `render_privacy_audit` and `_cmd_audit_privacy` fully covered.

What they pin (each failed before the code it proves):

- residue in `prev-1.json` (path asserted), session files, `quote` field, `scene` field, recall.db current-vs-stale fingerprint fork, orphan tmp, team copy, `events.jsonl` `note`/`item_text`/`status`
- teammate's copy under a resolved team path with the writer's own slug is detected; an author directory named like the audited project's slug does not leak another project's file in (both directions mutation-verified)
- exit semantics: clean 0; residue 1 and dominating; unscannable-only 3; zero surfaces 3; empty audit set 3; informational never moves the exit code
- read-only guarantee with teeth: a run against planted checkpoint + recall.db + WAL-mode orphan + team surfaces leaves all of `~/.daimon` minus `logs/` byte-identical, and no sqlite `-wal`/`-shm` sidecars appear
- best-effort failure branches each pin a stated guarantee: corrupt checkpoint / recall.db / orphan / team file → `unscannable`, non-UTF-8 events ledger → `unscannable`, unreadable checkpoint dir → exit 3, foreign-bucket stray files don't poison another project's verdict
- `audit quotes` group parity and the deprecated `audit-quotes` alias (same args, same exit, deprecation notice); `--all`/`--project` mutually exclusive
- render never prints plaintext (asserted against a real finding)

Docs: `website/docs/reference/cli.md` (en + es) updated — `audit` group and the 0/1/3 exit contract.
