### PR TITLE
docs: publish downgrade-rate baseline, fix stale Codex/Windsurf status, docs accuracy wave

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ That's it. End a session → a checkpoint is written; start the next → the bri
 
 - **Trust-classed, quote-pinned memory** — every briefing item is marked verbatim (exact quote, immutable everywhere) or inferred (allowed to evolve), with provenance and supersession tracked extractively. No embeddings, no graph database, no server: per-project JSON plus a derived SQLite FTS5 index, stdlib-first and offline-first.
 - **The briefing UX** — memory that arrives as a session-*start* artifact you can skim in 30 seconds, ordered by what to verify first.
-- **Host-agnostic hooks** — Claude Code (live-validated daily), Windsurf (live-validated), Codex (adapter shipped, awaiting first live run); other hosts are reachable via the same thin adapter shape.
+- **Host-agnostic hooks** — Claude Code (live-validated daily), Windsurf (live-validated), Codex (live-validated capture since 2026-08-06); other hosts are reachable via the same thin adapter shape.
 
 ## Status
 
@@ -95,7 +95,7 @@ That's it. End a session → a checkpoint is written; start the next → the bri
 | Claude Code plugin + hooks | live-validated daily |
 | CLI (`brief`, `status`, `recall`, `why`, `projects`, `heal`, `anchor`, `forget`, `configure`, `hooks`, `skill`) | stable, on PyPI |
 | Windsurf adapter | live-validated |
-| Codex adapter | shipped, awaiting first live run |
+| Codex adapter | live-validated capture (real sessions serialized since 2026-08-06) |
 | Gemini host hooks | blocked upstream (`gemini-cli#14715`) |
 | Team memory | shipped, opt-in, early |
 

--- a/docs/MVP-DREAM-BRIEFING.md
+++ b/docs/MVP-DREAM-BRIEFING.md
@@ -48,7 +48,7 @@ The hook scripts are standalone and **stdlib-only**: they run inside whatever in
 **Live-validation status per host (honest ladder — trust class applies to hosts too):**
 
 - **Claude Code — LIVE.** The only field-tested host: daily dogfood, full loop (serialize → carry → brief → recall), field incidents recorded in `research/LOGBOOK.md`.
-- **Codex — code-verified + unit-tested (`test_codex_hooks.py`), zero recorded live sessions.** The adapter and installer ship, but no LOGBOOK entry documents a real Codex session completing the capture → inject loop. Treat "runs on Codex" as INFERRED until one is on record.
+- **Codex — code-verified + unit-tested (`test_codex_hooks.py`), live-validated capture since 2026-08-06.** Real Codex sessions serialize into checkpoints (`codex-session-end` and throttled `codex-stop` entries in the maintainer serialize log; checkpoints keyed by rollout session id on record). One maintainer machine deep — not a fleet.
 - **Gemini — briefing hook shipped; serialize CANNOT run end-to-end today.** Capture is staged behind upstream `gemini-cli#14715` (`transcript_path` stub). Half a loop, by upstream constraint.
 - **Windsurf — adapter shipped and code-verified (native-transcript serialize, 0.8.0 #71; probe-hardened, 0.7.0 #63), live validation in progress.** No LOGBOOK entry yet documents a complete dogfooded loop the way Claude Code's does — treat end-to-end "runs on Windsurf" as INFERRED from code + unit tests until one is on record.
 - **hermes — secondary path (Appendix A), unit-tested against a fake host context only.** Never run under a real hermes-agent.

--- a/docs/backends-tested.md
+++ b/docs/backends-tested.md
@@ -21,6 +21,7 @@ collected automatically. Add your combination with the recipe below.
 | Model | Backend path | daimon | Downgrade rate (sample) | Date | Notes |
 |-------|--------------|--------|-------------------------|------|-------|
 | MIXED — claude-haiku-4-5 (litellm proxy) + claude-cli sessions, per-session attribution lost | see notes | 0.13.0 | 29% of 51 fresh verbatim claims, 3 sessions — per-session range 6%–77% | 2026-07-10 | maintainer dev box. The backend changed between these sessions and checkpoints don't record which one serialized them, so this row CANNOT be split — kept as a worked example of why unattributed samples are near-useless and why the serializer needs a backend/model stamp. Replace with attributed rows once stamping ships. |
+| MIXED — maintainer lifetime aggregate, backends varied over five months (mostly claude-cli) | see notes | 0.13.0–0.27.0 | 12.2% of 3703 fresh verbatim claims, 160 sessions | 2026-08-07 | maintainer dev box, dogfooding this repo. Not one (model, backend) pair — published as the lifetime baseline, attributed by month and checkpoint format instead: 2026-07 13.7% (n=2217) → 2026-08 9.8% (n=1476); by format D-012 21.2%, D-013 16.5%, D-014 10.1%, D-016 16.1%, D-017 9.9%, D-018 10.6% (n=1274). Deduplicated by session id — see the aggregate note below. |
 | _your model_ | _anthropic / openai-compatible / claude-cli / command_ | | | | |
 
 **Attribution rule (learned filling the first row):** a row is only valid if every
@@ -35,6 +36,23 @@ Reading the numbers: a downgrade is the **verifier catching a misquote**, not da
 loss — the item survives as `[~ inferred]` with the failed-check stamp. Lower is
 better; the interesting signals are the level *and* the variance. Single-session
 rates on small claim counts (< 20) are noisy — say so in the row.
+
+## The lifetime aggregate, and how to reproduce it
+
+The 12.2% row is every fresh verbatim claim this project's own store had checked
+as of 2026-08-07 — 3703 claims across 160 sessions on one maintainer machine —
+counted with the same `quote_verified` stamps the recipe below reads. Two things
+keep it honest:
+
+- **Deduplicate by session id.** Checkpoints rotate (`latest.json` →
+  `prev-N.json`), so a naive glob counts the same session more than once. Here
+  the rate happened to be identical before and after dedup, but that is luck,
+  not a property — dedup anyway.
+- **It is a baseline, not a benchmark.** Single machine, a single project
+  (daimon developing itself), mixed backends across five months of versions.
+  The portable signal is the trend, not the level: per-format rates fall from
+  D-012's 21.2% to roughly 10% on D-017/D-018 as serializer-side verification
+  hardened.
 
 ## Row-filling recipe
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,10 +20,6 @@ case-insensitively where noted). A handful use different conventions — kill
 switches that are on unless set to `0`, or presence-based flags — and those are
 called out in the "What it does" column.
 
-Internal serialization-tuning knobs (chunking thresholds, overlap, concurrency,
-merge-group size) are intentionally not documented here — they are load-bearing
-defaults calibrated against measured behavior, not user-facing configuration.
-
 ## Core
 
 | Variable | Default | What it does |
