### PR TITLE
feat(render): lifecycle and report verbs route through render.py

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -1053,7 +1053,7 @@ def _cmd_handoff(args) -> int:
             print("error: handoff not recorded (daimon disabled or project "
                   "unknown)", file=sys.stderr)
             return 1
-        print("handoff cleared")
+        render.render_lifecycle_lines(["handoff cleared"])
         return 0
     text = (args.text or "").strip()
     if not text:
@@ -1081,7 +1081,8 @@ def _cmd_handoff(args) -> int:
         print("error: handoff not recorded (daimon disabled or project "
               "unknown)", file=sys.stderr)
         return 1
-    print("handoff recorded — will lead the next briefing for this project.")
+    render.render_lifecycle_lines(
+        ["handoff recorded — will lead the next briefing for this project."])
     return 0
 
 
@@ -1095,7 +1096,7 @@ def _cmd_log(args) -> int:
     if not ok:
         print("event not written (daimon disabled or project unknown)")
         return 1
-    print(f"logged [{args.kind}] {args.text}")
+    render.render_lifecycle_lines([f"logged [{args.kind}] {args.text}"])
     return 0
 
 
@@ -1708,8 +1709,7 @@ def _cmd_verify_receipt(args) -> int:
             return 2
         session_id = checkpoint["session_id"]
     rc, lines = receipts.verify_receipt(str(session_id))
-    for line in lines:
-        print(line)
+    render.render_lifecycle_lines(lines)
     return rc
 
 

--- a/plugin/daimon_briefing/cli/audit.py
+++ b/plugin/daimon_briefing/cli/audit.py
@@ -102,7 +102,8 @@ def _cmd_audit_privacy(args) -> int:
     return code
 
 def _cmd_audit_quotes_deprecated(args) -> int:
-    print("note: 'daimon audit-quotes' is deprecated — use 'daimon audit quotes'")
+    render.render_lifecycle_lines(
+        ["note: 'daimon audit-quotes' is deprecated — use 'daimon audit quotes'"])
     return _cmd_audit_quotes(args)
 
 def _cmd_audit_quotes(args) -> int:
@@ -204,7 +205,7 @@ def _cmd_audit_quotes(args) -> int:
         lines.append(f"  top {min(top, len(failures))} failures (item text prefix):")
         for sid, text in failures[:top]:
             lines.append(f"    [{sid}] {text[:80]}")
-    print("\n".join(lines))
+    render.render_lifecycle_lines(lines)
     # #504: the only read-side verification verb recorded nothing, so there was
     # no evidence either way about whether anyone reaches for it. The unpaired
     # variant is a distinct event, not a detail of this one: a run that resolved

--- a/plugin/daimon_briefing/cli/lifecycle.py
+++ b/plugin/daimon_briefing/cli/lifecycle.py
@@ -18,6 +18,7 @@ from .. import (
     normalize,
     refutations,
     relations,
+    render,
     serializer,
     store,
 )
@@ -109,7 +110,8 @@ def _cmd_resolve(args) -> int:
         # exists to expose. Not silent either: the tag still shows up in
         # `daimon stats` usage counts, just apart from resolve/resolve:*.
         _cli._note_usage("resolve:dry-run")
-        print(f"would resolve {target['id']}: {target.get('text', '')} [{effective_status}]")
+        render.render_lifecycle_lines(
+            [f"would resolve {target['id']}: {target.get('text', '')} [{effective_status}]"])
         return 0
     ok = store.append_event(
         target["id"], effective_status,
@@ -121,11 +123,13 @@ def _cmd_resolve(args) -> int:
         return 1
     if by_agent:
         _cli._note_usage("resolve:agent")
-        print(f"claim recorded {target['id']}: {target.get('text', '')} "
-              "— pending verification at session end")
+        render.render_lifecycle_lines(
+            [f"claim recorded {target['id']}: {target.get('text', '')} "
+             "— pending verification at session end"])
         return 0
     _cli._note_usage("resolve")
-    print(f"resolved {target['id']}: {target.get('text', '')} [{args.status}]")
+    render.render_lifecycle_lines(
+        [f"resolved {target['id']}: {target.get('text', '')} [{args.status}]"])
     return 0
 
 def _cmd_forget(args) -> int:
@@ -358,22 +362,23 @@ def _cmd_forget(args) -> int:
             for row in amendments.events(project_dir=project)
             if value_key in amendments.row_content_keys(row)
             or str(row.get("item_id") or "") in spliced})
-        print(f"would forget {target['id']}: {target.get('text', '')}")
+        preview = [f"would forget {target['id']}: {target.get('text', '')}"]
         active_rulings = sorted(
             rid for rid in set(ref_reach) | {str(target["id"])}
             if ledger_meta.get(rid) == ("ruling", "active"))
         if active_rulings:
-            print("WARNING — this removes ACTIVE ruling(s): "
-                  + ", ".join(active_rulings))
+            preview.append("WARNING — this removes ACTIVE ruling(s): "
+                           + ", ".join(active_rulings))
         sibling_ids = sorted(spliced - {str(target["id"])})
         if sibling_ids:
-            print("also removed — checkpoint siblings holding the value: "
-                  + ", ".join(sibling_ids))
+            preview.append("also removed — checkpoint siblings holding the "
+                           "value: " + ", ".join(sibling_ids))
         also = [rid for rid in ref_reach + amend_reach
                 if rid and rid != target["id"]]
         if also:
-            print("also removed — ledger records reached by value or by "
-                  "doomed item id: " + ", ".join(also))
+            preview.append("also removed — ledger records reached by value "
+                           "or by doomed item id: " + ", ".join(also))
+        render.render_lifecycle_lines(preview)
         return 0
     # #402: key the tombstone on the CANONICAL value (normalize.content_key),
     # not the raw bytes — so a later re-extraction of the same claim (different
@@ -402,8 +407,9 @@ def _cmd_forget(args) -> int:
             return 1
         # Deleting what renders is strictly more power than rewriting it,
         # and rewriting confirms. A human can still say y (#421 unchanged).
-        print("WARNING — this removes ACTIVE ruling(s): "
-              + ", ".join(doomed_rulings))
+        render.render_lifecycle_lines(
+            ["WARNING — this removes ACTIVE ruling(s): "
+             + ", ".join(doomed_rulings)])
         answer = input("Remove? [y/N]: ").strip().casefold()
         if answer not in ("y", "yes"):
             print("not removed")
@@ -569,66 +575,76 @@ def _cmd_forget(args) -> int:
     if forgotten_amendments:
         surfaces.append(f"{len(forgotten_amendments)} amendment(s) "
                         f"({', '.join(forgotten_amendments)})")
-    print(f"forgot {target['id']} (content hash {content_hash}) — "
-          f"removed from {' and '.join(surfaces) or 'no store'}; "
-          "tombstone recorded")
+    report = [f"forgot {target['id']} (content hash {content_hash}) — "
+              f"removed from {' and '.join(surfaces) or 'no store'}; "
+              "tombstone recorded"]
     if team_scrubbed:
-        print(f"scrubbed {len(team_scrubbed)} own team-mirror cop(y/ies) — "
-              "run `daimon team sync` to publish; teammates' copies and "
-              "upstream git history remain until tombstone propagation")
+        report.append(
+            f"scrubbed {len(team_scrubbed)} own team-mirror cop(y/ies) — "
+            "run `daimon team sync` to publish; teammates' copies and "
+            "upstream git history remain until tombstone propagation")
     if events_scrubbed:
-        print(f"redacted {events_scrubbed} event-ledger field(s) "
-              "carrying the value (rows kept, field replaced)")
+        report.append(f"redacted {events_scrubbed} event-ledger field(s) "
+                      "carrying the value (rows kept, field replaced)")
     if purge_err is not None:
-        print(f"warning: chunk cache purge failed: {purge_err} — "
-              "cached pre-redaction chunks may persist up to "
-              f"{config.chunk_cache_days()} day(s) (age reaper)")
+        report.append(f"warning: chunk cache purge failed: {purge_err} — "
+                      "cached pre-redaction chunks may persist up to "
+                      f"{config.chunk_cache_days()} day(s) (age reaper)")
     else:
-        print(f"purged {purged} cached chunk extraction(s) "
-              "(pre-redaction serializer cache)")
+        report.append(f"purged {purged} cached chunk extraction(s) "
+                      "(pre-redaction serializer cache)")
     if ws_err is not None:
-        print(f"warning: windsurf transcript purge failed: {ws_err} — "
-              "daimon-authored conversation text may persist up to "
-              f"{config.windsurf_state_days()} day(s) (age reaper)")
+        report.append(
+            f"warning: windsurf transcript purge failed: {ws_err} — "
+            "daimon-authored conversation text may persist up to "
+            f"{config.windsurf_state_days()} day(s) (age reaper)")
     else:
-        # Always printed, like the chunk-cache line: a silent zero is how a
+        # Always reported, like the chunk-cache line: a silent zero is how a
         # misconfigured store (writer and deleter disagreeing about the
         # directory) stays invisible. The scope note is not decoration —
         # the store is keyed by trajectory and carries no project
         # attribution, so this purge is machine-wide by construction.
