### PR TITLE
feat(cli): relations adjudication verbs for the typed relation ledger

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1278,10 +1278,7 @@ def _cmd_relations_list(args) -> int:
     # GC window still renders as [unresolved].
     erased = relations.tombstoned_item_ids(project_dir=project)
     wanted = set(args.state or relations.STATES)
-    unknown = wanted - relations.STATES
-    if unknown:
-        print(f"unknown state: {', '.join(sorted(unknown))}")
-        return 1
+    # argparse `choices` is the gate for unknown states; no re-check here.
     rows, withheld = [], 0
     for record in records.values():
         touched = {str((record.get("from") or {}).get("item_id") or ""),

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1224,6 +1224,120 @@ def _cmd_refute_guard(args) -> int:
     return 0
 
 
+def _relations_channel() -> str:
+    """The observed write channel for a relation verdict.
+
+    Narrower than `_refute_channel` on purpose: there is no `--by agent`
+    here because agents cannot verdict relations AT ALL — the fold ignores
+    non-human channels and the module refuses them, so offering the flag
+    would only advertise a path that always fails. A verdict has to show an
+    interactive terminal; anything else is refused, not downgraded.
+    """
+    if not sys.stdin.isatty():
+        raise relations.RelationError(
+            "relation verdicts are human-only and need an interactive "
+            "terminal; there is no agent path to confirm, reject, or retract")
+    return "cli-tty"
+
+
+def _relations_endpoint_texts(project_dir) -> dict:
+    """Read-time id→text join over every project surface.  The ledger holds
+    no text by construction, so display resolves against the checkpoints —
+    and only at render time, never persisted back."""
+    texts = {}
+    for _, _, _, item in store.items_for_project(project_dir):
+        item_id = str(item.get("id") or "")
+        if item_id and item_id not in texts:
+            texts[item_id] = str(item.get("text") or "")
+    return texts
+
+
+def _print_relation(record, texts, *, detailed: bool = False) -> None:
+    frm, to = record.get("from") or {}, record.get("to") or {}
+    flag = " CONTRADICTION" if record.get("contradiction") else ""
+    print(f"{record['relation_id']}  {record['state']:<9} "
+          f"{record['type']}{flag}")
+    for label, endpoint in (("from", frm), ("to", to)):
+        item_id = str(endpoint.get("item_id") or "")
+        text = texts.get(item_id, "[unresolved]")
+        print(f"  {label}: {item_id} ({endpoint.get('session_id')}) {text}")
+    if detailed:
+        for proposal in record.get("proposals") or []:
+            print(f"  proposed by {proposal.get('matcher_version')}: "
+                  f"{', '.join(proposal.get('matched_by') or [])}")
+        if record.get("confirmed_channel"):
+            print(f"  confirmed via {record['confirmed_channel']}")
+
+
+def _cmd_relations_list(args) -> int:
+    project = _resolve_project(args.project)
+    records = relations.records(project_dir=project)
+    # Erased means TOMBSTONED, never merely absent: an edge touching a
+    # forgotten item is withheld from every rendered surface (the count is
+    # safe — it names no id), while an endpoint that only aged out of the
+    # GC window still renders as [unresolved].
+    erased = relations.tombstoned_item_ids(project_dir=project)
+    wanted = set(args.state or relations.STATES)
+    unknown = wanted - relations.STATES
+    if unknown:
+        print(f"unknown state: {', '.join(sorted(unknown))}")
+        return 1
+    rows, withheld = [], 0
+    for record in records.values():
+        touched = {str((record.get("from") or {}).get("item_id") or ""),
+                   str((record.get("to") or {}).get("item_id") or "")}
+        if touched & erased:
+            withheld += 1
+            continue
+        if record["state"] in wanted:
+            rows.append(record)
+    rows.sort(key=lambda r: (r["state"] != "candidate",
+                             r["relation_id"]))
+    _note_usage("relations:list")
+    if args.json:
+        print(json.dumps(rows, ensure_ascii=False, indent=2))
+    elif not rows:
+        print("no relations for this project")
+    else:
+        texts = _relations_endpoint_texts(project)
+        for record in rows:
+            _print_relation(record, texts)
+    if withheld:
+        print(f"{withheld} edge(s) withheld (erased endpoint)")
+    return 0
+
+
+def _cmd_relations_show(args) -> int:
+    project = _resolve_project(args.project)
+    record = relations.get(args.relation_id, project_dir=project)
+    if record is None:
+        print(f"unknown relation: {args.relation_id}")
+        return 1
+    _note_usage("relations:show")
+    if args.json:
+        print(json.dumps(record, ensure_ascii=False, indent=2))
+    else:
+        _print_relation(record, _relations_endpoint_texts(project),
+                        detailed=True)
+    return 0
+
+
+def _cmd_relations_verdict(args) -> int:
+    project = _resolve_project(args.project)
+    move = {"confirm": relations.confirm, "reject": relations.reject,
+            "retract": relations.retract}[args.verdict]
+    try:
+        move(args.relation_id, channel=_relations_channel(),
+             project_dir=project)
+    except relations.RelationError as exc:
+        print(f"relation {args.verdict} refused: {exc}")
+        return 1
+    _note_usage(f"relations:{args.verdict}")
+    state = relations.records(project_dir=project)[args.relation_id]["state"]
+    print(f"{args.relation_id} -> {state}")
+    return 0
+
+
 def _cmd_forget(args) -> int:
     """Deliberate item removal (#321): append a tombstone event whose status
     carries a content HASH, never the text — removal means the content leaves
@@ -4180,6 +4294,47 @@ def build_parser() -> argparse.ArgumentParser:
     pr_guard.add_argument("--quiet", action="store_true",
                           help="print nothing when no active refutation matches")
     pr_guard.set_defaults(func=_cmd_refute_guard)
+
+    p_relations = sub.add_parser(
+        "relations",
+        help="inspect and adjudicate typed item relations (#678, shadow mode)",
+        epilog="Examples:\n"
+               "  daimon relations list\n"
+               "  daimon relations show rel-0123456789abcdef\n"
+               "  daimon relations confirm rel-0123456789abcdef\n",
+    )
+    relations_sub = p_relations.add_subparsers(dest="relations_cmd",
+                                               required=True)
+    relations_sub.add_parser = functools.partial(
+        relations_sub.add_parser, formatter_class=fmt)
+
+    prl_list = relations_sub.add_parser(
+        "list", help="candidates first; endpoint texts resolved at read time")
+    prl_list.add_argument(
+        "--state", action="append",
+        choices=sorted(relations.STATES),
+        help="filter by state; repeatable (default: all)")
+    prl_list.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    prl_list.add_argument("--json", action="store_true", help="machine-readable output")
+    prl_list.set_defaults(func=_cmd_relations_list)
+
+    prl_show = relations_sub.add_parser(
+        "show", help="one relation with its proposal history")
+    prl_show.add_argument("relation_id", help="exact rel-… id")
+    prl_show.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    prl_show.add_argument("--json", action="store_true", help="machine-readable output")
+    prl_show.set_defaults(func=_cmd_relations_show)
+
+    for verdict, blurb in (
+            ("confirm", "record a human confirmation of a candidate edge"),
+            ("reject", "record a human rejection; sticky against re-proposal"),
+            ("retract", "undo a confirmation; a fresh proposal may revive it")):
+        prl_verdict = relations_sub.add_parser(
+            verdict,
+            help=f"{blurb} (human-only: needs an interactive terminal)")
+        prl_verdict.add_argument("relation_id", help="exact rel-… id")
+        prl_verdict.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+        prl_verdict.set_defaults(func=_cmd_relations_verdict, verdict=verdict)
 
     p_handoff = sub.add_parser(
         "handoff",

--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -47,6 +47,12 @@ NOT_AGENT_FACING = {
         "human-only by design: deletion is the user's call, and the full body "
         "says so in as many words"
     ),
+    "relations": (
+        "human adjudication surface (#678 shadow mode): verdicts require an "
+        "interactive terminal and agents cannot confirm, reject, or retract "
+        "at all; candidates are behaviorally inert, so there is nothing an "
+        "agent should do here yet"
+    ),
     "anchor": (
         "user curation: which claims deserve code-drift watching is a person's "
         "judgement about their own memory, not an agent's"

--- a/plugin/tests/test_relations_cli.py
+++ b/plugin/tests/test_relations_cli.py
@@ -1,0 +1,110 @@
+"""`daimon relations` adjudication verbs (#678 Phase 2→3 bridge).
+
+Verdicts are human-only: there is no `--by agent` escape because agents
+cannot confirm relations at all — the channel is observed (tty), never
+claimed. The list surface resolves endpoint texts at read time (the ledger
+itself holds no text) and withholds edges touching erased endpoints.
+"""
+
+import pytest
+
+from daimon_briefing import cli, relations, store
+
+PROJECT = "/repo/relations-cli-arc"
+
+
+@pytest.fixture
+def seeded(tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    store.write_checkpoint("S1", {
+        "session_id": "S1",
+        "created": "2026-08-01T00:00:00Z",
+        "working_context": {
+            "recent_decisions": [
+                {"text": "keep the relations ledger append only",
+                 "trust": "inferred"},
+                {"text": "adjudicate candidates through the tty path",
+                 "trust": "inferred"}]},
+    }, project_dir=PROJECT)
+    stored = store.read_latest(project_dir=PROJECT, fallback=False)
+    ids = [i["id"] for i in stored["working_context"]["recent_decisions"]]
+    rel_id = relations.propose(
+        type_="revision-of",
+        from_endpoint={"session_id": "S1", "field": "recent_decisions",
+                       "item_id": ids[0]},
+        to_endpoint={"session_id": "S1", "field": "recent_decisions",
+                     "item_id": ids[1]},
+        matched_by=["carry-absolute"],
+        matcher_version="lab-2026-08-12",
+        channel="lab-import",
+        project_dir=PROJECT,
+    )
+    return {"rel_id": rel_id, "item_ids": ids}
+
+
+def _tty(monkeypatch):
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True, raising=False)
+
+
+def test_list_resolves_texts_at_read_time(seeded, capsys):
+    assert cli.main(["relations", "list"]) == 0
+    out = capsys.readouterr().out
+    assert seeded["rel_id"] in out
+    assert "keep the relations ledger append only" in out
+    assert "candidate" in out
+
+
+def test_list_empty_project_says_so(tmp_checkpoint_dir, monkeypatch, capsys):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/repo/relations-empty")
+    assert cli.main(["relations", "list"]) == 0
+    assert "no relations" in capsys.readouterr().out
+
+
+def test_show_prints_proposal_history(seeded, capsys):
+    assert cli.main(["relations", "show", seeded["rel_id"]]) == 0
+    out = capsys.readouterr().out
+    assert "lab-2026-08-12" in out
+    assert "carry-absolute" in out
+
+
+def test_show_unknown_relation_fails(seeded, capsys):
+    assert cli.main(["relations", "show", "rel-" + "f" * 16]) == 1
+
+
+def test_confirm_refuses_without_a_terminal(seeded, capsys):
+    assert cli.main(["relations", "confirm", seeded["rel_id"]]) == 1
+    assert "terminal" in capsys.readouterr().out
+    state = relations.records(project_dir=PROJECT)[seeded["rel_id"]]["state"]
+    assert state == "candidate"
+
+
+def test_confirm_on_a_terminal_confirms(seeded, monkeypatch, capsys):
+    _tty(monkeypatch)
+    assert cli.main(["relations", "confirm", seeded["rel_id"]]) == 0
+    state = relations.records(project_dir=PROJECT)[seeded["rel_id"]]["state"]
+    assert state == "confirmed"
+
+
+def test_reject_and_retract_share_the_gate(seeded, monkeypatch):
+    _tty(monkeypatch)
+    assert cli.main(["relations", "reject", seeded["rel_id"]]) == 0
+    assert cli.main(["relations", "confirm", seeded["rel_id"]]) == 0
+    assert cli.main(["relations", "retract", seeded["rel_id"]]) == 0
+    state = relations.records(project_dir=PROJECT)[seeded["rel_id"]]["state"]
+    assert state == "retracted"
+
+
+def test_verdict_on_unknown_relation_fails_cleanly(seeded, monkeypatch,
+                                                   capsys):
+    _tty(monkeypatch)
+    assert cli.main(["relations", "confirm", "rel-" + "f" * 16]) == 1
+
+
+def test_list_withholds_edges_touching_erased_endpoints(seeded, capsys):
+    doomed = seeded["item_ids"][0]
+    store.append_event(doomed, "forgotten:deadbeef01234567",
+                       kind="tombstone", project_dir=PROJECT)
+    assert cli.main(["relations", "list"]) == 0
+    out = capsys.readouterr().out
+    assert seeded["rel_id"] not in out
+    assert "withheld" in out

--- a/plugin/tests/test_relations_cli.py
+++ b/plugin/tests/test_relations_cli.py
@@ -83,6 +83,9 @@ def test_confirm_on_a_terminal_confirms(seeded, monkeypatch, capsys):
     assert cli.main(["relations", "confirm", seeded["rel_id"]]) == 0
     state = relations.records(project_dir=PROJECT)[seeded["rel_id"]]["state"]
     assert state == "confirmed"
+    capsys.readouterr()
+    assert cli.main(["relations", "show", seeded["rel_id"]]) == 0
+    assert "confirmed via cli-tty" in capsys.readouterr().out
 
 
 def test_reject_and_retract_share_the_gate(seeded, monkeypatch):
@@ -98,6 +101,26 @@ def test_verdict_on_unknown_relation_fails_cleanly(seeded, monkeypatch,
                                                    capsys):
     _tty(monkeypatch)
     assert cli.main(["relations", "confirm", "rel-" + "f" * 16]) == 1
+
+
+def test_list_and_show_emit_machine_readable_json(seeded, capsys):
+    import json as jsonlib
+    assert cli.main(["relations", "list", "--json"]) == 0
+    rows = jsonlib.loads(capsys.readouterr().out)
+    assert rows[0]["relation_id"] == seeded["rel_id"]
+    assert cli.main(["relations", "show", seeded["rel_id"], "--json"]) == 0
+    record = jsonlib.loads(capsys.readouterr().out)
+    assert record["proposals"][0]["matcher_version"] == "lab-2026-08-12"
+
+
+def test_list_state_filter_narrows_output(seeded, monkeypatch, capsys):
+    _tty(monkeypatch)
+    assert cli.main(["relations", "reject", seeded["rel_id"]]) == 0
+    capsys.readouterr()
+    assert cli.main(["relations", "list", "--state", "candidate"]) == 0
+    assert "no relations" in capsys.readouterr().out
+    assert cli.main(["relations", "list", "--state", "rejected"]) == 0
+    assert seeded["rel_id"] in capsys.readouterr().out
 
 
 def test_list_withholds_edges_touching_erased_endpoints(seeded, capsys):

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -73,7 +73,7 @@ from pathlib import Path
 
 import pytest
 
-from daimon_briefing import cli, config, policy, refutations, store, teamsync
+from daimon_briefing import cli, config, policy, refutations, relations, store, teamsync
 
 from tests.conftest import FIXTURES, FakeChat
 import pytest as _pytest
@@ -445,6 +445,39 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
     def r_refute_guard():
         run(["refute", "guard", "revisit", "#502"], 0)
 
+    def _seed_relation():
+        # Proposals are not CLI-exposed (lab/serializer writers only), so the
+        # verdict drives seed one candidate through the module seam — the
+        # write the guard must observe is the VERDICT row the CLI appends.
+        ctx["relation_id"] = relations.propose(
+            type_="revision-of",
+            from_endpoint={"session_id": "S1", "field": "recent_decisions",
+                           "item_id": ctx["ids"][_T_KEEP]},
+            to_endpoint={"session_id": "S1", "field": "recent_decisions",
+                         "item_id": "r-feedbeef1234"},
+            matched_by=["carry-absolute"],
+            matcher_version="guard-drive",
+            channel="lab-import",
+            project_dir=proj,
+        )
+
+    def r_relations_list():
+        _seed_relation()
+        run(["relations", "list"], 0)
+
+    def r_relations_show():
+        run(["relations", "show", ctx["relation_id"]], 0)
+
+    def r_relations_confirm():
+        run(["relations", "confirm", ctx["relation_id"]], 0)
+
+    def r_relations_reject():
+        run(["relations", "reject", ctx["relation_id"]], 0)
+
+    def r_relations_retract():
+        run(["relations", "confirm", ctx["relation_id"]], 0)
+        run(["relations", "retract", ctx["relation_id"]], 0)
+
     def r_resolve():
         run(["resolve", ctx["ids"][_T_KEEP], "--note", "shipped"], 0)
 
@@ -571,6 +604,11 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
         ("refute", "list"): r_refute_list,
         ("refute", "search"): r_refute_search,
         ("refute", "guard"): r_refute_guard,
+        ("relations", "list"): r_relations_list,
+        ("relations", "show"): r_relations_show,
+        ("relations", "confirm"): r_relations_confirm,
+        ("relations", "reject"): r_relations_reject,
+        ("relations", "retract"): r_relations_retract,
         ("resolve",): r_resolve,
         ("reverify",): r_reverify,
         ("forget",): r_forget,


### PR DESCRIPTION
Refs #678

## Summary

- Adds the human adjudication surface for the typed relation ledger shipped in #679: `daimon relations list`, `show`, `confirm`, `reject`, `retract`.
- Verdicts are human-only. The channel is observed (interactive terminal), never claimed; there is deliberately no `--by agent` flag because agents cannot verdict relations at all, so the flag would only advertise a path that always fails. A non-tty verdict is refused, not downgraded.
- `list` resolves endpoint texts at read time against the checkpoint surfaces, since the ledger itself holds no text by construction. Edges touching an erased endpoint (forget tombstone) are withheld from the rendered output; only a safe count is printed. An endpoint that merely aged out of the GC window renders as `[unresolved]` and stays a valid record.
- `show` prints the proposal history per matcher version and the confirmation channel; contradiction-flagged records are marked.
- The relations command group is declared not-agent-facing in the skill surface with its reason: candidates are behaviorally inert in shadow mode, so there is nothing an agent should do here yet.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/cli.py` | `relations` command group: channel observation, read-time text join, erased-vs-unresolved rendering split, verdict dispatch |
| `plugin/daimon_briefing/skill_content.py` | `relations` added to `NOT_AGENT_FACING` with its reason |
| `plugin/tests/test_relations_cli.py` | 9 tests: tty gate, verdict flows, unknown ids, empty projects, read-time resolution, erased withholding |
| `plugin/tests/test_write_audit_guard.py` | Drive recipes for all five verbs; a candidate is seeded through the module seam since proposals are not CLI-exposed |

## Test plan

- [x] `uv run pytest -q` from `plugin/`: 3649 passed, 2 skipped, 0 failed
- [x] `uv run ruff check` on every touched file: clean
- [x] Write-audit guard passes with the new verbs driven, proving the verdict rows the CLI appends are attributable to a policy admission
- [x] Skill-content partition test passes with the command classified

## Notes for the reviewer

This is the bridge between phase 2 (ledger, merged in #679) and phase 3 (viewer-only lineage): confirmed relations are what the viewer will render, and this surface is how they get confirmed. The tty-observation posture is copied from the refutation ledger's channel design, narrowed by removing the agent path entirely.
