### PR TITLE
docs: regroup the CLI reference by user intent and drop adjudication wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ And because the briefing is injected automatically when a session starts, the ag
 
 Nothing here is mocked — the transcripts, the recording scripts, and the steps to reproduce it are in [`docs/demo/`](docs/demo/).
 
-The name comes from the Greek *δαίμων* — a guiding spirit (distinct from "demon") believed to accompany a person, offering counsel and warnings.
-
 ---
 
 ## Install
@@ -111,3 +109,7 @@ Daimon is self-contained at runtime — no external memory backend, no server. T
 - [MVP — Dream-Briefing](./docs/MVP-DREAM-BRIEFING.md) — authoritative architecture
 - [Research Logbook](./research/README.md) — findings, decisions, evidence trail
 - [Contributing](./CONTRIBUTING.md) — dev setup, tests, lint, pre-commit hooks
+
+---
+
+The name comes from the Greek *δαίμων* — a guiding spirit (distinct from "demon") believed to accompany a person, offering counsel and warnings. This one shows its sources.

--- a/website/blog/2026-07-30-negative-knowledge.md
+++ b/website/blog/2026-07-30-negative-knowledge.md
@@ -72,9 +72,10 @@ no sessions to author from. Its field record so far is mostly noise: the
 first tally was 4 candidates, 0 promotable, and the false-trigger log is
 longer than the keep list. A qualification filter shipped in response,
 enforcing the same structural obligations at machine-write time, and its
-verdict is still pending. We tell you this because the receipts are the
-point: we measured our own tooling, it missed the bar, we gated it, and the
-gate is on trial. A memory system that cannot reject its own writes is the
+results are still accumulating. We tell you this because the receipts are
+the point: we measured our own tooling, it missed the bar, we gated it, and
+now we measure the gate too. A memory system that cannot reject its own
+writes is the
 poisoning vector the behavioral-rules paper warns about.
 
 **A human promotes.** Candidates land in `.scars/candidates/`, never in the

--- a/website/docs/concepts/trust-classes.md
+++ b/website/docs/concepts/trust-classes.md
@@ -127,7 +127,7 @@ What never earns it:
   corroboration is not in this version.
 
 Demotion outranks the badge. Anything that contradicts an item — a
-[resolution](./lifecycle.md), a `superseded-by` verdict, a flagged likely
+[resolution](./lifecycle.md), a `superseded-by` marker, a flagged likely
 supersession, a state-changed-since-capture note, a tombstone — zeroes the
 count from that moment on, and the contradiction renders alone. "Three
 sessions agreed" printed next to "this is probably wrong" reads as support for

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -7,34 +7,33 @@ sidebar_position: 1
 Every daimon verb, grouped by what you are trying to do. Each command's
 `--help` carries the full flag surface; this page is the map.
 
-## The daily loop
+## Set up
+
+| command | what it does |
+| --- | --- |
+| `daimon configure` | Detect the resolved LLM backend and fill gaps in `~/.daimon/env`. `--test` runs a live round-trip. |
+| `daimon hooks install <host>` | Ship the host hook scripts (Windsurf, Codex) from the package. `list` / `status` inspect. |
+| `daimon skill install <host>` | Install the daimon agent skill into a host's skill directory. Re-run after upgrades. |
+| `daimon heal` | Re-serialize the most recent failed session when it is safe to do so. |
+| `daimon mcp serve` | Serve the daimon tools over MCP (stdio). |
+
+## Brief
 
 | command | what it does |
 | --- | --- |
 | `daimon brief` | Render the briefing from the latest checkpoint — where you left off, trust-tagged. `--team` adds teammates' latest; `--slug <s>` reads another project's bucket explicitly. |
 | `daimon recall "query"` | Full-text search across local + team checkpoint history. `--json` for rows, `--all-projects` to widen. |
 | `daimon handoff "Do X first. Beware: Y."` | Leave an authored baton for the next session — it renders above every briefing section and never competes with ranked items. `--clear` retracts; a new baton supersedes the old. |
-| `daimon loops` | List open, addressable loop items with their ids — the read counterpart to `resolve`'s write path. |
-| `daimon status` | Checkpoint presence and age, last serialize outcome, health warnings. `--suppressed` lists withheld resolved items. |
 
-## Closing and correcting
+## Check
 
 | command | what it does |
 | --- | --- |
