### PR TITLE
fix(privacy): fold compatibility forms before the scrub looks at them

### DIFF
--- a/hook/redact.py
+++ b/hook/redact.py
@@ -9,6 +9,7 @@ Replacement is a stable visible marker, [redacted:<kind>]: auditable,
 never silent."""
 
 import re
+import unicodedata
 
 # (kind, compiled pattern). Order matters only for overlap (pem first: a key
 # block may contain assignment-looking lines that must not double-count).
@@ -57,6 +58,23 @@ def redact_text(s):
     if not isinstance(s, str) or not s:
         return s, counts
 
+    # #660: every pattern below is anchored on uppercase ASCII, so a credential
+    # written in a compatibility form (fullwidth, mathematical alphanumeric)
+    # matches none of them and returns an EMPTY count — indistinguishable to
+    # the caller from "there was nothing to redact". `audit privacy` then reads
+    # the surface as clean while the value sits in it, recoverable by one
+    # normalize() call. Fold BEFORE looking. Folding after would be worse than
+    # not folding: it turns an unscanned compatibility form into a literal
+    # credential once the scrub has already run.
+    #
+    # NFKC is inlined rather than imported from normalize.compat_fold because
+    # this module ships STANDALONE next to the Windsurf hook scripts (see the
+    # file list in cli.py) and must not import from the package. Keep the two
+    # in step: normalize.compat_fold is NFKC + invisible strip, this is the
+    # NFKC half. Invisible characters do not split these patterns, so the
+    # other half is not needed here.
+    original, s = s, unicodedata.normalize("NFKC", s)
+
     def _mark(kind):
         counts[kind] = counts.get(kind, 0) + 1
 
@@ -72,4 +90,9 @@ def redact_text(s):
             s = rx.sub(_sub, s)
         except re.error:  # pragma: no cover — static patterns
             continue
-    return s, counts
+    # Fold-on-hit-only: the folded text is returned ONLY when it actually held
+    # a secret. Clean input comes back byte-identical, so redaction never
+    # silently rewrites ordinary content (fullwidth CJK is legitimate text, not
+    # an evasion). When something WAS found the content is being altered
+    # anyway, and the folded form is the one that cannot be un-redacted.
+    return (s, counts) if counts else (original, counts)

--- a/plugin/daimon_briefing/_hooks/redact.py
+++ b/plugin/daimon_briefing/_hooks/redact.py
@@ -9,6 +9,7 @@ Replacement is a stable visible marker, [redacted:<kind>]: auditable,
 never silent."""
 
 import re
+import unicodedata
 
 # (kind, compiled pattern). Order matters only for overlap (pem first: a key
 # block may contain assignment-looking lines that must not double-count).
@@ -57,6 +58,23 @@ def redact_text(s):
     if not isinstance(s, str) or not s:
         return s, counts
 
+    # #660: every pattern below is anchored on uppercase ASCII, so a credential
+    # written in a compatibility form (fullwidth, mathematical alphanumeric)
+    # matches none of them and returns an EMPTY count — indistinguishable to
+    # the caller from "there was nothing to redact". `audit privacy` then reads
+    # the surface as clean while the value sits in it, recoverable by one
+    # normalize() call. Fold BEFORE looking. Folding after would be worse than
+    # not folding: it turns an unscanned compatibility form into a literal
+    # credential once the scrub has already run.
+    #
+    # NFKC is inlined rather than imported from normalize.compat_fold because
+    # this module ships STANDALONE next to the Windsurf hook scripts (see the
+    # file list in cli.py) and must not import from the package. Keep the two
+    # in step: normalize.compat_fold is NFKC + invisible strip, this is the
+    # NFKC half. Invisible characters do not split these patterns, so the
+    # other half is not needed here.
+    original, s = s, unicodedata.normalize("NFKC", s)
+
     def _mark(kind):
         counts[kind] = counts.get(kind, 0) + 1
 
@@ -72,4 +90,9 @@ def redact_text(s):
             s = rx.sub(_sub, s)
         except re.error:  # pragma: no cover — static patterns
             continue
-    return s, counts
+    # Fold-on-hit-only: the folded text is returned ONLY when it actually held
+    # a secret. Clean input comes back byte-identical, so redaction never
+    # silently rewrites ordinary content (fullwidth CJK is legitimate text, not
+    # an evasion). When something WAS found the content is being altered
+    # anyway, and the folded form is the one that cannot be un-redacted.
+    return (s, counts) if counts else (original, counts)

