### PR TITLE
feat(ui): history lane renders confirmed relations inside the entry page

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1241,38 +1241,18 @@ def _relations_channel() -> str:
 
 
 def _relations_endpoint_texts(project_dir) -> dict:
-    """Read-time id→text join over every project surface.  The ledger holds
-    no text by construction, so display resolves against the checkpoints —
-    and only at render time, never persisted back."""
-    texts = {}
-    for _, _, _, item in store.items_for_project(project_dir):
-        item_id = str(item.get("id") or "")
-        if item_id and item_id not in texts:
-            texts[item_id] = str(item.get("text") or "")
-    return texts
+    """Stable cli seam over the engine's read-time id→text join."""
+    return relations.endpoint_texts(project_dir)
 
 
 def _cmd_relations_list(args) -> int:
     project = _resolve_project(args.project)
-    records = relations.records(project_dir=project)
-    # Erased means TOMBSTONED, never merely absent: an edge touching a
-    # forgotten item is withheld from every rendered surface (the count is
-    # safe — it names no id), while an endpoint that only aged out of the
-    # GC window still renders as [unresolved].
-    erased = relations.tombstoned_item_ids(project_dir=project)
-    wanted = set(args.state or relations.STATES)
-    # argparse `choices` is the gate for unknown states; no re-check here.
-    rows, withheld = [], 0
-    for record in records.values():
-        touched = {str((record.get("from") or {}).get("item_id") or ""),
-                   str((record.get("to") or {}).get("item_id") or "")}
-        if touched & erased:
-            withheld += 1
-            continue
-        if record["state"] in wanted:
-            rows.append(record)
-    rows.sort(key=lambda r: (r["state"] != "candidate",
-                             r["relation_id"]))
+    # Sort, state filter, and erased-edge withholding all live in
+    # relations.listing — the presentation contract shared with the viewer
+    # lane, so the two surfaces cannot drift. argparse `choices` already
+    # gates unknown states.
+    rows, withheld = relations.listing(
+        states=set(args.state or relations.STATES), project_dir=project)
     _note_usage("relations:list")
     if args.json:
         print(json.dumps(rows, ensure_ascii=False, indent=2))

--- a/plugin/daimon_briefing/relations.py
+++ b/plugin/daimon_briefing/relations.py
@@ -3,7 +3,10 @@
 Relations describe how cognitive items relate across checkpoints — revision,
 answer, supersession, arc membership — as an append-only stream of typed
 events folded into current records.  Candidates are behaviorally inert:
-recall, lifecycle, corroboration, carry, and the viewer read nothing here.
+recall, lifecycle, corroboration, and carry read nothing here, and the only
+reader-facing surface is the viewer's History lane, which renders
+CONFIRMED records alone (`for_item`) — a chain a reader sees is always one
+a human vouched for.
 
 Every writable string is either a hash-derived id or drawn from a closed set,
 refused at the seam otherwise.  That gate is load-bearing: rows referencing
@@ -402,6 +405,83 @@ def records(project_dir=None) -> dict[str, dict]:
 
 def get(relation_id: str, project_dir=None) -> dict | None:
     return records(project_dir=project_dir).get(relation_id)
