### PR TITLE
chore(scars): promote seven reviewed candidates and repair unreachable evidence receipts

### DIFF
--- a/.scars/0042-coverage-test-walking-the-scrubbers-own-surface-set.landmine.md
+++ b/.scars/0042-coverage-test-walking-the-scrubbers-own-surface-set.landmine.md
@@ -1,22 +1,22 @@
 ---
-id: 0
+id: 42
 type: landmine
 title: A residue test that enumerates surfaces via the scrubber's own walk cannot fail for a missed surface class
 severity: high
 confidence: 0.95
 created: 2026-08-07
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/tests/test_team_tombstone_propagation.py
   - path: plugin/daimon_briefing/store.py
   - pattern: "project_surfaces\("
 evidence:
-  - note: "test_opt_in_scrubs_local_copies asserted no residue by iterating store.project_surfaces(PROJECT) — the exact set scrub_content_key walks. apply_foreign_tombstones reaches only that set, so the chunk cache, crash log, adapter transcripts, events.jsonl and own team-mirror copies all kept the plaintext while the test passed and the CLI printed success. Found in the #600 slice B design review, 2026-08-07; filed as #620."
-  - note: "Second instance of the class. The first shipped a forget bug to main because a passing test asserted the residue it was meant to catch (see forget-plaintext-surfaces)."
+  - note: test_opt_in_scrubs_local_copies asserted no residue by iterating store.project_surfaces(PROJECT) — the exact set scrub_content_key walks. apply_foreign_tombstones reaches only that set, so the chunk cache, crash log, adapter transcripts, events.jsonl and own team-mirror copies all kept the plaintext while the test passed and the CLI printed success. Found in the #600 slice B design review, 2026-08-07; filed as #620.
+  - note: Second instance of the class. The first shipped a forget bug to main because a passing test asserted the residue it was meant to catch (see forget-plaintext-surfaces).
 expires:
   condition: "residue assertions enumerate surfaces from surfaces.SURFACES (plaintext=True) rather than from the walk under test"
   review_after: 2027-02-07
-status: candidate
+status: active
 ---
 
 A deletion test must not ask the code under test which files exist. When the

--- a/.scars/0043-hook-config-mirror-must-copy-quirks-not-intent.landmine.md
+++ b/.scars/0043-hook-config-mirror-must-copy-quirks-not-intent.landmine.md
@@ -1,22 +1,22 @@
 ---
-id: 0
+id: 43
 type: landmine
 title: A hook mirroring a config accessor must copy its QUIRKS (no-strip, env-file fallback), not its intent — divergence silently splits a writer from its deleter
 severity: high
 confidence: 0.95
 created: 2026-08-06
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: hook/
   - path: plugin/daimon_briefing/config.py
 evidence:
-  - note: "2026-08-06, #605. crash_log_path() in hook/_daimon_hook_lib.py was written as os.environ.get(DAIMON_LOG_DIR, '').strip(). Adversarial review found both halves wrong: config._get falls back to ~/.daimon/env, and config.log_dir() never strips. With DAIMON_LOG_DIR set only in the env file, the serialize child wrote tracebacks to ~/.daimon/logs while `daimon forget` purged the configured directory and printed a clean zero — permanent plaintext residue under a surface registry entry that declared the file reachable by forget."
-  - note: "2026-08-06, prior bite of the same class: #607, where hook/daimon-windsurf-hooks.py hardcoded ~/.daimon/windsurf while the package honored DAIMON_WINDSURF_DIR, so purge/reap/audit all reported cleanly on an empty directory while the adapter filled another one."
+  - note: 2026-08-06, #605. crash_log_path() in hook/_daimon_hook_lib.py was written as os.environ.get(DAIMON_LOG_DIR, '').strip(). Adversarial review found both halves wrong: config._get falls back to ~/.daimon/env, and config.log_dir() never strips. With DAIMON_LOG_DIR set only in the env file, the serialize child wrote tracebacks to ~/.daimon/logs while `daimon forget` purged the configured directory and printed a clean zero — permanent plaintext residue under a surface registry entry that declared the file reachable by forget.
+  - note: 2026-08-06, prior bite of the same class: #607, where hook/daimon-windsurf-hooks.py hardcoded ~/.daimon/windsurf while the package honored DAIMON_WINDSURF_DIR, so purge/reap/audit all reported cleanly on an empty directory while the adapter filled another one.
 expires:
   condition: "hooks can import daimon_briefing.config directly, or both sides call one shared hook-safe resolver instead of two copies"
   review_after: 2027-02-06
 violation: "os\.environ\.get\(.DAIMON_LOG_DIR"
