### PR TITLE
test(cli): freeze the clock in the status payload parity test

### DIFF
--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -5375,6 +5375,22 @@ def test_status_payload_matches_status_json_output(
         "(reason: exit, project: /p/A)",
         "wrote checkpoint: /tmp/ck/S-prev.json (took 7s)",
     ])
+    # #631: the assertion is about the ASSEMBLER, not the wall clock — but
+    # each call fetches its own `now`, so a second boundary between the two
+    # builds skewed every age/freshness field by one and flaked CI. Freeze
+    # both clock sources for the comparison; ticking is exercised on purpose
+    # in the repro that filed the issue, not here.
+    frozen = time.time()
+    monkeypatch.setattr(time, "time", lambda: frozen)
+    frozen_dt = datetime.now(timezone.utc)
+
+    class _FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return frozen_dt.astimezone(tz) if tz else \
+                frozen_dt.replace(tzinfo=None)
+
+    monkeypatch.setattr(cli, "datetime", _FrozenDatetime)
     rc = cli.main(["status", "--json"])
     data = json.loads(capsys.readouterr().out)
     payload, prc = cli.status_payload(None)


### PR DESCRIPTION
Closes #631

## What

Freezes both clock sources (`time.time` and `cli`'s `datetime`) inside `test_status_payload_matches_status_json_output` so the two payload builds it compares see one clock.

## Why

The test asserts byte-equality between the payload printed by `daimon status --json` and a second `cli.status_payload(None)` build. Each call fetches its own `now`, so a second boundary between the two builds skews every age and freshness field by one and flakes CI (observed twice, most recently py3.13 failing while py3.10 passed on the same pull request). The assertion is about the single payload assembler, not the wall clock.

## Tests

- Reproduced the flake deterministically first: ticking the clock one second between the two builds fails the comparison on demand (`age_seconds` 1 vs 0 in `project` and `last_serialize`).
- The frozen version passed 10/10 consecutive runs plus the full `tests/test_cli.py` file (568 passed).
- The sibling `projects` parity test emits no clock-derived fields (stamps only), so it does not share the flake class.
