### PR TITLE
feat(store): surface registry — new stores must declare a delete strategy

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -2308,6 +2308,12 @@ def _cmd_heal(args) -> int:
     wrapped directly; no restructuring of `_run_serialize` needed."""
     dry_run = getattr(args, "dry_run", False)
     force = getattr(args, "force", False)
+    # #601: heal owns repair, so the dead-index-snapshot reap lives here (the
+    # audit group is read-only by charter). Runs even when nothing is
+    # healable — the strands are what pin `audit privacy` at cannot-prove.
+    for p in recall.reap_dead_snapshots(apply=not dry_run):
+        print(f"{'would reap' if dry_run else 'reaped'} "
+              f"dead index snapshot: {p.name}")
     try:
         text = (config.log_dir() / "serialize.log").read_text(encoding="utf-8")
     except OSError:

--- a/plugin/daimon_briefing/privacy.py
+++ b/plugin/daimon_briefing/privacy.py
@@ -18,7 +18,7 @@ import sqlite3
 import time
 from pathlib import Path
 
-from . import config, normalize, store, teamproject
+from . import config, normalize, store, surfaces, teamproject
 
 # Plaintext-bearing item fields — the same CLASS policy.redact_checkpoint
 # enumerates (its links[].target and active_topic coverage lives in _hashes
@@ -37,26 +37,14 @@ _EVENT_FIELDS = ("note", "item_text", "status")
 _EVENTS_NAME = "events.jsonl"
 
 # Files that live in the checkpoint store and hold NO item plaintext BY
-# CONSTRUCTION. Every exemption is checked against its owning module, because
-# an exemption granted on a hunch is exactly how a plaintext surface goes
-# unreported. Reporting these made exit 0 unreachable on a real install (74
-# `.receipt` sidecars in the flat dir of the machine this was specced on).
-_EXEMPT_NAMES = frozenset({
-    # store._pointer_lock: an empty flock sidecar, opened "a+" and never written.
-    store._LOCK_NAME,
-    # store.append_verification: item_ref + a reason CODE, "never the rejected
-    # text" — quote verification runs pre-redaction, so it must not log text.
-    "verification.jsonl",
-    # store.record_forget_hits: {ts, key} — the canonical hash only, "NEVER the
-    # text or any prefix of it".
-    "forget-hits.jsonl",
-    # macOS Finder metadata: directory listing/positions, never file contents.
-    ".DS_Store",
-})
-# receipts._sidecar_path. The blob is {jws, receipt, kid, performer_id} where
-# the receipt carries inputs/outputs HASHES, method and nonce — it binds to a
-# checkpoint's bytes, it never copies them.
-_EXEMPT_SUFFIX = ".receipt"
+# CONSTRUCTION. Since #601 both sets are VIEWS of the declared surface
+# registry (surfaces.py) — the per-entry justifications live there, next to
+# each shape's owner and delete strategy, so the auditor cannot drift from
+# the declaration. An exemption granted on a hunch is exactly how a
+# plaintext surface goes unreported; the registry's audit_exempt flag is
+# the single place such a claim is made and reviewed.
+_EXEMPT_NAMES = surfaces.exempt_names()
+_EXEMPT_SUFFIX = surfaces.exempt_suffix()
 
 
 def _is_plaintext_free(path: Path) -> bool:

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -520,27 +520,32 @@ def reap_dead_snapshots(now: float | None = None, apply: bool = True) -> list:
     fail. The strands are full plaintext copies, and the unopenable sidecars
     pinned real installs at `daimon audit privacy` exit 3 (cannot-prove).
 
-    Registry contract (surfaces.py): shape `recall.db.{pid}.tmp*`, strategy
-    `reap`. The filter is EXACTLY that shape — `<db>.<digits>.tmp` plus a
-    dash-sidecar tail — never a substring test: `recall.db.tmp`,
+    The filter IS the registry declaration (surfaces.match → the entry
+    whose strategy is `reap`, shape `recall.db.{pid}.tmp*` with {pid}
+    digit-anchored) — never a second hand-written predicate, which would
+    reintroduce the parallel-list defect in the one path that DELETES
+    files (adversarial-review finding). `recall.db.tmp`,
     `recall.db.bak.tmp`, `recall.db.tmp.gz` beside a DAIMON_RECALL_DB
-    override are a user's own files (adversarial-review finding), and the
-    live db's sqlite sidecars are dash-named (`recall.db-journal`) so they
-    cannot match either. Age-gated like the checkpoint reaper — anything
-    older than an hour is dead by construction. `apply=False` only lists
-    (heal --dry-run). Best-effort per file; returns the paths reaped (or
+    override are a user's own files and stay undeclared; the live db's
+    sqlite sidecars are dash-named (`recall.db-journal`) so they cannot
+    match the dotted glob at all. Age-gated like the checkpoint reaper —
+    anything older than an hour is dead by construction (this runs
+    unattended from heal at session start on some hosts, so containment
+    is the load-bearing property). `apply=False` only lists (heal
+    --dry-run). Best-effort per file; returns the paths reaped (or
     would-reap)."""
+    from . import surfaces
     db = config.recall_db()
     if now is None:
         now = time.time()
     reaped: list = []
-    strand = re.compile(re.escape(db.name) + r"\.\d+\.tmp(-[a-z]+)?$")
     try:
         candidates = sorted(db.parent.glob(db.name + ".*"))
     except OSError:
         return reaped
     for p in candidates:
-        if not strand.fullmatch(p.name):
+        entry = surfaces.match(p.name)
+        if entry is None or entry.delete != "reap":
             continue
         try:
             if not p.is_file():

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -521,20 +521,26 @@ def reap_dead_snapshots(now: float | None = None, apply: bool = True) -> list:
     pinned real installs at `daimon audit privacy` exit 3 (cannot-prove).
 
     Registry contract (surfaces.py): shape `recall.db.{pid}.tmp*`, strategy
