### PR TITLE
feat(store): declare the human event-source set and instrument reverify

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1563,6 +1563,10 @@ def _cmd_reverify(args) -> int:
     if not ok:
         print("event not written (daimon disabled or project unknown)")
         return 1
+    # A typed baseline for this verb. Without it reverify's count is
+    # structurally zero, and a zero that measures missing instrumentation
+    # cannot be compared against a UI channel's count later.
+    _note_usage("reverify")
     print(f"reopened {item['id']}: {item.get('text', '')}")
     return 0
 
@@ -3369,7 +3373,8 @@ def _stats_resolutions(project_dir, usage: dict) -> dict:
             status = str(evt.get("status") or "")
             kind = str(evt.get("kind") or "")
             ts = str(evt.get("ts") or "")
-            if source == "cli" and kind == "resolution" and store.is_resolved(evt):
+            if (source in store.HUMAN_EVENT_SOURCES and kind == "resolution"
+                    and store.is_resolved(evt)):
                 human += 1
                 human_stamps.append(ts)
             elif source == "serializer" and status == capture.AGENT_VERIFIED_STATUS:

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -1795,6 +1795,24 @@ def forget_hit_stats(project_dir=None) -> dict:
     return out
 
 
+# Event-ledger `source` values whose authority tier is HUMAN. Declared here,
+# beside the writer that stamps the field, so consumers derive one view of
+# "a person decided this" instead of each hardcoding a literal — the same
+# single-declaration shape surfaces.py uses for delete strategies.
+#
+# `ui` is a peer of `cli`, not a replacement: the ledger is append-only and
+# every row already written says `cli`, so the set widens and never renames.
+# It matches refutations.CHANNEL_AUTHORITY["ui"] == "human", which is the
+# same claim in the refutation ledger's own vocabulary. The two vocabularies
+# stay separate on purpose — that ledger's channels distinguish `cli-tty`
+# from `cli-agent`, a split this ledger expresses through `source="agent"`.
+#
+# Widening this set widens WHO counts, never WHAT counts: callers must still
+# filter on `kind` themselves (scar 0025 — kind never isolates a fold on its
+# own), or forget's tombstones and log's freeform rows ride in as decisions.
+HUMAN_EVENT_SOURCES = frozenset({"cli", "ui"})
+
+
 def append_event(item_ref: str, status: str, note: str = "",
                  kind: str = "resolution", source: str = "cli",
                  project_dir=None, item_text: str = "",

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -6244,6 +6244,56 @@ def _res(capsys, monkeypatch, project):
     return json.loads(capsys.readouterr().out)["resolutions"]
 
 
+def test_reverify_records_a_usage_tag(
+        tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    # Language-contract 7.6 precondition: reverify emitted no usage tag at
+    # all, so its count was structurally zero. A zero that measures missing
+    # instrumentation cannot be compared against anything, which made the
+    # amendment's own falsification condition uncheckable for this verb.
+    from daimon_briefing import store
+
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/repo/rv")
+    cp = {"working_context": {"open_questions": [{"text": "close then reopen"}]}}
+    store.write_checkpoint("S1", cp, project_dir="/repo/rv")
+    item = store.read_latest(project_dir="/repo/rv")[
+        "working_context"]["open_questions"][0]
+    assert cli.main(["resolve", item["id"], "--project", "/repo/rv"]) == 0
+    assert cli.main(["reverify", item["id"], "--evidence", "checked the release page",
+                     "--project", "/repo/rv"]) == 0
+
+    capsys.readouterr()
+    assert cli.main(["stats", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out)["usage"]["reverify"] == 1
+
+
+def test_stats_resolutions_credits_a_ui_write_as_human(
+        tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    # Language-contract 7.4 prerequisite: a write surface records source="ui"
+    # rather than impersonating the CLI. Human credit was pinned to
+    # source=="cli", so every click would have dropped out of the counter
+    # silently and `daimon stats` would under-report human decisions the day
+    # a UI ships.
+    _write_events(tmp_checkpoint_dir, "/repo/ui", [
+        {"item_ref": "o-ui", "source": "ui", "kind": "resolution",
+         "status": "resolved", "ts": "2026-08-11T00:00:00Z"},
+    ])
+    assert _res(capsys, monkeypatch, "/repo/ui")["human"] == 1
+
+
+def test_stats_resolutions_ui_source_still_filters_on_kind(
+        tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    # Widening the source set must not widen the kind set: forget's tombstone
+    # rows and log's freeform rows are not resolve decisions, whichever
+    # channel wrote them (scar 0025 — kind never isolates a fold on its own).
+    _write_events(tmp_checkpoint_dir, "/repo/uikind", [
+        {"item_ref": "o-a", "source": "ui", "kind": "tombstone",
+         "status": "resolved", "ts": "2026-08-11T00:00:00Z"},
+        {"item_ref": "o-b", "source": "ui", "kind": "note",
+         "status": "resolved", "ts": "2026-08-11T00:00:01Z"},
+    ])
+    assert _res(capsys, monkeypatch, "/repo/uikind")["human"] == 0
+
+
 def test_stats_resolutions_reports_when_agent_credit_became_possible(
         tmp_checkpoint_dir, capsys, monkeypatch):
     # #562: a lifetime fold spanning the agent path's arrival reads as human


### PR DESCRIPTION
Closes #668

## What

`store.HUMAN_EVENT_SOURCES` declares `{cli, ui}` once, beside `append_event` which stamps the field. `_stats_resolutions` derives from it instead of matching the literal `"cli"`.

`reverify` now records a usage tag on its success path.

## Why

Both are silent failures, which is why they are worth fixing before rather than after a write surface exists.

Human resolution credit matched `source == "cli"`. A write surface records `source="ui"`, matching no branch: not `cli`, not `serializer`, not `agent`. Every click would drop out of the human counter and `daimon stats` would under-report human decisions, with nothing erroring.

`reverify` emitted no usage tag at all, so its lifetime count was structurally zero. A zero that measures missing instrumentation is indistinguishable from a verb nobody uses, and cannot serve as a baseline.

## Design notes

**The set widens, it never renames.** The event ledger is append-only and every row already on disk says `cli`. `ui` joins as a peer.

**Deliberately not unified with the refutation ledger's channels.** That vocabulary splits `cli-tty` from `cli-agent`; this ledger already expresses that distinction through `source="agent"`. Merging them would change the meaning of rows that cannot be rewritten.

**Widening WHO counts must not widen WHAT counts.** The `kind` filter stays, and a regression test pins it: `ui` rows with kind `tombstone` or `note` score zero. Scar 0025's lesson is that kind never isolates a fold on its own.

## Tests

`uv run pytest tests/` in `plugin/`: **3337 passed, 2 skipped**. `ruff check`: clean.

Three new tests, each watched failing first:

- `test_stats_resolutions_credits_a_ui_write_as_human`: failed `assert 0 == 1`
- `test_stats_resolutions_ui_source_still_filters_on_kind`: regression guard, passed before the change and must keep passing
- `test_reverify_records_a_usage_tag`: failed `KeyError: 'reverify'`

## Not included

No UI-side tags such as `resolve:ui`. Those can only be emitted by a surface that does not exist yet; adding them now would ship dead strings.
