### PR TITLE
fix(refutations): report ledger growth instead of claiming a retention that does not exist

### DIFF
--- a/plugin/daimon_briefing/privacy.py
+++ b/plugin/daimon_briefing/privacy.py
@@ -316,6 +316,7 @@ def audit_project(project_dir=None) -> dict:
     if not slug:
         result["zero_surfaces"] = True
         result["cache"] = {"entries": 0, "oldest_days": None}
+        result["ledger"] = {"records": 0, "rows": 0, "bytes": 0}
         return result
     known, unknown = _checkpoint_candidates()
     # Only this project's blind spots: an unknown file in ANOTHER bucket is
@@ -400,6 +401,8 @@ def audit_project(project_dir=None) -> dict:
     except (OSError, ValueError):
         lines = []
         result["unscannable"].append(str(ledger))
+    ledger_records: set[str] = set()
+    ledger_rows = 0
     for line in lines:
         try:
             row = json.loads(line)
@@ -407,11 +410,34 @@ def audit_project(project_dir=None) -> dict:
             continue
         if not isinstance(row, dict):
             continue
+        ledger_rows += 1
+        ref_id = str(row.get("refutation_id") or "")
+        if ref_id:
+            ledger_records.add(ref_id)
         for h in refutations.row_content_keys(row) & keys:
             result["findings"].append({
                 "path": str(ledger),
                 "item_id": row.get("refutation_id"),
                 "content_hash": h, "surface": "refutation-ledger"})
+    # #648: the ledger is append-only and NOTHING reaps it by age. That is the
+    # posture, not an oversight — `daimon refute` records rejected approaches
+    # "outside checkpoint decay" (README), and a refutation is worth more with
+    # age: it exists so a lesson outlives the temptation to retry the approach.
+    # Every other reaped store here (chunk cache, windsurf state, crash log,
+    # stale tmps) holds derived or diagnostic data that is worthless when old.
+    #
+    # So the audit owes a MEASUREMENT, not a cleanup claim — the chunk cache's
+    # posture below, for the same reason: report the store, touch neither the
+    # findings nor the exit code, and never assert bounded. Rows and records
+    # are separate because the difference is the growth story: a record gains a
+    # row per lifecycle event while the record count stays put.
+    try:
+        ledger_bytes = ledger.stat().st_size
+    except OSError:
+        ledger_bytes = 0
+    result["ledger"] = {"records": len(ledger_records),
+                        "rows": ledger_rows,
+                        "bytes": ledger_bytes}
     # Chunk cache: value-level detection impossible (cache keyed by chunk
     # text, values are substrings). Store-level honesty: entry count + real
     # oldest age — the reaper runs only on WRITES, so never assert bounded.

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -1350,6 +1350,12 @@ def render_privacy_audit(results: list[dict]) -> None:
             print(f"  chunk cache: {cache['entries']} entr(y/ies) — age unknown,"
                   " value-level scan impossible (substring vs hash); purge is"
                   " wholesale on forget")