-    `reap`. Age-gated like the checkpoint reaper — anything older than an
-    hour is dead by construction; the live db itself never matches the
-    glob's `.tmp` requirement. `apply=False` only lists (heal --dry-run).
-    Best-effort per file; returns the paths reaped (or would-reap)."""
+    `reap`. The filter is EXACTLY that shape — `<db>.<digits>.tmp` plus a
+    dash-sidecar tail — never a substring test: `recall.db.tmp`,
+    `recall.db.bak.tmp`, `recall.db.tmp.gz` beside a DAIMON_RECALL_DB
+    override are a user's own files (adversarial-review finding), and the
+    live db's sqlite sidecars are dash-named (`recall.db-journal`) so they
+    cannot match either. Age-gated like the checkpoint reaper — anything
+    older than an hour is dead by construction. `apply=False` only lists
+    (heal --dry-run). Best-effort per file; returns the paths reaped (or
+    would-reap)."""
     db = config.recall_db()
     if now is None:
         now = time.time()
     reaped: list = []
+    strand = re.compile(re.escape(db.name) + r"\.\d+\.tmp(-[a-z]+)?$")
     try:
         candidates = sorted(db.parent.glob(db.name + ".*"))
     except OSError:
         return reaped
     for p in candidates:
-        if ".tmp" not in p.name:
+        if not strand.fullmatch(p.name):
             continue
         try:
             if not p.is_file():

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -504,6 +504,51 @@ def _apply_event_resolutions(conn: sqlite3.Connection) -> None:
             conn.execute("DELETE FROM items WHERE id = ?", (rowid,))
 
 
