### PR TITLE
fix(transcript): parse Codex 0.147.0 item_completed rollout events

### DIFF
--- a/.scars/candidates/host-format-drift-reads-as-too-short-skip.md
+++ b/.scars/candidates/host-format-drift-reads-as-too-short-skip.md
@@ -1,0 +1,29 @@
+---
+id: 0
+type: landmine
+title: Host transcript format drift parses to 0 messages and the too-short gate eats it silently
+severity: high
+confidence: 0.9
+created: 2026-08-07
+authors: ["claude-code"]
+anchors:
+  - path: plugin/daimon_briefing/transcript.py
+evidence:
+  - commit: 64c5fb6
+  - note: "issue #622 — Codex CLI 0.146.0→0.147.0 replaced event_msg/user_message and agent_message with item_completed (PascalCase item.type, content-block lists); a 13MB real session parsed to 0 messages and serialize skipped it 9 times as 'transcript too short (0 < 10 messages)' with nothing recorded for heal"
+expires:
+  condition: "serializer treats a multi-record transcript that parses to 0 messages as a parse failure (loud, heal-visible) instead of a too-short skip"
+  review_after: 2026-11-07
+---
+
+Host JSONL schemas are explicitly unstable (Codex says so in its docs), and
+the parser's per-host branches match exact record shapes. When a host CLI
+upgrade renames its event types, the branch collects zero messages, the
+generic fallback cannot read payload-nested rows, and the length gate then
+classifies the session as "too short" — a legitimate-looking skip, not a
+failure. Nothing reaches serialize-crash logging or `daimon heal`; the loss
+is invisible until a user notices a missing checkpoint (issue #622, fixed in
+64c5fb6). When touching parser branches or the too-short gate: a transcript
+with many raw records that parses to 0 messages is a parse failure, never a
+short session — and any new host-format support needs a fixture copied from a
+field transcript, not from that host's docs.

--- a/plugin/daimon_briefing/transcript.py
+++ b/plugin/daimon_briefing/transcript.py
@@ -210,6 +210,38 @@ def _from_jsonl(text: str) -> list[dict]:
         content = payload.get("message")
         if role and isinstance(content, str) and content.strip():
             codex_messages.append({"role": role, "content": content.strip()})
+            continue
+        # Codex CLI 0.147.0 (#622) dropped user_message/agent_message events:
+        # visible turns now arrive as item_completed with a PascalCase
+        # item.type and text as a content-block list. Block-type case differs
+        # by role in the field (UserMessage blocks say "text", AgentMessage
+        # blocks say "Text") — match it case-insensitively. AgentMessage
+        # phases (commentary, final_answer) are both assistant content.
+        if payload_type != "item_completed":
+            continue
+        item = payload.get("item")
+        if not isinstance(item, dict):
+            continue
+        role = {"UserMessage": "user", "AgentMessage": "assistant"}.get(
+            item.get("type")
+        )
+        if role is None:
+            continue
+        blocks = item.get("content")
+        if not isinstance(blocks, list):
+            continue
+        parts = []
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+            if str(block.get("type") or "").lower() != "text":
+                continue
+            text = block.get("text")
+            if isinstance(text, str) and text.strip():
+                parts.append(text.strip())
+        joined = "\n".join(parts)
+        if joined:
+            codex_messages.append({"role": role, "content": joined})
     if codex_messages:
         return codex_messages
 

--- a/plugin/tests/test_transcript.py
+++ b/plugin/tests/test_transcript.py
@@ -192,8 +192,21 @@ def test_from_file_parses_codex_0147_item_completed_stream(tmp_path):
         {"type": "event_msg", "ordinal": 6, "payload": {
             "type": "item_completed", "item": {
                 "type": "AgentMessage", "id": "a2", "content": [
+                    "stray-string-block",
+                    {"type": "image", "url": "x"},
                     {"type": "Text", "text": "Branch is clean."},
                 ], "phase": "final_answer",
+            },
+        }},
+        {"type": "event_msg", "ordinal": 7, "payload": {
+            "type": "token_count", "info": {"total_tokens": 4212},
+        }},
+        {"type": "event_msg", "ordinal": 8, "payload": {
+            "type": "item_completed", "item": "not-a-dict",
+        }},
+        {"type": "event_msg", "ordinal": 9, "payload": {
+            "type": "item_completed", "item": {
+                "type": "UserMessage", "id": "u2", "content": None,
             },
         }},
     ])

