### PR TITLE
feat(team): propagate forget tombstones, suppressing by default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,7 +83,7 @@ Opt-in shared-memory mirror. See [docs/team.md](./team.md) for the full workflow
 | `DAIMON_TEAM_DIR` | `~/.daimon/team` | Root of the shared team-memory mirror. |
 | `DAIMON_TEAM_PROJECT` | unset | Explicit logical project path for this machine's sessions (relative, e.g. `core/api-gateway`). Overrides the sidecar's `daimon-team.toml` mapping and the origin-derived fallback when routing checkpoints under `projects/`. |
 | `DAIMON_TEAM_RETENTION_DAYS` | `365` | Read-time age window: teammates' checkpoints older than this many days are skipped when reading. `0` = keep all. Never physically deletes from the shared append-only branch. |
-| `DAIMON_TEAM_APPLY_FORGET` | off | When truthy, a TEAMMATE's published forget tombstone also rewrites this machine's own checkpoints during a typed `daimon team sync`. Default off: a foreign tombstone always suppresses the value on read and in the index, but deleting local belief state from someone else's hash is a decision to make knowingly — the shared branch is append-only, so there is no undo. |
+| `DAIMON_TEAM_APPLY_FORGET` | off | Standing consent for a TEAMMATE's published forget tombstone to rewrite this machine's own checkpoints. NOT sufficient alone — the apply also requires the typed `daimon team sync --apply-forget`, because a bare `daimon team sync` is spawned detached at SessionStart. Default off: a foreign tombstone always suppresses the value on read and in the index, but deleting local belief state from someone else's hash is a decision to make knowingly — the shared branch is append-only, so there is no undo. |
 
 ## Receipts
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,6 +83,7 @@ Opt-in shared-memory mirror. See [docs/team.md](./team.md) for the full workflow
 | `DAIMON_TEAM_DIR` | `~/.daimon/team` | Root of the shared team-memory mirror. |
 | `DAIMON_TEAM_PROJECT` | unset | Explicit logical project path for this machine's sessions (relative, e.g. `core/api-gateway`). Overrides the sidecar's `daimon-team.toml` mapping and the origin-derived fallback when routing checkpoints under `projects/`. |
 | `DAIMON_TEAM_RETENTION_DAYS` | `365` | Read-time age window: teammates' checkpoints older than this many days are skipped when reading. `0` = keep all. Never physically deletes from the shared append-only branch. |
+| `DAIMON_TEAM_APPLY_FORGET` | off | When truthy, a TEAMMATE's published forget tombstone also rewrites this machine's own checkpoints during a typed `daimon team sync`. Default off: a foreign tombstone always suppresses the value on read and in the index, but deleting local belief state from someone else's hash is a decision to make knowingly — the shared branch is append-only, so there is no undo. |
 
 ## Receipts
 

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -2387,14 +2387,22 @@ def _cmd_team_sync(args) -> int:
         return 0
     reports = teamsync.sync()
     # #600 slice B, opt-in: apply teammates' tombstones to THIS machine's own
-    # checkpoints. Here and nowhere else — sync is typed by a person, while
-    # heal runs detached from session start on some hosts, and a deletion
-    # crossing a trust boundary must never arrive unattended. A no-op unless
-    # DAIMON_TEAM_APPLY_FORGET is on; suppression (always on) is elsewhere.
-    applied = store.apply_foreign_tombstones(project_dir=_resolve_project(None))
-    if applied:
-        print(f"applied teammates' forget tombstones to {len(applied)} local "
-              "surface(s) (DAIMON_TEAM_APPLY_FORGET is on)")
+    # checkpoints. TWO gates, and the flag is the load-bearing one: bare
+    # `daimon team sync` is spawned DETACHED at SessionStart by
+    # lib.spawn_team_sync with stdout to DEVNULL, exactly like heal — so a
+    # setting alone would delete local belief state unattended and silently,
+    # which is the failure this design exists to prevent. The hook never
+    # passes --apply-forget, so only a typed command can reach this.
+    # Machine-wide, matching sync's own project-agnostic contract.
+    if getattr(args, "apply_forget", False):
+        if not config.team_apply_forget():
+            print("daimon team: --apply-forget needs DAIMON_TEAM_APPLY_FORGET=1"
+                  " — a teammate's forget rewriting your own checkpoints is"
+                  " opt-in, and there is no undo", file=sys.stderr)
+        else:
+            applied = store.apply_foreign_tombstones(all_projects=True)
+            print(f"applied teammates' forget tombstones to {len(applied)} "
+                  "local surface(s) across all projects")
     # #246: fetched teammate files are fingerprint input — freshen here (the
     # SessionStart hook spawns sync detached, off the prompt path) so the
     # first recall after a fetch doesn't pay the rebuild. Unconditional on
@@ -3730,6 +3738,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--project",
         help="accepted for CLI symmetry; sync is currently project-agnostic "
              "(all own checkpoints sync regardless of project)",
