### PR TITLE
feat(render): ledger record headers style their spans apart

### DIFF
--- a/plugin/daimon_briefing/cli/refute.py
+++ b/plugin/daimon_briefing/cli/refute.py
@@ -12,10 +12,11 @@ import daimon_briefing.cli as _cli
 from .. import refutations, render
 from ._ledger import (
     _print_refutation,
-    _print_ruling,
     _refutation_json,
+    _refutation_lines,
     _refuse_ruling_id,
     _refute_channel,
+    _ruling_lines,
 )
 
 
@@ -149,8 +150,7 @@ def _cmd_refute_list(args) -> int:
     elif not rows:
         render.render_ledger_lines(["no refutations for this project"])
     else:
-        for row in rows:
-            _print_refutation(row)
+        render.render_ledger_records([_refutation_lines(row) for row in rows])
     return 0
 
 
@@ -173,11 +173,12 @@ def _cmd_refute_search(args) -> int:
         # polarities, labelled by their own printers — filtering rulings out
         # would leave the records that matter most with no pull surface
         # mid-session, after the briefing has scrolled away.
-        for row in rows:
-            if row.get("polarity") == "ruling":
-                _print_ruling(row, tag=True)
-            else:
-                _print_refutation(row, tag=True)
+        render.render_ledger_records([
+            _ruling_lines(row, tag=True)
+            if row.get("polarity") == "ruling"
+            else _refutation_lines(row, tag=True)
+            for row in rows
+        ])
     return 0
 
 

--- a/plugin/daimon_briefing/cli/ruling.py
+++ b/plugin/daimon_briefing/cli/ruling.py
@@ -12,7 +12,12 @@ import sys
 import daimon_briefing.cli as _cli
 
 from .. import config, normalize, refutations, render
-from ._ledger import _print_ruling, _refutation_json, _refute_channel
+from ._ledger import (
+    _print_ruling,
+    _refutation_json,
+    _refute_channel,
+    _ruling_lines,
+)
 
 
 def _cmd_ruling_propose(args) -> int:
@@ -206,8 +211,7 @@ def _cmd_ruling_list(args) -> int:
     if not rows:
         render.render_ledger_lines(["no rulings for this project"])
         return 0
-    for row in rows:
-        _print_ruling(row)
+    render.render_ledger_records([_ruling_lines(row) for row in rows])
     # The cap binds ACTIVATION; a lowered DAIMON_RULING_CAP leaves the
     # excess active, so the over-cap state must be visible somewhere.
     active = sum(1 for r in rows if r.get("state") == "active")

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -1111,13 +1111,66 @@ def _ledger_style(ln: str) -> str | None:
         if re.match(r"\[(?:\w+ )?× ", ln):
             return "dim"
         return None
-    if ln.startswith("  Pending"):
+    if ln.startswith(("  Pending", "  Overturn proposed")):
         return "yellow"
     if ln.startswith("  (evidence sources"):
         return "dim"
     if ln.startswith("over cap:"):
         return "yellow"
     return None
+
+
+_LEDGER_HEADER_RE = re.compile(r"^(\[[^\]]*\]) (r-[0-9a-f]{12})  (.*)$")
+
+
+def _ledger_header_spans(ln: str):
+    """Split a record header into (state bracket, id, text) for span styling,
+    or None for any other line shape."""
+    m = _LEDGER_HEADER_RE.match(ln)
+    return m.groups() if m else None
+
+
+def _print_ledger_line(console, ln: str) -> None:
+    """One ledger line on the rich path. A record header gets three spans —
+    state bracket in the state's color (quiet metadata), the id bold cyan
+    (the handle a human copies), the verdict/subject in the default color
+    (prose reads as prose). A uniformly colored header buried all three
+    (#707 stage 1 feedback). Every other line keeps whole-line styling; the
+    recomposition prints exactly the plain line's characters."""
+    spans = _ledger_header_spans(ln)
+    if spans is None:
+        console.print(ln, style=_ledger_style(ln), markup=False)
+        return
+    from rich.text import Text
+
+    bracket, record_id, rest = spans
+    text = Text()
+    text.append(bracket, style=_ledger_style(bracket) or "dim")
+    text.append(" ")
+    text.append(record_id, style="bold cyan")
+    text.append("  ")
+    text.append(rest)
+    console.print(text)
+
+
+def render_ledger_records(records) -> None:
+    """A sequence of record cards (each a list of pre-formatted lines) —
+    `ruling list`, `refute list`, `refute search`. Plain path prints them
+    flat, byte-identical to the single-list form; rich separates records
+    with one blank line so wrapped verdicts don't read as a wall."""
+    if not supports_rich():
+        for lines in records:
+            for ln in lines:
+                print(ln)
+        return
+    from rich.console import Console
+
+    console = Console()
+    for i, lines in enumerate(records):
+        if i:
+            console.print("")
+        for ln in lines:
+            _print_ledger_line(console, ln)
 
 
 def render_ledger_lines(lines) -> None:
@@ -1136,7 +1189,7 @@ def render_ledger_lines(lines) -> None:
 
     console = Console()
     for ln in lines:
-        console.print(ln, style=_ledger_style(ln), markup=False)
+        _print_ledger_line(console, ln)
 
 
 # ---- stats: `daimon stats` (#68) --------------------------------------------

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -1442,3 +1442,58 @@ def test_ledger_style_state_map():
     assert style("  (evidence sources are recorded as cited; ...)") == "dim"
     assert style("over cap: 8 active vs cap 7") == "yellow"
     assert style("  Governs: commit signing") is None
+
+
+def test_ledger_header_spans_parses_the_record_header():
+    # Header format is "[<state bracket>] <id>  <text>"; the parser feeds the
+    # rich path its three spans. Non-header lines return None and fall back to
+    # whole-line styling.
+    spans = render._ledger_header_spans(
+        "[§ active · agent-written, ratified (interactive)] "
+        "r-00809234be96  Every commit is signed.")
+    assert spans == ("[§ active · agent-written, ratified (interactive)]",
+                     "r-00809234be96", "Every commit is signed.")
+    assert render._ledger_header_spans("  Governs: commit signing") is None
+    assert render._ledger_header_spans("no rulings for this project") is None
+
+
+def test_ledger_style_pending_overturn_note_is_yellow():
+    assert render._ledger_style(
+        "  Overturn proposed by agent — still active") == "yellow"
+
+
+def test_render_ledger_records_plain_is_flat(capsys):
+    render.render_ledger_records([
+        ["[§ active · x] r-1a2b3c4d5e6f  First."],
+        ["[? candidate · y] r-9f8e7d6c5b4a  Second."],
+    ])
+    out = capsys.readouterr().out
+    assert out == ("[§ active · x] r-1a2b3c4d5e6f  First.\n"
+                   "[? candidate · y] r-9f8e7d6c5b4a  Second.\n")
+
+
+def test_render_ledger_records_rich_separates_records(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_ledger_records([
+        ["[§ active · x] r-1a2b3c4d5e6f  First."],
+        ["[? candidate · y] r-9f8e7d6c5b4a  Second."],
+    ])
+    out = capsys.readouterr().out
+    assert "First." in out and "Second." in out
+    assert "[§ active" in out          # brackets survive markup
+    assert "\n\n" in out               # one blank line between records
+
+
+def test_render_ledger_lines_rich_header_spans_preserve_content(monkeypatch, capsys):
+    # Span styling recomposes the header from parts; every character of the
+    # plain line must survive the recomposition.
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_ledger_lines([
+        "[§ active · ratified (interactive)] r-00809234be96  Signed always.",
+        "  Governs: commit signing",
+    ])
+    out = capsys.readouterr().out
+    assert "[§ active · ratified (interactive)]" in out
+    assert "r-00809234be96" in out
+    assert "Signed always." in out
+    assert "Governs: commit signing" in out


### PR DESCRIPTION
Refs #707

## What

Readability pass on the ledger record cards the first #707 stage introduced. A uniformly colored header buried the three things a reader scans for; the rich path now styles them apart:

- the state bracket (`[§ active · …]`) renders in the state's color as quiet metadata
- the record id renders bold cyan, since it is the handle a human copies into the next command
- the verdict/subject text renders in the default terminal color, so prose reads as prose (a side effect of composing spans: rich's automatic token highlighter no longer recolors fragments inside verdict text)
- `ruling list`, `refute list`, and `refute search` separate records with one blank line on the rich path, so wrapped verdicts stop reading as a wall
- the refutation "Overturn proposed" note now gets the same yellow its ruling counterpart already had

Plain output is untouched on every surface: the span renderer recomposes exactly the plain line's characters, and record separation applies only on the rich path (the same license the briefing panels already take).

## Why

Field feedback on the merged first stage: five active rulings render as one solid green block; nothing distinguishes the id from the metadata from the rule text.

## Tests

- TDD: header-span parser, records-separation (plain flat + rich gap), span content preservation, and the style-map addition written red first
- full suite green
- plain `ruling list` output diffed byte-identical against the pre-change snapshot on a real ledger
- rich path driven with color forced over the same ledger: spans and record gaps render as designed
