### PR TITLE
docs(blog): publish the 0.29.0 ship-log

### DIFF
--- a/website/blog/2026-08-09-daimon-0-29.md
+++ b/website/blog/2026-08-09-daimon-0-29.md
@@ -1,0 +1,71 @@
+---
+slug: daimon-0-29
+title: "daimon 0.29.0: recording what was ruled out"
+authors: [daimon]
+tags: [release, refutations, trust]
+---
+
+A memory that only records what you decided is half a memory. The other half is
+what you ruled out, and why, so nobody spends another afternoon rediscovering
+it. 0.29.0 adds that half.
+
+{/* truncate */}
+
+## The refutation ledger
+
+`daimon refute add` records a scoped verdict against a subject, with evidence
+cited at the point of assertion. An agent's assertion stays a candidate until a
+human runs `daimon refute ratify`. `daimon refute guard` checks a proposed
+action against the active ledger before you repeat something already settled,
+and `daimon refute overturn` is how a verdict comes back off the books when the
+evidence changes.
+
+Two design choices are worth stating plainly.
+
+Nothing in the ledger is reaped on a schedule. A refutation is worth more with
+age, not less: the fact that an approach failed eight months ago is exactly what
+you want surfaced when someone proposes it again. So `daimon refute search`
+reads the complete ledger with no age decay, unlike checkpoint recall.
+
+And the guard is advisory. It surfaces the prior verdict; it does not block the
+action. An agent can still proceed. What changes is that the record of what it
+was told exists either way, so a repeated mistake is now traceable to a decision
+rather than to ignorance.
+
+## The skills a host could not see
+
+The plugin ships two skills, `daimon-briefing` and `daimon-end`. They sat one
+directory below where the loader looks, so nothing failed and nothing warned.
+They were simply absent from the session's skill list.
+
+0.29.0 puts them where hosts look, confirmed on a real install rather than
+inferred. The same release adds `daimon why`, the read side of an item's
+evidence, to the skill an agent actually reads. It had been documented for
+people and invisible to agents.
+
+## Also in this release
+
+Codex rollout stems now resolve to the spawned session id.
+
+The CLI reference is regrouped by what you are trying to do rather than by
+subsystem.
+
+A new claims page lists every number we publish about daimon itself, each with
+the command that measures the same thing on your own install. Those commands run
+locally and send nothing. Your numbers stay on your machine.
+
+## Getting it
+
+```console
+uv tool install daimon-briefing
+```
+
+Upgrading:
+
+```console
+uv tool upgrade daimon-briefing
+```
+
+Plugin users need `/plugin` and a reload. The plugin cache is pinned per
+version, so the skills fix arrives with the release commit rather than with the
+PyPI publish.

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-08-09-daimon-0-29.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-08-09-daimon-0-29.md
@@ -1,0 +1,71 @@
+---
+slug: daimon-0-29
+title: "daimon 0.29.0: dejar registro de lo que se descartó"
+authors: [daimon]
+tags: [release, refutations, trust]
+---
+
+Una memoria que solo registra lo que decidiste es media memoria. La otra mitad
+es lo que descartaste, y por qué, para que nadie vuelva a perder una tarde
+redescubriéndolo. 0.29.0 agrega esa mitad.
+
+{/* truncate */}
+
+## El ledger de refutaciones
+
+`daimon refute add` registra un veredicto acotado sobre un sujeto, con la
+evidencia citada en el momento de afirmarlo. La afirmación de un agente queda
+como candidata hasta que una persona ejecuta `daimon refute ratify`.
+`daimon refute guard` contrasta una acción propuesta contra el ledger activo
+antes de que repitas algo ya resuelto, y `daimon refute overturn` es la forma de
+dar de baja un veredicto cuando la evidencia cambia.
+
+Hay dos decisiones de diseño que conviene decir sin rodeos.
+
+Nada en el ledger se purga por antigüedad. Una refutación vale más con el
+tiempo, no menos: que un enfoque haya fallado hace ocho meses es justamente lo
+que querés ver cuando alguien lo propone de nuevo. Por eso
+`daimon refute search` lee el ledger completo sin decaimiento por edad, a
+diferencia del recall de checkpoints.
+
+Y el guard es consultivo. Muestra el veredicto previo; no bloquea la acción. Un
+agente puede seguir adelante igual. Lo que cambia es que queda registro de lo
+que se le advirtió, así que un error repetido ahora se puede rastrear hasta una
+decisión y no hasta el desconocimiento.
+
+## Las skills que el host no podía ver
+
+El plugin publica dos skills, `daimon-briefing` y `daimon-end`. Estaban un
+directorio por debajo de donde el loader busca, así que nada falló y nada avisó.
+Simplemente no aparecían en la lista de skills de la sesión.
+
+0.29.0 las ubica donde los hosts buscan, confirmado sobre una instalación real y
+no inferido. La misma versión suma `daimon why`, el lado de lectura de la
+evidencia de un ítem, a la skill que un agente efectivamente lee. Estaba
+documentado para personas e invisible para agentes.
+
+## También en esta versión
+
+Los rollout stems de Codex ahora resuelven al id de sesión generado.
+
+La referencia de CLI está reagrupada por lo que querés hacer y no por subsistema.
+
+Una nueva página de claims lista cada número que publicamos sobre daimon, cada
+uno con el comando que mide lo mismo en tu propia instalación. Esos comandos
+corren de forma local y no envían nada. Tus números se quedan en tu máquina.
+
+## Cómo obtenerlo
+
+```console
+uv tool install daimon-briefing
+```
+
+Para actualizar:
+
+```console
+uv tool upgrade daimon-briefing
+```
+
+Quienes usan el plugin necesitan `/plugin` y recargar. La caché del plugin está
+fijada por versión, así que el arreglo de las skills llega con el commit de
+release y no con la publicación en PyPI.


### PR DESCRIPTION
Closes #656

## What

Publishes the `0.29.0` ship-log in both locales.

| File | Change |
|------|--------|
| `website/blog/2026-08-09-daimon-0-29.md` | new post |
| `website/i18n/es/docusaurus-plugin-content-blog/2026-08-09-daimon-0-29.md` | Spanish twin, shared slug and tags |

## Why

`0.29.0` shipped on 2026-08-08 with no post, leaving the changelog as the only account of it.

Contents were verified against the `v0.29.0` tag rather than read off the changelog's grouping. That check mattered: `#651`, `#652` and `#654` landed after the release commit and are deliberately absent from the post, since they belong to the next release.

The post states the two ledger design choices a reader would otherwise have to discover. The ledger is never reaped on a schedule, because a refutation is worth more with age, not less. And `daimon refute guard` is advisory rather than blocking, which is stated as a design position rather than left implicit.

## Tests

- Both files use the `{/* truncate */}` marker and the frontmatter shape the existing posts use, checked against `2026-07-30-origin-bound-corroboration.md` in both locales.
- No admonition syntax in either file.
- Both files reviewed for stray local paths or identifiers before commit. None present.
- No download, star, or traffic figures appear in either file.
