### PR TITLE
feat(relations): typed relation ledger in shadow mode

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -31,7 +31,7 @@ import traceback
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from . import anchor, briefing, capture, carry, config, configure, harvest, inspector, ledger, llm, normalize, privacy, provenance, recall, receipts, redact, refutations, render, schema, serializer, store, teamsync, transcript, worldcheck
+from . import anchor, briefing, capture, carry, config, configure, harvest, inspector, ledger, llm, normalize, privacy, provenance, recall, receipts, redact, refutations, relations, render, schema, serializer, store, teamsync, transcript, worldcheck
 from . import __version__
 
 # The serialize.log ledger subsystem lives in ledger.py (#147 + #162, pure
@@ -1398,6 +1398,15 @@ def _cmd_forget(args) -> int:
     # forgotten value goes with it whether or not it was the named target.
     forgotten_refutations = refutations.forget_content_key(
         content_hash, project_dir=project)
+    # #678 fork A: relation rows hold no text, but an edge touching this item
+    # is an equivalence CLAIM about its content (an `exact-text` rail against
+    # a surviving twin re-derives what the value was), and post-forget the
+    # relations ledger would be the only surface binding the forgotten id to
+    # its sessions, kind, and revision-chain length. The scrub is id-keyed —
+    # the tombstone above landed on this exact id — and the audit's
+    # relations-ledger scan is what proves it reached the edges.
+    forgotten_relations = relations.forget_item_id(
+        target["id"], project_dir=project)
     # #422: the serializer chunk cache holds PRE-redaction extraction output
     # (quote verification forbids redacting before caching, #125), keyed by
     # chunk text — the forgotten value cannot be located selectively, so the
@@ -1447,6 +1456,9 @@ def _cmd_forget(args) -> int:
     if forgotten_refutations:
         surfaces.append(f"{len(forgotten_refutations)} refutation(s) "
                         f"({', '.join(forgotten_refutations)})")
+    if forgotten_relations:
+        surfaces.append(f"{len(forgotten_relations)} relation(s) "
+                        f"({', '.join(forgotten_relations)})")
     print(f"forgot {target['id']} (content hash {content_hash}) — "
           f"removed from {' and '.join(surfaces) or 'no store'}; "
           "tombstone recorded")

--- a/plugin/daimon_briefing/privacy.py
+++ b/plugin/daimon_briefing/privacy.py
@@ -18,7 +18,8 @@ import sqlite3
 import time
 from pathlib import Path
 
-from . import config, normalize, refutations, store, surfaces, teamproject
+from . import (config, normalize, refutations, relations, store, surfaces,
+               teamproject)
 
 # Plaintext-bearing item fields — the same CLASS policy.redact_checkpoint
 # enumerates (its links[].target and active_topic coverage lives in _hashes
@@ -41,6 +42,7 @@ _EVENTS_NAME = "events.jsonl"
 # rather than restated — the deleter (refutations.forget_content_key) and this
 # auditor asking the question separately is how a surface goes unreported.
 _REFUTATIONS_NAME = "refutations.jsonl"
+_RELATIONS_NAME = "relations.jsonl"
 
 # Files that live in the checkpoint store and hold NO item plaintext BY
 # CONSTRUCTION. Since #601 both sets are VIEWS of the declared surface
@@ -111,7 +113,8 @@ def _checkpoint_candidates() -> tuple[list[Path], list[tuple[Path, str | None]]]
                         unknown.append((p, entry.name))
                     elif p.suffix == ".json":
                         known.append(p)
-                    elif p.name not in (_EVENTS_NAME, _REFUTATIONS_NAME) \
+                    elif p.name not in (_EVENTS_NAME, _REFUTATIONS_NAME,
+                                        _RELATIONS_NAME) \
                             and not _is_plaintext_free(p):
                         unknown.append((p, entry.name))
         except OSError:
@@ -317,6 +320,8 @@ def audit_project(project_dir=None) -> dict:
         result["zero_surfaces"] = True
         result["cache"] = {"entries": 0, "oldest_days": None}
         result["ledger"] = {"records": 0, "rows": 0, "bytes": 0}
+        result["relations"] = {"records": 0, "rows": 0, "bytes": 0,
+                               "by_state": {}}
         return result
     known, unknown = _checkpoint_candidates()
     # Only this project's blind spots: an unknown file in ANOTHER bucket is
@@ -438,6 +443,59 @@ def audit_project(project_dir=None) -> dict:
     result["ledger"] = {"records": len(ledger_records),
                         "rows": ledger_rows,
                         "bytes": ledger_bytes}
+    # Relations ledger (#678 fork A): the third bucket ledger, declared at
+    # birth so it can never repeat #645's unknown->unscannable->exit-3 arc.
+    # Rows hold ids and closed-vocabulary codes, never text — so the residue
+    # check is not a hash intersection but an ID one: an edge touching an
+    # item whose latest event is a forget tombstone is an equivalence claim
+    # about erased content, which relations.forget_item_id exists to remove.
+    # A hit here means the scrub was missed or raced; after it runs, this
+    # scan is what proves the deletion reached the edges.
+    rel_path = config.checkpoint_dir() / slug / _RELATIONS_NAME
+    try:
+        lines = rel_path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        lines = []                  # no relation recorded yet
+    except (OSError, ValueError):
+        lines = []
+        result["unscannable"].append(str(rel_path))
+    tombstoned = relations.tombstoned_item_ids(project_dir=project_dir)
+    rel_records: set[str] = set()
+    rel_rows = 0
+    for line in lines:
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(row, dict):
+            continue
+        rel_rows += 1
+        rel_id = str(row.get("relation_id") or "")
+        if rel_id:
+            rel_records.add(rel_id)
+        for endpoint_key in ("from", "to"):
+            endpoint = row.get(endpoint_key)
+            if not isinstance(endpoint, dict):
+                continue
+            item = str(endpoint.get("item_id") or "")
+            if item and item in tombstoned:
+                result["findings"].append({
+                    "path": str(rel_path),
+                    "item_id": item,
+                    "content_hash": None,
+                    "surface": "relations-ledger"})
+    try:
+        rel_bytes = rel_path.stat().st_size
+    except OSError:
+        rel_bytes = 0
+    rel_states: dict[str, int] = {}
+    for record in relations.records(project_dir=project_dir).values():
+        state = str(record.get("state") or "")
+        rel_states[state] = rel_states.get(state, 0) + 1
+    result["relations"] = {"records": len(rel_records),
+                           "rows": rel_rows,
+                           "bytes": rel_bytes,
+                           "by_state": rel_states}
     # Chunk cache: value-level detection impossible (cache keyed by chunk
     # text, values are substrings). Store-level honesty: entry count + real
     # oldest age — the reaper runs only on WRITES, so never assert bounded.

