### PR TITLE
feat(render): route ledger verb output through render.py

### DIFF
--- a/plugin/daimon_briefing/cli/_ledger.py
+++ b/plugin/daimon_briefing/cli/_ledger.py
@@ -9,7 +9,7 @@ they cannot live inside either family module without a cross-family import.
 import json
 import sys
 
-from .. import refutations
+from .. import refutations, render
 
 
 def _refutation_json(record) -> str:
@@ -32,42 +32,49 @@ def _refutation_json(record) -> str:
     return json.dumps(payload, ensure_ascii=False, sort_keys=True)
 
 
-def _print_refutation(record: dict, *, detailed: bool = False,
-                      tag: bool = False) -> None:
+def _refutation_lines(record: dict, *, detailed: bool = False,
+                      tag: bool = False) -> list:
     state = record.get("state") or "candidate"
     activation = record.get("activation") or f"{record.get('asserted_by', '?')}-proposed"
     mark = "✗" if state == "active" else ("×" if state == "overturned" else "?")
     word = "refutation " if tag else ""
-    print(f"[{word}{mark} {state} · {activation}] {record['refutation_id']}  "
-          f"{record.get('subject', '')}")
+    lines = [f"[{word}{mark} {state} · {activation}] {record['refutation_id']}  "
+             f"{record.get('subject', '')}"]
     if not detailed:
-        return
-    print(f"  Verdict: {record.get('verdict', '')}")
-    print(f"  Scope: {record.get('scope', '')}")
+        return lines
+    lines.append(f"  Verdict: {record.get('verdict', '')}")
+    lines.append(f"  Scope: {record.get('scope', '')}")
     anchors = record.get("anchors") or []
     if anchors:
-        print(f"  Anchors: {', '.join(anchors)}")
+        lines.append(f"  Anchors: {', '.join(anchors)}")
     revisit = record.get("revisit_when") or ""
     if revisit:
-        print(f"  Revisit when: {revisit}")
+        lines.append(f"  Revisit when: {revisit}")
     evidence = record.get("evidence") or []
     for item in evidence:
-        print(f"  Evidence: {item}")
+        lines.append(f"  Evidence: {item}")
     if evidence:
         # #576: Evidence sits in the same Label: value register as Provenance
         # and Authority, which ARE derived from recorded lifecycle facts.  The
         # source string is shape-checked and never resolved, so say so here —
         # this is the only surface a reader of `refute show` actually reads.
-        print("  (evidence sources are recorded as cited; "
-              "daimon does not verify them)")
-    print(f"  Provenance: asserted by {record.get('asserted_by', '?')} "
-          f"({record.get('asserted_author') or 'unknown'})")
+        lines.append("  (evidence sources are recorded as cited; "
+                     "daimon does not verify them)")
+    lines.append(f"  Provenance: asserted by {record.get('asserted_by', '?')} "
+                 f"({record.get('asserted_author') or 'unknown'})")
     if record.get("activation"):
-        print(f"  Authority: {record['activation']} "
-              f"({record.get('activation_author') or 'unknown'})")
+        lines.append(f"  Authority: {record['activation']} "
+                     f"({record.get('activation_author') or 'unknown'})")
     pending = record.get("overturn_proposed")
     if isinstance(pending, dict):
-        print(f"  Overturn proposed by {pending.get('by', '?')} — still active")
+        lines.append(f"  Overturn proposed by {pending.get('by', '?')} — still active")
+    return lines
+
+
+def _print_refutation(record: dict, *, detailed: bool = False,
+                      tag: bool = False) -> None:
+    render.render_ledger_lines(
+        _refutation_lines(record, detailed=detailed, tag=tag))
 
 
 def _refute_channel(args) -> str:
@@ -88,8 +95,8 @@ def _refute_channel(args) -> str:
     return "cli-tty"
 
 
