### PR TITLE
docs(reference): add a claims page with re-run methods

### DIFF
--- a/docs/backends-tested.md
+++ b/docs/backends-tested.md
@@ -21,7 +21,7 @@ collected automatically. Add your combination with the recipe below.
 | Model | Backend path | daimon | Downgrade rate (sample) | Date | Notes |
 |-------|--------------|--------|-------------------------|------|-------|
 | MIXED — claude-haiku-4-5 (litellm proxy) + claude-cli sessions, per-session attribution lost | see notes | 0.13.0 | 29% of 51 fresh verbatim claims, 3 sessions — per-session range 6%–77% | 2026-07-10 | maintainer dev box. The backend changed between these sessions and checkpoints don't record which one serialized them, so this row CANNOT be split — kept as a worked example of why unattributed samples are near-useless and why the serializer needs a backend/model stamp. Replace with attributed rows once stamping ships. |
-| MIXED — maintainer lifetime aggregate, backends varied over five months (mostly claude-cli) | see notes | 0.13.0–0.27.0 | 12.2% of 3703 fresh verbatim claims, 160 sessions | 2026-08-07 | maintainer dev box, dogfooding this repo. Not one (model, backend) pair — published as the lifetime baseline, attributed by month and checkpoint format instead: 2026-07 13.7% (n=2217) → 2026-08 9.8% (n=1476); by format D-012 21.2%, D-013 16.5%, D-014 10.1%, D-016 16.1%, D-017 9.9%, D-018 10.6% (n=1274). Deduplicated by session id — see the aggregate note below. |
+| MIXED — maintainer lifetime aggregate, backends varied over two months (mostly claude-cli) | see notes | 0.13.0–0.27.0 | 12.2% of 3703 fresh verbatim claims, 160 sessions | 2026-08-07 | maintainer dev box, dogfooding this repo. Not one (model, backend) pair — published as the lifetime baseline, attributed by month and checkpoint format instead: 2026-07 13.7% (n=2217) → 2026-08 9.8% (n=1476); by format D-012 21.2%, D-013 16.5%, D-014 10.1%, D-016 16.1%, D-017 9.9%, D-018 10.6% (n=1274). Deduplicated by session id — see the aggregate note below. |
 | _your model_ | _anthropic / openai-compatible / claude-cli / command_ | | | | |
 
 **Attribution rule (learned filling the first row):** a row is only valid if every
@@ -49,7 +49,7 @@ keep it honest:
   the rate happened to be identical before and after dedup, but that is luck,
   not a property — dedup anyway.
 - **It is a baseline, not a benchmark.** Single machine, a single project
-  (daimon developing itself), mixed backends across five months of versions.
+  (daimon developing itself), mixed backends across two months of versions.
   The portable signal is the trend, not the level: per-format rates fall from
   D-012's 21.2% to roughly 10% on D-017/D-018 as serializer-side verification
   hardened.

--- a/website/docs/reference/backends-tested.md
+++ b/website/docs/reference/backends-tested.md
@@ -21,7 +21,7 @@ collected automatically. Add your combination with the recipe below.
 | Model | Backend path | daimon | Downgrade rate (sample) | Date | Notes |
 |-------|--------------|--------|-------------------------|------|-------|
 | MIXED — claude-haiku-4-5 (litellm proxy) + claude-cli sessions, per-session attribution lost | see notes | 0.13.0 | 29% of 51 fresh verbatim claims, 3 sessions — per-session range 6%–77% | 2026-07-10 | maintainer dev box. The backend changed between these sessions and checkpoints don't record which one serialized them, so this row CANNOT be split — kept as a worked example of why unattributed samples are near-useless and why the serializer needs a backend/model stamp. Replace with attributed rows once stamping ships. |
