### PR TITLE
fix(serializer): restate the extraction contract after the transcript

### DIFF
--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -273,6 +273,55 @@ def _serialize_sys() -> str:
     return SERIALIZE_SYS
 
 
+def _chunk_tail_contract(system: str | None = None) -> str:
+    """The output contract, repeated AFTER the transcript text (#664).
+
+    Used by all three extraction call sites — chunked, escalated, and
+    single-pass. There is no cliff at DAIMON_CHUNK_LINES: a 1,199-line
+    transcript leaves the same tens-of-KB gap between the contract and the end
+    of the prompt as a chunk does.
+
+    `system` is the contract THIS call is running under — escalation passes
+    each carry their own perspective, and a pass reminded of the default
+    contract would be told to extract something other than what its system
+    prompt asked for. Defaults to the ordinary D-007 extraction contract.
+
+    A chunk prompt puts the contract at the head and then tens of KB of
+    transcript, so the last thing the model reads is somebody else's finished
+    conversation — and it continues that conversation instead of extracting
+    from it. The failing responses were not refusals or truncations: they were
+    substantial, well-formed status lines in the transcript's own voice
+    ("✅ All 3 agents complete."), 1,085-4,471 output tokens of the wrong shape.
+
+    Measured on the real transcript that produced #664, 5 samples per arm over
+    one chunk, varying ONLY where the contract sits:
+
+        contract at the prompt head (shipped behavior)   0/5 parsed
+        contract as a genuine system role (--system-prompt) 0/5 parsed
+        contract restated after the chunk text           5/5 parsed
+
+    So POSITION is the operative variable, not role — elevating the contract to
+    a real system message does not help (0 of 6 counting the earlier single
+    run), and repeating it last does (6 of 6). Do not "simplify" this into a
+    one-line reminder: _call_and_parse's terse retry note already sits in this
+    position and lost 3 of 3 in the field. The tested intervention is the
+    anti-continuation instruction AND the full contract together; which half
+    carries the weight was not isolated.
+
+    Cost: this repeats the system prompt once per chunk call, after the
+    variable chunk text, so it is not prefix-cacheable. That is the price of
+    the only placement measured to work.
+    """
+    return (
+        "\n\n--- END OF TRANSCRIPT CHUNK ---\n\n"
+        "Now perform the extraction described in the SYSTEM section above. "
+        "Do NOT continue the conversation. Do NOT reply as the assistant in "
+        "that transcript. Your entire response must be the single JSON object "
+        "for this chunk, starting with { and nothing before it.\n\n"
+        "Restated contract:\n" + (system if system is not None else _serialize_sys())
+    )
+
+
 def _merge_sys() -> str:
     if config.scene_traces_enabled():
         return MERGE_SYS + _SCENE_MERGE_ADDENDUM
