### PR TITLE
docs(site): reference pages for the viewer and the relations verbs

### DIFF
--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -35,6 +35,8 @@ Every daimon verb, grouped by what you are trying to do. Each command's
 | `daimon audit quotes` | Re-check every stored verbatim quote against its source transcript and report mismatches. Read-only — it never rewrites trust tags. |
 | `daimon audit privacy` | Prove the deletion contract: hash every plaintext field on every surface (checkpoints, rotated pointers, the event ledger, the team mirror, the recall index and its orphan snapshots) and report any forgotten value that survived. Read-only. |
 | `daimon refute list\|show\|search\|guard` | Read the negative-knowledge ledger without decay. `guard` emits active exact-anchor/subject matches only; it is advisory and never blocks a command. Add `--json` for deliberation integrations. |
+| `daimon serve` | Open the [read-only local viewer](viewer.md) on localhost — search as recall, per-entry "why" pages, refutations, diff, check strip, print view. Nothing writes. |
+| `daimon relations list\|show\|confirm\|reject\|retract` | The [typed relation ledger](relations.md): machines propose, only a person confirms, and verdicts need an interactive terminal. Candidates never render on an entry surface. |
 
 The auditors share one exit contract, so a script can act on the answer:
 

--- a/website/docs/reference/relations.md
+++ b/website/docs/reference/relations.md
@@ -1,0 +1,39 @@
+# Relations (typed, human-confirmed)
+
+The relation ledger records typed claims between memory items — "this decision
+revises that one", "this answers that question" — as an append-only record in
+shadow mode: relations exist alongside your memory and never change what any
+other surface does on their own.
+
+The authority boundary is the whole design: **machines may propose, and none
+may confirm.** A verdict requires an interactive terminal, and there is no
+flag that delegates it to an agent. Candidates never render on an entry's
+surface — the adjudication list is the one place they are visible. A chain a
+reader sees in the viewer's History panel is one a person vouched for.
+
+## Verbs
+
+| command | what it does |
+| --- | --- |
+| `daimon relations list` | Every renderable relation, candidates first; endpoint texts resolved at read time. `--state` filters; `--json` for rows. |
+| `daimon relations show <rel-id>` | One relation with its full proposal history. |
+| `daimon relations confirm <rel-id>` | Record a human confirmation of a candidate edge. Human-only: needs an interactive terminal. |
+| `daimon relations reject <rel-id>` | Record a human rejection — sticky against re-proposal. Human-only. |
+| `daimon relations retract <rel-id>` | Undo a confirmation; a fresh proposal may revive the edge. Human-only. |
+
+## Deletion contract
+
+An edge is itself a claim about content, so relations honor `daimon forget`:
+an edge touching a forgotten item is withheld from rendered surfaces, and only
+a count of withheld edges is shown — the wording on the CLI and in the viewer
+is the same, and it names no id. An endpoint that merely aged out of the
+checkpoint retention window is different: it renders as `[unresolved]` and
+stays a valid record.
+
+## Adjudication advice
+
+Read a chain whole before confirming its edges. Two items can look related
+pairwise because they share project vocabulary while being different thoughts —
+the honest verdicts are "this is the same thought evolving" (confirm),
+"this edge is wrong" (reject), or leaving the candidate alone when you are
+not sure. An unconfirmed candidate is inert; a wrong confirmation is not.