-        print(f"purged {ws_purged} daimon-authored windsurf transcript "
-              "file(s) across all projects (machine-wide: the store is keyed "
-              "by trajectory, not project); host-authored transcripts are "
-              "untouched")
+        report.append(
+            f"purged {ws_purged} daimon-authored windsurf transcript "
+            "file(s) across all projects (machine-wide: the store is keyed "
+            "by trajectory, not project); host-authored transcripts are "
+            "untouched")
     if crash_err is not None:
-        print(f"warning: crash log purge failed: {crash_err} — serializer "
-              "tracebacks may persist (bounded to a trimmed tail at the next "
-              "spawn, never removed)")
+        report.append(
+            f"warning: crash log purge failed: {crash_err} — serializer "
+            "tracebacks may persist (bounded to a trimmed tail at the next "
+            "spawn, never removed)")
     else:
-        # Printed even at zero, like the two lines above: a silent zero is
+        # Reported even at zero, like the two lines above: a silent zero is
         # how a writer and a deleter disagreeing about DAIMON_LOG_DIR stays
         # invisible. One crash log per machine, so the scope note is the
         # same honesty the windsurf line owes.
-        print(f"purged {crash_purged} serializer crash log(s) across all "
-              "projects (machine-wide: the log is raw child stderr, not "
-              "keyed by project)")
+        report.append(
+            f"purged {crash_purged} serializer crash log(s) across all "
+            "projects (machine-wide: the log is raw child stderr, not "
+            "keyed by project)")
     if backend_err is not None:
-        print(f"warning: backend log purge failed: {backend_err} — backend "
-              "echo of transcript text may persist (byte-bounded at the "
-              "write seam, never removed)")
+        report.append(
+            f"warning: backend log purge failed: {backend_err} — backend "
+            "echo of transcript text may persist (byte-bounded at the "
+            "write seam, never removed)")
     else:
         # Same silent-zero rule as the three lines above.
-        print(f"purged {backend_purged} backend stderr log(s) across all "
-              "projects (machine-wide: backend diagnostics are not keyed "
-              "by project)")
+        report.append(
+            f"purged {backend_purged} backend stderr log(s) across all "
+            "projects (machine-wide: backend diagnostics are not keyed "
+            "by project)")
     if scrub_err is not None:
-        print(f"warning: serialize.log scrub failed: {scrub_err} — legacy "
-              "downgrade lines may still carry item text")
+        report.append(
+            f"warning: serialize.log scrub failed: {scrub_err} — legacy "
+            "downgrade lines may still carry item text")
     else:
-        # Printed even at zero, same rule again: a scrubber resolving a
+        # Reported even at zero, same rule again: a scrubber resolving a
         # different log dir than the writer must not read as "nothing left".
-        print(f"scrubbed {scrubbed_lines} legacy downgrade line(s) in "
-              "serialize.log (payload replaced; ledger lines kept)")
+        report.append(
+            f"scrubbed {scrubbed_lines} legacy downgrade line(s) in "
+            "serialize.log (payload replaced; ledger lines kept)")
+    render.render_lifecycle_lines(report)
     return 0
 
 def _is_supersede_candidate(item_id: str, project) -> bool:
@@ -706,7 +722,8 @@ def _cmd_reverify(args) -> int:
     # structurally zero, and a zero that measures missing instrumentation
     # cannot be compared against a UI channel's count later.
     _cli._note_usage("reverify")
-    print(f"reopened {item['id']}: {item.get('text', '')}")
+    render.render_lifecycle_lines(
+        [f"reopened {item['id']}: {item.get('text', '')}"])
     return 0
 
 def _cmd_loops(args) -> int:
@@ -767,10 +784,11 @@ def _cmd_loops(args) -> int:
                     text += f" (amended ×{n})"
             rows.append((item["id"], key, text, briefing._mark(item)))
     if not rows:
-        print("no open loops")
+        render.render_lifecycle_lines(["no open loops"])
         return 0
-    for item_id, key, text, mark in rows:
-        print(f"  {item_id}  [{key}] [{mark}] {text}")
+    render.render_lifecycle_lines(
+        [f"  {item_id}  [{key}] [{mark}] {text}"
+         for item_id, key, text, mark in rows])
     return 0
 
 

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -1153,6 +1153,39 @@ def _print_ledger_line(console, ln: str) -> None:
     console.print(text)
 
 