+
+
+def endpoint_texts(project_dir=None) -> dict:
+    """Read-time id→text join over every project surface, live or not.
+
+    The ledger holds no text by construction, so display resolves against
+    the checkpoints — and only at render time, never persisted back.  Every
+    surface is walked (not just the live checkpoint) because a relation
+    endpoint may name a session that only survives in prev-N.
+    """
+    texts = {}
+    for _, _, _, item in store.items_for_project(project_dir):
+        item_id = str(item.get("id") or "")
+        if item_id and item_id not in texts:
+            texts[item_id] = str(item.get("text") or "")
+    return texts
+
+
+def _withhold_erased(records_map, *, project_dir):
+    """Split folded records into (renderable, withheld_count).
+
+    Erased means TOMBSTONED, never merely absent: an edge touching a
+    forgotten item is withheld from every rendered surface (the count is
+    safe — it names no id), while an endpoint that only aged out of the GC
+    window still renders as unresolved.
+    """
+    erased = tombstoned_item_ids(project_dir=project_dir)
+    kept, withheld = [], 0
+    for record in records_map.values():
+        if _row_item_ids(record) & erased:
+            withheld += 1
+            continue
+        kept.append(record)
+    return kept, withheld
+
+
+def listing(*, states=None, project_dir=None) -> tuple[list[dict], int]:
+    """Every renderable record in adjudication order: candidates first,
+    ties by id, erased edges withheld.  This sort and the withholding are
+    the presentation contract shared by the CLI and the viewer lane; they
+    live here so the two surfaces cannot drift apart."""
+    wanted = set(states or STATES)
+    unknown = wanted - STATES
+    if unknown:
+        raise RelationError(f"unknown state: {', '.join(sorted(unknown))}")
+    kept, withheld = _withhold_erased(
+        records(project_dir=project_dir), project_dir=project_dir)
+    rows = [record for record in kept if record["state"] in wanted]
+    rows.sort(key=lambda record: (record["state"] != "candidate",
+                                  record["relation_id"]))
+    return rows, withheld
+
+
+def for_item(item_id: str, *, project_dir=None) -> tuple[list[dict], int]:
+    """CONFIRMED edges touching one item, erased chains withheld.
+
+    Confirmed-only is the Phase 3 boundary: candidates and rejections stay
+    off every reader-facing history surface (they exist for adjudication
+    and evaluator metrics), so a chain a reader sees is always one a human
+    vouched for.  The withheld count is scoped to THIS item's edges — it
+    names no id and never distinguishes forget from absence to a reader."""
+    target = str(item_id or "")
+    if not target:
+        return [], 0
+    erased = tombstoned_item_ids(project_dir=project_dir)
+    rows, withheld = [], 0
+    for record in records(project_dir=project_dir).values():
+        touched = _row_item_ids(record)
+        if target not in touched:
+            continue
+        if touched & erased:
+            withheld += 1
+            continue
+        if record["state"] == "confirmed":
+            rows.append(record)
+    rows.sort(key=lambda record: record["relation_id"])
+    return rows, withheld
 
 
 def tombstoned_item_ids(*, project_dir=None) -> set[str]:

--- a/plugin/daimon_ui/server.py
+++ b/plugin/daimon_ui/server.py
@@ -12,7 +12,7 @@ from . import reader
 # never grows a second search engine) and inspector.inspect_item is the same
 # read-side receipt `daimon why` prints. reader.py stays daimon-import-free
 # (files are its seam); the engine boundary lives here in dispatch only.
-from daimon_briefing import inspector, recall, refutations
+from daimon_briefing import inspector, recall, refutations, relations
 
 _PAGE = Path(__file__).parent / "page.html"
 _SLUG_RE = re.compile(r"^[\w-]+$")
@@ -206,6 +206,27 @@ class _Handler(BaseHTTPRequestHandler):
             # own project_slug, so passing it as project_dir resolves to the same
             # bucket (the inspector endpoint leans on the same property).
             self._json({"ok": True, "rows": refutations.listing(project_dir=slug)})
+        elif path == "/api/relations":
+            slug = self._resolve_slug(params)
+            if slug is None:
+                self._json(self._bad_slug_error(params.get("project", [self.default_slug])[0]))
+                return
+            # History lane (#678 Phase 3): CONFIRMED edges only — the fold,
+            # the confirmed boundary, and the erased-edge withholding all live
+            # in relations.for_item, shared with the CLI's presentation seam,
+            # so the two surfaces cannot drift. Texts are a read-time join
+            # (the ledger holds no text by construction) scoped to the ids the
+            # response actually names.
+            item_id = params.get("id", [""])[0]
+            rows, withheld = relations.for_item(item_id, project_dir=slug)
+            named = {item_id}
+            for row in rows:
+                for endpoint in (row.get("from") or {}, row.get("to") or {}):
+                    named.add(str(endpoint.get("item_id") or ""))
+            texts = {k: v for k, v in relations.endpoint_texts(slug).items()
+                     if k in named}
+            self._json({"ok": True, "rows": rows, "texts": texts,
+                        "withheld": withheld})
         elif path == "/api/ledger":
             slug = self._resolve_slug(params)
             if slug is None:

--- a/plugin/daimon_ui/static/app.css
+++ b/plugin/daimon_ui/static/app.css
@@ -1276,3 +1276,19 @@
     .print-margin { text-align: left; }
     .print-body { border-left: 0; padding-left: 0; }
   }
