### PR TITLE
fix(serializer): thread the capture clock into quote verification stamps

### DIFF
--- a/plugin/daimon_briefing/capture.py
+++ b/plugin/daimon_briefing/capture.py
@@ -51,16 +51,26 @@ def run(session_id: str, messages, *, project, chat, deadline,
         session_id, transcript_path, author=config.author(),
         host_hint=capture_host or config.capture_host(),
         claude_projects=config.claude_projects_dir())
+    # #604: compute the session-end stamp BEFORE serializing so quote
+    # verification can stamp from it too. Every other time that lands on
+    # disk is threaded from this clock (`created` below, carry's `now`);
+    # verify_quotes read the wall clock instead, so two captures of one
+    # transcript disagreed whenever they straddled a second boundary and a
+    # re-serialize could not reproduce its own receipts. None (no transcript
+    # file) leaves the serializer on its wall-clock fallback.
+    session_end = (_session_end_stamp(transcript_path)
+                   if transcript_path is not None else None)
     checkpoint = serializer.serialize_strict(
         session_id, messages, chat=chat, deadline=deadline, escalate=escalate,
-        source_ref=source_ref, transcript_hash=transcript_sha)
+        source_ref=source_ref, transcript_hash=transcript_sha,
+        now=session_end)
     # `created` = when the SESSION ended, not when this write happens (#123).
     # Stamped here — not left to store's setdefault-now — so a heal/re-serialize
     # of an old transcript carries its true age and store's pointer guard can
     # keep it from stealing `latest` from a newer session. Needs a transcript
     # FILE; a hook host that provides none falls through to setdefault-now.
-    if transcript_path is not None:
-        checkpoint["created"] = _session_end_stamp(transcript_path)
+    if session_end is not None:
+        checkpoint["created"] = session_end
     # Bind the checkpoint to its exact source content (#125). The sha is
     # computed by the caller at read time, before any LLM work; absent
     # (unreadable file / no file) means no stamp — readers tolerate that.

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -1013,7 +1013,7 @@ def stripped_transcript(messages) -> str:
 
 
 def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
-                  source_ref=None, transcript_hash=None) -> int:
+                  source_ref=None, transcript_hash=None, now=None) -> int:
     """Verify every verbatim item's quote against the rendered transcript, in
     place (#125). On a hit the item gets `quote_verified: true` AND a
     `last_verified` ISO-8601 UTC stamp (#215: the staleness-budget's freshest
@@ -1070,6 +1070,14 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
     signals = signal_message_ids(messages) if messages else set()
     downgraded = echoed = 0
     digest = provenance.source_digest(transcript_hash, transcript_text)
+    # #604: ONE stamp for the whole pass, threaded from the caller's clock —
+    # the session-end stamp `created` also uses. Reading the wall clock per
+    # item made two captures of the same transcript differ whenever they
+    # straddled a second boundary (the capture-parity flake), and left a
+    # re-serialize unable to reproduce its own receipts. Scar 0016's rule:
+    # a now-consumer takes the clock, it does not fetch one. Wall clock
+    # stays the fallback for callers with no transcript stamp to thread.
+    stamp = now or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     def stamp_receipt(item, outcome, checked_at, binding_mode, message_ids=()):
         receipt = provenance.quote_receipt(
@@ -1091,8 +1099,7 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
             continue
         scoped = scoped_haystack(item, texts_by_id, exclude=signals)
         if scoped is not None and quote_matches(quote, scoped):
-            checked_at = datetime.now(timezone.utc).strftime(
-                "%Y-%m-%dT%H:%M:%SZ")
+            checked_at = stamp
             item["quote_verified"] = True
             item["last_verified"] = checked_at
             quote_ids = [i for i in item.get(SOURCE_IDS_KEY) or []
@@ -1113,8 +1120,7 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
                 log.warning("quote verification: quote not found in its cited "
                             "message(s) — binding dropped, verified via "
                             "whole-transcript scan (#358)")
-            checked_at = datetime.now(timezone.utc).strftime(
-                "%Y-%m-%dT%H:%M:%SZ")
+            checked_at = stamp
             item["quote_verified"] = True
             item["last_verified"] = checked_at
             stamp_receipt(item, "verified", checked_at, "transcript-scan")
@@ -1133,8 +1139,7 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
             item["quote_verified"] = False
             # A downgraded quote is not evidence; a binding for it is noise.
             item.pop(SOURCE_IDS_KEY, None)
-            checked_at = datetime.now(timezone.utc).strftime(
-                "%Y-%m-%dT%H:%M:%SZ")
+            checked_at = stamp
             stamp_receipt(item, "not-verified", checked_at,
                           "transcript-scan")
             downgraded += 1
@@ -2039,7 +2044,8 @@ def _stamp_llm_provenance(checkpoint: dict) -> None:
 
 
 def serialize_strict(session_id: str, messages, chat=None, deadline=None,
-                     escalate=False, source_ref=None, transcript_hash=None) -> dict:
+                     escalate=False, source_ref=None, transcript_hash=None,
+                     now=None) -> dict:
     """Transcript -> validated checkpoint, or a named SerializeError.
 
     `chat` is an injectable callable (messages, **kwargs) -> str; defaults to the
