### PR TITLE
docs: state the quote check's real matching contract

### DIFF
--- a/website/blog/2026-07-28-verbatim-vs-inferred.md
+++ b/website/blog/2026-07-28-verbatim-vs-inferred.md
@@ -63,7 +63,7 @@ session read that line, believed the memory layer was healthy, and built on a
 foundation that was not there.
 
 Every step of that is faithful. The model did say it. The transcript records it
-exactly. The quote verifier matched it character for character and stamped it
+exactly. The quote verifier found it in the transcript and stamped it
 `✓ verbatim`, correctly. The trust class did its job and the memory was still
 false, because the thing being certified was that the sentence was *said*, not
 that the event *happened*.

--- a/website/docs/concepts/trust-classes.md
+++ b/website/docs/concepts/trust-classes.md
@@ -12,7 +12,7 @@ which parts of it are quotes and which parts are guesses.
 
 ### `[✓ verbatim]`
 
-An exact quote from a past session's transcript, pinned character-for-character.
+An exact quote from a past session's transcript, pinned at capture.
 Verbatim items are never reworded — not by carry-over between sessions, not by
 rendering, not by budget truncation. When a briefing shows
 
@@ -67,6 +67,15 @@ by a deterministic verifier — pure string operations, no LLM, on the principle
 that *the checker must be dumber than the thing it checks*. A quote that
 verifies gets stamped; a quote that doesn't is **downgraded to `~ inferred`**
 on the spot, so a hallucinated "quote" can never wear the verbatim badge.
+
+What the check actually guarantees, precisely: the quote is **found in the
+transcript after both sides are folded the same way** — case, whitespace runs,
+markdown emphasis and list markers, and curly-quote/dash glyph variants are
+normalized; a quote elided with `…` is split into fragments that must appear
+in order, with very short fragments dropped as too generic to pin. It is a
+mechanical presence check, not a byte-for-byte guarantee and not a truth
+claim about the world. Byte-immutability applies to *storage*: once pinned,
+the stored quote is never reworded by carry, rendering, or truncation.
 
 The guarantee extends past write time: with [receipts](./receipts.md) enabled,
 the checkpoint's exact bytes are signed when written — so if a checkpoint file

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -95,8 +95,8 @@ Decisions made:
 Active topic: Migrating the scheduler off cron to the new worker pool
 ```
 
-`[✓ verbatim]` means that quote was checked character-for-character against the
-session transcript; `[~ inferred]` marks the model's own conclusions. The full
+`[✓ verbatim]` means a deterministic checker found that quote in the session
+transcript; `[~ inferred]` marks the model's own conclusions. The full
 tag system is the point of the product — see [Trust classes](../concepts/trust-classes.md).
 
 You can also read it in a terminal anytime with `daimon brief`.

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -36,10 +36,10 @@ checkpoint, injected when the next session starts.
 
 Most memory tools store what a model *wrote about* what happened — and when
 that text is wrong, nothing tells you. daimon marks every line with how it
-came to exist: `[✓ verbatim]` lines are exact quotes checked
-character-for-character against the session transcript by a deterministic
-verifier (pure string operations, no LLM); `[~ inferred]` lines are the
-model's own conclusions, honest about being derivations. A "quote" that fails
+came to exist: `[✓ verbatim]` lines are exact quotes a deterministic verifier
+found in the session transcript (pure string operations, no LLM — case,
+whitespace, and formatting folded, elided spans allowed); `[~ inferred]` lines
+are the model's own conclusions, honest about being derivations. A "quote" that fails
 the check is demoted to inferred on the spot, so a hallucinated quote can
 never wear the verbatim badge. With [receipts](concepts/receipts.md) enabled,
 the checkpoint's exact bytes are signed — everything above is checkable

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-07-28-verbatim-vs-inferred.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-07-28-verbatim-vs-inferred.md
@@ -67,7 +67,7 @@ siguiente leyó esa línea, creyó que la capa de memoria estaba sana y construy
 sobre unos cimientos que no existían.
 
 Cada paso es fiel. El modelo lo dijo. El transcript lo registra exacto. El
-verificador de citas lo hizo coincidir carácter por carácter y lo selló como
+verificador de citas lo encontró en el transcript y lo selló como
 `✓ verbatim`, correctamente. La clase de confianza hizo su trabajo y la memoria
 igual era falsa, porque lo que se estaba certificando era que la frase *se
 dijo*, no que el evento *pasó*.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/trust-classes.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/trust-classes.md
@@ -12,8 +12,8 @@ que te dice qué partes son citas y qué partes son conjeturas.
 
 ### `[✓ verbatim]`
 
-Una cita exacta del transcript de una sesión pasada, fijada
-carácter por carácter. Los ítems verbatim nunca se reformulan — ni al
+Una cita exacta del transcript de una sesión pasada, fijada al
+capturarse. Los ítems verbatim nunca se reformulan — ni al
 arrastrarse entre sesiones, ni al renderizarse, ni al truncarse por
 presupuesto. Cuando un briefing muestra
 
@@ -72,6 +72,17 @@ sin LLM, bajo el principio de que *el verificador debe ser más tonto que lo
 que verifica*. Una cita que verifica queda sellada; una que no, se **degrada
 a `~ inferred`** en el acto — una "cita" alucinada nunca puede llevar la
 insignia verbatim.
+
+Lo que el chequeo garantiza, con precisión: la cita se **encuentra en el
+transcript después de plegar ambos lados de la misma manera** — se normalizan
+mayúsculas, corridas de espacios, énfasis y marcadores de lista de markdown, y
+variantes de comillas curvas y guiones; una cita elidida con `…` se parte en
+fragmentos que deben aparecer en orden, y los fragmentos muy cortos se
+descartan por demasiado genéricos para fijar. Es un chequeo mecánico de
+presencia, no una garantía byte por byte ni una afirmación de verdad sobre el
+mundo. La inmutabilidad byte a byte aplica al *almacenamiento*: una vez
+fijada, la cita guardada nunca se reformula por arrastre, renderizado ni
+truncamiento.
 
 La garantía se extiende más allá del momento de escritura: con
 [receipts](./receipts.md) habilitados, los bytes exactos del checkpoint se

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
@@ -99,8 +99,8 @@ Decisions made:
 Active topic: Migrating the scheduler off cron to the new worker pool
 ```
 