+    )
+    pt_sync.add_argument(
+        "--apply-forget", action="store_true", dest="apply_forget",
+        help="also rewrite THIS machine's checkpoints under teammates' forget "
+             "tombstones (#600). Requires DAIMON_TEAM_APPLY_FORGET=1; typed "
+             "only — the SessionStart hook spawns a bare sync, so this can "
+             "never delete your belief state unattended",
     )
     pt_sync.set_defaults(func=_cmd_team_sync)
     pt_status = team_sub.add_parser(

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1061,6 +1061,10 @@ def _cmd_forget(args) -> int:
     # propagation), not a local rewrite's.
     team_scrubbed = store.scrub_team_copies(content_hash,
                                             project_dir=project)
+    # #600 slice B: publish the deletion itself (hash only) so teammates can
+    # suppress the value without waiting to pull the scrubbed file — and so
+    # a copy THEY extracted independently can be acted on at all.
+    store.publish_tombstone(content_hash, project_dir=project)
     # #599: rows appended BEFORE this forget can carry the value in
     # `item_text`/`status`/`note` — redacted in place, rows never dropped
     # (the one ratified rewrite of the append-only ledger).
@@ -2382,6 +2386,15 @@ def _cmd_team_sync(args) -> int:
         render.render_team_sync(["daimon team: git not found on PATH — sync skipped"])
         return 0
     reports = teamsync.sync()
+    # #600 slice B, opt-in: apply teammates' tombstones to THIS machine's own
+    # checkpoints. Here and nowhere else — sync is typed by a person, while
+    # heal runs detached from session start on some hosts, and a deletion
+    # crossing a trust boundary must never arrive unattended. A no-op unless
+    # DAIMON_TEAM_APPLY_FORGET is on; suppression (always on) is elsewhere.
+    applied = store.apply_foreign_tombstones(project_dir=_resolve_project(None))
+    if applied:
+        print(f"applied teammates' forget tombstones to {len(applied)} local "
+              "surface(s) (DAIMON_TEAM_APPLY_FORGET is on)")
     # #246: fetched teammate files are fingerprint input — freshen here (the
     # SessionStart hook spawns sync detached, off the prompt path) so the
     # first recall after a fetch doesn't pay the rebuild. Unconditional on

--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -199,7 +199,12 @@ def team_apply_forget() -> bool:
     primitive over your memory, and the shared branch is append-only, so
     there is no undo; that is a decision to make knowingly, not one to
     inherit from a `git pull`. Same default-closed posture as #279 scope.
-    Applied during a typed `daimon team sync`, never an unattended path."""
+
+    Standing consent only — it is NOT sufficient on its own. The apply also
+    needs `daimon team sync --apply-forget`, because a bare `daimon team
+    sync` is spawned DETACHED at SessionStart (lib.spawn_team_sync, stdout
+    to DEVNULL) exactly like heal: a setting alone would delete local belief
+    state unattended and silently."""
     return _flag("DAIMON_TEAM_APPLY_FORGET")
 
 

--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -191,6 +191,18 @@ def team_enabled() -> bool:
     return _flag("DAIMON_TEAM")
 
 
+def team_apply_forget() -> bool:
+    """#600 slice B: may a TEAMMATE's forget rewrite this machine's own
+    checkpoints? Default NO — a foreign tombstone suppresses on read and in
+    the index (the admit_foreign posture), but never deletes local belief
+    state. Turning this on hands every member of the sidecar a delete
+    primitive over your memory, and the shared branch is append-only, so
+    there is no undo; that is a decision to make knowingly, not one to
+    inherit from a `git pull`. Same default-closed posture as #279 scope.
+    Applied during a typed `daimon team sync`, never an unattended path."""
+    return _flag("DAIMON_TEAM_APPLY_FORGET")
+
+
 def team_dir() -> Path:
     """Root of the shared team-memory mirror. Sibling of the checkpoint dir under
     ~/.daimon by default; DAIMON_TEAM_DIR overrides (tests point it under tmp so no

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -207,7 +207,11 @@ def _scan_sources():
     root = config.team_dir()
     cutoff = store.team_retention_cutoff()
     self_author = store.project_slug(config.author())
-    forgotten = store.all_forgotten_content_keys()
+    # #600 slice B: teammates' published tombstones gate the index too — an
+    # inbound row is suppressed by ANY tombstone this machine can see, local
+    # or foreign (over-suppression is this path's documented posture).
+    forgotten = (store.all_forgotten_content_keys()
+                 | store.foreign_forgotten_content_keys())
     try:
         remotes = list(root.iterdir())
     except OSError:

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -315,6 +315,14 @@ def _fingerprint() -> str:
         pass
     try:
         paths.extend(config.team_dir().rglob("*.json"))
+        # #600 slice B: a teammate's tombstone ledger is index CONTENT for
+        # the same reason events.jsonl is — _scan_sources suppresses rows
+        # against it — so it must be fingerprint INPUT too. Without this a
+        # pulled tombstone leaves the fingerprint unchanged, no rebuild
+        # runs, and the index keeps serving the value read_team already
+        # withholds. Naming the file .jsonl to dodge the *.json walks is
+        # exactly what made this easy to miss.
+        paths.extend(config.team_dir().rglob(store._TOMBSTONE_NAME))
     except OSError:
         pass
     entries = []

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -502,10 +502,23 @@ def publish_tombstone(content_hash: str, project_dir=None) -> list[str]:
     return written
 
 
+# One ledger is read on the briefing path, so it cannot be unbounded: a
+# teammate publishing a huge file must not make every read pay for it.
+# ~1 MB is ~12k rows, far past any real forget history.
+_MAX_TOMBSTONE_BYTES = 1_000_000
+
+
 def _tombstone_keys(path) -> set[str]:
     keys: set[str] = set()
     try:
-        raw = path.read_text(encoding="utf-8")
+        if path.stat().st_size > _MAX_TOMBSTONE_BYTES:
+            log.warning("daimon team: %s exceeds %d bytes — reading the "
+                        "first %d only", path.name, _MAX_TOMBSTONE_BYTES,
+                        _MAX_TOMBSTONE_BYTES)
+            with path.open("r", encoding="utf-8", errors="replace") as f:
+                raw = f.read(_MAX_TOMBSTONE_BYTES)
+        else:
+            raw = path.read_text(encoding="utf-8")
     except (OSError, ValueError):
         return keys
     for line in raw.splitlines():
@@ -521,23 +534,42 @@ def _tombstone_keys(path) -> set[str]:
 
 
 def foreign_forgotten_content_keys() -> set[str]:
-    """Every tombstone key published by ANY author in the team mirror.
+    """Tombstone keys published by OTHER authors in synced sidecars.
 
-    Includes this author's own rows — harmless, they are already in the
-    local ledger — because filtering by author would make the set depend on
-    identity resolution at read time, and over-inclusion is the fail-safe
-    direction the whole deletion path takes. Never raises."""
+    Own rows are excluded, and that exclusion is load-bearing rather than
+    tidiness: the local ledger is a latest-event-wins fold, so a `reopen`
+    lifts a local tombstone — but a published row has no retraction. Folding
+    your own rows back in would let a key you deliberately reopened suppress
+    the value forever, and (with the opt-in on) re-scrub it on every sync,
+    because reopen removes it from apply_foreign_tombstones' local subtrahend.
+
+    The machine-local mirror is excluded for the same reason: nothing there
+    is another author's, it never syncs, and a solo user with DAIMON_TEAM=1
+    would otherwise poison their own reopen through a dead-end path.
+
+    Bounded on purpose: only `authors/*/` directories inside real sidecars
+    are walked, so a clone's .git object store is never traversed, and each
+    ledger is capped — a teammate cannot make every briefing pay for an
+    unbounded file. Never raises."""
     keys: set[str] = set()
+    own = project_slug(config.author()) or "unknown"
     try:
-        paths = list(config.team_dir().rglob(_TOMBSTONE_NAME))
+        remotes = [d for d in config.team_dir().iterdir()
+                   if d.is_dir() and d.name != _TEAM_LOCAL_REMOTE]
     except OSError:
         return keys
-    for path in paths:
-        keys |= _tombstone_keys(path)
+    for remote in remotes:
+        try:
+            paths = [p for p in remote.rglob(f"authors/*/{_TOMBSTONE_NAME}")
+                     if p.parent.name != own]
+        except OSError:
+            continue
+        for path in paths:
+            keys |= _tombstone_keys(path)
     return keys
 
 
-def apply_foreign_tombstones(project_dir=None) -> list[str]:
+def apply_foreign_tombstones(project_dir=None, all_projects=False) -> list[str]:
     """Opt-in (#600 slice B): rewrite THIS machine's own checkpoints under
     a teammate's tombstone.
 
@@ -552,10 +584,22 @@ def apply_foreign_tombstones(project_dir=None) -> list[str]:
     forget would be work without effect."""
     if not config.team_apply_forget():
         return []
-    keys = foreign_forgotten_content_keys() - forgotten_content_keys(project_dir)
+    if all_projects:
+        try:
+            targets = [d.name for d in config.checkpoint_dir().iterdir()
+                       if d.is_dir() and d.name != ".chunk-cache"]
+        except OSError:
+            targets = []
+    else:
+        targets = [project_dir]
+    foreign = foreign_forgotten_content_keys()
     rewritten: list[str] = []
-    for key in sorted(keys):
-        rewritten.extend(scrub_content_key(key, project_dir=project_dir))
+    for target in targets:
+        # Per project, minus what that project already tombstoned locally:
+        # re-applying a local forget is work without effect, and a project
+        # that REOPENED a value must not have it scrubbed by a stale row.
+        for key in sorted(foreign - forgotten_content_keys(target)):
+            rewritten.extend(scrub_content_key(key, project_dir=target))
     return rewritten
 
 

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -445,6 +445,120 @@ def scrub_team_copies(content_hash: str, project_dir=None) -> list[str]:
     return rewritten
 
 
+# #600 slice B: the per-author tombstone ledger published into the team
+# mirror. `.jsonl`, so every `*.json` walk in the codebase (read_team,
+# privacy's team scan, recall's fingerprint) steps over it by construction,
+# and it sits INSIDE the own-author dir so teamsync._commit_own carries it
+# with no protocol change.
+_TOMBSTONE_NAME = "tombstones.jsonl"
+
+
+def _own_team_dirs(project_dir=None) -> list:
+    """This author's directories in every sidecar the project routes to —
+    the same identity and routing _dual_write_team writes checkpoints with,
+    so a published tombstone lands where the sync already looks."""
+    own = project_slug(config.author()) or "unknown"
+    segs = teamproject.resolve(project_dir)
+    out = []
+    for slug in _team_write_slugs(project_dir):
+        base = config.team_dir() / slug
+        if segs:
+            base = base.joinpath("projects", *segs)
+        out.append(base / "authors" / own)
+    return out
+
+
+def publish_tombstone(content_hash: str, project_dir=None) -> list[str]:
+    """Publish a forget so teammates can act on it (#600 slice B).
+
+    A hash-only row — {ts, key, author}, never the text (#321) — appended
+    to the author's own tombstone ledger in each sidecar this project
+    routes to. Append-only and idempotent: a key already present is not
+    re-appended, so repeated forgets of the same value do not grow the
+    file, and re-publishing after a pull is a no-op.
+
+    Gated on config.team_enabled(): nothing is published into a team the
+    user has not opted into. Best-effort — a failed publish never costs the
+    local deletion, which already happened by the time this runs."""
+    if not content_hash or not config.team_enabled():
+        return []
+    written: list[str] = []
+    row = json.dumps({
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "key": content_hash,
+        "author": config.author(),
+    }, ensure_ascii=False)
+    for adir in _own_team_dirs(project_dir):
+        path = adir / _TOMBSTONE_NAME
+        try:
+            if path.exists() and content_hash in _tombstone_keys(path):
+                continue
+            adir.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as f:
+                f.write(row + "\n")
+        except OSError:
+            continue
+        written.append(str(path))
+    return written
+
+
+def _tombstone_keys(path) -> set[str]:
+    keys: set[str] = set()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return keys
+    for line in raw.splitlines():
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue          # a corrupt row must not hide the rest
+        if isinstance(row, dict):
+            key = row.get("key")
+            if isinstance(key, str) and key.strip():
+                keys.add(key.strip())
+    return keys
+
+
+def foreign_forgotten_content_keys() -> set[str]:
+    """Every tombstone key published by ANY author in the team mirror.
+
+    Includes this author's own rows — harmless, they are already in the
+    local ledger — because filtering by author would make the set depend on
+    identity resolution at read time, and over-inclusion is the fail-safe
+    direction the whole deletion path takes. Never raises."""
+    keys: set[str] = set()
+    try:
+        paths = list(config.team_dir().rglob(_TOMBSTONE_NAME))
+    except OSError:
+        return keys
+    for path in paths:
+        keys |= _tombstone_keys(path)
+    return keys
+
+
+def apply_foreign_tombstones(project_dir=None) -> list[str]:
+    """Opt-in (#600 slice B): rewrite THIS machine's own checkpoints under
+    a teammate's tombstone.
+
+    Off by default and deliberately so — see config.team_apply_forget. When
+    off this is a pure no-op that returns [], which is the whole authority
+    guarantee: a teammate writing a hash cannot delete local belief state,
+    it can only stop that value being read (the suppression path, which is
+    always on).
+
+    Returns the surfaces rewritten. The keys are the foreign ledger minus
+    what this project already tombstoned locally — re-applying a local
+    forget would be work without effect."""
+    if not config.team_apply_forget():
+        return []
+    keys = foreign_forgotten_content_keys() - forgotten_content_keys(project_dir)
+    rewritten: list[str] = []
+    for key in sorted(keys):
+        rewritten.extend(scrub_content_key(key, project_dir=project_dir))
+    return rewritten
+
+
 def checkpoints_written_since(cutoff: float) -> int:
     """How many per-session checkpoints were WRITTEN since `cutoff` (epoch
     seconds), counted by file mtime — the write-side signal for the silent-
@@ -1057,7 +1171,11 @@ def read_team(project_dir=None) -> list[tuple[str, dict]]:
     want_slug = project_slug(project_dir)
     cutoff = team_retention_cutoff()
     candidates = teamproject.read_candidates(project_dir)
-    forgotten = forgotten_content_keys(project_dir)
+    # #600 slice B: a teammate's published tombstone suppresses their value
+    # here too. Always on — suppression is not deletion, it costs a teammate
+    # nothing but the sight of a value they asked to be forgotten, and their
+    # own scrubbed file may not have reached this clone yet.
+    forgotten = forgotten_content_keys(project_dir) | foreign_forgotten_content_keys()
     self_author = project_slug(config.author())
     # author-slug (dir identity, one per author) -> (recency, author, checkpoint)
     best: dict[str, tuple[float, str, dict]] = {}

--- a/plugin/daimon_briefing/surfaces.py
+++ b/plugin/daimon_briefing/surfaces.py
@@ -111,6 +111,12 @@ SURFACES: tuple[Surface, ...] = (
             False, "exempt-no-plaintext", "none"),
     Surface("team/{remote}/daimon-team.toml", "teamsync.init",
             False, "exempt-no-plaintext", "none"),
+    # #600 slice B: the published tombstone ledger — {ts, key, author}, the
+    # canonical hash and never the text (#321), the same posture
+    # forget-hits.jsonl takes locally. Deliberately BEFORE the json entry
+    # and named `.jsonl` so no `*.json` walk claims it.
+    Surface("team/{remote}/**/tombstones.jsonl", "store.publish_tombstone",
+            False, "exempt-no-plaintext", "none"),
     Surface("team/{remote}/**/*.json", "store._dual_write_team",
             True, "known-gap", "audit", issue="#600"),
     Surface("team/{remote}/.git/**", "git (teamsync subprocess)",

--- a/plugin/tests/test_team_tombstone_propagation.py
+++ b/plugin/tests/test_team_tombstone_propagation.py
@@ -283,6 +283,92 @@ def test_the_flag_refuses_without_the_standing_consent(
     assert "DAIMON_TEAM_APPLY_FORGET" in capsys.readouterr().err
 
 
+# ---- a broken sidecar degrades, it never aborts ---------------------------
+#
+# Every path here runs on the briefing/forget hot path against files another
+# machine wrote and git delivered. None of them may raise, and none may cost
+# more than the broken thing itself.
+
+
+def test_a_failed_publish_never_costs_the_local_deletion(
+        tmp_checkpoint_dir, tmp_path, monkeypatch):
+    """Publishing runs AFTER the local forget and is best-effort. If the
+    sidecar cannot be written at all — a read-only mount, or a stale file
+    sitting where the tree belongs — the teammate simply does not learn.
+    The deletion this machine was actually asked for still happened."""
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    blocked = tmp_path / "team-is-a-file"
+    blocked.write_text("a file where the mirror root should be",
+                       encoding="utf-8")
+    monkeypatch.setenv("DAIMON_TEAM_DIR", str(blocked))
+    store.write_checkpoint("S1", _cp("S1", [THEIRS, MINE]),
+                           project_dir=PROJECT)
+    assert _local_plaintext_present(), \
+        "seed failed — the canary must be on disk BEFORE we assert it is gone"
+    assert cli.main(["forget", THEIRS, "--project", PROJECT]) == 0
+    assert store.publish_tombstone(KEY, project_dir=PROJECT) == [], \
+        "an unwritable sidecar must report nothing published, not raise"
+    assert not _local_plaintext_present(), \
+        "the local forget must not be undone by a failed publish"
+
+
+def test_an_unreadable_ledger_never_hides_the_other_authors(
+        tmp_checkpoint_dir):
+    """A ledger that cannot be READ — here a directory left where the file
+    belongs, the shape a half-applied pull leaves behind — is skipped, not
+    fatal. One broken author's dir must not blind this machine to every
+    other teammate's deletion."""
+    _teammate_publishes_a_tombstone(remote="team-a", author="grace")
+    broken = (config.team_dir() / "team-a" / "authors" / "kay"
+              / store._TOMBSTONE_NAME)
+    broken.mkdir(parents=True)
+    assert store.foreign_forgotten_content_keys() == {KEY}
+
+
+def test_a_remote_whose_walk_explodes_costs_only_its_own_keys(
+        tmp_checkpoint_dir, monkeypatch):
+    """`foreign_forgotten_content_keys` documents that it never raises, and
+    it is called on the read path, so a sidecar that cannot be walked at all
+    must cost only ITS keys — the briefing still suppresses everything the
+    reachable remotes published. Injected rather than staged on disk:
+    pathlib swallows scandir errors during a walk, so no filesystem state
+    reaches this branch."""
+    _teammate_publishes_a_tombstone(remote="team-a", author="grace")
+    other = normalize.content_key("zqxothercanary9182 staging db password")
+    hopper = config.team_dir() / "team-b" / "authors" / "hopper"
+    hopper.mkdir(parents=True)
+    (hopper / store._TOMBSTONE_NAME).write_text(
+        json.dumps({"ts": "2026-08-02T00:00:00Z", "key": other,
+                    "author": "hopper"}) + "\n", encoding="utf-8")
+    assert store.foreign_forgotten_content_keys() == {KEY, other}, \
+        "seed failed — both remotes must be readable before one is broken"
+
+    real_rglob = type(config.team_dir()).rglob
+
+    def explode_on_team_a(self, pattern):
+        if self.name == "team-a":
+            raise OSError("EIO reading the sidecar")
+        return real_rglob(self, pattern)
+
+    monkeypatch.setattr(type(config.team_dir()), "rglob", explode_on_team_a)
+    assert store.foreign_forgotten_content_keys() == {other}
+
+
+def test_apply_across_all_projects_survives_a_missing_checkpoint_dir(
+        tmp_checkpoint_dir, monkeypatch):
+    """`--apply-forget` is machine-wide, and a machine can have pulled the
+    sidecar before it ever wrote a checkpoint of its own. Nothing to rewrite
+    is not an error."""
+    monkeypatch.setenv("DAIMON_TEAM_APPLY_FORGET", "1")
+    _teammate_publishes_a_tombstone()
+    assert store.foreign_forgotten_content_keys() == {KEY}, \
+        "seed failed — an empty foreign set would make the result vacuous"
+    assert not tmp_checkpoint_dir.exists(), \
+        "nothing has been written here, so there is no store to walk"
+    assert store.apply_foreign_tombstones(all_projects=True) == []
+
+
 # ---- the registry knows about the new file -------------------------------
 
 

--- a/plugin/tests/test_team_tombstone_propagation.py
+++ b/plugin/tests/test_team_tombstone_propagation.py
@@ -44,9 +44,13 @@ def _cp(sid, texts, author=None):
     return payload
 
 
-def _teammate_publishes_a_tombstone(remote="local", author="Grace"):
+def _teammate_publishes_a_tombstone(remote="team-a", author="grace"):
     """Grace's sidecar state as it lands here after a pull: her checkpoint
-    plus the tombstone row her forget published."""
+    plus the tombstone row her forget published.
+
+    A real remote, never `local`: the machine-local mirror holds only this
+    machine's own writes, never syncs, and is deliberately excluded from
+    the foreign set so a solo user cannot poison their own reopen."""
     adir = config.team_dir() / remote / "authors" / author
     adir.mkdir(parents=True, exist_ok=True)
     (adir / "SG.json").write_text(
@@ -122,6 +126,43 @@ def test_no_team_dir_yields_no_foreign_keys(tmp_checkpoint_dir):
     assert store.foreign_forgotten_content_keys() == set()
 
 
+def test_own_rows_are_never_read_back_as_foreign(tmp_checkpoint_dir,
+                                                 monkeypatch):
+    """Adversarial finding (MAJOR): a published row has no retraction, but a
+    local `reopen` lifts the local tombstone — so folding your own rows back
+    in would let a value you deliberately reopened stay suppressed forever,
+    and (with the opt-in on) be re-scrubbed on every sync, because reopen
+    also removes it from the subtrahend."""
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    adir = config.team_dir() / "team-a" / "authors" / "ada"
+    adir.mkdir(parents=True)
+    (adir / store._TOMBSTONE_NAME).write_text(
+        json.dumps({"ts": "2026-08-02T00:00:00Z", "key": KEY,
+                    "author": "ada"}) + "\n", encoding="utf-8")
+    assert store.foreign_forgotten_content_keys() == set()
+
+
+def test_the_local_mirror_is_never_a_foreign_source(tmp_checkpoint_dir):
+    """A solo user with DAIMON_TEAM=1 publishes into team/local, which no
+    teammate ever sees — it must not read back as someone else's deletion."""
+    _teammate_publishes_a_tombstone(remote="local", author="someone")
+    assert store.foreign_forgotten_content_keys() == set()
+
+
+def test_an_oversized_ledger_is_bounded(tmp_checkpoint_dir, monkeypatch):
+    """One ledger is read on the briefing path, so a teammate publishing a
+    huge file must not make every read pay for it."""
+    monkeypatch.setattr(store, "_MAX_TOMBSTONE_BYTES", 200)
+    adir = config.team_dir() / "team-a" / "authors" / "grace"
+    adir.mkdir(parents=True)
+    rows = [json.dumps({"ts": "2026-08-02T00:00:00Z", "key": f"{i:016x}",
+                        "author": "grace"}) for i in range(50)]
+    (adir / store._TOMBSTONE_NAME).write_text("\n".join(rows) + "\n",
+                                              encoding="utf-8")
+    keys = store.foreign_forgotten_content_keys()
+    assert 0 < len(keys) < 50, len(keys)
+
+
 # ---- default A: suppress, never rewrite ----------------------------------
 
 
@@ -193,19 +234,53 @@ def test_opt_in_scrubs_local_copies(tmp_checkpoint_dir, monkeypatch):
     assert texts == [MINE], "only the tombstoned value goes"
 
 
-def test_opt_in_applies_during_a_typed_sync_not_an_unattended_path(
-        tmp_checkpoint_dir, monkeypatch, capsys):
-    """`daimon team sync` is typed by a person. heal runs detached from
-    session start on some hosts, and a cross-trust deletion must never
-    arrive unattended."""
+def _seed_for_apply(monkeypatch):
     monkeypatch.setenv("DAIMON_TEAM_APPLY_FORGET", "1")
     store.write_checkpoint("S1", _cp("S1", [THEIRS, MINE]),
                            project_dir=PROJECT)
-    _teammate_publishes_a_tombstone()
-    assert cli.main(["heal"]) == 0
+    _teammate_publishes_a_tombstone(remote="team-a", author="grace")
     assert any(THEIRS in p.read_text()
-               for p in store.project_surfaces(PROJECT)), \
-        "heal must not apply a teammate's deletion"
+               for p in store.project_surfaces(PROJECT)), "seed failed"
+
+
+def _local_plaintext_present():
+    return any(THEIRS in p.read_text()
+               for p in store.project_surfaces(PROJECT))
+
+
+def test_a_bare_sync_never_applies_it(tmp_checkpoint_dir, monkeypatch):
+    """THE authority test. `daimon team sync` with no flag is what
+    lib.spawn_team_sync fires DETACHED at SessionStart with stdout to
+    DEVNULL — the same shape as heal. If the setting alone were enough, a
+    teammate's hash would delete local belief state unattended and
+    silently, which is the whole failure this design exists to prevent."""
+    _seed_for_apply(monkeypatch)
+    assert cli.main(["team", "sync"]) == 0
+    assert _local_plaintext_present(), \
+        "a bare (hook-spawned) sync must never apply a teammate's deletion"
+
+
+def test_heal_never_applies_it(tmp_checkpoint_dir, monkeypatch):
+    _seed_for_apply(monkeypatch)
+    assert cli.main(["heal"]) == 0
+    assert _local_plaintext_present()
+
+
+def test_the_typed_flag_applies_it(tmp_checkpoint_dir, monkeypatch, capsys):
+    """The positive half: the flag is the deliberate act, and it reports."""
+    _seed_for_apply(monkeypatch)
+    assert cli.main(["team", "sync", "--apply-forget"]) == 0
+    assert not _local_plaintext_present()
+    assert "applied teammates' forget tombstones" in capsys.readouterr().out
+
+
+def test_the_flag_refuses_without_the_standing_consent(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    _seed_for_apply(monkeypatch)
+    monkeypatch.delenv("DAIMON_TEAM_APPLY_FORGET")
+    assert cli.main(["team", "sync", "--apply-forget"]) == 0
+    assert _local_plaintext_present()
+    assert "DAIMON_TEAM_APPLY_FORGET" in capsys.readouterr().err
 
 
 # ---- the registry knows about the new file -------------------------------

--- a/plugin/tests/test_team_tombstone_propagation.py
+++ b/plugin/tests/test_team_tombstone_propagation.py
@@ -1,0 +1,218 @@
+"""#600 slice B: a teammate's forget reaches this machine.
+
+Slice A scrubbed the author's OWN mirror copies, and because `_commit_own`
+stages modifications those converge to teammates through git on the next
+sync. What never travelled is the DELETION ITSELF: store's tombstone
+readers walk config.checkpoint_dir() only, so a teammate's forget is
+invisible here — their scrubbed file arrives eventually, but nothing tells
+this machine that the value is dead, and nothing touches a copy this
+machine extracted independently.
+
+Propagation is a hash-only row published into the author's own sidecar dir
+(so `_commit_own` carries it with no teamsync change, and #321 holds: the
+ledger records the key, never the text).
+
+Authority is the whole design. A foreign tombstone SUPPRESSES by default —
+reads and the recall index, exactly what admit_foreign already does with
+local tombstones — and never rewrites this machine's belief state. Scrubbing
+local checkpoints from a teammate's hash is opt-in
+(DAIMON_TEAM_APPLY_FORGET), applied during a TYPED `daimon team sync` rather
+than an unattended path, because the shared branch is append-only and a
+deletion that crosses a trust boundary has no undo.
+"""
+import json
+
+from daimon_briefing import cli, config, normalize, store, surfaces
+
+PROJECT = "/p/tombstone-propagation"
+MINE = "a decision this machine extracted on its own"
+THEIRS = "zqxsharedcanary4417 the vault root token is rotating tonight"
+
+KEY = normalize.content_key(THEIRS)
+
+
+def _cp(sid, texts, author=None):
+    payload = {
+        "session_id": sid,
+        "created": "2026-08-01T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": t, "trust": "inferred"} for t in texts]},
+    }
+    if author:
+        payload["author"] = author
+        payload["project_slug"] = store.project_slug(PROJECT)
+    return payload
+
+
+def _teammate_publishes_a_tombstone(remote="local", author="Grace"):
+    """Grace's sidecar state as it lands here after a pull: her checkpoint
+    plus the tombstone row her forget published."""
+    adir = config.team_dir() / remote / "authors" / author
+    adir.mkdir(parents=True, exist_ok=True)
+    (adir / "SG.json").write_text(
+        json.dumps(_cp("SG", [MINE], author=author), ensure_ascii=False),
+        encoding="utf-8")
+    (adir / store._TOMBSTONE_NAME).write_text(
+        json.dumps({"ts": "2026-08-02T00:00:00Z", "key": KEY,
+                    "author": author}) + "\n", encoding="utf-8")
+    return adir
+
+
+# ---- publishing: hash only, in a path the sync already carries -----------
+
+
+def test_forget_publishes_a_hash_only_tombstone_into_the_own_author_dir(
+        tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    store.write_checkpoint("S1", _cp("S1", [THEIRS, MINE]),
+                           project_dir=PROJECT)
+    assert cli.main(["forget", THEIRS, "--project", PROJECT]) == 0
+    published = list(config.team_dir().rglob(store._TOMBSTONE_NAME))
+    assert published, "forget published no tombstone for teammates"
+    for path in published:
+        assert "authors" in path.parts, "must sit in an own-author dir"
+        body = path.read_text()
+        assert THEIRS not in body, "#321: the key, never the text"
+        row = json.loads(body.splitlines()[0])
+        assert row["key"] == KEY
+        assert set(row) == {"ts", "key", "author"}
+
+
+def test_publishing_is_append_only_and_idempotent(tmp_checkpoint_dir,
+                                                  monkeypatch):
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "Ada")
+    store.write_checkpoint("S1", _cp("S1", [THEIRS, MINE]),
+                           project_dir=PROJECT)
+    assert cli.main(["forget", THEIRS, "--project", PROJECT]) == 0
+    path = next(iter(config.team_dir().rglob(store._TOMBSTONE_NAME)))
+    first = path.read_text()
+    store.publish_tombstone(KEY, project_dir=PROJECT)
+    assert path.read_text() == first, "a repeat publish must not duplicate"
+
+
+def test_publishing_is_skipped_when_team_mirroring_is_off(
+        tmp_checkpoint_dir, monkeypatch):
+    """Nothing is published into a team the user has not opted into."""
+    monkeypatch.delenv("DAIMON_TEAM", raising=False)
+    store.write_checkpoint("S1", _cp("S1", [THEIRS, MINE]),
+                           project_dir=PROJECT)
+    assert cli.main(["forget", THEIRS, "--project", PROJECT]) == 0
+    assert list(config.team_dir().rglob(store._TOMBSTONE_NAME)) == []
+
+
+# ---- reading a teammate's tombstone --------------------------------------
+
+
+def test_foreign_keys_are_read_from_every_author_dir(tmp_checkpoint_dir):
+    _teammate_publishes_a_tombstone()
+    assert KEY in store.foreign_forgotten_content_keys()
+
+
+def test_foreign_keys_survive_a_corrupt_or_unreadable_row(tmp_checkpoint_dir):
+    adir = _teammate_publishes_a_tombstone()
+    with (adir / store._TOMBSTONE_NAME).open("a", encoding="utf-8") as f:
+        f.write("not json at all\n")
+        f.write(json.dumps({"ts": "x"}) + "\n")      # no key
+    assert KEY in store.foreign_forgotten_content_keys()
+
+
+def test_no_team_dir_yields_no_foreign_keys(tmp_checkpoint_dir):
+    assert store.foreign_forgotten_content_keys() == set()
+
+
+# ---- default A: suppress, never rewrite ----------------------------------
+
+
+def test_teammate_content_under_a_foreign_tombstone_is_withheld_on_read(
+        tmp_checkpoint_dir, monkeypatch):
+    """Their own copy may not have been scrubbed yet (they have not synced,
+    or we have not pulled) — the value must still not reach a briefing.
+
+    Seeded under a real remote, not `local`: the machine-local mirror is
+    ungated by design (it holds this machine's own writes), so a teammate
+    can only ever arrive through a synced clone."""
+    # Same fixture shape as test_store's foreign-read tests: a .git marker
+    # makes the dir a real synced remote, and the env grant is honored with
+    # a single clone.
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/x")
+    remote = config.team_dir() / "team-a"
+    (remote / ".git").mkdir(parents=True, exist_ok=True)
+    adir = remote / "projects" / "core" / "x" / "authors" / "grace"
+    adir.mkdir(parents=True, exist_ok=True)
+    blob = _cp("SG", [THEIRS, MINE], author="grace")
+    blob["team_project"] = "core/x"
+    (adir / "SG.json").write_text(json.dumps(blob, ensure_ascii=False),
+                                  encoding="utf-8")
+    (adir / store._TOMBSTONE_NAME).write_text(
+        json.dumps({"ts": "2026-08-02T00:00:00Z", "key": KEY,
+                    "author": "grace"}) + "\n", encoding="utf-8")
+    seen = store.read_team(project_dir=PROJECT)   # [(author, checkpoint), …]
+    texts = [i.get("text") for _author, cp in seen
+             for section, key in store._ITEM_LISTS
+             for i in ((cp or {}).get(section) or {}).get(key) or []]
+    assert texts, "the teammate's checkpoint must be read at all"
+    assert THEIRS not in texts
+
+
+def test_default_never_rewrites_this_machines_own_checkpoints(
+        tmp_checkpoint_dir):
+    """The authority rule: a teammate writing a hash cannot delete local
+    belief state. The plaintext stays until the user opts in."""
+    store.write_checkpoint("S1", _cp("S1", [THEIRS, MINE]),
+                           project_dir=PROJECT)
+    _teammate_publishes_a_tombstone()
+    before = [p.read_text() for p in store.project_surfaces(PROJECT)]
+    assert store.apply_foreign_tombstones(project_dir=PROJECT) == []
+    after = [p.read_text() for p in store.project_surfaces(PROJECT)]
+    assert after == before
+
+
+# ---- opt-in B: scrub, only when switched on ------------------------------
+
+
+def test_opt_in_is_off_by_default(monkeypatch):
+    monkeypatch.delenv("DAIMON_TEAM_APPLY_FORGET", raising=False)
+    assert config.team_apply_forget() is False
+
+
+def test_opt_in_scrubs_local_copies(tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_TEAM_APPLY_FORGET", "1")
+    store.write_checkpoint("S1", _cp("S1", [THEIRS, MINE]),
+                           project_dir=PROJECT)
+    _teammate_publishes_a_tombstone()
+    rewritten = store.apply_foreign_tombstones(project_dir=PROJECT)
+    assert rewritten, "opt-in must reach local surfaces"
+    residue = [str(p) for p in store.project_surfaces(PROJECT)
+               if THEIRS in p.read_text()]
+    assert residue == [], f"plaintext survives in {residue}"
+    kept = store.read_latest(project_dir=PROJECT, fallback=False)
+    texts = [i["text"] for i in
+             kept["working_context"]["recent_decisions"]]
+    assert texts == [MINE], "only the tombstoned value goes"
+
+
+def test_opt_in_applies_during_a_typed_sync_not_an_unattended_path(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    """`daimon team sync` is typed by a person. heal runs detached from
+    session start on some hosts, and a cross-trust deletion must never
+    arrive unattended."""
+    monkeypatch.setenv("DAIMON_TEAM_APPLY_FORGET", "1")
+    store.write_checkpoint("S1", _cp("S1", [THEIRS, MINE]),
+                           project_dir=PROJECT)
+    _teammate_publishes_a_tombstone()
+    assert cli.main(["heal"]) == 0
+    assert any(THEIRS in p.read_text()
+               for p in store.project_surfaces(PROJECT)), \
+        "heal must not apply a teammate's deletion"
+
+
+# ---- the registry knows about the new file -------------------------------
+
+
+def test_registry_declares_the_tombstone_ledger():
+    entry = surfaces.match(f"team/{{remote}}/authors/ada/{store._TOMBSTONE_NAME}")
+    assert entry is not None
+    assert entry.plaintext is False
+    assert entry.delete == "exempt-no-plaintext"

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -87,6 +87,7 @@ Opt-in shared-memory mirror. See [docs/team.md](../team/team.md) for the full wo
 | `DAIMON_TEAM_DIR` | `~/.daimon/team` | Root of the shared team-memory mirror. |
 | `DAIMON_TEAM_PROJECT` | unset | Explicit logical project path for this machine's sessions (relative, e.g. `core/api-gateway`). Overrides the sidecar's `daimon-team.toml` mapping and the origin-derived fallback when routing checkpoints under `projects/`. |
 | `DAIMON_TEAM_RETENTION_DAYS` | `365` | Read-time age window: teammates' checkpoints older than this many days are skipped when reading. `0` = keep all. Never physically deletes from the shared append-only branch. |
+| `DAIMON_TEAM_APPLY_FORGET` | off | When truthy, a TEAMMATE's published forget tombstone also rewrites this machine's own checkpoints during a typed `daimon team sync`. Default off: a foreign tombstone always suppresses the value on read and in the index, but deleting local belief state from someone else's hash is a decision to make knowingly — the shared branch is append-only, so there is no undo. |
 
 ## Receipts
 

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -87,7 +87,7 @@ Opt-in shared-memory mirror. See [docs/team.md](../team/team.md) for the full wo
 | `DAIMON_TEAM_DIR` | `~/.daimon/team` | Root of the shared team-memory mirror. |
 | `DAIMON_TEAM_PROJECT` | unset | Explicit logical project path for this machine's sessions (relative, e.g. `core/api-gateway`). Overrides the sidecar's `daimon-team.toml` mapping and the origin-derived fallback when routing checkpoints under `projects/`. |
 | `DAIMON_TEAM_RETENTION_DAYS` | `365` | Read-time age window: teammates' checkpoints older than this many days are skipped when reading. `0` = keep all. Never physically deletes from the shared append-only branch. |
-| `DAIMON_TEAM_APPLY_FORGET` | off | When truthy, a TEAMMATE's published forget tombstone also rewrites this machine's own checkpoints during a typed `daimon team sync`. Default off: a foreign tombstone always suppresses the value on read and in the index, but deleting local belief state from someone else's hash is a decision to make knowingly — the shared branch is append-only, so there is no undo. |
+| `DAIMON_TEAM_APPLY_FORGET` | off | Standing consent for a TEAMMATE's published forget tombstone to rewrite this machine's own checkpoints. NOT sufficient alone — the apply also requires the typed `daimon team sync --apply-forget`, because a bare `daimon team sync` is spawned detached at SessionStart. Default off: a foreign tombstone always suppresses the value on read and in the index, but deleting local belief state from someone else's hash is a decision to make knowingly — the shared branch is append-only, so there is no undo. |
 
 ## Receipts
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
@@ -90,6 +90,7 @@ para el flujo completo.
 | `DAIMON_TEAM_DIR` | `~/.daimon/team` | Raíz del mirror de memoria de equipo compartida. |
 | `DAIMON_TEAM_PROJECT` | sin definir | Ruta lógica de proyecto explícita para las sesiones de esta máquina (relativa, p. ej. `core/api-gateway`). Prevalece sobre el mapeo de `daimon-team.toml` del sidecar y sobre el fallback derivado del origin al enrutar checkpoints bajo `projects/`. |
 | `DAIMON_TEAM_RETENTION_DAYS` | `365` | Ventana de edad al leer: los checkpoints de compañeros más viejos que esta cantidad de días se omiten al leer. `0` = conservar todos. Nunca borra físicamente de la rama compartida de solo-anexado. |
+| `DAIMON_TEAM_APPLY_FORGET` | off | Cuando es verdadero, el tombstone de olvido publicado por un COMPAÑERO también reescribe los checkpoints propios de esta máquina durante un `daimon team sync` escrito a mano. Por defecto apagado: un tombstone ajeno siempre suprime el valor al leer y en el índice, pero borrar estado local a partir del hash de otra persona es una decisión que se toma a conciencia — la rama compartida es de solo-anexado, así que no hay vuelta atrás. |
 
 ## Receipts
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
@@ -90,7 +90,7 @@ para el flujo completo.
 | `DAIMON_TEAM_DIR` | `~/.daimon/team` | Raíz del mirror de memoria de equipo compartida. |
 | `DAIMON_TEAM_PROJECT` | sin definir | Ruta lógica de proyecto explícita para las sesiones de esta máquina (relativa, p. ej. `core/api-gateway`). Prevalece sobre el mapeo de `daimon-team.toml` del sidecar y sobre el fallback derivado del origin al enrutar checkpoints bajo `projects/`. |
 | `DAIMON_TEAM_RETENTION_DAYS` | `365` | Ventana de edad al leer: los checkpoints de compañeros más viejos que esta cantidad de días se omiten al leer. `0` = conservar todos. Nunca borra físicamente de la rama compartida de solo-anexado. |
-| `DAIMON_TEAM_APPLY_FORGET` | off | Cuando es verdadero, el tombstone de olvido publicado por un COMPAÑERO también reescribe los checkpoints propios de esta máquina durante un `daimon team sync` escrito a mano. Por defecto apagado: un tombstone ajeno siempre suprime el valor al leer y en el índice, pero borrar estado local a partir del hash de otra persona es una decisión que se toma a conciencia — la rama compartida es de solo-anexado, así que no hay vuelta atrás. |
+| `DAIMON_TEAM_APPLY_FORGET` | off | Consentimiento permanente para que el tombstone de olvido publicado por un COMPAÑERO reescriba los checkpoints propios de esta máquina. NO alcanza por sí solo — el borrado además exige el `daimon team sync --apply-forget` escrito a mano, porque un `daimon team sync` pelado se lanza en segundo plano al iniciar la sesión. Por defecto apagado: un tombstone ajeno siempre suprime el valor al leer y en el índice, pero borrar estado local a partir del hash de otra persona es una decisión que se toma a conciencia — la rama compartida es de solo-anexado, así que no hay vuelta atrás. |
 
 ## Receipts
 


### PR DESCRIPTION
Refs #600

## What

`daimon forget` now publishes the deletion itself so teammates can act on it: a hash-only row — `{ts, key, author}`, never the text (#321) — appended to the author's own sidecar directory, which `teamsync._commit_own` already carries, so the sync protocol is unchanged. Publishing is gated on `DAIMON_TEAM` and is idempotent.

Slice A had already covered more than the issue assumed: because `_commit_own` stages modifications, an author's scrubbed mirror files converge to teammates through git on the next sync. What never travelled was the deletion itself — every tombstone reader walked `config.checkpoint_dir()` only — so nothing told this machine a value was dead, and nothing could act on a copy this machine extracted independently.

## Authority is the design

A foreign tombstone **suppresses** by default: `store.read_team` and the recall index gate against it, exactly what `admit_foreign` already does with local tombstones. It never rewrites local belief state.

Scrubbing this machine's own checkpoints from a teammate's hash needs **two** gates: `DAIMON_TEAM_APPLY_FORGET=1` as standing consent, and the typed `daimon team sync --apply-forget` as the deliberate act. Both are required because the shared branch is append-only and there is no undo.

The flag is not ceremony. A bare `daimon team sync` is spawned **detached at SessionStart** by `lib.spawn_team_sync` with stdout to `DEVNULL` — the same shape as `heal`. A setting alone would have deleted local belief state unattended and silently. The hook never passes the flag.

## Tests

- `plugin/tests/test_team_tombstone_propagation.py` (new, 18 tests, written first): publishing is hash-only, append-only, idempotent, and skipped when team mirroring is off; foreign keys are read across author dirs and survive corrupt rows; a teammate's tombstoned value is withheld on read even before their scrubbed file arrives; the default never rewrites local checkpoints; own rows and the machine-local mirror are never read back as foreign; an oversized ledger is bounded; a bare sync and `heal` never apply, the typed flag does and reports, and the flag refuses without the standing consent; the registry declares the ledger.
- Full suite: 3104 passed, 2 skipped.

## Adversarial review

Two blockers, both of which invalidated a claim I had made without checking it, and both fixed here.

The first is the `spawn_team_sync` finding above — I wrote "sync is typed by a person" into code comments, a config docstring, and three doc tables without verifying it, and it was false. The second: `tombstones.jsonl` was not part of `recall._fingerprint`, so a pulled tombstone left the fingerprint unchanged, no rebuild ran, and the index kept serving a value `read_team` already withheld — the primary case the feature exists for. `events.jsonl` is fingerprint input for exactly this reason, and naming the ledger `.jsonl` to dodge the `*.json` walks is what made it easy to miss.

Also fixed: own rows are excluded from the foreign set, because a published row has no retraction while a local `reopen` lifts the local tombstone — folding them back in kept a reopened value suppressed forever and re-scrubbed it on every sync, since `reopen` also removes it from the subtrahend. The machine-local mirror is excluded for the same reason, since a solo user with `DAIMON_TEAM=1` was poisoning their own reopen through a path no teammate ever sees. The apply is now machine-wide rather than silently scoped to the cwd's project, and the foreign walk is bounded and no longer descends a clone's `.git`.

Confirmed safe on the record: the foreign union never reaches a write path, so a teammate cannot block your future captures; `_apply_event_resolutions` is driven by the local ledger only, so foreign keys never delete index rows; publishing was verified end to end with a real bare-repo two-machine round trip; and concurrent publishes of one key fold to a single row.

## Known and still declared

Pre-scrub blobs remain in every clone's git history — no local action reaches them, and the registry keeps `team/{remote}/.git/**` a `known-gap`. A published tombstone also has no retraction: once pushed, teammates suppress that key even if the author later reopens it locally. Both are worth their own issue rather than a silent expansion of this one, which is why this is `Refs` and not `Closes`.