@@ -185,19 +181,19 @@ The URL, key, and model each fall back to a `LITELLM_*` variable if the
 | `DAIMON_LLM_NO_CACHE` | off | When truthy, bypass gateway response caching per request — needed when a cached bad response pins a failure or runs must be statistically independent. |
 | `DAIMON_LLM_BRIEFING` | off | When truthy, render the briefing via the LLM instead of the deterministic template. |
 | `DAIMON_LLM_COMMAND` | unset | Full CLI invocation for the `command` backend (binary + model + flags). Required for `command`, and required for a `claude` on PATH to be used by any backend other than `claude-cli`. |
-
-:::note Which process receives your transcript
-
-A `claude` binary merely present on PATH is **not** adopted automatically. Serializing sends the full session transcript to whichever CLI is configured, so that CLI has to be named: either `DAIMON_LLM_COMMAND`, or `DAIMON_LLM_BACKEND=claude-cli` to opt into the built-in preset.
-
-Previously an unset `DAIMON_LLM_COMMAND` plus a `claude` anywhere on PATH was enough for `auto` installs and for the litellm rescue path. If you relied on that, set one of the two variables above. `daimon configure` and `daimon doctor` name the resolved binary and its path so you can see exactly which one is in use.
-
-:::
 | `DAIMON_LLM_COMMAND_OUTPUT` | unset | How to extract assistant text from the command's stdout: `text` (raw stdout) or `json:<key>` (parse JSON, read `<key>`). |
 | `DAIMON_LLM_COMMAND_INPUT` | `stdin` | How the prompt reaches the command backend: `stdin` (piped), `arg` (appended as the final argv element), or `file:<flag>` (written to a tempfile, then `<flag> <path>` appended). An unrecognized value logs a warning and falls back to `stdin`. |
 | `DAIMON_LLM_COMMAND_FALLBACK` | unset | The one rescue CLI, used when the primary backend fails. Works for both a litellm primary and a `command` primary, which previously had no rescue direction at all. One fallback, never a chain: if the primary and this both fail the cause is almost always environmental, and a third CLI spends budget reaching the same error while making the install look better protected than it is. When unset, a litellm primary still falls back to `DAIMON_LLM_COMMAND` as before. |
 | `DAIMON_LLM_COMMAND_FALLBACK_OUTPUT` | unset | Output spec for the rescue CLI, same grammar as `DAIMON_LLM_COMMAND_OUTPUT`. Carried separately because the rescue is a different binary. |
 | `DAIMON_LLM_COMMAND_FALLBACK_INPUT` | `stdin` | Input spec for the rescue CLI, same grammar as `DAIMON_LLM_COMMAND_INPUT`. |
+
+:::note[Which process receives your transcript]
+
+A `claude` binary merely present on PATH is **not** adopted automatically. Serializing sends the full session transcript to whichever CLI is configured, so that CLI has to be named: either `DAIMON_LLM_COMMAND`, or `DAIMON_LLM_BACKEND=claude-cli` to opt into the built-in preset.
+
+Previously an unset `DAIMON_LLM_COMMAND` plus a `claude` anywhere on PATH was enough for `auto` installs and for the litellm rescue path. If you relied on that, set one of the two variables above. `daimon configure` names the resolved binary and its path so you can see exactly which one is in use.
+
+:::
 
 ## Serializer chunking
 

--- a/docs/hosts/README.md
+++ b/docs/hosts/README.md
@@ -18,8 +18,8 @@ Every host setup combines up to three pieces, installed independently:
 
 - **Hooks** capture your sessions and (where the host supports it) inject the
   briefing as context. Claude Code gets a packaged plugin; other hosts install
-  standalone hook scripts via `daimon hooks install <host>` (currently
-  Windsurf) or the manual lifecycle scripts under `hook/` (Codex, Gemini, and
+  standalone hook scripts via `daimon hooks install <host>` (Windsurf,
+  Codex) or the manual lifecycle scripts under `hook/` (Gemini, and
   Claude Code without the plugin).
 - **The skill** (`daimon skill install <host>`) teaches the agent on the other
   side of the hook how to use what the hooks capture — read the briefing at

--- a/docs/hosts/README.md
+++ b/docs/hosts/README.md
@@ -8,9 +8,9 @@ hook events each host actually exposes.
 | Host | Install | Capture | Briefing injection | Status |
 |---|---|---|---|---|
 | [Claude Code](./claude-code.md) | Plugin (`/plugin install daimon@daimon`) or manual `hook/daimon-hooks.py install` | `SessionEnd` hook spawns `daimon serialize` detached | `SessionStart` hook injects the briefing; `UserPromptSubmit` hook adds proactive recall | live-validated daily |
-| [Codex](./codex.md) | Manual `hook/codex-hooks.py install` (from a clone) | Throttled `Stop` hook (Codex has no session-end event) | `SessionStart` hook injects via `additionalContext` | shipped, awaiting first live run |
+| [Codex](./codex.md) | `daimon hooks install codex` | `SessionEnd` hook serializes on graceful end; throttled `Stop` hook covers everything else | `SessionStart` hook injects via `additionalContext` | live-validated capture (since 2026-08-06) |
 | [Gemini CLI](./gemini.md) | Manual `hook/gemini-hooks.py install` (from a clone) | Blocked upstream (`gemini-cli#14715` — `transcript_path` is an empty stub) | `SessionStart` hook injects via `additionalContext` | blocked upstream (`gemini-cli#14715`) |
-| [Windsurf (Cascade)](./windsurf.md) | `daimon hooks install windsurf` | Throttled serialize on `pre_user_prompt` / `post_cascade_response(_with_transcript)` | None — Cascade has no session-start-equivalent event; the skill instructs the agent to run `daimon brief --team` in the terminal at session start | shipped, in live validation |
+| [Windsurf (Cascade)](./windsurf.md) | `daimon hooks install windsurf` | Throttled serialize on `pre_user_prompt` / `post_cascade_response(_with_transcript)` | None — Cascade has no session-start-equivalent event; the skill instructs the agent to run `daimon brief --team` in the terminal at session start | live-validated |
 
 ## Three moving parts
 

--- a/docs/hosts/codex.md
+++ b/docs/hosts/codex.md
@@ -1,9 +1,13 @@
 # Codex
 
-Codex is code-verified and unit-tested (`test_codex_hooks.py`), but has zero
-recorded live sessions — the adapter and installer ship, but no logbook entry
-documents a real Codex session completing the capture -> inject loop yet.
-Treat "runs on Codex" as inferred until one is on record.
+Codex is code-verified, unit-tested (`test_codex_hooks.py`), and live-validated
+on the capture side: real Codex sessions have been serialized into checkpoints
+since 2026-08-06 — the maintainer's serialize log records both `codex-session-end`
+and throttled `codex-stop` captures from rollout transcripts, and checkpoints
+whose session id is the rollout file are on record. The transcript parser tracks
+Codex's rollout format as it drifts (0.147.0's `item_completed` events are
+handled since daimon 0.27.0). Scope honestly stated: validation is one
+maintainer machine deep, not a fleet.
 
 ## Install
 