+# A dead snapshot is unambiguous after this long: a live rebuild holds its
+# tmp for seconds, and store._TMP_REAP_SECONDS set the same one-hour
+# precedent for checkpoint staging twins.
+_SNAPSHOT_REAP_SECONDS = 3600
+
+
+def reap_dead_snapshots(now: float | None = None, apply: bool = True) -> list:
+    """Delete index snapshots left by crashed rebuilds (#601).
+
+    rebuild() stages into `recall.db.<pid>.tmp` and only unlinks ITS OWN
+    pid's leftover — a crash under any other pid strands the snapshot (plus
+    sqlite's `-journal` sidecar) forever: store._reap_stale_tmps never visits
+    this directory and its filter is `.endswith(".tmp")`, which the sidecars
+    fail. The strands are full plaintext copies, and the unopenable sidecars
+    pinned real installs at `daimon audit privacy` exit 3 (cannot-prove).
+
+    Registry contract (surfaces.py): shape `recall.db.{pid}.tmp*`, strategy
+    `reap`. Age-gated like the checkpoint reaper — anything older than an
+    hour is dead by construction; the live db itself never matches the
+    glob's `.tmp` requirement. `apply=False` only lists (heal --dry-run).
+    Best-effort per file; returns the paths reaped (or would-reap)."""
+    db = config.recall_db()
+    if now is None:
+        now = time.time()
+    reaped: list = []
+    try:
+        candidates = sorted(db.parent.glob(db.name + ".*"))
+    except OSError:
+        return reaped
+    for p in candidates:
+        if ".tmp" not in p.name:
+            continue
+        try:
+            if not p.is_file():
+                continue
+            if now - p.stat().st_mtime < _SNAPSHOT_REAP_SECONDS:
+                continue
+            if apply:
+                p.unlink()
+        except OSError:
+            continue
+        reaped.append(p)
+    return reaped
+
+
 def rebuild() -> int:
     """Drop + rebuild the whole index by scanning local + team checkpoints.
     Atomic: builds into a sibling temp file, then os.replace — a concurrent

--- a/plugin/daimon_briefing/surfaces.py
+++ b/plugin/daimon_briefing/surfaces.py
@@ -40,9 +40,13 @@ from typing import NamedTuple
 # known-gap          — holds plaintext deletion cannot reach TODAY; must cite
 #                      the tracking issue. The registry makes the debt
 #                      visible; it never silences it.
+# lazy-rebuild        — derived cache; forgotten rows leave at the NEXT
+#                       fingerprint-triggered rebuild, not at forget time —
+#                       if no recall command ever runs, plaintext persists
+#                       (the audit's stale-index-pending-rebuild class)
 DELETE_STRATEGIES = frozenset({
     "rewrite", "append-tombstone", "wholesale-purge", "reap",
-    "exempt-no-plaintext", "known-gap",
+    "lazy-rebuild", "exempt-no-plaintext", "known-gap",
 })
 
 
@@ -112,7 +116,7 @@ SURFACES: tuple[Surface, ...] = (
     #    from crashed rebuilds are reaped on sight. --
     Surface("recall.db.{pid}.tmp*", "recall.rebuild",
             True, "reap", "reaper"),
-    Surface("recall.db", "recall.rebuild", True, "rewrite", "recall"),
+    Surface("recall.db", "recall.rebuild", True, "lazy-rebuild", "recall"),
     Surface("recall_seen/*.json", "cli._save_seen",
             False, "exempt-no-plaintext", "none"),
     # -- logs: no item text by construction, except the crash sink, which
@@ -134,15 +138,41 @@ SURFACES: tuple[Surface, ...] = (
     # codex host adapter stop stamps: an epoch float per session.
     Surface("codex/*.last-stop", "_hooks/daimon-codex-*.py",
             False, "exempt-no-plaintext", "none"),
+    # -- windsurf host adapter state: FULL RAW TRANSCRIPTS appended turn by
+    #    turn, plus unparsed event payloads (secret-scrubbed at write, never
+    #    item-text scrubbed). The largest plaintext store daimon writes, and
+    #    nothing in forget or the audit reaches it — THE declared gap after
+    #    the team mirror. provenance.py reads the transcripts as a
+    #    first-class source, so this is load-bearing, not vestigial. --
+    Surface("windsurf/transcripts/*.md", "_hooks/daimon-windsurf-hooks.py",
+            True, "known-gap", "none", issue="#607"),
+    Surface("windsurf/unparsed-*.json", "_hooks/daimon-windsurf-hooks.py",
+            True, "known-gap", "none", issue="#607"),
+    # trajectory activity/serialize stamps: epoch floats, no item text.
+    Surface("windsurf/*.last-activity", "_hooks/daimon-windsurf-hooks.py",
+            False, "exempt-no-plaintext", "none"),
+    Surface("windsurf/*.last-serialize", "_hooks/daimon-windsurf-hooks.py",
+            False, "exempt-no-plaintext", "none"),
+    # installed hook copies under ~/.daimon/hooks — program text, not
+    # belief bytes (cli._hooks_target_dir).
+    Surface("hooks/*", "cli install-hooks", False, "exempt-no-plaintext",
+            "none"),
 )
 
 _PLACEHOLDER_RE = re.compile(r"\{[a-z]+\}")
+
+# {pid} is digits, not a bare wildcard: `recall.db.bak.tmp` beside a
+# DAIMON_RECALL_DB override is a user's own backup and must stay UNDECLARED
+# so the registry-derived reaper cannot touch it.
+_PLACEHOLDER_GLOBS = {"{pid}": "[0-9]*"}
 
 
 def _part_matches(shape_part: str, part: str) -> bool:
     if shape_part == part:
         return True
-    return fnmatch.fnmatchcase(part, _PLACEHOLDER_RE.sub("*", shape_part))
+    pat = _PLACEHOLDER_RE.sub(
+        lambda m: _PLACEHOLDER_GLOBS.get(m.group(0), "*"), shape_part)
+    return fnmatch.fnmatchcase(part, pat)
 
 
 def _parts_match(shape_parts: tuple, parts: tuple) -> bool:
@@ -180,10 +210,19 @@ def exempt_names() -> frozenset:
 
 
 def exempt_suffix() -> str:
-    """The one suffix-shaped audit exemption (receipts sidecars)."""
+    """The one suffix-shaped audit exemption (receipts sidecars).
+
+    Exactly one: privacy._is_plaintext_free compares a single suffix, so a
+    second declaration would have declaration ORDER silently pick the
+    winner — the guess this registry exists to forbid. Fail loudly both
+    ways."""
+    found = []
     for s in SURFACES:
         if s.audit_exempt:
             name = s.shape.rsplit("/", 1)[-1]
             if name.startswith("*."):
-                return name[1:]
-    raise LookupError("no suffix-shaped exemption declared")
+                found.append(name[1:])
+    if len(found) != 1:
+        raise LookupError(
+            f"expected exactly one suffix-shaped exemption, got {found}")
+    return found[0]

--- a/plugin/daimon_briefing/surfaces.py
+++ b/plugin/daimon_briefing/surfaces.py
@@ -1,0 +1,183 @@
+"""The declared surface registry (#601): every file shape daimon writes under
+~/.daimon, with its deletion contract.
+
+Four shipped defects of one class (#583, #599 twice over, the #600 team gap)
+traced to the same hole: three hand-maintained lists — store's deletion walk,
+privacy's audit exemptions, recall's fingerprint set — each answered "what
+files exist and what may they hold" separately, so a new file shape silently
+inherited a hole in whichever list its author forgot. This module is the
+single declaration; consumers derive their views from it (privacy's
+exemptions today; the write-audit guard refuses write shapes that were never
+declared), and a plaintext shape with no reachable deletion must name the
+tracking issue for its gap — visible debt, never silence.
+
+Follows schema.py's pattern: one NamedTuple table, every consumer derived.
+A shape added here propagates; a shape written but not declared fails the
+guard in tests/test_write_audit_guard.py.
+
+Shape syntax: path parts relative to ~/.daimon. `{slug}`/`{remote}`/`{pid}`/
+`{hash}` are placeholders (they match anything, and match themselves
+literally so write-audit-normalized patterns classify too); `*` is fnmatch
+within one part; `**` spans zero or more parts. First declaration wins, so
+specific shapes come before the generic ones they would otherwise shadow.
+"""
+from __future__ import annotations
+
+import fnmatch
+import re
+from typing import NamedTuple
+
+# rewrite            — forget reaches it by rewriting the file (atomic replace)
+# append-tombstone   — append-only ledger; forget appends a tombstone and the
+#                      ONE ratified carve-out (store.scrub_event_fields)
+#                      redacts fields in place
+# wholesale-purge    — cannot be selectively scrubbed; deletion drops the
+#                      whole store (chunk cache, in-flight tmps)
+# reap               — dead by construction; a reaper deletes on sight
+#                      (recall.reap_dead_snapshots)
+# exempt-no-plaintext— holds no item plaintext BY CONSTRUCTION; every such
+#                      claim cites the owning module's own guarantee
+# known-gap          — holds plaintext deletion cannot reach TODAY; must cite
+#                      the tracking issue. The registry makes the debt
+#                      visible; it never silences it.
+DELETE_STRATEGIES = frozenset({
+    "rewrite", "append-tombstone", "wholesale-purge", "reap",
+    "exempt-no-plaintext", "known-gap",
+})
+
+
+class Surface(NamedTuple):
+    shape: str          # path pattern relative to ~/.daimon (syntax above)
+    owner: str          # writer, as module.function
+    plaintext: bool     # can item text/quote/scene/note ever land in it?
+    delete: str         # one of DELETE_STRATEGIES
+    walker: str         # who walks it: forget | audit | recall | reaper | none
+    issue: str = ""     # required when delete == "known-gap"
+    audit_exempt: bool = False  # feeds privacy's name/suffix exemption sets
+
+
+SURFACES: tuple[Surface, ...] = (
+    # -- per-project bucket ledgers (specific before the *.json generics) --
+    Surface("checkpoints/{slug}/events.jsonl", "store.append_event",
+            True, "append-tombstone", "audit"),
+    # store.append_verification: "a POINTER and a REASON CODE, never the
+    # rejected text" (store.py docstring).
+    Surface("checkpoints/{slug}/verification.jsonl",
+            "store.append_verification", False, "exempt-no-plaintext",
+            "none", audit_exempt=True),
+    # store.record_forget_hits: {ts, key} — "NEVER the text or any prefix".
+    Surface("checkpoints/{slug}/forget-hits.jsonl",
+            "store.record_forget_hits", False, "exempt-no-plaintext",
+            "none", audit_exempt=True),
+    # -- serializer chunk cache: PRE-redaction by design (#125), so it can
+    #    only be purged wholesale (#422); age reaper bounds survivors. --
+    Surface("checkpoints/.chunk-cache/*", "serializer._save_chunk_cache",
+            True, "wholesale-purge", "forget"),
+    # -- receipts sidecars: hashes, method, nonce — bind to bytes, never
+    #    copy them (receipts._sidecar_path). The suffix exemption. --
+    Surface("checkpoints/**/*.receipt", "receipts._atomic_write_text",
+            False, "exempt-no-plaintext", "none", audit_exempt=True),
+    # store._pointer_lock: empty flock sidecar, opened a+, never written.
+    Surface("checkpoints/**/.pointer.lock", "store._pointer_lock",
+            False, "exempt-no-plaintext", "none", audit_exempt=True),
+    # macOS Finder metadata: listing positions, never file contents.
+    Surface("**/.DS_Store", "macOS Finder", False, "exempt-no-plaintext",
+            "none", audit_exempt=True),
+    # -- checkpoint JSON: the core belief state, flat and bucketed. --
+    Surface("checkpoints/{slug}/*.json", "store.write_checkpoint",
+            True, "rewrite", "forget"),
+    Surface("checkpoints/*.json",
+            "store.write_checkpoint / store._rotate_pointers",
+            True, "rewrite", "forget"),
+    # store._atomic_write staging twins; reaped by store._reap_stale_tmps.
+    Surface("checkpoints/**/*.tmp", "store._atomic_write",
+            True, "wholesale-purge", "reaper"),
+    # -- team mirror: forward plaintext copies, no tombstone propagation
+    #    yet — THE declared gap. --
+    Surface("team/{remote}/README.md", "teamsync.init",
+            False, "exempt-no-plaintext", "none"),
+    Surface("team/{remote}/daimon-team.toml", "teamsync.init",
+            False, "exempt-no-plaintext", "none"),
+    Surface("team/{remote}/**/*.json", "store._dual_write_team",
+            True, "known-gap", "audit", issue="#600"),
+    Surface("team/{remote}/.git/**", "git (teamsync subprocess)",
+            True, "known-gap", "none", issue="#600"),
+    # -- recall index: derived cache; rows leave at rebuild, dead snapshots
+    #    from crashed rebuilds are reaped on sight. --
+    Surface("recall.db.{pid}.tmp*", "recall.rebuild",
+            True, "reap", "reaper"),
+    Surface("recall.db", "recall.rebuild", True, "rewrite", "recall"),
+    Surface("recall_seen/*.json", "cli._save_seen",
+            False, "exempt-no-plaintext", "none"),
+    # -- logs: no item text by construction, except the crash sink, which
+    #    captures raw serializer-child stderr — tracebacks can embed item
+    #    text and nothing deletes it. Declared debt. --
+    Surface("logs/serialize-crash.log", "cli serialize child stderr",
+            True, "known-gap", "none", issue="#605"),
+    Surface("logs/heartbeats/*", "ledger.touch_heartbeat",
+            False, "exempt-no-plaintext", "none"),
+    Surface("logs/*.log", "ledger / cli._note_usage / recall._note_error",
+            False, "exempt-no-plaintext", "none"),
+    # -- key material and env: secrets, never item plaintext. --
+    Surface("keys/signing.seed", "receipts._ensure_seed",
+            False, "exempt-no-plaintext", "none"),
+    Surface("keys/signing.pub.json", "receipts._ensure_pubkey",
+            False, "exempt-no-plaintext", "none"),
+    Surface("env", "configure.write_env", False, "exempt-no-plaintext",
+            "none"),
+    # codex host adapter stop stamps: an epoch float per session.
+    Surface("codex/*.last-stop", "_hooks/daimon-codex-*.py",
+            False, "exempt-no-plaintext", "none"),
+)
+
+_PLACEHOLDER_RE = re.compile(r"\{[a-z]+\}")
+
+
+def _part_matches(shape_part: str, part: str) -> bool:
+    if shape_part == part:
+        return True
+    return fnmatch.fnmatchcase(part, _PLACEHOLDER_RE.sub("*", shape_part))
+
+
+def _parts_match(shape_parts: tuple, parts: tuple) -> bool:
+    if not shape_parts:
+        return not parts
+    head, rest = shape_parts[0], shape_parts[1:]
+    if head == "**":
+        return any(_parts_match(rest, parts[i:])
+                   for i in range(len(parts) + 1))
+    return bool(parts) and _part_matches(head, parts[0]) \
+        and _parts_match(rest, parts[1:])
+
+
+def match(pattern: str) -> Surface | None:
+    """Classify a path (or a write-audit-normalized pattern) against the
+    registry. First declaration wins; None means UNDECLARED — the caller's
+    cue to fail loudly, never to guess."""
+    parts = tuple(p for p in pattern.split("/") if p)
+    for s in SURFACES:
+        if _parts_match(tuple(s.shape.split("/")), parts):
+            return s
+    return None
+
+
+def exempt_names() -> frozenset:
+    """Fixed-filename audit exemptions — privacy._EXEMPT_NAMES is this view."""
+    out = set()
+    for s in SURFACES:
+        if not s.audit_exempt:
+            continue
+        name = s.shape.rsplit("/", 1)[-1]
+        if not any(c in name for c in "*?[{"):
+            out.add(name)
+    return frozenset(out)
+
+
+def exempt_suffix() -> str:
+    """The one suffix-shaped audit exemption (receipts sidecars)."""
+    for s in SURFACES:
+        if s.audit_exempt:
+            name = s.shape.rsplit("/", 1)[-1]
+            if name.startswith("*."):
+                return name[1:]
+    raise LookupError("no suffix-shaped exemption declared")

--- a/plugin/daimon_briefing/surfaces.py
+++ b/plugin/daimon_briefing/surfaces.py
@@ -90,6 +90,12 @@ SURFACES: tuple[Surface, ...] = (
             "store.write_checkpoint / store._rotate_pointers",
             True, "rewrite", "forget"),
     # store._atomic_write staging twins; reaped by store._reap_stale_tmps.
+    # Honest bounds (adversarial-review finding): the reaper walks the flat
+    # dir plus ONE level of bucket subdirs, so a depth-2+ .tmp has no live
+    # deletion mechanism; and any future .tmp-suffixed store auto-classifies
+    # here, blinding the declaration ratchet — the conservative inherited
+    # contract (plaintext=True, never audit_exempt) keeps the auditor
+    # scanning such files regardless.
     Surface("checkpoints/**/*.tmp", "store._atomic_write",
             True, "wholesale-purge", "reaper"),
     # -- team mirror: forward plaintext copies, no tombstone propagation

--- a/plugin/tests/test_surface_registry.py
+++ b/plugin/tests/test_surface_registry.py
@@ -1,0 +1,159 @@
+"""#601: the declared surface registry — new stores must declare a delete
+strategy.
+
+Four shipped defects of one class (#583, quote/scene #599, events item_text
+#599, team copies #600-pending) came from the same structural hole: three
+hand-maintained parallel lists (store._plaintext_surfaces, privacy's
+exemptions, recall._fingerprint) each answered "what files exist and what may
+they hold" differently, and a new file shape silently inherited a hole in
+whichever list its author forgot. The registry is the single declaration:
+every file shape daimon writes under ~/.daimon states whether it can hold
+item plaintext, how deletion reaches it, and who owns it. The auditor derives
+its exemptions from it; the write-audit guard refuses shapes it has never
+seen declared; a plaintext shape with no reachable deletion must name the
+tracking issue for its gap.
+"""
+import os
+import time
+
+from daimon_briefing import cli, config, privacy, recall, store, surfaces
+
+
+# ---- declaration hygiene --------------------------------------------------
+
+
+def test_every_entry_declares_the_full_contract():
+    assert surfaces.SURFACES, "registry must not be empty"
+    seen = set()
+    for s in surfaces.SURFACES:
+        assert s.shape and s.owner, f"underspecified entry: {s}"
+        assert s.shape not in seen, f"duplicate shape: {s.shape}"
+        seen.add(s.shape)
+        assert s.delete in surfaces.DELETE_STRATEGIES, \
+            f"{s.shape}: unknown delete strategy {s.delete!r}"
+
+
+def test_plaintext_never_pairs_with_exempt():
+    for s in surfaces.SURFACES:
+        if s.plaintext:
+            assert s.delete != "exempt-no-plaintext", \
+                f"{s.shape} holds plaintext but claims the exemption"
+        else:
+            assert s.delete == "exempt-no-plaintext", \
+                f"{s.shape} holds no plaintext yet declares {s.delete}"
+
+
+def test_known_gaps_name_their_tracking_issue():
+    gaps = [s for s in surfaces.SURFACES if s.delete == "known-gap"]
+    assert gaps, "the team mirror gap (#600) must be declared, not hidden"
+    for s in gaps:
+        assert s.issue, f"{s.shape}: a known gap must cite its issue"
+
+
+def test_the_load_bearing_shapes_are_registered():
+    for shape in ("checkpoints/{slug}/events.jsonl",
+                  "checkpoints/{slug}/verification.jsonl",
+                  "checkpoints/{slug}/forget-hits.jsonl",
+                  "checkpoints/.chunk-cache/*",
+                  "recall.db",
+                  "recall.db.{pid}.tmp*"):
+        assert surfaces.match(shape) is not None, f"unregistered: {shape}"
+
+
+# ---- pattern matching -----------------------------------------------------
+
+
+def test_match_classifies_write_audit_patterns():
+    assert surfaces.match("checkpoints/{slug}/events.jsonl").delete \
+        == "append-tombstone"
+    assert surfaces.match("checkpoints/{hash}.json").plaintext is True
+    assert surfaces.match("checkpoints/{slug}/S1.json").plaintext is True
+    assert surfaces.match("team/{remote}/README.md").delete \
+        == "exempt-no-plaintext"
+    assert surfaces.match("team/{remote}/projects/p/authors/a/S1.json").delete \
+        == "known-gap"
+    assert surfaces.match("checkpoints/latest.json.bak-1782874461") is None
+    assert surfaces.match("somewhere/unregistered.bin") is None
+
+
+# ---- derivations ----------------------------------------------------------
+
+
+def test_privacy_exemptions_derive_from_the_registry():
+    """The auditor's name-based exemption set is a VIEW of the registry, not
+    a fourth parallel list."""
+    assert privacy._EXEMPT_NAMES == surfaces.exempt_names()
+    assert privacy._EXEMPT_SUFFIX == surfaces.exempt_suffix()
+
+
+# ---- the reap verb --------------------------------------------------------
+
+
+def _plant_orphans():
+    db = config.recall_db()
+    db.parent.mkdir(parents=True, exist_ok=True)
+    dead = db.parent / f"{db.name}.44594.tmp"
+    journal = db.parent / f"{db.name}.44594.tmp-journal"
+    dead.write_text("dead snapshot bytes")
+    journal.write_text("journal bytes")
+    old = time.time() - 2 * 3600
+    os.utime(dead, (old, old))
+    os.utime(journal, (old, old))
+    fresh = db.parent / f"{db.name}.{os.getpid()}.tmp"
+    fresh.write_text("live rebuild in flight")
+    return dead, journal, fresh
+
+
+def test_reap_removes_dead_snapshots_and_spares_fresh_ones(tmp_path):
+    dead, journal, fresh = _plant_orphans()
+    reaped = recall.reap_dead_snapshots()
+    assert sorted(p.name for p in reaped) == [dead.name, journal.name]
+    assert not dead.exists() and not journal.exists()
+    assert fresh.exists(), "a fresh in-flight rebuild tmp must survive"
+
+
+def test_reap_never_touches_the_live_db(tmp_path):
+    db = config.recall_db()
+    db.parent.mkdir(parents=True, exist_ok=True)
+    db.write_text("the live derived index")
+    _plant_orphans()
+    recall.reap_dead_snapshots()
+    assert db.exists()
+
+
+def test_heal_reaps_orphans_and_dry_run_only_lists(tmp_path, capsys):
+    dead, journal, fresh = _plant_orphans()
+    assert cli.main(["heal", "--dry-run"]) == 0
+    out = capsys.readouterr().out
+    assert dead.name in out
+    assert dead.exists() and journal.exists(), "--dry-run must not delete"
+    assert cli.main(["heal"]) == 0
+    out = capsys.readouterr().out
+    assert dead.name in out
+    assert not dead.exists() and not journal.exists()
+    assert fresh.exists()
+
+
+def test_reap_clears_the_audit_unscannable_class(tmp_path):
+    """The four dead -journal sidecars were what pinned a real install at
+    exit 3 (cannot-prove): unopenable as databases, so the audit honestly
+    refused to certify. After the reap they are gone, not explained away."""
+    _write_min_checkpoint()
+    dead, journal, fresh = _plant_orphans()
+    fresh.unlink()          # leave only the dead pair
+    before = privacy.audit_project(project_dir=_P)
+    assert any(journal.name in u for u in before["unscannable"])
+    recall.reap_dead_snapshots()
+    after = privacy.audit_project(project_dir=_P)
+    assert not any(journal.name in u for u in after["unscannable"])
+
+
+_P = "/p/surface-registry"
+
+
+def _write_min_checkpoint():
+    store.write_checkpoint("S1", {
+        "session_id": "S1", "created": "2026-08-01T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "a decision that stays", "trust": "inferred"}]},
+    }, project_dir=_P)

--- a/plugin/tests/test_surface_registry.py
+++ b/plugin/tests/test_surface_registry.py
@@ -79,6 +79,17 @@ def test_match_classifies_write_audit_patterns():
 # ---- derivations ----------------------------------------------------------
 
 
+def test_exempt_suffix_refuses_a_registry_without_one(monkeypatch):
+    """A registry stripped of its suffix exemption must fail loudly — a
+    silent empty string would quietly un-exempt every receipt sidecar and
+    flood the audit with false residue."""
+    import pytest
+
+    monkeypatch.setattr(surfaces, "SURFACES", ())
+    with pytest.raises(LookupError):
+        surfaces.exempt_suffix()
+
+
 def test_privacy_exemptions_derive_from_the_registry():
     """The auditor's name-based exemption set is a VIEW of the registry, not
     a fourth parallel list."""
@@ -110,6 +121,37 @@ def test_reap_removes_dead_snapshots_and_spares_fresh_ones(tmp_path):
     assert sorted(p.name for p in reaped) == [dead.name, journal.name]
     assert not dead.exists() and not journal.exists()
     assert fresh.exists(), "a fresh in-flight rebuild tmp must survive"
+
+
+def test_reap_skips_non_tmp_siblings_directories_and_glob_errors(
+        tmp_path, monkeypatch):
+    db = config.recall_db()
+    db.parent.mkdir(parents=True, exist_ok=True)
+    backup = db.parent / f"{db.name}.backup"      # no .tmp — never a target
+    backup.write_text("user's own backup")
+    dirlike = db.parent / f"{db.name}.olddir.tmp"  # directory, not a file
+    dirlike.mkdir()
+    old = time.time() - 2 * 3600
+    os.utime(backup, (old, old))
+    os.utime(dirlike, (old, old))
+    assert recall.reap_dead_snapshots() == []
+    assert backup.exists() and dirlike.is_dir()
+    # an undeletable strand is skipped, not fatal, and not reported reaped
+    dead, journal, _fresh = _plant_orphans()
+    real_unlink = type(dead).unlink
+
+    def deny_dead(self, missing_ok=False):
+        if self.name == dead.name:
+            raise OSError("EPERM")
+        return real_unlink(self, missing_ok=missing_ok)
+
+    monkeypatch.setattr(type(dead), "unlink", deny_dead)
+    assert [p.name for p in recall.reap_dead_snapshots()] == [journal.name]
+    monkeypatch.undo()
+    # an unreadable parent aborts quietly with nothing reaped
+    monkeypatch.setattr(type(db.parent), "glob",
+                        lambda self, pat: (_ for _ in ()).throw(OSError()))
+    assert recall.reap_dead_snapshots() == []
 
 
 def test_reap_never_touches_the_live_db(tmp_path):

--- a/plugin/tests/test_surface_registry.py
+++ b/plugin/tests/test_surface_registry.py
@@ -60,6 +60,43 @@ def test_the_load_bearing_shapes_are_registered():
         assert surfaces.match(shape) is not None, f"unregistered: {shape}"
 
 
+def test_windsurf_state_is_declared_not_invisible():
+    """Adversarial finding (BLOCKER): the windsurf adapter accumulates FULL
+    RAW TRANSCRIPTS under ~/.daimon/windsurf/transcripts — the largest
+    plaintext store daimon writes, and the registry claimed completeness
+    without it. Declared as the #607 gap; the activity stamps and installed
+    hook copies hold no item text."""
+    t = surfaces.match("windsurf/transcripts/traj-1.md")
+    assert t is not None and t.delete == "known-gap" and t.issue == "#607"
+    u = surfaces.match("windsurf/unparsed-post_cascade_response-123.json")
+    assert u is not None and u.delete == "known-gap" and u.issue == "#607"
+    assert surfaces.match("windsurf/traj-1.last-activity").delete \
+        == "exempt-no-plaintext"
+    assert surfaces.match("windsurf/traj-1.last-serialize").delete \
+        == "exempt-no-plaintext"
+    assert surfaces.match("hooks/daimon-windsurf-hooks.py").delete \
+        == "exempt-no-plaintext"
+
+
+def test_pid_placeholder_matches_digits_only():
+    """{pid} must not degrade to a bare wildcard: recall.db.bak.tmp and
+    recall.db.tmp are a user's own files and must stay UNDECLARED so the
+    registry-derived reaper cannot touch them."""
+    reap = surfaces.match("recall.db.44594.tmp")
+    assert reap is not None and reap.delete == "reap"
+    assert surfaces.match("recall.db.44594.tmp-journal").delete == "reap"
+    assert surfaces.match("recall.db.bak.tmp") is None
+    assert surfaces.match("recall.db.tmp") is None
+    assert surfaces.match("recall.db.tmpfoo") is None
+
+
+def test_recall_db_declares_lazy_rebuild_not_rewrite():
+    """Nothing rewrites recall.db at forget time — rows leave at the next
+    fingerprint-triggered rebuild, and if no recall command ever runs the
+    plaintext persists. The strategy name must say so."""
+    assert surfaces.match("recall.db").delete == "lazy-rebuild"
+
+
 # ---- pattern matching -----------------------------------------------------
 
 
@@ -88,6 +125,34 @@ def test_exempt_suffix_refuses_a_registry_without_one(monkeypatch):
     monkeypatch.setattr(surfaces, "SURFACES", ())
     with pytest.raises(LookupError):
         surfaces.exempt_suffix()
+
+
+def test_exempt_suffix_refuses_two_suffix_exemptions(monkeypatch):
+    """privacy._is_plaintext_free compares against exactly ONE suffix —
+    declaration order silently deciding the winner is the guess the
+    registry exists to forbid."""
+    import pytest
+
+    two = (surfaces.Surface("a/*.receipt", "x", False,
+                            "exempt-no-plaintext", "none", audit_exempt=True),
+           surfaces.Surface("b/*.sidecar", "y", False,
+                            "exempt-no-plaintext", "none", audit_exempt=True))
+    monkeypatch.setattr(surfaces, "SURFACES", two)
+    with pytest.raises(LookupError):
+        surfaces.exempt_suffix()
+
+
+def test_reap_is_registry_derived_not_a_parallel_predicate(
+        tmp_path, monkeypatch):
+    """The reaper's filter IS surfaces.match() — remove the reap declaration
+    and the reaper must delete nothing, proving there is no second
+    hand-written predicate (the parallel-list defect this issue exists to
+    kill, reintroduced in the one path that deletes files)."""
+    dead, journal, _fresh = _plant_orphans()
+    no_reap = tuple(s for s in surfaces.SURFACES if s.delete != "reap")
+    monkeypatch.setattr(surfaces, "SURFACES", no_reap)
+    assert recall.reap_dead_snapshots() == []
+    assert dead.exists() and journal.exists()
 
 
 def test_privacy_exemptions_derive_from_the_registry():

--- a/plugin/tests/test_surface_registry.py
+++ b/plugin/tests/test_surface_registry.py
@@ -95,6 +95,10 @@ def test_privacy_exemptions_derive_from_the_registry():
     a fourth parallel list."""
     assert privacy._EXEMPT_NAMES == surfaces.exempt_names()
     assert privacy._EXEMPT_SUFFIX == surfaces.exempt_suffix()
+    # The registry hardcodes the lock filename in a shape string — this pin
+    # is what breaks if store._LOCK_NAME is ever renamed without the
+    # registry following (the shape is a copy, not a reference).
+    assert store._LOCK_NAME in surfaces.exempt_names()
 
 
 # ---- the reap verb --------------------------------------------------------
@@ -129,13 +133,39 @@ def test_reap_skips_non_tmp_siblings_directories_and_glob_errors(
     db.parent.mkdir(parents=True, exist_ok=True)
     backup = db.parent / f"{db.name}.backup"      # no .tmp — never a target
     backup.write_text("user's own backup")
-    dirlike = db.parent / f"{db.name}.olddir.tmp"  # directory, not a file
+    dirlike = db.parent / f"{db.name}.44594.tmp"   # directory, not a file
     dirlike.mkdir()
     old = time.time() - 2 * 3600
     os.utime(backup, (old, old))
     os.utime(dirlike, (old, old))
     assert recall.reap_dead_snapshots() == []
     assert backup.exists() and dirlike.is_dir()
+
+
+def test_reap_takes_only_pid_shaped_strands_never_user_files(
+        tmp_path, monkeypatch):
+    """Adversarial finding: the first filter (`.tmp` substring) was a strict
+    superset of the declared shape `recall.db.{pid}.tmp*` — a user backup
+    named recall.db.tmp / recall.db.bak.tmp / recall.db.tmp.gz beside a
+    DAIMON_RECALL_DB override would have been silently deleted. The reaper
+    deletes ONLY what rebuild() manufactures: <db>.<digits>.tmp plus its
+    sqlite dash-sidecars."""
+    db = config.recall_db()
+    db.parent.mkdir(parents=True, exist_ok=True)
+    old = time.time() - 2 * 3600
+    spared = []
+    for name in (f"{db.name}.tmp", f"{db.name}.bak.tmp",
+                 f"{db.name}.tmp.gz", f"{db.name}.tmpl"):
+        p = db.parent / name
+        p.write_text("not daimon's to delete")
+        os.utime(p, (old, old))
+        spared.append(p)
+    dead = db.parent / f"{db.name}.44594.tmp-journal"
+    dead.write_text("strand")
+    os.utime(dead, (old, old))
+    assert [p.name for p in recall.reap_dead_snapshots()] == [dead.name]
+    for p in spared:
+        assert p.exists(), f"{p.name} is a user file, not a strand"
     # an undeletable strand is skipped, not fatal, and not reported reaped
     dead, journal, _fresh = _plant_orphans()
     real_unlink = type(dead).unlink

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -581,6 +581,42 @@ def test_every_command_write_carries_an_admit_frame(
     assert saw("anchor", "latest.json")             # --attach rewrite
 
 
+def _observed_shapes(audit):
+    return {audit.pattern(label, rel)
+            for _cmd, label, rel, _governed, _frames in audit.records}
+
+
+def _undeclared(shapes):
+    from daimon_briefing import surfaces
+    return sorted(s for s in shapes if surfaces.match(s) is None)
+
+
+def test_every_observed_write_shape_is_declared(
+        write_audit, tmp_path, monkeypatch, capsys):
+    """#601: the surface registry ratchet. Every file shape a command writes
+    under the audited roots must be DECLARED in surfaces.SURFACES with a
+    delete strategy — a new store cannot ship without stating how deletion
+    reaches it. (The registry's own hygiene tests live in
+    test_surface_registry.py; this is the enforcement side.)"""
+    proj = _setup_env(tmp_path, monkeypatch)
+    write_audit.placeholders[store.project_slug(str(proj))] = "{slug}"
+    _drive_all(write_audit, tmp_path, monkeypatch, proj)
+    undeclared = _undeclared(_observed_shapes(write_audit))
+    assert undeclared == [], \
+        f"writes to shapes never declared in surfaces.py: {undeclared}"
+
+
+def test_registry_ratchet_trips_on_an_undeclared_shape():
+    """Sensitivity twin: prove the alarm rings — an empty registry must
+    classify every observed shape as undeclared."""
+    from unittest import mock
+
+    from daimon_briefing import surfaces
+    with mock.patch.object(surfaces, "SURFACES", ()):
+        assert _undeclared({"checkpoints/{slug}/events.jsonl"}) \
+            == ["checkpoints/{slug}/events.jsonl"]
+
+
 # ---------------------------------------------------------------------------
 # SENSITIVITY — the guard must FAIL when the seam is removed (the #420/#426
 # mutation-check precedent: prove the alarm rings, don't assume it).

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -601,9 +601,20 @@ def test_every_observed_write_shape_is_declared(
     proj = _setup_env(tmp_path, monkeypatch)
     write_audit.placeholders[store.project_slug(str(proj))] = "{slug}"
     _drive_all(write_audit, tmp_path, monkeypatch, proj)
-    undeclared = _undeclared(_observed_shapes(write_audit))
+    shapes = _observed_shapes(write_audit)
+    # Anti-vacuity (adversarial finding): an empty observation set passes
+    # the undeclared check trivially — a broken driver or root registration
+    # must fail here, not go green.
+    assert len(shapes) >= 5, f"drive observed almost nothing: {shapes}"
+    undeclared = _undeclared(shapes)
     assert undeclared == [], \
         f"writes to shapes never declared in surfaces.py: {undeclared}"
+    # Known limitation, stated where it bites: the audited roots are the
+    # checkpoint store and the team mirror. logs/, recall_seen/, keys/,
+    # codex/, windsurf/ writes are not observed here (log appends are
+    # ungoverned by design, sqlite writes happen below Python I/O, host
+    # hooks run out of process) — their shapes are pinned statically by
+    # test_surface_registry.py instead.
 
 
 def test_registry_ratchet_trips_on_an_undeclared_shape():


### PR DESCRIPTION
Closes #601

## What

- **`surfaces.py`** — the declared surface registry: every file shape daimon writes under `~/.daimon`, each stating whether it can hold item plaintext, its delete strategy (`rewrite` / `append-tombstone` / `wholesale-purge` / `reap` / `exempt-no-plaintext` / `known-gap`+issue), and its owning walker. Follows `schema.py`'s one-table-many-views pattern; first declaration wins, specific shapes before generics.
- **Enforcement ratchet** — the write-audit guard now asserts every observed write shape is declared (`test_every_observed_write_shape_is_declared`), with a sensitivity twin proving the alarm rings against an empty registry. A new store cannot ship without declaring how deletion reaches it.
- **Auditor derivation** — `privacy._EXEMPT_NAMES` / `_EXEMPT_SUFFIX` are now views of the registry's `audit_exempt` entries; the per-exemption justifications live next to each shape's owner instead of in a fourth parallel list.
- **Reap verb** — `recall.reap_dead_snapshots()` deletes `recall.db.<pid>.tmp*` strands from crashed rebuilds, age-gated at one hour (the `_TMP_REAP_SECONDS` precedent). Wired into `daimon heal` (repair is heal's charter; the `audit` group is read-only by its own help text); `--dry-run` lists without deleting. `store._reap_stale_tmps` misses these strands for two independent reasons — wrong directory (they live one level above the checkpoint store) and wrong suffix (`-journal` sidecars fail `.endswith(".tmp")`) — and the unopenable sidecars are what pinned real installs at `audit privacy` exit 3 (cannot-prove).
- **Known gaps declared, not hidden** — the team mirror (#600) and `serialize-crash.log` raw child stderr (#605, filed with this change) are `known-gap` entries citing their issues. The registry's hygiene tests refuse a plaintext shape with no reachable deletion and no cited issue.

## Why

#583 shipped because forget's surface set missed prev-N; the #598 audit work found the same class three more times. The diagnosis on #584: "there is no registry of which stores hold plaintext, so a registry that fails CI until a new store declares a delete strategy is the durable version." This is that registry.

Scope note: the issue's full vision has `forget`/`audit`/`recall._fingerprint` all deriving their walks from the declaration. This PR lands the declaration, the auditor's derived exemptions, and the CI ratchet; rewriting the store/recall walks to be registry-driven is staged behind it — the ratchet already prevents the defect class (an undeclared shape fails tests), and rewriting three battle-tested walks in the same change would couple a guarantee mechanism to a high-regression refactor.

## Tests

- `plugin/tests/test_surface_registry.py` (new, 18 tests, each written first and watched fail): declaration hygiene (full contract, no duplicates, plaintext never pairs with exempt, gaps cite issues, windsurf state declared, digit-anchored `{pid}`, `lazy-rebuild` honesty), pattern classification, privacy derivation equality incl. the `store._LOCK_NAME` pin, reaper behavior (dead pair reaped; fresh in-flight tmp, live db, and user backups spared; registry-derived filter proven by deleting the declaration; heal integration incl. `--dry-run`; audit unscannable class cleared).
- `plugin/tests/test_write_audit_guard.py`: the enforcement ratchet + sensitivity twin + anti-vacuity floor.
- Full suite: 3077 passed, 2 skipped.
- Live validation on a real install: `daimon heal --dry-run` lists all 8 stranded snapshot files (4 `.tmp` + 4 `.tmp-journal`) that currently hold that install at audit exit 3.

## Adversarial review rounds

Two independent passes over the branch. Round 1 (focused): no blocker — live-db safety (sqlite sidecars are dash-named, the dotted glob cannot match them; a journal deleted mid-rebuild fails loudly at commit and never corrupts the live db), matcher ordering, and derivation equality all confirmed with runnable evidence; reaper filter tightened to pid-shaped strands. Round 2 (wide sweep) found the real one: the registry claimed completeness while omitting `~/.daimon/windsurf/transcripts/*.md` — full raw transcripts, the largest plaintext store daimon writes — now declared as known-gap #607 (filed) along with the unparsed payload dumps. Same round: the reaper now derives its filter from `surfaces.match()` itself (no second hand-written predicate — the parallel-list defect must not reappear in the one path that deletes files), `{pid}` is digit-anchored so `recall.db.bak.tmp`/`recall.db.tmp` beside a `DAIMON_RECALL_DB` override stay untouchable, `recall.db` is re-declared `lazy-rebuild` (rows leave at the next rebuild, not at forget time), `exempt_suffix()` fails loudly on zero or two declarations, and the ratchet gained an anti-vacuity floor. Deferred with a stated limitation: widening the guard's audited roots beyond checkpoints/team (log appends are ungoverned by design and would balloon the bypass ratchet) — those shapes are pinned statically by the registry tests instead.
