### PR TITLE
feat(ui): ledger screen and session page for the viewer

### DIFF
--- a/plugin/daimon_ui/page.html
+++ b/plugin/daimon_ui/page.html
@@ -12,8 +12,7 @@
   <span class="project-label"><span id="project"></span></span>
   <nav class="view-nav" aria-label="Views">
     <span id="back-link-slot"></span>
-    <span id="history-link-slot"></span>
-    <span id="activity-link-slot"></span>
+    <span id="nav-pills-slot"></span>
   </nav>
   <form id="search-form" role="search">
     <input id="search-box" type="search" placeholder="search — renders daimon recall"

--- a/plugin/daimon_ui/reader.py
+++ b/plugin/daimon_ui/reader.py
@@ -479,6 +479,165 @@ def diff_checkpoints(data_dir: Path, slug: str, sid_a: str, sid_b: str) -> dict:
         "partial": partial,
     }
 
+def _walk_transitions(data_dir: Path, slug: str):
+    """Pairwise walk over every session, oldest -> newest, emitting one event per
+    recorded transition: first_seen (item appears), changed (a tracked field
+    differs from the previous sighting), last_seen (item present before, absent
+    now — ts is the created of its FINAL sighting, the session named is the one
+    whose absence recorded it). Carried, unchanged sightings emit nothing:
+    a carry is not an event, and counting it would let agreement pose as
+    corroboration. Shared by project_ledger and session_events so the two
+    surfaces can never disagree about what happened."""
+    hist = project_history(data_dir, slug)
+    events, latest_item, last_sight = [], {}, {}
+    prev_ids, gone = None, set()
+    for s in reversed(hist["sessions"]):  # oldest -> newest
+        data, err = _load_session(data_dir, s["session_id"])
+        if err:
+            continue  # torn/missing session file: skip, don't abort the whole walk
+        _, sections, _ = _normalize(data)
+        cur = _index_items(sections)
+        for iid, item in cur.items():
+            if iid not in latest_item or iid in gone:
+                gone.discard(iid)
+                events.append({"item_id": iid, "kind": "first_seen", "ts": s["created"],
+                               "session_id": s["session_id"], "detail": None})
+            else:
+                changed = [f for f in _BIO_TRACKED_FIELDS
+                           if item.get(f) != latest_item[iid].get(f)]
+                if changed:
+                    events.append({"item_id": iid, "kind": "changed", "ts": s["created"],
+                                   "session_id": s["session_id"],
+                                   "detail": ", ".join(changed)})
+            latest_item[iid] = item
+        if prev_ids is not None:
+            for iid in sorted(prev_ids - set(cur)):
+                gone.add(iid)
+                events.append({"item_id": iid, "kind": "last_seen",
+                               "ts": last_sight.get(iid),
+                               "session_id": s["session_id"], "detail": None})
+        for iid in cur:
+            last_sight[iid] = s["created"]
+        prev_ids = set(cur)
+    return {"events": events, "items": latest_item, "unreadable": hist["unreadable"]}
+
+# Row order inside a ledger group and a session page: births, then changes,
+# then departures — the order the header counts read in — id-tiebroken so the
+# output never depends on dict insertion.
+_TRANSITION_ORDER = {"first_seen": 0, "changed": 1, "last_seen": 2}
+
+# Viewer section key -> the kind word recall already prints (schema.ITEM_FIELDS
+# vocabulary: question/decision/belief/uncertainty/contradiction). The ledger's
+# chip must say exactly what a recall row for the same item says — two surfaces,
+# one vocabulary. verify_first and open_loops are both slices of open_questions.
+_SECTION_KIND = {"verify_first": "question", "open_loops": "question",
+                 "decisions": "decision", "beliefs": "belief",
+                 "uncertainties": "uncertainty", "contradictions": "contradiction"}
+
+def _ledger_partial(unreadable):
+    if not unreadable:
+        return []
+    return [f"{unreadable} session file(s) couldn't be read and are missing from the ledger."]
+
+def project_ledger(data_dir: Path, slug: str) -> dict:
+    """The ledger screen: one row per object, grouped under the session of its
+    latest recorded transition. A later resolution or quote check (own ts, no
+    session attribution in their ledgers) can overtake the LAST EVENT field,
+    but never moves the row to another group — the viewer must not invent the
+    attribution the stored rows don't carry."""
+    walk = _walk_transitions(data_dir, slug)
+    hist_sessions = project_history(data_dir, slug)["sessions"]  # newest -> oldest
+    head = None
+    if hist_sessions:
+        head = {"session_id": hist_sessions[0]["session_id"],
+                "created": hist_sessions[0]["created"]}
+
+    bucket = data_dir / slug
+    res_fold = resolutions(bucket)
+    ver_rows = _jsonl_rows(bucket / "verification.jsonl")
+
+    latest_tr = {}
+    for ev in walk["events"]:  # emitted oldest -> newest, so last write wins
+        latest_tr[ev["item_id"]] = ev
+
+    by_sid = {}
+    for iid, tr in latest_tr.items():
+        last_event = {"kind": tr["kind"], "ts": tr["ts"]}
+        res = res_fold.get(iid)
+        if res and (res.get("ts") or "") > (last_event["ts"] or ""):
+            last_event = {"kind": "resolved", "ts": res.get("ts")}
+        for row in ver_rows:
+            if row.get("item_ref") == iid and (row.get("ts") or "") > (last_event["ts"] or ""):
+                last_event = {"kind": "quote_check", "ts": row.get("ts")}
+        item = walk["items"][iid]
+        entry = by_sid.setdefault(tr["session_id"], {
+            "counts": {"first_seen": 0, "changed": 0, "last_seen": 0}, "rows": []})
+        entry["counts"][tr["kind"]] += 1
+        entry["rows"].append({"id": iid, "text": item.get("text"),
+                              "trust": item.get("trust"),
+                              "kind": _SECTION_KIND.get(item.get("section")),
+                              "transition": tr["kind"], "last_event": last_event})
+
+    groups = []
+    for s in hist_sessions:  # newest first, only sessions that kept rows
+        entry = by_sid.get(s["session_id"])
+        if entry is None:
+            continue
+        entry["rows"].sort(key=lambda r: (_TRANSITION_ORDER[r["transition"]], r["id"]))
+        groups.append({"session_id": s["session_id"], "created": s["created"],
+                       "active_topic": s.get("active_topic"),
+                       "counts": entry["counts"], "rows": entry["rows"]})
+
+    return {"ok": True, "groups": groups, "head": head,
+            "totals": {"objects": len(walk["items"]),
+                       "events": len(walk["events"]) + len(res_fold) + len(ver_rows)},
+            "partial": _ledger_partial(walk["unreadable"])}
+
+def session_events(data_dir: Path, slug: str, sid: str) -> dict:
+    """The session page: every transition the named session wrote, grouped by
+    object. sid must exact-match a session_id from project_history before any
+    path is built, same discipline as diff_checkpoints. Resolutions and quote
+    checks are deliberately absent: their ledgers record no session, and this
+    page must not claim them for one."""
+    valid_ids = {s["session_id"] for s in project_history(data_dir, slug)["sessions"]}
+    if sid not in valid_ids:
+        return {"ok": False, "error": {
+            "what": f"Session {sid!r} isn't part of {slug}'s history.",
+            "why": "The session id doesn't match any recorded checkpoint.",
+            "fix": "Pick a session from the ledger's session list.",
+        }}
+    data, err = _load_session(data_dir, sid)
+    if err:
+        return {"ok": False, "error": err}
+
+    walk = _walk_transitions(data_dir, slug)
+    mine = [ev for ev in walk["events"] if ev["session_id"] == sid]
+
+    by_item = {}
+    counts = {"first_seen": 0, "changed": 0, "last_seen": 0}
+    for ev in mine:
+        counts[ev["kind"]] += 1
+        item = walk["items"].get(ev["item_id"]) or {}
+        obj = by_item.setdefault(ev["item_id"], {
+            "id": ev["item_id"], "text": item.get("text"),
+            "trust": item.get("trust"),
+            "kind": _SECTION_KIND.get(item.get("section")), "events": []})
+        obj["events"].append({"kind": ev["kind"], "ts": ev["ts"], "detail": ev["detail"]})
+
+    objects = sorted(by_item.values(), key=lambda o: (
+        _TRANSITION_ORDER[o["events"][0]["kind"]], o["id"]))
+
+    wc = data.get("working_context") or {}
+    topic = wc.get("active_topic") if isinstance(wc.get("active_topic"), dict) else {}
+    session = {"session_id": sid, "created": data.get("created"),
+               "author": data.get("author"),
+               "active_topic": (topic or {}).get("text")}
+    if receipts_enabled(data_dir / slug):
+        session["receipt"] = receipt_state(data_dir, data)
+
+    return {"ok": True, "session": session, "objects": objects, "counts": counts,
+            "partial": _ledger_partial(walk["unreadable"])}
+
 def _bad_item_id_error(item_id):
     return {"ok": False, "error": {
         "what": f"{item_id!r} isn't a valid item id.",

--- a/plugin/daimon_ui/server.py
+++ b/plugin/daimon_ui/server.py
@@ -190,6 +190,26 @@ class _Handler(BaseHTTPRequestHandler):
                 }})
                 return
             self._json(dict({"ok": True}, **result))