-status: candidate
+status: active
 ---
 
 `daimon forget` deletes `logs/serialize-crash.log` through `config.log_dir()`,

--- a/.scars/0044-hook-source-of-truth-is-hook-dir.landmine.md
+++ b/.scars/0044-hook-source-of-truth-is-hook-dir.landmine.md
@@ -1,0 +1,35 @@
+---
+id: 44
+type: landmine
+title: Editing plugin/daimon_briefing/_hooks/ is silently reverted — hook/ is the source of truth
+severity: medium
+confidence: 0.9
+created: 2026-08-06
+authors: ["claude-code", "Kibukx"]
+anchors:
+  - path: plugin/daimon_briefing/_hooks/
+  - path: scripts/sync_hooks.py
+evidence:
+  - note: 2026-08-06, #607: edited the package copy of daimon-windsurf-hooks.py, ran scripts/sync_hooks.py, and the edit was overwritten — two tests kept failing against code that had reverted itself
+expires:
+  condition: "sync_hooks.py syncs bidirectionally, or the package copy becomes a symlink/generated artifact that cannot be edited by hand"
+  review_after: 2027-02-01
+status: active
+---
+
+`scripts/sync_hooks.py` copies ONE direction: `hook/<name>.py` INTO
+`plugin/daimon_briefing/_hooks/<name>.py`. Its output line reads
+`synced plugin/... <- hook/...`, and the arrow is the whole contract.
+
+Editing the package copy therefore looks like it worked — the file on disk
+holds your change, tests may even pass — until anything runs the sync, at
+which point the change is gone with no error. The pre-commit "hook mirror
+drift" check does NOT save you: it only asserts the two copies match, so a
+reverted edit passes it happily.
+
+Edit `hook/<name>.py`, then run `uv run python scripts/sync_hooks.py`.
+Grep the arrow direction in the script's output before trusting any hook
+edit, and be aware that hook scripts cannot import the package (they run
+standalone with a `sys.path` insert), so shared values like
+`DAIMON_WINDSURF_DIR` must be read from `os.environ` on both sides rather
+than imported from `config`.

--- a/.scars/0045-host-format-drift-reads-as-too-short-skip.landmine.md
+++ b/.scars/0045-host-format-drift-reads-as-too-short-skip.landmine.md
@@ -1,19 +1,21 @@
 ---
-id: 0
+id: 45
 type: landmine
 title: Host transcript format drift parses to 0 messages and the too-short gate eats it silently
 severity: high
 confidence: 0.9
 created: 2026-08-07
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/transcript.py
 evidence:
-  - commit: 64c5fb6
-  - note: "issue #622 — Codex CLI 0.146.0→0.147.0 replaced event_msg/user_message and agent_message with item_completed (PascalCase item.type, content-block lists); a 13MB real session parsed to 0 messages and serialize skipped it 9 times as 'transcript too short (0 < 10 messages)' with nothing recorded for heal"
+  - commit: 4222243
+  - pr: 623
+  - note: issue #622 — Codex CLI 0.146.0→0.147.0 replaced event_msg/user_message and agent_message with item_completed (PascalCase item.type, content-block lists); a 13MB real session parsed to 0 messages and serialize skipped it 9 times as 'transcript too short (0 < 10 messages)' with nothing recorded for heal
 expires:
   condition: "serializer treats a multi-record transcript that parses to 0 messages as a parse failure (loud, heal-visible) instead of a too-short skip"
   review_after: 2026-11-07
+status: active
 ---
 
 Host JSONL schemas are explicitly unstable (Codex says so in its docs), and
@@ -23,7 +25,7 @@ generic fallback cannot read payload-nested rows, and the length gate then
 classifies the session as "too short" — a legitimate-looking skip, not a
 failure. Nothing reaches serialize-crash logging or `daimon heal`; the loss
 is invisible until a user notices a missing checkpoint (issue #622, fixed in
-64c5fb6). When touching parser branches or the too-short gate: a transcript
+PR #623, squashed as 4222243). When touching parser branches or the too-short gate: a transcript
 with many raw records that parses to 0 messages is a parse failure, never a
 short session — and any new host-format support needs a fixture copied from a
 field transcript, not from that host's docs.