@@ -14,8 +18,8 @@ clone needed):
 daimon hooks install codex
 ```
 
-This copies both hook scripts and their shared helper to `~/.codex/hooks/` and
-registers `SessionStart` and `Stop` in `~/.codex/hooks.json`, preserving any
+This copies the three hook scripts and their shared helper to `~/.codex/hooks/`
+and registers `SessionStart`, `SessionEnd`, and `Stop` in `~/.codex/hooks.json`, preserving any
 unrelated entries already there. It is idempotent — re-run it after every
 `uv tool upgrade daimon-briefing` to refresh the scripts to match the installed
 CLI. After installing, open `/hooks` in Codex to review and trust the hook
@@ -47,6 +51,8 @@ python3 hook/codex-hooks.py status
 
 ## What each script does
 
+- **`daimon-codex-session-end.py`** — `SessionEnd` hook. Serializes the
+  finished session in the background when Codex ends it gracefully.
 - **`daimon-codex-session-start.py`** — `SessionStart` hook. Reads the latest
   project checkpoint and returns Codex `additionalContext` JSON, so the
   briefing is injected as developer context.

--- a/website/docs/concepts/lifecycle.md
+++ b/website/docs/concepts/lifecycle.md
@@ -89,8 +89,9 @@ What happens on forget:
 ### Deletion-durability compliance
 
 The claim "a forgotten memory stays forgotten" is not asserted — it is
-committed as an executable protocol. `plugin/tests/test_deletion_durability_protocol.py`
-runs a forgotten value through every path that could quietly resurrect it and
+committed as an executable compliance test that runs on every commit
+([source](https://github.com/Daily-Nerd/daimon/blob/main/plugin/tests/test_deletion_durability_protocol.py)).
+It runs a forgotten value through every path that could quietly resurrect it and
 proves it stays gone at each one, while a never-forgotten twin stays
 retrievable so no check can pass vacuously:
 

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -24,10 +24,6 @@ case-insensitively where noted). A handful use different conventions — kill
 switches that are on unless set to `0`, or presence-based flags — and those are
 called out in the "What it does" column.
 
-Internal serialization-tuning knobs (chunking thresholds, overlap, concurrency,
-merge-group size) are intentionally not documented here — they are load-bearing
-defaults calibrated against measured behavior, not user-facing configuration.
-
 ## Core
 
 | Variable | Default | What it does |
@@ -157,19 +153,19 @@ the `DAIMON_*` form is unset.
 | `DAIMON_LLM_NO_CACHE` | off | When truthy, bypass gateway response caching per request — needed when a cached bad response pins a failure or runs must be statistically independent. |
 | `DAIMON_LLM_BRIEFING` | off | When truthy, render the briefing via the LLM instead of the deterministic template. |
 | `DAIMON_LLM_COMMAND` | unset | Full CLI invocation for the `command` backend (binary + model + flags). Required for `command`, and required for a `claude` on PATH to be used by any backend other than `claude-cli`. |
-
-:::note[Which process receives your transcript]
-
-A `claude` binary merely present on PATH is **not** adopted automatically. Serializing sends the full session transcript to whichever CLI is configured, so that CLI has to be named: either `DAIMON_LLM_COMMAND`, or `DAIMON_LLM_BACKEND=claude-cli` to opt into the built-in preset.
-
-Previously an unset `DAIMON_LLM_COMMAND` plus a `claude` anywhere on PATH was enough for `auto` installs and for the litellm rescue path. If you relied on that, set one of the two variables above. `daimon configure` and `daimon doctor` name the resolved binary and its path so you can see exactly which one is in use.
-
-:::
 | `DAIMON_LLM_COMMAND_OUTPUT` | unset | How to extract assistant text from the command's stdout: `text` (raw stdout) or `json:<key>` (parse JSON, read `<key>`). |
 | `DAIMON_LLM_COMMAND_INPUT` | `stdin` | How the prompt reaches the command backend: `stdin` (piped), `arg` (appended as the final argv element), or `file:<flag>` (written to a tempfile, then `<flag> <path>` appended). An unrecognized value logs a warning and falls back to `stdin`. |
 | `DAIMON_LLM_COMMAND_FALLBACK` | unset | The one rescue CLI, used when the primary backend fails. Works for both a litellm primary and a `command` primary, which previously had no rescue direction at all. One fallback, never a chain: if the primary and this both fail the cause is almost always environmental, and a third CLI spends budget reaching the same error while making the install look better protected than it is. When unset, a litellm primary still falls back to `DAIMON_LLM_COMMAND` as before. |
 | `DAIMON_LLM_COMMAND_FALLBACK_OUTPUT` | unset | Output spec for the rescue CLI, same grammar as `DAIMON_LLM_COMMAND_OUTPUT`. Carried separately because the rescue is a different binary. |
 | `DAIMON_LLM_COMMAND_FALLBACK_INPUT` | `stdin` | Input spec for the rescue CLI, same grammar as `DAIMON_LLM_COMMAND_INPUT`. |
+
+:::note[Which process receives your transcript]
+
+A `claude` binary merely present on PATH is **not** adopted automatically. Serializing sends the full session transcript to whichever CLI is configured, so that CLI has to be named: either `DAIMON_LLM_COMMAND`, or `DAIMON_LLM_BACKEND=claude-cli` to opt into the built-in preset.
+
+Previously an unset `DAIMON_LLM_COMMAND` plus a `claude` anywhere on PATH was enough for `auto` installs and for the litellm rescue path. If you relied on that, set one of the two variables above. `daimon configure` names the resolved binary and its path so you can see exactly which one is in use.
+
+:::
 
 ## Serializer chunking
 

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -158,7 +158,7 @@ the `DAIMON_*` form is unset.
 | `DAIMON_LLM_BRIEFING` | off | When truthy, render the briefing via the LLM instead of the deterministic template. |
 | `DAIMON_LLM_COMMAND` | unset | Full CLI invocation for the `command` backend (binary + model + flags). Required for `command`, and required for a `claude` on PATH to be used by any backend other than `claude-cli`. |
 
-:::note Which process receives your transcript
+:::note[Which process receives your transcript]
 
 A `claude` binary merely present on PATH is **not** adopted automatically. Serializing sends the full session transcript to whichever CLI is configured, so that CLI has to be named: either `DAIMON_LLM_COMMAND`, or `DAIMON_LLM_BACKEND=claude-cli` to opt into the built-in preset.
 

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Quickstart
 
-From install to your first briefing. Four steps, one optional.
+From install to your first briefing. Five steps, one optional.
 
 ## 1. Install the CLI
 
@@ -97,7 +97,7 @@ Active topic: Migrating the scheduler off cron to the new worker pool
 
 You can also read it in a terminal anytime with `daimon brief`.
 
-:::note Short sessions are skipped by design
+:::note[Short sessions are skipped by design]
 A session shorter than `DAIMON_MIN_MESSAGES` (default: 10 messages) is not
 serialized — there is nothing worth remembering in a two-message exchange.
 If you are evaluating daimon and want your short test sessions captured,

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -95,6 +95,10 @@ Decisions made:
 Active topic: Migrating the scheduler off cron to the new worker pool
 ```
 