+
+  /* -- history lane (#678 Phase 3): confirmed relations inside the entry -- */
+  .why-history { padding: 22px 20px 14px; }
+  .why-history-body { margin-top: 12px; }
+  .why-history-note { font-size: 11.5px; color: var(--ink-tertiary); margin-bottom: 10px; }
+  .why-history-empty { font-size: 13px; color: var(--ink-secondary); }
+  .hist-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px; padding: 6px 0; border-top: 1px solid var(--line); }
+  .hist-row:first-of-type { border-top: 0; }
+  .hist-type { font-family: var(--mono); font-size: 11px; color: var(--accent); }
+  .hist-flag { font-family: var(--mono); font-size: 11px; color: var(--danger, #b54d3f); font-weight: 600; }
+  .hist-pair { font-size: 13px; }
+  .hist-self { color: var(--ink-tertiary); font-size: 12px; }
+  .hist-chip { font: inherit; font-size: 13px; color: var(--accent); background: none; border: 0; padding: 0; cursor: pointer; text-align: left; }
+  .hist-chip:hover { text-decoration: underline; }
+  .hist-chip-raw { color: var(--ink-tertiary); cursor: default; }
+  .why-history-withheld { font-size: 11.5px; color: var(--ink-tertiary); margin-top: 10px; }

--- a/plugin/daimon_ui/static/app.js
+++ b/plugin/daimon_ui/static/app.js
@@ -2,7 +2,7 @@ import {
   ACT_ITEM_ID_RE, displaySid, escapeHtml, fmtRelative, navCurrent, renderBioPanel,
   renderDiffView, renderEmptyProjects, renderError, renderLedgerSessions, renderLedgerView,
   renderProjCard, renderRefutationsView, renderSearchResults, renderSections,
-  renderPrintView, renderSessionView, renderSidebarScope, renderStripView, renderWhyView,
+  renderHistoryLane, renderPrintView, renderSessionView, renderSidebarScope, renderStripView, renderWhyView,
   skeletonHtml
 } from "./render.js";
 import { state } from "./state.js";
@@ -637,6 +637,34 @@ import { state } from "./state.js";
         });
       });
   }
