### PR TITLE
feat(ui): local read-only viewer with search-as-recall and why detail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         # fails loudly instead of silently touching a real ~/.daimon.
         run: |
           mkdir -p "$RUNNER_TEMP/fake-home"
-          HOME="$RUNNER_TEMP/fake-home" uv run --extra dev --extra pretty pytest -q --cov=daimon_briefing --cov-report=xml --junitxml=junit.xml
+          HOME="$RUNNER_TEMP/fake-home" uv run --extra dev --extra pretty pytest -q --cov=daimon_briefing --cov=daimon_ui --cov-report=xml --junitxml=junit.xml
 
       - name: Upload test results to Codecov
         if: ${{ matrix.python-version == '3.13' && !cancelled() }}

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -782,6 +782,24 @@ def _cmd_why(args) -> int:
     return 0
 
 
+def _cmd_serve(args) -> int:
+    """Front door to the read-only viewer (#670). Delegates to daimon_ui's own
+    argv path so there is exactly one config surface — the CLI never grows its
+    own copy of the flag handling."""
+    _note_usage("serve")
+    import daimon_ui.__main__ as ui_main
+    argv = []
+    if args.data_dir:
+        argv += ["--data-dir", args.data_dir]
+    if args.project_dir:
+        argv += ["--project-dir", args.project_dir]
+    if args.port is not None:
+        argv += ["--port", str(args.port)]
+    if args.no_browser:
+        argv.append("--no-browser")
+    return ui_main.main(argv) or 0
+
+
 # ---- projects: cross-project bucket list (#243) ----
 
 
@@ -3928,6 +3946,28 @@ def build_parser() -> argparse.ArgumentParser:
         "--slug", metavar="SLUG",
         help="scope to a project bucket by its slug (see `daimon projects`)")
     p_why.set_defaults(func=_cmd_why)