+        elif path == "/api/ledger":
+            slug = self._resolve_slug(params)
+            if slug is None:
+                self._json(self._bad_slug_error(params.get("project", [self.default_slug])[0]))
+                return
+            self._json(reader.project_ledger(self.data_dir, slug))
+        elif path == "/api/session":
+            slug = self._resolve_slug(params)
+            if slug is None:
+                self._json(self._bad_slug_error(params.get("project", [self.default_slug])[0]))
+                return
+            sid = params.get("sid", [None])[0]
+            if not sid:
+                self._json({"ok": False, "error": {
+                    "what": "No session id was given.",
+                    "why": "/api/session needs a sid parameter to look up.",
+                    "fix": "Open a session from the ledger's session list.",
+                }})
+                return
+            self._json(reader.session_events(self.data_dir, slug, sid))
         elif path == "/api/activity":
             slug = self._resolve_slug(params)
             if slug is None:

--- a/plugin/daimon_ui/static/app.css
+++ b/plugin/daimon_ui/static/app.css
@@ -799,6 +799,13 @@
     padding: 4px 10px; cursor: pointer;
   }
   .view-nav button:hover, .back-link:hover { border-color: #484f58; color: var(--ink); }
+  /* The pill for the surface being looked at reads as pressed-in, matching the
+     design chrome's active chip: same words, one look. */
+  .view-nav button[aria-current="page"] {
+    color: var(--ink);
+    background: var(--raised);
+    border-color: #484f58;
+  }
   #search-box {
     border-color: var(--border-strong); background: var(--raised); color: var(--ink);
     font-family: var(--mono); font-size: 11.5px;
@@ -885,3 +892,154 @@
   .why-life { padding: 22px 20px 14px; }
   .why-life .why-bio { margin-top: 12px; }
   .why-card .card-foot { margin-top: 8px; }
+
+  /* ---- ledger + session page (#670 slice 2) ---- */
+  .side-label {
+    margin: 0 0 var(--s2);
+    padding: var(--s2) var(--s4) 0;
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-tertiary);
+  }
+
+  .ledger-group {
+    border: 1px solid var(--border-strong);
+    border-radius: 8px;
+    background: var(--surface);
+    overflow: hidden;
+    margin-bottom: 14px;
+  }
+
+  /* A session strip carries two controls: the strip itself discloses the
+     group's rows (newest session open by default, the rest read as their
+     counts), and a separate "open session" button jumps to the session page. */
+  .ledger-ck {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    width: 100%;
+    background: var(--inset);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+  .ledger-ck-toggle {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    flex: 1;
+    min-width: 0;
+    text-align: left;
+    padding: 10px 18px;
+    background: none;
+    border: 0;
+    cursor: pointer;
+    font: inherit;
+    color: var(--ink);
+    transition: background var(--transition);
+  }
+  .ledger-ck-toggle:hover { background: var(--surface-hover); }
+  .ledger-ck-toggle .disclosure {
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    color: var(--ink-secondary);
+  }
+  .ledger-ck-open {
+    flex: none;
+    margin: 6px 12px 6px 0;
+    padding: 3px 10px;
+    background: none;
+    border: 1px solid var(--border-strong);
+    border-radius: 6px;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--ink-secondary);
+    cursor: pointer;
+    transition: border-color var(--transition), color var(--transition);
+  }
+  .ledger-ck-open:hover { border-color: #484f58; color: var(--ink); }
+  .ledger-sid { font-family: var(--mono); font-size: 12px; font-weight: 600; color: var(--ink); }
+  .ledger-ck-meta { font-family: var(--mono); font-size: 11.5px; color: var(--ink-tertiary); }
+
+  .ledger-cols {
+    display: grid;
+    grid-template-columns: 9px 1fr 130px 190px;
+    gap: 14px;
+    padding: 7px 18px;
+    border-bottom: 1px solid var(--border-subtle);
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-tertiary);
+  }
+  /* column 1 is the glyph gutter: "claim" starts over the text column and the
+     remaining labels auto-place over object and last event */
+  .ledger-cols span:first-child { grid-column: 2; }
+
+  .ledger-rows { display: flex; flex-direction: column; }
+
+  .ledger-row {
+    display: grid;
+    grid-template-columns: 9px 1fr 130px 190px;
+    align-items: baseline;
+    gap: 14px;
+    width: 100%;
+    text-align: left;
+    padding: 11px 18px;
+    border: 0;
+    border-bottom: 1px solid #161b22;
+    background: none;
+    color: var(--ink);
+    font: inherit;
+    cursor: pointer;
+    transition: background var(--transition);
+  }
+  .ledger-row:last-child { border-bottom: 0; }
+  .ledger-row:hover { background: var(--surface-hover); }
+  .ledger-row .glyph { margin-top: 0; align-self: center; }
+  .ledger-row .it-text { font-size: 13.5px; line-height: 1.5; min-width: 0; overflow-wrap: anywhere; }
+  .ledger-row .obj-id { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .ledger-ev { font-family: var(--mono); font-size: 11.5px; color: var(--ink-tertiary); white-space: nowrap; }
+
+  @media (max-width: 720px) {
+    .ledger-cols { display: none; }
+    .ledger-row { grid-template-columns: 9px 1fr; }
+    .ledger-row .obj-id, .ledger-ev { grid-column: 2; }
+  }
+
+  .sess-objs { display: flex; flex-direction: column; gap: 14px; }
+  .sess-obj {
+    border: 1px solid var(--border-strong);
+    border-radius: 8px;
+    background: var(--surface);
+    overflow: hidden;
+  }
+  .sess-obj .ledger-row { border-bottom: 1px solid var(--border-subtle); }
+  .sess-obj-events { padding: 8px 18px 12px; display: flex; flex-direction: column; gap: 6px; }
+  .sess-ev { display: flex; align-items: baseline; gap: 12px; }
+  .sess-ev-label {
+    font-family: var(--mono);
+    font-size: 11.5px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    color: var(--ink-secondary);
+  }
+  .sess-ev-detail { font-family: var(--mono); font-size: 11.5px; color: var(--ink-tertiary); }
+
+  /* Kind chip: recall's word for the item's shelf (question/decision/belief/
+     uncertainty/contradiction). Neutral paint — a kind is a category, never a
+     judgment. */
+  .kind-chip {
+    display: inline-block;
+    margin-left: 10px;
+    font-family: var(--mono);
+    font-size: 10.5px;
+    color: var(--ink-tertiary);
+    border: 1px solid var(--border-subtle);
+    border-radius: 4px;
+    padding: 0 var(--s1);
+    vertical-align: 1px;
+  }

--- a/plugin/daimon_ui/static/app.js
+++ b/plugin/daimon_ui/static/app.js
@@ -1,7 +1,8 @@
 import {
-  ACT_ITEM_ID_RE, escapeHtml, fmtRelative, navCurrent, renderActivityView, renderBioPanel,
-  renderEmptyProjects, renderError, renderHistoryView, renderProjCard, renderSearchResults,
-  renderSections, renderSidebarScope, renderSingleCheckpointEmpty, renderWhyView, skeletonHtml
+  ACT_ITEM_ID_RE, escapeHtml, fmtRelative, navCurrent, renderBioPanel,
+  renderEmptyProjects, renderError, renderLedgerSessions, renderLedgerView, renderProjCard,
+  renderSearchResults, renderSections, renderSessionView, renderSidebarScope, renderWhyView,
+  skeletonHtml
 } from "./render.js";
 import { state } from "./state.js";
 
@@ -23,6 +24,12 @@ import { state } from "./state.js";
   }
   function setShellView(view) {
     document.querySelector(".shell").classList.toggle("grid-view", view === "grid");
+  }
+  // Every view swap starts reading at the top. Without this, a search or a nav
+  // click from deep in a long page renders the new view 2000px above the
+  // viewport — the page looks blank and the app reads as broken or slow.
+  function toTop() {
+    window.scrollTo(0, 0);
   }
   function loadList() {
     state.requestId += 1;
@@ -64,44 +71,37 @@ import { state } from "./state.js";
     state.view = "grid";
     renderGrid();
   }