--- a/plugin/daimon_briefing/normalize.py
+++ b/plugin/daimon_briefing/normalize.py
@@ -101,14 +101,28 @@ _MAX_KEY_INPUT = 4096
 _KEY_HEX_LEN = 16
 
 
+def compat_fold(text) -> str:
+    """NFKC + invisible strip, and NOTHING that changes case (#660).
+
+    Split out of `canonical_text` for scanners whose patterns are anchored on
+    uppercase ASCII: `redact.py` classes like aws-key and jwt stop matching if
+    the text is casefolded first, which is the #647 failure one layer up. A
+    compatibility form (fullwidth, mathematical alphanumeric) walks past every
+    such pattern, so a scanner must fold BEFORE it looks, then decide for
+    itself whether to keep the folded text.
+
+    Pure, stdlib-only, total, idempotent."""
+    if not isinstance(text, str):
+        text = "" if text is None else str(text)
+    text = unicodedata.normalize("NFKC", text)
+    return _INVISIBLE_RE.sub("", text)
+
+
 def canonical_text(text) -> str:
     """Fold `text` to a comparison-stable canonical form. Pure, stdlib-only,
     total — never raises for any input; a non-str is coerced first. Idempotent:
     canonical_text of its own output is a fixed point."""
-    if not isinstance(text, str):
-        text = "" if text is None else str(text)
-    text = unicodedata.normalize("NFKC", text)
-    text = _INVISIBLE_RE.sub("", text)
+    text = compat_fold(text)
     text = _WS_RE.sub(" ", text).strip()
     text = text.casefold()
     text = text.translate(_CONFUSABLE_TABLE)