-def _print_ruling(record: dict, *, detailed: bool = False,
-                  tag: bool = False) -> None:
+def _ruling_lines(record: dict, *, detailed: bool = False,
+                  tag: bool = False) -> list:
     """#693: a ruling renders its VERDICT (the rule text) and never the
     refutation's ✗ glyph; an overturned ruling reads "retired" (label only,
     the state vocabulary is unchanged); and text authored by a non-human
@@ -103,27 +110,34 @@ def _print_ruling(record: dict, *, detailed: bool = False,
         activation = f"{authored}-written, {activation}"
     mark = "§" if state == "active" else ("×" if state == "overturned" else "?")
     word = "ruling " if tag else ""
-    print(f"[{word}{mark} {shown_state} · {activation}] "
-          f"{record['refutation_id']}  {record.get('verdict', '')}")
+    lines = [f"[{word}{mark} {shown_state} · {activation}] "
+             f"{record['refutation_id']}  {record.get('verdict', '')}"]
     if not detailed:
-        return
-    print(f"  Governs: {record.get('subject', '')}")
-    print(f"  Scope: {record.get('scope', '')}")
+        return lines
+    lines.append(f"  Governs: {record.get('subject', '')}")
+    lines.append(f"  Scope: {record.get('scope', '')}")
     anchors = record.get("anchors") or []
     if anchors:
-        print(f"  Anchors: {', '.join(anchors)}")
+        lines.append(f"  Anchors: {', '.join(anchors)}")
     revisit = record.get("revisit_when") or ""
     if revisit:
-        print(f"  Revisit when: {revisit}")
+        lines.append(f"  Revisit when: {revisit}")
     for item in record.get("evidence") or []:
-        print(f"  Evidence: {item}")
+        lines.append(f"  Evidence: {item}")
     proposal = record.get("revision_proposed")
     if proposal:
-        print(f"  Pending revision proposal ({proposal.get('by', '?')}): "
-              f"{proposal.get('verdict') or proposal.get('subject') or ''}")
+        lines.append(f"  Pending revision proposal ({proposal.get('by', '?')}): "
+                     f"{proposal.get('verdict') or proposal.get('subject') or ''}")
     retirement = record.get("overturn_proposed")
     if retirement:
-        print(f"  Pending retirement proposal ({retirement.get('by', '?')})")
+        lines.append(f"  Pending retirement proposal ({retirement.get('by', '?')})")
+    return lines
+
+
+def _print_ruling(record: dict, *, detailed: bool = False,
+                  tag: bool = False) -> None:
+    render.render_ledger_lines(
+        _ruling_lines(record, detailed=detailed, tag=tag))
 
 
 def _refuse_ruling_id(record, verb: str) -> bool:

--- a/plugin/daimon_briefing/cli/amend.py
+++ b/plugin/daimon_briefing/cli/amend.py
@@ -12,7 +12,7 @@ import sys
 
 import daimon_briefing.cli as _cli
 
-from .. import amendments, briefing, store
+from .. import amendments, briefing, render, store
 
 
 def _amend_channel(args) -> str:
@@ -71,14 +71,16 @@ def _cmd_amend_propose(args) -> int:
     state = record["state"] if record else "candidate"
     _cli._note_usage("amend:agent" if getattr(args, "by", None) == "agent"
                      else "amend")
-    print(f"amendment {a_id} recorded on {item_id}: {args.change} ({state})")
+    render.render_ledger_lines(
+        [f"amendment {a_id} recorded on {item_id}: {args.change} ({state})"])
     if state == "candidate":
         # Same posture as refute add: an agent-authored candidate is never
         # handed its own escalation command — verification is the transcript
         # byte-check at session end, settlement is a human's.
-        print("  evidence is byte-checked against the transcript at session "
-              "end; a human settles it earlier with `daimon amend ratify` "
-              "or `daimon amend reject`")
+        render.render_ledger_lines(
+            ["  evidence is byte-checked against the transcript at session "
+             "end; a human settles it earlier with `daimon amend ratify` "
+             "or `daimon amend reject`"])
     return 0
 
 
@@ -100,7 +102,8 @@ def _cmd_amend_verdict(args) -> int:
         return 1
     _cli._note_usage(f"amend:{verb}")
     record = amendments.get(args.amendment_id, project_dir=project)
-    print(f"{args.amendment_id}: {record['state'] if record else 'unknown'}")
+    render.render_ledger_lines(
+        [f"{args.amendment_id}: {record['state'] if record else 'unknown'}"])
     return 0
 
 
@@ -115,12 +118,14 @@ def _cmd_amend_list(args) -> int:
         print(json.dumps(rows, ensure_ascii=False, indent=2))
         return 0
     if not rows:
-        print("no amendments recorded for this project")
+        render.render_ledger_lines(["no amendments recorded for this project"])
         return 0
+    lines = []
     for r in rows:
         quote = briefing._truncate_agent_claim(r.get("evidence"))
-        print(f'{r["amendment_id"]}  {r["state"]:<9} {r["item_id"]}  '
-              f'{r["change"]}: "{quote}"')
+        lines.append(f'{r["amendment_id"]}  {r["state"]:<9} {r["item_id"]}  '
+                     f'{r["change"]}: "{quote}"')
+    render.render_ledger_lines(lines)
     return 0
 
 

--- a/plugin/daimon_briefing/cli/refute.py
+++ b/plugin/daimon_briefing/cli/refute.py
@@ -9,7 +9,7 @@ import functools
 
 import daimon_briefing.cli as _cli
 
-from .. import refutations
+from .. import refutations, render
 from ._ledger import (
     _print_refutation,
     _print_ruling,
@@ -41,11 +41,13 @@ def _cmd_refute_add(args) -> int:
             # An agent-authored candidate never gets handed its own escalation
             # command; activation is a decision the human has to reach.
             if getattr(args, "by", None) != "agent":
-                print(f"  Next: daimon refute ratify {ref_id} "
-                      f"--project {project}")
+                render.render_ledger_lines(
+                    [f"  Next: daimon refute ratify {ref_id} "
+                     f"--project {project}"])
             else:
-                print("  Candidate recorded. Activation requires an explicit "
-                      "human decision.")
+                render.render_ledger_lines(
+                    ["  Candidate recorded. Activation requires an explicit "
+                     "human decision."])
     return 0
 
 
@@ -91,7 +93,8 @@ def _cmd_refute_revise(args) -> int:
     else:
         _print_refutation(record, detailed=True)
         if record["state"] == "candidate":
-            print("  Revision is not load-bearing until explicit human ratification.")
+            render.render_ledger_lines(
+                ["  Revision is not load-bearing until explicit human ratification."])
     return 0
 
 
@@ -115,7 +118,8 @@ def _cmd_refute_overturn(args) -> int:
     else:
         _print_refutation(record, detailed=True)
         if event == "overturn-proposed":
-            print("  Agent evidence recorded; the active guard remains until human ratification.")
+            render.render_ledger_lines(
+                ["  Agent evidence recorded; the active guard remains until human ratification."])
     return 0
 
 
@@ -143,7 +147,7 @@ def _cmd_refute_list(args) -> int:
     if args.json:
         print(_refutation_json(rows))
     elif not rows:
-        print("no refutations for this project")
+        render.render_ledger_lines(["no refutations for this project"])
     else:
         for row in rows:
             _print_refutation(row)
@@ -163,7 +167,7 @@ def _cmd_refute_search(args) -> int:
     if args.json:
         print(_refutation_json(rows))
     elif not rows:
-        print("no matching refutations")
+        render.render_ledger_lines(["no matching refutations"])
     else:
         # #693: search is the topic-addressable pull path, so it returns BOTH
         # polarities, labelled by their own printers — filtering rulings out
@@ -197,13 +201,15 @@ def _cmd_refute_guard(args) -> int:
         print(_refutation_json(rows))
     elif not rows:
         if not args.quiet:
-            print("no active refutation matched exact anchors or subject")
+            render.render_ledger_lines(
+                ["no active refutation matched exact anchors or subject"])
     else:
         # One warning is the v1 attention budget. JSON retains every exact hit
         # for deliberation integrations that can reconcile them in batch.
         _print_refutation(rows[0], detailed=True)
         if len(rows) > 1:
-            print(f"  + {len(rows) - 1} more exact match(es); use --json to inspect")
+            render.render_ledger_lines(
+                [f"  + {len(rows) - 1} more exact match(es); use --json to inspect"])
     return 0
 
 

--- a/plugin/daimon_briefing/cli/ruling.py
+++ b/plugin/daimon_briefing/cli/ruling.py
@@ -11,7 +11,7 @@ import sys
 
 import daimon_briefing.cli as _cli
 
-from .. import config, normalize, refutations
+from .. import config, normalize, refutations, render
 from ._ledger import _print_ruling, _refutation_json, _refute_channel
 
 
@@ -35,11 +35,13 @@ def _cmd_ruling_propose(args) -> int:
         _print_ruling(record, detailed=True)
         if record["state"] == "candidate":
             if getattr(args, "by", None) != "agent":
-                print(f"  Next: daimon ruling ratify {ruling_id} "
-                      f"--project {project}")
+                render.render_ledger_lines(
+                    [f"  Next: daimon ruling ratify {ruling_id} "
+                     f"--project {project}"])
             else:
-                print("  Candidate recorded. Activation requires an explicit "
-                      "human decision.")
+                render.render_ledger_lines(
+                    ["  Candidate recorded. Activation requires an explicit "
+                     "human decision."])
     return 0
 
 
@@ -154,11 +156,13 @@ def _cmd_ruling_revise(args) -> int:
     else:
         _print_ruling(record, detailed=True)
         if record.get("revision_proposed"):
-            print("  Proposal recorded; the active ruling is untouched "
-                  "until a human verdict.")
+            render.render_ledger_lines(
+                ["  Proposal recorded; the active ruling is untouched "
+                 "until a human verdict."])
         elif record["state"] == "candidate":
-            print("  Revision is not load-bearing until explicit human "
-                  "ratification.")
+            render.render_ledger_lines(
+                ["  Revision is not load-bearing until explicit human "
+                 "ratification."])
     return 0
 
 
@@ -179,8 +183,9 @@ def _cmd_ruling_retire(args) -> int:
     else:
         _print_ruling(record, detailed=True)
         if event == "overturn-proposed":
-            print("  Retirement proposed; the ruling stands until a human "
-                  "verdict.")
+            render.render_ledger_lines(
+                ["  Retirement proposed; the ruling stands until a human "
+                 "verdict."])
     return 0
 
 
@@ -199,7 +204,7 @@ def _cmd_ruling_list(args) -> int:
                   file=sys.stderr)
         return 0
     if not rows:
-        print("no rulings for this project")
+        render.render_ledger_lines(["no rulings for this project"])
         return 0
     for row in rows:
         _print_ruling(row)
@@ -208,8 +213,9 @@ def _cmd_ruling_list(args) -> int:
     active = sum(1 for r in rows if r.get("state") == "active")
     cap = config.ruling_cap()
     if active > cap:
-        print(f"over cap: {active} active vs cap {cap} — retire one, or "
-              "raise DAIMON_RULING_CAP deliberately")
+        render.render_ledger_lines(
+            [f"over cap: {active} active vs cap {cap} — retire one, or "
+             "raise DAIMON_RULING_CAP deliberately"])
     return 0
 
 

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -1090,6 +1090,53 @@ def render_heal_abort(lines) -> None:
     _render_lines(lines)
 
 
+# ---- ledger: refute/ruling/amend record cards (#707) -------------------------
+
+
+def _ledger_style(ln: str) -> str | None:
+    """Per-line style for a ledger record card. Header lines are literal
+    bracketed text (`[§ active · …] r-… <verdict>`), so styling keys off the
+    state token INSIDE the line — never off rich markup. Restraint on purpose:
+    the polarity glyph carries the meaning (§ standing law, ✗ negative guard),
+    color only echoes the state."""
+    if ln.startswith("["):
+        if "✗ active" in ln:
+            return "red"
+        if "§ active" in ln:
+            return "green"
+        if "? candidate" in ln:
+            return "yellow"
+        if " × " in ln:
+            return "dim"
+        return None
+    if ln.startswith("  Pending"):
+        return "yellow"
+    if ln.startswith("  (evidence sources"):
+        return "dim"
+    if ln.startswith("over cap:"):
+        return "yellow"
+    return None
+
+
+def render_ledger_lines(lines) -> None:
+    """Refutation/ruling/amendment record cards and their advisory notes
+    (#707). Plain path is the bare print loop the ledger verbs always had
+    (byte-identical); rich upgrades header lines by state and dims the
+    boilerplate. `markup=False` is load-bearing — the state header is literal
+    bracketed text rich would otherwise parse as a (silently dropped) style
+    tag. Refusal/error lines never route through here; they stay plain, the
+    same contract render_anchor_attach documents."""
+    if not supports_rich():
+        for ln in lines:
+            print(ln)
+        return
+    from rich.console import Console
+
+    console = Console()
+    for ln in lines:
+        console.print(ln, style=_ledger_style(ln), markup=False)
+
+
 # ---- stats: `daimon stats` (#68) --------------------------------------------
 
 

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -1106,7 +1106,9 @@ def _ledger_style(ln: str) -> str | None:
             return "green"
         if "? candidate" in ln:
             return "yellow"
-        if " × " in ln:
+        # both spellings: untagged "[× retired …" and tagged
+        # "[refutation × overturned …" / "[ruling × retired …"
+        if re.match(r"\[(?:\w+ )?× ", ln):
             return "dim"
         return None
     if ln.startswith("  Pending"):

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -1380,3 +1380,43 @@ def test_rich_teammates_labels_foreign_verbatim_claim(monkeypatch, capsys):
     # Both the marked topic and the marked decision carry the label; the
     # unmarked decision does not (2 labels exactly).
     assert out.count("unverifiable here") == 2
+
+
+# ---- ledger: refute/ruling/amend record cards (#707) -------------------------
+
+
+def test_render_ledger_lines_plain_exact_format(capsys):
+    render.render_ledger_lines([
+        "[§ active · agent-written, ratified (interactive)] r-1a2b3c4d5e6f  "
+        "Every commit is signed.",
+        "  Governs: commit signing",
+        "  Evidence: transcript:abc",
+    ])
+    out = capsys.readouterr().out
+    assert out == (
+        "[§ active · agent-written, ratified (interactive)] r-1a2b3c4d5e6f  "
+        "Every commit is signed.\n"
+        "  Governs: commit signing\n"
+        "  Evidence: transcript:abc\n"
+    )
+
+
+def test_render_ledger_lines_rich_smoke_preserves_brackets(monkeypatch, capsys):
+    # The state header is literal bracketed text ("[§ active · ...]"); rich
+    # markup parsing would silently eat it as an invalid style tag — the same
+    # data-loss mode render_recall_lines guards against.
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_ledger_lines([
+        "[ruling § active · ratified (interactive)] r-1a2b3c4d5e6f  Text.",
+        "[refutation ✗ active · ratified (interactive)] r-9f8e7d6c5b4a  Gone.",
+        "[? candidate · agent-proposed] r-0a1b2c3d4e5f  Maybe.",
+        "  Pending retirement proposal (agent)",
+        "  (evidence sources are recorded as cited; daimon does not verify them)",
+        "over cap: 8 active vs cap 7 — retire one, or raise DAIMON_RULING_CAP deliberately",
+    ])
+    out = capsys.readouterr().out
+    assert "[ruling § active" in out
+    assert "[refutation ✗ active" in out
+    assert "[? candidate" in out
+    assert "Pending retirement proposal" in out
+    assert "over cap: 8 active vs cap 7" in out

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -1420,3 +1420,25 @@ def test_render_ledger_lines_rich_smoke_preserves_brackets(monkeypatch, capsys):
     assert "[? candidate" in out
     assert "Pending retirement proposal" in out
     assert "over cap: 8 active vs cap 7" in out
+
+
+def test_ledger_style_state_map():
+    # Header styling keys off the state token inside the literal bracket text;
+    # both the untagged ("[× retired") and tagged ("[ruling × retired")
+    # spellings of the ended states must dim — the bracket sits flush against
+    # the glyph in the untagged form.
+    style = render._ledger_style
+    assert style("[✗ active · ratified (interactive)] r-1  s") == "red"
+    assert style("[refutation ✗ active · x] r-1  s") == "red"
+    assert style("[§ active · ratified (interactive)] r-2  v") == "green"
+    assert style("[ruling § active · x] r-2  v") == "green"
+    assert style("[? candidate · agent-proposed] r-3  v") == "yellow"
+    assert style("[× retired · ratified (interactive)] r-4  v") == "dim"
+    assert style("[× overturned · x] r-5  s") == "dim"
+    assert style("[ruling × retired · x] r-4  v") == "dim"
+    assert style("[refutation × overturned · x] r-5  s") == "dim"
+    assert style("[unrecognized header] r-6  v") is None
+    assert style("  Pending revision proposal (agent): v2") == "yellow"
+    assert style("  (evidence sources are recorded as cited; ...)") == "dim"
+    assert style("over cap: 8 active vs cap 7") == "yellow"
+    assert style("  Governs: commit signing") is None


### PR DESCRIPTION
Refs #707

## What

First stage of #707: the ledger verb families (`ruling`, `refute`, `amend`) route their human-facing output through `render.py` like `brief` and `status` already do.

- new `render.render_ledger_lines(lines)`: plain path is the bare print loop these verbs always had (byte-identical); rich upgrades header lines by state (active ruling green, active refutation red, candidate yellow, retired dim) and dims the evidence boilerplate. `markup=False` is load-bearing: the state header is literal bracketed text rich would otherwise parse as a silently dropped style tag.
- `_print_ruling` / `_print_refutation` become line builders (`_ruling_lines` / `_refutation_lines`) that hand the exact same strings to the renderer; every caller is unchanged.
- informational lines around the records (the "Next: daimon ruling ratify" hint, "no rulings for this project", the over-cap warning, amendment confirmations) route through the same helper.
- refusal and error lines stay plain on purpose, the same contract `render_anchor_attach` documents; `--json` paths and the recall-inject machine surface are untouched; the ratify and revise ceremonies print the same text they always did.

Later stages cover the remaining plain human-facing surfaces (lifecycle verbs, handoff, log, verify-receipt, audit); this PR uses `Refs` so merging does not close the issue.

## Why

The CLI had two output registers: styled panels for briefings, bare stdout for the ledger. Rulings and refutations are among the most human-read surfaces daimon has.

## Tests

- TDD: `test_render_ledger_lines_plain_exact_format` and `test_render_ledger_lines_rich_smoke_preserves_brackets` written first (red), then the helper (green)
- full suite green
- plain-output byte parity proven against the installed 0.31.0 on a real ledger: `ruling list`, `ruling show`, `refute list` diffed byte-identical in `DAIMON_PLAIN` mode
- rich path driven end-to-end over the same ledger with color forced: state styling correct, bracketed headers survive
