### PR TITLE
fix(cli): forget by value reaches every declared plaintext field of the refutation ledger

### DIFF
--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1427,23 +1427,31 @@ def _cmd_forget(args) -> int:
     # #578: the refutation ledger is a second plaintext store, so a value can
     # live there with no checkpoint at all. Bailing on a missing checkpoint
     # would leave that value permanently unreachable.
-    # Every subject the record has EVER carried, not only the folded one: a
-    # revision rewrites the subject, so the forgotten value can sit in an
-    # earlier row that nothing renders. Matching only the current subject would
-    # leave exactly the text `forget` exists to reach unreachable. One entry per
-    # record, so a record whose old and new subjects both match is one hit.
-    ledger_subjects: dict[str, list[str]] = {}
+    # Every plaintext value the record has EVER carried, not only the folded
+    # ones: a revision rewrites fields, so the forgotten value can sit in an
+    # earlier row that nothing renders. #698: the field walk is the module's
+    # OWN declaration (plaintext_values, scalars only — a shared anchor or
+    # evidence token must never become a by-value target), never a hand-read
+    # `subject`. One entry per record, so a record whose old and new values
+    # both match is one hit; `text` stays the latest subject for display.
+    ledger_texts: dict[str, list[str]] = {}
+    ledger_display: dict[str, str] = {}
     for row in refutations.events(project_dir=project):
         ref_id = str(row.get("refutation_id") or "")
+        if not ref_id:
+            continue
+        for value in refutations.plaintext_values(row):
+            ledger_texts.setdefault(ref_id, [])
+            if value not in ledger_texts[ref_id]:
+                ledger_texts[ref_id].append(value)
         subject = str(row.get("subject") or "")
-        if ref_id and subject:
-            ledger_subjects.setdefault(ref_id, [])
-            if subject not in ledger_subjects[ref_id]:
-                ledger_subjects[ref_id].append(subject)
+        if subject:
+            ledger_display[ref_id] = subject
     ledger = [
-        (None, "refutation", {"id": ref_id, "text": subjects[-1],
-                              "_texts": subjects})
-        for ref_id, subjects in ledger_subjects.items()
+        (None, "refutation", {"id": ref_id,
+                              "text": ledger_display.get(ref_id, texts[0]),
+                              "_texts": texts})
+        for ref_id, texts in ledger_texts.items()
     ]
     # #691: the amendment ledger is another plaintext store — evidence quotes
     # and human notes. Same every-row posture as the refutation subjects

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1527,9 +1527,10 @@ def _cmd_forget(args) -> int:
 
         def _matched_value(it, generic):
             # The value the QUERY named. The exact canonical match is a rail
-            # the generic filter can never subtract — verbatim text sitting on
-            # disk always binds, no matter how common its terms have become
-            # (#698 review). The fuzzy fallback matches each value against the
+            # the GENERIC FILTER can never subtract, no matter how common the
+            # value's terms have become (#698 review) — the never-guess
+            # ambiguity gate below may still refuse it when several values
+            # match. The fuzzy fallback matches each value against the
             # candidate's own store vocabulary.
             for t in _texts_of(it):
                 if normalize.content_key(t) == query_key:
@@ -1539,28 +1540,28 @@ def _cmd_forget(args) -> int:
                     return t
             return None
 
-        matched_by_id: dict[int, str] = {}
+        # Hits carry the value they matched IN the tuple — a side table keyed
+        # on object identity would silently degrade to display text if a
+        # refactor ever copied a candidate dict (#698 review).
         if len(exact) > 1:
-            hits = [(s, k, it) for s, k, it in candidates
+            hits = [(s, k, it, None) for s, k, it in candidates
                     if it["id"] == args.target]
         else:
-            hits = []
-            for pool, generic in pools:
-                for s, k, it in pool:
-                    value = _matched_value(it, generic)
-                    if value is not None:
-                        hits.append((s, k, it))
-                        matched_by_id[id(it)] = value
+            hits = [(s, k, it, value)
+                    for pool, generic in pools
+                    for s, k, it in pool
+                    for value in [_matched_value(it, generic)]
+                    if value is not None]
         # #691: an amendment's evidence is by construction ABOUT its item, so
         # a query matching the item routinely fuzzy-matches the amendment too
         # — a false-ambiguity surface, not a real second value. When an item
         # hit exists, amendment hits that merely target one of the hit items
         # are dropped: forgetting the item removes its amendments anyway
         # (forget_item_id below), so nothing becomes unreachable.
-        item_hit_ids = {it["id"] for _, k, it in hits
+        item_hit_ids = {it["id"] for _, k, it, _ in hits
                         if k not in ("refutation", "amendment")}
         if item_hit_ids:
-            hits = [(s, k, it) for s, k, it in hits
+            hits = [(s, k, it, m) for s, k, it, m in hits
                     if not (k == "amendment"
                             and it.get("_target") in item_hit_ids)]
         # Ambiguity is about distinct MATCHED values, not hit count and never
@@ -1573,28 +1574,51 @@ def _cmd_forget(args) -> int:
         # different matched values leave the user a choice, and there
         # never-guess still refuses.
         distinct = {normalize.content_key(
-            matched_by_id.get(id(it), str(it.get("text") or "")))
-            for _, _, it in hits}
+            m if m is not None else str(it.get("text") or ""))
+            for _, _, it, m in hits}
         if len(distinct) == 1:
-            target = hits[0][2]
+            _, _, target, matched = hits[0]
             # #691: a record can hold several values (evidence, note,
             # historical rows). The tombstone must key on the value the QUERY
             # named, never on an arbitrary field — rebind `text` to the
             # matched value before the hash below derives from it.
-            matched = matched_by_id.get(id(target))
             if matched is not None and matched != target.get("text"):
                 target = dict(target, text=matched)
         else:
             _note_usage("forget:no-match" if not hits else "forget:ambiguous")
             label = "no item matches" if not hits else "ambiguous — matches"
             print(f"{label} {args.target!r}; candidates:")
-            for _, key, it in (hits or candidates):
-                print(f"  {it['id']}  [{key}] {it.get('text', '')}")
+            # A never-guess refusal is only useful if the user can make the
+            # choice: when the matched value differs from the display text,
+            # show it, or two candidates separated by their verdicts render
+            # as identical lines (#698 review).
+            rows = hits or [(s, k, it, None) for s, k, it in candidates]
+            for _, key, it, m in rows:
+                line = f"  {it['id']}  [{key}] {it.get('text', '')}"
+                if m is not None and m != it.get("text"):
+                    line += f" — matched: {m}"
+                print(line)
             print("forget by exact id: daimon forget <id>")
             return 1
     if getattr(args, "dry_run", False):
         _note_usage("forget:dry-run")
+        # #698 review: forget is irreversible and this preview is the only
+        # pre-deletion check. The deleters reach EVERY record whose any
+        # declared field folds to the value's key — including list fields the
+        # selector deliberately never offers — so the preview enumerates that
+        # reach non-destructively instead of naming only the selected target.
+        value_key = normalize.content_key(str(target.get("text") or ""))
+        ref_reach = sorted({str(row.get("refutation_id") or "")
+                            for row in refutations.events(project_dir=project)
+                            if value_key in refutations.row_content_keys(row)})
+        amend_reach = sorted({str(row.get("amendment_id") or "")
+                              for row in amendments.events(project_dir=project)
+                              if value_key in amendments.row_content_keys(row)})
         print(f"would forget {target['id']}: {target.get('text', '')}")
+        also = [rid for rid in ref_reach + amend_reach
+                if rid and rid != target["id"]]
+        if also:
+            print("value-keyed reach — also removed: " + ", ".join(also))
         return 0
     # #402: key the tombstone on the CANONICAL value (normalize.content_key),
     # not the raw bytes — so a later re-extraction of the same claim (different

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1514,16 +1514,43 @@ def _cmd_forget(args) -> int:
         def _texts_of(it):
             return it.get("_texts") or [str(it.get("text") or "")]
 
+        # #698 review: document frequency is per CANDIDATE, never per field.
+        # A record's subject/verdict/scope restate each other by construction,
+        # so counting them as separate documents lets one record push its own
+        # terms over the generic threshold and hide itself from its exact
+        # subject. One concatenated document per candidate keeps the statistic
+        # meaning what carry.py says it means: terms shared by >= k ITEMS.
         pools = [(pool, carry._generic_terms(
-            [t for _, _, it in pool for t in _texts_of(it)]))
+            [" ".join(_texts_of(it)) for _, _, it in pool]))
             for pool in (items, ledger, amend_pool)]
