### PR TITLE
feat(briefing): pinned rulings reach every context surface, with the echo loop closed

### DIFF
--- a/.scars/candidates/source-text-assertions-are-satisfied-by-comments.md
+++ b/.scars/candidates/source-text-assertions-are-satisfied-by-comments.md
@@ -1,0 +1,27 @@
+---
+id: 0
+type: landmine
+title: A getsource substring assertion on a call site is satisfied by its own explaining comment
+severity: high
+confidence: 0.9
+created: 2026-08-15
+authors: ["claude-code"]
+anchors:
+  - path: plugin/tests/
+  - pattern: "inspect\.getsource"
+evidence:
+  - pr: "693 PR 2 review round 1: both blind reviewers independently proved the mutation survives"
+  - note: "removing admit=True from capture.py's write_checkpoint call left the suite green — the comment above the call contained the same literal"
+---
+
+`test_capture_path_admits` asserted `"admit=True" in inspect.getsource(capture.run)`
+to pin that the capture path opts into the #693 echo admission filter. The call
+site carried the house-style comment `# admit=True (#693): capture is one of the
+two admission paths` — so deleting the actual kwarg left the assertion green: the
+comment alone satisfied it. The repo's comment discipline (name the flag you are
+explaining) makes this collision the NORM, not a fluke: any source-text substring
+assertion about a call site will usually also match the comment that documents it.
+Two independent reviewers had to mutation-test to expose it. Instead: spy on the
+seam (monkeypatch the callee, assert the kwarg it RECEIVES) or drive the caller
+end-to-end; if you must assert on source text, first prove the test fails with the
+real code removed and the comment left in place.

--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -20,7 +20,7 @@ import time
 # scoring, nor serializer imports briefing — no cycle, so this stays a normal
 # module-level import (contrast carry.py's own local-import notes, which
 # don't apply here).
-from . import (capture, carry, config, llm, receipts, schema,
+from . import (capture, carry, config, llm, receipts, refutations, schema,
                scoring, serializer, store)
 # Imported as constants, not as the module: withhold()'s `amendments`
 # parameter (the public keyword every caller uses) would shadow the module
@@ -718,14 +718,64 @@ _DROP_ORDER = (("beliefs", "tail"), ("uncertainties", "tail"),
                ("decisions", "head"), ("open_loops", "tail"))
 
 
-def render_plain(b: dict, degraded: bool = False) -> str:
+# ---- #693: standing rulings — the always-present positive-polarity section ----
+
+# The section renders at the TOP of the briefing, outside _DROP_ORDER: a
+# ruling is a human-ratified standing constraint, and budget pressure must
+# never silently drop the one section whose whole point is that it cannot
+# fade. Worst case (a full cap of maximum-length rulings) costs ~17-20% of
+# the default 3000-token budget — pinned by test.
+_RULING_HEADER = "Standing rulings (human-ratified — honor these):"
+
+
+def active_rulings(project_dir=None) -> list[dict]:
+    """Active rulings for the briefing section, newest-ratified first.
+
+    Fail-open: any ledger read error yields [] — a briefing must never be
+    lost to an unreadable refutations.jsonl. The renderer holds the cap on
+    its own (count backstop): a hand-edited ledger holding more actives than
+    DAIMON_RULING_CAP still renders at most the cap, newest `activated_at`
+    first — the same sort the ratify-path backstop uses."""
+    try:
+        rows = refutations.listing(states={"active"}, polarity="ruling",
+                                   project_dir=project_dir)
+        cap = config.ruling_cap()
+    except Exception:
+        return []
+    rows.sort(key=lambda r: ((r.get("activated_at") or ""),
+                             r.get("refutation_id") or ""), reverse=True)
+    return rows[:cap]
+
+
+def ruling_lines(project_dir=None) -> list[str]:
+    """The section's rendered lines ([] when no active rulings — the section
+    is skeleton furniture, but empty furniture is noise). Verdict, never
+    subject: the verdict IS the rule text (cli._print_ruling's contract, one
+    vocabulary across surfaces). Text backstop: a hand-edited verdict longer
+    than the write-time bound is clipped rather than trusted. Non-human
+    `text_authored_by` is labeled even after human ratification — who wrote
+    the words survives who approved them."""
+    rows = active_rulings(project_dir)
+    if not rows:
+        return []
+    lines = [_RULING_HEADER]
+    for row in rows:
+        verdict = str(row.get("verdict") or "")[:refutations._MAX_RULING_TEXT]
+        authored = row.get("text_authored_by")
+        suffix = ("  [agent-written]"
+                  if authored and authored != "human" else "")
+        lines.append(f"§ {verdict}{suffix}")
+    return lines
+
+
+def render_plain(b: dict, degraded: bool = False, rulings=()) -> str:
     """The deterministic briefing text. Under the #79 budget this is
     BYTE-IDENTICAL to the legacy render(); over it, long items truncate
     (sections preserved) and then whole items drop, lowest value first,
     each cut announced with a trim note. `degraded` (#204) downgrades every
     verbatim label and adds one header note when the receipt is unverifiable."""
     budget = config.brief_max_tokens()
-    text = _render_parts(b, {}, degraded)
+    text = _render_parts(b, {}, degraded, rulings)
     if not budget or estimate_tokens(text) <= budget:
         return text
 
@@ -743,7 +793,7 @@ def render_plain(b: dict, degraded: bool = False) -> str:
             for i in (b.get(key) or [])
         ]
     trimmed = {key: 0 for key, _ in _DROP_ORDER}
-    text = _render_parts(b, trimmed, degraded)
+    text = _render_parts(b, trimmed, degraded, rulings)
 
     # Stage 2: drop whole items, least valuable first, until the budget holds
     # or only the skeleton remains.
@@ -753,19 +803,26 @@ def render_plain(b: dict, degraded: bool = False) -> str:
             items.pop(-1 if end == "tail" else 0)
             b[key] = items
             trimmed[key] += 1
-            text = _render_parts(b, trimmed, degraded)
+            text = _render_parts(b, trimmed, degraded, rulings)
         if estimate_tokens(text) <= budget:
             break
     return text
 
 
-def _render_parts(b: dict, trimmed: dict, degraded: bool = False) -> str:
+def _render_parts(b: dict, trimmed: dict, degraded: bool = False,
+                  rulings=()) -> str:
     parts = ["While you were away — here's where we left off."]
     if degraded:
         # One header note (#204), embedded in the text so the hook-injected
         # briefing carries it too — not just the human-facing CLI render.
         parts.append("")
         parts.append(DEGRADE_NOTE)
+    if rulings:
+        # #693: skeleton furniture at the top, outside _DROP_ORDER — the
+        # budget loops re-render with the same lines and can only trim the
+        # sections below.
+        parts.append("")
+        parts.extend(rulings)
 
     def _section(header: str, key: str) -> None:
         items = b.get(key) or []
@@ -834,24 +891,34 @@ def _validate_llm_render(rendered: str, checkpoint) -> bool:
     return True
 
 
-def render(checkpoint) -> str | None:
+def render(checkpoint, project_dir=None) -> str | None:
     """Render the briefing, or None if there is nothing worth surfacing.
     LLM rendering is opt-in (DAIMON_LLM_BRIEFING), post-validated for verbatim
-    quote integrity, and falls back to deterministic on any doubt."""
+    quote integrity, and falls back to deterministic on any doubt.
+
+    `project_dir` (#693) scopes the standing-rulings section; None (legacy
+    callers, hand-built checkpoints in tests) renders without it — an
+    unscoped ledger read here would mix another project's rulings into this
+    briefing, the exact leak the polarity parameter exists to prevent."""
     b = build(checkpoint)
     if b is None:
         return None
     degraded = receipt_degraded(checkpoint)
+    rulings = ruling_lines(project_dir) if project_dir is not None else []
     if config.llm_briefing():
         rendered = _render_llm(checkpoint)
         if rendered:
             if _validate_llm_render(rendered, checkpoint):
                 # The LLM render carries no per-item marks to degrade; prepend the
                 # one header note so an unverifiable receipt still fails loud (#204).
-                return f"{DEGRADE_NOTE}\n\n{rendered}" if degraded else rendered
+                out = f"{DEGRADE_NOTE}\n\n{rendered}" if degraded else rendered
+                # #693: the LLM narrates the CHECKPOINT; rulings live outside
+                # it, so the deterministic section is prepended verbatim —
+                # never re-narrated, never trusted to a generative pass.
+                return "\n".join(rulings) + "\n\n" + out if rulings else out
             log.warning("llm briefing dropped a verbatim quote — "
                         "falling back to the deterministic render")
-    return render_plain(b, degraded)
+    return render_plain(b, degraded, rulings)
 
 
 # Seeded from research/experiments/track-a/prompts/02-reconstruct.md, tuned for a

--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -729,42 +729,64 @@ _RULING_HEADER = "Standing rulings (human-ratified — honor these):"
 
 
 def active_rulings(project_dir=None) -> list[dict]:
-    """Active rulings for the briefing section, newest-ratified first.
+    """Every active ruling for the briefing section, newest-activated first
+    (ties break on refutation_id — the fold keeps no finer stamp). This is
+    the SECTION's order, chosen so the cap slice in ruling_lines keeps the
+    newest ratifications; `daimon ruling list` and the viewer lane keep
+    refutations.listing's own presentation order.
 
-    Fail-open: any ledger read error yields [] — a briefing must never be
-    lost to an unreadable refutations.jsonl. The renderer holds the cap on
-    its own (count backstop): a hand-edited ledger holding more actives than
-    DAIMON_RULING_CAP still renders at most the cap, newest `activated_at`
-    first — the same sort the ratify-path backstop uses."""
+    Fail-open: ANY error — read, fold, or sort over hand-edited rows —
+    yields [] rather than costing the briefing."""
     try:
         rows = refutations.listing(states={"active"}, polarity="ruling",
                                    project_dir=project_dir)
-        cap = config.ruling_cap()
+        rows.sort(key=lambda r: (str(r.get("activated_at") or ""),
+                                 str(r.get("refutation_id") or "")),
+                  reverse=True)
+        return rows
     except Exception:
         return []
-    rows.sort(key=lambda r: ((r.get("activated_at") or ""),
-                             r.get("refutation_id") or ""), reverse=True)
-    return rows[:cap]
 
 
 def ruling_lines(project_dir=None) -> list[str]:
     """The section's rendered lines ([] when no active rulings — the section
     is skeleton furniture, but empty furniture is noise). Verdict, never
     subject: the verdict IS the rule text (cli._print_ruling's contract, one
-    vocabulary across surfaces). Text backstop: a hand-edited verdict longer
-    than the write-time bound is clipped rather than trusted. Non-human
-    `text_authored_by` is labeled even after human ratification — who wrote
-    the words survives who approved them."""
-    rows = active_rulings(project_dir)
+    vocabulary across surfaces).
+
+    Backstops, both LOUD: more actives than DAIMON_RULING_CAP — a
+    hand-edited ledger, or simply LOWERING the cap after activations, a
+    supported move the cap guard's own error text invites — renders the
+    cap's worth PLUS a note naming how many were withheld (a silent
+    truncation of human-ratified constraints is the one failure this
+    section must never have); a hand-edited verdict longer
+    than the write-time bound is clipped with a visible marker; an empty
+    verdict renders nothing. Non-human `text_authored_by` is labeled with
+    its own AUTHORITY word (agent / mechanical — CHANNEL_AUTHORITY's
+    vocabulary, cli._print_ruling's own label) even after human
+    ratification — who wrote the words survives who approved them."""
+    rows = [r for r in active_rulings(project_dir)
+            if str(r.get("verdict") or "").strip()]
     if not rows:
         return []
+    try:
+        cap = config.ruling_cap()
+    except Exception:
+        return []
+    shown, over = rows[:cap], rows[cap:]
     lines = [_RULING_HEADER]
-    for row in rows:
-        verdict = str(row.get("verdict") or "")[:refutations._MAX_RULING_TEXT]
+    for row in shown:
+        verdict = str(row.get("verdict") or "")
+        if len(verdict) > refutations._MAX_RULING_TEXT:
+            verdict = verdict[:refutations._MAX_RULING_TEXT] + "…"
         authored = row.get("text_authored_by")