+  // History lane (#678 Phase 3): same async-panel shape as the ladder above.
+  // No cache: a confirmation made in the CLI between navigations must show
+  // on the next open, and the payload is small.
+  function loadHistory(itemId, panel) {
+    var reqId = state.requestId;
+    var timer = setTimeout(function () {
+      panel.innerHTML = skeletonHtml();
+    }, 1000);
+    api("/api/relations?project=" + encodeURIComponent(state.currentSlug) + "&id=" + encodeURIComponent(itemId))
+      .then(function (data) {
+        clearTimeout(timer);
+        if (reqId !== state.requestId) return; // navigated away meanwhile
+        if (data.ok) {
+          panel.innerHTML = renderHistoryLane(data, itemId);
+          wireWhyOpeners(panel);
+        } else {
+          panel.innerHTML = renderError(data.error);
+        }
+      }).catch(function () {
+        clearTimeout(timer);
+        if (reqId !== state.requestId) return;
+        panel.innerHTML = renderError({
+          what: "Could not load this entry's confirmed connections.",
+          why: "The request to the daimon server failed.",
+          fix: "Check the server is running and try again."
+        });
+      });
+  }
   // ---- search (#670): the box renders daimon recall — one matcher, two renderings ----
   function searchSlug() {
     return state.currentSlug || state.defaultSlug;
@@ -733,6 +761,8 @@ import { state } from "./state.js";
         var bio = document.getElementById("why-bio");
         state.whyBio = null; // a stale ladder must not aim the print door
         if (bio) loadBiography(itemId, bio);
+        var hist = document.getElementById("why-history");
+        if (hist) loadHistory(itemId, hist);
         var printBtn = sectionsEl.querySelector("[data-open-print]");
         if (printBtn) printBtn.addEventListener("click", function () {
           var chain = (state.whyBio && state.whyBio.trust_anatomy &&

--- a/plugin/daimon_ui/static/render.js
+++ b/plugin/daimon_ui/static/render.js
@@ -972,6 +972,11 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
 
     html += '<div class="why-life"><span class="why-label">Life</span>' +
       '<div id="why-bio" class="why-bio"></div></div>';
+    // History lane (#678 Phase 3): confirmed relations only, painted async
+    // like the ladder above. Candidates and rejections never render here —
+    // a chain a reader sees is always one a person vouched for.
+    html += '<div class="why-history"><span class="why-label">History</span>' +
+      '<div id="why-history" class="why-history-body"></div></div>';
     // The door to the print view: the entry's own footer, per the frozen
     // design. The button arms once the biography arrives — the print shows
     // the checkpoint of the entry's latest sighting, and only the ladder
@@ -979,6 +984,48 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
     html += '<div class="why-actions"><button type="button" class="ledger-ck-open" data-open-print>print view</button></div>';
     html += '<div class="card-foot">read-only · this page renders the record; it holds nothing of its own</div>';
     html += "</div></div>";
+    return html;
+  }
+
+  // ---- history lane (#678 Phase 3): confirmed relations for one entry ----
+  // Confirmed only, by contract: relations.for_item never returns another
+  // state, and this renderer adds no fallback that could widen it. The
+  // withheld line copies the CLI's exact wording (one frozen phrase, two
+  // surfaces). An id the read-time join cannot resolve renders with the
+  // frozen word [unresolved]; direction is shown structurally (this entry
+  // vs the counterpart chip), never with new verbs.
+  export function renderHistoryLane(payload, itemId) {
+    var rows = (payload && payload.rows) || [];
+    var texts = (payload && payload.texts) || {};
+    var withheld = (payload && payload.withheld) || 0;
+    var html = '<div class="why-history-note">confirmed by a person · candidates never shown</div>';
+    if (!rows.length && !withheld) {
+      html += '<div class="why-history-empty">no confirmed connections yet</div>';
+    }
+    html += rows.map(function (r) {
+      var from = r.from || {}, to = r.to || {};
+      var mine = String(from.item_id) === String(itemId);
+      var other = mine ? to : from;
+      var otherId = String(other.item_id || "");
+      var otherText = texts[otherId] || "[unresolved]";
+      var chip = ACT_ITEM_ID_RE.test(otherId)
+        ? '<button type="button" class="hist-chip" data-open-why data-item-id="' +
+          escapeHtml(otherId) + '">' + escapeHtml(otherText) + "</button>"
+        : '<span class="hist-chip hist-chip-raw">' + escapeHtml(otherText) + "</span>";
+      var self = '<span class="hist-self">this entry</span>';
+      var pair = r.type === "same-arc"
+        ? self + " · " + chip
+        : (mine ? self + " → " + chip : chip + " → " + self);
+      return '<div class="hist-row">' +
+        '<span class="hist-type">' + escapeHtml(r.type) + "</span>" +
+        (r.contradiction ? '<span class="hist-flag">CONTRADICTION</span>' : "") +
+        '<div class="hist-pair">' + pair + "</div>" +
+        "</div>";
+    }).join("");
+    if (withheld) {
+      html += '<div class="why-history-withheld">' + withheld +
+        " edge(s) withheld (erased endpoint)</div>";
+    }
     return html;
   }
 

--- a/plugin/tests/test_relations.py
+++ b/plugin/tests/test_relations.py
@@ -240,6 +240,67 @@ def test_erased_comes_from_tombstones_not_absence(bucket):
     assert "r-def123456789" not in erased
 
 
+# -- shared listing: one presentation fold for CLI and viewer (#678 P3) --
+
+def test_listing_sorts_candidates_first_and_withholds_erased(bucket):
+    kept = _propose(bucket)
+    relations.confirm(kept, channel="cli-tty", project_dir=bucket)
+    second = _propose(bucket, frm=_endpoint("S3", item="r-aaa111222333"),
+                      to=_endpoint("S1", item="r-bbb444555666"))
+    doomed = _propose(bucket, frm=_endpoint("S4", item="r-ccc777888999"),
+                      to=_endpoint("S1", item="r-ddd000111222"))
+    store.append_event("r-ccc777888999", "forgotten:deadbeef01234567",
+                       kind="tombstone", project_dir=bucket)
+    rows, withheld = relations.listing(project_dir=bucket)
+    ids = [r["relation_id"] for r in rows]
+    assert doomed not in ids
+    assert withheld == 1
+    assert ids == [second, kept]  # candidate first, then confirmed
+
+
+def test_listing_state_filter_and_unknown_state_refusal(bucket):
+    rel_id = _propose(bucket)
+    relations.reject(rel_id, channel="cli-tty", project_dir=bucket)
+    rows, _ = relations.listing(states={"rejected"}, project_dir=bucket)
+    assert [r["relation_id"] for r in rows] == [rel_id]
+    with pytest.raises(relations.RelationError):
+        relations.listing(states={"vibes"}, project_dir=bucket)
+
+
+def test_for_item_returns_confirmed_edges_only(bucket):
+    confirmed = _propose(bucket)
+    relations.confirm(confirmed, channel="cli-tty", project_dir=bucket)
+    _propose(bucket, frm=_endpoint("S3", item="r-abc123456789"),
+             to=_endpoint("S1", item="r-bbb444555666"))  # stays candidate
+    rows, withheld = relations.for_item("r-abc123456789", project_dir=bucket)
+    assert [r["relation_id"] for r in rows] == [confirmed]
+    assert withheld == 0
+    other, _ = relations.for_item("r-feedbeef1234", project_dir=bucket)
+    assert other == []
+
+
+def test_for_item_withholds_chains_touching_erased_endpoints(bucket):
+    rel_id = _propose(bucket)
+    relations.confirm(rel_id, channel="cli-tty", project_dir=bucket)
+    store.append_event("r-def123456789", "forgotten:deadbeef01234567",
+                       kind="tombstone", project_dir=bucket)
+    rows, withheld = relations.for_item("r-abc123456789", project_dir=bucket)
+    assert rows == [] and withheld == 1
+
+
+def test_endpoint_texts_joins_over_project_surfaces(bucket):
+    from daimon_briefing import policy
+    cp = {"session_id": "S1", "created": "2026-08-01T00:00:00Z",
+          "project_slug": store.project_slug(bucket),
+          "working_context": {"recent_decisions": [
+              {"text": "keep the fold deterministic", "trust": "inferred"}]}}
+    policy.stamp_item_ids(cp)
+    store.write_checkpoint("S1", cp, project_dir=bucket)
+    item_id = cp["working_context"]["recent_decisions"][0]["id"]
+    texts = relations.endpoint_texts(project_dir=bucket)
+    assert texts[item_id] == "keep the fold deterministic"
+
+
 # -- registry (fork A) --
 
 def test_registry_declares_relations_ledger_plaintext_rewrite_forget():

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -114,9 +114,10 @@ SKIPPED: dict = {
         "foreground HTTP server: serve_forever() never returns, so the recipe "
         "harness cannot drive it to completion. Its write surface is bounded "
         "by construction — the handler defines only do_GET, and its engine "
-        "calls (recall.search, inspector.inspect_item) are the same paths the "
-        "`recall` recipe already audits (tests/ui/test_server_engines.py "
-        "covers the dispatch)."
+        "calls (recall.search, inspector.inspect_item, refutations.listing, "
+        "relations.for_item/endpoint_texts — all read-only) are the same "
+        "paths the `recall`, `refute`, and `relations` recipes already audit "
+        "(tests/ui/test_server_engines.py covers the dispatch)."
     ),
 }
 

--- a/plugin/tests/ui/test_page_relations.py
+++ b/plugin/tests/ui/test_page_relations.py
@@ -1,0 +1,45 @@
+"""History lane frontend (#678 Phase 3): served source carries the wiring
+and the frozen wording. Same shape as test_page_refutations.py — fetch the
+static bytes over HTTP, assert on source text."""
+
+import urllib.request
+
+from tests.ui.conftest import *  # noqa: F401,F403  (bucket/srv fixtures)
+
+
+def _text(base, path):
+    with urllib.request.urlopen(base + path) as r:
+        return r.read().decode("utf-8")
+
+
+def test_client_fetches_the_relations_endpoint(srv):
+    app_js = _text(srv, "/static/app.js")
+    assert "/api/relations?" in app_js
+    assert "loadHistory" in app_js
+
+
+def test_why_view_carries_the_history_placeholder(srv):
+    render_js = _text(srv, "/static/render.js")
+    assert 'id="why-history"' in render_js
+    assert "renderHistoryLane" in render_js
+
+
+def test_lane_carries_the_frozen_wording(srv):
+    render_js = _text(srv, "/static/render.js")
+    assert "confirmed by a person · candidates never shown" in render_js
+    assert "no confirmed connections yet" in render_js
+    assert "edge(s) withheld (erased endpoint)" in render_js
+    assert "[unresolved]" in render_js
+
+
+def test_lane_styles_are_served(srv):
+    css = _text(srv, "/static/app.css")
+    assert ".why-history" in css
+    assert ".hist-chip" in css
+
+
+def test_counterpart_chips_reuse_the_universal_entry_door(srv):
+    render_js = _text(srv, "/static/render.js")
+    lane = render_js.split("renderHistoryLane", 1)[1]
+    assert 'data-open-why' in lane.split("function", 1)[0] or \
+        'data-open-why' in lane[:2000]

--- a/plugin/tests/ui/test_server_relations.py
+++ b/plugin/tests/ui/test_server_relations.py
@@ -1,0 +1,110 @@
+"""/api/relations — the Phase 3 History lane's engine endpoint (#678).
+
+Confirmed edges only, erased chains withheld, engine fields passed through
+untouched. Candidates and rejections never reach this surface: a chain a
+reader sees is always one a human vouched for.
+"""
+
+import json
+import threading
+from urllib.request import urlopen
+
+import pytest
+
+from daimon_briefing import relations, store
+from daimon_ui import server
+
+PROJECT_NAME = "relations-lane-arc"
+
+
+def _cp(sid):
+    return {
+        "session_id": sid,
+        "created": "2026-08-01T00:00:00Z",
+        "working_context": {
+            "recent_decisions": [
+                {"text": "keep the history lane confirmed only",
+                 "trust": "inferred"},
+                {"text": "resolve endpoint texts at read time",
+                 "trust": "inferred"}]},
+    }
+
+
+@pytest.fixture
+def rel_proj(tmp_checkpoint_dir, tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    proj = tmp_path / PROJECT_NAME
+    proj.mkdir()
+    store.write_checkpoint("S1", _cp("S1"), project_dir=proj)
+    stored = store.read_latest(project_dir=proj, fallback=False)
+    ids = [i["id"] for i in stored["working_context"]["recent_decisions"]]
+    confirmed = relations.propose(
+        type_="revision-of",
+        from_endpoint={"session_id": "S1", "field": "recent_decisions",
+                       "item_id": ids[0]},
+        to_endpoint={"session_id": "S1", "field": "recent_decisions",
+                     "item_id": ids[1]},
+        matched_by=["carry-absolute"], matcher_version="lab-2026-08-12",
+        channel="lab-import", project_dir=proj)
+    # `ui` is an in-process human channel: no tty observation at the module
+    # seam (that check is the CLI's), which is exactly how a future in-process
+    # confirmer would write.
+    relations.confirm(confirmed, channel="ui", project_dir=proj)
+    # a candidate that must never reach the wire
+    relations.propose(
+        type_="answers",
+        from_endpoint={"session_id": "S1", "field": "recent_decisions",
+                       "item_id": ids[0]},
+        to_endpoint={"session_id": "S1", "field": "open_questions",
+                     "item_id": "r-feedbeef1234"},
+        matched_by=["carry-absolute"], matcher_version="lab-2026-08-12",
+        channel="lab-import", project_dir=proj)
+    return {"proj": proj, "ids": ids, "confirmed": confirmed}
+
+
+@pytest.fixture
+def rel_srv(rel_proj, tmp_checkpoint_dir):
+    slug = store.project_slug(rel_proj["proj"])
+    s = server.make_server(tmp_checkpoint_dir, slug, PROJECT_NAME, port=0)
+    threading.Thread(target=s.serve_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{s.server_address[1]}"
+    s.shutdown()
+
+
+def _get(base, path):
+    with urlopen(base + path) as r:
+        return json.loads(r.read())
+
+
+def test_confirmed_edges_pass_through_with_texts(rel_proj, rel_srv):
+    out = _get(rel_srv, f"/api/relations?id={rel_proj['ids'][0]}")
+    assert out["ok"] is True
+    assert [r["relation_id"] for r in out["rows"]] == [rel_proj["confirmed"]]
+    row = out["rows"][0]
+    assert row["state"] == "confirmed"
+    assert row["type"] == "revision-of"
+    assert row["from"]["item_id"] == rel_proj["ids"][0]
+    assert out["texts"][rel_proj["ids"][1]] == \
+        "resolve endpoint texts at read time"
+    assert out["withheld"] == 0
+
+
+def test_candidates_never_reach_the_wire(rel_proj, rel_srv):
+    out = _get(rel_srv, f"/api/relations?id={rel_proj['ids'][0]}")
+    assert all(r["state"] == "confirmed" for r in out["rows"])
+    assert len(out["rows"]) == 1
+
+
+def test_erased_chains_are_withheld_with_a_safe_count(rel_proj, rel_srv):
+    store.append_event(rel_proj["ids"][1], "forgotten:deadbeef01234567",
+                       kind="tombstone", project_dir=rel_proj["proj"])
+    out = _get(rel_srv, f"/api/relations?id={rel_proj['ids'][0]}")
+    assert out["rows"] == []
+    assert out["withheld"] == 1
+    assert rel_proj["ids"][1] not in json.dumps(out)
+
+
+def test_unknown_slug_yields_the_three_key_error(rel_srv):
+    out = _get(rel_srv, "/api/relations?id=r-feedbeef1234&project=nope")
+    assert out["ok"] is False
+    assert set(out["error"]) == {"what", "why", "fix"}


### PR DESCRIPTION
Refs #678

## Summary

- Phase 3 of #678, viewer-only: the entry ("why") page gains a History section rendering the item's CONFIRMED typed relations. Candidates and rejections never reach a reader surface; a chain a reader sees is always one a person vouched for.
- The presentation fold moves into the engine so surfaces cannot drift: `relations.listing` (sort, state filter, erased-edge withholding) now backs `daimon relations list`, and `relations.for_item` (confirmed-only edges for one item, withheld count scoped to that item) backs the new `/api/relations` endpoint. `relations.endpoint_texts` is the shared read-time id-to-text join over every project surface, live or not.
- Erased means tombstoned, never merely absent: edges touching a forgotten item are withheld with a count that names no id (the CLI's exact wording, one frozen phrase on both surfaces), while an endpoint that only aged out of the checkpoint GC window renders as `[unresolved]` and stays a valid record.
- The lane paints asynchronously like the biography ladder, counterpart chips go through the universal entry door (`data-open-why`), direction is shown structurally (this entry vs the counterpart), `same-arc` renders symmetric, and confirmed contradictions carry the CONTRADICTION mark.
- The `serve` write-audit skip reason's engine-call enumeration is updated in the same change, and the relations module docstring now names the History lane as the one reader-facing consumer of confirmed records.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/relations.py` | `listing`, `for_item`, `endpoint_texts`, `_withhold_erased`; docstring amended |
| `plugin/daimon_briefing/cli.py` | `relations list` and the text join switched onto the shared engine functions |
| `plugin/daimon_ui/server.py` | `/api/relations` branch: slug gate, confirmed-only rows, texts scoped to the ids the response names |
| `plugin/daimon_ui/static/render.js` | `#why-history` placeholder in the entry view; `renderHistoryLane` pure renderer |
| `plugin/daimon_ui/static/app.js` | `loadHistory` async painter, wired after the entry loads; no cache so a CLI confirmation shows on next open |
| `plugin/daimon_ui/static/app.css` | Lane styles on existing tokens |
| `plugin/tests/test_relations.py` | Engine tests: listing sort and withholding, state refusal, for-item boundary, text join |
| `plugin/tests/ui/test_server_relations.py` | Endpoint tests incl. candidates-never-on-the-wire and erased-withheld-with-safe-count |
| `plugin/tests/ui/test_page_relations.py` | Served-source pins: wiring, frozen wording, styles, universal door |
| `plugin/tests/test_write_audit_guard.py` | `serve` skip reason enumeration updated |

## Test plan

- [x] `uv run pytest -q` from `plugin/`: 3667 passed, 2 skipped, 0 failed
- [x] `uv run ruff check` on every touched file: clean
- [x] Live smoke: the lane renders the empty state on a real project with no confirmed relations yet, which is the designed boundary working
- [x] Engine and server tests were written first and watched fail; the static-text pins were written after the source they pin

## Notes for the reviewer

The scout finding that shaped this: the CLI previously did the fold inline, so a viewer endpoint would have re-implemented it and drifted by construction. Both surfaces now call one engine function, the same shape `refutations.listing` established.
