### PR TITLE
chore(research): identity lineage shadow laboratory and calibration importer

### DIFF
--- a/research/experiments/identity-lineage-678/.gitignore
+++ b/research/experiments/identity-lineage-678/.gitignore
@@ -1,0 +1,5 @@
+# Real checkpoint text and human judgments are private by construction.
+out*/
+*.jsonl
+__pycache__/
+

--- a/research/experiments/identity-lineage-678/README.md
+++ b/research/experiments/identity-lineage-678/README.md
@@ -1,0 +1,45 @@
+# Identity Lineage Shadow Laboratory — #678
+
+Read-only replay for testing persistent item lineage without changing Daimon's
+checkpoint, carry, recall, lifecycle, corroboration, or viewer behavior.
+
+The laboratory copies the selected checkpoint bytes into a temporary directory,
+compares adjacent checkpoints there, and emits a private review queue. It hashes
+the source corpus before and after the run and refuses success if any source byte
+changed while it was reading.
+
+## Self-check
+
+```bash
+uv run --project ../../../plugin pytest -q test_lineage_lab.py
+```
+
+## Private dogfood run
+
+```bash
+uv run --project ../../../plugin python lineage_lab.py \
+  --project /path/to/your/project \
+  --out out-current
+```
+
+Open `out-current/review.html` locally. Review decisions are stored only in the
+browser's local storage until exported. The export and `candidates.jsonl` contain
+real checkpoint text and MUST NOT be committed.
+
+## Outputs
+
+- `summary.json` — aggregate measurements and before/after integrity digests;
+  contains no item text.
+- `candidates.jsonl` — private typed-relation proposals with both item texts.
+- `review.html` — private, dependency-free review UI over the same proposals.
+
+## Interpretation
+
+`observed` means the store already exposes the relationship (unchanged identical
+ID). `candidate` means exactly that: it is never a resolution, merge, lifecycle
+transition, corroboration, deletion scope, or recall-dedup instruction.
+
+The current carry matcher appears as one evidence rail so its behavior can be
+measured. It is not promoted to an identity oracle. Ambiguous endpoints remain
+visible and are never collapsed to a guessed winner.
+