-        suffix = ("  [agent-written]"
+        suffix = (f"  [{authored}-written]"
                   if authored and authored != "human" else "")
         lines.append(f"§ {verdict}{suffix}")
+    if over:
+        plural = "s" if len(over) != 1 else ""
+        lines.append(f"  (+{len(over)} active ruling{plural} over cap — "
+                     "daimon ruling list shows all)")
     return lines
 
 
@@ -897,25 +919,32 @@ def render(checkpoint, project_dir=None) -> str | None:
     quote integrity, and falls back to deterministic on any doubt.
 
     `project_dir` (#693) scopes the standing-rulings section; None (legacy
-    callers, hand-built checkpoints in tests) renders without it — an
-    unscoped ledger read here would mix another project's rulings into this
-    briefing, the exact leak the polarity parameter exists to prevent."""
+    callers, hand-built checkpoints in tests) skips the read entirely — an
+    unknown project resolves to no ledger path and reads nothing, so the
+    guard saves a pointless call rather than preventing a leak."""
     b = build(checkpoint)
-    if b is None:
-        return None
-    degraded = receipt_degraded(checkpoint)
     rulings = ruling_lines(project_dir) if project_dir is not None else []
+    if b is None:
+        # #693: a ruling ratified before the first real checkpoint (a day-one
+        # action) must still reach context — "nothing worth surfacing" is no
+        # longer true when active rulings exist.
+        return "\n".join(rulings) if rulings else None
+    degraded = receipt_degraded(checkpoint)
     if config.llm_briefing():
         rendered = _render_llm(checkpoint)
         if rendered:
             if _validate_llm_render(rendered, checkpoint):
-                # The LLM render carries no per-item marks to degrade; prepend the
-                # one header note so an unverifiable receipt still fails loud (#204).
-                out = f"{DEGRADE_NOTE}\n\n{rendered}" if degraded else rendered
-                # #693: the LLM narrates the CHECKPOINT; rulings live outside
-                # it, so the deterministic section is prepended verbatim —
+                # The LLM render carries no per-item marks to degrade; the one
+                # header note stays FIRST on every path (#204 — the loudest
+                # line never moves below another section). #693: the LLM
+                # narrates the CHECKPOINT; rulings live outside it, so the
+                # deterministic section is prepended verbatim after the note —
                 # never re-narrated, never trusted to a generative pass.
-                return "\n".join(rulings) + "\n\n" + out if rulings else out
+                parts = ([DEGRADE_NOTE] if degraded else [])
+                if rulings:
+                    parts.append("\n".join(rulings))
+                parts.append(rendered)
+                return "\n\n".join(parts)
             log.warning("llm briefing dropped a verbatim quote — "
                         "falling back to the deterministic render")
     return render_plain(b, degraded, rulings)

--- a/plugin/daimon_briefing/capture.py
+++ b/plugin/daimon_briefing/capture.py
@@ -136,7 +136,10 @@ def run(session_id: str, messages, *, project, chat, deadline,
                 project, str(checkpoint.get("session_id") or ""))
         except Exception:  # keep the unmerged checkpoint, proceed to write
             pass
-    out = store.write_checkpoint(session_id, checkpoint, project_dir=project)
+    # admit=True (#693): capture is one of the two admission paths — new
+    # cognitive content passes the ruling echo filter here.
+    out = store.write_checkpoint(session_id, checkpoint, project_dir=project,
+                                 admit=True)
     if out is None:
         # #421: the write boundary refused (kill switch) — nothing landed, so
         # there is nothing to ledger rejections against either.

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -404,7 +404,11 @@ def _cmd_write_checkpoint(args) -> int:
     serializer.downgrade_unverifiable_verbatim(checkpoint)
     checkpoint["source"] = args.source  # provenance: introspection vs reconstruction
     session_id = str(checkpoint["session_id"])
-    out = store.write_checkpoint(session_id, checkpoint, project_dir=_resolve_project(args.project))
+    # admit=True (#693): the stdin path is the second admission caller — a
+    # model-authored checkpoint passes the ruling echo filter like capture's.
+    out = store.write_checkpoint(session_id, checkpoint,
+                                 project_dir=_resolve_project(args.project),
+                                 admit=True)
     if out is None:  # #421: write boundary refused (kill switch)
         print("error: daimon disabled (DAIMON_DISABLE) — checkpoint not written",
               file=sys.stderr)

--- a/plugin/daimon_briefing/cli.py
+++ b/plugin/daimon_briefing/cli.py
@@ -576,7 +576,7 @@ def _render_briefing_body(checkpoint, route, *, drift_project, teammates,
     except Exception:
         handoff = None
     render.render_brief(checkpoint, drift=drift, teammates=teammates,
-                        handoff=handoff)
+                        handoff=handoff, project_dir=route)
     if withheld:
         render.render_brief_note([
             f"{len(withheld)} resolved item(s) withheld — "

--- a/plugin/daimon_briefing/hooks.py
+++ b/plugin/daimon_briefing/hooks.py
@@ -185,7 +185,9 @@ def pre_llm_call(session_id=None, user_message=None, conversation_history=None,
                 checkpoint, store.corroborations(project_dir=project))
         except Exception:
             pass
-        text = briefing.render(checkpoint)
+        # #693: scope the standing-rulings section to the SAME project the
+        # checkpoint was read for — never the process cwd.
+        text = briefing.render(checkpoint, project_dir=project)
         if not text:
             return None
         return {"context": text}

--- a/plugin/daimon_briefing/hooks.py
+++ b/plugin/daimon_briefing/hooks.py
@@ -162,7 +162,10 @@ def pre_llm_call(session_id=None, user_message=None, conversation_history=None,
         project = config.resolve_project_root(config.project_dir())
         checkpoint = store.read_latest(project_dir=project)
         if checkpoint is None:
-            return None
+            # #693: standing rulings exist before the first checkpoint does —
+            # a day-one ratification must reach the very next session.
+            rulings = briefing.ruling_lines(project)
+            return {"context": "\n".join(rulings)} if rulings else None
         # Withhold (#103 I1): this in-process injection path used to render the
         # RAW checkpoint, so a resolved item still auto-injected into every new
         # session's context — `daimon brief` already suppressed it, this hook
@@ -185,8 +188,10 @@ def pre_llm_call(session_id=None, user_message=None, conversation_history=None,
                 checkpoint, store.corroborations(project_dir=project))
         except Exception:
             pass
-        # #693: scope the standing-rulings section to the SAME project the
-        # checkpoint was read for — never the process cwd.
+        # #693: rulings are scoped to the RESOLVED project (never the raw
+        # process cwd). Note read_latest above keeps its global fallback, so
+        # the checkpoint may be another project's — the rulings are still
+        # this project's own.
         text = briefing.render(checkpoint, project_dir=project)
         if not text:
             return None

--- a/plugin/daimon_briefing/mcp_tools.py
+++ b/plugin/daimon_briefing/mcp_tools.py
@@ -58,6 +58,11 @@ def _brief(arguments: dict) -> str:
     # Strictly scoped read (#94): never the global pointer. A named slug is
     # passed straight through; otherwise the resolved project's own bucket.
     target = slug if slug else cli._resolve_project(project_arg)
+    # #693: one strictly-scoped ledger read serves every return below —
+    # standing rulings exist before the first checkpoint does, so both
+    # no-content returns carry them too.
+    rulings = briefing.ruling_lines(target)
+    ruling_text = ("\n".join(rulings) + "\n\n") if rulings else ""
     checkpoint = store.read_latest(project_dir=target, fallback=False)
     if checkpoint is None:
         # Orientation without content: name the explicit path, leak nothing
@@ -69,7 +74,7 @@ def _brief(arguments: dict) -> str:
                 if others else
                 "no projects have checkpoints yet — the first serialized "
                 "session creates one.")
-        return f"no checkpoint for this project. {hint}"
+        return f"{ruling_text}no checkpoint for this project. {hint}"
     filtered, _withheld, _candidates = briefing.withhold(
         checkpoint, store.resolutions(project_dir=target),
         amendments=amendments.renderable(project_dir=target))
@@ -80,13 +85,11 @@ def _brief(arguments: dict) -> str:
         filtered, store.corroborations(project_dir=target))
     b = briefing.build(filtered)
     if b is None:
-        return "checkpoint exists but has nothing worth surfacing."
+        return f"{ruling_text}checkpoint exists but has nothing worth surfacing."
     # Deterministic render only over MCP — the opt-in LLM re-render is a
     # human-display affordance, and a machine consumer wants stable bytes.
-    # #693: the standing-rulings section rides the same strictly-scoped
-    # target as every other read in this tool.
     return briefing.render_plain(b, briefing.receipt_degraded(filtered),
-                                 briefing.ruling_lines(target))
+                                 rulings)
 
 
 def _projects(arguments: dict) -> str:

--- a/plugin/daimon_briefing/mcp_tools.py
+++ b/plugin/daimon_briefing/mcp_tools.py
@@ -83,7 +83,10 @@ def _brief(arguments: dict) -> str:
         return "checkpoint exists but has nothing worth surfacing."
     # Deterministic render only over MCP — the opt-in LLM re-render is a
     # human-display affordance, and a machine consumer wants stable bytes.
-    return briefing.render_plain(b, briefing.receipt_degraded(filtered))
+    # #693: the standing-rulings section rides the same strictly-scoped
+    # target as every other read in this tool.
+    return briefing.render_plain(b, briefing.receipt_degraded(filtered),
+                                 briefing.ruling_lines(target))
 
 
 def _projects(arguments: dict) -> str:

--- a/plugin/daimon_briefing/policy.py
+++ b/plugin/daimon_briefing/policy.py
@@ -302,6 +302,37 @@ def bind_origin(checkpoint: dict) -> None:
                 item.setdefault(field, val)
 
 
+def drop_matching_items(checkpoint: dict, keys: set) -> list:
+    """#693: whole-item-only twin of drop_forgotten, for the ruling echo
+    filter. A ruling carries no deletion promise, so everything the forget
+    gate does BEYOND the whole-item drop is out of bounds here: no
+    quote/scene scrubs, no trust downgrades, and the active_topic singleton
+    (working context, not a decaying belief copy) is untouched. An item is
+    either an exact echo copy — text folds into `keys` — dropped whole for
+    the caller to count, or it is not touched at all. Pure, in place,
+    returns the dropped items."""
+    if not keys:
+        return []
+    dropped: list = []
+    for section, key in _ITEM_LISTS:
+        block = checkpoint.get(section)
+        if not isinstance(block, dict):
+            continue
+        lst = block.get(key)
+        if not isinstance(lst, list):
+            continue
+        kept = []
+        for item in lst:
+            if (isinstance(item, dict)
+                    and normalize.content_key(item.get("text") or "") in keys):
+                dropped.append(item)
+            else:
+                kept.append(item)
+        if len(kept) != len(lst):
+            block[key] = kept
+    return dropped
+
+
 def admit_checkpoint(checkpoint: dict, forgotten_keys: set) -> list:
     """Run the full admission pipeline, in the only valid order (module
     docstring): redact, then the forget gate, then origin binding, then
@@ -312,7 +343,12 @@ def admit_checkpoint(checkpoint: dict, forgotten_keys: set) -> list:
     bound to an origin it will not reach disk under — the same reason ids are
     stamped after it. Its position relative to stamp_item_ids is free (they
     touch disjoint fields and neither reads the other's output); it runs
-    first only so id-stamping keeps its documented place as the LAST gate."""
+    first only so id-stamping keeps its documented place as the LAST gate.
+
+    One later gate lives OUTSIDE this pipeline: store's #693 ruling echo
+    filter (admission callers only) runs after it, so echo-dropped items are
+    briefly bound and id-stamped before dropping — harmless (both stamps are
+    pure in-place) but stated here so "the only valid order" stays honest."""
     redact_checkpoint(checkpoint)
     dropped = drop_forgotten(checkpoint, forgotten_keys)
     bind_origin(checkpoint)

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -672,6 +672,21 @@ def _forget_hits_line(data: dict) -> str | None:
             f"re-assertion{'s' if n != 1 else ''}, most recent {ts}")
 
 
+def _ruling_echo_line(data: dict) -> str | None:
+    """#693: one line when the admission filter has dropped a ruling echo on
+    this install; silent otherwise. Its own counter, never folded into the
+    forget-suppression number — the echo rate is a different measurement."""
+    fh = data.get("forget_hits")
+    if not isinstance(fh, dict):
+        return None
+    n = fh.get("ruling_echo_count") or 0
+    if not n:
+        return None
+    return (f"ruling echo (this project): dropped {n} "
+            f"re-extraction{'s' if n != 1 else ''} of active ruling text "
+            "at admission")
+
+
 def _plugin_drift_line(pd: dict) -> str:
     """#554: name BOTH versions and the command that moves the stale half.
     "out of date" alone does not say which half, and the two are updated by
@@ -721,6 +736,9 @@ def _plain_status(data: dict) -> None:
     fh_line = _forget_hits_line(data)
     if fh_line:
         print(fh_line)  # #404: one line, only when a re-assertion was suppressed
+    re_line = _ruling_echo_line(data)
+    if re_line:
+        print(re_line)  # #693: one line, only when an echo was dropped
     proj, glob, last = data["proj"], data["glob"], data["last"]
     print(f"project: {data['project']}")
     if proj["exists"]:
@@ -814,6 +832,9 @@ def _rich_status(data: dict) -> None:
     fh_line = _forget_hits_line(data)
     if fh_line:
         console.print(fh_line)  # #404: one line, only when a re-assertion was suppressed
+    re_line = _ruling_echo_line(data)
+    if re_line:
+        console.print(re_line)  # #693: one line, only when an echo was dropped
     proj, glob, last = data["proj"], data["glob"], data["last"]
     table = Table(title=f"daimon status — {data['project']}", title_justify="left",
                   show_header=True, header_style="bold")

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -153,9 +153,15 @@ def _print_handoff(handoff) -> None:
     print("")
 
 
-def render_brief(checkpoint, drift=None, teammates=None, handoff=None) -> None:
+def render_brief(checkpoint, drift=None, teammates=None, handoff=None,
+                 project_dir=None) -> None:
     _print_handoff(handoff)
     b = briefing.build(checkpoint)
+    # #693: one ledger read serves both render paths below; None (legacy
+    # callers) renders without the section rather than reading an unscoped
+    # ledger.
+    rulings = (briefing.ruling_lines(project_dir)
+               if project_dir is not None else [])
     if b is None:
         # Point at the real flow (#29): checkpoints come from the hooks; bare
         # `serialize` dead-ends (it needs a transcript path).
@@ -169,7 +175,8 @@ def render_brief(checkpoint, drift=None, teammates=None, handoff=None) -> None:
     # the hermes hook. Free-form LLM text can't be sectioned into rich panels, so when
     # it is active we print its narrative regardless of TTY.
     if config.llm_briefing():
-        rendered = briefing.render(checkpoint)  # tries LLM, falls back to deterministic
+        # Tries LLM, falls back to deterministic; #693 rulings ride inside.
+        rendered = briefing.render(checkpoint, project_dir=project_dir)
         if rendered:
             print(rendered)
             _print_drift(drift)
@@ -179,9 +186,9 @@ def render_brief(checkpoint, drift=None, teammates=None, handoff=None) -> None:
     # Cheap check (sidecar + byte match), computed once for both render paths.
     degraded = briefing.receipt_degraded(checkpoint)
     if not supports_rich():
-        print(briefing.render_plain(b, degraded))
+        print(briefing.render_plain(b, degraded, rulings))
     else:
-        _rich_brief(b, degraded)
+        _rich_brief(b, degraded, rulings)
     _print_drift(drift)
     _print_teammates(teammates)
 
@@ -214,7 +221,7 @@ def _print_drift(drift) -> None:
     )
 
 