@@ -2278,7 +2284,8 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
     # validated binding resolve their id and compare bytes against just that
     # message, whole-transcript scan as fallback.
     verify_quotes(checkpoint, transcript_text, messages,
-                  source_ref=source_ref, transcript_hash=transcript_hash)
+                  source_ref=source_ref, transcript_hash=transcript_hash,
+                  now=now)
     # #359: derive the code-owned `grounded` verdict AFTER verification (it
     # must judge the surviving bindings) — outcome claims with a validated
     # signal pointer are marked grounded; unwitnessed verbatim outcome

--- a/plugin/tests/test_capture_clock_determinism.py
+++ b/plugin/tests/test_capture_clock_determinism.py
@@ -1,0 +1,167 @@
+"""#604: quote verification stamps must come from the threaded clock.
+
+`verify_quotes` read `datetime.now()` directly for `last_verified` and, since
+#595, for the quote receipt's `checked_at` too. That is the unthreaded
+now-consumer scar 0016 exists to forbid: every other stamp that lands on
+disk is threaded from the transcript's own clock (`created` from the session
+end, carry's `now` from that stamp), so two captures of the same transcript
+are byte-identical — except these, which differ whenever the two runs
+straddle a second boundary.
+
+The symptom was `test_capture_parity` failing 1-3 runs in 40. That test had
+already noticed half the problem and worked around it, avoiding a verbatim
+item whose quote WOULD verify because "a hit stamps wall-clock
+`last_verified`". #595 then put wall clock on the MISS path as well, which
+is the case the workaround had chosen as safe.
+
+Determinism here is not only about the test: a re-serialize of the same
+transcript should produce the same checkpoint, which is what makes a
+receipt re-checkable at all.
+"""
+import json
+import os
+
+from daimon_briefing import capture, provenance, serializer, store
+
+PROJECT = "/p/clock-determinism"
+SESSION = "S-clock"
+
+_QUOTED = "the retry budget is shared across attempts"
+
+_EXTRACTION = json.dumps({
+    "session_id": SESSION,
+    "working_context": {
+        "active_topic": {"text": "t", "trust": "inferred"},
+        "open_questions": [
+            # verifies: the quote is really in the transcript below
+            {"text": "retry budget semantics", "trust": "verbatim",
+             "quote": _QUOTED},
+            # misses: stamps a not-verified receipt, the #595 path
+            {"text": "unrelated claim", "trust": "verbatim",
+             "quote": "this sentence appears nowhere"},
+        ],
+        "recent_decisions": [],
+    },
+    "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []},
+})
+
+_STAMPS = ["2026-07-01T10:00:00Z", "2026-07-01T10:01:00Z",
+           "2026-07-01T10:02:00Z"]
+
+
+def _write_transcript(tmp_path):
+    rows = []
+    for i, ts in enumerate(_STAMPS):
+        role = "user" if i % 2 == 0 else "assistant"
+        content = f"turn {i}: {_QUOTED}" if i == 0 else f"turn {i}"
+        rows.append({"type": role,
+                     "message": {"role": role, "content": content},
+                     "timestamp": ts})
+    p = tmp_path / f"{SESSION}.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in rows), encoding="utf-8")
+    os.utime(p, (1782000000, 1782000000))   # scar 0016: pin the mtime
+    return p
+
+
+def _stamps(checkpoint):
+    """Every verification stamp the checkpoint carries."""
+    out = []
+    for section, key in store._ITEM_LISTS:
+        for item in ((checkpoint.get(section) or {}).get(key) or []):
+            if not isinstance(item, dict):
+                continue
+            receipt = item.get("quote_provenance") or {}
+            out.append((item.get("text"), item.get("last_verified"),
+                        receipt.get("checked_at")))
+    return sorted(out, key=lambda r: r[0] or "")
+
+
+def _serialize(tmp_path, monkeypatch, fake_chat_factory, home_name):
+    home = tmp_path / home_name
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(home / "checkpoints"))
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(home / "logs"))
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    tpath = _write_transcript(tmp_path)
+    from daimon_briefing import transcript as tmod
+    messages = tmod.from_file(tpath)
+    capture.run(SESSION, messages, project=PROJECT,
+                chat=fake_chat_factory(_EXTRACTION), deadline=None,
+                transcript_path=tpath)
+    return json.loads((home / "checkpoints" / f"{SESSION}.json")
+                      .read_text(encoding="utf-8"))
+
+
+class _AdvancingClock:
+    """Wall clock that moves one second per reading.
+
+    The bug only shows when two runs straddle a second boundary, which is
+    why the parity guard failed 1-3 times in 40 and passed the rest. A test
+    that reproduces it by luck proves nothing, so the boundary is forced:
+    under this clock a wall-clock implementation CANNOT produce equal
+    stamps, and a threaded one is unaffected by it entirely.
+    """
+
+    def __init__(self):
+        self.calls = 0
+
+    def now(self, tz=None):
+        from datetime import datetime as _dt, timedelta, timezone as _tz
+        self.calls += 1
+        return (_dt(2026, 7, 2, 9, 0, 0, tzinfo=tz or _tz.utc)
+                + timedelta(seconds=self.calls))
+
+
+def test_two_captures_of_one_transcript_stamp_identically(
+        tmp_path, fake_chat_factory, monkeypatch):
+    """The whole bug in one assertion: same transcript, two runs, same
+    stamps — including the verifying item the parity guard had to avoid."""
+    clock = _AdvancingClock()
+    monkeypatch.setattr(serializer, "datetime", clock)
+    first = _serialize(tmp_path, monkeypatch, fake_chat_factory, "home-a")
+    second = _serialize(tmp_path, monkeypatch, fake_chat_factory, "home-b")
+    assert _stamps(first) == _stamps(second)
+    assert first == second
+
+
+def test_stamps_come_from_the_transcript_not_the_wall(
+        tmp_path, fake_chat_factory, monkeypatch):
+    """Not merely equal to each other — equal to the session's own clock.
+    Two runs could agree by both being fast; this pins the SOURCE."""
+    cp = _serialize(tmp_path, monkeypatch, fake_chat_factory, "home-c")
+    created = cp.get("created")
+    assert created == _STAMPS[-1], created
+    for text, last_verified, checked_at in _stamps(cp):
+        if last_verified is not None:
+            assert last_verified == created, text
+        if checked_at is not None:
+            assert checked_at == created, text
+
+
+def test_both_receipt_outcomes_are_stamped_and_valid(
+        tmp_path, fake_chat_factory, monkeypatch):
+    """The threaded stamp must still satisfy the receipt validator — a
+    malformed checked_at would silently drop the receipt entirely."""
+    cp = _serialize(tmp_path, monkeypatch, fake_chat_factory, "home-d")
+    receipts = [i.get("quote_provenance")
+                for i in (cp["working_context"]["open_questions"] or [])]
+    assert len(receipts) == 2 and all(r is not None for r in receipts)
+    assert {r["outcome"] for r in receipts} == {"verified", "not-verified"}
+    assert all(provenance.valid_quote_receipt(r) for r in receipts)
+
+
+def test_verify_quotes_falls_back_to_wall_clock_without_a_clock(monkeypatch):
+    """A caller with no transcript stamp (a hook host that provides no file)
+    must still stamp — the fallback is wall clock, never an empty string,
+    which valid_quote_receipt would reject."""
+    checkpoint = {
+        "session_id": "S1",
+        "working_context": {"open_questions": [
+            {"text": "x", "trust": "verbatim", "quote": "hello world"}]},
+    }
+    source_ref = provenance.capture_source_ref("S1", None)
+    serializer.verify_quotes(checkpoint, "hello world", None,
+                             source_ref=source_ref)
+    item = checkpoint["working_context"]["open_questions"][0]
+    assert item["quote_verified"] is True
+    assert item["last_verified"]
+    assert provenance.valid_quote_receipt(item["quote_provenance"])

