### PR TITLE
fix(team): forget scrubs the author's own team-mirror copies

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1055,6 +1055,12 @@ def _cmd_forget(args) -> int:
     # session files hold the same plaintext and were never in the contract
     # (#419: plaintext is what puts a file inside it, not its role).
     store.scrub_content_key(content_hash, project_dir=project)
+    # #600 slice A: the author's own team-mirror copies are plaintext this
+    # machine owns (#419) — scrubbed here; teammates' copies and upstream
+    # git history are the sync protocol's to converge (tombstone
+    # propagation), not a local rewrite's.
+    team_scrubbed = store.scrub_team_copies(content_hash,
+                                            project_dir=project)
     # #599: rows appended BEFORE this forget can carry the value in
     # `item_text`/`status`/`note` — redacted in place, rows never dropped
     # (the one ratified rewrite of the append-only ledger).
@@ -1074,6 +1080,10 @@ def _cmd_forget(args) -> int:
     _note_usage("forget")
     print(f"forgot {target['id']} (content hash {content_hash}) — "
           "item removed from the live checkpoint; tombstone recorded")
+    if team_scrubbed:
+        print(f"scrubbed {len(team_scrubbed)} own team-mirror cop(y/ies) — "
+              "run `daimon team sync` to publish; teammates' copies and "
+              "upstream git history remain until tombstone propagation")
     if events_scrubbed:
         print(f"redacted {events_scrubbed} event-ledger field(s) "
               "carrying the value (rows kept, field replaced)")

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -380,12 +380,18 @@ def scrub_team_copies(content_hash: str, project_dir=None) -> list[str]:
     admission, the scrub_event_fields precedent. Upstream git history and
     the remote remain out of reach (the registry's `.git/**` known-gap).
 
+    Known blindness, shared with the audit: a pre-stamp-era flat mirror
+    file with no project_slug payload field cannot be attributed and is
+    skipped — privacy._scan_team_dir misses it by the identical rule, so
+    scrub and audit at least agree.
+
     Best-effort per file; returns the paths rewritten."""
     if not content_hash:
         return []
     team = config.team_dir()
     own = project_slug(config.author()) or "unknown"
     slug = project_slug(project_dir)
+    keys = forgotten_content_keys(project_dir) | {content_hash}
     try:
         segs = {tuple(s) for s in teamproject.read_candidates(project_dir)}
     except Exception:
@@ -399,9 +405,16 @@ def scrub_team_copies(content_hash: str, project_dir=None) -> list[str]:
         candidates = list(remote.glob(f"authors/{own}/*.json"))
         candidates += remote.glob(f"projects/**/authors/{own}/*.json")
         for path in sorted(set(candidates)):
+            # nested layout: projects/<seg…>/authors/<own>/<sid>.json —
+            # the logical segments are parts[1:-3] (the same slice the
+            # audit takes; [1:-2] kept the "authors" segment and made this
+            # check unreachable). A copy of the SAME logical project
+            # written from another checkout carries that path's slug, so
+            # the logical-path match is what rescues it.
             parts = path.relative_to(remote).parts
-            nested_ok = (len(parts) > 3 and parts[0] == "projects"
-                         and parts[1:-2] in segs)
+            nested_ok = (len(parts) > 4 and parts[0] == "projects"
+                         and parts[-3] == "authors"
+                         and parts[1:-3] in segs)
             try:
                 payload = json.loads(path.read_text(encoding="utf-8"))
             except (OSError, ValueError):
@@ -410,16 +423,23 @@ def scrub_team_copies(content_hash: str, project_dir=None) -> list[str]:
                 continue
             if not nested_ok and payload.get("project_slug") != slug:
                 continue
-            before = json.dumps(payload, sort_keys=True)
-            policy.admit_checkpoint(payload,
-                                    forgotten_content_keys(project_dir)
-                                    | {content_hash})
-            if json.dumps(payload, sort_keys=True) == before:
+            # Probe on a copy first: only files the forget actually changes
+            # are re-admitted and rewritten — admission drift (missing ids,
+            # a new redact pattern) must not masquerade as a scrub, and a
+            # torn payload the probe cannot change is skipped before the
+            # stricter admission can trip on it.
+            probe = json.loads(json.dumps(payload))
+            _, changed = policy.scrub_forgotten_payload(probe, keys)
+            if not changed:
                 continue
             try:
+                policy.admit_checkpoint(payload, keys)
                 _atomic_write(path, json.dumps(payload, indent=2,
                                                ensure_ascii=False) + "\n")
-            except OSError:
+            except Exception:
+                # best-effort per file: one unwritable or half-torn surface
+                # must not abort the rest of the scrub — nor the forget's
+                # remaining steps (event scrub, cache purge) behind it.
                 continue
             rewritten.append(str(path))
     return rewritten

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -347,6 +347,84 @@ def scrub_content_key(content_hash: str, project_dir=None) -> list[str]:
     return rewritten
 
 
+def scrub_team_copies(content_hash: str, project_dir=None) -> list[str]:
+    """#600 slice A: scrub the author's OWN team-mirror checkpoint copies.
+
+    The mirror holds full plaintext copies of every mirrored session, and
+    the deletion walk never reached it (team_dir is a SIBLING of the
+    checkpoint store). #419's rule puts it squarely inside the contract:
+    holding plaintext, not its role, is what counts.
+
+    Scope discipline is the whole design:
+    - OWN author dirs only — `authors/<project_slug(config.author())>`,
+      the same identity _dual_write_team writes and teamsync._own_pathspecs
+      commits, so a later `team sync` stages the rewrite as an ordinary
+      own-file modification. The spike verdict forbids mutable POINTERS and
+      cross-author deletes (those race appends); a rewrite inside the
+      disjoint own-author dir is non-racing by the same construction that
+      makes appends safe. Teammates' files are never touched — their
+      copies converge via tombstone propagation (slice B), and the audit
+      keeps reporting them meanwhile.
+    - THIS project only — nested layout segments must be one of
+      teamproject.read_candidates' logical paths, or the payload's own
+      project_slug stamp (written by _dual_write_team) must match. Another
+      project's mirror copy of the same sentence is that project's belief
+      state.
+    - Runs regardless of config.team_enabled(): deletion parallels the
+      kill-switch exemption; a toggle flipped off later must not orphan
+      plaintext the mirror already holds.
+
+    Each rewrite passes through policy.admit_checkpoint — re-admission
+    under the project's forgotten keys (the key that motivated this call
+    included) — so the write-audit guard binds the bytes on disk to a real
+    admission, the scrub_event_fields precedent. Upstream git history and
+    the remote remain out of reach (the registry's `.git/**` known-gap).
+
+    Best-effort per file; returns the paths rewritten."""
+    if not content_hash:
+        return []
+    team = config.team_dir()
+    own = project_slug(config.author()) or "unknown"
+    slug = project_slug(project_dir)
+    try:
+        segs = {tuple(s) for s in teamproject.read_candidates(project_dir)}
+    except Exception:
+        segs = set()
+    try:
+        remotes = [d for d in team.iterdir() if d.is_dir()]
+    except OSError:
+        return []
+    rewritten: list[str] = []
+    for remote in remotes:
+        candidates = list(remote.glob(f"authors/{own}/*.json"))
+        candidates += remote.glob(f"projects/**/authors/{own}/*.json")
+        for path in sorted(set(candidates)):
+            parts = path.relative_to(remote).parts
+            nested_ok = (len(parts) > 3 and parts[0] == "projects"
+                         and parts[1:-2] in segs)
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                continue
+            if not isinstance(payload, dict):
+                continue
+            if not nested_ok and payload.get("project_slug") != slug:
+                continue
+            before = json.dumps(payload, sort_keys=True)
+            policy.admit_checkpoint(payload,
+                                    forgotten_content_keys(project_dir)
+                                    | {content_hash})
+            if json.dumps(payload, sort_keys=True) == before:
+                continue
+            try:
+                _atomic_write(path, json.dumps(payload, indent=2,
+                                               ensure_ascii=False) + "\n")
+            except OSError:
+                continue
+            rewritten.append(str(path))
+    return rewritten
+
+
 def checkpoints_written_since(cutoff: float) -> int:
     """How many per-session checkpoints were WRITTEN since `cutoff` (epoch
     seconds), counted by file mtime — the write-side signal for the silent-

--- a/plugin/daimon_briefing/surfaces.py
+++ b/plugin/daimon_briefing/surfaces.py
@@ -102,8 +102,11 @@ SURFACES: tuple[Surface, ...] = (
     # scanning such files regardless.
     Surface("checkpoints/**/*.tmp", "store._atomic_write",
             True, "wholesale-purge", "reaper"),
-    # -- team mirror: forward plaintext copies, no tombstone propagation
-    #    yet — THE declared gap. --
+    # -- team mirror: forward plaintext copies. #600 slice A: forget now
+    #    rewrites the author's OWN copies (store.scrub_team_copies); the
+    #    remaining gap — teammates' copies and every clone's git history —
+    #    needs tombstone propagation through the sync protocol, so the
+    #    json entry stays a known-gap until that lands. --
     Surface("team/{remote}/README.md", "teamsync.init",
             False, "exempt-no-plaintext", "none"),
     Surface("team/{remote}/daimon-team.toml", "teamsync.init",

--- a/plugin/tests/test_forget_team_mirror.py
+++ b/plugin/tests/test_forget_team_mirror.py
@@ -1,0 +1,119 @@
+"""#600 slice A: forget scrubs the author's OWN team-mirror copies.
+
+The mirror under ~/.daimon/team holds full plaintext checkpoint copies, and
+forget never walked it — store.project_surfaces is rooted at the checkpoint
+dir, a sibling. The one mirror file that DID get scrubbed was the live
+session's, and only because forget's rewrite happens to dual-write while
+DAIMON_TEAM is on — a coincidence, not a contract.
+
+Scope discipline: own-author files only (the author dir name is the reliable
+discriminator — store._dual_write_team and teamsync._own_pathspecs derive it
+identically), and only for this project (nested segments in
+teamproject.read_candidates, or the payload's own project_slug stamp).
+Teammates' copies and upstream git history are the remaining #600 gap
+(slice B): the sync protocol must carry the tombstone; no local scrub can
+reach a remote. The spike verdict ("deletes race appends") forbids pointer
+files and cross-author deletes — a rewrite inside the disjoint own-author
+dir is non-racing by the same construction that makes appends safe.
+
+Each rewrite passes through policy.admit_checkpoint — re-admission under the
+project's forgotten keys — so the write-audit guard binds the bytes to a
+real admission (the scrub_event_fields precedent), not to the correlation
+blind spot.
+"""
+import json
+
+from daimon_briefing import cli, config, normalize, privacy, store
+
+PROJECT = "/p/team-mirror-forget"
+CANARY = "zqxteamcanary5527 the payroll export token lives in vault七"
+KEEPER = "an unrelated decision that must survive"
+
+KEY = normalize.content_key(CANARY)
+
+
+def _cp(sid, items):
+    return {
+        "session_id": sid,
+        "created": "2026-08-01T00:00:00Z",
+        "working_context": {
+            "recent_decisions": [{"text": t, "trust": "inferred"}
+                                 for t in items]},
+    }
+
+
+def _mirror_files():
+    return sorted(p for p in config.team_dir().rglob("*.json"))
+
+
+def _forget(monkeypatch=None):
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+
+
+def _seed_mirrored_sessions(monkeypatch):
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    store.write_checkpoint("S1", _cp("S1", [CANARY, KEEPER]),
+                           project_dir=PROJECT)
+    store.write_checkpoint("S2", _cp("S2", [KEEPER]), project_dir=PROJECT)
+
+
+def test_forget_scrubs_every_own_mirror_copy(tmp_checkpoint_dir, monkeypatch):
+    _seed_mirrored_sessions(monkeypatch)
+    assert any(CANARY in p.read_text() for p in _mirror_files())
+    _forget()
+    residue = [str(p) for p in _mirror_files() if CANARY in p.read_text()]
+    assert residue == [], f"mirror plaintext survives in {residue}"
+
+
+def test_forget_scrubs_mirror_even_when_team_is_off_at_forget_time(
+        tmp_checkpoint_dir, monkeypatch):
+    """The mirror was written while DAIMON_TEAM was on; the flag being off
+    LATER must not orphan the plaintext — deletion parallels the kill-switch
+    exemption, it does not honor the mirroring toggle."""
+    _seed_mirrored_sessions(monkeypatch)
+    monkeypatch.delenv("DAIMON_TEAM")
+    _forget()
+    residue = [str(p) for p in _mirror_files() if CANARY in p.read_text()]
+    assert residue == [], f"mirror plaintext survives in {residue}"
+
+
+def test_forget_never_touches_a_teammate_copy(tmp_checkpoint_dir, monkeypatch):
+    """A teammate's file is not ours to rewrite (disjoint author dirs are
+    what make the sync conflict-free); their copy converges via slice B's
+    tombstone propagation, and the audit keeps reporting it meanwhile."""
+    _seed_mirrored_sessions(monkeypatch)
+    mate = (config.team_dir() / "local" / "authors" / "Grace" / "SX.json")
+    mate.parent.mkdir(parents=True, exist_ok=True)
+    mate_payload = _cp("SX", [CANARY])
+    mate_payload["author"] = "Grace"
+    mate_payload["project_slug"] = store.project_slug(PROJECT)
+    mate.write_text(json.dumps(mate_payload), encoding="utf-8")
+    before = mate.read_text()
+    _forget()
+    assert mate.read_text() == before
+
+
+def test_forget_team_scrub_is_project_scoped(tmp_checkpoint_dir, monkeypatch):
+    """An own-author copy stamped with a DIFFERENT project's slug is another
+    project's belief state — this project's tombstone must not reach it."""
+    _seed_mirrored_sessions(monkeypatch)
+    other = (config.team_dir() / "local" / "authors"
+             / store.project_slug("Ada") / "SO.json")
+    other.parent.mkdir(parents=True, exist_ok=True)
+    other_payload = _cp("SO", [CANARY])
+    other_payload["author"] = "Ada"
+    other_payload["project_slug"] = store.project_slug("/p/other-project")
+    other.write_text(json.dumps(other_payload), encoding="utf-8")
+    before = other.read_text()
+    _forget()
+    assert other.read_text() == before
+
+
+def test_audit_is_clean_after_forget_when_only_own_copies_exist(
+        tmp_checkpoint_dir, monkeypatch):
+    _seed_mirrored_sessions(monkeypatch)
+    _forget()
+    result = privacy.audit_project(project_dir=PROJECT)
+    hits = [f for f in result["findings"] if f["content_hash"] == KEY]
+    assert hits == [], f"audit still finds residue: {hits}"

--- a/plugin/tests/test_forget_team_mirror.py
+++ b/plugin/tests/test_forget_team_mirror.py
@@ -88,8 +88,10 @@ def test_forget_never_touches_a_teammate_copy(tmp_checkpoint_dir, monkeypatch):
     mate_payload = _cp("SX", [CANARY])
     mate_payload["author"] = "Grace"
     mate_payload["project_slug"] = store.project_slug(PROJECT)
-    mate.write_text(json.dumps(mate_payload), encoding="utf-8")
+    mate.write_text(json.dumps(mate_payload, ensure_ascii=False),
+                    encoding="utf-8")
     before = mate.read_text()
+    assert CANARY in before
     _forget()
     assert mate.read_text() == before
 
@@ -104,8 +106,10 @@ def test_forget_team_scrub_is_project_scoped(tmp_checkpoint_dir, monkeypatch):
     other_payload = _cp("SO", [CANARY])
     other_payload["author"] = "Ada"
     other_payload["project_slug"] = store.project_slug("/p/other-project")
-    other.write_text(json.dumps(other_payload), encoding="utf-8")
+    other.write_text(json.dumps(other_payload, ensure_ascii=False),
+                     encoding="utf-8")
     before = other.read_text()
+    assert CANARY in before
     _forget()
     assert other.read_text() == before
 
@@ -117,3 +121,88 @@ def test_audit_is_clean_after_forget_when_only_own_copies_exist(
     result = privacy.audit_project(project_dir=PROJECT)
     hits = [f for f in result["findings"] if f["content_hash"] == KEY]
     assert hits == [], f"audit still finds residue: {hits}"
+
+
+def test_team_scrub_edge_guards(tmp_checkpoint_dir, monkeypatch):
+    """Guard branches: empty key, garbage / non-dict payloads, a half-torn
+    file whose good section scrubs but whose torn sibling section trips the
+    stricter re-admission (skipped, not fatal), and an unreadable team
+    dir."""
+    _seed_mirrored_sessions(monkeypatch)
+    assert store.scrub_team_copies("", project_dir=PROJECT) == []
+    own = store.project_slug("Ada")
+    author_dir = config.team_dir() / "local" / "authors" / own
+    (author_dir / "garbage.json").write_text("not json", encoding="utf-8")
+    (author_dir / "list.json").write_text('["a", "list"]', encoding="utf-8")
+    half = author_dir / "half-torn.json"
+    half.write_text(json.dumps({
+        "session_id": "H", "author": "Ada",
+        "project_slug": store.project_slug(PROJECT),
+        "working_context": {"recent_decisions": [
+            {"text": CANARY, "trust": "inferred"}]},
+        "epistemic_snapshot": "torn",
+    }, ensure_ascii=False), encoding="utf-8")
+    before = half.read_text()
+    _forget()
+    assert half.read_text() == before, \
+        "a file re-admission cannot process is left byte-identical"
+    # a resolver crash degrades to slug-only scoping, never aborts (belt —
+    # read_candidates documents it never raises)
+    from daimon_briefing import teamproject
+    monkeypatch.setattr(teamproject, "read_candidates",
+                        lambda project_dir: (_ for _ in ()).throw(OSError()))
+    assert store.scrub_team_copies("deadbeef", project_dir=PROJECT) == []
+    monkeypatch.setattr(type(config.team_dir()), "iterdir",
+                        lambda self: (_ for _ in ()).throw(OSError()))
+    assert store.scrub_team_copies("deadbeef", project_dir=PROJECT) == []
+
+
+def test_forget_scrubs_nested_copy_written_from_another_checkout(
+        tmp_checkpoint_dir, monkeypatch):
+    """Refuter BLOCKER: the nested-layout logical-path check was dead code
+    (`parts[1:-2]` kept the `authors` segment, so it never matched) — a
+    mirror copy of the SAME logical project written from a different
+    checkout path (worktree, second machine, moved repo) carries that
+    path's project_slug and was silently missed while the audit correctly
+    flagged it forever."""
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/finance")
+    _seed_mirrored_sessions(monkeypatch)
+    own = store.project_slug("Ada")
+    other = (config.team_dir() / "local" / "projects" / "core" / "finance"
+             / "authors" / own / "SA.json")
+    other.parent.mkdir(parents=True, exist_ok=True)
+    payload = _cp("SA", [CANARY])
+    payload["author"] = "Ada"
+    payload["project_slug"] = store.project_slug("/p/another-checkout")
+    # ensure_ascii=False: CANARY carries a non-ASCII char, and the default
+    # \uXXXX escaping made the residue assertion below pass vacuously.
+    other.write_text(json.dumps(payload, ensure_ascii=False),
+                     encoding="utf-8")
+    assert CANARY in other.read_text()
+    _forget()
+    assert CANARY not in other.read_text(), \
+        "same logical project, different checkout — must be scrubbed"
+
+
+def test_one_torn_mirror_file_never_aborts_the_forget(
+        tmp_checkpoint_dir, monkeypatch):
+    """Refuter MAJOR: an unguarded re-admission crashed on a torn payload
+    (working_context as a string trips redact_checkpoint's `or {}`) AFTER
+    the tombstone landed but BEFORE the event scrub and cache purge — and
+    a second forget of the same value refuses ('no item matches'), so the
+    residue was stranded. Best-effort per file must mean it."""
+    _seed_mirrored_sessions(monkeypatch)
+    own = store.project_slug("Ada")
+    torn = config.team_dir() / "local" / "authors" / own / "AA-torn.json"
+    torn.parent.mkdir(parents=True, exist_ok=True)
+    torn.write_text(json.dumps({
+        "session_id": "T", "author": "Ada",
+        "project_slug": store.project_slug(PROJECT),
+        "working_context": "not a dict",
+    }), encoding="utf-8")
+    before = torn.read_text()
+    _forget()          # asserts rc 0 — the torn file must not abort
+    assert torn.read_text() == before
+    residue = [str(p) for p in _mirror_files()
+               if p.name != "AA-torn.json" and CANARY in p.read_text()]
+    assert residue == [], f"files after the torn one unscrubbed: {residue}"

--- a/plugin/tests/test_teamsync.py
+++ b/plugin/tests/test_teamsync.py
@@ -138,6 +138,32 @@ def test_sync_commits_and_pushes_own_new_files(bare_remote, monkeypatch):
     assert subject == "sync: Ada 1 checkpoint(s)"
 
 
+def test_sync_publishes_a_forget_rewrite_of_an_own_file(
+        bare_remote, monkeypatch):
+    """#600 slice A: store.scrub_team_copies rewrites own mirror files in
+    place; the NEXT sync must publish that modification like any own-file
+    change (`git add` on the own-author pathspec stages modifications, not
+    only additions). Pin it so a future 'new files only' optimization
+    cannot silently strand scrubbed state locally."""
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    sidecar = teamsync.init(str(bare_remote))
+    _write_team_file(sidecar, "Ada", "S1.json",
+                     {"session_id": "S1", "author": "Ada",
+                      "secret": "the payroll token"})
+    assert teamsync.sync_remote(sidecar)["pushed"] is True
+    # forget-time rewrite of the same file (scrub in place, no delete)
+    path = sidecar / "authors" / "Ada" / "S1.json"
+    path.write_text(json.dumps({"session_id": "S1", "author": "Ada",
+                                "secret": "[gone]"}), encoding="utf-8")
+    r = teamsync.sync_remote(sidecar)
+    assert r["committed"] == 1 and r["pushed"] is True
+    blob = subprocess.run(
+        ["git", "-C", str(bare_remote), "show", "HEAD:authors/Ada/S1.json"],
+        capture_output=True, text=True, timeout=30).stdout
+    assert "payroll token" not in blob
+    assert "[gone]" in blob
+
+
 def test_sync_never_touches_other_authors_paths(bare_remote, monkeypatch):
     monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
     sidecar = teamsync.init(str(bare_remote))


### PR DESCRIPTION
Refs #600

## What

`store.scrub_team_copies`, called from `daimon forget`: rewrites the author's **own** team-mirror checkpoint copies with the same full-enumeration scrub every other surface gets (`policy.admit_checkpoint` re-admission under the project's forgotten keys — the write-audit guard binds each rewrite to a real admission).

Scope discipline, which is the whole design:

- **Own-author dirs only** — `authors/<project_slug(author)>`, the identity `_dual_write_team` writes and `teamsync._own_pathspecs` commits. A later `daimon team sync` stages the rewrite as an ordinary own-file modification (pinned by a new bare-remote round-trip test). The spike verdict forbids mutable pointers and cross-author deletes because those race appends; an own-dir rewrite is non-racing by the same disjointness that makes appends safe. Teammates' files are never touched.
- **This project only** — nested layout segments must be one of `teamproject.read_candidates`' logical paths, or the payload's own `project_slug` stamp must match. Another project's mirror copy of the same sentence is that project's belief state.
- **Independent of `DAIMON_TEAM`** — deletion parallels the kill-switch exemption; a mirroring toggle flipped off after the mirror was written must not orphan the plaintext it already holds.

`daimon forget` reports the count and says exactly what remains out of reach.

## Why

Issue #600: forgotten values persisted in every mirror copy except (coincidentally) the live session's — and only while `DAIMON_TEAM` was on at forget time. #419's rule puts these files inside the deletion contract: holding plaintext is what counts, not the file's role.

**Staged (`Refs`, not `Closes`):** this is slice A — the local files this machine owns. Slice B is tombstone propagation through the sync protocol (a hash-only record in the shared stream each member applies to their own mirror), which is what reaches teammates' copies; upstream git history additionally retains pre-scrub blobs in every clone, which no local rewrite can reach. The surface registry keeps `team/{remote}/**/*.json` a `known-gap` citing #600 until propagation lands, and `daimon audit privacy` keeps reporting teammate copies honestly meanwhile.

## Tests

- `plugin/tests/test_forget_team_mirror.py` (new, 8 tests, each written first and watched fail): every own mirror copy scrubbed (not just the live session's); scrub runs with `DAIMON_TEAM` off at forget time; a teammate's copy is byte-identical after forget; an own-author copy stamped with another project's slug is untouched; the nested same-logical-project/different-checkout copy is scrubbed; one torn file never aborts the forget; edge guards (garbage/non-dict payloads, resolver crash, unreadable team dir); `audit privacy` reports no residue when only own copies exist.
- `plugin/tests/test_teamsync.py`: new round-trip test — a forget-style in-place rewrite of an own file is committed and pushed by the next sync, and the remote HEAD blob no longer carries the value (pins the `git add`-stages-modifications mechanism slice A depends on).
- Full suite: 3086 passed, 2 skipped.

## Adversarial review round

Wide-sweep pass over the diff, two real bugs, both repro'd and fixed: (1) the nested-layout logical-path check was dead code — `parts[1:-2]` kept the `authors` segment so it never matched, silently missing mirror copies of the same logical project written from another checkout while the audit flagged them forever; correct slice is `parts[1:-3]`, now covered by a test that seeds exactly that shape (the first version of the test passed vacuously: `json.dumps` escaped the canary's non-ASCII char, so the presence assertion never saw it — the test now asserts the canary is really on disk first). (2) Re-admission was unguarded: one torn payload raised out of forget after the tombstone landed but before the event scrub and cache purge, with no retry path; the scrub now probes a copy with `scrub_forgotten_payload` first (drift-only files are never rewritten, torn files are skipped before the stricter admission can trip) and admission/write errors skip the file, never the forget. Confirmed-safe findings on record: `_atomic_write` never touches `.git/index` so no lock collisions; sync commits own files before integrate so a scrub cannot be destroyed by merge recovery; mirror re-admissions are not counted as forget-hits; guard and registry ratchets hold. Known blindness documented in the docstring: pre-stamp-era flat files with no `project_slug` cannot be attributed — the audit misses them by the identical rule, so scrub and audit agree.