-  function renderHistoryLink() {
-    var slot = document.getElementById("history-link-slot");
-    if ((state.view === "project" || state.view === "history" || state.view === "activity") && state.currentSlug) {
+  // The mockup nav: two pills, briefing and ledger, shown whenever a project
+  // is open. The scaffold's History/Activity buttons are gone — the ledger and
+  // session pages are the design's reading of the same recorded events.
+  function renderNavPills() {
+    var slot = document.getElementById("nav-pills-slot");
+    slot.innerHTML = "";
+    var inProject = state.currentSlug &&
+      ["project", "ledger", "session", "search", "why"].indexOf(state.view) !== -1;
+    if (!inProject) return;
+    [["briefing", "project", goBriefing], ["ledger", "ledger", enterLedger]].forEach(function (pill) {
       var btn = document.createElement("button");
       btn.type = "button";
-      btn.className = "history-link";
-      btn.textContent = "History";
-      btn.setAttribute("aria-current", navCurrent(state.view, "history"));
-      btn.addEventListener("click", enterHistory);
-      slot.innerHTML = "";
+      btn.className = "nav-pill";
+      btn.textContent = pill[0];
+      btn.setAttribute("aria-current", navCurrent(state.view, pill[1]));
+      btn.addEventListener("click", pill[2]);
       slot.appendChild(btn);
-    } else {
-      slot.innerHTML = "";
-    }
+    });
   }
-  function renderActivityLink() {
-    var slot = document.getElementById("activity-link-slot");
-    if ((state.view === "project" || state.view === "history" || state.view === "activity") && state.currentSlug) {
-      var btn = document.createElement("button");
-      btn.type = "button";
-      btn.className = "history-link";
-      btn.textContent = "Activity";
-      btn.setAttribute("aria-current", navCurrent(state.view, "activity"));
-      btn.addEventListener("click", enterActivity);
-      slot.innerHTML = "";
-      slot.appendChild(btn);
-    } else {
-      slot.innerHTML = "";
-    }
+  function goBriefing() {
+    if (!state.currentSlug) return;
+    enterProject(state.currentSlug, state.cameFromGrid);
   }
-  function enterActivity() {
+  // ---- ledger (#670 slice 2): one row per object, grouped by session ----
+  function enterLedger() {
     if (!state.currentSlug) return;
     var slug = state.currentSlug;
-    state.view = "activity";
+    state.view = "ledger";
     state.requestId += 1;
     var reqId = state.requestId;
-    renderHistoryLink();
-    renderActivityLink();
+    renderNavPills();
     var stateEl = document.getElementById("state");
     var sectionsEl = document.getElementById("sections");
     var mainEl = document.getElementById("main");
@@ -111,26 +111,117 @@ import { state } from "./state.js";
       if (reqId !== state.requestId) return;
       stateEl.innerHTML = skeletonHtml();
     }, 1000);
-    api("/api/activity?project=" + encodeURIComponent(slug)).then(function (data) {
-      if (reqId !== state.requestId) return;
+    Promise.all([
+      api("/api/ledger?project=" + encodeURIComponent(slug)),
+      api("/api/history?project=" + encodeURIComponent(slug))
+    ]).then(function (results) {
+      if (reqId !== state.requestId) return; // superseded by a newer navigation
       clearTimeout(state.pendingTimer);
       mainEl.removeAttribute("aria-busy");
-      sectionsEl.innerHTML = "";
-      if (!data.ok) { showError(stateEl, data.error); return; }
-      stateEl.innerHTML = renderActivityView(data);
-      announce("Activity loaded.");
-      wireBioToggles(stateEl);
+      var ledger = results[0], hist = results[1];
+      state.ledgerSessions = hist.sessions || [];
+      stateEl.innerHTML = "";
+      if (!ledger.ok) {
+        sectionsEl.innerHTML = "";
+        showError(stateEl, ledger.error);
+        return;
+      }
+      renderSessionSidebar(null);
+      sectionsEl.innerHTML = renderLedgerView(ledger);
+      toTop();
+      announce("Ledger loaded.");
+      wireWhyOpeners(sectionsEl);
+      wireSessionOpeners(sectionsEl);
+      wireLedgerToggles(sectionsEl);
     }).catch(function () {
       if (reqId !== state.requestId) return;
       clearTimeout(state.pendingTimer);
       mainEl.removeAttribute("aria-busy");
       sectionsEl.innerHTML = "";
       showError(stateEl, {
-        what: "Could not load activity.",
+        what: "Could not load the ledger.",
         why: "The request to the daimon server failed.",
         fix: "Check the server is running and try again."
       });
     });
+  }
+  function renderSessionSidebar(activeSid) {
+    var nav = document.getElementById("sidebar");
+    nav.innerHTML = renderLedgerSessions(state.ledgerSessions, activeSid);
+    Array.prototype.forEach.call(nav.querySelectorAll(".sess-item"), function (btn) {
+      btn.addEventListener("click", function () { enterSession(btn.dataset.sid); });
+    });
+  }
+  function wireLedgerToggles(container) {
+    Array.prototype.forEach.call(container.querySelectorAll(".ledger-ck-toggle"), function (btn) {
+      btn.addEventListener("click", function () {
+        var body = document.getElementById(btn.getAttribute("aria-controls"));
+        var marker = btn.querySelector(".disclosure");
+        var open = !body.hasAttribute("hidden");
+        if (open) {
+          body.setAttribute("hidden", "");
+          btn.setAttribute("aria-expanded", "false");
+          if (marker) marker.textContent = "▸";
+        } else {
+          body.removeAttribute("hidden");
+          btn.setAttribute("aria-expanded", "true");
+          if (marker) marker.textContent = "▾";
+        }
+      });
+    });
+  }
+  function wireSessionOpeners(container) {
+    Array.prototype.forEach.call(container.querySelectorAll("[data-open-session][data-sid]"), function (btn) {
+      btn.addEventListener("click", function () { enterSession(btn.dataset.sid); });
+    });
+  }
+  // ---- session page (#670 slice 2): what one session wrote ----
+  function enterSession(sid) {
+    if (!state.currentSlug || !sid) return;
+    var slug = state.currentSlug;
+    state.view = "session";
+    state.sessionSid = sid;
+    state.requestId += 1;
+    var reqId = state.requestId;
+    renderNavPills();
+    var stateEl = document.getElementById("state");
+    var sectionsEl = document.getElementById("sections");
+    var mainEl = document.getElementById("main");
+    mainEl.setAttribute("aria-busy", "true");
+    if (state.pendingTimer) clearTimeout(state.pendingTimer);
+    state.pendingTimer = setTimeout(function () {
+      if (reqId !== state.requestId) return;
+      stateEl.innerHTML = skeletonHtml();
+    }, 1000);
+    api("/api/session?project=" + encodeURIComponent(slug) + "&sid=" + encodeURIComponent(sid))
+      .then(function (data) {
+        if (reqId !== state.requestId) return; // superseded by a newer navigation
+        clearTimeout(state.pendingTimer);
+        mainEl.removeAttribute("aria-busy");
+        stateEl.innerHTML = "";
+        if (!data.ok) {
+          sectionsEl.innerHTML = "";
+          showError(stateEl, data.error);
+          return;
+        }
+        renderSessionSidebar(sid);
+        sectionsEl.innerHTML = renderSessionView(data);
+        toTop();
+        announce("Session loaded.");
+        wireWhyOpeners(sectionsEl);
+        var back = sectionsEl.querySelector("[data-session-back]");
+        if (back) back.addEventListener("click", enterLedger);
+      }).catch(function () {
+        if (reqId !== state.requestId) return;
+        clearTimeout(state.pendingTimer);
+        mainEl.removeAttribute("aria-busy");
+        sectionsEl.innerHTML = "";
+        showError(stateEl, {
+          what: "Could not load this session.",
+          why: "The request to the daimon server failed.",
+          fix: "Check the server is running and try again."
+        });
+      });
   }
   function renderGrid() {
     state.view = "grid";
@@ -139,8 +230,7 @@ import { state } from "./state.js";
     document.getElementById("sidebar").innerHTML = "";
     document.getElementById("project").textContent = "";
     renderBackLink();
-    renderHistoryLink();
-    renderActivityLink();
+    renderNavPills();
     var stateEl = document.getElementById("state");
     var sectionsEl = document.getElementById("sections");
     if (state.projects.length === 0) {
@@ -150,6 +240,7 @@ import { state } from "./state.js";
       return;
     }
     stateEl.innerHTML = "";
+    toTop();
     announce("All projects.");
     // Current project first — it is where the user physically is — then the
     // rest stay in the server's newest-first order.
@@ -171,8 +262,7 @@ import { state } from "./state.js";
     state.cameFromGrid = !!cameFromGrid;
     setShellView("project");
     renderBackLink();
-    renderHistoryLink();
-    renderActivityLink();
+    renderNavPills();
     loadCheckpointsList(slug);
   }
   function loadCheckpointsList(slug) {
@@ -220,8 +310,7 @@ import { state } from "./state.js";
     state.requestId += 1;
     if (state.view !== "project") {
       state.view = "project";
-      renderHistoryLink();
-      renderActivityLink();
+      renderNavPills();
     }
     renderSidebar();
     loadCheckpoint(ref, state.requestId);
@@ -243,6 +332,7 @@ import { state } from "./state.js";
       stateEl.innerHTML = "";
       if (data.ok) {
         sectionsEl.innerHTML = renderSections(data);
+        toTop();
         announce("Checkpoint " + ref + " loaded.");
         wireWhyOpeners(sectionsEl);
         wireSectionToggles(sectionsEl);
@@ -339,6 +429,7 @@ import { state } from "./state.js";
     var slug = searchSlug();
     if (!slug || !q || !q.trim()) return;
     state.view = "search";
+    renderNavPills();
     state.requestId += 1;
     var reqId = state.requestId;
     var stateEl = document.getElementById("state");
@@ -354,6 +445,7 @@ import { state } from "./state.js";
         }
         state.lastSearchQ = q;
         sectionsEl.innerHTML = renderSearchResults(q, data.rows);
+        toTop();
         announce(data.rows.length + " search result(s).");
         Array.prototype.forEach.call(sectionsEl.querySelectorAll(".search-row[data-item-id]"), function (btn) {
           btn.addEventListener("click", function () { openWhy(btn.dataset.itemId); });
@@ -372,7 +464,13 @@ import { state } from "./state.js";
   function openWhy(itemId) {
     var slug = searchSlug();
     if (!slug || !ACT_ITEM_ID_RE.test(itemId || "")) return;
+    // Remember which surface the entry was opened from: back must return the
+    // reader to the ledger or session page they were on, not to the briefing.
+    if (state.view === "ledger") state.whyReturn = { view: "ledger" };
+    else if (state.view === "session") state.whyReturn = { view: "session", sid: state.sessionSid };
+    else state.whyReturn = null;
     state.view = "why";
+    renderNavPills();
     state.requestId += 1;
     var reqId = state.requestId;
     var stateEl = document.getElementById("state");
@@ -387,10 +485,13 @@ import { state } from "./state.js";
           return;
         }
         sectionsEl.innerHTML = renderWhyView(data);
+        toTop();
         announce("Entry loaded.");
         var back = sectionsEl.querySelector("[data-why-back]");
         if (back) back.addEventListener("click", function () {
-          if (state.lastSearchQ) { runSearch(state.lastSearchQ); }
+          if (state.whyReturn && state.whyReturn.view === "session") { enterSession(state.whyReturn.sid); }
+          else if (state.whyReturn && state.whyReturn.view === "ledger") { enterLedger(); }
+          else if (state.lastSearchQ) { runSearch(state.lastSearchQ); }
           else if (state.activeRef) { selectCheckpoint(state.activeRef); }
           else { loadList(); }
         });
@@ -412,7 +513,17 @@ import { state } from "./state.js";
     if (!form || !box) return;
     form.addEventListener("submit", function (ev) {
       ev.preventDefault();
+      if (state.searchTimer) clearTimeout(state.searchTimer);
       runSearch(box.value);
+    });
+    // Search-as-you-type, debounced: still one matcher — every keystroke's
+    // results are recall's, the debounce only spaces the calls out. Enter
+    // still fires immediately via the submit handler above.
+    box.addEventListener("input", function () {
+      if (state.searchTimer) clearTimeout(state.searchTimer);
+      var q = box.value;
+      if (!q || q.trim().length < 2) return;
+      state.searchTimer = setTimeout(function () { runSearch(q); }, 250);
     });
   }
   function wireSectionToggles(container) {
@@ -431,117 +542,6 @@ import { state } from "./state.js";
           btn.setAttribute("aria-expanded", "true");
           if (marker) marker.textContent = "▾";
         }
-      });
-    });
-  }
-  function enterHistory() {
-    if (!state.currentSlug) return;
-    var slug = state.currentSlug;
-    state.view = "history";
-    state.requestId += 1;
-    var reqId = state.requestId;
-    renderHistoryLink();
-    renderActivityLink();
-    var stateEl = document.getElementById("state");
-    var sectionsEl = document.getElementById("sections");
-    var mainEl = document.getElementById("main");
-    mainEl.setAttribute("aria-busy", "true");
-    if (state.pendingTimer) clearTimeout(state.pendingTimer);
-    state.pendingTimer = setTimeout(function () {
-      if (reqId !== state.requestId) return; // superseded by a newer navigation
-      stateEl.innerHTML = skeletonHtml();
-    }, 1000);
-    Promise.all([
-      api("/api/history?project=" + encodeURIComponent(slug)),
-      api("/api/diff?project=" + encodeURIComponent(slug))
-    ]).then(function (results) {
-      if (reqId !== state.requestId) return; // stale response — a newer request is in flight
-      clearTimeout(state.pendingTimer);
-      mainEl.removeAttribute("aria-busy");
-      var hist = results[0], diff = results[1];
-      state.historySessions = hist.sessions || [];
-      state.historyUnreadable = hist.unreadable || 0;
-      stateEl.innerHTML = "";
-      if (!diff.ok) {
-        sectionsEl.innerHTML = "";
-        showError(stateEl, diff.error);
-        return;
-      }
-      if (diff.empty === "single_checkpoint") {
-        sectionsEl.innerHTML = "";
-        stateEl.innerHTML = renderSingleCheckpointEmpty();
-        announce("Only one checkpoint — nothing to compare.");
-        return;
-      }
-      // Defaults must come from the filename-based session list (same source the server
-      // uses when a/b are omitted) — diff.a/diff.b meta.session_id is read from inside the
-      // checkpoint JSON and isn't guaranteed to match the filename the API expects back.
-      state.historyPick = {
-        a: state.historySessions.length > 1 ? state.historySessions[1].session_id : null,
-        b: state.historySessions.length > 0 ? state.historySessions[0].session_id : null
-      };
-      sectionsEl.innerHTML = renderHistoryView(diff);
-      announce("History loaded.");
-      wireHistoryControls(sectionsEl, slug);
-      wireSectionToggles(sectionsEl);
-      wireBioToggles(sectionsEl);
-    }).catch(function () {
-      if (reqId !== state.requestId) return; // stale response — a newer request is in flight
-      clearTimeout(state.pendingTimer);
-      mainEl.removeAttribute("aria-busy");
-      sectionsEl.innerHTML = "";
-      showError(stateEl, {
-        what: "Could not load history.",
-        why: "The request to the daimon server failed.",
-        fix: "Check the server is running and reload the page."
-      });
-    });
-  }
-  function loadDiff(slug, a, b) {
-    state.requestId += 1;
-    var reqId = state.requestId;
-    var stateEl = document.getElementById("state");
-    var sectionsEl = document.getElementById("sections");
-    var mainEl = document.getElementById("main");
-    mainEl.setAttribute("aria-busy", "true");
-    if (state.pendingTimer) clearTimeout(state.pendingTimer);
-    state.pendingTimer = setTimeout(function () {
-      if (reqId !== state.requestId) return; // superseded by a newer navigation
-      stateEl.innerHTML = skeletonHtml();
-    }, 1000);
-    api("/api/diff?project=" + encodeURIComponent(slug) + "&a=" + encodeURIComponent(a) +
-      "&b=" + encodeURIComponent(b)).then(function (diff) {
-      if (reqId !== state.requestId) return; // stale response — a newer request is in flight
-      clearTimeout(state.pendingTimer);
-      mainEl.removeAttribute("aria-busy");
-      stateEl.innerHTML = "";
-      if (!diff.ok) {
-        sectionsEl.innerHTML = "";
-        showError(stateEl, diff.error);
-        return;
-      }
-      sectionsEl.innerHTML = renderHistoryView(diff);
-      announce("Comparison updated.");
-      wireHistoryControls(sectionsEl, slug);
-      wireSectionToggles(sectionsEl);
-      wireBioToggles(sectionsEl);
-    }).catch(function () {
-      if (reqId !== state.requestId) return; // stale response — a newer request is in flight
-      clearTimeout(state.pendingTimer);
-      mainEl.removeAttribute("aria-busy");
-      sectionsEl.innerHTML = "";
-      showError(stateEl, {
-        what: "Could not load the diff.",
-        why: "The request to the daimon server failed.",
-        fix: "Check the server is running and reload the page."
-      });
-    });
-  }
-  function wireHistoryControls(container, slug) {
-    Array.prototype.forEach.call(container.querySelectorAll(".sess-pick"), function (sel) {
-      sel.addEventListener("change", function () {
-        state.historyPick[sel.dataset.pick] = sel.value;
-        loadDiff(slug, state.historyPick.a, state.historyPick.b);
       });
     });
   }