+
+    p_serve = sub.add_parser(
+        "serve",
+        help="serve the read-only local viewer (localhost only)",
+        description="Serve the read-only local viewer on localhost. Every "
+                    "surface renders an existing engine's output; nothing "
+                    "writes.",
+        epilog="Examples:\n"
+               "  daimon serve\n"
+               "  daimon serve --port 7800 --no-browser\n",
+    )
+    p_serve.add_argument(
+        "--data-dir", default=None,
+        help="checkpoint dir (default: DAIMON_CHECKPOINT_DIR, then ~/.daimon/checkpoints)")
+    p_serve.add_argument(
+        "--project-dir", default=None,
+        help="project directory to scope to (default: cwd)")
+    p_serve.add_argument(
+        "--port", type=int, default=None, help="port to bind (default: 7717)")
+    p_serve.add_argument(
+        "--no-browser", action="store_true", help="don't open a browser tab")
+    p_serve.set_defaults(func=_cmd_serve)
 
     p_projects = sub.add_parser(
         "projects", help="list every project daimon has a checkpoint for",

--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -52,6 +52,11 @@ NOT_AGENT_FACING = {
         "judgement about their own memory, not an agent's"
     ),
     "log": "human bookkeeping: a freeform timeline entry, zero-LLM",
+    "serve": (
+        "human-only viewer: opens a local browser UI for a person to read "
+        "memory; an agent reads the same engines through brief/recall/why "
+        "and has no business holding a server open"
+    ),
     "team": (
         "read side already taught as `daimon brief --team`; the write side "
         "(`init`, `sync`) publishes this machine's memory to a shared remote, "

--- a/plugin/daimon_ui/__main__.py
+++ b/plugin/daimon_ui/__main__.py
@@ -40,5 +40,5 @@ def main(argv=None):
         pass
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover — exercised only as a script
     main()

--- a/plugin/daimon_ui/__main__.py
+++ b/plugin/daimon_ui/__main__.py
@@ -1,0 +1,44 @@
+import argparse
+import webbrowser
+from pathlib import Path
+
+from . import reader, server
+
+
+def build_config(argv, env, cwd: Path):
+    ap = argparse.ArgumentParser(prog="daimon_ui", description="Read-only daimon checkpoint inspector")
+    ap.add_argument("--data-dir", type=Path, default=None)
+    ap.add_argument("--project-dir", type=Path, default=None)
+    # 7717 is the viewer's home port (the design freezes localhost:7717 in its
+    # chrome); pass --port 0 for an ephemeral one.
+    ap.add_argument("--port", type=int, default=7717)
+    ap.add_argument("--no-browser", action="store_true")
+    ns = ap.parse_args(argv)
+    data_dir = ns.data_dir or reader.resolve_data_dir(env)
+    project_dir = ns.project_dir or cwd
+    return {
+        "data_dir": data_dir,
+        "default_slug": reader.project_slug(project_dir),
+        "project_label": Path(project_dir).name,
+        "port": ns.port,
+        "open_browser": not ns.no_browser,
+    }
+
+
+def main(argv=None):
+    import os
+    import sys
+    cfg = build_config(argv if argv is not None else sys.argv[1:], os.environ, Path.cwd())
+    srv = server.make_server(cfg["data_dir"], cfg["default_slug"], cfg["project_label"], cfg["port"])
+    url = f"http://127.0.0.1:{srv.server_address[1]}/"
+    print(f"daimon-ui serving {cfg['project_label']} at {url}  (read-only, Ctrl-C to stop)")
+    if cfg["open_browser"]:
+        webbrowser.open(url)
+    try:
+        srv.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/plugin/daimon_ui/page.html
+++ b/plugin/daimon_ui/page.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>daimon — inspector</title>
+<link rel="stylesheet" href="/static/app.css">
+</head><body>
+<header>
+  <span class="wordmark">daimon</span>
+  <span class="project-label">· <span id="project"></span></span>
+  <nav class="view-nav" aria-label="Views">
+    <span id="back-link-slot"></span>
+    <span id="history-link-slot"></span>
+    <span id="activity-link-slot"></span>
+  </nav>
+  <form id="search-form" role="search">
+    <input id="search-box" type="search" placeholder="search — renders daimon recall"
+           aria-label="Search memory. Results are daimon recall's, rendered.">
+  </form>
+  <!-- branch omitted: checkpoint JSON carries no branch field; reading git would break the file-seam scope -->
+  <span class="ro">READ-ONLY</span>
+</header>
+<div class="shell">
+  <nav id="sidebar" aria-label="Checkpoints"></nav>
+  <!-- #status, not #state, is the live region: #state receives whole views via
+       innerHTML, so announcing it would re-read the entire page on every nav. -->
+  <main id="main"><p id="status" role="status" class="sr-only"></p><div id="state"></div><div id="sections"></div></main>
+</div>
+<footer class="legend">solid verbatim · dashed inferred · dotted untagged · ⟳ carried · tap item → evidence</footer>
+<script type="module" src="/static/app.js"></script>
+</body></html>

--- a/plugin/daimon_ui/page.html
+++ b/plugin/daimon_ui/page.html
@@ -6,8 +6,10 @@
 <link rel="stylesheet" href="/static/app.css">
 </head><body>
 <header>
-  <span class="wordmark">daimon</span>
-  <span class="project-label">· <span id="project"></span></span>
+  <!-- inline SVG needs no xmlns in an HTML document, and the static-audit test
+       rightly refuses any http(s) token in served bytes -->
+  <svg class="wordmark-svg" width="92" height="20" viewBox="0 0 132 28" role="img" aria-label="daimon"><text x="0" y="21" font-family="ui-monospace,Menlo,monospace" font-size="20" font-weight="600" fill="currentColor" letter-spacing="-0.5">daimon</text><rect x="76" y="7" width="9" height="16" fill="#00d4aa"></rect></svg>
+  <span class="project-label"><span id="project"></span></span>
   <nav class="view-nav" aria-label="Views">
     <span id="back-link-slot"></span>
     <span id="history-link-slot"></span>
@@ -18,7 +20,7 @@
            aria-label="Search memory. Results are daimon recall's, rendered.">
   </form>
   <!-- branch omitted: checkpoint JSON carries no branch field; reading git would break the file-seam scope -->
-  <span class="ro">READ-ONLY</span>
+  <span class="ro">daimon serve · ./.daimon · read-only</span>
 </header>
 <div class="shell">
   <nav id="sidebar" aria-label="Checkpoints"></nav>

--- a/plugin/daimon_ui/reader.py
+++ b/plugin/daimon_ui/reader.py
@@ -1,0 +1,618 @@
+"""Read daimon checkpoint JSON from disk. No daimon imports — files are the seam."""
+import base64
+import hashlib
+import json
+import re
+from pathlib import Path
+
+POINTER_RE = re.compile(r"^(latest|prev-[1-9][0-9]?)$")
+ITEM_ID_RE = re.compile(r"^[a-z]-[0-9a-f]{6,40}(-\d+)?$")
+SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{0,63}$")
+
+# vitni/0.2 outputs_hash: multibase base64url-nopad ("u") over multihash
+# sha2-256 (multicodec 0x12 + 32-byte length 0x20). Re-derived here rather
+# than imported — reader.py has no daimon imports, files are the seam.
+_MULTIHASH_SHA256 = bytes([0x12, 0x20])
+
+def _multihash_b64(raw: bytes) -> str:
+    digest = _MULTIHASH_SHA256 + hashlib.sha256(raw).digest()
+    return "u" + base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+def receipt_state(data_dir: Path, data: dict) -> dict:
+    """Cheap tamper check only: sidecar present and outputs_hash covers the ROOT
+    session file's bytes (<data_dir>/<session_id>.json) — a receipt is a statement
+    about a SESSION, keyed by session_id, not about whichever pointer snapshot the
+    caller happened to open. daimon writes several pointer copies during one
+    session but only binds the receipt to the final root bytes, so this is resolved
+    from session_id regardless of what path the checkpoint view is showing.
+    NOT signature verification — that is `daimon verify-receipt` and needs the vitni
+    CLI. Absence of a claim is quiet; a broken claim is loud. Never raises: a receipt
+    problem must not break the checkpoint view.
+    """
+    if not isinstance(data, dict):
+        return {"state": "unsigned", "detail": None}
+    if data.get("receipts") is not True:
+        return {"state": "unsigned", "detail": None}
+
+    sid = data.get("session_id")
+    # sid arrives from file content and is about to be joined to a path — twice.
+    if not isinstance(sid, str) or not SESSION_ID_RE.fullmatch(sid):
+        return {"state": "missing", "detail": None}
+
+    sidecar = data_dir / f"{sid}.receipt"
+    try:
+        want = json.loads(sidecar.read_text(encoding="utf-8"))["receipt"]["outputs_hash"]
+        if not isinstance(want, str):
+            raise KeyError("outputs_hash")
+    except FileNotFoundError:
+        return {"state": "missing", "detail": None}
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return {"state": "missing", "detail": f"{sidecar.name} is not a readable receipt"}
+    except (KeyError, TypeError):
+        # Sidecar parsed fine as JSON — it just doesn't carry outputs_hash. That is
+        # not an unreadable file, so it gets no detail claiming otherwise.
+        return {"state": "missing", "detail": None}
+
+    root = data_dir / f"{sid}.json"
+    try:
+        got = _multihash_b64(root.read_bytes())
+    except OSError:
+        return {"state": "missing", "detail": None}
+
+    return {"state": "match" if got == want else "mismatch", "detail": None}
+
+def receipts_enabled(bucket: Path) -> bool:
+    """Has this project opted into receipts? Answered from the pointer files the
+    sidebar already reads, so a project that never enabled them shows nothing at
+    all rather than being nagged about a feature it declined."""
+    for _ref, path in _pointer_files(bucket):
+        try:
+            parsed = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if isinstance(parsed, dict) and parsed.get("receipts") is True:
+            return True
+    return False
+
+def resolve_data_dir(env=None):
+    import os
+    env = os.environ if env is None else env
+    raw = env.get("DAIMON_CHECKPOINT_DIR")
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".daimon" / "checkpoints"
+
+def project_slug(project_dir):
+    return re.sub(r"[^\w-]", "-", str(project_dir).strip())
+
+def _pointer_files(bucket: Path):
+    if not bucket.is_dir():
+        return []
+    out = []
+    for p in bucket.iterdir():
+        ref = p.name.removesuffix(".json")
+        if p.suffix == ".json" and p.name.endswith(".json") and POINTER_RE.fullmatch(ref):
+            out.append((ref, p))
+    def order(item):
+        ref, _ = item
+        return 0 if ref == "latest" else int(ref.split("-")[1])
+    return sorted(out, key=order)
+
+def list_buckets(data_dir: Path) -> list[dict]:
+    """Discover project buckets under data_dir. A bucket is any subdir containing latest.json
+    (mirrors daimon's own store.list_buckets() semantics) — this naturally skips sidecar dirs
+    like .chunk-cache/ and .partials/ without needing to name them."""
+    if not data_dir.is_dir():
+        return []
+    out = []
+    for p in data_dir.iterdir():
+        if not p.is_dir():
+            continue
+        latest = p / "latest.json"
+        if not latest.is_file():
+            continue
+        created = active_topic = item_count = None
+        try:
+            data = json.loads(latest.read_text(encoding="utf-8"))
+            created = data.get("created")
+            wc = data.get("working_context") or {}
+            es = data.get("epistemic_snapshot") or {}
+            topic = wc.get("active_topic") if isinstance(wc, dict) else None
+            active_topic = topic.get("text") if isinstance(topic, dict) else None
+            count = 0
+            for container, key in (
+                (wc, "open_questions"), (wc, "recent_decisions"),
+                (es, "strong_beliefs"), (es, "uncertainties"), (es, "contradictions_flagged"),
+            ):
+                v = container.get(key) if isinstance(container, dict) else None
+                if isinstance(v, list):
+                    count += len(v)
+            item_count = count
+        except (OSError, json.JSONDecodeError, AttributeError):
+            pass  # torn latest.json: keep the bucket listed, fields stay None
+        out.append({"slug": p.name, "created": created, "active_topic": active_topic, "item_count": item_count})
+    out.sort(key=lambda b: b["created"] or "", reverse=True)  # "" sorts lowest, so None lands last
+    return out
+
+def list_recent(bucket: Path):
+    out = []
+    for ref, path in _pointer_files(bucket):
+        created = topic = None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            created = data.get("created")
+            topic = (data.get("working_context", {}).get("active_topic") or {}).get("text")
+        except (OSError, json.JSONDecodeError, AttributeError):
+            pass  # torn pointer: keep the entry, fields stay None
+        out.append({"ref": ref, "created": created, "active_topic": topic})
+    return out
+
+KNOWN_FORMAT = "D-018"
+
+_SECTIONS = [  # (ui key, label, checkpoint container, checkpoint key)
+    ("decisions", "Decisions", "working_context", "recent_decisions"),
+    # container/key unused: open_loops is derived from open_questions minus external_state items (see loop below)
+    ("open_loops", "Open loops", "working_context", "open_questions"),
+    ("beliefs", "Beliefs", "epistemic_snapshot", "strong_beliefs"),
+    ("uncertainties", "Uncertainties", "epistemic_snapshot", "uncertainties"),
+    ("contradictions", "Contradictions", "epistemic_snapshot", "contradictions_flagged"),
+]
+
+def _norm_str(v):
+    return v if isinstance(v, str) and v else None
+
+def _norm_str_list(v):
+    if not isinstance(v, list):
+        return None
+    return [x for x in v if isinstance(x, str)]
+
+def _norm_provenance(raw):
+    """Normalize a quote_provenance receipt to the subset the panel renders.
+    Each field individually None when absent/wrong-shaped; whole value None
+    when raw is not a dict — absence must read as absence downstream."""
+    if not isinstance(raw, dict):
+        return None
+    digest = raw.get("digest") if isinstance(raw.get("digest"), dict) else {}
+    binding = raw.get("binding") if isinstance(raw.get("binding"), dict) else {}
+    return {
+        "verifier": _norm_str(raw.get("verifier")),
+        "outcome": _norm_str(raw.get("outcome")),
+        "checked_at": _norm_str(raw.get("checked_at")),
+        "digest_algorithm": _norm_str(digest.get("algorithm")),
+        "message_ids": _norm_str_list(binding.get("message_ids")),
+    }
+
+def _norm_item(raw):
+    if isinstance(raw, str):
+        raw = {"text": raw}
+    if not isinstance(raw, dict):
+        return None
+    trust = raw.get("trust")
+    qv = raw.get("quote_verified")
+    imp = raw.get("importance")
+    return {
+        "text": str(raw.get("text", "")),
+        "trust": trust if trust in ("verbatim", "inferred") else None,
+        "carried_from": raw.get("carried_from") or None,
+        "quote": raw.get("quote") or None,
+        "quote_verified": qv if isinstance(qv, bool) else None,
+        "because": raw.get("because") or None,
+        "id": raw.get("id") or None,
+        "external_state": bool(raw.get("external_state")),
+        "importance": imp if isinstance(imp, int) and not isinstance(imp, bool) and 1 <= imp <= 5 else None,
+        "last_verified": _norm_str(raw.get("last_verified")),
+        "origin_session": _norm_str(raw.get("origin_session")),
+        "source_message_ids": _norm_str_list(raw.get("source_message_ids")),
+        "quote_provenance": _norm_provenance(raw.get("quote_provenance")),
+    }
+
+def _normalize(data):
+    """Turn raw checkpoint JSON into (meta, sections, partial). Shared by load_checkpoint
+    (pointer-based) and diff_checkpoints (arbitrary session files) — the seam that lets
+    diff reuse checkpoint normalization without going through the pointer chain."""
+    partial = []
+    fv = data.get("format_version")
+    if fv != KNOWN_FORMAT:
+        partial.append(f"Checkpoint uses schema {fv or 'unknown'}; this inspector understands {KNOWN_FORMAT}. Showing what's readable.")
+
+    wc = data.get("working_context") or {}
+    es = data.get("epistemic_snapshot") or {}
+    containers = {"working_context": wc, "epistemic_snapshot": es}
+    topic = (wc.get("active_topic") or {}) if isinstance(wc.get("active_topic"), dict) else {}
+
+    def items_for(container, key):
+        raw = containers[container].get(key)
+        if raw is None:
+            return []
+        if not isinstance(raw, list):
+            partial.append(f"Section '{key}' has an unexpected shape and was skipped.")
+            return []
+        return [i for i in (_norm_item(r) for r in raw) if i is not None]
+
+    all_questions = items_for("working_context", "open_questions")
+    sections = [
+        {"key": "verify_first", "label": "Verify before trusting",
+         "items": [i for i in all_questions if i["external_state"]]},
+    ]
+    for ui_key, label, container, cp_key in _SECTIONS:
+        if ui_key == "open_loops":
+            items = [i for i in all_questions if not i["external_state"]]
+        else:
+            items = items_for(container, cp_key)
+        sections.append({"key": ui_key, "label": label, "items": items})
+
+    meta = {
+        "created": data.get("created"),
+        "author": data.get("author"),
+        "format_version": fv,
+        "session_id": data.get("session_id"),
+        "active_topic": topic.get("text"),
+    }
+    return meta, sections, partial
+
+def load_checkpoint(data_dir: Path, slug: str, ref: str):
+    bucket = data_dir / slug
+    if not POINTER_RE.fullmatch(ref or ""):
+        return {"ok": False, "error": {
+            "what": f"Checkpoint reference {ref!r} isn't one this inspector serves.",
+            "why": "Only 'latest' and 'prev-N' pointers are served.",
+            "fix": "Pick a checkpoint from the sidebar.",
+        }}
+    path = bucket / f"{ref}.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {"ok": False, "error": {
+            "what": f"Checkpoint {ref} doesn't exist.",
+            "why": "The pointer chain is shorter than requested.",
+            "fix": "Pick a checkpoint from the sidebar.",
+        }}
+    except (OSError, json.JSONDecodeError):
+        return {"ok": False, "error": {
+            "what": f"Couldn't read checkpoint {ref}.",
+            "why": "The file isn't complete JSON — possibly a partial write.",
+            "fix": "Re-run `daimon heal`, or pick another checkpoint from the sidebar.",
+        }}
+
+    meta, sections, partial = _normalize(data)
+    if receipts_enabled(bucket):
+        meta["receipt"] = receipt_state(data_dir, data)
+    return {"ok": True, "partial": partial, "sections": sections, "meta": meta}
+
+def project_history(data_dir: Path, slug: str):
+    sessions, unreadable = [], 0
+    if data_dir.is_dir():
+        for p in data_dir.iterdir():
+            if not p.is_file() or p.suffix != ".json":
+                continue
+            if POINTER_RE.fullmatch(p.name.removesuffix(".json")):
+                continue
+            try:
+                data = json.loads(p.read_text(encoding="utf-8"))
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+                unreadable += 1
+                continue
+            if not isinstance(data, dict) or data.get("project_slug") != slug:
+                continue
+            wc = data.get("working_context") or {}
+            topic = wc.get("active_topic") if isinstance(wc.get("active_topic"), dict) else {}
+            sessions.append({
+                "session_id": p.name.removesuffix(".json"),
+                "created": data.get("created"),
+                "active_topic": (topic or {}).get("text"),
+            })
+    sessions.sort(key=lambda s: s["created"] or "", reverse=True)
+    return {"sessions": sessions, "unreadable": unreadable}
+
+def resolutions(bucket: Path) -> dict:
+    """Fold events.jsonl into last-event-per-item_ref, keeping only resolved ones.
+    Missing bucket/events.jsonl, or a file with no readable resolution events, is {} —
+    not an error. Malformed lines are skipped silently (append-log, may be torn mid-write)."""
+    try:
+        text = (bucket / "events.jsonl").read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return {}
+    folded = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(ev, dict) or ev.get("kind") != "resolution":
+            continue
+        ref = ev.get("item_ref")
+        if not ref:
+            continue
+        folded[ref] = ev
+    return {
+        ref: {"ts": ev.get("ts"), "note": ev.get("note")}
+        for ref, ev in folded.items()
+        if ev.get("status") == "resolved"
+    }
+
+def _activity_events(bucket: Path):
+    rows = []
+    for ev in _jsonl_rows(bucket / "events.jsonl"):
+        kind = _norm_str(ev.get("kind")) or "unknown"
+        note = _norm_str(ev.get("note"))
+        item_text = _norm_str(ev.get("item_text"))
+        status = _norm_str(ev.get("status"))
+        if kind == "corroboration":
+            detail = item_text or note or status
+        elif kind == "handoff":
+            detail = note
+        else:
+            detail = note or item_text
+        rows.append({
+            "ts": _norm_str(ev.get("ts")), "kind": kind, "session_id": None,
+            "item_ref": _norm_str(ev.get("item_ref")), "detail": detail,
+            "extra": {"status": status, "source": _norm_str(ev.get("source")),
+                       "item_text": item_text},
+        })
+    return rows
+
+def _activity_quote_checks(bucket: Path):
+    rows = []
+    for ev in _jsonl_rows(bucket / "verification.jsonl"):
+        check = _norm_str(ev.get("check"))
+        reason = _norm_str(ev.get("reason"))
+        detail = f"{check}: {reason}" if check and reason else (reason or check)
+        rows.append({
+            "ts": _norm_str(ev.get("ts")), "kind": "quote_check", "session_id": None,
+            "item_ref": _norm_str(ev.get("item_ref")), "detail": detail,
+            "extra": {"check": check, "reason": reason},
+        })
+    return rows
+
+def project_activity(data_dir: Path, slug: str) -> dict:
+    """One chronological feed per project: session markers + events.jsonl +
+    verification.jsonl, newest -> oldest. Every row is literally on disk."""
+    hist = project_history(data_dir, slug)
+    rows = []
+    for s in hist["sessions"]:
+        topic = _norm_str(s.get("active_topic"))
+        rows.append({"ts": _norm_str(s.get("created")), "kind": "session",
+                      "session_id": s["session_id"], "item_ref": None,
+                      "detail": topic, "extra": {"topic": topic}})
+    bucket = data_dir / slug
+    rows.extend(_activity_events(bucket))
+    rows.extend(_activity_quote_checks(bucket))
+    rows.sort(key=lambda r: r["ts"] or "", reverse=True)
+    partial = []
+    unreadable = hist.get("unreadable") or 0
+    if unreadable:
+        partial.append(f"{unreadable} session file(s) couldn't be read and are missing from the feed.")
+    return {"ok": True, "rows": rows, "partial": partial}
+
+def _load_session(data_dir: Path, sid: str):
+    path = data_dir / f"{sid}.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None, {
+            "what": f"Session {sid} doesn't exist.",
+            "why": "No checkpoint file was found for that session.",
+            "fix": "Pick a session from the project's history.",
+        }
+    except (OSError, json.JSONDecodeError):
+        return None, {
+            "what": f"Couldn't read session {sid}.",
+            "why": "The file isn't complete JSON — possibly a partial write.",
+            "fix": "Re-run `daimon heal`, or pick another session from the history.",
+        }
+    return data, None
+
+def diff_checkpoints(data_dir: Path, slug: str, sid_a: str, sid_b: str) -> dict:
+    """A=older, B=newer. sid_a/sid_b must exact-match a session_id from project_history —
+    checked before any path is built, so raw input never reaches the filesystem."""
+    valid_ids = {s["session_id"] for s in project_history(data_dir, slug)["sessions"]}
+    for sid in (sid_a, sid_b):
+        if sid not in valid_ids:
+            return {"ok": False, "error": {
+                "what": f"Session {sid!r} isn't part of {slug}'s history.",
+                "why": "The session id doesn't match any recorded checkpoint.",
+                "fix": "Pick a session from the project's history list.",
+            }}
+
+    data_a, err = _load_session(data_dir, sid_a)
+    if err:
+        return {"ok": False, "error": err}
+    data_b, err = _load_session(data_dir, sid_b)
+    if err:
+        return {"ok": False, "error": err}
+
+    meta_a, sections_a, partial_a = _normalize(data_a)
+    meta_b, sections_b, partial_b = _normalize(data_b)
+
+    def index(sections):
+        by_id, skipped = {}, 0
+        for sec in sections:
+            for item in sec["items"]:
+                iid = item.get("id")
+                if not iid:
+                    skipped += 1
+                    continue
+                by_id[iid] = dict(item, section=sec["key"])
+        return by_id, skipped
+
+    map_a, skipped_a = index(sections_a)
+    map_b, skipped_b = index(sections_b)
+    ids_a, ids_b = set(map_a), set(map_b)
+
+    res_fold = resolutions(data_dir / slug)
+
+    born = [map_b[i] for i in sorted(ids_b - ids_a)]
+    resolved, gone = [], []
+    for iid in sorted(ids_a - ids_b):
+        item = map_a[iid]
+        ev = res_fold.get(iid)
+        if ev:
+            resolved.append({"item": item, "note": ev.get("note"), "ts": ev.get("ts")})
+        else:
+            gone.append(item)
+
+    carried, trust_changed = [], []
+    for iid in sorted(ids_a & ids_b):
+        item_a, item_b = map_a[iid], map_b[iid]
+        if item_a.get("trust") != item_b.get("trust"):
+            trust_changed.append({"item": item_b, "from": item_a.get("trust"), "to": item_b.get("trust")})
+        else:
+            carried.append({"item": item_b})
+
+    partial = list(partial_a) + list(partial_b)
+    skipped_total = skipped_a + skipped_b
+    if skipped_total:
+        partial.append(f"Skipped {skipped_total} item(s) without an id during diff.")
+
+    return {
+        "ok": True,
+        "a": meta_a, "b": meta_b,
+        "born": born, "resolved": resolved, "gone": gone,
+        "carried": carried, "trust_changed": trust_changed,
+        "partial": partial,
+    }
+
+def _bad_item_id_error(item_id):
+    return {"ok": False, "error": {
+        "what": f"{item_id!r} isn't a valid item id.",
+        "why": "Item ids look like a-<hex>, e.g. o-1a2b3c4d5e6f — that doesn't.",
+        "fix": "Open the History diff to find current item ids.",
+    }}
+
+def _unknown_item_id_error(item_id):
+    return {"ok": False, "error": {
+        "what": f"No item with id {item_id!r} was found in this project's history.",
+        "why": "The id doesn't match any item across the scanned sessions.",
+        "fix": "Open the History diff to find current item ids.",
+    }}
+
+def _index_items(sections):
+    """id -> normalized item + section, same shape as diff_checkpoints' index()."""
+    by_id = {}
+    for sec in sections:
+        for item in sec["items"]:
+            iid = item.get("id")
+            if iid:
+                by_id[iid] = dict(item, section=sec["key"])
+    return by_id
+
+_BIO_TRACKED_FIELDS = ("trust", "quote_verified", "text")
+
+def _jsonl_rows(path: Path):
+    """Defensive line-by-line jsonl parse: torn/non-dict lines skipped,
+    missing/unreadable file -> []. Shared by verification + activity readers."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    rows = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(ev, dict):
+            rows.append(ev)
+    return rows
+
+def _verification_rows(bucket: Path, item_id: str):
+    return [ev for ev in _jsonl_rows(bucket / "verification.jsonl")
+            if ev.get("item_ref") == item_id]
+
+def _verification_events(bucket: Path, item_id: str):
+    out = []
+    for ev in _verification_rows(bucket, item_id):
+        check, reason = ev.get("check"), ev.get("reason")
+        detail = f"{check}: {reason}" if check and reason else (reason or check)
+        out.append({"kind": "verified", "session_id": None,
+                    "ts_or_created": ev.get("ts"), "detail": detail})
+    return out
+
+def item_biography(data_dir: Path, slug: str, item_id: str) -> dict:
+    """Walk a single item's life across a project's session history, oldest -> newest,
+    merging in verification.jsonl and events.jsonl (resolution) rows from the bucket."""
+    if not ITEM_ID_RE.fullmatch(item_id or ""):
+        return _bad_item_id_error(item_id)
+
+    sessions = list(reversed(project_history(data_dir, slug)["sessions"]))  # oldest -> newest
+
+    events, chain, last_item, prev_sighting = [], [], None, None
+    scanned_count = 0
+    oldest_has_item = False
+
+    for s in sessions:
+        data, err = _load_session(data_dir, s["session_id"])
+        if err:
+            continue  # torn/missing session file: skip, don't abort the whole walk
+        _, sections, _ = _normalize(data)
+        is_first_scanned = scanned_count == 0
+        scanned_count += 1
+
+        item = _index_items(sections).get(item_id)
+        if item is None:
+            continue
+
+        created = s["created"]
+        if prev_sighting is None:
+            if is_first_scanned:
+                oldest_has_item = True
+            events.append({"kind": "born", "session_id": s["session_id"],
+                            "ts_or_created": created, "detail": item.get("quote")})
+            chain.append({"session_id": s["session_id"], "created": created, "changed": []})
+        else:
+            changed_fields = [f for f in _BIO_TRACKED_FIELDS if item.get(f) != prev_sighting.get(f)]
+            if changed_fields:
+                events.append({"kind": "changed", "session_id": s["session_id"],
+                                "ts_or_created": created, "detail": ", ".join(changed_fields)})
+            else:
+                events.append({"kind": "seen", "session_id": s["session_id"],
+                                "ts_or_created": created, "detail": None})
+            chain.append({"session_id": s["session_id"], "created": created,
+                           "changed": changed_fields})
+        prev_sighting = item
+        last_item = item
+
+    if last_item is None:
+        return _unknown_item_id_error(item_id)
+
+    bucket = data_dir / slug
+    events.extend(_verification_events(bucket, item_id))
+
+    res = resolutions(bucket).get(item_id)
+    if res:
+        events.append({"kind": "resolved", "session_id": None,
+                        "ts_or_created": res.get("ts"), "detail": res.get("note")})
+
+    events.sort(key=lambda e: e["ts_or_created"] or "")
+
+    rows = _verification_rows(bucket, item_id)
+    failures = [r for r in rows if r.get("reason")]
+    # origin_session is untrusted checkpoint content -- a value like "../../x" would turn
+    # origin_on_disk into an existence oracle over arbitrary .json paths, so it must match
+    # a conservative session-id shape before it's used in path construction. chain[0]'s
+    # session_id comes from actual scanned filenames and is already safe, but it's run
+    # through the same guard for uniformity.
+    origin_sid = last_item.get("origin_session") or chain[0]["session_id"]
+    origin_sid_safe = origin_sid if SESSION_ID_RE.fullmatch(origin_sid or "") else None
+    anatomy = {
+        "stored": {k: last_item.get(k) for k in
+                   ("trust", "quote", "quote_verified", "last_verified", "origin_session")},
+        "receipt": last_item.get("quote_provenance"),
+        "chain": chain,
+        "checks": {
+            "origin_on_disk": bool(
+                origin_sid_safe and (data_dir / f"{origin_sid_safe}.json").exists()),
+            "quote_check_failures": len(failures),
+            "last_check_ts": max((r.get("ts") for r in failures if r.get("ts")), default=None),
+        },
+    }
+
+    window_note = "history starts here — earlier sessions may have been cleaned up" if oldest_has_item else None
+    return {"ok": True, "item": last_item, "events": events,
+            "window_note": window_note, "trust_anatomy": anatomy}

--- a/plugin/daimon_ui/server.py
+++ b/plugin/daimon_ui/server.py
@@ -1,0 +1,211 @@
+import json
+import re
+from functools import partial
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, unquote, urlsplit
+
+from . import reader
+
+# Engine imports (#670): search and item inspection are served by daimon's own
+# engines — recall.search is the one matcher (the viewer renders recall, it
+# never grows a second search engine) and inspector.inspect_item is the same
+# read-side receipt `daimon why` prints. reader.py stays daimon-import-free
+# (files are its seam); the engine boundary lives here in dispatch only.
+from daimon_briefing import inspector, recall
+
+_PAGE = Path(__file__).parent / "page.html"
+_SLUG_RE = re.compile(r"^[\w-]+$")
+
+_STATIC_DIR = Path(__file__).parent / "static"
+
+# Fixed literal allowlist. Request text is NEVER joined to a directory, never
+# normalized, never resolved. An unlisted name 404s without touching the filesystem.
+_STATIC = {
+    "app.css": (_STATIC_DIR / "app.css", "text/css; charset=utf-8"),
+    "state.js": (_STATIC_DIR / "state.js", "text/javascript; charset=utf-8"),
+    "render.js": (_STATIC_DIR / "render.js", "text/javascript; charset=utf-8"),
+    "app.js": (_STATIC_DIR / "app.js", "text/javascript; charset=utf-8"),
+}
+
+class _Handler(BaseHTTPRequestHandler):
+    def __init__(self, data_dir, default_slug, project_label, *a, **kw):
+        self.data_dir = data_dir
+        self.default_slug = default_slug
+        self.project_label = project_label
+        super().__init__(*a, **kw)
+
+    def log_message(self, *a):  # keep the terminal quiet
+        pass
+
+    def _send(self, status, ctype, body: bytes):
+        self.send_response(status)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _json(self, obj):
+        self._send(200, "application/json", json.dumps(obj).encode("utf-8"))
+
+    def _label_for(self, slug):
+        return self.project_label if slug == self.default_slug else slug
+
+    def _bad_slug_error(self, raw_slug):
+        return {"ok": False, "error": {
+            "what": f"Project {raw_slug!r} isn't one this inspector knows.",
+            "why": "The slug doesn't match a project directory discovered under the data dir.",
+            "fix": "Pick a project from the grid, or check the URL.",
+        }}
+
+    def _resolve_slug(self, params):
+        """Slug is accepted only if it matches ^[\\w-]+$ AND exact-matches a name from a
+        fresh list_buckets() scan. Never joined to a path before that double-check passes."""
+        raw = params.get("project", [self.default_slug])[0]
+        if not _SLUG_RE.fullmatch(raw or ""):
+            return None
+        buckets = reader.list_buckets(self.data_dir)
+        if not any(b["slug"] == raw for b in buckets):
+            return None
+        return raw
+
+    def do_GET(self):
+        host = (self.headers.get("Host") or "").rsplit(":", 1)[0].lower()
+        if host not in ("127.0.0.1", "localhost"):
+            self._send(403, "text/plain", b"forbidden: bad host header")
+            return
+        parsed = urlsplit(self.path)
+        path = unquote(parsed.path)
+        params = parse_qs(parsed.query)
+        if path == "/":
+            self._send(200, "text/html; charset=utf-8", _PAGE.read_bytes())
+        elif path == "/api/projects":
+            self._json({"projects": reader.list_buckets(self.data_dir), "current": self.default_slug})
+        elif path == "/api/checkpoints":
+            slug = self._resolve_slug(params)
+            if slug is None:
+                self._json(self._bad_slug_error(params.get("project", [self.default_slug])[0]))
+                return
+            bucket = self.data_dir / slug
+            # list_recent serves the pointer window; project_history serves every
+            # session file for the slug. The sidebar needs both numbers or it
+            # silently presents a window as if it were the whole history.
+            self._json({"project": self._label_for(slug),
+                        "checkpoints": reader.list_recent(bucket),
+                        "sessions_total": len(reader.project_history(self.data_dir, slug)["sessions"])})
+        elif path.startswith("/api/checkpoint/"):
+            slug = self._resolve_slug(params)
+            if slug is None:
+                self._json(self._bad_slug_error(params.get("project", [self.default_slug])[0]))
+                return
+            ref = path.removeprefix("/api/checkpoint/")
+            self._json(reader.load_checkpoint(self.data_dir, slug, ref))
+        elif path == "/api/history":
+            slug = self._resolve_slug(params)
+            if slug is None:
+                self._json(self._bad_slug_error(params.get("project", [self.default_slug])[0]))
+                return
+            result = reader.project_history(self.data_dir, slug)
+            result["project"] = self._label_for(slug)
+            self._json(result)
+        elif path == "/api/diff":
+            slug = self._resolve_slug(params)
+            if slug is None:
+                self._json(self._bad_slug_error(params.get("project", [self.default_slug])[0]))
+                return
+            a = params.get("a", [None])[0]
+            b = params.get("b", [None])[0]
+            if a is None or b is None:
+                hist = reader.project_history(self.data_dir, slug)
+                sessions = hist["sessions"]
+                if len(sessions) < 2:
+                    self._json({"ok": True, "empty": "single_checkpoint", "sessions": len(sessions)})
+                    return
+                a = sessions[1]["session_id"]
+                b = sessions[0]["session_id"]
+            self._json(reader.diff_checkpoints(self.data_dir, slug, a, b))
+        elif path == "/api/biography":
+            slug = self._resolve_slug(params)
+            if slug is None:
+                self._json(self._bad_slug_error(params.get("project", [self.default_slug])[0]))
+                return
+            item_id = params.get("id", [None])[0]
+            self._json(reader.item_biography(self.data_dir, slug, item_id))
+        elif path == "/api/recall":
+            slug = self._resolve_slug(params)
+            if slug is None:
+                self._json(self._bad_slug_error(params.get("project", [self.default_slug])[0]))
+                return
+            q = params.get("q", [None])[0]
+            if not q or not q.strip():
+                self._json({"ok": False, "error": {
+                    "what": "No search query was given.",
+                    "why": "/api/recall needs a q parameter to match against.",
+                    "fix": "Type something in the search box.",
+                }})
+                return
+            raw_limit = params.get("limit", ["20"])[0]
+            try:
+                limit = int(raw_limit)
+                if limit < 1:
+                    raise ValueError
+            except ValueError:
+                self._json({"ok": False, "error": {
+                    "what": f"limit {raw_limit!r} isn't a positive whole number.",
+                    "why": "The result window must be at least 1.",
+                    "fix": "Drop the limit parameter or pass a positive number.",
+                }})
+                return
+            try:
+                rows = recall.search(q, slug=slug, limit=limit)
+            except recall.RecallError as exc:
+                self._json({"ok": False, "error": {
+                    "what": "Search is unavailable.",
+                    "why": str(exc),
+                    "fix": "Check that this Python's sqlite3 has FTS5.",
+                }})
+                return
+            self._json({"ok": True, "rows": rows})
+        elif path == "/api/why":
+            slug = self._resolve_slug(params)
+            if slug is None:
+                self._json(self._bad_slug_error(params.get("project", [self.default_slug])[0]))
+                return
+            item_id = params.get("id", [None])[0]
+            if not inspector.valid_item_id(item_id or ""):
+                self._json({"ok": False, "error": {
+                    "what": f"{item_id!r} isn't a valid item id.",
+                    "why": "Item ids look like a-<hex>, e.g. o-1a2b3c4d5e6f.",
+                    "fix": "Open an entry from search or the checkpoint view.",
+                }})
+                return
+            include_source = params.get("source", ["0"])[0] not in ("0", "", "false")
+            result = inspector.inspect_item(slug, item_id, include_source=include_source)
+            if result is None:
+                self._json({"ok": False, "error": {
+                    "what": f"No item with id {item_id!r} in this project.",
+                    "why": "The id doesn't match any item across the project's checkpoints.",
+                    "fix": "Search for the item to find its current id.",
+                }})
+                return
+            self._json(dict({"ok": True}, **result))
+        elif path == "/api/activity":
+            slug = self._resolve_slug(params)
+            if slug is None:
+                self._json(self._bad_slug_error(params.get("project", [self.default_slug])[0]))
+                return
+            self._json(reader.project_activity(self.data_dir, slug))
+        elif path.startswith("/static/"):
+            entry = _STATIC.get(path[len("/static/"):])
+            if entry is None:
+                self._send(404, "text/plain", b"not found")
+                return
+            file_path, ctype = entry
+            self._send(200, ctype, file_path.read_bytes())
+        else:
+            self._send(404, "text/plain", b"not found")
+
+def make_server(data_dir: Path, default_slug: str, project_label: str, port: int = 0):
+    handler = partial(_Handler, data_dir, default_slug, project_label)
+    return ThreadingHTTPServer(("127.0.0.1", port), handler)

--- a/plugin/daimon_ui/static/app.css
+++ b/plugin/daimon_ui/static/app.css
@@ -1,0 +1,762 @@
+  :root {
+    --s1: 4px; --s2: 8px; --s3: 12px; --s4: 16px; --s6: 24px; --s8: 32px;
+
+    --fs-xs: 0.75rem;  /* 12px */
+    --fs-sm: 0.875rem; /* 14px */
+    --fs-base: 1rem;   /* 16px */
+    --fs-lg: 1.5rem;   /* 24px */
+
+    --paper: #f6f7f5;
+    --surface: #eceeec;
+    --surface-hover: #e3e5e2;
+    --border-subtle: #dfe2df;
+    --border-strong: #c9cdc9;
+    --border-inferred: #7d8279;
+    --ink: #1d211f;
+    --ink-secondary: #52584f;
+    --ink-tertiary: #626760;
+    --accent: #0e7264;
+    --accent-wash: rgba(14, 114, 100, 0.14);
+    --accent-chip-text: #0b5f54; /* darker than --accent — clears 4.5:1 on the wash-tinted chip bg */
+    --danger: #9a3b32;
+    --danger-wash: rgba(154, 59, 50, 0.08);
+    --amber: #92610e;
+    --amber-wash: rgba(146, 97, 14, 0.12);
+    --amber-chip-text: #7a4f0b; /* darker than --amber — clears 4.5:1 on the wash-tinted chip bg */
+
+    --mono: ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    --transition: 180ms ease;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --paper: #171a19;
+      --surface: #1e2221;
+      --surface-hover: #242826;
+      --border-subtle: #272c2a;
+      --border-strong: #343a37;
+      --border-inferred: #65706a;
+      --ink: #eef0ee;
+      --ink-secondary: #9ba69f;
+      --ink-tertiary: #8b9691;
+      --accent: #4fb3a5;
+      --accent-wash: rgba(79, 179, 165, 0.14);
+      --accent-chip-text: var(--accent); /* dark already clears 4.5:1 at this wash alpha */
+      --danger: #d98f86;
+      --danger-wash: rgba(217, 143, 134, 0.12);
+      --amber: #e0b466;
+      --amber-wash: rgba(224, 180, 102, 0.12);
+      --amber-chip-text: var(--amber); /* dark already clears 4.5:1 at this wash alpha */
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      transition-duration: 0.01ms !important;
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+    }
+  }
+
+  * { box-sizing: border-box; }
+
+  html, body {
+    margin: 0;
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--sans);
+    line-height: 1.5;
+  }
+
+  body {
+    font-size: var(--fs-sm);
+  }
+
+  a { color: var(--accent); }
+
+  button {
+    font-family: inherit;
+    color: inherit;
+  }
+
+  :focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  header {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--s3);
+    padding: var(--s3) var(--s6);
+    border-bottom: 1px solid var(--border-subtle);
+    position: sticky;
+    top: 0;
+    background: var(--paper);
+    z-index: 10;
+  }
+
+  @media (max-width: 560px) {
+    header { padding: var(--s3) var(--s4); }
+  }
+
+  header .wordmark {
+    font-size: var(--fs-lg);
+    font-weight: 700;
+    line-height: 1.33;
+  }
+
+  header .project-label {
+    font-size: var(--fs-sm);
+    color: var(--ink-secondary);
+  }
+
+  /* The three view-link slots used to be direct children of the flex header. The
+     <nav> landmark wraps them without changing the layout: same gap, and empty
+     slots are hidden so their flex gaps do not leave phantom space. */
+  .view-nav {
+    display: flex;
+    align-items: center;
+    gap: var(--s3);
+  }
+
+  .view-nav > span:empty { display: none; }
+
+  /* Announcement-only text: read by screen readers, never painted. Not
+     display:none and not hidden — either of those drops it from the
+     accessibility tree and nothing would be announced. */
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  .ro {
+    margin-left: auto;
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    color: var(--ink-secondary);
+    background: var(--surface);
+    border: 1px solid var(--border-subtle);
+    border-radius: 4px;
+    padding: var(--s1) var(--s2);
+  }
+
+  .shell {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: var(--s6);
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: var(--s6);
+  }
+
+  @media (max-width: 560px) {
+    .shell { grid-template-columns: 1fr; }
+  }
+
+  #sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s2);
+  }
+
+  .cp-item {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s1);
+    text-align: left;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 4px;
+    padding: var(--s3) var(--s4);
+    cursor: pointer;
+    transition: background var(--transition), border-color var(--transition);
+  }
+
+  .cp-item:hover { background: var(--surface-hover); }
+
+  .cp-item.active {
+    border-left-color: var(--accent);
+    background: var(--accent-wash);
+  }
+
+  .cp-topic {
+    font-size: var(--fs-sm);
+    font-weight: 500;
+    color: var(--ink);
+  }
+
+  .cp-meta {
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    color: var(--ink-tertiary);
+  }
+
+  .cp-scope {
+    margin: var(--s3) 0 0;
+    padding: 0 var(--s4);
+    font-size: var(--fs-xs);
+    line-height: 1.45;
+    color: var(--ink-tertiary);
+  }
+
+  #main { min-width: 0; }
+
+  #state:empty, #sections:empty { display: none; }
+
+  .banner {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--s2);
+    background: var(--amber-wash);
+    border: 1px solid var(--amber);
+    border-radius: 4px;
+    padding: var(--s3);
+    margin-bottom: var(--s4);
+    font-size: var(--fs-sm);
+    color: var(--ink);
+  }
+
+  .banner-icon { color: var(--amber); flex-shrink: 0; }
+
+  .state-card {
+    max-width: 65ch;
+    background: var(--surface);
+    border: 1px solid var(--border-strong);
+    border-radius: 4px;
+    padding: var(--s4);
+  }
+
+  .state-card p { margin: 0 0 var(--s2) 0; }
+  .state-card p:last-child { margin-bottom: 0; }
+
+  .state-title {
+    font-weight: 600;
+    font-size: var(--fs-base);
+  }
+
+  .state-error {
+    background: var(--danger-wash);
+    border-color: var(--danger);
+  }
+
+  .state-error .state-title { color: var(--danger); }
+
+  .state-card code {
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    background: var(--surface);
+    border: 1px solid var(--border-subtle);
+    border-radius: 4px;
+    padding: 0 var(--s1);
+  }
+
+  .page-heading {
+    font-size: var(--fs-base);
+    font-weight: 600;
+    line-height: 1.4;
+    margin: 0 0 var(--s1) 0;
+  }
+
+  .page-meta {
+    font-size: var(--fs-sm);
+    color: var(--ink-secondary);
+    margin: 0 0 var(--s4) 0;
+  }
+
+  .sec { margin-bottom: var(--s6); }
+
+  .sec-toggle {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    gap: var(--s2);
+    text-align: left;
+    background: none;
+    border: none;
+    border-bottom: 1px solid var(--border-subtle);
+    border-radius: 4px;
+    margin: 0 0 var(--s3) 0;
+    padding: var(--s3) var(--s1);
+    font-size: var(--fs-base);
+    font-weight: 600;
+    line-height: 1.4;
+    cursor: pointer;
+    transition: background var(--transition), border-color var(--transition);
+  }
+
+  .sec-toggle:hover:not(:disabled) { background: var(--surface-hover); }
+
+  .sec-toggle:disabled {
+    cursor: default;
+    color: var(--ink-tertiary);
+  }
+
+  .sec-toggle .count {
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    font-weight: 600;
+    color: var(--accent);
+  }
+
+  .sec-toggle:disabled .count { color: var(--ink-tertiary); }
+
+  .sec-toggle .disclosure {
+    margin-left: auto;
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    color: var(--ink-secondary);
+  }
+
+  .sec-verify {
+    background: var(--amber-wash);
+    border: 1px solid var(--amber);
+    border-radius: 4px;
+    padding: var(--s4);
+  }
+
+  .sec-verify .sec-toggle { border-bottom-color: var(--amber); }
+
+  .it-wrap { margin-bottom: var(--s2); }
+
+  .it {
+    display: block;
+    width: 100%;
+    text-align: left;
+    background: var(--surface);
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 4px;
+    padding: var(--s3) var(--s4);
+    font-size: var(--fs-sm);
+    line-height: 1.5;
+  }
+
+  button.it { cursor: pointer; transition: background var(--transition); }
+  button.it:hover { background: var(--surface-hover); }
+
+  .it-verbatim { border-left: 3px solid var(--accent); color: var(--ink); }
+  .it-inferred { border-left: 3px dashed var(--border-inferred); color: var(--ink); }
+  .it-untagged { border-left: 3px dotted var(--ink-tertiary); color: var(--ink-secondary); }
+
+  .chip-carried {
+    display: inline-block;
+    margin-left: var(--s2);
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    color: var(--ink-tertiary);
+    border: 1px dashed var(--border-inferred);
+    border-radius: 4px;
+    padding: 0 var(--s1);
+  }
+
+  .ev {
+    margin-top: var(--s2);
+    background: var(--paper);
+    border-left: 3px solid var(--accent);
+    border-radius: 4px;
+    padding: var(--s3) var(--s4);
+    max-width: 65ch;
+  }
+
+  .ev-tag {
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    color: var(--accent);
+  }
+
+  .ev-quote {
+    font-family: var(--mono);
+    font-style: italic;
+    font-size: var(--fs-sm);
+    color: var(--ink);
+    margin-top: var(--s1);
+  }
+
+  .ev-because {
+    font-size: var(--fs-sm);
+    color: var(--ink-secondary);
+    margin-top: var(--s2);
+  }
+
+  .skeleton {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s2);
+  }
+
+  .skel-bar, .skel-row {
+    background: var(--surface);
+    border-radius: 4px;
+    animation: skel-pulse 1.4s ease-in-out infinite;
+  }
+
+  .skel-bar { height: var(--s4); width: 30%; }
+  .skel-row { height: 48px; width: 100%; }
+
+  @keyframes skel-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.55; }
+  }
+
+  .shell.grid-view { grid-template-columns: 1fr; }
+
+  .proj-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: var(--s4);
+  }
+
+  .proj-card {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--s1);
+    text-align: left;
+    background: var(--surface);
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 4px;
+    padding: var(--s4);
+    cursor: pointer;
+    transition: background var(--transition), border-color var(--transition);
+  }
+
+  .proj-card:hover { background: var(--surface-hover); }
+
+  .proj-card.current {
+    border-left-color: var(--accent);
+    background: var(--accent-wash);
+  }
+
+  .proj-title {
+    font-size: var(--fs-sm);
+    font-weight: 500;
+    color: var(--ink);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .proj-slug, .proj-meta {
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    color: var(--ink-tertiary);
+  }
+
+  .proj-chip {
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    color: var(--accent);
+    border: 1px solid var(--accent);
+    border-radius: 4px;
+    padding: 0 var(--s1);
+  }
+
+  .back-link {
+    display: inline-flex;
+    align-items: center;
+    background: none;
+    border: none;
+    color: var(--accent);
+    font-size: var(--fs-sm);
+    font-weight: 500;
+    cursor: pointer;
+    padding: var(--s3);
+    min-height: 44px;
+    border-radius: 4px;
+    transition: background var(--transition);
+  }
+
+  .back-link:hover { background: var(--surface-hover); }
+
+  .history-link {
+    background: none;
+    border: none;
+    color: var(--accent);
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    padding: var(--s4) var(--s3);
+    border-radius: 4px;
+    transition: background var(--transition);
+  }
+
+  .history-link:hover { background: var(--surface-hover); }
+
+  .sess-pickbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--s2);
+    margin-bottom: var(--s4);
+  }
+
+  .sess-label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s1);
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    color: var(--ink-secondary);
+    flex: 1 1 240px;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .sess-pick {
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    color: var(--ink);
+    background: var(--surface);
+    border: 1px solid var(--border-subtle);
+    border-radius: 4px;
+    padding: var(--s2) var(--s3);
+    min-height: 44px;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .tag-chip {
+    display: inline-block;
+    margin-right: var(--s2);
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    border-radius: 4px;
+    padding: 0 var(--s1);
+  }
+
+  .t-born { background: var(--accent-wash); color: var(--accent-chip-text); border: 1px solid var(--accent); }
+  .t-resolved { background: var(--amber-wash); color: var(--amber-chip-text); border: 1px solid var(--amber); }
+  .t-carried { background: none; color: var(--ink-tertiary); border: 1px dashed var(--border-inferred); }
+  /* Contract §8.4: LAST SEEN is a status, not a failure — danger paint here
+     rendered a judgment no word supplies (rule 1). Solid border against
+     .t-carried's dashed keeps the two states distinguishable without colour. */
+  .t-gone { background: none; color: var(--ink-tertiary); border: 1px solid var(--border-inferred); }
+  .t-trust { background: var(--accent-wash); color: var(--accent-chip-text); border: 1px solid var(--accent); }
+
+  .hist-note {
+    margin-top: var(--s1);
+    max-width: 65ch;
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    color: var(--ink-secondary);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .hist-suffix {
+    margin-left: var(--s2);
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    color: var(--ink-tertiary);
+  }
+
+  .history-btn {
+    display: inline-block;
+    background: none;
+    border: none;
+    color: var(--accent);
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    padding: var(--s4) var(--s3);
+    margin-top: var(--s2);
+    margin-left: calc(-1 * var(--s3));
+    border-radius: 4px;
+    transition: background var(--transition);
+  }
+
+  .history-btn:hover { background: var(--surface-hover); }
+
+  .bio-panel { margin-top: var(--s2); }
+
+  .life-note {
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    color: var(--ink-secondary);
+    margin: 0 0 var(--s2) 0;
+  }
+
+  .act-row .life-label { min-width: 96px; }
+  .act-ref { margin-top: var(--s1); font-size: var(--fs-xs); }
+  .act-ref-raw { font-family: var(--mono); color: var(--ink-tertiary); overflow-wrap: anywhere; }
+  /* The item id is the only thing distinguishing otherwise-identical rows, so it is
+     printed next to the toggle rather than hidden behind its "View history" label. */
+  .act-ref-id {
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    color: var(--ink-secondary);
+    overflow-wrap: anywhere;
+    margin-right: var(--s2);
+  }
+  .act-item-text { color: var(--ink-secondary); }
+
+  .trust-anatomy { border: 1px solid var(--border-subtle); border-radius: 4px;
+    padding: var(--s4); margin-bottom: var(--s4); background: var(--surface); }
+  .ta-row { display: flex; gap: var(--s4); padding: var(--s1) 0; font-size: var(--fs-sm); }
+  .ta-row + .ta-row { border-top: 1px solid var(--border-subtle); }
+  .ta-label { flex: 0 0 64px; color: var(--ink-secondary); font-size: var(--fs-xs);
+    text-transform: uppercase; letter-spacing: 0.04em; padding-top: var(--s1); }
+  .ta-val { flex: 1; min-width: 0; color: var(--ink); overflow-wrap: anywhere; }
+  .ta-none { color: var(--ink-tertiary); }
+  .ta-quote { font-family: var(--mono); font-size: var(--fs-xs); }
+  .ta-chain-row { display: flex; gap: var(--s2); font-size: var(--fs-xs);
+    color: var(--ink-secondary); padding: var(--s1) 0; }
+  .ta-chain-sid { font-family: var(--mono); }
+  .ta-flag-ok { color: var(--ink-secondary); }
+  .ta-flag-warn { color: var(--amber-chip-text); background: var(--amber-wash);
+    border-radius: 4px; padding: 0 var(--s1); }
+
+  .life {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    max-width: 65ch;
+  }
+
+  .life-row {
+    display: grid;
+    grid-template-columns: var(--s4) 1fr;
+    column-gap: var(--s3);
+  }
+
+  .life-rail { position: relative; display: flex; justify-content: center; }
+
+  .life-row:not(:last-child) .life-rail::after {
+    content: "";
+    position: absolute;
+    top: var(--s3);
+    bottom: 0;
+    width: 1px;
+    background: var(--border-subtle);
+  }
+
+  .life-dot {
+    width: var(--s2);
+    height: var(--s2);
+    border-radius: 50%;
+    margin-top: var(--s1);
+    flex-shrink: 0;
+  }
+
+  .life-dot-born, .life-dot-changed { background: var(--accent); }
+  .life-dot-resolved { background: var(--amber); }
+  /* One verification.jsonl row, one paint (contract §8.4): the bio's "verified"
+     kind and the activity feed's quote_check kind are the same ledger rows, and
+     both now read QUOTE CHECK. The old split — accent ring in the bio, danger
+     in the feed — had the bio pointing the wrong way on what is a rejection
+     log, and the feed rendering a judgment (rule 1). Neutral ring for both:
+     distinct from ordinary traffic without asserting an outcome. */
+  .life-dot-verified, .life-dot-flagged { background: var(--paper); border: 2px solid var(--ink-tertiary); }
+  .life-dot-seen { background: var(--paper); border: 1px dashed var(--border-inferred); }
+
+  .life-body { padding-bottom: var(--s3); min-width: 0; }
+  .life-row:last-child .life-body { padding-bottom: 0; }
+
+  .life-label {
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    color: var(--ink-secondary);
+  }
+
+  .life-when {
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    color: var(--ink-tertiary);
+    margin-left: var(--s2);
+  }
+
+  .life-detail {
+    font-size: var(--fs-sm);
+    color: var(--ink);
+    margin-top: var(--s1);
+    overflow-wrap: anywhere;
+  }
+
+  .life-quote {
+    font-family: var(--mono);
+    font-style: italic;
+    font-size: var(--fs-sm);
+    color: var(--ink);
+    margin-top: var(--s1);
+    overflow-wrap: anywhere;
+  }
+
+  footer.legend {
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    color: var(--ink-tertiary);
+    text-align: center;
+    padding: var(--s4) var(--s6) var(--s8);
+  }
+
+  /* ---- search + why (#670) ---- */
+  #search-form { margin-left: auto; }
+  #search-box {
+    width: 240px; padding: 4px 10px; border: 1px solid var(--line, var(--ink-tertiary));
+    border-radius: 6px; background: var(--surface); color: var(--ink);
+    font: inherit; font-size: 13px;
+  }
+  .search-head { display: flex; align-items: baseline; gap: 12px; margin-bottom: 12px; }
+  .search-title { font-weight: 600; }
+  .search-note { color: var(--ink-tertiary); font-size: 12px; }
+  .search-rows { display: flex; flex-direction: column; }
+  .search-row {
+    display: flex; align-items: baseline; gap: 8px; width: 100%; text-align: left;
+    padding: 10px 12px; border: 0; border-bottom: 1px solid var(--surface-hover);
+    background: none; color: var(--ink); cursor: pointer; font: inherit;
+  }
+  .search-row:hover { background: var(--surface-hover); }
+  .search-trust, .search-kind, .search-meta { color: var(--ink-tertiary); font-size: 12px; white-space: nowrap; }
+  .search-text { flex: 1; }
+  .search-id { color: var(--accent-chip-text, var(--accent)); font-size: 12px; }
+  .why-view { display: flex; flex-direction: column; gap: 16px; }
+  .why-claim { font-size: 15px; display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; }
+  .why-origin { color: var(--ink-tertiary); font-size: 12px; }
+  .why-label {
+    display: block; font-size: 10px; letter-spacing: .1em; text-transform: uppercase;
+    color: var(--ink-tertiary); margin-bottom: 6px;
+  }
+  .why-quote blockquote {
+    margin: 0; padding-left: 12px; border-left: 2px solid var(--ink-tertiary);
+    font-family: ui-monospace, Menlo, monospace; font-size: 13px;
+  }
+  .why-none { color: var(--ink-tertiary); }
+  .why-axes dl { display: grid; grid-template-columns: max-content 1fr; gap: 4px 16px; margin: 0; }
+  .why-axes dt { color: var(--ink-secondary); font-size: 12px; }
+  .why-axes dd { margin: 0; font-size: 12px; font-family: ui-monospace, Menlo, monospace; }
+  .why-cor p { margin: 0; font-size: 12px; }
+  .why-source pre {
+    margin: 0; padding: 10px 12px; background: var(--surface); border-radius: 6px;
+    font-size: 12px; overflow-x: auto; white-space: pre-wrap;
+  }

--- a/plugin/daimon_ui/static/app.css
+++ b/plugin/daimon_ui/static/app.css
@@ -418,22 +418,43 @@
     transition: background var(--transition), border-color var(--transition);
   }
 
-  .proj-card:hover { background: var(--surface-hover); }
+  .proj-card:hover { background: var(--surface-hover); border-color: #484f58; }
 
   .proj-card.current {
     border-left-color: var(--accent);
-    background: var(--accent-wash);
   }
 
-  .proj-title {
-    font-size: var(--fs-sm);
-    font-weight: 500;
+  .proj-top { display: flex; align-items: baseline; gap: 8px; width: 100%; }
+
+  .proj-name {
+    font-family: var(--mono);
+    font-size: 13px;
+    font-weight: 600;
     color: var(--ink);
+  }
+
+  .proj-age {
+    margin-left: auto;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--ink-tertiary);
+  }
+
+  /* The topic is the card's substance: the sentence this project left off on. */
+  .proj-topic {
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--ink-secondary);
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
+    min-height: 2.6em;
   }
+
+  .proj-topic-dim { color: var(--ink-tertiary); font-style: italic; }
+
+  .proj-foot { display: flex; align-items: baseline; gap: 10px; width: 100%; min-width: 0; }
 
   .proj-slug, .proj-meta {
     font-family: var(--mono);
@@ -441,16 +462,33 @@
     color: var(--ink-tertiary);
   }
 
+  /* Slugs overflow from the LEFT so the distinguishing tail stays visible;
+     rtl only reorders the rendered clip, the text itself is untouched. */
+  .proj-foot .proj-slug {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    direction: rtl;
+    text-align: left;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .proj-foot .proj-meta { flex: none; }
+
   .proj-chip {
     font-family: var(--mono);
-    font-size: var(--fs-xs);
+    font-size: 10px;
     font-weight: 600;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
     color: var(--accent);
     border: 1px solid var(--accent);
     border-radius: 4px;
     padding: 0 var(--s1);
   }
+
+  .grid-head { display: flex; align-items: baseline; gap: 12px; margin-bottom: 14px; }
 
   .back-link {
     display: inline-flex;

--- a/plugin/daimon_ui/static/app.css
+++ b/plugin/daimon_ui/static/app.css
@@ -6,49 +6,31 @@
     --fs-base: 1rem;   /* 16px */
     --fs-lg: 1.5rem;   /* 24px */
 
-    --paper: #f6f7f5;
-    --surface: #eceeec;
-    --surface-hover: #e3e5e2;
-    --border-subtle: #dfe2df;
-    --border-strong: #c9cdc9;
-    --border-inferred: #7d8279;
-    --ink: #1d211f;
-    --ink-secondary: #52584f;
-    --ink-tertiary: #626760;
-    --accent: #0e7264;
-    --accent-wash: rgba(14, 114, 100, 0.14);
-    --accent-chip-text: #0b5f54; /* darker than --accent — clears 4.5:1 on the wash-tinted chip bg */
-    --danger: #9a3b32;
-    --danger-wash: rgba(154, 59, 50, 0.08);
-    --amber: #92610e;
-    --amber-wash: rgba(146, 97, 14, 0.12);
-    --amber-chip-text: #7a4f0b; /* darker than --amber — clears 4.5:1 on the wash-tinted chip bg */
+    /* Frozen viewer palette: one dark look, committed on purpose. Values come
+       from the design reference; this file does not carry a light theme. */
+    --paper: #090c10;
+    --surface: #0d1117;
+    --surface-hover: #111820;
+    --raised: #161b22;
+    --inset: #0b0f14;
+    --border-subtle: #21262d;
+    --border-strong: #30363d;
+    --border-inferred: #8b949e;
+    --ink: #e6edf3;
+    --ink-secondary: #8b949e;
+    --ink-tertiary: #6e7681;
+    --accent: #00d4aa;
+    --accent-wash: rgba(0, 212, 170, 0.12);
+    --accent-chip-text: #00d4aa;
+    --danger: #d98f86;
+    --danger-wash: rgba(217, 143, 134, 0.12);
+    --amber: #e0b466;
+    --amber-wash: rgba(224, 180, 102, 0.12);
+    --amber-chip-text: #e0b466;
 
     --mono: ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas, monospace;
-    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    --sans: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
     --transition: 180ms ease;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --paper: #171a19;
-      --surface: #1e2221;
-      --surface-hover: #242826;
-      --border-subtle: #272c2a;
-      --border-strong: #343a37;
-      --border-inferred: #65706a;
-      --ink: #eef0ee;
-      --ink-secondary: #9ba69f;
-      --ink-tertiary: #8b9691;
-      --accent: #4fb3a5;
-      --accent-wash: rgba(79, 179, 165, 0.14);
-      --accent-chip-text: var(--accent); /* dark already clears 4.5:1 at this wash alpha */
-      --danger: #d98f86;
-      --danger-wash: rgba(217, 143, 134, 0.12);
-      --amber: #e0b466;
-      --amber-wash: rgba(224, 180, 102, 0.12);
-      --amber-chip-text: var(--amber); /* dark already clears 4.5:1 at this wash alpha */
-    }
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -760,3 +742,108 @@
     margin: 0; padding: 10px 12px; background: var(--surface); border-radius: 6px;
     font-size: 12px; overflow-x: auto; white-space: pre-wrap;
   }
+
+  /* ---- design conformance (#670): frozen viewer look ---- */
+  header {
+    background: var(--paper);
+    border-bottom: 1px solid var(--border-subtle);
+    gap: var(--s3);
+  }
+  header .wordmark-svg { color: var(--ink); display: block; }
+  header .project-label { font-family: var(--mono); font-size: 11.5px; color: var(--ink-tertiary); }
+  header .ro {
+    font-family: var(--mono); font-size: 11px; color: var(--ink-tertiary);
+    background: none; border: 0; padding: 0; letter-spacing: 0;
+  }
+  .view-nav button, .back-link {
+    font-family: var(--mono); font-size: 11px; color: var(--ink-secondary);
+    background: none; border: 1px solid var(--border-strong); border-radius: 6px;
+    padding: 4px 10px; cursor: pointer;
+  }
+  .view-nav button:hover, .back-link:hover { border-color: #484f58; color: var(--ink); }
+  #search-box {
+    border-color: var(--border-strong); background: var(--raised); color: var(--ink);
+    font-family: var(--mono); font-size: 11.5px;
+  }
+  #search-box::placeholder { color: var(--ink-tertiary); }
+  #sidebar { background: var(--inset); border-right: 1px solid var(--border-subtle); }
+
+  .brief-head { display: flex; align-items: baseline; gap: 12px; }
+  .brief-head .page-heading { font-size: 15px; font-weight: 600; margin: 0; }
+  .brief-sub { font-family: var(--mono); font-size: 11.5px; color: var(--ink-tertiary); }
+  .page-meta { font-family: var(--mono); font-size: 11.5px; color: var(--ink-tertiary); }
+
+  .sec { border: 1px solid var(--border-strong); border-radius: 8px; background: var(--surface);
+         overflow: hidden; margin-bottom: 14px; }
+  .sec-toggle { width: 100%; }
+  .items { display: flex; flex-direction: column; }
+
+  .glyph { width: 9px; height: 9px; flex: none; display: inline-block; margin-top: 5px; }
+  .glyph-verbatim { background: #8b949e; }
+  .glyph-inferred { border: 1px solid #8b949e; }
+  .glyph-untagged { border: 1px dashed #6e7681; }
+
+  .brief-row {
+    display: flex; align-items: baseline; gap: 14px; width: 100%; text-align: left;
+    padding: 14px 18px; border: 0; border-bottom: 1px solid #161b22;
+    background: none; color: var(--ink); font: inherit; cursor: pointer;
+  }
+  .brief-row:hover { background: var(--surface-hover); }
+  .brief-row-static { cursor: default; }
+  .brief-row .it-text { flex: 1; font-size: 14px; line-height: 1.55; }
+  .obj-id, .obj-ref {
+    font-family: var(--mono); font-size: 11.5px; color: var(--accent);
+    background: none; border: 0; padding: 0; flex: none;
+  }
+  .chip-carried { font-family: var(--mono); font-size: 11px; color: var(--ink-tertiary); margin-left: 10px; }
+
+  .card-foot {
+    padding: 12px 18px; background: var(--inset);
+    font-family: var(--mono); font-size: 11px; color: var(--ink-tertiary);
+    border-top: 1px solid var(--border-subtle);
+  }
+
+  .search-head { padding: 0 0 4px; }
+  .search-title { font-size: 15px; font-weight: 600; }
+  .search-rows { border: 1px solid var(--border-strong); border-radius: 8px;
+                 background: var(--surface); overflow: hidden; }
+  .search-row { border-bottom: 1px solid #161b22; padding: 11px 18px; gap: 14px; }
+  .search-meta { font-family: var(--mono); font-size: 11.5px; }
+
+  .why-crumb { display: flex; align-items: center; gap: 10px; padding: 0 0 14px; }
+  .crumb-sep { font-family: var(--mono); font-size: 11.5px; color: var(--ink-tertiary); }
+  .crumb-id { font-family: var(--mono); font-size: 12.5px; font-weight: 600; color: var(--ink); }
+  .crumb-trust { margin-left: auto; display: inline-flex; align-items: center; gap: 7px;
+                 font-family: var(--mono); font-size: 11.5px; color: var(--ink-secondary); }
+  .crumb-trust .glyph { margin-top: 0; }
+  .why-card { border: 1px solid var(--border-strong); border-radius: 8px;
+              background: var(--surface); overflow: hidden; padding-top: 22px; }
+  .why-text { margin: 0; padding: 0 20px; font-size: 18px; line-height: 1.45;
+              letter-spacing: -0.01em; max-width: 60ch; }
+  .why-meta { display: flex; flex-wrap: wrap; gap: 0 22px; padding: 14px 20px 6px;
+              font-family: var(--mono); font-size: 11.5px; color: var(--ink-tertiary); }
+  .why-label {
+    display: block; font-family: var(--mono); font-size: 10px; font-weight: 600;
+    letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-tertiary);
+  }
+  .why-quote { margin: 18px 20px 0; border: 1px solid var(--border-strong); border-radius: 8px;
+               background: var(--raised); overflow: hidden; }
+  .why-quote-head { padding: 8px 13px; border-bottom: 1px solid var(--border-subtle); background: #12171e; }
+  .why-quote blockquote { margin: 14px 15px; border-left: 2px solid #8b949e; padding-left: 13px;
+                          font-family: var(--mono); font-size: 13px; line-height: 1.65; color: var(--ink); }
+  .why-none { margin: 12px 15px; font-family: var(--mono); font-size: 12.5px; color: var(--ink-secondary); }
+  .why-source { margin: 14px 20px 0; }
+  .why-source pre { margin: 8px 0 0; padding: 12px 15px; background: #12171e;
+                    border: 1px solid var(--border-strong); border-radius: 8px;
+                    font-size: 12.5px; line-height: 1.7; color: var(--ink-tertiary);
+                    overflow-x: auto; white-space: pre-wrap; }
+  .why-seen { margin: 14px 20px 0; padding: 11px 15px; border: 1px solid var(--border-strong);
+              border-radius: 8px; background: #12171e; font-family: var(--mono);
+              font-size: 11.5px; line-height: 1.7; color: var(--ink-secondary); }
+  .why-axes { padding: 22px 20px 6px; }
+  .why-axes dl { display: grid; grid-template-columns: max-content 1fr; gap: 6px 18px; margin: 12px 0 0; }
+  .why-axes dt { font-family: var(--mono); font-size: 12px; color: var(--ink-secondary); }
+  .why-axes dd { margin: 0; font-family: var(--mono); font-size: 12px; color: var(--ink); }
+  .why-life { padding: 22px 20px 14px; }
+  .why-life .why-bio { margin-top: 12px; }
+  .why-card .card-foot { margin-top: 8px; }

--- a/plugin/daimon_ui/static/app.js
+++ b/plugin/daimon_ui/static/app.js
@@ -1,0 +1,538 @@
+import {
+  ACT_ITEM_ID_RE, escapeHtml, fmtRelative, navCurrent, renderActivityView, renderBioPanel,
+  renderEmptyProjects, renderError, renderHistoryView, renderProjCard, renderSearchResults,
+  renderSections, renderSidebarScope, renderSingleCheckpointEmpty, renderWhyView, skeletonHtml
+} from "./render.js";
+import { state } from "./state.js";
+
+  function api(path) {
+    return fetch(path).then(function (r) { return r.json(); });
+  }
+  // #status is the page's only live region. Keep what goes in short: a screen
+  // reader interrupts to read it. Views themselves render into #state, which is
+  // deliberately NOT live — announcing it would re-read the whole view each nav.
+  function announce(msg) {
+    document.getElementById("status").textContent = msg;
+  }
+  // Every error path renders and announces the same way. `what` is the error's own
+  // one-line summary; when the payload carries none we say so rather than inventing
+  // a friendlier message the server never sent.
+  function showError(el, err) {
+    el.innerHTML = renderError(err);
+    announce((err && err.what) || "Request failed.");
+  }
+  function setShellView(view) {
+    document.querySelector(".shell").classList.toggle("grid-view", view === "grid");
+  }
+  function loadList() {
+    state.requestId += 1;
+    var reqId = state.requestId;
+    api("/api/projects").then(function (data) {
+      if (reqId !== state.requestId) return; // superseded by a newer navigation
+      state.projects = data.projects || [];
+      state.defaultSlug = data.current;
+      var hasCurrent = state.projects.some(function (p) { return p.slug === state.defaultSlug; });
+      if (state.projects.length > 1 || !hasCurrent) {
+        renderGrid();
+      } else {
+        enterProject(state.defaultSlug, false); // solo-user fast path: skip the grid
+      }
+    }).catch(function () {
+      showError(document.getElementById("state"), {
+        what: "Could not load projects.",
+        why: "The request to the daimon server failed.",
+        fix: "Check the server is running and reload the page."
+      });
+    });
+  }
+  function renderBackLink() {
+    var slot = document.getElementById("back-link-slot");
+    if (state.view === "project" && state.cameFromGrid) {
+      var btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "back-link";
+      btn.textContent = "← All projects";
+      btn.addEventListener("click", returnToGrid);
+      slot.innerHTML = "";
+      slot.appendChild(btn);
+    } else {
+      slot.innerHTML = "";
+    }
+  }
+  function returnToGrid() {
+    state.requestId += 1; // invalidate any in-flight project fetch
+    state.view = "grid";
+    renderGrid();
+  }
+  function renderHistoryLink() {
+    var slot = document.getElementById("history-link-slot");
+    if ((state.view === "project" || state.view === "history" || state.view === "activity") && state.currentSlug) {
+      var btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "history-link";
+      btn.textContent = "History";
+      btn.setAttribute("aria-current", navCurrent(state.view, "history"));
+      btn.addEventListener("click", enterHistory);
+      slot.innerHTML = "";
+      slot.appendChild(btn);
+    } else {
+      slot.innerHTML = "";
+    }
+  }
+  function renderActivityLink() {
+    var slot = document.getElementById("activity-link-slot");
+    if ((state.view === "project" || state.view === "history" || state.view === "activity") && state.currentSlug) {
+      var btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "history-link";
+      btn.textContent = "Activity";
+      btn.setAttribute("aria-current", navCurrent(state.view, "activity"));
+      btn.addEventListener("click", enterActivity);
+      slot.innerHTML = "";
+      slot.appendChild(btn);
+    } else {
+      slot.innerHTML = "";
+    }
+  }
+  function enterActivity() {
+    if (!state.currentSlug) return;
+    var slug = state.currentSlug;
+    state.view = "activity";
+    state.requestId += 1;
+    var reqId = state.requestId;
+    renderHistoryLink();
+    renderActivityLink();
+    var stateEl = document.getElementById("state");
+    var sectionsEl = document.getElementById("sections");
+    var mainEl = document.getElementById("main");
+    mainEl.setAttribute("aria-busy", "true");
+    if (state.pendingTimer) clearTimeout(state.pendingTimer);
+    state.pendingTimer = setTimeout(function () {
+      if (reqId !== state.requestId) return;
+      stateEl.innerHTML = skeletonHtml();
+    }, 1000);
+    api("/api/activity?project=" + encodeURIComponent(slug)).then(function (data) {
+      if (reqId !== state.requestId) return;
+      clearTimeout(state.pendingTimer);
+      mainEl.removeAttribute("aria-busy");
+      sectionsEl.innerHTML = "";
+      if (!data.ok) { showError(stateEl, data.error); return; }
+      stateEl.innerHTML = renderActivityView(data);
+      announce("Activity loaded.");
+      wireBioToggles(stateEl);
+    }).catch(function () {
+      if (reqId !== state.requestId) return;
+      clearTimeout(state.pendingTimer);
+      mainEl.removeAttribute("aria-busy");
+      sectionsEl.innerHTML = "";
+      showError(stateEl, {
+        what: "Could not load activity.",
+        why: "The request to the daimon server failed.",
+        fix: "Check the server is running and try again."
+      });
+    });
+  }
+  function renderGrid() {
+    state.view = "grid";
+    state.currentSlug = null;
+    setShellView("grid");
+    document.getElementById("sidebar").innerHTML = "";
+    document.getElementById("project").textContent = "";
+    renderBackLink();
+    renderHistoryLink();
+    renderActivityLink();
+    var stateEl = document.getElementById("state");
+    var sectionsEl = document.getElementById("sections");
+    if (state.projects.length === 0) {
+      sectionsEl.innerHTML = "";
+      stateEl.innerHTML = renderEmptyProjects();
+      announce("No projects found.");
+      return;
+    }
+    stateEl.innerHTML = "";
+    announce("All projects.");
+    sectionsEl.innerHTML = '<div class="proj-grid">' +
+      state.projects.map(renderProjCard).join("") + "</div>";
+    Array.prototype.forEach.call(sectionsEl.querySelectorAll(".proj-card"), function (btn) {
+      btn.addEventListener("click", function () { enterProject(btn.dataset.slug, true); });
+    });
+  }
+  function enterProject(slug, cameFromGrid) {
+    state.currentSlug = slug;
+    state.view = "project";
+    state.cameFromGrid = !!cameFromGrid;
+    setShellView("project");
+    renderBackLink();
+    renderHistoryLink();
+    renderActivityLink();
+    loadCheckpointsList(slug);
+  }
+  function loadCheckpointsList(slug) {
+    state.requestId += 1;
+    var reqId = state.requestId;
+    api("/api/checkpoints?project=" + encodeURIComponent(slug)).then(function (data) {
+      if (reqId !== state.requestId) return; // superseded by a newer navigation
+      document.getElementById("project").textContent = data.project || "";
+      state.checkpoints = data.checkpoints || [];
+      state.sessionsTotal = data.sessions_total || 0;
+      renderSidebar();
+      if (state.checkpoints.length === 0) {
+        renderEmptyCheckpoints();
+        document.getElementById("sections").innerHTML = "";
+        return;
+      }
+      selectCheckpoint(state.checkpoints[0].ref);
+    }).catch(function () {
+      if (reqId !== state.requestId) return; // superseded by a newer navigation
+      showError(document.getElementById("state"), {
+        what: "Could not load checkpoints.",
+        why: "The request to the daimon server failed.",
+        fix: "Check the server is running and reload the page."
+      });
+    });
+  }
+  function renderSidebar() {
+    var nav = document.getElementById("sidebar");
+    nav.innerHTML = state.checkpoints.map(function (c) {
+      var active = c.ref === state.activeRef;
+      var topic = c.active_topic ? escapeHtml(c.active_topic) : "(untitled)";
+      var rel = fmtRelative(c.created);
+      return '<button type="button" class="cp-item' + (active ? " active" : "") +
+        '" data-ref="' + escapeHtml(c.ref) + '" aria-current="' + (active ? "true" : "false") + '">' +
+        '<span class="cp-topic">' + topic + '</span>' +
+        '<span class="cp-meta">' + escapeHtml(c.ref) + (rel ? " · " + escapeHtml(rel) : "") + '</span>' +
+        '</button>';
+    }).join("") + renderSidebarScope(state.checkpoints.length, state.sessionsTotal);
+    Array.prototype.forEach.call(nav.querySelectorAll(".cp-item"), function (btn) {
+      btn.addEventListener("click", function () { selectCheckpoint(btn.dataset.ref); });
+    });
+  }
+  function selectCheckpoint(ref) {
+    state.activeRef = ref;
+    state.requestId += 1;
+    if (state.view !== "project") {
+      state.view = "project";
+      renderHistoryLink();
+      renderActivityLink();
+    }
+    renderSidebar();
+    loadCheckpoint(ref, state.requestId);
+  }
+  function loadCheckpoint(ref, requestId) {
+    var stateEl = document.getElementById("state");
+    var sectionsEl = document.getElementById("sections");
+    var mainEl = document.getElementById("main");
+    mainEl.setAttribute("aria-busy", "true");
+    if (state.pendingTimer) clearTimeout(state.pendingTimer);
+    state.pendingTimer = setTimeout(function () {
+      if (requestId !== state.requestId) return; // superseded by a newer selection
+      stateEl.innerHTML = skeletonHtml();
+    }, 1000);
+    api("/api/checkpoint/" + encodeURIComponent(ref) + "?project=" + encodeURIComponent(state.currentSlug)).then(function (data) {
+      if (requestId !== state.requestId) return; // stale response — a newer request is in flight
+      clearTimeout(state.pendingTimer);
+      mainEl.removeAttribute("aria-busy");
+      stateEl.innerHTML = "";
+      if (data.ok) {
+        sectionsEl.innerHTML = renderSections(data);
+        announce("Checkpoint " + ref + " loaded.");
+        wireItemToggles(sectionsEl);
+        wireSectionToggles(sectionsEl);
+        wireBioToggles(sectionsEl);
+      } else {
+        sectionsEl.innerHTML = "";
+        showError(stateEl, data.error);
+      }
+    }).catch(function () {
+      if (requestId !== state.requestId) return; // stale response — a newer request is in flight
+      clearTimeout(state.pendingTimer);
+      mainEl.removeAttribute("aria-busy");
+      sectionsEl.innerHTML = "";
+      showError(stateEl, {
+        what: "Could not load this checkpoint.",
+        why: "The request to the daimon server failed.",
+        fix: "Check the server is running and reload the page."
+      });
+    });
+  }
+  function wireItemToggles(container) {
+    var buttons = container.querySelectorAll(".it-wrap > button[aria-controls]:not([data-bio-toggle])");
+    Array.prototype.forEach.call(buttons, function (btn) {
+      btn.addEventListener("click", function () {
+        var ev = btn.parentElement.querySelector(".ev");
+        var open = !ev.hasAttribute("hidden");
+        if (open) {
+          ev.setAttribute("hidden", "");
+          btn.setAttribute("aria-expanded", "false");
+        } else {
+          ev.removeAttribute("hidden");
+          btn.setAttribute("aria-expanded", "true");
+        }
+      });
+    });
+  }
+  function wireBioToggles(container) {
+    Array.prototype.forEach.call(container.querySelectorAll("[data-bio-toggle]"), function (btn) {
+      btn.addEventListener("click", function () {
+        var panel = document.getElementById(btn.getAttribute("aria-controls"));
+        var open = !panel.hasAttribute("hidden");
+        if (open) {
+          panel.setAttribute("hidden", "");
+          btn.setAttribute("aria-expanded", "false");
+          return;
+        }
+        panel.removeAttribute("hidden");
+        btn.setAttribute("aria-expanded", "true");
+        loadBiography(btn.dataset.itemId, panel);
+      });
+    });
+  }
+  function loadBiography(itemId, panel) {
+    var reqId = state.requestId;
+    var cacheKey = reqId + ":" + itemId;
+    if (state.bioCache[cacheKey]) {
+      panel.innerHTML = renderBioPanel(state.bioCache[cacheKey]);
+      return;
+    }
+    var timer = setTimeout(function () {
+      panel.innerHTML = skeletonHtml();
+    }, 1000);
+    api("/api/biography?project=" + encodeURIComponent(state.currentSlug) + "&id=" + encodeURIComponent(itemId))
+      .then(function (data) {
+        clearTimeout(timer);
+        if (reqId !== state.requestId) return; // navigated away meanwhile
+        if (data.ok) {
+          state.bioCache[cacheKey] = data;
+          panel.innerHTML = renderBioPanel(data);
+        } else {
+          panel.innerHTML = renderError(data.error);
+        }
+      }).catch(function () {
+        clearTimeout(timer);
+        if (reqId !== state.requestId) return;
+        panel.innerHTML = renderError({
+          what: "Could not load this item's history.",
+          why: "The request to the daimon server failed.",
+          fix: "Check the server is running and try again."
+        });
+      });
+  }
+  // ---- search (#670): the box renders daimon recall — one matcher, two renderings ----
+  function searchSlug() {
+    return state.currentSlug || state.defaultSlug;
+  }
+  function runSearch(q) {
+    var slug = searchSlug();
+    if (!slug || !q || !q.trim()) return;
+    state.view = "search";
+    state.requestId += 1;
+    var reqId = state.requestId;
+    var stateEl = document.getElementById("state");
+    var sectionsEl = document.getElementById("sections");
+    api("/api/recall?project=" + encodeURIComponent(slug) + "&q=" + encodeURIComponent(q))
+      .then(function (data) {
+        if (reqId !== state.requestId) return; // superseded by a newer navigation
+        stateEl.innerHTML = "";
+        if (!data.ok) {
+          sectionsEl.innerHTML = "";
+          showError(stateEl, data.error);
+          return;
+        }
+        sectionsEl.innerHTML = renderSearchResults(q, data.rows);
+        announce(data.rows.length + " search result(s).");
+        Array.prototype.forEach.call(sectionsEl.querySelectorAll(".search-row[data-item-id]"), function (btn) {
+          btn.addEventListener("click", function () { openWhy(btn.dataset.itemId); });
+        });
+      }).catch(function () {
+        if (reqId !== state.requestId) return;
+        sectionsEl.innerHTML = "";
+        showError(stateEl, {
+          what: "Search failed.",
+          why: "The request to the daimon server failed.",
+          fix: "Check the server is running and try again."
+        });
+      });
+  }
+  // ---- why (#670): the entry page renders daimon why's receipt as recorded ----
+  function openWhy(itemId) {
+    var slug = searchSlug();
+    if (!slug || !ACT_ITEM_ID_RE.test(itemId || "")) return;
+    state.view = "why";
+    state.requestId += 1;
+    var reqId = state.requestId;
+    var stateEl = document.getElementById("state");
+    var sectionsEl = document.getElementById("sections");
+    api("/api/why?project=" + encodeURIComponent(slug) + "&id=" + encodeURIComponent(itemId) + "&source=1")
+      .then(function (data) {
+        if (reqId !== state.requestId) return; // superseded by a newer navigation
+        stateEl.innerHTML = "";
+        if (!data.ok) {
+          sectionsEl.innerHTML = "";
+          showError(stateEl, data.error);
+          return;
+        }
+        sectionsEl.innerHTML = renderWhyView(data);
+        announce("Entry loaded.");
+        var bio = document.getElementById("why-bio");
+        if (bio) loadBiography(itemId, bio);
+      }).catch(function () {
+        if (reqId !== state.requestId) return;
+        sectionsEl.innerHTML = "";
+        showError(stateEl, {
+          what: "Could not load this entry.",
+          why: "The request to the daimon server failed.",
+          fix: "Check the server is running and try again."
+        });
+      });
+  }
+  function wireSearchForm() {
+    var form = document.getElementById("search-form");
+    var box = document.getElementById("search-box");
+    if (!form || !box) return;
+    form.addEventListener("submit", function (ev) {
+      ev.preventDefault();
+      runSearch(box.value);
+    });
+  }
+  function wireSectionToggles(container) {
+    Array.prototype.forEach.call(container.querySelectorAll(".sec-toggle"), function (btn) {
+      if (btn.disabled) return;
+      btn.addEventListener("click", function () {
+        var body = document.getElementById(btn.getAttribute("aria-controls"));
+        var marker = btn.querySelector(".disclosure");
+        var open = !body.hasAttribute("hidden");
+        if (open) {
+          body.setAttribute("hidden", "");
+          btn.setAttribute("aria-expanded", "false");
+          if (marker) marker.textContent = "▸";
+        } else {
+          body.removeAttribute("hidden");
+          btn.setAttribute("aria-expanded", "true");
+          if (marker) marker.textContent = "▾";
+        }
+      });
+    });
+  }
+  function enterHistory() {
+    if (!state.currentSlug) return;
+    var slug = state.currentSlug;
+    state.view = "history";
+    state.requestId += 1;
+    var reqId = state.requestId;
+    renderHistoryLink();
+    renderActivityLink();
+    var stateEl = document.getElementById("state");
+    var sectionsEl = document.getElementById("sections");
+    var mainEl = document.getElementById("main");
+    mainEl.setAttribute("aria-busy", "true");
+    if (state.pendingTimer) clearTimeout(state.pendingTimer);
+    state.pendingTimer = setTimeout(function () {
+      if (reqId !== state.requestId) return; // superseded by a newer navigation
+      stateEl.innerHTML = skeletonHtml();
+    }, 1000);
+    Promise.all([
+      api("/api/history?project=" + encodeURIComponent(slug)),
+      api("/api/diff?project=" + encodeURIComponent(slug))
+    ]).then(function (results) {
+      if (reqId !== state.requestId) return; // stale response — a newer request is in flight
+      clearTimeout(state.pendingTimer);
+      mainEl.removeAttribute("aria-busy");
+      var hist = results[0], diff = results[1];
+      state.historySessions = hist.sessions || [];
+      state.historyUnreadable = hist.unreadable || 0;
+      stateEl.innerHTML = "";
+      if (!diff.ok) {
+        sectionsEl.innerHTML = "";
+        showError(stateEl, diff.error);
+        return;
+      }
+      if (diff.empty === "single_checkpoint") {
+        sectionsEl.innerHTML = "";
+        stateEl.innerHTML = renderSingleCheckpointEmpty();
+        announce("Only one checkpoint — nothing to compare.");
+        return;
+      }
+      // Defaults must come from the filename-based session list (same source the server
+      // uses when a/b are omitted) — diff.a/diff.b meta.session_id is read from inside the
+      // checkpoint JSON and isn't guaranteed to match the filename the API expects back.
+      state.historyPick = {
+        a: state.historySessions.length > 1 ? state.historySessions[1].session_id : null,
+        b: state.historySessions.length > 0 ? state.historySessions[0].session_id : null
+      };
+      sectionsEl.innerHTML = renderHistoryView(diff);
+      announce("History loaded.");
+      wireHistoryControls(sectionsEl, slug);
+      wireSectionToggles(sectionsEl);
+      wireBioToggles(sectionsEl);
+    }).catch(function () {
+      if (reqId !== state.requestId) return; // stale response — a newer request is in flight
+      clearTimeout(state.pendingTimer);
+      mainEl.removeAttribute("aria-busy");
+      sectionsEl.innerHTML = "";
+      showError(stateEl, {
+        what: "Could not load history.",
+        why: "The request to the daimon server failed.",
+        fix: "Check the server is running and reload the page."
+      });
+    });
+  }
+  function loadDiff(slug, a, b) {
+    state.requestId += 1;
+    var reqId = state.requestId;
+    var stateEl = document.getElementById("state");
+    var sectionsEl = document.getElementById("sections");
+    var mainEl = document.getElementById("main");
+    mainEl.setAttribute("aria-busy", "true");
+    if (state.pendingTimer) clearTimeout(state.pendingTimer);
+    state.pendingTimer = setTimeout(function () {
+      if (reqId !== state.requestId) return; // superseded by a newer navigation
+      stateEl.innerHTML = skeletonHtml();
+    }, 1000);
+    api("/api/diff?project=" + encodeURIComponent(slug) + "&a=" + encodeURIComponent(a) +
+      "&b=" + encodeURIComponent(b)).then(function (diff) {
+      if (reqId !== state.requestId) return; // stale response — a newer request is in flight
+      clearTimeout(state.pendingTimer);
+      mainEl.removeAttribute("aria-busy");
+      stateEl.innerHTML = "";
+      if (!diff.ok) {
+        sectionsEl.innerHTML = "";
+        showError(stateEl, diff.error);
+        return;
+      }
+      sectionsEl.innerHTML = renderHistoryView(diff);
+      announce("Comparison updated.");
+      wireHistoryControls(sectionsEl, slug);
+      wireSectionToggles(sectionsEl);
+      wireBioToggles(sectionsEl);
+    }).catch(function () {
+      if (reqId !== state.requestId) return; // stale response — a newer request is in flight
+      clearTimeout(state.pendingTimer);
+      mainEl.removeAttribute("aria-busy");
+      sectionsEl.innerHTML = "";
+      showError(stateEl, {
+        what: "Could not load the diff.",
+        why: "The request to the daimon server failed.",
+        fix: "Check the server is running and reload the page."
+      });
+    });
+  }
+  function wireHistoryControls(container, slug) {
+    Array.prototype.forEach.call(container.querySelectorAll(".sess-pick"), function (sel) {
+      sel.addEventListener("change", function () {
+        state.historyPick[sel.dataset.pick] = sel.value;
+        loadDiff(slug, state.historyPick.a, state.historyPick.b);
+      });
+    });
+  }
+  function renderEmptyCheckpoints() {
+    document.getElementById("state").innerHTML =
+      '<div class="state-card state-empty"><p class="state-title">No checkpoints yet</p>' +
+      "<p>Once you run <code>daimon brief</code>, checkpoints will appear here with decisions, " +
+      "open loops, and verified quotes ready to browse.</p></div>";
+    announce("No checkpoints yet.");
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    wireSearchForm();
+    loadList();
+  });

--- a/plugin/daimon_ui/static/app.js
+++ b/plugin/daimon_ui/static/app.js
@@ -236,7 +236,7 @@ import { state } from "./state.js";
       if (data.ok) {
         sectionsEl.innerHTML = renderSections(data);
         announce("Checkpoint " + ref + " loaded.");
-        wireItemToggles(sectionsEl);
+        wireWhyOpeners(sectionsEl);
         wireSectionToggles(sectionsEl);
         wireBioToggles(sectionsEl);
       } else {
@@ -321,6 +321,12 @@ import { state } from "./state.js";
   function searchSlug() {
     return state.currentSlug || state.defaultSlug;
   }
+  // Briefing lines and search rows both open the entry page the same way.
+  function wireWhyOpeners(container) {
+    Array.prototype.forEach.call(container.querySelectorAll("[data-open-why][data-item-id]"), function (btn) {
+      btn.addEventListener("click", function () { openWhy(btn.dataset.itemId); });
+    });
+  }
   function runSearch(q) {
     var slug = searchSlug();
     if (!slug || !q || !q.trim()) return;
@@ -338,6 +344,7 @@ import { state } from "./state.js";
           showError(stateEl, data.error);
           return;
         }
+        state.lastSearchQ = q;
         sectionsEl.innerHTML = renderSearchResults(q, data.rows);
         announce(data.rows.length + " search result(s).");
         Array.prototype.forEach.call(sectionsEl.querySelectorAll(".search-row[data-item-id]"), function (btn) {
@@ -373,6 +380,12 @@ import { state } from "./state.js";
         }
         sectionsEl.innerHTML = renderWhyView(data);
         announce("Entry loaded.");
+        var back = sectionsEl.querySelector("[data-why-back]");
+        if (back) back.addEventListener("click", function () {
+          if (state.lastSearchQ) { runSearch(state.lastSearchQ); }
+          else if (state.activeRef) { selectCheckpoint(state.activeRef); }
+          else { loadList(); }
+        });
         var bio = document.getElementById("why-bio");
         if (bio) loadBiography(itemId, bio);
       }).catch(function () {

--- a/plugin/daimon_ui/static/app.js
+++ b/plugin/daimon_ui/static/app.js
@@ -151,8 +151,16 @@ import { state } from "./state.js";
     }
     stateEl.innerHTML = "";
     announce("All projects.");
-    sectionsEl.innerHTML = '<div class="proj-grid">' +
-      state.projects.map(renderProjCard).join("") + "</div>";
+    // Current project first — it is where the user physically is — then the
+    // rest stay in the server's newest-first order.
+    var ordered = state.projects.slice().sort(function (a, b) {
+      return (b.slug === state.defaultSlug) - (a.slug === state.defaultSlug);
+    });
+    sectionsEl.innerHTML =
+      '<div class="grid-head"><h1 class="page-heading">Projects</h1>' +
+      '<span class="brief-sub">' + ordered.length +
+      ' project(s) · each card is where that project left off</span></div>' +
+      '<div class="proj-grid">' + ordered.map(renderProjCard).join("") + "</div>";
     Array.prototype.forEach.call(sectionsEl.querySelectorAll(".proj-card"), function (btn) {
       btn.addEventListener("click", function () { enterProject(btn.dataset.slug, true); });
     });

--- a/plugin/daimon_ui/static/render.js
+++ b/plugin/daimon_ui/static/render.js
@@ -170,19 +170,31 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
       ' sessions. The earlier ones are reachable in History.</p>';
   }
 
+  // A slug is a flattened path, so the true directory name is unrecoverable —
+  // the tail segment is a best-effort display name, never an identity.
+  export function slugTail(slug) {
+    var parts = String(slug || "").split("-").filter(Boolean);
+    return parts.length ? parts[parts.length - 1] : String(slug || "");
+  }
   export function renderProjCard(p) {
     var isCurrent = p.slug === state.defaultSlug;
     var torn = p.active_topic == null && p.created == null && p.item_count == null;
-    var title = torn ? "Unreadable checkpoint" : (p.active_topic || "(untitled)");
-    var meta = torn ? "run daimon heal" :
-      [fmtRelative(p.created), p.item_count != null ? p.item_count + " items" : null]
-        .filter(Boolean).join(" · ");
-    var chip = isCurrent ? '<span class="proj-chip">CURRENT DIR</span>' : "";
+    var chip = isCurrent ? '<span class="proj-chip">current dir</span>' : "";
+    var name = '<span class="proj-name">' + escapeHtml(slugTail(p.slug)) + "</span>";
+    var age = !torn && p.created
+      ? '<span class="proj-age">' + escapeHtml(fmtRelative(p.created)) + "</span>" : "";
+    var topic = torn ? "Unreadable checkpoint" : (p.active_topic || "(untitled)");
+    var foot = torn ? "run daimon heal"
+      : [p.item_count != null ? p.item_count + " items" : null]
+          .filter(Boolean).join(" · ");
     return '<button type="button" class="proj-card' + (isCurrent ? " current" : "") +
       '" data-slug="' + escapeHtml(p.slug) + '">' +
-      '<span class="proj-title">' + escapeHtml(title) + '</span>' +
-      '<span class="proj-slug">' + escapeHtml(p.slug) + '</span>' +
-      '<span class="proj-meta">' + escapeHtml(meta) + '</span>' + chip + '</button>';
+      '<span class="proj-top">' + name + chip + age + "</span>" +
+      '<span class="proj-topic' + (torn || !p.active_topic ? " proj-topic-dim" : "") + '">' +
+      escapeHtml(topic) + "</span>" +
+      '<span class="proj-foot"><span class="proj-slug">' + escapeHtml(p.slug) +
+      "</span>" + (foot ? '<span class="proj-meta">' + escapeHtml(foot) + "</span>" : "") +
+      "</span></button>";
   }
   export function renderEmptyProjects() {
     return '<div class="state-card state-empty"><p class="state-title">No daimon projects yet</p>' +

--- a/plugin/daimon_ui/static/render.js
+++ b/plugin/daimon_ui/static/render.js
@@ -1,0 +1,631 @@
+import { state } from "./state.js";
+
+let evidenceCounter = 0;
+let bioCounter = 0;
+
+// Test-only. IDs derive from these counters, so tests reset them for determinism.
+export function resetCounters() {
+  evidenceCounter = 0;
+  bioCounter = 0;
+}
+
+export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of reader ITEM_ID_RE
+
+  export function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
+  export function fmtRelative(iso) {
+    if (!iso) return "";
+    var d = new Date(iso);
+    if (isNaN(d.getTime())) return "";
+    var diff = Math.floor((Date.now() - d.getTime()) / 1000);
+    if (diff < 60) return "just now";
+    var m = Math.floor(diff / 60); if (m < 60) return m + "m ago";
+    var h = Math.floor(m / 60); if (h < 24) return h + "h ago";
+    var dd = Math.floor(h / 24); if (dd < 30) return dd + "d ago";
+    var mo = Math.floor(dd / 30); if (mo < 12) return mo + "mo ago";
+    return Math.floor(mo / 12) + "y ago";
+  }
+  export function fmtDate(iso) {
+    if (!iso) return "unknown date";
+    return String(iso).split("T")[0];
+  }
+  // The activity feed is chronological, so the time of day is load-bearing: this
+  // project's own feed has 15 rows sharing one second and 25 sharing one date, and
+  // a date-only stamp erases every ordering cue. Rendered in UTC (the ledger's own
+  // zone) rather than local time — mixing a UTC date with a local clock silently
+  // disagrees near midnight, and a pure string read keeps tests timezone-independent.
+  // Anything that is not ISO-shaped keeps fmtDate's lenient behavior rather than
+  // manufacturing a "00:00" the data never recorded.
+  export function fmtDateTime(iso) {
+    if (!iso) return "unknown date";
+    var m = /^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2})/.exec(String(iso));
+    return m ? m[1] + " " + m[2] + "Z" : fmtDate(iso);
+  }
+  // aria-current value for a header view button. Pure so it is testable without a
+  // DOM; app.js does the setAttribute. Returns the literal strings the attribute
+  // takes, not booleans, so callers cannot stringify `false` into a truthy "false"
+  // by accident. Views with no header button (grid, project) mark nothing current.
+  export function navCurrent(view, target) {
+    return view === target ? "page" : "false";
+  }
+  export function activityLabel(r) {
+    if (r.kind === "resolution") {
+      var st = (r.extra && r.extra.status) || "";
+      if (st === "resolved") return "RESOLVED";
+      if (st === "reopened") return "REOPENED";
+      return st ? escapeHtml(spellOutEnum(st)) : "RESOLUTION";
+    }
+    var L = { session: "SESSION", handoff: "HANDOFF", corroboration: "CORROBORATED",
+              note: "NOTE", quote_check: "QUOTE CHECK" };
+    return Object.prototype.hasOwnProperty.call(L, r.kind) ?
+      L[r.kind] : escapeHtml(spellOutEnum(String(r.kind)));
+  }
+  // Unmapped statuses and kinds arrive as machine values ("resolved-agent-verified").
+  // Uppercasing alone shipped the punctuation straight to the reader. Only the
+  // separators change — the words stay exactly as recorded, so nothing is renamed.
+  function spellOutEnum(s) {
+    return String(s).replace(/[-_]+/g, " ").toUpperCase();
+  }
+  // quote_check gets its own dot. It used to share "changed" with ordinary edits,
+  // which made 20 recorded check reasons read as routine traffic.
+  var ACT_DOTS = { session: "seen", resolution: "resolved", handoff: "born",
+                   corroboration: "verified", note: "seen", quote_check: "flagged" };
+  export function renderActivityRow(r) {
+    var dotCls = "life-dot-" + (Object.prototype.hasOwnProperty.call(ACT_DOTS, r.kind) ?
+      ACT_DOTS[r.kind] : "seen");
+    var when = escapeHtml(fmtDateTime(r.ts));
+    var body = "";
+    if (r.kind === "handoff" && r.detail) {
+      body = '<div class="life-quote">“' + escapeHtml(r.detail) + '”</div>';
+    } else if (r.detail) {
+      body = '<div class="life-detail">' + escapeHtml(r.detail) + "</div>";
+    }
+    // The server sends extra.item_text for some rows and it was being dropped, so
+    // rows that could say WHICH item they concern said nothing. Only rendered when
+    // it differs from detail — for corroborations the reader already folds item_text
+    // into detail, and printing it twice would read as two separate facts.
+    var itemText = (r.extra && r.extra.item_text) || "";
+    if (itemText && itemText !== r.detail) {
+      body += '<div class="life-detail act-item-text">' + escapeHtml(itemText) + "</div>";
+    }
+    // The ref itself is now printed, not just linked. With only a "View history"
+    // button here, twenty rows about twenty different items were indistinguishable.
+    var refHtml = "";
+    if (r.item_ref) {
+      if (ACT_ITEM_ID_RE.test(r.item_ref)) {
+        refHtml = '<div class="act-ref"><code class="act-ref-id">' + escapeHtml(r.item_ref) +
+          "</code> " + renderHistoryToggle(r.item_ref) + "</div>";
+      } else {
+        refHtml = '<div class="act-ref act-ref-raw">' + escapeHtml(r.item_ref) + "</div>";
+      }
+    }
+    return '<li class="life-row act-row"><div class="life-rail"><span class="life-dot ' +
+      dotCls + '"></span></div><div class="life-body"><span class="life-label">' +
+      activityLabel(r) + '</span><span class="life-when">' + when + "</span>" +
+      body + refHtml + "</div></li>";
+  }
+  // Counts quote_check rows by their recorded reason. Deliberately reports only what
+  // the ledger literally stores: verification.jsonl carries ts/check/item_ref/reason
+  // and no pass-fail verdict, so calling these rows "failures" would be our word, not
+  // the data's. What was actually wrong is that twenty of them read as ambient traffic
+  // — the scale never reached the viewer. Counting fixes that without interpreting.
+  // A null prototype keeps a reason literally named "constructor" from tallying onto
+  // an inherited function, the same bug class as activityLabel's.
+  export function activityCheckSummary(rows) {
+    var counts = Object.create(null);
+    var total = 0;
+    (rows || []).forEach(function (r) {
+      if (!r || r.kind !== "quote_check") return;
+      var reason = (r.extra && r.extra.reason) || "no reason recorded";
+      counts[reason] = (counts[reason] || 0) + 1;
+      total += 1;
+    });
+    if (total === 0) return null;
+    var breakdown = Object.keys(counts).map(function (reason) {
+      return { reason: reason, count: counts[reason] };
+    });
+    // Commonest first; ties broken by name so the order never depends on key insertion.
+    breakdown.sort(function (x, y) {
+      return y.count - x.count || (x.reason < y.reason ? -1 : x.reason > y.reason ? 1 : 0);
+    });
+    return { total: total, breakdown: breakdown };
+  }
+  function renderCheckSummary(rows) {
+    var s = activityCheckSummary(rows);
+    if (!s) return "";
+    var parts = s.breakdown.map(function (b) {
+      return b.count + " × " + escapeHtml(b.reason);
+    }).join(" · ");
+    return '<div class="banner banner-check"><span class="banner-icon" aria-hidden="true">⚠</span><span>' +
+      s.total + (s.total === 1 ? " quote check recorded" : " quote checks recorded") +
+      ": " + parts + ".</span></div>";
+  }
+  export function renderActivityView(data) {
+    var partial = data.partial || [];
+    var partialHtml = partial.map(function (p) {
+      return '<p class="life-note">' + escapeHtml(p) + "</p>";
+    }).join("");
+    if (!data.rows || data.rows.length === 0) {
+      var emptyHtml = partial.length > 0 ?
+        '<div class="state-card"><p class="state-title">No readable activity</p>' +
+          "<p>Some files couldn't be read; nothing readable remains to show.</p></div>" :
+        '<div class="state-card"><p class="state-title">No activity recorded</p>' +
+          "<p>This project's checkpoints carry no session history and its ledgers are empty.</p></div>";
+      return partialHtml + emptyHtml;
+    }
+    return partialHtml + renderCheckSummary(data.rows) + '<ul class="life act-feed">' +
+      data.rows.map(renderActivityRow).join("") + "</ul>";
+  }
+  // The sidebar lists pointer checkpoints only (latest, prev-N), so it is a window
+  // onto the sessions History can reach, not the whole set. Unlabelled, the two
+  // views give different counts and neither says why. Silent when nothing is
+  // hidden, and silent if total ever arrives smaller than shown — an unreadable
+  // file or a racing request must not make the sidebar claim "3 of 2".
+  export function renderSidebarScope(shown, total) {
+    if (!(total > shown)) return "";
+    return '<p class="cp-scope">Showing the ' + shown + ' most recent of ' + total +
+      ' sessions. The earlier ones are reachable in History.</p>';
+  }
+
+  export function renderProjCard(p) {
+    var isCurrent = p.slug === state.defaultSlug;
+    var torn = p.active_topic == null && p.created == null && p.item_count == null;
+    var title = torn ? "Unreadable checkpoint" : (p.active_topic || "(untitled)");
+    var meta = torn ? "run daimon heal" :
+      [fmtRelative(p.created), p.item_count != null ? p.item_count + " items" : null]
+        .filter(Boolean).join(" · ");
+    var chip = isCurrent ? '<span class="proj-chip">CURRENT DIR</span>' : "";
+    return '<button type="button" class="proj-card' + (isCurrent ? " current" : "") +
+      '" data-slug="' + escapeHtml(p.slug) + '">' +
+      '<span class="proj-title">' + escapeHtml(title) + '</span>' +
+      '<span class="proj-slug">' + escapeHtml(p.slug) + '</span>' +
+      '<span class="proj-meta">' + escapeHtml(meta) + '</span>' + chip + '</button>';
+  }
+  export function renderEmptyProjects() {
+    return '<div class="state-card state-empty"><p class="state-title">No daimon projects yet</p>' +
+      "<p>Once you run <code>daimon brief</code> in a project directory, it'll appear here as a " +
+      "card you can open.</p></div>";
+  }
+  export function skeletonHtml() {
+    return '<div class="skeleton" aria-hidden="true">' +
+      '<div class="skel-bar"></div><div class="skel-row"></div>' +
+      '<div class="skel-row"></div><div class="skel-row"></div></div>';
+  }
+
+  // Plain descriptions of a byte comparison. NOT "verified" — the inspector does
+  // not check the signature; `daimon verify-receipt` does. hasOwnProperty guards
+  // the lookup so an inherited key like "constructor" cannot fabricate a label.
+  //
+  // The `unsigned` KEY and its "no receipt claimed" STRING differ on purpose, and
+  // the mismatch is not a typo to tidy up. The key is a machine value under the
+  // contract's machine-key exemption (§4, same shape as `verdict` in the debt
+  // register); the string is a §8.2 composite. "unsigned" fails §8.2 condition 1
+  // — no frozen head noun — and was wrong-adjacent anyway: this state fires when
+  // a checkpoint never CLAIMED a receipt (reader.py:33-35), and also when the
+  // payload is unreadable. Neither is a missing signature. Renaming the key buys
+  // no governance and churns test_receipts.py in five places.
+  // The daimon CLI still says "unsigned" for this state (receipts.py:545-547).
+  // That divergence is REGISTERED in the contract's §4 naming-debt register with
+  // the CLI as named successor — it is not drift, and it is not yours to
+  // "reconcile" by reverting this string.
+  var RECEIPT_TEXT = { match: "receipt matches", missing: "receipt missing",
+                       mismatch: "receipt does not match this file",
+                       unsigned: "no receipt claimed" };
+  export function receiptMetaText(receipt) {
+    var state = receipt && receipt.state;
+    return Object.prototype.hasOwnProperty.call(RECEIPT_TEXT, state) ? RECEIPT_TEXT[state] : "";
+  }
+
+  // Only a BROKEN claim is loud. Both sentences describe what was found on disk and
+  // stop: the inspector cannot tell tampering from a failed signing run from a
+  // deleted file, and under fail-open a signing failure is routine.
+  var RECEIPT_BANNER = {
+    missing: "This checkpoint is marked as having a receipt, but no receipt file was found beside it.",
+    mismatch: "The receipt beside this checkpoint records a different file than the one on disk."
+  };
+  export function receiptBanner(receipt) {
+    var state = receipt && receipt.state;
+    if (!Object.prototype.hasOwnProperty.call(RECEIPT_BANNER, state)) return "";
+    var detail = receipt.detail ? " " + escapeHtml(receipt.detail) : "";
+    return '<div class="banner"><span class="banner-icon" aria-hidden="true">⚠</span><span>' +
+      escapeHtml(RECEIPT_BANNER[state]) + detail + "</span></div>";
+  }
+
+  export function renderSections(data) {
+    var meta = data.meta || {};
+    var metaParts = [meta.active_topic, fmtDate(meta.created), meta.author,
+                     receiptMetaText(meta.receipt)].filter(Boolean);
+    var html = '<h1 class="page-heading">While you were away</h1>' +
+      '<p class="page-meta">' + metaParts.map(escapeHtml).join(" · ") + "</p>" +
+      receiptBanner(meta.receipt);
+    (data.partial || []).forEach(function (p) {
+      html += '<div class="banner banner-partial"><span class="banner-icon" aria-hidden="true">' +
+        "ⓘ</span><span>" + escapeHtml(p) + "</span></div>";
+    });
+    var hasItems = data.sections.some(function (sec) { return sec.items && sec.items.length > 0; });
+    if (!hasItems) {
+      html += '<div class="state-card"><p class="state-title">This checkpoint has no recorded items yet</p>' +
+        "<p>Items appear here as daimon captures decisions, questions, and beliefs from your sessions.</p></div>";
+    } else {
+      data.sections.forEach(function (sec) {
+        html += renderSection(sec, data.meta);
+      });
+    }
+    return html;
+  }
+  export function sortByImportance(items) {
+    return items.map(function (it, i) { return [it, i]; }).sort(function (a, b) {
+      var ai = a[0].importance == null ? -1 : a[0].importance;
+      var bi = b[0].importance == null ? -1 : b[0].importance;
+      if (ai !== bi) return bi - ai; // descending, null last
+      return a[1] - b[1]; // stable tie-break on original order
+    }).map(function (pair) { return pair[0]; });
+  }
+  export function renderSection(sec, meta) {
+    var cls = sec.key === "verify_first" ? "sec sec-verify" : "sec";
+    var n = sec.items ? sec.items.length : 0;
+    var bodyId = "sec-" + sec.key;
+    var expanded = sec.key === "verify_first" && n > 0;
+    var disabled = n === 0;
+    var items = sortByImportance(sec.items || []);
+    var itemsHtml = items.map(function (it) { return renderItem(it, meta); }).join("");
+    var marker = expanded ? "▾" : "▸";
+    var btn = '<button type="button" class="sec-toggle" aria-expanded="' +
+      (expanded ? "true" : "false") + '" aria-controls="sec-' + sec.key + '"' +
+      (disabled ? " disabled" : "") + '>' + escapeHtml(sec.label) +
+      ' <span class="count">· ' + n + '</span> <span class="disclosure" aria-hidden="true">' +
+      marker + '</span></button>';
+    var body = '<div id="' + bodyId + '" class="sec-body"' + (expanded ? "" : " hidden") + '>' +
+      '<div class="items">' + itemsHtml + "</div></div>";
+    return '<section class="' + cls + '" aria-label="' + escapeHtml(sec.label) + '">' + btn + body + "</section>";
+  }
+  export function trustClass(it) {
+    if (it.trust === "verbatim") return "it-verbatim";
+    if (it.trust === "inferred") return "it-inferred";
+    return "it-untagged";
+  }
+  export function renderItem(it, meta) {
+    var cls = "it " + trustClass(it);
+    var carried = it.carried_from
+      ? '<span class="chip-carried">⟳ carried from ' + escapeHtml(it.carried_from) + "</span>"
+      : "";
+    var inner = '<span class="it-text">' + escapeHtml(it.text) + "</span>" + carried;
+    var hasQuote = !!it.quote;
+    var hasId = !!it.id;
+    if (!hasQuote && !hasId) {
+      return '<div class="it-wrap"><div class="' + cls + '">' + inner + "</div></div>";
+    }
+    if (hasId && !hasQuote) {
+      // No evidence to show, so the item's own button opens the biography panel directly —
+      // no empty evidence shell in between.
+      bioCounter += 1;
+      var bioId = "bio-" + bioCounter;
+      return '<div class="it-wrap"><button type="button" class="' + cls +
+        '" aria-expanded="false" aria-controls="' + bioId + '" data-bio-toggle data-item-id="' +
+        escapeHtml(it.id) + '">' + inner + "</button>" +
+        '<div class="bio-panel" id="' + bioId + '" hidden></div></div>';
+    }
+    evidenceCounter += 1;
+    var evId = "ev-" + evidenceCounter;
+    var panelHtml = renderEvidence(it, meta);
+    if (hasId) panelHtml += renderHistoryToggle(it.id);
+    return '<div class="it-wrap"><button type="button" class="' + cls +
+      '" aria-expanded="false" aria-controls="' + evId + '" data-quote="1">' + inner + "</button>" +
+      '<div class="ev" id="' + evId + '" hidden>' + panelHtml + "</div></div>";
+  }
+  export function renderHistoryToggle(itemId) {
+    bioCounter += 1;
+    var bioId = "bio-" + bioCounter;
+    return '<button type="button" class="history-btn" aria-expanded="false" aria-controls="' + bioId +
+      '" data-bio-toggle data-item-id="' + escapeHtml(itemId) + '">View history</button>' +
+      '<div class="bio-panel" id="' + bioId + '" hidden></div>';
+  }
+  export function renderEvidence(it, meta) {
+    var label = it.quote_verified === false
+      ? "EVIDENCE — UNVERIFIED QUOTE"
+      : "EVIDENCE — EXACT QUOTE · " + escapeHtml(fmtDate(meta.created));
+    var because = it.because
+      ? '<div class="ev-because">Because: ' + escapeHtml(it.because) + "</div>"
+      : "";
+    return '<div class="ev-tag">' + label + '</div><div class="ev-quote">“' +
+      escapeHtml(it.quote) + '”</div>' + because;
+  }
+  export function compressBioEvents(events) {
+    var out = [];
+    var i = 0;
+    while (i < events.length) {
+      var e = events[i];
+      if (e.kind !== "seen") { out.push(e); i += 1; continue; }
+      var j = i;
+      while (j < events.length && events[j].kind === "seen") j += 1;
+      out.push({ kind: "seen-run", count: j - i, ts_or_created: events[j - 1].ts_or_created,
+        session_id: null, detail: null });
+      i = j;
+    }
+    return out;
+  }
+  export function taVal(v) {
+    return (v === null || v === undefined || v === "")
+      ? '<span class="ta-none">not recorded</span>'
+      : escapeHtml(String(v));
+  }
+  export function taRow(label, valueHtml) {
+    return '<div class="ta-row"><span class="ta-label">' + label +
+      '</span><div class="ta-val">' + valueHtml + "</div></div>";
+  }
+  export function renderTrustAnatomy(data) {
+    var a = data.trust_anatomy;
+    if (!a) return "";
+    var s = a.stored || {};
+    var c = a.checks || {};
+    var r = a.receipt;
+
+    var claim = taVal(s.trust) +
+      (s.quote ? ' <span class="ta-quote">"' + escapeHtml(s.quote) + '"</span>' : "") +
+      " · quote check: " + (s.quote_verified === true ? "passed"
+        : s.quote_verified === false ? "failed"
+        : '<span class="ta-none">not recorded</span>') +
+      " · last verified: " + taVal(s.last_verified);
+
+    var receipt;
+    if (r) {
+      receipt = "verifier " + taVal(r.verifier) + " · outcome " + taVal(r.outcome) +
+        " · checked " + taVal(r.checked_at) + " · digest " + taVal(r.digest_algorithm) +
+        " · bound to " + (r.message_ids ? r.message_ids.length + " message" +
+          (r.message_ids.length === 1 ? "" : "s") : '<span class="ta-none">not recorded</span>');
+    } else {
+      receipt = '<span class="ta-none">not recorded</span>';
+    }
+
+    var firstSeenSid = a.chain && a.chain[0] && a.chain[0].session_id;
+    var originBits = "origin " + taVal(s.origin_session) +
+      " · first seen " + (firstSeenSid ? escapeHtml(String(firstSeenSid)) : taVal(null)) +
+      " · " +
+      (c.origin_on_disk
+        ? '<span class="ta-flag-ok">source file present</span>'
+        : '<span class="ta-flag-warn">source file missing from disk</span>');
+    if (c.quote_check_failures > 0) {
+      originBits += " · " + c.quote_check_failures + " failed quote check" +
+        (c.quote_check_failures === 1 ? "" : "s") +
+        (c.last_check_ts ? ", last " + escapeHtml(fmtDate(c.last_check_ts)) : "");
+    }
+
+    var chainRows = (a.chain || []).map(function (link) {
+      return '<div class="ta-chain-row"><span class="ta-chain-sid">' +
+        escapeHtml(String(link.session_id).slice(0, 12)) + "</span><span>" +
+        escapeHtml(fmtDate(link.created)) + "</span>" +
+        (link.changed && link.changed.length
+          ? "<span>changed: " + escapeHtml(link.changed.join(", ")) + "</span>" : "") +
+        "</div>";
+    }).join("");
+
+    return '<div class="trust-anatomy">' +
+      taRow("Claim", claim) +
+      taRow("Receipt", receipt) +
+      taRow("Origin", originBits) +
+      taRow("Chain", chainRows || '<span class="ta-none">not recorded</span>') +
+      "</div>";
+  }
+  // Contract §8 (ratified 2026-08-11): "verified" events are verification.jsonl
+  // rows, and that ledger records rejections — the activity feed already calls
+  // the same rows QUOTE CHECK, so the bio must not give them a second name.
+  var BIO_LABELS = {
+    born: "FIRST SEEN", changed: "CHANGED", verified: "QUOTE CHECK", resolved: "RESOLVED", "seen-run": "CARRIED"
+  };
+  export function renderBioEventRow(e) {
+    var dotCls = "life-dot-" + escapeHtml(e.kind === "seen-run" ? "seen" : e.kind);
+    var label = BIO_LABELS[e.kind] || escapeHtml(e.kind.toUpperCase());
+    var when = e.ts_or_created ? escapeHtml(fmtDate(e.ts_or_created)) : "unknown date";
+    var body = "";
+    if (e.kind === "born" && e.detail) {
+      body = '<div class="life-quote">“' + escapeHtml(e.detail) + '”</div>';
+    } else if (e.kind === "seen-run") {
+      body = '<div class="life-detail">carried, unchanged × ' + e.count +
+        (e.count === 1 ? " session" : " sessions") + "</div>";
+    } else if (e.detail) {
+      body = '<div class="life-detail">' + escapeHtml(e.detail) + "</div>";
+    }
+    return '<li class="life-row"><div class="life-rail"><span class="life-dot ' + dotCls +
+      '"></span></div><div class="life-body"><span class="life-label">' + label +
+      '</span><span class="life-when">' + when + "</span>" + body + "</div></li>";
+  }
+  export function renderBioPanel(data) {
+    var anatomyHtml = renderTrustAnatomy(data);
+    var events = compressBioEvents(data.events || []);
+    var noteHtml = data.window_note
+      ? '<p class="life-note">' + escapeHtml(data.window_note) + "</p>"
+      : "";
+    if (events.length === 0) {
+      return anatomyHtml + noteHtml +
+        '<div class="state-card"><p class="state-title">No history recorded</p>' +
+        "<p>This item has no recorded events yet.</p></div>";
+    }
+    return anatomyHtml + noteHtml + '<ul class="life">' +
+      events.map(renderBioEventRow).join("") + "</ul>";
+  }
+  export function renderHistoryPicker() {
+    var opts = state.historySessions.map(function (s) {
+      return {
+        id: s.session_id,
+        label: (s.active_topic || "(untitled)") + " · " + (fmtRelative(s.created) || "unknown date")
+      };
+    });
+    function selectHtml(pickKey, selected) {
+      return '<select class="sess-pick" data-pick="' + pickKey + '">' +
+        opts.map(function (o) {
+          return '<option value="' + escapeHtml(o.id) + '"' +
+            (o.id === selected ? " selected" : "") + '>' + escapeHtml(o.label) + '</option>';
+        }).join("") + '</select>';
+    }
+    return '<div class="sess-pickbar">' +
+      '<label class="sess-label">From' + selectHtml("a", state.historyPick.a) + '</label>' +
+      '<label class="sess-label">To' + selectHtml("b", state.historyPick.b) + '</label>' +
+      '</div>';
+  }
+  export function renderTagChip(cls, label) {
+    return '<span class="tag-chip ' + escapeHtml(cls) + '">' + escapeHtml(label) + '</span>';
+  }
+  export function renderHistoryRow(item, chipCls, chipLabel, note, suffix) {
+    var cls = "it " + trustClass(item);
+    var suffixHtml = suffix ? '<span class="hist-suffix">' + escapeHtml(suffix) + "</span>" : "";
+    var inner = renderTagChip(chipCls, chipLabel) + '<span class="it-text">' + escapeHtml(item.text) +
+      "</span>" + suffixHtml;
+    var noteHtml = note ? '<div class="hist-note">' + escapeHtml(note) + "</div>" : "";
+    if (!item.id) {
+      return '<div class="it-wrap"><div class="' + cls + '">' + inner + noteHtml + "</div></div>";
+    }
+    bioCounter += 1;
+    var bioId = "bio-" + bioCounter;
+    return '<div class="it-wrap"><button type="button" class="' + cls +
+      '" aria-expanded="false" aria-controls="' + bioId + '" data-bio-toggle data-item-id="' +
+      escapeHtml(item.id) + '">' + inner + "</button>" + noteHtml +
+      '<div class="bio-panel" id="' + bioId + '" hidden></div></div>';
+  }
+  export function renderHistoryGroup(key, label, count, wantOpen, bodyHtml) {
+    var expanded = wantOpen && count > 0;
+    var disabled = count === 0;
+    var marker = expanded ? "▾" : "▸";
+    var btn = '<button type="button" class="sec-toggle" aria-expanded="' +
+      (expanded ? "true" : "false") + '" aria-controls="hist-sec-' + key + '"' +
+      (disabled ? " disabled" : "") + '>' + escapeHtml(label) +
+      ' <span class="count">· ' + count + '</span> <span class="disclosure" aria-hidden="true">' +
+      marker + '</span></button>';
+    var body = '<div id="hist-sec-' + key + '" class="sec-body"' + (expanded ? "" : " hidden") + '>' +
+      '<div class="items">' + bodyHtml + "</div></div>";
+    return '<section class="sec" aria-label="' + escapeHtml(label) + '">' + btn + body + "</section>";
+  }
+  function historyReferent(meta) {
+    if (!meta) return null;
+    if (meta.created) return fmtDate(meta.created);
+    return meta.session_id || null;
+  }
+  export function renderHistoryView(diffData) {
+    var born = diffData.born || [];
+    var resolved = diffData.resolved || [];
+    var trustChanged = diffData.trust_changed || [];
+    var carried = diffData.carried || [];
+    var gone = diffData.gone || [];
+
+    var aTopic = (diffData.a && diffData.a.active_topic) || "(untitled)";
+    var bTopic = (diffData.b && diffData.b.active_topic) || "(untitled)";
+    var html = '<h1 class="page-heading">History</h1>' +
+      '<p class="page-meta">' + escapeHtml(aTopic) + " → " + escapeHtml(bTopic) + "</p>";
+    html += renderHistoryPicker();
+
+    if (state.historyUnreadable > 0) {
+      html += '<div class="banner banner-partial"><span class="banner-icon" aria-hidden="true">ⓘ</span><span>' +
+        escapeHtml(state.historyUnreadable + " session file(s) couldn't be read and were skipped.") + "</span></div>";
+    }
+    (diffData.partial || []).forEach(function (p) {
+      html += '<div class="banner banner-partial"><span class="banner-icon" aria-hidden="true">ⓘ</span><span>' +
+        escapeHtml(p) + "</span></div>";
+    });
+
+    var hasChanges = born.length || resolved.length || trustChanged.length || carried.length || gone.length;
+    if (!hasChanges) {
+      html += '<div class="state-card"><p class="state-title">No changes between these sessions</p>' +
+        "<p>Items, resolutions, and trust changes will appear here once something changes " +
+        "between the two selected sessions.</p></div>";
+      return html;
+    }
+
+    // Contract §8.1: the sighting states carry a named referent — the compared
+    // checkpoint's date, or its session id when the date is missing. The
+    // referent renders in the hist-suffix slot, never inside the chip: the
+    // vocabulary tripwire reads the chip's whole inner text as one token.
+    var refB = historyReferent(diffData.b);
+    var refA = historyReferent(diffData.a);
+    html += renderHistoryGroup("born", "First seen", born.length, true,
+      born.map(function (it) { return renderHistoryRow(it, "t-born", "FIRST SEEN", null, refB); }).join(""));
+    html += renderHistoryGroup("resolved", "Resolved", resolved.length, true,
+      resolved.map(function (e) { return renderHistoryRow(e.item, "t-resolved", "RESOLVED", e.note); }).join(""));
+    html += renderHistoryGroup("trust", "Trust class changed", trustChanged.length, true,
+      trustChanged.map(function (e) {
+        return renderHistoryRow(e.item, "t-trust", "TRUST CLASS CHANGED", null, e.from + " → " + e.to);
+      }).join(""));
+    html += renderHistoryGroup("carried", "Carried", carried.length, false,
+      carried.map(function (e) {
+        return renderHistoryRow(e.item, "t-carried", "CARRIED", null);
+      }).join(""));
+    html += renderHistoryGroup("gone", "Last seen", gone.length, false,
+      gone.map(function (it) { return renderHistoryRow(it, "t-gone", "LAST SEEN", null, refA); }).join(""));
+    return html;
+  }
+  export function renderError(e) {
+    return '<div class="state-card state-error"><p class="state-title">⚠ Error — ' +
+      escapeHtml(e.what) + "</p><p>" + escapeHtml(e.why) + "</p><p><strong>Fix:</strong> " +
+      escapeHtml(e.fix) + "</p></div>";
+  }
+  export function renderSingleCheckpointEmpty() {
+    return '<div class="state-card state-empty"><p class="state-title">History starts here — ' +
+      'one checkpoint so far</p><p>Come back after your next session to see what changed.</p></div>';
+  }
+
+  // ---- search (#670): rows are daimon recall's, rendered — one matcher ----
+  function ageOf(created) {
+    if (typeof created === "number") return fmtRelative(new Date(created * 1000).toISOString());
+    return fmtRelative(created);
+  }
+  export function renderSearchResults(q, rows) {
+    var head = '<div class="search-head"><span class="search-title">Search</span>' +
+      '<span class="search-note">results from daimon recall · ' + rows.length +
+      ' match(es) for “' + escapeHtml(q) + '”</span></div>';
+    if (!rows.length) {
+      return head + '<div class="state-card state-empty"><p class="state-title">no matches</p>' +
+        "<p>Same answer <code>daimon recall</code> gives; try fewer or different words.</p></div>";
+    }
+    var body = rows.map(function (r) {
+      var trust = r.trust || "untagged";
+      var sup = !r.superseded_by ? "" :
+        (r.superseded_by === "resolved" ? " [resolved]" : " [superseded by " + escapeHtml(r.superseded_by) + "]");
+      var id = r.item_id ? '<code class="search-id">' + escapeHtml(r.item_id) + "</code>" : "";
+      var open = r.item_id ? ' data-item-id="' + escapeHtml(r.item_id) + '"' : "";
+      return '<button type="button" class="search-row"' + open + ">" +
+        '<span class="search-trust t-' + escapeHtml(trust) + '">[' + escapeHtml(trust) + "]</span>" +
+        '<span class="search-kind">[' + escapeHtml(r.kind || "") + "]</span>" +
+        '<span class="search-text">' + escapeHtml(r.text || "") + "</span>" + id +
+        '<span class="search-meta">(' + escapeHtml(r.session_id || "") + ", " + ageOf(r.created) + ")" +
+        escapeHtml(sup) + "</span></button>";
+    }).join("");
+    return head + '<div class="search-rows">' + body + "</div>";
+  }
+
+  // ---- why (#670): the payload is daimon why's receipt, rendered as-is.
+  // JSON carries no derived summary and the viewer must not invent one:
+  // axes render as recorded values, nothing is folded into a verdict. ----
+  export function renderWhyView(payload) {
+    var item = payload.item || {};
+    var axes = payload.axes || {};
+    var cor = payload.corroboration || {};
+    var html = '<div class="why-view"><div class="why-claim">' +
+      '<span class="search-trust t-' + escapeHtml(item.trust || "untagged") + '">[' +
+      escapeHtml(item.trust || "untagged") + "]</span> " +
+      '<span class="why-text">' + escapeHtml(item.text || "") + "</span>" +
+      '<code class="search-id">' + escapeHtml(item.item_id || "") + "</code></div>";
+    html += '<div class="why-origin">origin ' + escapeHtml(item.origin_session || item.session_id || "") +
+      " · " + escapeHtml(String(item.occurrences || 0)) + " occurrence(s)</div>";
+    if (item.quote) {
+      html += '<div class="why-quote"><span class="why-label">stored quote</span>' +
+        "<blockquote>" + escapeHtml(item.quote) + "</blockquote></div>";
+    } else {
+      html += '<div class="why-quote"><span class="why-label">stored quote</span>' +
+        '<p class="why-none">no quote stored</p></div>';
+    }
+    html += '<div class="why-axes"><span class="why-label">evidence axes</span><dl>' +
+      Object.keys(axes).map(function (k) {
+        return "<dt>" + escapeHtml(k) + "</dt><dd>" + escapeHtml(String(axes[k])) + "</dd>";
+      }).join("") + "</dl></div>";
+    html += '<div class="why-cor"><span class="why-label">corroboration</span><p>' +
+      escapeHtml(String(cor.count || 0)) + " reference(s)" +
+      (cor.references && cor.references.length
+        ? ": " + cor.references.map(escapeHtml).join(", ") : "") + "</p></div>";
+    if (payload.source_excerpt) {
+      html += '<div class="why-source"><span class="why-label">transcript context · fetched now, not stored</span>' +
+        "<pre>" + escapeHtml(String(payload.source_excerpt)) + "</pre></div>";
+    }
+    html += '<div id="why-bio" class="why-bio"></div></div>';
+    return html;
+  }

--- a/plugin/daimon_ui/static/render.js
+++ b/plugin/daimon_ui/static/render.js
@@ -238,7 +238,10 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
     var meta = data.meta || {};
     var metaParts = [meta.active_topic, fmtDate(meta.created), meta.author,
                      receiptMetaText(meta.receipt)].filter(Boolean);
-    var html = '<h1 class="page-heading">While you were away</h1>' +
+    var sub = (meta.session_id ? "s-" + String(meta.session_id).slice(0, 8) + " · " : "") +
+      "every line carries the object it came from";
+    var html = '<div class="brief-head"><h1 class="page-heading">Briefing</h1>' +
+      '<span class="brief-sub">' + escapeHtml(sub) + "</span></div>" +
       '<p class="page-meta">' + metaParts.map(escapeHtml).join(" · ") + "</p>" +
       receiptBanner(meta.receipt);
     (data.partial || []).forEach(function (p) {
@@ -287,34 +290,29 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
     if (it.trust === "inferred") return "it-inferred";
     return "it-untagged";
   }
+  // Trust glyphs are the design's frozen legend: solid square = verbatim,
+  // outlined = inferred, dashed = untagged.
+  export function trustGlyph(trust) {
+    var g = trust === "verbatim" ? "glyph-verbatim"
+      : trust === "inferred" ? "glyph-inferred" : "glyph-untagged";
+    return '<span class="glyph ' + g + '" aria-hidden="true"></span>';
+  }
   export function renderItem(it, meta) {
-    var cls = "it " + trustClass(it);
     var carried = it.carried_from
       ? '<span class="chip-carried">⟳ carried from ' + escapeHtml(it.carried_from) + "</span>"
       : "";
-    var inner = '<span class="it-text">' + escapeHtml(it.text) + "</span>" + carried;
-    var hasQuote = !!it.quote;
-    var hasId = !!it.id;
-    if (!hasQuote && !hasId) {
-      return '<div class="it-wrap"><div class="' + cls + '">' + inner + "</div></div>";
+    var inner = trustGlyph(it.trust) +
+      '<span class="it-text">' + escapeHtml(it.text) + carried + "</span>";
+    // Design contract: a briefing line carries the object it came from, and
+    // clicking the line opens that entry. No inline expansion here — the entry
+    // page is where evidence lives.
+    if (it.id) {
+      return '<div class="it-wrap"><button type="button" class="brief-row ' + trustClass(it) +
+        '" data-open-why data-item-id="' + escapeHtml(it.id) + '">' + inner +
+        '<code class="obj-id">' + escapeHtml(it.id) + "</code></button></div>";
     }
-    if (hasId && !hasQuote) {
-      // No evidence to show, so the item's own button opens the biography panel directly —
-      // no empty evidence shell in between.
-      bioCounter += 1;
-      var bioId = "bio-" + bioCounter;
-      return '<div class="it-wrap"><button type="button" class="' + cls +
-        '" aria-expanded="false" aria-controls="' + bioId + '" data-bio-toggle data-item-id="' +
-        escapeHtml(it.id) + '">' + inner + "</button>" +
-        '<div class="bio-panel" id="' + bioId + '" hidden></div></div>';
-    }
-    evidenceCounter += 1;
-    var evId = "ev-" + evidenceCounter;
-    var panelHtml = renderEvidence(it, meta);
-    if (hasId) panelHtml += renderHistoryToggle(it.id);
-    return '<div class="it-wrap"><button type="button" class="' + cls +
-      '" aria-expanded="false" aria-controls="' + evId + '" data-quote="1">' + inner + "</button>" +
-      '<div class="ev" id="' + evId + '" hidden>' + panelHtml + "</div></div>";
+    return '<div class="it-wrap"><div class="brief-row brief-row-static ' + trustClass(it) + '">' +
+      inner + "</div></div>";
   }
   export function renderHistoryToggle(itemId) {
     bioCounter += 1;
@@ -580,17 +578,17 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
     var body = rows.map(function (r) {
       var trust = r.trust || "untagged";
       var sup = !r.superseded_by ? "" :
-        (r.superseded_by === "resolved" ? " [resolved]" : " [superseded by " + escapeHtml(r.superseded_by) + "]");
-      var id = r.item_id ? '<code class="search-id">' + escapeHtml(r.item_id) + "</code>" : "";
+        (r.superseded_by === "resolved" ? " · resolved" : " · superseded by " + escapeHtml(r.superseded_by));
+      var id = r.item_id ? '<code class="obj-id">' + escapeHtml(r.item_id) + "</code>" : "";
       var open = r.item_id ? ' data-item-id="' + escapeHtml(r.item_id) + '"' : "";
-      return '<button type="button" class="search-row"' + open + ">" +
-        '<span class="search-trust t-' + escapeHtml(trust) + '">[' + escapeHtml(trust) + "]</span>" +
-        '<span class="search-kind">[' + escapeHtml(r.kind || "") + "]</span>" +
+      return '<button type="button" class="search-row"' + open + ">" + trustGlyph(trust) +
         '<span class="search-text">' + escapeHtml(r.text || "") + "</span>" + id +
-        '<span class="search-meta">(' + escapeHtml(r.session_id || "") + ", " + ageOf(r.created) + ")" +
-        escapeHtml(sup) + "</span></button>";
+        '<span class="search-meta">' + escapeHtml(r.kind || "") + " · " +
+        escapeHtml(String(r.session_id || "").slice(0, 8)) + " · " + ageOf(r.created) +
+        sup + "</span></button>";
     }).join("");
-    return head + '<div class="search-rows">' + body + "</div>";
+    return head + '<div class="search-rows">' + body +
+      '<div class="card-foot">click any row to open its entry</div></div>';
   }
 
   // ---- why (#670): the payload is daimon why's receipt, rendered as-is.
@@ -600,32 +598,60 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
     var item = payload.item || {};
     var axes = payload.axes || {};
     var cor = payload.corroboration || {};
-    var html = '<div class="why-view"><div class="why-claim">' +
-      '<span class="search-trust t-' + escapeHtml(item.trust || "untagged") + '">[' +
-      escapeHtml(item.trust || "untagged") + "]</span> " +
-      '<span class="why-text">' + escapeHtml(item.text || "") + "</span>" +
-      '<code class="search-id">' + escapeHtml(item.item_id || "") + "</code></div>";
-    html += '<div class="why-origin">origin ' + escapeHtml(item.origin_session || item.session_id || "") +
-      " · " + escapeHtml(String(item.occurrences || 0)) + " occurrence(s)</div>";
+    var trust = item.trust || "untagged";
+    var origin = item.origin_session || item.session_id || "";
+
+    var html = '<div class="why-view">' +
+      '<div class="why-crumb"><button type="button" class="back-link" data-why-back>← back</button>' +
+      '<span class="crumb-sep">/</span><code class="crumb-id">' + escapeHtml(item.item_id || "") +
+      '</code><span class="crumb-trust">' + trustGlyph(trust) + escapeHtml(trust) + "</span></div>";
+
+    html += '<div class="why-card">';
+    html += '<p class="why-text">' + escapeHtml(item.text || "") + "</p>";
+    html += '<div class="why-meta"><span>origin <span class="obj-ref">' +
+      escapeHtml(String(origin).slice(0, 8)) + "</span></span><span>" +
+      escapeHtml(String(item.occurrences || 0)) + " occurrence(s)</span><span>" +
+      escapeHtml(item.kind || "") + "</span></div>";
+
     if (item.quote) {
-      html += '<div class="why-quote"><span class="why-label">stored quote</span>' +
-        "<blockquote>" + escapeHtml(item.quote) + "</blockquote></div>";
+      html += '<div class="why-quote"><div class="why-quote-head">' +
+        '<span class="why-label">Stored quote</span></div>' +
+        '<blockquote>' + escapeHtml(item.quote) + "</blockquote></div>";
     } else {
-      html += '<div class="why-quote"><span class="why-label">stored quote</span>' +
+      html += '<div class="why-quote"><div class="why-quote-head">' +
+        '<span class="why-label">Stored quote</span></div>' +
         '<p class="why-none">no quote stored</p></div>';
     }
-    html += '<div class="why-axes"><span class="why-label">evidence axes</span><dl>' +
+
+    // source_excerpt is structured: {kind, text, truncated?} — render the text,
+    // label its kind, and say when it was cut rather than pretending it wasn't.
+    var src = payload.source_excerpt;
+    if (src && src.text) {
+      html += '<div class="why-source"><span class="why-label">Transcript context · fetched now, not stored' +
+        (src.kind ? " · " + escapeHtml(String(src.kind)) : "") + "</span>" +
+        "<pre>" + escapeHtml(String(src.text)) +
+        (src.truncated ? "\n[truncated]" : "") + "</pre></div>";
+    }
+
+    // Sightings rule: agreement is not corroboration — references are listed as
+    // session referents, never a bare count alone.
+    if (cor.references && cor.references.length) {
+      html += '<div class="why-seen">seen independently in ' +
+        cor.references.map(function (s) {
+          return '<span class="obj-ref">' + escapeHtml(String(s).slice(0, 8)) + "</span>";
+        }).join(", ") + "</div>";
+    } else {
+      html += '<div class="why-seen">seen only at origin, no other sightings</div>';
+    }
+
+    html += '<div class="why-axes"><span class="why-label">Evidence axes</span><dl>' +
       Object.keys(axes).map(function (k) {
         return "<dt>" + escapeHtml(k) + "</dt><dd>" + escapeHtml(String(axes[k])) + "</dd>";
       }).join("") + "</dl></div>";
-    html += '<div class="why-cor"><span class="why-label">corroboration</span><p>' +
-      escapeHtml(String(cor.count || 0)) + " reference(s)" +
-      (cor.references && cor.references.length
-        ? ": " + cor.references.map(escapeHtml).join(", ") : "") + "</p></div>";
-    if (payload.source_excerpt) {
-      html += '<div class="why-source"><span class="why-label">transcript context · fetched now, not stored</span>' +
-        "<pre>" + escapeHtml(String(payload.source_excerpt)) + "</pre></div>";
-    }
-    html += '<div id="why-bio" class="why-bio"></div></div>';
+
+    html += '<div class="why-life"><span class="why-label">Life</span>' +
+      '<div id="why-bio" class="why-bio"></div></div>';
+    html += '<div class="card-foot">read-only · this page renders the record; it holds nothing of its own</div>';
+    html += "</div></div>";
     return html;
   }

--- a/plugin/daimon_ui/static/state.js
+++ b/plugin/daimon_ui/static/state.js
@@ -1,0 +1,8 @@
+// Shared mutable app state. Read by pure render functions (defaultSlug, historyPick,
+// historySessions, historyUnreadable) and read/written by the DOM layer in app.js.
+export const state = {
+  checkpoints: [], sessionsTotal: 0, activeRef: null, pendingTimer: null, requestId: 0,
+  projects: [], defaultSlug: null, currentSlug: null, view: "loading", cameFromGrid: false,
+  historySessions: [], historyUnreadable: 0, historyPick: { a: null, b: null },
+  bioCache: {}
+};

--- a/plugin/daimon_ui/static/state.js
+++ b/plugin/daimon_ui/static/state.js
@@ -4,5 +4,5 @@ export const state = {
   checkpoints: [], sessionsTotal: 0, activeRef: null, pendingTimer: null, requestId: 0,
   projects: [], defaultSlug: null, currentSlug: null, view: "loading", cameFromGrid: false,
   historySessions: [], historyUnreadable: 0, historyPick: { a: null, b: null },
-  bioCache: {}
+  bioCache: {}, lastSearchQ: null
 };

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -66,7 +66,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["daimon_briefing"]
+packages = ["daimon_briefing", "daimon_ui"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -92,7 +92,7 @@ python_version = "3.10"
 ignore_missing_imports = true
 
 [tool.coverage.run]
-source = ["daimon_briefing"]
+source = ["daimon_briefing", "daimon_ui"]
 # _hooks/ ships byte-identical mirrors of files whose canonical sources are
 # tested (drift-guarded by test_hooks_install.py), and the adapter scripts
 # execute only as subprocesses under the host's Python — in-process line

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -108,8 +108,17 @@ KNOWN_BYPASSES = frozenset({
 
 # Commands that genuinely cannot be driven headless would be named here with
 # a reason — the guard fails on any command lacking BOTH a recipe and a
-# SKIPPED entry, so a skip can never be silent. Currently every command runs.
-SKIPPED: dict = {}
+# SKIPPED entry, so a skip can never be silent.
+SKIPPED: dict = {
+    ("serve",): (
+        "foreground HTTP server: serve_forever() never returns, so the recipe "
+        "harness cannot drive it to completion. Its write surface is bounded "
+        "by construction — the handler defines only do_GET, and its engine "
+        "calls (recall.search, inspector.inspect_item) are the same paths the "
+        "`recall` recipe already audits (tests/ui/test_server_engines.py "
+        "covers the dispatch)."
+    ),
+}
 
 # Pure log sinks, allowlisted BY FILENAME if one ever lands under an audited
 # root. Today they all live under config.log_dir() (outside the roots), so

--- a/plugin/tests/ui/conftest.py
+++ b/plugin/tests/ui/conftest.py
@@ -1,0 +1,109 @@
+import json
+import threading
+import pytest
+from daimon_ui import server
+
+def make_checkpoint(created="2026-08-06T08:05:12Z", topic="Scoping the inspector", **over):
+    cp = {
+        "session_id": over.get("session_id", "aaaa-bbbb"),
+        "format_version": over.get("format_version", "D-018"),
+        "created": created,
+        "author": "ada",
+        "project_slug": "-tmp-proj",
+        "working_context": {
+            "active_topic": {"text": topic},
+            "open_questions": over.get("open_questions", []),
+            "recent_decisions": over.get("recent_decisions", []),
+        },
+        "epistemic_snapshot": {
+            "strong_beliefs": over.get("strong_beliefs", []),
+            "uncertainties": over.get("uncertainties", []),
+            "contradictions_flagged": over.get("contradictions_flagged", []),
+        },
+        "worker_queue": [{"type": "task", "id": 1, "name": "x", "status": "open", "importance": 2, "scene": ""}],
+    }
+    return cp
+
+@pytest.fixture
+def bucket(tmp_path):
+    b = tmp_path / "checkpoints" / "-tmp-proj"
+    b.mkdir(parents=True)
+    (b / "latest.json").write_text(json.dumps(make_checkpoint()))
+    (b / "prev-1.json").write_text(json.dumps(make_checkpoint(created="2026-08-06T02:04:00Z", topic="Option B decided")))
+    (b / "prev-2.json").write_text(json.dumps(make_checkpoint(created="2026-08-05T22:00:00Z", topic="Moat strategy read")))
+    (b / "latest.json.bak-123").write_text("{}")          # stray sidecar — must be ignored
+    (b / "events.jsonl").write_text("")                    # append log — must be ignored
+    return b
+
+@pytest.fixture
+def second_bucket(bucket):
+    root = bucket.parent
+    b2 = root / "-other-proj"
+    b2.mkdir()
+    (b2 / "latest.json").write_text(json.dumps(
+        make_checkpoint(created="2026-08-04T00:00:00Z", topic="Other project topic")))
+    return b2
+
+@pytest.fixture
+def srv(bucket):
+    data_dir = bucket.parent
+    s = server.make_server(data_dir, "-tmp-proj", "daimon-ui-init", port=0)
+    t = threading.Thread(target=s.serve_forever, daemon=True)
+    t.start()
+    yield f"http://127.0.0.1:{s.server_address[1]}"
+    s.shutdown()
+
+@pytest.fixture
+def srv_multi(bucket, second_bucket):
+    data_dir = bucket.parent
+    s = server.make_server(data_dir, "-tmp-proj", "daimon-ui-init", port=0)
+    t = threading.Thread(target=s.serve_forever, daemon=True)
+    t.start()
+    yield f"http://127.0.0.1:{s.server_address[1]}"
+    s.shutdown()
+
+@pytest.fixture
+def flat_history(tmp_path):
+    d = tmp_path / "checkpoints"
+    d.mkdir(parents=True)
+    slug = "-tmp-proj"
+    bucket = d / slug
+    bucket.mkdir()
+    for i, (sid, created, topic) in enumerate([
+        ("aaaa-1111", "2026-08-04T10:00:00Z", "day one"),
+        ("bbbb-2222", "2026-08-05T10:00:00Z", "day two"),
+        ("rollout-2026-08-06-cccc", "2026-08-06T10:00:00Z", "day three"),
+    ]):
+        cp = make_checkpoint(created=created, topic=topic, session_id=sid)
+        cp["project_slug"] = slug
+        (d / f"{sid}.json").write_text(json.dumps(cp))
+    other = make_checkpoint(created="2026-08-05T12:00:00Z", topic="other proj")
+    other["project_slug"] = "-other"
+    (d / "dddd-9999.json").write_text(json.dumps(other))
+    (d / "latest.json").write_text(json.dumps(make_checkpoint()))   # pointer: excluded
+    (d / "torn.json").write_text("{nope")                            # unreadable: counted
+    (d / "x.tmp").write_text("{}")                                   # excluded
+    (bucket / "latest.json").write_text(json.dumps(make_checkpoint()))  # for server bucket discovery
+    return d, slug
+
+@pytest.fixture
+def srv_flat(flat_history):
+    """A project whose sidebar window is narrower than its history: the bucket
+    holds one pointer, the root holds three sessions. The asymmetry is the point."""
+    d, slug = flat_history
+    s = server.make_server(d, slug, "daimon-ui-init", port=0)
+    t = threading.Thread(target=s.serve_forever, daemon=True)
+    t.start()
+    yield f"http://127.0.0.1:{s.server_address[1]}"
+    s.shutdown()
+
+@pytest.fixture
+def flat_with_events(flat_history):
+    d, slug = flat_history
+    ev = d / slug / "events.jsonl"
+    ev.write_text('\n'.join([
+        json.dumps({"ts": "2026-08-06T09:00:00Z", "kind": "resolution", "item_ref": "o-aaa111aaa111", "status": "resolved", "source": "cli", "note": "closed it", "item_text": "old question"}),
+        '{broken line',
+        json.dumps({"ts": "2026-08-06T09:05:00Z", "kind": "other", "item_ref": "o-zzz", "status": "resolved"}),
+    ]) + '\n')
+    return d, slug

--- a/plugin/tests/ui/test_activity.py
+++ b/plugin/tests/ui/test_activity.py
@@ -1,0 +1,126 @@
+import json
+from daimon_ui import reader
+from tests.ui.conftest import make_checkpoint
+
+
+def _write_sessions(d, slug):
+    for sid, created, topic in [
+        ("aaaa-1111", "2026-08-04T10:00:00Z", "day one"),
+        ("bbbb-2222", "2026-08-05T10:00:00Z", "day two"),
+    ]:
+        cp = make_checkpoint(created=created, topic=topic, session_id=sid)
+        cp["project_slug"] = slug
+        (d / f"{sid}.json").write_text(json.dumps(cp))
+
+
+def test_activity_merges_and_sorts_newest_first(tmp_path):
+    d = tmp_path / "checkpoints"
+    slug = "-tmp-proj"
+    (d / slug).mkdir(parents=True)
+    _write_sessions(d, slug)
+    (d / slug / "events.jsonl").write_text("\n".join([
+        json.dumps({"ts": "2026-08-05T12:00:00Z", "kind": "resolution",
+                    "item_ref": "o-abc123abc123", "status": "resolved",
+                    "source": "cli", "note": "closed it", "item_text": "the question"}),
+        json.dumps({"ts": "2026-08-06T09:00:00Z", "kind": "handoff",
+                    "item_ref": "", "status": "open", "source": "cli",
+                    "note": "Do X next. Beware Y."}),
+    ]) + "\n")
+    (d / slug / "verification.jsonl").write_text(json.dumps(
+        {"ts": "2026-08-04T11:00:00Z", "check": "quote",
+         "item_ref": "o-abc123abc123", "reason": "quote-not-in-transcript"}) + "\n")
+
+    got = reader.project_activity(d, slug)
+    assert got["ok"] is True
+    assert [r["kind"] for r in got["rows"]] == [
+        "handoff", "resolution", "session", "quote_check", "session"]
+    assert got["rows"][0]["detail"] == "Do X next. Beware Y."
+    assert got["rows"][0]["item_ref"] is None          # "" normalizes to None
+    assert got["rows"][1]["extra"]["status"] == "resolved"
+    assert got["rows"][3]["detail"] == "quote: quote-not-in-transcript"
+
+
+def test_activity_session_rows_carry_topic(tmp_path):
+    d = tmp_path / "checkpoints"
+    slug = "-tmp-proj"
+    (d / slug).mkdir(parents=True)
+    _write_sessions(d, slug)
+    got = reader.project_activity(d, slug)
+    sess = [r for r in got["rows"] if r["kind"] == "session"]
+    assert [s["session_id"] for s in sess] == ["bbbb-2222", "aaaa-1111"]
+    assert sess[0]["detail"] == "day two"
+    assert sess[0]["extra"] == {"topic": "day two"}
+
+
+def test_activity_resolution_detail_falls_back_to_item_text(tmp_path):
+    d = tmp_path / "checkpoints"
+    slug = "-tmp-proj"
+    (d / slug).mkdir(parents=True)
+    (d / slug / "events.jsonl").write_text(json.dumps(
+        {"ts": "2026-08-05T12:00:00Z", "kind": "resolution",
+         "item_ref": "r-3031f5303030", "status": "resolved", "source": "cli",
+         "item_text": "the described item"}) + "\n")
+    got = reader.project_activity(d, slug)
+    assert got["rows"][0]["detail"] == "the described item"
+
+
+def test_activity_corroboration_detail_falls_back_to_status(tmp_path):
+    d = tmp_path / "checkpoints"
+    slug = "-tmp-proj"
+    (d / slug).mkdir(parents=True)
+    (d / slug / "events.jsonl").write_text(json.dumps(
+        {"ts": "2026-08-07T01:41:07Z", "kind": "corroboration",
+         "item_ref": "corroboration:o-e00b696fa67a",
+         "status": "corroborated-by:fddace65", "source": "serializer"}) + "\n")
+    got = reader.project_activity(d, slug)
+    row = got["rows"][0]
+    assert row["detail"] == "corroborated-by:fddace65"
+    assert row["item_ref"] == "corroboration:o-e00b696fa67a"   # kept verbatim
+
+
+def test_activity_unknown_kind_passes_through(tmp_path):
+    d = tmp_path / "checkpoints"
+    slug = "-tmp-proj"
+    (d / slug).mkdir(parents=True)
+    (d / slug / "events.jsonl").write_text(json.dumps(
+        {"ts": "2026-08-07T02:00:00Z", "kind": "wormhole",
+         "item_ref": "o-abc123abc123", "status": "weird", "source": "cli",
+         "note": "novel event"}) + "\n")
+    got = reader.project_activity(d, slug)
+    assert got["rows"][0]["kind"] == "wormhole"
+    assert got["rows"][0]["detail"] == "novel event"
+
+
+def test_activity_torn_lines_skipped_tsless_rows_last(tmp_path):
+    d = tmp_path / "checkpoints"
+    slug = "-tmp-proj"
+    (d / slug).mkdir(parents=True)
+    (d / slug / "events.jsonl").write_text("\n".join([
+        "{broken",
+        json.dumps({"kind": "note", "item_ref": "", "status": "open",
+                    "source": "cli", "note": "no timestamp"}),
+        json.dumps({"ts": "2026-08-07T03:00:00Z", "kind": "note", "item_ref": "",
+                    "status": "open", "source": "cli", "note": "stamped"}),
+    ]) + "\n")
+    got = reader.project_activity(d, slug)
+    assert [r["detail"] for r in got["rows"]] == ["stamped", "no timestamp"]
+    assert got["rows"][1]["ts"] is None
+
+
+def test_activity_unreadable_session_lands_in_partial(tmp_path):
+    d = tmp_path / "checkpoints"
+    slug = "-tmp-proj"
+    (d / slug).mkdir(parents=True)
+    _write_sessions(d, slug)
+    (d / "torn.json").write_text("{nope")
+    got = reader.project_activity(d, slug)
+    assert got["partial"] and "1" in got["partial"][0]
+
+
+def test_activity_empty_bucket_is_honestly_empty(tmp_path):
+    d = tmp_path / "checkpoints"
+    slug = "-tmp-proj"
+    (d / slug).mkdir(parents=True)
+    got = reader.project_activity(d, slug)
+    assert got["ok"] is True
+    assert got["rows"] == []

--- a/plugin/tests/ui/test_biography.py
+++ b/plugin/tests/ui/test_biography.py
@@ -1,0 +1,255 @@
+import json
+from daimon_ui import reader
+from tests.ui.conftest import make_checkpoint
+
+BIO_ID = "o-abc123abc123"
+LATE_BORN_ID = "o-def456def456"
+
+
+def _write_bio_sessions(d, slug):
+    # aaaa-1111 (day one, oldest): item is born here, verbatim, with a quote.
+    cp_a = make_checkpoint(
+        created="2026-08-04T10:00:00Z", topic="day one", session_id="aaaa-1111",
+        open_questions=[
+            {"text": "root cause of the outage", "id": BIO_ID, "trust": "verbatim",
+             "quote": "it was the DNS all along", "quote_verified": True},
+        ],
+    )
+    cp_a["project_slug"] = slug
+    (d / "aaaa-1111.json").write_text(json.dumps(cp_a))
+
+    # bbbb-2222 (day two): item carried unchanged -> "seen". Also where LATE_BORN_ID appears
+    # for the first time (not the oldest session) so window_note should NOT fire for it.
+    cp_b = make_checkpoint(
+        created="2026-08-05T10:00:00Z", topic="day two", session_id="bbbb-2222",
+        open_questions=[
+            {"text": "root cause of the outage", "id": BIO_ID, "trust": "verbatim",
+             "quote": "it was the DNS all along", "quote_verified": True},
+            {"text": "second question", "id": LATE_BORN_ID, "trust": "inferred"},
+        ],
+    )
+    cp_b["project_slug"] = slug
+    (d / "bbbb-2222.json").write_text(json.dumps(cp_b))
+
+    # rollout-2026-08-06-cccc (day three, newest): trust mutated verbatim -> inferred.
+    cp_c = make_checkpoint(
+        created="2026-08-06T10:00:00Z", topic="day three", session_id="rollout-2026-08-06-cccc",
+        open_questions=[
+            {"text": "root cause of the outage", "id": BIO_ID, "trust": "inferred",
+             "quote": "it was the DNS all along", "quote_verified": True},
+            {"text": "second question", "id": LATE_BORN_ID, "trust": "inferred"},
+        ],
+    )
+    cp_c["project_slug"] = slug
+    (d / "rollout-2026-08-06-cccc.json").write_text(json.dumps(cp_c))
+
+
+def test_item_biography_rejects_path_traversal_id(flat_history):
+    d, slug = flat_history
+    got = reader.item_biography(d, slug, "../x")
+    assert got["ok"] is False
+    assert set(got["error"]) == {"what", "why", "fix"}
+
+
+def test_item_biography_rejects_malformed_id(flat_history):
+    d, slug = flat_history
+    got = reader.item_biography(d, slug, "o-XYZ")
+    assert got["ok"] is False
+    assert set(got["error"]) == {"what", "why", "fix"}
+
+
+def test_item_biography_unknown_valid_id_points_at_diff_view(flat_history):
+    d, slug = flat_history
+    got = reader.item_biography(d, slug, "o-ffffff000000")
+    assert got["ok"] is False
+    assert "diff" in got["error"]["fix"].lower()
+
+
+def test_item_biography_born_carried_changed_sequence(flat_history):
+    d, slug = flat_history
+    _write_bio_sessions(d, slug)
+
+    got = reader.item_biography(d, slug, BIO_ID)
+    assert got["ok"] is True
+
+    kinds = [e["kind"] for e in got["events"]]
+    assert kinds == ["born", "seen", "changed"]
+
+    born = got["events"][0]
+    assert born["session_id"] == "aaaa-1111"
+    assert born["ts_or_created"] == "2026-08-04T10:00:00Z"
+    assert born["detail"] == "it was the DNS all along"
+
+    seen = got["events"][1]
+    assert seen["session_id"] == "bbbb-2222"
+    assert seen["detail"] is None
+
+    changed = got["events"][2]
+    assert changed["session_id"] == "rollout-2026-08-06-cccc"
+    assert "trust" in changed["detail"]
+
+    assert got["item"]["id"] == BIO_ID
+    assert got["item"]["trust"] == "inferred"  # latest sighting
+    assert got["item"]["section"] == "open_loops"
+
+    # item already present in the oldest scanned session -> window_note fires.
+    assert got["window_note"] == "history starts here — earlier sessions may have been cleaned up"
+
+
+def test_item_biography_no_window_note_when_born_after_oldest_session(flat_history):
+    d, slug = flat_history
+    _write_bio_sessions(d, slug)
+
+    got = reader.item_biography(d, slug, LATE_BORN_ID)
+    assert got["ok"] is True
+    assert got["events"][0]["kind"] == "born"
+    assert got["events"][0]["session_id"] == "bbbb-2222"
+    assert got["window_note"] is None
+
+
+def test_item_biography_verified_event_folded_in_ts_order(flat_history):
+    d, slug = flat_history
+    _write_bio_sessions(d, slug)
+    bucket = d / slug
+    bucket.mkdir(exist_ok=True)
+    (bucket / "verification.jsonl").write_text('\n'.join([
+        json.dumps({"ts": "2026-08-05T15:00:00Z", "check": "quote", "item_ref": BIO_ID,
+                     "reason": "quote-not-in-transcript"}),
+        '{broken line',
+        json.dumps({"ts": "2026-08-05T16:00:00Z", "check": "quote", "item_ref": "o-someone-else",
+                     "reason": "quote-not-in-transcript"}),
+    ]) + '\n')
+
+    got = reader.item_biography(d, slug, BIO_ID)
+    assert got["ok"] is True
+    kinds = [e["kind"] for e in got["events"]]
+    # verified sits between "seen" (day two, 08-05T10:00) and "changed" (day three, 08-06T10:00)
+    assert kinds == ["born", "seen", "verified", "changed"]
+    verified = got["events"][2]
+    assert verified["session_id"] is None
+    assert verified["ts_or_created"] == "2026-08-05T15:00:00Z"
+    assert "quote-not-in-transcript" in verified["detail"]
+
+
+def test_item_biography_resolved_event_from_bucket_events(flat_history):
+    d, slug = flat_history
+    _write_bio_sessions(d, slug)
+    bucket = d / slug
+    bucket.mkdir(exist_ok=True)
+    (bucket / "events.jsonl").write_text(json.dumps({
+        "ts": "2026-08-07T09:00:00Z", "kind": "resolution", "item_ref": BIO_ID,
+        "status": "resolved", "note": "root cause confirmed and fixed",
+    }) + '\n')
+
+    got = reader.item_biography(d, slug, BIO_ID)
+    assert got["ok"] is True
+    assert got["events"][-1]["kind"] == "resolved"
+    assert got["events"][-1]["ts_or_created"] == "2026-08-07T09:00:00Z"
+    assert got["events"][-1]["detail"] == "root cause confirmed and fixed"
+    assert got["events"][-1]["session_id"] is None
+
+
+def test_biography_includes_trust_anatomy_block(flat_history):
+    d, slug = flat_history
+    _write_bio_sessions(d, slug)
+    got = reader.item_biography(d, slug, BIO_ID)
+    assert got["ok"] is True
+    a = got["trust_anatomy"]
+    assert a["stored"]["trust"] == "inferred"          # newest sighting wins
+    assert a["stored"]["quote"] == "it was the DNS all along"
+    assert a["stored"]["quote_verified"] is True
+    assert [c["session_id"] for c in a["chain"]] == [
+        "aaaa-1111", "bbbb-2222", "rollout-2026-08-06-cccc"]
+    assert a["chain"][0]["changed"] == []
+    assert a["chain"][2]["changed"] == ["trust"]
+    assert a["checks"]["quote_check_failures"] == 0
+    assert a["checks"]["last_check_ts"] is None
+
+
+def test_biography_origin_on_disk_true_when_first_sighting_file_exists(flat_history):
+    d, slug = flat_history
+    _write_bio_sessions(d, slug)
+    got = reader.item_biography(d, slug, BIO_ID)
+    # no origin_session stored -> falls back to first-sighting session aaaa-1111,
+    # whose file exists in the flat dir
+    assert got["trust_anatomy"]["checks"]["origin_on_disk"] is True
+
+
+def test_biography_origin_on_disk_false_when_stored_origin_missing(flat_history):
+    d, slug = flat_history
+    _write_bio_sessions(d, slug)
+    cp = json.loads((d / "rollout-2026-08-06-cccc.json").read_text())
+    cp["working_context"]["open_questions"][0]["origin_session"] = "gone-0000"
+    (d / "rollout-2026-08-06-cccc.json").write_text(json.dumps(cp))
+    got = reader.item_biography(d, slug, BIO_ID)
+    assert got["trust_anatomy"]["checks"]["origin_on_disk"] is False
+
+
+def test_biography_origin_on_disk_false_for_path_traversal_origin_session(flat_history):
+    d, slug = flat_history
+    _write_bio_sessions(d, slug)
+    # a file that exists OUTSIDE the checkpoints dir -- if origin_session were used
+    # unvalidated in path construction, "../secret" would resolve to it and turn
+    # origin_on_disk into an existence oracle over arbitrary .json paths.
+    (d.parent / "secret.json").write_text("{}")
+    cp = json.loads((d / "rollout-2026-08-06-cccc.json").read_text())
+    cp["working_context"]["open_questions"][0]["origin_session"] = "../secret"
+    (d / "rollout-2026-08-06-cccc.json").write_text(json.dumps(cp))
+    got = reader.item_biography(d, slug, BIO_ID)
+    assert got["ok"] is True
+    assert got["trust_anatomy"]["checks"]["origin_on_disk"] is False
+
+
+def test_biography_receipt_from_quote_provenance(flat_history):
+    d, slug = flat_history
+    _write_bio_sessions(d, slug)
+    cp = json.loads((d / "rollout-2026-08-06-cccc.json").read_text())
+    cp["working_context"]["open_questions"][0]["quote_provenance"] = {
+        "verifier": "quote-v2", "outcome": "verified",
+        "checked_at": "2026-08-06T10:00:00Z",
+        "digest": {"algorithm": "sha256", "value": "ff"},
+        "binding": {"message_ids": ["m1", "m2"]},
+    }
+    (d / "rollout-2026-08-06-cccc.json").write_text(json.dumps(cp))
+    got = reader.item_biography(d, slug, BIO_ID)
+    assert got["trust_anatomy"]["receipt"]["verifier"] == "quote-v2"
+    assert got["trust_anatomy"]["receipt"]["message_ids"] == ["m1", "m2"]
+
+
+def test_biography_receipt_none_when_absent(flat_history):
+    d, slug = flat_history
+    _write_bio_sessions(d, slug)
+    got = reader.item_biography(d, slug, BIO_ID)
+    assert got["trust_anatomy"]["receipt"] is None
+
+
+def test_biography_quote_check_failures_counted_with_reason_filter(flat_history):
+    d, slug = flat_history
+    _write_bio_sessions(d, slug)
+    (d / slug).mkdir(exist_ok=True)
+    (d / slug / "verification.jsonl").write_text("\n".join([
+        json.dumps({"ts": "2026-08-06T09:00:00Z", "check": "quote",
+                    "item_ref": BIO_ID, "reason": "quote-not-in-transcript"}),
+        json.dumps({"ts": "2026-08-06T11:00:00Z", "check": "quote",
+                    "item_ref": BIO_ID, "reason": "quote-not-in-transcript"}),
+        json.dumps({"ts": "2026-08-06T12:00:00Z", "check": "quote",
+                    "item_ref": BIO_ID}),                       # no reason: not a failure
+        json.dumps({"ts": "2026-08-06T13:00:00Z", "check": "quote",
+                    "item_ref": "o-other0other0", "reason": "x"}),  # other item
+    ]) + "\n")
+    got = reader.item_biography(d, slug, BIO_ID)
+    assert got["trust_anatomy"]["checks"]["quote_check_failures"] == 2
+    assert got["trust_anatomy"]["checks"]["last_check_ts"] == "2026-08-06T11:00:00Z"
+
+
+def test_biography_single_session_chain_length_one(flat_history):
+    d, slug = flat_history
+    cp = make_checkpoint(created="2026-08-04T10:00:00Z", topic="solo",
+                         session_id="aaaa-1111",
+                         open_questions=[{"text": "only", "id": "o-111111111111",
+                                          "trust": "verbatim"}])
+    cp["project_slug"] = slug
+    (d / "aaaa-1111.json").write_text(json.dumps(cp))
+    got = reader.item_biography(d, slug, "o-111111111111")
+    assert got["ok"] is True
+    assert len(got["trust_anatomy"]["chain"]) == 1

--- a/plugin/tests/ui/test_biography_bench.py
+++ b/plugin/tests/ui/test_biography_bench.py
@@ -1,0 +1,48 @@
+import json
+import time
+from daimon_ui import reader
+from tests.ui.conftest import make_checkpoint
+
+BENCH_ID = "o-beeecc0beeecc0"
+
+
+def test_flat_scan_cost_60_sessions_with_cross_project_noise(tmp_path):
+    """Spec o-7b14d1fb03e7: measure the flat-scan cost of item_biography.
+    Real deployment shape: the shared flat dir holds many projects' files
+    (162 today, only 3 ours) and project_history parses every one to filter
+    by slug — so noise files dominate wall time and MUST be in the fixture."""
+    d = tmp_path / "checkpoints"
+    d.mkdir()
+    slug = "-tmp-proj"
+    (d / slug).mkdir()
+
+    for i in range(60):
+        cp = make_checkpoint(
+            created=f"2026-06-{(i % 28) + 1:02d}T10:00:00Z",
+            topic=f"session {i}", session_id=f"sess-{i:04d}",
+            open_questions=[
+                {"text": "benched item", "id": BENCH_ID, "trust": "verbatim",
+                 "quote": "measured, not guessed"}] + [
+                {"text": f"filler {j}", "id": f"o-{j:06d}{i:06d}"} for j in range(20)],
+        )
+        cp["project_slug"] = slug
+        (d / f"sess-{i:04d}.json").write_text(json.dumps(cp))
+
+    for i in range(100):
+        cp = make_checkpoint(created="2026-07-01T10:00:00Z",
+                             topic=f"noise {i}", session_id=f"noise-{i:04d}",
+                             open_questions=[
+                                 {"text": f"noise q {j}", "id": f"o-n{j:05d}{i:05d}"}
+                                 for j in range(20)])
+        cp["project_slug"] = f"-other-{i % 10}"
+        (d / f"noise-{i:04d}.json").write_text(json.dumps(cp))
+
+    t0 = time.perf_counter()
+    got = reader.item_biography(d, slug, BENCH_ID)
+    elapsed_ms = (time.perf_counter() - t0) * 1000
+
+    assert got["ok"] is True
+    assert len(got["trust_anatomy"]["chain"]) == 60
+    print(f"\nflat-scan cost: {elapsed_ms:.1f}ms "
+          f"(160 files, 60 target sessions, 100 cross-project noise)")
+    assert elapsed_ms < 200, f"flat scan took {elapsed_ms:.1f}ms, budget 200ms"

--- a/plugin/tests/ui/test_defensive_branches.py
+++ b/plugin/tests/ui/test_defensive_branches.py
@@ -1,0 +1,126 @@
+"""Defensive branches the happy-path suites never reach: torn files, hostile
+params, and engine failure. Each test names the guarantee — a broken input
+degrades to an error shape or a skip, never a traceback."""
+import json
+
+from daimon_ui import reader
+
+
+# ---- receipt sidecar edge shapes ----
+
+def _root_with_receipt(tmp_path, sidecar_body):
+    d = tmp_path / "checkpoints"
+    d.mkdir()
+    (d / "S1.json").write_text(json.dumps({"session_id": "S1", "receipts": True}))
+    if sidecar_body is not None:
+        (d / "S1.receipt").write_text(sidecar_body)
+    return d
+
+
+def test_receipt_with_non_string_hash_reads_missing(tmp_path):
+    d = _root_with_receipt(tmp_path, json.dumps({"receipt": {"outputs_hash": 7}}))
+    got = reader.receipt_state(d, {"receipts": True, "session_id": "S1"})
+    assert got["state"] == "missing"
+
+
+def test_receipt_root_unreadable_reads_missing(tmp_path):
+    d = _root_with_receipt(
+        tmp_path, json.dumps({"receipt": {"outputs_hash": "uABC"}}))
+    (d / "S1.json").unlink()
+    (d / "S1.json").mkdir()  # a directory: read_bytes raises OSError
+    got = reader.receipt_state(d, {"receipts": True, "session_id": "S1"})
+    assert got["state"] == "missing"
+
+
+def test_receipts_enabled_skips_torn_pointer(tmp_path):
+    b = tmp_path / "checkpoints" / "-proj"
+    b.mkdir(parents=True)
+    (b / "latest.json").write_text("{torn")
+    assert reader.receipts_enabled(b) is False
+
+
+# ---- normalization and event-log edge shapes ----
+
+def test_norm_item_rejects_non_dict_non_string():
+    assert reader._norm_item(42) is None
+
+
+def test_resolutions_skips_torn_lines_and_refless_events(tmp_path):
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "events.jsonl").write_text("\n".join([
+        "",  # blank line: the fold must step over it
+        "{torn",
+        json.dumps({"kind": "resolution", "status": "resolved"}),  # no item_ref
+        json.dumps({"kind": "resolution", "item_ref": "o-aaa111aaa111",
+                     "status": "resolved", "ts": "t", "note": "n"}),
+    ]) + "\n")
+    got = reader.resolutions(b)
+    assert list(got) == ["o-aaa111aaa111"]
+
+
+def test_jsonl_rows_skips_torn_lines(tmp_path):
+    p = tmp_path / "verification.jsonl"
+    p.write_text('\n{broken\n' + json.dumps({"item_ref": "o-a1b2c3d4e5f6"}) + "\n")
+    rows = reader._jsonl_rows(p)
+    assert rows == [{"item_ref": "o-a1b2c3d4e5f6"}]
+
+
+# ---- session-file loss between scan and read ----
+
+def test_load_session_missing_and_torn(tmp_path):
+    data, err = reader._load_session(tmp_path, "gone")
+    assert data is None and err["what"].startswith("Session")
+    (tmp_path / "torn.json").write_text("{nope")
+    data, err = reader._load_session(tmp_path, "torn")
+    assert data is None and "Couldn't read" in err["what"]
+
+
+def test_diff_surfaces_load_error_for_either_side(tmp_path, monkeypatch):
+    """A session can vanish between the history scan and the read (GC race).
+    Both sides must surface the load error rather than diffing nothing."""
+    valid = [{"session_id": "A", "created": "1"}, {"session_id": "B", "created": "2"}]
+    monkeypatch.setattr(reader, "project_history",
+                        lambda *a: {"sessions": valid, "unreadable": 0})
+    err = {"what": "x", "why": "y", "fix": "z"}
+    real_load = reader._load_session
+
+    def only_b(data_dir, sid):
+        if sid == "A":
+            return None, err
+        return {"session_id": sid}, None
+
+    monkeypatch.setattr(reader, "_load_session", only_b)
+    got = reader.diff_checkpoints(tmp_path, "-p", "A", "B")
+    assert got == {"ok": False, "error": err}
+
+    def only_a(data_dir, sid):
+        if sid == "B":
+            return None, err
+        return {"session_id": sid}, None
+
+    monkeypatch.setattr(reader, "_load_session", only_a)
+    got = reader.diff_checkpoints(tmp_path, "-p", "A", "B")
+    assert got == {"ok": False, "error": err}
+    monkeypatch.setattr(reader, "_load_session", real_load)
+
+
+def test_biography_skips_a_torn_session_and_still_answers(tmp_path, monkeypatch):
+    item = {"id": "o-a1b2c3d4e5f6", "text": "t", "trust": "inferred"}
+    sessions = [{"session_id": "OLD", "created": "1"},
+                {"session_id": "NEW", "created": "2"}]
+    monkeypatch.setattr(reader, "project_history",
+                        lambda *a: {"sessions": list(reversed(sessions)), "unreadable": 0})
+
+    def load(data_dir, sid):
+        if sid == "OLD":
+            return None, {"what": "torn", "why": "", "fix": ""}
+        return {"session_id": sid,
+                "working_context": {"open_questions": [item],
+                                     "recent_decisions": []},
+                "epistemic_snapshot": {}}, None
+
+    monkeypatch.setattr(reader, "_load_session", load)
+    got = reader.item_biography(tmp_path, "-p", "o-a1b2c3d4e5f6")
+    assert got["ok"] is True
+    assert got["item"]["text"] == "t"

--- a/plugin/tests/ui/test_diff.py
+++ b/plugin/tests/ui/test_diff.py
@@ -1,0 +1,106 @@
+import json
+from daimon_ui import reader
+from tests.ui.conftest import make_checkpoint
+
+def test_resolutions_fold_skips_broken_line_and_non_resolution_kind(flat_with_events):
+    d, slug = flat_with_events
+    got = reader.resolutions(d / slug)
+    assert got == {"o-aaa111aaa111": {"ts": "2026-08-06T09:00:00Z", "note": "closed it"}}
+
+def test_resolutions_last_event_wins(tmp_path):
+    bucket = tmp_path / "-tmp-proj"
+    bucket.mkdir(parents=True)
+    (bucket / "events.jsonl").write_text('\n'.join([
+        json.dumps({"ts": "1", "kind": "resolution", "item_ref": "o-xxx", "status": "resolved", "note": "first"}),
+        json.dumps({"ts": "2", "kind": "resolution", "item_ref": "o-xxx", "status": "active"}),
+        json.dumps({"ts": "3", "kind": "resolution", "item_ref": "o-yyy", "status": "active"}),
+        json.dumps({"ts": "4", "kind": "resolution", "item_ref": "o-yyy", "status": "resolved", "note": "second"}),
+    ]) + '\n')
+    got = reader.resolutions(bucket)
+    assert got == {"o-yyy": {"ts": "4", "note": "second"}}
+
+def test_resolutions_missing_events_file_is_empty(flat_history):
+    d, slug = flat_history
+    assert reader.resolutions(d / slug) == {}
+
+def test_resolutions_all_torn_lines_is_empty(tmp_path):
+    bucket = tmp_path / "-tmp-proj"
+    bucket.mkdir(parents=True)
+    (bucket / "events.jsonl").write_text("{nope\n{also nope\n")
+    assert reader.resolutions(bucket) == {}
+
+
+def _write_diff_sessions(d, slug, sid_a, sid_b):
+    cp_a = make_checkpoint(session_id=sid_a, open_questions=[
+        {"text": "resolved question", "id": "o-aaa111aaa111", "trust": "verbatim"},
+        {"text": "gone question", "id": "o-bbb222bbb222", "trust": "verbatim"},
+        {"text": "trust change item", "id": "o-ccc333ccc333", "trust": "verbatim"},
+        {"text": "carried item", "id": "o-ddd444ddd444", "trust": "inferred"},
+        {"text": "no id item old"},
+    ])
+    cp_a["project_slug"] = slug
+    (d / f"{sid_a}.json").write_text(json.dumps(cp_a))
+
+    cp_b = make_checkpoint(session_id=sid_b, open_questions=[
+        {"text": "trust change item", "id": "o-ccc333ccc333", "trust": "inferred"},
+        {"text": "carried item", "id": "o-ddd444ddd444", "trust": "inferred"},
+        {"text": "new born item", "id": "o-eee555eee555", "trust": "verbatim"},
+        {"text": "no id item new"},
+    ])
+    cp_b["project_slug"] = slug
+    (d / f"{sid_b}.json").write_text(json.dumps(cp_b))
+
+
+def test_diff_checkpoints_categorizes_born_resolved_gone_carried_trust_changed(flat_with_events):
+    d, slug = flat_with_events
+    sid_a, sid_b = "diff-a-0001", "diff-b-0002"
+    _write_diff_sessions(d, slug, sid_a, sid_b)
+
+    got = reader.diff_checkpoints(d, slug, sid_a, sid_b)
+    assert got["ok"] is True
+    assert got["a"]["session_id"] == sid_a
+    assert got["b"]["session_id"] == sid_b
+
+    born_ids = [i["id"] for i in got["born"]]
+    assert born_ids == ["o-eee555eee555"]
+    assert got["born"][0]["section"] == "open_loops"
+
+    assert len(got["resolved"]) == 1
+    resolved = got["resolved"][0]
+    assert resolved["item"]["id"] == "o-aaa111aaa111"
+    assert resolved["note"] == "closed it"
+    assert resolved["ts"] == "2026-08-06T09:00:00Z"
+
+    gone_ids = [i["id"] for i in got["gone"]]
+    assert gone_ids == ["o-bbb222bbb222"]
+
+    assert len(got["carried"]) == 1
+    carried = got["carried"][0]
+    assert carried["item"]["id"] == "o-ddd444ddd444"
+    assert "sessions_present" not in carried
+
+    assert len(got["trust_changed"]) == 1
+    tc = got["trust_changed"][0]
+    assert tc["item"]["id"] == "o-ccc333ccc333"
+    assert tc["from"] == "verbatim"
+    assert tc["to"] == "inferred"
+
+    assert any("without an id" in p for p in got["partial"])
+
+
+def test_diff_checkpoints_bad_sid_a_is_error(flat_with_events):
+    d, slug = flat_with_events
+    sid_b = "diff-b-0002"
+    _write_diff_sessions(d, slug, "diff-a-0001", sid_b)
+    got = reader.diff_checkpoints(d, slug, "not-a-real-session", sid_b)
+    assert got["ok"] is False
+    assert set(got["error"]) == {"what", "why", "fix"}
+
+
+def test_diff_checkpoints_bad_sid_b_rejects_path_traversal(flat_with_events):
+    d, slug = flat_with_events
+    sid_a = "diff-a-0001"
+    _write_diff_sessions(d, slug, sid_a, "diff-b-0002")
+    got = reader.diff_checkpoints(d, slug, sid_a, "../../../etc/passwd")
+    assert got["ok"] is False
+    assert set(got["error"]) == {"what", "why", "fix"}

--- a/plugin/tests/ui/test_history.py
+++ b/plugin/tests/ui/test_history.py
@@ -1,0 +1,18 @@
+from daimon_ui import reader
+
+def test_history_filters_and_sorts(flat_history):
+    d, slug = flat_history
+    got = reader.project_history(d, slug)
+    assert [s["session_id"] for s in got["sessions"]] == ["rollout-2026-08-06-cccc", "bbbb-2222", "aaaa-1111"]
+    assert got["sessions"][0]["active_topic"] == "day three"
+    assert got["unreadable"] == 1
+
+def test_history_empty_for_unknown_slug(flat_history):
+    d, _ = flat_history
+    assert reader.project_history(d, "-nope")["sessions"] == []
+
+def test_history_counts_non_utf8_file_as_unreadable(flat_history):
+    d, slug = flat_history
+    (d / "bin.json").write_bytes(b"\xff\xfe{")
+    got = reader.project_history(d, slug)
+    assert got["unreadable"] == 2  # pre-existing torn.json + this non-UTF-8 file

--- a/plugin/tests/ui/test_js_python_drift.py
+++ b/plugin/tests/ui/test_js_python_drift.py
@@ -1,0 +1,36 @@
+"""Values hand-copied across the Python/JS seam, with nothing keeping them in sync.
+
+reader.py owns the item-id shape; render.js carries its own copy because a pure
+render module cannot import Python. The copy has been correct since v0.3.0 purely
+because nobody edited one side — that is luck, not a guarantee, and the comment
+"mirror of reader ITEM_ID_RE" is a claim no test was checking.
+"""
+import re
+from pathlib import Path
+
+import daimon_ui
+from daimon_ui import reader
+
+_RENDER_JS = Path(daimon_ui.__file__).parent / "static" / "render.js"
+
+def _js_literal(name):
+    """The source text of a top-level JS regex literal, without its slashes."""
+    src = _RENDER_JS.read_text(encoding="utf-8")
+    m = re.search(r"^export const " + re.escape(name) + r" = /(.+?)/;", src, re.MULTILINE)
+    assert m, f"{name} is no longer a top-level regex literal in render.js"
+    return m.group(1)
+
+def test_act_item_id_re_still_mirrors_reader_item_id_re():
+    """Drift here is silent in both directions: a widened Python pattern makes the
+    feed drop refs it should link, and a widened JS pattern makes it link refs the
+    server would reject. Neither raises, so only this comparison catches it."""
+    assert _js_literal("ACT_ITEM_ID_RE") == reader.ITEM_ID_RE.pattern
+
+def test_the_js_mirror_stays_anchored():
+    """reader.py applies its pattern with fullmatch; render.js applies its copy with
+    .test(), which searches. Identical text is only equivalent while the pattern
+    keeps both anchors — drop ^ or $ and the JS copy starts accepting substrings
+    while this file's text comparison still passes."""
+    pattern = _js_literal("ACT_ITEM_ID_RE")
+    assert pattern.startswith("^"), pattern
+    assert pattern.endswith("$"), pattern

