### PR TITLE
test(skill): partition the command surface so a missing verb fails loudly

### DIFF
--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -21,6 +21,49 @@ _DESCRIPTION = (
     "cross-session memory looks stale, missing, or wrong."
 )
 
+# Commands that reach no skill ON PURPOSE, each with the reason (#650).
+#
+# The list exists because the alternative is silence. `daimon why` shipped in
+# 0.28.0 and reached no skill for a whole release while its human
+# documentation was complete, and nothing failed — every omission is
+# individually small and individually reasonable at the time, and there is no
+# moment where the gap becomes visible. tests/test_skill_content.py partitions
+# the command surface against this map, so a NEW command must be taught here or
+# named below. Neither answer is privileged; what is forbidden is not deciding.
+#
+# Scope: TOP-LEVEL subcommands. A nested one (`audit privacy`, `refute add`,
+# `team sync`) inherits its parent's classification.
+NOT_AGENT_FACING = {
+    # -- human setup: run once by a person configuring the machine --
+    "configure": "human setup: resolves the LLM backend and writes ~/.daimon/env",
+    "hooks": "human setup: installs host hook scripts",
+    "skill": "human setup: installs this very skill",
+    # -- internal plumbing: the hooks invoke these, never an agent --
+    "serialize": "internal: the session-end child that writes the checkpoint",
+    "write-checkpoint": "internal: the write seam serialize calls",
+    "recall-inject": "internal: the per-prompt recall hook",
+    # -- deliberate product boundaries --
+    "forget": (
+        "human-only by design: deletion is the user's call, and the full body "
+        "says so in as many words"
+    ),
+    "anchor": (
+        "user curation: which claims deserve code-drift watching is a person's "
+        "judgement about their own memory, not an agent's"
+    ),
+    "log": "human bookkeeping: a freeform timeline entry, zero-LLM",
+    "team": (
+        "read side already taught as `daimon brief --team`; the write side "
+        "(`init`, `sync`) publishes this machine's memory to a shared remote, "
+        "which is a person's decision like forget is"
+    ),
+    "audit-quotes": (
+        "deprecated alias for `audit quotes`, which IS taught; teaching both "
+        "would spend budget advertising a spelling that prints a deprecation "
+        "notice"
+    ),
+}
+
 _FULL_BODY = """\
 # Using daimon memory
 
@@ -122,8 +165,9 @@ span — the same QUOTE DISCIPLINE rule 17 holds a verbatim capture item to.
 It is byte-checked against the transcript at session end: found confirms
 and credits the resolution to you; not found leaves the loop open, nothing
 withheld early. Never use this for a loop you merely SUSPECT is stale —
-that is `reverify`/worldcheck territory, not a resolve claim. `forget`
-stays human-only.
+that is world-check territory, not a resolve claim: run
+`daimon reverify <id> --evidence "<what you checked>"` to assert a carried
+item is still true and reset its staleness clock. `forget` stays human-only.
 
 ## Handing off
 

--- a/plugin/tests/test_skill_content.py
+++ b/plugin/tests/test_skill_content.py
@@ -5,7 +5,9 @@ Windsurf's 6,000-char global-rules file with the user's own rules — the
 2,000-char cap is a hard product constraint, not a style preference.
 """
 
-from daimon_briefing import skill_content
+import re
+
+from daimon_briefing import cli, skill_content
 
 
 def test_compact_fits_budget():
@@ -346,3 +348,63 @@ def test_the_trust_verbs_reach_the_symptom_table():
     section = full.split("## When memory looks wrong")[1].split("\n## ")[0]
     for verb in ("daimon why", "daimon audit", "daimon verify-receipt"):
         assert verb in section, f"{verb} has no symptom that reaches it"