--- a/plugin/daimon_ui/static/render.js
+++ b/plugin/daimon_ui/static/render.js
@@ -167,7 +167,7 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
   export function renderSidebarScope(shown, total) {
     if (!(total > shown)) return "";
     return '<p class="cp-scope">Showing the ' + shown + ' most recent of ' + total +
-      ' sessions. The earlier ones are reachable in History.</p>';
+      ' sessions. Every session is listed in the ledger.</p>';
   }
 
   // A slug is a flattened path, so the true directory name is unrecoverable —
@@ -567,6 +567,156 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
       gone.map(function (it) { return renderHistoryRow(it, "t-gone", "LAST SEEN", null, refA); }).join(""));
     return html;
   }
+  // ---- ledger + session page (#670 slice 2) ----
+  // Frozen event vocabulary (§8): the walk's kinds render under exactly these
+  // names — the same words the briefing, history view, and CLI already use.
+  // Nothing is coined at the render layer.
+  export const LEDGER_EVENT_LABELS = {
+    first_seen: "first seen", changed: "changed", last_seen: "last seen",
+    resolved: "resolved", quote_check: "quote check"
+  };
+  // groupTs: the containing session's created stamp. An event whose ts IS the
+  // group's own stamp repeats what the group header already says, so the row
+  // shows the bare kind; a differing ts (a last_seen naming its final sighting,
+  // a later resolution or quote check) is information and keeps its date.
+  export function ledgerEventText(ev, groupTs) {
+    var kind = ev && ev.kind;
+    if (!Object.prototype.hasOwnProperty.call(LEDGER_EVENT_LABELS, kind)) return "";
+    if (ev.ts && groupTs && ev.ts === groupTs) return LEDGER_EVENT_LABELS[kind];
+    var when = ev.ts ? " " + fmtDateTime(ev.ts) : "";
+    return LEDGER_EVENT_LABELS[kind] + when;
+  }
+  // "2 first seen · 1 changed" — zero counts stay silent; the order is the
+  // order a session writes them: births, changes, departures.
+  export function ledgerCountsText(counts) {
+    var parts = [];
+    ["first_seen", "changed", "last_seen"].forEach(function (k) {
+      var n = (counts || {})[k] || 0;
+      if (n > 0) parts.push(n + " " + LEDGER_EVENT_LABELS[k]);
+    });
+    return parts.join(" · ");
+  }
+  // UUID-shaped session ids keep the established "s-" + 8-hex short form; a
+  // human-named session renders whole. An 8-char slice of a name ("s-introspe")
+  // is garble, and two names sharing a prefix would collide — an ambiguous
+  // label in a tool whose point is that labels resolve.
+  var UUID_SID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-/;
+  export function displaySid(sid) {
+    var s = String(sid || "");
+    return UUID_SID_RE.test(s) ? "s-" + s.slice(0, 8) : s;
+  }
+  // The kind chip prints recall's word for the same item — question, decision,
+  // belief, uncertainty, contradiction. It is what separates an evergreen
+  // belief from a one-session work note, and why one sentence can honestly
+  // appear under two ids (filed as question AND as uncertainty).
+  export function kindChip(kind) {
+    return kind ? '<span class="kind-chip">' + escapeHtml(kind) + "</span>" : "";
+  }
+  export function renderLedgerRow(r, groupTs) {
+    var trust = r.trust || null;
+    var ev = '<span class="ledger-ev">' + ledgerEventText(r.last_event, groupTs) + "</span>";
+    var id = '<code class="obj-id">' + escapeHtml(r.id) + "</code>";
+    return '<button type="button" class="ledger-row" data-open-why data-item-id="' +
+      escapeHtml(r.id) + '">' + trustGlyph(trust) +
+      '<span class="it-text">' + escapeHtml(r.text || "") + kindChip(r.kind) +
+      "</span>" + id + ev + "</button>";
+  }
+  export function renderLedgerGroup(g, index) {
+    var when = fmtDateTime(g.created);
+    var counts = ledgerCountsText(g.counts);
+    var expanded = index === 0;  // newest session open, the rest behind their counts
+    var bodyId = "lg-" + escapeHtml(String(g.session_id));
+    var toggle = '<button type="button" class="ledger-ck-toggle" aria-expanded="' +
+      (expanded ? "true" : "false") + '" aria-controls="' + bodyId + '">' +
+      '<span class="disclosure" aria-hidden="true">' + (expanded ? "▾" : "▸") + "</span>" +
+      '<code class="ledger-sid">' + escapeHtml(displaySid(g.session_id)) +
+      '</code><span class="ledger-ck-meta">' + escapeHtml(when) +
+      (counts ? " · " + escapeHtml(counts) : "") + "</span></button>";
+    var open = '<button type="button" class="ledger-ck-open" data-open-session data-sid="' +
+      escapeHtml(g.session_id) + '">open session</button>';
+    var rows = (g.rows || []).map(function (r) {
+      return renderLedgerRow(r, g.created);
+    }).join("");
+    return '<section class="ledger-group" aria-label="' + escapeHtml(displaySid(g.session_id)) + '">' +
+      '<div class="ledger-ck">' + toggle + open + "</div>" +
+      '<div id="' + bodyId + '" class="ledger-body"' + (expanded ? "" : " hidden") + '>' +
+      '<div class="ledger-cols" aria-hidden="true"><span>claim</span><span>object</span>' +
+      '<span>last event</span></div><div class="ledger-rows">' + rows + "</div></div></section>";
+  }
+  export function renderLedgerView(data) {
+    var totals = data.totals || {};
+    var head = data.head ? " · head " + displaySid(data.head.session_id) : "";
+    var html = '<div class="brief-head"><h1 class="page-heading">Ledger</h1>' +
+      '<span class="brief-sub">' + escapeHtml(
+        (totals.objects || 0) + " object(s) · " + (totals.events || 0) + " event(s)" + head) +
+      "</span></div>";
+    (data.partial || []).forEach(function (p) {
+      html += '<div class="banner banner-partial"><span class="banner-icon" aria-hidden="true">ⓘ</span><span>' +
+        escapeHtml(p) + "</span></div>";
+    });
+    if (!data.groups || data.groups.length === 0) {
+      return html + '<div class="state-card"><p class="state-title">Nothing in the ledger yet</p>' +
+        "<p>Objects appear here as sessions record them — first seen, changed, last seen.</p></div>";
+    }
+    html += data.groups.map(renderLedgerGroup).join("");
+    html += '<div class="card-foot">click a row to open its entry · open session shows what it wrote</div>';
+    return html;
+  }
+  // Sidebar for the ledger and session views: every session on disk, newest
+  // first — the same list /api/history serves, so the two surfaces cannot
+  // disagree about what history holds.
+  export function renderLedgerSessions(sessions, activeSid) {
+    var head = '<p class="side-label">Sessions</p>';
+    var body = (sessions || []).map(function (s) {
+      var active = s.session_id === activeSid;
+      var topic = s.active_topic ? escapeHtml(s.active_topic) : "(untitled)";
+      var rel = fmtRelative(s.created);
+      return '<button type="button" class="cp-item sess-item' + (active ? " active" : "") +
+        '" data-sid="' + escapeHtml(s.session_id) + '" aria-current="' + (active ? "true" : "false") + '">' +
+        '<span class="cp-topic">' + topic + "</span>" +
+        '<span class="cp-meta">' + escapeHtml(displaySid(s.session_id)) +
+        (rel ? " · " + escapeHtml(rel) : "") + "</span></button>";
+    }).join("");
+    return head + body;
+  }
+  export function renderSessionObject(o) {
+    var eventsHtml = (o.events || []).map(function (e) {
+      var detail = e.detail ? '<span class="sess-ev-detail">' + escapeHtml(e.detail) + "</span>" : "";
+      return '<div class="sess-ev"><span class="sess-ev-label">' +
+        ledgerEventText(e) + "</span>" + detail + "</div>";
+    }).join("");
+    return '<div class="sess-obj"><button type="button" class="ledger-row" data-open-why data-item-id="' +
+      escapeHtml(o.id) + '">' + trustGlyph(o.trust || null) +
+      '<span class="it-text">' + escapeHtml(o.text || "") + kindChip(o.kind) + "</span>" +
+      '<code class="obj-id">' + escapeHtml(o.id) + "</code></button>" +
+      '<div class="sess-obj-events">' + eventsHtml + "</div></div>";
+  }
+  export function renderSessionView(data) {
+    var s = data.session || {};
+    var metaParts = [fmtDateTime(s.created), s.active_topic, s.author,
+                     receiptMetaText(s.receipt)].filter(Boolean);
+    var counts = ledgerCountsText(data.counts);
+    var html = '<div class="why-crumb"><button type="button" class="back-link" data-session-back>' +
+      "← ledger</button>" + '<span class="crumb-sep">/</span><code class="crumb-id">' +
+      escapeHtml(displaySid(s.session_id)) + "</code></div>";
+    html += '<div class="brief-head"><h1 class="page-heading">Session</h1>' +
+      '<span class="brief-sub">' + escapeHtml(counts ? "wrote " + counts : "wrote no recorded events") +
+      "</span></div>";
+    html += '<p class="page-meta">' + metaParts.map(escapeHtml).join(" · ") + "</p>";
+    (data.partial || []).forEach(function (p) {
+      html += '<div class="banner banner-partial"><span class="banner-icon" aria-hidden="true">ⓘ</span><span>' +
+        escapeHtml(p) + "</span></div>";
+    });
+    if (!data.objects || data.objects.length === 0) {
+      html += '<div class="state-card"><p class="state-title">No recorded events from this session</p>' +
+        "<p>Carried, unchanged items write nothing — a carry is not an event.</p></div>";
+    } else {
+      html += '<div class="sess-objs">' + data.objects.map(renderSessionObject).join("") + "</div>";
+    }
+    html += '<div class="card-foot">read-only · This page reads the ledger; it holds nothing of its own</div>';
+    return html;
+  }
+
   export function renderError(e) {
     return '<div class="state-card state-error"><p class="state-title">⚠ Error — ' +
       escapeHtml(e.what) + "</p><p>" + escapeHtml(e.why) + "</p><p><strong>Fix:</strong> " +

--- a/plugin/daimon_ui/static/state.js
+++ b/plugin/daimon_ui/static/state.js
@@ -4,5 +4,6 @@ export const state = {
   checkpoints: [], sessionsTotal: 0, activeRef: null, pendingTimer: null, requestId: 0,
   projects: [], defaultSlug: null, currentSlug: null, view: "loading", cameFromGrid: false,
   historySessions: [], historyUnreadable: 0, historyPick: { a: null, b: null },
-  bioCache: {}, lastSearchQ: null
+  ledgerSessions: [], sessionSid: null, whyReturn: null, bioCache: {}, lastSearchQ: null,
+  searchTimer: null
 };

--- a/plugin/tests/ui/test_page.py
+++ b/plugin/tests/ui/test_page.py
@@ -17,7 +17,7 @@ def test_view_links_sit_in_a_nav_landmark(srv):
     assert '<nav class="view-nav"' in html, "no view-nav landmark in page"
     nav = html.split('<nav class="view-nav"', 1)[1].split("</nav>", 1)[0]
     for needle in ['aria-label="Views"', 'id="back-link-slot"',
-                   'id="history-link-slot"', 'id="activity-link-slot"']:
+                   'id="nav-pills-slot"']:
         assert needle in nav, needle
 
 