--- a/plugin/tests/ui/test_main.py
+++ b/plugin/tests/ui/test_main.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from daimon_ui.__main__ import build_config
+
+
+def test_defaults_derive_from_cwd(tmp_path):
+    cfg = build_config([], {}, cwd=Path("/Users/x/proj"))
+    assert cfg["data_dir"] == Path.home() / ".daimon" / "checkpoints"
+    assert cfg["default_slug"] == "-Users-x-proj"
+    assert cfg["project_label"] == "proj"
+    assert cfg["port"] == 7717 and cfg["open_browser"] is True
+
+
+def test_flags_override(tmp_path):
+    cfg = build_config(
+        ["--data-dir", str(tmp_path), "--project-dir", "/a/b", "--port", "7777", "--no-browser"],
+        {}, cwd=Path("/elsewhere"))
+    assert cfg["data_dir"] == tmp_path
+    assert cfg["default_slug"] == "-a-b"
+    assert cfg["port"] == 7777 and cfg["open_browser"] is False

--- a/plugin/tests/ui/test_main.py
+++ b/plugin/tests/ui/test_main.py
@@ -17,3 +17,47 @@ def test_flags_override(tmp_path):
     assert cfg["data_dir"] == tmp_path
     assert cfg["default_slug"] == "-a-b"
     assert cfg["port"] == 7777 and cfg["open_browser"] is False