-| `daimon resolve <id or text>` | Mark an item resolved — append-only event; the item stops carrying. `--dry-run` previews the match; `--by agent --evidence "<quote>"` claims a close that is byte-checked at session end. |
-| `daimon reverify <id>` | Assert a carried item is still true — evidence-gated, resets its staleness clock. Also the reject half of a supersession candidate. |
-| `daimon forget <id or text>` | Remove one item's content from disk and index, leaving a hash-only tombstone. The deletion survives re-serialization of the original transcript. |
-| `daimon log --text "…"` | Append a freeform timeline event to the project's event log — zero-LLM, audit-trail only. |
-
-## Trust and audit
-
-| command | what it does |
-| --- | --- |
-| `daimon why <item-id>` | The trust inspector: show every evidence axis behind one item — independent capture, provenance, source, byte-integrity, current support, verifier verdict, lifecycle, corroboration. `--source` adds one bounded, redacted source window; `--json` for machines. Item ids come from `daimon recall` or `daimon loops`. |
+| `daimon why <item-id>` | The trust inspector: show every evidence axis behind one item — independent capture, provenance, source, byte-integrity, current support, quote-check outcome, lifecycle, corroboration. `--source` adds one bounded, redacted source window; `--json` for machines. Item ids come from `daimon recall` or `daimon loops`. |
 | `daimon verify-receipt` | Verify a checkpoint's signed provenance receipt (full cryptographic check via the vitni CLI). |
+| `daimon reverify <id>` | Assert a carried item is still true — evidence-gated, resets its staleness clock. Also the reject half of a supersession candidate. |
 | `daimon audit quotes` | Re-check every stored verbatim quote against its source transcript and report mismatches. Read-only — it never rewrites trust tags. |
 | `daimon audit privacy` | Prove the deletion contract: hash every plaintext field on every surface (checkpoints, rotated pointers, the event ledger, the team mirror, the recall index and its orphan snapshots) and report any forgotten value that survived. Read-only. |
-| `daimon anchor <file> <symbol>` | Bind a cognitive item to a code symbol; briefings then warn when the anchored code drifts. |
 
 The auditors share one exit contract, so a script can act on the answer:
 
@@ -47,17 +46,29 @@ The auditors share one exit contract, so a script can act on the answer:
 `--project <dir>` scopes to one project, `--all` audits every local project
 (each against its own tombstones); the two are mutually exclusive.
 
-## Setup and operations
+## Correct
 
 | command | what it does |
 | --- | --- |
-| `daimon configure` | Detect the resolved LLM backend and fill gaps in `~/.daimon/env`. `--test` runs a live round-trip. |
-| `daimon hooks install <host>` | Ship the host hook scripts (Windsurf, Codex) from the package. `list` / `status` inspect. |
-| `daimon skill install <host>` | Install the daimon agent skill into a host's skill directory. Re-run after upgrades. |
-| `daimon team init\|sync\|status` | Shared team memory via a sidecar repo — default-closed routing, shape-redacted before anything syncs. |
+| `daimon resolve <id or text>` | Mark an item resolved — append-only event; the item stops carrying. `--dry-run` previews the match; `--by agent --evidence "<quote>"` claims a close that is byte-checked at session end. |
+| `daimon anchor <file> <symbol>` | Bind a cognitive item to a code symbol; briefings then warn when the anchored code drifts. |
+
+## Forget
+
+| command | what it does |
+| --- | --- |
+| `daimon forget <id or text>` | Remove one item's content from disk and index, leaving a hash-only tombstone. The deletion survives re-serialization of the original transcript. |
+
+## Status
+
+| command | what it does |
+| --- | --- |
+| `daimon status` | Checkpoint presence and age, last serialize outcome, health warnings. `--suppressed` lists withheld resolved items. |
 | `daimon stats` | Local usage and capture aggregates — nothing is transmitted; sharing the output is a deliberate paste. `--json` for machines. |
-| `daimon heal` | Re-serialize the most recent failed session when it is safe to do so. |
+| `daimon log --text "…"` | Append a freeform timeline event to the project's event log — zero-LLM, audit-trail only. |
+| `daimon loops` | List open, addressable loop items with their ids — the read counterpart to `resolve`'s write path. |
 | `daimon projects` | List every project daimon holds a checkpoint for, with topic teasers. |
+| `daimon team init\|sync\|status` | Shared team memory via a sidecar repo — default-closed routing, shape-redacted before anything syncs. |
 
 ## Internals (invoked by hooks, documented for completeness)
 