@@ -79,12 +79,14 @@ def test_css_has_tokens_and_media_queries(srv):
         assert needle in css, needle
     assert "prefers-color-scheme" not in css, "single committed look — no theme fork"
 
-def test_activity_catch_clears_stale_sections(srv):
-    """enterActivity lives in app.js and touches the DOM, so this stays a source
+def test_session_catch_clears_stale_sections(srv):
+    """enterSession lives in app.js and touches the DOM, so this stays a source
     grep — a weaker test than the render.js behavior tests, kept deliberately and
-    labelled as such rather than dropped silently."""
+    labelled as such rather than dropped silently. (enterActivity's version of
+    this test left with the Activity button: slice 2 replaced the scaffold nav
+    with the design's pills, and the ledger/session pages read the same rows.)"""
     _, _, body = _get(srv + "/static/app.js")
     js = body.decode()
-    fn = js.split("function enterActivity", 1)[1].split("\n  function ", 1)[0]
+    fn = js.split("function enterSession", 1)[1].split("\n  function ", 1)[0]
     catch_block = fn.split(".catch(function ()", 1)[1]
     assert 'sectionsEl.innerHTML = "";' in catch_block

--- a/plugin/tests/ui/test_page_ledger.py
+++ b/plugin/tests/ui/test_page_ledger.py
@@ -1,0 +1,56 @@
+"""Ledger screen + session page (#670 slice 2): the nav carries the design's
+pills (briefing, ledger) instead of the scaffold's History/Activity buttons,
+and the client renders /api/ledger and /api/session. Wording checks pin the
+frozen vocabulary — the event names render exactly as the CLI family prints
+them, and the session page's footer states what the page is."""
+import urllib.request
+
+
+def _get(url):
+    with urllib.request.urlopen(url) as r:
+        return r.status, r.headers.get_content_type(), r.read()
+
+
+def test_nav_carries_pills_not_the_scaffold_buttons(srv):
+    _, _, body = _get(srv + "/")
+    html = body.decode()
+    nav = html.split('<nav class="view-nav"', 1)[1].split("</nav>", 1)[0]
+    assert 'id="nav-pills-slot"' in nav
+    for gone in ('id="history-link-slot"', 'id="activity-link-slot"'):
+        assert gone not in nav, f"scaffold slot survived: {gone}"
+
+
+def test_client_renders_ledger_and_session(srv):
+    _, _, body = _get(srv + "/static/app.js")
+    js = body.decode()
+    assert "/api/ledger" in js
+    assert "/api/session" in js
+
+
+def test_event_labels_are_the_frozen_words(srv):
+    """§8: first seen / changed / last seen / quote check / resolved — the
+    ledger renders the recorded event kinds under their frozen names, nothing
+    coined at the render layer."""
+    _, _, body = _get(srv + "/static/render.js")
+    js = body.decode()
+    labels_src = js.split("LEDGER_EVENT_LABELS", 1)[1].split("}", 1)[0]
+    for label in ('"first seen"', '"changed"', '"last seen"',
+                  '"quote check"', '"resolved"'):
+        assert label in labels_src, label
+
+
+def test_session_page_declares_it_holds_nothing(srv):
+    _, _, body = _get(srv + "/static/render.js")
+    js = body.decode()
+    assert "This page reads the ledger; it holds nothing of its own" in js
+
+
+def test_ledger_catch_clears_stale_sections(srv):
+    """Same defensive shape the other views carry: a failed fetch must not
+    leave the previous view's sections behind an error card. Source grep,
+    kept deliberately and labelled as such."""
+    _, _, body = _get(srv + "/static/app.js")
+    js = body.decode()
+    fn = js.split("function enterLedger", 1)[1].split("\n  function ", 1)[0]
+    catch_block = fn.split(".catch(function ()", 1)[1]
+    assert 'sectionsEl.innerHTML = "";' in catch_block

