### PR TITLE
feat(ui): refutations lane, ladder-anchored diff, and check strip for the viewer

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1161,12 +1161,8 @@ def _cmd_refute_show(args) -> int:
 
 def _cmd_refute_list(args) -> int:
     project = _resolve_project(args.project)
-    wanted = set(args.state or refutations.STATES)
-    rows = [row for row in refutations.records(project_dir=project).values()
-            if row["state"] in wanted]
-    rows.sort(key=lambda row: (row.get("state") != "active",
-                               row.get("updated_at") or "",
-                               row["refutation_id"]))
+    rows = refutations.listing(states=set(args.state or refutations.STATES),
+                               project_dir=project)
     _note_usage("refute:list")
     if args.json:
         print(_refutation_json(rows))

--- a/plugin/daimon_briefing/refutations.py
+++ b/plugin/daimon_briefing/refutations.py
@@ -703,6 +703,22 @@ def overturn(refutation_id: str, *, channel: str, evidence, note: str = "",
     return event
 
 
+def listing(*, states=None, project_dir=None) -> list[dict]:
+    """Every record in `refute list` order: active first, then most recently
+    updated, ties broken by id. This sort is the CLI's presentation contract;
+    it lives here so the viewer's lane and the CLI cannot drift apart."""
+    wanted = set(states or STATES)
+    unknown = wanted - STATES
+    if unknown:
+        raise RefutationError(f"unknown state: {', '.join(sorted(unknown))}")
+    rows = [row for row in records(project_dir=project_dir).values()
+            if row["state"] in wanted]
+    rows.sort(key=lambda row: (row.get("state") != "active",
+                               row.get("updated_at") or "",
+                               row["refutation_id"]))
+    return rows
+
+
 def search(query: str, *, project_dir=None, states=None) -> list[dict]:
     query = _text("query", query)
     wanted = set(states or STATES)

--- a/plugin/daimon_ui/reader.py
+++ b/plugin/daimon_ui/reader.py
@@ -492,7 +492,9 @@ def _walk_transitions(data_dir: Path, slug: str):
     now — ts is the created of its FINAL sighting, the session named is the one
     whose absence recorded it). Carried, unchanged sightings emit nothing:
     a carry is not an event, and counting it would let agreement pose as
