### PR TITLE
feat(ui): print view sets one checkpoint as a printed record

### DIFF
--- a/plugin/daimon_ui/reader.py
+++ b/plugin/daimon_ui/reader.py
@@ -632,7 +632,12 @@ def session_events(data_dir: Path, slug: str, sid: str) -> dict:
         obj = by_item.setdefault(ev["item_id"], {
             "id": ev["item_id"], "text": item.get("text"),
             "trust": item.get("trust"),
-            "kind": _SECTION_KIND.get(item.get("section")), "events": []})
+            "kind": _SECTION_KIND.get(item.get("section")), "events": [],
+            # The print view's provenance line: the stored quote's PRESENCE
+            # and origin, never the quote text — this payload leaves the
+            # machine for a render layer, and presence answers the question.
+            "has_quote": bool(item.get("quote")),
+            "origin_session": _norm_str(item.get("origin_session"))})
         obj["events"].append({"kind": ev["kind"], "ts": ev["ts"], "detail": ev["detail"]})
 
     objects = sorted(by_item.values(), key=lambda o: (

--- a/plugin/daimon_ui/static/app.css
+++ b/plugin/daimon_ui/static/app.css
@@ -1213,3 +1213,66 @@
   .strip-legend .glyph { margin: 0; }
   .strip-tick-legend { position: static; width: 1px; height: 12px; display: inline-block; }
   .strip-line-legend { position: static; width: 14px; height: 1px; display: inline-block; }
+
+  /* Print view: one checkpoint set as a printed record — no rows, no rules,
+     claims at reading size with provenance as a hanging monospace margin. */
+  .print-sub { font-family: var(--mono); font-size: 11.5px; color: var(--ink-tertiary); }
+  .print-card {
+    max-width: 720px;
+    border: 1px solid var(--border-strong);
+    border-radius: 8px;
+    background: var(--surface);
+    overflow: hidden;
+  }
+  .print-head {
+    padding: 24px 26px 10px;
+    border-bottom: 1px solid var(--border-subtle);
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--ink-tertiary);
+  }
+  .print-blocks {
+    padding: 20px 26px 26px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+  .print-block {
+    display: grid;
+    grid-template-columns: 118px 1fr;
+    gap: 0 18px;
+  }
+  .print-margin {
+    font-family: var(--mono);
+    font-size: 11px;
+    line-height: 1.7;
+    color: var(--ink-tertiary);
+    text-align: right;
+    overflow-wrap: anywhere;
+  }
+  .print-body { border-left: 1px solid var(--border-subtle); padding-left: 18px; min-width: 0; }
+  .print-claim {
+    margin: 0;
+    font-size: 15.5px;
+    line-height: 1.55;
+    color: var(--ink);
+    text-wrap: pretty;
+    overflow-wrap: anywhere;
+  }
+  .print-prov {
+    margin: 6px 0 0;
+    font-family: var(--mono);
+    font-size: 11.5px;
+    line-height: 1.6;
+    color: var(--ink-tertiary);
+  }
+  .why-actions { margin-top: 14px; display: flex; gap: 8px; }
+
+  @media (max-width: 720px) {
+    .print-block { grid-template-columns: 1fr; }
+    .print-margin { text-align: left; }
+    .print-body { border-left: 0; padding-left: 0; }
+  }

--- a/plugin/daimon_ui/static/app.js
+++ b/plugin/daimon_ui/static/app.js
@@ -2,7 +2,8 @@ import {
   ACT_ITEM_ID_RE, displaySid, escapeHtml, fmtRelative, navCurrent, renderBioPanel,
   renderDiffView, renderEmptyProjects, renderError, renderLedgerSessions, renderLedgerView,
   renderProjCard, renderRefutationsView, renderSearchResults, renderSections,
-  renderSessionView, renderSidebarScope, renderStripView, renderWhyView, skeletonHtml
+  renderPrintView, renderSessionView, renderSidebarScope, renderStripView, renderWhyView,
+  skeletonHtml
 } from "./render.js";
 import { state } from "./state.js";
 
@@ -78,7 +79,7 @@ import { state } from "./state.js";
     var slot = document.getElementById("nav-pills-slot");
     slot.innerHTML = "";
     var inProject = state.currentSlug &&
-      ["project", "ledger", "session", "search", "why", "refutations", "diff", "strip"].indexOf(state.view) !== -1;
+      ["project", "ledger", "session", "search", "why", "refutations", "diff", "strip", "print"].indexOf(state.view) !== -1;
     if (!inProject) return;
     // Pill order is the frozen chrome: briefing · ledger · check strip · refutations.
     [["briefing", "project", goBriefing], ["ledger", "ledger", enterLedger],
@@ -605,6 +606,7 @@ import { state } from "./state.js";
     var reqId = state.requestId;
     var cacheKey = reqId + ":" + itemId;
     function paint(data) {
+      state.whyBio = data; // the print door reads the ladder's tail from here
       panel.innerHTML = renderBioPanel(data, state.whyHighlightSid);
       wireRungOpeners(panel, data);
     }
@@ -686,15 +688,19 @@ import { state } from "./state.js";
     if (!slug || !ACT_ITEM_ID_RE.test(itemId || "")) return;
     // Remember which surface the entry was opened from: back must return the
     // reader to the ledger or session page they were on, not to the briefing.
-    if (state.view === "ledger") state.whyReturn = { view: "ledger" };
-    else if (state.view === "session") state.whyReturn = { view: "session", sid: state.sessionSid };
-    else if (state.view === "refutations") state.whyReturn = { view: "refutations" };
-    else if (state.view === "diff") state.whyReturn = { view: "diff", a: state.diffPick.a, b: state.diffPick.b };
-    else if (state.view === "strip") state.whyReturn = { view: "strip" };
-    else state.whyReturn = null;
-    // Only a diff row or a strip mark lights a rung; any other door opens
-    // the ladder unlit.
-    if (state.view !== "diff" && state.view !== "strip") state.whyHighlightSid = null;
+    // Returning from the print view is not a new door: the entry keeps the
+    // return target and highlight it had before printing.
+    if (state.view !== "print") {
+      if (state.view === "ledger") state.whyReturn = { view: "ledger" };
+      else if (state.view === "session") state.whyReturn = { view: "session", sid: state.sessionSid };
+      else if (state.view === "refutations") state.whyReturn = { view: "refutations" };
+      else if (state.view === "diff") state.whyReturn = { view: "diff", a: state.diffPick.a, b: state.diffPick.b };
+      else if (state.view === "strip") state.whyReturn = { view: "strip" };
+      else state.whyReturn = null;
+      // Only a diff row or a strip mark lights a rung; any other door opens
+      // the ladder unlit.
+      if (state.view !== "diff" && state.view !== "strip") state.whyHighlightSid = null;
+    }
     state.view = "why";
     renderNavPills();
     state.requestId += 1;
@@ -725,12 +731,67 @@ import { state } from "./state.js";
           else { loadList(); }
         });
         var bio = document.getElementById("why-bio");
+        state.whyBio = null; // a stale ladder must not aim the print door
         if (bio) loadBiography(itemId, bio);
+        var printBtn = sectionsEl.querySelector("[data-open-print]");
+        if (printBtn) printBtn.addEventListener("click", function () {
+          var chain = (state.whyBio && state.whyBio.trust_anatomy &&
+            state.whyBio.trust_anatomy.chain) || [];
+          if (!chain.length) return; // door arms once the ladder loads
+          enterPrint(chain[chain.length - 1].session_id, itemId);
+        });
       }).catch(function () {
         if (reqId !== state.requestId) return;
         sectionsEl.innerHTML = "";
         showError(stateEl, {
           what: "Could not load this entry.",
+          why: "The request to the daimon server failed.",
+          fix: "Check the server is running and try again."
+        });
+      });
+  }
+  // ---- print view (#670 slice 4): one checkpoint, set as a printed record.
+  // Same /api/session payload the session page renders — no second walk. ----
+  function enterPrint(sid, itemId) {
+    if (!state.currentSlug || !sid) return;
+    var slug = state.currentSlug;
+    state.view = "print";
+    state.printItemId = itemId;
+    state.requestId += 1;
+    var reqId = state.requestId;
+    renderNavPills();
+    var stateEl = document.getElementById("state");
+    var sectionsEl = document.getElementById("sections");
+    var mainEl = document.getElementById("main");
+    mainEl.setAttribute("aria-busy", "true");
+    if (state.pendingTimer) clearTimeout(state.pendingTimer);
+    state.pendingTimer = setTimeout(function () {
+      if (reqId !== state.requestId) return;
+      stateEl.innerHTML = skeletonHtml();
+    }, 1000);
+    api("/api/session?project=" + encodeURIComponent(slug) + "&sid=" + encodeURIComponent(sid))
+      .then(function (data) {
+        if (reqId !== state.requestId) return; // superseded by a newer navigation
+        clearTimeout(state.pendingTimer);
+        mainEl.removeAttribute("aria-busy");
+        stateEl.innerHTML = "";
+        if (!data.ok) {
+          sectionsEl.innerHTML = "";
+          showError(stateEl, data.error);
+          return;
+        }
+        sectionsEl.innerHTML = renderPrintView(data);
+        toTop();
+        announce("Print view loaded.");
+        var back = sectionsEl.querySelector("[data-print-back]");
+        if (back) back.addEventListener("click", function () { openWhy(state.printItemId); });
+      }).catch(function () {
+        if (reqId !== state.requestId) return;
+        clearTimeout(state.pendingTimer);
+        mainEl.removeAttribute("aria-busy");
+        sectionsEl.innerHTML = "";
+        showError(stateEl, {
+          what: "Could not load the print view.",
           why: "The request to the daimon server failed.",
           fix: "Check the server is running and try again."
         });

--- a/plugin/daimon_ui/static/render.js
+++ b/plugin/daimon_ui/static/render.js
@@ -972,7 +972,54 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
 
     html += '<div class="why-life"><span class="why-label">Life</span>' +
       '<div id="why-bio" class="why-bio"></div></div>';
+    // The door to the print view: the entry's own footer, per the frozen
+    // design. The button arms once the biography arrives — the print shows
+    // the checkpoint of the entry's latest sighting, and only the ladder
+    // knows which one that is.
+    html += '<div class="why-actions"><button type="button" class="ledger-ck-open" data-open-print>print view</button></div>';
     html += '<div class="card-foot">read-only · this page renders the record; it holds nothing of its own</div>';
     html += "</div></div>";
+    return html;
+  }
+
+  // ---- print view (#670 slice 4): one checkpoint, set as a printed record ----
+  // No rows, no rules: each object is a claim at reading size with its
+  // provenance as a hanging monospace margin. The provenance line states the
+  // stored quote's presence and origin, never the quote text.
+  export function printProvenance(o) {
+    if (o.has_quote) {
+      return "quote stored" + (o.origin_session ? " · " + displaySid(o.origin_session) : "");
+    }
+    return o.trust ? "no quote stored" : "no class asserted · no quote stored";
+  }
+  export function renderPrintBlock(o) {
+    var ev = (o.events && o.events[0]) || null;
+    var margin = [escapeHtml(o.id), escapeHtml(o.trust || "untagged")];
+    if (ev) margin.push(escapeHtml(ledgerEventText(ev)));
+    return '<div class="print-block">' +
+      '<div class="print-margin">' + margin.join("<br>") + "</div>" +
+      '<div class="print-body"><p class="print-claim">' + escapeHtml(o.text || "") + "</p>" +
+      '<p class="print-prov">' + escapeHtml(printProvenance(o)) + "</p></div></div>";
+  }
+  export function renderPrintView(data) {
+    var s = data.session || {};
+    var html = '<div class="why-crumb"><button type="button" class="back-link" data-print-back>' +
+      "← entry</button><span class=\"crumb-sep\">/</span>" +
+      '<span class="print-sub">print view · one checkpoint, set as a printed record</span></div>';
+    (data.partial || []).forEach(function (p) {
+      html += '<div class="banner banner-partial"><span class="banner-icon" aria-hidden="true">ⓘ</span><span>' +
+        escapeHtml(p) + "</span></div>";
+    });
+    html += '<div class="print-card">' +
+      '<div class="print-head">Checkpoint ' + escapeHtml(displaySid(s.session_id)) +
+      " · " + escapeHtml(fmtDateTime(s.created)) + "</div>";
+    if (!data.objects || data.objects.length === 0) {
+      html += '<div class="state-card"><p class="state-title">No recorded events from this session</p>' +
+        "<p>Carried, unchanged items write nothing — a carry is not an event.</p></div>";
+    } else {
+      html += '<div class="print-blocks">' + data.objects.map(renderPrintBlock).join("") + "</div>";
+    }
+    html += "</div>";
+    html += '<div class="card-foot">read-only · this page reads the ledger; it holds nothing of its own</div>';
     return html;
   }

--- a/plugin/daimon_ui/static/state.js
+++ b/plugin/daimon_ui/static/state.js
@@ -7,5 +7,6 @@ export const state = {
   projects: [], defaultSlug: null, currentSlug: null, view: "loading", cameFromGrid: false,
   diffSessions: [], diffUnreadable: 0, diffPick: { a: null, b: null },
   ledgerSessions: [], sessionSid: null, whyReturn: null, whyHighlightSid: null,
+  whyBio: null, printItemId: null,
   bioCache: {}, lastSearchQ: null, searchTimer: null
 };

--- a/plugin/tests/ui/test_page_print.py
+++ b/plugin/tests/ui/test_page_print.py
@@ -1,0 +1,45 @@
+"""Print view (#670 slice 4): one checkpoint set as a printed record. The door
+is the entry page's footer; back returns to the entry. Blocks render a hanging
+monospace margin (id / trust class / event) beside the claim at reading size,
+with the provenance line under it — the stored quote's presence and origin,
+never the quote text itself. Renders the same session_events the session page
+reads, so the two surfaces cannot disagree."""
+import urllib.request
+
+
+def _get(url):
+    with urllib.request.urlopen(url) as r:
+        return r.status, r.headers.get_content_type(), r.read()
+
+
+def _js(srv, name):
+    _, _, body = _get(srv + "/static/" + name)
+    return body.decode()
+
+
+def test_print_view_carries_the_frozen_wording(srv):
+    js = _js(srv, "render.js")
+    assert "print view · one checkpoint, set as a printed record" in js
+    assert "no class asserted · no quote stored" in js
+    assert "quote stored" in js
+    assert "no quote stored" in js
+
+
+def test_the_entry_footer_is_the_door(srv):
+    js = _js(srv, "render.js")
+    assert "data-open-print" in js
+    assert "← entry" in js
+
+
+def test_back_returns_to_the_entry(srv):
+    js = _js(srv, "app.js")
+    assert "data-print-back" in js
+
+
+def test_print_renders_the_session_engine(srv):
+    """No second walk: the print view fetches the same /api/session payload
+    the session page renders."""
+    js = _js(srv, "app.js")
+    wiring = js.split("enterPrint", 1)
+    assert len(wiring) == 2, "print view has no entry point"
+    assert "/api/session" in wiring[1]

--- a/plugin/tests/ui/test_reader_session_page.py
+++ b/plugin/tests/ui/test_reader_session_page.py
@@ -97,3 +97,27 @@ def test_receipt_rides_along_only_when_the_project_opted_in(session_history):
     (d / "s2-bbbb.json").write_text(json.dumps(session))
     result = reader.session_events(d, slug, "s2-bbbb")
     assert result["session"]["receipt"]["state"] in ("match", "mismatch", "missing")
+
+def test_session_objects_carry_quote_presence_and_origin(tmp_path):
+    """The print view's provenance line states the stored quote's PRESENCE and
+    its origin session — never the quote text itself (#670 slice 4). The
+    fields ride the same session_events payload the session page reads."""
+    d = tmp_path / "checkpoints"
+    slug = "-tmp-proj"
+    (d / slug).mkdir(parents=True)
+    quoted = _item("o-aaa111aaa111", "build gates on bundle", "verbatim")
+    quoted["quote"] = "gates on the bundle"
+    quoted["origin_session"] = "s0-origin"
+    bare = _item("o-bbb222bbb222", "no class asserted here")
+    (d / "s1-aaaa.json").write_text(json.dumps(_cp(
+        "s1-aaaa", "2026-08-04T10:00:00Z", slug, [quoted, bare])))
+    (d / slug / "latest.json").write_text(json.dumps(_cp(
+        "s1-aaaa", "2026-08-04T10:00:00Z", slug, [])))
+
+    result = reader.session_events(d, slug, "s1-aaaa")
+    by_id = {o["id"]: o for o in result["objects"]}
+    assert by_id["o-aaa111aaa111"]["has_quote"] is True
+    assert by_id["o-aaa111aaa111"]["origin_session"] == "s0-origin"
+    assert "gates on the bundle" not in json.dumps(result)  # presence, not text
+    assert by_id["o-bbb222bbb222"]["has_quote"] is False
+    assert by_id["o-bbb222bbb222"]["origin_session"] is None


### PR DESCRIPTION
Closes #670

## What

- Print view: one checkpoint set as a printed record. No rows, no rules: each object renders as a claim at reading size with its provenance as a hanging monospace margin (id, trust class, event and time). The provenance line under each claim states the stored quote's presence and its origin session ("quote stored · s-XXXXXXXX", "no quote stored", "no class asserted · no quote stored") and never the quote text itself; session objects now carry `has_quote` and `origin_session` so quotes stay off the wire.
- The door is the entry page's footer: a print view button that arms once the biography loads (the print shows the checkpoint of the entry's latest sighting, and only the ladder knows which one that is). Back reads "← entry" and returns to the same entry with its return target and rung highlight intact.
- No second walk: the view fetches the same `/api/session` payload the session page renders, so the two surfaces cannot disagree about what a session wrote.

## Why

Final slice of #670's build order: briefing, search and entry (#671); ledger and session page (#675); refutations lane, diff and check strip (#676); and now the printed-record reading of a single checkpoint. This closes the issue.

## Tests

- ui suite 239 green locally, daimon_ui coverage 100%. New behavior landed red-first:
  - `tests/ui/test_reader_session_page.py`: session objects carry quote presence and origin, and the payload never contains the quote text
  - `tests/ui/test_page_print.py`: frozen wording (print view header line, the three provenance forms), the entry-footer door, the back control, and the view fetching the session engine
- Verified in a browser against a real store: entry to print view (hanging margins, provenance lines on real objects) and back to the same entry.
