### PR TITLE
fix(receipts): name the real reason a checkpoint is unsigned

### DIFF
--- a/plugin/daimon_briefing/receipts.py
+++ b/plugin/daimon_briefing/receipts.py
@@ -537,4 +537,11 @@ def status_line(project_dir=None) -> str | None:
     if checkpoint.get("receipts") is True:
         return (f"receipts: on — latest checkpoint {sid} is marked receipt-era but "
                 "its receipt is MISSING (see serialize.log)")
+    # #653: unsigned has two causes and they are not interchangeable. Ask the same
+    # gate plan_mint asks rather than assuming age: with nothing bindable there was
+    # never a receipt to make, which is the normal in-session write-checkpoint
+    # shape. Only a checkpoint that COULD have been bound predates the feature.
+    if _wrap_hex_sha256(checkpoint.get("transcript_hash")) is None:
+        return (f"receipts: on — latest checkpoint {sid} is unsigned: no transcript "
+                "to bind (expected for an in-session write-checkpoint)")
     return f"receipts: on — latest checkpoint {sid} predates receipts (unsigned)"

--- a/plugin/tests/test_receipts.py
+++ b/plugin/tests/test_receipts.py
@@ -781,9 +781,31 @@ def test_status_line_marked_but_missing(tmp_checkpoint_dir, monkeypatch):
 
 def test_status_line_predates_receipts(tmp_checkpoint_dir, monkeypatch):
     monkeypatch.setenv("DAIMON_RECEIPTS", "1")
-    store.write_checkpoint("S-pre2", {"session_id": "S-pre2"})  # no marker, no sidecar
+    # A genuinely pre-receipts checkpoint: written while the feature was OFF, so
+    # no marker and no sidecar, but it DOES carry a bindable transcript_hash.
+    # The hash is the point — without it this is the #653 case below, not this
+    # one, and the age wording would be a false cause.
+    monkeypatch.delenv("DAIMON_RECEIPTS", raising=False)
+    store.write_checkpoint("S-pre2", {"session_id": "S-pre2",
+                                      "transcript_hash": "ab" * 32})
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
     line = receipts.status_line()
     assert "predates receipts" in line
+
+
+def test_status_line_unsigned_without_transcript_does_not_blame_age(
+    tmp_checkpoint_dir, monkeypatch
+):
+    # #653: `write-checkpoint` (the daimon-end in-session path) has no transcript
+    # to bind, so plan_mint correctly refuses to mint. Status reported that true
+    # state with a false cause — it said the checkpoint PREDATES receipts, for a
+    # checkpoint written seconds earlier. Say which of the two it actually is.
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    store.write_checkpoint("S-insession", {"session_id": "S-insession"})
+    line = receipts.status_line()
+    assert "predates receipts" not in line
+    assert "no transcript to bind" in line
+    assert "expected" in line
 
 
 # ---- cross-module #204 seams (briefing / render / config) ---------------------


### PR DESCRIPTION
Closes #653

## What

`daimon status` reported every unsigned checkpoint as old. The status line's third
branch was a catch-all that stated an age-based cause, so a checkpoint written
seconds earlier by `write-checkpoint` was described as predating a feature it does
not predate.

Same store, same checkpoint, before and after:

```
BEFORE: receipts: on - latest checkpoint <sid> predates receipts (unsigned)
AFTER : receipts: on - latest checkpoint <sid> is unsigned: no transcript
        to bind (expected for an in-session write-checkpoint)
```

## Why

Unsigned has two causes and they are not interchangeable. Rather than adding an age
threshold, which would reproduce the same class of error from the other direction,
the status line now asks the question `plan_mint` already asks. When
`transcript_hash` yields nothing bindable there was never a receipt to make, which
is the ordinary in-session shape and is expected rather than a fault. Only a
checkpoint that could have been bound is one the feature did not yet cover when it
was written.

The mint gate is unchanged. Refusing to bind nothing stays correct; the defect was
only that a true state carried a false explanation. That is the exact failure this
project exists to surface, so leaving it in its own status line was not an option.

## Tests

`test_status_line_unsigned_without_transcript_does_not_blame_age` is new and failed
before the change on the `predates receipts` string.

The existing `test_status_line_predates_receipts` was pinning the defect: its
fixture wrote a checkpoint with no `transcript_hash` at all, which is the in-session
shape rather than an uncovered-era one, and asserted the age wording over it. It
passed for the wrong reason and would have kept passing. Rewritten to write while
receipts are off and to carry a bindable hash, so it models the case it names and
now fails if the two branches are collapsed again.

- Full suite: 3558 passed, 2 skipped
- `ruff check daimon_briefing tests ../scripts`: clean
- `mypy daimon_briefing`: unchanged from the base commit, none in `receipts.py`
- Verified end to end against an isolated checkpoint directory, output above

The issue also records an uninvestigated lead about checkpoint session id shape.
That is untouched here and stays open on the issue.