-        hits = ([(s, k, it) for s, k, it in candidates if it["id"] == args.target]
-                if len(exact) > 1 else
-                [(s, k, it)
-                 for pool, generic in pools
-                 for s, k, it in pool
-                 if any(carry._same_item(args.target, t, generic)
-                        for t in _texts_of(it))])
+        query_key = normalize.content_key(args.target)
+
+        def _matched_value(it, generic):
+            # The value the QUERY named. The exact canonical match is a rail
+            # the generic filter can never subtract — verbatim text sitting on
+            # disk always binds, no matter how common its terms have become
+            # (#698 review). The fuzzy fallback matches each value against the
+            # candidate's own store vocabulary.
+            for t in _texts_of(it):
+                if normalize.content_key(t) == query_key:
+                    return t
+            for t in _texts_of(it):
+                if carry._same_item(args.target, t, generic):
+                    return t
+            return None
+
+        matched_by_id: dict[int, str] = {}
+        if len(exact) > 1:
+            hits = [(s, k, it) for s, k, it in candidates
+                    if it["id"] == args.target]
+        else:
+            hits = []
+            for pool, generic in pools:
+                for s, k, it in pool:
+                    value = _matched_value(it, generic)
+                    if value is not None:
+                        hits.append((s, k, it))
+                        matched_by_id[id(it)] = value
         # #691: an amendment's evidence is by construction ABOUT its item, so
         # a query matching the item routinely fuzzy-matches the amendment too
         # — a false-ambiguity surface, not a real second value. When an item
@@ -1536,37 +1563,27 @@ def _cmd_forget(args) -> int:
             hits = [(s, k, it) for s, k, it in hits
                     if not (k == "amendment"
                             and it.get("_target") in item_hit_ids)]
-        # Ambiguity is about distinct VALUES, not hit count. The same sentence
-        # carried by sibling ids, held on several surfaces, or held in both the
-        # checkpoint and the refutation ledger is one thing to forget; #418
-        # already splices sibling ids from a single key. Only genuinely
-        # different values leave the user a choice to make, and there
+        # Ambiguity is about distinct MATCHED values, not hit count and never
+        # the display text. The same sentence carried by sibling ids, held on
+        # several surfaces, or held in both the checkpoint and the refutation
+        # ledger is one thing to forget; #418 already splices sibling ids from
+        # a single key. But two records matched on DIFFERENT values behind one
+        # shared display subject are two things — collapsing them over the
+        # display text silently under-deleted (#698 review). Only genuinely
+        # different matched values leave the user a choice, and there
         # never-guess still refuses.
-        distinct = {normalize.content_key(str(it.get("text") or ""))
-                    for _, _, it in hits}
+        distinct = {normalize.content_key(
+            matched_by_id.get(id(it), str(it.get("text") or "")))
+            for _, _, it in hits}
         if len(distinct) == 1:
             target = hits[0][2]