+        led = r.get("ledger") or {}
+        if led.get("rows"):
+            print(f"  refutation ledger: {led['records']} record(s) in"
+                  f" {led['rows']} row(s), {led['bytes'] / 1024:.0f} KB —"
+                  " append-only negative knowledge; forget reaches it by"
+                  " value, nothing reaps it by age")
         ws = r.get("windsurf") or {}
         if ws.get("entries"):
             age = (f", oldest {ws['oldest_days']:.1f}d"

--- a/plugin/daimon_briefing/surfaces.py
+++ b/plugin/daimon_briefing/surfaces.py
@@ -72,7 +72,34 @@ SURFACES: tuple[Surface, ...] = (
     #    rewrites this file, atomically, dropping every row of a matched
     #    record. Never audit_exempt (#645) — an exemption here would silence
     #    exit 3 in one line while the file holds the very text the registry
-    #    exists to declare. --
+    #    exists to declare.
+    #
+    #    RETENTION (#648): there is none, and that is the posture rather than
+    #    an oversight. `delete` holds one value and `rewrite` is the true one —
+    #    forget reaches this file by VALUE — so the growth story cannot live in
+    #    this field and is recorded here instead.
+    #
+    #    Nothing reaps it by age, deliberately. `daimon refute` records
+    #    rejected approaches "outside checkpoint decay" (README, and the CLI
+    #    reference in both locales), and a refutation is worth MORE with age:
+    #    it exists so a lesson outlives the temptation to retry the approach.
+    #    Every other reaped store here — chunk cache, windsurf state, crash
+    #    log, stale tmps — holds derived or diagnostic data that is worthless
+    #    when old. Reaping this one would delete the lesson exactly when it
+    #    finally becomes useful.
+    #
+    #    Growth is bounded by deliberate action instead: the only writers are
+    #    the four `refute` CLI verbs, the `mechanical` channel is a socket
+    #    nothing plugs into, and the audit reports record/row/byte counts every
+    #    run (privacy.audit_project) so this is measured, never silent.
+    #
+    #    Two things reopen it, and neither is a clock. If #581 ships mechanical
+    #    activation, something writes without a human asking. If the reported
+    #    counts actually climb, the sanctioned fix is a CANDIDATE-scoped
+    #    reaper: the design of record scopes no-decay to ACTIVE records and
+    #    already allows candidates to expire (research/experiments/
+    #    refutation-573/README.md). An active-record reaper would falsify a
+    #    published claim and needs the contract amended first. --
     Surface("checkpoints/{slug}/refutations.jsonl", "refutations.append",
             True, "rewrite", "forget"),
     # store.append_verification: "a POINTER and a REASON CODE, never the

--- a/plugin/tests/test_refutation_privacy.py
+++ b/plugin/tests/test_refutation_privacy.py
@@ -202,3 +202,66 @@ def test_redaction_of_an_ordinary_anchor_changes_nothing(tmp_checkpoint_dir):
     record = refutations.get(ref_id, project_dir=PROJECT)
 
     assert record["anchors"] == ["issue:645", "command:daimon-why"]
+
+
+# -- #648: growth is reported, never silently unbounded ----------------------
+
+def test_the_audit_reports_the_ledger_at_store_level(tmp_checkpoint_dir):
+    """#648. The ledger is append-only and nothing reaps it by age. That is a
+    deliberate posture, not an oversight — `daimon refute` records rejected
+    approaches "outside checkpoint decay" (README.md), and a refutation is
+    worth MORE with age: it exists so a lesson survives long enough that
+    someone is tempted to retry the approach.
+
+    What the audit owes is therefore not a cleanup claim but a measurement.
+    Same store-level honesty the chunk cache and windsurf state already get:
+    report what is there, let the exit code alone, and never assert bounded."""
+    _checkpoint()
+    _refute()
+    _refute(subject="sharding the audit table by tenant", scope="storage")
+
+    ledger = privacy.audit_project(project_dir=PROJECT)["ledger"]
+
+    assert ledger["records"] == 2
+    assert ledger["rows"] == 2, "one asserted row per record"
+    assert ledger["bytes"] == _ledger_path().stat().st_size
+
+
+def test_the_ledger_report_counts_rows_and_records_separately(
+        tmp_checkpoint_dir):
+    """Rows and records diverge, and the difference IS the growth story: a
+    record accumulates a row per lifecycle event while the record count stays
+    put. Reporting only one of them would hide which kind of growth happened."""
+    _checkpoint()
+    ref_id = _refute()
+    refutations.ratify(ref_id, channel="cli-tty", project_dir=PROJECT)
+    refutations.revise(ref_id, channel="cli-tty", evidence=["measurement:run-2"],
+                       verdict="a sharper statement of the same finding",
+                       project_dir=PROJECT)
+
+    ledger = privacy.audit_project(project_dir=PROJECT)["ledger"]
+
+    assert ledger["records"] == 1
+    assert ledger["rows"] == 3
+
+
+def test_no_ledger_reports_zero_rather_than_absent(tmp_checkpoint_dir):
+    """A missing key would make callers guess. Zero is a fact; absent is not."""
+    _checkpoint()
+    ledger = privacy.audit_project(project_dir=PROJECT)["ledger"]
+    assert ledger == {"records": 0, "rows": 0, "bytes": 0}
+
+
+def test_the_ledger_line_reports_growth_without_claiming_retention(
+        tmp_checkpoint_dir, capsys):
+    _checkpoint()
+    _refute()
+    assert cli.main(["audit", "privacy", "--project", PROJECT]) == 0
+    out = capsys.readouterr().out
+
+    assert "refutation ledger" in out
+    assert "1 record(s)" in out
+    # The honest half: say what does NOT happen, in the report itself.
+    assert "nothing reaps it by age" in out
+    for false_claim in ("bounded", "pruned", "expires"):
+        assert false_claim not in out, f"the report claims {false_claim}"


### PR DESCRIPTION
Closes #648

## What

The issue's exit condition was "either implement retention or name the gap honestly". This is the honest naming, plus the measurement that stops it being silent.

`daimon audit privacy` now reports the ledger at store level, the way it already reports the chunk cache and windsurf state:

```
refutation ledger: 412 record(s) in 1103 row(s), 780 KB — append-only
negative knowledge; forget reaches it by value, nothing reaps it by age
```

Findings and exit code are untouched. Records and rows are counted separately because the difference IS the growth story: a record gains a row per lifecycle event while the record count stays put, so one number would hide which kind of growth happened.

## Why not a reaper

Adding one would be pattern-matching on the file's shape rather than its meaning.

A refutation is worth MORE with age. It exists so a lesson outlives the temptation to retry the approach, and reaping deletes it exactly when it finally becomes useful. Every other reaped store here — chunk cache, windsurf state, crash log, stale tmps — holds derived or diagnostic data that is worthless when old. This one is the opposite.

It would also falsify a published claim. `README.md:79` and the CLI reference in both locales say `daimon refute` records rejected approaches **outside checkpoint decay**. Under the amendment rule the contract changes before the surface does, so an active-record reaper is not a code change, it is a contract change.

## What was measured rather than assumed

| records | rows | size | `guard` | `records()` |
| ---: | ---: | ---: | ---: | ---: |
| 100 | 201 | 71 KB | 0.8 ms | 0.6 ms |
| 500 | 1,001 | 357 KB | 4.3 ms | 2.7 ms |
| 2,000 | 4,001 | 1.4 MB | 15.8 ms | 11.2 ms |
| 10,000 | 20,001 | 7.0 MB | 88.5 ms | 67.5 ms |

Linear throughout. One asserted+ratified record is ~760 bytes over 2 rows.

Growth is bounded by deliberate action, verified rather than assumed:

- The only writers are the four `refute` CLI verbs. `rg 'refutations\.[a-z_]+\(' --glob '!tests' --glob '!cli.py'` returns one hit, and it is read-only.
- `harvest` is not a bridge. It writes `.scars/candidates/*.md` and never imports the module.
- The `mechanical` channel is a socket nothing plugs into. There are no hardcoded channel sites; the only source is `cli._refute_channel(args)`.
- Field state today: `fd -t f 'refutations.jsonl' ~/.daimon` returns nothing, across every project bucket on a real machine.

## Where the posture is recorded, and why not in the registry field

`surfaces.Surface.delete` holds one value and `rewrite` is the true one, because `forget` reaches this file by value. Declaring `known-gap` would trade a true statement for a different one. So the growth story lives in the registry comment beside the declaration, next to the shape it describes.

## The two conditions that reopen it

Neither is a clock, which is the same posture `--revisit-when` takes for refutations themselves.

1. **#581 ships mechanical activation.** Something would then write without a human asking, and the growth model above stops being true.
2. **The reported counts actually climb.** The sanctioned fix is a **candidate-scoped** reaper. The design of record scopes no-decay to ACTIVE records and already allows candidates to expire (`research/experiments/refutation-573/README.md:144`). That distinction matters: a candidate reaper falsifies nothing published, an active-record one does.

## Tests

`3317 passed, 2 skipped`. Four new, all failing before the change:

- store-level report present with correct record/row/byte counts
- rows and records diverge correctly across a ratify plus revise
- absent ledger reports zeros rather than omitting the key, so callers never have to guess
- the rendered line says what does NOT happen, and asserts the words "bounded", "pruned" and "expires" never appear in the report