--- a/.scars/0046-host-spawn-id-must-match-checkpoint-stem.landmine.md
+++ b/.scars/0046-host-spawn-id-must-match-checkpoint-stem.landmine.md
@@ -1,0 +1,37 @@
+---
+id: 46
+type: landmine
+title: A host adapter's spawn-line session id and its checkpoint file name must resolve to the same ledger key
+severity: high
+confidence: 0.9
+created: 2026-08-08
+authors: ["claude-code", "Kibukx"]
+anchors:
+  - path: plugin/daimon_briefing/ledger.py
+evidence:
+  - pr: 642
+  - issue: 634
+expires:
+  condition: "the ledger keys sessions by an explicit id carried on every result line, instead of deriving it from a file stem"
+  review_after: 2027-02-08
+status: active
+---
+
+`_session_ledger` derives a session key two different ways: spawn lines give it
+the id the HOOK logged, success/error lines give it the STEM of the checkpoint
+or transcript path. Those are the same string for Claude and Gemini, so the
+coupling is invisible — until a host names its files differently.
+
+Codex does. It spawn-logs the bare session id but names both the rollout
+transcript and the checkpoint `rollout-<stamp>-<id>`, so spawn and result folded
+under different keys. Every SUCCESSFUL Codex capture therefore also produced a
+phantom "spawned, no result (hung/killed)" failure in `daimon status`, and once
+Codex rotated the transcript the phantom stuck forever as "not auto-repairable"
+(#634, fixed in #642 by `_session_key`).
+
+Adding a host adapter: if its checkpoint or transcript file name is not exactly
+the id its hook writes on the spawn line, extend `_session_key` — do NOT assume
+`Path(p).stem` is a session id. The failure is silent and inverted: status
+reports healthy captures as losses, so the gauge reads WORSE than reality and
+nobody suspects a parsing bug. `_has_checkpoint` carries the same assumption on
+the probe side and needs the same treatment.

--- a/.scars/0047-pre-element-carried-layout-and-code-reset.landmine.md
+++ b/.scars/0047-pre-element-carried-layout-and-code-reset.landmine.md
@@ -1,0 +1,31 @@
+---
+id: 47
+type: landmine
+title: Replacing pre/code elements for nesting fixes silently drops the UA and Infima styles they carried
+severity: medium
+confidence: 0.85
+created: 2026-08-06
+authors: ["claude-code", "Kibukx"]
+anchors:
+  - path: website/src/pages/index.tsx
+  - path: website/src/css/custom.css
+evidence:
+  - commit: 2c35964
+  - pr: 627
+expires:
+  condition: "installBlock markup stops using code elements inside a non-pre wrapper"
+  review_after: 2027-02-01
+status: active
+---
+
+PR #627 swapped the install block's outer element from pre to div to fix
+invalid div-inside-code nesting. Correct fix, but the pre was silently doing two
+other jobs: Infima's "pre code" reset (no border, no background, font-size 100%)
+and, before that, an inline-block wrapper constrained the block's width. Both
+were lost — bare code elements regressed to grey bordered chips at ~12.6px
+(90% code-font var compounding on 0.875rem) and the block went full-bleed at
+wide viewports. Neither showed at 320px, so narrow-viewport rendering checks
+passed. Restored explicitly later in the same PR (.installBlock inline-block +
+.installBlock code reset). When you change a semantic element here, grep what
+the UA sheet and infima/dist/css/default/default.css attach to it, and re-check
+at BOTH narrow and wide viewports.

--- a/.scars/0048-secret-canary-in-memory-triggers-itself.landmine.md
+++ b/.scars/0048-secret-canary-in-memory-triggers-itself.landmine.md
@@ -1,0 +1,42 @@
+---
+id: 48
+type: landmine
+title: Verifying redaction with a prefix literal is doubly invalid — it matches its own instructions and assumes a prefix the local key never had
+severity: medium
+confidence: 0.9
+created: 2026-08-04
+authors: ["claude-code", "Kibukx"]
+anchors:
+  - path: plugin/daimon_briefing/_hooks/redact.py
+  - path: plugin/daimon_briefing/store.py
+evidence:
+  - note: 2026-08-04. A handoff prescribed `rg -l 'sk-proj' ~/.daimon/checkpoints/`, documented as 'empty = held', to verify #513 shape-based redaction. It failed twice over. (1) The credential in use is a local litellm proxy key, 25 chars, with no `sk-proj` prefix, so the grep could not have found it even had redaction failed. (2) It returned 4 files anyway, all of them the handoff sentence itself, which had serialized into latest.json, the session checkpoint, and events.jsonl.
+  - note: 2026-08-04, the check redone correctly against the live value: the exact key appears in 3 raw transcripts under ~/.claude/projects/ and 0 checkpoints, and `sk-[A-Za-z0-9_-]{20,}` matches 0 checkpoint files. Redaction held, and this is the first evidence that actually tests it.
+expires:
+  condition: "redaction verification moves to a scanner that reads the configured key from the environment and excludes daimon's own captured prose"
+  review_after: 2027-02-04
+status: active
+---
+
+Two independent defects, either one fatal to the verification.
+
+First, never hardcode a vendor prefix. daimon's configured credential is
+whatever `DAIMON_LLM_API_KEY` holds, which on a proxy install is a local
+litellm key that resembles no cloud vendor's format. A check written around
+`sk-proj` silently passes on every install that does not use OpenAI directly,
+which is the quietest possible failure for a security check.
+
+Second, daimon captures the session that discusses daimon. Any literal used to
+hunt for secrets is copied into the checkpoints it will later search, so the
+detector starts matching its own instructions and can no longer distinguish
+"a key leaked" from "someone wrote down how to look for a key".
+
+Verify by reading the key from the environment and grepping for that value,
+plus a generic shape (`sk-[A-Za-z0-9_-]{20,}`) as a backstop. Confirm the key
+is present in the source transcript before claiming redaction held, or the test
+proves nothing about redaction. Classify every hit before calling it a breach.
+
+The same trap applies beyond secrets: the pre-post rg gate that keeps private
+identifiers out of public issues keys on literals that land in checkpoints the
+same way. Expected and unchanged: redaction runs at capture, so raw keys stay
+in the host transcript regardless. Only checkpoints are cleaned.


### PR DESCRIPTION
Scars-only change. Seven reviewed candidates promoted to active, reviewer recorded in each scar's `authors`.

## What

| ID | Type | Constraint |
|---|---|---|
| 0042 | landmine | A residue test that enumerates surfaces via the scrubber's own walk cannot fail for a missed surface class |
| 0043 | landmine | A hook mirroring a config accessor must copy its quirks, not its intent |
| 0044 | landmine | Editing the package copy of a hook is silently reverted; `hook/` is the source of truth |
| 0045 | landmine | Host transcript format drift parses to 0 messages and the too-short gate eats it silently |
| 0046 | landmine | A host adapter's spawn-line session id and its checkpoint file name must resolve to the same ledger key |
| 0047 | landmine | Replacing pre/code elements for nesting fixes silently drops the UA and Infima styles they carried |
| 0048 | landmine | Verifying redaction with a prefix literal is doubly invalid: it matches its own instructions and assumes a prefix the local key never had |

## Evidence receipts repaired

Three receipts cited pre-squash commit SHAs. Those objects survive in a local clone but are unreachable from `main`, so they resolve to nothing for anyone cloning fresh. `scar lint` reported them as `evidence-unreachable`.

Each now cites the squashed commit on `main` plus its PR number, and the body prose no longer names an unreachable SHA:

| Was | Now |
|---|---|
| `64c5fb6` | `4222243` plus `pr: 623` |
| `bf24d6a`, `32ae018` | `2c35964` plus `pr: 627` |

This is scar 0041 biting a second time: squash-merge replaces the local commit, so anything citing the original SHA is left pointing at nothing. Worth treating commit receipts on scars as needing the post-merge SHA, not the one from the working branch.

## Verification

```
scar lint
lint: 52 file(s), 0 with errors, 0 orphan(s), 0 partial-rot, 0 unreachable-evidence
```

Down from 3 unreachable before the repair. The one remaining warning is pre-existing and belongs to scar 0016, whose path anchor is too broad. Not touched here.

## Not included

Four candidates stay under review in `.scars/candidates/` and are deliberately out of this PR.