--- a/website/docs/reference/viewer.md
+++ b/website/docs/reference/viewer.md
@@ -1,0 +1,42 @@
+# Viewer (read-only)
+
+`daimon serve` opens a local, read-only view of one project's memory in your
+browser. Every surface renders an existing engine's output — the viewer has no
+logic of its own to disagree with the CLI, and nothing in it writes.
+
+```bash
+daimon serve                      # binds 127.0.0.1:7717, opens a browser tab
+daimon serve --port 7800 --no-browser
+```
+
+Flags: `--data-dir` (checkpoint dir, default `DAIMON_CHECKPOINT_DIR` then
+`~/.daimon/checkpoints`), `--project-dir` (project to scope to, default the
+working directory), `--port` (default 7717), `--no-browser`.
+
+## What you see
+
+- **Search** is `daimon recall`, rendered. The results header says so —
+  what you find in the browser is what an agent would be briefed with.
+- **Every entry has a "why" page**: the stored text, its origin, the stored
+  quote, a transcript context window (fetched at read time, never stored),
+  the evidence axes behind the item, a **Life** panel showing how the entry
+  changed across checkpoints, and a **History** panel rendering its
+  human-confirmed relations (see [relations](relations.md)).
+- **Sibling views** alongside the entry page: the project ledger, a session
+  page, a **Refutations** page reading the negative-knowledge ledger, a
+  **Check strip**, a checkpoint **Diff**, and a **print view** that sets one
+  checkpoint as a printed record.
+
+## Read-only as a commitment
+
+Read-only is structural, not a promise: the server answers GET requests only —
+there is no code path that writes. Confirming a relation, resolving a loop, or
+forgetting an item all stay in the CLI, where the terminal enforces who is
+speaking.
+
+## Localhost-only posture
+
+The server binds `127.0.0.1` and additionally refuses any request whose `Host`
+header is not `127.0.0.1` or `localhost`. Nothing is exposed to your network,
+and nothing is transmitted anywhere — the viewer reads the same local files
+the CLI reads.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -35,6 +35,8 @@ comando trae la superficie completa de flags; esta página es el mapa.
 | `daimon audit quotes` | Re-verifica cada cita verbatim almacenada contra su transcripción de origen y reporta discrepancias. Solo lectura — nunca reescribe etiquetas. |
 | `daimon audit privacy` | Prueba el contrato de borrado: hashea cada campo con texto plano en cada superficie (checkpoints, punteros rotados, el registro de eventos, el espejo de equipo, el índice de recall y sus snapshots huérfanos) y reporta todo valor olvidado que haya sobrevivido. Solo lectura. |
 | `daimon refute list\|show\|search\|guard` | Lee el ledger de conocimiento negativo sin decaimiento. `guard` emite solo matches activos por ancla exacta o frase de sujeto; es consultivo y nunca bloquea un comando. Sumá `--json` para integraciones de deliberación. |