--- a/plugin/tests/ui/test_reader_ledger.py
+++ b/plugin/tests/ui/test_reader_ledger.py
@@ -1,0 +1,158 @@
+"""project_ledger: the all-objects walk behind the ledger screen (#670 slice 2).
+
+Grouping rule under test: an object sits under the session of its latest
+recorded transition (first seen / changed / last seen), never under a carry —
+agreement is not corroboration, and a carried rung is not an event. The LAST
+EVENT column may still be later than the group when a resolution or quote
+check (which carry their own ts but no session attribution) postdates the walk.
+"""
+import json
+import pytest
+from daimon_ui import reader
+
+def _cp(sid, created, slug, items, topic="t"):
+    return {
+        "session_id": sid, "format_version": "D-018", "created": created,
+        "author": "ada", "project_slug": slug,
+        "working_context": {"active_topic": {"text": topic},
+                            "open_questions": items, "recent_decisions": []},
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": [],
+                               "contradictions_flagged": []},
+    }
+
+def _item(iid, text, trust=None):
+    it = {"id": iid, "text": text}
+    if trust:
+        it["trust"] = trust
+    return it
+
+@pytest.fixture
+def ledger_history(tmp_path):
+    d = tmp_path / "checkpoints"
+    slug = "-tmp-proj"
+    (d / slug).mkdir(parents=True)
+    # s1: o-aaa111aaa111 and o-bbb222bbb222 first seen
+    (d / "s1-aaaa.json").write_text(json.dumps(_cp(
+        "s1-aaaa", "2026-08-04T10:00:00Z", slug,
+        [_item("o-aaa111aaa111", "build gates on bundle", "inferred"),
+         _item("o-bbb222bbb222", "old question")])))
+    # s2: o-aaa changed (trust), o-bbb carried, o-ccc first seen
+    (d / "s2-bbbb.json").write_text(json.dumps(_cp(
+        "s2-bbbb", "2026-08-05T10:00:00Z", slug,
+        [_item("o-aaa111aaa111", "build gates on bundle", "verbatim"),
+         _item("o-bbb222bbb222", "old question"),
+         _item("o-ccc333ccc333", "token lifetime rewritten", "verbatim")])))
+    # s3 (head): o-aaa carried, o-ccc carried, o-bbb gone (last seen), o-ddd first seen
+    (d / "s3-cccc.json").write_text(json.dumps(_cp(
+        "s3-cccc", "2026-08-06T10:00:00Z", slug,
+        [_item("o-aaa111aaa111", "build gates on bundle", "verbatim"),
+         _item("o-ccc333ccc333", "token lifetime rewritten", "verbatim"),
+         _item("o-ddd444ddd444", "database client rule")])))
+    (d / slug / "latest.json").write_text(json.dumps(_cp(
+        "s3-cccc", "2026-08-06T10:00:00Z", slug, [])))
+    # o-bbb was resolved after vanishing; o-aaa got a later quote check
+    (d / slug / "events.jsonl").write_text(json.dumps(
+        {"ts": "2026-08-06T11:00:00Z", "kind": "resolution", "status": "resolved",
+         "item_ref": "o-bbb222bbb222", "note": "closed it", "source": "cli"}) + "\n")
+    (d / slug / "verification.jsonl").write_text(json.dumps(
+        {"ts": "2026-08-06T12:00:00Z", "check": "quote", "reason": "compacted",
+         "item_ref": "o-aaa111aaa111"}) + "\n")
+    return d, slug
+
+def _group(result, sid):
+    hits = [g for g in result["groups"] if g["session_id"] == sid]
+    assert hits, f"no group for {sid}: {[g['session_id'] for g in result['groups']]}"
+    return hits[0]
+
+def _row(group, iid):
+    hits = [r for r in group["rows"] if r["id"] == iid]
+    assert hits, f"no row {iid} in group {group['session_id']}"
+    return hits[0]
+
+def test_groups_are_newest_first_and_carry_counts(ledger_history):
+    d, slug = ledger_history
+    result = reader.project_ledger(d, slug)
+    assert result["ok"] is True
+    assert [g["session_id"] for g in result["groups"]] == ["s3-cccc", "s2-bbbb"]
+    assert _group(result, "s3-cccc")["counts"] == {"first_seen": 1, "changed": 0, "last_seen": 1}
+    assert _group(result, "s2-bbbb")["counts"] == {"first_seen": 1, "changed": 1, "last_seen": 0}
+    # s1 keeps nothing: both its objects moved on (o-aaa changed at s2,
+    # o-bbb last seen at s3) — but the group only exists when it has rows.
+    assert not any(g["session_id"] == "s1-aaaa" for g in result["groups"])
+
+def test_object_rows_sit_under_their_latest_transition(ledger_history):
+    d, slug = ledger_history
+    result = reader.project_ledger(d, slug)
+    s3 = _group(result, "s3-cccc")
+    assert {r["id"] for r in s3["rows"]} == {"o-ddd444ddd444", "o-bbb222bbb222"}
+    s2 = _group(result, "s2-bbbb")
+    assert {r["id"] for r in s2["rows"]} == {"o-aaa111aaa111", "o-ccc333ccc333"}
+
+def test_last_event_prefers_later_resolution_and_quote_check(ledger_history):
+    d, slug = ledger_history
+    result = reader.project_ledger(d, slug)
+    # o-bbb vanished at the s3 transition but was then resolved: resolution wins.
+    bbb = _row(_group(result, "s3-cccc"), "o-bbb222bbb222")
+    assert bbb["last_event"]["kind"] == "resolved"
+    assert bbb["last_event"]["ts"] == "2026-08-06T11:00:00Z"
+    # o-aaa changed at s2 but a later quote check postdates it.
+    aaa = _row(_group(result, "s2-bbbb"), "o-aaa111aaa111")
+    assert aaa["last_event"]["kind"] == "quote_check"
+    assert aaa["last_event"]["ts"] == "2026-08-06T12:00:00Z"
+    # untouched-after-birth object keeps its first-seen event.
+    ddd = _row(_group(result, "s3-cccc"), "o-ddd444ddd444")
+    assert ddd["last_event"]["kind"] == "first_seen"
+    assert ddd["last_event"]["ts"] == "2026-08-06T10:00:00Z"
+
+def test_last_seen_event_names_the_last_sighting_not_the_transition(ledger_history):
+    d, slug = ledger_history
+    # o-bbb without the resolution: last_seen ts = created of its final sighting (s2).
+    (d / slug / "events.jsonl").write_text("")
+    result = reader.project_ledger(d, slug)
+    bbb = _row(_group(result, "s3-cccc"), "o-bbb222bbb222")
+    assert bbb["last_event"]["kind"] == "last_seen"
+    assert bbb["last_event"]["ts"] == "2026-08-05T10:00:00Z"
+
+def test_totals_count_objects_and_recorded_events(ledger_history):
+    d, slug = ledger_history
+    result = reader.project_ledger(d, slug)
+    assert result["totals"]["objects"] == 4
+    # 2 born@s1 + 1 born@s2 + 1 changed@s2 + 1 born@s3 + 1 last_seen@s3
+    # + 1 resolution + 1 quote check
+    assert result["totals"]["events"] == 8
+
+def test_head_is_the_newest_session(ledger_history):
+    d, slug = ledger_history
+    result = reader.project_ledger(d, slug)
+    assert result["head"]["session_id"] == "s3-cccc"
+    assert result["head"]["created"] == "2026-08-06T10:00:00Z"
+
+def test_rows_carry_text_and_trust_for_rendering(ledger_history):
+    d, slug = ledger_history
+    result = reader.project_ledger(d, slug)
+    aaa = _row(_group(result, "s2-bbbb"), "o-aaa111aaa111")
+    assert aaa["text"] == "build gates on bundle"
+    assert aaa["trust"] == "verbatim"
+
+def test_rows_carry_the_recall_kind_word(ledger_history):
+    """The chip prints recall's vocabulary — question/decision/belief/
+    uncertainty/contradiction — never a viewer-coined section name. Fixture
+    items live in open_questions, so every row here is a question."""
+    d, slug = ledger_history
+    result = reader.project_ledger(d, slug)
+    aaa = _row(_group(result, "s2-bbbb"), "o-aaa111aaa111")
+    assert aaa["kind"] == "question"
+
+def test_empty_project_is_ok_and_empty(tmp_path):
+    d = tmp_path / "checkpoints"
+    d.mkdir()
+    result = reader.project_ledger(d, "-nope")
+    assert result == {"ok": True, "groups": [], "head": None,
+                      "totals": {"objects": 0, "events": 0}, "partial": []}
+
+def test_unreadable_session_files_land_in_partial(ledger_history):
+    d, slug = ledger_history
+    (d / "torn.json").write_text("{nope")
+    result = reader.project_ledger(d, slug)
+    assert result["ok"] is True
+    assert any("read" in p for p in result["partial"])

