### PR TITLE
fix(serializer): strip model-supplied pinned; the flag is code-owned

### DIFF
--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -1982,15 +1982,20 @@ _CODE_OWNED_KEYS = (
 # re-write. That makes any value already on an item authoritative forever —
 # so a model-emitted one is a self-issued witness that corroboration counting
 # would then treat as an independent session. Stripped from freshly authored
-# model output only, exactly like `grounded`/`pinned` (#292 discipline).
+# model output only, exactly like `grounded` (#292 discipline).
 # #511: `quote_verified`/`last_verified` are verify_quotes' verdicts — on the
 # serialize path they are re-derived AFTER this strip, and on the introspection
 # path (no transcript, verify_quotes never runs) nothing may hold either stamp.
+# #689: `pinned` is pin_imperatives' verdict, minted only from user-authored
+# transcript text (#369) — that pass pops model copies itself but never runs
+# on the introspection path, so without this entry a piped checkpoint keeps a
+# self-issued pin that the recall index then honors as a #452 age-gate
+# exemption. On the serialize path pin_imperatives re-pins after this strip.
 # Safe to strip on both paths because carry.merge folds prev items in AFTER
 # serialize_strict returns — a carried item's genuine stamps never pass here.
 _CODE_OWNED_ITEM_KEYS = ("origin_session", "origin_author",
                          "quote_verified", "last_verified",
-                         "quote_provenance")
+                         "quote_provenance", "pinned")
 
 
 def strip_code_owned_keys(checkpoint: dict) -> None:

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1591,6 +1591,27 @@ def test_cli_write_checkpoint_strips_model_claimed_grounded(
     assert "grounded" not in dec
 
 
+def test_cli_write_checkpoint_strips_model_claimed_pinned(
+        tmp_checkpoint_dir, monkeypatch):
+    # #689, same discipline: `pinned` is minted only by pin_imperatives from
+    # user-authored transcript text (#369), and that pass never runs on this
+    # path. A caller-supplied pin would survive into the recall index and
+    # exempt the item from the #452 age gate — an exemption the code never
+    # derived.
+    from daimon_briefing import store
+
+    cp = json.loads(_valid_json("S-intro"))
+    cp["epistemic_snapshot"]["strong_beliefs"] = [{
+        "text": "never push to main", "trust": "inferred", "pinned": True,
+    }]
+    _stdin(monkeypatch, json.dumps(cp))
+    rc = cli.main(["write-checkpoint", "--project", "/p/A"])
+    assert rc == 0
+    ck = store.read_latest(project_dir="/p/A")
+    belief = ck["epistemic_snapshot"]["strong_beliefs"][0]
+    assert "pinned" not in belief
+
+
 def test_suggest_line_collapses_multiline_item_text():
     # #512: the injection line's echo strip is line-scoped (`[^\n]*`), so item
     # text carrying a newline would leave its tail in the verification

--- a/plugin/tests/test_provenance.py
+++ b/plugin/tests/test_provenance.py
@@ -187,6 +187,20 @@ def test_model_cannot_self_issue_source_or_quote_receipt():
     assert "quote_provenance" not in item
 
 
+def test_strip_code_owned_keys_removes_model_emitted_pinned():
+    # #689: `pinned` is code-owned (#292 discipline, same as `grounded`) —
+    # pin_imperatives is its only legitimate writer. The strip must remove a
+    # model-emitted value at the boundary so both capture doors share the
+    # guarantee; on the serialize path pin_imperatives re-pins genuine user
+    # imperatives after this runs.
+    item = {"text": "claim", "trust": "inferred", "pinned": True}
+    cp = _checkpoint("S-new", item, "2026-08-05T10:00:00Z")
+
+    serializer.strip_code_owned_keys(cp)
+
+    assert "pinned" not in item
+
+
 def test_resolver_unique_ambiguous_absent_remote_and_unsupported(tmp_path):
     claude = tmp_path / ".claude" / "projects"
     one = claude / "one"


### PR DESCRIPTION
Closes #689

## What

Adds `pinned` to `_CODE_OWNED_ITEM_KEYS`, so a model-supplied `pinned` flag is stripped on every door a model authors a checkpoint through. Two new tests: one proving the strip at the boundary, one proving the introspection door end to end.

## Why

`pinned` is minted only by `pin_imperatives` from user-authored transcript text (#369). That pass pops model copies itself but never runs on the introspection door, so a checkpoint piped to `daimon write-checkpoint` kept a caller-supplied `"pinned": true`, which the recall index then honored as a #452 age-gate exemption the code never derived. Same class as #684: one tuple entry to the same constant.

## Tests

- `test_strip_code_owned_keys_removes_model_emitted_pinned` (test_provenance.py): unit, failed before the change, passes after.
- `test_cli_write_checkpoint_strips_model_claimed_pinned` (test_cli.py): end to end through the introspection door, failed before the change, passes after.
- Full plugin suite: 3669 passed, 2 skipped, no regressions. The serialize-path pin tests confirm `pin_imperatives` still re-pins genuine user imperatives after the strip.