+| `daimon serve` | Abre el [visor local de solo lectura](viewer.md) en localhost — búsqueda como recall, páginas "why" por entrada, refutaciones, diff, check strip, vista de impresión. Nada escribe. |
+| `daimon relations list\|show\|confirm\|reject\|retract` | El [ledger de relaciones tipadas](relations.md): las máquinas proponen, solo una persona confirma, y los veredictos necesitan una terminal interactiva. Los candidatos nunca se renderizan en la superficie de una entrada. |
 
 Los auditores comparten un mismo contrato de salida, para que un script pueda
 actuar sobre la respuesta:

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/relations.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/relations.md
@@ -1,0 +1,42 @@
+# Relaciones (tipadas, confirmadas por humanos)
+
+El ledger de relaciones registra afirmaciones tipadas entre items de memoria —
+"esta decisión revisa aquella", "esto responde aquella pregunta" — como un
+registro append-only en modo sombra: las relaciones existen junto a tu memoria
+y nunca cambian por sí solas lo que hace cualquier otra superficie.
+
+La frontera de autoridad es todo el diseño: **las máquinas pueden proponer, y
+ninguna puede confirmar.** Un veredicto requiere una terminal interactiva, y no
+existe flag que lo delegue a un agente. Los candidatos nunca se renderizan en
+la superficie de una entrada — la lista de adjudicación es el único lugar
+donde son visibles. Una cadena que un lector ve en el panel History del visor
+es una que una persona avaló.
+
+## Verbos
+
+| comando | qué hace |
+| --- | --- |
+| `daimon relations list` | Cada relación renderizable, candidatos primero; los textos de los endpoints se resuelven al leer. `--state` filtra; `--json` para filas. |
+| `daimon relations show <rel-id>` | Una relación con su historial completo de propuestas. |
+| `daimon relations confirm <rel-id>` | Registra una confirmación humana de una edge candidata. Solo humanos: necesita una terminal interactiva. |
+| `daimon relations reject <rel-id>` | Registra un rechazo humano — pegajoso contra re-propuestas. Solo humanos. |
+| `daimon relations retract <rel-id>` | Deshace una confirmación; una propuesta nueva puede revivir la edge. Solo humanos. |
+
+## Contrato de borrado
+
+Una edge es en sí misma una afirmación sobre contenido, así que las relaciones
+honran `daimon forget`: una edge que toca un item olvidado se retiene fuera de
+las superficies renderizadas, y solo se muestra un conteo de edges retenidas —
+la redacción en la CLI y en el visor es la misma, y no nombra ningún id. Un
+endpoint que simplemente envejeció fuera de la ventana de retención de
+checkpoints es distinto: se renderiza como `[unresolved]` y sigue siendo un
+registro válido.
+
+## Consejo de adjudicación
+
+Leé la cadena completa antes de confirmar sus edges. Dos items pueden parecer
+relacionados de a pares porque comparten vocabulario del proyecto siendo
+pensamientos distintos — los veredictos honestos son "es el mismo pensamiento
+evolucionando" (confirm), "esta edge está mal" (reject), o dejar el candidato
+en paz cuando no estás seguro. Un candidato sin confirmar es inerte; una
+confirmación equivocada no.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/viewer.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/viewer.md
@@ -1,0 +1,46 @@
+# Visor (solo lectura)
+
+`daimon serve` abre en tu navegador una vista local, de solo lectura, de la
+memoria de un proyecto. Cada superficie renderiza la salida de un motor que ya
+existe — el visor no tiene lógica propia con la que discrepar de la CLI, y
+nada en él escribe.
+
+```bash
+daimon serve                      # enlaza 127.0.0.1:7717 y abre una pestaña
+daimon serve --port 7800 --no-browser
+```
+
+Flags: `--data-dir` (directorio de checkpoints, por defecto
+`DAIMON_CHECKPOINT_DIR` y luego `~/.daimon/checkpoints`), `--project-dir`
+(proyecto al que se limita, por defecto el directorio actual), `--port` (por
+defecto 7717), `--no-browser`.
+
+## Qué ves
+
+- **La búsqueda** es `daimon recall`, renderizado. El encabezado de resultados
+  lo dice — lo que encuentres en el navegador es lo que recibiría un agente en
+  su briefing.
+- **Cada entrada tiene una página "why"**: el texto almacenado, su origen, la
+  cita almacenada, una ventana de contexto del transcript (obtenida al leer,
+  nunca almacenada), los ejes de evidencia detrás del item, un panel **Life**
+  que muestra cómo cambió la entrada a través de los checkpoints, y un panel
+  **History** que renderiza sus relaciones confirmadas por humanos (ver
+  [relaciones](relations.md)).
+- **Vistas hermanas** junto a la página de entrada: el ledger del proyecto,
+  una página de sesión, una página de **Refutations** que lee el ledger de
+  conocimiento negativo, un **Check strip**, un **Diff** entre checkpoints, y
+  una **vista de impresión** que fija un checkpoint como registro impreso.
+
+## Solo lectura como compromiso
+
+Solo lectura es estructural, no una promesa: el servidor responde únicamente
+peticiones GET — no existe camino de código que escriba. Confirmar una
+relación, resolver un loop u olvidar un item siguen viviendo en la CLI, donde
+la terminal hace cumplir quién está hablando.
+
+## Postura solo-localhost
+
+El servidor enlaza `127.0.0.1` y además rechaza cualquier petición cuyo header
+`Host` no sea `127.0.0.1` o `localhost`. Nada queda expuesto a tu red y nada
+se transmite a ningún lado — el visor lee los mismos archivos locales que lee
+la CLI.


### PR DESCRIPTION
Closes #685

## Summary

- Two new reference pages: the read-only local viewer (`daimon serve`) and the typed relation verbs (`daimon relations`), EN plus ES mirrors.
- CLI reference map gains one row for each command family, so "every daimon verb" stays true.

## Changes

| File | Change |
|------|--------|
| `website/docs/reference/viewer.md` | New: what `daimon serve` opens, search-as-recall, the entry "why" page (Life and History panels), sibling views, read-only and localhost-only posture |
| `website/docs/reference/relations.md` | New: shadow-mode relation ledger, human-only verdict boundary, the five verbs, deletion contract wording, adjudication advice |
| `website/docs/reference/cli.md` | Two rows in the Check bucket: `daimon serve` and the `daimon relations` family |
| `website/i18n/es/.../reference/viewer.md` | ES mirror |
| `website/i18n/es/.../reference/relations.md` | ES mirror |
| `website/i18n/es/.../reference/cli.md` | ES rows |

## Test Plan

- [x] Every behavioral claim verified against v0.30.0 shipped code and `--help` text (port and binding, GET-only handler, five verbs, tty-only verdicts, withheld-count wording)
- [x] No `sidebar_position` declared, matching `mcp.md`; sidebar is autogenerated
- [x] ES tree stays a 1:1 mirror of EN docs pages

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Shellcheck not applicable (no shell scripts modified)
- [x] Docs-only change; no behavior altered
- [x] Conventional commit format
- [x] No Co-Authored-By trailers