--- a/plugin/tests/ui/test_reader_ledger.py
+++ b/plugin/tests/ui/test_reader_ledger.py
@@ -156,3 +156,22 @@ def test_unreadable_session_files_land_in_partial(ledger_history):
     result = reader.project_ledger(d, slug)
     assert result["ok"] is True
     assert any("read" in p for p in result["partial"])
+
+def test_walk_skips_a_session_that_tears_between_listing_and_reading(ledger_history, monkeypatch):
+    """project_history lists from filenames; a file torn (or deleted) between
+    that listing and the walk's read must be skipped, not abort the ledger."""
+    d, slug = ledger_history
+    real = reader._load_session
+
+    def flaky(data_dir, sid):
+        if sid == "s2-bbbb":
+            return None, {"what": "torn", "why": "torn", "fix": "heal"}
+        return real(data_dir, sid)
+
+    monkeypatch.setattr(reader, "_load_session", flaky)
+    result = reader.project_ledger(d, slug)
+    assert result["ok"] is True
+    # s2 never scanned: o-ccc is first seen at s3 instead, and no changed
+    # event for o-aaa exists anywhere.
+    ids = {r["id"] for g in result["groups"] for r in g["rows"]}
+    assert "o-ccc333ccc333" in ids

--- a/plugin/tests/ui/test_reader_session_page.py
+++ b/plugin/tests/ui/test_reader_session_page.py
@@ -63,6 +63,21 @@ def test_session_objects_carry_the_recall_kind_word(session_history):
     kinds = {o["id"]: o["kind"] for o in result["objects"]}
     assert set(kinds.values()) == {"question"}  # fixture items are open_questions
 
+def test_session_torn_between_validation_and_read_reports_the_error(session_history, monkeypatch):
+    """sid passes the history exact-match, then the file tears before the page's
+    own read: the reader must hand back the load error, not crash or invent."""
+    d, slug = session_history
+
+    def gone(data_dir, sid):
+        return None, {"what": f"Session {sid} doesn't exist.",
+                      "why": "No checkpoint file was found for that session.",
+                      "fix": "Pick a session from the project's history."}
+
+    monkeypatch.setattr(reader, "_load_session", gone)
+    result = reader.session_events(d, slug, "s2-bbbb")
+    assert result["ok"] is False
+    assert "doesn't exist" in result["error"]["what"]
+
 def test_changed_event_names_the_fields(session_history):
     d, slug = session_history
     result = reader.session_events(d, slug, "s2-bbbb")