+def _lifecycle_style(ln: str) -> str | None:
+    """Per-line style for the lifecycle/report surfaces. The forget report
+    interleaves successes with per-store degradations; the two failure
+    registers stay visually distinct — a lowercase `warning:` is a degraded
+    cleanup (yellow, the register _render_lines already uses), an uppercase
+    `WARNING` discloses removal of an ACTIVE ruling (red, the same weight the
+    active-refutation header carries)."""
+    if ln.startswith("WARNING"):
+        return "red"
+    if ln.startswith(("warning:", "⚠")):
+        return "yellow"
+    return None
+
+
+def render_lifecycle_lines(lines) -> None:
+    """Human-facing result lines of the item-lifecycle and report verbs
+    (#707 stage 2): resolve, forget (dry-run preview and success report),
+    reverify, loops, handoff, log, verify-receipt, and the quote audit.
+    Plain path is the bare print loop these commands always had
+    (byte-identical); rich styles the two warning registers. `markup=False`
+    is load-bearing — loops rows carry literal [key] [mark] brackets.
+    Refusals and error lines stay plain, the render_anchor_attach contract."""
+    if not supports_rich():
+        for ln in lines:
+            print(ln)
+        return
+    from rich.console import Console
+
+    console = Console()
+    for ln in lines:
+        console.print(ln, style=_lifecycle_style(ln), markup=False)
+
+
 def render_ledger_records(records) -> None:
     """A sequence of record cards (each a list of pre-formatted lines) —
     `ruling list`, `refute list`, `refute search`. Plain path prints them

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -1497,3 +1497,44 @@ def test_render_ledger_lines_rich_header_spans_preserve_content(monkeypatch, cap
     assert "r-00809234be96" in out
     assert "Signed always." in out
     assert "Governs: commit signing" in out
+
+
+# ---- lifecycle/report surfaces (#707 stage 2) ---------------------------------
+
+
+def test_render_lifecycle_lines_plain_exact_format(capsys):
+    render.render_lifecycle_lines([
+        "  o-3f8a2c1b9d7e  [open_questions] [?] does the reaper fire",
+        "forgot o-3f8a2c1b9d7e (content hash k-12) — removed from checkpoint; "
+        "tombstone recorded",
+        "warning: chunk cache purge failed: boom — cached chunks may persist",
+    ])
+    out = capsys.readouterr().out
+    assert out == (
+        "  o-3f8a2c1b9d7e  [open_questions] [?] does the reaper fire\n"
+        "forgot o-3f8a2c1b9d7e (content hash k-12) — removed from checkpoint; "
+        "tombstone recorded\n"
+        "warning: chunk cache purge failed: boom — cached chunks may persist\n"
+    )
+
+
+def test_render_lifecycle_lines_rich_smoke_preserves_brackets(monkeypatch, capsys):
+    # loops rows carry literal [key] [mark] brackets; rich markup parsing
+    # would silently eat them — same guard as the recall and ledger lines.
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_lifecycle_lines([
+        "  o-3f8a2c1b9d7e  [open_questions] [?] does the reaper fire",
+        "WARNING — this removes ACTIVE ruling(s): r-1a2b3c4d5e6f",
+    ])
+    out = capsys.readouterr().out
+    assert "[open_questions]" in out
+    assert "[?]" in out
+    assert "WARNING — this removes ACTIVE" in out
+
+
+def test_lifecycle_style_map():
+    style = render._lifecycle_style
+    assert style("WARNING — this removes ACTIVE ruling(s): r-1") == "red"
+    assert style("warning: purge failed: boom") == "yellow"
+    assert style("forgot o-1 (content hash k) — removed") is None
+    assert style("  o-1  [open_questions] [?] text") is None


### PR DESCRIPTION
Closes #707

## What

Final stage of #707: the item-lifecycle and report verbs route their human-facing output through `render.py`, closing the two-output-registers gap the issue named.

- new `render.render_lifecycle_lines(lines)`: plain path is the bare print loop these commands always had (byte-identical); rich styles the two warning registers apart: lowercase `warning:` (a degraded cleanup) renders yellow, uppercase `WARNING` (removal of an ACTIVE ruling) renders red. `markup=False` guards the literal `[key] [mark]` brackets loops rows carry.
- migrated surfaces: `resolve` (dry-run, agent claim, resolved), `forget` (dry-run preview, the active-ruling disclosure before the confirm prompt, and the full success report), `reverify`, `loops`, `handoff`, `log`, `verify-receipt`, and `audit quotes` (report and the deprecation note).
- refusals, error lines, stderr warnings, and prompts stay plain, the same contract the first stage kept.

With this, every human-facing informational surface renders through `render.py`. Deliberately still plain: refusal/error paths (contract), `recall-inject` (machine-consumed by the prompt hook), and `skill show` (a raw content dump another tool ingests).

## Why

#707: the CLI had styled output for briefings and bare stdout for everything else. The ledger families landed in the earlier stages; this covers the rest.

## Tests

- TDD: `render_lifecycle_lines` plain exact-format, rich bracket-preservation smoke, and the warning-register style map written red first
- full suite green
- plain output diffed byte-identical against the installed build on a real project for `loops` and `verify-receipt`; `audit quotes` produces the same lines through the new path (per-line prints equal the old single joined print)