@@ -2164,7 +2213,7 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
             t0 = time.monotonic()
             partial = _call_and_parse(
                 chat, system,
-                f"session_id: {session_id}\n\n{body}",
+                f"session_id: {session_id}\n\n{body}{_chunk_tail_contract(system)}",
                 deadline, f"perspective {name}, chunk {i + 1} of {len(chunks)}",
             )
             log.info("perspective %s: chunk %d/%d done in %.0fs",
@@ -2192,7 +2241,8 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
             log.info("single-pass serialize: %d lines", len(transcript_text.splitlines()))
             return _call_and_parse(
                 chat, _serialize_sys(),
-                f"session_id: {session_id}\n\nTRANSCRIPT:\n{transcript_text}{note}",
+                f"session_id: {session_id}\n\nTRANSCRIPT:\n{transcript_text}"
+                f"{_chunk_tail_contract()}{note}",
                 deadline, "transcript",
             )
         if partials is None:
@@ -2219,7 +2269,8 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
                 partial = _call_and_parse(
                     chat, _serialize_sys(),
                     f"session_id: {session_id}\n\n"
-                    f"TRANSCRIPT (chunk {i + 1} of {len(chunks)}):\n{chunk_text}",
+                    f"TRANSCRIPT (chunk {i + 1} of {len(chunks)}):\n{chunk_text}"
+                    f"{_chunk_tail_contract()}",
                     deadline, f"chunk {i + 1} of {len(chunks)}",
                 )
                 log.info("chunk %d/%d done in %.0fs",

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from daimon_briefing import serializer
+from daimon_briefing import config, serializer
 from tests.conftest import make_messages
 
 _REPO = Path(__file__).resolve().parents[2]
@@ -206,6 +206,73 @@ def test_serialize_long_session_chunks_then_merges(fake_chat_factory, monkeypatc
     # chunk calls use the D-007 serialize prompt
     assert all(c["messages"][0]["content"] == serializer.SERIALIZE_SYS
                for c in chat.calls[:-1])
+
+
+def test_chunk_prompt_restates_contract_after_the_transcript(fake_chat_factory,
+                                                             monkeypatch):
+    # #664: the output contract is the HEAD of the chunk prompt, tens of KB
+    # before the end, so a chunk ending on a finished assistant turn gets
+    # continued instead of extracted. Measured over 15 samples on one real
+    # transcript: contract at the head 0/5 parsed, contract as a genuine
+    # system role 0/5, contract restated after the chunk text 5/5. Position
+    # is the operative variable, so the contract must ALSO appear last.
+    monkeypatch.setenv("DAIMON_CHUNK_LINES", "6")
+    monkeypatch.setenv("DAIMON_CHUNK_OVERLAP", "1")
+    monkeypatch.setenv("DAIMON_MERGE_GROUP_SIZE", "100")
+    # Serial chunks so FakeChat's call order matches chunk order, and no cache
+    # so every chunk really issues its call.
+    monkeypatch.setenv("DAIMON_CHUNK_CONCURRENCY", "1")
+    monkeypatch.setenv("DAIMON_CHUNK_CACHE", "0")
+    messages = make_messages(20)
+    rendered = serializer._render_transcript(messages)
+    chunks = serializer.chunk_transcript(rendered, 6, 1)
+    assert len(chunks) > 1
+
+    responses = [_valid_checkpoint_json(f"chunk{i}") for i in range(len(chunks))]
+    responses.append(_valid_checkpoint_json("S1"))
+    chat = fake_chat_factory(responses)
+    assert serializer.serialize("S1", messages, chat=chat) is not None
+
+    for call, chunk_text in zip(chat.calls[:-1], chunks):
+        body = call["messages"][1]["content"]
+        end_of_transcript = body.index(chunk_text) + len(chunk_text)
+        tail = body[end_of_transcript:]
+        # The transcript is no longer the last thing the model reads.
+        assert tail.strip(), "chunk prompt ends on transcript text"
+        # An explicit instruction not to continue the conversation.
+        assert "Do NOT continue the conversation" in tail
+        # The contract itself, not just a one-line nag: the schema key that
+        # every extraction must emit has to be present in the tail too.
+        assert "epistemic_snapshot" in tail
+
+
+def test_single_pass_prompt_restates_contract_after_the_transcript(fake_chat_factory):
+    # #664 has no cliff at DAIMON_CHUNK_LINES: a 1,199-line transcript is the
+    # same tens-of-KB gap between the contract and the end of the prompt as a
+    # chunk is, so the single-pass path gets the same tail.
+    chat = fake_chat_factory(_valid_checkpoint_json("S1"))
+    messages = make_messages(20)
+    rendered = serializer._render_transcript(messages)
+    assert len(serializer.chunk_transcript(
+        rendered, config.chunk_lines(), config.chunk_overlap())) == 1
+
+    assert serializer.serialize_strict("S1", messages, chat=chat) is not None
+    body = chat.calls[0]["messages"][1]["content"]
+    tail = body[body.index(rendered) + len(rendered):]
+    assert "Do NOT continue the conversation" in tail
+    assert "epistemic_snapshot" in tail
+
+
+def test_single_pass_validation_retry_note_stays_last(fake_chat_factory):
+    # The retry note is the most specific instruction in the prompt, so the
+    # restated contract must not displace it from the end.
+    bad = json.dumps({"session_id": "S1", "working_context": {}})
+    chat = fake_chat_factory([bad, _valid_checkpoint_json("S1")])
+    serializer.serialize("S1", make_messages(20), chat=chat)
+    assert len(chat.calls) == 2
+    retry_body = chat.calls[1]["messages"][1]["content"]
+    assert "Do NOT continue the conversation" in retry_body
+    assert retry_body.rstrip().endswith("Re-emit the full corrected JSON.")
 
 
 def test_serialize_chunked_forwards_deadline_to_every_call(fake_chat_factory, monkeypatch):
@@ -2339,7 +2406,12 @@ def test_serialize_strict_idless_host_stays_on_todays_path(
          "source_message_ids": ["m2"]}))
     out = serializer.serialize_strict("S1", make_messages(6), chat=chat)
     sent = chat.calls[0]["messages"][1]["content"]
-    assert "[m" not in sent  # rendered transcript is marker-free
+    # Slice out the transcript itself: since #664 the user message also carries
+    # the restated contract, whose rule 19 spells out `[m12]` as an example.
+    # Those examples were always in the system prompt, so the model learns
+    # nothing new — but the marker-free claim is about the TRANSCRIPT.
+    rendered = sent.split("TRANSCRIPT:\n", 1)[1].split("--- END OF TRANSCRIPT", 1)[0]
+    assert "[m" not in rendered  # rendered transcript is marker-free
     item = out["working_context"]["recent_decisions"][0]
     assert "source_message_ids" not in item
     assert item["quote_verified"] is True
@@ -2657,6 +2729,31 @@ def test_escalation_perspectives_are_three_distinct_lanes():
         # appends its perspective — never replaces the extraction contract
         assert system.startswith(serializer.SERIALIZE_SYS)
         assert "EXTRACTION PERSPECTIVE" in system
+
+
+def test_escalated_pass_restates_its_own_perspective_contract_after_the_transcript(
+        fake_chat_factory, monkeypatch):
+    # #664, same defect on the escalation lane: each pass puts its perspective
+    # contract at the head and the transcript last. The tail must restate the
+    # contract that pass is actually running, not the default one — a pass
+    # reminded of the wrong contract would extract the wrong perspective.
+    monkeypatch.setenv("DAIMON_CHUNK_CONCURRENCY", "1")
+    monkeypatch.setenv("DAIMON_MERGE_GROUP_SIZE", "100")
+    monkeypatch.setenv("DAIMON_CHUNK_CACHE", "0")
+    chat = fake_chat_factory(
+        [_valid_checkpoint_json(f"p{i}") for i in range(3)]
+        + [_valid_checkpoint_json("merged")])
+    assert serializer.serialize_strict(
+        "S1", make_messages(20), chat=chat, escalate=True) is not None
+
+    for call in chat.calls[:3]:
+        system = call["messages"][0]["content"]
+        body = call["messages"][1]["content"]
+        tail = body[body.index("TRANSCRIPT:") + len("TRANSCRIPT:"):]
+        assert "Do NOT continue the conversation" in tail
+        # The tail carries THIS pass's perspective, not a generic reminder.
+        perspective = system.split("EXTRACTION PERSPECTIVE", 1)[1]
+        assert perspective in tail
 
 
 def test_base_prompt_untouched_by_escalation():


### PR DESCRIPTION
Closes #664

## What

Repeat the extraction contract after the transcript text, at all three extraction call sites: chunked, escalated, and single-pass.

New helper `_chunk_tail_contract(system=None)`. Escalation passes restate their own perspective contract rather than the default one, because a pass reminded of the wrong contract would be told to extract the wrong perspective.

`EXTRACTION_VERSION` is deliberately **not** bumped. The output contract and the extraction targets are unchanged, so cached chunks are still valid extractions of the identical contract, and #367 reserves bumps for semantic changes. Bumping would re-charge every warm chunk for no correctness gain.

## Why

The contract sits at the head of the prompt with tens of KB of transcript after it, so the last thing the model reads is somebody else's finished conversation. It continues that conversation instead of extracting from it.

The failing responses were not refusals or truncations. They were substantial, well formed status lines in the transcript's own voice, 1,085 to 4,471 output tokens of the wrong shape.

Five samples per arm on the transcript from the report, varying only where the contract sits:

| contract placement | parsed | output tokens |
| --- | --- | --- |
| head of the prompt (shipped behavior) | 0 of 5 | 1,775 to 4,471 |
| genuine system role, via `--system-prompt` | 0 of 5 | 1,085 to 2,993 |
| restated after the transcript | 5 of 5 | 9,302 to 14,534 |

Folding in the original field failures and the earlier single runs: 0 of 12 at the head, 0 of 6 as a system role, 6 of 6 restated last. **Position is the operative variable, not role.** Output token ranges are fully disjoint between failing and passing runs, which is a second signal independent of the parse rate.

Applied at all three sites rather than only the chunked one: a single-pass transcript just under `DAIMON_CHUNK_LINES` leaves the same gap as a chunk, so a chunked-only fix would leave an arbitrary cliff at the threshold.

## Tests

`uv run pytest tests/` in `plugin/`: **3326 passed, 2 skipped**.

Four new tests, each watched failing before the change:

- `test_chunk_prompt_restates_contract_after_the_transcript`: failed with `chunk prompt ends on transcript text`
- `test_escalated_pass_restates_its_own_perspective_contract_after_the_transcript`: failed on the missing tail; asserts the tail carries *this* pass's perspective, not a generic reminder
- `test_single_pass_prompt_restates_contract_after_the_transcript`: failed on the missing tail
- `test_single_pass_validation_retry_note_stays_last`: guards that the restated contract does not displace the validation-retry note from the end of the prompt

One existing test needed its assertion narrowed. `test_serialize_strict_idless_host_stays_on_todays_path` asserted `"[m" not in sent` over the whole user message; the restated contract's rule 19 spells out `[m12]` as an example. Those examples were already in `SERIALIZE_SYS`, sent as `messages[0]`, so the model learns nothing new. The assertion now slices out the transcript itself, which is what the test's own comment says it is checking.

## Not covered

Which half of the intervention carries the weight was not isolated. The tested text is the anti-continuation instruction **and** the full contract together, so the docstring warns against shrinking it to a one-line reminder. `_call_and_parse`'s terse retry note already occupies that position and lost 3 of 3 in the field.

Cost: the contract is repeated after the variable transcript text, so that copy is not prefix-cacheable. That is the price of the only placement measured to work.

Scope of the evidence: one chunk of one transcript on one model. It establishes the mechanism and the fix direction, not how often the condition occurs.
