### PR TITLE
docs(blog): publish the 0.31.0 ship-log

### DIFF
--- a/website/blog/2026-08-15-daimon-0-31.md
+++ b/website/blog/2026-08-15-daimon-0-31.md
@@ -1,0 +1,99 @@
+---
+slug: daimon-0-31
+title: "daimon 0.31.0: rules that stand until a human ends them"
+authors: [daimon]
+tags: [release, rulings, refutations, trust]
+---
+
+Some facts in a project are not beliefs. "Never deploy the payments service
+on a Friday" is not something the agent should re-derive each session, weigh
+against newer context, or quietly forget under budget pressure. It is a
+standing constraint, and until now daimon had no home for one: a rule stated
+once landed in the belief partition, did not carry, and was first in the drop
+order when the briefing ran over budget. 0.31.0 adds pinned rulings.
+
+{/* truncate */}
+
+## Standing rulings
+
+A ruling is the refutation ledger's positive polarity. A refutation records
+what was ruled out; a ruling records what stands. Same ledger, same lifecycle
+machinery, opposite claim, and the polarity is derived from the founding
+event, never from a field a writer could set.
+
+`daimon ruling propose` records a candidate. An agent can propose with
+`--by agent`, and a candidate is all an agent can ever produce: activation
+requires `daimon ruling ratify` from a human at an interactive terminal.
+This is the same authority rule the rest of daimon holds. Identity and
+authority are derived, never self-asserted.
+
+Once active, a ruling renders at the top of every briefing, on every
+surface, as a compact section:
+
+```text
+Standing rulings (human-ratified — honor these):
+§ never deploy the payments service on a friday
+```
+
+That section is skeleton furniture. It survives budget pressure that trims
+every other section, it renders before the first checkpoint of a fresh
+project exists, and when the opt-in LLM briefing is active the section is
+prepended verbatim, never re-narrated by a generative pass.
+
+## The design choices worth stating plainly
+
+**Ratification is content-bound.** `ruling ratify` records a hash of the
+exact text it displayed to you, and activation refuses if the stored text
+changed between the prompt and your confirmation. What you approve is what
+activates, byte for byte.
+
+**An agent proposal cannot change what renders.** Agents may propose a
+revision or a retirement of an active ruling, but the active text stands
+untouched until a human settles the proposal, and the fold enforces this
+below the CLI, so even a hand-edited ledger cannot promote an agent's words
+into your briefing.
+
+**The echo loop is closed at the write boundary.** A section that renders
+into every session would otherwise be a copy machine: the next capture
+re-extracts the ruling text as a fresh belief, which decays, drifts, and
+renders twice. 0.31.0 filters exact echoes at checkpoint admission. The drop
+is counted under its own reason code and visible in `daimon status`, never
+silent, and the filter fails open: an unreadable ledger can never cost you a
+capture.
+
+**The section is bounded and never silently truncated.** Rulings are capped
+(seven by default, `DAIMON_RULING_CAP` to change it) and each ruling's text
+is bounded at write time. If a ledger ever holds more active rulings than
+the cap, the briefing says how many were withheld and where to see them.
+
+Rulings never decay. Retirement is a human ceremony, and `daimon forget`
+reaches ruling text by value like everything else on the ledger.
+
+## Also since 0.29
+
+**The local viewer shipped in 0.30.0.** `daimon serve` opens a read-only
+localhost viewer: briefing, ledger, per-session pages, search-as-recall,
+a check strip, and a print view. 0.31.0 adds the rulings lane beside the
+refutations lane, each polarity under its own vocabulary.
+
+**A typed relation ledger shipped in shadow mode**, with adjudication verbs
+and history rendering in the viewer.
+
+**0.30.2 fixed a real forget defect:** forget by value only matched a
+refutation's subject field, leaving four of its five plaintext fields
+unreachable by value. Found during this release's design review, fixed and
+shipped ahead of the feature that made it matter.
+
+## Getting it
+
+```console
+uv tool install 'daimon-briefing[pretty]'
+```
+
+Upgrading:
+
+```console
+uv tool upgrade daimon-briefing
+```
+
+Plugin users: `/plugin`, update daimon, then reload.

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-08-15-daimon-0-31.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-08-15-daimon-0-31.md
@@ -1,0 +1,104 @@
+---
+slug: daimon-0-31
+title: "daimon 0.31.0: reglas que se sostienen hasta que una persona las retira"
+authors: [daimon]
+tags: [release, rulings, refutations, trust]
+---
+
+Hay hechos de un proyecto que no son creencias. "Nunca desplegar el servicio
+de pagos un viernes" no es algo que el agente deba re-derivar en cada sesión,
+sopesar contra contexto más nuevo, ni olvidar en silencio bajo presión de
+presupuesto. Es una restricción vigente, y hasta ahora daimon no tenía un
+lugar para eso: una regla dicha una vez caía en la partición de creencias, no
+se arrastraba entre sesiones, y era lo primero que se recortaba cuando el
+briefing excedía el presupuesto. 0.31.0 agrega los pinned rulings.
+
+{/* truncate */}
+
+## Reglas vigentes
+
+Un ruling es la polaridad positiva del ledger de refutaciones. Una refutación
+registra lo que se descartó; un ruling registra lo que rige. Mismo ledger,
+misma maquinaria de ciclo de vida, afirmación opuesta, y la polaridad se
+deriva del evento fundacional, nunca de un campo que un escritor pueda fijar.
+
+`daimon ruling propose` registra un candidato. Un agente puede proponer con
+`--by agent`, y un candidato es todo lo que un agente puede producir: la
+activación exige `daimon ruling ratify` de una persona en una terminal
+interactiva. Es la misma regla de autoridad que sostiene el resto de daimon.
+La identidad y la autoridad se derivan, nunca se autoafirman.
+
+Una vez activo, un ruling se renderiza al tope de cada briefing, en cada
+superficie, como una sección compacta:
+
+```text
+Standing rulings (human-ratified — honor these):
+§ never deploy the payments service on a friday
+```
+
+Esa sección es parte del esqueleto. Sobrevive la presión de presupuesto que
+recorta todas las demás secciones, se renderiza antes de que exista el primer
+checkpoint de un proyecto nuevo, y cuando el briefing por LLM (opt-in) está
+activo la sección se antepone literal, nunca re-narrada por un paso
+generativo.
+
+## Las decisiones de diseño que conviene decir sin rodeos
+
+**La ratificación está ligada al contenido.** `ruling ratify` registra un
+hash del texto exacto que te mostró, y la activación se rehúsa si el texto
+almacenado cambió entre el prompt y tu confirmación. Lo que aprobás es lo que
+se activa, byte por byte.
+
+**Una propuesta de agente no puede cambiar lo que se renderiza.** Los agentes
+pueden proponer una revisión o el retiro de un ruling activo, pero el texto
+activo queda intacto hasta que una persona resuelva la propuesta, y el fold
+lo garantiza por debajo del CLI: ni siquiera un ledger editado a mano puede
+promover las palabras de un agente a tu briefing.
+
+**El bucle de eco se cierra en la frontera de escritura.** Una sección que se
+renderiza en cada sesión sería, si no, una fotocopiadora: la próxima captura
+re-extrae el texto del ruling como una creencia nueva, que decae, deriva y se
+renderiza dos veces. 0.31.0 filtra los ecos exactos en la admisión del
+checkpoint. El descarte se cuenta bajo su propio código de razón y se ve en
+`daimon status`, nunca en silencio, y el filtro falla abierto: un ledger
+ilegible jamás puede costarte una captura.
+
+**La sección está acotada y nunca se trunca en silencio.** Los rulings tienen
+tope (siete por defecto, `DAIMON_RULING_CAP` para cambiarlo) y el texto de
+cada uno está acotado al momento de escribir. Si un ledger llega a tener más
+rulings activos que el tope, el briefing dice cuántos quedaron afuera y dónde
+verlos.
+
+Los rulings no decaen. El retiro es una ceremonia humana, y `daimon forget`
+alcanza el texto de un ruling por valor como todo lo demás en el ledger.
+
+## También desde 0.29
+
+**El visor local llegó en 0.30.0.** `daimon serve` abre un visor de solo
+lectura en localhost: briefing, ledger, páginas por sesión, búsqueda como
+recall, una tira de verificación y una vista de impresión. 0.31.0 agrega el
+carril de rulings junto al de refutaciones, cada polaridad con su propio
+vocabulario.
+
+**Un ledger tipado de relaciones llegó en modo sombra**, con verbos de
+adjudicación e historial renderizado en el visor.
+
+**0.30.2 corrigió un defecto real de forget:** forget por valor solo
+comparaba contra el campo subject de una refutación, dejando cuatro de sus
+cinco campos de texto plano inalcanzables por valor. Se encontró durante la
+revisión de diseño de este release, y se corrigió y publicó antes que la
+feature que lo hacía importar.
+
+## Cómo obtenerlo
+
+```console
+uv tool install 'daimon-briefing[pretty]'
+```
+
+Para actualizar:
+
+```console
+uv tool upgrade daimon-briefing
+```
+
+Usuarios del plugin: `/plugin`, actualizar daimon y recargar.


### PR DESCRIPTION
Closes #704

## What

Publishes the `0.31.0` ship-log in both locales.

| File | Change |
|------|--------|
| `website/blog/2026-08-15-daimon-0-31.md` | new post, slug `daimon-0-31` |
| `website/i18n/es/docusaurus-plugin-content-blog/2026-08-15-daimon-0-31.md` | Spanish version, same slug and tags |

## Why

The blog is the canonical home for release notes; `0.31.0` (pinned rulings end to end) was only legible from the changelog. The post states the design choices a reader needs plainly: content-bound ratification, agent proposals never changing what renders, the echo admission filter as a counted drop, and the loud cap. A since-0.29 section covers the viewer, the relation ledger's shadow mode, and the 0.30.2 forget-by-value fix.

## Tests

Every behavioral claim verified against the shipped code (`v0.31.0`) rather than the changelog: the ceremony's tty requirement, the content-bound refusal, the budget exemption, the echo counter in `daimon status`, the cap default and its over-cap note, and the `daimon serve` entry point. Docs-only change; site build runs in CI.