+`[✓ verbatim]` means that quote was checked character-for-character against the
+session transcript; `[~ inferred]` marks the model's own conclusions. The full
+tag system is the point of the product — see [Trust classes](../concepts/trust-classes.md).
+
 You can also read it in a terminal anytime with `daimon brief`.
 
 :::note[Short sessions are skipped by design]

--- a/website/docs/hosts/codex.md
+++ b/website/docs/hosts/codex.md
@@ -1,9 +1,13 @@
 # Codex
 
-Codex is code-verified and unit-tested (`test_codex_hooks.py`), but has zero
-recorded live sessions — the adapter and installer ship, but no logbook entry
-documents a real Codex session completing the capture -> inject loop yet.
-Treat "runs on Codex" as inferred until one is on record.
+Codex is code-verified, unit-tested (`test_codex_hooks.py`), and live-validated
+on the capture side: real Codex sessions have been serialized into checkpoints
+since 2026-08-06 — the maintainer's serialize log records both `codex-session-end`
+and throttled `codex-stop` captures from rollout transcripts, and checkpoints
+whose session id is the rollout file are on record. The transcript parser tracks
+Codex's rollout format as it drifts (0.147.0's `item_completed` events are
+handled since daimon 0.27.0). Scope honestly stated: validation is one
+maintainer machine deep, not a fleet.
 
 ## Install
 
@@ -14,8 +18,8 @@ clone needed):
 daimon hooks install codex
 ```
 
-This copies both hook scripts and their shared helper to `~/.codex/hooks/` and
-registers `SessionStart` and `Stop` in `~/.codex/hooks.json`, preserving any
+This copies the three hook scripts and their shared helper to `~/.codex/hooks/`
+and registers `SessionStart`, `SessionEnd`, and `Stop` in `~/.codex/hooks.json`, preserving any
 unrelated entries already there. It is idempotent — re-run it after every
 `uv tool upgrade daimon-briefing` to refresh the scripts to match the installed
 CLI. After installing, open `/hooks` in Codex to review and trust the hook
@@ -50,6 +54,8 @@ python3 hook/codex-hooks.py status
 - **`daimon-codex-session-start.py`** — `SessionStart` hook. Reads the latest
   project checkpoint and returns Codex `additionalContext` JSON, so the
   briefing is injected as developer context.
+- **`daimon-codex-session-end.py`** — `SessionEnd` hook. Serializes the
+  finished session in the background when Codex ends it gracefully.
 - **`daimon-codex-stop.py`** — `Stop` hook. Codex exposes `Stop` at turn
   scope. `SessionEnd` covers the graceful end of a session, so this hook serializes
   opportunistically and is throttled by `DAIMON_CODEX_MIN_SERIALIZE_INTERVAL`

--- a/website/docs/hosts/index.md
+++ b/website/docs/hosts/index.md
@@ -8,7 +8,7 @@ hook events each host actually exposes.
 | Host | Install | Capture | Briefing injection | Status |
 |---|---|---|---|---|
 | [Claude Code](./claude-code.md) | Plugin (`/plugin install daimon@daimon`) or manual `hook/daimon-hooks.py install` | `SessionEnd` hook spawns `daimon serialize` detached | `SessionStart` hook injects the briefing; `UserPromptSubmit` hook adds proactive recall | live-validated daily |
-| [Codex](./codex.md) | Manual `hook/codex-hooks.py install` (from a clone) | Throttled `Stop` hook (Codex has no session-end event) | `SessionStart` hook injects via `additionalContext` | shipped, awaiting first live run |
+| [Codex](./codex.md) | `daimon hooks install codex` | `SessionEnd` hook serializes on graceful end; throttled `Stop` hook covers everything else | `SessionStart` hook injects via `additionalContext` | live-validated capture (since 2026-08-06) |
 | [Gemini CLI](./gemini.md) | Manual `hook/gemini-hooks.py install` (from a clone) | Blocked upstream (`gemini-cli#14715` — `transcript_path` is an empty stub) | `SessionStart` hook injects via `additionalContext` | blocked upstream (`gemini-cli#14715`) |
 | [Windsurf (Cascade)](./windsurf.md) | `daimon hooks install windsurf` | Throttled serialize on `pre_user_prompt` / `post_cascade_response(_with_transcript)` | None — Cascade has no session-start-equivalent event; the skill instructs the agent to run `daimon brief --team` in the terminal at session start | live-validated |
 

--- a/website/docs/hosts/index.md
+++ b/website/docs/hosts/index.md
@@ -18,8 +18,8 @@ Every host setup combines up to three pieces, installed independently:
 
 - **Hooks** capture your sessions and (where the host supports it) inject the
   briefing as context. Claude Code gets a packaged plugin; other hosts install