--- a/plugin/daimon_briefing/relations.py
+++ b/plugin/daimon_briefing/relations.py
@@ -1,0 +1,498 @@
+"""Project-scoped typed-relation ledger (#678 Phase 2, shadow mode).
+
+Relations describe how cognitive items relate across checkpoints — revision,
+answer, supersession, arc membership — as an append-only stream of typed
+events folded into current records.  Candidates are behaviorally inert:
+recall, lifecycle, corroboration, carry, and the viewer read nothing here.
+
+Every writable string is either a hash-derived id or drawn from a closed set,
+refused at the seam otherwise.  That gate is load-bearing: rows referencing
+forgotten items survive on disk (fork A ratifies that forget REACHES this
+file — see `forget_item_id`), so no field may ever be able to carry item text.
+
+Authority is a property of the write path, never a caller's claim (the
+refutation ledger's contract).  Agents and the lab import can only propose;
+state moves on human channels alone, and there is no mechanical channel in
+v1 because Phase 1 proved no evidence rail qualifies for automatic
+confirmation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import time
+import uuid
+from datetime import datetime, timezone
+
+from . import config, policy, provenance, schema, store
+
+
+VERSION = 1
+EVENTS = frozenset({"proposed", "confirmed", "rejected", "retracted"})
+STATES = frozenset({"candidate", "confirmed", "rejected", "retracted"})
+TYPES = frozenset({
+    "revision-of", "answers", "supersedes", "reclassified-from",
+    "quoted-from", "same-arc",
+})
+# Symmetric types name one fact regardless of endpoint order, so their two
+# spellings must mint ONE id (endpoints sort before hashing) — otherwise a
+# single arc becomes two records and every arc metric double-counts.
+SYMMETRIC_TYPES = frozenset({"same-arc"})
+# Persisted rails are a closed set: `matched_by` is the one list-shaped field
+# a writer controls, and an open vocabulary here is a free-text channel into
+# a file whose deletion story depends on no field ever carrying prose.
+RAILS = frozenset({
+    "exact-text", "bound-exact-quote", "shared-source-message",
+    "exact-anchor", "carry-absolute", "carry-ratio", "typed-supersedes",
+})
+NOTE_CODES = frozenset({""})
+# No `mechanical` channel, deliberately: adding machine confirmation later
+# requires the held-out gate (zero identity-confirmations on arc specimens)
+# and a version bump, not a vocabulary entry.
+CHANNEL_AUTHORITY = {
+    "serializer": "agent",
+    "lab-import": "agent",
+    "cli-agent": "agent",
+    "cli-tty": "human",
+    "ui": "human",
+    "signed": "human",
+}
+CHANNELS = frozenset(CHANNEL_AUTHORITY)
+_EVENT_RANK = {
+    # Same-order ambiguity fails toward refusal: a confirm/reject tie lands
+    # on rejected (rank strictly after confirmed — the refuter round proved
+    # a shared rank resolves opposite verdicts by uuid4 comparison), and a
+    # retraction outranks both.
+    "proposed": 0,
+    "confirmed": 1,
+    "rejected": 2,
+    "retracted": 3,
+}
+_REL_ID_RE = re.compile(r"rel-[0-9a-f]{16}")
+# Everything policy.stamp_item_ids can mint: prefix letter per list key,
+# width ladder 12/16/24/40 plus the legacy 6-hex era ({6,40} covers both),
+# and the `-{n}` identical-text twin counter.
+_ITEM_ID_RE = re.compile(r"[orsuc]-[0-9a-f]{6,40}(?:-\d+)?")
+_MATCHER_RE = re.compile(r"[a-z0-9-]{1,32}")
+_FIELD_KEYS = frozenset(key for _, key in schema.ITEM_LISTS)
+_MAX_RAILS = 8
+_MAX_AUTHOR = 200
+# With every field capped or closed above, normal input cannot approach this;
+# reaching it is a caller bug and refusal is LOUD (RelationError), never a
+# silent False the audit would read as absence.
+_MAX_ROW_BYTES = 2048
+_FORGOTTEN_PREFIX = "forgotten:"
+
+
+class RelationError(ValueError):
+    """A requested ledger row or transition is invalid."""
+
+
+def _path(project_dir=None):
+    slug = store.project_slug(project_dir)
+    if not slug:
+        return None
+    return config.checkpoint_dir() / slug / "relations.jsonl"
+
+
+def _validate_endpoint(name: str, endpoint) -> dict:
+    if not isinstance(endpoint, dict):
+        raise RelationError(f"{name} endpoint must be a dict")
+    session_id = str(endpoint.get("session_id") or "")
+    field = str(endpoint.get("field") or "")
+    item_id = str(endpoint.get("item_id") or "")
+    if not provenance.valid_session_id(session_id):
+        raise RelationError(f"{name}.session_id is not a valid session id")
+    if field not in _FIELD_KEYS:
+        raise RelationError(
+            f"{name}.field must be one of: {', '.join(sorted(_FIELD_KEYS))}")
+    if not _ITEM_ID_RE.fullmatch(item_id):
+        raise RelationError(f"{name}.item_id is not a minted item id")
+    return {"session_id": session_id, "field": field, "item_id": item_id}
+
+
+def make_id(type_: str, from_endpoint: dict, to_endpoint: dict) -> str:
+    """Deterministic edge id.  `field` and matcher metadata are excluded:
+    the id names the edge, not how it was observed or displayed."""
+    if type_ not in TYPES:
+        raise RelationError(f"unknown relation type: {type_}")
+    a = (from_endpoint["session_id"], from_endpoint["item_id"])
+    b = (to_endpoint["session_id"], to_endpoint["item_id"])
+    if type_ in SYMMETRIC_TYPES and b < a:
+        a, b = b, a
+    raw = "\0".join((type_, a[0], a[1], b[0], b[1]))
+    return "rel-" + hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def _stamp(event: str, relation_id: str, channel: str,
+           *, now_ns: int | None = None) -> dict:
+    if event not in EVENTS:
+        raise RelationError(f"unknown relation event: {event}")
+    if not _REL_ID_RE.fullmatch(str(relation_id or "")):
+        raise RelationError(f"invalid relation id: {relation_id!r}")
+    if channel not in CHANNELS:
+        raise RelationError(
+            f"channel must be one of: {', '.join(sorted(CHANNELS))}")
+    order = time.time_ns() if now_ns is None else int(now_ns)
+    ts = datetime.fromtimestamp(order / 1_000_000_000, timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ")
+    return {
+        "version": VERSION,
+        "ts": ts,
+        "order": order,
+        "event_id": uuid.uuid4().hex,
+        "event": event,
+        "relation_id": relation_id,
+        "channel": channel,
+        # Derived, never accepted: no way to name one channel and claim
+        # another's authority.
+        "authority": CHANNEL_AUTHORITY[channel],
+        "author": str(config.author() or "")[:_MAX_AUTHOR],
+    }
+
+
+def _is_torn(path) -> bool:
+    """True when the last append died before writing its terminator."""
+    try:
+        if path.stat().st_size == 0:
+            return False
+        with path.open("rb") as handle:
+            handle.seek(-1, 2)
+            return handle.read(1) != b"\n"
+    except OSError:
+        return False
+
+
+def _append(row: dict, project_dir=None) -> bool:
+    """Append one admitted row.  Never raises; never mutates another ledger."""
+    if config.is_disabled():
+        return False
+    path = _path(project_dir)
+    if path is None:
+        return False
+    admitted = policy.admit_row(row, redact_fields=("author",))
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            if _is_torn(path):
+                handle.write("\n")
+            handle.write(json.dumps(admitted, ensure_ascii=False) + "\n")
+        return True
+    except OSError:
+        return False
+
+
+def _write(row: dict, project_dir=None) -> None:
+    blob = json.dumps(row, ensure_ascii=False)
+    if len(blob.encode("utf-8")) > _MAX_ROW_BYTES:
+        raise RelationError(
+            f"relation row too large ({len(blob)} > {_MAX_ROW_BYTES} bytes)")
+    if not _append(row, project_dir=project_dir):
+        raise RelationError(
+            "relation not written (daimon disabled, project unknown, or "
+            "ledger unwritable)")
+
+
+def propose(*, type_: str, from_endpoint, to_endpoint, matched_by,
+            matcher_version: str, channel: str, note_code: str = "",
+            project_dir=None, now_ns: int | None = None) -> str:
+    """Record a candidate edge.  Any channel may propose; none may confirm."""
+    if type_ not in TYPES:
+        raise RelationError(f"unknown relation type: {type_}")
+    frm = _validate_endpoint("from", from_endpoint)
+    to = _validate_endpoint("to", to_endpoint)
+    rails = [str(rail) for rail in (matched_by or [])]
+    if not rails or len(rails) > _MAX_RAILS:
+        raise RelationError(
+            f"matched_by must name 1..{_MAX_RAILS} evidence rails")
+    unknown = set(rails) - RAILS
+    if unknown:
+        raise RelationError(
+            f"unknown evidence rail: {', '.join(sorted(unknown))}")
+    if not _MATCHER_RE.fullmatch(str(matcher_version or "")):
+        raise RelationError("matcher_version must match [a-z0-9-]{1,32}")
+    if str(note_code or "") not in NOTE_CODES:
+        raise RelationError(f"unknown note_code: {note_code!r}")
+    if type_ in SYMMETRIC_TYPES:
+        # Store what the id hashed, so the record is one canonical fact.
+        a = (frm["session_id"], frm["item_id"])
+        b = (to["session_id"], to["item_id"])
+        if b < a:
+            frm, to = to, frm
+    rel_id = make_id(type_, frm, to)
+    row = _stamp("proposed", rel_id, channel, now_ns=now_ns)
+    row.update({
+        "type": type_,
+        "from": frm,
+        "to": to,
+        "matched_by": rails,
+        "matcher_version": str(matcher_version),
+        "note_code": str(note_code or ""),
+    })
+    _write(row, project_dir=project_dir)
+    return rel_id
+
+
+def _human_transition(event: str, relation_id: str, channel: str,
+                      project_dir, now_ns) -> None:
+    if CHANNEL_AUTHORITY.get(channel) != "human":
+        raise RelationError(
+            f"{event} requires a human channel; this call arrived "
+            f"through {channel!r}")
+    current = get(relation_id, project_dir=project_dir)
+    if current is None:
+        raise RelationError(f"unknown relation: {relation_id}")
+    if event in ("confirmed", "rejected") and current["state"] == "retracted":
+        raise RelationError(
+            f"{relation_id} is retracted; it needs a fresh proposal before "
+            "any new verdict")
+    row = _stamp(event, relation_id, channel, now_ns=now_ns)
+    _write(row, project_dir=project_dir)
+
+
+def confirm(relation_id: str, *, channel: str, project_dir=None,
+            now_ns: int | None = None) -> None:
+    _human_transition("confirmed", relation_id, channel, project_dir, now_ns)
+
+
+def reject(relation_id: str, *, channel: str, project_dir=None,
+           now_ns: int | None = None) -> None:
+    _human_transition("rejected", relation_id, channel, project_dir, now_ns)
+
+
+def retract(relation_id: str, *, channel: str, project_dir=None,
+            now_ns: int | None = None) -> None:
+    _human_transition("retracted", relation_id, channel, project_dir, now_ns)
+
+
+def events(project_dir=None) -> list[dict]:
+    """Read valid ledger rows best-effort; malformed lines never sink reads.
+
+    A row without a usable integer `order` is DROPPED, not defaulted: the
+    sort would place it at epoch zero, where `proposed` first-writer-wins
+    would hand it the record's payload.
+    """
+    path = _path(project_dir)
+    if path is None:
+        return []
+    # Read first, ask later: `path.exists()` RAISES on an unreadable parent
+    # dir (EACCES is not in pathlib's ignored set), which would crash the
+    # read-only auditor on exactly the tree it must report on.
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return []
+    rows = []
+    for index, line in enumerate(lines):
+        try:
+            row = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if (not isinstance(row, dict)
+                or row.get("event") not in EVENTS
+                or not _REL_ID_RE.fullmatch(str(row.get("relation_id") or ""))):
+            continue
+        try:
+            row_order = int(row.get("order"))
+        except (TypeError, ValueError):
+            continue
+        copy = dict(row)
+        copy["order"] = row_order
+        copy["_line"] = index
+        rows.append(copy)
+    return rows
+
+
+def fold(rows: list[dict]) -> dict[str, dict]:
+    """Fold relation events into current records, deterministic under reorder.
+
+    `_line` sits behind the unique uuid4 `event_id` in the sort key, so it
+    never decides; it keeps the key total for hand-built test rows.
+    """
+    ordered = sorted(rows, key=lambda row: (
+        int(row.get("order") or 0),
+        _EVENT_RANK.get(str(row.get("event") or ""), 99),
+        str(row.get("event_id") or ""),
+        int(row.get("_line") or 0),
+    ))
+    out: dict[str, dict] = {}
+    for row in ordered:
+        rel_id = row["relation_id"]
+        event = row["event"]
+        authority = CHANNEL_AUTHORITY.get(row.get("channel"))
+        current = out.get(rel_id)
+        if event == "proposed":
+            proposal = {
+                "matcher_version": str(row.get("matcher_version") or ""),
+                "matched_by": list(row.get("matched_by") or []),
+                "order": row.get("order"),
+            }
+            if current is None:
+                out[rel_id] = {
+                    "relation_id": rel_id,
+                    "state": "candidate",
+                    "type": str(row.get("type") or ""),
+                    "from": dict(row.get("from") or {}),
+                    "to": dict(row.get("to") or {}),
+                    "proposals": [proposal],
+                    "contradiction": False,
+                    "confirmed_channel": None,
+                    "confirmed_author": None,
+                    "created_at": row.get("ts"),
+                    "updated_at": row.get("ts"),
+                    "history_count": 1,
+                }
+                continue
+            current["history_count"] += 1
+            current["updated_at"] = row.get("ts") or current["updated_at"]
+            seen = {p["matcher_version"] for p in current["proposals"]}
+            if proposal["matcher_version"] not in seen:
+                # Accrual, not first-writer-wins: dropping later proposals
+                # froze `matched_by` at whatever the FIRST matcher said and
+                # made per-version evaluation impossible (refuter round).
+                current["proposals"].append(proposal)
+            if current["state"] == "retracted":
+                # A fresh proposal revives a retraction; a human rejection
+                # stays sticky — agents do not get to nag.
+                current["state"] = "candidate"
+            continue
+        if current is None:
+            continue  # orphan lifecycle event: visible in raw audit, inert
+        current["history_count"] += 1
+        current["updated_at"] = row.get("ts") or current["updated_at"]
+        if authority != "human":
+            continue  # no agent channel moves state, whatever the event says
+        if event == "confirmed" and current["state"] != "retracted":
+            current["state"] = "confirmed"
+            current["confirmed_channel"] = row.get("channel")
+            current["confirmed_author"] = row.get("author")
+        elif event == "rejected" and current["state"] != "retracted":
+            current["state"] = "rejected"
+            current["confirmed_channel"] = None
+            current["confirmed_author"] = None
+        elif event == "retracted":
+            current["state"] = "retracted"
+            current["confirmed_channel"] = None
+            current["confirmed_author"] = None
+    # A confirmed directional edge whose confirmed INVERSE also exists is a
+    # cycle asserting each item revises the other — invented continuity in
+    # its most literal form.  Surfaced on both records, never auto-resolved.
+    for record in out.values():
+        if record["state"] != "confirmed":
+            continue
+        if record["type"] in SYMMETRIC_TYPES or record["type"] not in TYPES:
+            continue
+        try:
+            inverse = make_id(record["type"], record["to"], record["from"])
+        except (RelationError, KeyError):
+            continue
+        twin = out.get(inverse)
+        if twin is not None and twin["state"] == "confirmed":
+            record["contradiction"] = True
+            twin["contradiction"] = True
+    return out
+
+
+def records(project_dir=None) -> dict[str, dict]:
+    return fold(events(project_dir=project_dir))
+
+
+def get(relation_id: str, project_dir=None) -> dict | None:
+    return records(project_dir=project_dir).get(relation_id)
+
+
+def tombstoned_item_ids(*, project_dir=None) -> set[str]:
+    """Item ids whose LATEST event is a forget tombstone — true erasure.
+
+    Absence from live surfaces is NOT this: per-session files GC and prev-N
+    rotates, so an aged-out occurrence must stay a valid, resolvable memory
+    (the refuter round: inerting on absence would have destroyed exactly the
+    long-range lineage this ledger exists to keep).  Latest-event folding
+    means a later `reopen` lifts the tombstone, matching
+    `store.forgotten_content_keys`.
+    """
+    out = set()
+    for ref, event in store.resolutions(project_dir=project_dir).items():
+        if str(event.get("status") or "").startswith(_FORGOTTEN_PREFIX):
+            out.add(str(ref))
+    return out
+
+
+def _row_item_ids(row: dict) -> set[str]:
+    out = set()
+    for key in ("from", "to"):
+        endpoint = row.get(key)
+        if isinstance(endpoint, dict):
+            item = str(endpoint.get("item_id") or "")
+            if item:
+                out.add(item)
+    return out
+
+
+def forget_item_id(item_id: str, *, project_dir=None) -> list[str]:
+    """Remove every record whose edge touches `item_id` (#678 fork A).
+
+    Rows here hold no text, but an edge is an equivalence CLAIM: a surviving
+    `exact-text` rail against a forgotten endpoint asserts the forgotten
+    value was identical to a surviving item's text, and post-forget this
+    file would be the only surface binding the forgotten id to its sessions,
+    kind, and revision-chain length.  #419's rule governs: holding the
+    sensitive relation to content, not the file format, is what puts a
+    surface inside the deletion contract.
+
+    Rewrites RAW LINES, never `events()` output — the tolerant reader drops
+    rows it cannot interpret and stamps `_line`; round-tripping through it
+    would silently delete every row a future daimon added (scars 0025/0042).
+    Every row of a matched record goes; everything else is written back
+    byte-identical, including rows this version cannot interpret.
+    Unparseable lines are dropped: already invisible to every read path, and
+    `_is_torn` establishes a torn row is expendable.
+
+    No kill-switch check: forget is the ratified deletion exemption (#421).
+    Atomic or nothing, staged beside the ledger and swapped with os.replace.
+    Returns the relation ids removed, or [] when nothing matched.
+    """
+    path = _path(project_dir)
+    if path is None:
+        return []
+    target = str(item_id or "")
+    if not target:
+        return []
+    doomed = {
+        str(row.get("relation_id") or "")
+        for row in events(project_dir=project_dir)
+        if target in _row_item_ids(row)
+    }
+    doomed.discard("")
+    if not doomed:
+        return []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return []
+    kept: list[str] = []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if (isinstance(row, dict)
+                and str(row.get("relation_id") or "") in doomed):
+            continue
+        kept.append(line)
+    tmp = path.with_name(path.name + ".forget-tmp")
+    try:
+        tmp.write_text("".join(line + "\n" for line in kept), encoding="utf-8")
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        return []
+    return sorted(doomed)

--- a/plugin/daimon_briefing/surfaces.py
+++ b/plugin/daimon_briefing/surfaces.py
@@ -111,6 +111,21 @@ SURFACES: tuple[Surface, ...] = (
     Surface("checkpoints/{slug}/forget-hits.jsonl",
             "store.record_forget_hits", False, "exempt-no-plaintext",
             "none", audit_exempt=True),
+    # -- the relations ledger (#678 fork A): ids and closed-vocabulary codes
+    #    only — no field can carry item text (relations.py refuses at the
+    #    seam). plaintext=True anyway, deliberately: an edge is an
+    #    equivalence CLAIM about content (`exact-text` against a forgotten
+    #    endpoint asserts the forgotten value equaled a surviving item's
+    #    text), and #419's rule is that holding the sensitive relation to
+    #    content — not the file format — is what puts a surface inside the
+    #    deletion contract. `rewrite` is relations.forget_item_id, the one
+    #    path that rewrites this file, dropping every row of a record whose
+    #    edge touches a tombstoned item id. Never audit_exempt: the audit
+    #    scans endpoint ids against tombstones (privacy.audit_project) and
+    #    reports records/rows/bytes/by_state, so residue is a finding and
+    #    growth is measured, never silent. --
+    Surface("checkpoints/{slug}/relations.jsonl", "relations._append",
+            True, "rewrite", "forget"),
     # -- serializer chunk cache: PRE-redaction by design (#125), so it can
     #    only be purged wholesale (#422); age reaper bounds survivors. --
     Surface("checkpoints/.chunk-cache/*", "serializer._save_chunk_cache",

--- a/plugin/tests/test_relations.py
+++ b/plugin/tests/test_relations.py
@@ -1,0 +1,312 @@
+"""Relations ledger (#678 Phase 2): validation gates, fold, deletion, registry.
+
+Spec: vault "Spec - Relations Ledger Phase 2 (678)" v2 (post-refutation,
+fork A ratified: forget reaches this file; audit scans it).
+"""
+
+import json
+
+import pytest
+
+from daimon_briefing import privacy, relations, store, surfaces
+
+
+@pytest.fixture
+def bucket(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
+    monkeypatch.delenv("DAIMON_DISABLED", raising=False)
+    return "/repo/relations-fixture"
+
+
+def _endpoint(session="S1", field="recent_decisions", item="r-abc123456789"):
+    return {"session_id": session, "field": field, "item_id": item}
+
+
+def _propose(project, *, type_="revision-of", frm=None, to=None,
+             channel="lab-import", rails=("carry-absolute",),
+             matcher="lineage-v1", now_ns=None):
+    return relations.propose(
+        type_=type_,
+        from_endpoint=frm or _endpoint("S2", item="r-abc123456789"),
+        to_endpoint=to or _endpoint("S1", item="r-def123456789"),
+        matched_by=list(rails),
+        matcher_version=matcher,
+        channel=channel,
+        project_dir=project,
+        now_ns=now_ns,
+    )
+
+
+# -- validation gates: every writable string, refusal on any failure --
+
+def test_propose_creates_candidate_record(bucket):
+    rel_id = _propose(bucket)
+    record = relations.records(project_dir=bucket)[rel_id]
+    assert record["state"] == "candidate"
+    assert record["type"] == "revision-of"
+    assert record["proposals"][0]["matcher_version"] == "lineage-v1"
+
+
+def test_refuses_prose_session_id(bucket):
+    with pytest.raises(relations.RelationError):
+        _propose(bucket, frm=_endpoint(session="sync for acme, key AKIA123"))
+
+
+def test_refuses_colon_session_id(bucket):
+    with pytest.raises(relations.RelationError):
+        _propose(bucket, frm=_endpoint(session="a:b"))
+
+
+def test_refuses_field_outside_item_lists(bucket):
+    with pytest.raises(relations.RelationError):
+        _propose(bucket, frm=_endpoint(field="the item text leaked here"))
+
+
+def test_refuses_text_shaped_item_id(bucket):
+    with pytest.raises(relations.RelationError):
+        _propose(bucket, frm=_endpoint(item="use mutable memory records"))
+
+
+def test_refuses_unknown_rail(bucket):
+    with pytest.raises(relations.RelationError):
+        _propose(bucket, rails=("vibes",))
+
+
+def test_refuses_unknown_note_code(bucket):
+    with pytest.raises(relations.RelationError):
+        relations.propose(
+            type_="revision-of",
+            from_endpoint=_endpoint("S2"),
+            to_endpoint=_endpoint("S1", item="r-def123456789"),
+            matched_by=["carry-absolute"],
+            matcher_version="lineage-v1",
+            channel="lab-import",
+            note_code="free prose",
+            project_dir=bucket,
+        )
+
+
+def test_accepts_every_minted_item_id_shape(bucket):
+    # width ladder + twin counter + legacy 6-hex era
+    for item in ("o-abc123", "s-" + "a" * 16, "u-" + "b" * 24,
+                 "c-" + "c" * 40, "r-abc123456789-2"):
+        relations.propose(
+            type_="revision-of",
+            from_endpoint=_endpoint("S2", field="open_questions", item=item),
+            to_endpoint=_endpoint("S1", item="r-def123456789"),
+            matched_by=["carry-absolute"],
+            matcher_version="lineage-v1",
+            channel="lab-import",
+            project_dir=bucket,
+        )
+
+
+# -- relation_id: determinism, symmetry, direction --
+
+def test_same_edge_mints_same_id_and_folds_to_one_record(bucket):
+    a = _propose(bucket)
+    b = _propose(bucket)
+    assert a == b
+    assert len(relations.records(project_dir=bucket)) == 1
+
+
+def test_same_arc_is_symmetric_one_fact_one_id(bucket):
+    x, y = _endpoint("S1", item="r-abc123456789"), _endpoint("S2", item="r-def123456789")
+    a = _propose(bucket, type_="same-arc", frm=x, to=y)
+    b = _propose(bucket, type_="same-arc", frm=y, to=x)
+    assert a == b
+
+
+def test_directional_types_keep_direction_distinct(bucket):
+    x, y = _endpoint("S1", item="r-abc123456789"), _endpoint("S2", item="r-def123456789")
+    assert _propose(bucket, frm=x, to=y) != _propose(bucket, frm=y, to=x)
+
+
+def test_field_is_display_data_not_identity(bucket):
+    a = _propose(bucket, frm=_endpoint("S2", field="recent_decisions"))
+    b = _propose(bucket, frm=_endpoint("S2", field="open_questions"))
+    assert a == b
+
+
+# -- authority: agents propose, only humans move state --
+
+def test_lab_import_channel_cannot_confirm(bucket):
+    rel_id = _propose(bucket)
+    with pytest.raises(relations.RelationError):
+        relations.confirm(rel_id, channel="lab-import", project_dir=bucket)
+
+
+def test_confirm_requires_reachable_human_channel(bucket):
+    rel_id = _propose(bucket)
+    relations.confirm(rel_id, channel="cli-tty", project_dir=bucket)
+    assert relations.records(project_dir=bucket)[rel_id]["state"] == "confirmed"
+
+
+def test_rejected_is_sticky_against_agent_reproposal(bucket):
+    rel_id = _propose(bucket)
+    relations.reject(rel_id, channel="cli-tty", project_dir=bucket)
+    _propose(bucket, matcher="lineage-v2")
+    assert relations.records(project_dir=bucket)[rel_id]["state"] == "rejected"
+
+
+def test_retracted_is_revived_by_fresh_proposal(bucket):
+    rel_id = _propose(bucket)
+    relations.confirm(rel_id, channel="cli-tty", project_dir=bucket)
+    relations.retract(rel_id, channel="cli-tty", project_dir=bucket)
+    _propose(bucket, matcher="lineage-v2")
+    assert relations.records(project_dir=bucket)[rel_id]["state"] == "candidate"
+
+
+def test_proposals_accrue_per_matcher_version(bucket):
+    rel_id = _propose(bucket, matcher="lineage-v1", rails=("carry-absolute",))
+    _propose(bucket, matcher="lineage-v2", rails=("bound-exact-quote",))
+    proposals = relations.records(project_dir=bucket)[rel_id]["proposals"]
+    assert [p["matcher_version"] for p in proposals] == ["lineage-v1", "lineage-v2"]
+    assert proposals[1]["matched_by"] == ["bound-exact-quote"]
+
+
+# -- fold: tie safety, order hygiene, contradiction --
+
+def test_equal_order_confirm_reject_tie_lands_on_rejected(bucket):
+    rel_id = _propose(bucket, now_ns=1_000)
+    relations.confirm(rel_id, channel="cli-tty", project_dir=bucket, now_ns=2_000)
+    relations.reject(rel_id, channel="ui", project_dir=bucket, now_ns=2_000)
+    assert relations.records(project_dir=bucket)[rel_id]["state"] == "rejected"
+
+
+def test_rows_without_usable_order_are_dropped_by_reader(bucket):
+    _propose(bucket)
+    path = relations._path(bucket)
+    row = json.loads(path.read_text().splitlines()[0])
+    row["order"] = "garbage"
+    row["event_id"] = "f" * 32
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row) + "\n")
+    assert len(relations.events(project_dir=bucket)) == 1
+
+
+def test_inverse_confirmed_revisions_are_flagged_never_resolved(bucket):
+    x, y = _endpoint("S1", item="r-abc123456789"), _endpoint("S2", item="r-def123456789")
+    a = _propose(bucket, frm=x, to=y)
+    b = _propose(bucket, frm=y, to=x)
+    relations.confirm(a, channel="cli-tty", project_dir=bucket)
+    relations.confirm(b, channel="cli-tty", project_dir=bucket)
+    folded = relations.records(project_dir=bucket)
+    assert folded[a]["contradiction"] is True
+    assert folded[b]["contradiction"] is True
+    assert folded[a]["state"] == "confirmed"  # surfaced, not auto-resolved
+
+
+def test_torn_append_costs_exactly_the_torn_row(bucket):
+    rel_id = _propose(bucket)
+    path = relations._path(bucket)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write('{"torn": tru')
+    _propose(bucket, frm=_endpoint("S3", item="r-aaa111222333"))
+    assert len(relations.records(project_dir=bucket)) == 2
+    assert rel_id in relations.records(project_dir=bucket)
+
+
+# -- deletion (fork A): forget reaches this file --
+
+def test_forget_item_id_rewrites_only_matching_rows(bucket):
+    doomed = _propose(bucket, frm=_endpoint("S2", item="r-abc123456789"))
+    kept = _propose(bucket, frm=_endpoint("S2", item="r-aaa111222333"),
+                    to=_endpoint("S1", item="r-bbb444555666"))
+    removed = relations.forget_item_id("r-abc123456789", project_dir=bucket)
+    assert removed == [doomed]
+    folded = relations.records(project_dir=bucket)
+    assert doomed not in folded and kept in folded
+
+
+def test_forget_item_id_keeps_uninterpretable_rows_byte_identical(bucket):
+    _propose(bucket)
+    path = relations._path(bucket)
+    alien = '{"event": "from-the-future", "relation_id": "rel-' + "a" * 16 + '"}'
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(alien + "\n")
+    relations.forget_item_id("r-abc123456789", project_dir=bucket)
+    assert alien in path.read_text().splitlines()
+
+
+# -- erased vs unresolved dangling: tombstone-derived, GC-immune --
+
+def test_erased_comes_from_tombstones_not_absence(bucket):
+    store.append_event("r-abc123456789", "forgotten:deadbeef01234567",
+                       kind="tombstone", project_dir=bucket)
+    erased = relations.tombstoned_item_ids(project_dir=bucket)
+    assert "r-abc123456789" in erased
+    # absent-but-never-tombstoned is NOT erased
+    assert "r-def123456789" not in erased
+
+
+# -- registry (fork A) --
+
+def test_registry_declares_relations_ledger_plaintext_rewrite_forget():
+    entry = surfaces.match("checkpoints/{slug}/relations.jsonl")
+    assert entry is not None
+    assert entry.plaintext is True
+    assert entry.delete == "rewrite"
+    assert entry.walker == "forget"
+    assert entry.audit_exempt is False
+
+
+def test_exempt_no_plaintext_bucket_ledgers_are_audit_exempt():
+    # The biconditional the refuters proved missing: an exempt-no-plaintext
+    # bucket ledger that is not audit_exempt lands in the unknown walk and
+    # pins the audit at permanent exit 3 (#645's actual hole).
+    for s in surfaces.SURFACES:
+        if (s.shape.startswith("checkpoints/{slug}/")
+                and s.delete == "exempt-no-plaintext"):
+            assert s.audit_exempt, s.shape
+
+
+# -- audit: counts + tombstone-intersection findings, never unknown --
+
+def test_audit_reports_relations_counts_and_stays_provable(bucket):
+    _propose(bucket)
+    results = privacy.audit_project(project_dir=bucket)
+    assert results["relations"]["rows"] == 1
+    assert results["relations"]["records"] == 1
+    unknown = [entry for entry in results.get("unscannable", [])
+               if "relations.jsonl" in str(entry)]
+    assert unknown == []
+
+
+def test_audit_finds_residue_when_scrub_missed_a_tombstoned_endpoint(bucket):
+    _propose(bucket)  # endpoint r-abc123456789 lands in the ledger
+    store.append_event("r-abc123456789", "forgotten:deadbeef01234567",
+                       kind="tombstone", project_dir=bucket)
+    results = privacy.audit_project(project_dir=bucket)
+    hits = [f for f in results["findings"]
+            if f.get("surface") == "relations-ledger"]
+    assert hits, "tombstoned endpoint surviving in relations.jsonl must be residue"
+    # and after the scrub runs, the audit proves the deletion
+    relations.forget_item_id("r-abc123456789", project_dir=bucket)
+    results = privacy.audit_project(project_dir=bucket)
+    assert [f for f in results["findings"]
+            if f.get("surface") == "relations-ledger"] == []
+
+
+# -- inertness: consumers do not read this ledger (with a live ratchet) --
+
+def test_only_declared_consumers_import_relations():
+    # Two-directional: a new production import fails (inertness breach), and a
+    # stale allowlist entry fails (the twin that keeps this test non-vacuous).
+    import pathlib
+    import re
+
+    import daimon_briefing
+    package = pathlib.Path(daimon_briefing.__file__).parent
+    allowed = {"privacy.py", "cli.py"}
+    import_re = re.compile(
+        r"^\s*(?:from\s+\.\s+import\s+.*\brelations\b"
+        r"|from\s+(?:daimon_briefing\.)?relations\s+import"
+        r"|import\s+(?:daimon_briefing\.)?relations\b)", re.MULTILINE)
+    importers = set()
+    for module in package.glob("*.py"):
+        if module.name == "relations.py":
+            continue
+        if import_re.search(module.read_text(encoding="utf-8")):
+            importers.add(module.name)
+    assert importers == allowed

--- a/plugin/tests/test_relations.py
+++ b/plugin/tests/test_relations.py
@@ -14,7 +14,7 @@ from daimon_briefing import privacy, relations, store, surfaces
 @pytest.fixture
 def bucket(tmp_path, monkeypatch):
     monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
-    monkeypatch.delenv("DAIMON_DISABLED", raising=False)
+    monkeypatch.delenv("DAIMON_DISABLE", raising=False)
     return "/repo/relations-fixture"
 
 
@@ -264,10 +264,12 @@ def test_exempt_no_plaintext_bucket_ledgers_are_audit_exempt():
 # -- audit: counts + tombstone-intersection findings, never unknown --
 
 def test_audit_reports_relations_counts_and_stays_provable(bucket):
-    _propose(bucket)
+    rel_id = _propose(bucket)
+    relations.confirm(rel_id, channel="cli-tty", project_dir=bucket)
     results = privacy.audit_project(project_dir=bucket)
-    assert results["relations"]["rows"] == 1
+    assert results["relations"]["rows"] == 2
     assert results["relations"]["records"] == 1
+    assert results["relations"]["by_state"] == {"confirmed": 1}
     unknown = [entry for entry in results.get("unscannable", [])
                if "relations.jsonl" in str(entry)]
     assert unknown == []
@@ -289,6 +291,300 @@ def test_audit_finds_residue_when_scrub_missed_a_tombstoned_endpoint(bucket):
 
 
 # -- inertness: consumers do not read this ledger (with a live ratchet) --
+
+# -- defensive branches and forged-row hardening --
+
+def test_unknown_project_refuses_loudly(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path))
+    monkeypatch.delenv("DAIMON_DISABLE", raising=False)
+    with pytest.raises(relations.RelationError):
+        _propose(None)
+
+
+def test_kill_switch_blocks_appends(bucket, monkeypatch):
+    monkeypatch.setenv("DAIMON_DISABLE", "1")
+    with pytest.raises(relations.RelationError):
+        _propose(bucket)
+
+
+def test_make_id_refuses_unknown_type():
+    with pytest.raises(relations.RelationError):
+        relations.make_id("friends-with", _endpoint(), _endpoint())
+
+
+def test_stamp_refuses_bad_event_id_and_channel():
+    good_id = "rel-" + "a" * 16
+    with pytest.raises(relations.RelationError):
+        relations._stamp("exploded", good_id, "cli-tty")
+    with pytest.raises(relations.RelationError):
+        relations._stamp("proposed", "not-an-id", "cli-tty")
+    with pytest.raises(relations.RelationError):
+        relations._stamp("proposed", good_id, "carrier-pigeon")
+
+
+def test_endpoint_must_be_a_dict(bucket):
+    with pytest.raises(relations.RelationError):
+        _propose(bucket, frm="r-abc123456789")
+
+
+def test_rails_are_required_and_capped(bucket):
+    with pytest.raises(relations.RelationError):
+        _propose(bucket, rails=())
+    with pytest.raises(relations.RelationError):
+        _propose(bucket, rails=("carry-absolute",) * 9)
+
+
+def test_matcher_version_shape_is_refused(bucket):
+    with pytest.raises(relations.RelationError):
+        _propose(bucket, matcher="Lineage V1!")
+
+
+def test_unknown_relation_type_is_refused_at_propose(bucket):
+    with pytest.raises(relations.RelationError):
+        _propose(bucket, type_="friends-with")
+
+
+def test_oversized_row_is_refused_loudly_not_silently(bucket):
+    with pytest.raises(relations.RelationError):
+        relations._write({"pad": "x" * 3000}, project_dir=bucket)
+
+
+def test_is_torn_survives_a_missing_file(tmp_path):
+    assert relations._is_torn(tmp_path / "absent.jsonl") is False
+
+
+def test_verdicts_on_unknown_relation_are_refused(bucket):
+    for move in (relations.confirm, relations.reject, relations.retract):
+        with pytest.raises(relations.RelationError):
+            move("rel-" + "f" * 16, channel="cli-tty", project_dir=bucket)
+
+
+def test_verdicts_on_retracted_record_are_refused_at_the_api(bucket):
+    rel_id = _propose(bucket)
+    relations.confirm(rel_id, channel="cli-tty", project_dir=bucket)
+    relations.retract(rel_id, channel="cli-tty", project_dir=bucket)
+    with pytest.raises(relations.RelationError):
+        relations.confirm(rel_id, channel="cli-tty", project_dir=bucket)
+    with pytest.raises(relations.RelationError):
+        relations.reject(rel_id, channel="cli-tty", project_dir=bucket)
+
+
+def test_orphan_lifecycle_event_is_inert(bucket):
+    row = relations._stamp("confirmed", "rel-" + "a" * 16, "cli-tty")
+    assert relations._append(row, project_dir=bucket)
+    assert relations.records(project_dir=bucket) == {}
+
+
+def test_forged_verdict_on_agent_channel_cannot_move_state(bucket):
+    # Bypass the API guard entirely: a script appending a raw `confirmed`
+    # row on an agent channel must still fold to candidate.
+    rel_id = _propose(bucket)
+    row = relations._stamp("confirmed", rel_id, "lab-import")
+    assert relations._append(row, project_dir=bucket)
+    assert relations.records(project_dir=bucket)[rel_id]["state"] == "candidate"
+
+
+def test_forged_verdicts_on_retracted_record_stay_inert_in_fold(bucket):
+    rel_id = _propose(bucket)
+    relations.confirm(rel_id, channel="cli-tty", project_dir=bucket)
+    relations.retract(rel_id, channel="cli-tty", project_dir=bucket)
+    for event in ("confirmed", "rejected"):
+        row = relations._stamp(event, rel_id, "cli-tty")
+        assert relations._append(row, project_dir=bucket)
+    assert relations.records(project_dir=bucket)[rel_id]["state"] == "retracted"
+
+
+def test_reject_then_human_confirm_overrides(bucket):
+    rel_id = _propose(bucket)
+    relations.reject(rel_id, channel="cli-tty", project_dir=bucket)
+    relations.confirm(rel_id, channel="ui", project_dir=bucket)
+    assert relations.records(project_dir=bucket)[rel_id]["state"] == "confirmed"
+
+
+def test_contradiction_pass_skips_symmetric_and_forged_types(bucket):
+    x = _endpoint("S1", item="r-abc123456789")
+    y = _endpoint("S2", item="r-def123456789")
+    arc = _propose(bucket, type_="same-arc", frm=x, to=y)
+    relations.confirm(arc, channel="cli-tty", project_dir=bucket)
+    forged = relations._stamp("proposed", "rel-" + "b" * 16, "lab-import")
+    forged.update({"type": "friends-with", "from": x, "to": y,
+                   "matched_by": ["carry-absolute"],
+                   "matcher_version": "lineage-v1"})
+    assert relations._append(forged, project_dir=bucket)
+    confirm_row = relations._stamp("confirmed", "rel-" + "b" * 16, "cli-tty")
+    assert relations._append(confirm_row, project_dir=bucket)
+    folded = relations.records(project_dir=bucket)
+    assert folded[arc]["contradiction"] is False
+    assert folded["rel-" + "b" * 16]["contradiction"] is False
+
+
+def test_contradiction_pass_survives_damaged_endpoints(bucket):
+    damaged = relations._stamp("proposed", "rel-" + "c" * 16, "lab-import")
+    damaged.update({"type": "revision-of", "from": {}, "to": {},
+                    "matched_by": ["carry-absolute"],
+                    "matcher_version": "lineage-v1"})
+    assert relations._append(damaged, project_dir=bucket)
+    confirm_row = relations._stamp("confirmed", "rel-" + "c" * 16, "cli-tty")
+    assert relations._append(confirm_row, project_dir=bucket)
+    folded = relations.records(project_dir=bucket)
+    assert folded["rel-" + "c" * 16]["contradiction"] is False
+
+
+def test_reader_and_forget_survive_unreadable_ledger(bucket):
+    _propose(bucket)
+    path = relations._path(bucket)
+    path.chmod(0)
+    try:
+        assert relations.events(project_dir=bucket) == []
+        assert relations.forget_item_id(
+            "r-abc123456789", project_dir=bucket) == []
+    finally:
+        path.chmod(0o600)
+
+
+def test_forget_empty_target_absent_ledger_and_no_match(bucket):
+    assert relations.forget_item_id("r-abc123456789",
+                                    project_dir=bucket) == []
+    _propose(bucket)
+    assert relations.forget_item_id("", project_dir=bucket) == []
+    assert relations.forget_item_id("r-ffffffffffff",
+                                    project_dir=bucket) == []
+
+
+def test_reopen_lifts_the_tombstone(bucket):
+    store.append_event("r-abc123456789", "forgotten:deadbeef01234567",
+                       kind="tombstone", project_dir=bucket)
+    store.append_event("r-abc123456789", "reopen", project_dir=bucket)
+    assert "r-abc123456789" not in relations.tombstoned_item_ids(
+        project_dir=bucket)
+
+
+def test_audit_reports_unreadable_relations_ledger_as_unscannable(bucket):
+    _propose(bucket)
+    path = relations._path(bucket)
+    path.chmod(0)
+    try:
+        results = privacy.audit_project(project_dir=bucket)
+        assert any("relations.jsonl" in entry
+                   for entry in results["unscannable"])
+    finally:
+        path.chmod(0o600)
+
+
+def test_audit_counts_skip_garbage_lines(bucket):
+    _propose(bucket)
+    path = relations._path(bucket)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write("not json\n42\n")
+    results = privacy.audit_project(project_dir=bucket)
+    assert results["relations"]["rows"] == 1
+
+
+def test_cli_forget_scrubs_relations_and_reports_them(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    from daimon_briefing import cli
+    project = "/repo/relations-forget-arc"
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", project)
+    store.write_checkpoint("S1", {
+        "session_id": "S1",
+        "created": "2026-08-01T00:00:00Z",
+        "working_context": {
+            "recent_decisions": [
+                {"text": "adopt sqlite for the relations cache",
+                 "trust": "inferred"}]},
+    }, project_dir=project)
+    stored = store.read_latest(project_dir=project, fallback=False)
+    item_id = stored["working_context"]["recent_decisions"][0]["id"]
+    rel_id = relations.propose(
+        type_="revision-of",
+        from_endpoint={"session_id": "S1", "field": "recent_decisions",
+                       "item_id": item_id},
+        to_endpoint=_endpoint("S0", item="r-def123456789"),
+        matched_by=["carry-absolute"],
+        matcher_version="lineage-v1",
+        channel="lab-import",
+        project_dir=project,
+    )
+    assert cli.main(["forget", item_id]) == 0
+    out = capsys.readouterr().out
+    assert "relation(s)" in out and rel_id in out
+    assert relations.records(project_dir=project) == {}
+
+
+def test_make_id_canonicalizes_symmetric_endpoints_directly():
+    x = _endpoint("S1", item="r-abc123456789")
+    y = _endpoint("S2", item="r-def123456789")
+    assert relations.make_id("same-arc", y, x) == relations.make_id(
+        "same-arc", x, y)
+
+
+def test_append_survives_unwritable_ledger(bucket):
+    _propose(bucket)
+    path = relations._path(bucket)
+    path.chmod(0o400)
+    try:
+        row = relations._stamp("proposed", "rel-" + "d" * 16, "lab-import")
+        assert relations._append(row, project_dir=bucket) is False
+    finally:
+        path.chmod(0o600)
+
+
+def test_reader_and_forget_return_empty_for_unknown_project(tmp_path,
+                                                            monkeypatch):
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path))
+    assert relations.events(project_dir=None) == []
+    assert relations.forget_item_id("r-abc123456789", project_dir=None) == []
+
+
+def test_forget_rewrite_drops_blank_and_unparseable_lines(bucket):
+    doomed = _propose(bucket)
+    kept = _propose(bucket, frm=_endpoint("S3", item="r-aaa111222333"),
+                    to=_endpoint("S1", item="r-bbb444555666"))
+    path = relations._path(bucket)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write("\n{broken json\n")
+    assert relations.forget_item_id("r-abc123456789",
+                                    project_dir=bucket) == [doomed]
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert all(line.strip() for line in lines)
+    assert kept in relations.records(project_dir=bucket)
+
+
+def test_forget_rewrite_failure_returns_empty_not_partial(bucket, monkeypatch):
+    _propose(bucket)
+    path = relations._path(bucket)
+    original = type(path).write_text
+
+    def failing_write(self, *args, **kwargs):
+        if self.name.endswith(".forget-tmp"):
+            raise OSError("disk full")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(type(path), "write_text", failing_write)
+    assert relations.forget_item_id("r-abc123456789",
+                                    project_dir=bucket) == []
+    # the ledger is untouched: atomic-or-nothing
+    assert relations.records(project_dir=bucket) != {}
+
+
+def test_forget_read_failure_after_doomed_scan_returns_empty(bucket,
+                                                             monkeypatch):
+    _propose(bucket)
+    path = relations._path(bucket)
+    original = type(path).read_text
+    calls = {"n": 0}
+
+    def flaky_read(self, *args, **kwargs):
+        if self.name == "relations.jsonl":
+            calls["n"] += 1
+            if calls["n"] > 1:      # events() scan works, rewrite read fails
+                raise OSError("io error")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(type(path), "read_text", flaky_read)
+    assert relations.forget_item_id("r-abc123456789",
+                                    project_dir=bucket) == []
+
 
 def test_only_declared_consumers_import_relations():
     # Two-directional: a new production import fails (inertness breach), and a

--- a/plugin/tests/test_surface_registry.py
+++ b/plugin/tests/test_surface_registry.py
@@ -53,6 +53,7 @@ def test_known_gaps_name_their_tracking_issue():
 def test_the_load_bearing_shapes_are_registered():
     for shape in ("checkpoints/{slug}/events.jsonl",
                   "checkpoints/{slug}/refutations.jsonl",
+                  "checkpoints/{slug}/relations.jsonl",
                   "checkpoints/{slug}/verification.jsonl",
                   "checkpoints/{slug}/forget-hits.jsonl",
                   "checkpoints/.chunk-cache/*",


### PR DESCRIPTION
Refs #678

## Summary

- New append-only ledger `checkpoints/{slug}/relations.jsonl` recording typed relation events between cognitive-item occurrences: `revision-of`, `answers`, `supersedes`, `reclassified-from`, `quoted-from`, `same-arc`. This is phase 2 of #678 (shadow mode): the ledger exists and is governed, but no consumer behavior changes.
- Every writable string is either a hash-derived id or drawn from a closed set, refused at append otherwise. Endpoints validate session id, field key, and item id shape independently; rails and note codes are closed vocabularies; the author field is redacted and capped.
- Authority derives from the write channel, never from a caller claim. Agent channels (`serializer`, `lab-import`, `cli-agent`) can only propose. Confirm, reject, and retract require a human channel. There is no mechanical channel.
- `forget` reaches the ledger: an edge carrying an `exact-text` rail against a forgotten endpoint would assert the forgotten value equaled a surviving item's text, so `relations.forget_item_id` drops every row of a record touching a tombstoned item id, atomically, rewriting raw lines and keeping uninterpretable rows byte-identical.
- The privacy audit scans endpoint ids against forget tombstones (surface `relations-ledger`), reports `records/rows/bytes/by_state`, and the file is registered in the surface registry at birth so it can never land in the unknown-file walk.

## Fold semantics worth reviewing

- Proposals accrue per matcher version instead of first-writer-wins, so a later matcher remains measurable per version.
- A confirm/reject tie at equal `order` lands on rejected. Rows without a usable integer `order` are dropped by the reader.
- `same-arc` is symmetric: endpoint pairs sort before hashing, so one fact mints one id. Confirmed inverse directional edges are flagged `contradiction` on both records and never auto-resolved.
- A rejected record is sticky against agent re-proposal; a retracted record is revived to candidate by a fresh proposal.
- Erasure is tombstone-derived, not absence-derived: an endpoint that aged out through checkpoint GC or pointer rotation stays a resolvable memory.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/relations.py` | New module: validation gates, deterministic ids, append with torn-line guard, typed fold, forget rewrite, tombstone derivation |
| `plugin/daimon_briefing/surfaces.py` | Registry entry for `checkpoints/{slug}/relations.jsonl` (plaintext, rewrite, forget walker) with posture comment |
| `plugin/daimon_briefing/privacy.py` | Relations scanner: tombstoned-endpoint findings, counts block, unknown-walk exclusion |
| `plugin/daimon_briefing/cli.py` | `forget` fan-out gains the relations scrub; removed relations reported in the forget summary |
| `plugin/tests/test_relations.py` | 30 tests: gates, id symmetry, authority, fold ties, torn lines, deletion, registry, audit, import ratchet |
| `plugin/tests/test_surface_registry.py` | `relations.jsonl` added to the load-bearing shape pins |

## Test plan

- [x] `uv run pytest -q` from `plugin/`: 3610 passed, 2 skipped, 0 failed
- [x] `uv run ruff check` on every touched file: clean
- [x] New coverage includes: text injection refusal on every writable field, permission-denied bucket dirs, torn appends, byte-identical preservation of rows this version cannot interpret, and a two-directional import ratchet proving only `privacy` and `cli` consume the module

## Notes for the reviewer

The design went through a two-refuter adversarial round before implementation; the spec with the full finding log lives in the project vault. The most load-bearing decisions: identity is strict same-thought (arc membership is a separate non-identity relation), and deletion reaches this file because relation rows are equivalence claims about content even though no field can carry text.