-`[✓ verbatim]` significa que esa cita fue verificada carácter por carácter
-contra la transcripción de la sesión; `[~ inferred]` marca las conclusiones
+`[✓ verbatim]` significa que un verificador determinista encontró esa cita
+en la transcripción de la sesión; `[~ inferred]` marca las conclusiones
 propias del modelo. El sistema de etiquetas es el punto del producto — mira
 [Clases de confianza](../concepts/trust-classes.md).
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/index.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/index.md
@@ -37,8 +37,9 @@ deja al terminar. Un **briefing** es la versión legible de un vistazo del
 La mayoría de las herramientas de memoria guardan lo que un modelo *escribió
 sobre* lo que pasó — y cuando ese texto está mal, nada te avisa. daimon marca
 cada línea con cómo llegó a existir: las líneas `[✓ verbatim]` son citas
-exactas verificadas carácter por carácter contra la transcripción de la sesión
-por un verificador determinista (operaciones de strings puras, sin LLM); las
+exactas que un verificador determinista encontró en la transcripción de la
+sesión (operaciones de strings puras, sin LLM — case, espacios y formato
+plegados, con tramos elididos permitidos); las
 líneas `[~ inferred]` son conclusiones propias del modelo, honestas sobre ser
 derivaciones. Una "cita" que falla la verificación se degrada a inferida en el
 acto, así que una cita alucinada nunca puede llevar la insignia verbatim. Con


### PR DESCRIPTION
Closes #629

## What

- Replaces every "character-for-character" (es: "caracter por caracter") description of the quote check with the check's real contract: the quote is found in the transcript after both sides are folded the same way, with elided spans allowed. Eight locations: docs entry page, quickstart gloss, trust-classes, and the launch blog post, in English and Spanish.
- Adds a precise "what the check actually guarantees" paragraph to trust-classes (en and es): the folding rules, the ordered-fragment handling for elided quotes, and the explicit statement that it is a mechanical presence check, not a byte-for-byte guarantee and not a truth claim.
- Keeps the storage-immutability wording ("never reworded", "stays byte-identical") untouched: stored quotes really are never rewritten, and that claim stays.

## Why

The verifier folds case, whitespace runs, markdown emphasis and list markers, and curly-quote and dash glyph variants on both sides, splits quotes on ellipsis and redaction markers into ordered fragments, and drops fragments shorter than 8 characters (plugin/daimon_briefing/serializer.py, tier-f normalization). The published claim was stronger than the shipped check. A project whose thesis is that trust claims must be mechanically accurate cannot carry an overclaim about its own checker.

## Tests

- Docs-only change, no runtime code. Searched the site, README, and repo docs for remaining instances of the phrase in both languages: none remain outside the backends page's unrelated usage.
- Wording verified against the implementation in serializer.py (_normalize_for_match and quote_matches) rather than from memory.
