### PR TITLE
chore(readme): document the skills CLI install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,15 @@ Serialization needs an LLM endpoint. If the `claude` CLI is on your PATH you are
 /plugin install daimon@daimon
 ```
 
-**Other hosts** (Windsurf, Codex, Gemini CLI) and the agent-side skill: per-host guides at [daily-nerd.github.io/daimon/docs/hosts](https://daily-nerd.github.io/daimon/docs/hosts/).
+**Agent-side skills, any host:**
+
+```sh
+npx skills add Daily-Nerd/daimon
+```
+
+Adds `daimon-briefing` and `daimon-end` to whichever agent it detects. Use `--skill daimon-briefing` for one of them. Claude Code users who installed the plugin above already have both, so there is no need to run this as well.
+
+**Other hosts** (Windsurf, Codex, Gemini CLI): per-host guides at [daily-nerd.github.io/daimon/docs/hosts](https://daily-nerd.github.io/daimon/docs/hosts/).
 
 That's it. End a session → a checkpoint is written; start the next → the briefing appears. Check state anytime with `daimon status` — it reports capture health honestly, including failures, skips, and crashes; a failed capture self-heals on the next start.
 


### PR DESCRIPTION
Closes #658

## What

Adds one install path to the README, next to the existing plugin and `uv tool install` blocks.

| File | Change |
|------|--------|
| `README.md` | documents `npx skills add Daily-Nerd/daimon` for the agent-side skills |

## Why

Moving the two skills to `<repo-root>/skills/` in #649 made them discoverable to hosts. That same layout is what the `skills` CLI scans, so the command already resolves against the published repository. The capability has existed since `c151741` and was undocumented.

The command resolves a git URL rather than a package registry, so there is no submission or listing step to complete first. It installs into whichever agent it detects, which reaches hosts that have no per-host guide here.

## Tests

Verified against the published repository before writing it down:

```console
$ npx skills@latest add Daily-Nerd/daimon --list
◇  Repository cloned
◇  Found 2 skills
│    daimon-briefing
│    daimon-end
```

Both descriptions render from the `SKILL.md` frontmatter.

Discovery is what was checked. The install itself was deliberately not run, because it writes into a real agent configuration, so the README claims what the tool does rather than a measured outcome.

The text also states that plugin users already have both skills, so the two paths cannot be followed twice by mistake.