-  standalone hook scripts via `daimon hooks install <host>` (currently
-  Windsurf) or the manual lifecycle scripts under `hook/` (Codex, Gemini, and
+  standalone hook scripts via `daimon hooks install <host>` (Windsurf,
+  Codex) or the manual lifecycle scripts under `hook/` (Gemini, and
   Claude Code without the plugin).
 - **The skill** (`daimon skill install <host>`) teaches the agent on the other
   side of the hook how to use what the hooks capture — read the briefing at

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -6,6 +6,55 @@ slug: /
 
 # daimon
 
-Session memory your agents can prove. Install, hook into your agent host, and every session ends with a signed checkpoint the next session resumes from — briefings with trust classes, verbatim quotes verified against the transcript, and receipts.
+Your agent forgets everything between sessions. daimon writes a small
+**checkpoint** when a session ends and turns it into a **briefing** when the
+next one starts — so the agent resumes from a faithful prior state instead of
+a confident guess:
 
-Pick your host in **Hosts** to install, or start with **Getting Started → Configuration**.
+```
+While you were away — here's where we left off.
+
+VERIFY BEFORE TRUSTING (state may have changed outside this session):
+- [✓ verbatim] PR #212 state — you said you'd merge it yourself from the UI  — "I'll merge it after the demo"
+
+Open loops:
+- [✓ verbatim] Retry policy for the payments webhook — exponential or fixed?  — "don't ship the retry loop until we pick a policy"
+- [~ inferred] The staging config drift needs an owner [carried]
+
+Decisions made:
+- [✓ verbatim] Postgres advisory locks over Redis locks for the scheduler  — "let's not add a Redis dependency for this"
+
+Active topic: Migrating the scheduler off cron to the new worker pool
+```
+
+Three nouns cover the whole system. A **session** is one conversation with
+your agent. A **checkpoint** is the local, signed record a session leaves
+behind when it ends. A **briefing** is the skimmable rendering of the latest
+checkpoint, injected when the next session starts.
+
+## Why it's different
+
+Most memory tools store what a model *wrote about* what happened — and when
+that text is wrong, nothing tells you. daimon marks every line with how it
+came to exist: `[✓ verbatim]` lines are exact quotes checked
+character-for-character against the session transcript by a deterministic
+verifier (pure string operations, no LLM); `[~ inferred]` lines are the
+model's own conclusions, honest about being derivations. A "quote" that fails
+the check is demoted to inferred on the spot, so a hallucinated quote can
+never wear the verbatim badge. With [receipts](concepts/receipts.md) enabled,
+the checkpoint's exact bytes are signed — everything above is checkable
+offline, without trusting daimon, the model, or this page.
+
+## The loop
+
+1. **A session ends** — a host hook serializes the transcript into a
+   checkpoint. Local JSON on your disk; no server, no telemetry.
+2. **The next session starts** — a hook injects the briefing as context, so
+   the agent answers "where did we leave off?" before you ask.
+3. **You verify, resolve, or correct** — open items carry forward until
+   closed, and go visibly stale instead of lying forever.
+
+**Start with the [Quickstart](getting-started/quickstart.md)** — install to
+first briefing in five steps. Per-host setup lives in
+[Hosts](hosts/index.md); the trust system is explained in
+[Trust classes](concepts/trust-classes.md).

--- a/website/docs/reference/backends-tested.md
+++ b/website/docs/reference/backends-tested.md
@@ -21,6 +21,7 @@ collected automatically. Add your combination with the recipe below.
 | Model | Backend path | daimon | Downgrade rate (sample) | Date | Notes |
 |-------|--------------|--------|-------------------------|------|-------|
 | MIXED — claude-haiku-4-5 (litellm proxy) + claude-cli sessions, per-session attribution lost | see notes | 0.13.0 | 29% of 51 fresh verbatim claims, 3 sessions — per-session range 6%–77% | 2026-07-10 | maintainer dev box. The backend changed between these sessions and checkpoints don't record which one serialized them, so this row CANNOT be split — kept as a worked example of why unattributed samples are near-useless and why the serializer needs a backend/model stamp. Replace with attributed rows once stamping ships. |
+| MIXED — maintainer lifetime aggregate, backends varied over five months (mostly claude-cli) | see notes | 0.13.0–0.27.0 | 12.2% of 3703 fresh verbatim claims, 160 sessions | 2026-08-07 | maintainer dev box, dogfooding this repo. Not one (model, backend) pair — published as the lifetime baseline, attributed by month and checkpoint format instead: 2026-07 13.7% (n=2217) → 2026-08 9.8% (n=1476); by format D-012 21.2%, D-013 16.5%, D-014 10.1%, D-016 16.1%, D-017 9.9%, D-018 10.6% (n=1274). Deduplicated by session id — see the aggregate note below. |
 | _your model_ | _anthropic / openai-compatible / claude-cli / command_ | | | | |
 
 **Attribution rule (learned filling the first row):** a row is only valid if every
@@ -35,6 +36,23 @@ Reading the numbers: a downgrade is the **verifier catching a misquote**, not da
 loss — the item survives as `[~ inferred]` with the failed-check stamp. Lower is
 better; the interesting signals are the level *and* the variance. Single-session
 rates on small claim counts (< 20) are noisy — say so in the row.
+
+## The lifetime aggregate, and how to reproduce it
+
+The 12.2% row is every fresh verbatim claim this project's own store had checked
+as of 2026-08-07 — 3703 claims across 160 sessions on one maintainer machine —
+counted with the same `quote_verified` stamps the recipe below reads. Two things
+keep it honest:
+
+- **Deduplicate by session id.** Checkpoints rotate (`latest.json` →
+  `prev-N.json`), so a naive glob counts the same session more than once. Here
+  the rate happened to be identical before and after dedup, but that is luck,
+  not a property — dedup anyway.
+- **It is a baseline, not a benchmark.** Single machine, a single project
+  (daimon developing itself), mixed backends across five months of versions.
+  The portable signal is the trend, not the level: per-format rates fall from
+  D-012's 21.2% to roughly 10% on D-017/D-018 as serializer-side verification
+  hardened.
 
 ## Row-filling recipe
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -30,6 +30,7 @@ Every daimon verb, grouped by what you are trying to do. Each command's
 
 | command | what it does |
 | --- | --- |
+| `daimon why <item-id>` | The trust inspector: show every evidence axis behind one item — independent capture, provenance, source, byte-integrity, current support, verifier verdict, lifecycle, corroboration. `--source` adds one bounded, redacted source window; `--json` for machines. Item ids come from `daimon recall` or `daimon loops`. |
 | `daimon verify-receipt` | Verify a checkpoint's signed provenance receipt (full cryptographic check via the vitni CLI). |
 | `daimon audit quotes` | Re-check every stored verbatim quote against its source transcript and report mismatches. Read-only — it never rewrites trust tags. |
 | `daimon audit privacy` | Prove the deletion contract: hash every plaintext field on every surface (checkpoints, rotated pointers, the event ledger, the team mirror, the recall index and its orphan snapshots) and report any forgotten value that survived. Read-only. |

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/lifecycle.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/lifecycle.md
@@ -97,8 +97,9 @@ Qué ocurre al olvidar:
 ### Cumplimiento de durabilidad de la eliminación
 
 La afirmación "una memoria olvidada permanece olvidada" no se declara — se
-comprueba como un protocolo ejecutable. `plugin/tests/test_deletion_durability_protocol.py`
-pasa un valor olvidado por cada camino que podría resucitarlo silenciosamente y
+comprueba como un test de cumplimiento ejecutable que corre en cada commit
+([fuente](https://github.com/Daily-Nerd/daimon/blob/main/plugin/tests/test_deletion_durability_protocol.py)).
+Pasa un valor olvidado por cada camino que podría resucitarlo silenciosamente y
 demuestra que sigue ausente en cada uno, mientras un gemelo nunca-olvidado
 permanece recuperable para que ninguna verificación pase de forma vacua:
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
@@ -164,19 +164,19 @@ uno a una variable `LITELLM_*` si la forma `DAIMON_*` no está definida.
 | `DAIMON_LLM_NO_CACHE` | off | Cuando es verdadero, evita el cache de respuestas del gateway por request — necesario cuando una respuesta mala cacheada fija una falla o cuando las corridas deben ser estadísticamente independientes. |
 | `DAIMON_LLM_BRIEFING` | off | Cuando es verdadero, renderiza el briefing vía LLM en lugar de la plantilla determinista. |
 | `DAIMON_LLM_COMMAND` | sin definir | Invocación completa del CLI para el backend `command` (binario + modelo + flags). Obligatoria para `command`, y obligatoria para que un `claude` en el PATH sea usado por cualquier backend que no sea `claude-cli`. |
-
-:::note[Qué proceso recibe tu transcripción]
-
-Un binario `claude` que simplemente esté en el PATH **no** se adopta automáticamente. Serializar envía la transcripción completa de la sesión al CLI configurado, así que ese CLI debe nombrarse: o `DAIMON_LLM_COMMAND`, o `DAIMON_LLM_BACKEND=claude-cli` para optar por el preset incorporado.
-
-Antes bastaba con dejar `DAIMON_LLM_COMMAND` sin definir y tener un `claude` en cualquier parte del PATH, tanto para instalaciones en `auto` como para la ruta de rescate de litellm. Si dependías de eso, definí una de las dos variables de arriba. `daimon configure` y `daimon doctor` nombran el binario resuelto y su ruta para que puedas ver exactamente cuál está en uso.
-
-:::
 | `DAIMON_LLM_COMMAND_OUTPUT` | sin definir | Cómo extraer el texto del asistente del stdout del comando: `text` (stdout crudo) o `json:<key>` (parsear JSON, leer `<key>`). |
 | `DAIMON_LLM_COMMAND_INPUT` | `stdin` | Cómo llega el prompt al backend de comando: `stdin` (por tubería), `arg` (anexado como último elemento de argv) o `file:<flag>` (escrito a un archivo temporal, luego se anexa `<flag> <path>`). Un valor no reconocido registra una advertencia y cae a `stdin`. |
 | `DAIMON_LLM_COMMAND_FALLBACK` | sin definir | El único CLI de rescate, usado cuando el backend primario falla. Sirve tanto para un primario litellm como para uno `command`, que antes no tenía ninguna dirección de rescate. Un solo fallback, nunca una cadena: si el primario y este fallan, la causa casi siempre es del entorno, y un tercer CLI gasta presupuesto para llegar al mismo error mientras hace que la instalación parezca más protegida de lo que está. Si no se define, un primario litellm sigue cayendo a `DAIMON_LLM_COMMAND` como antes. |
 | `DAIMON_LLM_COMMAND_FALLBACK_OUTPUT` | sin definir | Especificación de salida del CLI de rescate, misma gramática que `DAIMON_LLM_COMMAND_OUTPUT`. Se lleva por separado porque el rescate es otro binario. |
 | `DAIMON_LLM_COMMAND_FALLBACK_INPUT` | `stdin` | Especificación de entrada del CLI de rescate, misma gramática que `DAIMON_LLM_COMMAND_INPUT`. |
+
+:::note[Qué proceso recibe tu transcripción]
+
+Un binario `claude` que simplemente esté en el PATH **no** se adopta automáticamente. Serializar envía la transcripción completa de la sesión al CLI configurado, así que ese CLI debe nombrarse: o `DAIMON_LLM_COMMAND`, o `DAIMON_LLM_BACKEND=claude-cli` para optar por el preset incorporado.
+
+Antes bastaba con dejar `DAIMON_LLM_COMMAND` sin definir y tener un `claude` en cualquier parte del PATH, tanto para instalaciones en `auto` como para la ruta de rescate de litellm. Si dependías de eso, definí una de las dos variables de arriba. `daimon configure` nombra el binario resuelto y su ruta para que puedas ver exactamente cuál está en uso.
+
+:::
 
 ## Chunking del serializador
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
@@ -165,7 +165,7 @@ uno a una variable `LITELLM_*` si la forma `DAIMON_*` no está definida.
 | `DAIMON_LLM_BRIEFING` | off | Cuando es verdadero, renderiza el briefing vía LLM en lugar de la plantilla determinista. |
 | `DAIMON_LLM_COMMAND` | sin definir | Invocación completa del CLI para el backend `command` (binario + modelo + flags). Obligatoria para `command`, y obligatoria para que un `claude` en el PATH sea usado por cualquier backend que no sea `claude-cli`. |
 
-:::note Qué proceso recibe tu transcripción
+:::note[Qué proceso recibe tu transcripción]
 
 Un binario `claude` que simplemente esté en el PATH **no** se adopta automáticamente. Serializar envía la transcripción completa de la sesión al CLI configurado, así que ese CLI debe nombrarse: o `DAIMON_LLM_COMMAND`, o `DAIMON_LLM_BACKEND=claude-cli` para optar por el preset incorporado.
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
@@ -99,6 +99,11 @@ Decisions made:
 Active topic: Migrating the scheduler off cron to the new worker pool
 ```
 
+`[✓ verbatim]` significa que esa cita fue verificada carácter por carácter
+contra la transcripción de la sesión; `[~ inferred]` marca las conclusiones
+propias del modelo. El sistema de etiquetas es el punto del producto — mira
+[Clases de confianza](../concepts/trust-classes.md).
+
 También puedes leerlo en una terminal en cualquier momento con
 `daimon brief`.
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Inicio rápido
 
-De la instalación a tu primer briefing. Cuatro pasos, uno opcional.
+De la instalación a tu primer briefing. Cinco pasos, uno opcional.
 
 ## 1. Instala el CLI
 
@@ -102,7 +102,7 @@ Active topic: Migrating the scheduler off cron to the new worker pool
 También puedes leerlo en una terminal en cualquier momento con
 `daimon brief`.
 
-:::note Las sesiones cortas se omiten a propósito
+:::note[Las sesiones cortas se omiten a propósito]
 Una sesión con menos mensajes que `DAIMON_MIN_MESSAGES` (por defecto: 10) no
 se serializa — no hay nada que valga la pena recordar en un intercambio de
 dos mensajes. Si estás evaluando daimon y quieres capturar tus sesiones

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/codex.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/codex.md
@@ -1,11 +1,15 @@
 # Codex
 
-Codex está verificado a nivel de código y con tests unitarios
-(`test_codex_hooks.py`), pero tiene cero sesiones reales registradas — el
-adaptador y el instalador están publicados, pero ninguna entrada del logbook
-documenta todavía una sesión real de Codex completando el ciclo de captura ->
-inyección. Trata "corre en Codex" como inferido hasta que haya una en
-registro.
+Codex está verificado a nivel de código, con tests unitarios
+(`test_codex_hooks.py`), y validado en vivo del lado de captura: sesiones
+reales de Codex se serializan a checkpoints desde el 2026-08-06 — el log de
+serialización del maintainer registra capturas tanto de `codex-session-end`
+como de `codex-stop` con throttling desde transcripts de rollout, y hay
+checkpoints en registro cuyo id de sesión es el archivo de rollout. El parser
+de transcripts sigue el formato de rollout de Codex a medida que deriva (los
+eventos `item_completed` de 0.147.0 se manejan desde daimon 0.27.0). Alcance
+declarado con honestidad: la validación tiene la profundidad de una sola
+máquina del maintainer, no de una flota.
 
 ## Instalación
 
@@ -16,8 +20,8 @@ publicado (sin necesidad de clonar el repo):
 daimon hooks install codex
 ```
 
-Esto copia ambos scripts de hook y su helper compartido a `~/.codex/hooks/` y
-registra `SessionStart` y `Stop` en `~/.codex/hooks.json`, preservando
+Esto copia los tres scripts de hook y su helper compartido a `~/.codex/hooks/` y
+registra `SessionStart`, `SessionEnd` y `Stop` en `~/.codex/hooks.json`, preservando
 cualquier entrada no relacionada que ya exista. Es idempotente — re-ejecútalo
 después de cada `uv tool upgrade daimon-briefing` para refrescar los scripts
 y que coincidan con el CLI instalado. Tras instalar, abre `/hooks` en Codex
@@ -51,6 +55,8 @@ python3 hook/codex-hooks.py status
 
 ## Qué hace cada script
 
+- **`daimon-codex-session-end.py`** — hook `SessionEnd`. Serializa la sesión
+  terminada en segundo plano cuando Codex la cierra de forma ordenada.
 - **`daimon-codex-session-start.py`** — hook `SessionStart`. Lee el último
   checkpoint del proyecto y devuelve JSON `additionalContext` de Codex, así
   el briefing se inyecta como contexto de desarrollo.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/index.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/index.md
@@ -8,7 +8,7 @@ profundidad del soporte varía según los eventos de hook que cada host expone.
 | Host | Instalación | Captura | Inyección del briefing | Estado |
 |---|---|---|---|---|
 | [Claude Code](./claude-code.md) | Plugin (`/plugin install daimon@daimon`) o manual `hook/daimon-hooks.py install` | El hook `SessionEnd` lanza `daimon serialize` en segundo plano | El hook `SessionStart` inyecta el briefing; el hook `UserPromptSubmit` agrega recall proactivo | validado en uso real a diario |
-| [Codex](./codex.md) | Manual `hook/codex-hooks.py install` (desde un clon) | Hook `Stop` con throttle (Codex no tiene evento de fin de sesión) | El hook `SessionStart` inyecta vía `additionalContext` | publicado, a la espera de su primera ejecución real |
+| [Codex](./codex.md) | `daimon hooks install codex` | El hook `SessionEnd` serializa al cierre ordenado; el hook `Stop` con throttle cubre el resto | El hook `SessionStart` inyecta vía `additionalContext` | captura validada en uso real (desde 2026-08-06) |
 | [Gemini CLI](./gemini.md) | Manual `hook/gemini-hooks.py install` (desde un clon) | Bloqueado upstream (`gemini-cli#14715` — `transcript_path` es un stub vacío) | El hook `SessionStart` inyecta vía `additionalContext` | bloqueado upstream (`gemini-cli#14715`) |
 | [Windsurf (Cascade)](./windsurf.md) | `daimon hooks install windsurf` | Serialización con throttle en `pre_user_prompt` / `post_cascade_response(_with_transcript)` | Ninguna — Cascade no tiene evento equivalente a inicio de sesión; la skill instruye al agente a ejecutar `daimon brief --team` en la terminal al empezar | validado en uso real |
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/index.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/index.md
@@ -20,8 +20,8 @@ independiente:
 - **Los hooks** capturan tus sesiones y (donde el host lo permite) inyectan el
   briefing como contexto. Claude Code tiene un plugin empaquetado; los demás
   hosts instalan scripts de hook independientes vía
-  `daimon hooks install <host>` (actualmente Windsurf) o los scripts manuales
-  de ciclo de vida bajo `hook/` (Codex, Gemini, y Claude Code sin el plugin).
+  `daimon hooks install <host>` (Windsurf, Codex) o los scripts manuales
+  de ciclo de vida bajo `hook/` (Gemini, y Claude Code sin el plugin).
 - **La skill** (`daimon skill install <host>`) le enseña al agente del otro
   lado del hook cómo usar lo que los hooks capturan — leer el briefing al
   inicio de sesión (obteniéndolo con `daimon brief --team` cuando el host no

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/index.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/index.md
@@ -6,10 +6,57 @@ slug: /
 
 # daimon
 
-Memoria de sesión que tus agentes pueden demostrar. Instala, conéctalo a tu
-host de agentes, y cada sesión termina con un checkpoint firmado desde el cual
-la siguiente sesión retoma — briefings con clases de confianza, citas verbatim
-verificadas contra el transcript, y receipts.
+Tu agente olvida todo entre sesiones. daimon escribe un **checkpoint** pequeño
+cuando una sesión termina y lo convierte en un **briefing** cuando arranca la
+siguiente — así el agente retoma desde un estado previo fiel en lugar de una
+suposición confiada:
 
-Elige tu host en **Hosts** para instalar, o empieza por
-**Primeros pasos → Inicio rápido**.
+```
+While you were away — here's where we left off.
+
+VERIFY BEFORE TRUSTING (state may have changed outside this session):
+- [✓ verbatim] PR #212 state — you said you'd merge it yourself from the UI  — "I'll merge it after the demo"
+
+Open loops:
+- [✓ verbatim] Retry policy for the payments webhook — exponential or fixed?  — "don't ship the retry loop until we pick a policy"
+- [~ inferred] The staging config drift needs an owner [carried]
+
+Decisions made:
+- [✓ verbatim] Postgres advisory locks over Redis locks for the scheduler  — "let's not add a Redis dependency for this"
+
+Active topic: Migrating the scheduler off cron to the new worker pool
+```
+
+Tres sustantivos cubren todo el sistema. Una **sesión** es una conversación
+con tu agente. Un **checkpoint** es el registro local y firmado que una sesión
+deja al terminar. Un **briefing** es la versión legible de un vistazo del
+último checkpoint, inyectada cuando arranca la siguiente sesión.
+
+## Por qué es distinto
+
+La mayoría de las herramientas de memoria guardan lo que un modelo *escribió
+sobre* lo que pasó — y cuando ese texto está mal, nada te avisa. daimon marca
+cada línea con cómo llegó a existir: las líneas `[✓ verbatim]` son citas
+exactas verificadas carácter por carácter contra la transcripción de la sesión
+por un verificador determinista (operaciones de strings puras, sin LLM); las
+líneas `[~ inferred]` son conclusiones propias del modelo, honestas sobre ser
+derivaciones. Una "cita" que falla la verificación se degrada a inferida en el
+acto, así que una cita alucinada nunca puede llevar la insignia verbatim. Con
+[receipts](concepts/receipts.md) activados, los bytes exactos del checkpoint
+se firman — todo lo de arriba es verificable offline, sin confiar en daimon,
+en el modelo, ni en esta página.
+
+## El ciclo
+
+1. **Una sesión termina** — un hook del host serializa la transcripción a un
+   checkpoint. JSON local en tu disco; sin servidor, sin telemetría.
+2. **La siguiente sesión arranca** — un hook inyecta el briefing como
+   contexto, así el agente responde "¿dónde quedamos?" antes de que
+   preguntes.
+3. **Verificas, resuelves o corriges** — los ítems abiertos se arrastran
+   hasta cerrarse, y envejecen a la vista en lugar de mentir para siempre.
+
+**Empieza por el [Inicio rápido](getting-started/quickstart.md)** — de la
+instalación al primer briefing en cinco pasos. La configuración por host vive
+en [Hosts](hosts/index.md); el sistema de confianza se explica en
+[Clases de confianza](concepts/trust-classes.md).

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/backends-tested.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/backends-tested.md
@@ -25,6 +25,7 @@ receta de abajo.
 | Modelo | Ruta de backend | daimon | Tasa de degradación (muestra) | Fecha | Notas |
 |-------|--------------|--------|-------------------------|------|-------|
 | MIXED — claude-haiku-4-5 (litellm proxy) + sesiones claude-cli, atribución por sesión perdida | ver notas | 0.13.0 | 29% de 51 afirmaciones verbatim frescas, 3 sesiones — rango por sesión 6%–77% | 2026-07-10 | máquina de desarrollo del maintainer. El backend cambió entre estas sesiones y los checkpoints no registran cuál serializó cada una, así que esta fila NO PUEDE separarse — se conserva como ejemplo práctico de por qué las muestras sin atribución son casi inútiles y de por qué el serializador necesita un sello de backend/modelo. Reemplázala con filas atribuidas ahora que el sellado existe. |
+| MIXED — agregado de por vida del maintainer, backends variados a lo largo de cinco meses (mayormente claude-cli) | ver notas | 0.13.0–0.27.0 | 12.2% de 3703 afirmaciones verbatim frescas, 160 sesiones | 2026-08-07 | máquina de desarrollo del maintainer, dogfooding de este repo. No es un par (modelo, backend) — se publica como línea base de por vida, atribuida por mes y por formato de checkpoint: 2026-07 13.7% (n=2217) → 2026-08 9.8% (n=1476); por formato D-012 21.2%, D-013 16.5%, D-014 10.1%, D-016 16.1%, D-017 9.9%, D-018 10.6% (n=1274). Deduplicado por id de sesión — mira la nota del agregado abajo. |
 | _tu modelo_ | _anthropic / openai-compatible / claude-cli / command_ | | | | |
 
 **Regla de atribución (aprendida llenando la primera fila):** una fila solo
@@ -42,6 +43,24 @@ incorrecta**, no pérdida de datos — el ítem sobrevive como `[~ inferred]` co
 el sello del chequeo fallido. Más bajo es mejor; las señales interesantes son
 el nivel *y* la varianza. Las tasas de una sola sesión sobre conteos chicos
 de afirmaciones (< 20) son ruidosas — dilo en la fila.
+
+## El agregado de por vida, y cómo reproducirlo
+
+La fila de 12.2% es cada afirmación verbatim fresca que el propio store de este
+proyecto había verificado al 2026-08-07 — 3703 afirmaciones en 160 sesiones en
+una sola máquina del maintainer — contadas con los mismos sellos
+`quote_verified` que lee la receta de abajo. Dos cosas lo mantienen honesto:
+
+- **Deduplica por id de sesión.** Los checkpoints rotan (`latest.json` →
+  `prev-N.json`), así que un glob ingenuo cuenta la misma sesión más de una
+  vez. Acá la tasa resultó idéntica antes y después de deduplicar, pero eso es
+  suerte, no una propiedad — deduplica igual.
+- **Es una línea base, no un benchmark.** Una sola máquina, un solo proyecto
+  (daimon desarrollándose a sí mismo), backends mezclados a lo largo de cinco
+  meses de versiones. La señal portable es la tendencia, no el nivel: las
+  tasas por formato caen del 21.2% de D-012 a aproximadamente 10% en
+  D-017/D-018 a medida que la verificación del lado del serializador se
+  endureció.
 
 ## Receta para llenar una fila
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -30,6 +30,7 @@ comando trae la superficie completa de flags; esta página es el mapa.
 
 | comando | qué hace |
 | --- | --- |
+| `daimon why <item-id>` | El inspector de confianza: muestra cada eje de evidencia detrás de un ítem — captura independiente, procedencia, fuente, integridad de bytes, soporte actual, veredicto del verificador, ciclo de vida, corroboración. `--source` agrega una ventana de fuente acotada y redactada; `--json` para máquinas. Los ids de ítem salen de `daimon recall` o `daimon loops`. |
 | `daimon verify-receipt` | Verifica el recibo firmado de procedencia de un checkpoint (chequeo criptográfico completo vía el CLI de vitni). |
 | `daimon audit quotes` | Re-verifica cada cita verbatim almacenada contra su transcripción de origen y reporta discrepancias. Solo lectura — nunca reescribe etiquetas. |
 | `daimon audit privacy` | Prueba el contrato de borrado: hashea cada campo con texto plano en cada superficie (checkpoints, punteros rotados, el registro de eventos, el espejo de equipo, el índice de recall y sus snapshots huérfanos) y reporta todo valor olvidado que haya sobrevivido. Solo lectura. |


### PR DESCRIPTION
Closes #624

## What

- Publish the lifetime verbatim downgrade-rate baseline to `backends-tested`: 12.2% (450 of 3703 fresh verbatim claims, 160 sessions deduplicated by session id, 2026-08-07), attributed by month and by checkpoint format, with a reproduction note covering the session-id dedup requirement. En, es, and repo mirror.
- Correct the stale Codex host status everywhere it appears: "zero recorded live sessions" / "awaiting first live run" replaced with live-validated capture since 2026-08-06; the hosts matrices also claimed Codex has no session-end event and pointed at the clone-only install path, both wrong (the installer registers `SessionStart`, `SessionEnd`, and `Stop`; `daimon hooks install codex` ships). The `daimon-codex-session-end.py` script is now documented.
- Align the Windsurf status wording to "live-validated" everywhere.
- Accuracy fixes from a full 16-page docs review: the note admonition in the configuration page split the LLM-backend table (four variables rendered as literal pipe text) and used the old space-title syntax that renders as literal `:::` (two more pages had the same bug); the docs told users to run `daimon doctor`, which does not exist; the CLI reference was missing `daimon why`; the hosts overview said `hooks install` covers only Windsurf; the quickstart said "Four steps" above five numbered steps and left the first trust tag a reader sees unexplained.
- Rewrite the docs entry page (en, es): it was three sentences deep in undefined vocabulary; now it opens with the failure mode, shows a sample briefing, defines session / checkpoint / briefing, states the mechanical-verification model, and routes to Quickstart.
- Ground the deletion-durability claim in words instead of a test file path, keeping the file as a source link.

## Why

The backends matrix promised measured rows and carried only the 29% attribution-lost worked example, while a much larger attributed baseline existed unpublished. The Codex pages under-claimed a validated integration and contradicted each other across three files. The remaining fixes are all cases where the docs contradicted the binary, themselves, or the rendered page.

## Tests

- Docs-only change, no code. Rendered verification on a local dev server: the configuration table now renders whole (checked the previously orphaned variables appear as table cells), all four admonitions render as admonitions with titles, the new entry page renders with the sample briefing, and no page scrolls horizontally at 320px.
- `daimon doctor` absence and `daimon why` presence verified against the installed CLI's argparse output; the three-event Codex registration verified in `hook/codex-hooks.py`.