--- a/plugin/tests/ui/test_reader_session_page.py
+++ b/plugin/tests/ui/test_reader_session_page.py
@@ -1,0 +1,84 @@
+"""session_events: what one session wrote (#670 slice 2 session page).
+
+The page renders only events attributable to the named session — first seen,
+changed, last seen transitions from the walk. Resolutions and quote checks
+carry no session attribution in their ledgers and must NOT be claimed by a
+session page; inventing attribution would be the viewer asserting something
+the stored data does not.
+"""
+import json
+import pytest
+from daimon_ui import reader
+
+from tests.ui.test_reader_ledger import _cp, _item  # same history shapes
+
+@pytest.fixture
+def session_history(tmp_path):
+    d = tmp_path / "checkpoints"
+    slug = "-tmp-proj"
+    (d / slug).mkdir(parents=True)
+    (d / "s1-aaaa.json").write_text(json.dumps(_cp(
+        "s1-aaaa", "2026-08-04T10:00:00Z", slug,
+        [_item("o-aaa111aaa111", "build gates on bundle", "inferred"),
+         _item("o-bbb222bbb222", "old question")])))
+    (d / "s2-bbbb.json").write_text(json.dumps(_cp(
+        "s2-bbbb", "2026-08-05T10:00:00Z", slug,
+        [_item("o-aaa111aaa111", "build gates on bundle", "verbatim"),
+         _item("o-ccc333ccc333", "token lifetime rewritten", "verbatim")],
+        topic="day two")))
+    (d / slug / "latest.json").write_text(json.dumps(_cp(
+        "s2-bbbb", "2026-08-05T10:00:00Z", slug, [])))
+    return d, slug
+
+def test_session_page_reports_this_sessions_transitions(session_history):
+    d, slug = session_history
+    result = reader.session_events(d, slug, "s2-bbbb")
+    assert result["ok"] is True
+    assert result["session"]["session_id"] == "s2-bbbb"
+    assert result["session"]["created"] == "2026-08-05T10:00:00Z"
+    assert result["session"]["active_topic"] == "day two"
+    by_id = {o["id"]: o for o in result["objects"]}
+    assert by_id["o-aaa111aaa111"]["events"][0]["kind"] == "changed"
+    assert by_id["o-ccc333ccc333"]["events"][0]["kind"] == "first_seen"
+    # o-bbb vanished at the s2 transition: last seen, ts = its final sighting (s1)
+    assert by_id["o-bbb222bbb222"]["events"][0]["kind"] == "last_seen"
+    assert by_id["o-bbb222bbb222"]["events"][0]["ts"] == "2026-08-04T10:00:00Z"
+    assert result["counts"] == {"first_seen": 1, "changed": 1, "last_seen": 1}
+
+def test_oldest_session_births_everything_it_holds(session_history):
+    d, slug = session_history
+    result = reader.session_events(d, slug, "s1-aaaa")
+    kinds = {o["id"]: o["events"][0]["kind"] for o in result["objects"]}
+    assert kinds == {"o-aaa111aaa111": "first_seen", "o-bbb222bbb222": "first_seen"}
+
+def test_unknown_session_id_is_refused_before_any_path_is_built(session_history):
+    d, slug = session_history
+    result = reader.session_events(d, slug, "../../etc/passwd")
+    assert result["ok"] is False
+    assert "isn't part of" in result["error"]["what"]
+
+def test_session_objects_carry_the_recall_kind_word(session_history):
+    d, slug = session_history
+    result = reader.session_events(d, slug, "s2-bbbb")
+    kinds = {o["id"]: o["kind"] for o in result["objects"]}
+    assert set(kinds.values()) == {"question"}  # fixture items are open_questions
+
+def test_changed_event_names_the_fields(session_history):
+    d, slug = session_history
+    result = reader.session_events(d, slug, "s2-bbbb")
+    by_id = {o["id"]: o for o in result["objects"]}
+    assert by_id["o-aaa111aaa111"]["events"][0]["detail"] == "trust"
+
+def test_receipt_rides_along_only_when_the_project_opted_in(session_history):
+    d, slug = session_history
+    result = reader.session_events(d, slug, "s2-bbbb")
+    assert "receipt" not in result["session"]  # no opt-in: silence, not nagging
+    # opt in: latest.json claims receipts, session file claims one too
+    marked = _cp("s2-bbbb", "2026-08-05T10:00:00Z", slug, [])
+    marked["receipts"] = True
+    (d / slug / "latest.json").write_text(json.dumps(marked))
+    session = json.loads((d / "s2-bbbb.json").read_text())
+    session["receipts"] = True
+    (d / "s2-bbbb.json").write_text(json.dumps(session))
+    result = reader.session_events(d, slug, "s2-bbbb")
+    assert result["session"]["receipt"]["state"] in ("match", "mismatch", "missing")

--- a/plugin/tests/ui/test_server_ledger.py
+++ b/plugin/tests/ui/test_server_ledger.py
@@ -27,6 +27,11 @@ def test_session_serves_one_sessions_events(srv_flat):
     assert data["session"]["active_topic"] == "day two"
     assert "objects" in data and "counts" in data
 
+def test_session_refuses_unknown_project(srv_flat):
+    data = _get_json(srv_flat + "/api/session?project=..%2F..%2Fetc&sid=bbbb-2222")
+    assert data["ok"] is False
+    assert "isn't one this inspector knows" in data["error"]["what"]
+
 def test_session_requires_a_sid(srv_flat):
     data = _get_json(srv_flat + "/api/session?project=-tmp-proj")
     assert data["ok"] is False

--- a/plugin/tests/ui/test_server_ledger.py
+++ b/plugin/tests/ui/test_server_ledger.py
@@ -1,0 +1,37 @@
+"""/api/ledger and /api/session (#670 slice 2): dispatch, slug discipline,
+and sid validation happen at the server seam; the payload shapes are the
+reader's and are covered by the reader tests."""
+import json
+import urllib.request
+
+def _get_json(url):
+    with urllib.request.urlopen(url) as r:
+        return json.loads(r.read())
+
+def test_ledger_serves_the_reader_walk(srv_flat):
+    data = _get_json(srv_flat + "/api/ledger?project=-tmp-proj")
+    assert data["ok"] is True
+    assert data["head"]["session_id"] == "rollout-2026-08-06-cccc"
+    assert isinstance(data["groups"], list)
+    assert data["totals"]["objects"] >= 0
+
+def test_ledger_refuses_unknown_project(srv_flat):
+    data = _get_json(srv_flat + "/api/ledger?project=..%2F..%2Fetc")
+    assert data["ok"] is False
+    assert "isn't one this inspector knows" in data["error"]["what"]
+
+def test_session_serves_one_sessions_events(srv_flat):
+    data = _get_json(srv_flat + "/api/session?project=-tmp-proj&sid=bbbb-2222")
+    assert data["ok"] is True
+    assert data["session"]["session_id"] == "bbbb-2222"
+    assert data["session"]["active_topic"] == "day two"
+    assert "objects" in data and "counts" in data
+
+def test_session_requires_a_sid(srv_flat):
+    data = _get_json(srv_flat + "/api/session?project=-tmp-proj")
+    assert data["ok"] is False
+
+def test_session_refuses_a_sid_outside_history(srv_flat):
+    data = _get_json(srv_flat + "/api/session?project=-tmp-proj&sid=..%2Fother")
+    assert data["ok"] is False
+    assert "isn't part of" in data["error"]["what"]


### PR DESCRIPTION
Refs #670

## What

- Ledger screen: one row per object, grouped under the session of its latest recorded transition (first seen / changed / last seen). Groups are collapsible; the newest session opens by default and every other session reads as its counts plus an "open session" control. A later resolution or quote check can overtake a row's LAST EVENT by timestamp, but a row never moves to a session the stored rows do not attribute it to.
- Session page: what one session wrote, grouped by object, with the project's receipt wording when receipts are enabled. The footer states that the page reads the ledger and holds nothing of its own.
- Nav pills (briefing, ledger) replace the scaffold's History/Activity buttons per the ratified build order for #670; the diff surface returns restructured in a later slice.
- Kind chip per row prints recall's word for the item (question, decision, belief, uncertainty, contradiction). One vocabulary across surfaces: the chip must say exactly what a recall row for the same item says.
- Inside a group, a last event whose date is the group's own date renders as the bare kind; the date appears only when it differs and therefore informs.
- UUID session ids keep the established s-XXXXXXXX short form; named sessions render whole. An 8-character slice of a name is garble and two names sharing a prefix would collide.
- Search fixes: every view swap scrolls to top (results used to render far above a scrolled viewport, which read as a broken or slow search), and the box now searches as you type, debounced, through the same recall engine. One matcher, unchanged.

## Why

Slice 2 of #670's build order. The briefing is the overview; the ledger is the record read: every object, every session, every recorded transition, each row deep-linking to its entry page.

## Tests

- ui suite 197 green locally; new behavior landed red-first:
  - `tests/ui/test_reader_ledger.py`: grouping under the latest transition, group counts, last-event precedence, last seen naming its final sighting, totals, unreadable-file partials, kind words
  - `tests/ui/test_reader_session_page.py`: per-session transitions, oldest-session births, sid exact-match refusal before any path is built, receipt opt-in silence, kind words
  - `tests/ui/test_server_ledger.py`: endpoint dispatch, slug and sid refusal shapes
  - `tests/ui/test_page_ledger.py`: nav pills replace the scaffold slots, frozen event labels, session-page footer wording, ledger catch clears stale sections
- Verified in a browser against a real store (3418 objects, 7336 events, 81 sessions): grid to briefing to ledger to session page to entry page and back, collapse toggles, search as you type from a scrolled page.