-    corroboration. Shared by project_ledger and session_events so the two
+    corroboration. Every event carries the trust class the item held AT that
+    session — the strip draws marks with the class of the time, not today's.
+    Shared by project_ledger, session_events and project_grid so the
     surfaces can never disagree about what happened."""
     hist = project_history(data_dir, slug)
     events, latest_item, last_sight = [], {}, {}
@@ -507,21 +509,24 @@ def _walk_transitions(data_dir: Path, slug: str):
             if iid not in latest_item or iid in gone:
                 gone.discard(iid)
                 events.append({"item_id": iid, "kind": "first_seen", "ts": s["created"],
-                               "session_id": s["session_id"], "detail": None})
+                               "session_id": s["session_id"], "detail": None,
+                               "trust": item.get("trust")})
             else:
                 changed = [f for f in _BIO_TRACKED_FIELDS
                            if item.get(f) != latest_item[iid].get(f)]
                 if changed:
                     events.append({"item_id": iid, "kind": "changed", "ts": s["created"],
                                    "session_id": s["session_id"],
-                                   "detail": ", ".join(changed)})
+                                   "detail": ", ".join(changed),
+                                   "trust": item.get("trust")})
             latest_item[iid] = item
         if prev_ids is not None:
             for iid in sorted(prev_ids - set(cur)):
                 gone.add(iid)
                 events.append({"item_id": iid, "kind": "last_seen",
                                "ts": last_sight.get(iid),
-                               "session_id": s["session_id"], "detail": None})
+                               "session_id": s["session_id"], "detail": None,
+                               "trust": latest_item[iid].get("trust")})
         for iid in cur:
             last_sight[iid] = s["created"]
         prev_ids = set(cur)
@@ -785,3 +790,84 @@ def item_biography(data_dir: Path, slug: str, item_id: str) -> dict:
     window_note = "history starts here — earlier sessions may have been cleaned up" if oldest_has_item else None
     return {"ok": True, "item": last_item, "events": events,
             "window_note": window_note, "trust_anatomy": anatomy}
+
+# The strip renders a window, never a silent cap: what lies beyond each edge
+# is named in partial. Six columns is the frozen reference's width.
+GRID_COLUMNS = 6
+GRID_ROWS = 30
+
+def project_grid(data_dir: Path, slug: str) -> dict:
+    """The check strip: object × checkpoint lanes over the shared walk.
+    Sightings land in the column of the session that wrote them, with the
+    trust class of that time. A departure marks the transition session —
+    the same attribution the ledger makes — and the lane reads gone after
+    it. Quote checks carry NO session attribution on disk; each is bucketed
+    by ts into the earliest window column whose created stamp is >= its ts
+    (later than head folds into head), and the row keeps the exact ts so
+    the hover states when, not who."""
+    walk = _walk_transitions(data_dir, slug)
+    hist = project_history(data_dir, slug)["sessions"]  # newest -> oldest
+    window = list(reversed(hist[:GRID_COLUMNS]))        # oldest -> newest
+    older_columns = max(0, len(hist) - len(window))
+    columns = [{"session_id": s["session_id"], "created": s["created"],
+                "is_head": i == len(window) - 1}
+               for i, s in enumerate(window)]
+    window_ids = {c["session_id"] for c in columns}
+
+    by_item, latest_ts = {}, {}
+    for ev in walk["events"]:  # oldest -> newest
+        iid = ev["item_id"]
+        latest_ts[iid] = ev["ts"] or latest_ts.get(iid) or ""
+        entry = by_item.setdefault(iid, {"cells": {}, "checks": [], "gone_after": None})
+        # A re-appearance after a departure clears the dashed tail.
+        entry["gone_after"] = ev["session_id"] if ev["kind"] == "last_seen" else None
+        if ev["session_id"] in window_ids:
+            entry["cells"][ev["session_id"]] = {
+                "kind": ev["kind"], "trust": ev.get("trust"),
+                "ts": ev["ts"], "detail": ev["detail"]}
+
+    checks_before_window = 0
+    for row in _jsonl_rows(data_dir / slug / "verification.jsonl"):
+        iid = row.get("item_ref")
+        if iid not in walk["items"]:
+            continue
+        ts = _norm_str(row.get("ts")) or ""
+        column = None
+        for c in columns:
+            if (c["created"] or "") >= ts:
+                column = c["session_id"]
+                break
+        if column is None and columns:
+            column = columns[-1]["session_id"]  # later than head folds into head
+        if columns and ts and ts <= (columns[0]["created"] or "") and older_columns:
+            checks_before_window += 1
+            continue
+        if column is None:
+            continue
+        entry = by_item.setdefault(iid, {"cells": {}, "checks": [], "gone_after": None})
+        check, reason = _norm_str(row.get("check")), _norm_str(row.get("reason"))
+        detail = f"{check}: {reason}" if check and reason else (reason or check)
+        entry["checks"].append({"column": column, "ts": row.get("ts"), "detail": detail})
+        latest_ts[iid] = max(latest_ts.get(iid) or "", ts)
+
+    ordered = sorted(by_item, key=lambda iid: (latest_ts.get(iid) or "", iid), reverse=True)
+    shown = ordered[:GRID_ROWS]
+    rows = []
+    for iid in shown:
+        item = walk["items"].get(iid) or {}
+        entry = by_item[iid]
+        rows.append({"id": iid, "text": item.get("text"), "trust": item.get("trust"),
+                     "kind": _SECTION_KIND.get(item.get("section")),
+                     "cells": entry["cells"], "checks": entry["checks"],
+                     "gone_after": entry["gone_after"]})
+
+    partial = _ledger_partial(walk["unreadable"])
+    if older_columns:
+        partial.append(f"{older_columns} older checkpoint(s) beyond this window.")
+    if len(ordered) > len(shown):
+        partial.append(f"{len(ordered) - len(shown)} further object(s) beyond this window.")
+    if checks_before_window:
+        partial.append(f"{checks_before_window} quote check(s) predate this window.")
+
+    return {"ok": True, "columns": columns, "rows": rows,
+            "older_columns": older_columns, "partial": partial}

--- a/plugin/daimon_ui/reader.py
+++ b/plugin/daimon_ui/reader.py
@@ -827,23 +827,22 @@ def project_grid(data_dir: Path, slug: str) -> dict:
                 "ts": ev["ts"], "detail": ev["detail"]}
 
     checks_before_window = 0
-    for row in _jsonl_rows(data_dir / slug / "verification.jsonl"):
+    # No columns means no sessions, so nothing can anchor a check row —
+    # walk["items"] is empty too and the guard below would skip every row.
+    ver_rows = _jsonl_rows(data_dir / slug / "verification.jsonl") if columns else []
+    for row in ver_rows:
         iid = row.get("item_ref")
         if iid not in walk["items"]:
             continue
         ts = _norm_str(row.get("ts")) or ""
-        column = None
+        if ts and ts <= (columns[0]["created"] or "") and older_columns:
+            checks_before_window += 1
+            continue
+        column = columns[-1]["session_id"]  # later than head folds into head
         for c in columns:
             if (c["created"] or "") >= ts:
                 column = c["session_id"]
                 break
-        if column is None and columns:
-            column = columns[-1]["session_id"]  # later than head folds into head
-        if columns and ts and ts <= (columns[0]["created"] or "") and older_columns:
-            checks_before_window += 1
-            continue
-        if column is None:
-            continue
         entry = by_item.setdefault(iid, {"cells": {}, "checks": [], "gone_after": None})
         check, reason = _norm_str(row.get("check")), _norm_str(row.get("reason"))
         detail = f"{check}: {reason}" if check and reason else (reason or check)

--- a/plugin/daimon_ui/reader.py
+++ b/plugin/daimon_ui/reader.py
@@ -458,11 +458,17 @@ def diff_checkpoints(data_dir: Path, slug: str, sid_a: str, sid_b: str) -> dict:
         else:
             gone.append(item)
 
-    carried, trust_changed = [], []
+    # One changed list for every tracked field, values included: the diff view
+    # renders old struck through above new, so field names alone are not
+    # enough. Trust transitions are changed rows like any other — the frozen
+    # vocabulary rides "changed" (§8), nothing gets its own bucket.
+    carried, changed = [], []
     for iid in sorted(ids_a & ids_b):
         item_a, item_b = map_a[iid], map_b[iid]
-        if item_a.get("trust") != item_b.get("trust"):
-            trust_changed.append({"item": item_b, "from": item_a.get("trust"), "to": item_b.get("trust")})
+        fields = [{"field": f, "from": item_a.get(f), "to": item_b.get(f)}
+                  for f in _BIO_TRACKED_FIELDS if item_a.get(f) != item_b.get(f)]
+        if fields:
+            changed.append({"item": item_b, "fields": fields})
         else:
             carried.append({"item": item_b})
 
@@ -475,7 +481,7 @@ def diff_checkpoints(data_dir: Path, slug: str, sid_a: str, sid_b: str) -> dict:
         "ok": True,
         "a": meta_a, "b": meta_b,
         "born": born, "resolved": resolved, "gone": gone,
-        "carried": carried, "trust_changed": trust_changed,
+        "carried": carried, "changed": changed,
         "partial": partial,
     }
 

--- a/plugin/daimon_ui/server.py
+++ b/plugin/daimon_ui/server.py
@@ -190,6 +190,12 @@ class _Handler(BaseHTTPRequestHandler):
                 }})
                 return
             self._json(dict({"ok": True}, **result))
+        elif path == "/api/grid":
+            slug = self._resolve_slug(params)
+            if slug is None:
+                self._json(self._bad_slug_error(params.get("project", [self.default_slug])[0]))
+                return
+            self._json(reader.project_grid(self.data_dir, slug))
         elif path == "/api/refutations":
             slug = self._resolve_slug(params)
             if slug is None:

--- a/plugin/daimon_ui/server.py
+++ b/plugin/daimon_ui/server.py
@@ -12,7 +12,7 @@ from . import reader
 # never grows a second search engine) and inspector.inspect_item is the same
 # read-side receipt `daimon why` prints. reader.py stays daimon-import-free
 # (files are its seam); the engine boundary lives here in dispatch only.
-from daimon_briefing import inspector, recall
+from daimon_briefing import inspector, recall, refutations
 
 _PAGE = Path(__file__).parent / "page.html"
 _SLUG_RE = re.compile(r"^[\w-]+$")
@@ -190,6 +190,16 @@ class _Handler(BaseHTTPRequestHandler):
                 }})
                 return
             self._json(dict({"ok": True}, **result))
+        elif path == "/api/refutations":
+            slug = self._resolve_slug(params)
+            if slug is None:
+                self._json(self._bad_slug_error(params.get("project", [self.default_slug])[0]))
+                return
+            # The lane renders `daimon refute list` — refutations.listing is the
+            # same fold and the same order the CLI prints. A slug is already its
+            # own project_slug, so passing it as project_dir resolves to the same
+            # bucket (the inspector endpoint leans on the same property).
+            self._json({"ok": True, "rows": refutations.listing(project_dir=slug)})
         elif path == "/api/ledger":
             slug = self._resolve_slug(params)
             if slug is None:

--- a/plugin/daimon_ui/static/app.css
+++ b/plugin/daimon_ui/static/app.css
@@ -1043,3 +1043,51 @@
     padding: 0 var(--s1);
     vertical-align: 1px;
   }
+
+  /* Refutations lane: Record | Refutes | Recorded | Origin */
+  .refut-cols {
+    display: grid;
+    grid-template-columns: 190px 1fr 130px 110px;
+    gap: 14px;
+    padding: 7px 18px;
+    border-bottom: 1px solid var(--border-subtle);
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-tertiary);
+  }
+  .refut-rows { display: flex; flex-direction: column; }
+  .refut-row {
+    display: grid;
+    grid-template-columns: 190px 1fr 130px 110px;
+    align-items: baseline;
+    gap: 14px;
+    padding: 12px 18px;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+  .refut-row:last-child { border-bottom: 0; }
+  .refut-record { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+  .refut-record .obj-id { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .refut-state { font-family: var(--mono); font-size: 10.5px; color: var(--ink-tertiary); }
+  .refut-subject { font-size: 13.5px; line-height: 1.5; overflow-wrap: anywhere; }
+  .refut-anchors { margin-top: 4px; display: flex; flex-wrap: wrap; gap: 6px; }
+  .refut-anchor {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--accent);
+    background: none;
+    border: 0;
+    padding: 0;
+    cursor: pointer;
+  }
+  .refut-anchor:hover { text-decoration: underline; }
+  .refut-anchor-raw { color: var(--ink-tertiary); cursor: default; }
+  .refut-anchor-raw:hover { text-decoration: none; }
+  .refut-at, .refut-origin { font-family: var(--mono); font-size: 11.5px; color: var(--ink-tertiary); }
+
+  @media (max-width: 720px) {
+    .refut-cols { display: none; }
+    .refut-row { grid-template-columns: 1fr; }
+  }

--- a/plugin/daimon_ui/static/app.css
+++ b/plugin/daimon_ui/static/app.css
@@ -1115,3 +1115,101 @@
     .refut-cols { display: none; }
     .refut-row { grid-template-columns: 1fr; }
   }
+
+  /* Check strip: object × checkpoint lanes. Marks reuse the trust-glyph
+     language; the lane line goes dashed after a departure. */
+  .strip-grid {
+    display: grid;
+    grid-template-columns: 150px 1fr;
+    gap: 12px 16px;
+    align-items: center;
+    padding: 14px 18px 8px;
+  }
+  .strip-heads { display: grid; justify-items: center; }
+  .strip-col-head {
+    font-family: var(--mono);
+    font-size: 10px;
+    color: var(--ink-tertiary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
+  }
+  .strip-col-current { color: var(--accent); }
+  .strip-obj {
+    font-family: var(--mono);
+    font-size: 11.5px;
+    color: var(--ink-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .strip-obj-gone { color: var(--ink-tertiary); }
+  .strip-lane {
+    position: relative;
+    height: 22px;
+    display: grid;
+    justify-items: center;
+    align-items: center;
+  }
+  .strip-line {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: var(--border-subtle);
+  }
+  .strip-line-gone {
+    background: repeating-linear-gradient(to right, var(--border-subtle) 0 3px, transparent 3px 7px);
+  }
+  .strip-mark {
+    position: relative;
+    width: 9px;
+    height: 9px;
+    padding: 0;
+    border: 0;
+    background: var(--ink-secondary);
+    cursor: pointer;
+  }
+  .strip-mark:hover { box-shadow: 0 0 0 3px var(--surface-hover); }
+  .strip-mark-inferred, .strip-mark-check {
+    background: var(--bg);
+    border: 1px solid var(--ink-secondary);
+  }
+  .strip-mark-untagged {
+    background: var(--bg);
+    border: 1px dashed var(--ink-tertiary);
+  }
+  .strip-tick {
+    position: absolute;
+    left: 50%;
+    top: -7px;
+    width: 1px;
+    height: 22px;
+    background: var(--border-strong);
+  }
+  .strip-hover {
+    margin-top: 16px;
+    padding: 12px 15px;
+    border: 1px solid var(--border-strong);
+    border-radius: 8px;
+    background: var(--surface);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .strip-hover-meta { font-family: var(--mono); font-size: 11px; color: var(--ink-tertiary); }
+  .strip-hover-text { font-size: 13px; line-height: 1.5; }
+  .strip-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px 20px;
+    padding: 14px 2px 0;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--ink-tertiary);
+  }
+  .strip-legend > span { display: inline-flex; align-items: center; gap: 7px; }
+  .strip-legend .glyph { margin: 0; }
+  .strip-tick-legend { position: static; width: 1px; height: 12px; display: inline-block; }
+  .strip-line-legend { position: static; width: 14px; height: 1px; display: inline-block; }

--- a/plugin/daimon_ui/static/app.css
+++ b/plugin/daimon_ui/static/app.css
@@ -556,44 +556,68 @@
     min-width: 0;
   }
 
-  .tag-chip {
-    display: inline-block;
-    margin-right: var(--s2);
+  /* Diff view (#670 slice 3): sign | kind | entry rows. No judgment paint —
+     added/changed/dropped are statuses the ledger records, not verdicts. */
+  .diff-cols {
+    display: grid;
+    grid-template-columns: 26px 92px 1fr;
+    gap: 14px;
+    padding: 7px 18px;
+    border-bottom: 1px solid var(--border-subtle);
     font-family: var(--mono);
-    font-size: var(--fs-xs);
+    font-size: 10px;
     font-weight: 600;
-    letter-spacing: 0.05em;
-    border-radius: 4px;
-    padding: 0 var(--s1);
-  }
-
-  .t-born { background: var(--accent-wash); color: var(--accent-chip-text); border: 1px solid var(--accent); }
-  .t-resolved { background: var(--amber-wash); color: var(--amber-chip-text); border: 1px solid var(--amber); }
-  .t-carried { background: none; color: var(--ink-tertiary); border: 1px dashed var(--border-inferred); }
-  /* Contract §8.4: LAST SEEN is a status, not a failure — danger paint here
-     rendered a judgment no word supplies (rule 1). Solid border against
-     .t-carried's dashed keeps the two states distinguishable without colour. */
-  .t-gone { background: none; color: var(--ink-tertiary); border: 1px solid var(--border-inferred); }
-  .t-trust { background: var(--accent-wash); color: var(--accent-chip-text); border: 1px solid var(--accent); }
-
-  .hist-note {
-    margin-top: var(--s1);
-    max-width: 65ch;
-    font-family: var(--mono);
-    font-size: var(--fs-xs);
-    color: var(--ink-secondary);
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
-
-  .hist-suffix {
-    margin-left: var(--s2);
-    font-family: var(--mono);
-    font-size: var(--fs-xs);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
     color: var(--ink-tertiary);
   }
+  .diff-rows { display: flex; flex-direction: column; }
+  .diff-row {
+    display: grid;
+    grid-template-columns: 26px 92px 1fr;
+    align-items: baseline;
+    gap: 14px;
+    width: 100%;
+    text-align: left;
+    padding: 12px 18px;
+    border: 0;
+    border-bottom: 1px solid var(--border-subtle);
+    background: none;
+    color: var(--ink);
+    font: inherit;
+  }
+  button.diff-row { cursor: pointer; transition: background var(--transition); }
+  button.diff-row:hover { background: var(--surface-hover); }
+  .diff-row:last-child { border-bottom: 0; }
+  .diff-sign { font-family: var(--mono); font-size: 14px; color: var(--ink-secondary); }
+  .diff-kind { font-family: var(--mono); font-size: 11.5px; color: var(--ink-secondary); }
+  .diff-entry { min-width: 0; }
+  .diff-old {
+    font-size: 13.5px;
+    line-height: 1.5;
+    color: var(--ink-tertiary);
+    text-decoration: line-through;
+    text-decoration-color: var(--border-strong);
+    overflow-wrap: anywhere;
+  }
+  .diff-text { font-size: 13.5px; line-height: 1.5; overflow-wrap: anywhere; }
+  .diff-text-dim { color: var(--ink-secondary); }
+  .diff-trans { margin-top: 3px; font-size: 13px; line-height: 1.5; color: var(--ink-secondary); }
+  .diff-meta { margin-top: 6px; font-family: var(--mono); font-size: 11px; color: var(--ink-tertiary); }
+  .diff-meta .glyph { vertical-align: baseline; }
+
+  /* LIFE rungs: a session-written rung is a door into its pairwise diff. */
+  .life-rung {
+    background: none;
+    border: 0;
+    padding: 0;
+    text-align: left;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+  }
+  .life-rung:hover .life-label { color: var(--accent); }
+  .rung-lit .life-body { border-left: 2px solid var(--accent); padding-left: 11px; }
 
   .history-btn {
     display: inline-block;

--- a/plugin/daimon_ui/static/app.js
+++ b/plugin/daimon_ui/static/app.js
@@ -1,8 +1,8 @@
 import {
   ACT_ITEM_ID_RE, escapeHtml, fmtRelative, navCurrent, renderBioPanel,
   renderEmptyProjects, renderError, renderLedgerSessions, renderLedgerView, renderProjCard,
-  renderSearchResults, renderSections, renderSessionView, renderSidebarScope, renderWhyView,
-  skeletonHtml
+  renderRefutationsView, renderSearchResults, renderSections, renderSessionView,
+  renderSidebarScope, renderWhyView, skeletonHtml
 } from "./render.js";
 import { state } from "./state.js";
 
@@ -78,9 +78,11 @@ import { state } from "./state.js";
     var slot = document.getElementById("nav-pills-slot");
     slot.innerHTML = "";
     var inProject = state.currentSlug &&
-      ["project", "ledger", "session", "search", "why"].indexOf(state.view) !== -1;
+      ["project", "ledger", "session", "search", "why", "refutations"].indexOf(state.view) !== -1;
     if (!inProject) return;
-    [["briefing", "project", goBriefing], ["ledger", "ledger", enterLedger]].forEach(function (pill) {
+    // Pill order is the frozen chrome: briefing · ledger · refutations.
+    [["briefing", "project", goBriefing], ["ledger", "ledger", enterLedger],
+     ["refutations", "refutations", enterRefutations]].forEach(function (pill) {
       var btn = document.createElement("button");
       btn.type = "button";
       btn.className = "nav-pill";
@@ -174,6 +176,50 @@ import { state } from "./state.js";
     Array.prototype.forEach.call(container.querySelectorAll("[data-open-session][data-sid]"), function (btn) {
       btn.addEventListener("click", function () { enterSession(btn.dataset.sid); });
     });
+  }
+  // ---- refutations lane (#670 slice 3): renders `daimon refute list` ----
+  function enterRefutations() {
+    if (!state.currentSlug) return;
+    var slug = state.currentSlug;
+    state.view = "refutations";
+    state.requestId += 1;
+    var reqId = state.requestId;
+    renderNavPills();
+    var stateEl = document.getElementById("state");
+    var sectionsEl = document.getElementById("sections");
+    var mainEl = document.getElementById("main");
+    mainEl.setAttribute("aria-busy", "true");
+    if (state.pendingTimer) clearTimeout(state.pendingTimer);
+    state.pendingTimer = setTimeout(function () {
+      if (reqId !== state.requestId) return;
+      stateEl.innerHTML = skeletonHtml();
+    }, 1000);
+    api("/api/refutations?project=" + encodeURIComponent(slug))
+      .then(function (data) {
+        if (reqId !== state.requestId) return; // superseded by a newer navigation
+        clearTimeout(state.pendingTimer);
+        mainEl.removeAttribute("aria-busy");
+        stateEl.innerHTML = "";
+        if (!data.ok) {
+          sectionsEl.innerHTML = "";
+          showError(stateEl, data.error);
+          return;
+        }
+        sectionsEl.innerHTML = renderRefutationsView(data);
+        toTop();
+        announce("Refutations loaded.");
+        wireWhyOpeners(sectionsEl);
+      }).catch(function () {
+        if (reqId !== state.requestId) return;
+        clearTimeout(state.pendingTimer);
+        mainEl.removeAttribute("aria-busy");
+        sectionsEl.innerHTML = "";
+        showError(stateEl, {
+          what: "Could not load refutations.",
+          why: "The request to the daimon server failed.",
+          fix: "Check the server is running and try again."
+        });
+      });
   }
   // ---- session page (#670 slice 2): what one session wrote ----
   function enterSession(sid) {
@@ -468,6 +514,7 @@ import { state } from "./state.js";
     // reader to the ledger or session page they were on, not to the briefing.
     if (state.view === "ledger") state.whyReturn = { view: "ledger" };
     else if (state.view === "session") state.whyReturn = { view: "session", sid: state.sessionSid };
+    else if (state.view === "refutations") state.whyReturn = { view: "refutations" };
     else state.whyReturn = null;
     state.view = "why";
     renderNavPills();
@@ -491,6 +538,7 @@ import { state } from "./state.js";
         if (back) back.addEventListener("click", function () {
           if (state.whyReturn && state.whyReturn.view === "session") { enterSession(state.whyReturn.sid); }
           else if (state.whyReturn && state.whyReturn.view === "ledger") { enterLedger(); }
+          else if (state.whyReturn && state.whyReturn.view === "refutations") { enterRefutations(); }
           else if (state.lastSearchQ) { runSearch(state.lastSearchQ); }
           else if (state.activeRef) { selectCheckpoint(state.activeRef); }
           else { loadList(); }

--- a/plugin/daimon_ui/static/app.js
+++ b/plugin/daimon_ui/static/app.js
@@ -1,8 +1,8 @@
 import {
   ACT_ITEM_ID_RE, escapeHtml, fmtRelative, navCurrent, renderBioPanel,
-  renderEmptyProjects, renderError, renderLedgerSessions, renderLedgerView, renderProjCard,
-  renderRefutationsView, renderSearchResults, renderSections, renderSessionView,
-  renderSidebarScope, renderWhyView, skeletonHtml
+  renderDiffView, renderEmptyProjects, renderError, renderLedgerSessions, renderLedgerView,
+  renderProjCard, renderRefutationsView, renderSearchResults, renderSections,
+  renderSessionView, renderSidebarScope, renderWhyView, skeletonHtml
 } from "./render.js";
 import { state } from "./state.js";
 
@@ -78,7 +78,7 @@ import { state } from "./state.js";
     var slot = document.getElementById("nav-pills-slot");
     slot.innerHTML = "";
     var inProject = state.currentSlug &&
-      ["project", "ledger", "session", "search", "why", "refutations"].indexOf(state.view) !== -1;
+      ["project", "ledger", "session", "search", "why", "refutations", "diff"].indexOf(state.view) !== -1;
     if (!inProject) return;
     // Pill order is the frozen chrome: briefing · ledger · refutations.
     [["briefing", "project", goBriefing], ["ledger", "ledger", enterLedger],
@@ -175,6 +175,111 @@ import { state } from "./state.js";
   function wireSessionOpeners(container) {
     Array.prototype.forEach.call(container.querySelectorAll("[data-open-session][data-sid]"), function (btn) {
       btn.addEventListener("click", function () { enterSession(btn.dataset.sid); });
+    });
+  }
+  // ---- diff view (#670 slice 3): hangs off the LIFE ladder, no pill ----
+  // Ordered oldest -> newest is what the reader expects: a must precede b.
+  // Sessions arrive newest-first, so a HIGHER index is OLDER.
+  function orderPair(a, b) {
+    var ids = state.diffSessions.map(function (s) { return s.session_id; });
+    var ia = ids.indexOf(a), ib = ids.indexOf(b);
+    if (ia !== -1 && ib !== -1 && ia < ib) return { a: b, b: a };
+    return { a: a, b: b };
+  }
+  function enterDiff(a, b) {
+    if (!state.currentSlug || !a || !b || a === b) return;
+    var slug = state.currentSlug;
+    state.view = "diff";
+    state.requestId += 1;
+    var reqId = state.requestId;
+    renderNavPills();
+    var stateEl = document.getElementById("state");
+    var sectionsEl = document.getElementById("sections");
+    var mainEl = document.getElementById("main");
+    mainEl.setAttribute("aria-busy", "true");
+    if (state.pendingTimer) clearTimeout(state.pendingTimer);
+    state.pendingTimer = setTimeout(function () {
+      if (reqId !== state.requestId) return;
+      stateEl.innerHTML = skeletonHtml();
+    }, 1000);
+    Promise.all([
+      api("/api/history?project=" + encodeURIComponent(slug)),
+      api("/api/diff?project=" + encodeURIComponent(slug) +
+        "&a=" + encodeURIComponent(a) + "&b=" + encodeURIComponent(b))
+    ]).then(function (results) {
+      if (reqId !== state.requestId) return; // superseded by a newer navigation
+      clearTimeout(state.pendingTimer);
+      mainEl.removeAttribute("aria-busy");
+      var hist = results[0], diff = results[1];
+      state.diffSessions = hist.sessions || [];
+      state.diffUnreadable = hist.unreadable || 0;
+      state.diffPick = orderPair(a, b);
+      stateEl.innerHTML = "";
+      if (!diff.ok) {
+        sectionsEl.innerHTML = "";
+        showError(stateEl, diff.error);
+        return;
+      }
+      sectionsEl.innerHTML = renderDiffView(diff, state.diffSessions, state.diffPick, state.diffUnreadable);
+      toTop();
+      announce("Diff loaded.");
+      wireDiffView(sectionsEl);
+    }).catch(function () {
+      if (reqId !== state.requestId) return;
+      clearTimeout(state.pendingTimer);
+      mainEl.removeAttribute("aria-busy");
+      sectionsEl.innerHTML = "";
+      showError(stateEl, {
+        what: "Could not load the diff.",
+        why: "The request to the daimon server failed.",
+        fix: "Check the server is running and try again."
+      });
+    });
+  }
+  function wireDiffView(container) {
+    var back = container.querySelector("[data-diff-back]");
+    if (back) back.addEventListener("click", enterLedger);
+    Array.prototype.forEach.call(container.querySelectorAll(".sess-pick"), function (sel) {
+      sel.addEventListener("change", function () {
+        var pick = { a: state.diffPick.a, b: state.diffPick.b };
+        pick[sel.dataset.pick] = sel.value;
+        var ordered = orderPair(pick.a, pick.b);
+        enterDiff(ordered.a, ordered.b);
+      });
+    });
+    // A diff row opens its entry with the source rung lit: the entry's LIFE
+    // ladder highlights the newer checkpoint of the pair the row came from.
+    Array.prototype.forEach.call(container.querySelectorAll(".diff-row[data-item-id]"), function (btn) {
+      btn.addEventListener("click", function () {
+        state.whyHighlightSid = state.diffPick.b;
+        openWhy(btn.dataset.itemId);
+      });
+    });
+  }
+  // A LIFE rung opens the diff between the sighting before it and itself.
+  // The previous sighting comes from the item's own chain; an item's first
+  // sighting falls back to the previous session on disk, which shows it
+  // as added — the same attribution the ledger already makes.
+  function wireRungOpeners(panel, bio) {
+    Array.prototype.forEach.call(panel.querySelectorAll("[data-diff-sid]"), function (btn) {
+      btn.addEventListener("click", function () {
+        var sid = btn.dataset.diffSid;
+        var chain = (bio.trust_anatomy && bio.trust_anatomy.chain) || [];
+        var idx = -1;
+        chain.forEach(function (link, i) { if (link.session_id === sid) idx = i; });
+        var prev = idx > 0 ? chain[idx - 1].session_id : null;
+        if (prev) { enterDiff(prev, sid); return; }
+        // First sighting: the previous session on disk. The ledger's session
+        // list may not be loaded yet (entry opened from the briefing), so
+        // fetch the same /api/history list the ledger uses.
+        api("/api/history?project=" + encodeURIComponent(state.currentSlug || state.defaultSlug))
+          .then(function (hist) {
+            var ids = (hist.sessions || []).map(function (s) { return s.session_id; });
+            var at = ids.indexOf(sid);
+            var older = at !== -1 ? ids[at + 1] : null; // newest-first: +1 is older
+            if (older) enterDiff(older, sid);
+          }).catch(function () { /* no diff pair reachable — the rung stays inert */ });
+      });
     });
   }
   // ---- refutations lane (#670 slice 3): renders `daimon refute list` ----
@@ -434,8 +539,12 @@ import { state } from "./state.js";
   function loadBiography(itemId, panel) {
     var reqId = state.requestId;
     var cacheKey = reqId + ":" + itemId;
+    function paint(data) {
+      panel.innerHTML = renderBioPanel(data, state.whyHighlightSid);
+      wireRungOpeners(panel, data);
+    }
     if (state.bioCache[cacheKey]) {
-      panel.innerHTML = renderBioPanel(state.bioCache[cacheKey]);
+      paint(state.bioCache[cacheKey]);
       return;
     }
     var timer = setTimeout(function () {
@@ -447,7 +556,7 @@ import { state } from "./state.js";
         if (reqId !== state.requestId) return; // navigated away meanwhile
         if (data.ok) {
           state.bioCache[cacheKey] = data;
-          panel.innerHTML = renderBioPanel(data);
+          paint(data);
         } else {
           panel.innerHTML = renderError(data.error);
         }
@@ -515,7 +624,10 @@ import { state } from "./state.js";
     if (state.view === "ledger") state.whyReturn = { view: "ledger" };
     else if (state.view === "session") state.whyReturn = { view: "session", sid: state.sessionSid };
     else if (state.view === "refutations") state.whyReturn = { view: "refutations" };
+    else if (state.view === "diff") state.whyReturn = { view: "diff", a: state.diffPick.a, b: state.diffPick.b };
     else state.whyReturn = null;
+    // Only a diff row lights a rung; any other door opens the ladder unlit.
+    if (state.view !== "diff") state.whyHighlightSid = null;
     state.view = "why";
     renderNavPills();
     state.requestId += 1;
@@ -539,6 +651,7 @@ import { state } from "./state.js";
           if (state.whyReturn && state.whyReturn.view === "session") { enterSession(state.whyReturn.sid); }
           else if (state.whyReturn && state.whyReturn.view === "ledger") { enterLedger(); }
           else if (state.whyReturn && state.whyReturn.view === "refutations") { enterRefutations(); }
+          else if (state.whyReturn && state.whyReturn.view === "diff") { enterDiff(state.whyReturn.a, state.whyReturn.b); }
           else if (state.lastSearchQ) { runSearch(state.lastSearchQ); }
           else if (state.activeRef) { selectCheckpoint(state.activeRef); }
           else { loadList(); }

--- a/plugin/daimon_ui/static/app.js
+++ b/plugin/daimon_ui/static/app.js
@@ -1,8 +1,8 @@
 import {
-  ACT_ITEM_ID_RE, escapeHtml, fmtRelative, navCurrent, renderBioPanel,
+  ACT_ITEM_ID_RE, displaySid, escapeHtml, fmtRelative, navCurrent, renderBioPanel,
   renderDiffView, renderEmptyProjects, renderError, renderLedgerSessions, renderLedgerView,
   renderProjCard, renderRefutationsView, renderSearchResults, renderSections,
-  renderSessionView, renderSidebarScope, renderWhyView, skeletonHtml
+  renderSessionView, renderSidebarScope, renderStripView, renderWhyView, skeletonHtml
 } from "./render.js";
 import { state } from "./state.js";
 
@@ -78,10 +78,11 @@ import { state } from "./state.js";
     var slot = document.getElementById("nav-pills-slot");
     slot.innerHTML = "";
     var inProject = state.currentSlug &&
-      ["project", "ledger", "session", "search", "why", "refutations", "diff"].indexOf(state.view) !== -1;
+      ["project", "ledger", "session", "search", "why", "refutations", "diff", "strip"].indexOf(state.view) !== -1;
     if (!inProject) return;
-    // Pill order is the frozen chrome: briefing · ledger · refutations.
+    // Pill order is the frozen chrome: briefing · ledger · check strip · refutations.
     [["briefing", "project", goBriefing], ["ledger", "ledger", enterLedger],
+     ["check strip", "strip", enterStrip],
      ["refutations", "refutations", enterRefutations]].forEach(function (pill) {
       var btn = document.createElement("button");
       btn.type = "button";
@@ -279,6 +280,70 @@ import { state } from "./state.js";
             var older = at !== -1 ? ids[at + 1] : null; // newest-first: +1 is older
             if (older) enterDiff(older, sid);
           }).catch(function () { /* no diff pair reachable — the rung stays inert */ });
+      });
+    });
+  }
+  // ---- check strip (#670 slice 3): object × checkpoint lanes ----
+  function enterStrip() {
+    if (!state.currentSlug) return;
+    var slug = state.currentSlug;
+    state.view = "strip";
+    state.requestId += 1;
+    var reqId = state.requestId;
+    renderNavPills();
+    var stateEl = document.getElementById("state");
+    var sectionsEl = document.getElementById("sections");
+    var mainEl = document.getElementById("main");
+    mainEl.setAttribute("aria-busy", "true");
+    if (state.pendingTimer) clearTimeout(state.pendingTimer);
+    state.pendingTimer = setTimeout(function () {
+      if (reqId !== state.requestId) return;
+      stateEl.innerHTML = skeletonHtml();
+    }, 1000);
+    api("/api/grid?project=" + encodeURIComponent(slug))
+      .then(function (data) {
+        if (reqId !== state.requestId) return; // superseded by a newer navigation
+        clearTimeout(state.pendingTimer);
+        mainEl.removeAttribute("aria-busy");
+        stateEl.innerHTML = "";
+        if (!data.ok) {
+          sectionsEl.innerHTML = "";
+          showError(stateEl, data.error);
+          return;
+        }
+        sectionsEl.innerHTML = renderStripView(data);
+        toTop();
+        announce("Check strip loaded.");
+        wireStripMarks(sectionsEl);
+      }).catch(function () {
+        if (reqId !== state.requestId) return;
+        clearTimeout(state.pendingTimer);
+        mainEl.removeAttribute("aria-busy");
+        sectionsEl.innerHTML = "";
+        showError(stateEl, {
+          what: "Could not load the check strip.",
+          why: "The request to the daimon server failed.",
+          fix: "Check the server is running and try again."
+        });
+      });
+  }
+  function wireStripMarks(container) {
+    var hover = container.querySelector("#strip-hover");
+    Array.prototype.forEach.call(container.querySelectorAll("[data-open-mark]"), function (btn) {
+      btn.addEventListener("click", function () {
+        // A mark opens its entry with that column's rung lit; quote-check
+        // marks carry no session, so they open the ladder unlit.
+        state.whyHighlightSid = btn.dataset.sid || null;
+        openWhy(btn.dataset.itemId);
+      });
+      btn.addEventListener("mouseenter", function () {
+        if (!hover) return;
+        var whereBits = [];
+        if (btn.dataset.sid) whereBits.push(displaySid(btn.dataset.sid));
+        whereBits.push(btn.dataset.itemId);
+        hover.innerHTML = '<span class="strip-hover-meta">hovering ' +
+          escapeHtml(whereBits.join(" · ")) + "</span>" +
+          '<span class="strip-hover-text">' + escapeHtml(btn.dataset.hover || "") + "</span>";
       });
     });
   }
@@ -625,9 +690,11 @@ import { state } from "./state.js";
     else if (state.view === "session") state.whyReturn = { view: "session", sid: state.sessionSid };
     else if (state.view === "refutations") state.whyReturn = { view: "refutations" };
     else if (state.view === "diff") state.whyReturn = { view: "diff", a: state.diffPick.a, b: state.diffPick.b };
+    else if (state.view === "strip") state.whyReturn = { view: "strip" };
     else state.whyReturn = null;
-    // Only a diff row lights a rung; any other door opens the ladder unlit.
-    if (state.view !== "diff") state.whyHighlightSid = null;
+    // Only a diff row or a strip mark lights a rung; any other door opens
+    // the ladder unlit.
+    if (state.view !== "diff" && state.view !== "strip") state.whyHighlightSid = null;
     state.view = "why";
     renderNavPills();
     state.requestId += 1;
@@ -652,6 +719,7 @@ import { state } from "./state.js";
           else if (state.whyReturn && state.whyReturn.view === "ledger") { enterLedger(); }
           else if (state.whyReturn && state.whyReturn.view === "refutations") { enterRefutations(); }
           else if (state.whyReturn && state.whyReturn.view === "diff") { enterDiff(state.whyReturn.a, state.whyReturn.b); }
+          else if (state.whyReturn && state.whyReturn.view === "strip") { enterStrip(); }
           else if (state.lastSearchQ) { runSearch(state.lastSearchQ); }
           else if (state.activeRef) { selectCheckpoint(state.activeRef); }
           else { loadList(); }

--- a/plugin/daimon_ui/static/render.js
+++ b/plugin/daimon_ui/static/render.js
@@ -733,6 +733,95 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
     return html;
   }
 
+  // ---- check strip (#670 slice 3): object × checkpoint lanes ----
+  // Marks speak the viewer's two existing languages and nothing new: sighting
+  // marks wear the trust glyph of the class the item held AT that session;
+  // quote-check marks are the outlined square with the rejection tick — the
+  // ledger only records rejections, so every stored check carries one.
+  export function stripMarkHover(cell) {
+    var label = LEDGER_EVENT_LABELS[cell.kind] || cell.kind;
+    var when = cell.ts ? " · " + fmtDateTime(cell.ts) : "";
+    var detail = cell.detail ? " — " + cell.detail : "";
+    return label + detail + when;
+  }
+  function stripMark(colIndex, cls, itemId, sid, hover, inner) {
+    return '<button type="button" class="strip-mark ' + cls +
+      '" style="grid-column:' + (colIndex + 1) + '" data-open-mark data-item-id="' +
+      escapeHtml(itemId) + '"' + (sid ? ' data-sid="' + escapeHtml(sid) + '"' : "") +
+      ' data-hover="' + escapeHtml(hover) + '" aria-label="' + escapeHtml(hover) + '">' +
+      (inner || "") + "</button>";
+  }
+  export function renderStripRow(r, columns) {
+    var n = columns.length;
+    var colIndex = {};
+    columns.forEach(function (c, i) { colIndex[c.session_id] = i; });
+    var goneIdx = r.gone_after != null ? colIndex[r.gone_after] : undefined;
+    var lines;
+    if (goneIdx !== undefined) {
+      var pct = ((goneIdx + 0.5) / n) * 100;
+      lines = '<span class="strip-line" style="right:' + (100 - pct).toFixed(2) + '%"></span>' +
+        '<span class="strip-line strip-line-gone" style="left:' + pct.toFixed(2) + '%"></span>';
+    } else {
+      lines = '<span class="strip-line"></span>';
+    }
+    var marks = [];
+    Object.keys(r.cells || {}).forEach(function (sid) {
+      var i = colIndex[sid];
+      if (i === undefined) return;
+      var cell = r.cells[sid];
+      var glyph = cell.trust === "verbatim" ? "strip-mark-verbatim"
+        : cell.trust === "inferred" ? "strip-mark-inferred" : "strip-mark-untagged";
+      marks.push(stripMark(i, glyph, r.id, sid, stripMarkHover(cell)));
+    });
+    (r.checks || []).forEach(function (ck) {
+      var i = colIndex[ck.column];
+      if (i === undefined) return;
+      var hover = "quote check" + (ck.detail ? " — " + ck.detail : "") +
+        (ck.ts ? " · " + fmtDateTime(ck.ts) : "");
+      marks.push(stripMark(i, "strip-mark-check", r.id, null, hover,
+        '<span class="strip-tick" aria-hidden="true"></span>'));
+    });
+    var cols = "repeat(" + n + ",1fr)";
+    return '<span class="strip-obj' + (goneIdx !== undefined ? " strip-obj-gone" : "") +
+      '">' + escapeHtml(r.id) + "</span>" +
+      '<div class="strip-lane" style="grid-template-columns:' + cols + '">' +
+      lines + marks.join("") + "</div>";
+  }
+  export function renderStripView(data) {
+    var columns = data.columns || [];
+    var html = '<div class="brief-head"><h1 class="page-heading">Check strip</h1>' +
+      '<span class="brief-sub">one column per checkpoint · click a mark to open that event</span></div>';
+    (data.partial || []).forEach(function (p) {
+      html += '<div class="banner banner-partial"><span class="banner-icon" aria-hidden="true">ⓘ</span><span>' +
+        escapeHtml(p) + "</span></div>";
+    });
+    if (!columns.length || !(data.rows || []).length) {
+      return html + '<div class="state-card state-empty"><p class="state-title">Nothing to draw yet</p>' +
+        "<p>Lanes appear here as sessions record objects — first seen, changed, last seen.</p></div>";
+    }
+    var cols = "repeat(" + columns.length + ",1fr)";
+    var heads = columns.map(function (c) {
+      var label = escapeHtml(displaySid(c.session_id));
+      return c.is_head
+        ? '<span class="strip-col-head strip-col-current">' + label + " head</span>"
+        : '<span class="strip-col-head">' + label + "</span>";
+    }).join("");
+    html += '<div class="strip-grid">' +
+      '<span></span><div class="strip-heads" style="grid-template-columns:' + cols + '">' +
+      heads + "</div>";
+    html += (data.rows || []).map(function (r) { return renderStripRow(r, columns); }).join("");
+    html += "</div>";
+    html += '<div class="strip-hover" id="strip-hover"><span class="strip-hover-meta">hover a mark to read its event</span></div>';
+    html += '<div class="strip-legend">' +
+      '<span><span class="glyph glyph-verbatim" aria-hidden="true"></span>written / carried</span>' +
+      '<span><span class="glyph glyph-inferred" aria-hidden="true"></span>quote check</span>' +
+      '<span><span class="strip-tick strip-tick-legend" aria-hidden="true"></span>rejection recorded</span>' +
+      '<span><span class="strip-line-gone strip-line-legend" aria-hidden="true"></span>no longer carried</span>' +
+      "</div>";
+    html += '<div class="card-foot">read-only · every mark is an event the store already holds</div>';
+    return html;
+  }
+
   // ---- refutations lane (#670 slice 3): rows are `daimon refute list`'s ----
   // The marker glyphs are the CLI's own (cli.py _print_refutation): ✗ active,
   // × overturned, ? candidate. The lane renders refute list; it must not

--- a/plugin/daimon_ui/static/render.js
+++ b/plugin/daimon_ui/static/render.js
@@ -717,6 +717,57 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
     return html;
   }
 
+  // ---- refutations lane (#670 slice 3): rows are `daimon refute list`'s ----
+  // The marker glyphs are the CLI's own (cli.py _print_refutation): ✗ active,
+  // × overturned, ? candidate. The lane renders refute list; it must not
+  // invent a second vocabulary, so the whole bracket reads exactly as the CLI
+  // prints it: [? candidate · agent-proposed].
+  export const REFUTATION_MARKS = { active: "✗", overturned: "×", candidate: "?" };
+  export function refutationMarker(r) {
+    var state = (r && r.state) || "candidate";
+    var mark = Object.prototype.hasOwnProperty.call(REFUTATION_MARKS, state)
+      ? REFUTATION_MARKS[state] : "?";
+    var activation = (r && r.activation) ||
+      ((r && r.asserted_by) || "?") + "-proposed";
+    return "[" + mark + " " + state + " · " + activation + "]";
+  }
+  function renderRefutationAnchors(anchors) {
+    if (!anchors || !anchors.length) return "";
+    var chips = anchors.map(function (a) {
+      if (ACT_ITEM_ID_RE.test(a)) {
+        return '<button type="button" class="refut-anchor" data-open-why data-item-id="' +
+          escapeHtml(a) + '">' + escapeHtml(a) + "</button>";
+      }
+      return '<span class="refut-anchor refut-anchor-raw">' + escapeHtml(a) + "</span>";
+    }).join(" ");
+    return '<div class="refut-anchors">' + chips + "</div>";
+  }
+  export function renderRefutationRow(r) {
+    return '<div class="refut-row">' +
+      '<div class="refut-record"><code class="obj-id">' + escapeHtml(r.refutation_id || "") +
+      '</code><span class="refut-state">' + escapeHtml(refutationMarker(r)) + "</span></div>" +
+      '<div class="refut-body"><span class="refut-subject">' + escapeHtml(r.subject || "") +
+      "</span>" + renderRefutationAnchors(r.anchors) + "</div>" +
+      '<span class="refut-at">' + escapeHtml(fmtDateTime(r.created_at)) + "</span>" +
+      '<span class="refut-origin">' + escapeHtml(r.asserted_author || "") + "</span></div>";
+  }
+  export function renderRefutationsView(data) {
+    var rows = data.rows || [];
+    var html = '<div class="brief-head"><h1 class="page-heading">Refutations</h1>' +
+      '<span class="brief-sub">recorded against entries · status, never judgment</span></div>';
+    if (!rows.length) {
+      // The CLI's own empty words — one vocabulary across surfaces.
+      return html + '<div class="state-card state-empty"><p class="state-title">' +
+        "no refutations for this project</p>" +
+        "<p>Records appear here as <code>daimon refute add</code> writes them.</p></div>";
+    }
+    html += '<div class="refut-cols" aria-hidden="true"><span>Record</span><span>Refutes</span>' +
+      "<span>Recorded</span><span>Origin</span></div>";
+    html += '<div class="refut-rows">' + rows.map(renderRefutationRow).join("") + "</div>";
+    html += '<div class="card-foot">These records live outside checkpoints and survive checkpoint expiry.</div>';
+    return html;
+  }
+
   export function renderError(e) {
     return '<div class="state-card state-error"><p class="state-title">⚠ Error — ' +
       escapeHtml(e.what) + "</p><p>" + escapeHtml(e.why) + "</p><p><strong>Fix:</strong> " +

--- a/plugin/daimon_ui/static/render.js
+++ b/plugin/daimon_ui/static/render.js
@@ -428,7 +428,7 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
   var BIO_LABELS = {
     born: "FIRST SEEN", changed: "CHANGED", verified: "QUOTE CHECK", resolved: "RESOLVED", "seen-run": "CARRIED"
   };
-  export function renderBioEventRow(e) {
+  export function renderBioEventRow(e, highlightSid) {
     var dotCls = "life-dot-" + escapeHtml(e.kind === "seen-run" ? "seen" : e.kind);
     var label = BIO_LABELS[e.kind] || escapeHtml(e.kind.toUpperCase());
     var when = e.ts_or_created ? escapeHtml(fmtDate(e.ts_or_created)) : "unknown date";
@@ -441,11 +441,20 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
     } else if (e.detail) {
       body = '<div class="life-detail">' + escapeHtml(e.detail) + "</div>";
     }
-    return '<li class="life-row"><div class="life-rail"><span class="life-dot ' + dotCls +
-      '"></span></div><div class="life-body"><span class="life-label">' + label +
-      '</span><span class="life-when">' + when + "</span>" + body + "</div></li>";
+    var inner = '<span class="life-label">' + label +
+      '</span><span class="life-when">' + when + "</span>" + body;
+    var lit = highlightSid && e.session_id === highlightSid;
+    // A rung a session wrote is a door into that session's pairwise diff —
+    // the diff hangs off the ladder, it has no pill of its own.
+    var bodyHtml = e.session_id
+      ? '<button type="button" class="life-body life-rung" data-diff-sid="' +
+        escapeHtml(e.session_id) + '">' + inner + "</button>"
+      : '<div class="life-body">' + inner + "</div>";
+    return '<li class="life-row' + (lit ? " rung-lit" : "") +
+      '"><div class="life-rail"><span class="life-dot ' + dotCls +
+      '"></span></div>' + bodyHtml + "</li>";
   }
-  export function renderBioPanel(data) {
+  export function renderBioPanel(data, highlightSid) {
     var anatomyHtml = renderTrustAnatomy(data);
     var events = compressBioEvents(data.events || []);
     var noteHtml = data.window_note
@@ -457,13 +466,21 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
         "<p>This item has no recorded events yet.</p></div>";
     }
     return anatomyHtml + noteHtml + '<ul class="life">' +
-      events.map(renderBioEventRow).join("") + "</ul>";
+      events.map(function (e) { return renderBioEventRow(e, highlightSid); }).join("") + "</ul>";
   }
-  export function renderHistoryPicker() {
-    var opts = state.historySessions.map(function (s) {
+  // ---- diff view (#670 slice 3): a reading of two checkpoints ----
+  // The kind words are the frozen reference's: added / changed / dropped,
+  // plus resolved for departures the events ledger closed — that word is
+  // already frozen (§8); a resolution must not be flattened into "dropped".
+  export const DIFF_KINDS = {
+    born: "added", changed: "changed", gone: "dropped", resolved: "resolved"
+  };
+  var DIFF_SIGNS = { born: "+", changed: "~", gone: "−", resolved: "−" };
+  export function renderDiffPicker(sessions, pick) {
+    var opts = (sessions || []).map(function (s) {
       return {
         id: s.session_id,
-        label: (s.active_topic || "(untitled)") + " · " + (fmtRelative(s.created) || "unknown date")
+        label: displaySid(s.session_id) + " · " + (fmtDateTime(s.created) || "unknown date")
       };
     });
     function selectHtml(pickKey, selected) {
@@ -474,97 +491,96 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
         }).join("") + '</select>';
     }
     return '<div class="sess-pickbar">' +
-      '<label class="sess-label">From' + selectHtml("a", state.historyPick.a) + '</label>' +
-      '<label class="sess-label">To' + selectHtml("b", state.historyPick.b) + '</label>' +
+      '<label class="sess-label">From' + selectHtml("a", pick.a) + '</label>' +
+      '<label class="sess-label">To' + selectHtml("b", pick.b) + '</label>' +
       '</div>';
   }
-  export function renderTagChip(cls, label) {
-    return '<span class="tag-chip ' + escapeHtml(cls) + '">' + escapeHtml(label) + '</span>';
+  // "N checkpoints apart · X added, Y changed, Z dropped" — the distance is
+  // computed from the two picked sessions' positions in the history list,
+  // never copied from a default pair (the prototype shipped that bug once).
+  export function diffSummary(sessions, pick, data) {
+    var ids = (sessions || []).map(function (s) { return s.session_id; });
+    var ia = ids.indexOf(pick.a), ib = ids.indexOf(pick.b);
+    var apart = (ia !== -1 && ib !== -1) ? Math.abs(ia - ib) : null;
+    var counts = [(data.born || []).length + " added",
+                  (data.changed || []).length + " changed",
+                  (data.gone || []).length + " dropped"];
+    if ((data.resolved || []).length) counts.push(data.resolved.length + " resolved");
+    return (apart !== null ? apart + " checkpoints apart · " : "") + counts.join(", ");
   }
-  export function renderHistoryRow(item, chipCls, chipLabel, note, suffix) {
-    var cls = "it " + trustClass(item);
-    var suffixHtml = suffix ? '<span class="hist-suffix">' + escapeHtml(suffix) + "</span>" : "";
-    var inner = renderTagChip(chipCls, chipLabel) + '<span class="it-text">' + escapeHtml(item.text) +
-      "</span>" + suffixHtml;
-    var noteHtml = note ? '<div class="hist-note">' + escapeHtml(note) + "</div>" : "";
+  // A changed row shows the old value struck through above the new one. Trust
+  // transitions ride the frozen changed-row shape: changed — "from" → "to",
+  // with "; quote supplied" folded in when the quote check flipped true in
+  // the same step (§8's ratified composite, not a coinage).
+  export function diffChangeLines(fields) {
+    var byField = {};
+    (fields || []).forEach(function (f) { byField[f.field] = f; });
+    var lines = [];
+    if (byField.text) {
+      lines.push('<div class="diff-old">' + escapeHtml(byField.text.from || "") + "</div>");
+    }
+    if (byField.trust) {
+      var to = String(byField.trust.to || "untagged");
+      if (byField.quote_verified && byField.quote_verified.to === true) to += "; quote supplied";
+      lines.push('<div class="diff-trans">changed — “' +
+        escapeHtml(String(byField.trust.from || "untagged")) + "” → “" + escapeHtml(to) + "”</div>");
+    } else if (byField.quote_verified) {
+      lines.push('<div class="diff-trans">changed — quote check ' +
+        (byField.quote_verified.to === true ? "passed" :
+          byField.quote_verified.to === false ? "failed" : "not recorded") + "</div>");
+    }
+    return lines.join("");
+  }
+  export function renderDiffRow(kind, item, extra) {
+    extra = extra || {};
+    var word = DIFF_KINDS[kind];
+    var body = "";
+    if (kind === "changed") body += diffChangeLines(extra.fields);
+    body += '<div class="diff-text' + (kind === "gone" ? " diff-text-dim" : "") + '">' +
+      escapeHtml(item.text || "") + "</div>";
+    if (kind === "resolved" && extra.note) {
+      body += '<div class="diff-trans">' + escapeHtml(extra.note) + "</div>";
+    }
+    var metaBits = [item.trust || "untagged", item.id];
+    if (kind === "gone") metaBits.push("entry retained, no longer in working set");
+    var meta = '<div class="diff-meta">' + trustGlyph(item.trust) + " " +
+      metaBits.map(escapeHtml).join(" · ") + "</div>";
+    var inner = '<span class="diff-sign" aria-hidden="true">' + DIFF_SIGNS[kind] + "</span>" +
+      '<span class="diff-kind">' + word + "</span><div class=\"diff-entry\">" + body + meta + "</div>";
     if (!item.id) {
-      return '<div class="it-wrap"><div class="' + cls + '">' + inner + noteHtml + "</div></div>";
+      return '<div class="diff-row">' + inner + "</div>";
     }
-    bioCounter += 1;
-    var bioId = "bio-" + bioCounter;
-    return '<div class="it-wrap"><button type="button" class="' + cls +
-      '" aria-expanded="false" aria-controls="' + bioId + '" data-bio-toggle data-item-id="' +
-      escapeHtml(item.id) + '">' + inner + "</button>" + noteHtml +
-      '<div class="bio-panel" id="' + bioId + '" hidden></div></div>';
+    return '<button type="button" class="diff-row" data-open-why data-item-id="' +
+      escapeHtml(item.id) + '">' + inner + "</button>";
   }
-  export function renderHistoryGroup(key, label, count, wantOpen, bodyHtml) {
-    var expanded = wantOpen && count > 0;
-    var disabled = count === 0;
-    var marker = expanded ? "▾" : "▸";
-    var btn = '<button type="button" class="sec-toggle" aria-expanded="' +
-      (expanded ? "true" : "false") + '" aria-controls="hist-sec-' + key + '"' +
-      (disabled ? " disabled" : "") + '>' + escapeHtml(label) +
-      ' <span class="count">· ' + count + '</span> <span class="disclosure" aria-hidden="true">' +
-      marker + '</span></button>';
-    var body = '<div id="hist-sec-' + key + '" class="sec-body"' + (expanded ? "" : " hidden") + '>' +
-      '<div class="items">' + bodyHtml + "</div></div>";
-    return '<section class="sec" aria-label="' + escapeHtml(label) + '">' + btn + body + "</section>";
-  }
-  function historyReferent(meta) {
-    if (!meta) return null;
-    if (meta.created) return fmtDate(meta.created);
-    return meta.session_id || null;
-  }
-  export function renderHistoryView(diffData) {
-    var born = diffData.born || [];
-    var resolved = diffData.resolved || [];
-    var trustChanged = diffData.trust_changed || [];
-    var carried = diffData.carried || [];
-    var gone = diffData.gone || [];
-
-    var aTopic = (diffData.a && diffData.a.active_topic) || "(untitled)";
-    var bTopic = (diffData.b && diffData.b.active_topic) || "(untitled)";
-    var html = '<h1 class="page-heading">History</h1>' +
-      '<p class="page-meta">' + escapeHtml(aTopic) + " → " + escapeHtml(bTopic) + "</p>";
-    html += renderHistoryPicker();
-
-    if (state.historyUnreadable > 0) {
+  export function renderDiffView(data, sessions, pick, unreadable) {
+    var html = '<div class="why-crumb"><button type="button" class="back-link" data-diff-back>' +
+      "← ledger</button><span class=\"crumb-sep\">/</span>" +
+      '<span class="crumb-id">Diff</span></div>';
+    html += '<div class="brief-head"><h1 class="page-heading">Diff</h1>' +
+      '<span class="brief-sub">' + escapeHtml(diffSummary(sessions, pick, data)) + "</span></div>";
+    html += renderDiffPicker(sessions, pick);
+    if (unreadable > 0) {
       html += '<div class="banner banner-partial"><span class="banner-icon" aria-hidden="true">ⓘ</span><span>' +
-        escapeHtml(state.historyUnreadable + " session file(s) couldn't be read and were skipped.") + "</span></div>";
+        escapeHtml(unreadable + " session file(s) couldn't be read and were skipped.") + "</span></div>";
     }
-    (diffData.partial || []).forEach(function (p) {
+    (data.partial || []).forEach(function (p) {
       html += '<div class="banner banner-partial"><span class="banner-icon" aria-hidden="true">ⓘ</span><span>' +
         escapeHtml(p) + "</span></div>";
     });
-
-    var hasChanges = born.length || resolved.length || trustChanged.length || carried.length || gone.length;
-    if (!hasChanges) {
-      html += '<div class="state-card"><p class="state-title">No changes between these sessions</p>' +
-        "<p>Items, resolutions, and trust changes will appear here once something changes " +
-        "between the two selected sessions.</p></div>";
-      return html;
+    var rows = [];
+    (data.born || []).forEach(function (it) { rows.push(renderDiffRow("born", it)); });
+    (data.changed || []).forEach(function (e) { rows.push(renderDiffRow("changed", e.item, { fields: e.fields })); });
+    (data.resolved || []).forEach(function (e) { rows.push(renderDiffRow("resolved", e.item, { note: e.note })); });
+    (data.gone || []).forEach(function (it) { rows.push(renderDiffRow("gone", it)); });
+    if (!rows.length) {
+      html += '<div class="state-card"><p class="state-title">no entries changed between these checkpoints</p>' +
+        "<p>Carried, unchanged items write nothing — a carry is not an event.</p></div>";
+    } else {
+      html += '<div class="diff-cols" aria-hidden="true"><span></span><span>Kind</span><span>Entry</span></div>';
+      html += '<div class="diff-rows">' + rows.join("") + "</div>";
     }
-
-    // Contract §8.1: the sighting states carry a named referent — the compared
-    // checkpoint's date, or its session id when the date is missing. The
-    // referent renders in the hist-suffix slot, never inside the chip: the
-    // vocabulary tripwire reads the chip's whole inner text as one token.
-    var refB = historyReferent(diffData.b);
-    var refA = historyReferent(diffData.a);
-    html += renderHistoryGroup("born", "First seen", born.length, true,
-      born.map(function (it) { return renderHistoryRow(it, "t-born", "FIRST SEEN", null, refB); }).join(""));
-    html += renderHistoryGroup("resolved", "Resolved", resolved.length, true,
-      resolved.map(function (e) { return renderHistoryRow(e.item, "t-resolved", "RESOLVED", e.note); }).join(""));
-    html += renderHistoryGroup("trust", "Trust class changed", trustChanged.length, true,
-      trustChanged.map(function (e) {
-        return renderHistoryRow(e.item, "t-trust", "TRUST CLASS CHANGED", null, e.from + " → " + e.to);
-      }).join(""));
-    html += renderHistoryGroup("carried", "Carried", carried.length, false,
-      carried.map(function (e) {
-        return renderHistoryRow(e.item, "t-carried", "CARRIED", null);
-      }).join(""));
-    html += renderHistoryGroup("gone", "Last seen", gone.length, false,
-      gone.map(function (it) { return renderHistoryRow(it, "t-gone", "LAST SEEN", null, refA); }).join(""));
+    html += '<div class="card-foot">A diff is a reading of the ledger, not a mutation of it. Both checkpoints remain on disk. Click a row to open its entry.</div>';
     return html;
   }
   // ---- ledger + session page (#670 slice 2) ----

--- a/plugin/daimon_ui/static/state.js
+++ b/plugin/daimon_ui/static/state.js
@@ -1,9 +1,11 @@
-// Shared mutable app state. Read by pure render functions (defaultSlug, historyPick,
-// historySessions, historyUnreadable) and read/written by the DOM layer in app.js.
+// Shared mutable app state. Read by pure render functions (defaultSlug) and
+// read/written by the DOM layer in app.js. diffSessions/diffPick back the diff
+// view's picker; whyHighlightSid lights the source rung when an entry is
+// opened from a diff row.
 export const state = {
   checkpoints: [], sessionsTotal: 0, activeRef: null, pendingTimer: null, requestId: 0,
   projects: [], defaultSlug: null, currentSlug: null, view: "loading", cameFromGrid: false,
-  historySessions: [], historyUnreadable: 0, historyPick: { a: null, b: null },
-  ledgerSessions: [], sessionSid: null, whyReturn: null, bioCache: {}, lastSearchQ: null,
-  searchTimer: null
+  diffSessions: [], diffUnreadable: 0, diffPick: { a: null, b: null },
+  ledgerSessions: [], sessionSid: null, whyReturn: null, whyHighlightSid: null,
+  bioCache: {}, lastSearchQ: null, searchTimer: null
 };

--- a/plugin/tests/ui/test_diff.py
+++ b/plugin/tests/ui/test_diff.py
@@ -36,6 +36,7 @@ def _write_diff_sessions(d, slug, sid_a, sid_b):
         {"text": "gone question", "id": "o-bbb222bbb222", "trust": "verbatim"},
         {"text": "trust change item", "id": "o-ccc333ccc333", "trust": "verbatim"},
         {"text": "carried item", "id": "o-ddd444ddd444", "trust": "inferred"},
+        {"text": "old wording", "id": "o-fff666fff666", "trust": "verbatim"},
         {"text": "no id item old"},
     ])
     cp_a["project_slug"] = slug
@@ -45,13 +46,14 @@ def _write_diff_sessions(d, slug, sid_a, sid_b):
         {"text": "trust change item", "id": "o-ccc333ccc333", "trust": "inferred"},
         {"text": "carried item", "id": "o-ddd444ddd444", "trust": "inferred"},
         {"text": "new born item", "id": "o-eee555eee555", "trust": "verbatim"},
+        {"text": "new wording", "id": "o-fff666fff666", "trust": "verbatim"},
         {"text": "no id item new"},
     ])
     cp_b["project_slug"] = slug
     (d / f"{sid_b}.json").write_text(json.dumps(cp_b))
 
 
-def test_diff_checkpoints_categorizes_born_resolved_gone_carried_trust_changed(flat_with_events):
+def test_diff_checkpoints_categorizes_born_resolved_gone_carried_changed(flat_with_events):
     d, slug = flat_with_events
     sid_a, sid_b = "diff-a-0001", "diff-b-0002"
     _write_diff_sessions(d, slug, sid_a, sid_b)
@@ -79,13 +81,28 @@ def test_diff_checkpoints_categorizes_born_resolved_gone_carried_trust_changed(f
     assert carried["item"]["id"] == "o-ddd444ddd444"
     assert "sessions_present" not in carried
 
-    assert len(got["trust_changed"]) == 1
-    tc = got["trust_changed"][0]
-    assert tc["item"]["id"] == "o-ccc333ccc333"
-    assert tc["from"] == "verbatim"
-    assert tc["to"] == "inferred"
-
     assert any("without an id" in p for p in got["partial"])
+
+
+def test_diff_changed_rows_carry_old_and_new_values(flat_with_events):
+    """The diff view renders strikethrough old -> new, so the reader must emit
+    the VALUES that changed, not just the field names (#670 slice 3). One
+    changed list covers every tracked field; trust transitions are changed
+    rows like any other — the frozen vocabulary rides 'changed'."""
+    d, slug = flat_with_events
+    sid_a, sid_b = "diff-a-0001", "diff-b-0002"
+    _write_diff_sessions(d, slug, sid_a, sid_b)
+
+    got = reader.diff_checkpoints(d, slug, sid_a, sid_b)
+    assert "trust_changed" not in got
+    by_id = {c["item"]["id"]: c for c in got["changed"]}
+    assert set(by_id) == {"o-ccc333ccc333", "o-fff666fff666"}
+
+    trust_fields = by_id["o-ccc333ccc333"]["fields"]
+    assert {"field": "trust", "from": "verbatim", "to": "inferred"} in trust_fields
+
+    text_fields = by_id["o-fff666fff666"]["fields"]
+    assert {"field": "text", "from": "old wording", "to": "new wording"} in text_fields
 
 
 def test_diff_checkpoints_bad_sid_a_is_error(flat_with_events):

--- a/plugin/tests/ui/test_page_diff.py
+++ b/plugin/tests/ui/test_page_diff.py
@@ -1,0 +1,67 @@
+"""Diff view (#670 slice 3): the diff hangs off the LIFE ladder — a bio rung
+opens the pairwise diff between that sighting and the one before it, and a
+diff row returns to the entry with its source rung highlighted. Kinds render
+the frozen words (added / changed / dropped / resolved), changed rows show
+the old value struck through above the new one, and the footer states what a
+diff is."""
+import urllib.request
+
+
+def _get(url):
+    with urllib.request.urlopen(url) as r:
+        return r.status, r.headers.get_content_type(), r.read()
+
+
+def _js(srv, name):
+    _, _, body = _get(srv + "/static/" + name)
+    return body.decode()
+
+
+def test_diff_view_kinds_are_the_frozen_words(srv):
+    js = _js(srv, "render.js")
+    src = js.split("DIFF_KINDS", 1)[1].split("}", 1)[0]
+    for pair in ('born: "added"', 'changed: "changed"', 'gone: "dropped"',
+                 'resolved: "resolved"'):
+        assert pair in src, pair
+
+
+def test_diff_view_declares_what_a_diff_is(srv):
+    js = _js(srv, "render.js")
+    assert ("A diff is a reading of the ledger, not a mutation of it. "
+            "Both checkpoints remain on disk.") in js
+
+
+def test_diff_summary_counts_from_picker_order(srv):
+    """'N checkpoints apart' is computed from the two picked sessions'
+    positions in the history list — never copied from a default pair."""
+    js = _js(srv, "render.js")
+    assert "checkpoints apart" in js
+
+
+def test_changed_rows_strike_the_old_value(srv):
+    js = _js(srv, "render.js")
+    assert "diff-old" in js
+
+
+def test_bio_rungs_open_the_pairwise_diff(srv):
+    """A LIFE rung carries the session that wrote it; clicking it must open
+    the diff between the previous sighting and that session."""
+    js = _js(srv, "app.js")
+    assert "data-diff-sid" in js
+    assert "/api/diff" in js
+
+
+def test_diff_rows_return_to_the_entry_with_the_rung_lit(srv):
+    render = _js(srv, "render.js")
+    app = _js(srv, "app.js")
+    assert "rung-lit" in render
+    assert "whyHighlightSid" in app
+
+
+def test_the_orphaned_history_view_is_gone(srv):
+    """Slice 2 deleted the History entry points; slice 3 replaces the view
+    itself. The old renderer must not survive as dead code beside the new
+    one — two diff renderings would be two vocabularies waiting to drift."""
+    js = _js(srv, "render.js")
+    assert "renderHistoryView" not in js
+    assert "renderDiffView" in js

--- a/plugin/tests/ui/test_page_refutations.py
+++ b/plugin/tests/ui/test_page_refutations.py
@@ -1,0 +1,43 @@
+"""Refutations lane frontend (#670 slice 3): a refutations pill joins the nav,
+the client fetches /api/refutations, and the lane carries the frozen wording —
+column heads Record / Refutes / Recorded / Origin, the standing footer, and a
+density line instead of a silent cap. State markers print the CLI's own words
+([? candidate · agent-proposed]); nothing is coined at the render layer."""
+import urllib.request
+
+
+def _get(url):
+    with urllib.request.urlopen(url) as r:
+        return r.status, r.headers.get_content_type(), r.read()
+
+
+def test_nav_gains_the_refutations_pill(srv):
+    _, _, body = _get(srv + "/static/app.js")
+    js = body.decode()
+    pills = js.split("nav-pills-slot", 1)[1]
+    assert '"refutations"' in pills
+
+
+def test_client_fetches_the_engine_endpoint(srv):
+    _, _, body = _get(srv + "/static/app.js")
+    js = body.decode()
+    assert "/api/refutations" in js
+
+
+def test_lane_carries_the_frozen_wording(srv):
+    _, _, body = _get(srv + "/static/render.js")
+    js = body.decode()
+    assert "recorded against entries · status, never judgment" in js
+    assert "These records live outside checkpoints and survive checkpoint expiry." in js
+    for col in (">Record<", ">Refutes<", ">Recorded<", ">Origin<"):
+        assert col in js, col
+
+
+def test_lane_state_marker_is_the_cli_word(srv):
+    """The marker glyphs are the CLI's: ✗ active, × overturned, ? candidate.
+    The lane renders refute list; it must not invent a second vocabulary."""
+    _, _, body = _get(srv + "/static/render.js")
+    js = body.decode()
+    src = js.split("REFUTATION_MARKS", 1)[1].split("}", 1)[0]
+    for pair in ('active: "✗"', 'overturned: "×"', 'candidate: "?"'):
+        assert pair in src, pair

--- a/plugin/tests/ui/test_page_strip.py
+++ b/plugin/tests/ui/test_page_strip.py
@@ -1,0 +1,50 @@
+"""Check strip frontend (#670 slice 3): a check strip pill joins the nav in
+the frozen order (briefing · ledger · check strip · refutations), the client
+renders /api/grid, marks open their entry with the column's rung lit, and the
+legend prints the frozen words. No check-now control ships — §7.5.4's
+disposition is undecided and this surface stays read-only."""
+import urllib.request
+
+
+def _get(url):
+    with urllib.request.urlopen(url) as r:
+        return r.status, r.headers.get_content_type(), r.read()
+
+
+def _js(srv, name):
+    _, _, body = _get(srv + "/static/" + name)
+    return body.decode()
+
+
+def test_nav_pill_order_is_the_frozen_chrome(srv):
+    js = _js(srv, "app.js")
+    pills = js.split("Pill order is the frozen chrome", 1)[1].split("forEach", 1)[0]
+    order = [pills.index('"briefing"'), pills.index('"ledger"'),
+             pills.index('"check strip"'), pills.index('"refutations"')]
+    assert order == sorted(order)
+
+
+def test_client_renders_the_grid_endpoint(srv):
+    js = _js(srv, "app.js")
+    assert "/api/grid" in js
+
+
+def test_strip_carries_the_frozen_wording(srv):
+    js = _js(srv, "render.js")
+    assert "one column per checkpoint · click a mark to open that event" in js
+    for legend in ("written / carried", "quote check", "rejection recorded",
+                   "no longer carried"):
+        assert legend in js, legend
+
+
+def test_strip_ships_no_check_now_control(srv):
+    for name in ("render.js", "app.js"):
+        js = _js(srv, name)
+        assert "check now" not in js, name
+
+
+def test_marks_open_the_entry_with_the_rung_lit(srv):
+    js = _js(srv, "app.js")
+    wiring = js.split("wireStripMarks", 1)
+    assert len(wiring) == 2, "strip marks have no wiring"
+    assert "whyHighlightSid" in wiring[1].split("}", 2)[-2] or "whyHighlightSid" in wiring[1]

--- a/plugin/tests/ui/test_reader_grid.py
+++ b/plugin/tests/ui/test_reader_grid.py
@@ -95,6 +95,51 @@ def test_grid_windows_columns_and_reports_what_lies_beyond(tmp_path):
     assert any("older checkpoint" in p for p in got["partial"])
 
 
+def test_grid_skips_check_rows_for_unknown_items(tmp_path):
+    d, slug = _grid_project(tmp_path)
+    (d / slug / "verification.jsonl").write_text(json.dumps({
+        "ts": "2026-08-02T23:00:00Z", "check": "quote", "reason": "compacted",
+        "item_ref": "o-feedfeedfeed"}) + "\n")
+    got = reader.project_grid(d, slug)
+    assert all(not r["checks"] for r in got["rows"])
+
+
+def test_grid_folds_checks_after_head_into_the_head_column(tmp_path):
+    d, slug = _grid_project(tmp_path)
+    (d / slug / "verification.jsonl").write_text(json.dumps({
+        "ts": "2026-08-09T23:00:00Z", "check": "quote", "reason": "compacted",
+        "item_ref": "o-aaa111aaa111"}) + "\n")
+    got = reader.project_grid(d, slug)
+    a = {r["id"]: r for r in got["rows"]}["o-aaa111aaa111"]
+    assert a["checks"][0]["column"] == "grid-s3"  # head
+
+
+def test_grid_counts_checks_that_predate_the_window(tmp_path):
+    d, slug = _grid_project(tmp_path)
+    for i in range(4, 12):
+        _write_session(d, slug, f"grid-s{i}", f"2026-08-{i:02d}T10:00:00Z", [
+            {"text": "the build gates on the bundle", "id": "o-aaa111aaa111",
+             "trust": "verbatim", "quote": "gates on the bundle"},
+        ])
+    (d / slug / "verification.jsonl").write_text(json.dumps({
+        "ts": "2026-08-02T23:00:00Z", "check": "quote", "reason": "compacted",
+        "item_ref": "o-aaa111aaa111"}) + "\n")
+    got = reader.project_grid(d, slug)
+    a = {r["id"]: r for r in got["rows"]}["o-aaa111aaa111"]
+    assert a["checks"] == []
+    assert any("quote check(s) predate this window" in p for p in got["partial"])
+
+
+def test_grid_windows_rows_and_reports_what_lies_beyond(tmp_path):
+    d, slug = _grid_project(tmp_path)
+    many = [{"text": f"object number {i}", "id": f"o-{i:012x}"}
+            for i in range(reader.GRID_ROWS + 5)]
+    _write_session(d, slug, "grid-s4", "2026-08-04T10:00:00Z", many)
+    got = reader.project_grid(d, slug)
+    assert len(got["rows"]) == reader.GRID_ROWS
+    assert any("further object(s) beyond this window" in p for p in got["partial"])
+
+
 def test_grid_unknown_project_is_empty_not_an_error(tmp_path):
     d = tmp_path / "checkpoints"
     d.mkdir()

--- a/plugin/tests/ui/test_reader_grid.py
+++ b/plugin/tests/ui/test_reader_grid.py
@@ -1,0 +1,104 @@
+"""Check strip reader (#670 slice 3): project_grid widens the shared walk
+into object × checkpoint lanes. Sightings come from _walk_transitions with
+the trust the item carried AT that session; quote checks carry no session
+attribution on disk, so they are bucketed by ts into the checkpoint interval
+they precede and the payload keeps their exact ts — the viewer must never
+claim a session wrote them."""
+import json
+
+from daimon_ui import reader
+from tests.ui.conftest import make_checkpoint
+
+
+def _write_session(d, slug, sid, created, questions):
+    cp = make_checkpoint(created=created, session_id=sid, open_questions=questions)
+    cp["project_slug"] = slug
+    (d / f"{sid}.json").write_text(json.dumps(cp))
+
+
+def _grid_project(tmp_path):
+    d = tmp_path / "checkpoints"
+    slug = "-grid-proj"
+    bucket = d / slug
+    bucket.mkdir(parents=True)
+    (bucket / "latest.json").write_text(json.dumps(make_checkpoint()))
+    _write_session(d, slug, "grid-s1", "2026-08-01T10:00:00Z", [
+        {"text": "the build gates on the bundle", "id": "o-aaa111aaa111"},
+        {"text": "flags are cached at boot", "id": "o-bbb222bbb222", "trust": "inferred"},
+    ])
+    _write_session(d, slug, "grid-s2", "2026-08-02T10:00:00Z", [
+        {"text": "the build gates on the bundle", "id": "o-aaa111aaa111",
+         "trust": "verbatim", "quote": "gates on the bundle"},
+        {"text": "flags are cached at boot", "id": "o-bbb222bbb222", "trust": "inferred"},
+    ])
+    _write_session(d, slug, "grid-s3", "2026-08-03T10:00:00Z", [
+        {"text": "the build gates on the bundle", "id": "o-aaa111aaa111",
+         "trust": "verbatim", "quote": "gates on the bundle"},
+    ])
+    return d, slug
+
+
+def test_grid_columns_are_the_session_window_oldest_first(tmp_path):
+    d, slug = _grid_project(tmp_path)
+    got = reader.project_grid(d, slug)
+    assert got["ok"] is True
+    assert [c["session_id"] for c in got["columns"]] == ["grid-s1", "grid-s2", "grid-s3"]
+    assert [c["is_head"] for c in got["columns"]] == [False, False, True]
+
+
+def test_grid_cells_carry_kind_and_trust_at_that_session(tmp_path):
+    d, slug = _grid_project(tmp_path)
+    got = reader.project_grid(d, slug)
+    rows = {r["id"]: r for r in got["rows"]}
+    a = rows["o-aaa111aaa111"]["cells"]
+    assert a["grid-s1"]["kind"] == "first_seen"
+    assert a["grid-s1"]["trust"] is None            # untagged when first written
+    assert a["grid-s2"]["kind"] == "changed"
+    assert a["grid-s2"]["trust"] == "verbatim"      # the class it held THEN
+
+
+def test_grid_marks_the_departure_at_the_transition_column(tmp_path):
+    """A vanished object marks the session whose absence recorded it — the
+    same attribution the ledger makes — and the lane is dashed after it."""
+    d, slug = _grid_project(tmp_path)
+    got = reader.project_grid(d, slug)
+    b = {r["id"]: r for r in got["rows"]}["o-bbb222bbb222"]
+    assert b["cells"]["grid-s3"]["kind"] == "last_seen"
+    assert b["gone_after"] == "grid-s3"
+
+
+def test_grid_buckets_quote_checks_by_ts_without_naming_a_session(tmp_path):
+    d, slug = _grid_project(tmp_path)
+    (d / slug / "verification.jsonl").write_text(json.dumps({
+        "ts": "2026-08-02T23:00:00Z", "check": "quote", "reason": "compacted",
+        "item_ref": "o-aaa111aaa111"}) + "\n")
+    got = reader.project_grid(d, slug)
+    a = {r["id"]: r for r in got["rows"]}["o-aaa111aaa111"]
+    assert len(a["checks"]) == 1
+    check = a["checks"][0]
+    # bucketed into the interval that closed at grid-s3; the ts stays exact
+    assert check["column"] == "grid-s3"
+    assert check["ts"] == "2026-08-02T23:00:00Z"
+    assert "session" not in check
+
+
+def test_grid_windows_columns_and_reports_what_lies_beyond(tmp_path):
+    d, slug = _grid_project(tmp_path)
+    for i in range(4, 12):
+        _write_session(d, slug, f"grid-s{i}", f"2026-08-{i:02d}T10:00:00Z", [
+            {"text": "the build gates on the bundle", "id": "o-aaa111aaa111",
+             "trust": "verbatim", "quote": "gates on the bundle"},
+        ])
+    got = reader.project_grid(d, slug)
+    assert len(got["columns"]) == reader.GRID_COLUMNS
+    assert got["older_columns"] == 11 - reader.GRID_COLUMNS
+    assert any("older checkpoint" in p for p in got["partial"])
+
+
+def test_grid_unknown_project_is_empty_not_an_error(tmp_path):
+    d = tmp_path / "checkpoints"
+    d.mkdir()
+    got = reader.project_grid(d, "-nothing-here")
+    assert got["ok"] is True
+    assert got["columns"] == []
+    assert got["rows"] == []

--- a/plugin/tests/ui/test_server_grid.py
+++ b/plugin/tests/ui/test_server_grid.py
@@ -1,0 +1,23 @@
+"""/api/grid (#670 slice 3): the check strip's data — reader.project_grid
+over the same walk every other surface reads."""
+import json
+import urllib.request
+
+
+def _get(url):
+    with urllib.request.urlopen(url) as r:
+        return json.loads(r.read())
+
+
+def test_api_grid_happy_path(srv_flat):
+    out = _get(srv_flat + "/api/grid")
+    assert out["ok"] is True
+    assert [c["session_id"] for c in out["columns"]] == [
+        "aaaa-1111", "bbbb-2222", "rollout-2026-08-06-cccc"]
+    assert out["columns"][-1]["is_head"] is True
+
+
+def test_api_grid_rejects_unknown_slug(srv_flat):
+    out = _get(srv_flat + "/api/grid?project=not-a-project")
+    assert out["ok"] is False
+    assert set(out["error"]) == {"what", "why", "fix"}

--- a/plugin/tests/ui/test_server_refutations.py
+++ b/plugin/tests/ui/test_server_refutations.py
@@ -1,0 +1,104 @@
+"""Refutations lane (#670 slice 3): /api/refutations dispatches to the
+refutations engine — the lane renders `daimon refute list`, it never grows a
+second fold. Row order is the CLI's own (active first, then updated_at, then
+refutation_id), owned by refutations.listing() so the two surfaces cannot
+drift apart."""
+import json
+import threading
+from urllib.request import urlopen
+
+import pytest
+
+from daimon_briefing import refutations, store
+from daimon_ui import server
+
+
+def _cp(sid):
+    return {
+        "session_id": sid,
+        "working_context": {
+            "active_topic": {"text": "wiring the lane"},
+            "open_questions": [],
+            "recent_decisions": [],
+        },
+        "epistemic_snapshot": {
+            "strong_beliefs": [], "uncertainties": [],
+            "contradictions_flagged": [],
+        },
+    }
+
+
+@pytest.fixture
+def refut_proj(tmp_checkpoint_dir, tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    store.write_checkpoint("S1", _cp("S1"), project_dir=proj)
+    return proj
+
+
+@pytest.fixture
+def refut_srv(refut_proj, tmp_checkpoint_dir):
+    slug = store.project_slug(refut_proj)
+    s = server.make_server(tmp_checkpoint_dir, slug, refut_proj.name, port=0)
+    t = threading.Thread(target=s.serve_forever, daemon=True)
+    t.start()
+    yield f"http://127.0.0.1:{s.server_address[1]}"
+    s.shutdown()
+
+
+def _get(base, path):
+    with urlopen(base + path) as r:
+        return json.loads(r.read())
+
+
+def test_listing_is_the_cli_order(refut_proj):
+    """active sorts before candidate regardless of recency — the shared
+    listing() carries the exact sort _cmd_refute_list used inline."""
+    cand = refutations.assert_refutation(
+        subject="the newer candidate", verdict="does not hold",
+        scope="tests", evidence=["artifact:a"], channel="cli-agent",
+        project_dir=refut_proj)
+    active = refutations.assert_refutation(
+        subject="the older active", verdict="does not hold",
+        scope="tests", evidence=["artifact:b"], channel="cli-tty",
+        ratified=True, project_dir=refut_proj)
+    rows = refutations.listing(project_dir=refut_proj)
+    assert [r["refutation_id"] for r in rows] == [active, cand]
+    assert rows[0]["state"] == "active"
+
+
+def test_listing_filters_states(refut_proj):
+    refutations.assert_refutation(
+        subject="a candidate", verdict="does not hold", scope="tests",
+        evidence=["artifact:a"], channel="cli-agent", project_dir=refut_proj)
+    assert refutations.listing(states={"active"}, project_dir=refut_proj) == []
+
+
+def test_endpoint_rows_are_the_engines(refut_srv, refut_proj):
+    rid = refutations.assert_refutation(
+        subject="feature flags reload live", verdict="does not hold",
+        scope="the boot path", evidence=["artifact:src/boot.ts"],
+        anchors=["o-6ba3d7e51f08"], channel="cli-agent",
+        project_dir=refut_proj)
+    out = _get(refut_srv, "/api/refutations")
+    assert out["ok"] is True
+    row = out["rows"][0]
+    # engine fields pass through untouched — no viewer reshaping
+    assert row["refutation_id"] == rid
+    assert row["subject"] == "feature flags reload live"
+    assert row["state"] == "candidate"
+    assert row["asserted_by"] == "agent"
+    assert row["anchors"] == ["o-6ba3d7e51f08"]
+
+
+def test_endpoint_empty_ledger_is_ok_and_empty(refut_srv):
+    out = _get(refut_srv, "/api/refutations")
+    assert out["ok"] is True
+    assert out["rows"] == []
+
+
+def test_endpoint_rejects_unknown_slug(refut_srv):
+    out = _get(refut_srv, "/api/refutations?project=not-a-project")
+    assert out["ok"] is False
+    assert set(out["error"]) == {"what", "why", "fix"}


### PR DESCRIPTION
Refs #670

## What

- Refutations lane: a new surface rendering the refute list engine. `refutations.listing()` now owns the list order (active first, then updated_at, then id); the CLI list command and the viewer's `/api/refutations` both call it, so the two surfaces cannot drift apart. Rows print the CLI's own state marker (`[? candidate · agent-proposed]`) plus subject, anchors, recorded date, and author; anchors that are item ids deep-link to their entry page, and the footer states that these records live outside checkpoints and survive checkpoint expiry. The empty state reuses the CLI's own words.
- Diff, restructured to hang off the LIFE ladder: a bio rung a session wrote opens the pairwise diff between the previous sighting and that session, and a diff row returns to the entry with its source rung highlighted. Kinds render as `+ added`, `~ changed`, `- dropped`, `- resolved`; changed rows show the old value struck through above the new one, so `diff_checkpoints` now emits per-field from/to values for every tracked field in one changed list (trust transitions ride the changed-row shape instead of their own bucket). The summary counts checkpoints apart from the two picked sessions' positions in the history list, never from a default pair. The orphaned History renderer is deleted; the diff has no nav pill and is reachable from the ladder.
- Check strip: object by checkpoint lanes over the same shared walk every other surface reads. Sighting marks wear the trust glyph of the class the item held at that session (the walk now stamps trust on every event); a departure marks the transition session and the lane reads dashed after it. Quote checks carry no session attribution on disk, so each is bucketed by timestamp into the checkpoint interval it precedes and keeps its exact ts in the hover: it states when, not who. Both axes are windowed with a visible line naming what lies beyond, never a silent cap. No check-now control ships; the strip stays read-only.
- Nav pills now read briefing, ledger, check strip, refutations.

## Why

Slice 3 of #670's build order. The ledger says what each session wrote; these three surfaces answer the follow-up questions: what refutes an entry, what changed between two checkpoints, and where every object was checked across its life.

## Tests

- ui suite 234 green locally, daimon_ui coverage 100%; full suite 3572 passed, 2 skipped. New behavior landed red-first:
  - `tests/ui/test_server_refutations.py`: listing order (active before candidate), state filtering, engine fields passing through untouched, empty ledger, slug refusal
  - `tests/ui/test_page_refutations.py`: refutations pill, frozen lane wording and column heads, CLI state marker glyphs
  - `tests/ui/test_diff.py`: changed rows carry per-field old and new values; trust transitions fold into the changed list
  - `tests/ui/test_page_diff.py`: frozen kind words, strikethrough class, picker-order summary, rung wiring, rung-lit return, old renderer gone
  - `tests/ui/test_reader_grid.py`: column window and order, trust at that session, departure at the transition column, ts bucketing without a session claim, both density windows, checks predating the window, unknown project
  - `tests/ui/test_server_grid.py` and `tests/ui/test_page_strip.py`: endpoint dispatch, pill order, frozen legend words, no check-now control, mark wiring
- Verified in a browser against a real store (83 sessions, 3400+ objects): briefing to entry to ladder rung to diff, changed rows with struck old text, diff row back to the entry with the rung lit, check strip lanes with hover card and honest density banners, refutations lane rendering a real record.
