### PR TITLE
fix(forget): reach quote/scene/links/topic fields and redact the event ledger

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1055,6 +1055,11 @@ def _cmd_forget(args) -> int:
     # session files hold the same plaintext and were never in the contract
     # (#419: plaintext is what puts a file inside it, not its role).
     store.scrub_content_key(content_hash, project_dir=project)
+    # #599: rows appended BEFORE this forget can carry the value in
+    # `item_text`/`status`/`note` — redacted in place, rows never dropped
+    # (the one ratified rewrite of the append-only ledger).
+    events_scrubbed = store.scrub_event_fields(content_hash,
+                                               project_dir=project)
     # #422: the serializer chunk cache holds PRE-redaction extraction output
     # (quote verification forbids redacting before caching, #125), keyed by
     # chunk text — the forgotten value cannot be located selectively, so the
@@ -1069,6 +1074,9 @@ def _cmd_forget(args) -> int:
     _note_usage("forget")
     print(f"forgot {target['id']} (content hash {content_hash}) — "
           "item removed from the live checkpoint; tombstone recorded")
+    if events_scrubbed:
+        print(f"redacted {events_scrubbed} event-ledger field(s) "
+              "carrying the value (rows kept, field replaced)")
     if purge_err is not None:
         print(f"warning: chunk cache purge failed: {purge_err} — "
               "cached pre-redaction chunks may persist up to "

--- a/plugin/daimon_briefing/policy.py
+++ b/plugin/daimon_briefing/policy.py
@@ -104,9 +104,22 @@ def drop_forgotten(checkpoint: dict, forgotten_keys: set) -> list:
     over-suppresses on a hash collision (via the bounded content key) — a
     forgotten value re-appearing is the worse failure. A no-op with zero cost
     when nothing was ever forgotten here."""
+    return scrub_forgotten_payload(checkpoint, forgotten_keys)[0]
+
+
+def scrub_forgotten_payload(checkpoint: dict,
+                            forgotten_keys: set) -> tuple[list, bool]:
+    """drop_forgotten's full-enumeration body (#599): covers the same
+    plaintext-bearing CLASS redact_checkpoint enumerates — every list item's
+    text/quote/scene and links[].target, plus the active_topic singleton
+    (outside _ITEM_LISTS, so a list-only walk indexes it for retrieval while
+    leaving it unreachable by deletion). Returns (dropped_items, changed) —
+    `changed` also covers field-level scrubs that drop nothing, so a caller
+    rewriting files knows whether bytes moved."""
     if not forgotten_keys:
-        return []
+        return [], False
     dropped: list = []
+    changed = False
     for section, key in _ITEM_LISTS:
         block = checkpoint.get(section)
         if not isinstance(block, dict):
@@ -120,10 +133,73 @@ def drop_forgotten(checkpoint: dict, forgotten_keys: set) -> list:
                     and normalize.content_key(item.get("text") or "") in forgotten_keys):
                 dropped.append(item)
             else:
+                if (isinstance(item, dict)
+                        and scrub_forgotten_fields(item, forgotten_keys)):
+                    changed = True
                 kept.append(item)
         if len(kept) != len(lst):
             block[key] = kept
-    return dropped
+            changed = True
+    wc = checkpoint.get("working_context")
+    topic = wc.get("active_topic") if isinstance(wc, dict) else None
+    if isinstance(topic, dict):
+        if normalize.content_key(topic.get("text") or "") in forgotten_keys:
+            del wc["active_topic"]
+            dropped.append(topic)
+            changed = True
+        elif scrub_forgotten_fields(topic, forgotten_keys):
+            changed = True
+    return dropped, changed
+
+
+# A quote that leaves an item takes its verification claim with it: a stale
+# receipt would keep carry._capture_verified answering True (corroboration G3
+# trusts the receipt over the flat flag), and `trust=verbatim` with no quote
+# fails serializer revalidation ("trust=verbatim item has no quote").
+_QUOTE_CLAIM_KEYS = ("quote_provenance", "quote_verified", "last_verified",
+                     "source_message_ids")
+
+
+def scrub_forgotten_fields(item: dict, forgotten_keys: set) -> bool:
+    """Field-level twin of drop_forgotten (#599): an item whose TEXT folds
+    into the forgotten set is dropped whole, but an item that merely carries
+    the value in `quote` or `scene` loses that FIELD, not its own text.
+    Whole-field equality under the same canonical key the tombstone uses —
+    the same granularity `daimon audit privacy` detects at. A scrubbed quote
+    downgrades trust to "inferred" (the verify_quotes miss posture); a
+    scrubbed scene touches nothing else. Returns whether the item changed."""
+    changed = False
+    for field in ("quote", "scene"):
+        value = item.get(field)
+        if (isinstance(value, str) and value
+                and normalize.content_key(value) in forgotten_keys):
+            del item[field]
+            changed = True
+            if field == "quote":
+                for stale in _QUOTE_CLAIM_KEYS:
+                    item.pop(stale, None)
+                if item.get("trust") == "verbatim":
+                    item["trust"] = "inferred"
+    # links[].target copies another item's WHOLE text (the serializer's
+    # supersedes contract) until bind_links resolves it to an id — a link
+    # whose target folds to a forgotten key points at removed content, so
+    # the element goes (never a marker: a marker target would fuzzy-bind
+    # to nothing and read as a live supersession claim).
+    links = item.get("links")
+    if isinstance(links, list):
+        kept_links = [
+            link for link in links
+            if not (isinstance(link, dict)
+                    and isinstance(link.get("target"), str)
+                    and link["target"]
+                    and normalize.content_key(link["target"]) in forgotten_keys)]
+        if len(kept_links) != len(links):
+            changed = True
+            if kept_links:
+                item["links"] = kept_links
+            else:
+                del item["links"]
+    return changed
 
 
 def stamp_item_ids(checkpoint: dict) -> None:

--- a/plugin/daimon_briefing/privacy.py
+++ b/plugin/daimon_briefing/privacy.py
@@ -20,10 +20,11 @@ from pathlib import Path
 
 from . import config, normalize, store, teamproject
 
-# Plaintext-bearing item fields. forget currently hashes only `text`
-# (cli._cmd_forget, store.scrub_content_key, recall rebuild) — auditing
-# quote/scene as well is deliberate: it detects the residue forget cannot
-# yet reach, which is this tool's reason to exist.
+# Plaintext-bearing item fields — the same CLASS policy.redact_checkpoint
+# enumerates (its links[].target and active_topic coverage lives in _hashes
+# and _payload_findings below). #599 taught forget to reach all of them; the
+# audit keeps hashing them independently so a future field addition that
+# misses one side surfaces as a finding, not silence.
 _FIELDS = ("text", "quote", "scene")
 
 # Free-text fields store.append_event writes to events.jsonl. `note` alone was
@@ -68,6 +69,15 @@ def _hashes(item: dict) -> set[str]:
         value = item.get(field)
         if isinstance(value, str) and value.strip():
             out.add(normalize.content_key(value))
+    # links[].target copies another item's whole text until bind_links
+    # resolves it to an id (#599 class finding) — a plaintext carrier.
+    links = item.get("links")
+    if isinstance(links, list):
+        for link in links:
+            if isinstance(link, dict):
+                target = link.get("target")
+                if isinstance(target, str) and target.strip():
+                    out.add(normalize.content_key(target))
     return out
 
 
@@ -139,6 +149,16 @@ def _payload_findings(payload: dict, path: Path, keys: set[str],
                                  "item_id": item.get("id"),
                                  "content_hash": h,
                                  "surface": surface})
+    # The active_topic singleton sits outside _ITEM_LISTS (#599 class
+    # finding): indexed for retrieval by schema.KIND_SOURCES, so an audit
+    # walking only the list sections certifies exit 0 over live plaintext.
+    topic = (payload.get("working_context") or {}).get("active_topic")
+    if isinstance(topic, dict):
+        for h in _hashes(topic) & keys:
+            findings.append({"path": str(path),
+                             "item_id": topic.get("id"),
+                             "content_hash": h,
+                             "surface": surface})
     return findings
 
 

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -481,9 +481,19 @@ def _apply_event_resolutions(conn: sqlite3.Connection) -> None:
             "SELECT id, text, quote, scene, item_id FROM items"
             " WHERE project_slug IS ?", (bucket.name,)).fetchall()
         for rowid, text, quote, scene, item_id in rows:
+            # #599: the value can also sit in a row's quote/scene column
+            # (indexed verbatim). Whole-row delete is the fail-safe: the
+            # rebuilt row from the scrubbed checkpoint re-inserts the
+            # survivor without the field; a row only reachable here (its
+            # surface was unwritable) over-suppresses rather than serves
+            # forgotten plaintext.
             if item_id not in forgotten_ids and not (
                     forgotten_keys
-                    and normalize.content_key(text or "") in forgotten_keys):
+                    and (normalize.content_key(text or "") in forgotten_keys
+                         or (quote and normalize.content_key(quote)
+                             in forgotten_keys)
+                         or (scene and normalize.content_key(scene)
+                             in forgotten_keys))):
                 continue
             # contentless fts5: deletion is the special 'delete'
             # INSERT and must repeat the original column values

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -332,18 +332,10 @@ def scrub_content_key(content_hash: str, project_dir=None) -> list[str]:
             continue
         if not isinstance(payload, dict):
             continue
-        changed = False
-        for section, key in _ITEM_LISTS:
-            lst = (payload.get(section) or {}).get(key)
-            if not isinstance(lst, list):
-                continue
-            kept = [i for i in lst
-                    if not (isinstance(i, dict)
-                            and normalize.content_key(i.get("text") or "")
-                            == content_hash)]
-            if len(kept) != len(lst):
-                lst[:] = kept
-                changed = True
+        # #599: one predicate for every path — the same full-enumeration
+        # scrub the write gate runs (items by text, survivors' quote/scene,
+        # links[].target, the active_topic singleton).
+        _, changed = policy.scrub_forgotten_payload(payload, {content_hash})
         if not changed:
             continue
         try:
@@ -1272,7 +1264,10 @@ def append_event(item_ref: str, status: str, note: str = "",
                  allow_disabled: bool = False) -> bool:
     """One appended JSON line per lifecycle fact (#102). Append-only: the
     file is never rewritten — resolution is a derivation at read, so the
-    audit trail must stay byte-stable. Silent no-op under the kill switch
+    audit trail must stay byte-stable. The ONE exception is
+    scrub_event_fields (#599), forget's redaction-in-place, which replaces a
+    field VALUE but never drops, adds, or reorders rows. Silent no-op under
+    the kill switch
     and when the project is unknown (an event without a bucket has no
     reader). `allow_disabled` (#421) is the narrow deletion exemption:
     passed ONLY by cli._cmd_forget's tombstone append — forget must work
@@ -1306,6 +1301,108 @@ def append_event(item_ref: str, status: str, note: str = "",
         return True
     except OSError:
         return False
+
+
+# The in-place redaction marker for event fields (#599). Carries the
+# tombstoned key so the row stays auditable — and a hash can never collide
+# with the plaintext it names, so re-running the scrub is idempotent.
+_FORGOTTEN_FIELD_MARKER = "[forgotten:{}]"
+
+# Every status reader classifies by PREFIX (is_resolved, _tie_rank, _demotes,
+# recall's fold) — so a scrubbed status must keep its class token or the
+# redaction re-classifies the row: a revival whose free-form wording IS the
+# forgotten sentence would fold back to "resolved" and hide an unrelated
+# item forever. Longest-match order: candidate forms before their shorter
+# cousins. The kept token is generic lifecycle vocabulary, not the value.
+_STATUS_CLASS_PREFIXES = ("supersede-candidate", "superseded-by:",
+                          "resolving-candidate", "reopen", "forgotten")
+
+
+def _class_preserving_marker(status: str, marker: str) -> str:
+    low = status.lower()
+    for prefix in _STATUS_CLASS_PREFIXES:
+        if low.startswith(prefix):
+            return f"{status[:len(prefix)]} {marker}"
+    return marker
+
+
+def scrub_event_fields(content_hash: str, project_dir=None) -> int:
+    """#599: the narrow carve-out to append_event's append-only contract,
+    called ONLY by cli._cmd_forget after the tombstone lands. events.jsonl
+    rows written BEFORE a forget can carry the value in `item_text` (resolve/
+    reopen pass the item's full text), free-form `status`, or `note` — and an
+    append-only file is otherwise unreachable by deletion (#419: holding
+    plaintext is what puts a file inside the contract).
+
+    Redaction-in-place, never row removal: the resolutions fold keys on
+    `item_ref`/`status`/row order (scar 0025 — a dropped row changes what
+    counts as resolved), so only a field whose WHOLE value folds to the
+    tombstoned key is replaced with the visible marker; every other byte of
+    every row survives verbatim, and uninterpretable lines are copied through
+    untouched. Best-effort like scrub_content_key: an unreadable or
+    unwritable ledger returns 0 rather than aborting the forget. Known
+    window: an append racing the read→rename pair is lost. A lock exists
+    (_pointer_lock) but is deliberately not taken — append_event locks
+    nothing, so locking only this side closes nothing, and adding a lock to
+    every append buys a per-event cost for a window one rare interactive
+    command opens. The atomic replace keeps the file parseable either way.
+
+    Accepted residuals (adversarial review, #599): (1) a same-second tie
+    (_tie_wins) involving a scrubbed row can flip its content tie-break —
+    class rank is preserved, only the arbitrary-but-deterministic byte
+    comparison moves, and content removal cannot leave content unchanged;
+    (2) briefing.withhold's legacy fuzzy pool loses entries whose item_text
+    was scrubbed, so an id-less PARAPHRASE of the value may resurface —
+    that suppression only ever worked because this plaintext residue
+    existed, and keeping it would mean keeping the value.
+    Returns the number of rows redacted."""
+    if not content_hash:
+        return 0
+    path = _events_path(project_dir)
+    if path is None:
+        return 0
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return 0
+    marker = _FORGOTTEN_FIELD_MARKER.format(content_hash)
+    out_lines = []
+    scrubbed = 0
+    for line in raw.splitlines():
+        try:
+            row = json.loads(line)
+        except ValueError:
+            out_lines.append(line)
+            continue
+        if not isinstance(row, dict):
+            out_lines.append(line)
+            continue
+        changed = False
+        for field in ("item_text", "status", "note"):
+            value = row.get(field)
+            if (isinstance(value, str) and value
+                    and normalize.content_key(value) == content_hash):
+                row[field] = (_class_preserving_marker(value, marker)
+                              if field == "status" else marker)
+                changed = True
+        if changed:
+            scrubbed += 1
+            # Same admission seam the append took (#431): the rewrite is
+            # governed for real, not merely correlated — the write-audit
+            # guard can bind the row that lands on disk to this admission,
+            # and any secret shape the row carried pre-#141 is re-scrubbed.
+            row = policy.admit_row(row, redact_fields=("status", "note",
+                                                       "item_text"))
+            out_lines.append(json.dumps(row, ensure_ascii=False))
+        else:
+            out_lines.append(line)
+    if not scrubbed:
+        return 0
+    try:
+        _atomic_write(path, "\n".join(out_lines) + "\n")
+    except OSError:
+        return 0
+    return scrubbed
 
 
 def _tie_rank(evt: dict) -> int:

--- a/plugin/tests/test_audit_privacy.py
+++ b/plugin/tests/test_audit_privacy.py
@@ -71,6 +71,44 @@ def test_residue_in_quote_field_detected(tmp_checkpoint_dir):
     assert any(f["content_hash"] == key for f in result["findings"])
 
 
+def test_residue_in_active_topic_detected(tmp_checkpoint_dir):
+    """#599 class finding: active_topic is a singleton outside _ITEM_LISTS —
+    indexed for retrieval (schema.KIND_SOURCES) but invisible to an auditor
+    iterating the list sections only. An audit blind to it certifies exit 0
+    over live plaintext."""
+    store.write_checkpoint("S1", {
+        "session_id": "S1", "created": "2026-08-01T00:00:00Z",
+        "working_context": {
+            "active_topic": {"text": KEEPER, "quote": CANARY,
+                             "trust": "verbatim"},
+            "recent_decisions": [{"text": KEEPER, "trust": "inferred"}]},
+    }, project_dir=PROJECT)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert any(f["content_hash"] == key for f in result["findings"]), \
+        "active_topic residue must be detected"
+
+
+def test_residue_in_link_target_detected(tmp_checkpoint_dir):
+    """#599 class finding: links[].target copies another item's whole text
+    (the serializer's supersedes contract) and redact_checkpoint scrubs it —
+    so it is a plaintext carrier the audit must hash too."""
+    store.write_checkpoint("S1", {
+        "session_id": "S1", "created": "2026-08-01T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": KEEPER, "trust": "inferred",
+             "links": [{"type": "supersedes", "target": CANARY}]}]},
+    }, project_dir=PROJECT)
+    key = normalize.content_key(CANARY)
+    store.append_event("i-x", f"forgotten:{key}", kind="tombstone",
+                       project_dir=PROJECT)
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert any(f["content_hash"] == key for f in result["findings"]), \
+        "links[].target residue must be detected"
+
+
 def test_clean_tree_reports_nothing(tmp_checkpoint_dir):
     _write("S1", KEEPER)
     result = privacy.audit_project(project_dir=PROJECT)

--- a/plugin/tests/test_forget_field_residue.py
+++ b/plugin/tests/test_forget_field_residue.py
@@ -1,0 +1,325 @@
+"""#599: forget must reach quote/scene item fields and the event ledger.
+
+Every forget path keyed on `normalize.content_key(item["text"])` alone, so a
+forgotten value survived deletion wherever it sat in another item's `quote` or
+`scene` field, and in `events.jsonl` `item_text` / free-form `status` / `note`
+rows written before the forget. The contract (#321/#419): holding plaintext is
+what puts a file inside the deletion contract, not its role.
+
+Field scrub semantics (not whole-item drop): an item whose TEXT folds to the
+tombstoned key is removed entirely (unchanged behavior); an item that merely
+carries the value in `quote`/`scene` loses that field. A scrubbed quote also
+loses its verification claim — `quote_provenance` / `quote_verified` /
+`last_verified` / `source_message_ids` go with it and `trust` drops to
+"inferred" — because a stale receipt would keep corroboration treating the
+item as capture-verified, and `trust=verbatim` with no quote fails
+serializer revalidation.
+
+Event rows are never dropped (scar 0025: the resolutions fold keys on
+`item_ref` and row order); the matching FIELD value is replaced in place with
+`[forgotten:<content_key>]` — visible, auditable, and impossible to collide
+with the value it names.
+"""
+import json
+
+from daimon_briefing import cli, normalize, privacy, recall, store
+
+PROJECT = "/p/forget-field-residue"
+CANARY = "zqxfieldcanary9917 the staging db password rotates on fridays"
+KEEPER = "an unrelated decision that must survive the forget"
+FRESH = "a decision captured after the forget happened"
+
+
+def _checkpoint(sid, created, items):
+    return {
+        "session_id": sid,
+        "created": created,
+        "working_context": {"recent_decisions": items},
+    }
+
+
+def _write(sid, created, items):
+    store.write_checkpoint(sid, _checkpoint(sid, created, items),
+                           project_dir=PROJECT)
+
+
+def _forget_canary():
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+
+
+def _live_decisions():
+    cp = store.read_latest(project_dir=PROJECT, fallback=False)
+    return (cp.get("working_context") or {}).get("recent_decisions") or []
+
+
+def _events_rows():
+    path = store._events_path(PROJECT)
+    return [json.loads(line) for line in path.read_text().splitlines() if line]
+
+
+KEY = normalize.content_key(CANARY)
+MARKER = f"[forgotten:{KEY}]"
+
+
+# ---- item fields: quote / scene ------------------------------------------
+
+
+def test_forget_scrubs_quote_copy_and_its_verification_claim(tmp_checkpoint_dir):
+    _write("S1", "2026-08-01T00:00:00Z", [
+        {"text": CANARY, "trust": "inferred"},
+        {"text": KEEPER, "trust": "verbatim", "quote": CANARY,
+         "quote_verified": True, "last_verified": "2026-08-01T00:00:00Z",
+         "source_message_ids": ["m-1"],
+         "quote_provenance": {"version": 1, "outcome": "verified"}},
+    ])
+    _forget_canary()
+    kept = _live_decisions()
+    assert [i["text"] for i in kept] == [KEEPER]
+    survivor = kept[0]
+    assert "quote" not in survivor
+    assert survivor["trust"] == "inferred"
+    for stale in ("quote_provenance", "quote_verified", "last_verified",
+                  "source_message_ids"):
+        assert stale not in survivor, f"{stale} must not outlive the quote"
+
+
+def test_forget_scrubs_scene_copy_without_touching_trust(tmp_checkpoint_dir):
+    _write("S1", "2026-08-01T00:00:00Z", [
+        {"text": CANARY, "trust": "inferred"},
+        {"text": KEEPER, "trust": "inferred", "scene": CANARY},
+    ])
+    _forget_canary()
+    kept = _live_decisions()
+    assert [i["text"] for i in kept] == [KEEPER]
+    assert "scene" not in kept[0]
+    assert kept[0]["trust"] == "inferred"
+
+
+def test_forget_scrubs_quote_copy_in_prev_history(tmp_checkpoint_dir):
+    _write("S1", "2026-08-01T00:00:00Z", [
+        {"text": CANARY, "trust": "inferred"},
+        {"text": KEEPER, "trust": "verbatim", "quote": CANARY},
+    ])
+    # rotation: S1 state now sits in prev-1 and in its session file
+    _write("S2", "2026-08-02T00:00:00Z", [
+        {"text": KEEPER, "trust": "verbatim", "quote": CANARY},
+    ])
+    _forget_canary()
+    residue = [str(p) for p in store.project_surfaces(PROJECT)
+               if CANARY in p.read_text()]
+    assert residue == [], f"plaintext survives in {residue}"
+
+
+def test_recapture_with_forgotten_quote_is_scrubbed_at_the_write_gate(
+        tmp_checkpoint_dir):
+    _write("S1", "2026-08-01T00:00:00Z", [{"text": CANARY, "trust": "inferred"}])
+    _forget_canary()
+    # a later session re-extracts the value inside a fresh item's quote
+    _write("S2", "2026-08-02T00:00:00Z", [
+        {"text": FRESH, "trust": "verbatim", "quote": CANARY},
+    ])
+    kept = _live_decisions()
+    assert [i["text"] for i in kept] == [FRESH]
+    assert "quote" not in kept[0]
+    assert kept[0]["trust"] == "inferred"
+
+
+def test_rebuilt_recall_index_holds_no_quote_residue(tmp_checkpoint_dir):
+    _write("S1", "2026-08-01T00:00:00Z", [
+        {"text": CANARY, "trust": "inferred"},
+        {"text": KEEPER, "trust": "verbatim", "quote": CANARY},
+    ])
+    recall.rebuild()
+    _forget_canary()
+    recall.rebuild()
+    import sqlite3
+
+    from daimon_briefing import config
+    conn = sqlite3.connect(str(config.recall_db()))
+    try:
+        rows = conn.execute(
+            "SELECT text, quote, scene FROM items").fetchall()
+    finally:
+        conn.close()
+    assert all(CANARY not in (field or "") for row in rows for field in row)
+
+
+# ---- the plaintext-bearing CLASS: active_topic + links[].target -----------
+# (refuter finding 3: redact_checkpoint's enumeration is the class — item
+# text/quote/scene, links[].target, and the active_topic singleton — and a
+# fix that patches two named fields repeats the #575 class mistake.)
+
+
+def test_forget_drops_active_topic_carrying_the_value(tmp_checkpoint_dir):
+    store.write_checkpoint("S1", {
+        "session_id": "S1", "created": "2026-08-01T00:00:00Z",
+        "working_context": {
+            "active_topic": {"text": CANARY, "trust": "inferred"},
+            "recent_decisions": [{"text": CANARY, "trust": "inferred"},
+                                 {"text": KEEPER, "trust": "inferred"}]},
+    }, project_dir=PROJECT)
+    _forget_canary()
+    cp = store.read_latest(project_dir=PROJECT, fallback=False)
+    assert "active_topic" not in (cp.get("working_context") or {})
+    residue = [str(p) for p in store.project_surfaces(PROJECT)
+               if CANARY in p.read_text()]
+    assert residue == [], f"plaintext survives in {residue}"
+
+
+def test_forget_scrubs_active_topic_quote(tmp_checkpoint_dir):
+    store.write_checkpoint("S1", {
+        "session_id": "S1", "created": "2026-08-01T00:00:00Z",
+        "working_context": {
+            "active_topic": {"text": KEEPER, "quote": CANARY,
+                             "trust": "verbatim"},
+            "recent_decisions": [{"text": CANARY, "trust": "inferred"}]},
+    }, project_dir=PROJECT)
+    _forget_canary()
+    cp = store.read_latest(project_dir=PROJECT, fallback=False)
+    topic = (cp.get("working_context") or {}).get("active_topic")
+    assert topic and topic["text"] == KEEPER
+    assert "quote" not in topic
+    assert topic["trust"] == "inferred"
+
+
+def test_forget_drops_link_whose_target_is_the_value(tmp_checkpoint_dir):
+    store.write_checkpoint("S1", {
+        "session_id": "S1", "created": "2026-08-01T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": CANARY, "trust": "inferred"},
+            {"text": KEEPER, "trust": "inferred",
+             "links": [{"type": "supersedes", "target": CANARY},
+                       {"type": "supersedes", "target": "r-abcdef123456"}]},
+        ]},
+    }, project_dir=PROJECT)
+    _forget_canary()
+    kept = _live_decisions()
+    assert [i["text"] for i in kept] == [KEEPER]
+    links = kept[0].get("links")
+    assert links == [{"type": "supersedes", "target": "r-abcdef123456"}], \
+        f"only the forgotten-target link goes: {links}"
+    residue = [str(p) for p in store.project_surfaces(PROJECT)
+               if CANARY in p.read_text()]
+    assert residue == [], f"plaintext survives in {residue}"
+
+
+# ---- event ledger: item_text / status / note -----------------------------
+
+
+def test_forget_scrubs_event_item_text_in_place(tmp_checkpoint_dir):
+    _write("S1", "2026-08-01T00:00:00Z", [{"text": CANARY, "trust": "inferred"}])
+    store.append_event("i-y", "resolved", item_text=CANARY,
+                       project_dir=PROJECT)
+    _forget_canary()
+    rows = _events_rows()
+    scrubbed = [r for r in rows if r.get("item_ref") == "i-y"]
+    assert scrubbed and scrubbed[0]["item_text"] == MARKER
+    # row structure survives: same keys, untouched fields byte-identical
+    assert scrubbed[0]["status"] == "resolved"
+    assert set(scrubbed[0]) >= {"ts", "kind", "item_ref", "status", "item_text"}
+
+
+def test_forget_scrubs_event_status_and_note_fields(tmp_checkpoint_dir):
+    _write("S1", "2026-08-01T00:00:00Z", [{"text": CANARY, "trust": "inferred"}])
+    store.append_event("i-y", CANARY, project_dir=PROJECT)
+    store.append_event("i-z", "resolved", note=CANARY, project_dir=PROJECT)
+    _forget_canary()
+    rows = _events_rows()
+    by_ref = {r["item_ref"]: r for r in rows if r.get("item_ref") in ("i-y", "i-z")}
+    assert by_ref["i-y"]["status"] == MARKER
+    assert by_ref["i-z"]["note"] == MARKER
+    assert by_ref["i-z"]["status"] == "resolved"
+
+
+def test_events_scrub_preserves_unrelated_rows_verbatim(tmp_checkpoint_dir):
+    _write("S1", "2026-08-01T00:00:00Z", [{"text": CANARY, "trust": "inferred"}])
+    store.append_event("i-k", "resolved", item_text=KEEPER, note="fine",
+                       project_dir=PROJECT)
+    before = [r for r in _events_rows() if r.get("item_ref") == "i-k"]
+    _forget_canary()
+    after = [r for r in _events_rows() if r.get("item_ref") == "i-k"]
+    assert after == before
+
+
+def test_status_scrub_preserves_reopen_classification(tmp_checkpoint_dir):
+    """Refuter finding 1 (BLOCKER): every status reader classifies by PREFIX
+    (is_resolved, _tie_rank, _demotes, the recall fold). A revival whose
+    free-form status happens to BE the forgotten sentence must stay a
+    revival after the scrub — a bare marker re-classified it as free-form
+    resolved and hid the unrelated item forever."""
+    revival = "reopen the postgres migration debate before shipping"
+    rkey = normalize.content_key(revival)
+    _write("S1", "2026-08-01T00:00:00Z", [
+        {"text": "b-victim item that must stay live", "trust": "inferred"},
+        {"text": revival, "trust": "inferred"},
+    ])
+    victim_id = next(i["id"] for i in _live_decisions()
+                     if i["text"].startswith("b-victim"))
+    store.append_event(victim_id, "resolved", project_dir=PROJECT)
+    store.append_event(victim_id, revival, project_dir=PROJECT)  # revived
+    assert not store.is_resolved(store.resolutions(project_dir=PROJECT)[victim_id])
+    assert cli.main(["forget", revival, "--project", PROJECT]) == 0
+    evt = store.resolutions(project_dir=PROJECT)[victim_id]
+    assert not store.is_resolved(evt), \
+        f"revival lost: victim folded to {evt.get('status')!r}"
+    assert evt["status"] == f"reopen [forgotten:{rkey}]"
+
+
+def test_status_scrub_keeps_free_form_resolved_class(tmp_checkpoint_dir):
+    _write("S1", "2026-08-01T00:00:00Z", [
+        {"text": "some other item", "trust": "inferred"},
+        {"text": CANARY, "trust": "inferred"},
+    ])
+    other_id = next(i["id"] for i in _live_decisions()
+                    if i["text"] == "some other item")
+    store.append_event(other_id, CANARY, project_dir=PROJECT)
+    assert store.is_resolved(store.resolutions(project_dir=PROJECT)[other_id])
+    _forget_canary()
+    evt = store.resolutions(project_dir=PROJECT)[other_id]
+    assert store.is_resolved(evt)
+    assert evt["status"] == MARKER
+
+
+def test_event_scrub_routes_rewritten_rows_through_admit_row(
+        tmp_checkpoint_dir, monkeypatch):
+    """Refuter finding 4: the ledger rewrite must be GOVERNED, not merely
+    read as governed via the guard's correlation blind spot. Every rewritten
+    row passes through policy.admit_row — the same admission seam the append
+    took — so the write-audit architecture guard can correlate the row that
+    landed on disk with a real admission."""
+    from daimon_briefing import policy
+    _write("S1", "2026-08-01T00:00:00Z", [{"text": CANARY, "trust": "inferred"}])
+    store.append_event("i-y", "resolved", item_text=CANARY,
+                       project_dir=PROJECT)
+    admitted = []
+    orig = policy.admit_row
+
+    def spy(row, redact_fields=(), redact_fn=None):
+        admitted.append(dict(row))
+        return orig(row, redact_fields=redact_fields, redact_fn=redact_fn)
+
+    monkeypatch.setattr(policy, "admit_row", spy)
+    assert store.scrub_event_fields(KEY, project_dir=PROJECT) == 1
+    assert any(r.get("item_text") == MARKER for r in admitted), \
+        "the rewritten row never passed the admission seam"
+
+
+# ---- the detector agrees the value is gone --------------------------------
+
+
+def test_audit_privacy_is_clean_after_forget(tmp_checkpoint_dir):
+    _write("S1", "2026-08-01T00:00:00Z", [
+        {"text": CANARY, "trust": "inferred"},
+        {"text": KEEPER, "trust": "verbatim", "quote": CANARY,
+         "quote_verified": True},
+        {"text": FRESH, "trust": "inferred", "scene": CANARY},
+    ])
+    store.append_event("i-y", "resolved", item_text=CANARY,
+                       project_dir=PROJECT)
+    _write("S2", "2026-08-02T00:00:00Z", [
+        {"text": KEEPER, "trust": "verbatim", "quote": CANARY},
+    ])
+    _forget_canary()
+    result = privacy.audit_project(project_dir=PROJECT)
+    hits = [f for f in result["findings"] if f["content_hash"] == KEY]
+    assert hits == [], f"audit still finds residue: {hits}"