-            # #691: an amendment record can hold several values (evidence,
-            # note, historical rows). The tombstone must key on the value
-            # the QUERY named, never on an arbitrary field — rebind `text`
-            # to the matched value before the hash below derives from it.
-            texts = target.get("_texts")
-            if isinstance(texts, list) and len(texts) > 1:
-                query_key = normalize.content_key(args.target)
-                matched = next(
-                    (t for t in texts
-                     if normalize.content_key(t) == query_key),
-                    None)
-                if matched is None:
-                    _, generic = next(
-                        (p for p in pools if target in [it for _, _, it in p[0]]),
-                        (None, carry._generic_terms(texts)))
-                    matched = next(
-                        (t for t in texts
-                         if carry._same_item(args.target, t, generic)),
-                        None)
-                if matched:
-                    target = dict(target, text=matched)
+            # #691: a record can hold several values (evidence, note,
+            # historical rows). The tombstone must key on the value the QUERY
+            # named, never on an arbitrary field — rebind `text` to the
+            # matched value before the hash below derives from it.
+            matched = matched_by_id.get(id(target))
+            if matched is not None and matched != target.get("text"):
+                target = dict(target, text=matched)
         else:
             _note_usage("forget:no-match" if not hits else "forget:ambiguous")
             label = "no item matches" if not hits else "ambiguous — matches"

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1612,8 +1612,11 @@ def _cmd_forget(args) -> int:
         # its id — and amendments die with their item BY ID, carrying prose
         # that is not the forgotten value, so both must be previewed too
         # (#698 review). Same computation as the destructive path below,
-        # against the in-memory checkpoint, writing nothing.
-        spliced = set()
+        # against the in-memory checkpoint, writing nothing — INCLUDING the
+        # seed: a target superseded out of the live checkpoint (or ledger-
+        # only) never appears in the walk, but its own id still reaches the
+        # amendments keyed on it.
+        spliced = {str(target["id"] or "")}
         if isinstance(checkpoint, dict):
             for section, key in store._ITEM_LISTS:
                 for i in (checkpoint.get(section) or {}).get(key) or []:

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -1608,17 +1608,39 @@ def _cmd_forget(args) -> int:
         # selector deliberately never offers — so the preview enumerates that
         # reach non-destructively instead of naming only the selected target.
         value_key = normalize.content_key(str(target.get("text") or ""))
+        # The checkpoint splice takes every item holding the value, whatever
+        # its id — and amendments die with their item BY ID, carrying prose
+        # that is not the forgotten value, so both must be previewed too
+        # (#698 review). Same computation as the destructive path below,
+        # against the in-memory checkpoint, writing nothing.
+        spliced = set()
+        if isinstance(checkpoint, dict):
+            for section, key in store._ITEM_LISTS:
+                for i in (checkpoint.get(section) or {}).get(key) or []:
+                    if isinstance(i, dict) and (
+                            i.get("id") == target["id"]
+                            or normalize.content_key(i.get("text") or "")
+                            == value_key):
+                        spliced.add(str(i.get("id") or ""))
+        spliced.discard("")
         ref_reach = sorted({str(row.get("refutation_id") or "")
                             for row in refutations.events(project_dir=project)
                             if value_key in refutations.row_content_keys(row)})
-        amend_reach = sorted({str(row.get("amendment_id") or "")
-                              for row in amendments.events(project_dir=project)
-                              if value_key in amendments.row_content_keys(row)})
+        amend_reach = sorted({
+            str(row.get("amendment_id") or "")
+            for row in amendments.events(project_dir=project)
+            if value_key in amendments.row_content_keys(row)
+            or str(row.get("item_id") or "") in spliced})
         print(f"would forget {target['id']}: {target.get('text', '')}")
+        sibling_ids = sorted(spliced - {str(target["id"])})
+        if sibling_ids:
+            print("also removed — checkpoint siblings holding the value: "
+                  + ", ".join(sibling_ids))
         also = [rid for rid in ref_reach + amend_reach
                 if rid and rid != target["id"]]
         if also:
-            print("value-keyed reach — also removed: " + ", ".join(also))
+            print("also removed — ledger records reached by value or by "
+                  "doomed item id: " + ", ".join(also))
         return 0
     # #402: key the tombstone on the CANONICAL value (normalize.content_key),
     # not the raw bytes — so a later re-extraction of the same claim (different

--- a/plugin/daimon_briefing/refutations.py
+++ b/plugin/daimon_briefing/refutations.py
@@ -317,6 +317,24 @@ def append(row: dict, project_dir=None) -> bool:
         return False
 
 
