### PR TITLE
feat(store): stamp the project directory name on checkpoints at write time

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -817,8 +817,12 @@ def projects_rows(project_arg=None) -> list:
         cp = b["checkpoint"] or {}
         created = cp.get("created")
         topic = ((cp.get("working_context") or {}).get("active_topic") or {})
+        name = cp.get("project_name")
         rows.append({
             "slug": b["slug"],
+            # #672 write-time stamp; None when the bucket predates it — never
+            # a slug-derived guess, the flattening is not invertible.
+            "name": name if isinstance(name, str) and name else None,
             "session_id": cp.get("session_id"),
             "created": created if isinstance(created, str) else None,
             "git_branch": cp.get("git_branch"),
@@ -856,6 +860,7 @@ def _cmd_projects(args) -> int:
             topic = topic[:_TOPIC_TEASER_CHARS - 1] + "…"
         display.append({
             "mark": "*" if r["current"] else " ",
+            "name": r["name"] or "—",
             "slug": r["slug"], "age": age,
             "branch": r["git_branch"] or "—", "topic": topic or "?",
         })

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -890,14 +890,17 @@ def _render_lines(lines, *, footer=None) -> None:
 
 def render_projects(rows) -> None:
     """`daimon projects`: one row per checkpoint bucket. `rows` is
-    [{mark, slug, age, branch, topic}], pre-formatted strings — sorting,
-    truncation, and the current-project mark are the CLI's concern."""
+    [{mark, name, slug, age, branch, topic}], pre-formatted strings — sorting,
+    truncation, and the current-project mark are the CLI's concern. `name` is
+    the #672 write-time stamp; the slug column stays untouched because it is
+    what users copy into --slug."""
     if not supports_rich():
+        n = max((len(r["name"]) for r in rows), default=0)
         w = max((len(r["slug"]) for r in rows), default=0)
         a = max((len(r["age"]) for r in rows), default=0)
         b = max((len(r["branch"]) for r in rows), default=0)
         for r in rows:
-            print(f"{r['mark']} {r['slug']:<{w}}  {r['age']:<{a}}  "
+            print(f"{r['mark']} {r['name']:<{n}}  {r['slug']:<{w}}  {r['age']:<{a}}  "
                   f"{r['branch']:<{b}}  {r['topic']}")
         return
     from rich.console import Console
@@ -906,12 +909,13 @@ def render_projects(rows) -> None:
     console = Console()
     table = Table(show_header=True, header_style="bold")
     table.add_column("")
+    table.add_column("name")
     table.add_column("project")
     table.add_column("last")
     table.add_column("branch")
     table.add_column("topic")
     for r in rows:
-        table.add_row(r["mark"], r["slug"], r["age"], r["branch"], r["topic"])
+        table.add_row(r["mark"], r["name"], r["slug"], r["age"], r["branch"], r["topic"])
     console.print(table)
 
 

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -1100,6 +1100,14 @@ def write_checkpoint(session_id: str, checkpoint: dict, project_dir=None,
     slug = project_slug(project_dir)
     if slug:
         checkpoint.setdefault("project_slug", slug)
+        # #672: the slug is a lossy flattening (slash, space, and hyphen all
+        # collapse to "-"), so the directory's real name is recoverable only
+        # here, at the write boundary. Optional additive field; readers fall
+        # back to slug-derived display when absent. Guarded by `slug` so the
+        # unknown-project convention stays: absent field = unknown.
+        name = Path(project_dir).name
+        if name:
+            checkpoint.setdefault("project_name", name)
     # Stamp the git branch at capture time (#222), same idempotent setdefault
     # shape. Capture-side only — read-side filtering is a follow-up. Resolved
     # from `project_dir` (the session's OWN project), never os.getcwd(): heal

--- a/plugin/daimon_ui/reader.py
+++ b/plugin/daimon_ui/reader.py
@@ -111,10 +111,13 @@ def list_buckets(data_dir: Path) -> list[dict]:
         latest = p / "latest.json"
         if not latest.is_file():
             continue
-        created = active_topic = item_count = None
+        created = active_topic = item_count = project_name = None
         try:
             data = json.loads(latest.read_text(encoding="utf-8"))
             created = data.get("created")
+            # #672 write-time stamp; None when the bucket predates it.
+            raw_name = data.get("project_name")
+            project_name = raw_name if isinstance(raw_name, str) and raw_name else None
             wc = data.get("working_context") or {}
             es = data.get("epistemic_snapshot") or {}
             topic = wc.get("active_topic") if isinstance(wc, dict) else None
@@ -130,7 +133,8 @@ def list_buckets(data_dir: Path) -> list[dict]:
             item_count = count
         except (OSError, json.JSONDecodeError, AttributeError):
             pass  # torn latest.json: keep the bucket listed, fields stay None
-        out.append({"slug": p.name, "created": created, "active_topic": active_topic, "item_count": item_count})
+        out.append({"slug": p.name, "project_name": project_name, "created": created,
+                    "active_topic": active_topic, "item_count": item_count})
     out.sort(key=lambda b: b["created"] or "", reverse=True)  # "" sorts lowest, so None lands last
     return out
 

--- a/plugin/daimon_ui/static/render.js
+++ b/plugin/daimon_ui/static/render.js
@@ -180,7 +180,10 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
     var isCurrent = p.slug === state.defaultSlug;
     var torn = p.active_topic == null && p.created == null && p.item_count == null;
     var chip = isCurrent ? '<span class="proj-chip">current dir</span>' : "";
-    var name = '<span class="proj-name">' + escapeHtml(slugTail(p.slug)) + "</span>";
+    // #672: prefer the write-time stamped name; the slug tail stays only as
+    // the fallback for buckets written before the stamp existed.
+    var name = '<span class="proj-name">' +
+      escapeHtml(p.project_name || slugTail(p.slug)) + "</span>";
     var age = !torn && p.created
       ? '<span class="proj-age">' + escapeHtml(fmtRelative(p.created)) + "</span>" : "";
     var topic = torn ? "Unreadable checkpoint" : (p.active_topic || "(untitled)");

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -7886,7 +7886,8 @@ def test_projects_json_shape(tmp_checkpoint_dir, capsys, monkeypatch):
     assert cli.main(["projects", "--json"]) == 0
     rows = json.loads(capsys.readouterr().out)
     assert rows == [{
-        "slug": "-p-b", "session_id": "S-1", "created": "2026-07-11T00:00:00Z",
+        "slug": "-p-b", "name": None, "session_id": "S-1",
+        "created": "2026-07-11T00:00:00Z",
         "git_branch": "main", "topic": "topic text", "current": False,
     }]
 
@@ -8961,3 +8962,31 @@ def test_run_serialize_error_clears_heartbeat(
 def test_clear_heartbeat_missing_file_is_noop(tmp_log_dir):
     from daimon_briefing import ledger
     ledger.clear_heartbeat("S-never-stamped")  # must not raise
+
+
+def test_projects_json_includes_project_name(tmp_checkpoint_dir, capsys, monkeypatch):
+    # #672: the stamped directory name rides the row; absent stamp = None,
+    # never a slug-derived guess.
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    bucket = tmp_checkpoint_dir / "-p-named"
+    bucket.mkdir(parents=True)
+    (bucket / "latest.json").write_text(json.dumps({
+        "session_id": "S-n", "project_slug": "-p-named",
+        "project_name": "named", "created": "2026-07-11T00:00:00Z"}))
+    _write_bucket(tmp_checkpoint_dir, "-p-anon", "S-a", "2026-07-10T00:00:00Z")
+    assert cli.main(["projects", "--json"]) == 0
+    rows = json.loads(capsys.readouterr().out)
+    by_slug = {r["slug"]: r for r in rows}
+    assert by_slug["-p-named"]["name"] == "named"
+    assert by_slug["-p-anon"]["name"] is None
+
+
+def test_projects_human_render_shows_name_when_present(tmp_checkpoint_dir, capsys, monkeypatch):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    bucket = tmp_checkpoint_dir / "-p-named"
+    bucket.mkdir(parents=True)
+    (bucket / "latest.json").write_text(json.dumps({
+        "session_id": "S-n", "project_slug": "-p-named",
+        "project_name": "My Proj", "created": "2026-07-11T00:00:00Z"}))
+    assert cli.main(["projects"]) == 0
+    assert "My Proj" in capsys.readouterr().out

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -1259,21 +1259,24 @@ def test_working_plain_body_exception_propagates(capsys):
 
 def test_render_projects_plain_exact_format(capsys):
     render.render_projects([
-        {"mark": "*", "slug": "-p-a", "age": "1h ago", "branch": "main", "topic": "work a"},
-        {"mark": " ", "slug": "-p-bb", "age": "2d ago", "branch": "—", "topic": "work b"},
+        {"mark": "*", "name": "projA", "slug": "-p-a", "age": "1h ago",
+         "branch": "main", "topic": "work a"},
+        {"mark": " ", "name": "—", "slug": "-p-bb", "age": "2d ago",
+         "branch": "—", "topic": "work b"},
     ])
     out = capsys.readouterr().out
-    assert out == ("* -p-a   1h ago  main  work a\n"
-                   "  -p-bb  2d ago  —     work b\n")
+    assert out == ("* projA  -p-a   1h ago  main  work a\n"
+                   "  —      -p-bb  2d ago  —     work b\n")
 
 
 def test_render_projects_rich_smoke(monkeypatch, capsys):
     monkeypatch.setattr(render, "supports_rich", lambda: True)
     render.render_projects([
-        {"mark": "*", "slug": "-p-a", "age": "1h ago", "branch": "main", "topic": "work a"},
+        {"mark": "*", "name": "projA", "slug": "-p-a", "age": "1h ago",
+         "branch": "main", "topic": "work a"},
     ])
     out = capsys.readouterr().out
-    assert "-p-a" in out and "work a" in out
+    assert "-p-a" in out and "work a" in out and "projA" in out
 
 
 # --- #376 rejection ledger in stats output ---------------------------------

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -2118,3 +2118,24 @@ def test_tie_rank_resolved_agent_verified_is_ordinary_rank_not_candidate_rank():
     assert store._tie_rank({"status": "resolving-candidate"}) == 0
     assert store._tie_rank({"status": "resolved-agent-verified"}) != \
         store._tie_rank({"status": "resolving-candidate"})
+
+
+def test_write_stamps_project_name(tmp_checkpoint_dir, sample_checkpoint):
+    # #672: the slug is a lossy flattening, so the directory's real name exists
+    # only at write time — stamp it or lose it.
+    store.write_checkpoint("S1", sample_checkpoint, project_dir="/Users/x/My Proj")
+    blob = json.loads((tmp_checkpoint_dir / "S1.json").read_text(encoding="utf-8"))
+    assert blob["project_name"] == "My Proj"
+
+
+def test_write_unknown_project_stamps_no_name(tmp_checkpoint_dir, sample_checkpoint):
+    store.write_checkpoint("S1", sample_checkpoint)
+    blob = json.loads((tmp_checkpoint_dir / "S1.json").read_text(encoding="utf-8"))
+    assert "project_name" not in blob
+
+
+def test_write_does_not_overwrite_existing_project_name(tmp_checkpoint_dir, sample_checkpoint):
+    pre = {**sample_checkpoint, "project_name": "original"}
+    store.write_checkpoint("S1", pre, project_dir="/Users/x/projA")
+    blob = json.loads((tmp_checkpoint_dir / "S1.json").read_text(encoding="utf-8"))
+    assert blob["project_name"] == "original"

--- a/plugin/tests/ui/test_reader_discovery.py
+++ b/plugin/tests/ui/test_reader_discovery.py
@@ -97,3 +97,22 @@ def test_list_buckets_item_count_correctness(multi_buckets):
 
 def test_list_buckets_empty_data_dir(tmp_path):
     assert reader.list_buckets(tmp_path / "nope") == []
+
+
+def test_list_buckets_carries_project_name(tmp_path):
+    # #672: the write-time stamp reaches the grid; absent stamp = None so the
+    # client can fall back to its slug-tail display.
+    import json
+    d = tmp_path / "checkpoints"
+    named = d / "-p-named"
+    named.mkdir(parents=True)
+    (named / "latest.json").write_text(json.dumps(
+        {"session_id": "S", "project_name": "My Proj", "created": "2026-08-01T00:00:00Z"}))
+    anon = d / "-p-anon"
+    anon.mkdir()
+    (anon / "latest.json").write_text(json.dumps(
+        {"session_id": "S2", "created": "2026-08-02T00:00:00Z"}))
+    from daimon_ui import reader
+    by_slug = {b["slug"]: b for b in reader.list_buckets(d)}
+    assert by_slug["-p-named"]["project_name"] == "My Proj"
+    assert by_slug["-p-anon"]["project_name"] is None


### PR DESCRIPTION
Closes #672

## What

- `store.write_checkpoint` stamps `project_name` (the project directory's basename) next to `project_slug`, with the same idempotent `setdefault` contract as the other identity fields. Guarded by the known-project check: absent field still means unknown, and an empty basename is never stamped.
- `daimon projects` grows a `name` column in both render paths and a `name` key in the JSON rows (shared with the MCP projects tool). The slug column is untouched; it is what users copy into `--slug`.
- The viewer's project grid prefers the stamped name and keeps its slug-tail display only as the fallback for buckets written before the stamp existed.

## Why

The slug is a lossy flattening: slash, space, and hyphen all collapse to a hyphen, so the real directory name cannot be recovered from it by any reader. It exists exactly once, at the write boundary. Old buckets show a dash and heal on their next serialized session.

## Tests

- Stamp: written from `project_dir`, absent when the project is unknown, never overwrites an existing stamp (mirrors the `project_slug` test triplet).
- `projects_rows`: name rides the JSON row, `None` for pre-stamp buckets, never a slug-derived guess; human render shows the name; exact-shape and render-format tests updated for the new column.
- Viewer reader: `list_buckets` carries `project_name`, `None` when absent.
- Full plugin suite green: 3513 passed, 2 skipped. Live check of `daimon projects` shows the dash fallback on pre-stamp buckets.