+
+
+def test_main_serves_and_stops_cleanly(monkeypatch, tmp_path):
+    """main() wires config -> server -> browser. Driven with a fake server whose
+    serve_forever raises KeyboardInterrupt — the documented way to stop serve."""
+    from daimon_ui import __main__ as ui_main
+
+    calls = {}
+
+    class FakeServer:
+        server_address = ("127.0.0.1", 7717)
+
+        def serve_forever(self):
+            calls["served"] = True
+            raise KeyboardInterrupt
+
+    def fake_make_server(data_dir, slug, label, port):
+        calls["make"] = (data_dir, slug, label, port)
+        return FakeServer()
+
+    monkeypatch.setattr(ui_main.server, "make_server", fake_make_server)
+    monkeypatch.setattr("webbrowser.open", lambda url: calls.setdefault("browser", url))
+    ui_main.main(["--data-dir", str(tmp_path), "--no-browser"])
+    assert calls["served"] is True
+    assert calls["make"][0] == tmp_path
+    assert "browser" not in calls, "no-browser must not open a tab"
+
+
+def test_main_opens_browser_by_default(monkeypatch, tmp_path):
+    from daimon_ui import __main__ as ui_main
+
+    calls = {}
+
+    class FakeServer:
+        server_address = ("127.0.0.1", 7800)
+
+        def serve_forever(self):
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(ui_main.server, "make_server",
+                        lambda *a, **k: FakeServer())
+    monkeypatch.setattr("webbrowser.open", lambda url: calls.setdefault("browser", url))
+    ui_main.main(["--data-dir", str(tmp_path)])
+    assert calls["browser"] == "http://127.0.0.1:7800/"