--- a/plugin/tests/test_capture_parity.py
+++ b/plugin/tests/test_capture_parity.py
@@ -49,9 +49,13 @@ _PREV = {
 # - a supersedes link with a free-text target that uniquely matches the prev
 #   decision -> bind_links pair -> supersede-candidate event in events.jsonl;
 # - a verbatim item whose quote is NOT in the transcript -> quote_verified
-#   False -> a #376 rejection row in verification.jsonl. (Deliberately no
-#   verbatim item whose quote WOULD verify: a hit stamps wall-clock
-#   `last_verified`, which would be flaky noise here, not signal.)
+#   False -> a #376 rejection row in verification.jsonl;
+# - a verbatim item whose quote DOES verify. This one was deliberately
+#   absent until #604 because a hit stamped wall-clock `last_verified`.
+#   That workaround never covered the whole hazard — #595 put a wall-clock
+#   receipt on the MISS path too, which is how this guard started failing
+#   1-3 runs in 40 on the case it thought was safe. Verification stamps are
+#   threaded from the transcript clock now, so the hit belongs here.
 _NEW_CP = json.dumps({
     "session_id": SESSION,
     "working_context": {
@@ -59,6 +63,8 @@ _NEW_CP = json.dumps({
         "open_questions": [
             {"text": "PR #6 state", "trust": "verbatim",
              "quote": "this quote appears nowhere in the transcript"},
+            {"text": "what turn 0 said", "trust": "verbatim",
+             "quote": "turn 0"},
         ],
         "recent_decisions": [
             {"text": "postgres replaces the old lookup store",


### PR DESCRIPTION
Closes #604

## What

`verify_quotes` read `datetime.now()` per item for `last_verified` and — since #595 — for the quote receipt's `checked_at` as well. `capture.run` now computes the session-end stamp **before** serializing and threads it through `serialize_strict` into `verify_quotes`, which takes one stamp for the whole pass. A caller with no transcript file keeps the wall-clock fallback.

## Why

This is the unthreaded now-consumer scar 0016 exists to forbid. Every other time that lands on disk is threaded from the transcript's own clock — `created` from the session end, carry's `now` from that stamp — which is what makes two captures of one transcript byte-identical. These stamps were the exception, so they differed whenever the two runs straddled a second boundary.

Beyond the flake: a re-serialize of the same transcript could not reproduce its own receipts, which is the property that makes a receipt re-checkable at all.

## The guard had a blind spot, and it is now closed

`test_capture_parity` had already noticed half of this and worked around it, deliberately omitting a verbatim item whose quote **would** verify because "a hit stamps wall-clock `last_verified`". The workaround never covered the whole hazard — #595 later put a wall-clock receipt on the **miss** path too, which is exactly the case the workaround had chosen as safe. That is how the guard started failing on the scenario it thought was deterministic. The verifying item is now in the fixture, so both outcomes are covered.

## Tests

- `plugin/tests/test_capture_clock_determinism.py` (new, 4 tests, written first): two captures of one transcript stamp identically; the stamps equal the session's own clock rather than merely equalling each other; both receipt outcomes are stamped and pass `valid_quote_receipt`; and a caller with no transcript still stamps via the fallback.
- The determinism test forces the boundary with an advancing fake clock instead of hoping to straddle one. Under it a wall-clock implementation **cannot** produce equal stamps, so the failure reproduces on every run rather than 1-3 times in 40 — a test that only fails by luck proves nothing.
- `plugin/tests/test_capture_parity.py`: the verifying-quote item added, workaround comment replaced with the history.
- Ran the parity guard 40 times after the fix: **40/40 green** (it was 1-3 failures per 40 before).
- Full suite: 3090 passed, 2 skipped.

Note: `mypy` reports one pre-existing "Missing return statement" in `serializer.py`; confirmed present on `main` at the same function before this change.