--- a/research/experiments/identity-lineage-678/import_calibration.py
+++ b/research/experiments/identity-lineage-678/import_calibration.py
@@ -1,0 +1,113 @@
+"""Import CALIBRATION-set human labels as lab-import proposals (#678).
+
+Ratified boundaries (2026-08-13, decisions.jsonl):
+- Calibration partition ONLY; the held-out partition stays out of the
+  product ledger until the gate evaluation is spent.
+- Every imported row is a `lab-import` PROPOSAL (agent authority).  Human
+  judgments influence which type is proposed — thought keeps the matcher's
+  relation, arc becomes same-arc — but no imported row confirms anything.
+- `legacy-shared-id` is not a persistable rail (derived at read time); rows
+  whose evidence is legacy-only are skipped and counted.
+
+Idempotent: candidate ids already present in the ledger are skipped, so a
+re-run appends nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from daimon_briefing import relations
+
+HERE = Path(__file__).parent
+OUT = HERE / "out-current"
+
+KIND_TO_FIELD = {
+    "question": "open_questions",
+    "decision": "recent_decisions",
+    "belief": "strong_beliefs",
+    "uncertainty": "uncertainties",
+    "contradiction": "contradictions_flagged",
+}
+
+
+def _endpoint(side: dict) -> dict:
+    return {
+        "session_id": side["session_id"],
+        "field": KIND_TO_FIELD[side["kind"]],
+        "item_id": side["item_id"],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project", required=True)
+    parser.add_argument("--apply", action="store_true",
+                        help="write proposals; default is a dry run")
+    args = parser.parse_args()
+
+    partitions = json.loads(
+        (OUT / "partitions-frozen-2026-08-12.json").read_text())
+    calibration = partitions["calibration"]          # {candidate_id: label}
+    rows = {r["candidate_id"]: r for r in (
+        json.loads(line) for line in
+        (OUT / "candidates.jsonl").read_text().splitlines())}
+    existing = set(relations.records(project_dir=args.project))
+
+    planned, skipped_legacy, skipped_present, errors = [], 0, 0, []
+    for cid, label in sorted(calibration.items()):
+        row = rows[cid]
+        rails = [r for r in row["matched_by"] if r in relations.RAILS]
+        if not rails:
+            skipped_legacy += 1
+            continue
+        type_ = "same-arc" if label == "arc" else row["relation"]
+        frm = _endpoint(row["current"])
+        to = _endpoint(row["previous"])
+        try:
+            rel_id = relations.make_id(
+                type_,
+                relations._validate_endpoint("from", frm),
+                relations._validate_endpoint("to", to))
+        except relations.RelationError as err:
+            errors.append((cid, str(err)))
+            continue
+        if rel_id in existing:
+            skipped_present += 1
+            continue
+        planned.append((cid, label, type_, frm, to, rails))
+
+    print(f"calibration labels: {len(calibration)}")
+    print(f"planned proposals:  {len(planned)}")
+    print(f"skipped legacy-only rails: {skipped_legacy}")
+    print(f"skipped already-present:   {skipped_present}")
+    for cid, err in errors:
+        print(f"REFUSED {cid}: {err}")
+    if not args.apply:
+        print("dry run — nothing written (pass --apply)")
+        return 0
+
+    written = 0
+    for cid, label, type_, frm, to, rails in planned:
+        relations.propose(
+            type_=type_,
+            from_endpoint=frm,
+            to_endpoint=to,
+            matched_by=rails,
+            matcher_version="lab-2026-08-12",
+            channel="lab-import",
+            project_dir=args.project,
+        )
+        written += 1
+    folded = relations.records(project_dir=args.project)
+    states: dict[str, int] = {}
+    for record in folded.values():
+        states[record["state"]] = states.get(record["state"], 0) + 1
+    print(f"written: {written}; ledger records now {len(folded)} {states}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/experiments/identity-lineage-678/lineage_lab.py
+++ b/research/experiments/identity-lineage-678/lineage_lab.py
@@ -1,0 +1,432 @@
+"""Read-only identity-lineage laboratory for daimon issue #678.
+
+This is research instrumentation, not a product write path. It snapshots source
+checkpoint bytes into a temporary directory, proposes typed relationships over
+adjacent checkpoints, and writes private review artifacts only to ``--out``.
+No proposal is allowed to mutate identity or affect a Daimon consumer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import json
+import shutil
+import tempfile
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from daimon_briefing import carry, schema, store
+
+
+POINTER_NAMES = {"latest.json", "prev-1.json", "prev-2.json"}
+
+
+@dataclass(frozen=True)
+class Occurrence:
+    session_id: str
+    created: str
+    section: str
+    field: str
+    kind: str
+    item_id: str
+    text: str
+    item: dict
+
+    @property
+    def ref(self) -> str:
+        return f"{self.session_id}:{self.field}:{self.item_id}"
+
+
+def _load_json(path: Path) -> dict | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _created_epoch(value) -> float:
+    if not value:
+        return 0.0
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.timestamp()
+    except ValueError:
+        return 0.0
+
+
+def _content_key(text: str) -> str:
+    return " ".join(str(text).split()).casefold()
+
+
+def _anchor_key(item: dict) -> str:
+    anchor = item.get("anchored_to")
+    if not isinstance(anchor, dict) or not anchor:
+        return ""
+    return json.dumps(anchor, sort_keys=True, separators=(",", ":"))
+
+
+def _source_ids(item: dict) -> frozenset[str]:
+    values = item.get("source_message_ids")
+    if not isinstance(values, list):
+        return frozenset()
+    return frozenset(str(value) for value in values if str(value).strip())
+
+
+def _quote_is_bound(item: dict) -> bool:
+    if item.get("quote_verified") is True:
+        return True
+    receipt = item.get("quote_provenance")
+    return isinstance(receipt, dict) and bool(receipt.get("binding"))
+
+
+def source_manifest(paths: list[Path], root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(paths):
+        digest.update(str(path.relative_to(root)).encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def discover_checkpoints(root: Path, project_slug: str) -> list[Path]:
+    """Find canonical per-session files only; pointer copies are excluded."""
+    found = []
+    for path in sorted(root.glob("*.json")):
+        if path.name in POINTER_NAMES or path.name.startswith("prev-"):
+            continue
+        checkpoint = _load_json(path)
+        if checkpoint and checkpoint.get("project_slug") == project_slug:
+            found.append(path)
+    return found
+
+
+def copy_snapshot(paths: list[Path], destination: Path) -> list[dict]:
+    checkpoints = []
+    for source in paths:
+        target = destination / source.name
+        shutil.copyfile(source, target)
+        checkpoint = _load_json(target)
+        if checkpoint:
+            checkpoints.append(checkpoint)
+    checkpoints.sort(key=lambda cp: (
+        _created_epoch(cp.get("created")), str(cp.get("session_id") or "")))
+    return checkpoints
+
+
+def iter_occurrences(checkpoint: dict) -> list[Occurrence]:
+    occurrences = []
+    sid = str(checkpoint.get("session_id") or "")
+    created = str(checkpoint.get("created") or "")
+    for field in schema.ITEM_FIELDS:
+        if field.singleton:
+            continue
+        values = (checkpoint.get(field.section) or {}).get(field.key)
+        if not isinstance(values, list):
+            continue
+        for item in values:
+            if not isinstance(item, dict):
+                continue
+            text = str(item.get("text") or "").strip()
+            item_id = str(item.get("id") or "").strip()
+            if not text or not item_id:
+                continue
+            occurrences.append(Occurrence(
+                sid, created, field.section, field.key, field.kind,
+                item_id, text, item))
+    return occurrences
+
+
+def _typed_supersedes(previous: Occurrence, current: Occurrence) -> bool:
+    links = current.item.get("links")
+    if not isinstance(links, list):
+        return False
+    for link in links:
+        if not isinstance(link, dict) or link.get("type") != "supersedes":
+            continue
+        target = str(link.get("target") or "")
+        if target == previous.item_id or _content_key(target) == _content_key(previous.text):
+            return True
+    return False
+
+
+def _evidence(previous: Occurrence, current: Occurrence,
+              generic: frozenset[str]) -> list[str]:
+    methods = []
+    if _content_key(previous.text) == _content_key(current.text):
+        methods.append("exact-text")
+    quote_a = str(previous.item.get("quote") or "").strip()
+    quote_b = str(current.item.get("quote") or "").strip()
+    if (quote_a and quote_a == quote_b and _quote_is_bound(previous.item)
+            and _quote_is_bound(current.item)):
+        methods.append("bound-exact-quote")
+    if _source_ids(previous.item) & _source_ids(current.item):
+        methods.append("shared-source-message")
+    anchor_a, anchor_b = _anchor_key(previous.item), _anchor_key(current.item)
+    if anchor_a and anchor_a == anchor_b:
+        methods.append("exact-anchor")
+    rail = carry._match_path(previous.text, current.text, generic)
+    if rail:
+        methods.append(f"carry-{rail}")
+    if _typed_supersedes(previous, current):
+        methods.append("typed-supersedes")
+    return methods
+
+
+def _candidate(previous: Occurrence, current: Occurrence, methods: list[str],
+               relation: str, state: str = "candidate") -> dict:
+    raw = f"{previous.ref}\0{current.ref}\0{relation}".encode("utf-8")
+    return {
+        "candidate_id": "rel-" + hashlib.sha256(raw).hexdigest()[:16],
+        "relation": relation,
+        "state": state,
+        "matched_by": methods,
+        "ambiguous": False,
+        "previous": {
+            "session_id": previous.session_id,
+            "created": previous.created,
+            "kind": previous.kind,
+            "item_id": previous.item_id,
+            "text": previous.text,
+        },
+        "current": {
+            "session_id": current.session_id,
+            "created": current.created,
+            "kind": current.kind,
+            "item_id": current.item_id,
+            "text": current.text,
+        },
+    }
+
+
+def compare_transition(previous_cp: dict, current_cp: dict) -> tuple[list[dict], dict]:
+    previous = iter_occurrences(previous_cp)
+    current = iter_occurrences(current_cp)
+    prev_ids = {item.item_id for item in previous}
+    curr_ids = {item.item_id for item in current}
+    previous_by_kind = defaultdict(list)
+    current_by_kind = defaultdict(list)
+    for item in previous:
+        previous_by_kind[item.kind].append(item)
+    for item in current:
+        current_by_kind[item.kind].append(item)
+
+    candidates = []
+    for kind in sorted(set(previous_by_kind) | set(current_by_kind)):
+        old_items = previous_by_kind[kind]
+        new_items = current_by_kind[kind]
+        generic = carry._generic_terms(
+            [item.text for item in old_items] + [item.text for item in new_items])
+        for old in old_items:
+            for new in new_items:
+                if old.item_id == new.item_id:
+                    if _content_key(old.text) != _content_key(new.text):
+                        candidates.append(_candidate(
+                            old, new, ["legacy-shared-id"], "revision-of"))
+                    continue
+                methods = _evidence(old, new, generic)
+                if methods:
+                    relation = "supersedes" if "typed-supersedes" in methods else "revision-of"
+                    candidates.append(_candidate(old, new, methods, relation))
+
+    # Cross-kind transition worth testing: a decision may answer a prior
+    # question. It is always a candidate; surface similarity cannot prove the
+    # speech act. Strong evidence or the existing absolute carry rail is enough
+    # to put it in the review queue, never enough to confirm it.
+    old_questions = previous_by_kind["question"]
+    new_decisions = current_by_kind["decision"]
+    generic = carry._generic_terms(
+        [item.text for item in old_questions] + [item.text for item in new_decisions])
+    existing = {(c["previous"]["item_id"], c["current"]["item_id"], c["relation"])
+                for c in candidates}
+    for old in old_questions:
+        for new in new_decisions:
+            methods = _evidence(old, new, generic)
+            strong = {"bound-exact-quote", "shared-source-message", "exact-anchor",
+                      "carry-absolute", "typed-supersedes"}
+            if not (set(methods) & strong):
+                continue
+            key = (old.item_id, new.item_id, "answers")
+            if key not in existing:
+                candidates.append(_candidate(old, new, methods, "answers"))
+
+    endpoint_counts = Counter()
+    for candidate in candidates:
+        endpoint_counts[("previous", candidate["previous"]["session_id"],
+                         candidate["previous"]["item_id"])] += 1
+        endpoint_counts[("current", candidate["current"]["session_id"],
+                         candidate["current"]["item_id"])] += 1
+    for candidate in candidates:
+        candidate["ambiguous"] = any((
+            endpoint_counts[("previous", candidate["previous"]["session_id"],
+                             candidate["previous"]["item_id"])] > 1,
+            endpoint_counts[("current", candidate["current"]["session_id"],
+                             candidate["current"]["item_id"])] > 1,
+        ))
+
+    changed = 0
+    old_by_id = {item.item_id: item for item in previous}
+    new_by_id = {item.item_id: item for item in current}
+    for item_id in prev_ids & curr_ids:
+        if _content_key(old_by_id[item_id].text) != _content_key(new_by_id[item_id].text):
+            changed += 1
+    metrics = {
+        "previous_items": len(previous),
+        "current_items": len(current),
+        "shared_ids": len(prev_ids & curr_ids),
+        "added_ids": len(curr_ids - prev_ids),
+        "dropped_ids": len(prev_ids - curr_ids),
+        "shared_id_text_changes": changed,
+    }
+    return candidates, metrics
+
+
+def analyse(checkpoints: list[dict], project_slug: str) -> tuple[list[dict], dict]:
+    all_candidates = []
+    transition_totals = Counter()
+    occurrences = []
+    for checkpoint in checkpoints:
+        occurrences.extend(iter_occurrences(checkpoint))
+    for previous, current in zip(checkpoints, checkpoints[1:]):
+        candidates, metrics = compare_transition(previous, current)
+        all_candidates.extend(candidates)
+        transition_totals.update(metrics)
+
+    by_relation = Counter(c["relation"] for c in all_candidates)
+    by_method = Counter(method for c in all_candidates for method in c["matched_by"])
+    id_counts = Counter(item.item_id for item in occurrences)
+    summary = {
+        "issue": 678,
+        "mode": "read-only-shadow",
+        "project_slug": project_slug,
+        "privacy": "aggregate-only summary; candidates.jsonl and review.html are private",
+        "checkpoints": len(checkpoints),
+        "transitions": max(0, len(checkpoints) - 1),
+        "item_occurrences": len(occurrences),
+        "unique_item_ids": len(id_counts),
+        "single_occurrence_ids": sum(count == 1 for count in id_counts.values()),
+        "transition_totals": dict(sorted(transition_totals.items())),
+        "candidate_count": len(all_candidates),
+        "ambiguous_candidates": sum(c["ambiguous"] for c in all_candidates),
+        "candidates_by_relation": dict(sorted(by_relation.items())),
+        "evidence_rail_counts": dict(sorted(by_method.items())),
+        "consumer_effects": {
+            "checkpoint_writes": 0,
+            "events_writes": 0,
+            "recall_writes": 0,
+            "viewer_changes": 0,
+        },
+    }
+    return all_candidates, summary
+
+
+def _review_html(candidates: list[dict], summary: dict) -> str:
+    payload = json.dumps(candidates, ensure_ascii=False).replace("<", "\\u003c")
+    safe_summary = html.escape(json.dumps(summary, sort_keys=True))
+    return f"""<!doctype html>
+<html lang=\"en\"><head><meta charset=\"utf-8\">
+<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">
+<title>Daimon identity review</title>
+<style>
+:root{{--paper:#090c10;--surface:#0d1117;--raised:#161b22;--border:#30363d;
+--muted:#8b949e;--ink:#e6edf3;--accent:#00d4aa;--amber:#e0b466;--danger:#d98f86;
+--mono:ui-monospace,"SF Mono","Cascadia Code",Menlo,Consolas,monospace;
+--sans:ui-sans-serif,-apple-system,BlinkMacSystemFont,system-ui,sans-serif}}
+*{{box-sizing:border-box}}body{{margin:0;background:var(--paper);color:var(--ink);
+font:14px/1.5 var(--sans)}}header{{position:sticky;top:0;z-index:2;display:flex;
+gap:16px;align-items:center;padding:12px 24px;background:var(--paper);
+border-bottom:1px solid #21262d}}h1{{font-size:18px;margin:0}}header p{{margin:0;color:var(--muted)}}
+button,select{{font:inherit;color:inherit;background:var(--surface);border:1px solid var(--border);
+border-radius:6px;padding:7px 10px}}button{{cursor:pointer}}button:hover{{border-color:var(--muted)}}
+button:focus-visible,select:focus-visible{{outline:2px solid var(--accent);outline-offset:2px}}
+.toolbar{{margin-left:auto;display:flex;gap:8px;align-items:center}}main{{max-width:1100px;margin:auto;padding:24px}}
+.safety{{border-left:3px solid var(--amber);background:var(--surface);padding:12px 16px;margin-bottom:16px}}
+.summary{{display:flex;gap:24px;color:var(--muted);padding:10px 0 18px;border-bottom:1px solid #21262d}}
+.summary strong{{color:var(--ink);font-family:var(--mono)}}#queue{{display:grid;gap:12px;margin-top:16px}}
+.pair{{border:1px solid #21262d;background:var(--surface);border-radius:8px;overflow:hidden}}
+.pair.active{{border-color:var(--accent)}}.meta{{display:flex;gap:10px;align-items:center;padding:10px 14px;
+border-bottom:1px solid #21262d;color:var(--muted);font-family:var(--mono);font-size:12px}}
+.meta .relation{{color:var(--accent)}}.meta .ambiguous{{color:var(--amber)}}.texts{{display:grid;
+grid-template-columns:1fr 1fr}}.item{{padding:16px}}.item+ .item{{border-left:1px solid #21262d}}
+.item .where{{color:var(--muted);font:12px var(--mono);margin-bottom:8px}}.item p{{margin:0}}
+.actions{{display:flex;gap:8px;padding:10px 14px;border-top:1px solid #21262d}}
+.actions button.selected{{background:#12372f;border-color:var(--accent)}}.actions button[data-v=\"different\"].selected{{background:#3b2020;border-color:var(--danger)}}
+.empty{{padding:40px;text-align:center;color:var(--muted)}}@media(max-width:720px){{header{{align-items:flex-start;flex-wrap:wrap}}
+.toolbar{{margin-left:0;width:100%}}.texts{{grid-template-columns:1fr}}.item+.item{{border-left:0;border-top:1px solid #21262d}}
+.summary{{flex-wrap:wrap}}}}
+</style></head><body>
+<header><h1>Daimon identity review</h1><p>Issue #678 · private shadow output</p>
+<div class=\"toolbar\"><select id=\"filter\" aria-label=\"Filter candidates\"><option value=\"all\">All candidates</option>
+<option value=\"unreviewed\">Unreviewed</option><option value=\"ambiguous\">Ambiguous</option>
+<option value=\"revision-of\">revision-of</option><option value=\"answers\">answers</option><option value=\"supersedes\">supersedes</option></select>
+<button id=\"export\">Export reviews</button></div></header><main>
+<div class=\"safety\"><strong>Nothing here changes Daimon.</strong> These are review candidates only. They do not merge IDs, resolve loops, alter recall, propagate corroboration, or widen deletion.</div>
+<div class=\"summary\"><span><strong id=\"visible\">0</strong> visible</span><span><strong id=\"done\">0</strong> reviewed</span>
+<span>Keys: <strong>J/K</strong> move · <strong>1</strong> same thread · <strong>2</strong> different · <strong>3</strong> uncertain</span></div>
+<div id=\"queue\"></div><script id=\"data\" type=\"application/json\">{payload}</script>
+<script>
+const rows=JSON.parse(document.getElementById('data').textContent),key='daimon-lineage-{summary.get('source_manifest_before','')[:12]}';
+let reviews=JSON.parse(localStorage.getItem(key)||'{{}}'),active=0;
+const esc=s=>String(s).replace(/[&<>\"']/g,c=>({{'&':'&amp;','<':'&lt;','>':'&gt;','\"':'&quot;',"'":'&#39;'}}[c]));
+function filtered(){{const f=document.getElementById('filter').value;return rows.filter(r=>f==='all'||(f==='unreviewed'&&!reviews[r.candidate_id])||(f==='ambiguous'&&r.ambiguous)||r.relation===f)}}
+function render(){{const list=filtered();active=Math.min(active,Math.max(0,list.length-1));document.getElementById('visible').textContent=list.length;
+document.getElementById('done').textContent=Object.keys(reviews).length;const q=document.getElementById('queue');if(!list.length){{q.innerHTML='<div class=\"empty\">No candidates in this view.</div>';return}}
+q.innerHTML=list.map((r,i)=>`<article class=\"pair ${{i===active?'active':''}}\" data-id=\"${{r.candidate_id}}\"><div class=\"meta\"><span class=\"relation\">${{esc(r.relation)}}</span><span>${{esc(r.matched_by.join(' + '))}}</span>${{r.ambiguous?'<span class=\"ambiguous\">ambiguous endpoints</span>':''}}</div><div class=\"texts\"><section class=\"item\"><div class=\"where\">previous · ${{esc(r.previous.kind)}} · ${{esc(r.previous.session_id)}}</div><p>${{esc(r.previous.text)}}</p></section><section class=\"item\"><div class=\"where\">current · ${{esc(r.current.kind)}} · ${{esc(r.current.session_id)}}</div><p>${{esc(r.current.text)}}</p></section></div><div class=\"actions\">${{[['same','Same thread'],['different','Different'],['uncertain','Uncertain']].map(([v,l])=>`<button data-v=\"${{v}}\" class=\"${{reviews[r.candidate_id]===v?'selected':''}}\">${{l}}</button>`).join('')}}</div></article>`).join('');
+q.querySelectorAll('button[data-v]').forEach(b=>b.onclick=()=>{{const id=b.closest('.pair').dataset.id;reviews[id]=b.dataset.v;localStorage.setItem(key,JSON.stringify(reviews));render()}});q.querySelector('.active')?.scrollIntoView({{block:'nearest'}})}}
+document.getElementById('filter').onchange=()=>{{active=0;render()}};document.addEventListener('keydown',e=>{{if(['SELECT','BUTTON'].includes(e.target.tagName))return;const list=filtered();if(e.key.toLowerCase()==='j')active=Math.min(active+1,list.length-1);else if(e.key.toLowerCase()==='k')active=Math.max(0,active-1);else if(['1','2','3'].includes(e.key)){{const r=list[active];if(r)reviews[r.candidate_id]={{'1':'same','2':'different','3':'uncertain'}}[e.key],localStorage.setItem(key,JSON.stringify(reviews))}}else return;render()}});
+document.getElementById('export').onclick=()=>{{const blob=new Blob([JSON.stringify({{generated_at:new Date().toISOString(),reviews}},null,2)],{{type:'application/json'}}),a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download='lineage-reviews.json';a.click();URL.revokeObjectURL(a.href)}};render();
+</script><details hidden><summary>Aggregate run metadata</summary><pre>{safe_summary}</pre></details></main></body></html>"""
+
+
+def write_outputs(out_dir: Path, candidates: list[dict], summary: dict) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "candidates.jsonl").write_text(
+        "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in candidates),
+        encoding="utf-8")
+    (out_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (out_dir / "review.html").write_text(
+        _review_html(candidates, summary), encoding="utf-8")
+
+
+def run(checkpoint_dir: Path, project: str, out_dir: Path) -> dict:
+    project_slug = store.project_slug(project)
+    paths = discover_checkpoints(checkpoint_dir, project_slug)
+    if len(paths) < 2:
+        raise SystemExit(f"need at least 2 checkpoints for {project_slug}; found {len(paths)}")
+    before = source_manifest(paths, checkpoint_dir)
+    with tempfile.TemporaryDirectory(prefix="daimon-lineage-shadow-") as raw:
+        checkpoints = copy_snapshot(paths, Path(raw))
+        candidates, summary = analyse(checkpoints, project_slug)
+    after = source_manifest(paths, checkpoint_dir)
+    summary["source_manifest_before"] = before
+    summary["source_manifest_after"] = after
+    summary["source_byte_integrity"] = "verified" if before == after else "FAILED"
+    if before != after:
+        raise RuntimeError("source checkpoint bytes changed during shadow replay")
+    write_outputs(out_dir, candidates, summary)
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint-dir", type=Path,
+                        default=Path.home() / ".daimon" / "checkpoints")
+    parser.add_argument("--project", default=str(Path.cwd()))
+    parser.add_argument("--out", type=Path, default=Path("out-current"))
+    args = parser.parse_args()
+    summary = run(args.checkpoint_dir.expanduser(), args.project, args.out)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/research/experiments/identity-lineage-678/test_lineage_lab.py
+++ b/research/experiments/identity-lineage-678/test_lineage_lab.py
@@ -1,0 +1,124 @@
+import json
+from pathlib import Path
+
+import lineage_lab
+from daimon_briefing import policy, store
+
+
+PROJECT = "/repo/identity-fixture"
+
+
+def _cp(sid, created, questions=(), decisions=(), beliefs=()):
+    cp = {
+        "session_id": sid,
+        "created": created,
+        "project_slug": store.project_slug(PROJECT),
+        "working_context": {
+            "open_questions": [{"text": text} for text in questions],
+            "recent_decisions": [{"text": text} for text in decisions],
+        },
+        "epistemic_snapshot": {
+            "strong_beliefs": [{"text": text} for text in beliefs],
+            "uncertainties": [],
+            "contradictions_flagged": [],
+        },
+    }
+    policy.stamp_item_ids(cp)
+    return cp
+
+
+def _write(root: Path, cp: dict):
+    (root / f"{cp['session_id']}.json").write_text(
+        json.dumps(cp, indent=2), encoding="utf-8")
+
+
+def test_shadow_run_is_deterministic_and_source_bytes_do_not_change(tmp_path):
+    source = tmp_path / "checkpoints"
+    source.mkdir()
+    first = _cp(
+        "S1", "2026-01-01T00:00:00Z",
+        questions=["Should the lineage ledger remain append only?"],
+        decisions=["Keep checkpoint representations immutable"],
+        beliefs=["False identity merges are worse than missed links"],
+    )
+    second = _cp(
+        "S2", "2026-01-02T00:00:00Z",
+        decisions=[
+            "The lineage ledger should remain append only",
+            "Checkpoint representations remain immutable",
+        ],
+        beliefs=["Invented continuity is worse than a missed relationship"],
+    )
+    _write(source, first)
+    _write(source, second)
+    before = {path.name: path.read_bytes() for path in source.iterdir()}
+
+    one = lineage_lab.run(source, PROJECT, tmp_path / "out-one")
+    two = lineage_lab.run(source, PROJECT, tmp_path / "out-two")
+
+    assert one == two
+    assert one["source_byte_integrity"] == "verified"
+    assert one["consumer_effects"] == {
+        "checkpoint_writes": 0,
+        "events_writes": 0,
+        "recall_writes": 0,
+        "viewer_changes": 0,
+    }
+    assert before == {path.name: path.read_bytes() for path in source.iterdir()}
+    assert (tmp_path / "out-one" / "review.html").exists()
+    assert (tmp_path / "out-one" / "candidates.jsonl").exists()
+
+
+def test_changed_shared_id_is_reviewed_not_confirmed():
+    first = _cp("S1", "2026-01-01T00:00:00Z",
+                decisions=["Keep the record immutable"])
+    second = _cp("S2", "2026-01-02T00:00:00Z",
+                 decisions=["The record remains immutable"])
+    old = first["working_context"]["recent_decisions"][0]
+    second["working_context"]["recent_decisions"][0]["id"] = old["id"]
+
+    candidates, metrics = lineage_lab.compare_transition(first, second)
+
+    assert metrics["shared_id_text_changes"] == 1
+    assert len(candidates) == 1
+    assert candidates[0]["state"] == "candidate"
+    assert candidates[0]["matched_by"] == ["legacy-shared-id"]
+
+
+def test_ambiguous_overlap_is_never_collapsed_to_one_guess():
+    first = _cp(
+        "S1", "2026-01-01T00:00:00Z",
+        decisions=[
+            "Persist immutable checkpoint records",
+            "Review lineage relation candidates",
+        ],
+    )
+    second = _cp(
+        "S2", "2026-01-02T00:00:00Z",
+        decisions=[
+            "Persist immutable checkpoint records while reviewing lineage relation candidates"
+        ],
+    )
+
+    candidates, _ = lineage_lab.compare_transition(first, second)
+
+    revisions = [row for row in candidates if row["relation"] == "revision-of"]
+    assert len(revisions) == 2
+    assert all(row["ambiguous"] for row in revisions)
+
+
+def test_explicit_supersession_is_typed_not_identity():
+    first = _cp("S1", "2026-01-01T00:00:00Z",
+                decisions=["Use mutable memory records"])
+    second = _cp("S2", "2026-01-02T00:00:00Z",
+                 decisions=["Use immutable relation records"])
+    old = first["working_context"]["recent_decisions"][0]
+    new = second["working_context"]["recent_decisions"][0]
+    new["links"] = [{"type": "supersedes", "target": old["id"]}]
+
+    candidates, _ = lineage_lab.compare_transition(first, second)
+
+    supersedes = [row for row in candidates if row["relation"] == "supersedes"]
+    assert len(supersedes) == 1
+    assert supersedes[0]["state"] == "candidate"
+    assert "typed-supersedes" in supersedes[0]["matched_by"]


### PR DESCRIPTION
Refs #678

## Summary

- Commits the identity lineage shadow laboratory to `research/experiments/`, following the refutation-573 precedent: research instrumentation lives in the repo, its text-bearing outputs stay local.
- `lineage_lab.py` replays canonical checkpoints read-only (source-manifest SHA proof before and after, hard failure if any source byte changes), proposes typed relation candidates over adjacent checkpoints with per-rail evidence, preserves ambiguity instead of guessing winners, and generates a dependency-free private review UI.
- `import_calibration.py` is the idempotent importer that seeded the production relations ledger with lab-import proposals; committing it makes the provenance of those ledger rows auditable from the repo itself.
- The experiment `.gitignore` excludes `out*/` and `*.jsonl`, so candidate pairs, review pages, judgments, and frozen evaluation partitions never leave the local machine.

## Changes

| File | Change |
|------|--------|
| `research/experiments/identity-lineage-678/lineage_lab.py` | Read-only shadow replay, candidate generation, integrity proof, review UI generator |
| `research/experiments/identity-lineage-678/test_lineage_lab.py` | Determinism, byte-preservation, ambiguity, and typed-supersession safety checks |
| `research/experiments/identity-lineage-678/import_calibration.py` | Idempotent lab-import proposal seeding with dry-run default |
| `research/experiments/identity-lineage-678/README.md` | Operation and privacy contract |
| `research/experiments/identity-lineage-678/.gitignore` | Keeps every text-bearing output local |

## Test plan

- [x] `uv run --project ../../../plugin pytest -q test_lineage_lab.py`: 4 passed
- [x] Full diff scanned for private strings, absolute paths, and internal measurement numbers before publishing; the one absolute local path in the README example was genericized
