### PR TITLE
fix(store): bring the serializer crash log inside the deletion contract (#605)

### DIFF
--- a/.scars/candidates/hook-config-mirror-must-copy-quirks-not-intent.md
+++ b/.scars/candidates/hook-config-mirror-must-copy-quirks-not-intent.md
@@ -1,0 +1,45 @@
+---
+id: 0
+type: landmine
+title: A hook mirroring a config accessor must copy its QUIRKS (no-strip, env-file fallback), not its intent — divergence silently splits a writer from its deleter
+severity: high
+confidence: 0.95
+created: 2026-08-06
+authors: ["claude-code"]
+anchors:
+  - path: hook/
+  - path: plugin/daimon_briefing/config.py
+evidence:
+  - note: "2026-08-06, #605. crash_log_path() in hook/_daimon_hook_lib.py was written as os.environ.get(DAIMON_LOG_DIR, '').strip(). Adversarial review found both halves wrong: config._get falls back to ~/.daimon/env, and config.log_dir() never strips. With DAIMON_LOG_DIR set only in the env file, the serialize child wrote tracebacks to ~/.daimon/logs while `daimon forget` purged the configured directory and printed a clean zero — permanent plaintext residue under a surface registry entry that declared the file reachable by forget."
+  - note: "2026-08-06, prior bite of the same class: #607, where hook/daimon-windsurf-hooks.py hardcoded ~/.daimon/windsurf while the package honored DAIMON_WINDSURF_DIR, so purge/reap/audit all reported cleanly on an empty directory while the adapter filled another one."
+expires:
+  condition: "hooks can import daimon_briefing.config directly, or both sides call one shared hook-safe resolver instead of two copies"
+  review_after: 2027-02-06
+violation: "os\.environ\.get\(.DAIMON_LOG_DIR"
+status: candidate
+---
+
+`daimon forget` deletes `logs/serialize-crash.log` through `config.log_dir()`,
+so a hook resolving that path must reproduce config's accessor exactly —
+including the parts that look like bugs. Two natural simplifications each split
+the writer from the deleter SILENTLY, because a one-file purge reporting
+`purged 0` is indistinguishable from an empty log dir:
+
+- **Process env only.** `config._get` falls back to `~/.daimon/env` (scar #36).
+  That file is not exotic: it exists because a GUI-launched host inherits no
+  shell profile, so shell exports never reach it. Set there and nowhere else,
+  the child wrote to `~/.daimon/logs` while forget purged the configured
+  directory and reported clean.
+- **`.strip()` on the value.** `config.log_dir()` does not strip, so `"   "` is
+  a RELATIVE directory named three spaces and `"  /x  "` keeps its spaces. A
+  stripping writer resolves both somewhere the purge never looks.
+
+Hooks cannot import the package, so the duplicated parser is unavoidable. What
+keeps it honest is a behavioral-equality probe table asserting identity with the
+config function — over process-env values AND env-file line forms (quoting,
+`export`, whitespace, comments, empty value) — never against hand-written
+literals a test author has to get right twice. See
+`plugin/tests/test_crash_log_privacy.py`, and the same idiom at
+`test_claude_hooks.py` for `hung_after_seconds`. Deliberate exception: values
+nothing deletes (serialize.log's `LOG_DIR`, `DAIMON_HUNG_AFTER`) stay
+process-env-only — no deleter, so nothing has to agree.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,7 +158,7 @@ checkpoints, so candidate files are committable.
 
 | Variable | Default | What it does |
 |---|---|---|
-| `DAIMON_LOG_DIR` | `~/.daimon/logs` | Where the session-end hook writes `serialize.log`. The hook itself hardcodes `~/.daimon/logs`; this override exists so the CLI (and tests) can point `status` elsewhere. |
+| `DAIMON_LOG_DIR` | `~/.daimon/logs` | Log directory. `serialize-crash.log` honors this on both sides — the hooks that spawn the serialize child read it (process env and this file) exactly as the CLI does, because `daimon forget` deletes that file and writer and deleter must agree on where it is. `serialize.log` is the exception: the hooks still write it to `~/.daimon/logs` unconditionally, and this override only moves where the CLI (and tests) look for it. |
 | `DAIMON_CLAUDE_PROJECTS_DIR` | `~/.claude/projects` | Where host transcripts live (`<slug>/<session>.jsonl`). Read-only — the quote-reverification audit reads them to re-check stored quotes against their source. |
 
 ## LLM backend

--- a/hook/_daimon_hook_lib.py
+++ b/hook/_daimon_hook_lib.py
@@ -34,6 +34,14 @@ FALLBACKS = [
 
 LOG_DIR = Path.home() / ".daimon" / "logs"
 
+# #605: the crash sink grows only on crashes, but it grew FOREVER — nothing
+# reaped it and, until forget started purging it, nothing deleted it either.
+# The cap bounds the plaintext that can accumulate between two forgets. Trim
+# keeps the TAIL because `status` reports the LAST crash: the newest
+# traceback is the one anyone is debugging.
+CRASH_LOG_MAX_BYTES = 262144
+CRASH_LOG_KEEP_BYTES = 65536
+
 
 def _load_redact():
     """Load the shipped redaction module (#104) from THIS file's own directory,
@@ -258,9 +266,11 @@ def hung_after_seconds() -> int:
 
     Reads the PROCESS env only. The package form also consults ~/.daimon/env,
     so a DAIMON_HUNG_AFTER set only in that file is invisible here — the same
-    documented boundary as LOG_DIR, which the hooks hardcode while the CLI
-    honors DAIMON_LOG_DIR. A disagreement costs at most a delayed or an extra
-    sweep, never a lost transcript."""
+    documented boundary as LOG_DIR, which the hooks hardcode for serialize.log
+    while the CLI honors DAIMON_LOG_DIR. A disagreement costs at most a
+    delayed or an extra sweep, never a lost transcript. crash_log_path() is
+    the one exception: that file is inside the deletion contract (#605), so
+    the writer must at least read the process env the deleter reads."""
     try:
         return int(os.environ.get("DAIMON_HUNG_AFTER") or "1800")
     except ValueError:
@@ -429,6 +439,108 @@ def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
         log(f"session-start: catch-up sweep failed ({type(exc).__name__}: {exc})")
 
 
+def _env_file_path() -> Path:
+    """Mirror of daimon_briefing.config._env_file_path."""
+    raw = os.environ.get("DAIMON_ENV_FILE")
+    return Path(raw).expanduser() if raw else Path.home() / ".daimon" / "env"
+
+
+def _env_file_values() -> dict:
+    """Mirror of daimon_briefing.config._file_values — KEY=VALUE lines, with
+    the `export ` prefix, surrounding quotes, blank lines and `#` comments
+    tolerated. Copied rather than imported because hooks run standalone and
+    cannot import the package; config.py is the CANONICAL form and this copy
+    must follow it line-form for line-form. A behavioral-equality test over
+    a probe table of line shapes guards the drift."""
+    try:
+        text = _env_file_path().read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    values = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
+        key, _, val = line.partition("=")
+        key, val = key.strip(), val.strip()
+        if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+            val = val[1:-1]
+        if key:
+            values[key] = val
+    return values
+
+
+def _config_get(name: str) -> str:
+    """Mirror of daimon_briefing.config._get: process env WINS, env file is
+    the fallback. Present-but-empty in the process env is a value, so it
+    shadows the file exactly as it does on the package side (scar 0036 in
+    reverse — the file is consulted more often than anyone expects)."""
+    val = os.environ.get(name)
+    if val is not None:
+        return val
+    return _env_file_values().get(name) or ""
+
+
+def crash_log_path() -> Path:
+    """The crash sink, resolved the way the DELETER resolves it.
+
+    serialize-crash.log is inside the deletion contract (#605): `daimon
+    forget` purges it through config.log_dir(). A path resolved any other way
+    here has the child filling one directory while the purge reports cleanly
+    on another — silently, since a one-file purge reporting zero is
+    indistinguishable from an empty log dir. That is the #607 writer/deleter
+    split, one directory over.
+
+    So this reproduces config.log_dir() EXACTLY, including the parts that
+    look like bugs: no strip (config does not strip, so "   " is a relative
+    directory named three spaces and the writer must agree), and the env-file
+    fallback, which is the channel a GUI-launched host actually uses — shell
+    exports never reach it. Resolved per call, like config's, so a moved HOME
+    cannot split the two.
+
+    serialize.log keeps the hardcoded LOG_DIR: nothing deletes it, so nothing
+    has to agree about where it is (hung_after_seconds' documented boundary)."""
+    raw = _config_get("DAIMON_LOG_DIR")
+    base = Path(raw).expanduser() if raw else Path.home() / ".daimon" / "logs"
+    return base / "serialize-crash.log"
+
+
+def trim_crash_log(path) -> None:
+    """Cap the crash sink at CRASH_LOG_MAX_BYTES, keeping its last
+    CRASH_LOG_KEEP_BYTES (#605). Called at the spawn seams — the only moments
+    daimon touches this file — so the bound costs no separate reaper.
+
+    Rewritten IN PLACE rather than through a temp-and-rename: the file is an
+    open append target for any child still running, and replacing the inode
+    would send those writes to a file nobody reads. The cut lands mid-line;
+    harmless, because _crash_log_info anchors on the `--- crash ` header and
+    ignores everything before the last one.
+
+    Accepted, deliberately: in place means unlocked, so a crash written by a
+    concurrent child between the read() and the truncate() is cut away. That
+    is diagnostics loss, bounded to the rare overlap of a spawn with another
+    child's death throes, and the alternative (a lock in a fail-open hook
+    seam, or the inode swap above) costs more than the traceback is worth.
+    llm._log_backend_stderr made the same call for backend-stderr.log.
+
+    Best-effort and silent: the log is diagnostics, a capture is the product,
+    and a trim that raises into a spawn seam would cost the capture."""
+    try:
+        size = path.stat().st_size
+        if size <= CRASH_LOG_MAX_BYTES:
+            return
+        with path.open("r+b") as f:
+            f.seek(size - CRASH_LOG_KEEP_BYTES)
+            tail = f.read()
+            f.seek(0)
+            f.write(tail)
+            f.truncate()
+    except Exception:  # noqa: BLE001 — diagnostics must never block a spawn
+        pass
+
+
 def spawn_serialize(cli, transcript_path, env) -> None:
     """Spawn `daimon serialize <transcript>` DETACHED so the hook returns
     immediately (serialization is a 30s+ LLM call). Raises OSError on spawn
@@ -438,8 +550,10 @@ def spawn_serialize(cli, transcript_path, env) -> None:
     DON'T capture the child's stdout here — that double-logged results. stderr
     goes to a SEPARATE crash log to preserve uncaught tracebacks without
     duplicating the CLI's `error:` result lines in serialize.log."""
-    LOG_DIR.mkdir(parents=True, exist_ok=True)
-    with (LOG_DIR / "serialize-crash.log").open("a", encoding="utf-8") as crashf:
+    crash = crash_log_path()
+    crash.parent.mkdir(parents=True, exist_ok=True)
+    trim_crash_log(crash)
+    with crash.open("a", encoding="utf-8") as crashf:
         subprocess.Popen(
             [cli, "serialize", transcript_path],
             stdin=subprocess.DEVNULL,

--- a/hook/daimon-windsurf-hooks.py
+++ b/hook/daimon-windsurf-hooks.py
@@ -386,10 +386,15 @@ def _arm_finalizer(trajectory_id: str, transcript_path) -> None:
     # Same detached shape as lib.spawn_serialize: stderr to the crash log so
     # an uncaught sleeper traceback is preserved without polluting
     # serialize.log; start_new_session so it survives the exiting hook.
+    # Through lib.crash_log_path(), not a home literal: this file is the crash
+    # sink's SECOND writer, and #605 put the sink inside the deletion
+    # contract, so it has to land where `daimon forget` purges (state_dir()
+    # above carries the same reasoning for the transcript store).
     try:
-        log_dir = Path.home() / ".daimon" / "logs"
-        log_dir.mkdir(parents=True, exist_ok=True)
-        with (log_dir / "serialize-crash.log").open("a", encoding="utf-8") as crashf:
+        crash = lib.crash_log_path()
+        crash.parent.mkdir(parents=True, exist_ok=True)
+        lib.trim_crash_log(crash)
+        with crash.open("a", encoding="utf-8") as crashf:
             subprocess.Popen(
                 [sys.executable, str(Path(__file__).resolve()), "--finalize",
                  trajectory_id, str(transcript_path), str(armed_mtime_ns)],

--- a/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
+++ b/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
@@ -34,6 +34,14 @@ FALLBACKS = [
 
 LOG_DIR = Path.home() / ".daimon" / "logs"
 
+# #605: the crash sink grows only on crashes, but it grew FOREVER — nothing
+# reaped it and, until forget started purging it, nothing deleted it either.
+# The cap bounds the plaintext that can accumulate between two forgets. Trim
+# keeps the TAIL because `status` reports the LAST crash: the newest
+# traceback is the one anyone is debugging.
+CRASH_LOG_MAX_BYTES = 262144
+CRASH_LOG_KEEP_BYTES = 65536
+
 
 def _load_redact():
     """Load the shipped redaction module (#104) from THIS file's own directory,
@@ -258,9 +266,11 @@ def hung_after_seconds() -> int:
 
     Reads the PROCESS env only. The package form also consults ~/.daimon/env,
     so a DAIMON_HUNG_AFTER set only in that file is invisible here — the same
-    documented boundary as LOG_DIR, which the hooks hardcode while the CLI
-    honors DAIMON_LOG_DIR. A disagreement costs at most a delayed or an extra
-    sweep, never a lost transcript."""
+    documented boundary as LOG_DIR, which the hooks hardcode for serialize.log
+    while the CLI honors DAIMON_LOG_DIR. A disagreement costs at most a
+    delayed or an extra sweep, never a lost transcript. crash_log_path() is
+    the one exception: that file is inside the deletion contract (#605), so
+    the writer must at least read the process env the deleter reads."""
     try:
         return int(os.environ.get("DAIMON_HUNG_AFTER") or "1800")
     except ValueError:
@@ -429,6 +439,108 @@ def sweep_orphans(cli, cwd, session_id, transcript_path) -> None:
         log(f"session-start: catch-up sweep failed ({type(exc).__name__}: {exc})")
 
 
+def _env_file_path() -> Path:
+    """Mirror of daimon_briefing.config._env_file_path."""
+    raw = os.environ.get("DAIMON_ENV_FILE")
+    return Path(raw).expanduser() if raw else Path.home() / ".daimon" / "env"
+
+
+def _env_file_values() -> dict:
+    """Mirror of daimon_briefing.config._file_values — KEY=VALUE lines, with
+    the `export ` prefix, surrounding quotes, blank lines and `#` comments
+    tolerated. Copied rather than imported because hooks run standalone and
+    cannot import the package; config.py is the CANONICAL form and this copy
+    must follow it line-form for line-form. A behavioral-equality test over
+    a probe table of line shapes guards the drift."""
+    try:
+        text = _env_file_path().read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    values = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
+        key, _, val = line.partition("=")
+        key, val = key.strip(), val.strip()
+        if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+            val = val[1:-1]
+        if key:
+            values[key] = val
+    return values
+
+
+def _config_get(name: str) -> str:
+    """Mirror of daimon_briefing.config._get: process env WINS, env file is
+    the fallback. Present-but-empty in the process env is a value, so it
+    shadows the file exactly as it does on the package side (scar 0036 in
+    reverse — the file is consulted more often than anyone expects)."""
+    val = os.environ.get(name)
+    if val is not None:
+        return val
+    return _env_file_values().get(name) or ""
+
+
+def crash_log_path() -> Path:
+    """The crash sink, resolved the way the DELETER resolves it.
+
+    serialize-crash.log is inside the deletion contract (#605): `daimon
+    forget` purges it through config.log_dir(). A path resolved any other way
+    here has the child filling one directory while the purge reports cleanly
+    on another — silently, since a one-file purge reporting zero is
+    indistinguishable from an empty log dir. That is the #607 writer/deleter
+    split, one directory over.
+
+    So this reproduces config.log_dir() EXACTLY, including the parts that
+    look like bugs: no strip (config does not strip, so "   " is a relative
+    directory named three spaces and the writer must agree), and the env-file
+    fallback, which is the channel a GUI-launched host actually uses — shell
+    exports never reach it. Resolved per call, like config's, so a moved HOME
+    cannot split the two.
+
+    serialize.log keeps the hardcoded LOG_DIR: nothing deletes it, so nothing
+    has to agree about where it is (hung_after_seconds' documented boundary)."""
+    raw = _config_get("DAIMON_LOG_DIR")
+    base = Path(raw).expanduser() if raw else Path.home() / ".daimon" / "logs"
+    return base / "serialize-crash.log"
+
+
+def trim_crash_log(path) -> None:
+    """Cap the crash sink at CRASH_LOG_MAX_BYTES, keeping its last
+    CRASH_LOG_KEEP_BYTES (#605). Called at the spawn seams — the only moments
+    daimon touches this file — so the bound costs no separate reaper.
+
+    Rewritten IN PLACE rather than through a temp-and-rename: the file is an
+    open append target for any child still running, and replacing the inode
+    would send those writes to a file nobody reads. The cut lands mid-line;
+    harmless, because _crash_log_info anchors on the `--- crash ` header and
+    ignores everything before the last one.
+
+    Accepted, deliberately: in place means unlocked, so a crash written by a
+    concurrent child between the read() and the truncate() is cut away. That
+    is diagnostics loss, bounded to the rare overlap of a spawn with another
+    child's death throes, and the alternative (a lock in a fail-open hook
+    seam, or the inode swap above) costs more than the traceback is worth.
+    llm._log_backend_stderr made the same call for backend-stderr.log.
+
+    Best-effort and silent: the log is diagnostics, a capture is the product,
+    and a trim that raises into a spawn seam would cost the capture."""
+    try:
+        size = path.stat().st_size
+        if size <= CRASH_LOG_MAX_BYTES:
+            return
+        with path.open("r+b") as f:
+            f.seek(size - CRASH_LOG_KEEP_BYTES)
+            tail = f.read()
+            f.seek(0)
+            f.write(tail)
+            f.truncate()
+    except Exception:  # noqa: BLE001 — diagnostics must never block a spawn
+        pass
+
+
 def spawn_serialize(cli, transcript_path, env) -> None:
     """Spawn `daimon serialize <transcript>` DETACHED so the hook returns
     immediately (serialization is a 30s+ LLM call). Raises OSError on spawn
@@ -438,8 +550,10 @@ def spawn_serialize(cli, transcript_path, env) -> None:
     DON'T capture the child's stdout here — that double-logged results. stderr
     goes to a SEPARATE crash log to preserve uncaught tracebacks without
     duplicating the CLI's `error:` result lines in serialize.log."""
-    LOG_DIR.mkdir(parents=True, exist_ok=True)
-    with (LOG_DIR / "serialize-crash.log").open("a", encoding="utf-8") as crashf:
+    crash = crash_log_path()
+    crash.parent.mkdir(parents=True, exist_ok=True)
+    trim_crash_log(crash)
+    with crash.open("a", encoding="utf-8") as crashf:
         subprocess.Popen(
             [cli, "serialize", transcript_path],
             stdin=subprocess.DEVNULL,

--- a/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
+++ b/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
@@ -386,10 +386,15 @@ def _arm_finalizer(trajectory_id: str, transcript_path) -> None:
     # Same detached shape as lib.spawn_serialize: stderr to the crash log so
     # an uncaught sleeper traceback is preserved without polluting
     # serialize.log; start_new_session so it survives the exiting hook.
+    # Through lib.crash_log_path(), not a home literal: this file is the crash
+    # sink's SECOND writer, and #605 put the sink inside the deletion
+    # contract, so it has to land where `daimon forget` purges (state_dir()
+    # above carries the same reasoning for the transcript store).
     try:
-        log_dir = Path.home() / ".daimon" / "logs"
-        log_dir.mkdir(parents=True, exist_ok=True)
-        with (log_dir / "serialize-crash.log").open("a", encoding="utf-8") as crashf:
+        crash = lib.crash_log_path()
+        crash.parent.mkdir(parents=True, exist_ok=True)
+        lib.trim_crash_log(crash)
+        with crash.open("a", encoding="utf-8") as crashf:
             subprocess.Popen(
                 [sys.executable, str(Path(__file__).resolve()), "--finalize",
                  trajectory_id, str(transcript_path), str(armed_mtime_ns)],

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -27,6 +27,7 @@ import logging
 import os
 import sys
 import time
+import traceback
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -1089,6 +1090,15 @@ def _cmd_forget(args) -> int:
         ws_purged, ws_err = store.purge_windsurf_state()
     except Exception as e:  # belt: purge_windsurf_state never raises
         ws_purged, ws_err = 0, str(e)
+    # #605: serialize-crash.log is the detached child's RAW stderr — an
+    # uncaught traceback carries whatever the crashing frame held, and the
+    # bytes were never scrubbed (status redacted its tail on READ, #513, over
+    # a file nothing deleted). Wholesale like the two purges above: the
+    # tombstone is a hash, so a value inside a traceback cannot be located.
+    try:
+        crash_purged, crash_err = store.purge_crash_log()
+    except Exception as e:  # belt: purge_crash_log never raises
+        crash_purged, crash_err = 0, str(e)
     _note_usage("forget")
     print(f"forgot {target['id']} (content hash {content_hash}) — "
           "item removed from the live checkpoint; tombstone recorded")
@@ -1120,6 +1130,18 @@ def _cmd_forget(args) -> int:
               "file(s) across all projects (machine-wide: the store is keyed "
               "by trajectory, not project); host-authored transcripts are "
               "untouched")
+    if crash_err is not None:
+        print(f"warning: crash log purge failed: {crash_err} — serializer "
+              "tracebacks may persist (bounded to a trimmed tail at the next "
+              "spawn, never removed)")
+    else:
+        # Printed even at zero, like the two lines above: a silent zero is
+        # how a writer and a deleter disagreeing about DAIMON_LOG_DIR stays
+        # invisible. One crash log per machine, so the scope note is the
+        # same honesty the windsurf line owes.
+        print(f"purged {crash_purged} serializer crash log(s) across all "
+              "projects (machine-wide: the log is raw child stderr, not "
+              "keyed by project)")
     return 0
 
 
@@ -3377,13 +3399,30 @@ def _crash_stamp_excepthook(exc_type, exc, tb) -> None:
     """Uncaught-crash header (#92): serialize-crash.log is the detached
     child's RAW stderr fd — no logger sits in the write path, so the only
     process that can timestamp a crash is the crashing one. One ISO-stamped
-    line, then the stock traceback. Covers uncaught Python exceptions (the
-    dominant case); interpreter-level deaths still write nothing."""
+    line, then the traceback. Covers uncaught Python exceptions (the
+    dominant case); interpreter-level deaths still write nothing.
+
+    #605: the traceback is formatted HERE rather than handed to
+    sys.__excepthook__, so it can pass through redact_text on the way out.
+    The crashing process is the only one that can scrub these bytes — for
+    the same reason it is the only one that can stamp them — and #513
+    redacted the tail on READ over a file nothing deleted. Item text still
+    survives (redaction catches secrets, not beliefs), which is why the
+    purge above it is wholesale.
+
+    Fail-open, redact.py's own posture: anything that goes wrong formatting
+    or redacting falls back to the stock hook, because a swallowed traceback
+    is a crash nobody can diagnose."""
     stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     cmd = next((a for a in sys.argv[1:] if not a.startswith("-")), "?")
     print(f"--- crash {stamp} pid={os.getpid()} cmd={cmd} ---",
           file=sys.stderr, flush=True)
-    sys.__excepthook__(exc_type, exc, tb)
+    try:
+        formatted = "".join(traceback.format_exception(exc_type, exc, tb))
+        redacted, _ = redact.redact_text(formatted)
+        print(redacted, end="", file=sys.stderr, flush=True)
+    except Exception:  # noqa: BLE001 — see fail-open above
+        sys.__excepthook__(exc_type, exc, tb)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -28,6 +28,7 @@ import json
 import logging
 import os
 import re
+import stat
 import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -536,6 +537,66 @@ def reap_windsurf_state(now: float | None = None, apply: bool = True) -> list:
             continue
         reaped.append(path)
     return reaped
+
+
+def purge_crash_log() -> tuple:
+    """#605: the serializer child's RAW stderr sink, inside the contract.
+
+    `logs/serialize-crash.log` is the fd spawn_serialize hands a detached
+    child (and the Windsurf finalizer its sleeper), so an uncaught traceback
+    lands there verbatim — exception message, repr'd arguments, whatever the
+    crashing frame was holding. `status` redacted that tail on READ (#513)
+    while the bytes underneath stayed; nothing ever removed them.
+
+    Wholesale for the same reason as the chunk cache (#422) and the Windsurf
+    transcript store (#607): forget keeps the canonical HASH and never the
+    text (#321), so no component downstream holds the plaintext a substring
+    search of a traceback would need. Detection is impossible by
+    construction, so the whole file goes — and unlike those two stores there
+    is no age reaper behind it, because the write seam trims the file to a
+    bounded tail instead (_daimon_hook_lib.trim_crash_log).
+
+    Accepted cost: `daimon status` reports no last-crash line until the next
+    one happens. That is the same trade `forget` already makes against quote
+    provenance — a receipt degrades, a diagnostic goes quiet, and neither
+    outranks removing plaintext the user asked to be gone.
+
+    Returns (purged_count, error_or_None) and NEVER raises: deleting belief
+    state is the primary contract; a failed purge is reported, not fatal."""
+    try:
+        path = config.log_dir() / "serialize-crash.log"
+    except Exception as e:  # noqa: BLE001 — e.g. UnicodeDecodeError from a
+        # corrupt ~/.daimon/env: a ValueError, so the OSError net below never
+        # sees it. The writer resolves through the same accessors and raises
+        # identically, so nothing was written where this purge cannot look.
+        return 0, str(e)
+    try:
+        st = os.lstat(path)
+    except FileNotFoundError:
+        return 0, None                 # never crashed, or already purged
+    except OSError as e:
+        # A log dir this process cannot see is not a clean purge. The count
+        # is a privacy CLAIM — "the tracebacks are gone" — and a silent zero
+        # over an unreadable directory is that claim made without evidence.
+        return 0, str(e)
+    # lstat rather than is_file(): those follow the link and answer False for
+    # every failure alike. daimon creates this file itself with open("a"), so
+    # a symlink or a directory standing in its place is not a shape daimon
+    # wrote. This is _windsurf_text_files' containment rule (#607) narrowed
+    # to a FIXED filename, where a resolve()-parents check would be strictly
+    # weaker: a link pointing back inside the log dir passes containment,
+    # yet unlink() removes only the link and leaves the plaintext behind a
+    # count that says it went.
+    if stat.S_ISLNK(st.st_mode):
+        return 0, (f"{path} is a symlink — refusing to unlink through a file "
+                   "daimon did not create")
+    if not stat.S_ISREG(st.st_mode):
+        return 0, f"{path} is not a regular file — refusing to unlink it"
+    try:
+        os.unlink(path)
+    except OSError as e:
+        return 0, str(e)
+    return 1, None
 
 
 # #600 slice B: the per-author tombstone ledger published into the team

--- a/plugin/daimon_briefing/surfaces.py
+++ b/plugin/daimon_briefing/surfaces.py
@@ -128,13 +128,32 @@ SURFACES: tuple[Surface, ...] = (
     Surface("recall.db", "recall.rebuild", True, "lazy-rebuild", "recall"),
     Surface("recall_seen/*.json", "cli._save_seen",
             False, "exempt-no-plaintext", "none"),
-    # -- logs: no item text by construction, except the crash sink, which
-    #    captures raw serializer-child stderr — tracebacks can embed item
-    #    text and nothing deletes it. Declared debt. --
+    # -- the crash sink: RAW child stderr, so its contents are whatever the
+    #    serialize child wrote to fd 2. An uncaught traceback, yes — but also
+    #    logging.lastResort output from any logger OUTSIDE the
+    #    `daimon_briefing` hierarchy the #194 handler attaches to
+    #    (`daimon.recall` and `daimon.briefing` are not under it). Any of it
+    #    can carry item text.
+    #    The WHOLESALE PURGE at forget and the write-seam trim are therefore
+    #    the whole contract (#605): a value inside a traceback cannot be
+    #    located when the tombstone is a hash — the chunk-cache situation —
+    #    and the trim bounds what accumulates between forgets without a
+    #    second reaper. The #92 excepthook redacts secrets on the way out,
+    #    but it sees ONLY uncaught top-level exceptions in the child: a
+    #    narrowing of what lands here, never a claim about the file, and
+    #    nothing in this entry rests on it. --
     Surface("logs/serialize-crash.log", "cli serialize child stderr",
-            True, "known-gap", "none", issue="#605"),
+            True, "wholesale-purge", "forget"),
     Surface("logs/heartbeats/*", "ledger.touch_heartbeat",
             False, "exempt-no-plaintext", "none"),
+    # The two entries above and below keep the declarations they shipped
+    # with. Deliberately NOT restated here: the old blanket "logs hold no
+    # item text by construction". serializer's quote-verification downgrade
+    # logs the item's own text (secret-redacted, not item-redacted) and the
+    # CLI routes that line into serialize.log, so the claim is false as
+    # written — #616 tracks re-declaring this entry (backend-stderr.log has
+    # the same problem). #605 changed the sink above it and left this one
+    # alone rather than quietly widening its own scope.
     Surface("logs/*.log", "ledger / cli._note_usage / recall._note_error",
             False, "exempt-no-plaintext", "none"),
     # -- key material and env: secrets, never item plaintext. --

--- a/plugin/tests/test_crash_log_privacy.py
+++ b/plugin/tests/test_crash_log_privacy.py
@@ -1,0 +1,507 @@
+"""#605: the serializer crash sink, inside the deletion contract.
+
+`logs/serialize-crash.log` is the detached serialize child's RAW stderr fd —
+_daimon_hook_lib.spawn_serialize points it there, and the Windsurf finalizer
+arms its sleeper the same way. An uncaught traceback carries whatever the
+crashing frame held: the exception message, a repr'd argument, a quoted
+config line. Nothing ever removed those bytes. forget did not walk the file,
+no reaper bounded it, and `status` redacted the tail on READ (#513) while the
+original stayed on disk underneath.
+
+Three parts, the shape #607 settled on for the Windsurf transcript store:
+
+  * a WHOLESALE purge at forget — the tombstone is a canonical HASH (#321),
+    so no component downstream holds the plaintext a substring search of a
+    traceback would need, and detection is impossible by construction;
+  * secret redaction at CAPTURE, so the excepthook stops writing to a file
+    nobody scrubs the very thing redaction exists to catch (#104);
+  * a byte cap at the write seam, so what accumulates between forgets is
+    bounded rather than unbounded-forever.
+
+The canary below uses redact.py's aws-key shape — the same synthetic literal
+test_redact.py uses. A canary shaped like a vendor prefix this install does
+not issue would prove nothing about redaction (scar: a `sk-proj` grep passed
+on every non-OpenAI install and then matched its own instructions).
+"""
+import contextlib
+import importlib.util
+import io
+import os
+import re
+import subprocess
+import sys
+import time
+import types
+from pathlib import Path
+
+from daimon_briefing import cli, config, store, surfaces
+
+PROJECT = "/p/crash-log"
+CANARY = "zqxcrashcanary4417 the migration lock is held by the old worker"
+KEEPER = "an unrelated decision that must survive"
+SECRET = "AKIAIOSFODNN7EXAMPLE"
+
+
+def _crash_path() -> Path:
+    """Where the DELETER looks — cli status reads this exact expression."""
+    return config.log_dir() / "serialize-crash.log"
+
+
+def _lib():
+    """The shared hook library, loaded under its own module name (it is a
+    standalone script the package cannot import)."""
+    src = (Path(__file__).parent.parent / "daimon_briefing" / "_hooks"
+           / "_daimon_hook_lib.py")
+    spec = importlib.util.spec_from_file_location("_crash_hook_lib_under_test",
+                                                  src)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _hook_module():
+    """The Windsurf adapter — the crash log's SECOND writer."""
+    src = (Path(__file__).parent.parent / "daimon_briefing" / "_hooks"
+           / "daimon-windsurf-hooks.py")
+    spec = importlib.util.spec_from_file_location("_ws_hook_crash_under_test",
+                                                  src)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _fake_subprocess(recorded):
+    """subprocess stand-in for the two spawn seams: records the Popen kwargs
+    (so the stderr fd can be asserted) and never starts a real child."""
+    def popen(*args, **kwargs):
+        recorded.append(kwargs)
+        return None
+    return types.SimpleNamespace(popen=None, Popen=popen,
+                                 DEVNULL=subprocess.DEVNULL)
+
+
+def _seed_crash_log(text: str | None = None) -> Path:
+    path = _crash_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        text if text is not None else
+        "--- crash 2026-08-06T00:00:00Z pid=1 cmd=serialize ---\n"
+        "Traceback (most recent call last):\n"
+        '  File "serializer.py", line 1, in <module>\n'
+        f"RuntimeError: {CANARY}\n",
+        encoding="utf-8")
+    return path
+
+
+def _write_checkpoint():
+    store.write_checkpoint("S1", {
+        "session_id": "S1", "created": "2026-08-01T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": CANARY, "trust": "inferred"},
+            {"text": KEEPER, "trust": "inferred"}]},
+    }, project_dir=PROJECT)
+
+
+# ---- the writer and the deleter must agree on WHERE ----------------------
+
+
+def test_hook_and_package_resolve_the_same_crash_log(tmp_path, monkeypatch):
+    """The #607 split, one directory over: the hook hardcoded ~/.daimon while
+    the CLI honored the override, so with the var set the child kept writing
+    tracebacks into one directory while the purge reported cleanly on an
+    empty other one. A zero-file purge says nothing, so the divergence would
+    be silent. The moment this file entered the deletion contract, the
+    writer had to read the same var the deleter does."""
+    lib = _lib()
+    override = tmp_path / "elsewhere"
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(override))
+    assert config.log_dir() == override
+    assert lib.crash_log_path() == override / "serialize-crash.log"
+
+
+def test_both_sides_default_under_the_real_daimon_home(tmp_path, monkeypatch):
+    """The DEFAULT path is the field path — with the var redirected suite-wide
+    by conftest, nothing else asserts it, and a typo in either default is
+    otherwise invisible. Resolved per CALL on both sides, so a home that
+    moves (a test, a hook running under a different HOME than the CLI) cannot
+    split the writer from the deleter."""
+    lib = _lib()
+    monkeypatch.delenv("DAIMON_LOG_DIR", raising=False)
+    monkeypatch.setenv("DAIMON_ENV_FILE", str(tmp_path / "no-such-env-file"))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    expected = tmp_path / ".daimon" / "logs" / "serialize-crash.log"
+    assert config.log_dir() / "serialize-crash.log" == expected
+    assert lib.crash_log_path() == expected
+
+
+def test_the_env_file_alone_still_lands_both_sides_in_one_place(
+        tmp_path, monkeypatch):
+    """The hook read the PROCESS env only while config._get falls back to
+    ~/.daimon/env (scar 0036). That file is not an exotic configuration — it
+    exists precisely because a GUI-launched host inherits no shell profile,
+    so it is the channel a real install uses. Set there and nowhere else, the
+    child wrote its tracebacks to ~/.daimon/logs while forget purged the
+    configured directory and reported a clean zero: permanent residue, under
+    a registry entry claiming the surface is reachable."""
+    lib = _lib()
+    monkeypatch.delenv("DAIMON_LOG_DIR", raising=False)
+    custom = tmp_path / "custom-logs"
+    env_file = Path(os.environ["DAIMON_ENV_FILE"])
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    env_file.write_text(f"export DAIMON_LOG_DIR={custom}\n", encoding="utf-8")
+    assert config.log_dir() == custom, "fixture never configured the deleter"
+    assert lib.crash_log_path() == custom / "serialize-crash.log"
+
+
+def test_env_file_only_config_is_written_and_purged_end_to_end(
+        tmp_checkpoint_dir, tmp_path, monkeypatch):
+    """The path assertion above is the unit; this is the claim that matters —
+    what the WRITER actually created is what the PURGE actually removes."""
+    lib = _lib()
+    monkeypatch.delenv("DAIMON_LOG_DIR", raising=False)
+    custom = tmp_path / "custom-logs"
+    env_file = Path(os.environ["DAIMON_ENV_FILE"])
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    env_file.write_text(f"DAIMON_LOG_DIR={custom}\n", encoding="utf-8")
+    monkeypatch.setattr(lib, "subprocess", _fake_subprocess([]))
+    lib.spawn_serialize("daimon", "/t/x.jsonl", None)
+    written = custom / "serialize-crash.log"
+    assert written.exists(), "the writer missed the configured directory"
+    written.write_text(
+        "--- crash 2026-08-06T00:00:00Z pid=1 cmd=serialize ---\n"
+        f"RuntimeError: {CANARY}\n", encoding="utf-8")
+    _write_checkpoint()
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+    assert not written.exists(), "the purge looked somewhere else"
+
+
+def test_writer_and_deleter_agree_over_the_whole_probe_table(
+        tmp_path, monkeypatch):
+    """Behavioral equality, the idiom hung_after_seconds already uses: every
+    probe asserts identity with config.log_dir() rather than with a literal
+    this test would also have to get right.
+
+    The strip axis is load-bearing and was wrong. config.log_dir() does NOT
+    strip, so "  /tmp/dlogs  " names a directory whose name carries spaces
+    and "   " is a RELATIVE directory named three spaces. A writer that
+    stripped resolved both somewhere the purge never looks — the same split
+    as the env-file gap, reached through a different door."""
+    lib = _lib()
+    for raw in (None, "", "   ", "  /tmp/dlogs  ", "/tmp/dlogs", "~/dlogs"):
+        monkeypatch.delenv("DAIMON_LOG_DIR", raising=False)
+        if raw is not None:
+            monkeypatch.setenv("DAIMON_LOG_DIR", raw)
+        assert lib.crash_log_path() == (
+            config.log_dir() / "serialize-crash.log"), repr(raw)
+
+    # The env-file PARSER is a second copy of config._file_values, so it can
+    # drift line-form by line-form. Each of these discriminates one rule:
+    # quoting, the export prefix, whitespace, comments, an empty value.
+    monkeypatch.delenv("DAIMON_LOG_DIR", raising=False)
+    env_file = Path(os.environ["DAIMON_ENV_FILE"])
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    resolved = set()
+    for line in (f"DAIMON_LOG_DIR={tmp_path}/plain",
+                 f'DAIMON_LOG_DIR="{tmp_path}/quoted"',
+                 f"DAIMON_LOG_DIR='{tmp_path}/single'",
+                 f"export DAIMON_LOG_DIR={tmp_path}/exported",
+                 f"  export   DAIMON_LOG_DIR =  {tmp_path}/spaced  ",
+                 f"# DAIMON_LOG_DIR={tmp_path}/commented",
+                 "DAIMON_LOG_DIR=",
+                 "DAIMON_LOG_DIR=~/tilde",
+                 f"NOT_THE_VAR={tmp_path}/other",
+                 f"DAIMON_LOG_DIR={tmp_path}/first\nDAIMON_LOG_DIR={tmp_path}/last"):
+        env_file.write_text(line + "\n", encoding="utf-8")
+        assert lib.crash_log_path() == (
+            config.log_dir() / "serialize-crash.log"), line
+        resolved.add(lib.crash_log_path())
+    assert len(resolved) > 1, \
+        "every probe resolved alike — the env file was never read at all"
+
+
+# ---- purge on forget ------------------------------------------------------
+
+
+def test_forget_purges_the_crash_log(tmp_checkpoint_dir):
+    path = _seed_crash_log()
+    assert CANARY in path.read_text(encoding="utf-8"), "fixture wrote no canary"
+    _write_checkpoint()
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+    assert not path.exists(), "the traceback daimon wrote must go"
+
+
+def test_forget_dry_run_never_purges(tmp_checkpoint_dir):
+    """The higher-blast-radius call site: a purge inserted into the dry-run
+    branch deletes on a command whose whole promise is that it does not."""
+    path = _seed_crash_log()
+    _write_checkpoint()
+    assert cli.main(["forget", CANARY, "--project", PROJECT, "--dry-run"]) == 0
+    assert path.exists()
+
+
+def test_a_refused_forget_never_purges(tmp_checkpoint_dir):
+    path = _seed_crash_log()
+    _write_checkpoint()
+    assert cli.main(["forget", "no such value here", "--project", PROJECT]) == 1
+    assert path.exists()
+
+
+def test_purge_reports_count_and_never_raises(tmp_checkpoint_dir):
+    _seed_crash_log()
+    assert store.purge_crash_log() == (1, None)
+    # vacuous purge on a machine whose serializer never crashed
+    assert store.purge_crash_log() == (0, None)
+
+
+def test_purge_never_unlinks_through_a_symlink(tmp_checkpoint_dir, tmp_path):
+    """A symlink standing in for the crash sink would have the purge delete a
+    file daimon never created. The reading path (_crash_log_info) only ever
+    reads a tail; the DELETING path must not be laxer."""
+    outside = tmp_path / "my-notes"
+    outside.mkdir()
+    kept = outside / "important.log"
+    kept.write_text("a user file", encoding="utf-8")
+    path = _crash_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.symlink_to(kept)
+    purged, err = store.purge_crash_log()
+    assert purged == 0
+    assert err is not None, "a refusal the user never hears about is a leak"
+    assert kept.exists(), "unlinked a file daimon did not write"
+
+
+def test_a_directory_named_like_the_crash_log_is_never_unlinked(
+        tmp_checkpoint_dir):
+    """The sink is a fixed NAME, not a type check. A directory sitting there
+    must be refused before unlink() sees it, and refused OUT LOUD — a zero
+    with no error reads as "the machine never crashed"."""
+    decoy = _crash_path()
+    decoy.mkdir(parents=True)
+    (decoy / "inside.txt").write_text("not daimon's to delete",
+                                      encoding="utf-8")
+    purged, err = store.purge_crash_log()
+    assert purged == 0 and err is not None
+    assert (decoy / "inside.txt").exists()
+
+
+def test_purge_reports_a_file_it_could_not_remove(tmp_checkpoint_dir):
+    """The count is a privacy CLAIM — "the tracebacks are gone" — so a file
+    that survived a read-only log dir must not be inside it, and the error
+    must surface for the forget warning to carry."""
+    path = _seed_crash_log()
+    path.parent.chmod(0o500)          # readable and stat-able, not writable
+    try:
+        purged, err = store.purge_crash_log()
+    finally:
+        path.parent.chmod(0o700)
+    assert purged == 0, "only a file that actually went may be counted"
+    assert err is not None, "a silent partial purge reads as a clean one"
+    assert CANARY in path.read_text(encoding="utf-8")
+
+
+def test_a_log_dir_it_cannot_see_is_never_reported_clean(tmp_checkpoint_dir):
+    """Path.is_file() answers False for "absent" and for "I am not allowed to
+    look" alike, and the second one purging silently is a clean-purge claim
+    made without evidence. lstat separates them: absent is (0, None), blind
+    is an error the forget warning carries."""
+    path = _seed_crash_log()
+    path.parent.chmod(0o000)          # neither readable nor searchable
+    try:
+        purged, err = store.purge_crash_log()
+    finally:
+        path.parent.chmod(0o700)
+    assert purged == 0
+    assert err is not None, "a blind purge must not read as an empty one"
+    assert CANARY in path.read_text(encoding="utf-8")
+
+
+def test_a_corrupt_env_file_fails_the_purge_closed(monkeypatch, tmp_path):
+    """config._file_values catches OSError, but a non-UTF-8 env file raises
+    UnicodeDecodeError — a ValueError — out of read_text, past that net and
+    out of config.log_dir(). The purge's NEVER-raises contract has to hold
+    anyway: resolution failure is (0, err), not an exception. The writer
+    resolves through the same accessors and raises identically, so nothing
+    was written where this purge cannot look."""
+    monkeypatch.delenv("DAIMON_LOG_DIR", raising=False)
+    env_file = tmp_path / "env"
+    env_file.write_bytes(b"DAIMON_LOG_DIR=\xff\xfe broken\n")
+    monkeypatch.setenv("DAIMON_ENV_FILE", str(env_file))
+    purged, err = store.purge_crash_log()
+    assert purged == 0
+    assert err is not None, "a purge that cannot even resolve its target " \
+                            "must not read as a clean zero"
+
+
+def test_forget_survives_a_failed_purge(tmp_checkpoint_dir, monkeypatch,
+                                        capsys):
+    """The belief-state deletion is the primary contract — a failed purge is
+    reported honestly, never fatal (the #422 posture)."""
+    _seed_crash_log()
+    _write_checkpoint()
+    monkeypatch.setattr(store, "purge_crash_log", lambda: (0, "disk on fire"))
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+    assert "disk on fire" in capsys.readouterr().out
+
+
+def test_forget_survives_a_purge_that_raises(tmp_checkpoint_dir, monkeypatch,
+                                             capsys):
+    """purge_crash_log promises a tuple and never an exception, so the belt
+    around the call site reads as dead code — it is not. It is what keeps a
+    future bug in the purge from taking the SCRUB down with it, and the
+    scrub is the contract the user actually invoked."""
+    _seed_crash_log()
+    _write_checkpoint()
+
+    def boom():
+        raise RuntimeError("purge exploded")
+
+    monkeypatch.setattr(store, "purge_crash_log", boom)
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+    out = capsys.readouterr().out
+    assert "purge exploded" in out, "a swallowed failure is an invisible leak"
+    latest = store.read_latest(project_dir=PROJECT, fallback=False)
+    texts = [i["text"] for i
+             in latest["working_context"]["recent_decisions"]]
+    assert texts == [KEEPER], "the checkpoint scrub must survive the blowup"
+
+
+def test_forget_states_the_purge_is_machine_wide(tmp_checkpoint_dir, capsys):
+    """One crash log per machine, not per project — a forget in ANY project
+    removes every serializer traceback on the box. That is the only option
+    (the file carries no project attribution), so it must be said out loud
+    rather than discovered."""
+    _seed_crash_log()
+    _write_checkpoint()
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+    out = capsys.readouterr().out.lower()
+    assert "crash log" in out
+    assert "all projects" in out or "machine-wide" in out
+
+
+# ---- redaction at capture -------------------------------------------------
+
+
+def test_excepthook_redacts_the_traceback_and_keeps_the_header(capsys):
+    """#513 redacted this file on READ while the disk kept the original. The
+    only process that can scrub it at WRITE is the crashing one — nothing
+    else sits in the path between the child's stderr fd and the file."""
+    try:
+        raise RuntimeError(f"connecting with {SECRET} failed")
+    except RuntimeError:
+        exc_info = sys.exc_info()
+    cli._crash_stamp_excepthook(*exc_info)
+    err = capsys.readouterr().err
+    assert re.fullmatch(
+        r"--- crash \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z pid=\d+ "
+        r"cmd=\S+ ---", err.splitlines()[0]), "the #92 header shape is parsed"
+    assert SECRET not in err
+    assert "[redacted:aws-key]" in err
+    assert "RuntimeError: connecting with" in err, "the crash stays readable"
+
+
+def test_the_redacted_block_still_parses_as_a_crash(tmp_checkpoint_dir):
+    """status reads this file back through _crash_log_info, which finds the
+    exception line by INDENTATION (traceback frames are indented, the raising
+    line is not). Formatting the traceback ourselves must not disturb that."""
+    try:
+        raise RuntimeError(f"secret {SECRET} in the message")
+    except RuntimeError:
+        exc_info = sys.exc_info()
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        cli._crash_stamp_excepthook(*exc_info)
+    path = _seed_crash_log(buf.getvalue())
+    # The DISK bytes are the new guarantee. _crash_log_info redacts its own
+    # output (#513), so asserting on last_line alone would pass unchanged
+    # against the old excepthook and prove nothing.
+    assert SECRET not in path.read_text(encoding="utf-8")
+    info = cli._crash_log_info(path, now=time.time())
+    assert info is not None, "the header must still register as a crash"
+    assert info["last_line"].startswith("RuntimeError: secret ")
+
+
+def test_excepthook_falls_back_when_redaction_breaks(monkeypatch, capsys):
+    """Fail-open, redact.py's own posture: a swallowed traceback is a crash
+    nobody can diagnose, which costs more than the redaction it was buying."""
+    def boom(_s):
+        raise RuntimeError("redaction exploded")
+
+    monkeypatch.setattr(cli.redact, "redact_text", boom)
+    try:
+        raise ValueError("the traceback must survive")
+    except ValueError:
+        exc_info = sys.exc_info()
+    cli._crash_stamp_excepthook(*exc_info)
+    err = capsys.readouterr().err
+    assert err.splitlines()[0].startswith("--- crash ")
+    assert "ValueError: the traceback must survive" in err
+
+
+# ---- the byte cap at the write seam --------------------------------------
+
+
+def test_spawn_trims_an_oversized_crash_log_and_keeps_the_tail(
+        tmp_checkpoint_dir, monkeypatch):
+    """Between forgets the file grew forever. The cap bounds the residue —
+    and it must keep the TAIL, because status reports the LAST crash and the
+    newest traceback is the one anyone is debugging."""
+    lib = _lib()
+    path = _crash_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    newest = b"RuntimeError: the newest crash line\n"
+    path.write_bytes(b"o" * (lib.CRASH_LOG_MAX_BYTES + 4096) + newest)
+    recorded: list = []
+    monkeypatch.setattr(lib, "subprocess", _fake_subprocess(recorded))
+    lib.spawn_serialize("daimon", "/t/x.jsonl", None)
+    data = path.read_bytes()
+    assert len(data) <= lib.CRASH_LOG_KEEP_BYTES
+    assert data.endswith(newest), "the newest crash is the one status reports"
+    assert recorded and recorded[0]["stderr"] is not None, "child still spawned"
+
+
+def test_a_crash_log_under_the_cap_is_left_alone(tmp_checkpoint_dir,
+                                                 monkeypatch):
+    lib = _lib()
+    path = _crash_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"--- crash 2026-08-06T00:00:00Z pid=1 cmd=serialize ---\n")
+    before = path.read_bytes()
+    recorded: list = []
+    monkeypatch.setattr(lib, "subprocess", _fake_subprocess(recorded))
+    lib.spawn_serialize("daimon", "/t/x.jsonl", None)
+    assert path.read_bytes() == before, "trimming is not truncating"
+
+
+def test_a_trim_that_cannot_run_never_blocks_the_spawn(tmp_path):
+    """The log is diagnostics; a capture is the product. Trimming must fail
+    silently rather than raise into a spawn seam whose whole contract is
+    that it starts the child."""
+    lib = _lib()
+    lib.trim_crash_log(tmp_path / "no-such-dir" / "serialize-crash.log")
+
+
+def test_the_finalizer_writes_where_forget_looks(tmp_checkpoint_dir,
+                                                 monkeypatch):
+    """The Windsurf sleeper is the crash log's SECOND writer and had its own
+    hardcoded ~/.daimon/logs — the writer/deleter divergence #607 closed for
+    the transcript store, still open one directory over."""
+    hook = _hook_module()
+    recorded: list = []
+    monkeypatch.setattr(hook, "subprocess", _fake_subprocess(recorded))
+    hook._arm_finalizer("traj-1", Path("/t/traj-1.md"))
+    assert recorded, "the finalizer never armed"
+    assert _crash_path().exists(), \
+        "the sleeper's stderr must land where the purge looks"
+
+
+# ---- the registry stops calling this a gap -------------------------------
+
+
+def test_registry_declares_the_crash_log_reachable():
+    s = surfaces.match("logs/serialize-crash.log")
+    assert s is not None
+    assert s.plaintext is True and s.delete == "wholesale-purge"
+    assert s.walker == "forget"
+    assert not any(x.issue == "#605" for x in surfaces.SURFACES), \
+        "#605 is closed — no entry may still cite it as an open gap"
+    assert surfaces.match("logs/serialize.log").delete == "exempt-no-plaintext"

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -134,7 +134,7 @@ Serialize-throttle knobs for hosts that lack a clean session-end event. See
 
 | Variable | Default | What it does |
 |---|---|---|
-| `DAIMON_LOG_DIR` | `~/.daimon/logs` | Where the session-end hook writes `serialize.log`. The hook itself hardcodes `~/.daimon/logs`; this override exists so the CLI (and tests) can point `status` elsewhere. |
+| `DAIMON_LOG_DIR` | `~/.daimon/logs` | Log directory. `serialize-crash.log` honors this on both sides — the hooks that spawn the serialize child read it (process env and this file) exactly as the CLI does, because `daimon forget` deletes that file and writer and deleter must agree on where it is. `serialize.log` is the exception: the hooks still write it to `~/.daimon/logs` unconditionally, and this override only moves where the CLI (and tests) look for it. |
 | `DAIMON_CLAUDE_PROJECTS_DIR` | `~/.claude/projects` | Where host transcripts live (`<slug>/<session>.jsonl`). Read-only — the quote-reverification audit reads them to re-check stored quotes against their source. |
 | `DAIMON_SCAR_HARVEST` | off | When truthy, draft scar (negative-knowledge) candidates from the transcript at session-end. |
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
@@ -141,7 +141,7 @@ de sesión. Mira [Hosts](../hosts/) para la configuración por host.
 
 | Variable | Default | Qué hace |
 |---|---|---|
-| `DAIMON_LOG_DIR` | `~/.daimon/logs` | Dónde escribe `serialize.log` el hook de fin de sesión. El hook en sí tiene `~/.daimon/logs` fijo; este override existe para que el CLI (y los tests) puedan apuntar `status` a otra parte. |
+| `DAIMON_LOG_DIR` | `~/.daimon/logs` | Directorio de logs. `serialize-crash.log` respeta esta variable de los dos lados: los hooks que lanzan el proceso hijo de serialize la leen (del entorno y de este archivo) igual que el CLI, porque `daimon forget` borra ese archivo y quien escribe y quien borra tienen que coincidir en dónde está. `serialize.log` es la excepción: los hooks lo siguen escribiendo en `~/.daimon/logs` siempre, y este override solo cambia dónde lo busca el CLI (y los tests). |
 | `DAIMON_CLAUDE_PROJECTS_DIR` | `~/.claude/projects` | Dónde viven los transcripts del host (`<slug>/<session>.jsonl`). Solo-lectura — la auditoría de re-verificación de citas los lee para re-revisar citas almacenadas contra su fuente. |
 | `DAIMON_SCAR_HARVEST` | off | Cuando es verdadero, borra candidatos de scar (conocimiento negativo) desde el transcript al fin de sesión. |
 


### PR DESCRIPTION
Closes #605

## What

Brings `logs/serialize-crash.log` — the detached serializer child's raw stderr — inside the deletion contract, following the #607 shape:

- `store.purge_crash_log()`: wholesale unlink on `daimon forget`, wired after the windsurf purge with the same belt; not reached on dry-run or refused forgets. `lstat`-based refusal of symlinks and directories (for a fixed filename this is strictly stronger than a resolve-parents check: a link pointing back inside the log dir passes containment, yet unlink removes only the link). Never raises — resolution failure from a corrupt `~/.daimon/env` reports `(0, err)`.
- Write seam: hooks trim the log to a bounded tail (256KiB cap, 64KiB keep) before each append-open. In place, not temp-and-rename, so a still-running child's `O_APPEND` fd keeps the inode; the rare crash line written mid-trim is accepted diagnostics loss, stated in the docstring (`llm._log_backend_stderr` made the same call for the same reasons).
- `crash_log_path()` resolves `DAIMON_LOG_DIR` through the same process-env + `~/.daimon/env` fallback `config._get` uses, quirk-for-quirk (no strip, present-but-empty shadows the file, duplicate-key-last-wins) — with `DAIMON_LOG_DIR` set only in the env file, the writer previously filled `~/.daimon/logs` while the purge reported a clean zero on the configured directory. The windsurf finalizer now resolves through the same helper instead of hardcoding `~/.daimon/logs`.
- The #92 excepthook formats the traceback through `redact.redact_text` before stderr (secret shapes only — item text cannot be located in a traceback, which is why the purge is wholesale), fail-open to `sys.__excepthook__`; the `--- crash … ---` header shape `_crash_log_info` parses is unchanged.
- `surfaces.py`: the entry flips from `known-gap #605` to `wholesale-purge` / `forget`; the comment is scoped to what is provable (the excepthook sees only uncaught top-level exceptions; `daimon.recall` / `daimon.briefing` sit outside the #194 handler hierarchy, so lastResort output lands here too). The neighboring `logs/*.log` blanket claim is not restated — #616 tracks re-declaring that entry.
- Docs (en ×2, es): the crash sink honors `DAIMON_LOG_DIR` from both channels on both sides; `serialize.log` stays hardcoded by design (nothing deletes it, so writer and deleter need not agree).

New scar candidate: a hook-side mirror of a config accessor must copy its quirks, not its intent — second bite of the writer/deleter split class (#607, then this).

## Why

A Python traceback routinely embeds the values being processed; for the serializer that means item text and quotes. `forget`'s walk never left the checkpoint store, no reaper covered the file, and `daimon audit privacy` never scanned `logs/` — so a forgotten value surviving there was invisible to the tool that certifies deletion, with no age bound. #605 ranks redact/truncate-at-write plus wholesale-purge-on-forget as the pair that closes the gap without teaching the auditor a new root; #607 is the shipped precedent for the same shape.

Known residual, deliberate: the registry entry is a claim wired by a hardcoded call in `_cmd_forget`, not a mechanism derived from the registry — same as the chunk-cache and windsurf entries.

## Tests

`plugin/tests/test_crash_log_privacy.py`, 25 new tests, modeled on `test_windsurf_state_privacy.py`. Full suite `3166 passed, 2 skipped`; ruff clean; mypy unchanged from baseline; `sync_hooks.py --check` in sync; scar lint clean.

- Purge matrix: forget purges / dry-run and refused forgets never purge / symlink and directory decoys refused / missing file is a clean no-op / unreadable log dir is `(0, err)` not a silent zero / forget survives a failed and a raising purge / corrupt env file fails the purge closed.
- Writer/deleter agreement: env-file-only config end-to-end (`spawn_serialize` creates the file, `forget` removes that file — failed before the fix), plus a 16-probe table asserting `crash_log_path()` is byte-identical to `config.log_dir()` across quoting, `export`, whitespace, tilde, duplicate-key, and comment forms.
- Excepthook: redacts a secret-shaped canary in the on-disk bytes (asserting through `_crash_log_info` is vacuous — it already redacts on read, #513), preserves the header parse, falls back when redaction breaks.
- Trim: caps an oversized log keeping the tail, leaves an under-cap log alone, never blocks a spawn.
- Registry: the declaration is `wholesale-purge`/`forget` with no gap issue.