@@ -66,7 +77,6 @@ The auditors share one exit contract, so a script can act on the answer:
 | `daimon serialize <transcript>` | Turn a transcript file into a checkpoint — the SessionEnd hooks call this; running it by hand backfills one. |
 | `daimon write-checkpoint` | Store a checkpoint supplied as JSON on stdin — the in-session introspection path. Trust is code-clamped: nothing on this path can claim `verbatim`, because there is no transcript to verify against. |
 | `daimon recall-inject` | The per-prompt suggestion backend behind the recall hook: prompt on stdin, zero to two prior-work lines out, exit 0 always. |
-| `daimon mcp serve` | Serve the daimon tools over MCP (stdio). |
 
 ## Briefing annotations, decoded
 

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-07-30-negative-knowledge.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-07-30-negative-knowledge.md
@@ -80,9 +80,10 @@ Su historial de campo hasta ahora es mayormente ruido: el primer conteo fue 4
 candidatos, 0 promovibles, y el log de falsos disparos es más largo que la
 lista de aceptados. En respuesta se agregó un filtro de calificación que
 exige las mismas obligaciones estructurales al momento de escritura
-automática, y su veredicto sigue pendiente. Te lo contamos porque los
-recibos son el punto: medimos nuestra propia herramienta, no llegó a la vara,
-la enrejamos, y la reja está a prueba. Un sistema de memoria que no puede
+automática, y sus resultados todavía se están acumulando. Te lo contamos
+porque los recibos son el punto: medimos nuestra propia herramienta, no llegó
+a la vara, la enrejamos, y ahora también medimos la reja. Un sistema de
+memoria que no puede
 rechazar sus propias escrituras es el vector de envenenamiento del que
 advierte el paper de reglas de comportamiento.
 

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-07-30-origin-bound-corroboration.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-07-30-origin-bound-corroboration.md
@@ -39,7 +39,7 @@ encontramos que nuestro verificador de citas comparaba las citas verbatim
 contra la transcripción *sin filtrar*. Una cita copiada de una línea inyectada
 por el propio daimon pasaba la verificación y se guardaba como `verbatim`,
 `quote_verified: true` — un ítem de una sesión anterior lavado como si fuera
-testimonio fresco. Ese agujero no esperó a la funcionalidad de corroboración:
+recién atestiguado. Ese agujero no esperó a la funcionalidad de corroboración:
 salió como fix de seguridad independiente el mismo día en que se encontró, y
 la verificación ahora rechaza cualquier cita cuyo único soporte esté dentro de
 la salida del propio daimon. Los ecos rechazados tienen su propia razón en el

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/trust-classes.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/trust-classes.md
@@ -138,7 +138,7 @@ Qué nunca la gana:
   La corroboración de equipo no está en esta versión.
 
 La degradación le gana a la insignia. Cualquier cosa que contradiga un ítem —
-una [resolución](./lifecycle.md), un veredicto `superseded-by`, una supersesión
+una [resolución](./lifecycle.md), un marcador `superseded-by`, una supersesión
 marcada como probable, una nota de estado cambiado desde la captura, una
 tumba — pone el conteo en cero desde ese momento, y la contradicción se
 muestra sola. "Tres sesiones coincidieron" impreso junto a "esto probablemente

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -7,34 +7,33 @@ sidebar_position: 1
 Cada verbo de daimon, agrupado por lo que querés hacer. El `--help` de cada
 comando trae la superficie completa de flags; esta página es el mapa.
 
-## El ciclo diario
+## Preparar
+
+| comando | qué hace |
+| --- | --- |
+| `daimon configure` | Detecta el backend LLM resuelto y completa los huecos en `~/.daimon/env`. `--test` corre un round-trip real. |
+| `daimon hooks install <host>` | Instala los hook scripts del host (Windsurf, Codex) desde el paquete. `list` / `status` inspeccionan. |
+| `daimon skill install <host>` | Instala la skill de agente de daimon en el directorio de skills del host. Volvé a correrlo después de cada upgrade. |
+| `daimon heal` | Re-serializa la última sesión fallida cuando es seguro hacerlo. |
+| `daimon mcp serve` | Sirve las herramientas de daimon por MCP (stdio). |
+
+## Brief
 
 | comando | qué hace |
 | --- | --- |
 | `daimon brief` | Renderiza el briefing del último checkpoint — dónde quedaste, con etiquetas de confianza. `--team` suma lo último del equipo; `--slug <s>` lee el bucket de otro proyecto explícitamente. |
 | `daimon recall "consulta"` | Búsqueda full-text sobre el historial local + de equipo. `--json` para filas, `--all-projects` para ampliar. |
 | `daimon handoff "Hacé X primero. Ojo con Y."` | Deja un batón autoral para la próxima sesión — se renderiza arriba de todas las secciones del briefing y nunca compite con ítems rankeados. `--clear` lo retira; uno nuevo reemplaza al anterior. |