+def plaintext_values(row: dict) -> list[str]:
+    """Every scalar plaintext value this row carries (#698).
+
+    The forget TARGETING pool reads this (cli._cmd_forget) instead of
+    hand-reading `subject` — the same one-declaration discipline
+    `row_content_keys` below gives the deleter and the auditor. Scalars only:
+    `anchors`/`evidence` are bounded typed tokens shared across records, so
+    offering one as a by-value target would show a single record in the
+    dry-run while the deleter removes every record carrying the token — the
+    same reasoning that keeps `author` out of the declared set entirely."""
+    out: list[str] = []
+    for field in _PLAINTEXT_FIELDS:
+        value = row.get(field)
+        if isinstance(value, str) and value.strip():
+            out.append(value)
+    return out
+
+
 def row_content_keys(row: dict) -> set[str]:
     """Canonical keys for every plaintext field this row carries (#645).
 

--- a/plugin/tests/test_forget_refutations.py
+++ b/plugin/tests/test_forget_refutations.py
@@ -489,3 +489,63 @@ def test_forget_still_refuses_an_unmatched_target(
 
     assert cli.main(["forget", target, "--project", PROJECT]) == 1
     assert "no item matches" in capsys.readouterr().out
+
+
+VERDICT = "it deadlocked under concurrent writes"
+
+
+def test_plaintext_values_walks_the_declared_scalar_fields():
+    # #698: the forget TARGETING pool must read the module's own declaration,
+    # exactly as the amendment pool does (amendments.plaintext_values). Scalars
+    # only: anchors/evidence are bounded typed tokens shared across records,
+    # the reasoning that keeps `author` out of the declared set.
+    row = {
+        "subject": "receipt design", "verdict": "CANARY must never ship",
+        "scope": "receipts", "revisit_when": "when the audit lands",
+        "note": "a human note", "anchors": ["issue:698"],
+        "evidence": ["measurement:trace-1"], "author": "someone",
+    }
+    values = refutations.plaintext_values(row)
+    assert "receipt design" in values
+    assert "CANARY must never ship" in values
+    assert "receipts" in values
+    assert "when the audit lands" in values
+    assert "a human note" in values
+    assert "issue:698" not in values
+    assert "measurement:trace-1" not in values
+    assert "someone" not in values
+
+
+def test_forget_removes_a_refutation_by_its_verdict_text(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    # #698: the natural deletion gesture for ledger prose is the text itself.
+    # Before the fix the pool hand-read `subject` only, so a verdict value
+    # answered "no item matches" while the audit promised reach by value.
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    _checkpoint("an unrelated decision about logging")
+    ref_id = _refute()
+
+    assert cli.main(["forget", VERDICT, "--project", PROJECT]) == 0
+
+    assert VERDICT not in _ledger_text()
+    assert refutations.get(ref_id, project_dir=PROJECT) is None
+
+
+def test_forget_selector_never_offers_a_shared_anchor_token(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    # #698 scoping: a typed anchor token is shared across records; offering it
+    # as a by-value target would show ONE record in the dry-run while the
+    # deleter removes every record carrying the token.
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    _checkpoint("an unrelated decision about logging")
+    kept = refutations.assert_refutation(
+        subject="a distinct subject about caching",
+        verdict="the cache thrashed", scope="caching",
+        evidence=["measurement:deadlock-trace-1"],
+        channel="cli-tty", ratified=True, project_dir=PROJECT)
+    _refute()  # shares evidence token "measurement:deadlock-trace-1"
+
+    assert cli.main(
+        ["forget", "measurement:deadlock-trace-1", "--project", PROJECT]) == 1
+
+    assert refutations.get(kept, project_dir=PROJECT) is not None

--- a/plugin/tests/test_forget_refutations.py
+++ b/plugin/tests/test_forget_refutations.py
@@ -622,3 +622,57 @@ def test_two_records_matched_on_different_verdicts_refuse_ambiguous(
 
     assert refutations.get(kept_a, project_dir=PROJECT) is not None
     assert refutations.get(kept_b, project_dir=PROJECT) is not None
+
+
+def test_dry_run_names_every_record_the_deleter_would_reach(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    # #698 review round 2: forget is irreversible and dry-run is the only
+    # pre-deletion check. Three records share a scope token; the deleter
+    # removes all three, so the preview must name all three.
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    _checkpoint("an unrelated decision about logging")
+    ids = [
+        refutations.assert_refutation(
+            subject=f"a distinct subject number {n}",
+            verdict=f"a distinct verdict number {n}",
+            scope="the account migrations area",
+            evidence=[f"measurement:trace-{n}"], channel="cli-tty",
+            ratified=True, project_dir=PROJECT)
+        for n in range(3)
+    ]
+
+    assert cli.main(["forget", "the account migrations area",
+                     "--dry-run", "--project", PROJECT]) == 0
+
+    out = capsys.readouterr().out
+    for ref_id in ids:
+        assert ref_id in out
+    for ref_id in ids:
+        assert refutations.get(ref_id, project_dir=PROJECT) is not None
+
+
+def test_ambiguous_refusal_shows_the_values_that_differ(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    # #698 review round 2: a never-guess refusal is only useful if the user
+    # can make the choice. Two candidates separated by their verdicts must
+    # show those verdicts, not two identical subject lines.
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    _checkpoint("an unrelated decision about logging")
+    refutations.assert_refutation(
+        subject="the account migration rewrite", scope="alpha",
+        verdict="the migration corrupted tenant rows silently",
+        evidence=["measurement:corruption-a"], channel="cli-tty",
+        ratified=True, project_dir=PROJECT)
+    refutations.assert_refutation(
+        subject="the account migration rewrite", scope="beta",
+        verdict="the migration corrupted tenant rows completely",
+        evidence=["measurement:corruption-b"], channel="cli-tty",
+        ratified=True, project_dir=PROJECT)
+
+    assert cli.main(
+        ["forget", "the migration corrupted tenant rows silently",
+         "--project", PROJECT]) == 1
+
+    out = capsys.readouterr().out
+    assert "the migration corrupted tenant rows silently" in out
+    assert "the migration corrupted tenant rows completely" in out

--- a/plugin/tests/test_forget_refutations.py
+++ b/plugin/tests/test_forget_refutations.py
@@ -548,4 +548,77 @@ def test_forget_selector_never_offers_a_shared_anchor_token(
     assert cli.main(
         ["forget", "measurement:deadlock-trace-1", "--project", PROJECT]) == 1
 
+    # The REASON must be the pool excluding the token, never the ambiguity
+    # gate masking an over-reach: with the token in the pool both records
+    # would hit and the refusal would read "ambiguous — matches" instead.
+    assert "no item matches" in capsys.readouterr().out
     assert refutations.get(kept, project_dir=PROJECT) is not None
+
+
+def test_forget_reaches_a_subject_whose_own_fields_share_its_terms(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    # #698 review: one record's subject/verdict/scope restate each other by
+    # construction. Counting each field as its own document pushed the
+    # record's OWN terms over the generic threshold and the record became
+    # unreachable by its exact subject. Frequency is per record, and an
+    # exact canonical match must always bind.
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    _checkpoint("an unrelated decision about logging")
+    refutations.assert_refutation(
+        subject="the account migration rewrite",
+        verdict="the account migration rewrite deadlocked",
+        scope="account migration",
+        evidence=["measurement:deadlock-trace-1"], channel="cli-tty",
+        ratified=True, project_dir=PROJECT)
+
+    assert cli.main(
+        ["forget", "the account migration rewrite", "--project", PROJECT]) == 0
+
+    assert "the account migration rewrite" not in _ledger_text()
+
+
+def test_forget_fuzzy_reach_to_a_subject_survives_the_widened_pool(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    # #698 review: a partial query that reached the subject before the pool
+    # widened must still reach it after.
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    _checkpoint("an unrelated decision about logging")
+    refutations.assert_refutation(
+        subject="the retry budget must be per-tenant and never global",
+        verdict="a global retry budget starved the busiest tenant under load",
+        scope="retry budget policy",
+        revisit_when="when the retry budget becomes per-tenant everywhere",
+        evidence=["measurement:starvation-trace"], channel="cli-tty",
+        ratified=True, project_dir=PROJECT)
+
+    assert cli.main(
+        ["forget", "retry budget must be per-tenant", "--project",
+         PROJECT]) == 0
+
+    assert "retry budget" not in _ledger_text()
+
+
+def test_two_records_matched_on_different_verdicts_refuse_ambiguous(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    # #698 review: never-guess is about distinct MATCHED values. Two records
+    # sharing a display subject but matched on different verdicts are two
+    # things; collapsing them over the display text silently under-deleted.
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    _checkpoint("an unrelated decision about logging")
+    kept_a = refutations.assert_refutation(
+        subject="the account migration rewrite", scope="alpha",
+        verdict="the migration corrupted tenant rows silently",
+        evidence=["measurement:corruption-a"], channel="cli-tty",
+        ratified=True, project_dir=PROJECT)
+    kept_b = refutations.assert_refutation(
+        subject="the account migration rewrite", scope="beta",
+        verdict="the migration corrupted tenant rows completely",
+        evidence=["measurement:corruption-b"], channel="cli-tty",
+        ratified=True, project_dir=PROJECT)
+
+    assert cli.main(
+        ["forget", "the migration corrupted tenant rows silently",
+         "--project", PROJECT]) == 1
+
+    assert refutations.get(kept_a, project_dir=PROJECT) is not None
+    assert refutations.get(kept_b, project_dir=PROJECT) is not None

--- a/plugin/tests/test_forget_refutations.py
+++ b/plugin/tests/test_forget_refutations.py
@@ -676,3 +676,50 @@ def test_ambiguous_refusal_shows_the_values_that_differ(
     out = capsys.readouterr().out
     assert "the migration corrupted tenant rows silently" in out
     assert "the migration corrupted tenant rows completely" in out
+
+
+def test_dry_run_names_amendments_keyed_to_the_doomed_item(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    # #698 review round 3: amendments die with their item by item id and
+    # carry prose that is NOT the forgotten value. Zero preview meant
+    # unrelated evidence quotes and notes vanished with no warning.
+    from daimon_briefing import amendments
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    _checkpoint("we ship the queue rewrite before the freeze")
+    stored = store.read_latest(project_dir=PROJECT, fallback=False)
+    item_id = stored["working_context"]["recent_decisions"][0]["id"]
+    a_id = amendments.propose(
+        item_id=item_id, change="progressed",
+        evidence="the user said only the consumer half ships",
+        channel="cli-agent", project_dir=PROJECT)
+
+    assert cli.main(["forget", "we ship the queue rewrite before the freeze",
+                     "--dry-run", "--project", PROJECT]) == 0
+
+    out = capsys.readouterr().out
+    assert a_id in out
+    assert any(str(r.get("amendment_id")) == a_id
+               for r in amendments.events(project_dir=PROJECT))
+
+
+def test_dry_run_names_spliced_checkpoint_siblings(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    # #698 review round 3: the checkpoint splice removes every item holding
+    # the value, whatever its id. The preview must name the siblings.
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    shared = "the shared sentence across two sections"
+    store.write_checkpoint("S1", {
+        "session_id": "S1", "created": "2026-07-01T00:00:00Z",
+        "working_context": {
+            "recent_decisions": [{"text": shared, "trust": "inferred"}],
+            "open_questions": [{"text": shared, "trust": "inferred"}]},
+    }, project_dir=PROJECT)
+    stored = store.read_latest(project_dir=PROJECT, fallback=False)
+    ids = {stored["working_context"]["recent_decisions"][0]["id"],
+           stored["working_context"]["open_questions"][0]["id"]}
+
+    assert cli.main(["forget", shared, "--dry-run", "--project", PROJECT]) == 0
+
+    out = capsys.readouterr().out
+    for item_id in ids:
+        assert item_id in out

--- a/plugin/tests/test_forget_refutations.py
+++ b/plugin/tests/test_forget_refutations.py
@@ -723,3 +723,35 @@ def test_dry_run_names_spliced_checkpoint_siblings(
     out = capsys.readouterr().out
     for item_id in ids:
         assert item_id in out
+
+
+def test_dry_run_previews_amendments_of_a_superseded_item(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    # #698 review round 4: a value superseded out of the live checkpoint is
+    # still reachable (#419), and the destructive path still removes the
+    # amendments keyed on its id. The preview's splice set must be seeded
+    # with the target id or exactly those amendments die unpreviewed.
+    from daimon_briefing import amendments
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    doomed_text = "we ship the queue rewrite before the freeze"
+    _checkpoint(doomed_text)
+    stored = store.read_latest(project_dir=PROJECT, fallback=False)
+    item_id = stored["working_context"]["recent_decisions"][0]["id"]
+    a_id = amendments.propose(
+        item_id=item_id, change="progressed",
+        evidence="the user said only the consumer half ships",
+        channel="cli-agent", project_dir=PROJECT)
+    store.write_checkpoint("S2", {
+        "session_id": "S2", "created": "2026-07-02T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "a completely different later decision",
+             "trust": "inferred"}]},
+    }, project_dir=PROJECT)
+
+    assert cli.main(["forget", doomed_text,
+                     "--dry-run", "--project", PROJECT]) == 0
+
+    out = capsys.readouterr().out
+    assert a_id in out
+    assert any(str(r.get("amendment_id")) == a_id
+               for r in amendments.events(project_dir=PROJECT))


### PR DESCRIPTION
## Summary

Closes #698.

The forget targeting pool now reads the refutation ledger's own plaintext declaration instead of hand-reading `subject`: a new `refutations.plaintext_values(row)` helper, mirroring the amendment ledger's, walks the declared scalar fields, so `daimon forget "<text in verdict, scope, revisit_when, or note>"` binds by value. Scalars only, deliberately: `anchors` and `evidence` are bounded typed tokens shared across records, and offering one as a by-value target would show a single record in the preview while the deleter removes every record carrying the token.

Widening the matchable corpus exposed three latent selector defects, fixed here rather than shipped:

- **Term frequency is counted per candidate, never per field.** A record's subject, verdict, and scope restate each other by construction; counting them as separate documents let one record push its own terms over the generic threshold and hide from its exact subject. One concatenated document per candidate restores the statistic's stated meaning, and a no-op for checkpoint items.
- **An exact canonical-key match is a rail the generic filter cannot subtract.** Verbatim text sitting on disk always survives the filter; the never-guess ambiguity gate may still refuse it when several values match.
- **Ambiguity is decided on matched values, not display text.** Two records sharing a display subject but matched on different verdicts are two things; collapsing them over the display text silently removed one and kept the other. Hits now carry the value they matched, the distinct-value set is computed from those, and refusal listings print the matched value when it differs from the display text so the `forget <id>` recovery path is usable.
- **`--dry-run` enumerates the real blast radius.** The deleters reach every record whose any declared field folds to the value's key, plus amendments keyed to doomed item ids and checkpoint siblings holding the value. The preview now runs the same computations non-destructively, seeded identically to the destructive path (including targets superseded out of the live checkpoint), and prints the reached ids under labeled lines. Previously it named one record while the run could remove several.

## Testing

- 9 new tests in `tests/test_forget_refutations.py`: by-value reach for the widened fields, the shared-token exclusion with its reason asserted, self-correlated-record reachability, partial-query reach, matched-value ambiguity refusal (both records survive), preview completeness for shared-scope records, item-keyed amendments, spliced siblings, and superseded items.
- Full suite: 3755 passed, 2 skipped. ruff clean.

## Open questions deliberately not decided here

- Whether a bare `scope` should be a by-value target at all: it is a categorical label, closer to the reasoning that keeps `author` out of the declared set than to item prose. With the preview now honest about multi-record reach, the question is narrower, but it deserves its own ruling.
- Whether an exact hit should suppress fuzzy-only hits: a user who types a value character-for-character has expressed the intent never-guess protects, yet a near-twin can still force an ambiguous refusal today. Pre-existing behavior, left unchanged.
- The success receipt says "removed from the live checkpoint" whenever a checkpoint exists, even when the splice matched nothing there. Pre-existing wording, worth a pass next time this code is touched.
