### PR TITLE
fix(surfaces): stop persisting item text under logs/*.log

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1099,6 +1099,20 @@ def _cmd_forget(args) -> int:
         crash_purged, crash_err = store.purge_crash_log()
     except Exception as e:  # belt: purge_crash_log never raises
         crash_purged, crash_err = 0, str(e)
+    # #616: backend-stderr.log holds backend stderr/stdout, which CLI
+    # backends can seed with transcript text (#141). Wholesale like the
+    # crash sink: prose diagnostics, hash tombstone, value unlocatable.
+    try:
+        backend_purged, backend_err = store.purge_backend_stderr_log()
+    except Exception as e:  # belt: purge_backend_stderr_log never raises
+        backend_purged, backend_err = 0, str(e)
+    # #616: pre-fix downgrade lines logged item text into serialize.log.
+    # Shape-targeted scrub, NOT a purge — serialize.log is also the ledger
+    # `status` parses, and the capture record must survive a forget.
+    try:
+        scrubbed_lines, scrub_err = store.scrub_serialize_log()
+    except Exception as e:  # belt: scrub_serialize_log never raises
+        scrubbed_lines, scrub_err = 0, str(e)
     _note_usage("forget")
     print(f"forgot {target['id']} (content hash {content_hash}) — "
           "item removed from the live checkpoint; tombstone recorded")
@@ -1142,6 +1156,23 @@ def _cmd_forget(args) -> int:
         print(f"purged {crash_purged} serializer crash log(s) across all "
               "projects (machine-wide: the log is raw child stderr, not "
               "keyed by project)")
+    if backend_err is not None:
+        print(f"warning: backend log purge failed: {backend_err} — backend "
+              "echo of transcript text may persist (byte-bounded at the "
+              "write seam, never removed)")
+    else:
+        # Same silent-zero rule as the three lines above.
+        print(f"purged {backend_purged} backend stderr log(s) across all "
+              "projects (machine-wide: backend diagnostics are not keyed "
+              "by project)")
+    if scrub_err is not None:
+        print(f"warning: serialize.log scrub failed: {scrub_err} — legacy "
+              "downgrade lines may still carry item text")
+    else:
+        # Printed even at zero, same rule again: a scrubber resolving a
+        # different log dir than the writer must not read as "nothing left".
+        print(f"scrubbed {scrubbed_lines} legacy downgrade line(s) in "
+              "serialize.log (payload replaced; ledger lines kept)")
     return 0
 
 

--- a/plugin/daimon_briefing/privacy.py
+++ b/plugin/daimon_briefing/privacy.py
@@ -410,6 +410,19 @@ def audit_project(project_dir=None) -> dict:
         ws_entries += 1
         ws_oldest = age if ws_oldest is None else max(ws_oldest, age)
     result["windsurf"] = {"entries": ws_entries, "oldest_days": ws_oldest}
+    # backend-stderr.log (#616): CLI-backend echo can carry transcript text.
+    # Same store-level honesty as the chunk cache and for the same reason —
+    # the value would live as a SUBSTRING of prose diagnostics and the
+    # tombstone is a hash. Reporting the file exists (with its real age) is
+    # what the auditor can prove; forget purges it wholesale.
+    present, age_days = False, None
+    try:
+        st = (config.log_dir() / "backend-stderr.log").stat()
+        present = True
+        age_days = (time.time() - st.st_mtime) / 86400
+    except (OSError, ValueError):
+        pass                       # absent, unreadable, or corrupt env
+    result["backend_log"] = {"present": present, "age_days": age_days}
     return result
 
 

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -1358,6 +1358,13 @@ def render_privacy_audit(results: list[dict]) -> None:
                   " daimon-authored conversation text; value-level scan"
                   " impossible (substring vs hash); purge is wholesale on"
                   " forget")
+        bl = r.get("backend_log") or {}
+        if bl.get("present"):
+            age = (f", last write {bl['age_days']:.1f}d ago"
+                   if bl.get("age_days") is not None else ", age unknown")
+            print(f"  backend stderr log: present{age} — backend echo can"
+                  " carry transcript text (#616); value-level scan impossible"
+                  " (substring vs hash); purge is wholesale on forget")
         if not (r["findings"] or r["informational"] or r["unscannable"]
                 or r.get("zero_surfaces")):
             print("  clean — no tombstoned value found on any surface")

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -21,7 +21,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 
-from . import config, configure, ledger, llm, provenance, redact, schema
+from . import (config, configure, ledger, llm, normalize, provenance, schema)
 
 # No handlers/basicConfig here — the library stays silent unless the caller
 # configures logging. Multi-hour serialize runs need this heartbeat to be killable.
@@ -1019,8 +1019,8 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
     `last_verified` ISO-8601 UTC stamp (#215: the staleness-budget's freshest
     signal — a carried item's world-check age is measured from here). On a
     miss it is downgraded to trust="inferred" with `quote_verified: false` and
-    the downgrade is logged (count + redacted item-text prefix — this runs
-    pre-redaction, so the raw text must not reach a log sink; #141). Items
+    the downgrade is logged (count + content hash — never the text: the line
+    lands in serialize.log, which is exempt-no-plaintext; #141, #616). Items
     already trust="inferred" are left untouched — no stamp, either field.
     Runs ONCE at serialize, PRE-redaction, so the quote is still the raw text
     (a quote whose secret redaction will later mask still verifies here
@@ -1143,19 +1143,21 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
             stamp_receipt(item, "not-verified", checked_at,
                           "transcript-scan")
             downgraded += 1
-            # Log-line-only scrub: item ids are not stamped until store-save,
-            # so the text is the only diagnostic handle here. The item itself
-            # stays raw (store redacts it; ids hash redacted text). Untruncated
-            # (#194): this line is the only surviving record of the downgrade —
-            # the CLI routes it to serialize.log, which holds full result lines.
-            logged, _ = redact.redact_text(item.get("text") or "")
+            # #616 (supersedes #194's untruncated payload): item ids are not
+            # stamped until store-save, so the CONTENT HASH is the diagnostic
+            # handle — the same normalize.content_key a later `forget` of this
+            # text would tombstone, so "which item downgraded" stays
+            # answerable. The text itself must never reach serialize.log: the
+            # CLI routes this line there, and logs/*.log is declared
+            # exempt-no-plaintext (surfaces.py) — a claim these writers carry.
+            key = normalize.content_key(item.get("text") or "")
             if item.get(ECHO_ONLY_KEY):
                 log.warning("quote verification: downgraded verbatim->inferred "
                             "(echo-only: quote appears only in daimon's own "
-                            "injected output): %s", logged)
+                            "injected output) (content hash %s)", key)
             else:
-                log.warning("quote verification: downgraded verbatim->inferred: %s",
-                            logged)
+                log.warning("quote verification: downgraded verbatim->inferred "
+                            "(content hash %s)", key)
     if downgraded:
         log.info("quote verification: %d verbatim item(s) downgraded to inferred"
                  " (%d echo-only)", downgraded, echoed)
@@ -1369,10 +1371,11 @@ def ground_outcomes(checkpoint, signal_ids) -> int:
         item["trust"] = "inferred"
         item[GROUNDED_KEY] = False
         downgraded += 1
-        # Same log-line-only scrub as verify_quotes: runs pre-redaction.
-        logged, _ = redact.redact_text(item.get("text") or "")
+        # Same #616 rule as verify_quotes' downgrade line: hash, never text.
+        key = normalize.content_key(item.get("text") or "")
         log.warning("outcome grounding: unwitnessed outcome claim downgraded "
-                    "verbatim->inferred (no signal cited): %s", logged)
+                    "verbatim->inferred (no signal cited) (content hash %s)",
+                    key)
     if downgraded:
         log.info("outcome grounding: %d outcome claim(s) downgraded to inferred",
                  downgraded)

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -563,8 +563,36 @@ def purge_crash_log() -> tuple:
 
     Returns (purged_count, error_or_None) and NEVER raises: deleting belief
     state is the primary contract; a failed purge is reported, not fatal."""
+    return _purge_fixed_log("serialize-crash.log")
+
+
+def purge_backend_stderr_log() -> tuple:
+    """#616: the CLI-backend diagnostics sink, inside the contract.
+
+    `logs/backend-stderr.log` holds backend stderr AND stdout — and CLI
+    backends can echo prompt fragments (transcript text) into either stream
+    (#141, llm._log_backend_stderr's own concession). The write seam
+    secret-redacts and byte-bounds the file, but item text is not a secret
+    shape, so a forgotten value echoed by a backend survived on disk while
+    the registry called the file plaintext-free.
+
+    Wholesale for the crash sink's reason (#605): the tombstone is a
+    canonical HASH (#321), so a value inside prose diagnostics cannot be
+    located to remove selectively. Accepted cost mirrors #605's: the next
+    backend failure has no history behind it — a diagnostic goes quiet,
+    and that never outranks removing plaintext the user asked to be gone.
+
+    Returns (purged_count, error_or_None) and NEVER raises: deleting belief
+    state is the primary contract; a failed purge is reported, not fatal."""
+    return _purge_fixed_log("backend-stderr.log")
+
+
+def _purge_fixed_log(name: str) -> tuple:
+    """Unlink ONE daimon-authored file under the log dir, defensively.
+
+    Shared by the fixed-name log purges above; returns (purged, err)."""
     try:
-        path = config.log_dir() / "serialize-crash.log"
+        path = config.log_dir() / name
     except Exception as e:  # noqa: BLE001 — e.g. UnicodeDecodeError from a
         # corrupt ~/.daimon/env: a ValueError, so the OSError net below never
         # sees it. The writer resolves through the same accessors and raises
@@ -573,10 +601,10 @@ def purge_crash_log() -> tuple:
     try:
         st = os.lstat(path)
     except FileNotFoundError:
-        return 0, None                 # never crashed, or already purged
+        return 0, None                 # never written, or already purged
     except OSError as e:
         # A log dir this process cannot see is not a clean purge. The count
-        # is a privacy CLAIM — "the tracebacks are gone" — and a silent zero
+        # is a privacy CLAIM — "the bytes are gone" — and a silent zero
         # over an unreadable directory is that claim made without evidence.
         return 0, str(e)
     # lstat rather than is_file(): those follow the link and answer False for
@@ -597,6 +625,98 @@ def purge_crash_log() -> tuple:
     except OSError as e:
         return 0, str(e)
     return 1, None
+
+
+# #616: the two line shapes pre-fix serializers wrote into serialize.log with
+# the item's OWN text as payload. Anchored on the logging router's record
+# prefix (`<iso> WARNING daimon_briefing.serializer: `, cli's
+# _attach_serialize_log_handler) so a ledger result line — raw, untimestamped
+# — can never match. Current writers log `(content hash <key>)` with no `: `
+# payload separator after these heads, so clean lines never match either.
+_LEGACY_DOWNGRADE_RE = re.compile(
+    r"^(?P<head>\S+ WARNING \S+: "
+    r"(?:quote verification: downgraded verbatim->inferred"
+    r"(?: \(echo-only: quote appears only in daimon's own injected output\))?"
+    r"|outcome grounding: unwitnessed outcome claim downgraded "
+    r"verbatim->inferred \(no signal cited\)): ).*$")
+
+_LOG_STAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T")
+
+_SCRUB_MARKER = "[payload scrubbed #616]"
+
+
+def scrub_serialize_log() -> tuple:
+    """#616: redact LEGACY downgrade payloads out of serialize.log in place.
+
+    Pre-fix, the quote-verification and outcome-grounding downgrade lines
+    logged the item's own text (secret-redacted, never item-redacted) and
+    the CLI routed them here. Current writers log a content hash instead,
+    but the old payloads persist on disk in every existing install.
+
+    NOT a wholesale purge, deliberately: serialize.log is also the ledger
+    `status` parses for capture stats (_SPAWN_RE / _RESULT_*_RE), and
+    destroying the measurement record on every forget trades one contract
+    for another. The legacy payloads sit behind two exactly-known line
+    shapes, so the scrub is SHAPE-targeted — value-blind, like every purge
+    on this path (the tombstone is a hash; the value cannot be located).
+
+    A matched line keeps its head and gets its payload replaced; the lines
+    AFTER it are dropped until the next router-timestamped line, because a
+    multi-line item text logs as untimestamped continuation lines. That can
+    in principle eat a raw ledger line that directly follows a multi-line
+    payload — accepted: over-scrubbing costs one stat row, under-scrubbing
+    persists a line of text the user asked to be gone, and content_key
+    already picks the same fail-safe direction (over-blocking).
+
+    Rewrite is atomic (temp + os.replace) and refuses symlinks/non-regular
+    files for _purge_fixed_log's reason. Returns (scrubbed_line_count,
+    error_or_None) and NEVER raises."""
+    try:
+        path = config.log_dir() / "serialize.log"
+    except Exception as e:  # noqa: BLE001 — same corrupt-env net as above
+        return 0, str(e)
+    try:
+        st = os.lstat(path)
+    except FileNotFoundError:
+        return 0, None                 # never serialized here — nothing to scrub
+    except OSError as e:
+        return 0, str(e)
+    if stat.S_ISLNK(st.st_mode):
+        return 0, (f"{path} is a symlink — refusing to rewrite through a "
+                   "file daimon did not create")
+    if not stat.S_ISREG(st.st_mode):
+        return 0, f"{path} is not a regular file — refusing to rewrite it"
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    except (OSError, ValueError) as e:
+        return 0, str(e)
+    out: list = []
+    scrubbed = 0
+    dropping = False
+    for line in lines:
+        if dropping and not _LOG_STAMP_RE.match(line):
+            continue                   # continuation of a scrubbed payload
+        dropping = False
+        m = _LEGACY_DOWNGRADE_RE.match(line.rstrip("\n"))
+        if m:
+            out.append(m.group("head") + _SCRUB_MARKER + "\n")
+            scrubbed += 1
+            dropping = True
+            continue
+        out.append(line)
+    if not scrubbed:
+        return 0, None
+    tmp = path.with_name(path.name + ".scrub.tmp")
+    try:
+        tmp.write_text("".join(out), encoding="utf-8")
+        os.replace(tmp, path)
+    except OSError as e:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        return 0, str(e)
+    return scrubbed, None
 
 
 # #600 slice B: the per-author tombstone ledger published into the team

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -699,6 +699,9 @@ def scrub_serialize_log() -> tuple:
         dropping = False
         m = _LEGACY_DOWNGRADE_RE.match(line.rstrip("\n"))
         if m:
+            if line.rstrip("\n") == m.group("head") + _SCRUB_MARKER:
+                out.append(line)       # already scrubbed — a marker is a
+                continue               # payload shape too; do not re-count
             out.append(m.group("head") + _SCRUB_MARKER + "\n")
             scrubbed += 1
             dropping = True

--- a/plugin/daimon_briefing/surfaces.py
+++ b/plugin/daimon_briefing/surfaces.py
@@ -146,14 +146,22 @@ SURFACES: tuple[Surface, ...] = (
             True, "wholesale-purge", "forget"),
     Surface("logs/heartbeats/*", "ledger.touch_heartbeat",
             False, "exempt-no-plaintext", "none"),
-    # The two entries above and below keep the declarations they shipped
-    # with. Deliberately NOT restated here: the old blanket "logs hold no
-    # item text by construction". serializer's quote-verification downgrade
-    # logs the item's own text (secret-redacted, not item-redacted) and the
-    # CLI routes that line into serialize.log, so the claim is false as
-    # written — #616 tracks re-declaring this entry (backend-stderr.log has
-    # the same problem). #605 changed the sink above it and left this one
-    # alone rather than quietly widening its own scope.
+    # -- backend diagnostics: stderr AND stdout of the LLM CLI child, which
+    #    can echo prompt fragments — transcript text (#141). Secret-redacted
+    #    and byte-bounded at the write seam (llm._log_backend_stderr), but
+    #    item text is not a secret shape, so the honest declaration is the
+    #    crash sink's (#616, same class #605 closed): plaintext, purged
+    #    wholesale at forget — a value inside prose diagnostics cannot be
+    #    located when the tombstone is a hash. BEFORE the *.log glob so the
+    #    specific contract wins. --
+    Surface("logs/backend-stderr.log", "llm._log_backend_stderr",
+            True, "wholesale-purge", "forget"),
+    # #616 restored the glob's claim instead of widening it: serializer's
+    # downgrade lines — the one writer that put item text under this shape —
+    # now log a content hash (normalize.content_key, the same key a forget
+    # would tombstone), and forget scrubs the LEGACY payloads by line shape
+    # (store.scrub_serialize_log) rather than purging serialize.log
+    # wholesale, because that file is also the ledger `status` parses.
     Surface("logs/*.log", "ledger / cli._note_usage / recall._note_error",
             False, "exempt-no-plaintext", "none"),
     # -- key material and env: secrets, never item plaintext. --

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -4966,17 +4966,19 @@ def _detach_serialize_log_handler():
 def test_serialize_routes_downgrade_warning_to_serialize_log(
         tmp_checkpoint_dir, tmp_log_dir, fake_chat_factory, capsys,
         monkeypatch, _detach_serialize_log_handler):
-    # A quote-verification downgrade must land in serialize.log UNTRUNCATED
-    # (no %.80s cap — this line is the only surviving record of the item text).
-    tail_marker = ("the item text runs well past eighty characters so the old "
-                   "prefix cap would have cut it long before END-OF-ITEM")
-    assert len(tail_marker) > 80
+    # A quote-verification downgrade must land in serialize.log as a CONTENT
+    # HASH, never the item text (#616 — supersedes #194's untruncated
+    # payload: logs/*.log is declared exempt-no-plaintext, and the writers
+    # carry that claim). The hash is content_key of the text, so "which item
+    # downgraded" stays answerable against the stored item.
+    item_text = ("the item text runs well past eighty characters so the old "
+                 "prefix cap would have cut it long before END-OF-ITEM")
     payload = json.dumps({
         "session_id": "sample_transcript",
         "working_context": {
             "active_topic": {"text": "t", "trust": "inferred"},
             "open_questions": [
-                {"text": tail_marker, "trust": "verbatim",
+                {"text": item_text, "trust": "verbatim",
                  "quote": "THIS QUOTE APPEARS NOWHERE IN THE TRANSCRIPT"}
             ],
             "recent_decisions": [],
@@ -4989,7 +4991,9 @@ def test_serialize_routes_downgrade_warning_to_serialize_log(
     assert rc == 0
     log = (tmp_log_dir / "serialize.log").read_text()
     assert "downgraded verbatim->inferred" in log
-    assert "END-OF-ITEM" in log  # full text survived, cap dropped
+    assert "END-OF-ITEM" not in log  # item text never reaches the log (#616)
+    from daimon_briefing import normalize
+    assert normalize.content_key(item_text) in log
 
 
 def test_attach_serialize_log_handler_is_idempotent(

--- a/plugin/tests/test_log_text_privacy.py
+++ b/plugin/tests/test_log_text_privacy.py
@@ -1,0 +1,280 @@
+"""#616: serialize.log and backend-stderr.log inside the privacy contract.
+
+`logs/*.log` was declared exempt-no-plaintext ("no item text by
+construction") while two writers under the glob falsified the claim:
+
+  * serializer's quote-verification and outcome-grounding downgrade lines
+    logged the item's OWN text (secret-shape redacted, not item-redacted),
+    and the CLI routes those records into serialize.log;
+  * llm._log_backend_stderr appends backend stderr/stdout, which CLI
+    backends can seed with prompt fragments — transcript text (#141).
+
+The fix keeps serialize.log's second job intact (it is the ledger `status`
+parses for capture stats), so it is NOT purged wholesale like the #605
+crash sink. Instead:
+
+  * the downgrade writers log a CONTENT HASH — the same normalize.content_key
+    a later `forget` of that text would tombstone — never the text;
+  * `forget` scrubs LEGACY downgrade payloads by line shape (the two known
+    warning prefixes), leaving ledger result lines untouched;
+  * backend-stderr.log cannot be no-plaintext by construction, so it is
+    declared plaintext=True and purged wholesale at forget, the crash-sink
+    posture.
+
+Canary style follows test_crash_log_privacy.py: distinctive synthetic
+literals, never vendor-prefix shapes.
+"""
+import logging
+
+from daimon_briefing import (cli, config, normalize, privacy, serializer,
+                             store, surfaces)
+
+PROJECT = "/p/616-logs"
+CANARY = "zqxlogcanary6161 the rollout gate is held by the blue worker"
+CANARY_ECHO = "zqxlogcanary6162 echoed only in daimon output"
+CANARY_OUTCOME = "zqxlogcanary6163 deploy succeeded on the green cluster"
+KEEPER = "an unrelated decision that must survive"
+
+
+def _serialize_log_path():
+    return config.log_dir() / "serialize.log"
+
+
+def _backend_log_path():
+    return config.log_dir() / "backend-stderr.log"
+
+
+def _write_checkpoint():
+    store.write_checkpoint("S1", {
+        "session_id": "S1", "created": "2026-08-01T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": CANARY, "trust": "inferred"},
+            {"text": KEEPER, "trust": "inferred"}]},
+    }, project_dir=PROJECT)
+
+
+def _seed_backend_log() -> object:
+    path = _backend_log_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "--- 2026-08-06T00:00:00Z ---\n"
+        "claude exited 1\n"
+        f"prompt fragment echoed by the backend: {CANARY}\n",
+        encoding="utf-8")
+    return path
+
+
+# ---- the writers stop persisting item text --------------------------------
+
+
+def test_quote_downgrade_logs_hash_never_text(caplog):
+    ckpt = {"working_context": {"recent_decisions": [
+        {"text": CANARY, "trust": "verbatim",
+         "quote": "this quote appears nowhere"}]}}
+    with caplog.at_level(logging.WARNING, logger="daimon_briefing.serializer"):
+        downgraded = serializer.verify_quotes(
+            ckpt, "a transcript that contains none of the item")
+    assert downgraded == 1
+    assert CANARY not in caplog.text, \
+        "the downgrade line is the leak #616 closes — no item text in logs"
+    assert normalize.content_key(CANARY) in caplog.text, \
+        "the content hash is the surviving diagnostic handle"
+
+
+def test_outcome_downgrade_logs_hash_never_text(caplog):
+    ckpt = {"working_context": {"recent_decisions": [
+        {"text": CANARY_OUTCOME, "trust": "verbatim"}]}}
+    with caplog.at_level(logging.WARNING, logger="daimon_briefing.serializer"):
+        downgraded = serializer.ground_outcomes(ckpt, {"m-signal"})
+    assert downgraded == 1
+    assert CANARY_OUTCOME not in caplog.text
+    assert normalize.content_key(CANARY_OUTCOME) in caplog.text
+
+
+# ---- the registry stops lying about the two files -------------------------
+
+
+def test_registry_declares_backend_stderr_log_reachable():
+    s = surfaces.match("logs/backend-stderr.log")
+    assert s is not None
+    assert s.plaintext is True and s.delete == "wholesale-purge"
+    assert s.walker == "forget"
+    # serialize.log keeps the exempt claim — true again by construction once
+    # the downgrade writers log hashes (and forget scrubs the legacy lines).
+    assert surfaces.match("logs/serialize.log").delete == "exempt-no-plaintext"
+    assert not any(x.issue == "#616" for x in surfaces.SURFACES), \
+        "#616 is closed — no entry may still cite it as an open gap"
+
+
+# ---- backend-stderr.log: purge on forget ----------------------------------
+
+
+def test_forget_purges_backend_stderr_log(tmp_checkpoint_dir):
+    path = _seed_backend_log()
+    _write_checkpoint()
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+    assert not path.exists(), "backend echo daimon persisted must go"
+
+
+def test_forget_dry_run_never_purges_backend_log(tmp_checkpoint_dir):
+    path = _seed_backend_log()
+    _write_checkpoint()
+    assert cli.main(["forget", CANARY, "--project", PROJECT,
+                     "--dry-run"]) == 0
+    assert path.exists()
+
+
+def test_a_refused_forget_never_purges_backend_log(tmp_checkpoint_dir):
+    path = _seed_backend_log()
+    _write_checkpoint()
+    assert cli.main(["forget", "no such value here",
+                     "--project", PROJECT]) == 1
+    assert path.exists()
+
+
+def test_backend_purge_reports_count_and_never_raises(tmp_checkpoint_dir):
+    _seed_backend_log()
+    assert store.purge_backend_stderr_log() == (1, None)
+    assert store.purge_backend_stderr_log() == (0, None)
+
+
+def test_backend_purge_never_unlinks_through_a_symlink(tmp_checkpoint_dir,
+                                                       tmp_path):
+    outside = tmp_path / "my-notes"
+    outside.mkdir()
+    kept = outside / "important.log"
+    kept.write_text("a user file", encoding="utf-8")
+    path = _backend_log_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.symlink_to(kept)
+    purged, err = store.purge_backend_stderr_log()
+    assert purged == 0
+    assert err is not None
+    assert kept.exists(), "unlinked a file daimon did not write"
+
+
+def test_forget_survives_a_failed_backend_purge(tmp_checkpoint_dir,
+                                                monkeypatch, capsys):
+    _seed_backend_log()
+    _write_checkpoint()
+    monkeypatch.setattr(store, "purge_backend_stderr_log",
+                        lambda: (0, "disk on fire"))
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+    assert "disk on fire" in capsys.readouterr().out
+
+
+# ---- serialize.log: legacy downgrade payloads scrubbed at forget ----------
+
+
+LEGACY_LOG = (
+    "2026-08-01T00:00:00Z WARNING daimon_briefing.serializer: "
+    f"quote verification: downgraded verbatim->inferred: {CANARY}\n"
+    "2026-08-01T00:00:01Z WARNING daimon_briefing.serializer: "
+    "quote verification: downgraded verbatim->inferred (echo-only: quote "
+    "appears only in daimon's own injected output): "
+    f"{CANARY_ECHO}\n"
+    "2026-08-01T00:00:02Z WARNING daimon_briefing.serializer: "
+    "outcome grounding: unwitnessed outcome claim downgraded "
+    f"verbatim->inferred (no signal cited): {CANARY_OUTCOME}\n"
+    "2026-08-01T00:00:03Z INFO daimon_briefing.serializer: "
+    "quote verification: 2 verbatim item(s) downgraded to inferred "
+    "(1 echo-only)\n"
+    "wrote checkpoint: /tmp/x/2026-08-01.json (took 12s)\n"
+    "2026-08-02T00:00:00Z WARNING daimon_briefing.serializer: "
+    "quote verification: downgraded verbatim->inferred "
+    "(content hash abc123def456)\n"
+)
+
+
+def _seed_serialize_log(text: str = LEGACY_LOG) -> object:
+    path = _serialize_log_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_forget_scrubs_legacy_downgrade_payloads(tmp_checkpoint_dir):
+    path = _seed_serialize_log()
+    _write_checkpoint()
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+    text = path.read_text(encoding="utf-8")
+    assert CANARY not in text
+    assert CANARY_ECHO not in text
+    assert CANARY_OUTCOME not in text
+    # the ledger job survives: result lines and counts are what status parses
+    assert "wrote checkpoint: /tmp/x/2026-08-01.json (took 12s)" in text
+    assert "2 verbatim item(s) downgraded to inferred" in text
+    # current-format hash lines are already clean and stay byte-identical
+    assert "(content hash abc123def456)" in text
+
+
+def test_scrub_drops_multiline_payload_continuations(tmp_checkpoint_dir):
+    _seed_serialize_log(
+        "2026-08-01T00:00:00Z WARNING daimon_briefing.serializer: "
+        f"quote verification: downgraded verbatim->inferred: {CANARY}\n"
+        f"second line of the same item body {CANARY_ECHO}\n"
+        "2026-08-01T00:00:01Z INFO daimon_briefing.serializer: "
+        "quote verification: 1 verbatim item(s) downgraded to inferred "
+        "(0 echo-only)\n")
+    scrubbed, err = store.scrub_serialize_log()
+    assert err is None and scrubbed >= 1
+    text = _serialize_log_path().read_text(encoding="utf-8")
+    assert CANARY not in text
+    assert CANARY_ECHO not in text, \
+        "a multi-line payload's continuation lines must go with it"
+    assert "1 verbatim item(s) downgraded to inferred" in text
+
+
+def test_scrub_is_idempotent(tmp_checkpoint_dir):
+    path = _seed_serialize_log()
+    assert store.scrub_serialize_log()[1] is None
+    first = path.read_text(encoding="utf-8")
+    scrubbed, err = store.scrub_serialize_log()
+    assert err is None
+    assert path.read_text(encoding="utf-8") == first
+
+
+def test_scrub_missing_log_is_a_clean_zero(tmp_checkpoint_dir):
+    assert store.scrub_serialize_log() == (0, None)
+
+
+def test_scrub_refuses_a_symlinked_log(tmp_checkpoint_dir, tmp_path):
+    outside = tmp_path / "my-notes"
+    outside.mkdir()
+    kept = outside / "user.log"
+    kept.write_text(LEGACY_LOG, encoding="utf-8")
+    path = _serialize_log_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.symlink_to(kept)
+    scrubbed, err = store.scrub_serialize_log()
+    assert scrubbed == 0
+    assert err is not None
+    assert CANARY in kept.read_text(encoding="utf-8"), \
+        "rewrote a file daimon did not create"
+
+
+def test_forget_survives_a_failed_scrub(tmp_checkpoint_dir, monkeypatch,
+                                        capsys):
+    _seed_serialize_log()
+    _write_checkpoint()
+    monkeypatch.setattr(store, "scrub_serialize_log",
+                        lambda: (0, "scrub exploded"))
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+    assert "scrub exploded" in capsys.readouterr().out
+
+
+# ---- the audit reports what it can prove ----------------------------------
+
+
+def test_audit_reports_backend_log_store(tmp_checkpoint_dir):
+    _seed_backend_log()
+    _write_checkpoint()
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert result["backend_log"]["present"] is True
+    assert result["backend_log"]["age_days"] is not None
+
+
+def test_audit_reports_backend_log_absent(tmp_checkpoint_dir):
+    _write_checkpoint()
+    result = privacy.audit_project(project_dir=PROJECT)
+    assert result["backend_log"]["present"] is False

--- a/plugin/tests/test_log_text_privacy.py
+++ b/plugin/tests/test_log_text_privacy.py
@@ -163,6 +163,21 @@ def test_forget_survives_a_failed_backend_purge(tmp_checkpoint_dir,
     assert "disk on fire" in capsys.readouterr().out
 
 
+def test_forget_survives_a_backend_purge_that_raises(tmp_checkpoint_dir,
+                                                     monkeypatch, capsys):
+    # The belt around the call site: a future bug in the purge must not take
+    # the scrub down with it (the crash-sink posture).
+    _seed_backend_log()
+    _write_checkpoint()
+
+    def boom():
+        raise RuntimeError("backend purge exploded")
+
+    monkeypatch.setattr(store, "purge_backend_stderr_log", boom)
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+    assert "backend purge exploded" in capsys.readouterr().out
+
+
 # ---- serialize.log: legacy downgrade payloads scrubbed at forget ----------
 
 
@@ -229,8 +244,9 @@ def test_scrub_is_idempotent(tmp_checkpoint_dir):
     path = _seed_serialize_log()
     assert store.scrub_serialize_log()[1] is None
     first = path.read_text(encoding="utf-8")
-    scrubbed, err = store.scrub_serialize_log()
-    assert err is None
+    # A marker line is itself a payload shape — the second pass must neither
+    # re-count it nor rewrite the file.
+    assert store.scrub_serialize_log() == (0, None)
     assert path.read_text(encoding="utf-8") == first
 
 
@@ -263,6 +279,78 @@ def test_forget_survives_a_failed_scrub(tmp_checkpoint_dir, monkeypatch,
     assert "scrub exploded" in capsys.readouterr().out
 
 
+def test_forget_survives_a_scrub_that_raises(tmp_checkpoint_dir, monkeypatch,
+                                             capsys):
+    _seed_serialize_log()
+    _write_checkpoint()
+
+    def boom():
+        raise RuntimeError("scrub blew up")
+
+    monkeypatch.setattr(store, "scrub_serialize_log", boom)
+    assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
+    assert "scrub blew up" in capsys.readouterr().out
+
+
+def test_scrub_a_corrupt_env_file_fails_closed(monkeypatch, tmp_path):
+    # Same net as the purge: a non-UTF-8 env file raises ValueError out of
+    # config.log_dir(), past the OSError handlers — (0, err), no exception.
+    monkeypatch.delenv("DAIMON_LOG_DIR", raising=False)
+    env_file = tmp_path / "env"
+    env_file.write_bytes(b"DAIMON_LOG_DIR=\xff\xfe broken\n")
+    monkeypatch.setenv("DAIMON_ENV_FILE", str(env_file))
+    scrubbed, err = store.scrub_serialize_log()
+    assert scrubbed == 0
+    assert err is not None
+
+
+def test_scrub_a_log_dir_it_cannot_see_is_never_reported_clean(
+        tmp_checkpoint_dir):
+    path = _seed_serialize_log()
+    path.parent.chmod(0o000)
+    try:
+        scrubbed, err = store.scrub_serialize_log()
+    finally:
+        path.parent.chmod(0o700)
+    assert scrubbed == 0
+    assert err is not None, "a blind scrub must not read as a clean one"
+    assert CANARY in path.read_text(encoding="utf-8")
+
+
+def test_scrub_refuses_a_directory_named_like_the_log(tmp_checkpoint_dir):
+    decoy = _serialize_log_path()
+    decoy.mkdir(parents=True)
+    (decoy / "inside.txt").write_text("not daimon's to rewrite",
+                                      encoding="utf-8")
+    scrubbed, err = store.scrub_serialize_log()
+    assert scrubbed == 0 and err is not None
+    assert (decoy / "inside.txt").exists()
+
+
+def test_scrub_reports_a_log_it_cannot_decode(tmp_checkpoint_dir):
+    # A non-UTF-8 log is cannot-check, not clean and not a traceback.
+    path = _serialize_log_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\xff\xfe not text\n")
+    scrubbed, err = store.scrub_serialize_log()
+    assert scrubbed == 0
+    assert err is not None
+
+
+def test_scrub_reports_a_rewrite_it_could_not_complete(tmp_checkpoint_dir):
+    # Readable file, unwritable dir: the temp-file write fails and the error
+    # must surface for the forget warning to carry; the original survives.
+    path = _seed_serialize_log()
+    path.parent.chmod(0o500)
+    try:
+        scrubbed, err = store.scrub_serialize_log()
+    finally:
+        path.parent.chmod(0o700)
+    assert scrubbed == 0
+    assert err is not None
+    assert CANARY in path.read_text(encoding="utf-8")
+
+
 # ---- the audit reports what it can prove ----------------------------------
 
 
@@ -278,3 +366,16 @@ def test_audit_reports_backend_log_absent(tmp_checkpoint_dir):
     _write_checkpoint()
     result = privacy.audit_project(project_dir=PROJECT)
     assert result["backend_log"]["present"] is False
+
+
+def test_render_shows_the_backend_log_line(capsys):
+    from daimon_briefing import render
+    render.render_privacy_audit([{
+        "slug": "-p-616-logs", "surfaces_scanned": 1, "zero_surfaces": False,
+        "findings": [], "informational": [], "unscannable": [],
+        "cache": {}, "windsurf": {},
+        "backend_log": {"present": True, "age_days": 0.5},
+    }])
+    out = capsys.readouterr().out
+    assert "backend stderr log: present" in out
+    assert "wholesale on forget" in out

--- a/plugin/tests/test_quote_verification.py
+++ b/plugin/tests/test_quote_verification.py
@@ -6,7 +6,8 @@ import logging
 
 import pytest
 
-from daimon_briefing import cli, provenance, serializer, store, transcript
+from daimon_briefing import (cli, normalize, provenance, serializer, store,
+                             transcript)
 from tests.conftest import FIXTURES, make_messages
 
 
@@ -250,15 +251,18 @@ def test_verify_quotes_downgrades_on_miss(caplog):
     assert n == 1
     assert item["trust"] == "inferred"
     assert item["quote_verified"] is False
-    # downgrade is visible in the log with an item-text prefix
-    assert any("fabricated decision" in r.getMessage() for r in caplog.records)
+    # downgrade is visible in the log as a content hash, never the text (#616)
+    key = normalize.content_key("a fabricated decision line")
+    assert any(key in r.getMessage() for r in caplog.records)
+    assert not any("fabricated decision" in r.getMessage()
+                   for r in caplog.records)
 
 
-def test_verify_quotes_downgrade_log_redacts_secret(caplog):
-    # #141: the downgrade warning is the one verify_quotes line that carries
-    # item text, and it fires PRE-redaction — a secret inside a downgraded
-    # item must be scrubbed in the log line while the checkpoint item itself
-    # stays raw (store redacts it at write time, ids must hash redacted text).
+def test_verify_quotes_downgrade_log_never_carries_the_secret(caplog):
+    # #141 asked for secret redaction on this line; #616 went further — the
+    # line carries no item text at all, only the content hash. The secret can
+    # therefore never appear, and the checkpoint item itself stays raw (store
+    # redacts it at write time, ids must hash redacted text).
     secret = "AKIAIOSFODNN7EXAMPLE"
     cp = _cp_with({("working_context", "recent_decisions"): [
         {"text": f"rotate key {secret} next", "trust": "verbatim",
@@ -267,9 +271,9 @@ def test_verify_quotes_downgrade_log_redacts_secret(caplog):
         serializer.verify_quotes(cp, "assistant: something entirely unrelated")
     msgs = [r.getMessage() for r in caplog.records]
     assert not any(secret in m for m in msgs)
-    assert any("[redacted:aws-key]" in m for m in msgs)
+    assert not any("rotate key" in m for m in msgs)
     item = cp["working_context"]["recent_decisions"][0]
-    assert item["text"] == f"rotate key {secret} next"  # log-only scrub
+    assert item["text"] == f"rotate key {secret} next"  # item stays raw
 
 
 def test_verify_quotes_leaves_inferred_items_unstamped():


### PR DESCRIPTION
Closes #616

## What

- Quote-verification and outcome-grounding downgrade lines now log the item's content hash (the same `normalize.content_key` a later `forget` would tombstone), never the item text. This supersedes the earlier untruncated-payload rule (`#194` marker) for these lines: "which item downgraded" stays answerable, and nothing under `logs/*.log` carries item text.
- `forget` scrubs legacy downgrade payloads out of `serialize.log` by exact line shape (`store.scrub_serialize_log`), keeping the ledger lines `status` parses. Continuation lines of a multi-line payload are dropped until the next timestamped record; over-scrubbing is the fail-safe direction, the same one `content_key` already picks.
- `logs/backend-stderr.log` is declared honestly (`plaintext=True`, `wholesale-purge`, walker `forget`) ahead of the `logs/*.log` glob, and `forget` purges it wholesale via `store.purge_backend_stderr_log()` (shared `_purge_fixed_log` seam with the #605 crash sink: symlink and non-regular refusal, an unreadable dir never reads as clean).
- `daimon audit privacy` reports the backend log store (presence and age), following the chunk-cache and windsurf honesty pattern: the value would live as a substring of prose, so store-level reporting is what the auditor can prove.

## Why

`logs/*.log` was declared `exempt-no-plaintext` ("no item text by construction") while two writers under the glob falsified the claim: serializer downgrade lines logged the item's own text into `serialize.log`, and CLI backends can echo prompt fragments into `backend-stderr.log` (the `#141` marker's own concession). A forgotten value that was ever quoted in a downgrade line or echoed by a backend survived on disk, unreachable by `forget` and invisible to the audit.

`serialize.log` is deliberately NOT purged wholesale: it is also the ledger `status` parses for capture stats, and destroying the measurement record on every forget would trade one contract for another.

## Tests

- New `plugin/tests/test_log_text_privacy.py` (17 tests): both downgrade writers log hash and never text (failed before the change), registry declarations, forget purges `backend-stderr.log` while dry-run and refused forgets do not, symlink refusal, legacy payload scrub including multi-line continuations, idempotence, missing log, symlinked log, forget survives a failed purge and a failed scrub, audit reports the backend log store.
- Updated the three tests that asserted the superseded contract (untruncated payload routing, item-text prefix in the downgrade log, secret redaction of a payload that no longer exists).
- Full plugin suite: 3184 passed, 2 skipped.