-| `daimon loops` | Lista los loops abiertos direccionables con sus ids — la contraparte de lectura del camino de escritura de `resolve`. |
-| `daimon status` | Presencia y edad del checkpoint, resultado del último serialize, avisos de salud. `--suppressed` lista los ítems resueltos retenidos. |
 
-## Cerrar y corregir
+## Comprobar
 
 | comando | qué hace |
 | --- | --- |
-| `daimon resolve <id o texto>` | Marca un ítem como resuelto — evento append-only; el ítem deja de arrastrarse. `--dry-run` previsualiza el match; `--by agent --evidence "<cita>"` reclama un cierre que se verifica byte a byte al final de la sesión. |
-| `daimon reverify <id>` | Afirma que un ítem arrastrado sigue siendo cierto — exige evidencia y reinicia su reloj de vencimiento. También es la mitad de rechazo de un candidato a supersesión. |
-| `daimon forget <id o texto>` | Elimina el contenido de un ítem del disco y del índice, dejando una lápida de solo-hash. La eliminación sobrevive a re-serializar la transcripción original. |
-| `daimon log --text "…"` | Agrega un evento libre a la línea de tiempo del proyecto — cero LLM, solo rastro de auditoría. |
-
-## Confianza y auditoría
-
-| comando | qué hace |
-| --- | --- |
-| `daimon why <item-id>` | El inspector de confianza: muestra cada eje de evidencia detrás de un ítem — captura independiente, procedencia, fuente, integridad de bytes, soporte actual, veredicto del verificador, ciclo de vida, corroboración. `--source` agrega una ventana de fuente acotada y redactada; `--json` para máquinas. Los ids de ítem salen de `daimon recall` o `daimon loops`. |
+| `daimon why <item-id>` | El inspector de confianza: muestra cada eje de evidencia detrás de un ítem — captura independiente, procedencia, fuente, integridad de bytes, soporte actual, resultado del chequeo de citas, ciclo de vida, corroboración. `--source` agrega una ventana de fuente acotada y redactada; `--json` para máquinas. Los ids de ítem salen de `daimon recall` o `daimon loops`. |
 | `daimon verify-receipt` | Verifica el recibo firmado de procedencia de un checkpoint (chequeo criptográfico completo vía el CLI de vitni). |
+| `daimon reverify <id>` | Afirma que un ítem arrastrado sigue siendo cierto — exige evidencia y reinicia su reloj de vencimiento. También es la mitad de rechazo de un candidato a supersesión. |
 | `daimon audit quotes` | Re-verifica cada cita verbatim almacenada contra su transcripción de origen y reporta discrepancias. Solo lectura — nunca reescribe etiquetas. |
 | `daimon audit privacy` | Prueba el contrato de borrado: hashea cada campo con texto plano en cada superficie (checkpoints, punteros rotados, el registro de eventos, el espejo de equipo, el índice de recall y sus snapshots huérfanos) y reporta todo valor olvidado que haya sobrevivido. Solo lectura. |
-| `daimon anchor <archivo> <símbolo>` | Ancla un ítem cognitivo a un símbolo de código; los briefings avisan cuando el código anclado cambió. |
 
 Los auditores comparten un mismo contrato de salida, para que un script pueda
 actuar sobre la respuesta:
@@ -48,17 +47,29 @@ actuar sobre la respuesta:
 `--project <dir>` acota a un proyecto, `--all` audita cada proyecto local
 (cada uno contra sus propias lápidas); los dos son mutuamente excluyentes.
 
-## Setup y operación
+## Corregir
 
 | comando | qué hace |
 | --- | --- |