--- a/plugin/tests/ui/test_page.py
+++ b/plugin/tests/ui/test_page.py
@@ -70,11 +70,14 @@ def test_flagged_dot_paints_differently_from_ordinary_event_dots(srv):
 
 
 def test_css_has_tokens_and_media_queries(srv):
+    """The viewer commits to one dark look (the design's frozen palette), so
+    there is deliberately no prefers-color-scheme block to assert on."""
     _, _, body = _get(srv + "/static/app.css")
     css = body.decode()
     for needle in ["--s1: 4px", "--s8: 32px", "--accent",
-                   "prefers-color-scheme: dark", "prefers-reduced-motion"]:
+                   "prefers-reduced-motion"]:
         assert needle in css, needle
+    assert "prefers-color-scheme" not in css, "single committed look — no theme fork"
 
 def test_activity_catch_clears_stale_sections(srv):
     """enterActivity lives in app.js and touches the DOM, so this stays a source

--- a/plugin/tests/ui/test_page.py
+++ b/plugin/tests/ui/test_page.py
@@ -1,0 +1,87 @@
+import urllib.request
+
+def _get(url):
+    with urllib.request.urlopen(url) as r:
+        return r.status, r.headers.get_content_type(), r.read()
+
+def test_page_has_regions(srv):
+    _, _, body = _get(srv + "/")
+    html = body.decode()
+    for needle in ['id="sidebar"', 'id="main"', 'id="state"', 'id="sections"',
+                   '<link rel="stylesheet" href="/static/app.css">']:
+        assert needle in html, needle
+
+def test_view_links_sit_in_a_nav_landmark(srv):
+    _, _, body = _get(srv + "/")
+    html = body.decode()
+    assert '<nav class="view-nav"' in html, "no view-nav landmark in page"
+    nav = html.split('<nav class="view-nav"', 1)[1].split("</nav>", 1)[0]
+    for needle in ['aria-label="Views"', 'id="back-link-slot"',
+                   'id="history-link-slot"', 'id="activity-link-slot"']:
+        assert needle in nav, needle
+
+
+def _tag_carrying(html, needle):
+    """The whole tag containing `needle`, both sides of it.
+
+    Reading only the text *after* the attribute makes the assertion depend on
+    attribute order: `<div id="state" aria-live="polite">` is caught while
+    `<div aria-live="polite" id="state">` slips past, and the two are the same
+    element to a browser. Scar 0006 fences the same blind spot in HTML."""
+    before, after = html.split(needle, 1)
+    return before.rsplit("<", 1)[1] + needle + after.split(">", 1)[0]
+
+
+def test_live_region_is_the_status_line_not_the_content_container(srv):
+    """#state receives whole rendered views via innerHTML (app.js renderActivityView,
+    renderEmptyProjects, renderError). A live region there re-announces the entire
+    view on every navigation. The announcement duty belongs to a dedicated, small
+    #status element instead. Scoped to each element's own tag so a stray aria-live
+    elsewhere in the document cannot satisfy it."""
+    _, _, body = _get(srv + "/")
+    html = body.decode()
+
+    assert 'id="status"' in html, "no dedicated #status announcement element in page"
+    status_tag = _tag_carrying(html, 'id="status"')
+    assert 'role="status"' in status_tag, status_tag
+
+    state_tag = _tag_carrying(html, 'id="state"')
+    assert "aria-live" not in state_tag, state_tag
+
+
+def test_flagged_dot_paints_differently_from_ordinary_event_dots(srv):
+    """The JS side asserts quote_check picks the "flagged" dot class; that alone
+    proves nothing if the class paints the same pixels as the dots it must stand
+    apart from. The original defect was exactly this shape — quote_check used
+    "changed", whose rule is `background: var(--accent)`, identical to
+    .life-dot-born. Compares declaration bodies, not just class presence."""
+    _, _, css = _get(srv + "/static/app.css")
+    css = css.decode()
+
+    def rule_for(cls):
+        hits = [blk for blk in css.split("}") if f".{cls}" in blk.split("{")[0]]
+        assert hits, f"no rule defines .{cls}"
+        return hits[0].split("{", 1)[1].strip()
+
+    flagged = rule_for("life-dot-flagged")
+    for ordinary in ("life-dot-born", "life-dot-seen", "life-dot-resolved"):
+        assert flagged != rule_for(ordinary), \
+            f".life-dot-flagged paints identically to .{ordinary}: {flagged}"
+
+
+def test_css_has_tokens_and_media_queries(srv):
+    _, _, body = _get(srv + "/static/app.css")
+    css = body.decode()
+    for needle in ["--s1: 4px", "--s8: 32px", "--accent",
+                   "prefers-color-scheme: dark", "prefers-reduced-motion"]:
+        assert needle in css, needle
+
+def test_activity_catch_clears_stale_sections(srv):
+    """enterActivity lives in app.js and touches the DOM, so this stays a source
+    grep — a weaker test than the render.js behavior tests, kept deliberately and
+    labelled as such rather than dropped silently."""
+    _, _, body = _get(srv + "/static/app.js")
+    js = body.decode()
+    fn = js.split("function enterActivity", 1)[1].split("\n  function ", 1)[0]
+    catch_block = fn.split(".catch(function ()", 1)[1]
+    assert 'sectionsEl.innerHTML = "";' in catch_block

--- a/plugin/tests/ui/test_page_search.py
+++ b/plugin/tests/ui/test_page_search.py
@@ -1,0 +1,24 @@
+"""Search surface (#670): the page ships a search box and the client renders
+/api/recall and /api/why — never a second matcher, never its own receipt logic."""
+import urllib.request
+
+
+def _get(url):
+    with urllib.request.urlopen(url) as r:
+        return r.status, r.headers.get_content_type(), r.read()
+
+
+def test_page_has_a_search_form(srv):
+    _, _, body = _get(srv + "/")
+    html = body.decode()
+    assert 'id="search-form"' in html
+    assert 'id="search-box"' in html
+    # the box announces what it searches with — recall, not a viewer matcher
+    assert 'recall' in html.lower()
+
+
+def test_client_renders_recall_and_why(srv):
+    _, _, body = _get(srv + "/static/app.js")
+    js = body.decode()
+    assert "/api/recall" in js
+    assert "/api/why" in js

--- a/plugin/tests/ui/test_reader_discovery.py
+++ b/plugin/tests/ui/test_reader_discovery.py
@@ -1,0 +1,99 @@
+import json
+from pathlib import Path
+import pytest
+from daimon_ui import reader
+
+def test_resolve_data_dir_env_override(tmp_path):
+    assert reader.resolve_data_dir({"DAIMON_CHECKPOINT_DIR": str(tmp_path)}) == tmp_path
+
+def test_resolve_data_dir_default():
+    assert reader.resolve_data_dir({}) == Path.home() / ".daimon" / "checkpoints"
+
+def test_project_slug_munging():
+    assert reader.project_slug("/Users/x/My Proj") == "-Users-x-My-Proj"
+
+def test_list_recent_orders_and_filters(bucket):
+    got = reader.list_recent(bucket)
+    assert [g["ref"] for g in got] == ["latest", "prev-1", "prev-2"]
+    assert got[0]["active_topic"] == "Scoping the inspector"
+    assert got[0]["created"] == "2026-08-06T08:05:12Z"
+
+def test_list_recent_empty_bucket(tmp_path):
+    assert reader.list_recent(tmp_path / "nope") == []
+
+def test_list_recent_torn_pointer(bucket):
+    (bucket / "prev-1.json").write_text("{not json")
+    got = reader.list_recent(bucket)
+    refs = [g["ref"] for g in got]
+    assert "prev-1" in refs                       # named, not hidden
+    assert got[refs.index("prev-1")]["created"] is None
+
+
+@pytest.fixture
+def multi_buckets(tmp_path):
+    root = tmp_path / "checkpoints"
+    root.mkdir()
+
+    a = root / "-proj-a"
+    a.mkdir()
+    (a / "latest.json").write_text(json.dumps({
+        "created": "2026-08-06T10:00:00Z",
+        "working_context": {
+            "active_topic": {"text": "Proj A topic"},
+            "open_questions": [{"text": "q1"}, {"text": "q2"}],
+            "recent_decisions": [{"text": "d1"}],
+        },
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": [], "contradictions_flagged": []},
+    }))
+
+    b = root / "-proj-b"
+    b.mkdir()
+    (b / "latest.json").write_text(json.dumps({
+        "created": "2026-08-05T10:00:00Z",
+        "working_context": {"active_topic": {"text": "Proj B topic"}, "open_questions": [], "recent_decisions": []},
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": [], "contradictions_flagged": []},
+    }))
+
+    torn = root / "-proj-torn"
+    torn.mkdir()
+    (torn / "latest.json").write_text("{not json")
+
+    missing = root / "-proj-missing"      # no latest.json — must be skipped
+    missing.mkdir()
+    (missing / "prev-1.json").write_text("{}")
+
+    (root / ".chunk-cache").mkdir()       # no latest.json — must be skipped
+
+    return root
+
+
+def test_list_buckets_sorts_by_created_desc_none_last(multi_buckets):
+    got = reader.list_buckets(multi_buckets)
+    assert [b["slug"] for b in got] == ["-proj-a", "-proj-b", "-proj-torn"]
+
+
+def test_list_buckets_skips_dirs_without_latest_json(multi_buckets):
+    got = reader.list_buckets(multi_buckets)
+    slugs = {b["slug"] for b in got}
+    assert "-proj-missing" not in slugs
+    assert ".chunk-cache" not in slugs
+
+
+def test_list_buckets_torn_listed_with_none_fields(multi_buckets):
+    got = reader.list_buckets(multi_buckets)
+    torn = next(b for b in got if b["slug"] == "-proj-torn")
+    assert torn["created"] is None
+    assert torn["active_topic"] is None
+    assert torn["item_count"] is None
+
+
+def test_list_buckets_item_count_correctness(multi_buckets):
+    got = reader.list_buckets(multi_buckets)
+    a = next(b for b in got if b["slug"] == "-proj-a")
+    b = next(b for b in got if b["slug"] == "-proj-b")
+    assert a["item_count"] == 3
+    assert b["item_count"] == 0
+
+
+def test_list_buckets_empty_data_dir(tmp_path):
+    assert reader.list_buckets(tmp_path / "nope") == []

--- a/plugin/tests/ui/test_reader_normalize.py
+++ b/plugin/tests/ui/test_reader_normalize.py
@@ -1,0 +1,173 @@
+import json
+from daimon_ui import reader
+from tests.ui.conftest import make_checkpoint
+
+def _write(bucket, name, data):
+    (bucket / name).write_text(json.dumps(data) if not isinstance(data, str) else data)
+
+def test_normalizes_sections_and_trust(bucket):
+    cp = make_checkpoint(
+        open_questions=[
+            {"text": "verify me", "trust": "verbatim", "quote": "q1", "id": "o-abc123abc123", "external_state": True},
+            {"text": "open loop", "trust": "inferred", "id": "o-def456def456"},
+            {"text": "no trust recorded"},
+        ],
+        recent_decisions=[{"text": "chose B", "trust": "verbatim", "quote": "I like B", "because": "both audiences", "id": "r-aaa111aaa111", "carried_from": "prev-sid"}],
+    )
+    _write(bucket, "latest.json", cp)
+    got = reader.load_checkpoint(bucket.parent, bucket.name, "latest")
+    assert got["ok"] is True
+    keys = [s["key"] for s in got["sections"]]
+    assert keys == ["verify_first", "decisions", "open_loops", "beliefs", "uncertainties", "contradictions"]
+    verify = got["sections"][0]["items"]
+    assert [i["text"] for i in verify] == ["verify me"]
+    loops = got["sections"][2]["items"]
+    assert [i["trust"] for i in loops] == ["inferred", None]
+    dec = got["sections"][1]["items"][0]
+    assert dec["because"] == "both audiences" and dec["carried_from"] == "prev-sid"
+
+def test_bare_string_contradictions(bucket):
+    _write(bucket, "latest.json", make_checkpoint(contradictions_flagged=["raw string item"]))
+    got = reader.load_checkpoint(bucket.parent, bucket.name, "latest")
+    contra = got["sections"][5]["items"]
+    assert contra[0]["text"] == "raw string item" and contra[0]["trust"] is None
+
+def test_unknown_format_version_is_partial(bucket):
+    _write(bucket, "latest.json", make_checkpoint(format_version="D-099"))
+    got = reader.load_checkpoint(bucket.parent, bucket.name, "latest")
+    assert got["ok"] is True and any("D-099" in p for p in got["partial"])
+
+def test_invalid_json_is_error(bucket):
+    _write(bucket, "latest.json", "{torn")
+    got = reader.load_checkpoint(bucket.parent, bucket.name, "latest")
+    assert got["ok"] is False
+    err = got["error"]
+    assert set(err) == {"what", "why", "fix"} and "daimon heal" in err["fix"]
+
+def test_bad_ref_rejected(bucket):
+    got = reader.load_checkpoint(bucket.parent, bucket.name, "../../../etc/passwd")
+    assert got["ok"] is False
+
+def test_worker_queue_never_leaks(bucket):
+    _write(bucket, "latest.json", make_checkpoint())
+    got = reader.load_checkpoint(bucket.parent, bucket.name, "latest")
+    texts = [i["text"] for s in got["sections"] for i in s["items"]]
+    assert "x" not in texts
+
+def test_malformed_section_shape_drift(bucket):
+    _write(bucket, "latest.json", make_checkpoint(strong_beliefs="not-a-list"))
+    got = reader.load_checkpoint(bucket.parent, bucket.name, "latest")
+    assert got["ok"] is True
+    beliefs = got["sections"][3]["items"]
+    assert beliefs == []
+    assert any("strong_beliefs" in p for p in got["partial"])
+
+def test_missing_pointer_in_chain_is_not_found(bucket):
+    got = reader.load_checkpoint(bucket.parent, bucket.name, "prev-9")
+    assert got["ok"] is False
+    err = got["error"]
+    assert set(err) == {"what", "why", "fix"}
+    assert "pointer chain" in err["why"].lower()
+
+def test_importance_valid_int_passes_through(bucket):
+    cp = make_checkpoint(open_questions=[{"text": "t", "importance": 3, "external_state": True}])
+    _write(bucket, "latest.json", cp)
+    got = reader.load_checkpoint(bucket.parent, bucket.name, "latest")
+    assert got["sections"][0]["items"][0]["importance"] == 3
+
+def test_importance_non_int_string_is_none(bucket):
+    cp = make_checkpoint(open_questions=[{"text": "t", "importance": "high", "external_state": True}])
+    _write(bucket, "latest.json", cp)
+    got = reader.load_checkpoint(bucket.parent, bucket.name, "latest")
+    assert got["sections"][0]["items"][0]["importance"] is None
+
+def test_importance_out_of_range_is_none(bucket):
+    cp = make_checkpoint(open_questions=[{"text": "t", "importance": 7, "external_state": True}])
+    _write(bucket, "latest.json", cp)
+    got = reader.load_checkpoint(bucket.parent, bucket.name, "latest")
+    assert got["sections"][0]["items"][0]["importance"] is None
+
+def test_importance_bool_is_none(bucket):
+    cp = make_checkpoint(open_questions=[{"text": "t", "importance": True, "external_state": True}])
+    _write(bucket, "latest.json", cp)
+    got = reader.load_checkpoint(bucket.parent, bucket.name, "latest")
+    assert got["sections"][0]["items"][0]["importance"] is None
+
+def test_importance_missing_is_none(bucket):
+    cp = make_checkpoint(open_questions=[{"text": "t", "external_state": True}])
+    _write(bucket, "latest.json", cp)
+    got = reader.load_checkpoint(bucket.parent, bucket.name, "latest")
+    assert got["sections"][0]["items"][0]["importance"] is None
+
+def test_quote_verified_normalized_to_bool_or_none(bucket):
+    cp = make_checkpoint(
+        open_questions=[
+            {"text": "has true", "quote_verified": True},
+            {"text": "has false", "quote_verified": False},
+            {"text": "has string", "quote_verified": "yes"},
+            {"text": "has number", "quote_verified": 1},
+            {"text": "has none", "quote_verified": None},
+            {"text": "missing", },
+        ],
+    )
+    _write(bucket, "latest.json", cp)
+    got = reader.load_checkpoint(bucket.parent, bucket.name, "latest")
+    items = got["sections"][0]["items"] + got["sections"][2]["items"]
+    qv_values = [i["quote_verified"] for i in items]
+    assert qv_values == [True, False, None, None, None, None]
+
+def test_norm_item_passes_trust_anatomy_fields():
+    got = reader._norm_item({
+        "text": "x", "id": "o-abc123abc123",
+        "last_verified": "2026-08-06T10:00:00Z",
+        "origin_session": "aaaa-1111",
+        "source_message_ids": ["m1", "m2"],
+        "quote_provenance": {
+            "verifier": "quote-v2", "outcome": "verified",
+            "checked_at": "2026-08-06T10:00:00Z",
+            "digest": {"algorithm": "sha256", "value": "ff"},
+            "binding": {"message_ids": ["m1"]},
+        },
+    })
+    assert got["last_verified"] == "2026-08-06T10:00:00Z"
+    assert got["origin_session"] == "aaaa-1111"
+    assert got["source_message_ids"] == ["m1", "m2"]
+    assert got["quote_provenance"] == {
+        "verifier": "quote-v2", "outcome": "verified",
+        "checked_at": "2026-08-06T10:00:00Z",
+        "digest_algorithm": "sha256", "message_ids": ["m1"],
+    }
+
+def test_norm_item_trust_anatomy_fields_default_none():
+    got = reader._norm_item({"text": "x"})
+    assert got["last_verified"] is None
+    assert got["origin_session"] is None
+    assert got["source_message_ids"] is None
+    assert got["quote_provenance"] is None
+
+def test_norm_item_junk_trust_anatomy_shapes_become_none():
+    got = reader._norm_item({
+        "text": "x",
+        "last_verified": 123,
+        "origin_session": ["not", "a", "str"],
+        "source_message_ids": "m1",              # str, not list
+        "quote_provenance": "not a dict",
+    })
+    assert got["last_verified"] is None
+    assert got["origin_session"] is None
+    assert got["source_message_ids"] is None
+    assert got["quote_provenance"] is None
+
+def test_norm_provenance_malformed_nested_shapes():
+    got = reader._norm_item({"text": "x", "quote_provenance": {
+        "verifier": 7, "outcome": "", "checked_at": None,
+        "digest": "not-a-dict", "binding": {"message_ids": ["ok", 5]},
+    }})
+    assert got["quote_provenance"] == {
+        "verifier": None, "outcome": None, "checked_at": None,
+        "digest_algorithm": None, "message_ids": ["ok"],
+    }
+
+def test_norm_item_source_message_ids_filters_non_strings():
+    got = reader._norm_item({"text": "x", "source_message_ids": ["a", 1, "b"]})
+    assert got["source_message_ids"] == ["a", "b"]

--- a/plugin/tests/ui/test_receipts.py
+++ b/plugin/tests/ui/test_receipts.py
@@ -1,0 +1,183 @@
+import base64
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from daimon_ui import reader
+
+def test_multihash_matches_the_vitni_format():
+    """outputs_hash is multibase base64url-nopad ("u") over multihash sha2-256
+    (0x12 0x20 + 32 bytes). Computed independently here rather than by calling
+    the implementation, so the test fails if the implementation drifts."""
+    raw = b'{"session_id": "abc"}'
+    want = "u" + base64.urlsafe_b64encode(
+        bytes([0x12, 0x20]) + hashlib.sha256(raw).digest()
+    ).decode().rstrip("=")
+    assert reader._multihash_b64(raw) == want
+
+def test_multihash_has_no_padding_and_the_u_prefix():
+    got = reader._multihash_b64(b"x")
+    assert got.startswith("u")
+    assert "=" not in got
+
+def _write_pair(root: Path, sid: str, claims: bool, sidecar: str | None):
+    """Write a checkpoint and optionally a sidecar whose outputs_hash covers it.
+    Returns the checkpoint path. sidecar: None = no file, "match" = true hash,
+    "wrong" = a different hash, "garbage" = unparseable, "nokey" = no outputs_hash."""
+    cp = {"session_id": sid, "format_version": "D-018"}
+    if claims:
+        cp["receipts"] = True
+    p = root / f"{sid}.json"
+    p.write_text(json.dumps(cp), encoding="utf-8")
+    if sidecar == "garbage":
+        (root / f"{sid}.receipt").write_text("{not json", encoding="utf-8")
+    elif sidecar == "nokey":
+        (root / f"{sid}.receipt").write_text(json.dumps({"receipt": {}}), encoding="utf-8")
+    elif sidecar in ("match", "wrong"):
+        h = reader._multihash_b64(p.read_bytes()) if sidecar == "match" else "uEiAwrongwrongwrong"
+        (root / f"{sid}.receipt").write_text(
+            json.dumps({"receipt": {"outputs_hash": h}}), encoding="utf-8")
+    return p
+
+@pytest.mark.parametrize("claims,sidecar,expected", [
+    (True,  "match",   "match"),
+    (True,  None,      "missing"),
+    (True,  "garbage", "missing"),
+    (True,  "nokey",   "missing"),
+    (True,  "wrong",   "mismatch"),
+    (False, None,      "unsigned"),
+    (False, "match",   "unsigned"),   # sidecar with no claim: unexplained, stays quiet
+])
+def test_receipt_state_table(tmp_path, claims, sidecar, expected):
+    p = _write_pair(tmp_path, "aaaa-bbbb", claims, sidecar)
+    data = json.loads(p.read_text())
+    assert reader.receipt_state(tmp_path, data)["state"] == expected
+
+def test_sidecar_missing_only_the_hash_key_is_not_called_unreadable(tmp_path):
+    """A sidecar that parses as JSON fine but lacks outputs_hash IS readable — the
+    detail must not claim otherwise. Only genuine parse failures get that wording."""
+    p = _write_pair(tmp_path, "aaaa-bbbb", True, "nokey")
+    got = reader.receipt_state(tmp_path, json.loads(p.read_text()))
+    assert got["state"] == "missing"
+    assert got["detail"] is None
+
+def test_non_dict_data_is_unsigned_not_a_crash(tmp_path):
+    """Docstring says 'Never raises.' A non-dict data payload used to reach
+    data.get() unguarded; it must degrade to the quiet 'unsigned' state instead."""
+    assert reader.receipt_state(tmp_path, "not a dict")["state"] == "unsigned"
+    assert reader.receipt_state(tmp_path, None)["state"] == "unsigned"
+    assert reader.receipt_state(tmp_path, [])["state"] == "unsigned"
+
+def test_tampering_one_byte_turns_match_into_mismatch(tmp_path):
+    """Injection proof: build a genuinely matching pair, then edit the checkpoint.
+    A state machine that reported "match" from the claim alone would stay green."""
+    p = _write_pair(tmp_path, "aaaa-bbbb", True, "match")
+    assert reader.receipt_state(tmp_path, json.loads(p.read_text()))["state"] == "match"
+    p.write_text(p.read_text().replace("D-018", "D-019"), encoding="utf-8")
+    assert reader.receipt_state(tmp_path, json.loads(p.read_text()))["state"] == "mismatch"
+
+def test_root_session_file_governs_even_when_a_pointer_copy_differs(tmp_path):
+    """Real-world shape: daimon writes several pointer snapshots during one session
+    but only binds the receipt to the FINAL root session file's bytes
+    (<data_dir>/<session_id>.json). A mid-session pointer copy (e.g. bucket's
+    latest.json) legitimately has different bytes and must not shadow the root
+    verdict with a false mismatch."""
+    sid = "aaaa-bbbb"
+    slug = "-proj"
+    bucket = tmp_path / slug
+    bucket.mkdir()
+
+    root_data = {"session_id": sid, "format_version": "D-018", "receipts": True,
+                 "working_context": {}, "epistemic_snapshot": {}}
+    root = tmp_path / f"{sid}.json"
+    root.write_text(json.dumps(root_data), encoding="utf-8")
+    h = reader._multihash_b64(root.read_bytes())
+    (tmp_path / f"{sid}.receipt").write_text(
+        json.dumps({"receipt": {"outputs_hash": h}}), encoding="utf-8")
+
+    # Pointer copy of the SAME session with DIFFERENT bytes (mid-session snapshot).
+    pointer_data = dict(root_data, active_topic_marker="pointer-snapshot-differs")
+    (bucket / "latest.json").write_text(json.dumps(pointer_data), encoding="utf-8")
+
+    got = reader.load_checkpoint(tmp_path, slug, "latest")
+    assert got["ok"] is True
+    assert got["meta"]["receipt"]["state"] == "match"
+
+def test_session_id_cannot_escape_the_data_dir(tmp_path):
+    """session_id comes from file content and is joined into a path — twice now
+    (sidecar AND root session file). Prove the SESSION_ID_RE guard actually does
+    something: point a traversal at files that genuinely EXIST outside data_dir
+    and would resolve to a false "match" if the guard were removed. (Verified by
+    injection: temporarily deleting the guard makes this test fail; restoring it
+    makes it pass again.)"""
+    data_dir = tmp_path / "checkpoints"
+    data_dir.mkdir()
+
+    secret = tmp_path / "secret.json"
+    secret.write_text(json.dumps({"top": "secret"}), encoding="utf-8")
+    h = reader._multihash_b64(secret.read_bytes())
+    (tmp_path / "secret.receipt").write_text(
+        json.dumps({"receipt": {"outputs_hash": h}}), encoding="utf-8")
+
+    data = {"session_id": "../secret", "receipts": True}
+    assert reader.receipt_state(data_dir, data)["state"] != "match"
+
+def test_unreadable_sidecar_names_the_file_in_detail(tmp_path):
+    p = _write_pair(tmp_path, "aaaa-bbbb", True, "garbage")
+    got = reader.receipt_state(tmp_path, json.loads(p.read_text()))
+    assert got["state"] == "missing"
+    assert "aaaa-bbbb.receipt" in got["detail"]
+
+def _bucket_with(root: Path, slug: str, claims_by_ref: dict):
+    b = root / slug
+    b.mkdir(parents=True, exist_ok=True)
+    for ref, claims in claims_by_ref.items():
+        cp = {"session_id": f"sid-{ref}", "format_version": "D-018",
+              "working_context": {}, "epistemic_snapshot": {}}
+        if claims:
+            cp["receipts"] = True
+        (b / f"{ref}.json").write_text(json.dumps(cp), encoding="utf-8")
+    return b
+
+def test_gate_opens_when_any_pointer_claims_receipts(tmp_path):
+    b = _bucket_with(tmp_path, "-proj", {"latest": False, "prev-1": True})
+    assert reader.receipts_enabled(b) is True
+
+def test_gate_stays_shut_when_no_pointer_claims_receipts(tmp_path):
+    b = _bucket_with(tmp_path, "-proj", {"latest": False, "prev-1": False})
+    assert reader.receipts_enabled(b) is False
+
+def test_gate_ignores_an_unreadable_pointer(tmp_path):
+    b = _bucket_with(tmp_path, "-proj", {"latest": True})
+    (b / "prev-1.json").write_text("{torn", encoding="utf-8")
+    assert reader.receipts_enabled(b) is True
+
+def test_closed_gate_omits_the_receipt_key_entirely(tmp_path):
+    _bucket_with(tmp_path, "-proj", {"latest": False})
+    got = reader.load_checkpoint(tmp_path, "-proj", "latest")
+    assert got["ok"] is True
+    assert "receipt" not in got["meta"]
+
+def test_open_gate_reports_state_in_meta(tmp_path):
+    _bucket_with(tmp_path, "-proj", {"latest": True})
+    got = reader.load_checkpoint(tmp_path, "-proj", "latest")
+    assert got["meta"]["receipt"]["state"] == "missing"
+
+def test_gate_survives_a_non_dict_pointer_string(tmp_path):
+    """A pointer file holding valid JSON that isn't an object (e.g. a bare
+    string) must not crash the scan — .get() would raise AttributeError on it."""
+    b = tmp_path / "-proj"
+    b.mkdir()
+    (b / "latest.json").write_text(json.dumps({"session_id": "a"}), encoding="utf-8")
+    (b / "prev-1.json").write_text(json.dumps("just a string"), encoding="utf-8")
+    assert reader.receipts_enabled(b) is False
+
+def test_gate_survives_a_non_dict_pointer_list(tmp_path):
+    """Same as above but for a JSON list, the other common non-object shape."""
+    b = tmp_path / "-proj"
+    b.mkdir()
+    (b / "latest.json").write_text(json.dumps({"session_id": "a"}), encoding="utf-8")
+    (b / "prev-1.json").write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    assert reader.receipts_enabled(b) is False

--- a/plugin/tests/ui/test_serve_command.py
+++ b/plugin/tests/ui/test_serve_command.py
@@ -1,0 +1,39 @@
+"""`daimon serve` (#670): the CLI front door to the read-only viewer. The
+subcommand delegates to daimon_ui.__main__ so there is exactly one config
+path — the CLI never grows its own copy of the flag handling."""
+from pathlib import Path
+
+import pytest
+
+from daimon_briefing import cli
+from daimon_ui.__main__ import build_config
+
+
+def test_default_port_is_the_viewer_port():
+    cfg = build_config([], {}, cwd=Path("/Users/x/proj"))
+    assert cfg["port"] == 7717
+
+
+def test_serve_subcommand_delegates_to_daimon_ui(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_ui_main(argv):
+        captured["argv"] = argv
+        return 0
+
+    import daimon_ui.__main__ as ui_main
+    monkeypatch.setattr(ui_main, "main", fake_ui_main)
+    rc = cli.main(["serve", "--no-browser", "--port", "7800",
+                   "--data-dir", str(tmp_path)])
+    assert rc == 0
+    assert "--no-browser" in captured["argv"]
+    assert ["--port", "7800"] == captured["argv"][
+        captured["argv"].index("--port"):captured["argv"].index("--port") + 2]
+    assert str(tmp_path) in captured["argv"]
+
+
+def test_serve_help_names_read_only(capsys):
+    with pytest.raises(SystemExit):
+        cli.main(["serve", "--help"])
+    out = capsys.readouterr().out
+    assert "read-only" in out

--- a/plugin/tests/ui/test_serve_command.py
+++ b/plugin/tests/ui/test_serve_command.py
@@ -24,9 +24,10 @@ def test_serve_subcommand_delegates_to_daimon_ui(monkeypatch, tmp_path):
     import daimon_ui.__main__ as ui_main
     monkeypatch.setattr(ui_main, "main", fake_ui_main)
     rc = cli.main(["serve", "--no-browser", "--port", "7800",
-                   "--data-dir", str(tmp_path)])
+                   "--data-dir", str(tmp_path), "--project-dir", str(tmp_path)])
     assert rc == 0
     assert "--no-browser" in captured["argv"]
+    assert "--project-dir" in captured["argv"]
     assert ["--port", "7800"] == captured["argv"][
         captured["argv"].index("--port"):captured["argv"].index("--port") + 2]
     assert str(tmp_path) in captured["argv"]

--- a/plugin/tests/ui/test_server.py
+++ b/plugin/tests/ui/test_server.py
@@ -1,0 +1,100 @@
+import json
+import urllib.request
+import pytest
+
+def _get(url):
+    with urllib.request.urlopen(url) as r:
+        return r.status, r.headers.get_content_type(), r.read()
+
+def test_root_serves_html(srv):
+    status, ctype, body = _get(srv + "/")
+    assert status == 200 and ctype == "text/html" and b"daimon" in body
+
+def test_api_checkpoints(srv):
+    status, ctype, body = _get(srv + "/api/checkpoints")
+    data = json.loads(body)
+    assert status == 200 and ctype == "application/json"
+    assert data["project"] == "daimon-ui-init"
+    assert [c["ref"] for c in data["checkpoints"]] == ["latest", "prev-1", "prev-2"]
+
+def test_api_checkpoint_ok(srv):
+    _, _, body = _get(srv + "/api/checkpoint/latest")
+    assert json.loads(body)["ok"] is True
+
+def test_api_checkpoint_bad_ref(srv):
+    _, _, body = _get(srv + "/api/checkpoint/..%2f..%2fetc")
+    assert json.loads(body)["ok"] is False
+
+def test_unknown_route_404(srv):
+    import urllib.error
+    with pytest.raises(urllib.error.HTTPError) as e:
+        _get(srv + "/nope")
+    assert e.value.code == 404
+
+def test_spoofed_host_header_rejected(srv):
+    import urllib.error
+    req = urllib.request.Request(srv + "/", headers={"Host": "evil.example.com"})
+    with pytest.raises(urllib.error.HTTPError) as e:
+        urllib.request.urlopen(req)
+    assert e.value.code == 403
+
+def test_api_projects_lists_discovered_and_current(srv):
+    status, ctype, body = _get(srv + "/api/projects")
+    data = json.loads(body)
+    assert status == 200 and ctype == "application/json"
+    assert data["current"] == "-tmp-proj"
+    assert "-tmp-proj" in [p["slug"] for p in data["projects"]]
+
+def test_api_projects_multi(srv_multi):
+    _, _, body = _get(srv_multi + "/api/projects")
+    data = json.loads(body)
+    assert sorted(p["slug"] for p in data["projects"]) == ["-other-proj", "-tmp-proj"]
+
+def test_checkpoints_project_param_switches_bucket(srv_multi):
+    _, _, body = _get(srv_multi + "/api/checkpoints?project=-other-proj")
+    data = json.loads(body)
+    assert data["project"] == "-other-proj"
+    assert [c["ref"] for c in data["checkpoints"]] == ["latest"]
+
+def test_checkpoints_missing_param_uses_default(srv_multi):
+    _, _, body = _get(srv_multi + "/api/checkpoints")
+    data = json.loads(body)
+    assert data["project"] == "daimon-ui-init"
+    assert [c["ref"] for c in data["checkpoints"]] == ["latest", "prev-1", "prev-2"]
+
+def test_checkpoints_invalid_slug_traversal(srv):
+    _, _, body = _get(srv + "/api/checkpoints?project=..%2Fevil")
+    data = json.loads(body)
+    assert data["ok"] is False and "error" in data
+
+def test_checkpoints_nonexistent_slug(srv):
+    _, _, body = _get(srv + "/api/checkpoints?project=nonexistent")
+    data = json.loads(body)
+    assert data["ok"] is False
+
+def test_checkpoint_ref_project_param_switches_bucket(srv_multi):
+    _, _, body = _get(srv_multi + "/api/checkpoint/latest?project=-other-proj")
+    data = json.loads(body)
+    assert data["ok"] is True
+    assert data["meta"]["active_topic"] == "Other project topic"
+
+def test_checkpoint_ref_invalid_slug(srv):
+    _, _, body = _get(srv + "/api/checkpoint/latest?project=nonexistent")
+    data = json.loads(body)
+    assert data["ok"] is False
+
+def test_checkpoints_reports_how_many_sessions_exist_beyond_the_window(srv_flat):
+    """The sidebar serves pointer files only (latest, prev-N); History serves every
+    session file for the slug. When the two disagree the screen shows two answers to
+    "how much history is there" with nothing explaining the gap, so the endpoint that
+    feeds the sidebar has to carry the total the sidebar is a window onto."""
+    _, _, body = _get(srv_flat + "/api/checkpoints?project=-tmp-proj")
+    data = json.loads(body)
+    assert [c["ref"] for c in data["checkpoints"]] == ["latest"]
+    assert data["sessions_total"] == 3
+
+def test_checkpoints_total_counts_only_the_requested_project(srv_flat):
+    """flat_history plants a session owned by -other. A total that swept the whole
+    root directory would read 4 and overstate this project's history."""
+    _, _, body = _get(srv_flat + "/api/checkpoints?project=-tmp-proj")
+    assert json.loads(body)["sessions_total"] == 3

--- a/plugin/tests/ui/test_server_activity.py
+++ b/plugin/tests/ui/test_server_activity.py
@@ -1,0 +1,50 @@
+import json
+import threading
+import urllib.request
+from daimon_ui import server
+
+
+def _get(base, path):
+    req = urllib.request.Request(base + path)
+    with urllib.request.urlopen(req) as r:
+        return json.loads(r.read().decode())
+
+
+def _serve(data_dir, slug):
+    s = server.make_server(data_dir, slug, "test-proj", port=0)
+    t = threading.Thread(target=s.serve_forever, daemon=True)
+    t.start()
+    return s, f"http://127.0.0.1:{s.server_address[1]}"
+
+
+def test_activity_route_returns_rows(flat_history):
+    d, slug = flat_history
+    s, base = _serve(d, slug)
+    try:
+        got = _get(base, "/api/activity?project=" + slug)
+        assert got["ok"] is True
+        kinds = {r["kind"] for r in got["rows"]}
+        assert "session" in kinds
+    finally:
+        s.shutdown()
+
+
+def test_activity_route_rejects_unknown_slug(flat_history):
+    d, slug = flat_history
+    s, base = _serve(d, slug)
+    try:
+        got = _get(base, "/api/activity?project=-nope-")
+        assert got["ok"] is False
+        assert set(got["error"]) == {"what", "why", "fix"}
+    finally:
+        s.shutdown()
+
+
+def test_activity_route_rejects_traversal_slug(flat_history):
+    d, slug = flat_history
+    s, base = _serve(d, slug)
+    try:
+        got = _get(base, "/api/activity?project=..%2Fx")
+        assert got["ok"] is False
+    finally:
+        s.shutdown()

--- a/plugin/tests/ui/test_server_engines.py
+++ b/plugin/tests/ui/test_server_engines.py
@@ -116,3 +116,38 @@ def test_why_missing_id_is_an_error(engine_srv):
     out = _get(engine_srv, "/api/why")
     assert out["ok"] is False
     assert set(out["error"]) == {"what", "why", "fix"}
+
+
+def test_recall_rejects_unknown_project_slug(engine_srv):
+    out = _get(engine_srv, "/api/recall?project=-nope&q=sqlite")
+    assert out["ok"] is False
+    assert set(out["error"]) == {"what", "why", "fix"}
+
+
+def test_recall_whitespace_query_is_an_error(engine_srv):
+    out = _get(engine_srv, "/api/recall?q=%20%20")
+    assert out["ok"] is False
+
+
+def test_recall_engine_failure_is_an_error_shape(engine_srv, monkeypatch):
+    from daimon_briefing import recall as recall_mod
+
+    def boom(*a, **k):
+        raise recall_mod.RecallError("no FTS5")
+
+    monkeypatch.setattr(recall_mod, "search", boom)
+    out = _get(engine_srv, "/api/recall?q=sqlite")
+    assert out["ok"] is False
+    assert "FTS5" in out["error"]["fix"]
+
+
+def test_why_rejects_unknown_project_slug(engine_srv):
+    out = _get(engine_srv, "/api/why?project=-nope&id=d-0a1b2c3d4e5f")
+    assert out["ok"] is False
+    assert set(out["error"]) == {"what", "why", "fix"}
+
+
+def test_recall_zero_limit_is_an_error(engine_srv):
+    out = _get(engine_srv, "/api/recall?q=sqlite&limit=0")
+    assert out["ok"] is False
+    assert set(out["error"]) == {"what", "why", "fix"}

--- a/plugin/tests/ui/test_server_engines.py
+++ b/plugin/tests/ui/test_server_engines.py
@@ -1,0 +1,118 @@
+"""Engine endpoints (#670): /api/recall and /api/why dispatch to daimon_briefing's
+own engines. recall.search is THE matcher (one-matcher rule: the viewer renders
+recall, it never grows a second search engine) and inspect_item is the read-side
+receipt behind `daimon why`. reader.py stays daimon-import-free; the engine
+imports live in the server dispatch layer only.
+"""
+import json
+import threading
+from urllib.request import urlopen
+
+import pytest
+
+from daimon_briefing import store
+from daimon_ui import server
+
+
+def _engine_cp(sid):
+    return {
+        "session_id": sid,
+        "working_context": {
+            "active_topic": {"text": "wiring the viewer", "trust": "inferred"},
+            "open_questions": [],
+            "recent_decisions": [
+                {"text": "Adopt sqlite for the recall index",
+                 "trust": "verbatim", "id": "d-0a1b2c3d4e5f",
+                 "quote": "let's adopt sqlite for the recall index"},
+            ],
+        },
+        "epistemic_snapshot": {
+            "strong_beliefs": [], "uncertainties": [],
+            "contradictions_flagged": [],
+        },
+    }
+
+
+@pytest.fixture
+def engine_srv(tmp_checkpoint_dir, tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    store.write_checkpoint("S1", _engine_cp("S1"), project_dir=proj)
+    slug = store.project_slug(proj)
+    s = server.make_server(tmp_checkpoint_dir, slug, proj.name, port=0)
+    t = threading.Thread(target=s.serve_forever, daemon=True)
+    t.start()
+    yield f"http://127.0.0.1:{s.server_address[1]}"
+    s.shutdown()
+
+
+def _get(base, path):
+    with urlopen(base + path) as r:
+        return json.loads(r.read())
+
+
+# ---- /api/recall ----
+
+def test_recall_returns_matcher_rows(engine_srv):
+    out = _get(engine_srv, "/api/recall?q=sqlite")
+    assert out["ok"] is True
+    texts = [r["text"] for r in out["rows"]]
+    assert "Adopt sqlite for the recall index" in texts
+    row = out["rows"][texts.index("Adopt sqlite for the recall index")]
+    # the row is recall.search's row, passed through — not a viewer reshaping
+    assert row["item_id"] == "d-0a1b2c3d4e5f"
+    assert row["trust"] == "verbatim"
+    assert row["session_id"] == "S1"
+
+
+def test_recall_respects_limit(engine_srv):
+    out = _get(engine_srv, "/api/recall?q=sqlite&limit=1")
+    assert out["ok"] is True
+    assert len(out["rows"]) <= 1
+
+
+def test_recall_missing_query_is_an_error_shape(engine_srv):
+    out = _get(engine_srv, "/api/recall")
+    assert out["ok"] is False
+    assert set(out["error"]) == {"what", "why", "fix"}
+
+
+def test_recall_bad_limit_is_an_error_shape(engine_srv):
+    out = _get(engine_srv, "/api/recall?q=sqlite&limit=zero")
+    assert out["ok"] is False
+    assert set(out["error"]) == {"what", "why", "fix"}
+
+
+def test_recall_no_matches_is_ok_and_empty(engine_srv):
+    out = _get(engine_srv, "/api/recall?q=zzzznothing")
+    assert out["ok"] is True
+    assert out["rows"] == []
+
+
+# ---- /api/why ----
+
+def test_why_returns_inspect_item_payload(engine_srv):
+    out = _get(engine_srv, "/api/why?id=d-0a1b2c3d4e5f")
+    assert out["ok"] is True
+    # the payload is inspect_item's, passed through: item + axes + corroboration
+    assert out["item"]["item_id"] == "d-0a1b2c3d4e5f"
+    assert "axes" in out and "corroboration" in out
+
+
+def test_why_invalid_id_shape_is_an_error(engine_srv):
+    out = _get(engine_srv, "/api/why?id=not-an-id!")
+    assert out["ok"] is False
+    assert set(out["error"]) == {"what", "why", "fix"}
+
+
+def test_why_unknown_id_is_an_error(engine_srv):
+    out = _get(engine_srv, "/api/why?id=d-ffffffffffff")
+    assert out["ok"] is False
+    assert set(out["error"]) == {"what", "why", "fix"}
+
+
+def test_why_missing_id_is_an_error(engine_srv):
+    out = _get(engine_srv, "/api/why")
+    assert out["ok"] is False
+    assert set(out["error"]) == {"what", "why", "fix"}

--- a/plugin/tests/ui/test_server_history.py
+++ b/plugin/tests/ui/test_server_history.py
@@ -1,0 +1,232 @@
+import json
+import urllib.request
+import urllib.error
+import pytest
+from tests.ui.conftest import make_checkpoint
+
+def _get(url):
+    with urllib.request.urlopen(url) as r:
+        return r.status, r.headers.get_content_type(), r.read()
+
+@pytest.fixture
+def srv_with_history(flat_history):
+    """Server with flat_history fixture (3 sessions in -tmp-proj)."""
+    import threading
+    from daimon_ui import server
+    d, slug = flat_history
+    # flat_history creates session files but not bucket structure
+    # Add latest.json to bucket so list_buckets discovers it
+    bucket = d / slug
+    bucket.mkdir(parents=True, exist_ok=True)
+    (bucket / "latest.json").write_text(json.dumps(make_checkpoint()))
+    srv = server.make_server(d, slug, "Test Project", port=0)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    yield f"http://127.0.0.1:{srv.server_address[1]}"
+    srv.shutdown()
+
+@pytest.fixture
+def srv_with_biography_items(tmp_path):
+    """Server with sessions that have items with ids for biography testing."""
+    import threading
+    from daimon_ui import server
+    d = tmp_path / "checkpoints"
+    d.mkdir(parents=True)
+    slug = "-tmp-proj"
+    bucket = d / slug
+    bucket.mkdir()
+
+    BIO_ID = "o-abc123abc123"
+
+    # Session 1: item born
+    cp_1 = make_checkpoint(
+        created="2026-08-04T10:00:00Z", topic="day one", session_id="aaaa-1111",
+        open_questions=[
+            {"text": "test question", "id": BIO_ID, "trust": "verbatim", "quote": "test quote"},
+        ],
+    )
+    cp_1["project_slug"] = slug
+    (d / "aaaa-1111.json").write_text(json.dumps(cp_1))
+
+    # Session 2: item carried
+    cp_2 = make_checkpoint(
+        created="2026-08-05T10:00:00Z", topic="day two", session_id="bbbb-2222",
+        open_questions=[
+            {"text": "test question", "id": BIO_ID, "trust": "verbatim", "quote": "test quote"},
+        ],
+    )
+    cp_2["project_slug"] = slug
+    (d / "bbbb-2222.json").write_text(json.dumps(cp_2))
+
+    # Create bucket pointer so list_buckets discovers the bucket
+    (bucket / "latest.json").write_text(json.dumps(make_checkpoint()))
+
+    srv = server.make_server(d, slug, "Test Project", port=0)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    yield f"http://127.0.0.1:{srv.server_address[1]}", BIO_ID
+    srv.shutdown()
+
+# Tests for /api/history
+
+def test_api_history_happy_path(srv_with_history):
+    status, ctype, body = _get(srv_with_history + "/api/history")
+    data = json.loads(body)
+    assert status == 200 and ctype == "application/json"
+    assert "project" in data
+    assert "sessions" in data
+    assert len(data["sessions"]) == 3
+    assert "unreadable" in data
+    assert data["sessions"][0]["session_id"] == "rollout-2026-08-06-cccc"
+
+def test_api_history_with_project_param(srv_with_history):
+    status, ctype, body = _get(srv_with_history + "/api/history?project=-tmp-proj")
+    data = json.loads(body)
+    assert status == 200
+    assert data["project"] == "Test Project"
+    assert len(data["sessions"]) == 3
+
+def test_api_history_invalid_slug(srv_with_history):
+    status, ctype, body = _get(srv_with_history + "/api/history?project=nonexistent")
+    data = json.loads(body)
+    assert status == 200
+    assert data["ok"] is False
+    assert "error" in data
+
+def test_api_history_traversal_attempt_rejected(srv_with_history):
+    status, ctype, body = _get(srv_with_history + "/api/history?project=..%2Fevil")
+    data = json.loads(body)
+    assert status == 200
+    assert data["ok"] is False
+    assert "error" in data
+
+# Tests for /api/diff
+
+def test_api_diff_with_explicit_sids(srv_with_history):
+    """Diff between two specific sessions."""
+    status, ctype, body = _get(srv_with_history + "/api/diff?project=-tmp-proj&a=aaaa-1111&b=bbbb-2222")
+    data = json.loads(body)
+    assert status == 200 and ctype == "application/json"
+    assert data["ok"] is True
+    assert data["a"]["session_id"] == "aaaa-1111"
+    assert data["b"]["session_id"] == "bbbb-2222"
+
+def test_api_diff_default_uses_newest_two_sessions(srv_with_history):
+    """Without a/b params, diff should use the two newest sessions."""
+    status, ctype, body = _get(srv_with_history + "/api/diff?project=-tmp-proj")
+    data = json.loads(body)
+    assert status == 200
+    assert data["ok"] is True
+    # Two newest are: rollout-2026-08-06-cccc and bbbb-2222
+    # a (older) should be bbbb-2222, b (newer) should be rollout-2026-08-06-cccc
+    assert data["a"]["session_id"] == "bbbb-2222"
+    assert data["b"]["session_id"] == "rollout-2026-08-06-cccc"
+
+def test_api_diff_single_session_no_explicit_ab_returns_empty_state(tmp_path):
+    """With fewer than 2 sessions and no explicit a/b, return the empty state, not an error."""
+    import threading
+    from daimon_ui import server
+    d = tmp_path / "checkpoints"
+    d.mkdir(parents=True)
+    slug = "-tmp-proj"
+    bucket = d / slug
+    bucket.mkdir()
+
+    cp = make_checkpoint(created="2026-08-04T10:00:00Z", topic="day one", session_id="only-session")
+    cp["project_slug"] = slug
+    (d / "only-session.json").write_text(json.dumps(cp))
+
+    # Create bucket pointer so list_buckets discovers the bucket
+    (bucket / "latest.json").write_text(json.dumps(make_checkpoint()))
+
+    srv = server.make_server(d, slug, "Test Project", port=0)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    try:
+        base_url = f"http://127.0.0.1:{srv.server_address[1]}"
+        status, ctype, body = _get(base_url + "/api/diff?project=-tmp-proj")
+        data = json.loads(body)
+        assert status == 200
+        assert data["ok"] is True
+        assert data["empty"] == "single_checkpoint"
+        assert data["sessions"] == 1
+    finally:
+        srv.shutdown()
+
+def test_api_diff_invalid_project_param(srv_with_history):
+    status, ctype, body = _get(srv_with_history + "/api/diff?project=nonexistent")
+    data = json.loads(body)
+    assert status == 200
+    assert data["ok"] is False
+    assert "error" in data
+
+def test_api_diff_traversal_attempt_in_a_param(srv_with_history):
+    """Traversal in a param should be caught by reader's session validation."""
+    status, ctype, body = _get(srv_with_history + "/api/diff?project=-tmp-proj&a=../../etc&b=bbbb-2222")
+    data = json.loads(body)
+    assert status == 200
+    assert data["ok"] is False
+    assert "error" in data
+
+def test_api_diff_traversal_attempt_in_b_param(srv_with_history):
+    """Traversal in b param should be caught by reader's session validation."""
+    status, ctype, body = _get(srv_with_history + "/api/diff?project=-tmp-proj&a=aaaa-1111&b=../../etc/passwd")
+    data = json.loads(body)
+    assert status == 200
+    assert data["ok"] is False
+    assert "error" in data
+
+def test_api_diff_partial_param_a_only_uses_default_b(srv_with_history):
+    """When only a is supplied, b should still default to newest session."""
+    status, ctype, body = _get(srv_with_history + "/api/diff?project=-tmp-proj&a=aaaa-1111")
+    data = json.loads(body)
+    assert status == 200
+    # Intentional behavior: when either a or b is missing, both default to the two newest
+    assert data["ok"] is True
+    assert data["a"]["session_id"] == "bbbb-2222"
+    assert data["b"]["session_id"] == "rollout-2026-08-06-cccc"
+
+# Tests for /api/biography
+
+def test_api_biography_happy_path(srv_with_biography_items):
+    base_url, item_id = srv_with_biography_items
+    status, ctype, body = _get(base_url + f"/api/biography?project=-tmp-proj&id={item_id}")
+    data = json.loads(body)
+    assert status == 200 and ctype == "application/json"
+    assert data["ok"] is True
+    assert "item" in data
+    assert "events" in data
+    assert data["item"]["id"] == item_id
+
+def test_api_biography_bad_item_id_format(srv_with_biography_items):
+    base_url, _ = srv_with_biography_items
+    status, ctype, body = _get(base_url + "/api/biography?project=-tmp-proj&id=invalid-id-format")
+    data = json.loads(body)
+    assert status == 200
+    assert data["ok"] is False
+    assert "error" in data
+
+def test_api_biography_nonexistent_item(srv_with_biography_items):
+    base_url, _ = srv_with_biography_items
+    status, ctype, body = _get(base_url + "/api/biography?project=-tmp-proj&id=o-aaa111aaa111")
+    data = json.loads(body)
+    assert status == 200
+    assert data["ok"] is False
+    assert "error" in data
+
+def test_api_biography_traversal_attempt_in_id_param(srv_with_biography_items):
+    """Traversal in id param should be caught by reader's format validation."""
+    base_url, _ = srv_with_biography_items
+    status, ctype, body = _get(base_url + "/api/biography?project=-tmp-proj&id=../../etc")
+    data = json.loads(body)
+    assert status == 200
+    assert data["ok"] is False
+    assert "error" in data
+
+def test_api_biography_invalid_project_param(srv_with_biography_items):
+    base_url, item_id = srv_with_biography_items
+    status, ctype, body = _get(base_url + f"/api/biography?project=nonexistent&id={item_id}")
+    data = json.loads(body)
+    assert status == 200
+    assert data["ok"] is False
+    assert "error" in data

--- a/plugin/tests/ui/test_server_static.py
+++ b/plugin/tests/ui/test_server_static.py
@@ -1,0 +1,126 @@
+import http.client
+import re
+import urllib.error
+import urllib.request
+
+import pytest
+
+
+def _get(url):
+    with urllib.request.urlopen(url) as r:
+        return r.status, r.headers.get("Content-Type"), r.read()
+
+
+def _raw_get(srv, raw_path):
+    """Send raw_path verbatim. urllib normalizes '..' out of URLs before sending;
+    http.client does not, so traversal probes must go through this."""
+    host = srv.replace("http://", "").rstrip("/")
+    conn = http.client.HTTPConnection(host)
+    conn.putrequest("GET", raw_path, skip_accept_encoding=True)
+    conn.endheaders()
+    r = conn.getresponse()
+    body = r.read()
+    conn.close()
+    return r.status, body
+
+
+def test_css_served_with_exact_mime(srv):
+    status, ctype, body = _get(srv + "/static/app.css")
+    assert status == 200
+    assert ctype == "text/css; charset=utf-8"
+    assert b"--s1: 4px" in body
+
+
+def test_css_response_keeps_nosniff(srv):
+    with urllib.request.urlopen(srv + "/static/app.css") as r:
+        assert r.headers.get("X-Content-Type-Options") == "nosniff"
+
+
+def test_unlisted_static_name_is_404(srv):
+    try:
+        _get(srv + "/static/nope.txt")
+        raise AssertionError("expected 404")
+    except urllib.error.HTTPError as e:
+        assert e.code == 404
+
+
+def test_traversal_never_returns_source(srv):
+    probes = [
+        "/static/../server.py",
+        "/static/../../daimon_ui/server.py",
+        "/static/%2e%2e/server.py",
+        "/static/..%2Fserver.py",
+        "/static/app.css/../../reader.py",
+        "/static//etc/passwd",
+        "/static/",
+    ]
+    for probe in probes:
+        status, body = _raw_get(srv, probe)
+        assert status == 404, f"{probe} returned {status}"
+        assert b"def " not in body, f"{probe} leaked Python source"
+        assert b"root:" not in body, f"{probe} leaked system file"
+
+
+
+
+@pytest.mark.parametrize("name", ["state.js", "render.js", "app.js"])
+def test_js_served_with_exact_mime(srv, name):
+    status, ctype, body = _get(srv + "/static/" + name)
+    assert status == 200
+    assert ctype == "text/javascript; charset=utf-8"
+    assert len(body) > 0
+
+
+def test_app_js_imports_every_render_js_name_it_uses(srv):
+    """A render.js export referenced by name in app.js (including bare references
+    passed to .map()/.forEach() with no trailing '(') but missing from app.js's
+    import block is undefined at runtime — a ReferenceError that only surfaces when
+    that code path actually runs in a browser, not from `node --check` or any other
+    syntax-only check. This walks every export render.js offers and confirms app.js
+    either imports it or defines it locally before it can be referenced."""
+    _, _, render_body = _get(srv + "/static/render.js")
+    _, _, app_body = _get(srv + "/static/app.js")
+    render_src = render_body.decode()
+    app_src = app_body.decode()
+
+    exported = sorted(set(re.findall(r"^\s*export (?:function|const)\s+(\w+)", render_src, re.MULTILINE)))
+    assert exported, "no exports found in render.js — parsing broke, fix the test"
+
+    m = re.search(r'import\s*\{(.*?)\}\s*from\s*["\']\./render\.js["\']', app_src, re.DOTALL)
+    assert m, "app.js has no `import { ... } from \"./render.js\"` block"
+    imported = {name.strip() for name in m.group(1).split(",") if name.strip()}
+
+    # Body to scan for usage = app.js source with the import block itself blanked out,
+    # so the import statement's own name list doesn't count as a "reference".
+    body_for_usage = app_src[:m.start()] + app_src[m.end():]
+
+    offenders = []
+    for name in exported:
+        word = re.compile(r"\b" + re.escape(name) + r"\b")
+        if name in imported:
+            continue
+        if not word.search(body_for_usage):
+            continue  # app.js never references this render.js export — fine
+        if re.search(r"\bfunction\s+" + re.escape(name) + r"\s*\(", body_for_usage):
+            continue  # shadowed by a local app.js function of the same name — fine
+        if re.search(r"\bvar\s+" + re.escape(name) + r"\b", body_for_usage):
+            continue  # shadowed by a local app.js var — fine
+        line_no = app_src[:app_src.index(name)].count("\n") + 1 if name in app_src else "?"
+        offenders.append(f"{name} (first referenced near app.js:{line_no})")
+
+    assert not offenders, (
+        "app.js references render.js export(s) not in its import block: "
+        + ", ".join(offenders)
+    )
+
+
+def test_no_external_resources_anywhere(srv):
+    """Offline, localhost-only inspector: nothing may load from a third-party origin.
+    Replaces test_page_is_single_file_no_external_refs, whose <link>/src= half the
+    /static/ split legitimately invalidated — this keeps the half that still holds."""
+    for path in ["/", "/static/app.css", "/static/app.js",
+                 "/static/render.js", "/static/state.js"]:
+        _, _, body = _get(srv + path)
+        text = re.sub(r'http://127\.0\.0\.1(:\d+)?(?=[/"\s]|$)', '', body.decode())
+        for needle in ["https://", "http://", "@import"]:
+            assert needle not in text, f"{path} references {needle}"


### PR DESCRIPTION
Refs #670

## What

- New `daimon_ui` package: a localhost-only, read-only web viewer. Python stdlib server plus vanilla JS, no build step, no new dependencies; the handler defines only `do_GET`.
- `daimon serve` subcommand as its front door (default port 7717), declared not-agent-facing in the skill: a person reads memory here, an agent already has `brief`/`recall`/`why`.
- `/api/recall` renders `recall.search` rows. The search box reuses recall's matcher: one engine, two renderings. The viewer never grows a second search engine, because two matchers with different scoring would disagree about what memory holds, and a trust tool whose surfaces disagree is its own bug.
- `/api/why` renders `inspector.inspect_item` as recorded: item, evidence axes, corroboration, bounded source excerpt. The JSON carries no derived summary and the viewer does not invent one.
- The entry view wires the existing biography ladder under the why receipt; search rows deep-link to it.

## Why

First slice of #670, search first per the issue's build order. Memory was inspectable only one CLI command at a time; a briefing line names an item id, and turning that id into its receipt meant retyping it by hand. This makes checking cheap without adding a single write surface.

## Tests

- 154 tests under `tests/ui`: reader, server, page, static allowlist, plus new engine-endpoint tests that drive a real store fixture through `recall.search` and `inspect_item` (error shapes included), and serve-command delegation tests. New behavior was written test-first; each endpoint test failed before its implementation.
- Full plugin suite green: 3491 passed, 2 skipped. The write-audit guard names `serve` in SKIPPED with its reason: `serve_forever()` cannot be driven headless, the handler is GET-only, and its engine calls are the same paths the `recall` recipe already audits.
- `ruff check` clean.
- Manual round-trip against a real project store: `daimon serve --no-browser`, then `/api/recall?q=...` and `/api/why?id=...` returned live rows and a full receipt.