-| MIXED — maintainer lifetime aggregate, backends varied over five months (mostly claude-cli) | see notes | 0.13.0–0.27.0 | 12.2% of 3703 fresh verbatim claims, 160 sessions | 2026-08-07 | maintainer dev box, dogfooding this repo. Not one (model, backend) pair — published as the lifetime baseline, attributed by month and checkpoint format instead: 2026-07 13.7% (n=2217) → 2026-08 9.8% (n=1476); by format D-012 21.2%, D-013 16.5%, D-014 10.1%, D-016 16.1%, D-017 9.9%, D-018 10.6% (n=1274). Deduplicated by session id — see the aggregate note below. |
+| MIXED — maintainer lifetime aggregate, backends varied over two months (mostly claude-cli) | see notes | 0.13.0–0.27.0 | 12.2% of 3703 fresh verbatim claims, 160 sessions | 2026-08-07 | maintainer dev box, dogfooding this repo. Not one (model, backend) pair — published as the lifetime baseline, attributed by month and checkpoint format instead: 2026-07 13.7% (n=2217) → 2026-08 9.8% (n=1476); by format D-012 21.2%, D-013 16.5%, D-014 10.1%, D-016 16.1%, D-017 9.9%, D-018 10.6% (n=1274). Deduplicated by session id — see the aggregate note below. |
 | _your model_ | _anthropic / openai-compatible / claude-cli / command_ | | | | |
 
 **Attribution rule (learned filling the first row):** a row is only valid if every
@@ -49,7 +49,7 @@ keep it honest:
   the rate happened to be identical before and after dedup, but that is luck,
   not a property — dedup anyway.
 - **It is a baseline, not a benchmark.** Single machine, a single project
-  (daimon developing itself), mixed backends across five months of versions.
+  (daimon developing itself), mixed backends across two months of versions.
   The portable signal is the trend, not the level: per-format rates fall from
   D-012's 21.2% to roughly 10% on D-017/D-018 as serializer-side verification
   hardened.

--- a/website/docs/reference/claims.md
+++ b/website/docs/reference/claims.md
@@ -5,7 +5,7 @@ sidebar_position: 4
 # Claims, with re-run methods
 
 Every number daimon publishes about itself ships with the method to reproduce
-it. The numbers below describe **our own store** — five months of dogfooding on
+it. The numbers below describe **our own store** — two months of dogfooding on
 one machine. Running the same commands on your install measures **your** store;
 that is the point. A claim you cannot re-run is a testimonial, and this page
 does not carry testimonials.