-| `daimon configure` | Detecta el backend LLM resuelto y completa los huecos en `~/.daimon/env`. `--test` corre un round-trip real. |
-| `daimon hooks install <host>` | Instala los hook scripts del host (Windsurf, Codex) desde el paquete. `list` / `status` inspeccionan. |
-| `daimon skill install <host>` | Instala la skill de agente de daimon en el directorio de skills del host. Volvé a correrlo después de cada upgrade. |
-| `daimon team init\|sync\|status` | Memoria de equipo compartida vía repo sidecar — ruteo cerrado por defecto, redacción por forma antes de sincronizar nada. |
+| `daimon resolve <id o texto>` | Marca un ítem como resuelto — evento append-only; el ítem deja de arrastrarse. `--dry-run` previsualiza el match; `--by agent --evidence "<cita>"` reclama un cierre que se verifica byte a byte al final de la sesión. |
+| `daimon anchor <archivo> <símbolo>` | Ancla un ítem cognitivo a un símbolo de código; los briefings avisan cuando el código anclado cambió. |
+
+## Olvidar
+
+| comando | qué hace |
+| --- | --- |
+| `daimon forget <id o texto>` | Elimina el contenido de un ítem del disco y del índice, dejando una lápida de solo-hash. La eliminación sobrevive a re-serializar la transcripción original. |
+
+## Estado
+
+| comando | qué hace |
+| --- | --- |
+| `daimon status` | Presencia y edad del checkpoint, resultado del último serialize, avisos de salud. `--suppressed` lista los ítems resueltos retenidos. |
 | `daimon stats` | Agregados locales de uso y captura — nada se transmite; compartir la salida es un pegado deliberado. `--json` para máquinas. |
-| `daimon heal` | Re-serializa la última sesión fallida cuando es seguro hacerlo. |
+| `daimon log --text "…"` | Agrega un evento libre a la línea de tiempo del proyecto — cero LLM, solo rastro de auditoría. |
+| `daimon loops` | Lista los loops abiertos direccionables con sus ids — la contraparte de lectura del camino de escritura de `resolve`. |
 | `daimon projects` | Lista cada proyecto con checkpoint, con un adelanto del tema. |
+| `daimon team init\|sync\|status` | Memoria de equipo compartida vía repo sidecar — ruteo cerrado por defecto, redacción por forma antes de sincronizar nada. |
 
 ## Internos (los invocan los hooks; documentados por completitud)
 
@@ -67,7 +78,6 @@ actuar sobre la respuesta:
 | `daimon serialize <transcripción>` | Convierte un archivo de transcripción en checkpoint — lo llaman los hooks de fin de sesión; a mano, rellena uno. |
 | `daimon write-checkpoint` | Almacena un checkpoint recibido como JSON por stdin — el camino de introspección en sesión. La confianza la fija el código: nada en este camino puede reclamar `verbatim`, porque no hay transcripción contra la cual verificar. |
 | `daimon recall-inject` | El backend de sugerencias por prompt detrás del hook de recall: prompt por stdin, de cero a dos líneas de trabajo previo, exit 0 siempre. |
-| `daimon mcp serve` | Sirve las herramientas de daimon por MCP (stdio). |
 
 ## Anotaciones del briefing, decodificadas
 


### PR DESCRIPTION
Closes #637

## What

- Regroups `website/docs/reference/cli.md` (and its Spanish mirror) by user intent: Set up, Brief, Check, Correct, Forget, Status. `reverify` moves beside the other checks, `anchor` beside `resolve`, `mcp serve` into setup; hook-invoked internals keep their own note. No commands renamed, no behavior changes.
- Replaces adjudication wording with status wording, in both languages: "verifier verdict" becomes "quote-check outcome", "`superseded-by` verdict" becomes "`superseded-by` marker", the 2026-07-30 post now says the qualification filter's "results are still accumulating" and "now we measure the gate too", and its Spanish twin drops "testimonio" for "recién atestiguado".
- Moves the name-origin sentence from mid-README (between the demo and Install) to the README's close, adding: "This one shows its sources."

## Why

Grouping by internal taxonomy made related verbs land in surprising places, and courtroom vocabulary promises a judgment the tool does not render: it reports mechanical check outcomes. The name origin interrupted the evaluation flow where it sat.

## Tests

- Copy-only; docs site build runs in CI.
- Swept README, docs, blog, and the Spanish translations for remaining adjudication vocabulary and for exactness overclaims about the quote check; the only remaining byte-level wording is the trust-classes disclaimer, which denies the guarantee rather than claiming it.
