### PR TITLE
chore(scars): promote 0049-0052 and narrow 0016 path anchor

### DIFF
--- a/.scars/0016-simulated-clock-must-thread-into-every-now-consumer.landmine.md
+++ b/.scars/0016-simulated-clock-must-thread-into-every-now-consumer.landmine.md
@@ -7,7 +7,8 @@ confidence: 0.9
 created: 2026-07-02
 authors: ["claude-code", "Kibukx"]
 anchors:
-  - path: research/experiments/multicycle/
+  - path: research/experiments/multicycle/run_multicycle.py
+  - path: research/experiments/multicycle/test_run.py
   - pattern: "briefing\.build\b"
 violation: "briefing\.build\((?![^)]{0,300}now=)"
 evidence:

--- a/.scars/0049-redact-py-is-package-owned-and-import-free.landmine.md
+++ b/.scars/0049-redact-py-is-package-owned-and-import-free.landmine.md
@@ -1,0 +1,38 @@
+---
+id: 49
+type: landmine
+title: redact.py syncs package to hook (opposite of the hook scripts) and must import stdlib only
+severity: medium
+confidence: 0.85
+created: 2026-08-10
+authors: ["claude-code", "Kibukx"]
+anchors:
+  - path: plugin/daimon_briefing/redact.py
+  - path: hook/redact.py
+  - pattern: "from \. import|from daimon_briefing"
+evidence:
+  - commit: a5f3a64
+  - pr: 661
+  - note: "2026-08-10, #660/#661 — added `from . import normalize` to redact.py; it is copied verbatim next to the standalone Windsurf hook scripts, which run with a sys.path insert and cannot resolve the package"
+expires:
+  condition: "redact.py stops being shipped standalone beside the hook scripts, or the hook copies become real imports of the installed package"
+  review_after: 2027-02-01
+status: active
+---
+
+`redact.py` exists three times: `plugin/daimon_briefing/redact.py` (canonical),
+`plugin/daimon_briefing/_hooks/redact.py`, and `hook/redact.py`. A test pins the
+first two byte-identical and `scripts/sync_hooks.py --check` gates the third.
+
+Two traps, and the second contradicts [[0044]].
+
+**It may import stdlib ONLY.** The file lives inside the package, so
+`from . import normalize` looks completely ordinary and passes every local test.
+It breaks the standalone hooks, which run with a `sys.path` insert and cannot
+resolve `daimon_briefing`. Duplicate the few lines you need and comment both
+sides as paired, as the NFKC fold does against `normalize.compat_fold`.
+
+**Sync direction is REVERSED here.** Scar 0044 teaches that `hook/` is the
+source of truth and package copies get overwritten. For `redact.py` it is the
+opposite: `sync_hooks.py` reports `synced hook/redact.py <- plugin/daimon_briefing/redact.py`.
+Edit the package copy, then sync. Editing `hook/redact.py` loses the work.

--- a/.scars/0050-forced-data-theme-breaks-themedimage-screenshots.deadend.md
+++ b/.scars/0050-forced-data-theme-breaks-themedimage-screenshots.deadend.md
@@ -1,0 +1,30 @@
+---
+id: 50
+type: deadend
+title: Forcing data-theme via setAttribute does not re-render Docusaurus ThemedImage — screenshots then show phantom missing-logo bugs
+severity: medium
+confidence: 0.9
+created: 2026-08-07
+authors: ["claude-code", "Kibukx"]
+anchors:
+  - path: website/docusaurus.config.ts
+  - path: website/src/css/custom.css
+evidence:
+  - note: 2026-08-06 blind design review: 'light-mode wordmark missing' filed as CRITICAL in three consecutive rounds; refuted by emulating colorScheme light + clean reload — navbar img renders 139x32
+expires:
+  condition: "site stops using ThemedImage/srcDark for the navbar logo"
+  review_after: 2027-02-01
+status: active
+---
+
+To capture light/dark screenshots of the Docusaurus site, setting
+`document.documentElement.setAttribute('data-theme', 'light')` flips CSS
+variables but NOT React state: ThemedImage keeps only the variant node it
+mounted for the ORIGINAL theme, so the navbar logo (and any srcDark asset)
+renders as a zero-width hole in the forced theme. Three independent blind
+design reviewers filed "light-mode wordmark missing" as CRITICAL from such
+screenshots; a fix (min-width reservation) was even committed and later
+reverted. The truth: emulate the color scheme at the browser level
+(prefers-color-scheme), clear the `theme` localStorage key, and RELOAD before
+capturing — then the correct themed node mounts and the logo measures 139x32.
+Never diagnose theme-dependent asset bugs from attribute-forced captures.

