### PR TITLE
feat(store): cross-project requests object — PR 1 of #694

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -916,6 +916,14 @@ from .amend import (  # noqa: E402
     _cmd_amend_propose,  # noqa: F401 — re-exported for compat
     _cmd_amend_verdict,  # noqa: F401 — re-exported for compat
 )
+from .request import (  # noqa: E402
+    _cmd_request_done,  # noqa: F401 — re-exported for compat
+    _cmd_request_list,  # noqa: F401 — re-exported for compat
+    _cmd_request_open,  # noqa: F401 — re-exported for compat
+    _cmd_request_revise,  # noqa: F401 — re-exported for compat
+    _cmd_request_verdict,  # noqa: F401 — re-exported for compat
+    _request_channel,  # noqa: F401 — re-exported for compat
+)
 from .lifecycle import (  # noqa: E402
     _cmd_forget,  # noqa: F401 — re-exported for compat
     _cmd_loops,  # noqa: F401 — re-exported for compat
@@ -955,6 +963,7 @@ from . import (  # noqa: E402
     hooks,
     lifecycle,
     refute,
+    request,
     ruling,
     skill,
     team,
@@ -2928,6 +2937,8 @@ def build_parser() -> argparse.ArgumentParser:
     ruling.register(sub, fmt)
 
     amend.register(sub, fmt)
+
+    request.register(sub, fmt)
 
     p_relations = sub.add_parser(
         "relations",

--- a/plugin/daimon_briefing/cli/lifecycle.py
+++ b/plugin/daimon_briefing/cli/lifecycle.py
@@ -19,6 +19,7 @@ from .. import (
     refutations,
     relations,
     render,
+    requests,
     serializer,
     store,
 )
@@ -208,7 +209,26 @@ def _cmd_forget(args) -> int:
                              "_target": amend_targets.get(a_id, "")})
         for a_id, texts in amend_texts.items()
     ]
-    if not isinstance(checkpoint, dict) and not ledger and not amend_pool:
+    # #694: the request ledger is the fifth plaintext store — an ask, its
+    # rationale, a verdict note, a completion quote. Same every-row posture
+    # as the two pools above (a revision rewrites `ask`, so the forgotten
+    # wording can sit in a row nothing renders), and the field walk is again
+    # the module's OWN declaration. No `_target`: a request names a PROJECT,
+    # never a checkpoint item, so there is no orbiting-hit class to drop.
+    request_texts: dict[str, list[str]] = {}
+    for row in requests.events(project_dir=project):
+        # events() admits only rows whose request_id matched the id shape.
+        q_id = str(row["request_id"])
+        for value in requests.plaintext_values(row):
+            request_texts.setdefault(q_id, [])
+            if value not in request_texts[q_id]:
+                request_texts[q_id].append(value)
+    request_pool = [
+        (None, "request", {"id": q_id, "text": texts[0], "_texts": texts})
+        for q_id, texts in request_texts.items()
+    ]
+    if (not isinstance(checkpoint, dict) and not ledger and not amend_pool
+            and not request_pool):
         print("no checkpoint for this project yet — nothing to forget")
         return 1
     # Every surface this project holds, not just the live checkpoint (#419
@@ -226,7 +246,7 @@ def _cmd_forget(args) -> int:
     # `r-<12 hex>`, so an exact-id lookup can legitimately hit both surfaces.
     # forget's never-guess contract decides it: an ambiguous id is refused, not
     # resolved by preferring a store.
-    candidates = items + ledger + amend_pool
+    candidates = items + ledger + amend_pool + request_pool
     exact = [it for _, _, it in candidates if it["id"] == args.target]
     target = exact[0] if len(exact) == 1 else None
     if target is None:
@@ -250,7 +270,7 @@ def _cmd_forget(args) -> int:
         # meaning what carry.py says it means: terms shared by >= k ITEMS.
         pools = [(pool, carry._generic_terms(
             [" ".join(_texts_of(it)) for _, _, it in pool]))
-            for pool in (items, ledger, amend_pool)]
+            for pool in (items, ledger, amend_pool, request_pool)]
         query_key = normalize.content_key(args.target)
 
         def _matched_value(it, generic):
@@ -287,7 +307,7 @@ def _cmd_forget(args) -> int:
         # are dropped: forgetting the item removes its amendments anyway
         # (forget_item_id below), so nothing becomes unreachable.
         item_hit_ids = {it["id"] for _, k, it, _ in hits
-                        if k not in ("refutation", "amendment")}
+                        if k not in ("refutation", "amendment", "request")}
         if item_hit_ids:
             hits = [(s, k, it, m) for s, k, it, m in hits
                     if not (k == "amendment"
@@ -362,6 +382,10 @@ def _cmd_forget(args) -> int:
             for row in amendments.events(project_dir=project)
             if value_key in amendments.row_content_keys(row)
             or str(row.get("item_id") or "") in spliced})
