### PR TITLE
fix(windsurf): bring the adapter's own transcript store inside the deletion contract

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,6 +122,8 @@ Serialize-throttle knobs for hosts that lack a clean session-end event. See
 | `DAIMON_CODEX_MIN_SERIALIZE_INTERVAL` | `300` | Minimum seconds between Codex serialize spawns. `0` serializes on every `Stop`. |
 | `DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL` | `300` | Minimum seconds between Windsurf serialize spawns (Windsurf has no session-end event, so capture runs on this throttle). `0` serializes every turn. |
 | `DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS` | `600` | Quiet period after the last Windsurf activity before a debounced finalizer serializes the trajectory's final transcript state — covers sessions whose last turns land inside the throttle window. Fractional values accepted; `0` disables the finalizer. |
+| `DAIMON_WINDSURF_DIR` | `~/.daimon/windsurf` | Where the Windsurf adapter keeps the transcripts it accumulates. Read by both the hook that writes them and the `forget`/`heal` paths that delete them — change it in one place only, or the writer and the deleter stop agreeing. |
+| `DAIMON_WINDSURF_STATE_DAYS` | `7` | Age window for daimon-authored Windsurf transcripts and unparsed payload dumps, reaped by `daimon heal`. A privacy bound: a forgotten value cannot be located inside prose, so this limits how long the source conversation lingers between `forget` runs. Clamped to at least 1 — unlike the other Windsurf knobs, `0` does not disable it. |
 
 ## Scar harvest
 

--- a/hook/daimon-windsurf-hooks.py
+++ b/hook/daimon-windsurf-hooks.py
@@ -80,8 +80,21 @@ try:
 except Exception:  # noqa: BLE001 — missing/corrupt lib must never crash the hook
     lib = None
 