--- a/.scars/0051-mobile-hero-shrink-breaks-hierarchy-floor.deadend.md
+++ b/.scars/0051-mobile-hero-shrink-breaks-hierarchy-floor.deadend.md
@@ -1,0 +1,28 @@
+---
+id: 51
+type: deadend
+title: Shrinking the landing hero on mobile drops it below the 2x-body hierarchy floor
+severity: low
+confidence: 0.8
+created: 2026-08-06
+authors: ["claude-code", "Kibukx"]
+anchors:
+  - path: website/src/css/custom.css
+violation: "hero--daimon h1 [{][^}]*font-size: 1[.]"
+evidence:
+  - commit: abbfe08
+  - pr: 615
+expires:
+  condition: "landing h1 becomes a long multi-word headline that genuinely cannot fit at 36px on 320px screens"
+  review_after: 2027-02-01
+status: active
+---
+
+Tried the reflex mobile pattern: shrink the hero h1 to 1.875rem (30px) under
+640px (PR #615). That breaks the deliberate type hierarchy — hero must
+stay at 2.0-2.44x body (36px / 16px = 2.25x); 30px is 1.88x and the page loses
+its single dominant element exactly where screens are smallest. The title is
+the six-character word "daimon"; 36px fits every viewport down to 320px, so
+the shrink solved nothing. Reverted in the same PR: the mobile media query adjusts
+hero PADDING only, never the h1 font-size. If the h1 ever needs a mobile size,
+pick from {36, 48} or restructure the copy — do not slide below 2x body.

--- a/.scars/0052-system-prompt-flag-does-not-fix-transcript-continuation.deadend.md
+++ b/.scars/0052-system-prompt-flag-does-not-fix-transcript-continuation.deadend.md
@@ -1,0 +1,39 @@
+---
+id: 52
+type: deadend
+title: Passing the contract as a real system prompt does NOT stop transcript continuation — only repeating it last does
+severity: medium
+confidence: 0.85
+created: 2026-08-10
+authors: ["claude-code", "Kibukx"]
+anchors:
+  - path: plugin/daimon_briefing/llm.py
+  - path: plugin/daimon_briefing/serializer.py
+  - pattern: "--system-prompt"
+  - pattern: "_CLAUDE_PRESET"
+evidence:
+  - commit: dd7b748
+  - pr: 665
+  - note: issue #664, 15-sample three-arm study
+expires:
+  condition: "a re-run of the three-arm study shows the system-role arm parsing"
+  review_after: 2027-02-10
+status: active
+---
+
+The claude-cli preset folds the system message into the head of one stdin blob
+(`_flatten_messages`) and passes no `--system-prompt`. That looks like the bug,
+and "just pass it as a real system prompt" is the obvious fix. It was tried and
+it does not work.
+
+Measured on one real chunk, 5 samples per arm, only the contract's placement
+varying: head of the prompt 0/5 parsed, genuine system role via
+`--system-prompt` 0/5, contract restated AFTER the transcript 5/5. Counting an
+earlier single run each way: 0 of 6 as a system role, 6 of 6 restated last.
+Failures were not refusals — 1,085-4,471 tokens of status lines in the
+transcript's own voice, continuing the conversation.
+
+Position is the operative variable, not role. Do not re-plumb the preset to add
+`--system-prompt` expecting a fix, and do not shrink `_chunk_tail_contract()`
+to a one-line reminder: `_call_and_parse`'s terse retry note already sits in
+that position and lost 3 of 3 in the field.


### PR DESCRIPTION
Scars-only change, so the issue-first gate is skipped per the exemption in `pr-validation.yml`. The human sign-off already happened at `scar promote`; the reviewer is recorded in each scar's `authors`.

## What

Promote four reviewed candidates, and narrow one existing anchor that lint has been flagging.

| scar | type | what it protects |
| --- | --- | --- |
| 0049 redact-py-is-package-owned-and-import-free | landmine | `redact.py` syncs package to hook, the reverse of scar 0044, and may import stdlib only |
| 0050 forced-data-theme-breaks-themedimage-screenshots | deadend | attribute-forcing a theme does not re-render ThemedImage, so captures show phantom missing-asset bugs |
| 0051 mobile-hero-shrink-breaks-hierarchy-floor | deadend | shrinking the hero h1 under 640px drops below the 2x-body floor and solves nothing |
| 0052 system-prompt-flag-does-not-fix-transcript-continuation | deadend | passing the extraction contract as a real system prompt does not help; restating it after the transcript does |

Plus: `0016`'s path anchor narrowed from a directory to the two files that actually stamp simulated time.

## Why these four

**0049** cost real time this week. It contradicts an active scar, which is the case where negative knowledge earns its keep: scar 0044 teaches that `hook/` is the source of truth and package copies get overwritten, and for `redact.py` the direction is exactly reversed. `sync_hooks.py:26` maps package to hook.

**0050** produced three identical false CRITICAL reports from independent reviewers, and a fix was committed and later reverted before the method was understood.

**0051** is small but its `violation:` regex fires precisely on the reflex mistake.

**0052** rests on a 15-sample study run this week: contract at the prompt head 0 of 5 parsed, as a genuine system role 0 of 5, restated after the transcript 5 of 5. Position is the operative variable, not role.

## Why 0016's anchor changed

The anchor was `research/experiments/multicycle/`: 252 of 699 tracked files, 36% of the repo, which lint has flagged since the over-broad detector shipped.

Nine of those 252 are Python and exactly two stamp simulated time or call `briefing.build`. The directory fired on 252 files to protect 2, and noise is what trains a reader to skim the channel.

Coverage is unchanged. Those two files are the only ones in that tree doing the dangerous thing, the `briefing\.build\b` pattern anchor still covers every call site in the package, and the violation tripwire is untouched.

## Two repairs applied after promotion

- **0049** cited a pre-squash SHA not reachable from `main`, now `a5f3a64` plus `pr: 661`. Its evidence note had also been truncated by an unquoted `#`, which is intended parser behaviour: quoting the value is the documented remedy, and the note is restored in full.
- **0051**'s reintroduction-guard pattern moved from `anchors:` to `violation:`, which is where a guard that is healthy when absent belongs.

## Verification

`scar lint`: **0 errors, 0 orphans, 0 partial-rot, 0 unreachable-evidence, and no warnings**: the first fully clean run, since `0016` was the last outstanding advisory.