--- a/plugin/tests/test_transcript.py
+++ b/plugin/tests/test_transcript.py
@@ -146,6 +146,67 @@ def test_from_file_parses_current_codex_event_stream_without_duplicates(tmp_path
     ]
 
 
+def test_from_file_parses_codex_0147_item_completed_stream(tmp_path):
+    # Field-confirmed (#622): Codex CLI 0.147.0 stopped emitting
+    # user_message/agent_message events. Visible turns now arrive as
+    # event_msg/item_completed with a PascalCase item.type, text as a
+    # content-block list, and inconsistent block-type case between roles
+    # (UserMessage blocks say "text", AgentMessage blocks say "Text").
+    # AgentMessage carries a phase: commentary (mid-turn narration) and
+    # final_answer are both assistant content. response_item rows still
+    # duplicate each turn — the event stream stays the single source.
+    p = _write_jsonl(tmp_path / "codex.jsonl", [
+        {"type": "session_meta", "payload": {"cli_version": "0.147.0"}},
+        {"type": "event_msg", "ordinal": 1, "payload": {
+            "type": "item_completed", "item": {
+                "type": "UserMessage", "id": "u1", "content": [
+                    {"type": "text", "text": "Where did we leave off?",
+                     "text_elements": []},
+                ],
+            },
+        }},
+        {"type": "event_msg", "ordinal": 2, "payload": {
+            "type": "item_completed", "item": {
+                "type": "Reasoning", "id": "r1",
+                "summary_text": [], "raw_content": [],
+            },
+        }},
+        {"type": "event_msg", "ordinal": 3, "payload": {
+            "type": "item_completed", "item": {
+                "type": "AgentMessage", "id": "a1", "content": [
+                    {"type": "Text", "text": "Let me verify the repo."},
+                ], "phase": "commentary",
+            },
+        }},
+        {"type": "event_msg", "ordinal": 4, "payload": {
+            "type": "item_completed", "item": {
+                "type": "CommandExecution", "id": "e1",
+                "command": ["/bin/zsh", "-lc", "git status"],
+            },
+        }},
+        {"type": "response_item", "ordinal": 5, "payload": {
+            "type": "message", "role": "assistant", "content": [
+                {"type": "output_text", "text": "Let me verify the repo."},
+            ],
+        }},
+        {"type": "event_msg", "ordinal": 6, "payload": {
+            "type": "item_completed", "item": {
+                "type": "AgentMessage", "id": "a2", "content": [
+                    {"type": "Text", "text": "Branch is clean."},
+                ], "phase": "final_answer",
+            },
+        }},
+    ])
+
+    msgs = transcript.from_file(p)
+
+    assert msgs == [
+        {"role": "user", "content": "Where did we leave off?"},
+        {"role": "assistant", "content": "Let me verify the repo."},
+        {"role": "assistant", "content": "Branch is clean."},
+    ]
+
+
 def test_from_file_windsurf_cascade_jsonl_parses_user_and_assistant(tmp_path):
     # Field-confirmed (#70): native Cascade transcript rows are exactly
     # {type, status, <payload-key>}. canceled is dropped, error is kept


### PR DESCRIPTION
Closes #622

## What

Extends the Codex branch of `_from_jsonl` to parse the 0.147.0 rollout event stream: `event_msg/item_completed` records with PascalCase `item.type` (`UserMessage`/`AgentMessage`) and text as content-block lists. Block-type case differs by role in the field (`"text"` vs `"Text"`) and is matched case-insensitively. Both AgentMessage phases (`commentary`, `final_answer`) serialize as assistant content. The 0.146.0 `user_message`/`agent_message` mapping stays intact.

## Why

Codex CLI 0.147.0 dropped the old per-turn events, so a real session's rollout parsed to zero messages and serialize skipped it as "transcript too short (0 < 10 messages)" — silently, with nothing recorded for `daimon heal`. A full session produced no checkpoint and no error.

## Tests

- New `test_from_file_parses_codex_0147_item_completed_stream`, modeled on field-observed 0.147.0 record shapes — failed with `[] == [...]` before the fix (the exact production symptom), passes after.
- Full suite: 3167 passed, 2 skipped.
- Field check: the affected 13 MB 0.147.0 rollout now parses to 54 messages (12 user / 42 assistant), matching raw record counts.