### PR TITLE
fix(ledger): resolve Codex rollout stems to the spawned session id

### DIFF
--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -172,14 +172,17 @@ def _has_checkpoint(sid: str) -> bool:
     every host whose checkpoint is named by session id; the scan covers Codex,
     whose file is on disk under the rollout name the bare id cannot address
     (#634). The glob pattern is a literal — `sid` never reaches it — so no
-    session id can inject shell-style metacharacters into the match."""
+    session id can inject shell-style metacharacters into the match.
+
+    The scan needs no OSError guard, unlike this module's other filesystem
+    readers: `Path.glob` swallows a missing directory, a path that is a file
+    rather than a directory, and a permission-denied directory, returning an
+    empty iterator for all three (verified on 3.10 and 3.13, the versions CI
+    runs). A `try/except OSError` here would be unreachable."""
     if store.read_checkpoint(sid) is not None:
         return True
-    try:
-        entries = list(config.checkpoint_dir().glob("rollout-*.json"))
-    except OSError:
-        return False
-    return any(_session_key(p.stem) == sid for p in entries)
+    return any(_session_key(p.stem) == sid
+               for p in config.checkpoint_dir().glob("rollout-*.json"))
 
 
 def _session_ledger(text: str, now: float) -> dict:

--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -150,6 +150,37 @@ _LEDGER_PROJECT_RE = re.compile(r"project: (.*?)\)")
 # match keeps it disjoint from _HEAL_TRANSCRIPT_RE (error lines, `after Ns`).
 _LEDGER_SPAWN_TRANSCRIPT_RE = re.compile(r"\(transcript: (.+?)\)\s*$")
 
+# #634: Codex names BOTH its rollout transcript and the checkpoint written from
+# it `rollout-<stamp>-<session-id>`, while its hooks spawn-log the BARE session
+# id. Attributing a result by file stem therefore never meets its spawn, so
+# every successful Codex capture also left a phantom "spawned, no result"
+# failure in status. The stamp shape is matched exactly because both halves
+# contain dashes — a looser split would be ambiguous. Non-Codex stems (a Claude
+# checkpoint stem IS the session id) must pass through untouched.
+_ROLLOUT_STEM_RE = re.compile(r"^rollout-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-(.+)$")
+
+
+def _session_key(stem: str) -> str:
+    """Checkpoint/transcript file stem -> the session id its spawn line carries.
+    Identity for every host except Codex (#634)."""
+    m = _ROLLOUT_STEM_RE.match(stem)
+    return m.group(1) if m else stem
+
+
+def _has_checkpoint(sid: str) -> bool:
+    """Did this session's serialize land a checkpoint? A direct read covers
+    every host whose checkpoint is named by session id; the scan covers Codex,
+    whose file is on disk under the rollout name the bare id cannot address
+    (#634). The glob pattern is a literal — `sid` never reaches it — so no
+    session id can inject shell-style metacharacters into the match."""
+    if store.read_checkpoint(sid) is not None:
+        return True
+    try:
+        entries = list(config.checkpoint_dir().glob("rollout-*.json"))
+    except OSError:
+        return False
+    return any(_session_key(p.stem) == sid for p in entries)
+
 
 def _session_ledger(text: str, now: float) -> dict:
     """Fold serialize.log into per-session terminal state. Unlike
@@ -190,7 +221,7 @@ def _session_ledger(text: str, now: float) -> dict:
             continue
         m = _LEDGER_OK_RE.match(line)
         if m:
-            e = _entry(Path(m.group(1)).stem)
+            e = _entry(_session_key(Path(m.group(1)).stem))
             e["result_kind"] = "success"
             e["result_line"] = line
             e["transcript"] = None
@@ -205,7 +236,7 @@ def _session_ledger(text: str, now: float) -> dict:
             tm = _HEAL_TRANSCRIPT_RE.search(line)
             if not tm:
                 continue  # pre-flight error, no session to attribute
-            e = _entry(Path(tm.group(1)).stem)
+            e = _entry(_session_key(Path(tm.group(1)).stem))
             e["result_kind"] = "error"
             e["result_line"] = line
             e["transcript"] = tm.group(1)
@@ -280,7 +311,7 @@ def _compute_outstanding(text: str, now: float, force: bool = False) -> list:
     classification."""
     return _outstanding_failures(
         _session_ledger(text, now), now,
-        lambda sid: store.read_checkpoint(sid) is not None,
+        _has_checkpoint,
         config.hung_after_seconds(),
         lambda p: bool(p) and Path(p).exists(),
         force=force,

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2117,6 +2117,68 @@ def test_session_ledger_computes_spawn_age():
     assert led["A"]["result_kind"] is None
 
 
+# ---- #634: Codex rollout stem vs bare session id ----
+
+# Codex hooks spawn-log the BARE session id, but the serialize result lines
+# carry the rollout stem (`rollout-<stamp>-<id>`) because that is what the
+# checkpoint file and the host transcript are named. Folding them under
+# different keys makes every successful Codex capture also emit a phantom
+# "spawned, no result" failure.
+_CODEX_SID = "019fdf6a-8019-7dd0-b57f-bd20b7ac47e8"
+_CODEX_STEM = f"rollout-2026-08-07T21-28-46-{_CODEX_SID}"
+
+
+def test_session_ledger_pairs_codex_rollout_success_with_bare_spawn():
+    text = "\n".join([
+        f"2026-08-08T04:48:19Z codex-session-end: spawned serialize for {_CODEX_SID} "
+        "(reason: exit, project: /p/A)",
+        f"wrote checkpoint: /c/{_CODEX_STEM}.json (took 143s)",
+    ])
+    led = cli._session_ledger(text, now=0.0)
+    assert list(led) == [_CODEX_SID]
+    assert led[_CODEX_SID]["spawned"] is True
+    assert led[_CODEX_SID]["result_kind"] == "success"
+
+
+def test_session_ledger_pairs_codex_rollout_error_with_bare_spawn():
+    text = "\n".join([
+        f"2026-08-08T04:48:19Z codex-session-end: spawned serialize for {_CODEX_SID} "
+        "(reason: exit, project: /p/A)",
+        f"error: boom (transcript: /t/{_CODEX_STEM}.jsonl) after 3s",
+    ])
+    led = cli._session_ledger(text, now=0.0)
+    assert list(led) == [_CODEX_SID]
+    assert led[_CODEX_SID]["spawned"] is True
+    assert led[_CODEX_SID]["result_kind"] == "error"
+    assert led[_CODEX_SID]["transcript"] == f"/t/{_CODEX_STEM}.jsonl"
+
+
+def test_session_ledger_keeps_non_rollout_stems_verbatim():
+    # A Claude checkpoint stem IS the session id — normalisation must not
+    # touch it, and a rollout-shaped name without a valid stamp is not a
+    # Codex rollout either.
+    text = "\n".join([
+        "wrote checkpoint: /c/A.json (took 5s)",
+        "wrote checkpoint: /c/rollout-not-a-stamp-B.json (took 5s)",
+    ])
+    led = cli._session_ledger(text, now=0.0)
+    assert set(led) == {"A", "rollout-not-a-stamp-B"}
+
+
+def test_compute_outstanding_sees_codex_checkpoint_under_rollout_name(
+    tmp_checkpoint_dir, sample_checkpoint
+):
+    # The result line has aged out of the 200-line window, so only the probe
+    # can clear the spawn. The checkpoint on disk is named by rollout stem.
+    from daimon_briefing import store
+
+    store.write_checkpoint(_CODEX_STEM, sample_checkpoint)
+    log = (f"2026-08-08T04:48:19Z codex-session-end: spawned serialize for "
+           f"{_CODEX_SID} (reason: exit, project: /p/A)")
+    now = datetime(2026, 8, 8, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+    assert cli._compute_outstanding(log, now) == []
+
+
 # ---- _outstanding_failures: classify lost sessions per checkpoint store ----
 
 


### PR DESCRIPTION
Closes #634

## What

Codex names both its rollout transcript and the checkpoint written from it `rollout-<stamp>-<session-id>`, while its hooks spawn-log the bare session id. `_session_ledger` attributed spawns by the spawn-line id and results by the file stem, so the two never resolved to the same key.

- `_session_key()` normalises a checkpoint/transcript stem to the session id its spawn line carries. Applied on both result paths — the success path (`_LEDGER_OK_RE` → checkpoint stem) and the error path (`_HEAL_TRANSCRIPT_RE` → rollout transcript stem, which had the same mismatch and was not called out in the issue).
- `_has_checkpoint()` replaces the inline `store.read_checkpoint(sid)` probe. A direct read still covers every host whose checkpoint is named by session id; a scan of `rollout-*.json` covers Codex, whose file the bare id cannot address.

The stamp shape is matched exactly (`\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}`) because both halves of the name contain dashes — a looser split would be ambiguous. Non-Codex stems pass through untouched. The glob pattern is a literal; `sid` never reaches it.

## Why

Every successful Codex capture also emitted a phantom `spawned, no result (hung/killed)` entry in `daimon status`. Follow-on cost, both real: `heal` burned a run repairing a capture that never failed, and once Codex rotated the transcript the phantom stuck permanently as `not auto-repairable` noise.

Both seams are fixed rather than only the cheaper hook-side rename, because the probe repair is what clears historical spawns whose result line has already aged out of the 200-line ledger window.

The issue also asked whether the silent-capture alarm is distorted by the same mismatch. Checked: it is not. `_capture_alarm` (`cli.py:2001`) compares in-window spawn and checkpoint **counts** and never matches ids, so the key mismatch cannot reach it. No change made there.

## Tests

Four new tests in `plugin/tests/test_cli.py`, written before the fix:

- `test_session_ledger_pairs_codex_rollout_success_with_bare_spawn` — failed with a second, phantom `rollout-...` entry.
- `test_session_ledger_pairs_codex_rollout_error_with_bare_spawn` — same, on the error path.
- `test_compute_outstanding_sees_codex_checkpoint_under_rollout_name` — result line aged out, so only the probe can clear the spawn; failed with a `hung` classification.
- `test_session_ledger_keeps_non_rollout_stems_verbatim` — regression guard on the pass-through, including a `rollout-`-prefixed name with no valid stamp.

Suite: `3196 passed, 2 skipped`. `ruff check` clean.

Verified against the reporting install — the three sessions named in the issue clear, and no other status line changes:

```
$ daimon status              # 0.28.0
⚠ 3 sessions failed to serialize (no checkpoint):
  - 019fdf6a-8019-7dd0-b57f-bd20b7ac47e8  spawned 2h ago, no result (hung/killed; transcript unavailable)
  - 019fd48f-20a0-77a1-94dd-798781e27240  spawned 11h ago, no result (hung/killed; transcript unavailable)
  - 019fdaf1-0457-72e2-97dc-65a286278c1b  spawned 23h ago, no result (hung/killed; transcript unavailable)

$ uv run daimon status       # this branch
(no outstanding-failure section)
```