--- a/plugin/daimon_briefing/redact.py
+++ b/plugin/daimon_briefing/redact.py
@@ -9,6 +9,7 @@ Replacement is a stable visible marker, [redacted:<kind>]: auditable,
 never silent."""
 
 import re
+import unicodedata
 
 # (kind, compiled pattern). Order matters only for overlap (pem first: a key
 # block may contain assignment-looking lines that must not double-count).
@@ -57,6 +58,23 @@ def redact_text(s):
     if not isinstance(s, str) or not s:
         return s, counts
 
+    # #660: every pattern below is anchored on uppercase ASCII, so a credential
+    # written in a compatibility form (fullwidth, mathematical alphanumeric)
+    # matches none of them and returns an EMPTY count — indistinguishable to
+    # the caller from "there was nothing to redact". `audit privacy` then reads
+    # the surface as clean while the value sits in it, recoverable by one
+    # normalize() call. Fold BEFORE looking. Folding after would be worse than
+    # not folding: it turns an unscanned compatibility form into a literal
+    # credential once the scrub has already run.
+    #
+    # NFKC is inlined rather than imported from normalize.compat_fold because
+    # this module ships STANDALONE next to the Windsurf hook scripts (see the
+    # file list in cli.py) and must not import from the package. Keep the two
+    # in step: normalize.compat_fold is NFKC + invisible strip, this is the
+    # NFKC half. Invisible characters do not split these patterns, so the
+    # other half is not needed here.
+    original, s = s, unicodedata.normalize("NFKC", s)
+
     def _mark(kind):
         counts[kind] = counts.get(kind, 0) + 1
 
@@ -72,4 +90,9 @@ def redact_text(s):
             s = rx.sub(_sub, s)
         except re.error:  # pragma: no cover — static patterns
             continue
-    return s, counts
+    # Fold-on-hit-only: the folded text is returned ONLY when it actually held
+    # a secret. Clean input comes back byte-identical, so redaction never
+    # silently rewrites ordinary content (fullwidth CJK is legitimate text, not
+    # an evasion). When something WAS found the content is being altered
+    # anyway, and the folded form is the one that cannot be un-redacted.
+    return (s, counts) if counts else (original, counts)

--- a/plugin/tests/test_redact.py
+++ b/plugin/tests/test_redact.py
@@ -101,3 +101,55 @@ def test_credential_url_pattern_no_quadratic_blowup_on_long_scheme_run():
     # lowercase-dotted runs that never resolve to "://".
     out, counts = _one("a." * 25000)
     assert counts == {}
+
+
+# ---- #660: compatibility forms must not walk past the scrub --------------
+
+
+def _wide(s):
+    """ASCII -> fullwidth, the cheapest evasion of an uppercase-anchored rule."""
+    return "".join(chr(ord(c) - 0x21 + 0xFF01) if 0x21 <= ord(c) <= 0x7E else c
+                   for c in s)
+
+
+def _synthetic_aws_key():
+    """Built from parts so no credential-shaped literal sits in the source."""
+    return "AK" + "IA" + "".join(chr(65 + (i * 7) % 26) for i in range(16))
+
+
+def test_fullwidth_secret_is_detected_not_passed_through():
+    # The scrub returned hits={} for this input, which a caller cannot tell
+    # apart from "there was nothing to redact" — so `audit privacy` reported
+    # the surface clean while the value sat in it, recoverable by one NFKC.
+    key = _synthetic_aws_key()
+    out, counts = _one(f"avoid {_wide(key)} here")
+    assert counts.get("aws-key") == 1, f"compatibility form evaded the scrub: {counts}"
+    assert key not in out
+
+
+def test_fullwidth_secret_is_not_recoverable_by_normalizing_the_output():
+    # The actual harm: not that the stored bytes ARE the key, but that one
+    # normalize() call turns them back into it.
+    import unicodedata
+    key = _synthetic_aws_key()
+    out, _ = _one(f"avoid {_wide(key)} here")
+    assert key not in unicodedata.normalize("NFKC", out)
+
+
+def test_math_alphanumeric_secret_is_detected():
+    # Fullwidth is not the only compatibility block; the fix must be the
+    # normalization, not a fullwidth-shaped special case.
+    key = _synthetic_aws_key()
+    bold = "".join(chr(0x1D400 + ord(c) - 65) if "A" <= c <= "Z" else c for c in key)
+    _, counts = _one(f"avoid {bold} here")
+    assert counts.get("aws-key") == 1, f"math-alphanumeric form evaded: {counts}"
+
+
+def test_clean_text_is_returned_byte_identical():
+    # Fold-on-hit-only: normalization is a side effect of redacting, never a
+    # rewrite of content that had nothing to redact. Fullwidth CJK punctuation
+    # in ordinary prose must survive untouched.
+    original = "設定を確認する（フルワイド）and some ASCII"
+    out, counts = _one(original)
+    assert out == original
+    assert counts == {}


### PR DESCRIPTION
Closes #660

## What

Redaction now folds Unicode compatibility forms before it scans, so a credential written in fullwidth or mathematical-alphanumeric characters is detected instead of passing through with an empty count.

| File | Change |
|------|--------|
| `plugin/daimon_briefing/redact.py` | NFKC fold before the pattern loop; folded text returned only when a secret was found |
| `plugin/daimon_briefing/normalize.py` | `compat_fold` extracted from `canonical_text` so the fold has one definition |
| `plugin/daimon_briefing/_hooks/redact.py`, `hook/redact.py` | twins resynced |
| `plugin/tests/test_redact.py` | four regressions |

## Why

Every pattern is anchored on uppercase ASCII, so the compatibility forms matched none of them. The scrub returned `hits={}`, which a caller cannot distinguish from "nothing to redact", so the privacy audit reported the surface clean over a recoverable value.

Order matters in both directions. Folding after the scrub is worse than not folding: it turns an unscanned compatibility form into a literal credential once redaction has already run. This is #647 one layer up, where casefolding ahead of the scrub broke the same uppercase-anchored classes.

Fixing it in `redact_text` covers nine call sites at once rather than the refutation path alone: the inspector's `--source` window, backend stdout and stderr logs, scar-harvest excerpts, the CLI log lines, and the exception hook.

## Tests

Four new regressions in `test_redact.py`, all of which failed before the change:

- fullwidth form is detected, not passed through
- the output cannot be normalized back into the secret
- mathematical-alphanumeric form is detected, so the fix is the normalization rather than a fullwidth special case
- clean text is returned byte-identical, pinning fold-on-hit-only

Original reproduction, re-run after the change:

```
ASCII      hits={'aws-key': 1}
fullwidth  hits={'aws-key': 1}

end to end through the documented write path:
  exact secret on disk       : False
  NFKC of file yields SECRET : False
  stored subject             : the [redacted:aws-key] rotation approach
```

Suite: 3561 passed, 2 skipped. One failure in `research/experiments/track-a/test_rerun.py` is pre-existing and reproduces identically on the base commit.

`ruff` clean. `mypy` introduces nothing new in either changed module.

## Notes for review

`redact.py` ships standalone beside the Windsurf hook scripts, so it cannot import from the package. NFKC is inlined there and `normalize.compat_fold` is the paired definition; both files carry a comment saying so. The existing twin test caught the drift when the copies were out of step.

Invisible-character stripping is deliberately not part of the inlined half. Those characters do not split these patterns, so it would add a table to a standalone module for no detection benefit.

Only the refutation ledger was verified end to end. The other eight call sites inherit the fix by construction but were not individually exercised.