+
+
+def _top_level_commands():
+    parser = cli.build_parser()
+    for action in parser._actions:
+        if getattr(action, "choices", None) and hasattr(action.choices, "items"):
+            return set(action.choices)
+    raise AssertionError("no subparsers found on the top-level parser")
+
+
+def _taught(full, name):
+    """Is `name` taught as a COMMAND, not merely as a word?
+
+    Substring matching is wrong in both directions here: `anchor` appears only
+    as `--anchor`, a flag of `refute guard`; `serialize` appears inside the
+    word "serialized". Both would read as covered while the agent learns
+    nothing about the command."""
+    return re.search(rf"`daimon {re.escape(name)}\b", full) is not None
+
+
+def test_every_shipped_command_is_taught_or_declared_not_agent_facing():
+    """#650. `daimon why` shipped in 0.28.0 and reached no skill for a whole
+    release while its human documentation was complete. Nothing failed, because
+    nothing was asking.
+
+    This partitions the command surface: a subcommand is either taught in the
+    installed skill or named in `_NOT_AGENT_FACING` with a reason. A new
+    command that is in neither fails here, and the fix is one line in whichever
+    set is correct — the point is that the decision gets made, not that it goes
+    a particular way.
+
+    Governs `skill_content.render_full()`, the body `daimon skill install`
+    writes. The plugin-discovered `skills/*/SKILL.md` is a SEPARATE surface
+    with its own shape (prose overview, not a command reference), and #643
+    showed the two can fail independently: the CLI-installed skill was healthy
+    on the maintainer's machine for five releases while every plugin install
+    shipped no discoverable skill at all."""
+    full = skill_content.render_full()
+    commands = _top_level_commands()
+    declared = set(skill_content.NOT_AGENT_FACING)
+
+    unknown = declared - commands
+    assert not unknown, (
+        f"NOT_AGENT_FACING names commands that do not exist: {sorted(unknown)}")
+
+    untaught = {c for c in commands if not _taught(full, c)}
+    unclassified = sorted(untaught - declared)
+    assert not unclassified, (
+        "these commands reach no skill and are not declared "
+        f"not-agent-facing: {unclassified}. Teach them in _FULL_BODY, or add "
+        "them to skill_content.NOT_AGENT_FACING with the reason.")
+
+    contradicted = sorted(declared - untaught)
+    assert not contradicted, (
+        f"declared not-agent-facing but taught anyway: {contradicted}")
+
+
+def test_every_not_agent_facing_entry_gives_a_reason():
+    for name, reason in skill_content.NOT_AGENT_FACING.items():
+        assert reason and reason.strip(), f"{name}: no reason recorded"


### PR DESCRIPTION
Closes #650

## What

Every top-level subcommand must be either taught in the installed skill or named in `skill_content.NOT_AGENT_FACING` with a reason. A command in neither fails the test, and the fix is one line in whichever set is correct. Neither answer is privileged; what is forbidden is not deciding.

## Why matching a command AS a command is the load-bearing part

A substring check is wrong in both directions, and the current body contains an example of each:

| Command | Naive result | Truth |
| --- | --- | --- |
| `anchor` | looks taught | appears only as `--anchor`, a flag of `refute guard` |
| `serialize` | looks taught | appears inside the word "serialized" |
| `team` | looks taught | appears as `--team`, and in the prose "shares a daimon team" |
| `forget` | looks missing | deliberately addressed: "`forget` stays human-only" |

So the check requires a backticked `daimon <name>` at a word boundary. That is the house convention for writing a command, and it means a false failure is loud and one edit away, while a false pass is impossible.

## What running it found

Two commands nobody had classified.

**`reverify` was a real gap**, the same shape as `daimon why`. The body already teaches world-checking as a concept and named `reverify` in passing, without ever giving the verb. It is now runnable in the place that sends you there.

**`team`** is declared rather than taught. The read side was already covered by `daimon brief --team`; the write side (`init`, `sync`) publishes this machine's memory to a shared remote, which is a person's decision the same way `forget` is.

The rest of the declaration carries the classification #643 recorded in prose: `configure` / `hooks` / `skill` are human setup, `serialize` / `write-checkpoint` / `recall-inject` are hook-invoked plumbing, `forget` and `anchor` and `log` are product boundaries, `audit-quotes` is a deprecated alias for the spelling that IS taught.

## Which surface this governs

`render_full()` — the body `daimon skill install` writes — and the docstring says so rather than assuming the two skill surfaces agree.

They demonstrably do not. #643 showed them failing independently: the CLI-installed skill was healthy for five releases while every plugin install shipped nothing discoverable. That gap stayed invisible because the CLI path was being reinstalled on every merge, which kept one surface fresh and said nothing about the other.

Whether the two should share a source is a separate question, not settled here.

## Scope

Top-level subcommands. A nested one (`audit privacy`, `refute add`, `team sync`) inherits its parent's classification.

## Tests

`3313 passed, 2 skipped`. Two new tests, both failing before the change:

- `test_every_shipped_command_is_taught_or_declared_not_agent_facing` — the partition, with three separate assertions so the failure message names which way it broke: a declared command that does not exist, an untaught and undeclared command, or a command declared not-agent-facing that is taught anyway.
- `test_every_not_agent_facing_entry_gives_a_reason` — an entry without a reason is a silent exemption, which is what this replaces.

Full body 8,417 to 8,536 against the 8,900 cap, so no ratchet change. Compact body untouched at 1,999 of its hard 2,000.