-def _rich_brief(b: dict, degraded: bool = False) -> None:
+def _rich_brief(b: dict, degraded: bool = False, rulings=()) -> None:
     from rich.console import Console
     from rich.panel import Panel
     from rich.text import Text
@@ -224,6 +231,14 @@ def _rich_brief(b: dict, degraded: bool = False) -> None:
     if degraded:
         # One header note (#204), parity with the plain path's embedded note.
         console.print(Text(briefing.DEGRADE_NOTE, style="bold red"))
+    if rulings:
+        # #693: parity with the plain path's top section — same lines, same
+        # order (rulings[0] is the header, promoted to the panel title).
+        body = Text()
+        for line in rulings[1:]:
+            body.append(f"{line}\n", style="bold")
+        console.print(Panel(body, title=rulings[0], border_style="cyan",
+                            title_align="left"))
     for key, title, style in _SECTIONS:
         items = b.get(key) or []
         if not items:

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -157,12 +157,18 @@ def render_brief(checkpoint, drift=None, teammates=None, handoff=None,
                  project_dir=None) -> None:
     _print_handoff(handoff)
     b = briefing.build(checkpoint)
-    # #693: one ledger read serves both render paths below; None (legacy
-    # callers) renders without the section rather than reading an unscoped
-    # ledger.
-    rulings = (briefing.ruling_lines(project_dir)
-               if project_dir is not None else [])
+    # #693: each path below performs exactly one ledger read — the LLM path
+    # reads inside briefing.render, every other path reads here. None
+    # (legacy callers) skips the read; an unknown project resolves to no
+    # ledger path anyway, so the guard saves the call, not a leak.
     if b is None:
+        rulings = (briefing.ruling_lines(project_dir)
+                   if project_dir is not None else [])
+        if rulings:
+            # #693: standing rulings exist before the first checkpoint does —
+            # a day-one ratification must not wait for a session to end.
+            print("\n".join(rulings))
+            print("")
         # Point at the real flow (#29): checkpoints come from the hooks; bare
         # `serialize` dead-ends (it needs a transcript path).
         print("No checkpoint yet — nothing to brief. Checkpoints are written "
@@ -176,12 +182,15 @@ def render_brief(checkpoint, drift=None, teammates=None, handoff=None,
     # it is active we print its narrative regardless of TTY.
     if config.llm_briefing():
         # Tries LLM, falls back to deterministic; #693 rulings ride inside.
-        rendered = briefing.render(checkpoint, project_dir=project_dir)
-        if rendered:
-            print(rendered)
-            _print_drift(drift)
-            _print_teammates(teammates)
-            return
+        # Unconditional return: `b` is non-None here, so render() always
+        # yields text — a fall-through would double the ledger read below,
+        # and structure beats a comment at keeping that invariant.
+        print(briefing.render(checkpoint, project_dir=project_dir))
+        _print_drift(drift)
+        _print_teammates(teammates)
+        return
+    rulings = (briefing.ruling_lines(project_dir)
+               if project_dir is not None else [])
     # #204: degrade verbatim labels when the receipt can't be locally confirmed.
     # Cheap check (sidecar + byte match), computed once for both render paths.
     degraded = briefing.receipt_degraded(checkpoint)

--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -145,8 +145,12 @@ both assert a human decision. Ask the user to run them.
 ## Standing rulings
 Rulings are the OPPOSITE polarity: human-ratified standing constraints to
 honor, not dead approaches. Treat an active ruling as a veto, not advice.
-`daimon ruling list` shows them; `daimon refute search` returns both kinds,
-labelled. Agents may propose: `daimon ruling propose ... --by agent`, and on
+Active rulings render at the top of every briefing as `§` lines under the
+header "Standing rulings (human-ratified — honor these):" — when that
+section is in context, honor it directly; `[agent-written]` marks text a
+human ratified but did not author.
+`daimon ruling list` shows them; `daimon refute search` returns both
+kinds, labelled. Agents may propose: `daimon ruling propose ... --by agent`, and on
 an active ruling `ruling revise --by agent` or `ruling retire --by agent`
 record proposals while the text stands. Always pass `--by agent`. Never run
 `daimon ruling ratify`, and never `ruling revise`/`retire` without the flag:

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -1042,9 +1042,47 @@ _redact_checkpoint = policy.redact_checkpoint
 _stamp_item_ids = policy.stamp_item_ids
 
 
+def _drop_ruling_echoes(checkpoint: dict, project_dir=None) -> list:
+    """#693: drop exact echoes of ACTIVE ruling text at the admission
+    boundary. The standing-rulings section renders into every session's
+    context, so the next extraction can mint the ruling back as a fresh
+    belief — a copy that decays, drifts, and double-renders. Same canonical
+    machinery as the forget gate (whole-item drop on a content-key match,
+    field-level scrub for quote/scene), so the two admission filters cannot
+    diverge on what "the same text" means. Paraphrase shadows are out of
+    scope by design — they decay as ordinary beliefs.
+
+    A COUNTED drop, never silent: each one is reason-coded on the hit
+    ledger (`ruling-echo`, its own counter — the echo rate stays an
+    endogenous measurement) and logged as a content hash, never the text.
+    Fail-open on any ledger read error: an unreadable refutations.jsonl
+    must never cost a capture."""
+    # Function-local import: refutations imports store at module level, so
+    # the reverse edge must be deferred to call time.
+    from . import refutations
+    try:
+        rows = refutations.listing(states={"active"}, polarity="ruling",
+                                   project_dir=project_dir)
+    except Exception:
+        return []
+    keys = {normalize.content_key(row["verdict"])
+            for row in rows if row.get("verdict")}
+    if not keys:
+        return []
+    dropped = policy.drop_forgotten(checkpoint, keys)
+    if dropped:
+        record_forget_hits(dropped, project_dir, reason="ruling-echo")
+        for item in dropped:
+            log.warning(
+                "ruling echo: item dropped at admission (content hash %s)",
+                normalize.content_key(item.get("text") or ""))
+    return dropped
+
+
 def write_checkpoint(session_id: str, checkpoint: dict, project_dir=None,
                      allow_disabled: bool = False,
-                     rotate: bool = True) -> Path | None:
+                     rotate: bool = True,
+                     admit: bool = False) -> Path | None:
     """Write the session checkpoint + the global latest pointer, and — when the
     project is known — the per-project latest pointer too. The global pointer is
     kept for backward compatibility (pre-routing consumers and the fallback).
@@ -1059,7 +1097,14 @@ def write_checkpoint(session_id: str, checkpoint: dict, project_dir=None,
     exception — the same never-fatal posture as the ledger appenders. The ONE
     exemption is `allow_disabled=True`, passed only by cli._cmd_forget's
     rewrite: the maintainer ratified that deletion must still work while
-    disabled (the deletion promise outranks "disabled writes nothing")."""
+    disabled (the deletion promise outranks "disabled writes nothing").
+
+    `admit=True` (#693) marks this write as an ADMISSION of new cognitive
+    content — passed ONLY by the two admission callers (capture.run, the
+    `write-checkpoint` stdin path) — and switches on the ruling echo filter.
+    Rewrite callers stay at the default: `daimon anchor` must not strip
+    previously-admitted items, and the forget rewrite must not retroactively
+    delete outside its own contract."""
     if config.is_disabled() and not allow_disabled:
         return None
     d = config.checkpoint_dir()
@@ -1090,6 +1135,8 @@ def write_checkpoint(session_id: str, checkpoint: dict, project_dir=None,
         # #404: account each suppression on the telemetry ledger. Best-effort
         # (never fatal) — a hit record must never fail the capture it observes.
         record_forget_hits(forget_dropped, project_dir)
+    if admit:
+        _drop_ruling_echoes(checkpoint, project_dir)
     # Stamp project attribution the same idempotent way. Bucket pointers rotate
     # away after `history` writes, so pointer-derived attribution EXPIRES — a
     # session older than the pointer window would lose its project forever and
@@ -1742,11 +1789,16 @@ def _forget_hits_path(project_dir=None):
     return config.checkpoint_dir() / slug / _FORGET_HITS
 
 
-def record_forget_hits(items, project_dir=None) -> bool:
+def record_forget_hits(items, project_dir=None, reason: str = "") -> bool:
     """Append one row per capture-time forget suppression (#404): {ts, key}.
     Mirrors append_verification's contract — silent no-op under the kill switch
     or an unknown project, never fatal (a telemetry write must never fail a
     capture).
+
+    `reason` (#693): a non-empty value stamps each row and routes it to its
+    own counter in forget_hit_stats — a ruling-echo drop is a different
+    measurement from a forget suppression, and folding them together would
+    inflate the number the project already publishes.
 
     Records ONLY the canonical hash key + timestamp — NEVER the text or any
     prefix of it. forget's whole guarantee (#321) is that a forgotten value's
@@ -1767,7 +1819,10 @@ def record_forget_hits(items, project_dir=None) -> bool:
                 if not isinstance(item, dict):
                     continue
                 key = normalize.content_key(item.get("text") or "")
-                f.write(json.dumps({"ts": ts, "key": key}) + "\n")
+                row = {"ts": ts, "key": key}
+                if reason:
+                    row["reason"] = reason
+                f.write(json.dumps(row) + "\n")
         return True
     except OSError:
         return False
@@ -1780,8 +1835,12 @@ def forget_hit_stats(project_dir=None) -> dict:
     did the tombstone catch a re-assertion here". Count + timestamp only — the
     ledger holds no content to surface. Fails open to zeroes (missing/corrupt
     log, unknown project) — same posture as verification_counts and the
-    resolutions fold."""
-    out: dict = {"count": 0, "last_hit_at": None}
+    resolutions fold.
+
+    Reason-stamped rows (#693) count under their own key — `ruling-echo`
+    rows land in `ruling_echo_count`, never `count`, so the published
+    forget-suppression number stays what it always measured."""
+    out: dict = {"count": 0, "ruling_echo_count": 0, "last_hit_at": None}
     path = _forget_hits_path(project_dir)
     if path is None:
         return out
@@ -1796,7 +1855,10 @@ def forget_hit_stats(project_dir=None) -> dict:
             continue
         if not isinstance(row, dict):
             continue
-        out["count"] += 1
+        if row.get("reason") == "ruling-echo":
+            out["ruling_echo_count"] += 1
+        else:
+            out["count"] += 1
         ts = row.get("ts")
         if ts and (out["last_hit_at"] is None or ts > out["last_hit_at"]):
             out["last_hit_at"] = ts

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -1046,37 +1046,60 @@ def _drop_ruling_echoes(checkpoint: dict, project_dir=None) -> list:
     """#693: drop exact echoes of ACTIVE ruling text at the admission
     boundary. The standing-rulings section renders into every session's
     context, so the next extraction can mint the ruling back as a fresh
-    belief — a copy that decays, drifts, and double-renders. Same canonical
-    machinery as the forget gate (whole-item drop on a content-key match,
-    field-level scrub for quote/scene), so the two admission filters cannot
-    diverge on what "the same text" means. Paraphrase shadows are out of
-    scope by design — they decay as ordinary beliefs.
+    belief — a copy that decays, drifts, and double-renders. Note "next
+    extraction" includes carried items: capture re-admits what it carries,
+    so a belief admitted BEFORE its ruling was ratified is deduped at the
+    next capture — deliberate, counted, and logged like any other echo.
+    Whole-item drops ONLY (policy.drop_matching_items): a ruling carries no
+    deletion promise, so an item merely QUOTING the ruling keeps its quote,
+    its trust class, and its receipts — the forget gate's field scrubs are
+    the wrong tool here. The key set covers every form the briefing
+    actually renders — bare verdict, render-clipped, "§ "-prefixed, and
+    authority-suffixed lines — so the renderer and this filter cannot
+    disagree on "the same text". Paraphrase shadows are out of scope by
+    design — they decay as ordinary beliefs.
 
     A COUNTED drop, never silent: each one is reason-coded on the hit
-    ledger (`ruling-echo`, its own counter — the echo rate stays an
-    endogenous measurement) and logged as a content hash, never the text.
-    Fail-open on any ledger read error: an unreadable refutations.jsonl
-    must never cost a capture."""
-    # Function-local import: refutations imports store at module level, so
-    # the reverse edge must be deferred to call time.
-    from . import refutations
+    ledger (`ruling-echo`, its own counter and its own timestamp — the echo
+    rate stays an endogenous measurement) and logged as a content hash,
+    never the text. The WHOLE body fails open: no echo-filter failure of
+    any kind may cost the capture it observes."""
     try:
+        # Function-local import: refutations imports store at module level,
+        # so the reverse edge must be deferred to call time.
+        from . import refutations
         rows = refutations.listing(states={"active"}, polarity="ruling",
                                    project_dir=project_dir)
+        keys = set()
+        for row in rows:
+            verdict = str(row.get("verdict") or "")
+            if not verdict:
+                continue
+            clipped = verdict[:refutations._MAX_RULING_TEXT]
+            bases = {verdict, clipped, clipped + "…"}
+            authored = row.get("text_authored_by")
+            if authored and authored != "human":
+                bases.update({f"{b}  [{authored}-written]" for b in set(bases)})
+            for base in bases:
+                keys.add(normalize.content_key(base))
+                keys.add(normalize.content_key(f"§ {base}"))
+        dropped = policy.drop_matching_items(checkpoint, keys)
+        if dropped:
+            record_forget_hits(dropped, project_dir, reason="ruling-echo")
+            for item in dropped:
+                # INFO, not WARNING: a stable ruling being re-minted every
+                # session is the expected, measured event this filter exists
+                # for — not an anomaly worth an alert per capture.
+                log.info(
+                    "ruling echo: item dropped at admission "
+                    "(content hash %s)",
+                    normalize.content_key(item.get("text") or ""))
+        return dropped
     except Exception:
+        # Fail-open must still leave a trace: if this fires AFTER the drop
+        # mutated the checkpoint, the accounting above never ran.
+        log.debug("ruling echo filter failed open", exc_info=True)
         return []
-    keys = {normalize.content_key(row["verdict"])
-            for row in rows if row.get("verdict")}
-    if not keys:
-        return []
-    dropped = policy.drop_forgotten(checkpoint, keys)
-    if dropped:
-        record_forget_hits(dropped, project_dir, reason="ruling-echo")
-        for item in dropped:
-            log.warning(
-                "ruling echo: item dropped at admission (content hash %s)",
-                normalize.content_key(item.get("text") or ""))
-    return dropped
 
 
 def write_checkpoint(session_id: str, checkpoint: dict, project_dir=None,
@@ -1837,10 +1860,13 @@ def forget_hit_stats(project_dir=None) -> dict:
     log, unknown project) — same posture as verification_counts and the
     resolutions fold.
 
-    Reason-stamped rows (#693) count under their own key — `ruling-echo`
-    rows land in `ruling_echo_count`, never `count`, so the published
-    forget-suppression number stays what it always measured."""
-    out: dict = {"count": 0, "ruling_echo_count": 0, "last_hit_at": None}
+    Reason-stamped rows (#693) count under their own key AND their own
+    timestamp — `ruling-echo` rows land in `ruling_echo_count` /
+    `ruling_echo_last_at`, never `count` / `last_hit_at`, so the published
+    forget-suppression number and the stamp printed beside it both stay
+    what they always measured."""
+    out: dict = {"count": 0, "ruling_echo_count": 0, "last_hit_at": None,
+                 "ruling_echo_last_at": None}
     path = _forget_hits_path(project_dir)
     if path is None:
         return out
@@ -1856,12 +1882,13 @@ def forget_hit_stats(project_dir=None) -> dict:
         if not isinstance(row, dict):
             continue
         if row.get("reason") == "ruling-echo":
-            out["ruling_echo_count"] += 1
+            count_key, ts_key = "ruling_echo_count", "ruling_echo_last_at"
         else:
-            out["count"] += 1
+            count_key, ts_key = "count", "last_hit_at"
+        out[count_key] += 1
         ts = row.get("ts")
-        if ts and (out["last_hit_at"] is None or ts > out["last_hit_at"]):
-            out["last_hit_at"] = ts
+        if ts and (out[ts_key] is None or ts > out[ts_key]):
+            out[ts_key] = ts
     return out
 
 

--- a/plugin/daimon_briefing/surfaces.py
+++ b/plugin/daimon_briefing/surfaces.py
@@ -138,7 +138,8 @@ SURFACES: tuple[Surface, ...] = (
     Surface("checkpoints/{slug}/verification.jsonl",
             "store.append_verification", False, "exempt-no-plaintext",
             "none", audit_exempt=True),
-    # store.record_forget_hits: {ts, key} — "NEVER the text or any prefix".
+    # store.record_forget_hits: {ts, key, reason?} — "NEVER the text or any
+    # prefix"; reason (#693) is a closed-vocabulary code ("ruling-echo").
     Surface("checkpoints/{slug}/forget-hits.jsonl",
             "store.record_forget_hits", False, "exempt-no-plaintext",
             "none", audit_exempt=True),

--- a/plugin/daimon_ui/server.py
+++ b/plugin/daimon_ui/server.py
@@ -33,8 +33,14 @@ def _refutations_payload(slug):
     this lane's vocabulary (✗, "Refutes") would invert them. A rulings lane
     is its own surface. Kept as a seam so a test can assert on the ROWS the
     endpoint serves rather than grep the source."""
-    return {"ok": True, "rows": refutations.listing(
-        polarity="refutation", project_dir=slug)}
+    return {"ok": True,
+            "rows": refutations.listing(
+                polarity="refutation", project_dir=slug),
+            # #693 PR 2: the rulings lane rides the same payload, its own
+            # polarity — the two lanes never mix, and neither call is ever
+            # unscoped.
+            "rulings": refutations.listing(
+                polarity="ruling", project_dir=slug)}
 
 
 class _Handler(BaseHTTPRequestHandler):

--- a/plugin/daimon_ui/static/app.js
+++ b/plugin/daimon_ui/static/app.js
@@ -378,7 +378,7 @@ import { state } from "./state.js";
         }
         sectionsEl.innerHTML = renderRefutationsView(data);
         toTop();
-        announce("Refutations loaded.");
+        announce("Rulings and refutations loaded.");
         wireWhyOpeners(sectionsEl);
       }).catch(function () {
         if (reqId !== state.requestId) return;

--- a/plugin/daimon_ui/static/render.js
+++ b/plugin/daimon_ui/static/render.js
@@ -856,10 +856,47 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
       '<span class="refut-at">' + escapeHtml(fmtDateTime(r.created_at)) + "</span>" +
       '<span class="refut-origin">' + escapeHtml(r.asserted_author || "") + "</span></div>";
   }
+  // ---- rulings lane (#693 PR 2): the ledger's positive polarity ----
+  // Same bracket shape as the refutations lane, the CLI's own vocabulary
+  // (cli.py _print_ruling): § active, × overturned — shown as "retired" —
+  // ? candidate; agent-authored text stays labeled after human ratification.
+  // The row renders the VERDICT (the rule text), never the subject: a ruling
+  // shown under a refutation's wording is the exact inversion #693 prevents.
+  export const RULING_MARKS = { active: "§", overturned: "×", candidate: "?" };
+  export function rulingMarker(r) {
+    var state = (r && r.state) || "candidate";
+    var mark = Object.prototype.hasOwnProperty.call(RULING_MARKS, state)
+      ? RULING_MARKS[state] : "?";
+    var shown = state === "overturned" ? "retired" : state;
+    var activation = (r && r.activation) ||
+      ((r && r.asserted_by) || "?") + "-proposed";
+    var authored = r && r.text_authored_by;
+    if (state === "active" && authored && authored !== "human") {
+      activation = authored + "-written, " + activation;
+    }
+    return "[" + mark + " " + shown + " · " + activation + "]";
+  }
+  export function renderRulingRow(r) {
+    return '<div class="refut-row">' +
+      '<div class="refut-record"><code class="obj-id">' + escapeHtml(r.refutation_id || "") +
+      '</code><span class="refut-state">' + escapeHtml(rulingMarker(r)) + "</span></div>" +
+      '<div class="refut-body"><span class="refut-subject">' + escapeHtml(r.verdict || "") +
+      "</span>" + renderRefutationAnchors(r.anchors) + "</div>" +
+      '<span class="refut-at">' + escapeHtml(fmtDateTime(r.created_at)) + "</span>" +
+      '<span class="refut-origin">' + escapeHtml(r.asserted_author || "") + "</span></div>";
+  }
   export function renderRefutationsView(data) {
     var rows = data.rows || [];
+    var rulings = data.rulings || [];
     var html = '<div class="brief-head"><h1 class="page-heading">Refutations</h1>' +
       '<span class="brief-sub">recorded against entries · status, never judgment</span></div>';
+    if (rulings.length) {
+      html += '<div class="brief-head"><h2 class="page-heading">Standing rulings</h2>' +
+        '<span class="brief-sub">human-ratified standing constraints · honor, not history</span></div>';
+      html += '<div class="refut-cols" aria-hidden="true"><span>Record</span><span>Rule</span>' +
+        "<span>Recorded</span><span>Origin</span></div>";
+      html += '<div class="refut-rows">' + rulings.map(renderRulingRow).join("") + "</div>";
+    }
     if (!rows.length) {
       // The CLI's own empty words — one vocabulary across surfaces.
       return html + '<div class="state-card state-empty"><p class="state-title">' +

--- a/plugin/daimon_ui/static/render.js
+++ b/plugin/daimon_ui/static/render.js
@@ -888,15 +888,23 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
   export function renderRefutationsView(data) {
     var rows = data.rows || [];
     var rulings = data.rulings || [];
-    var html = '<div class="brief-head"><h1 class="page-heading">Refutations</h1>' +
-      '<span class="brief-sub">recorded against entries · status, never judgment</span></div>';
+    var html = "";
+    // The rulings lane is a SIBLING section ABOVE the refutations heading —
+    // the negative-polarity chrome ("status, never judgment") must never
+    // visually govern human-ratified standing constraints.
     if (rulings.length) {
-      html += '<div class="brief-head"><h2 class="page-heading">Standing rulings</h2>' +
-        '<span class="brief-sub">human-ratified standing constraints · honor, not history</span></div>';
+      // Status terms only: the lane serves EVERY state (it mirrors
+      // `daimon ruling list`), and an agent-proposed candidate under a
+      // "human-ratified" banner would assert an approval no human gave.
+      html += '<div class="brief-head"><h1 class="page-heading">Standing rulings</h1>' +
+        '<span class="brief-sub">the ledger’s positive polarity · active, proposed, retired</span></div>';
       html += '<div class="refut-cols" aria-hidden="true"><span>Record</span><span>Rule</span>' +
         "<span>Recorded</span><span>Origin</span></div>";
       html += '<div class="refut-rows">' + rulings.map(renderRulingRow).join("") + "</div>";
+      html += '<div class="card-foot">An active ruling stands until a human retires it.</div>';
     }
+    html += '<div class="brief-head"><h1 class="page-heading">Refutations</h1>' +
+      '<span class="brief-sub">recorded against entries · status, never judgment</span></div>';
     if (!rows.length) {
       // The CLI's own empty words — one vocabulary across surfaces.
       return html + '<div class="state-card state-empty"><p class="state-title">' +

--- a/plugin/tests/test_forget_hits.py
+++ b/plugin/tests/test_forget_hits.py
@@ -155,7 +155,7 @@ def test_forget_hit_stats_survives_read_error(tmp_checkpoint_dir, monkeypatch):
     p = store._forget_hits_path(_A)
     p.parent.mkdir(parents=True, exist_ok=True)
     p.mkdir()  # a directory -> read_text raises OSError -> fail open
-    assert store.forget_hit_stats(project_dir=_A) == {"count": 0, "last_hit_at": None}
+    assert store.forget_hit_stats(project_dir=_A) == {"count": 0, "ruling_echo_count": 0, "last_hit_at": None}
 
 
 def test_unknown_project_is_a_quiet_noop(tmp_checkpoint_dir):
@@ -163,7 +163,7 @@ def test_unknown_project_is_a_quiet_noop(tmp_checkpoint_dir):
     # fails open (same posture as verification_counts / the events fold).
     assert store._forget_hits_path("") is None
     assert store.record_forget_hits([{"text": _S}], project_dir="") is False
-    assert store.forget_hit_stats(project_dir="") == {"count": 0, "last_hit_at": None}
+    assert store.forget_hit_stats(project_dir="") == {"count": 0, "ruling_echo_count": 0, "last_hit_at": None}
 
 
 def test_forgotten_key_lifted_by_reopen(tmp_checkpoint_dir, monkeypatch):

--- a/plugin/tests/test_forget_hits.py
+++ b/plugin/tests/test_forget_hits.py
@@ -155,7 +155,7 @@ def test_forget_hit_stats_survives_read_error(tmp_checkpoint_dir, monkeypatch):
     p = store._forget_hits_path(_A)
     p.parent.mkdir(parents=True, exist_ok=True)
     p.mkdir()  # a directory -> read_text raises OSError -> fail open
-    assert store.forget_hit_stats(project_dir=_A) == {"count": 0, "ruling_echo_count": 0, "last_hit_at": None}
+    assert store.forget_hit_stats(project_dir=_A) == {"count": 0, "ruling_echo_count": 0, "last_hit_at": None, "ruling_echo_last_at": None}
 
 
 def test_unknown_project_is_a_quiet_noop(tmp_checkpoint_dir):
@@ -163,7 +163,7 @@ def test_unknown_project_is_a_quiet_noop(tmp_checkpoint_dir):
     # fails open (same posture as verification_counts / the events fold).
     assert store._forget_hits_path("") is None
     assert store.record_forget_hits([{"text": _S}], project_dir="") is False
-    assert store.forget_hit_stats(project_dir="") == {"count": 0, "ruling_echo_count": 0, "last_hit_at": None}
+    assert store.forget_hit_stats(project_dir="") == {"count": 0, "ruling_echo_count": 0, "last_hit_at": None, "ruling_echo_last_at": None}
 
 
 def test_forgotten_key_lifted_by_reopen(tmp_checkpoint_dir, monkeypatch):

--- a/plugin/tests/test_hooks.py
+++ b/plugin/tests/test_hooks.py
@@ -412,7 +412,7 @@ def test_on_session_end_routes_project_through_resolve_project_root(
 
     captured = {}
 
-    def _spy(session_id, checkpoint, project_dir=None):
+    def _spy(session_id, checkpoint, project_dir=None, admit=False):
         captured["project_dir"] = project_dir
         return None
 

--- a/plugin/tests/test_ruling_briefing.py
+++ b/plugin/tests/test_ruling_briefing.py
@@ -1,0 +1,181 @@
+"""#693 PR 2: the standing-rulings briefing section.
+
+Active rulings render as an always-present section at the TOP of the
+deterministic briefing — skeleton furniture, outside the budget drop order —
+because the briefing is the surface hooks and MCP actually consume. The
+section is loaded fail-open from the ledger and never blocks a render.
+"""
+
+from daimon_briefing import briefing, config, refutations
+
+
+PROJECT = "/p/ruling-brief"
+
+
+def _rule(verdict, *, channel="cli-tty", ratified=True, subject=None,
+          scope="this project"):
+    return refutations.assert_ruling(
+        subject=subject or f"subject for {verdict[:24]}",
+        verdict=verdict,
+        scope=scope,
+        evidence=["issue:693"],
+        channel=channel,
+        ratified=ratified,
+        project_dir=PROJECT,
+    )
+
+
+def test_active_ruling_renders_at_top_of_briefing(tmp_checkpoint_dir,
+                                                  sample_checkpoint):
+    _rule("never ship a Friday deploy")
+    out = briefing.render(sample_checkpoint, project_dir=PROJECT)
+    assert "Standing rulings" in out
+    assert "§ never ship a Friday deploy" in out
+    # Top means top: the section precedes every cognitive section.
+    assert out.index("Standing rulings") < out.index("VERIFY BEFORE TRUSTING")
+
+
+def test_candidate_and_retired_rulings_never_render(tmp_checkpoint_dir,
+                                                    sample_checkpoint):
+    _rule("candidate text stays out", channel="cli-agent", ratified=False)
+    retired = _rule("retired text stays out", subject="retired subject")
+    refutations.retire(retired, channel="cli-tty", project_dir=PROJECT)
+    out = briefing.render(sample_checkpoint, project_dir=PROJECT)
+    assert "candidate text stays out" not in out
+    assert "retired text stays out" not in out
+    assert "Standing rulings" not in out  # no active rulings -> no section
+
+
+def test_agent_authored_text_is_labeled(tmp_checkpoint_dir, sample_checkpoint):
+    ruling_id = _rule("agent drafted this rule", channel="cli-agent",
+                      ratified=False)
+    refutations.ratify(ruling_id, channel="cli-tty", project_dir=PROJECT)
+    out = briefing.render(sample_checkpoint, project_dir=PROJECT)
+    assert "agent drafted this rule" in out
+    assert "agent-written" in out
+
+
+def test_human_authored_text_carries_no_author_label(tmp_checkpoint_dir,
+                                                     sample_checkpoint):
+    _rule("human wrote this rule")
+    out = briefing.render(sample_checkpoint, project_dir=PROJECT)
+    assert "agent-written" not in out
+
+
+def test_rulings_survive_budget_pressure(tmp_checkpoint_dir, sample_checkpoint,
+                                         monkeypatch):
+    _rule("rulings are skeleton furniture")
+    # A budget small enough to force every droppable section to trim.
+    monkeypatch.setenv("DAIMON_BRIEF_MAX_TOKENS", "40")
+    out = briefing.render(sample_checkpoint, project_dir=PROJECT)
+    assert "§ rulings are skeleton furniture" in out
+
+
+def test_full_cap_section_stays_within_budget_share(tmp_checkpoint_dir):
+    # The design pins the worst case: a full cap of maximum-length rulings
+    # costs ~17-20% of the default 3000-token budget, never more.
+    for n in range(config.ruling_cap()):
+        _rule(f"rule {n} " + "x" * (refutations._MAX_RULING_TEXT
+                                    - len(f"rule {n} ")),
+              subject=f"subject {n}")
+    lines = briefing.ruling_lines(PROJECT)
+    section = "\n".join(lines)
+    assert briefing.estimate_tokens(section) <= 600  # 20% of 3000
+    assert briefing.estimate_tokens(section) >= 450  # the share is real
+
+
+def test_renderer_backstops_count_and_text(tmp_checkpoint_dir, monkeypatch):
+    # Hand-edited ledgers can exceed the cap or the text bound; the renderer
+    # holds the line on its own (the design's count-and-text backstop).
+    for n in range(3):
+        _rule(f"backstop rule number {n}", subject=f"backstop subject {n}")
+    monkeypatch.setenv("DAIMON_RULING_CAP", "2")
+    lines = briefing.ruling_lines(PROJECT)
+    body = [ln for ln in lines if ln.lstrip().startswith("§")]
+    assert len(body) == 2
+
+
+def test_ruling_loader_fails_open(tmp_checkpoint_dir, sample_checkpoint,
+                                  monkeypatch):
+    _rule("this ruling will not load")
+
+    def boom(**kwargs):
+        raise OSError("ledger unreadable")
+
+    monkeypatch.setattr(briefing.refutations, "listing", boom)
+    out = briefing.render(sample_checkpoint, project_dir=PROJECT)
+    assert out  # the briefing still renders
+    assert "Standing rulings" not in out
+
+
+def test_no_rulings_render_is_byte_identical_to_legacy(tmp_checkpoint_dir,
+                                                       sample_checkpoint):
+    b = briefing.build(sample_checkpoint)
+    assert (briefing.render(sample_checkpoint, project_dir=PROJECT)
+            == briefing.render_plain(b))
+
+
+def test_hook_injected_briefing_carries_rulings(tmp_checkpoint_dir,
+                                                sample_checkpoint,
+                                                monkeypatch):
+    from daimon_briefing import hooks, store
+    _rule("hook injection carries this")
+    store.write_checkpoint("S-prev", sample_checkpoint, project_dir=PROJECT)
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    out = hooks.pre_llm_call(
+        session_id="S2", user_message="hi", conversation_history=[],
+        is_first_turn=True, model="m", platform="cli",
+    )
+    assert "§ hook injection carries this" in out["context"]
+
+
+def test_mcp_brief_carries_rulings(tmp_checkpoint_dir, sample_checkpoint,
+                                   monkeypatch):
+    from daimon_briefing import store
+    from tests.test_mcp_server import rpc, _init, _call, _result
+    _rule("mcp brief carries this")
+    store.write_checkpoint("S-a", sample_checkpoint, project_dir=PROJECT)
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    _, out = rpc(_init(), _call("daimon_brief", {}))
+    text, is_err = _result(out)
+    assert is_err is False
+    assert "§ mcp brief carries this" in text
+
+
+def test_cli_brief_carries_rulings(tmp_checkpoint_dir, sample_checkpoint,
+                                   capsys):
+    from daimon_briefing import cli, store
+    _rule("cli brief carries this")
+    store.write_checkpoint("S-a", sample_checkpoint, project_dir=PROJECT)
+    assert cli.main(["brief", "--project", PROJECT]) == 0
+    out = capsys.readouterr().out
+    assert "§ cli brief carries this" in out
+
+
+def test_cli_rich_brief_carries_rulings(tmp_checkpoint_dir, sample_checkpoint,
+                                        monkeypatch, capsys):
+    from daimon_briefing import cli, render, store
+    _rule("rich brief carries this")
+    store.write_checkpoint("S-a", sample_checkpoint, project_dir=PROJECT)
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    assert cli.main(["brief", "--project", PROJECT]) == 0
+    out = capsys.readouterr().out
+    assert "rich brief carries this" in out
+
+
+def test_llm_render_gets_deterministic_section_prepended(
+        tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
+    _rule("prepend me to the llm narrative")
+    monkeypatch.setenv("DAIMON_LLM_BRIEFING", "1")
+    # The canned narrative must keep every verbatim quote intact or the
+    # #30 post-validation rejects it and the fallback path renders instead.
+    narrative = ("LLM NARRATIVE BODY\n"
+                 '"I\'ll merge it myself later from the GitHub UI"\n'
+                 '"do we chunk below 1200 lines or single-pass?"\n'
+                 '"we adopt the D-007 prompt for the serializer"')
+    monkeypatch.setattr(briefing, "_render_llm", lambda checkpoint: narrative)
+    out = briefing.render(sample_checkpoint, project_dir=PROJECT)
+    assert "LLM NARRATIVE BODY" in out
+    assert "§ prepend me to the llm narrative" in out
+    assert (out.index("prepend me to the llm narrative")
+            < out.index("LLM NARRATIVE BODY"))

--- a/plugin/tests/test_ruling_briefing.py
+++ b/plugin/tests/test_ruling_briefing.py
@@ -95,6 +95,17 @@ def test_renderer_backstops_count_and_text(tmp_checkpoint_dir, monkeypatch):
     assert len(body) == 2
 
 
+def test_ruling_lines_fail_open_on_cap_read_error(tmp_checkpoint_dir,
+                                                  monkeypatch):
+    _rule("cap failure hides me safely")
+
+    def boom():
+        raise ValueError("corrupt env")
+
+    monkeypatch.setattr(briefing.config, "ruling_cap", boom)
+    assert briefing.ruling_lines(PROJECT) == []
+
+
 def test_ruling_loader_fails_open(tmp_checkpoint_dir, sample_checkpoint,
                                   monkeypatch):
     _rule("this ruling will not load")

--- a/plugin/tests/test_ruling_briefing.py
+++ b/plugin/tests/test_ruling_briefing.py
@@ -115,6 +115,122 @@ def test_no_rulings_render_is_byte_identical_to_legacy(tmp_checkpoint_dir,
             == briefing.render_plain(b))
 
 
+def _hand_ruled_row(subject, verdict, project=PROJECT):
+    """A ledger row appended RAW — the hand-edited / version-skew shape the
+    renderer backstops exist for (assert_ruling's write-time guards refuse
+    it, which is the point)."""
+    row = refutations._stamp(
+        "ruled", refutations.make_id(subject, "tests"), "cli-tty")
+    row.update({"subject": subject, "verdict": verdict, "scope": "tests",
+                "anchors": [], "revisit_when": "", "evidence": [],
+                "ratified": True})
+    assert refutations.append(row, project_dir=project)
+    return row["refutation_id"]
+
+
+def test_over_cap_truncation_is_loud(tmp_checkpoint_dir, monkeypatch):
+    for n in range(3):
+        _rule(f"loud rule number {n}", subject=f"loud subject {n}")
+    monkeypatch.setenv("DAIMON_RULING_CAP", "2")
+    lines = briefing.ruling_lines(PROJECT)
+    joined = "\n".join(lines)
+    assert "over cap" in joined  # never a silent truncation
+    assert "daimon ruling list" in joined  # and it says where the rest live
+
+
+def test_overlength_verdict_clips_with_visible_marker(tmp_checkpoint_dir):
+    long_verdict = "x" * (refutations._MAX_RULING_TEXT + 40)
+    _hand_ruled_row("hand edited subject", long_verdict)
+    lines = briefing.ruling_lines(PROJECT)
+    body = [ln for ln in lines if ln.startswith("§")]
+    assert len(body) == 1
+    assert long_verdict not in body[0]  # clipped
+    assert "…" in body[0]               # and visibly so
+
+
+def test_empty_verdict_row_never_renders_bare_glyph(tmp_checkpoint_dir):
+    _hand_ruled_row("empty verdict subject", "")
+    _hand_ruled_row("whitespace verdict subject", "   ")
+    _rule("a real rule renders")
+    lines = briefing.ruling_lines(PROJECT)
+    assert all(ln.strip() != "§" for ln in lines)
+    assert any("a real rule renders" in ln for ln in lines)
+
+
+def test_authored_label_names_the_authority(tmp_checkpoint_dir):
+    # `text_authored_by` is the AUTHORITY word (agent / mechanical), not the
+    # channel — the label must state it, one vocabulary with
+    # cli._print_ruling.
+    ruling_id = refutations.assert_ruling(
+        subject="mechanical subject", verdict="mechanically drafted rule",
+        scope="tests", evidence=["issue:693"], channel="mechanical",
+        project_dir=PROJECT)
+    refutations.ratify(ruling_id, channel="cli-tty", project_dir=PROJECT)
+    lines = briefing.ruling_lines(PROJECT)
+    assert any("[mechanical-written]" in ln for ln in lines)
+
+
+def test_llm_branch_degrade_note_precedes_rulings(tmp_checkpoint_dir,
+                                                  sample_checkpoint,
+                                                  monkeypatch):
+    # #204: the unverified-receipt note is the loudest line in the briefing;
+    # the deterministic paths render it first and the LLM path must agree.
+    _rule("note comes before me")
+    monkeypatch.setenv("DAIMON_LLM_BRIEFING", "1")
+    narrative = ('"I\'ll merge it myself later from the GitHub UI"\n'
+                 '"do we chunk below 1200 lines or single-pass?"\n'
+                 '"we adopt the D-007 prompt for the serializer"')
+    monkeypatch.setattr(briefing, "_render_llm", lambda checkpoint: narrative)
+    monkeypatch.setattr(briefing, "receipt_degraded", lambda checkpoint: True)
+    out = briefing.render(sample_checkpoint, project_dir=PROJECT)
+    assert out.index(briefing.DEGRADE_NOTE) < out.index("note comes before me")
+
+
+def test_render_surfaces_rulings_when_checkpoint_has_nothing(
+        tmp_checkpoint_dir):
+    # A ruling ratified on day one — before any checkpoint holds items — must
+    # still reach context; "nothing worth surfacing" is no longer true.
+    _rule("day one rule reaches context")
+    empty = {"session_id": "S0", "working_context": {},
+             "epistemic_snapshot": {}}
+    out = briefing.render(empty, project_dir=PROJECT)
+    assert out is not None
+    assert "§ day one rule reaches context" in out
+
+
+def test_cli_brief_shows_rulings_with_no_checkpoint(tmp_checkpoint_dir,
+                                                    capsys):
+    from daimon_briefing import cli
+    _rule("cli shows me before any checkpoint")
+    assert cli.main(["brief", "--project", PROJECT]) in (0, 1)
+    out = capsys.readouterr().out
+    assert "§ cli shows me before any checkpoint" in out
+
+
+def test_mcp_brief_shows_rulings_with_no_checkpoint(tmp_checkpoint_dir,
+                                                    monkeypatch):
+    from tests.test_mcp_server import rpc, _init, _call, _result
+    _rule("mcp shows me before any checkpoint")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    _, out = rpc(_init(), _call("daimon_brief", {}))
+    text, is_err = _result(out)
+    assert is_err is False
+    assert "§ mcp shows me before any checkpoint" in text
+
+
+def test_hook_injects_rulings_with_no_checkpoint(tmp_checkpoint_dir,
+                                                 monkeypatch):
+    from daimon_briefing import hooks
+    _rule("hook injects me on day one")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    out = hooks.pre_llm_call(
+        session_id="S2", user_message="hi", conversation_history=[],
+        is_first_turn=True, model="m", platform="cli",
+    )
+    assert out is not None
+    assert "§ hook injects me on day one" in out["context"]
+
+
 def test_hook_injected_briefing_carries_rulings(tmp_checkpoint_dir,
                                                 sample_checkpoint,
                                                 monkeypatch):

--- a/plugin/tests/test_ruling_echo.py
+++ b/plugin/tests/test_ruling_echo.py
@@ -1,0 +1,157 @@
+"""#693 PR 2: the ruling echo admission filter.
+
+The standing-rulings section renders into every session's context, so the
+NEXT session's extractor can mint the ruling text back as a fresh belief —
+a copy that decays, drifts, and double-renders. The admission filter drops
+exact echoes at the write boundary, ONLY on the two admission paths
+(capture, `write-checkpoint` stdin). Rewrites (anchor --attach, the forget
+rewrite) never opt in: they must not strip previously-admitted items.
+"""
+
+from daimon_briefing import refutations, store
+
+
+PROJECT = "/p/ruling-echo"
+VERDICT = "never deploy the payments service on a friday"
+
+
+def _active_ruling():
+    return refutations.assert_ruling(
+        subject="friday payment deploys",
+        verdict=VERDICT,
+        scope="payments service",
+        evidence=["issue:693"],
+        channel="cli-tty",
+        ratified=True,
+        project_dir=PROJECT,
+    )
+
+
+def _checkpoint(text=VERDICT):
+    return {
+        "session_id": "S-echo",
+        "working_context": {
+            "active_topic": {"text": "deploy cadence", "trust": "inferred"},
+            "open_questions": [],
+            "recent_decisions": [],
+        },
+        "epistemic_snapshot": {
+            "strong_beliefs": [
+                {"text": text, "trust": "inferred"},
+                {"text": "an unrelated belief survives", "trust": "inferred"},
+            ],
+            "uncertainties": [],
+            "contradictions_flagged": [],
+        },
+    }
+
+
+def _beliefs(path):
+    import json
+    cp = json.loads(path.read_text(encoding="utf-8"))
+    return [i["text"] for i in cp["epistemic_snapshot"]["strong_beliefs"]]
+
+
+def test_admission_drops_exact_echo_of_active_ruling(tmp_checkpoint_dir):
+    _active_ruling()
+    out = store.write_checkpoint("S-echo", _checkpoint(),
+                                 project_dir=PROJECT, admit=True)
+    beliefs = _beliefs(out)
+    assert VERDICT not in beliefs
+    assert "an unrelated belief survives" in beliefs
+
+
+def test_rewrite_without_admit_keeps_previously_admitted_items(
+        tmp_checkpoint_dir):
+    _active_ruling()
+    out = store.write_checkpoint("S-echo", _checkpoint(),
+                                 project_dir=PROJECT)
+    assert VERDICT in _beliefs(out)
+
+
+def test_candidate_ruling_never_drops_anything(tmp_checkpoint_dir):
+    refutations.assert_ruling(
+        subject="friday payment deploys", verdict=VERDICT,
+        scope="payments service", evidence=["issue:693"],
+        channel="cli-agent", ratified=False, project_dir=PROJECT)
+    out = store.write_checkpoint("S-echo", _checkpoint(),
+                                 project_dir=PROJECT, admit=True)
+    assert VERDICT in _beliefs(out)
+
+
+def test_echo_drop_is_counted_under_its_own_reason(tmp_checkpoint_dir):
+    _active_ruling()
+    store.write_checkpoint("S-echo", _checkpoint(),
+                           project_dir=PROJECT, admit=True)
+    stats = store.forget_hit_stats(project_dir=PROJECT)
+    # The echo rate is its OWN measurement — it must not inflate the forget
+    # suppression count the project already publishes.
+    assert stats["count"] == 0
+    assert stats["ruling_echo_count"] == 1
+
+
+def test_echo_drop_logs_content_hash_never_text(tmp_checkpoint_dir, caplog):
+    import logging
+    _active_ruling()
+    with caplog.at_level(logging.WARNING):
+        store.write_checkpoint("S-echo", _checkpoint(),
+                               project_dir=PROJECT, admit=True)
+    echo_lines = [r.getMessage() for r in caplog.records
+                  if "ruling echo" in r.getMessage()]
+    assert echo_lines
+    assert all(VERDICT not in line for line in echo_lines)
+    assert any("content hash" in line for line in echo_lines)
+
+
+def test_status_surfaces_echo_drops_when_nonzero(tmp_checkpoint_dir,
+                                                 monkeypatch, capsys):
+    from daimon_briefing import cli
+    _active_ruling()
+    store.write_checkpoint("S-echo", _checkpoint(),
+                           project_dir=PROJECT, admit=True)
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    capsys.readouterr()
+    assert cli.main(["status"]) == 0
+    out = capsys.readouterr().out
+    assert "ruling echo" in out
+    assert VERDICT not in out
+
+
+def test_filter_fails_open_on_ledger_read_error(tmp_checkpoint_dir,
+                                                monkeypatch):
+    _active_ruling()
+
+    def boom(**kwargs):
+        raise OSError("ledger unreadable")
+
+    monkeypatch.setattr(refutations, "listing", boom)
+    out = store.write_checkpoint("S-echo", _checkpoint(),
+                                 project_dir=PROJECT, admit=True)
+    assert out is not None
+    assert VERDICT in _beliefs(out)  # fail-open: the write goes through whole
+
+
+def test_capture_path_admits(tmp_checkpoint_dir, monkeypatch):
+    # capture.run is the hook-side admission caller; its write must carry
+    # the filter. Reaching through the real extractor is a serializer test,
+    # so pin the seam instead: the call site passes admit=True.
+    import inspect
+    from daimon_briefing import capture
+    src = inspect.getsource(capture.run)
+    assert "admit=True" in src
+
+
+def test_write_checkpoint_stdin_path_admits(tmp_checkpoint_dir, monkeypatch,
+                                            capsys):
+    import io
+    import json
+    import sys
+    from daimon_briefing import cli
+    _active_ruling()
+    cp = _checkpoint()
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(cp)))
+    rc = cli.main(["write-checkpoint", "--project", PROJECT])
+    assert rc == 0
+    out = store.read_latest(project_dir=PROJECT)
+    beliefs = [i["text"] for i in out["epistemic_snapshot"]["strong_beliefs"]]
+    assert VERDICT not in beliefs

--- a/plugin/tests/test_ruling_echo.py
+++ b/plugin/tests/test_ruling_echo.py
@@ -143,6 +143,57 @@ def test_active_refutation_never_drops_anything(tmp_checkpoint_dir):
     assert stats["ruling_echo_count"] == 0
 
 
+def test_torn_checkpoint_shapes_never_crash_the_matcher(tmp_checkpoint_dir):
+    # Legacy/torn blobs: a section that is not a dict, a list key that is
+    # not a list — the matcher tolerates both, same posture as the forget
+    # gate's walk.
+    from daimon_briefing import normalize, policy
+    torn = {
+        "session_id": "S-torn",
+        "working_context": "not-a-dict",
+        "epistemic_snapshot": {"strong_beliefs": "not-a-list",
+                               "uncertainties": [
+                                   {"text": VERDICT, "trust": "inferred"}]},
+    }
+    dropped = policy.drop_matching_items(
+        torn, {normalize.content_key(VERDICT)})
+    assert [i["text"] for i in dropped] == [VERDICT]
+
+
+def test_hand_edited_empty_verdict_ruling_never_breaks_the_filter(
+        tmp_checkpoint_dir):
+    # A raw-appended active ruling with an empty verdict contributes no key
+    # and must not stop a real ruling's echo from dropping.
+    row = refutations._stamp(
+        "ruled", refutations.make_id("empty verdict", "tests"), "cli-tty")
+    row.update({"subject": "empty verdict", "verdict": "", "scope": "tests",
+                "anchors": [], "revisit_when": "", "evidence": [],
+                "ratified": True})
+    assert refutations.append(row, project_dir=PROJECT)
+    _active_ruling()
+    out = store.write_checkpoint("S-echo", _checkpoint(),
+                                 project_dir=PROJECT, admit=True)
+    assert VERDICT not in _beliefs(out)
+    assert store.forget_hit_stats(project_dir=PROJECT)[
+        "ruling_echo_count"] == 1
+
+
+def test_status_rich_path_surfaces_echo_drops(tmp_checkpoint_dir,
+                                              monkeypatch, capsys):
+    import pytest as _pytest
+    _pytest.importorskip("rich")
+    from daimon_briefing import cli, render
+    _active_ruling()
+    store.write_checkpoint("S-echo", _checkpoint(),
+                           project_dir=PROJECT, admit=True)
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    monkeypatch.delenv("DAIMON_PLAIN", raising=False)
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    capsys.readouterr()
+    assert cli.main(["status"]) == 0
+    assert "ruling echo" in capsys.readouterr().out
+
+
 def test_status_surfaces_echo_drops_when_nonzero(tmp_checkpoint_dir,
                                                  monkeypatch, capsys):
     from daimon_briefing import cli

--- a/plugin/tests/test_ruling_echo.py
+++ b/plugin/tests/test_ruling_echo.py
@@ -93,14 +93,54 @@ def test_echo_drop_is_counted_under_its_own_reason(tmp_checkpoint_dir):
 def test_echo_drop_logs_content_hash_never_text(tmp_checkpoint_dir, caplog):
     import logging
     _active_ruling()
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INFO):
         store.write_checkpoint("S-echo", _checkpoint(),
                                project_dir=PROJECT, admit=True)
-    echo_lines = [r.getMessage() for r in caplog.records
-                  if "ruling echo" in r.getMessage()]
-    assert echo_lines
-    assert all(VERDICT not in line for line in echo_lines)
-    assert any("content hash" in line for line in echo_lines)
+    echo = [r for r in caplog.records if "ruling echo" in r.getMessage()]
+    assert echo
+    # INFO, not WARNING: a stable ruling being re-minted every session is an
+    # expected, measured event — not an anomaly worth an alert per capture.
+    assert all(r.levelno == logging.INFO for r in echo)
+    assert all(VERDICT not in r.getMessage() for r in echo)
+    assert any("content hash" in r.getMessage() for r in echo)
+
+
+def test_rendered_line_forms_are_dropped_too(tmp_checkpoint_dir):
+    # What the briefing puts in context is not the bare verdict — it is
+    # "§ <verdict>" with an optional "  [<authority>-written]" suffix. An
+    # extractor copying that line verbatim is the most literal echo shape
+    # there is; the key set must cover it.
+    ruling_id = refutations.assert_ruling(
+        subject="friday payment deploys", verdict=VERDICT,
+        scope="payments service", evidence=["issue:693"],
+        channel="cli-agent", ratified=False, project_dir=PROJECT)
+    refutations.ratify(ruling_id, channel="cli-tty", project_dir=PROJECT)
+    cp = _checkpoint(text=f"§ {VERDICT}  [agent-written]")
+    cp["epistemic_snapshot"]["strong_beliefs"].append(
+        {"text": f"§ {VERDICT}", "trust": "inferred"})
+    out = store.write_checkpoint("S-echo", cp, project_dir=PROJECT,
+                                 admit=True)
+    beliefs = _beliefs(out)
+    assert f"§ {VERDICT}  [agent-written]" not in beliefs
+    assert f"§ {VERDICT}" not in beliefs
+    assert "an unrelated belief survives" in beliefs
+
+
+def test_active_refutation_never_drops_anything(tmp_checkpoint_dir):
+    # The polarity scope IS the safety property: an active REFUTATION whose
+    # verdict matches an item's text must never delete it at admission —
+    # that would hand the negative-polarity ledger a deletion power the
+    # design denies it.
+    ref = refutations.assert_refutation(
+        subject="friday payment deploys", verdict=VERDICT,
+        scope="payments service", evidence=["issue:693"],
+        channel="cli-tty", ratified=True, project_dir=PROJECT)
+    assert refutations.get(ref, project_dir=PROJECT)["state"] == "active"
+    out = store.write_checkpoint("S-echo", _checkpoint(),
+                                 project_dir=PROJECT, admit=True)
+    assert VERDICT in _beliefs(out)
+    stats = store.forget_hit_stats(project_dir=PROJECT)
+    assert stats["ruling_echo_count"] == 0
 
 
 def test_status_surfaces_echo_drops_when_nonzero(tmp_checkpoint_dir,
@@ -132,13 +172,116 @@ def test_filter_fails_open_on_ledger_read_error(tmp_checkpoint_dir,
 
 
 def test_capture_path_admits(tmp_checkpoint_dir, monkeypatch):
-    # capture.run is the hook-side admission caller; its write must carry
-    # the filter. Reaching through the real extractor is a serializer test,
-    # so pin the seam instead: the call site passes admit=True.
-    import inspect
+    # capture.run is the hook-side admission caller; its write must carry the
+    # filter. Spy on the seam and assert the kwarg the store actually
+    # RECEIVES — a source-text assertion here was once satisfied by a
+    # comment, which left the primary admission path guarded by nothing.
     from daimon_briefing import capture
-    src = inspect.getsource(capture.run)
-    assert "admit=True" in src
+    seen = {}
+
+    def _spy(session_id, checkpoint, project_dir=None, admit=False, **kw):
+        seen["admit"] = admit
+        return None  # kill-switch shape: capture returns right after
+
+    monkeypatch.setattr(capture.store, "write_checkpoint", _spy)
+    monkeypatch.setattr(
+        capture.serializer, "serialize_strict",
+        lambda *a, **k: {"session_id": "S-spy", "working_context": {},
+                         "epistemic_snapshot": {}})
+    assert capture.run("S-spy", [], project=PROJECT, chat=None,
+                       deadline=None) is None
+    assert seen.get("admit") is True
+
+
+def test_item_quoting_a_ruling_keeps_quote_and_trust(tmp_checkpoint_dir):
+    # An item whose own text is fresh but whose QUOTE repeats the ruling is a
+    # genuine witness, not an echo copy. A ruling carries no deletion
+    # promise; the filter must never strip fields or downgrade trust the way
+    # the forget gate does.
+    _active_ruling()
+    cp = _checkpoint(text="the team restated the deploy rule today")
+    cp["epistemic_snapshot"]["strong_beliefs"][0].update(
+        {"quote": VERDICT, "trust": "verbatim"})
+    out = store.write_checkpoint("S-echo", cp, project_dir=PROJECT,
+                                 admit=True)
+    import json
+    stored = json.loads(out.read_text(encoding="utf-8"))
+    item = stored["epistemic_snapshot"]["strong_beliefs"][0]
+    assert item["quote"] == VERDICT
+    assert item["trust"] == "verbatim"
+
+
+def test_active_topic_survives_echo_filter(tmp_checkpoint_dir):
+    # The active topic is working context, not a decaying belief copy —
+    # deleting it is context loss, not deduplication.
+    _active_ruling()
+    cp = _checkpoint(text="unrelated belief")
+    cp["working_context"]["active_topic"] = {"text": VERDICT,
+                                             "trust": "inferred"}
+    out = store.write_checkpoint("S-echo", cp, project_dir=PROJECT,
+                                 admit=True)
+    import json
+    stored = json.loads(out.read_text(encoding="utf-8"))
+    assert stored["working_context"]["active_topic"]["text"] == VERDICT
+
+
+def test_stats_last_hit_at_excludes_echo_rows(tmp_checkpoint_dir):
+    import json
+    _active_ruling()
+    path = store._forget_hits_path(PROJECT)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(
+        {"ts": "2020-01-01T00:00:00Z", "key": "k-forget"}) + "\n",
+        encoding="utf-8")
+    store.write_checkpoint("S-echo", _checkpoint(),
+                           project_dir=PROJECT, admit=True)
+    stats = store.forget_hit_stats(project_dir=PROJECT)
+    assert stats["count"] == 1
+    assert stats["ruling_echo_count"] == 1
+    # The forget line's timestamp must stay the forget ledger's own.
+    assert stats["last_hit_at"] == "2020-01-01T00:00:00Z"
+    assert stats["ruling_echo_last_at"] > "2020-01-01T00:00:00Z"
+
+
+def test_anchor_attach_rewrite_never_echo_drops(tmp_checkpoint_dir, tmp_path,
+                                                capsys):
+    # The anchor --attach rewrite re-writes a previously-admitted
+    # checkpoint; it must not strip items even when a ruling matching one
+    # was ratified in between.
+    from daimon_briefing import cli, refutations as refs
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / "mod.py").write_text("def fn():\n    pass\n", encoding="utf-8")
+    store.write_checkpoint("S-echo", _checkpoint(), project_dir=proj)
+    refs.assert_ruling(
+        subject="friday payment deploys", verdict=VERDICT,
+        scope="payments service", evidence=["issue:693"],
+        channel="cli-tty", ratified=True, project_dir=proj)
+    rc = cli.main(["anchor", "mod.py", "fn",
+                   "--attach", "unrelated belief survives",
+                   "--project", str(proj)])
+    assert rc == 0
+    out = store.read_latest(project_dir=proj)
+    beliefs = [i["text"] for i in out["epistemic_snapshot"]["strong_beliefs"]]
+    assert VERDICT in beliefs
+
+
+def test_forget_rewrite_never_echo_drops(tmp_checkpoint_dir, monkeypatch,
+                                         capsys):
+    # The forget rewrite deletes exactly what the user named — an active
+    # ruling matching a DIFFERENT stored item must not widen the deletion.
+    from daimon_briefing import cli
+    store.write_checkpoint("S-echo", _checkpoint(), project_dir=PROJECT)
+    _active_ruling()
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    stored = store.read_latest(project_dir=PROJECT)
+    doomed = next(i["id"] for i in
+                  stored["epistemic_snapshot"]["strong_beliefs"]
+                  if i["text"] == "an unrelated belief survives")
+    assert cli.main(["forget", doomed]) == 0
+    out = store.read_latest(project_dir=PROJECT)
+    beliefs = [i["text"] for i in out["epistemic_snapshot"]["strong_beliefs"]]
+    assert VERDICT in beliefs  # the ruling echo was NOT the forget target
 
 
 def test_write_checkpoint_stdin_path_admits(tmp_checkpoint_dir, monkeypatch,

--- a/plugin/tests/test_skill_content.py
+++ b/plugin/tests/test_skill_content.py
@@ -420,3 +420,13 @@ def test_every_shipped_command_is_taught_or_declared_not_agent_facing():
 def test_every_not_agent_facing_entry_gives_a_reason():
     for name, reason in skill_content.NOT_AGENT_FACING.items():
         assert reason and reason.strip(), f"{name}: no reason recorded"
+
+
+def test_full_teaches_the_briefing_rulings_section():
+    # #693 PR 2: the briefing now renders active rulings under this exact
+    # header. The skill must teach the section by its rendered literal —
+    # a paraphrased header would leave agents unable to recognize the one
+    # section whose whole point is to be honored on sight.
+    from daimon_briefing import briefing
+    full = skill_content.render_full()
+    assert briefing._RULING_HEADER in full

--- a/plugin/tests/ui/test_page_rulings.py
+++ b/plugin/tests/ui/test_page_rulings.py
@@ -36,3 +36,25 @@ def test_rulings_lane_carries_its_own_heading(srv):
     _, _, body = _get(srv + "/static/render.js")
     js = body.decode()
     assert "Standing rulings" in js
+
+
+def test_lane_chrome_never_asserts_ratification_over_candidates(srv):
+    # The lane serves EVERY state (it mirrors `daimon ruling list`), so its
+    # section chrome must speak in status terms: an agent-proposed candidate
+    # sitting under a "human-ratified" banner asserts an approval no human
+    # gave.
+    _, _, body = _get(srv + "/static/render.js")
+    js = body.decode()
+    lane = js.split("Standing rulings", 1)[1].split("Refutations</h1>", 1)[0]
+    assert "human-ratified" not in lane
+    assert "never decay" not in lane
+
+
+def test_rulings_lane_never_sits_under_the_refutations_heading(srv):
+    # The negative-polarity page chrome ("recorded against entries · status,
+    # never judgment") must not visually govern the rulings table — that is
+    # the presentational form of the inversion this lane exists to prevent.
+    _, _, body = _get(srv + "/static/render.js")
+    js = body.decode()
+    view = js.split("renderRefutationsView", 1)[1]
+    assert view.index("Standing rulings") < view.index(">Refutations</h1>")

--- a/plugin/tests/ui/test_page_rulings.py
+++ b/plugin/tests/ui/test_page_rulings.py
@@ -1,0 +1,38 @@
+"""Rulings lane frontend (#693 PR 2): the refutations view splits into two
+lanes. The rulings lane renders the VERDICT (the rule text, cli._print_ruling's
+contract) under the CLI's own glyphs — § active, × retired, ? candidate — and
+an overturned ruling reads "retired". Nothing is coined at the render layer."""
+import urllib.request
+
+
+def _get(url):
+    with urllib.request.urlopen(url) as r:
+        return r.status, r.headers.get_content_type(), r.read()
+
+
+def test_lane_glyphs_are_the_cli_words(srv):
+    _, _, body = _get(srv + "/static/render.js")
+    js = body.decode()
+    src = js.split("RULING_MARKS", 1)[1].split("}", 1)[0]
+    for pair in ('active: "§"', 'overturned: "×"', 'candidate: "?"'):
+        assert pair in src, pair
+
+
+def test_overturned_ruling_reads_retired(srv):
+    _, _, body = _get(srv + "/static/render.js")
+    js = body.decode()
+    assert '"retired"' in js
+
+
+def test_ruling_row_renders_the_verdict(srv):
+    _, _, body = _get(srv + "/static/render.js")
+    js = body.decode()
+    row = js.split("renderRulingRow", 1)[1].split("renderRefutationsView", 1)[0]
+    assert "verdict" in row
+    assert "r.subject" not in row  # verdict, never subject — the inversion trap
+
+
+def test_rulings_lane_carries_its_own_heading(srv):
+    _, _, body = _get(srv + "/static/render.js")
+    js = body.decode()
+    assert "Standing rulings" in js

--- a/plugin/tests/ui/test_server_rulings.py
+++ b/plugin/tests/ui/test_server_rulings.py
@@ -1,0 +1,88 @@
+"""Rulings lane (#693 PR 2): /api/refutations serves BOTH lanes in one
+payload — `rows` stays refutation-polarity (the ✗/"Refutes" vocabulary
+would invert a ruling), `rulings` carries the ruling-polarity records for
+the lane that renders VERDICT under its own § glyph. Every listing call is
+polarity-scoped explicitly: an unscoped call is the exact bug shape the
+polarity parameter exists to prevent."""
+import json
+import threading
+from urllib.request import urlopen
+
+import pytest
+
+from daimon_briefing import refutations, store
+from daimon_ui import server
+
+
+def _cp(sid):
+    return {
+        "session_id": sid,
+        "working_context": {
+            "active_topic": {"text": "wiring the lane"},
+            "open_questions": [],
+            "recent_decisions": [],
+        },
+        "epistemic_snapshot": {
+            "strong_beliefs": [], "uncertainties": [],
+            "contradictions_flagged": [],
+        },
+    }
+
+
+@pytest.fixture
+def proj(tmp_checkpoint_dir, tmp_path, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    p = tmp_path / "proj"
+    p.mkdir()
+    store.write_checkpoint("S1", _cp("S1"), project_dir=p)
+    return p
+
+
+@pytest.fixture
+def srv(proj, tmp_checkpoint_dir):
+    slug = store.project_slug(proj)
+    s = server.make_server(tmp_checkpoint_dir, slug, proj.name, port=0)
+    t = threading.Thread(target=s.serve_forever, daemon=True)
+    t.start()
+    yield f"http://127.0.0.1:{s.server_address[1]}"
+    s.shutdown()
+
+
+def _get(base, path):
+    with urlopen(base + path) as r:
+        return json.loads(r.read())
+
+
+def _seed_both(proj):
+    ruling = refutations.assert_ruling(
+        subject="friday deploys", verdict="never deploy on friday",
+        scope="payments", evidence=["issue:693"], channel="cli-tty",
+        ratified=True, project_dir=proj)
+    refut = refutations.assert_refutation(
+        subject="the polling approach", verdict="does not hold",
+        scope="tests", evidence=["artifact:a"], channel="cli-agent",
+        project_dir=proj)
+    return ruling, refut
+
+
+def test_payload_separates_the_two_polarities(proj, srv):
+    ruling, refut = _seed_both(proj)
+    slug = store.project_slug(proj)
+    data = _get(srv, f"/api/refutations?project={slug}")
+    assert data["ok"] is True
+    assert [r["refutation_id"] for r in data["rows"]] == [refut]
+    assert [r["refutation_id"] for r in data["rulings"]] == [ruling]
+
+
+def test_rulings_lane_order_is_the_cli_order(proj, srv):
+    cand = refutations.assert_ruling(
+        subject="newer candidate rule", verdict="candidate verdict",
+        scope="tests", evidence=["issue:693"], channel="cli-agent",
+        project_dir=proj)
+    active = refutations.assert_ruling(
+        subject="older active rule", verdict="active verdict",
+        scope="tests", evidence=["issue:693"], channel="cli-tty",
+        ratified=True, project_dir=proj)
+    slug = store.project_slug(proj)
+    data = _get(srv, f"/api/refutations?project={slug}")
+    assert [r["refutation_id"] for r in data["rulings"]] == [active, cand]


### PR DESCRIPTION
Closes #693

## What

PR 2 of the ratified pinned-rulings design — the render half. PR 1 (#700) shipped the module, CLI, and fold; this PR makes active rulings reach every context surface and closes the loop the feature would otherwise open.

- **Briefing section**: active rulings render at the top of every briefing as `§` lines under `Standing rulings (human-ratified — honor these):` — skeleton furniture outside the budget drop order, on all surfaces (plain, rich, hook injection, MCP, and prepended verbatim to the opt-in LLM narrative). Day-one rulings render before the first checkpoint exists. Renderer backstops are loud: over-cap emits a `+N over cap` note, over-length verdicts clip with a visible marker, non-human `text_authored_by` is labeled with its authority word.
- **Ruling echo admission filter**: `store.write_checkpoint` gains `admit=True`, passed only by the two admission callers (capture, `write-checkpoint` stdin). Exact echoes of active ruling text — every rendered form — drop whole at admission via a new `policy.drop_matching_items` (no quote scrubs, no trust downgrades, active_topic untouched: a ruling carries no deletion promise). Drops are counted under their own reason and timestamp (`ruling_echo_count` / `ruling_echo_last_at`, surfaced by `daimon status`; forget-suppression numbers stay uncontaminated), logged at INFO as a content hash only, and the whole filter fails open. Rewrite callers (`anchor --attach`, the forget rewrite) never opt in, pinned by call-site tests.
- **Viewer rulings lane**: `/api/refutations` serves both lanes in one payload, each `listing` call explicitly polarity-scoped (the shipped-scar shape). The lane sits above the refutations heading with status-term chrome, renders the **verdict** under the CLI's own glyphs (`§` active, `×` retired, `?` candidate), and never asserts ratification over agent-proposed candidates.
- **Skill text**: teaches the rendered section header by its exact literal, pinned against `briefing._RULING_HEADER` by test.

## Why

A rule stated once lands in the belief partition and fades: it does not carry, and under budget pressure beliefs drop first (#693). PR 1 gave rulings a durable, human-gated home; without this PR they would never reach context — and once they do reach context every session, the extractor would mint the text back as a decaying belief copy each capture, which is the echo loop the admission filter closes.

## Tests

- 48 new tests across `test_ruling_briefing.py`, `test_ruling_echo.py`, `tests/ui/test_server_rulings.py`, `tests/ui/test_page_rulings.py`, `test_skill_content.py` — each written first and watched fail (TDD throughout).
- Full plugin suite: **3857 passed, 2 skipped**; ruff clean.
- Two rounds of two blind adversarial reviewers on the diff. Round 1 found a vacuous capture-path test (assertion satisfied by a comment) and an over-broad echo filter (forget-gate field scrubs destroying verbatim quote provenance) — both fixed; Round 2 verified the fixes **by mutation** (removing `admit=True` from capture now fails exactly one test; an unscoped `polarity` in the echo filter now fails a dedicated guard test) and returned zero criticals.
- Notable pins: the full-cap section costs ~17% of the default 3000-token budget; rulings survive maximum budget pressure; an active *refutation* whose verdict matches an item's text never deletes it at admission.

Note for `status --json` consumers: `forget_hits` gains additive `ruling_echo_count` / `ruling_echo_last_at` fields.