+        request_reach = sorted({
+            str(row.get("request_id") or "")
+            for row in requests.events(project_dir=project)
+            if value_key in requests.row_content_keys(row)})
         preview = [f"would forget {target['id']}: {target.get('text', '')}"]
         active_rulings = sorted(
             rid for rid in set(ref_reach) | {str(target["id"])}
@@ -373,7 +397,7 @@ def _cmd_forget(args) -> int:
         if sibling_ids:
             preview.append("also removed — checkpoint siblings holding the "
                            "value: " + ", ".join(sibling_ids))
-        also = [rid for rid in ref_reach + amend_reach
+        also = [rid for rid in ref_reach + amend_reach + request_reach
                 if rid and rid != target["id"]]
         if also:
             preview.append("also removed — ledger records reached by value "
@@ -511,6 +535,14 @@ def _cmd_forget(args) -> int:
         forgotten_amendment_set.update(
             amendments.forget_item_id(doomed_id, project_dir=project))
     forgotten_amendments = sorted(forgotten_amendment_set)
+    # #694: the fifth plaintext store, and the only one whose prose was
+    # written FOR another project. Value-keyed only — a request names a
+    # project, never a checkpoint item, so there is no target-id sweep to
+    # pair with this one. Nothing enforces this dispatch; the surface
+    # registry declares the deleter but cannot call it, which is why the
+    # deletion contract for a new ledger is a hand-wired line here.
+    forgotten_requests = requests.forget_content_key(content_hash,
+                                                     project_dir=project)
     # #422: the serializer chunk cache holds PRE-redaction extraction output
     # (quote verification forbids redacting before caching, #125), keyed by
     # chunk text — the forgotten value cannot be located selectively, so the
@@ -575,6 +607,9 @@ def _cmd_forget(args) -> int:
     if forgotten_amendments:
         surfaces.append(f"{len(forgotten_amendments)} amendment(s) "
                         f"({', '.join(forgotten_amendments)})")
+    if forgotten_requests:
+        surfaces.append(f"{len(forgotten_requests)} request(s) "
+                        f"({', '.join(forgotten_requests)})")
     report = [f"forgot {target['id']} (content hash {content_hash}) — "
               f"removed from {' and '.join(surfaces) or 'no store'}; "
               "tombstone recorded"]

--- a/plugin/daimon_briefing/cli/request.py
+++ b/plugin/daimon_briefing/cli/request.py
@@ -1,0 +1,331 @@
+"""`daimon request` verbs — one project's ask of another (#694, PR 1).
+
+The object and its verbs. The inbox (`request inbox`, the briefing panel,
+the surfaced stamps) is PR 2, so what this family gives today is the
+pull-only view: open an ask, revise it, list what this bucket holds, and
+land the human verdicts.
+
+Shared helpers that live in the package `__init__` are reached through the
+module object (`_cli.<name>`) so the `cli.<name>` seam tests and hosts patch
+keeps working, the same contract the amend/ruling families follow.
+"""
+
+import argparse
+import difflib
+import functools
+import json
+import sys
+
+import daimon_briefing.cli as _cli
+
+from .. import render, requests, store
+
+# Verdicts land under their own verb names; the ledger's event vocabulary
+# spells one of them with an underscore.
+_VERDICT_CALLS = {
+    "accept": "accept",
+    "reject": "reject",
+    "needs-info": "needs_info",
+    "suppress": "suppress",
+}
+_MARKS = {"open": "→", "needs-info": "?", "accepted": "✓",
+          "rejected": "×", "done": "✔"}
+# Near-match budget for an unknown `--to`: enough to catch a typo, few
+# enough that the refusal stays a refusal rather than a project directory.
+_SUGGESTIONS = 3
+
+
+def _request_channel(args) -> str:
+    """The channel this invocation actually arrived through — the
+    `_refute_channel` contract restated for the request ledger (same
+    doctrine, its own error type so refusals stay per-surface)."""
+    if getattr(args, "by", None) == "agent":
+        return "cli-agent"
+    if not sys.stdin.isatty():
+        raise requests.RequestError(
+            "this is the human path and there is no interactive terminal; "
+            "pass --by agent to record it as an agent, or run it from a "
+            "terminal")
+    return "cli-tty"
+
+
+def _state_label(record: dict) -> str:
+    """#694 D8: an agent's completion claim is never rendered as fact. The
+    session-end byte-check (PR 3) is what drops the qualifier."""
+    if record.get("state") == "done" and record.get("done_claimed"):
+        return "done (claimed, unverified)"
+    return str(record.get("state") or "open")
+
+
+def _request_lines(record: dict) -> list:
+    """One request as a record card. The header follows the #711 three-span
+    shape (state bracket, id, prose); the body carries the two-party facts a
+    one-liner would drop — who it is addressed to, why, and whether the
+    sender is blocked on it."""
+    state = str(record.get("state") or "open")
+    who = record.get("verdict_label") or f"{record.get('opened_by', '?')}-asked"
+    lines = [f"[{_MARKS.get(state, '?')} {_state_label(record)} · {who}] "
+             f"{record['request_id']}  {record.get('ask', '')}"]
+    to = record.get("to", "")
+    lines.append(f"  To: {to}" + (" (for a human)" if record.get("to_human")
+                                  else ""))
+    if record.get("from_label"):
+        lines.append(f"  From: {record['from_label']}")
+    lines.append(f"  Why: {record.get('why', '')}")
+    if record.get("evidence"):
+        lines.append(f"  Evidence: {record['evidence']}")
+    if record.get("supersedes"):
+        lines.append(f"  Supersedes: {record['supersedes']}")
+    if record.get("blocking"):
+        lines.append("  Blocking: the sender is waiting on this")
+    if record.get("suppressed"):
+        # D5: say what suppression did and did not take away, on the surface
+        # that proves it — the record is right here.
+        lines.append("  Suppressed from the briefing panel; still listed "
+                     "here, and any verdict reverses it")
+    if record.get("note"):
+        lines.append(f"  Note: {record['note']}")
+    if record.get("done_evidence"):
+        lines.append(f"  Done: {record['done_evidence']}")
+    if record.get("revision"):
+        lines.append(f"  Revisions: {record['revision']} of "
+                     f"{requests.MAX_REVISIONS}")
+    return lines
+
+
+def _resolve_to(raw) -> str:
+    """The recipient slug, from either spelling the user can type.
+
+    `store.project_slug` munges every non-word char to '-', so a REAL slug
+    always begins with one — and argparse reads a leading dash as an option,
+    which makes `--to <slug>` unusable for exactly the values that exist
+    (`--to=<slug>` still works, and the help says so). Accepting the project
+    DIRECTORY is the spelling that survives a bare space: the transform is
+    idempotent, so a slug passed here comes back unchanged and a path comes
+    back as its slug.
+    """
+    return store.project_slug(str(raw or "").strip()) or ""
+
+
+def _cmd_request_open(args) -> int:
+    project = _cli._resolve_project(args.project)
+    to = _resolve_to(args.to)
+    known = {b["slug"] for b in store.list_buckets()}
+    if to not in known and not args.anyway:
+        # D4: an unknown slug is not a typo the ledger can absorb silently —
+        # such a record renders "never surfaced" forever and never decays,
+        # so the refusal names the shape before the write, not after.
+        _cli._note_usage("request:open:unknown-to")
+        print(f"no daimon bucket named {to!r} — that project has never "
+              "serialized a session on this machine")
+        near = difflib.get_close_matches(to, sorted(known), n=_SUGGESTIONS)
+        if near:
+            print(f"  did you mean: {', '.join(near)}")
+        print("  or re-run with --anyway to record the ask regardless")
+        return 1
+    try:
+        q_id = requests.open_request(
+            to=to, ask=args.ask, why=args.why, channel=_request_channel(args),
+            blocking=bool(args.blocking), to_human=bool(args.to_human),
+            evidence=args.evidence or "", supersedes=args.supersedes or "",
+            project_dir=project)
+    except requests.RequestError as exc:
+        _cli._note_usage("request:open:refused")
+        print(f"request not recorded: {exc}")
+        return 1
+    _cli._note_usage("request:open:agent"
+                     if getattr(args, "by", None) == "agent"
+                     else "request:open")
+    if to not in known:
+        render.render_ledger_lines(
+            [f"warning: {to} has no bucket on this machine, so this ask is "
+             "never surfaced there and never decays; it stays in "
+             "`daimon request list` until that project serializes a session"])
+    record = requests.get(q_id, project_dir=project)
+    render.render_ledger_lines(_request_lines(record) if record else
+                               [f"request {q_id} recorded"])
+    return 0
+
+
+def _cmd_request_revise(args) -> int:
+    project = _cli._resolve_project(args.project)
+    try:
+        requests.revise(args.request_id, channel=_request_channel(args),
+                        ask=args.ask, why=args.why, evidence=args.evidence,
+                        project_dir=project)
+    except requests.RequestError as exc:
+        _cli._note_usage("request:revise:refused")
+        print(f"request not revised: {exc}")
+        return 1
+    _cli._note_usage("request:revise")
+    record = requests.get(args.request_id, project_dir=project)
+    render.render_ledger_lines(_request_lines(record))
+    return 0
+
+
+def _cmd_request_verdict(args) -> int:
+    project = _cli._resolve_project(args.project)
+    verb = args.request_cmd
+    try:
+        channel = _request_channel(args)
+        getattr(requests, _VERDICT_CALLS[verb])(
+            args.request_id, channel=channel, note=args.note or "",
+            project_dir=project)
+    except requests.RequestError as exc:
+        _cli._note_usage(f"request:{verb}:refused")
+        print(f"request {verb} refused: {exc}")
+        return 1
+    _cli._note_usage(f"request:{verb}")
+    _report(args.request_id, project, verb)
+    return 0
+
+
+def _report(request_id: str, project, verb: str) -> None:
+    """Print the answered record, or say plainly that this bucket cannot see
+    it. A recipient's answer to a foreign ask is written here and pairs with
+    its origin only at the read-time join (PR 2) — until then the row is real
+    and the record is not, and printing an empty card would hide that."""
+    record = requests.get(request_id, project_dir=project)
+    if record is None:
+        render.render_ledger_lines(
+            [f"{request_id}: {verb} recorded in this project's ledger",
+             "  no matching request in this bucket — an answer to another "
+             "project's ask joins its origin at read time, and until then "
+             "it renders nowhere"])
+        return
+    render.render_ledger_lines(_request_lines(record))
+
+
+def _cmd_request_done(args) -> int:
+    project = _cli._resolve_project(args.project)
+    try:
+        requests.done(args.request_id, channel=_request_channel(args),
+                      evidence=args.evidence, project_dir=project)
+    except requests.RequestError as exc:
+        _cli._note_usage("request:done:refused")
+        print(f"request done refused: {exc}")
+        return 1
+    _cli._note_usage("request:done")
+    _report(args.request_id, project, "done")
+    return 0
+
+
+def _cmd_request_list(args) -> int:
+    project = _cli._resolve_project(args.project)
+    rows = requests.listing(project_dir=project)
+    _cli._note_usage("request:list")
+    if args.json:
+        print(json.dumps(rows, ensure_ascii=False, indent=2))
+        return 0
+    if not rows:
+        render.render_ledger_lines(["no requests for this project"])
+        return 0
+    render.render_ledger_records([_request_lines(row) for row in rows])
+    return 0
+
+
+def register(sub, fmt) -> None:
+    """Register the `request` parser family on the top-level subparsers."""
+    p_request = sub.add_parser(
+        "request",
+        help="ask another project for something, and answer what it asks "
+             "(#694)",
+        epilog="Examples:\n"
+               "  daimon request open --to ~/code/api "
+               "--ask 'publish the 0.32 schema' "
+               "--why 'the client cannot ship without it' --by agent\n"
+               "  daimon request list\n"
+               "  daimon request accept q-1a2b3c4d5e6f\n",
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    request_sub = p_request.add_subparsers(dest="request_cmd", required=True)
+    request_sub.add_parser = functools.partial(
+        request_sub.add_parser, formatter_class=fmt)
+
+    def _common(parser):
+        parser.add_argument(
+            "--project",
+            help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+
+    rq_open = request_sub.add_parser(
+        "open", help="open a request addressed to another project's slug")
+    rq_open.add_argument(
+        "--to", required=True, metavar="PROJECT",
+        help="recipient project directory, or its slug written as "
+             "--to=<slug> (a slug starts with '-', which a bare --to would "
+             "read as an option); `daimon projects` lists both")
+    rq_open.add_argument("--ask", required=True,
+                         help="what you are asking that project to do")
+    rq_open.add_argument("--why", required=True,
+                         help="why it matters; the recipient reads this first")
+    rq_open.add_argument(
+        "--to-human", action="store_true",
+        help="the ask is for that project's human, not its agent")
+    rq_open.add_argument(
+        "--blocking", action="store_true",
+        help="mark the sender as blocked on it; a flag on the record, never "
+             "a claim on the recipient's time")
+    rq_open.add_argument(
+        "--evidence",
+        help="optional source backing the ask; recorded, never resolved")
+    rq_open.add_argument(
+        "--supersedes", metavar="REQUEST_ID",
+        help="the earlier q-… this ask replaces; the lineage renders always")
+    rq_open.add_argument(
+        "--anyway", action="store_true",
+        help="record the ask even when the recipient slug has no bucket yet; "
+             "it is never surfaced there until that project serializes")
+    rq_open.add_argument("--by", choices=["agent"], default=None,
+                         help="declare yourself an agent; omit it only from "
+                              "an interactive terminal, which is the human path")
+    _common(rq_open)
+    rq_open.set_defaults(func=_cli._cmd_request_open)
+
+    rq_revise = request_sub.add_parser(
+        "revise", help="answer a needs-info or sharpen an open ask; capped "
+                       f"at {requests.MAX_REVISIONS} revisions per record")
+    rq_revise.add_argument("request_id", help="exact q-… id")
+    rq_revise.add_argument("--ask", help="replacement ask")
+    rq_revise.add_argument("--why", help="replacement rationale")
+    rq_revise.add_argument("--evidence", help="replacement source")
+    rq_revise.add_argument("--by", choices=["agent"], default=None,
+                           help="declare yourself an agent; omit it only from "
+                                "an interactive terminal")
+    _common(rq_revise)
+    rq_revise.set_defaults(func=_cli._cmd_request_revise)
+
+    for verb, blurb in (
+            ("accept", "accept an addressed request, as a human decision"),
+            ("reject", "reject it with a reason; rejection is final for that "
+                       "record, and the sender can open a new one citing it"),
+            ("needs-info", "ask the sender for more before deciding"),
+            ("suppress", "drop it out of the briefing panel; it stays in "
+                         "`request list`, and any later verdict reverses it")):
+        parser = request_sub.add_parser(verb, help=blurb)
+        parser.add_argument("request_id", help="exact q-… id")
+        parser.add_argument("--note", help="kept on the record")
+        parser.add_argument(
+            "--by", choices=["agent"], default=None,
+            help="declare yourself an agent; the call then refuses, because "
+                 "this verb requires a human channel")
+        _common(parser)
+        parser.set_defaults(func=_cli._cmd_request_verdict)
+
+    rq_done = request_sub.add_parser(
+        "done", help="report the ask as satisfied; an agent claim renders as "
+                     "claimed-and-unverified until the byte-check")
+    rq_done.add_argument("request_id", help="exact q-… id")
+    rq_done.add_argument("--evidence", required=True,
+                         help="what settles it; a verbatim quote from an "
+                              "agent is byte-checked at session end")
+    rq_done.add_argument("--by", choices=["agent"], default=None,
+                         help="declare yourself an agent; omit it only from "
+                              "an interactive terminal")
+    _common(rq_done)
+    rq_done.set_defaults(func=_cli._cmd_request_done)
+
+    rq_list = request_sub.add_parser(
+        "list", help="list this project's requests, undecided first")
+    rq_list.add_argument("--json", action="store_true",
+                         help="machine-readable output")
+    _common(rq_list)
+    rq_list.set_defaults(func=_cli._cmd_request_list)

--- a/plugin/daimon_briefing/privacy.py
+++ b/plugin/daimon_briefing/privacy.py
@@ -18,8 +18,8 @@ import sqlite3
 import time
 from pathlib import Path
 
-from . import (amendments, config, normalize, refutations, relations, store, surfaces,
-               teamproject)
+from . import (amendments, config, normalize, refutations, relations, requests,
+               store, surfaces, teamproject)
 
 # Plaintext-bearing item fields — the same CLASS policy.redact_checkpoint
 # enumerates (its links[].target and active_topic coverage lives in _hashes
@@ -44,6 +44,7 @@ _EVENTS_NAME = "events.jsonl"
 _REFUTATIONS_NAME = "refutations.jsonl"
 _RELATIONS_NAME = "relations.jsonl"
 _AMENDMENTS_NAME = "amendments.jsonl"
+_REQUESTS_NAME = "requests.jsonl"
 
 # Files that live in the checkpoint store and hold NO item plaintext BY
 # CONSTRUCTION. Since #601 both sets are VIEWS of the declared surface
@@ -115,7 +116,8 @@ def _checkpoint_candidates() -> tuple[list[Path], list[tuple[Path, str | None]]]
                     elif p.suffix == ".json":
                         known.append(p)
                     elif p.name not in (_EVENTS_NAME, _REFUTATIONS_NAME,
-                                        _RELATIONS_NAME, _AMENDMENTS_NAME) \
+                                        _RELATIONS_NAME, _AMENDMENTS_NAME,
+                                        _REQUESTS_NAME) \
                             and not _is_plaintext_free(p):
                         unknown.append((p, entry.name))
         except OSError:
@@ -324,6 +326,7 @@ def audit_project(project_dir=None) -> dict:
         result["relations"] = {"records": 0, "rows": 0, "bytes": 0,
                                "by_state": {}}
         result["amendments"] = {"records": 0, "rows": 0, "bytes": 0}
+        result["requests"] = {"records": 0, "rows": 0, "bytes": 0}
         return result
     known, unknown = _checkpoint_candidates()
     # Only this project's blind spots: an unknown file in ANOTHER bucket is
@@ -549,6 +552,48 @@ def audit_project(project_dir=None) -> dict:
     result["amendments"] = {"records": len(amend_records),
                             "rows": amend_rows,
                             "bytes": amend_bytes}
+    # Request ledger (#694): the fifth bucket ledger, declared at birth like
+    # relations and amendments so it can never repeat #645's
+    # unknown->unscannable->exit-3 arc. One residue check, not two: unlike
+    # amendments, no field here names a checkpoint item — a request is
+    # addressed to a PROJECT and carries only its own prose — so the
+    # tombstone comparison the amendment block makes against `item_id` has
+    # no counterpart, and inventing one would report a class of residue that
+    # cannot exist. The hash intersection runs over requests' own plaintext
+    # declaration, so a value the audit reports is a value forget can reach.
+    req_path = config.checkpoint_dir() / slug / _REQUESTS_NAME
+    try:
+        lines = req_path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        lines = []                  # no request recorded yet
+    except (OSError, ValueError):
+        lines = []
+        result["unscannable"].append(str(req_path))
+    req_records: set[str] = set()
+    req_rows = 0
+    for line in lines:
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(row, dict):
+            continue
+        req_rows += 1
+        q_id = str(row.get("request_id") or "")
+        if q_id:
+            req_records.add(q_id)
+        for h in requests.row_content_keys(row) & keys:
+            result["findings"].append({
+                "path": str(req_path),
+                "item_id": row.get("request_id"),
+                "content_hash": h, "surface": "request-ledger"})
+    try:
+        req_bytes = req_path.stat().st_size
+    except OSError:
+        req_bytes = 0
+    result["requests"] = {"records": len(req_records),
+                          "rows": req_rows,
+                          "bytes": req_bytes}
     # Chunk cache: value-level detection impossible (cache keyed by chunk
     # text, values are substrings). Store-level honesty: entry count + real
     # oldest age — the reaper runs only on WRITES, so never assert bounded.

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -1117,10 +1117,20 @@ def _ledger_style(ln: str) -> str | None:
         return "dim"
     if ln.startswith("over cap:"):
         return "yellow"
+    if ln.startswith("warning:"):
+        # #694: `request open --anyway` records an ask no bucket can surface.
+        # Same lowercase register _lifecycle_style uses for a degraded
+        # outcome, and the same colour, so one word means one thing across
+        # both families.
+        return "yellow"
     return None
 
 
-_LEDGER_HEADER_RE = re.compile(r"^(\[[^\]]*\]) (r-[0-9a-f]{12})  (.*)$")
+# #694 widened the id class from r- to the ledger id space (r- rulings and
+# refutations, q- requests): the three-span header is a per-LINE shape, not
+# a per-ledger one, and a request card that fell back to whole-line styling
+# would bury the id a human copies.
+_LEDGER_HEADER_RE = re.compile(r"^(\[[^\]]*\]) ([rq]-[0-9a-f]{12})  (.*)$")
 
 
 def _ledger_header_spans(ln: str):
@@ -1589,6 +1599,18 @@ def render_privacy_audit(results: list[dict]) -> None:
                   " forget reaches it by value (whole-value match) and by"
                   " target item; quotes merely CONTAINING a forgotten value"
                   " are beyond the hash scan")
+        req = r.get("requests") or {}
+        if req.get("rows"):
+            # #694: same measured-not-silent promise as the two ledgers
+            # above. The containment caveat is the same one, and it matters
+            # more here: the prose was authored FOR another project, so a
+            # value quoted inside an ask is exactly the shape a whole-value
+            # hash scan cannot see.
+            print(f"  request ledger: {req['records']} record(s) in"
+                  f" {req['rows']} row(s), {req['bytes'] / 1024:.0f} KB —"
+                  " forget reaches it by value (whole-value match); asks"
+                  " merely CONTAINING a forgotten value are beyond the hash"
+                  " scan")
         ws = r.get("windsurf") or {}
         if ws.get("entries"):
             age = (f", oldest {ws['oldest_days']:.1f}d"

--- a/plugin/daimon_briefing/requests.py
+++ b/plugin/daimon_briefing/requests.py
@@ -1,0 +1,724 @@
+"""Cross-project request ledger — one project's ask of another (#694).
+
+A request is a record in the SENDER's bucket: "project X asks project Y to
+do a thing, and here is why". The recipient never writes here. It discovers
+the ask by READ-THROUGH at brief time and answers it with verdict rows in
+its OWN `requests.jsonl`, referencing the request id — so every logical
+request spans two buckets by construction and the joined record is a
+read-time join (PR 2). Nobody writes a foreign ledger, and deletion happens
+once at the source: read-through has no copies to chase.
+
+This module is the object and its per-bucket fold. It follows the
+refutations/amendments shape rather than events.jsonl: its own append-only
+stream (scar 0025 — events.jsonl folds latest-wins per ref and its `source`
+is a caller's claim about itself), an OBSERVED channel recorded on every
+row, a deterministic full-pass fold, and rewrite deletion that reaches the
+bytes.
+
+Authority is asymmetric and the wedge is the point: any channel may ask,
+revise, or report completion, but a VERDICT — accept, reject, needs-info —
+is human-only, enforced at the write boundary AND re-checked in the fold.
+`suppressed` is human-only for the same reason: an agent that could mute an
+addressed ask from its own project's attention would have a soft-reject with
+no record. Suppression is panel attention only — the record stays visible in
+`request list` — and any later verdict lands normally and reverses it.
+
+Rejection is sticky per id: a human verdict may never be buried by a later
+sender event. A sender who still needs the thing opens a NEW request citing
+`supersedes`, so "asking again" is an append-only fact with visible lineage
+rather than a rewritten record. Revision is capped at three per record
+lifetime for the same reason `_MAX_OPEN_PROPOSALS` caps ruling proposals:
+without it, revise is a nag loop the recipient cannot stop.
+
+`stale` is DERIVED at render time (PR 3), never written. No field may carry
+another project's item text: the prose here is the ask, its rationale, a
+human verdict note, and a completion quote — all length-capped, all
+reachable by forget by value.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import time
+import uuid
+from datetime import datetime, timezone
+
+from . import config, normalize, policy, redact, store
+# One channel doctrine for every ledger: authority is a property of the WRITE
+# PATH, never a caller's claim about itself. Importing the table keeps a
+# future channel tier ("ui", "signed") consistent across ledgers instead of
+# forking per module.
+from .refutations import CHANNEL_AUTHORITY, CHANNEL_LABEL
+
+VERSION = 1
+# The closed event vocabulary, frozen in PR 1 so the format cannot drift as
+# the arc lands: `surfaced` (the recipient's brief stamped this ask) and
+# `verdict_surfaced` (the sender's brief stamped the answer) are written by
+# the inbox and return-path PRs, but their fold handling ships here — an
+# older reader that dropped them would silently re-render decided work.
+EVENTS = frozenset({
+    "opened", "revised",
+    "surfaced", "verdict_surfaced",
+    "needs_info", "accepted", "rejected", "done",
+    "suppressed",
+})
+# What a folded record may render as. `stale` is derived from consumption
+# (PR 3's baton count), never appended — an expiry that writes a row would
+# make attention decay indistinguishable from a verdict. `suppressed` is
+# deliberately NOT here: it is a marker on a record that still has a state.
+RENDER_STATES = frozenset({
+    "open", "needs-info", "accepted", "rejected", "done", "stale",
+})
+_STATE_BY_EVENT = {
+    "needs_info": "needs-info",
+    "accepted": "accepted",
+    "rejected": "rejected",
+    "done": "done",
+}
+# Verdicts and suppression: the human-only half of the verb table (D8).
+_HUMAN_ONLY = frozenset({"needs_info", "accepted", "rejected", "suppressed"})
+# States a sender-side event may still move. Everything else is settled by a
+# human verdict or by a completion claim, and re-opening it from the sender
+# side would be exactly the assertion the wedge principle forbids.
+_SENDER_MOVABLE = frozenset({"open", "needs-info"})
+# Per-brief render budget (D2). Over-cap renders a loud "+N more waiting"
+# line in PR 2; silent truncation of addressed asks is the one forbidden
+# failure, so the cap lives beside the overflow count it produces.
+RENDER_CAP = 3
+# Revisions per record lifetime (D7), fold-enforced and CLI-refused. Out of
+# revisions is not a dead end: D6's supersede opens a new record with the
+# lineage attached.
+MAX_REVISIONS = 3
+_EVENT_RANK = {
+    # Same-`order` ambiguity fails toward the human verdict that closes the
+    # loop: a same-instant reject beats an accept, and both beat a
+    # completion claim. Attention rows sort before verdicts so a verdict
+    # landing in the same instant still reverses a suppression.
+    "opened": 0,
+    "revised": 1,
+    "surfaced": 2,
+    "verdict_surfaced": 2,
+    "suppressed": 3,
+    "done": 4,
+    "needs_info": 5,
+    "accepted": 6,
+    "rejected": 7,
+}
+_REQUEST_ID_RE = re.compile(r"q-[0-9a-f]{12}")
+# store.project_slug's output: every non-word char munged to '-'. Validated
+# here for SHAPE only — whether the slug names a bucket that exists is the
+# CLI's check (it can offer near-matches and an --anyway override; this
+# module must stay writable for a project not yet initialized).
+_SLUG_RE = re.compile(r"[\w-]{1,255}")
+_SPACE_RE = re.compile(r"\s+")
+_MAX_TEXT = 2000
+_LABEL_MAX = 64
+
+# Every field of a ledger row that can hold plaintext (#645 discipline).
+# One declaration, two consumers: `forget_content_key` decides which records
+# a deletion reaches, and `privacy.audit_project` decides which fields it
+# hashes when proving the deletion happened.
+#
+# `author` is deliberately absent: it is a person's name, not item text, and
+# matching a tombstone against it would let one forgotten value delete every
+# record a given author ever wrote. `to` is absent for the same reason in
+# reverse — it is a filesystem-derived slug, not authored prose.
+_PLAINTEXT_FIELDS = ("ask", "why", "note", "evidence", "from_label")
+
+
+class RequestError(ValueError):
+    """A requested ledger transition is invalid or cannot be persisted."""
+
+
+def _path(project_dir=None):
+    slug = store.project_slug(project_dir)
+    if not slug:
+        return None
+    return config.checkpoint_dir() / slug / "requests.jsonl"
+
+
+def _text(name: str, value, *, required: bool = True,
+          limit: int = _MAX_TEXT) -> str:
+    out = _SPACE_RE.sub(" ", str(value or "")).strip()
+    if required and not out:
+        raise RequestError(f"{name} is required")
+    if len(out) > limit:
+        raise RequestError(
+            f"{name} is too long ({len(out)} > {limit} characters)")
+    return out
+
+
+def _scrub(name: str, value, *, required: bool = True,
+           limit: int = _MAX_TEXT) -> str:
+    """Cap, redact, then cap AGAIN — placeholder expansion can grow the
+    persisted bytes past what the raw text passed, and the bytes that
+    persist are the ones the cap exists to bound."""
+    out = _text(name, value, required=required, limit=limit)
+    out, _ = redact.redact_text(out)
+    return _text(name, out, required=required, limit=limit)
+
+
+def _sender_label(project_dir) -> str:
+    """The sender's own display label (D4): the basename of its directory,
+    captured at WRITE time because `store.project_slug` is irreversible — a
+    recipient reading the joined record cannot recover a readable name from
+    the slug, and daimon has no registry to look one up in."""
+    base = os.path.basename(str(project_dir or "").rstrip("/\\"))
+    return _scrub("from_label", base, required=False, limit=_LABEL_MAX)
+
+
+def make_id(sender_slug: str, ask: str, why: str, opened_ts: str) -> str:
+    """Stable logical id from the sender + the redacted ask identity + time.
+
+    The slug is in the hash because the inbox joins rows from every bucket on
+    id alone: two projects sending textually identical asks must never mint
+    the same id. `opened_ts` is in it because a deliberate re-ask is a NEW
+    record, not a collision with the one already answered.
+    """
+    raw = (f"{sender_slug}\0{ask.casefold()}\0{why.casefold()}\0"
+           f"{opened_ts}")
+    return "q-" + hashlib.sha256(raw.encode("utf-8")).hexdigest()[:12]
+
+
+def _ts(order: int) -> str:
+    return datetime.fromtimestamp(order / 1_000_000_000, timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ")
+
+
+def _stamp(event: str, request_id: str, channel: str,
+           *, now_ns: int | None = None, event_id: str | None = None) -> dict:
+    if event not in EVENTS:
+        raise RequestError(f"unknown request event: {event}")
+    if not _REQUEST_ID_RE.fullmatch(str(request_id or "")):
+        raise RequestError(f"invalid request id: {request_id!r}")
+    if channel not in CHANNEL_AUTHORITY:
+        raise RequestError(
+            f"channel must be one of: {', '.join(sorted(CHANNEL_AUTHORITY))}")
+    # Derived, never accepted: no way to name one channel and claim another's
+    # authority.
+    authority = CHANNEL_AUTHORITY[channel]
+    order = time.time_ns() if now_ns is None else int(now_ns)
+    return {
+        "version": VERSION,
+        "ts": _ts(order),
+        "order": order,
+        "event_id": event_id or uuid.uuid4().hex,
+        "event": event,
+        "request_id": request_id,
+        "channel": channel,
+        "authority": authority,
+        "author": config.author(),
+    }
+
+
+def _is_torn(path) -> bool:
+    """True when the last append died before writing its terminator."""
+    try:
+        if path.stat().st_size == 0:
+            return False
+        with path.open("rb") as handle:
+            handle.seek(-1, 2)
+            return handle.read(1) != b"\n"
+    except OSError:
+        return False
+
+
+def append(row: dict, project_dir=None) -> bool:
+    """Append one admitted lifecycle row. Never mutates another bucket."""
+    if config.is_disabled():
+        return False
+    path = _path(project_dir)
+    if path is None:
+        return False
+    admitted = policy.admit_row(
+        row, redact_fields=("ask", "why", "note", "evidence", "from_label",
+                            "author"))
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            if _is_torn(path):
+                handle.write("\n")
+            handle.write(json.dumps(admitted, ensure_ascii=False) + "\n")
+        return True
+    except OSError:
+        return False
+
+
+def events(project_dir=None) -> list[dict]:
+    """Read valid ledger rows best-effort; malformed lines never sink reads."""
+    path = _path(project_dir)
+    if path is None or not path.exists():
+        return []
+    rows = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return []
+    for index, line in enumerate(lines):
+        try:
+            row = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if (not isinstance(row, dict)
+                or row.get("event") not in EVENTS
+                or not _REQUEST_ID_RE.fullmatch(str(row.get("request_id") or ""))):
+            continue
+        copy = dict(row)
+        copy["_line"] = index
+        rows.append(copy)
+    return rows
+
+
+def fold(rows: list[dict]) -> dict[str, dict]:
+    """Fold this bucket's rows into current records, deterministic under
+    reorder.
+
+    Full-pass, never latest-wins: the ask, its revisions, and the verdict are
+    all witness data, and a later event must not erase the record of an
+    earlier one — the stream keeps every row; the fold states what holds NOW.
+
+    Per-bucket only. The cross-bucket join (orphan rule, supersede lineage,
+    suppress filter) is the read-time composer PR 2 builds ON TOP of this;
+    here a lifecycle row whose `opened` lives in another bucket is an orphan:
+    inert in the fold, visible in the raw audit.
+    """
+    def _integer(row, key, default=0):
+        try:
+            return int(row.get(key) or default)
+        except (TypeError, ValueError):
+            return default
+
+    ordered = sorted(rows, key=lambda row: (
+        _integer(row, "order"),
+        _EVENT_RANK.get(str(row.get("event") or ""), 99),
+        str(row.get("event_id") or ""),
+        _integer(row, "_line"),
+    ))
+    out: dict[str, dict] = {}
+    for row in ordered:
+        q_id = row["request_id"]
+        event = row["event"]
+        authority = CHANNEL_AUTHORITY.get(row.get("channel"))
+        current = out.get(q_id)
+        if event == "opened":
+            if current is not None:
+                continue  # duplicate logical open, first writer wins
+            # Read-boundary shape check (the write boundary is not the
+            # boundary that matters — events() is deliberately tolerant, and
+            # a row edited on disk must not ride into the render).
+            if not _SLUG_RE.fullmatch(str(row.get("to") or "")):
+                continue
+            if not str(row.get("ask") or "").strip():
+                continue
+            out[q_id] = {
+                "request_id": q_id,
+                "state": "open",
+                "to": str(row.get("to") or ""),
+                "to_human": row.get("to_human") is True,
+                "blocking": row.get("blocking") is True,
+                "ask": str(row.get("ask") or ""),
+                "why": str(row.get("why") or ""),
+                "evidence": str(row.get("evidence") or ""),
+                "from_label": str(row.get("from_label") or ""),
+                "supersedes": str(row.get("supersedes") or ""),
+                "note": "",
+                "opened_by": authority,
+                "opened_channel": row.get("channel"),
+                "opened_author": row.get("author"),
+                "verdict_by": None,
+                "verdict_label": None,
+                "verdict_at": None,
+                "done_by": None,
+                "done_claimed": False,
+                "done_evidence": "",
+                "suppressed": False,
+                # {revision epoch: earliest surfaced ts} — D1's write-once
+                # dedup key, consulted by the stamp PR 2 adds.
+                "surfaced": {},
+                "verdict_surfaced_at": None,
+                "revision": 0,
+                "created_at": row.get("ts"),
+                "updated_at": row.get("ts"),
+                "history_count": 1,
+            }
+            continue
+        if current is None:
+            continue  # orphan lifecycle event: visible in raw audit, inert here
+        if event in _HUMAN_ONLY and authority != "human":
+            # The fold re-check the write boundary cannot be trusted for: a
+            # row appended off-path or edited on disk claiming an agent
+            # channel is fully inert, verdict or suppression alike.
+            continue
+        if event in _STATE_BY_EVENT and current["state"] == "rejected":
+            # D6: rejection is terminal for this id. Re-proposal is a NEW
+            # record citing `supersedes`, so the rejected verdict stays on
+            # the record instead of being overwritten by the next ask.
+            continue
+        if event == "surfaced":
+            # Attention rows never move the record's rendered age: a brief
+            # that merely showed the card must not make an untouched ask
+            # sort as freshly updated. Earliest row of an epoch wins — the
+            # ordered pass means the first one seen for that revision is it.
+            current["history_count"] += 1
+            current["surfaced"].setdefault(current["revision"], row.get("ts"))
+            continue
+        if event == "verdict_surfaced":
+            current["history_count"] += 1
+            if current["verdict_surfaced_at"] is None:
+                current["verdict_surfaced_at"] = row.get("ts")
+            continue
+        if event == "suppressed":
+            current["history_count"] += 1
+            current["suppressed"] = True
+            continue
+        if event == "revised":
+            if current["state"] not in _SENDER_MOVABLE:
+                continue
+            if current["revision"] >= MAX_REVISIONS:
+                continue  # D7: revision 4+ is inert, not a silent success
+            # Scar 0042: replace only the keys the caller actually set. In an
+            # append-only stream the ABSENCE of a key is data, so a revise
+            # that names only `why` must not clear the ask.
+            for key in ("ask", "why", "evidence"):
+                if key in row:
+                    current[key] = str(row.get(key) or "")
+            current["revision"] += 1
+            current["state"] = "open"
+            current["history_count"] += 1
+            current["updated_at"] = row.get("ts") or current["updated_at"]
+            continue
+        if event == "done" and not str(row.get("evidence") or "").strip():
+            # D8: `done` is the one either-channel state move, and its price
+            # is evidence. A row without it never lands.
+            continue
+        current["history_count"] += 1
+        current["updated_at"] = row.get("ts") or current["updated_at"]
+        current["state"] = _STATE_BY_EVENT[event]
+        # D5: a verdict (or a completion) supersedes a suppression — that IS
+        # the reversal path, which is why no `unsuppress` verb exists.
+        current["suppressed"] = False
+        if event == "done":
+            current["done_by"] = authority
+            # An agent's completion claim renders as claimed-and-unverified
+            # until the session-end byte-check confirms the quote (PR 3).
+            current["done_claimed"] = authority != "human"
+            current["done_evidence"] = str(row.get("evidence") or "")
+        else:
+            current["verdict_by"] = authority
+            current["verdict_label"] = CHANNEL_LABEL.get(row.get("channel"))
+            current["verdict_at"] = row.get("ts")
+            if "note" in row:
+                current["note"] = str(row.get("note") or "")
+    return out
+
+
+def records(project_dir=None) -> dict[str, dict]:
+    return fold(events(project_dir=project_dir))
+
+
+def get(request_id: str, project_dir=None) -> dict | None:
+    return records(project_dir=project_dir).get(request_id)
+
+
+def listing(project_dir=None) -> list[dict]:
+    """Every record in this bucket, undecided first — the `request list`
+    order. Suppressed records are HERE by construction (D5): suppression
+    takes away panel placement, never visibility."""
+    return sorted(
+        records(project_dir=project_dir).values(),
+        key=lambda r: (r["state"] not in _SENDER_MOVABLE,
+                       r.get("updated_at") or "", r["request_id"]))
+
+
+def renderable(project_dir=None) -> dict:
+    """The records still awaiting attention: {"rows": [...], "overflow": N}.
+
+    Newest first, capped at RENDER_CAP with the remainder COUNTED — the
+    panel PR 2 builds renders the overflow loudly, because silently dropping
+    an addressed ask is the one failure this feature cannot have. Suppressed
+    records are filtered here and only here: that is the whole effect of
+    suppression, and it is why the verb had to be human-only.
+    """
+    rows = [r for r in records(project_dir=project_dir).values()
+            if r["state"] in _SENDER_MOVABLE and not r["suppressed"]]
+    rows.sort(key=lambda r: (r.get("updated_at") or "", r["request_id"]),
+              reverse=True)
+    return {"rows": rows[:RENDER_CAP], "overflow": max(0, len(rows) - RENDER_CAP)}
+
+
+def open_request(*, to: str, ask: str, why: str, channel: str,
+                 blocking: bool = False, to_human: bool = False,
+                 evidence: str = "", supersedes: str = "",
+                 project_dir=None) -> str:
+    """Open a request addressed to another project's slug.
+
+    Slug SHAPE is validated here; whether it names a bucket that exists is
+    the CLI's check — a project that has not serialized yet has no bucket,
+    and refusing to record the ask at the module seam would make the ledger
+    unusable exactly when a team is onboarding.
+    """
+    if not _SLUG_RE.fullmatch(str(to or "")):
+        raise RequestError(f"invalid recipient slug: {to!r}")
+    supersedes = str(supersedes or "").strip()
+    if supersedes and not _REQUEST_ID_RE.fullmatch(supersedes):
+        raise RequestError(f"invalid superseded request id: {supersedes!r}")
+    slug = store.project_slug(project_dir)
+    if not slug:
+        raise RequestError("project unknown; requests are recorded in the "
+                           "sender's own bucket")
+    ask = _scrub("ask", ask)
+    why = _scrub("why", why)
+    evidence = _scrub("evidence", evidence, required=False)
+    order = time.time_ns()
+    q_id = make_id(slug, ask, why, _ts(order))
+    if get(q_id, project_dir=project_dir) is not None:
+        raise RequestError(
+            f"{q_id} already exists — this exact ask was opened in the same "
+            "second; revise it or wait a moment to open a second one")
+    row = _stamp("opened", q_id, channel, now_ns=order)
+    row.update({
+        "to": to,
+        "to_human": bool(to_human),
+        "blocking": bool(blocking),
+        "ask": ask,
+        "why": why,
+        "from_label": _sender_label(project_dir),
+    })
+    if evidence:
+        row["evidence"] = evidence
+    if supersedes:
+        row["supersedes"] = supersedes
+    if not append(row, project_dir=project_dir):
+        raise RequestError(
+            "request not written (daimon disabled, project unknown, or "
+            "ledger unwritable)")
+    return q_id
+
+
+def revise(request_id: str, *, channel: str, ask: str | None = None,
+           why: str | None = None, evidence: str | None = None,
+           project_dir=None) -> None:
+    """Answer a needs-info, or sharpen an open ask. Capped at MAX_REVISIONS."""
+    current = _require(request_id, project_dir)
+    if current["state"] not in _SENDER_MOVABLE:
+        raise RequestError(
+            f"{request_id} is {current['state']}; a settled request is not "
+            "revised — open a new one with --supersedes to ask again")
+    if current["revision"] >= MAX_REVISIONS:
+        raise RequestError(
+            f"{request_id} has used all {MAX_REVISIONS} revisions; open a "
+            f"new request with `--supersedes {request_id}` so the lineage "
+            "stays visible")
+    row = _stamp("revised", request_id, channel)
+    # Scar 0042: only the keys the caller SET. `None` means unchanged, and
+    # the fold reads key presence as intent — forging a key here would clear
+    # the field the caller never mentioned.
+    if ask is not None:
+        row["ask"] = _scrub("ask", ask)
+    if why is not None:
+        row["why"] = _scrub("why", why)
+    if evidence is not None:
+        row["evidence"] = _scrub("evidence", evidence, required=False)
+    if not any(key in row for key in ("ask", "why", "evidence")):
+        raise RequestError(
+            "revision changes nothing; provide a new ask, why, or evidence")
+    if not append(row, project_dir=project_dir):
+        raise RequestError("revision not written")
+
+
+def _answering(request_id: str, project_dir) -> dict | None:
+    """The local record a recipient-side row answers, or None when this
+    bucket cannot see it.
+
+    Shape-checked, never resolved. A request lives in the SENDER's bucket, so
+    the recipient answering one has nothing local to resolve against: an
+    answer to a foreign id is written here and stays an orphan — inert in
+    this bucket's fold, visible in the raw audit — until the read-time join
+    (PR 2) pairs it with its origin. Refusing what cannot be resolved would
+    make the recipient side unimplementable.
+    """
+    if not _REQUEST_ID_RE.fullmatch(str(request_id or "")):
+        raise RequestError(f"invalid request id: {request_id!r}")
+    return get(request_id, project_dir=project_dir)
+
+
+def _require(request_id: str, project_dir) -> dict:
+    """The local record, or a refusal — for the SENDER-side verbs, which
+    cannot act without one (a revision needs the ask it is replacing and the
+    revision count it is bounded by)."""
+    current = get(request_id, project_dir=project_dir)
+    if current is None:
+        raise RequestError(f"unknown request: {request_id}")
+    return current
+
+
+def _verdict(event: str, request_id: str, *, channel: str, note: str = "",
+             project_dir=None) -> None:
+    if CHANNEL_AUTHORITY.get(channel) != "human":
+        raise RequestError(
+            f"a {_STATE_BY_EVENT.get(event, event)} verdict requires a human "
+            f"channel; this call arrived through {channel!r}")
+    current = _answering(request_id, project_dir)
+    if current is not None and current["state"] == "rejected":
+        raise RequestError(
+            f"{request_id} was rejected, and a rejection is final for that "
+            "record; the sender can open a new request with "
+            f"`--supersedes {request_id}`")
+    row = _stamp(event, request_id, channel)
+    note = _text("note", note, required=False)
+    if note:
+        row["note"] = note
+    if not append(row, project_dir=project_dir):
+        raise RequestError("verdict not written")
+
+
+def accept(request_id: str, *, channel: str, note: str = "",
+           project_dir=None) -> None:
+    _verdict("accepted", request_id, channel=channel, note=note,
+             project_dir=project_dir)
+
+
+def reject(request_id: str, *, channel: str, note: str = "",
+           project_dir=None) -> None:
+    _verdict("rejected", request_id, channel=channel, note=note,
+             project_dir=project_dir)
+
+
+def needs_info(request_id: str, *, channel: str, note: str = "",
+               project_dir=None) -> None:
+    _verdict("needs_info", request_id, channel=channel, note=note,
+             project_dir=project_dir)
+
+
+def suppress(request_id: str, *, channel: str, note: str = "",
+             project_dir=None) -> None:
+    """Drop a record out of the briefing panel — human-only, panel-only.
+
+    Not a verdict and not a state: the record stays in `request list`, and
+    any later accept/reject/needs-info lands normally and reverses this.
+    Human-only because an agent able to mute an addressed ask would hold a
+    soft-reject that never appears as one.
+    """
+    if CHANNEL_AUTHORITY.get(channel) != "human":
+        raise RequestError(
+            "suppressing an addressed request requires a human channel; this "
+            f"call arrived through {channel!r}")
+    _answering(request_id, project_dir)
+    row = _stamp("suppressed", request_id, channel)
+    note = _text("note", note, required=False)
+    if note:
+        row["note"] = note
+    if not append(row, project_dir=project_dir):
+        raise RequestError("suppression not written")
+
+
+def done(request_id: str, *, channel: str, evidence: str,
+         project_dir=None) -> None:
+    """Report the ask as satisfied. Either channel, evidence required — an
+    agent's claim renders as claimed-and-unverified until the session-end
+    byte-check confirms the quote (PR 3)."""
+    current = _answering(request_id, project_dir)
+    if current is not None and current["state"] == "rejected":
+        raise RequestError(
+            f"{request_id} was rejected; a rejected request cannot be "
+            "completed")
+    row = _stamp("done", request_id, channel)
+    row["evidence"] = _scrub("evidence", evidence)
+    if not append(row, project_dir=project_dir):
+        raise RequestError("completion not written")
+
+
+def plaintext_values(row: dict) -> list[str]:
+    """Every plaintext value this row carries, in declaration order.
+
+    The forget TARGETING pool reads this instead of hand-copying the field
+    tuple — the same one-declaration discipline row_content_keys below gives
+    the deleter and the auditor."""
+    out: list[str] = []
+    for field in _PLAINTEXT_FIELDS:
+        value = row.get(field)
+        if isinstance(value, str) and value.strip():
+            out.append(value)
+    return out
+
+
+def row_content_keys(row: dict) -> set[str]:
+    """Canonical keys for every plaintext field this row carries (#645).
+
+    The one reader of _PLAINTEXT_FIELDS besides plaintext_values, so the
+    deleter below and `privacy.audit_project` cannot drift apart about what
+    counts as plaintext on this surface."""
+    out: set[str] = set()
+    for field in _PLAINTEXT_FIELDS:
+        value = row.get(field)
+        if isinstance(value, str) and value.strip():
+            out.add(normalize.content_key(value))
+    return out
+
+
+def _rewrite_without(doomed: set[str], project_dir=None) -> list[str]:
+    """Rewrite the ledger dropping every row of the doomed record ids.
+
+    Raw LINES, never `events()` output — that reader is tolerant and would
+    silently delete rows a future daimon added (the scar 0025/0042 shape: a
+    forgiving read feeding a write). Atomic or nothing."""
+    doomed.discard("")
+    if not doomed:
+        return []
+    path = _path(project_dir)
+    if path is None or not path.exists():
+        return []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return []
+    kept: list[str] = []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except (ValueError, TypeError):
+            continue  # torn rows are expendable; keeping one leaves bytes
+        if (isinstance(row, dict)
+                and str(row.get("request_id") or "") in doomed):
+            continue
+        kept.append(line)
+    tmp = path.with_name(path.name + ".forget-tmp")
+    try:
+        tmp.write_text("".join(line + "\n" for line in kept), encoding="utf-8")
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        return []
+    return sorted(doomed)
+
+
+def forget_content_key(content_key: str, *, project_dir=None) -> list[str]:
+    """Remove every record holding `content_key` in a plaintext field.
+
+    The rewrite path exists because this ledger carries plaintext by design
+    (the ask, its rationale, verdict notes, completion quotes), so it is in
+    the checkpoint's deletion category — a removal must reach the bytes
+    (#578 posture). Matches on the same canonical whole-value key the
+    checkpoint splice uses, never on substring containment. Every row of a
+    matched record goes, including verdict rows written here by this side.
+
+    Deletion is local by design and that is the whole point of read-through:
+    the sender forgetting its ask removes it from every reader at once,
+    because no reader ever held a copy. Rows THIS bucket wrote about a
+    foreign request are this bucket's own prose and go the same way; the
+    foreign origin rows are the other side's to delete.
+    """
+    doomed = {
+        str(row.get("request_id") or "")
+        for row in events(project_dir=project_dir)
+        if content_key in row_content_keys(row)
+    }
+    return _rewrite_without(doomed, project_dir=project_dir)

--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -226,6 +226,20 @@ Memory is per-project. To deliberately read another project's memory:
 
 Never present cross-project content as the current project's memory.
 
+## Asking another project for something
+
+Never write into another project's memory — record the ask:
+
+```
+daimon request open --to <dir> --ask "<what>" --why "<why>" --by agent
+```
+
+`daimon request list` shows this project's asks and where each stands.
+`request revise` answers a needs-info (three per record, then a new one with
+`--supersedes <id>`). `request done --evidence "<quote>"` renders as an
+unverified claim until the quote is byte-checked. `accept`, `reject`,
+`needs-info`, `suppress` are human-only: print the command, never run it.
+
 ## When memory looks wrong
 
 | Symptom | Command |

--- a/plugin/daimon_briefing/surfaces.py
+++ b/plugin/daimon_briefing/surfaces.py
@@ -133,6 +133,31 @@ SURFACES: tuple[Surface, ...] = (
     #    (render_privacy_audit) so growth is measured, never silent. --
     Surface("checkpoints/{slug}/amendments.jsonl", "amendments.append",
             True, "rewrite", "forget"),
+    # -- the request ledger (#694): the fifth bucket ledger — one project's
+    #    ask of another, so its rows carry the ask, its rationale, a human
+    #    verdict note, and a completion quote: plaintext by design, in the
+    #    checkpoint's deletion category with refutations and amendments.
+    #    `rewrite` is requests.forget_content_key, matching the same
+    #    whole-value canonical key the checkpoint splice uses.
+    #
+    #    The cross-project shape is what makes deletion LOCAL and complete:
+    #    the recipient never holds a copy (it reads through to this file at
+    #    brief time), so one rewrite here removes the ask from every reader
+    #    at once — no tombstone propagation, nothing to chase. Rows this
+    #    bucket wrote ABOUT a foreign request are this bucket's own prose
+    #    and go by the same path; the foreign origin rows are the other
+    #    side's to delete, which is the whole point of mutual read-through.
+    #
+    #    Never audit_exempt: the audit hashes the module's own
+    #    _PLAINTEXT_FIELDS declaration (privacy.audit_project) and prints
+    #    record/row/byte counts, so growth is measured, never silent. Same
+    #    honest limit as the amendment ledger — forget matches a WHOLE
+    #    value, so an ask merely CONTAINING a forgotten value is beyond the
+    #    hash scan. No age reaper: attention decay (#694 D3) is DERIVED at
+    #    render time and deliberately never deletes a record — a request
+    #    that stopped mattering still happened. --
+    Surface("checkpoints/{slug}/requests.jsonl", "requests.append",
+            True, "rewrite", "forget"),
     # store.append_verification: "a POINTER and a REASON CODE, never the
     # rejected text" (store.py docstring).
     Surface("checkpoints/{slug}/verification.jsonl",

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -1462,6 +1462,43 @@ def test_ledger_style_pending_overturn_note_is_yellow():
         "  Overturn proposed by agent — still active") == "yellow"
 
 
+def test_ledger_style_warning_register_is_yellow():
+    # #694: `request open --anyway` records an ask no bucket can surface, and
+    # says so on the same line register the lifecycle surfaces use for a
+    # degraded outcome — one word, one colour, across both families. Card
+    # prose that merely CONTAINS the word is not the register.
+    assert render._ledger_style(
+        "warning: -p-x has no bucket on this machine") == "yellow"
+    assert render._ledger_style("  Why: warning: this is prose") is None
+
+
+def test_render_ledger_lines_paints_the_warning_register(monkeypatch, capsys):
+    # The style has to survive the rich path, not merely be returned by the
+    # mapper: FORCE_COLOR makes rich emit the escapes, so a warning that
+    # stopped being coloured fails here instead of passing as a smoke test.
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_ledger_lines(["warning: no bucket for -p-x",
+                                "  Why: the release note depends on it"])
+    lines = capsys.readouterr().out.splitlines()
+    assert lines[0] == "\x1b[33mwarning: no bucket for -p-x\x1b[0m"
+    assert lines[1] == "  Why: the release note depends on it"
+
+
+def test_render_ledger_lines_spans_a_request_id_like_a_ruling_id(
+        monkeypatch, capsys):
+    # #694 widened the header id class to the whole ledger id space. The span
+    # split is what puts the id a human copies in bold cyan; a q- header that
+    # fell back to whole-line styling would bury it.
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_ledger_lines(
+        ["[→ open · agent-asked] q-0123456789ab  review the proposal"])
+    out = capsys.readouterr().out
+    assert "\x1b[1;36mq-0123456789ab\x1b[0m" in out
+    assert "review the proposal" in out.split("\x1b[0m")[-1]
+
+
 def test_render_ledger_records_plain_is_flat(capsys):
     render.render_ledger_records([
         ["[§ active · x] r-1a2b3c4d5e6f  First."],

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -1,0 +1,758 @@
+"""Cross-project request ledger (#694, PR 1 — the object).
+
+A request is a record in the SENDER's bucket: an ask addressed to another
+project by slug. Verdicts are human-only, rejection is sticky, revision is
+capped, and forget reaches the prose by value. The join across buckets (the
+inbox, the briefing panel, the surfaced stamps) is PR 2/3 — what ships here
+is the object, its fold, and its deletion contract.
+"""
+
+import json
+
+import pytest
+
+from daimon_briefing import config, normalize, redact, requests, store
+
+
+@pytest.fixture
+def project(tmp_checkpoint_dir):
+    # conftest's autouse fixture already isolates DAIMON_CHECKPOINT_DIR.
+    return "/p/sender"
+
+
+RECIPIENT = "-p-recipient"
+ASK = "review the retrieval bar proposal before Friday"
+WHY = "it blocks the release note we owe the team"
+
+
+def _open(project, *, channel="cli-agent", to=RECIPIENT, ask=ASK, why=WHY,
+          **kwargs):
+    return requests.open_request(to=to, ask=ask, why=why, channel=channel,
+                                 project_dir=project, **kwargs)
+
+
+def _rows(project):
+    path = (config.checkpoint_dir() / store.project_slug(project)
+            / "requests.jsonl")
+    return [json.loads(ln) for ln in
+            path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+
+# ---- the object -----------------------------------------------------------
+
+
+def test_open_lands_as_open_with_its_fields(project):
+    q_id = _open(project, blocking=True, to_human=True,
+                 evidence="issue:694")
+    record = requests.get(q_id, project_dir=project)
+    assert record["state"] == "open"
+    assert record["to"] == RECIPIENT
+    assert record["to_human"] is True
+    assert record["blocking"] is True
+    assert record["ask"] == ASK
+    assert record["why"] == WHY
+    assert record["evidence"] == "issue:694"
+    assert record["opened_by"] == "agent"
+    assert record["revision"] == 0
+    assert record["suppressed"] is False
+
+
+def test_open_records_the_sender_label_and_supersedes(project):
+    first = _open(project)
+    second = _open(project, ask="review it again, with the new numbers",
+                   supersedes=first)
+    record = requests.get(second, project_dir=project)
+    assert record["supersedes"] == first
+    # D4: the slug is irreversible, so the sender's own label rides the row.
+    assert record["from_label"] == "sender"
+
+
+def test_ids_differ_across_senders_with_identical_ask_why_and_ts(project):
+    """D0: the inbox joins rows from every bucket on id alone, so two
+    projects sending textually identical asks in the same second must never
+    mint the same id."""
+    stamp = "2026-08-16T09:00:00Z"
+    mine = requests.make_id("-p-a", ASK, WHY, stamp)
+    theirs = requests.make_id("-p-b", ASK, WHY, stamp)
+    assert mine != theirs
+    assert mine == requests.make_id("-p-a", ASK, WHY, stamp)
+    # A deliberate re-ask at a later second is a NEW record.
+    assert mine != requests.make_id("-p-a", ASK, WHY,
+                                    "2026-08-16T09:00:01Z")
+
+
+def test_id_is_minted_over_post_redaction_bytes(project):
+    secret = f"{ASK} using token=abcdefghijkl"
+    q_id = _open(project, ask=secret)
+    record = requests.get(q_id, project_dir=project)
+    scrubbed, _ = redact.redact_text(secret)
+    assert record["ask"] == scrubbed
+    assert "abcdefghijkl" not in json.dumps(_rows(project))
+    assert q_id == requests.make_id(store.project_slug(project),
+                                    scrubbed, WHY, record["created_at"])
+
+
+def test_text_cap_is_rechecked_after_redaction(project):
+    """Placeholder expansion can grow the persisted bytes past what the raw
+    text passed: `token=abcdefgh` (14 chars) persists as 24."""
+    raw = " ".join(["token=abcdefgh"] * 120)
+    assert len(raw) <= requests._MAX_TEXT
+    with pytest.raises(requests.RequestError):
+        _open(project, ask=raw)
+
+
+def test_ask_and_why_are_required_and_capped(project):
+    with pytest.raises(requests.RequestError):
+        _open(project, ask="")
+    with pytest.raises(requests.RequestError):
+        _open(project, why="")
+    with pytest.raises(requests.RequestError):
+        _open(project, ask="x" * (requests._MAX_TEXT + 1))
+
+
+def test_unresolvable_project_writes_nothing(project):
+    assert requests._path(None) is None
+    assert requests.append({"event": "opened"}, project_dir=None) is False
+
+
+def test_unknown_event_refused_at_the_write_boundary(project):
+    with pytest.raises(requests.RequestError):
+        requests._stamp("escalated", "q-0123456789ab", "cli-tty")
+
+
+# ---- authority ------------------------------------------------------------
+
+
+@pytest.mark.parametrize("verb", ["accept", "reject", "needs_info",
+                                  "suppress"])
+def test_verdict_verbs_refuse_the_agent_channel(project, verb):
+    q_id = _open(project)
+    with pytest.raises(requests.RequestError):
+        getattr(requests, verb)(q_id, channel="cli-agent",
+                                project_dir=project)
+    assert requests.get(q_id, project_dir=project)["state"] == "open"
+
+
+@pytest.mark.parametrize("event", ["accepted", "rejected", "needs_info",
+                                   "suppressed"])
+def test_fold_rechecks_authority_on_a_forged_row(project, event):
+    """The write boundary is not the boundary that matters: a row appended
+    off-path (or edited on disk) claiming an agent channel must be inert."""
+    q_id = _open(project)
+    row = requests._stamp(event, q_id, "cli-agent")
+    row["note"] = "landing my own verdict"
+    assert requests.append(row, project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["state"] == "open"
+    assert record["suppressed"] is False
+
+
+def test_human_verdicts_move_the_record(project):
+    q_id = _open(project)
+    requests.needs_info(q_id, channel="cli-tty", note="which release?",
+                        project_dir=project)
+    assert requests.get(q_id, project_dir=project)["state"] == "needs-info"
+    requests.accept(q_id, channel="cli-tty", project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["state"] == "accepted"
+    assert record["verdict_by"] == "human"
+
+
+def test_rejection_is_sticky(project):
+    """D6: a human verdict may never be buried by a later sender event."""
+    q_id = _open(project)
+    requests.reject(q_id, channel="cli-tty", note="wrong project",
+                    project_dir=project)
+    for verb in ("accept", "needs_info"):
+        with pytest.raises(requests.RequestError):
+            getattr(requests, verb)(q_id, channel="cli-tty",
+                                    project_dir=project)
+    with pytest.raises(requests.RequestError):
+        requests.done(q_id, channel="cli-tty", evidence="shipped it",
+                      project_dir=project)
+    with pytest.raises(requests.RequestError):
+        requests.revise(q_id, channel="cli-agent", ask="softer ask",
+                        project_dir=project)
+    # …and the fold is inert too, for rows that arrive off-path.
+    for event in ("accepted", "needs_info", "done", "revised"):
+        row = requests._stamp(event, q_id, "cli-tty")
+        row["evidence"] = "it is finished"
+        row["ask"] = "softer ask"
+        requests.append(row, project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["state"] == "rejected"
+    assert record["ask"] == ASK
+    assert record["note"] == "wrong project"
+
+
+# ---- revise: bounded loop -------------------------------------------------
+
+
+def test_revise_returns_a_needs_info_record_to_open(project):
+    q_id = _open(project)
+    requests.needs_info(q_id, channel="cli-tty", note="which release?",
+                        project_dir=project)
+    requests.revise(q_id, channel="cli-agent", ask="review it for 0.32.0",
+                    project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["state"] == "open"
+    assert record["ask"] == "review it for 0.32.0"
+    assert record["revision"] == 1
+
+
+def test_revise_normalises_only_the_keys_the_caller_set(project):
+    """Scar 0042: in an append-only stream the ABSENCE of a key is data."""
+    q_id = _open(project, evidence="issue:694")
+    requests.revise(q_id, channel="cli-agent", why="the release moved",
+                    project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["ask"] == ASK           # untouched, not cleared
+    assert record["evidence"] == "issue:694"
+    assert record["why"] == "the release moved"
+
+
+def test_revise_is_capped_and_the_fourth_is_inert_in_the_fold(project):
+    q_id = _open(project)
+    for n in range(requests.MAX_REVISIONS):
+        requests.revise(q_id, channel="cli-agent", ask=f"revision {n}",
+                        project_dir=project)
+    with pytest.raises(requests.RequestError):
+        requests.revise(q_id, channel="cli-agent", ask="revision 3",
+                        project_dir=project)
+    # Off-path row: the CAP is the fold's, not the CLI's.
+    row = requests._stamp("revised", q_id, "cli-agent")
+    row["ask"] = "revision 3"
+    assert requests.append(row, project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["revision"] == requests.MAX_REVISIONS
+    assert record["ask"] == "revision 2"
+
+
+def test_revise_needs_something_to_change(project):
+    q_id = _open(project)
+    with pytest.raises(requests.RequestError):
+        requests.revise(q_id, channel="cli-agent", project_dir=project)
+
+
+# ---- done -----------------------------------------------------------------
+
+
+def test_done_requires_evidence_on_either_channel(project):
+    q_id = _open(project)
+    with pytest.raises(requests.RequestError):
+        requests.done(q_id, channel="cli-agent", evidence="",
+                      project_dir=project)
+    requests.done(q_id, channel="cli-agent", evidence="merged in PR #712",
+                  project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["state"] == "done"
+    # D8: an agent's completion claim is labeled until the byte-check.
+    assert record["done_by"] == "agent"
+    assert record["done_claimed"] is True
+    assert record["done_evidence"] == "merged in PR #712"
+
+
+def test_human_done_is_not_a_claim(project):
+    q_id = _open(project)
+    requests.done(q_id, channel="cli-tty", evidence="I did it myself",
+                  project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["done_by"] == "human"
+    assert record["done_claimed"] is False
+
+
+def test_done_without_evidence_is_inert_in_the_fold(project):
+    q_id = _open(project)
+    assert requests.append(requests._stamp("done", q_id, "cli-tty"),
+                           project_dir=project)
+    assert requests.get(q_id, project_dir=project)["state"] == "open"
+
+
+# ---- suppress: attention, never state -------------------------------------
+
+
+def test_suppress_hides_from_the_panel_but_never_from_the_list(project):
+    q_id = _open(project)
+    requests.suppress(q_id, channel="cli-tty", note="not this quarter",
+                      project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["suppressed"] is True
+    assert record["state"] == "open"       # a marker, never a state
+    assert q_id in {r["request_id"]
+                    for r in requests.listing(project_dir=project)}
+    assert q_id not in {r["request_id"]
+                        for r in requests.renderable(project_dir=project)["rows"]}
+
+
+def test_a_later_verdict_reverses_the_suppression(project):
+    """D5: suppress is attention, not state — a verdict lands normally and
+    supersedes it. That is the reversal path; no `unsuppress` verb exists."""
+    q_id = _open(project)
+    requests.suppress(q_id, channel="cli-tty", project_dir=project)
+    requests.needs_info(q_id, channel="cli-tty", note="which release?",
+                        project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["state"] == "needs-info"
+    assert record["suppressed"] is False
+
+
+# ---- fold mechanics -------------------------------------------------------
+
+
+def test_fold_is_deterministic_under_reorder(project):
+    q_id = _open(project)
+    requests.needs_info(q_id, channel="cli-tty", note="which release?",
+                        project_dir=project)
+    requests.revise(q_id, channel="cli-agent", ask="review it for 0.32.0",
+                    project_dir=project)
+    requests.accept(q_id, channel="cli-tty", project_dir=project)
+    rows = requests.events(project_dir=project)
+    forward = requests.fold(rows)[q_id]
+    backward = requests.fold(list(reversed(rows)))[q_id]
+    assert forward == backward
+    assert forward["state"] == "accepted"
+
+
+def test_same_instant_rejection_beats_an_acceptance(project):
+    """The rank tie-break fails toward the human verdict that closes the
+    loop: a same-`order` accept must not bury a reject."""
+    q_id = _open(project)
+    rows = requests.events(project_dir=project)
+    instant = rows[0]["order"] + 10 ** 9
+    for event in ("accepted", "rejected"):
+        rows.append(requests._stamp(event, q_id, "cli-tty", now_ns=instant))
+    assert requests.fold(rows)[q_id]["state"] == "rejected"
+
+
+def test_orphan_lifecycle_rows_are_inert_but_kept(project):
+    """D0 orphan rule: a verdict row whose origin is not in this bucket is
+    inert in the fold and visible in the raw audit."""
+    orphan = "q-0123456789ab"
+    assert requests.append(requests._stamp("accepted", orphan, "cli-tty"),
+                           project_dir=project)
+    assert requests.records(project_dir=project) == {}
+    assert len(_rows(project)) == 1
+
+
+def test_surfaced_rows_fold_per_revision_epoch(project):
+    """D1: the stamp is write-once per (request id, revision epoch); the fold
+    takes the earliest row of each epoch, and a revise opens a new epoch."""
+    q_id = _open(project)
+    rows = requests.events(project_dir=project)
+    base = rows[0]["order"]
+
+    def at(event, seconds, **extra):
+        row = requests._stamp(event, q_id, "mechanical",
+                              now_ns=base + seconds * 10 ** 9)
+        row.update(extra)
+        return row
+
+    rows.append(at("surfaced", 10))
+    rows.append(at("surfaced", 20))
+    assert set(requests.fold(rows)[q_id]["surfaced"]) == {0}
+    revised = requests._stamp("revised", q_id, "cli-agent",
+                              now_ns=base + 30 * 10 ** 9)
+    revised["ask"] = "second ask"
+    rows.append(revised)
+    rows.append(at("surfaced", 40))
+    record = requests.fold(rows)[q_id]
+    assert set(record["surfaced"]) == {0, 1}
+    # Earliest row of the epoch wins: the 20s stamp never overwrote the 10s.
+    assert record["surfaced"][0] == requests._ts(base + 10 * 10 ** 9)
+    assert record["surfaced"][1] == requests._ts(base + 40 * 10 ** 9)
+
+
+def test_attention_rows_never_move_the_records_age(project):
+    q_id = _open(project)
+    before = requests.get(q_id, project_dir=project)["updated_at"]
+    for event in ("surfaced", "verdict_surfaced"):
+        requests.append(requests._stamp(event, q_id, "mechanical",
+                                        now_ns=9 * 10**18),
+                        project_dir=project)
+    after = requests.get(q_id, project_dir=project)
+    assert after["updated_at"] == before
+    assert after["verdict_surfaced_at"]
+
+
+def test_renderable_caps_and_counts_the_overflow(project):
+    for n in range(requests.RENDER_CAP + 2):
+        _open(project, ask=f"ask number {n} about the release")
+    entry = requests.renderable(project_dir=project)
+    assert len(entry["rows"]) == requests.RENDER_CAP
+    assert entry["overflow"] == 2
+
+
+def test_renderable_drops_settled_records(project):
+    open_id = _open(project)
+    done_id = _open(project, ask="the second ask, already handled")
+    requests.done(done_id, channel="cli-tty", evidence="done last week",
+                  project_dir=project)
+    ids = {r["request_id"] for r in requests.renderable(project_dir=project)["rows"]}
+    assert ids == {open_id}
+
+
+def test_torn_last_line_is_repaired_by_the_next_append(project):
+    q_id = _open(project)
+    path = requests._path(project)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write('{"event": "torn"')
+    requests.suppress(q_id, channel="cli-tty", project_dir=project)
+    assert requests.get(q_id, project_dir=project)["suppressed"] is True
+
+
+# ---- forget ---------------------------------------------------------------
+
+
+def test_forget_by_value_removes_every_row_of_the_record(project):
+    doomed = _open(project)
+    kept = _open(project, ask="an unrelated ask about the docs site")
+    requests.needs_info(doomed, channel="cli-tty", note="which release?",
+                        project_dir=project)
+    gone = requests.forget_content_key(normalize.content_key(ASK),
+                                       project_dir=project)
+    assert gone == [doomed]
+    assert set(requests.records(project_dir=project)) == {kept}
+    blob = json.dumps(_rows(project))
+    assert ASK not in blob
+    assert "which release?" not in blob   # the verdict note went with it
+
+
+def test_forget_reaches_every_plaintext_field(project):
+    for field, kwargs in (("why", {"why": "the value to remove"}),
+                          ("evidence", {"evidence": "the value to remove"})):
+        q_id = _open(project, ask=f"ask carrying {field}", **kwargs)
+        assert requests.forget_content_key(
+            normalize.content_key("the value to remove"),
+            project_dir=project) == [q_id]
+
+
+def test_plaintext_declaration_has_one_reader(project):
+    q_id = _open(project, evidence="issue:694")
+    requests.reject(q_id, channel="cli-tty", note="a human note",
+                    project_dir=project)
+    keys = set()
+    values = []
+    rows = requests.events(project_dir=project)
+    for row in rows:
+        keys |= requests.row_content_keys(row)
+        values += requests.plaintext_values(row)
+    assert "a human note" in values
+    assert normalize.content_key(ASK) in keys
+    # `author` is a person's name, never item text (the refutations rule):
+    # matching a tombstone against it would let one forgotten value delete
+    # every record a given author ever wrote.
+    author = rows[0]["author"]
+    assert author and author not in values
+
+
+def test_forget_rewrite_reads_raw_lines_not_the_tolerant_reader(project):
+    """A forgiving read feeding a write is the scar 0025/0042 shape: rows a
+    FUTURE daimon added must survive a deletion aimed at another record."""
+    doomed = _open(project)
+    future = requests._stamp("opened", "q-abcdefabcdef", "cli-tty")
+    future.update({"to": RECIPIENT, "ask": "a future ask", "why": "because",
+                   "event": "escalated"})
+    path = requests._path(project)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(future) + "\n")
+    requests.forget_content_key(normalize.content_key(ASK),
+                                project_dir=project)
+    assert any(r.get("event") == "escalated" for r in _rows(project))
+    assert doomed not in requests.records(project_dir=project)
+
+
+# ---- the CLI --------------------------------------------------------------
+
+
+OTHER = "/p/recipient"
+
+
+@pytest.fixture
+def recipient(project):
+    """A second project with a real bucket, so `--to` validation has a
+    target that exists."""
+    store.write_checkpoint("S-r", {
+        "session_id": "S-r", "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "the recipient shipped something", "trust": "inferred"}]},
+    }, project_dir=OTHER)
+    return store.project_slug(OTHER)
+
+
+def _cli_open(project, recipient, *extra):
+    from daimon_briefing import cli
+    return cli.main(["request", "open", "--to", OTHER, "--ask", ASK,
+                     "--why", WHY, "--by", "agent", "--project", project,
+                     *extra])
+
+
+def test_cli_open_records_the_request(project, recipient, capsys):
+    assert _cli_open(project, recipient, "--blocking") == 0
+    records = list(requests.records(project_dir=project).values())
+    assert len(records) == 1
+    assert records[0]["to"] == recipient and records[0]["blocking"] is True
+    assert records[0]["request_id"] in capsys.readouterr().out
+
+
+def test_cli_open_takes_the_slug_spelling_too(project, recipient, capsys):
+    """A real slug begins with '-', so `--to <slug>` is unusable — argparse
+    reads it as an option. The `--to=<slug>` form is the one that works, and
+    it must land on the same bucket the directory form does."""
+    from daimon_briefing import cli
+    rc = cli.main(["request", "open", f"--to={recipient}", "--ask", ASK,
+                   "--why", WHY, "--by", "agent", "--project", project])
+    assert rc == 0
+    assert next(iter(requests.records(
+        project_dir=project).values()))["to"] == recipient
+
+
+def test_cli_open_refuses_an_unknown_recipient_with_near_matches(
+        project, recipient, capsys):
+    typo = recipient[:-1] + "x"
+    from daimon_briefing import cli
+    rc = cli.main(["request", "open", f"--to={typo}", "--ask", ASK,
+                   "--why", WHY, "--by", "agent", "--project", project])
+    assert rc == 1
+    assert not requests.records(project_dir=project)
+    out = capsys.readouterr().out
+    assert recipient in out and "--anyway" in out
+
+
+def test_cli_open_anyway_records_it_with_a_loud_warning(project, recipient,
+                                                        capsys):
+    from daimon_briefing import cli
+    rc = cli.main(["request", "open", "--to", "/p/not-yet-a-project",
+                   "--ask", ASK, "--why", WHY, "--by", "agent",
+                   "--anyway", "--project", project])
+    assert rc == 0
+    assert len(requests.records(project_dir=project)) == 1
+    out = capsys.readouterr().out
+    assert "warning:" in out and "never surfaced" in out
+
+
+def test_cli_open_human_path_requires_a_terminal(project, recipient,
+                                                 monkeypatch, capsys):
+    from daimon_briefing import cli
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False)
+    rc = cli.main(["request", "open", "--to", OTHER, "--ask", ASK,
+                   "--why", WHY, "--project", project])
+    assert rc == 1
+    assert not requests.records(project_dir=project)
+
+
+@pytest.mark.parametrize("verb", ["accept", "reject", "needs-info",
+                                  "suppress"])
+def test_cli_verdict_verbs_refuse_the_agent_channel(project, recipient, verb,
+                                                    capsys):
+    from daimon_briefing import cli
+    assert _cli_open(project, recipient) == 0
+    q_id = next(iter(requests.records(project_dir=project)))
+    rc = cli.main(["request", verb, q_id, "--by", "agent",
+                   "--project", project])
+    assert rc == 1
+    assert requests.get(q_id, project_dir=project)["state"] == "open"
+
+
+def test_cli_human_verdicts_and_done(project, recipient, monkeypatch, capsys):
+    from daimon_briefing import cli
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    assert _cli_open(project, recipient) == 0
+    q_id = next(iter(requests.records(project_dir=project)))
+    assert cli.main(["request", "needs-info", q_id, "--note", "which release?",
+                     "--project", project]) == 0
+    assert requests.get(q_id, project_dir=project)["state"] == "needs-info"
+    assert cli.main(["request", "revise", q_id, "--ask", "review it for 0.32.0",
+                     "--by", "agent", "--project", project]) == 0
+    assert cli.main(["request", "accept", q_id, "--project", project]) == 0
+    assert cli.main(["request", "done", q_id, "--evidence", "merged in #712",
+                     "--by", "agent", "--project", project]) == 0
+    record = requests.get(q_id, project_dir=project)
+    assert record["state"] == "done" and record["done_claimed"] is True
+    assert "claimed, unverified" in capsys.readouterr().out
+
+
+def test_cli_revise_refuses_past_the_cap(project, recipient, capsys):
+    from daimon_briefing import cli
+    assert _cli_open(project, recipient) == 0
+    q_id = next(iter(requests.records(project_dir=project)))
+    for n in range(requests.MAX_REVISIONS):
+        assert cli.main(["request", "revise", q_id, "--ask", f"ask {n}",
+                         "--by", "agent", "--project", project]) == 0
+    rc = cli.main(["request", "revise", q_id, "--ask", "one more",
+                   "--by", "agent", "--project", project])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "--supersedes" in out
+    assert requests.get(q_id, project_dir=project)["revision"] == \
+        requests.MAX_REVISIONS
+
+
+def test_cli_list_renders_records_and_json(project, recipient, monkeypatch,
+                                           capsys):
+    from daimon_briefing import cli
+    assert cli.main(["request", "list", "--project", project]) == 0
+    assert "no requests" in capsys.readouterr().out
+    assert _cli_open(project, recipient, "--blocking") == 0
+    q_id = next(iter(requests.records(project_dir=project)))
+    assert cli.main(["request", "list", "--project", project]) == 0
+    out = capsys.readouterr().out
+    assert q_id in out and "open" in out and "Blocking" in out
+    assert cli.main(["request", "list", "--json", "--project", project]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [r["request_id"] for r in payload] == [q_id]
+    assert payload[0]["state"] == "open"
+
+
+def test_cli_list_keeps_suppressed_records_visible(project, recipient,
+                                                   monkeypatch, capsys):
+    from daimon_briefing import cli
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    assert _cli_open(project, recipient) == 0
+    q_id = next(iter(requests.records(project_dir=project)))
+    assert cli.main(["request", "suppress", q_id, "--project", project]) == 0
+    capsys.readouterr()
+    assert cli.main(["request", "list", "--project", project]) == 0
+    out = capsys.readouterr().out
+    assert q_id in out and "Suppressed" in out
+
+
+def test_request_id_headers_get_their_own_spans():
+    """#711's three-span header contract, extended to the q- id space: the
+    id a human copies stays the bold-cyan span."""
+    from daimon_briefing import render
+    spans = render._ledger_header_spans(
+        "[→ open · agent-asked] q-0123456789ab  review the proposal")
+    assert spans == ("[→ open · agent-asked]", "q-0123456789ab",
+                     "review the proposal")
+
+
+# ---- registration, forget, audit ------------------------------------------
+
+
+def test_the_request_stream_is_a_declared_surface():
+    from daimon_briefing import surfaces
+    s = surfaces.match("checkpoints/{slug}/requests.jsonl")
+    assert s is not None
+    assert s.plaintext is True and s.delete == "rewrite"
+    # It must win over the generic per-bucket entries that follow it.
+    assert s.owner == "requests.append"
+
+
+def test_cli_forget_reaches_the_request_ledger_by_value(project, capsys):
+    from daimon_briefing import cli
+    store.write_checkpoint("S-1", {
+        "session_id": "S-1", "created": "2026-08-16T00:00:00Z",
+        "working_context": {"open_questions": [
+            {"text": "does the recipient own this", "trust": "inferred"}]},
+    }, project_dir=project)
+    q_id = _open(project)
+    rc = cli.main(["forget", ASK, "--project", project])
+    assert rc == 0
+    assert requests.get(q_id, project_dir=project) is None
+    assert "request" in capsys.readouterr().out
+
+
+def test_audit_privacy_scans_the_request_ledger(project):
+    from daimon_briefing import cli, privacy
+    store.write_checkpoint("S-1", {
+        "session_id": "S-1", "created": "2026-08-16T00:00:00Z",
+        "working_context": {"open_questions": [
+            {"text": "does the recipient own this", "trust": "inferred"}]},
+    }, project_dir=project)
+    q_id = _open(project)
+    assert cli.main(["forget", ASK, "--project", project]) == 0
+    assert requests.get(q_id, project_dir=project) is None
+    # A row landing AFTER the forget carries the forgotten value: the audit
+    # must see it (this is what proves the scanner works).
+    row = requests._stamp("opened", "q-abcabcabcabc", "cli-agent")
+    row.update({"to": "-p-recipient", "ask": ASK, "why": "residue"})
+    assert requests.append(row, project_dir=project)
+    path = requests._path(project)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write("junk line\n[1, 2]\n")
+    result = privacy.audit_project(project_dir=project)
+    assert "request-ledger" in {f["surface"] for f in result["findings"]}
+    assert result["requests"]["rows"] >= 1
+
+
+def test_audit_privacy_no_slug_shape_includes_requests():
+    from daimon_briefing import privacy
+    result = privacy.audit_project(project_dir="")
+    assert result["requests"] == {"records": 0, "rows": 0, "bytes": 0}
+
+
+# ---- the frozen vocabularies ----------------------------------------------
+
+
+def test_the_event_vocabulary_is_frozen():
+    """PR 1 freezes the format so PR 2/3 cannot widen it by accident: rows
+    an older reader drops are rows it silently re-renders as undecided."""
+    assert set(requests.EVENTS) == {
+        "opened", "revised", "surfaced", "verdict_surfaced",
+        "needs_info", "accepted", "rejected", "done", "suppressed"}
+
+
+def test_the_fold_reaches_every_render_state_but_never_stale(project):
+    """`stale` is DERIVED from consumption (PR 3) and never appended, so the
+    fold must produce every OTHER declared state and that one never."""
+    seen = set()
+    open_id = _open(project)
+    seen.add(requests.get(open_id, project_dir=project)["state"])
+    info_id = _open(project, ask="the second ask, awaiting an answer")
+    requests.needs_info(info_id, channel="cli-tty", note="which release?",
+                        project_dir=project)
+    accepted = _open(project, ask="the third ask, taken on")
+    requests.accept(accepted, channel="cli-tty", project_dir=project)
+    rejected = _open(project, ask="the fourth ask, declined")
+    requests.reject(rejected, channel="cli-tty", project_dir=project)
+    finished = _open(project, ask="the fifth ask, handled")
+    requests.done(finished, channel="cli-tty", evidence="shipped on Tuesday",
+                  project_dir=project)
+    seen |= {r["state"] for r in requests.records(project_dir=project).values()}
+    assert seen == set(requests.RENDER_STATES) - {"stale"}
+
+
+# ---- the PR-1 interim window (design r2-G) --------------------------------
+
+
+def test_a_verdict_on_an_id_this_bucket_cannot_see_is_written_and_inert(
+        project):
+    """A request lives in the SENDER's bucket, so a recipient answering one
+    has nothing local to resolve against. The answer is written here and
+    stays an orphan until PR 2's read-time join pairs it with its origin —
+    refusing it would make the recipient side unimplementable."""
+    foreign = "q-0123456789ab"
+    requests.accept(foreign, channel="cli-tty", note="on it",
+                    project_dir=project)
+    requests.done(foreign, channel="cli-tty", evidence="shipped it",
+                  project_dir=project)
+    requests.suppress(foreign, channel="cli-tty", project_dir=project)
+    assert requests.records(project_dir=project) == {}   # inert…
+    assert len(_rows(project)) == 3                      # …but on disk
+
+
+@pytest.mark.parametrize("verb", ["accept", "done", "suppress"])
+def test_a_malformed_id_is_still_refused(project, verb):
+    kwargs = {"evidence": "x"} if verb == "done" else {}
+    with pytest.raises(requests.RequestError):
+        getattr(requests, verb)("not-a-request-id", channel="cli-tty",
+                                project_dir=project, **kwargs)
+
+
+def test_revise_still_requires_a_record_it_can_read(project):
+    """The sender-side verb is the asymmetric one: a revision replaces text
+    it must read and is bounded by a count it must know."""
+    with pytest.raises(requests.RequestError):
+        requests.revise("q-0123456789ab", channel="cli-agent", ask="anything",
+                        project_dir=project)
+
+
+def test_cli_says_so_when_the_answered_request_is_not_in_this_bucket(
+        project, monkeypatch, capsys):
+    from daimon_briefing import cli
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    rc = cli.main(["request", "accept", "q-0123456789ab",
+                   "--project", project])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "no matching request in this bucket" in out

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -756,3 +756,242 @@ def test_cli_says_so_when_the_answered_request_is_not_in_this_bucket(
     assert rc == 0
     out = capsys.readouterr().out
     assert "no matching request in this bucket" in out
+
+
+# ---- refusal, degradation, and tolerance edges ----------------------------
+
+
+def test_stamp_refuses_a_malformed_id_and_an_unknown_channel(project):
+    """Nothing reaches the ledger through a hand-built row either: the stamp
+    is where an id shape and a channel name are checked, and a channel it
+    does not know has no authority to derive."""
+    with pytest.raises(requests.RequestError):
+        requests._stamp("opened", "not-an-id", "cli-tty")
+    with pytest.raises(requests.RequestError):
+        requests._stamp("opened", "q-0123456789ab", "cli-ui")
+    assert not _rows_or_empty(project)
+
+
+def _rows_or_empty(project):
+    path = requests._path(project)
+    return [] if path is None or not path.exists() else _rows(project)
+
+
+def test_a_missing_ledger_is_not_torn(project, tmp_path):
+    """`_is_torn` answers for a file it cannot stat: the first append to a
+    fresh bucket must not prepend a repair newline."""
+    assert requests._is_torn(tmp_path / "never-written.jsonl") is False
+    _open(project)
+    assert requests._path(project).read_text(
+        encoding="utf-8").startswith("{")
+
+
+def test_the_kill_switch_stops_the_ledger(project, monkeypatch):
+    """#421 posture: with daimon disabled the write path is a no-op, and the
+    verbs say so instead of reporting a record nobody wrote."""
+    q_id = _open(project)
+    before = len(_rows(project))
+    monkeypatch.setenv("DAIMON_DISABLE", "1")
+    assert requests.append(requests._stamp("suppressed", q_id, "cli-tty"),
+                           project_dir=project) is False
+    for call in (
+            lambda: _open(project, ask="an ask written while disabled"),
+            lambda: requests.revise(q_id, channel="cli-agent", ask="nope",
+                                    project_dir=project),
+            lambda: requests.accept(q_id, channel="cli-tty",
+                                    project_dir=project),
+            lambda: requests.suppress(q_id, channel="cli-tty",
+                                      project_dir=project),
+            lambda: requests.done(q_id, channel="cli-tty", evidence="x",
+                                  project_dir=project)):
+        with pytest.raises(requests.RequestError):
+            call()
+    assert len(_rows(project)) == before
+
+
+def test_an_unwritable_bucket_degrades_instead_of_raising(project):
+    """A bucket path occupied by a FILE cannot hold a ledger. `append` is the
+    layer that must not explode — it reports failure, and the verbs above it
+    turn that into a refusal."""
+    bucket = config.checkpoint_dir() / store.project_slug(project)
+    bucket.parent.mkdir(parents=True, exist_ok=True)
+    bucket.write_text("not a directory", encoding="utf-8")
+    assert requests.append(requests._stamp("opened", "q-0123456789ab",
+                                           "cli-tty"),
+                           project_dir=project) is False
+    with pytest.raises(requests.RequestError):
+        _open(project)
+
+
+def test_an_unreadable_ledger_reads_empty_and_deletes_nothing(project):
+    """Undecodable bytes are a read failure, not a licence to rewrite: the
+    tolerant reader returns nothing and the deleter touches nothing."""
+    q_id = _open(project)
+    path = requests._path(project)
+    before = path.read_bytes()
+    path.write_bytes(b"\xff\xfe not utf-8 at all\n")
+    assert requests.events(project_dir=project) == []
+    assert requests.records(project_dir=project) == {}
+    assert requests._rewrite_without({q_id}, project_dir=project) == []
+    assert path.read_bytes() != before        # still the corrupt bytes
+    assert path.read_bytes() == b"\xff\xfe not utf-8 at all\n"
+
+
+def test_fold_tolerates_garbage_ordering_values(project):
+    """`order` and `_line` come off disk; a non-integer must fall back to the
+    default rather than sink the whole fold."""
+    q_id = _open(project)
+    rows = requests.events(project_dir=project)
+    rows[0]["order"] = "not-a-number"
+    rows[0]["_line"] = [1]
+    assert requests.fold(rows)[q_id]["state"] == "open"
+
+
+def test_a_second_opened_row_never_rewrites_the_first(project):
+    """Duplicate logical opens: first writer wins, so a replayed row cannot
+    quietly change what the recipient was asked."""
+    q_id = _open(project)
+    replay = requests._stamp("opened", q_id, "cli-tty")
+    replay.update({"to": RECIPIENT, "ask": "something else entirely",
+                   "why": WHY})
+    assert requests.append(replay, project_dir=project)
+    assert requests.get(q_id, project_dir=project)["ask"] == ASK
+
+
+@pytest.mark.parametrize("field,value", [("to", ""), ("to", "not/a/slug"),
+                                         ("ask", "   ")])
+def test_an_opened_row_missing_its_addressing_never_founds_a_record(
+        project, field, value):
+    """The read-boundary shape check: a row edited on disk into something
+    unaddressable is inert, not a record addressed to nobody."""
+    row = requests._stamp("opened", "q-0123456789ab", "cli-tty")
+    row.update({"to": RECIPIENT, "ask": ASK, "why": WHY, field: value})
+    assert requests.append(row, project_dir=project)
+    assert requests.records(project_dir=project) == {}
+
+
+def test_open_refuses_a_malformed_recipient_or_supersedes_id(project):
+    with pytest.raises(requests.RequestError):
+        _open(project, to="not/a/slug")
+    with pytest.raises(requests.RequestError):
+        _open(project, supersedes="q-nope")
+
+
+def test_open_refuses_when_the_sender_project_is_unknown():
+    with pytest.raises(requests.RequestError):
+        requests.open_request(to=RECIPIENT, ask=ASK, why=WHY,
+                              channel="cli-agent", project_dir=None)
+
+
+def test_the_same_ask_twice_in_one_second_is_refused_not_collided(
+        project, monkeypatch):
+    """The id hashes the second, so a re-ask inside one second would land on
+    the record already open. It is refused instead of overwriting it."""
+    monkeypatch.setattr(requests.time, "time_ns", lambda: 1_786_000_000 * 10 ** 9)
+    first = _open(project)
+    with pytest.raises(requests.RequestError):
+        _open(project)
+    assert list(requests.records(project_dir=project)) == [first]
+
+
+def test_revise_can_replace_the_evidence_alone(project):
+    q_id = _open(project, evidence="issue:694")
+    requests.revise(q_id, channel="cli-agent", evidence="issue:712",
+                    project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["evidence"] == "issue:712"
+    assert record["ask"] == ASK and record["revision"] == 1
+
+
+# ---- forget: the rewrite edges -------------------------------------------
+
+
+def test_a_deletion_aimed_at_a_bucket_with_no_ledger_removes_nothing(project):
+    assert requests._rewrite_without({"q-0123456789ab"},
+                                     project_dir=project) == []
+    assert requests._rewrite_without({"q-0123456789ab"},
+                                     project_dir=None) == []
+
+
+def test_the_rewrite_drops_blank_and_torn_lines_it_passes_over(project):
+    """Torn rows are expendable — keeping one would leave bytes behind that
+    the deletion was asked to remove."""
+    doomed = _open(project)
+    kept = _open(project, ask="an unrelated ask about the docs site")
+    path = requests._path(project)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write("\n")
+        handle.write('{"request_id": "q-abcabcabcabc", "ask": "half a r')
+    assert requests.forget_content_key(normalize.content_key(ASK),
+                                       project_dir=project) == [doomed]
+    text = path.read_text(encoding="utf-8")
+    assert "half a r" not in text
+    assert "" not in text.splitlines()
+    assert set(requests.records(project_dir=project)) == {kept}
+
+
+def test_a_failed_swap_leaves_the_ledger_whole_and_no_tmp_behind(
+        project, monkeypatch):
+    """Atomic or nothing: if the replace fails, the deletion reports that it
+    removed nothing rather than leaving a half-written ledger."""
+    q_id = _open(project)
+    path = requests._path(project)
+    before = path.read_text(encoding="utf-8")
+
+    def boom(src, dst):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(requests.os, "replace", boom)
+    assert requests.forget_content_key(normalize.content_key(ASK),
+                                       project_dir=project) == []
+    assert path.read_text(encoding="utf-8") == before
+    assert requests.get(q_id, project_dir=project) is not None
+    assert not list(path.parent.glob("*.forget-tmp"))
+
+
+def test_a_failed_swap_survives_an_undeletable_tmp(project, monkeypatch):
+    """The cleanup of the temp file is best-effort; a failure there must not
+    turn a degraded deletion into a crash."""
+    _open(project)
+    monkeypatch.setattr(requests.os, "replace",
+                        lambda src, dst: (_ for _ in ()).throw(OSError()))
+    real_unlink = type(requests._path(project)).unlink
+
+    def deny(self, missing_ok=False):
+        if self.name.endswith(".forget-tmp"):
+            raise OSError("EPERM")
+        return real_unlink(self, missing_ok=missing_ok)
+
+    monkeypatch.setattr(type(requests._path(project)), "unlink", deny)
+    assert requests.forget_content_key(normalize.content_key(ASK),
+                                       project_dir=project) == []
+
+
+# ---- CLI: the remaining refusal and card branches -------------------------
+
+
+def test_cli_list_renders_evidence_and_supersedes(project, recipient, capsys):
+    from daimon_briefing import cli
+    first = _open(project, evidence="issue:694")
+    second = _open(project, ask="review it again, with the new numbers",
+                   supersedes=first)
+    assert cli.main(["request", "list", "--project", project]) == 0
+    out = capsys.readouterr().out
+    assert "Evidence: issue:694" in out
+    assert f"Supersedes: {first}" in out
+    assert second in out
+
+
+def test_cli_done_on_a_rejected_request_refuses(project, recipient,
+                                                monkeypatch, capsys):
+    from daimon_briefing import cli
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    q_id = _open(project)
+    assert cli.main(["request", "reject", q_id, "--note", "out of scope",
+                     "--project", project]) == 0
+    capsys.readouterr()
+    rc = cli.main(["request", "done", q_id, "--evidence", "I did it anyway",
+                   "--by", "agent", "--project", project])
+    assert rc == 1
+    assert "request done refused" in capsys.readouterr().out
+    assert requests.get(q_id, project_dir=project)["state"] == "rejected"

--- a/plugin/tests/test_skill_content.py
+++ b/plugin/tests/test_skill_content.py
@@ -61,8 +61,21 @@ def test_full_fits_size_budget():
     # else, stated where agents will read it. New deliberate-review size is
     # 9,502 (2026-08-15, after review folded the proposal-verb teaching in);
     # 9,900 keeps ~4% slack. Nothing was added to the compact body.
+    #
+    # RAISED 9,900 -> 10,700 on 2026-08-16 (#694), same discipline and the
+    # same subject. `request` ships an agent-facing verb family — an agent
+    # opens, revises, and completes asks — and the alternative was declaring
+    # it NOT_AGENT_FACING, which would have been false rather than economical.
+    # The addition is ~500 chars in the cross-project section, where an agent
+    # already goes to read another project: the doctrine line (never write
+    # into another project's memory), the one command that matters, and the
+    # human-only verb list, which is the wedge rule again. What was NOT
+    # taught: the verdict flow and the inbox, because neither exists until
+    # PR 2/3 — teaching a surface before it renders is how a skill starts
+    # lying. New deliberate-review size is 10,301 (2026-08-16); 10,700 keeps
+    # the same ~4% slack. Nothing was added to the compact body.
     full = skill_content.render_full()
-    assert len(full) <= 9900, f"full body is {len(full)} chars (cap 9900)"
+    assert len(full) <= 10700, f"full body is {len(full)} chars (cap 10700)"
 
 
 def test_full_has_trigger_only_frontmatter():

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -74,7 +74,7 @@ from pathlib import Path
 import pytest
 
 from daimon_briefing import (amendments, cli, config, policy, refutations,
-                             relations, store, teamsync)
+                             relations, requests, store, teamsync)
 
 from tests.conftest import FIXTURES, FakeChat
 import pytest as _pytest
@@ -502,6 +502,49 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
     def r_amend_list():
         run(["amend", "list"], 0)
 
+    def _open_request(ask):
+        # Self-addressed: the drive's own project is the one bucket that
+        # exists, and `--to` takes the project DIRECTORY (a real slug starts
+        # with '-', which argparse would read as an option).
+        run(["request", "open", "--to", str(proj), "--ask", ask,
+             "--why", "the release note depends on it", "--blocking",
+             "--by", "agent"], 0)
+        newest = max(requests.records(project_dir=str(proj)).values(),
+                     key=lambda r: r["created_at"])
+        return newest["request_id"]
+
+    def r_request_open():
+        ctx["request_id"] = _open_request("publish the 0.32 schema")
+
+    def r_request_revise():
+        run(["request", "revise", ctx["request_id"],
+             "--ask", "publish the 0.32 schema before Friday",
+             "--by", "agent"], 0)
+
+    def r_request_needs_info():
+        run(["request", "needs-info", ctx["request_id"],
+             "--note", "which schema version"], 0)
+
+    def r_request_suppress():
+        run(["request", "suppress", ctx["request_id"],
+             "--note", "not this week"], 0)
+
+    def r_request_accept():
+        run(["request", "accept", ctx["request_id"]], 0)
+
+    def r_request_done():
+        run(["request", "done", ctx["request_id"],
+             "--evidence", "the schema shipped in 0.32.0", "--by", "agent"], 0)
+
+    def r_request_reject():
+        # A fresh record: rejection is sticky, so it cannot reuse the one the
+        # accept/done recipes above already settled.
+        run(["request", "reject", _open_request("rewrite the client SDK"),
+             "--note", "out of scope this quarter"], 0)
+
+    def r_request_list():
+        run(["request", "list"], 0)
+
     def _seed_relation():
         # Proposals are not CLI-exposed (lab/serializer writers only), so the
         # verdict drives seed one candidate through the module seam — the
@@ -671,6 +714,14 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
         ("amend", "ratify"): r_amend_ratify,
         ("amend", "reject"): r_amend_reject,
         ("amend", "list"): r_amend_list,
+        ("request", "open"): r_request_open,
+        ("request", "revise"): r_request_revise,
+        ("request", "needs-info"): r_request_needs_info,
+        ("request", "suppress"): r_request_suppress,
+        ("request", "accept"): r_request_accept,
+        ("request", "done"): r_request_done,
+        ("request", "reject"): r_request_reject,
+        ("request", "list"): r_request_list,
         ("relations", "list"): r_relations_list,
         ("relations", "show"): r_relations_show,
         ("relations", "confirm"): r_relations_confirm,
@@ -745,6 +796,7 @@ def test_every_command_write_carries_an_admit_frame(
     assert saw("resolve", "events.jsonl")           # admit_row on the ledger
     assert saw("forget", "events.jsonl")            # tombstone append
     assert saw("refute add", "refutations.jsonl")  # negative ledger append
+    assert saw("request open", "requests.jsonl")   # cross-project ledger
     # #599: the ledger REWRITE (scrub_event_fields) must have run and been
     # governed — not merely the tombstone append hitting the same file.
     assert any(cmd == "forget" and rel.name == "events.jsonl" and governed


### PR DESCRIPTION
Refs #694

## Summary

- Ships the request object: a first-class open-loop-with-a-recipient record in the sender's own `requests.jsonl` bucket — PR 1 of the 3-PR arc (object → inbox → return path).
- All verbs land: `open`/`revise`/`list` (either channel), `accept`/`reject`/`needs-info`/`suppress` (human-only, enforced at the write boundary AND re-checked in the fold), `done` (evidence required, channel recorded).
- Full new-stream registration: surfaces entry, privacy-audit block, hand-wired forget dispatch, write-audit drive recipes, render.py ledger routing, skill teaching.

Design was twice-refuted before code (two independent adversarial passes, both folded): id = `make_id(sender_slug, ask, why, opened_ts)` so identical asks from two projects never collide; sticky reject with supersede lineage; revise capped ×3 with revision 4+ inert in the fold; suppress human-only and panel-only.

**Interim window (by design):** verdict verbs shape-check ids without resolving them, matching shipped ledger behavior (`_stamp` precedent). A verdict row for an id with no local origin is writable now and becomes inert-and-invisible when PR 2's join composer lands.

**`--to` takes a directory, not a raw slug**: a real slug always starts with a dash (project_slug munges every non-word char), so argparse reads it as an option. The slug transform is idempotent, so `--to=<slug>` also works.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/requests.py` | New stream module: events/fold/verbs/forget (724 lines) |
| `plugin/daimon_briefing/cli/request.py` | CLI family: 8 verbs, channel gate, ledger-card rendering |
| `plugin/tests/test_requests.py` | 65 tests: fold determinism, caps, sticky reject, id collision, human-only gates, forget rewrite |
| `plugin/daimon_briefing/surfaces.py` | Surface registration with rationale |
| `plugin/daimon_briefing/privacy.py` | Requests audit block (hash intersection + growth counts) |
| `plugin/daimon_briefing/cli/lifecycle.py` | Hand-wired forget dispatch for requests |
| `plugin/daimon_briefing/cli/__init__.py` | Family registration |
| `plugin/daimon_briefing/render.py` | `q-` header ids, audit count line |
| `plugin/daimon_briefing/skill_content.py` | Teaches `request` (guard test refuses untaught commands) |
| `plugin/tests/test_write_audit_guard.py` | 8 drive recipes + anti-vacuity assert |
| `plugin/tests/test_skill_content.py` | Size cap raised with reasoning |

## PR Type

- [x] New feature

## Test Plan

- [x] Full suite green: `uv run pytest tests/ -q` → 3938 passed, 2 skipped (run twice: implementer + independent verification)
- [x] `uv run ruff check daimon_briefing tests` → clean
- [x] New-stream guards exercised: write-audit ratchet, surface registry full-contract, taught-or-declared

## Contributor Checklist

- [x] Linked an approved issue (#694, `status:approved`)
- [x] Added exactly one `type:*` label
- [x] Skills content updated (`request` taught)
- [x] Docs: design doc updated in vault (internal)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers