### PR TITLE
fix(llm): let the fallback rescue an unparseable response

### DIFF
--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -41,6 +41,16 @@ class DeadlineExhausted(ChatError):
     expiry as budget expiry instead of blaming a healthy gateway."""
 
 
+class NoRescueAvailable(ChatError):
+    """rescue_unparseable() was asked for a fallback and none is configured.
+
+    A ChatError subclass so a caller that only wants "the rescue did not
+    produce anything" can catch broadly, but distinguishable so a caller can
+    tell NOTHING WAS TRIED apart from THE RESCUE ALSO FAILED. The serializer
+    needs that distinction to decide whether its own OutputParseError is
+    still the honest thing to raise (#663)."""
+
+
 class EmptyOutputError(ChatError):
     """The command backend returned rc=0 with empty (or whitespace-only) stdout.
 
@@ -451,6 +461,33 @@ def _rescue(messages, deadline, exc, primary_label):
         deadline = max(deadline,
                        time.monotonic() + config.fallback_min_seconds())
     return _chat_command(messages, deadline, resolved=fallback)
+
+
+def rescue_unparseable(messages, deadline):
+    """Hand a SUCCESSFUL-but-unusable primary response to the fallback (#663).
+
+    chat()'s rescue only fires from its two `except ChatError` branches, so it
+    covers everything that goes wrong INSIDE chat() — transport failures, a
+    non-zero exit, and rc=0-with-empty-stdout, which is a content failure that
+    reaches the rescue because EmptyOutputError subclasses ChatError. What it
+    cannot see is a response that arrives intact and turns out to be unusable:
+    by then chat() has already returned a string, and the caller discovers the
+    problem on its own. The field case was a backend returning `rc=0`,
+    `is_error: false`, `subtype: success` and prose where JSON belonged; the
+    session stayed unserializable across repeated heals while a configured
+    fallback sat unused.
+
+    Same one hop as chat()'s rescue, and deliberately routed through _rescue
+    so the three things that must travel together cannot drift: the
+    ledger-matched log literal, the _fallback_used flag, and the #341 deadline
+    re-arm. Raises NoRescueAvailable when no fallback resolves, so the caller
+    can tell "nothing was tried" from "the rescue also failed".
+    """
+    return _rescue(
+        messages, deadline,
+        NoRescueAvailable("no rescue configured for unparseable output"),
+        "primary returned unparseable output",
+    )
 
 
 def chat(messages, model=None, temperature=None, timeout=None, retries=3, deadline=None):

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -1592,6 +1592,39 @@ def _call_and_parse(chat, system, user_content, deadline, what: str,
                 deadline is None or deadline - time.monotonic() > 0
             )
 
+        def _try_rescue():
+            """One fallback hop for a primary that returned unusable output.
+
+            chat()'s own rescue fires only from its `except ChatError`
+            branches, so it never sees a response that arrives intact and
+            turns out to be prose: by then chat() has returned a string. The
+            field case left a session unserializable across repeated heals
+            while a configured fallback sat unused (#663).
+
+            The fallback gets the PRISTINE user content, not the marked-up
+            retry text — the retry marker apologises for a previous response
+            this backend never produced, and its nonce exists to defeat a
+            gateway cache the fallback does not share.
+
+            Returns None for every "no usable checkpoint" outcome, including
+            no fallback configured, so the caller keeps raising its own named
+            error rather than a new one about the rescue.
+            """
+            if deadline is not None and deadline - time.monotonic() <= 0:
+                return None
+            try:
+                rescued = llm.rescue_unparseable(
+                    [
+                        {"role": "system", "content": system},
+                        {"role": "user", "content": user_content},
+                    ],
+                    deadline,
+                )
+                parsed_rescue = llm.extract_json(rescued)
+            except (llm.ChatError, json.JSONDecodeError, ValueError, TypeError):
+                return None
+            return parsed_rescue if isinstance(parsed_rescue, dict) else None
+
         try:
             raw = chat(
                 [
@@ -1620,6 +1653,11 @@ def _call_and_parse(chat, system, user_content, deadline, what: str,
                 log.warning("unparseable output on %s (attempt %d/%d), "
                             "retrying with cache-buster", what, attempt, attempts)
                 continue
+            rescued = _try_rescue()
+            if rescued is not None:
+                log.warning("rescued unparseable output on %s via the fallback "
+                            "(#663)", what)
+                return rescued
             raise OutputParseError(
                 f"unparseable model output on {what} after {attempt} attempts: {exc}"
             ) from exc
@@ -1628,6 +1666,11 @@ def _call_and_parse(chat, system, user_content, deadline, what: str,
                 log.warning("unparseable output on %s (attempt %d/%d), "
                             "retrying with cache-buster", what, attempt, attempts)
                 continue
+            rescued = _try_rescue()
+            if rescued is not None:
+                log.warning("rescued non-object output on %s via the fallback "
+                            "(#663)", what)
+                return rescued
             raise OutputParseError(
                 f"model output on {what} is not a JSON object after {attempt} attempts"
             )

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -1880,3 +1880,43 @@ def test_rescue_posture_reresolves_liveness_every_call(monkeypatch):
     assert llm.rescue_posture() == "covered"
     live["resolves"] = False
     assert llm.rescue_posture() == "none"
+
+
+# ---- #663: a well-formed response with unusable content reaches the rescue ---
+
+
+def test_rescue_unparseable_routes_to_the_fallback(monkeypatch, caplog):
+    # The primary returned rc=0 and a successful envelope, so chat() never
+    # raised and never consulted the fallback. The caller that discovers the
+    # content is unusable needs its own way in.
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setattr(llm, "_resolve_fallback_command",
+                        lambda: ("rescuecli", "text", "stdin"))
+    seen = {}
+
+    def fake_command(messages, deadline, resolved=None):
+        seen["resolved"] = resolved
+        return "FALLBACK"
+
+    monkeypatch.setattr(llm, "_chat_command", fake_command)
+    llm.reset_fallback()
+    with caplog.at_level(logging.WARNING, logger="daimon_briefing.llm"):
+        out = llm.rescue_unparseable([{"role": "user", "content": "x"}], None)
+    assert out == "FALLBACK"
+    assert seen["resolved"] == ("rescuecli", "text", "stdin")
+    assert llm.fallback_used() is True
+    # The ledger counts rescues by matching this literal (ledger.py).
+    msgs = [r.getMessage() for r in caplog.records if "llm.fallback" in r.getMessage()]
+    assert msgs and msgs[0].startswith("llm.fallback backend=command")
+    assert "unparseable" in msgs[0]
+
+
+def test_rescue_unparseable_without_a_fallback_raises_no_rescue(monkeypatch):
+    # No fallback configured: the caller must be able to tell "nothing tried"
+    # apart from "the rescue also failed", so it can raise its own error.
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setattr(llm, "_resolve_fallback_command", lambda: None)
+    llm.reset_fallback()
+    with pytest.raises(llm.NoRescueAvailable):
+        llm.rescue_unparseable([{"role": "user", "content": "x"}], None)
+    assert llm.fallback_used() is False

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -823,6 +823,42 @@ def test_call_and_parse_raises_original_error_when_the_rescue_is_also_unparseabl
     assert len(rescues) == 1
 
 
+def test_call_and_parse_rescues_output_that_parses_to_a_non_object(
+        fake_chat_factory, monkeypatch):
+    # A response can be valid JSON and still be the wrong shape — a bare array
+    # parses fine and is not a checkpoint. Same rescue as unparseable prose:
+    # the primary produced something well formed and unusable.
+    from daimon_briefing import llm
+
+    chat = fake_chat_factory(["[1, 2, 3]", "[4, 5, 6]"])
+    rescues = []
+
+    def fake_rescue(messages, deadline):
+        rescues.append(messages)
+        return _valid_checkpoint_json("S1")
+
+    monkeypatch.setattr(llm, "rescue_unparseable", fake_rescue)
+    ckpt = serializer.serialize_strict("S1", make_messages(20), chat=chat)
+    assert ckpt is not None and ckpt["session_id"] == "S1"
+    assert len(chat.calls) == 2
+    assert len(rescues) == 1
+
+
+def test_call_and_parse_non_object_without_a_rescue_keeps_its_named_error(
+        fake_chat_factory, monkeypatch):
+    from daimon_briefing import llm
+
+    chat = fake_chat_factory(["[1, 2, 3]", "[4, 5, 6]"])
+
+    def no_rescue(messages, deadline):
+        raise llm.NoRescueAvailable("no rescue configured for unparseable output")
+
+    monkeypatch.setattr(llm, "rescue_unparseable", no_rescue)
+    with pytest.raises(serializer.OutputParseError,
+                       match="is not a JSON object"):
+        serializer.serialize_strict("S1", make_messages(20), chat=chat)
+
+
 def test_call_and_parse_skips_the_rescue_when_the_deadline_is_gone(
         fake_chat_factory, monkeypatch):
     # A dead deadline makes the rescue hop pointless, the same guard the parse

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -764,6 +764,88 @@ def test_call_and_parse_empty_output_error_skipped_when_deadline_exhausted():
     assert len(calls) == 1  # no second call once the deadline is gone
 
 
+# --- #663: unparseable output reaches the rescue, like a backend failure -----
+
+
+def test_call_and_parse_rescues_unparseable_output_via_the_fallback(
+        fake_chat_factory, monkeypatch):
+    # chat() returns a string, so its own rescue never fires. Once both parse
+    # attempts are spent, the configured fallback is the only thing left that
+    # could still produce a checkpoint.
+    from daimon_briefing import llm
+
+    chat = fake_chat_factory(["not json at all", "still not json"])
+    rescues = []
+
+    def fake_rescue(messages, deadline):
+        rescues.append(messages)
+        return _valid_checkpoint_json("S1")
+
+    monkeypatch.setattr(llm, "rescue_unparseable", fake_rescue)
+    ckpt = serializer.serialize_strict("S1", make_messages(20), chat=chat)
+    assert ckpt is not None and ckpt["session_id"] == "S1"
+    assert len(chat.calls) == 2   # both parse attempts spent on the primary first
+    assert len(rescues) == 1      # ONE hop, never a chain
+
+
+def test_call_and_parse_still_raises_when_no_rescue_is_configured(
+        fake_chat_factory, monkeypatch):
+    # Regression guard: an install with no fallback must keep today's named
+    # failure, not a new one about the rescue.
+    from daimon_briefing import llm
+
+    chat = fake_chat_factory(["nope", "nope"])
+
+    def no_rescue(messages, deadline):
+        raise llm.NoRescueAvailable("no rescue configured for unparseable output")
+
+    monkeypatch.setattr(llm, "rescue_unparseable", no_rescue)
+    with pytest.raises(serializer.OutputParseError, match="unparseable model output"):
+        serializer.serialize_strict("S1", make_messages(20), chat=chat)
+
+
+def test_call_and_parse_raises_original_error_when_the_rescue_is_also_unparseable(
+        fake_chat_factory, monkeypatch):
+    # The rescue is one hop. A fallback that also returns prose does not earn
+    # another attempt, and the operator sees the original named failure.
+    from daimon_briefing import llm
+
+    chat = fake_chat_factory(["nope", "nope"])
+    rescues = []
+
+    def fake_rescue(messages, deadline):
+        rescues.append(messages)
+        return "the fallback returned prose too"
+
+    monkeypatch.setattr(llm, "rescue_unparseable", fake_rescue)
+    with pytest.raises(serializer.OutputParseError, match="unparseable model output"):
+        serializer.serialize_strict("S1", make_messages(20), chat=chat)
+    assert len(rescues) == 1
+
+
+def test_call_and_parse_skips_the_rescue_when_the_deadline_is_gone(
+        fake_chat_factory, monkeypatch):
+    # A dead deadline makes the rescue hop pointless, the same guard the parse
+    # retry already applies.
+    import time
+
+    from daimon_briefing import llm
+
+    rescues = []
+    monkeypatch.setattr(llm, "rescue_unparseable",
+                        lambda m, d: rescues.append(m))
+
+    def slow_prose_chat(chat_messages, **kwargs):
+        time.sleep(0.15)
+        return "not json"
+
+    deadline = time.monotonic() + 0.05
+    with pytest.raises(serializer.OutputParseError):
+        serializer.serialize_strict("S1", make_messages(20),
+                                    chat=slow_prose_chat, deadline=deadline)
+    assert rescues == []
+
+
 # --- Live progress logging (40-min runs need a heartbeat) --------------------
 
 


### PR DESCRIPTION
Closes #663

## What

`llm.rescue_unparseable(messages, deadline)`: a fallback-only call for a primary that returned a successful response with unusable content. It routes through the existing `_rescue`, so the ledger-matched log literal `llm.fallback backend=command`, the `_fallback_used` flag and the #341 deadline re-arm stay in one place rather than drifting apart in a parallel path.

`llm.NoRescueAvailable`, a `ChatError` subclass, so a caller can tell "nothing was tried" from "the rescue also failed".

`_call_and_parse` takes one hop at both final-failure points, unparseable and parsed-but-not-an-object.

The `daimon status` half of the issue is deliberately **not** included, see below.

## Why

`chat()` calls `_rescue` only from its two `except ChatError` branches. That covers everything that fails inside `chat()`: transport errors, a non-zero exit, and `rc=0` with empty stdout, which reaches the rescue because `EmptyOutputError` subclasses `ChatError`.

What it cannot see is a response that arrives intact and turns out to be unusable. By then `chat()` has already returned a string, and `OutputParseError` is raised later in the serializer.

The reported case returned `rc=0`, `is_error: false`, `subtype: success`, and prose where JSON belonged. The session stayed unserializable across repeated `daimon heal --force` runs while a configured fallback sat unused, and `daimon status` recommended setting that very fallback as the remedy.

A parse failure is also the case where a *different* model is most likely to succeed and re-running the same one is least likely to, which is what the existing `parse_retries` loop does.

## Design notes

**Pristine content to the fallback.** The retry-marked text apologises for a previous response this backend never produced, and its nonce exists to defeat a gateway cache the fallback does not share.

**Fail closed to today's error.** `_try_rescue()` returns `None` for every unusable outcome, including no fallback configured, so an install without one keeps the exact named `OutputParseError` it raises today.

**One hop, never a chain.** A fallback that also returns prose does not earn another attempt.

## Not included: the status wording

The issue offered a second resolution, making `daimon status` stop advertising the fallback for this class. That change collapses once the rescue fires.

The warning is gated on `posture == "none"`, a command primary with no fallback at all, and its advice to set `DAIMON_LLM_COMMAND_FALLBACK` becomes correct with this PR. `rescue_posture()` returning `covered` likewise becomes accurate. Shipping a "covered, transport only" qualifier would encode a limitation this PR removes.

## Tests

`uv run pytest tests/` in `plugin/`: **3332 passed, 2 skipped**.

Six new tests. The two that required the feature were watched failing first; the rest are regression guards that pass on current behavior and must keep passing.

- `test_rescue_unparseable_routes_to_the_fallback`: resolves the fallback triple, sets the flag, and logs the literal `ledger.py` counts
- `test_rescue_unparseable_without_a_fallback_raises_no_rescue`: flag stays clear
- `test_call_and_parse_rescues_unparseable_output_via_the_fallback`: both parse attempts spent on the primary first, then exactly one rescue
- `test_call_and_parse_still_raises_when_no_rescue_is_configured`: today's named error survives
- `test_call_and_parse_raises_original_error_when_the_rescue_is_also_unparseable`: one hop, original error
- `test_call_and_parse_skips_the_rescue_when_the_deadline_is_gone`: same dead-deadline guard the parse retry already applies

## Scope

Not exercised against a live backend. The rescue path is covered by tests at both the `llm` and serializer layers, but no real fallback command has run through it.