--- a/plugin/tests/test_forget_field_residue.py
+++ b/plugin/tests/test_forget_field_residue.py
@@ -280,6 +280,46 @@ def test_status_scrub_keeps_free_form_resolved_class(tmp_checkpoint_dir):
     assert evt["status"] == MARKER
 
 
+def test_link_list_key_removed_when_its_only_link_is_forgotten(
+        tmp_checkpoint_dir):
+    _write("S1", "2026-08-01T00:00:00Z", [
+        {"text": CANARY, "trust": "inferred"},
+        {"text": KEEPER, "trust": "inferred",
+         "links": [{"type": "supersedes", "target": CANARY}]},
+    ])
+    _forget_canary()
+    kept = _live_decisions()
+    assert [i["text"] for i in kept] == [KEEPER]
+    assert "links" not in kept[0], "an emptied links list must not linger"
+
+
+def test_event_scrub_edge_guards_return_zero(tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    # no key, unknown project (no slug), and a project with no ledger yet
+    assert store.scrub_event_fields("", project_dir=PROJECT) == 0
+    assert store.scrub_event_fields("deadbeef", project_dir="") == 0
+    _write("S1", "2026-08-01T00:00:00Z", [{"text": KEEPER, "trust": "inferred"}])
+    assert not store._events_path(PROJECT).exists()  # no ledger yet
+    assert store.scrub_event_fields("deadbeef", project_dir=PROJECT) == 0
+
+
+def test_event_scrub_copies_uninterpretable_lines_verbatim(tmp_checkpoint_dir):
+    _write("S1", "2026-08-01T00:00:00Z", [{"text": CANARY, "trust": "inferred"}])
+    store.append_event("i-y", "resolved", item_text=CANARY,
+                       project_dir=PROJECT)
+    path = store._events_path(PROJECT)
+    with path.open("a", encoding="utf-8") as f:
+        f.write("not json at all\n")
+        f.write('["a", "json", "array", "row"]\n')
+    _forget_canary()
+    lines = path.read_text().splitlines()
+    assert "not json at all" in lines
+    assert '["a", "json", "array", "row"]' in lines
+    scrubbed = [json.loads(ln) for ln in lines
+                if ln.startswith("{") and json.loads(ln).get("item_ref") == "i-y"]
+    assert scrubbed[0]["item_text"] == MARKER
+
+
 def test_event_scrub_routes_rewritten_rows_through_admit_row(
         tmp_checkpoint_dir, monkeypatch):
     """Refuter finding 4: the ledger rewrite must be GOVERNED, not merely

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -389,6 +389,11 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
         run(["resolve", ctx["ids"][_T_KEEP], "--note", "shipped"], 0)
 
     def r_forget():
+        # #599: resolve first so events.jsonl holds the target's text as
+        # `item_text` — the forget below must REWRITE the ledger (the one
+        # ratified rewrite of the append-only file), not just append its
+        # tombstone, so that write is observed and asserted governed.
+        run(["resolve", ctx["ids"][_T_FORGET], "--note", "obsolete"], 0)
         run(["forget", ctx["ids"][_T_FORGET], "--reason", "stale"], 0)
 
     def r_reverify():
@@ -566,6 +571,12 @@ def test_every_command_write_carries_an_admit_frame(
     assert saw("serialize", "guard-serialize.json", "team")  # team dual-write
     assert saw("resolve", "events.jsonl")           # admit_row on the ledger
     assert saw("forget", "events.jsonl")            # tombstone append
+    # #599: the ledger REWRITE (scrub_event_fields) must have run and been
+    # governed — not merely the tombstone append hitting the same file.
+    assert any(cmd == "forget" and rel.name == "events.jsonl" and governed
+               and any(f.endswith("store.scrub_event_fields") for f in frames)
+               for cmd, lbl, rel, governed, frames in write_audit.records), \
+        "forget never exercised (or never governed) the events.jsonl rewrite"
     assert saw("heal", "forget-hits.jsonl")         # capture-time forget drop
     assert saw("anchor", "latest.json")             # --attach rewrite
 


### PR DESCRIPTION
Closes #599

## What

`daimon forget` now reaches every plaintext carrier in the class `policy.redact_checkpoint` already enumerates, not just item `text`:

- **quote/scene fields on surviving items** — field-level scrub instead of whole-item drop. A scrubbed quote takes its verification claim with it (`quote_provenance`, `quote_verified`, `last_verified`, `source_message_ids`) and downgrades trust `verbatim` → `inferred`: a stale receipt would keep `carry._capture_verified` answering True, and `trust=verbatim` with no quote fails serializer revalidation.
- **`links[].target`** — a supersedes target copies another item's whole text until `bind_links` resolves it to an id; a link whose target folds to the tombstoned key is dropped (a marker target would read as a live supersession claim that binds to nothing).
- **`active_topic`** — the singleton sits outside `_ITEM_LISTS`, so it was indexed for retrieval but unreachable by deletion. Topic text matching the key drops the singleton; quote/scene get the field scrub.
- **`events.jsonl` `item_text`/`status`/`note`** — the one ratified rewrite of the append-only ledger: field redaction in place with `[forgotten:<content_key>]`, rows never dropped or reordered (scar 0025 — the resolutions fold keys on `item_ref`/`status`/row order). A scrubbed `status` keeps its lifecycle class token (`reopen`, `superseded-by:`, …) because every reader classifies by prefix — a bare marker re-classified a revival as free-form resolved and hid an unrelated item forever. Rewritten rows re-enter `policy.admit_row`, so the write-audit guard binds the bytes on disk to a real admission.
- **`daimon audit privacy`** now hashes `links[].target` and the `active_topic` singleton too — before this, the detector certified exit 0 over live plaintext in both, so the fix's own acceptance test would have been self-certifying.

One shared predicate (`policy.scrub_forgotten_payload`) backs the write gate (`drop_forgotten`), the surface scrub (`store.scrub_content_key`), and the inbound team gate (`admit_foreign`). The recall rebuild fold extends its row delete to quote/scene key matches (whole-row delete is the fail-safe: the rebuilt row from the scrubbed checkpoint re-inserts the survivor without the field).

## Why

Every forget path minted and matched only `normalize.content_key(item["text"])`. `daimon audit privacy` (#602) made the residue visible as findings; #599 is the fix side. The scope grew from the issue's two named fields to the full class after review: patching named fields while the class leaks is the recorded mistake this repo already paid for once.

Known boundary: team-mirror copies of older sessions still hold plaintext — that is #600 (tombstone propagation), and the audit keeps reporting `team-copy` findings honestly until it lands.

## Tests

- `plugin/tests/test_forget_field_residue.py` (new, 15 tests) — every behavior written as a failing test first against the shipped code: quote/scene scrub + claim teardown, prev-N history, write-gate re-capture, links drop, active_topic drop/scrub, event-ledger redaction in place (structure preserved, unrelated rows byte-identical, class-preserving status marker), admit_row governance, rebuilt index residue, end-to-end `audit privacy` clean.
- `plugin/tests/test_audit_privacy.py` — 2 new detector tests (active_topic, links target) that fail against the shipped auditor.
- `plugin/tests/test_write_audit_guard.py` — forget recipe now exercises the ledger rewrite; new anti-vacuity assertion that the rewrite ran governed.
- Full suite: 3054 passed, 2 skipped.
- Adversarial review pass over the diff produced 6 findings: 4 fixed in this PR (status class preservation, the class extension, guard governance, race-note honesty), 2 accepted residuals documented in the `scrub_event_fields` docstring (same-second tie-break bytes move when a tied row is scrubbed; the legacy fuzzy withhold pool loses entries whose `item_text` was redacted, so an id-less paraphrase can resurface — that suppression only ever worked because the residue existed).