-STATE_DIR = Path.home() / ".daimon" / "windsurf"
-TRANSCRIPT_DIR = STATE_DIR / "transcripts"
+def state_dir() -> Path:
+    """Where this adapter keeps its own state. DAIMON_WINDSURF_DIR overrides
+    the default, and reading it here is load-bearing: `daimon forget` purges
+    this store and `daimon heal` reaps it by age (#607), both resolving the
+    same var through config.windsurf_state_dir(). A hardcoded home here
+    would have the writer filling one directory while the deleter reported
+    cleanly on another — silently, since a zero-file purge says nothing."""
+    raw = os.environ.get("DAIMON_WINDSURF_DIR", "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".daimon" / "windsurf"
+
+
+def transcript_dir() -> Path:
+    return state_dir() / "transcripts"
 
 # Keys tried, in order, for the user-prompt text — the pre_user_prompt payload
 # shape is not yet field-confirmed (post_cascade_response is), so the
@@ -124,7 +137,7 @@ def _safe_name(trajectory_id: str) -> str:
 
 
 def _activity_stamp(trajectory_id: str) -> Path:
-    return STATE_DIR / f"{_safe_name(trajectory_id)}.last-activity"
+    return state_dir() / f"{_safe_name(trajectory_id)}.last-activity"
 
 
 def _touch_activity(trajectory_id: str) -> None:
@@ -138,7 +151,7 @@ def _touch_activity(trajectory_id: str) -> None:
     if _finalizer_quiet_seconds() <= 0:
         return
     try:
-        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        state_dir().mkdir(parents=True, exist_ok=True)
         _activity_stamp(trajectory_id).write_text(
             str(int(time.time())), encoding="utf-8")
     except OSError:
@@ -150,8 +163,8 @@ def _should_spawn(trajectory_id: str) -> bool:
     if interval <= 0:
         return True
     try:
-        STATE_DIR.mkdir(parents=True, exist_ok=True)
-        marker = STATE_DIR / f"{_safe_name(trajectory_id)}.last-serialize"
+        state_dir().mkdir(parents=True, exist_ok=True)
+        marker = state_dir() / f"{_safe_name(trajectory_id)}.last-serialize"
         if marker.exists() and time.time() - marker.stat().st_mtime < interval:
             return False
         return True
@@ -163,8 +176,8 @@ def _mark_spawned(trajectory_id: str) -> None:
     if _interval_seconds() <= 0:
         return
     try:
-        STATE_DIR.mkdir(parents=True, exist_ok=True)
-        (STATE_DIR / f"{_safe_name(trajectory_id)}.last-serialize").write_text(
+        state_dir().mkdir(parents=True, exist_ok=True)
+        (state_dir() / f"{_safe_name(trajectory_id)}.last-serialize").write_text(
             str(int(time.time())), encoding="utf-8")
     except OSError:
         pass
@@ -177,8 +190,8 @@ def _append_turn(trajectory_id: str, role: str, text: str) -> Path:
     site (#109): the accumulation file is a disk artifact `daimon serialize`
     reads later, so a quoted secret must not land here raw. main() has already
     gated on lib.redaction_available(), so the scrub is guaranteed real."""
-    TRANSCRIPT_DIR.mkdir(parents=True, exist_ok=True)
-    path = TRANSCRIPT_DIR / f"{_safe_name(trajectory_id)}.md"
+    transcript_dir().mkdir(parents=True, exist_ok=True)
+    path = transcript_dir() / f"{_safe_name(trajectory_id)}.md"
     with path.open("a", encoding="utf-8") as f:
         f.write(f"**{role}**: {lib.redact_text(text).strip()}\n\n")
     return path
@@ -229,12 +242,12 @@ def _dump_probe(event: str, payload: dict) -> bool:
     Payload string leaves are secret-scrubbed at this write site (#109) so no
     quoted secret reaches unparsed-*.json, while structure stays usable."""
     try:
-        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        state_dir().mkdir(parents=True, exist_ok=True)
         tag = _safe_name(event or "unknown")
-        if any(STATE_DIR.glob(f"unparsed-{tag}-*.json")):
+        if any(state_dir().glob(f"unparsed-{tag}-*.json")):
             return False
         stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
-        (STATE_DIR / f"unparsed-{tag}-{stamp}.json").write_text(
+        (state_dir() / f"unparsed-{tag}-{stamp}.json").write_text(
             json.dumps(_redact_payload(payload), indent=2, ensure_ascii=False),
             encoding="utf-8")
         return True

--- a/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
+++ b/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
@@ -80,8 +80,21 @@ try:
 except Exception:  # noqa: BLE001 — missing/corrupt lib must never crash the hook
     lib = None
 
-STATE_DIR = Path.home() / ".daimon" / "windsurf"
-TRANSCRIPT_DIR = STATE_DIR / "transcripts"
+def state_dir() -> Path:
+    """Where this adapter keeps its own state. DAIMON_WINDSURF_DIR overrides
+    the default, and reading it here is load-bearing: `daimon forget` purges
+    this store and `daimon heal` reaps it by age (#607), both resolving the
+    same var through config.windsurf_state_dir(). A hardcoded home here
+    would have the writer filling one directory while the deleter reported
+    cleanly on another — silently, since a zero-file purge says nothing."""
+    raw = os.environ.get("DAIMON_WINDSURF_DIR", "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".daimon" / "windsurf"
+
+
+def transcript_dir() -> Path:
+    return state_dir() / "transcripts"
 
 # Keys tried, in order, for the user-prompt text — the pre_user_prompt payload
 # shape is not yet field-confirmed (post_cascade_response is), so the
@@ -124,7 +137,7 @@ def _safe_name(trajectory_id: str) -> str:
 
 
 def _activity_stamp(trajectory_id: str) -> Path:
-    return STATE_DIR / f"{_safe_name(trajectory_id)}.last-activity"
+    return state_dir() / f"{_safe_name(trajectory_id)}.last-activity"
 
 
 def _touch_activity(trajectory_id: str) -> None:
@@ -138,7 +151,7 @@ def _touch_activity(trajectory_id: str) -> None:
     if _finalizer_quiet_seconds() <= 0:
         return
     try:
-        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        state_dir().mkdir(parents=True, exist_ok=True)
         _activity_stamp(trajectory_id).write_text(
             str(int(time.time())), encoding="utf-8")
     except OSError:
@@ -150,8 +163,8 @@ def _should_spawn(trajectory_id: str) -> bool:
     if interval <= 0:
         return True
     try:
-        STATE_DIR.mkdir(parents=True, exist_ok=True)
-        marker = STATE_DIR / f"{_safe_name(trajectory_id)}.last-serialize"
+        state_dir().mkdir(parents=True, exist_ok=True)
+        marker = state_dir() / f"{_safe_name(trajectory_id)}.last-serialize"
         if marker.exists() and time.time() - marker.stat().st_mtime < interval:
             return False
         return True
@@ -163,8 +176,8 @@ def _mark_spawned(trajectory_id: str) -> None:
     if _interval_seconds() <= 0:
         return
     try:
-        STATE_DIR.mkdir(parents=True, exist_ok=True)
-        (STATE_DIR / f"{_safe_name(trajectory_id)}.last-serialize").write_text(
+        state_dir().mkdir(parents=True, exist_ok=True)
+        (state_dir() / f"{_safe_name(trajectory_id)}.last-serialize").write_text(
             str(int(time.time())), encoding="utf-8")
     except OSError:
         pass
@@ -177,8 +190,8 @@ def _append_turn(trajectory_id: str, role: str, text: str) -> Path:
     site (#109): the accumulation file is a disk artifact `daimon serialize`
     reads later, so a quoted secret must not land here raw. main() has already
     gated on lib.redaction_available(), so the scrub is guaranteed real."""
-    TRANSCRIPT_DIR.mkdir(parents=True, exist_ok=True)
-    path = TRANSCRIPT_DIR / f"{_safe_name(trajectory_id)}.md"
+    transcript_dir().mkdir(parents=True, exist_ok=True)
+    path = transcript_dir() / f"{_safe_name(trajectory_id)}.md"
     with path.open("a", encoding="utf-8") as f:
         f.write(f"**{role}**: {lib.redact_text(text).strip()}\n\n")
     return path
@@ -229,12 +242,12 @@ def _dump_probe(event: str, payload: dict) -> bool:
     Payload string leaves are secret-scrubbed at this write site (#109) so no
     quoted secret reaches unparsed-*.json, while structure stays usable."""
     try:
-        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        state_dir().mkdir(parents=True, exist_ok=True)
         tag = _safe_name(event or "unknown")
-        if any(STATE_DIR.glob(f"unparsed-{tag}-*.json")):
+        if any(state_dir().glob(f"unparsed-{tag}-*.json")):
             return False
         stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
-        (STATE_DIR / f"unparsed-{tag}-{stamp}.json").write_text(
+        (state_dir() / f"unparsed-{tag}-{stamp}.json").write_text(
             json.dumps(_redact_payload(payload), indent=2, ensure_ascii=False),
             encoding="utf-8")
         return True

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1077,6 +1077,14 @@ def _cmd_forget(args) -> int:
         purged, purge_err = serializer.purge_chunk_cache()
     except Exception as e:  # belt: purge_chunk_cache itself never raises
         purged, purge_err = 0, str(e)
+    # #607: the Windsurf adapter writes its own transcripts when Cascade
+    # gives it none — daimon-authored plaintext, so inside the contract.
+    # Wholesale for the same reason as the chunk cache: the tombstone is a
+    # hash, so a value inside prose cannot be located to remove selectively.
+    try:
+        ws_purged, ws_err = store.purge_windsurf_state()
+    except Exception as e:  # belt: purge_windsurf_state never raises
+        ws_purged, ws_err = 0, str(e)
     _note_usage("forget")
     print(f"forgot {target['id']} (content hash {content_hash}) — "
           "item removed from the live checkpoint; tombstone recorded")
@@ -1094,6 +1102,13 @@ def _cmd_forget(args) -> int:
     else:
         print(f"purged {purged} cached chunk extraction(s) "
               "(pre-redaction serializer cache)")
+    if ws_err is not None:
+        print(f"warning: windsurf transcript purge failed: {ws_err} — "
+              "daimon-authored conversation text may persist up to "
+              f"{config.windsurf_state_days()} day(s) (age reaper)")
+    elif ws_purged:
+        print(f"purged {ws_purged} daimon-authored windsurf transcript "
+              "file(s); host-authored transcripts are untouched")
     return 0
 
 
@@ -2324,6 +2339,11 @@ def _cmd_heal(args) -> int:
     for p in recall.reap_dead_snapshots(apply=not dry_run):
         print(f"{'would reap' if dry_run else 'reaped'} "
               f"dead index snapshot: {p.name}")
+    # #607: same repair charter — bound how long daimon-authored Windsurf
+    # conversation text lingers between forgets.
+    for p in store.reap_windsurf_state(apply=not dry_run):
+        print(f"{'would reap' if dry_run else 'reaped'} "
+              f"aged windsurf transcript: {p.name}")
     try:
         text = (config.log_dir() / "serialize.log").read_text(encoding="utf-8")
     except OSError:

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1106,9 +1106,16 @@ def _cmd_forget(args) -> int:
         print(f"warning: windsurf transcript purge failed: {ws_err} — "
               "daimon-authored conversation text may persist up to "
               f"{config.windsurf_state_days()} day(s) (age reaper)")
-    elif ws_purged:
+    else:
+        # Always printed, like the chunk-cache line: a silent zero is how a
+        # misconfigured store (writer and deleter disagreeing about the
+        # directory) stays invisible. The scope note is not decoration —
+        # the store is keyed by trajectory and carries no project
+        # attribution, so this purge is machine-wide by construction.
         print(f"purged {ws_purged} daimon-authored windsurf transcript "
-              "file(s); host-authored transcripts are untouched")
+              "file(s) across all projects (machine-wide: the store is keyed "
+              "by trajectory, not project); host-authored transcripts are "
+              "untouched")
     return 0
 
 

--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -201,6 +201,35 @@ def team_dir() -> Path:
     return Path.home() / ".daimon" / "team"
 
 
+def windsurf_state_dir() -> Path:
+    """Root of the Windsurf adapter's own state (#607). The adapter writes
+    FULL RAW TRANSCRIPTS here when Cascade gives it no native transcript, so
+    this is daimon-authored plaintext and inside the deletion contract —
+    unlike Codex rollouts or Claude Code JSONL, which daimon reads by path
+    and never copies. DAIMON_WINDSURF_DIR overrides (tests point it under
+    tmp; the hook hardcodes ~/.daimon/windsurf because it must run with no
+    package import at all)."""
+    raw = _get("DAIMON_WINDSURF_DIR")
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".daimon" / "windsurf"
+
+
+def windsurf_state_days() -> int:
+    """#607: age window for daimon-authored Windsurf transcripts and unparsed
+    payload dumps. A privacy bound, not a disk bound: a forgotten value
+    cannot be located inside prose (the tombstone is a hash, never the
+    text), so between forgets this window is what limits how long the
+    source conversation lingers. 7 days rather than the chunk cache's 3 —
+    the transcript is what quote provenance resolves against, and
+    provenance already degrades to `absent-local` rather than failing when
+    it is gone. Override with DAIMON_WINDSURF_STATE_DAYS."""
+    try:
+        return int(_get("DAIMON_WINDSURF_STATE_DAYS") or "7")
+    except ValueError:
+        return 7
+
+
 def recall_db() -> Path:
     """Location of the derived recall index (#112). NEVER source of truth —
     safe to delete at any time; recall rebuilds it by scanning the local flat

--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -223,9 +223,15 @@ def windsurf_state_days() -> int:
     source conversation lingers. 7 days rather than the chunk cache's 3 —
     the transcript is what quote provenance resolves against, and
     provenance already degrades to `absent-local` rather than failing when
-    it is gone. Override with DAIMON_WINDSURF_STATE_DAYS."""
+    it is gone. Override with DAIMON_WINDSURF_STATE_DAYS.
+
+    Clamped at 1 (the checkpoint_history / carry_max posture). Every other
+    DAIMON_WINDSURF_* knob reads 0 as "disable", so an unclamped 0 here
+    would make the cutoff `now` and delete the LIVE capture buffer at the
+    next heal — reading an ambiguous 0 as "delete everything" is the wrong
+    direction for a knob a user reaches for to turn something off."""
     try:
-        return int(_get("DAIMON_WINDSURF_STATE_DAYS") or "7")
+        return max(1, int(_get("DAIMON_WINDSURF_STATE_DAYS") or "7"))
     except ValueError:
         return 7
 

--- a/plugin/daimon_briefing/privacy.py
+++ b/plugin/daimon_briefing/privacy.py
@@ -391,6 +391,25 @@ def audit_project(project_dir=None) -> dict:
     except OSError:
         pass
     result["cache"] = {"entries": entries, "oldest_days": oldest}
+    # Windsurf adapter state (#607): daimon-authored conversation text. Same
+    # honesty as the chunk cache and for the same reason — the value lives
+    # as a SUBSTRING of prose and the tombstone is a hash, so neither a
+    # finding nor an `unscannable` entry would be true. Reporting the store
+    # exists (with its real oldest age) is what the auditor can prove; the
+    # exit code stays untouched, and forget purges it wholesale.
+    ws_entries, ws_oldest = 0, None
+    try:
+        ws_files = store._windsurf_text_files()
+    except OSError:
+        ws_files = []          # a walk that raises degrades, never aborts
+    for path in ws_files:
+        try:
+            age = (time.time() - path.stat().st_mtime) / 86400
+        except OSError:
+            continue
+        ws_entries += 1
+        ws_oldest = age if ws_oldest is None else max(ws_oldest, age)
+    result["windsurf"] = {"entries": ws_entries, "oldest_days": ws_oldest}
     return result
 
 

--- a/plugin/daimon_briefing/provenance.py
+++ b/plugin/daimon_briefing/provenance.py
@@ -47,6 +47,20 @@ def valid_session_id(value) -> bool:
     return isinstance(value, str) and _SESSION_RE.fullmatch(value) is not None
 
 
+def _daimon_windsurf_transcripts(home: Path) -> Path:
+    """The daimon-authored Windsurf transcript root, resolved the same way
+    the hook that writes it and the purge that deletes it resolve it (#607).
+    Hardcoding home here would put a THIRD component out of step with the
+    other two: with DAIMON_WINDSURF_DIR set, every Windsurf receipt would
+    report absent-local over a transcript sitting on disk. `home` stays a
+    parameter so the injected-home tests keep working when the var is
+    unset."""
+    raw = (os.environ.get("DAIMON_WINDSURF_DIR") or "").strip()
+    if raw:
+        return Path(raw).expanduser() / "transcripts"
+    return home / ".daimon" / "windsurf" / "transcripts"
+
+
 def _under(path: Path, root: Path) -> bool:
     try:
         path.resolve().relative_to(root.expanduser().resolve())
@@ -78,7 +92,7 @@ def infer_host(transcript_path, *, home=None, codex_home=None,
             or _under(path, codex_home / "archived_sessions")):
         return "codex", "managed"
     if (_under(path, home / ".windsurf" / "transcripts")
-            or _under(path, home / ".daimon" / "windsurf" / "transcripts")):
+            or _under(path, _daimon_windsurf_transcripts(home))):
         return "windsurf", "managed"
     return "manual", "unsupported"
 
@@ -254,7 +268,7 @@ class SourceResolver:
                     self.codex_home / "archived_sessions")
         if host == "windsurf":
             return (self.home / ".windsurf" / "transcripts",
-                    self.home / ".daimon" / "windsurf" / "transcripts")
+                    _daimon_windsurf_transcripts(self.home))
         return None
 
     def _candidates(self, source: dict) -> list[Path] | None:
@@ -277,7 +291,7 @@ class SourceResolver:
             if host == "windsurf":
                 return [
                     self.home / ".windsurf" / "transcripts" / f"{sid}.jsonl",
-                    self.home / ".daimon" / "windsurf" / "transcripts" / f"{sid}.md",
+                    _daimon_windsurf_transcripts(self.home) / f"{sid}.md",
                 ]
         except OSError:
             return []

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -1350,6 +1350,14 @@ def render_privacy_audit(results: list[dict]) -> None:
             print(f"  chunk cache: {cache['entries']} entr(y/ies) — age unknown,"
                   " value-level scan impossible (substring vs hash); purge is"
                   " wholesale on forget")
+        ws = r.get("windsurf") or {}
+        if ws.get("entries"):
+            age = (f", oldest {ws['oldest_days']:.1f}d"
+                   if ws.get("oldest_days") is not None else ", age unknown")
+            print(f"  windsurf transcripts: {ws['entries']} file(s){age} —"
+                  " daimon-authored conversation text; value-level scan"
+                  " impossible (substring vs hash); purge is wholesale on"
+                  " forget")
         if not (r["findings"] or r["informational"] or r["unscannable"]
                 or r.get("zero_surfaces")):
             print("  clean — no tombstoned value found on any surface")

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -451,11 +451,28 @@ _WINDSURF_TEXT_GLOBS = ("transcripts/*.md", "unparsed-*.json")
 
 
 def _windsurf_text_files() -> list:
+    """Containment before deletion: a symlinked `transcripts` directory
+    would otherwise have the purge unlink files outside the state root
+    entirely. provenance.SourceResolver already resolves-and-contains
+    before merely READING this directory; the deleting path must not be
+    laxer than the reading one."""
     root = config.windsurf_state_dir()
+    try:
+        real_root = root.resolve()
+    except OSError:
+        return []
     out: list = []
     for pattern in _WINDSURF_TEXT_GLOBS:
-        out.extend(root.glob(pattern))
-    return sorted(p for p in out if p.is_file())
+        for path in root.glob(pattern):
+            try:
+                if not path.is_file():
+                    continue
+                if real_root not in path.resolve().parents:
+                    continue
+            except OSError:
+                continue
+            out.append(path)
+    return sorted(set(out))
 
 
 def purge_windsurf_state() -> tuple:

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -445,6 +445,82 @@ def scrub_team_copies(content_hash: str, project_dir=None) -> list[str]:
     return rewritten
 
 
+# Daimon-authored Windsurf state that holds conversation text (#607). The
+# activity/serialize stamps beside it are epoch integers and stay.
+_WINDSURF_TEXT_GLOBS = ("transcripts/*.md", "unparsed-*.json")
+
+
+def _windsurf_text_files() -> list:
+    root = config.windsurf_state_dir()
+    out: list = []
+    for pattern in _WINDSURF_TEXT_GLOBS:
+        out.extend(root.glob(pattern))
+    return sorted(p for p in out if p.is_file())
+
+
+def purge_windsurf_state() -> tuple:
+    """#607: wholesale removal of the transcripts the Windsurf adapter wrote.
+
+    `daimon forget` calls this after the tombstone+rewrite, for the same
+    reason it purges the chunk cache (#422): the value cannot be located
+    selectively. A transcript is prose, the forgotten sentence is a
+    substring of a line, and the tombstone is a canonical HASH — forget
+    stores the key and never the text (#321), so no component downstream
+    holds the plaintext a substring search would need. Detection is
+    impossible by construction, so the whole store goes.
+
+    Accepted cost: quote provenance resolving against these files reports
+    `absent-local` afterward — a state provenance.SourceResolver already
+    models, so a purged transcript degrades a receipt rather than breaking
+    it. Host-authored transcripts (Codex rollouts, Claude Code JSONL) are
+    untouched: daimon reads those by path and never copies them, so they
+    are not daimon's to delete — and `forget` has never removed them.
+
+    Returns (purged_count, error_or_None) and NEVER raises: deleting belief
+    state is the primary contract; a failed purge is reported, not fatal."""
+    try:
+        targets = _windsurf_text_files()
+    except OSError as e:
+        return 0, str(e)
+    purged, error = 0, None
+    for path in targets:
+        try:
+            path.unlink()
+            purged += 1
+        except OSError as e:
+            error = error or str(e)
+    return purged, error
+
+
+def reap_windsurf_state(now: float | None = None, apply: bool = True) -> list:
+    """#607: age-bound what accumulates between forgets.
+
+    The purge above only fires when someone runs `forget`; without a window
+    the adapter's transcript store grows without limit, and every turn of
+    every conversation stays on disk forever. config.windsurf_state_days()
+    (default 7) is that bound — a privacy window, not a disk one. Wired
+    into `daimon heal` beside the index-snapshot reap; `apply=False` lists
+    only (heal --dry-run). Best-effort per file."""
+    if now is None:
+        now = time.time()
+    cutoff = now - config.windsurf_state_days() * 86400
+    reaped: list = []
+    try:
+        targets = _windsurf_text_files()
+    except OSError:
+        return reaped
+    for path in targets:
+        try:
+            if path.stat().st_mtime >= cutoff:
+                continue
+            if apply:
+                path.unlink()
+        except OSError:
+            continue
+        reaped.append(path)
+    return reaped
+
+
 def checkpoints_written_since(cutoff: float) -> int:
     """How many per-session checkpoints were WRITTEN since `cutoff` (epoch
     seconds), counted by file mtime — the write-side signal for the silent-

--- a/plugin/daimon_briefing/surfaces.py
+++ b/plugin/daimon_briefing/surfaces.py
@@ -142,15 +142,17 @@ SURFACES: tuple[Surface, ...] = (
     Surface("codex/*.last-stop", "_hooks/daimon-codex-*.py",
             False, "exempt-no-plaintext", "none"),
     # -- windsurf host adapter state: FULL RAW TRANSCRIPTS appended turn by
-    #    turn, plus unparsed event payloads (secret-scrubbed at write, never
-    #    item-text scrubbed). The largest plaintext store daimon writes, and
-    #    nothing in forget or the audit reaches it — THE declared gap after
-    #    the team mirror. provenance.py reads the transcripts as a
-    #    first-class source, so this is load-bearing, not vestigial. --
+    #    turn, plus unparsed event payloads. daimon-authored, so inside the
+    #    deletion contract (#419) — unlike Codex rollouts or Claude Code
+    #    JSONL, which daimon reads by path and never copies. #607: forget
+    #    purges wholesale (a value inside prose cannot be located when the
+    #    tombstone is a hash, the chunk-cache situation), heal reaps by age
+    #    (config.windsurf_state_days), and the audit reports the store
+    #    without claiming a verdict it cannot reach. --
     Surface("windsurf/transcripts/*.md", "_hooks/daimon-windsurf-hooks.py",
-            True, "known-gap", "none", issue="#607"),
+            True, "wholesale-purge", "forget"),
     Surface("windsurf/unparsed-*.json", "_hooks/daimon-windsurf-hooks.py",
-            True, "known-gap", "none", issue="#607"),
+            True, "wholesale-purge", "forget"),
     # trajectory activity/serialize stamps: epoch floats, no item text.
     Surface("windsurf/*.last-activity", "_hooks/daimon-windsurf-hooks.py",
             False, "exempt-no-plaintext", "none"),

--- a/plugin/tests/conftest.py
+++ b/plugin/tests/conftest.py
@@ -26,6 +26,10 @@ def _isolate_daimon_home(tmp_path, monkeypatch):
     monkeypatch.setenv("DAIMON_RECALL_DB", str(home / "recall.db"))
     # And the #125 per-session suggestion-cooldown state, same reasoning.
     monkeypatch.setenv("DAIMON_RECALL_SEEN_DIR", str(home / "recall_seen"))
+    # #607: the Windsurf adapter's own transcript store — no test may read or
+    # write the developer's real ~/.daimon/windsurf, and the purge/reap paths
+    # DELETE, so an unredirected default would destroy real host state.
+    monkeypatch.setenv("DAIMON_WINDSURF_DIR", str(home / "windsurf"))
     monkeypatch.delenv("DAIMON_TEAM", raising=False)
     monkeypatch.delenv("DAIMON_AUTHOR", raising=False)
     # #200: a host DAIMON_TEAM_PROJECT would nest every team write; and the

--- a/plugin/tests/test_surface_registry.py
+++ b/plugin/tests/test_surface_registry.py
@@ -64,12 +64,13 @@ def test_windsurf_state_is_declared_not_invisible():
     """Adversarial finding (BLOCKER): the windsurf adapter accumulates FULL
     RAW TRANSCRIPTS under ~/.daimon/windsurf/transcripts — the largest
     plaintext store daimon writes, and the registry claimed completeness
-    without it. Declared as the #607 gap; the activity stamps and installed
-    hook copies hold no item text."""
+    without it. #607 brought it inside the contract (wholesale purge on
+    forget, age reaper on heal); the activity stamps and installed hook
+    copies hold no item text."""
     t = surfaces.match("windsurf/transcripts/traj-1.md")
-    assert t is not None and t.delete == "known-gap" and t.issue == "#607"
+    assert t is not None and t.delete == "wholesale-purge"
     u = surfaces.match("windsurf/unparsed-post_cascade_response-123.json")
-    assert u is not None and u.delete == "known-gap" and u.issue == "#607"
+    assert u is not None and u.delete == "wholesale-purge"
     assert surfaces.match("windsurf/traj-1.last-activity").delete \
         == "exempt-no-plaintext"
     assert surfaces.match("windsurf/traj-1.last-serialize").delete \

--- a/plugin/tests/test_windsurf_state_privacy.py
+++ b/plugin/tests/test_windsurf_state_privacy.py
@@ -92,6 +92,22 @@ def test_hook_and_package_resolve_the_same_state_dir(tmp_path, monkeypatch):
     assert hook.transcript_dir() == override / "transcripts"
 
 
+def test_provenance_resolves_against_the_same_state_dir(tmp_path, monkeypatch):
+    """Third component of the same split: SourceResolver hardcoded the home
+    path too, so with the override set every Windsurf receipt would report
+    absent-local over a transcript that is on disk."""
+    from daimon_briefing import provenance
+    override = tmp_path / "elsewhere"
+    monkeypatch.setenv("DAIMON_WINDSURF_DIR", str(override))
+    tdir = override / "transcripts"
+    tdir.mkdir(parents=True)
+    (tdir / "traj-9.md").write_text("**user**: hi\n", encoding="utf-8")
+    resolver = provenance.SourceResolver()
+    cands = resolver._candidates({"host": "windsurf", "session_id": "traj-9"})
+    assert any(p == tdir / "traj-9.md" for p in cands), cands
+    assert provenance.infer_host(tdir / "traj-9.md")[0] == "windsurf"
+
+
 def test_both_sides_default_under_the_real_daimon_home(tmp_path, monkeypatch):
     """The DEFAULT path is the field path — with the var redirected suite-wide
     by conftest, nothing else asserts it. A typo in either default is

--- a/plugin/tests/test_windsurf_state_privacy.py
+++ b/plugin/tests/test_windsurf_state_privacy.py
@@ -65,6 +65,14 @@ def _seed_state(turns=("user", "assistant"), age_days=0.0):
     return path, dump, stamp
 
 
+def _holding(root, needle):
+    """Byte scan of the whole store — the pointer-history idiom (#603). A
+    seeded canary is asserted PRESENT through this before anything asserts
+    it is gone, so a fixture that never wrote it cannot pass as a scrub."""
+    return sorted(str(p.relative_to(root)) for p in root.rglob("*")
+                  if p.is_file() and needle.encode() in p.read_bytes())
+
+
 def _write_checkpoint():
     store.write_checkpoint("S1", {
         "session_id": "S1", "created": "2026-08-01T00:00:00Z",
@@ -120,6 +128,25 @@ def test_both_sides_default_under_the_real_daimon_home(tmp_path, monkeypatch):
     expected = tmp_path / ".daimon" / "windsurf"
     assert config.windsurf_state_dir() == expected
     assert hook.state_dir() == expected
+
+
+def test_provenance_default_matches_the_writer_default(tmp_path, monkeypatch):
+    """The override path is pinned above; the DEFAULT is the one that ships.
+    provenance is the third component that has to agree, and with the var
+    unset it falls back to its own literal — a typo in that literal sends
+    every Windsurf receipt on a stock install to absent-local while the
+    transcript sits on disk, which is the exact split this slice closed."""
+    from daimon_briefing import provenance
+    hook = _hook_module()
+    monkeypatch.delenv("DAIMON_WINDSURF_DIR", raising=False)
+    monkeypatch.setattr(hook.Path, "home", lambda: tmp_path)
+    expected = tmp_path / ".daimon" / "windsurf" / "transcripts"
+    assert provenance._daimon_windsurf_transcripts(tmp_path) == expected
+    assert hook.transcript_dir() == expected, "reader and writer disagree"
+    expected.mkdir(parents=True)
+    (expected / "traj-7.md").write_text("**user**: hi\n", encoding="utf-8")
+    assert provenance.infer_host(expected / "traj-7.md",
+                                 home=tmp_path)[0] == "windsurf"
 
 
 def test_state_window_defaults_to_seven_days_and_never_goes_below_one(
@@ -221,6 +248,100 @@ def test_forget_survives_a_failed_purge(tmp_checkpoint_dir, monkeypatch):
     assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
 
 
+def test_forget_survives_a_purge_that_raises(tmp_checkpoint_dir, monkeypatch,
+                                             capsys):
+    """purge_windsurf_state promises a tuple and never an exception, so the
+    belt around the call site reads as dead code — it is not. It is what
+    keeps a future bug in the purge from taking the SCRUB down with it,
+    and the scrub is the contract the user actually invoked. Losing the
+    checkpoint rewrite to a transcript-store bug would be the deletion
+    failing while the command reported a crash instead of a leak."""
+    _seed_state()
+    _write_checkpoint()
+    assert _holding(tmp_checkpoint_dir, CANARY), "fixture wrote no canary"
+
+    def boom():
+        raise RuntimeError("purge exploded")
+
+    monkeypatch.setattr(store, "purge_windsurf_state", boom)
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+    assert _holding(tmp_checkpoint_dir, CANARY) == [], \
+        "the checkpoint scrub must survive a purge that blew up"
+    out = capsys.readouterr().out
+    assert "purge exploded" in out, "a swallowed failure is an invisible leak"
+
+
+# ---- what the store must NOT delete, and what it must not claim ----------
+
+
+def test_a_directory_matching_the_glob_is_never_unlinked(tmp_checkpoint_dir):
+    """`transcripts/*.md` is a NAME pattern, not a type check. A directory
+    that happens to match must be filtered out before unlink() sees it —
+    otherwise the purge raises EISDIR partway through and abandons every
+    file ordered after it, silently, since the count is all anyone sees."""
+    path, dump, _stamp = _seed_state()
+    decoy = _state_dir() / "transcripts" / "archive.md"
+    decoy.mkdir()
+    (decoy / "inside.txt").write_text("not daimon's to delete",
+                                      encoding="utf-8")
+    purged, err = store.purge_windsurf_state()
+    assert (purged, err) == (2, None), "the real transcript store still goes"
+    assert not path.exists() and not dump.exists()
+    assert (decoy / "inside.txt").exists(), "a directory is not a transcript"
+
+
+def test_state_it_cannot_classify_is_skipped_and_the_rest_still_purges(
+        tmp_checkpoint_dir):
+    """A transcripts/ the process can list but not stat (no +x) makes
+    is_file() RAISE rather than answer. Skip that entry and keep going: a
+    store that is partly unreachable is no reason to leave the reachable
+    half of the plaintext sitting on disk."""
+    path, dump, _stamp = _seed_state()
+    assert CANARY in path.read_text(encoding="utf-8")
+    tdir = _state_dir() / "transcripts"
+    tdir.chmod(0o600)          # listable, not stat-able
+    try:
+        purged, err = store.purge_windsurf_state()
+    finally:
+        tdir.chmod(0o700)
+    assert (purged, err) == (1, None)
+    assert not dump.exists(), "the reachable half must still be purged"
+    assert path.exists(), "unlink is never attempted on an unclassified path"
+
+
+def test_a_state_root_that_cannot_be_resolved_deletes_nothing(
+        tmp_checkpoint_dir, monkeypatch):
+    """Containment is the whole reason this purge is safe to point at a
+    directory, so an unresolvable root is fail-CLOSED: it yields no
+    targets at all rather than falling back to the unresolved path and
+    unlinking through whatever that turns out to be."""
+    path, dump, _stamp = _seed_state()
+    monkeypatch.setattr(
+        type(_state_dir()), "resolve",
+        lambda self, **kw: (_ for _ in ()).throw(OSError("nope")))
+    assert store._windsurf_text_files() == []
+    assert store.purge_windsurf_state()[0] == 0
+    assert path.exists() and dump.exists()
+
+
+def test_purge_reports_a_file_it_could_not_remove(tmp_checkpoint_dir):
+    """The count is a privacy CLAIM — "this many plaintext files are gone" —
+    so a file that survived a read-only store must not be inside it, and
+    the error must surface for the forget warning to carry."""
+    path, dump, _stamp = _seed_state()
+    assert CANARY in path.read_text(encoding="utf-8")
+    tdir = _state_dir() / "transcripts"
+    tdir.chmod(0o500)          # readable and stat-able, not writable
+    try:
+        purged, err = store.purge_windsurf_state()
+    finally:
+        tdir.chmod(0o700)
+    assert purged == 1, "only a file that actually went may be counted"
+    assert err is not None, "a silent partial purge reads as a clean one"
+    assert not dump.exists()
+    assert CANARY in path.read_text(encoding="utf-8")
+
+
 # ---- age reaper -----------------------------------------------------------
 
 
@@ -250,6 +371,36 @@ def test_heal_reaps_windsurf_state_and_dry_run_only_lists(
     assert not path.exists()
 
 
+def test_reap_never_reports_a_file_it_could_not_remove(tmp_checkpoint_dir):
+    """`heal` prints "reaped <name>" straight out of this list, so every name
+    in it is a claim that the plaintext is gone. A file the reaper could
+    not unlink has to be ABSENT from the list — announcing it would tell a
+    user their conversation was deleted while it is still on disk."""
+    path, dump, _stamp = _seed_state(age_days=30)
+    assert CANARY in path.read_text(encoding="utf-8")
+    tdir = _state_dir() / "transcripts"
+    tdir.chmod(0o500)
+    try:
+        reaped = store.reap_windsurf_state()
+    finally:
+        tdir.chmod(0o700)
+    assert [p.name for p in reaped] == [dump.name]
+    assert not dump.exists(), "the writable half is still reaped"
+    assert CANARY in path.read_text(encoding="utf-8")
+
+
+def test_reap_survives_an_unreadable_state_dir(tmp_checkpoint_dir,
+                                               monkeypatch):
+    """Same posture as the purge, different call site: heal is a repair pass
+    over many surfaces, so a state dir that raises mid-walk costs this one
+    reaper and never the rest of the run."""
+    path, _dump, _stamp = _seed_state(age_days=30)
+    monkeypatch.setattr(type(_state_dir()), "glob",
+                        lambda self, pat: (_ for _ in ()).throw(OSError("nope")))
+    assert store.reap_windsurf_state() == []
+    assert path.exists(), "a walk that failed must not be read as reaped"
+
+
 def test_window_is_configurable(tmp_checkpoint_dir, monkeypatch):
     monkeypatch.setenv("DAIMON_WINDSURF_STATE_DAYS", "1")
     assert config.windsurf_state_days() == 1
@@ -277,6 +428,26 @@ def test_audit_reports_windsurf_state_informationally(tmp_checkpoint_dir):
     assert privacy.exit_code([result]) == 0
     assert not any(f["surface"].startswith("windsurf")
                    for f in result["findings"])
+
+
+def test_audit_skips_state_that_vanished_mid_walk(tmp_checkpoint_dir,
+                                                  monkeypatch):
+    """The reaper and the auditor run against the same store with no lock
+    between them, so a file can be listed and then gone before its stat.
+    It must drop out of the count — an entry the auditor never measured is
+    not evidence of a file, and the audit of every OTHER surface must not
+    die over it."""
+    _seed_state()
+    _write_checkpoint()
+    real = store._windsurf_text_files()
+    assert real, "fixture seeded no windsurf state"
+    ghost = _state_dir() / "transcripts" / "already-reaped.md"
+    monkeypatch.setattr(store, "_windsurf_text_files", lambda: [ghost] + real)
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert result["windsurf"]["entries"] == len(real), \
+        "a file that was never stat-able cannot be counted"
+    assert result["windsurf"]["oldest_days"] is not None
+    assert privacy.exit_code([result]) == 0
 
 
 def test_audit_render_names_the_purge_contract(tmp_checkpoint_dir, capsys):

--- a/plugin/tests/test_windsurf_state_privacy.py
+++ b/plugin/tests/test_windsurf_state_privacy.py
@@ -34,6 +34,19 @@ def _state_dir():
     return config.windsurf_state_dir()
 
 
+def _hook_module():
+    """The Windsurf adapter, loaded as a module (it is a standalone script
+    with a hyphenated name, so it cannot be imported normally)."""
+    import importlib.util
+    from pathlib import Path as _P
+    src = (_P(__file__).parent.parent / "daimon_briefing" / "_hooks"
+           / "daimon-windsurf-hooks.py")
+    spec = importlib.util.spec_from_file_location("_ws_hook_under_test", src)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 def _seed_state(turns=("user", "assistant"), age_days=0.0):
     tdir = _state_dir() / "transcripts"
     tdir.mkdir(parents=True, exist_ok=True)
@@ -61,7 +74,97 @@ def _write_checkpoint():
     }, project_dir=PROJECT)
 
 
+# ---- the writer and the deleter must agree on WHERE ----------------------
+
+
+def test_hook_and_package_resolve_the_same_state_dir(tmp_path, monkeypatch):
+    """Adversarial finding (MAJOR): the hook hardcoded ~/.daimon/windsurf
+    while the package honored DAIMON_WINDSURF_DIR, so with the var set the
+    hook kept writing plaintext into one directory while purge, reap and
+    audit all reported cleanly on an empty other one. Two halves of one
+    feature, tested against two different directories, agreeing about
+    nothing. Pin them together."""
+    hook = _hook_module()
+    override = tmp_path / "elsewhere"
+    monkeypatch.setenv("DAIMON_WINDSURF_DIR", str(override))
+    assert config.windsurf_state_dir() == override
+    assert hook.state_dir() == override
+    assert hook.transcript_dir() == override / "transcripts"
+
+
+def test_both_sides_default_under_the_real_daimon_home(tmp_path, monkeypatch):
+    """The DEFAULT path is the field path — with the var redirected suite-wide
+    by conftest, nothing else asserts it. A typo in either default is
+    otherwise invisible (it survived a `windsurf` -> `windsurfXX` mutant)."""
+    hook = _hook_module()
+    monkeypatch.delenv("DAIMON_WINDSURF_DIR", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(config.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(hook.Path, "home", lambda: tmp_path)
+    expected = tmp_path / ".daimon" / "windsurf"
+    assert config.windsurf_state_dir() == expected
+    assert hook.state_dir() == expected
+
+
+def test_state_window_defaults_to_seven_days_and_never_goes_below_one(
+        monkeypatch):
+    """0 means DISABLE for every other DAIMON_WINDSURF_* knob; here an
+    unclamped 0 made the cutoff `now`, so a live capture buffer was deleted
+    at the next heal. Clamp at 1 — the reaper has no off switch, and
+    silently deleting live state is the wrong reading of an ambiguous 0."""
+    monkeypatch.delenv("DAIMON_WINDSURF_STATE_DAYS", raising=False)
+    assert config.windsurf_state_days() == 7
+    for raw in ("0", "-1", "not-a-number"):
+        monkeypatch.setenv("DAIMON_WINDSURF_STATE_DAYS", raw)
+        assert config.windsurf_state_days() >= 1, raw
+
+
 # ---- purge on forget ------------------------------------------------------
+
+
+def test_forget_dry_run_never_purges(tmp_checkpoint_dir):
+    """The higher-blast-radius call site had no test at all: a purge
+    inserted into the dry-run branch passed 580 tests."""
+    path, dump, _stamp = _seed_state()
+    _write_checkpoint()
+    assert cli.main(["forget", CANARY, "--project", PROJECT, "--dry-run"]) == 0
+    assert path.exists() and dump.exists()
+
+
+def test_a_refused_forget_never_purges(tmp_checkpoint_dir):
+    path, dump, _stamp = _seed_state()
+    _write_checkpoint()
+    assert cli.main(["forget", "no such value here", "--project", PROJECT]) == 1
+    assert path.exists() and dump.exists()
+
+
+def test_purge_never_follows_a_symlinked_directory_out_of_its_root(
+        tmp_checkpoint_dir, tmp_path):
+    """provenance.SourceResolver already refuses to READ outside this root;
+    the deleting path must not be laxer than the reading one."""
+    outside = tmp_path / "my-notes"
+    outside.mkdir()
+    (outside / "important.md").write_text("a user file", encoding="utf-8")
+    _state_dir().mkdir(parents=True, exist_ok=True)
+    (_state_dir() / "transcripts").symlink_to(outside, target_is_directory=True)
+    purged, _err = store.purge_windsurf_state()
+    assert purged == 0
+    assert (outside / "important.md").exists(), "escaped its own root"
+
+
+def test_forget_states_the_purge_is_machine_wide(tmp_checkpoint_dir, capsys):
+    """The store is keyed by trajectory, not project — a forget in ANY
+    project purges every Windsurf transcript on the machine. That is the
+    only option (the files carry no project attribution), so it must be
+    said out loud rather than discovered."""
+    _seed_state()
+    _write_checkpoint()
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+    out = capsys.readouterr().out.lower()
+    assert "all projects" in out or "machine-wide" in out
+
+
+
 
 
 def test_forget_purges_the_daimon_authored_transcript_store(

--- a/plugin/tests/test_windsurf_state_privacy.py
+++ b/plugin/tests/test_windsurf_state_privacy.py
@@ -1,0 +1,193 @@
+"""#607: the Windsurf adapter's own transcript store, inside the contract.
+
+The Cascade adapter accumulates FULL RAW TRANSCRIPTS under
+~/.daimon/windsurf/transcripts/<trajectory>.md — daimon writes them, so
+#419's rule puts them inside the deletion contract — plus
+unparsed-<event>-<stamp>.json payload dumps (secret-scrubbed at write,
+never item-text scrubbed). Nothing reached either.
+
+Why this is a PURGE and not a scan: forget stores the canonical HASH and
+never the text (#321), so no component downstream holds the plaintext a
+substring search of prose would need. Detection inside a transcript is
+impossible by construction — exactly the chunk-cache situation (#422) —
+and the same three-part answer applies: wholesale purge at forget, an age
+reaper bounding what accumulates between forgets, and an INFORMATIONAL
+audit line rather than a clean/dirty verdict the auditor cannot honestly
+reach.
+
+Host-authored transcripts (Codex rollouts, Claude Code JSONL) stay out of
+scope: daimon reads those by path and never copies them, so they are not
+daimon's to delete.
+"""
+import json
+import os
+import time
+
+from daimon_briefing import cli, config, normalize, privacy, store, surfaces
+
+PROJECT = "/p/windsurf-state"
+CANARY = "zqxwindsurfcanary8841 the staging token rotates on fridays"
+KEEPER = "an unrelated decision that must survive"
+
+
+def _state_dir():
+    return config.windsurf_state_dir()
+
+
+def _seed_state(turns=("user", "assistant"), age_days=0.0):
+    tdir = _state_dir() / "transcripts"
+    tdir.mkdir(parents=True, exist_ok=True)
+    path = tdir / "traj-1.md"
+    path.write_text(
+        "".join(f"**{r}**: something about {CANARY} here\n" for r in turns),
+        encoding="utf-8")
+    dump = _state_dir() / "unparsed-post_cascade_response-1782874461.json"
+    dump.write_text(json.dumps({"prompt": CANARY}), encoding="utf-8")
+    stamp = _state_dir() / "traj-1.last-activity"
+    stamp.write_text(str(int(time.time())), encoding="utf-8")
+    if age_days:
+        old = time.time() - age_days * 86400
+        for p in (path, dump, stamp):
+            os.utime(p, (old, old))
+    return path, dump, stamp
+
+
+def _write_checkpoint():
+    store.write_checkpoint("S1", {
+        "session_id": "S1", "created": "2026-08-01T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": CANARY, "trust": "inferred"},
+            {"text": KEEPER, "trust": "inferred"}]},
+    }, project_dir=PROJECT)
+
+
+# ---- purge on forget ------------------------------------------------------
+
+
+def test_forget_purges_the_daimon_authored_transcript_store(
+        tmp_checkpoint_dir):
+    path, dump, stamp = _seed_state()
+    _write_checkpoint()
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+    assert not path.exists(), "the transcript daimon wrote must go"
+    assert not dump.exists(), "unparsed payload dumps carry the same text"
+    assert stamp.exists(), "activity stamps hold no item text — keep them"
+
+
+def test_purge_reports_count_and_never_raises(tmp_checkpoint_dir):
+    _seed_state()
+    purged, err = store.purge_windsurf_state()
+    assert purged == 2 and err is None
+    # vacuous purge on a machine that never ran Windsurf
+    purged, err = store.purge_windsurf_state()
+    assert purged == 0 and err is None
+
+
+def test_purge_survives_an_unreadable_state_dir(tmp_checkpoint_dir,
+                                                monkeypatch):
+    _seed_state()
+    monkeypatch.setattr(type(_state_dir()), "glob",
+                        lambda self, pat: (_ for _ in ()).throw(OSError("nope")))
+    purged, err = store.purge_windsurf_state()
+    assert purged == 0 and err is not None
+
+
+def test_forget_survives_a_failed_purge(tmp_checkpoint_dir, monkeypatch):
+    """The belief-state deletion is the primary contract — a failed purge is
+    reported honestly, never fatal (the #422 posture)."""
+    _seed_state()
+    _write_checkpoint()
+    monkeypatch.setattr(store, "purge_windsurf_state",
+                        lambda: (0, "disk on fire"))
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+
+
+# ---- age reaper -----------------------------------------------------------
+
+
+def test_reap_drops_state_older_than_the_window(tmp_checkpoint_dir):
+    old_path, old_dump, old_stamp = _seed_state(age_days=30)
+    reaped = store.reap_windsurf_state()
+    assert sorted(p.name for p in reaped) == sorted(
+        [old_path.name, old_dump.name])
+    assert not old_path.exists() and not old_dump.exists()
+    assert old_stamp.exists(), "a stamp is not item text"
+
+
+def test_reap_spares_state_inside_the_window(tmp_checkpoint_dir):
+    path, dump, _stamp = _seed_state(age_days=1)
+    assert store.reap_windsurf_state() == []
+    assert path.exists() and dump.exists()
+
+
+def test_heal_reaps_windsurf_state_and_dry_run_only_lists(
+        tmp_checkpoint_dir, capsys):
+    path, _dump, _stamp = _seed_state(age_days=30)
+    assert cli.main(["heal", "--dry-run"]) == 0
+    assert path.name in capsys.readouterr().out
+    assert path.exists(), "--dry-run must not delete"
+    assert cli.main(["heal"]) == 0
+    assert path.name in capsys.readouterr().out
+    assert not path.exists()
+
+
+def test_window_is_configurable(tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_WINDSURF_STATE_DAYS", "1")
+    assert config.windsurf_state_days() == 1
+    path, _dump, _stamp = _seed_state(age_days=2)
+    assert [p.name for p in store.reap_windsurf_state()] != []
+    assert not path.exists()
+    monkeypatch.setenv("DAIMON_WINDSURF_STATE_DAYS", "not-a-number")
+    assert config.windsurf_state_days() == 7
+
+
+# ---- audit reports it, and says what it cannot prove ----------------------
+
+
+def test_audit_reports_windsurf_state_informationally(tmp_checkpoint_dir):
+    """It must appear in the report — a surface nobody mentions reads as a
+    surface that does not exist — but it must NOT move the exit code: the
+    auditor cannot see inside prose, so neither a finding nor an
+    unscannable entry would be honest."""
+    _seed_state()
+    _write_checkpoint()
+    result = privacy.audit_project(project_dir=PROJECT)
+    state = result.get("windsurf") or {}
+    assert state.get("entries") == 2
+    assert state.get("oldest_days") is not None
+    assert privacy.exit_code([result]) == 0
+    assert not any(f["surface"].startswith("windsurf")
+                   for f in result["findings"])
+
+
+def test_audit_render_names_the_purge_contract(tmp_checkpoint_dir, capsys):
+    from daimon_briefing import render
+    _seed_state()
+    _write_checkpoint()
+    render.render_privacy_audit([privacy.audit_project(project_dir=PROJECT)])
+    out = capsys.readouterr().out
+    assert "windsurf" in out.lower()
+    assert "wholesale" in out.lower()
+
+
+# ---- the registry stops calling this a gap -------------------------------
+
+
+def test_registry_declares_windsurf_state_reachable():
+    t = surfaces.match("windsurf/transcripts/traj-1.md")
+    assert t.delete == "wholesale-purge" and t.plaintext is True
+    u = surfaces.match("windsurf/unparsed-post_cascade_response-1.json")
+    assert u.delete == "wholesale-purge"
+    assert not any(s.issue == "#607" for s in surfaces.SURFACES), \
+        "#607 is closed — no entry may still cite it as an open gap"
+
+
+def test_forgotten_value_never_reaches_the_purge_ledger(tmp_checkpoint_dir):
+    """Whatever the purge reports, it reports counts and paths — never the
+    value it removed (#321: removal means the content leaves the trail)."""
+    _seed_state()
+    _write_checkpoint()
+    key = normalize.content_key(CANARY)
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+    events = store._events_path(PROJECT).read_text()
+    assert CANARY not in events and key in events

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -126,6 +126,8 @@ Serialize-throttle knobs for hosts that lack a clean session-end event. See
 | `DAIMON_CODEX_MIN_SERIALIZE_INTERVAL` | `300` | Minimum seconds between Codex serialize spawns. `0` serializes on every `Stop`. |
 | `DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL` | `300` | Minimum seconds between Windsurf serialize spawns (Windsurf has no session-end event, so capture runs on this throttle). `0` serializes every turn. |
 | `DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS` | `600` | Quiet period after the last Windsurf activity before a debounced finalizer serializes the trajectory's final transcript state — covers sessions whose last turns land inside the throttle window. Fractional values accepted; `0` disables the finalizer. |
+| `DAIMON_WINDSURF_DIR` | `~/.daimon/windsurf` | Where the Windsurf adapter keeps the transcripts it accumulates. Read by both the hook that writes them and the `forget`/`heal` paths that delete them — change it in one place only, or the writer and the deleter stop agreeing. |
+| `DAIMON_WINDSURF_STATE_DAYS` | `7` | Age window for daimon-authored Windsurf transcripts and unparsed payload dumps, reaped by `daimon heal`. A privacy bound: a forgotten value cannot be located inside prose, so this limits how long the source conversation lingers between `forget` runs. Clamped to at least 1 — unlike the other Windsurf knobs, `0` does not disable it. |
 
 ## Ops & diagnostics
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
@@ -133,6 +133,8 @@ de sesión. Mira [Hosts](../hosts/) para la configuración por host.
 | `DAIMON_CODEX_MIN_SERIALIZE_INTERVAL` | `300` | Segundos mínimos entre lanzamientos de serialización de Codex. `0` serializa en cada `Stop`. |
 | `DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL` | `300` | Segundos mínimos entre lanzamientos de serialización de Windsurf (Windsurf no tiene evento de fin de sesión, así que la captura corre con este throttle). `0` serializa cada turno. |
 | `DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS` | `600` | Periodo de silencio tras la última actividad de Windsurf antes de que un finalizador con debounce serialice el estado final del transcript de la trayectoria — cubre sesiones cuyos últimos turnos caen dentro de la ventana del throttle. Acepta valores fraccionarios; `0` desactiva el finalizador. |
+| `DAIMON_WINDSURF_DIR` | `~/.daimon/windsurf` | Dónde guarda el adaptador de Windsurf los transcripts que acumula. Lo leen tanto el hook que los escribe como las rutas de `forget`/`heal` que los borran — cámbialo en un solo sitio, o el que escribe y el que borra dejan de coincidir. |
+| `DAIMON_WINDSURF_STATE_DAYS` | `7` | Ventana de antigüedad para los transcripts de Windsurf que escribe daimon y los volcados `unparsed`, recogidos por `daimon heal`. Es un límite de privacidad: un valor olvidado no puede localizarse dentro de la prosa, así que esto acota cuánto tiempo permanece la conversación de origen entre ejecuciones de `forget`. Con mínimo 1 — a diferencia de los otros ajustes de Windsurf, `0` no lo desactiva. |
 
 ## Operación y diagnóstico
 


### PR DESCRIPTION
Closes #607

## What

The Cascade adapter accumulates full raw transcripts under `~/.daimon/windsurf/transcripts/<trajectory>.md` when Cascade provides no native transcript, plus `unparsed-<event>-<stamp>.json` payload dumps. daimon authors those files, so #419's rule puts them inside the deletion contract — and nothing reached them.

**Why this is a purge and not a scan.** The value lives as a substring of prose, and the tombstone is a canonical hash — `forget` stores the key and never the text (#321), so no component downstream holds the plaintext a substring search would need. Detection inside a transcript is impossible by construction. That is exactly the chunk-cache situation (#422), and the same three-part answer applies:

- **`forget` purges the store wholesale** (`store.purge_windsurf_state`), reports the count, and states plainly that host-authored transcripts are untouched. Never fatal: a failed purge is reported, the belief-state deletion stands.
- **`heal` reaps by age** (`store.reap_windsurf_state`, `config.windsurf_state_days`, default 7 days) so the store is bounded between forgets. A privacy window, not a disk one — without it every turn of every conversation stays on disk until someone happens to run `forget`.
- **`audit privacy` reports the store** and its real oldest age **without moving the exit code**. Neither a finding nor an `unscannable` entry would be honest, and silence would read as "this surface does not exist". Same posture the chunk cache already gets.

The surface registry moves both shapes from `known-gap` to `wholesale-purge`, so #607 stops being cited as open debt.

## Scope

Codex rollouts and Claude Code JSONL stay out. Those hosts hand daimon a path to their own transcript, which daimon reads and never copies (`transcript_path = payload.get("transcript_path")` in the Codex Stop hook) — they are not daimon's files to delete, and `forget` has never removed them. Windsurf is the one host where daimon manufactures the transcript itself, because Cascade delivers per-event payloads rather than a file.

Quote provenance resolving against a purged transcript reports `absent-local`, a state `provenance.SourceResolver` already models, so a purge weakens a receipt rather than breaking it.

## Tests

- `plugin/tests/test_windsurf_state_privacy.py` (new, 19 tests, each written first and watched fail): the hook and the package resolve the same state dir and the same default; the window defaults to 7 and never drops below 1; purge removes transcripts and payload dumps while sparing epoch stamps; purge reports counts, survives an unreadable state dir, and never aborts a forget; reap drops state past the window and spares state inside it, with the window configurable and falling back on garbage input; heal integration including `--dry-run`; the audit reports the store informationally and leaves `exit_code` at 0; the render names the purge contract; the registry no longer cites #607; `--dry-run` and a refused forget never purge; the purge stays inside its own root through a symlinked directory; and the forgotten value never reaches the event ledger.
- `plugin/tests/conftest.py`: `DAIMON_WINDSURF_DIR` is now redirected under tmp for every test. These paths **delete**, so an unredirected default would have reaped real host state — the #54 isolation rule, applied to a new root.
- One pre-existing test caught a real bug in this change: `test_walks_that_raise_degrade_instead_of_crashing` failed because the audit's new walk could raise out of `audit_project`. Guarded, and the audit degrades as it must.
- Full suite: 3105 passed, 2 skipped.

## Adversarial review round

Wide sweep over the diff; six findings worth acting on, all addressed.

The important one: the feature was split in half. The hook hardcoded `~/.daimon/windsurf` while purge, reap and audit all honored `DAIMON_WINDSURF_DIR` — so with the var set, the writer kept filling one directory while the deleter reported cleanly on an empty other one, and nothing said so (a zero-file purge printed nothing). `provenance.SourceResolver` had the same hardcoded root, so receipts would report `absent-local` over a transcript that was on disk. The hook now reads the same var, and a test pins both sides to one directory and to the same default — which nothing covered before: a `windsurf` → `windsurfXX` mutant in config survived the entire suite, because conftest redirects the var suite-wide and no test asserted the field default.

The rest: `DAIMON_WINDSURF_STATE_DAYS` is clamped at 1, because every other Windsurf knob reads `0` as "disable" and unclamped it made the cutoff the present moment — a user turning the reaper off would have deleted their live capture buffer at the next session start. The purge now contains itself to its own root (a symlinked `transcripts` directory had it unlinking user files outside; `SourceResolver` already guards the same directory before merely reading it). `forget --dry-run` and a refused `forget` never purge — true before, now pinned, since a purge inserted into either branch passed 580 tests. The purge line always prints and states plainly that it is machine-wide: the store is keyed by trajectory and carries no project attribution, so a `forget` in any project takes every Windsurf transcript on the machine, and that is worth saying rather than leaving to be discovered. Both new environment variables are documented in all three configuration tables.

Two findings recorded and not fixed here: the audit reports this one global store once per project heading (the chunk-cache line has the identical shape and shipped that way — inherited, not introduced), and `heal` runs detached from every session start rather than only when typed, so the reaper deletes unattended. The clamp above is what makes that acceptable; the docstring says so.

Confirmed-safe on the record: exit-code neutrality holds in every branch; the kill-switch path purges, consistent with #421's ratified deletion exemption; provenance degrades to `absent-local` without crashing any read path; a purge mid-session lets the hook recreate the transcript and continue, and the debounced finalizer exits cleanly on a missing file; the reaper's `mtime >= cutoff` spares an actively appended transcript; and no test leaks into a real `~/.daimon`.