--- a/website/docs/reference/claims.md
+++ b/website/docs/reference/claims.md
@@ -1,0 +1,79 @@
+---
+sidebar_position: 4
+---
+
+# Claims, with re-run methods
+
+Every number daimon publishes about itself ships with the method to reproduce
+it. The numbers below describe **our own store** — five months of dogfooding on
+one machine. Running the same commands on your install measures **your** store;
+that is the point. A claim you cannot re-run is a testimonial, and this page
+does not carry testimonials.
+
+One definition rides with everything here: **verified means daimon found this
+exact quote in your transcript** — matched after folding case, whitespace, and
+formatting, with elided spans allowed. It is a mechanical check, not a truth
+claim.
+
+## The claims
+
+| Claim | Published number / guarantee | Re-run with |
+| --- | --- | --- |
+| Fresh verbatim claims fail the quote check at a measurable, published rate | **12.2%** lifetime (450 of 3703 claims, 160 sessions, snapshot 2026-08-07) — [dated row + caveats](./backends-tested.md) | snippet below |
+| Every stored verbatim quote stays re-checkable after the fact | exit `0` proven / `1` mismatch found / `3` cannot prove | `daimon audit quotes` |
+| A forgotten value is provably gone from every declared surface | same exit contract, hash-only reporting | `daimon audit privacy` |
+| Deletion survives re-serializing the original transcript | tombstone suppresses the item on re-capture | `daimon forget <id>`, then `daimon serialize <transcript>`, then `daimon recall` for the value |
+| A checkpoint's provenance is offline-checkable (opt-in) | ed25519 signature binding exact bytes to the source transcript | `daimon verify-receipt` |
+
+## Re-running the downgrade rate
+
+The rate is derived from your own checkpoint store — no network, no tooling
+beyond Python. Rotated pointer copies duplicate sessions on disk, so
+deduplication by session id is mandatory (a naive glob double-counts):
+
+```python
+python3 - <<'EOF'
+import json, glob, os
+def items(o):
+    if isinstance(o, dict):
+        if "quote_verified" in o: yield o
+        for v in o.values(): yield from items(v)
+    elif isinstance(o, list):
+        for v in o: yield from items(v)
+seen=set(); checked=downgraded=0
+for p in glob.glob(os.path.expanduser("~/.daimon/checkpoints/**/*.json"), recursive=True):
+    try: cp=json.load(open(p, encoding="utf-8"))
+    except Exception: continue
+    if not isinstance(cp, dict): continue
+    sid=cp.get("session_id")
+    if not sid or sid in seen: continue
+    seen.add(sid)
+    for it in items(cp):
+        checked+=1
+        if it.get("quote_verified") is False: downgraded+=1
+print(f"{downgraded}/{checked} downgraded across {len(seen)} sessions"
+      + (f" = {downgraded/checked:.1%}" if checked else ""))
+EOF
+```
+
+What it counts: every item that carries a `quote_verified` stamp — `false`
+means the quote failed re-verification at capture time and the item was
+demoted to `inferred`. The published 12.2% is a **dated snapshot**; the same
+command on the same store four sessions later already reads 11.9% (460/3869,
+164 sessions). Your store will read your number, from day one.
+
+## What the audits prove
+
+`daimon audit quotes` re-checks every stored verbatim quote against its source
+transcript, read-only. `daimon audit privacy` hashes every plaintext field on
+every declared surface and intersects with the deletion ledger. Both share one
+[exit contract](./cli.md#check): `0` is proven clean, `1` names the residue by
+surface and hash, and `3` means a surface could not be read — never treat `3`
+as clean. That last code exists because "could not check" reported as "all
+clean" is how audit theater works.
+
+## What is deliberately not on this page
+
+Anything measured once, on a sample too small to state, or not yet
+reproducible by a command you can run. When a number graduates to a method,
+it moves here with its date.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/backends-tested.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/backends-tested.md
@@ -25,7 +25,7 @@ receta de abajo.
 | Modelo | Ruta de backend | daimon | Tasa de degradación (muestra) | Fecha | Notas |
 |-------|--------------|--------|-------------------------|------|-------|
 | MIXED — claude-haiku-4-5 (litellm proxy) + sesiones claude-cli, atribución por sesión perdida | ver notas | 0.13.0 | 29% de 51 afirmaciones verbatim frescas, 3 sesiones — rango por sesión 6%–77% | 2026-07-10 | máquina de desarrollo del maintainer. El backend cambió entre estas sesiones y los checkpoints no registran cuál serializó cada una, así que esta fila NO PUEDE separarse — se conserva como ejemplo práctico de por qué las muestras sin atribución son casi inútiles y de por qué el serializador necesita un sello de backend/modelo. Reemplázala con filas atribuidas ahora que el sellado existe. |
-| MIXED — agregado de por vida del maintainer, backends variados a lo largo de cinco meses (mayormente claude-cli) | ver notas | 0.13.0–0.27.0 | 12.2% de 3703 afirmaciones verbatim frescas, 160 sesiones | 2026-08-07 | máquina de desarrollo del maintainer, dogfooding de este repo. No es un par (modelo, backend) — se publica como línea base de por vida, atribuida por mes y por formato de checkpoint: 2026-07 13.7% (n=2217) → 2026-08 9.8% (n=1476); por formato D-012 21.2%, D-013 16.5%, D-014 10.1%, D-016 16.1%, D-017 9.9%, D-018 10.6% (n=1274). Deduplicado por id de sesión — mira la nota del agregado abajo. |
+| MIXED — agregado de por vida del maintainer, backends variados a lo largo de dos meses (mayormente claude-cli) | ver notas | 0.13.0–0.27.0 | 12.2% de 3703 afirmaciones verbatim frescas, 160 sesiones | 2026-08-07 | máquina de desarrollo del maintainer, dogfooding de este repo. No es un par (modelo, backend) — se publica como línea base de por vida, atribuida por mes y por formato de checkpoint: 2026-07 13.7% (n=2217) → 2026-08 9.8% (n=1476); por formato D-012 21.2%, D-013 16.5%, D-014 10.1%, D-016 16.1%, D-017 9.9%, D-018 10.6% (n=1274). Deduplicado por id de sesión — mira la nota del agregado abajo. |
 | _tu modelo_ | _anthropic / openai-compatible / claude-cli / command_ | | | | |
 
 **Regla de atribución (aprendida llenando la primera fila):** una fila solo
@@ -56,7 +56,7 @@ una sola máquina del maintainer — contadas con los mismos sellos
   vez. Acá la tasa resultó idéntica antes y después de deduplicar, pero eso es
   suerte, no una propiedad — deduplica igual.
 - **Es una línea base, no un benchmark.** Una sola máquina, un solo proyecto
-  (daimon desarrollándose a sí mismo), backends mezclados a lo largo de cinco
+  (daimon desarrollándose a sí mismo), backends mezclados a lo largo de dos
   meses de versiones. La señal portable es la tendencia, no el nivel: las
   tasas por formato caen del 21.2% de D-012 a aproximadamente 10% en
   D-017/D-018 a medida que la verificación del lado del serializador se

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/claims.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/claims.md
@@ -5,7 +5,7 @@ sidebar_position: 4
 # Afirmaciones, con método para re-ejecutarlas
 
 Cada número que daimon publica sobre sí mismo viene con el método para
-reproducirlo. Los números de abajo describen **nuestro propio store** — cinco
+reproducirlo. Los números de abajo describen **nuestro propio store** — dos
 meses de dogfooding en una sola máquina. Correr los mismos comandos en tu
 instalación mide **tu** store; ese es el punto. Una afirmación que no podés
 re-ejecutar es un testimonio, y esta página no lleva testimonios.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/claims.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/claims.md
@@ -1,0 +1,81 @@
+---
+sidebar_position: 4
+---
+
+# Afirmaciones, con método para re-ejecutarlas
+
+Cada número que daimon publica sobre sí mismo viene con el método para
+reproducirlo. Los números de abajo describen **nuestro propio store** — cinco
+meses de dogfooding en una sola máquina. Correr los mismos comandos en tu
+instalación mide **tu** store; ese es el punto. Una afirmación que no podés
+re-ejecutar es un testimonio, y esta página no lleva testimonios.
+
+Una definición acompaña todo lo de acá: **verificado significa que daimon
+encontró esta cita exacta en tu transcript** — comparada tras normalizar
+mayúsculas, espacios y formato, con tramos elididos permitidos. Es una
+comprobación mecánica, no una afirmación de verdad.
+
+## Las afirmaciones
+
+| Afirmación | Número publicado / garantía | Re-ejecutar con |
+| --- | --- | --- |
+| Las citas verbatim frescas fallan el chequeo a una tasa medible y publicada | **12.2%** de por vida (450 de 3703 citas, 160 sesiones, corte 2026-08-07) — [fila fechada + salvedades](./backends-tested.md) | snippet de abajo |
+| Cada cita verbatim almacenada sigue siendo re-chequeable después | salida `0` probado / `1` discrepancia / `3` no se puede probar | `daimon audit quotes` |
+| Un valor olvidado está probadamente ausente de cada superficie declarada | mismo contrato de salida, reporte solo-hash | `daimon audit privacy` |
+| El borrado sobrevive a re-serializar la transcripción original | la lápida suprime el ítem al re-capturar | `daimon forget <id>`, después `daimon serialize <transcripción>`, después `daimon recall` del valor |
+| La procedencia de un checkpoint se chequea offline (opt-in) | firma ed25519 que ata los bytes exactos a su transcripción | `daimon verify-receipt` |
+
+## Re-ejecutar la tasa de degradación
+
+La tasa se deriva de tu propio store de checkpoints — sin red, sin más
+herramientas que Python. Las copias rotadas de punteros duplican sesiones en
+disco, así que deduplicar por session id es obligatorio (un glob ingenuo
+cuenta doble):
+
+```python
+python3 - <<'EOF'
+import json, glob, os
+def items(o):
+    if isinstance(o, dict):
+        if "quote_verified" in o: yield o
+        for v in o.values(): yield from items(v)
+    elif isinstance(o, list):
+        for v in o: yield from items(v)
+seen=set(); checked=downgraded=0
+for p in glob.glob(os.path.expanduser("~/.daimon/checkpoints/**/*.json"), recursive=True):
+    try: cp=json.load(open(p, encoding="utf-8"))
+    except Exception: continue
+    if not isinstance(cp, dict): continue
+    sid=cp.get("session_id")
+    if not sid or sid in seen: continue
+    seen.add(sid)
+    for it in items(cp):
+        checked+=1
+        if it.get("quote_verified") is False: downgraded+=1
+print(f"{downgraded}/{checked} degradadas en {len(seen)} sesiones"
+      + (f" = {downgraded/checked:.1%}" if checked else ""))
+EOF
+```
+
+Qué cuenta: cada ítem que lleva un sello `quote_verified` — `false` significa
+que la cita falló la re-verificación al capturar y el ítem fue degradado a
+`inferred`. El 12.2% publicado es un **corte fechado**; el mismo comando sobre
+el mismo store cuatro sesiones después ya lee 11.9% (460/3869, 164 sesiones).
+Tu store va a leer tu número, desde el primer día.
+
+## Qué prueban los auditores
+
+`daimon audit quotes` re-chequea cada cita verbatim contra su transcripción de
+origen, solo lectura. `daimon audit privacy` hashea cada campo con texto plano
+en cada superficie declarada y lo intersecta con el registro de borrados. Los
+dos comparten un [contrato de salida](./cli.md#comprobar): `0` es limpio
+probado, `1` nombra el residuo por superficie y hash, y `3` significa que una
+superficie no se pudo leer — nunca trates `3` como limpio. Ese último código
+existe porque "no pude chequear" reportado como "todo limpio" es exactamente
+cómo funciona el teatro de auditoría.
+
+## Qué no está en esta página, a propósito
+
+Todo lo medido una sola vez, sobre una muestra demasiado chica para afirmarse,
+o todavía no reproducible con un comando que puedas correr. Cuando un número
+gradúa a método, se muda acá con su fecha.


### PR DESCRIPTION
Closes #640

## What

Adds `website/docs/reference/claims.md` and its Spanish mirror: one table of every number daimon publishes about itself, each paired with the command that reproduces it on the reader's own install.

- The 12.2% downgrade-rate snapshot links its dated row and gains a standalone, dependency-free Python rederivation snippet (deduplication by session id, with the double-count warning).
- The two audits appear with their shared exit contract, including why exit `3` must never read as clean.
- Deletion surviving re-serialization and offline receipt verification each get their re-run commands.
- The page opens with the scope definition of "verified" and closes by naming what is deliberately excluded: anything measured once or not yet reproducible by a command.

## Why

The published numbers were scattered across a backends table, the CLI reference, and blog posts, with no single statement of how to reproduce them. For a tool whose pitch is checkability, that is a credibility gap: a claim you cannot re-run is a testimonial.

## Tests

- The snippet was run against the store that produced the published row before it was written into the page: 460/3869 = 11.9% across 164 sessions, four sessions after the published 450/3703 = 12.2% snapshot, same method. The page states both numbers so a reader sees the snapshot is dated, not massaged.
- Copy-only; docs site build runs in CI. Anchor links (`cli.md#check`, `cli.md#comprobar`) match the regrouped headings that landed on main today.
