### PR TITLE
feat(briefing): cross-project request inbox and panel — PR 2 of #694

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -20,8 +20,8 @@ import time
 # scoring, nor serializer imports briefing — no cycle, so this stays a normal
 # module-level import (contrast carry.py's own local-import notes, which
 # don't apply here).
-from . import (capture, carry, config, llm, receipts, refutations, schema,
-               scoring, serializer, store)
+from . import (capture, carry, config, llm, receipts, refutations, requests,
+               schema, scoring, serializer, store)
 # Imported as constants, not as the module: withhold()'s `amendments`
 # parameter (the public keyword every caller uses) would shadow the module
 # name inside that function.
@@ -790,14 +790,69 @@ def ruling_lines(project_dir=None) -> list[str]:
     return lines
 
 
-def render_plain(b: dict, degraded: bool = False, rulings=()) -> str:
+# ---- #694 PR 2: the recipient-side request panel ---------------------------
+
+# Ruling-shaped (D2): always-present, skeleton furniture, capped and loud on
+# overflow — never a section budget pressure is allowed to quietly thin out.
+_REQUEST_PANEL_HEADER = "Requests waiting on you (from other projects):"
+
+# An `ask` can be up to `requests._MAX_TEXT` (2000 chars); the panel line is
+# meant to be skimmable, not the full record — `daimon request inbox` has the
+# rest. Same display-cap idiom as `_truncate_agent_claim` above, and the
+# reason the worst-case-cap test can bound the section's cost at all.
+_REQUEST_ASK_CHARS = 160
+
+
+def _truncate_request_ask(ask: str) -> str:
+    text = str(ask or "").strip()
+    if len(text) <= _REQUEST_ASK_CHARS:
+        return text
+    return text[:_REQUEST_ASK_CHARS].rstrip() + "…"
+
+
+def request_panel_lines(project_dir=None) -> list[str]:
+    """The recipient-side panel's rendered lines ([] when nothing is
+    addressed to this project, or `project_dir` is None — the section is
+    skeleton furniture, but empty furniture is noise).
+
+    Fail-open like `ruling_lines`: ANY error from the composer yields []
+    rather than costing the briefing. `project_dir` here is the CLI's
+    `worldcheck_project` — the caller (render.render_brief /
+    cli._render_briefing_body) is the ONE place that decides whether this
+    request is same-project (D2's CLI-only gate); this function never
+    inspects route or surface on its own."""
+    if project_dir is None:
+        return []
+    try:
+        entry = requests.inbox_renderable(project_dir=project_dir)
+    except Exception:
+        return []
+    rows = entry.get("rows") or []
+    if not rows:
+        return []
+    lines = [_REQUEST_PANEL_HEADER]
+    for row in rows:
+        marker = "  [blocking]" if row.get("blocking") else ""
+        lines.append(f"→ {row['request_id']}  "
+                     f"{_truncate_request_ask(row.get('ask', ''))}{marker}")
+        lines.append(f"  From: {row.get('from_label') or 'an unnamed project'}")
+    overflow = entry.get("overflow") or 0
+    if overflow:
+        plural = "s" if overflow != 1 else ""
+        lines.append(f"  (+{overflow} more waiting{plural} — "
+                     "daimon request inbox)")
+    return lines
+
+
+def render_plain(b: dict, degraded: bool = False, rulings=(),
+                 request_lines=()) -> str:
     """The deterministic briefing text. Under the #79 budget this is
     BYTE-IDENTICAL to the legacy render(); over it, long items truncate
     (sections preserved) and then whole items drop, lowest value first,
     each cut announced with a trim note. `degraded` (#204) downgrades every
     verbatim label and adds one header note when the receipt is unverifiable."""
     budget = config.brief_max_tokens()
-    text = _render_parts(b, {}, degraded, rulings)
+    text = _render_parts(b, {}, degraded, rulings, request_lines)
     if not budget or estimate_tokens(text) <= budget:
         return text
 
@@ -815,7 +870,7 @@ def render_plain(b: dict, degraded: bool = False, rulings=()) -> str:
             for i in (b.get(key) or [])
         ]
     trimmed = {key: 0 for key, _ in _DROP_ORDER}
-    text = _render_parts(b, trimmed, degraded, rulings)
+    text = _render_parts(b, trimmed, degraded, rulings, request_lines)
 
     # Stage 2: drop whole items, least valuable first, until the budget holds
     # or only the skeleton remains.
@@ -825,14 +880,14 @@ def render_plain(b: dict, degraded: bool = False, rulings=()) -> str:
             items.pop(-1 if end == "tail" else 0)
             b[key] = items
             trimmed[key] += 1
-            text = _render_parts(b, trimmed, degraded, rulings)
+            text = _render_parts(b, trimmed, degraded, rulings, request_lines)
         if estimate_tokens(text) <= budget:
             break
     return text
 
 
 def _render_parts(b: dict, trimmed: dict, degraded: bool = False,
-                  rulings=()) -> str:
+                  rulings=(), request_lines=()) -> str:
     parts = ["While you were away — here's where we left off."]
     if degraded:
         # One header note (#204), embedded in the text so the hook-injected
@@ -845,6 +900,12 @@ def _render_parts(b: dict, trimmed: dict, degraded: bool = False,
         # sections below.
         parts.append("")
         parts.extend(rulings)
+    if request_lines:
+        # #694 PR 2: same posture as rulings above — skeleton furniture, the
+        # budget loops re-render with the same lines and can only trim the
+        # sections below.
+        parts.append("")
+        parts.extend(request_lines)
 
     def _section(header: str, key: str) -> None:
         items = b.get(key) or []
@@ -913,7 +974,7 @@ def _validate_llm_render(rendered: str, checkpoint) -> bool:
     return True
 
 
-def render(checkpoint, project_dir=None) -> str | None:
+def render(checkpoint, project_dir=None, worldcheck_project=None) -> str | None:
     """Render the briefing, or None if there is nothing worth surfacing.
     LLM rendering is opt-in (DAIMON_LLM_BRIEFING), post-validated for verbatim
     quote integrity, and falls back to deterministic on any doubt.
@@ -921,14 +982,23 @@ def render(checkpoint, project_dir=None) -> str | None:
     `project_dir` (#693) scopes the standing-rulings section; None (legacy
     callers, hand-built checkpoints in tests) skips the read entirely — an
     unknown project resolves to no ledger path and reads nothing, so the
-    guard saves a pointless call rather than preventing a leak."""
+    guard saves a pointless call rather than preventing a leak.
+
+    `worldcheck_project` (#694 PR 2) scopes the incoming-request panel — a
+    SEPARATE parameter from `project_dir`, never reused, because the panel's
+    gate is narrower than the rulings section's: rulings render on every
+    route (including `--slug`), the panel only on the CLI same-project
+    path (`cli._render_briefing_body`'s own `worldcheck_project`, D2)."""
     b = build(checkpoint)
     rulings = ruling_lines(project_dir) if project_dir is not None else []
+    request_lines = (request_panel_lines(worldcheck_project)
+                     if worldcheck_project is not None else [])
     if b is None:
         # #693: a ruling ratified before the first real checkpoint (a day-one
         # action) must still reach context — "nothing worth surfacing" is no
-        # longer true when active rulings exist.
-        return "\n".join(rulings) if rulings else None
+        # longer true when active rulings or addressed requests exist.
+        skeleton = rulings + ([""] if rulings and request_lines else []) + request_lines
+        return "\n".join(skeleton) if skeleton else None
     degraded = receipt_degraded(checkpoint)
     if config.llm_briefing():
         rendered = _render_llm(checkpoint)
@@ -936,18 +1006,21 @@ def render(checkpoint, project_dir=None) -> str | None:
             if _validate_llm_render(rendered, checkpoint):
                 # The LLM render carries no per-item marks to degrade; the one
                 # header note stays FIRST on every path (#204 — the loudest
-                # line never moves below another section). #693: the LLM
-                # narrates the CHECKPOINT; rulings live outside it, so the
-                # deterministic section is prepended verbatim after the note —
-                # never re-narrated, never trusted to a generative pass.
+                # line never moves below another section). #693/#694: the LLM
+                # narrates the CHECKPOINT; rulings and the request panel live
+                # outside it, so the deterministic sections are prepended
+                # verbatim after the note — never re-narrated, never trusted
+                # to a generative pass.
                 parts = ([DEGRADE_NOTE] if degraded else [])
                 if rulings:
                     parts.append("\n".join(rulings))
+                if request_lines:
+                    parts.append("\n".join(request_lines))
                 parts.append(rendered)
                 return "\n\n".join(parts)
             log.warning("llm briefing dropped a verbatim quote — "
                         "falling back to the deterministic render")
-    return render_plain(b, degraded, rulings)
+    return render_plain(b, degraded, rulings, request_lines)
 
 
 # Seeded from research/experiments/track-a/prompts/02-reconstruct.md, tuned for a

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -31,7 +31,7 @@ import traceback
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from .. import amendments, anchor, briefing, capture, carry, config, configure, harvest, inspector, ledger, llm, normalize, privacy, provenance, recall, receipts, redact, refutations, relations, render, schema, serializer, store, teamsync, transcript, worldcheck  # noqa: F401 — several are re-exported for compat only (#708): `cli.<name>` is a stable seam
+from .. import amendments, anchor, briefing, capture, carry, config, configure, harvest, inspector, ledger, llm, normalize, privacy, provenance, recall, receipts, redact, refutations, relations, render, requests, schema, serializer, store, teamsync, transcript, worldcheck  # noqa: F401 — several are re-exported for compat only (#708): `cli.<name>` is a stable seam
 from .. import __version__
 
 # The serialize.log ledger subsystem lives in ledger.py (#147 + #162, pure
@@ -580,7 +580,25 @@ def _render_briefing_body(checkpoint, route, *, drift_project, teammates,
     except Exception:
         handoff = None
     render.render_brief(checkpoint, drift=drift, teammates=teammates,
-                        handoff=handoff, project_dir=route)
+                        handoff=handoff, project_dir=route,
+                        worldcheck_project=worldcheck_project)
+    # #694 PR 2 (D1): the surfaced stamp, AFTER the render+print pipeline
+    # above completes — the card has already reached the terminal, so a
+    # crash between here and the write below just re-renders it next brief
+    # (the safe direction) rather than a false "surfaced". Gated on the same
+    # `worldcheck_project` parameter as the panel itself (D2) — never on
+    # `route`, which is set on every path including --slug. Fail-open, same
+    # posture as every other best-effort block in this function: a broken
+    # composer must never take the briefing down.
+    if worldcheck_project is not None:
+        try:
+            for row in requests.inbox_renderable(
+                    project_dir=worldcheck_project).get("rows") or []:
+                if requests.needs_surfaced_stamp(row):
+                    requests.stamp_surfaced(row["request_id"],
+                                            project_dir=worldcheck_project)
+        except Exception:
+            pass
     if withheld:
         render.render_brief_note([
             f"{len(withheld)} resolved item(s) withheld — "
@@ -918,6 +936,7 @@ from .amend import (  # noqa: E402
 )
 from .request import (  # noqa: E402
     _cmd_request_done,  # noqa: F401 — re-exported for compat
+    _cmd_request_inbox,  # noqa: F401 — re-exported for compat
     _cmd_request_list,  # noqa: F401 — re-exported for compat
     _cmd_request_open,  # noqa: F401 — re-exported for compat
     _cmd_request_revise,  # noqa: F401 — re-exported for compat

--- a/plugin/daimon_briefing/cli/request.py
+++ b/plugin/daimon_briefing/cli/request.py
@@ -93,6 +93,49 @@ def _request_lines(record: dict) -> list:
     return lines
 
 
+def _inbox_lines(record: dict) -> list:
+    """One inbox entry as a record card — same three-span header shape as
+    `_request_lines`, labeled with the foreign SENDER (`From:`) instead of
+    the local `to`, since every row here was addressed to THIS project."""
+    state = str(record.get("state") or "open")
+    lines = [f"[{_MARKS.get(state, '?')} {_state_label(record)}] "
+             f"{record['request_id']}  {record.get('ask', '')}"]
+    lines.append(f"  From: {record.get('from_label') or '?'}"
+                 + (" (for a human)" if record.get("to_human") else ""))
+    lines.append(f"  Why: {record.get('why', '')}")
+    if record.get("evidence"):
+        lines.append(f"  Evidence: {record['evidence']}")
+    if record.get("supersedes"):
+        lines.append(f"  Supersedes: {requests.supersedes_label(record)}")
+    if record.get("blocking"):
+        lines.append("  Blocking: the sender is waiting on this")
+    if record.get("suppressed"):
+        lines.append("  Suppressed from the briefing panel; still listed "
+                     "here, and any verdict reverses it")
+    if record.get("note"):
+        lines.append(f"  Note: {record['note']}")
+    if record.get("done_evidence"):
+        lines.append(f"  Done: {record['done_evidence']}")
+    if record.get("revision"):
+        lines.append(f"  Revisions: {record['revision']} of "
+                     f"{requests.MAX_REVISIONS}")
+    return lines
+
+
+def _cmd_request_inbox(args) -> int:
+    project = _cli._resolve_project(args.project)
+    rows = requests.inbox_listing(project_dir=project)
+    _cli._note_usage("request:inbox")
+    if args.json:
+        print(json.dumps(rows, ensure_ascii=False, indent=2))
+        return 0
+    if not rows:
+        render.render_ledger_lines(["no requests addressed to this project"])
+        return 0
+    render.render_ledger_records([_inbox_lines(row) for row in rows])
+    return 0
+
+
 def _resolve_to(raw) -> str:
     """The recipient slug, from either spelling the user can type.
 
@@ -329,3 +372,11 @@ def register(sub, fmt) -> None:
                          help="machine-readable output")
     _common(rq_list)
     rq_list.set_defaults(func=_cli._cmd_request_list)
+
+    rq_inbox = request_sub.add_parser(
+        "inbox", help="requests addressed TO this project, from every "
+                      "sender, undecided first")
+    rq_inbox.add_argument("--json", action="store_true",
+                          help="machine-readable output")
+    _common(rq_inbox)
+    rq_inbox.set_defaults(func=_cli._cmd_request_inbox)

--- a/plugin/daimon_briefing/mcp_server.py
+++ b/plugin/daimon_briefing/mcp_server.py
@@ -97,6 +97,23 @@ def _tool_descriptors():
             },
             "annotations": {"readOnlyHint": True},
         },
+        {
+            "name": "requests_inbox",
+            "description": (
+                "Requests other daimon projects have addressed to this one "
+                "(the cross-project ask ledger, #694). Deliberate pull, "
+                "never ambient — daimon_brief does not carry this content. "
+                "Read-only: opening, answering, or deciding a request is "
+                "CLI-only (`daimon request ...`)."),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "project": {"type": "string",
+                                "description": "project directory path"},
+                },
+            },
+            "annotations": {"readOnlyHint": True},
+        },
     ]
 
 

--- a/plugin/daimon_briefing/mcp_tools.py
+++ b/plugin/daimon_briefing/mcp_tools.py
@@ -12,7 +12,7 @@ distinguishably or the gate they measure goes blind.
 """
 import json
 
-from . import amendments, briefing, recall, store
+from . import amendments, briefing, recall, requests, store
 
 
 class ToolError(Exception):
@@ -105,9 +105,23 @@ def _status(arguments: dict) -> str:
     return json.dumps(payload, ensure_ascii=False, indent=2)
 
 
+def _requests_inbox(arguments: dict) -> str:
+    """Read-only pull (#694 PR 2): requests other projects have addressed to
+    this one. Deliberate — daimon_brief does NOT carry this content (D2's
+    CLI-only gate); an MCP client that wants it calls this tool explicitly.
+    Every write verb (open/revise/accept/reject/needs-info/suppress/done)
+    stays CLI-only — no tool here mutates the ledger."""
+    _note("requests_inbox")
+    from . import cli
+    project = cli._resolve_project(arguments.get("project") or None)
+    rows = requests.inbox_listing(project_dir=project)
+    return json.dumps(rows, ensure_ascii=False, indent=2)
+
+
 HANDLERS = {
     "daimon_recall": _recall,
     "daimon_brief": _brief,
     "daimon_projects": _projects,
     "daimon_status": _status,
+    "requests_inbox": _requests_inbox,
 }

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -154,20 +154,31 @@ def _print_handoff(handoff) -> None:
 
 
 def render_brief(checkpoint, drift=None, teammates=None, handoff=None,
-                 project_dir=None) -> None:
+                 project_dir=None, worldcheck_project=None) -> None:
+    """`worldcheck_project` (#694 PR 2) is a SEPARATE gate from `project_dir`
+    — the request panel's own `worldcheck_project` pattern (D2), never keyed
+    on route: the caller passes it only on the CLI same-project brief path
+    (`cli._render_briefing_body`), never for `--slug`, the global-pointer
+    fallback body, or MCP. None here means no panel, full stop."""
     _print_handoff(handoff)
     b = briefing.build(checkpoint)
-    # #693: each path below performs exactly one ledger read — the LLM path
-    # reads inside briefing.render, every other path reads here. None
-    # (legacy callers) skips the read; an unknown project resolves to no
-    # ledger path anyway, so the guard saves the call, not a leak.
+    # #693/#694: each path below performs exactly one ledger read per
+    # section — the LLM path reads inside briefing.render, every other path
+    # reads here. None (legacy callers, or a deliberately excluded route)
+    # skips the read entirely; an unknown project resolves to no ledger path
+    # anyway, so the guard saves the call, not a leak.
     if b is None:
         rulings = (briefing.ruling_lines(project_dir)
                    if project_dir is not None else [])
-        if rulings:
-            # #693: standing rulings exist before the first checkpoint does —
-            # a day-one ratification must not wait for a session to end.
-            print("\n".join(rulings))
+        request_lines = (briefing.request_panel_lines(worldcheck_project)
+                         if worldcheck_project is not None else [])
+        if rulings or request_lines:
+            # #693/#694: standing rulings and addressed requests exist before
+            # the first checkpoint does — a day-one ratification, or the
+            # first ask ever addressed to this project, must not wait for a
+            # session to end.
+            print("\n".join(rulings + (([""] if rulings and request_lines
+                                        else []) + request_lines)))
             print("")
         # Point at the real flow (#29): checkpoints come from the hooks; bare
         # `serialize` dead-ends (it needs a transcript path).
@@ -181,23 +192,27 @@ def render_brief(checkpoint, drift=None, teammates=None, handoff=None,
     # the hermes hook. Free-form LLM text can't be sectioned into rich panels, so when
     # it is active we print its narrative regardless of TTY.
     if config.llm_briefing():
-        # Tries LLM, falls back to deterministic; #693 rulings ride inside.
-        # Unconditional return: `b` is non-None here, so render() always
-        # yields text — a fall-through would double the ledger read below,
-        # and structure beats a comment at keeping that invariant.
-        print(briefing.render(checkpoint, project_dir=project_dir))
+        # Tries LLM, falls back to deterministic; #693 rulings and #694's
+        # request panel both ride inside. Unconditional return: `b` is
+        # non-None here, so render() always yields text — a fall-through
+        # would double the ledger reads below, and structure beats a comment
+        # at keeping that invariant.
+        print(briefing.render(checkpoint, project_dir=project_dir,
+                              worldcheck_project=worldcheck_project))
         _print_drift(drift)
         _print_teammates(teammates)
         return
     rulings = (briefing.ruling_lines(project_dir)
                if project_dir is not None else [])
+    request_lines = (briefing.request_panel_lines(worldcheck_project)
+                     if worldcheck_project is not None else [])
     # #204: degrade verbatim labels when the receipt can't be locally confirmed.
     # Cheap check (sidecar + byte match), computed once for both render paths.
     degraded = briefing.receipt_degraded(checkpoint)
     if not supports_rich():
-        print(briefing.render_plain(b, degraded, rulings))
+        print(briefing.render_plain(b, degraded, rulings, request_lines))
     else:
-        _rich_brief(b, degraded, rulings)
+        _rich_brief(b, degraded, rulings, request_lines)
     _print_drift(drift)
     _print_teammates(teammates)
 
@@ -230,7 +245,8 @@ def _print_drift(drift) -> None:
     )
 
 
-def _rich_brief(b: dict, degraded: bool = False, rulings=()) -> None:
+def _rich_brief(b: dict, degraded: bool = False, rulings=(),
+                request_lines=()) -> None:
     from rich.console import Console
     from rich.panel import Panel
     from rich.text import Text
@@ -248,6 +264,14 @@ def _rich_brief(b: dict, degraded: bool = False, rulings=()) -> None:
             body.append(f"{line}\n", style="bold")
         console.print(Panel(body, title=rulings[0], border_style="cyan",
                             title_align="left"))
+    if request_lines:
+        # #694 PR 2: same shape as the rulings panel above, its own border
+        # color so the two skeleton sections read as distinct at a glance.
+        body = Text()
+        for line in request_lines[1:]:
+            body.append(f"{line}\n", style="bold")
+        console.print(Panel(body, title=request_lines[0],
+                            border_style="blue", title_align="left"))
     for key, title, style in _SECTIONS:
         items = b.get(key) or []
         if not items:

--- a/plugin/daimon_briefing/requests.py
+++ b/plugin/daimon_briefing/requests.py
@@ -700,6 +700,187 @@ def _rewrite_without(doomed: set[str], project_dir=None) -> list[str]:
     return sorted(doomed)
 
 
+# ---- PR 2: the join composer -----------------------------------------------
+#
+# Verdict/suppress/done rows land in the RECIPIENT's own bucket, referencing
+# a foreign request id — orphans in that bucket's per-bucket fold above
+# (`fold`'s own docstring: "here a lifecycle row whose `opened` lives in
+# another bucket is an orphan"). The composer is the read-time join that
+# pairs them with their origin (D0), in both directions: `sender_join` (a
+# sender's own asks, joined with whatever their recipient decided) and
+# `recipient_join` (everything addressed to this project, scanning every
+# other known bucket for the origin row). Both reduce to the same move: read
+# the raw rows of the two buckets a record spans, and hand the union to
+# `fold` — the per-bucket fold above already knows what to do with an
+# `opened` row and a same-id verdict row that arrive from different buckets,
+# because it keys everything by `request_id` alone.
+
+
+def _rows_for(request_id: str, project_dir) -> list[dict]:
+    return [row for row in events(project_dir=project_dir)
+            if row.get("request_id") == request_id]
+
+
+def _without_suppression(rows: list[dict]) -> list[dict]:
+    """D5's named composer filter: drop `suppressed` rows before folding, so
+    a sender-side join never learns its own ask was muted from the
+    recipient's panel attention — it reads as still open/undecided instead,
+    then goes stale on the normal schedule (PR 3)."""
+    return [row for row in rows if row.get("event") != "suppressed"]
+
+
+def sender_join(project_dir=None) -> dict[str, dict]:
+    """Every request this project SENT, joined with whatever its recipient
+    decided (D0) — the per-bucket `records()` above only ever sees this
+    project's OWN rows, and a verdict lives in the recipient's bucket. One
+    recipient bucket is read once per distinct `to` target, not once per
+    record. Suppression is filtered before the fold runs (D5)."""
+    sender_slug = store.project_slug(project_dir)
+    if not sender_slug:
+        return {}
+    by_id: dict[str, list] = {}
+    to_by_id: dict[str, str] = {}
+    for row in events(project_dir=sender_slug):
+        rid = str(row.get("request_id") or "")
+        by_id.setdefault(rid, []).append(row)
+        if row.get("event") == "opened":
+            to_by_id[rid] = str(row.get("to") or "")
+    cache: dict[str, list] = {}
+    for rid, to_slug in to_by_id.items():
+        if not to_slug or to_slug == sender_slug:
+            continue  # already covered by this bucket's own rows above
+        if to_slug not in cache:
+            cache[to_slug] = events(project_dir=to_slug)
+        by_id[rid] = by_id[rid] + [row for row in cache[to_slug]
+                                   if row.get("request_id") == rid]
+    rows = _without_suppression(
+        [row for group in by_id.values() for row in group])
+    return fold(rows)
+
+
+def _bucket_slugs() -> list[str]:
+    """Every project bucket that has ever written a request, scanning
+    `checkpoints/*/requests.jsonl` directly rather than `store.list_buckets()`
+    (which requires a checkpoint pointer): a project can send or answer a
+    request before it has ever serialized a session, and such a bucket must
+    still be discoverable. One `exists()` stat per subdir, so a project with
+    checkpoints but no requests ledger costs almost nothing."""
+    root = config.checkpoint_dir()
+    try:
+        entries = sorted(root.iterdir())
+    except OSError:
+        return []
+    return [child.name for child in entries
+            if (child / "requests.jsonl").exists()]
+
+
+def recipient_join(project_dir=None) -> dict[str, dict]:
+    """Every request addressed TO this project, joined across every bucket
+    that might hold its origin (D0) — this project's own bucket holds only
+    the verdict/attention rows it wrote, orphaned in its own per-bucket fold
+    above; the `opened`/`revised` rows live in whichever bucket sent the ask.
+    Scans every bucket with a requests ledger (`_bucket_slugs`). Cost is the
+    PR 2 deliverable measured and budgeted separately.
+
+    This project's OWN bucket also holds every request it SENT (its own
+    `opened` rows), and those must never read as its own inbox — only a
+    LOCAL `opened` row whose `to` names this project (self-addressed) or a
+    verdict/attention row with NO local `opened` row at all (an orphan
+    answering a foreign ask, D0's other half) belongs here.
+
+    Every folded record carries a transient `from_slug` — the bucket whose
+    `opened` row founded it — so a supersedes reference can be resolved back
+    to its origin (`supersedes_label`) without a second scan."""
+    my_slug = store.project_slug(project_dir)
+    if not my_slug:
+        return {}
+    own_by_id: dict[str, list] = {}
+    for row in events(project_dir=my_slug):
+        own_by_id.setdefault(str(row.get("request_id") or ""), []).append(row)
+    by_id: dict[str, list] = {}
+    for rid, rows in own_by_id.items():
+        opened = next((r for r in rows if r.get("event") == "opened"), None)
+        if opened is not None and str(opened.get("to") or "") != my_slug:
+            continue  # this project's own OUTGOING ask — never its own inbox
+        by_id[rid] = rows
+    origin_of: dict[str, str] = {}
+    for slug in _bucket_slugs():
+        if slug == my_slug:
+            continue
+        grouped: dict[str, list] = {}
+        for row in events(project_dir=slug):
+            grouped.setdefault(str(row.get("request_id") or ""), []).append(row)
+        for rid, rows in grouped.items():
+            opened = next((r for r in rows if r.get("event") == "opened"),
+                         None)
+            if opened is not None and str(opened.get("to") or "") == my_slug:
+                by_id.setdefault(rid, []).extend(rows)
+                origin_of[rid] = slug
+    all_rows = [row for group in by_id.values() for row in group]
+    out = fold(all_rows)
+    for rid, record in out.items():
+        record["from_slug"] = origin_of.get(rid, "")
+    return out
+
+
+def inbox_listing(project_dir=None) -> list[dict]:
+    """Every request addressed to this project, undecided first — the
+    `request inbox` order. Suppressed records are HERE by construction
+    (D3/D5): suppression takes away panel placement, never visibility."""
+    return sorted(
+        recipient_join(project_dir=project_dir).values(),
+        key=lambda r: (r["state"] not in _SENDER_MOVABLE,
+                       r.get("updated_at") or "", r["request_id"]))
+
+
+def inbox_renderable(project_dir=None) -> dict:
+    """The recipient-side panel data: {"rows": [...], "overflow": N} —
+    requests addressed to this project still awaiting a decision, newest
+    first, capped at RENDER_CAP with the remainder COUNTED. Suppressed
+    records are filtered here and only here (mirrors `renderable` above):
+    that is the entire effect suppress is allowed to have."""
+    rows = [r for r in recipient_join(project_dir=project_dir).values()
+            if r["state"] in _SENDER_MOVABLE and not r["suppressed"]]
+    rows.sort(key=lambda r: (r.get("updated_at") or "", r["request_id"]),
+              reverse=True)
+    return {"rows": rows[:RENDER_CAP], "overflow": max(0, len(rows) - RENDER_CAP)}
+
+
+def needs_surfaced_stamp(record: dict) -> bool:
+    """D1: whether a `surfaced` row already exists for this record's CURRENT
+    revision epoch. The composer already computes `surfaced` (PR 1's fold) as
+    {epoch: earliest ts}; this just names the check the stamp write consults."""
+    return record.get("revision") not in (record.get("surfaced") or {})
+
+
+def stamp_surfaced(request_id: str, project_dir=None) -> bool:
+    """Write a `surfaced` row to THIS project's own bucket, referencing a
+    foreign request id (D1) — the recipient's brief observed and rendered
+    the card. Channel `mechanical`: nobody asserted anything, the render
+    pipeline stamped what it did. Write-once is the caller's job
+    (`needs_surfaced_stamp` before calling this) — a concurrent-brief
+    duplicate is at worst a second row the fold's earliest-wins tie-break
+    absorbs for free."""
+    row = _stamp("surfaced", request_id, "mechanical")
+    return append(row, project_dir=project_dir)
+
+
+def supersedes_label(record: dict) -> str:
+    """The `supersedes` render value, or "" when the record cites none.
+    Appends "(record forgotten)" when the superseded id no longer resolves
+    in its own origin bucket (D0's supersedes extension) — a re-ask must
+    never silently look like a first ask, even after deletion at the source.
+    Resolves against `record["from_slug"]`, the origin `recipient_join`
+    stamps on every record it returns."""
+    target = str(record.get("supersedes") or "")
+    if not target:
+        return ""
+    origin = record.get("from_slug") or ""
+    if origin and get(target, project_dir=origin) is None:
+        return f"{target} (record forgotten)"
+    return target
+
+
 def forget_content_key(content_key: str, *, project_dir=None) -> list[str]:
     """Remove every record holding `content_key` in a plaintext field.
 

--- a/plugin/daimon_briefing/requests.py
+++ b/plugin/daimon_briefing/requests.py
@@ -716,11 +716,6 @@ def _rewrite_without(doomed: set[str], project_dir=None) -> list[str]:
 # because it keys everything by `request_id` alone.
 
 
-def _rows_for(request_id: str, project_dir) -> list[dict]:
-    return [row for row in events(project_dir=project_dir)
-            if row.get("request_id") == request_id]
-
-
 def _without_suppression(rows: list[dict]) -> list[dict]:
     """D5's named composer filter: drop `suppressed` rows before folding, so
     a sender-side join never learns its own ask was muted from the

--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -240,6 +240,11 @@ daimon request open --to <dir> --ask "<what>" --why "<why>" --by agent
 unverified claim until the quote is byte-checked. `accept`, `reject`,
 `needs-info`, `suppress` are human-only: print the command, never run it.
 
+Requests OTHER projects addressed to this one surface automatically at the
+top of `daimon brief` (capped at 3, with an overflow count). `daimon request
+inbox` lists every one, including any the panel dropped for attention —
+`--suppress` hides a card from the panel, never from `list`/`inbox`.
+
 ## When memory looks wrong
 
 | Symptom | Command |

--- a/plugin/tests/test_cli_brief_requests.py
+++ b/plugin/tests/test_cli_brief_requests.py
@@ -1,0 +1,145 @@
+"""#694 PR 2: the request panel + surfaced stamp on the CLI `brief` path.
+
+D2's gate — panel and stamp inject ONLY on the CLI same-project brief path,
+keyed on the caller-supplied `worldcheck_project` parameter, never on route
+or surface detection. Mirrors test_worldcheck.py's never-probes shape for
+--slug / global-fallback: monkeypatch the composer to explode and assert it
+is never called on an excluded path.
+"""
+
+from daimon_briefing import cli, requests, store
+
+
+def _seed_checkpoint(project_dir, session):
+    store.write_checkpoint(session, {
+        "session_id": session, "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "x", "trust": "inferred"}]},
+    }, project_dir=project_dir)
+    return store.project_slug(project_dir)
+
+
+def _open_ask(recipient_dir, ask="publish the schema",
+             sender_dir="/p/cbr-sender", seed_recipient=True):
+    """Seeds the SENDER's bucket and opens an ask addressed to `recipient_dir`.
+
+    Also gives the RECIPIENT its own checkpoint by default: without one,
+    `daimon brief` falls into the global-pointer-fallback branch (a project
+    with zero checkpoints of its own never reaches `_render_briefing_body`
+    at all, so `worldcheck_project` is never computed) — a separate,
+    pre-existing #96 behavior this test file is not exercising."""
+    sender_slug = _seed_checkpoint(sender_dir, "S-cbr-sender")
+    if seed_recipient:
+        _seed_checkpoint(recipient_dir, "S-cbr-recipient")
+    to = store.project_slug(recipient_dir)
+    return requests.open_request(to=to, ask=ask, why="because",
+                                 channel="cli-agent", project_dir=sender_slug)
+
+
+def test_cli_brief_shows_the_panel_on_the_normal_path(tmp_checkpoint_dir,
+                                                       monkeypatch, capsys):
+    recipient = "/p/cbr-recipient-a"
+    _open_ask(recipient)
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", recipient)
+    rc = cli.main(["brief"])
+    assert rc == 0
+    assert "publish the schema" in capsys.readouterr().out
+
+
+def test_cli_brief_stamps_surfaced_after_the_print(tmp_checkpoint_dir,
+                                                    monkeypatch, capsys):
+    recipient = "/p/cbr-recipient-b"
+    q_id = _open_ask(recipient)
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", recipient)
+    assert cli.main(["brief"]) == 0
+    capsys.readouterr()
+    record = requests.recipient_join(project_dir=recipient)[q_id]
+    assert requests.needs_surfaced_stamp(record) is False
+    assert set(record["surfaced"]) == {0}
+
+
+def test_cli_brief_stamp_is_write_once_across_repeated_briefs(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    recipient = "/p/cbr-recipient-c"
+    q_id = _open_ask(recipient)
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", recipient)
+    assert cli.main(["brief"]) == 0
+    assert cli.main(["brief"]) == 0
+    capsys.readouterr()
+    record = requests.recipient_join(project_dir=recipient)[q_id]
+    assert len(record["surfaced"]) == 1
+
+
+def test_cli_brief_slug_path_never_stamps_or_shows_the_panel(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    recipient = "/p/cbr-recipient-d"
+    _open_ask(recipient)
+    slug = store.project_slug(recipient)
+
+    def _boom(*a, **k):
+        raise AssertionError("--slug briefs must never touch the composer")
+
+    monkeypatch.setattr(requests, "inbox_renderable", _boom)
+    monkeypatch.setattr(requests, "stamp_surfaced", _boom)
+    rc = cli.main(["brief", "--slug", slug])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "publish the schema" not in out
+
+
+def test_cli_brief_global_fallback_never_stamps_or_shows_the_panel(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    recipient = "/p/cbr-recipient-e"
+    # Recipient has no checkpoint of its own, so `brief` falls back to the
+    # global pointer — the branch under test.
+    _open_ask(recipient, seed_recipient=False)
+    # Global pointer belongs to a THIRD, unrelated project.
+    store.write_checkpoint("S-other", {
+        "session_id": "S-other", "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "y", "trust": "inferred"}]},
+    })  # no project_dir -> global pointer only
+    monkeypatch.setenv("DAIMON_BRIEF_GLOBAL_FALLBACK", "full")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/cbr-never-seen")
+
+    def _boom(*a, **k):
+        raise AssertionError("global-fallback briefs must never touch the "
+                             "composer")
+
+    monkeypatch.setattr(requests, "inbox_renderable", _boom)
+    monkeypatch.setattr(requests, "stamp_surfaced", _boom)
+    rc = cli.main(["brief"])
+    assert rc == 0
+
+
+def test_cli_brief_a_crash_before_the_stamp_leaves_it_unstamped(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    # D1's safe direction: a failure between print and stamp must re-surface
+    # the card next brief, never silently claim it was shown.
+    recipient = "/p/cbr-recipient-f"
+    q_id = _open_ask(recipient)
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", recipient)
+
+    def _boom(*a, **k):
+        raise RuntimeError("simulated crash between print and stamp")
+
+    monkeypatch.setattr(requests, "stamp_surfaced", _boom)
+    rc = cli.main(["brief"])  # fail-open: the brief itself must still succeed
+    assert rc == 0
+    assert "publish the schema" in capsys.readouterr().out
+    record = requests.recipient_join(project_dir=recipient)[q_id]
+    assert requests.needs_surfaced_stamp(record) is True
+
+
+def test_cli_brief_no_addressed_requests_shows_no_panel(tmp_checkpoint_dir,
+                                                         monkeypatch, capsys):
+    recipient = "/p/cbr-recipient-g"
+    store.write_checkpoint("S-cbr-g", {
+        "session_id": "S-cbr-g", "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "z", "trust": "inferred"}]},
+    }, project_dir=recipient)
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", recipient)
+    rc = cli.main(["brief"])
+    assert rc == 0
+    assert "Requests waiting on you" not in capsys.readouterr().out

--- a/plugin/tests/test_mcp_server.py
+++ b/plugin/tests/test_mcp_server.py
@@ -100,12 +100,12 @@ def test_ping_answers_empty_object():
 # ---- tools/list ----------------------------------------------------------------
 
 
-def test_tools_list_exposes_four_read_only_tools():
+def test_tools_list_exposes_five_read_only_tools():
     _, out = rpc(_init(), {"jsonrpc": "2.0", "id": 3, "method": "tools/list"})
     tools = out[1]["result"]["tools"]
     names = {t["name"] for t in tools}
-    assert names == {"daimon_recall", "daimon_brief",
-                     "daimon_projects", "daimon_status"}
+    assert names == {"daimon_recall", "daimon_brief", "daimon_projects",
+                     "daimon_status", "requests_inbox"}
     for t in tools:
         assert t["description"]
         assert t["inputSchema"]["type"] == "object"
@@ -186,6 +186,35 @@ def test_brief_tool_no_checkpoint_gives_orientation_never_foreign_content(
     assert "no checkpoint" in text
     assert "daimon_projects" in text    # the explicit path is named
     assert "S-other" not in text        # foreign content never leaks
+
+
+def test_brief_tool_never_carries_the_request_panel(tmp_checkpoint_dir,
+                                                     sample_checkpoint,
+                                                     monkeypatch):
+    # #694 PR 2 (D2): daimon_brief is untouched — the panel injects ONLY on
+    # the CLI same-project brief path. Without a gate, every MCP client
+    # would auto-receive foreign ask/why/from_label prose (#94/#96).
+    from daimon_briefing import requests, store
+    store.write_checkpoint("S-a", sample_checkpoint, project_dir="/p/A")
+    store.write_checkpoint("S-mcp-sender", {
+        "session_id": "S-mcp-sender", "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "x", "trust": "inferred"}]},
+    }, project_dir="/p/mcp-brief-sender")
+    requests.open_request(to=store.project_slug("/p/A"),
+                          ask="publish the schema", why="because",
+                          channel="cli-agent",
+                          project_dir="/p/mcp-brief-sender")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    _, out = rpc(_init(), _call("daimon_brief", {}))
+    text, is_err = _result(out)
+    assert is_err is False
+    assert "publish the schema" not in text
+    assert "Requests waiting on you" not in text
+    # And the tool never stamped a surfaced row either — no side effect from
+    # a read-only MCP call.
+    assert requests.needs_surfaced_stamp(
+        next(iter(requests.recipient_join(project_dir="/p/A").values())))
 
 
 def test_brief_tool_slug_and_project_conflict_is_tool_error(tmp_checkpoint_dir):
@@ -271,6 +300,70 @@ def test_brief_tool_empty_briefing_states_it(tmp_checkpoint_dir,
     assert "nothing worth surfacing" in text
 
 
+# ---- requests_inbox (#694 PR 2) -----------------------------------------------
+
+
+def test_requests_inbox_tool_returns_addressed_rows(tmp_checkpoint_dir,
+                                                     monkeypatch):
+    from daimon_briefing import requests, store
+    store.write_checkpoint("S-sender", {
+        "session_id": "S-sender", "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "the sender shipped something", "trust": "inferred"}]},
+    }, project_dir="/p/mcp-sender")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/mcp-recipient")
+    to = store.project_slug("/p/mcp-recipient")
+    q_id = requests.open_request(to=to, ask="publish the schema",
+                                 why="the client needs it", channel="cli-agent",
+                                 project_dir="/p/mcp-sender")
+    _, out = rpc(_init(), _call("requests_inbox", {}))
+    text, is_err = _result(out)
+    assert is_err is False
+    rows = json.loads(text)
+    assert [r["request_id"] for r in rows] == [q_id]
+    assert rows[0]["ask"] == "publish the schema"
+
+
+def test_requests_inbox_tool_takes_an_explicit_project(tmp_checkpoint_dir,
+                                                        monkeypatch):
+    from daimon_briefing import requests, store
+    store.write_checkpoint("S-sender", {
+        "session_id": "S-sender", "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "x", "trust": "inferred"}]},
+    }, project_dir="/p/mcp-sender-b")
+    to = store.project_slug("/p/mcp-recipient-b")
+    q_id = requests.open_request(to=to, ask="review this", why="because",
+                                 channel="cli-agent",
+                                 project_dir="/p/mcp-sender-b")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/somewhere-else")
+    _, out = rpc(_init(),
+                _call("requests_inbox", {"project": "/p/mcp-recipient-b"}))
+    text, is_err = _result(out)
+    assert is_err is False
+    rows = json.loads(text)
+    assert [r["request_id"] for r in rows] == [q_id]
+
+
+def test_requests_inbox_tool_empty_is_an_empty_list(tmp_checkpoint_dir,
+                                                     monkeypatch):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/mcp-nobody-asked")
+    _, out = rpc(_init(), _call("requests_inbox", {}))
+    text, is_err = _result(out)
+    assert is_err is False
+    assert json.loads(text) == []
+
+
+def test_mcp_tools_expose_no_request_write_verb():
+    # #694 PR 2: the tool tier is read-only by design — open/revise/accept/
+    # reject/needs-info/suppress/done stay CLI-only.
+    from daimon_briefing import mcp_tools
+    assert "requests_inbox" in mcp_tools.HANDLERS
+    for verb in ("open", "revise", "accept", "reject", "needs_info",
+                "suppress", "done"):
+        assert not any(verb in name for name in mcp_tools.HANDLERS)
+
+
 # ---- usage logging + kill switch ----------------------------------------------
 
 
@@ -280,10 +373,12 @@ def test_tools_call_logs_mcp_usage(tmp_checkpoint_dir, tmp_log_dir,
     store.write_checkpoint("S-a", sample_checkpoint, project_dir="/p/A")
     monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
     rpc(_init(), _call("daimon_projects", {}), _call("daimon_recall",
-                                                     {"query": "x"}))
+                                                     {"query": "x"}),
+       _call("requests_inbox", {}))
     usage = (config.log_dir() / "usage.log").read_text(encoding="utf-8")
     assert "mcp:projects" in usage
     assert "mcp:recall" in usage
+    assert "mcp:requests_inbox" in usage
 
 
 def test_serve_disabled_exits_clean_without_reading(monkeypatch):

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -114,6 +114,51 @@ def test_render_brief_no_content(capsys):
     assert "session end" in out  # checkpoints come from hooks automatically
 
 
+# ---- #694 PR 2: the request panel's worldcheck_project gate -----------------
+
+
+def _seed_request(recipient_dir, ask="publish the schema"):
+    from daimon_briefing import requests, store
+    store.write_checkpoint("S-render-req-sender", {
+        "session_id": "S-render-req-sender", "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "x", "trust": "inferred"}]},
+    }, project_dir="/p/render-req-sender")
+    to = store.project_slug(recipient_dir)
+    return requests.open_request(
+        to=to, ask=ask, why="because", channel="cli-agent",
+        project_dir="/p/render-req-sender")
+
+
+def test_render_brief_shows_the_panel_when_worldcheck_project_is_given(
+        tmp_checkpoint_dir, sample_checkpoint, capsys):
+    _seed_request("/p/render-req-recipient-a")
+    render.render_brief(sample_checkpoint,
+                        worldcheck_project="/p/render-req-recipient-a")
+    out = capsys.readouterr().out
+    assert "publish the schema" in out
+
+
+def test_render_brief_hides_the_panel_without_worldcheck_project(
+        tmp_checkpoint_dir, sample_checkpoint, capsys):
+    # D2: NEVER key on project_dir/route alone — a caller that omits
+    # worldcheck_project (the --slug / global-fallback / MCP shape) must get
+    # no panel even though a matching request exists.
+    _seed_request("/p/render-req-recipient-b")
+    render.render_brief(sample_checkpoint,
+                        project_dir="/p/render-req-recipient-b")
+    out = capsys.readouterr().out
+    assert "publish the schema" not in out
+
+
+def test_render_brief_no_checkpoint_still_shows_the_panel(
+        tmp_checkpoint_dir, capsys):
+    _seed_request("/p/render-req-recipient-c")
+    render.render_brief({}, worldcheck_project="/p/render-req-recipient-c")
+    out = capsys.readouterr().out
+    assert "publish the schema" in out
+
+
 def _serialize_status_data(last):
     return {
         "project": "/repo/x",

--- a/plugin/tests/test_request_briefing.py
+++ b/plugin/tests/test_request_briefing.py
@@ -1,0 +1,118 @@
+"""#694 PR 2: the recipient-side request panel — asks addressed to this
+project, surfaced in its own briefing. Mirrors test_ruling_briefing.py's
+shape: fail-open, always present, never budget-dropped. The CLI-only gate
+(worldcheck_project) is exercised in test_cli_brief_requests.py, not here —
+this file drives briefing.request_panel_lines/render directly.
+"""
+
+from daimon_briefing import briefing, requests, store
+
+RECIPIENT = "/p/req-brief-recipient"
+SENDER = "/p/req-brief-sender"
+
+
+def _seed_sender(session="S-req-sender"):
+    store.write_checkpoint(session, {
+        "session_id": session, "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "the sender shipped something", "trust": "inferred"}]},
+    }, project_dir=SENDER)
+    return store.project_slug(SENDER)
+
+
+def _ask(sender_slug, ask="publish the schema", **kw):
+    return requests.open_request(
+        to=store.project_slug(RECIPIENT), ask=ask,
+        why="the client needs it", channel="cli-agent",
+        project_dir=sender_slug, **kw)
+
+
+def test_panel_lists_asks_addressed_to_this_project(tmp_checkpoint_dir):
+    sender = _seed_sender()
+    _ask(sender)
+    lines = briefing.request_panel_lines(RECIPIENT)
+    assert any("publish the schema" in ln for ln in lines)
+
+
+def test_panel_names_the_foreign_sender(tmp_checkpoint_dir):
+    sender = _seed_sender()
+    _ask(sender)
+    lines = briefing.request_panel_lines(RECIPIENT)
+    assert any("req-brief-sender" in ln for ln in lines)
+
+
+def test_panel_marks_blocking(tmp_checkpoint_dir):
+    sender = _seed_sender()
+    _ask(sender, blocking=True)
+    lines = briefing.request_panel_lines(RECIPIENT)
+    assert any("blocking" in ln.lower() for ln in lines)
+
+
+def test_panel_never_silently_truncates_over_cap(tmp_checkpoint_dir):
+    sender = _seed_sender()
+    for n in range(requests.RENDER_CAP + 2):
+        _ask(sender, ask=f"ask number {n} about the release")
+    lines = briefing.request_panel_lines(RECIPIENT)
+    body = "\n".join(lines)
+    assert "+2 more waiting" in body
+    assert "daimon request inbox" in body
+
+
+def test_panel_excludes_suppressed(tmp_checkpoint_dir):
+    sender = _seed_sender()
+    q_id = _ask(sender)
+    requests.suppress(q_id, channel="cli-tty", project_dir=RECIPIENT)
+    assert briefing.request_panel_lines(RECIPIENT) == []
+
+
+def test_panel_empty_when_no_project_dir(tmp_checkpoint_dir):
+    sender = _seed_sender()
+    _ask(sender)
+    assert briefing.request_panel_lines(None) == []
+
+
+def test_panel_empty_with_nothing_addressed(tmp_checkpoint_dir):
+    assert briefing.request_panel_lines(RECIPIENT) == []
+
+
+def test_panel_fails_open_on_a_broken_composer(tmp_checkpoint_dir, monkeypatch):
+    def boom(project_dir=None):
+        raise RuntimeError("boom")
+    monkeypatch.setattr(requests, "inbox_renderable", boom)
+    sender = _seed_sender()
+    _ask(sender)
+    assert briefing.request_panel_lines(RECIPIENT) == []
+
+
+def test_panel_survives_budget_pressure(tmp_checkpoint_dir, sample_checkpoint,
+                                        monkeypatch):
+    sender = _seed_sender()
+    _ask(sender)
+    monkeypatch.setenv("DAIMON_BRIEF_MAX_TOKENS", "40")
+    out = briefing.render(sample_checkpoint, project_dir=RECIPIENT,
+                          worldcheck_project=RECIPIENT)
+    assert "publish the schema" in out
+
+
+def test_render_with_no_checkpoint_still_shows_the_panel(tmp_checkpoint_dir):
+    # #693's rulings precedent: a day-one ratification must not wait for a
+    # session to end. Same posture here — the FIRST thing this project ever
+    # gets might be an incoming ask, before it has serialized anything.
+    sender = _seed_sender()
+    _ask(sender)
+    out = briefing.render(None, project_dir=RECIPIENT,
+                          worldcheck_project=RECIPIENT)
+    assert out is not None
+    assert "publish the schema" in out
+
+
+def test_full_cap_worst_case_stays_within_budget_share(tmp_checkpoint_dir):
+    # Worst case pinned by test: RENDER_CAP asks at the max text length must
+    # still cost only a small, bounded share of the default budget.
+    sender = _seed_sender()
+    for n in range(requests.RENDER_CAP):
+        _ask(sender, ask=f"n{n} " + "x" * (requests._MAX_TEXT - 4))
+    lines = briefing.request_panel_lines(RECIPIENT)
+    section = "\n".join(lines)
+    assert briefing.estimate_tokens(section) <= 300  # 10% of the 3000 default
+    assert briefing.estimate_tokens(section) >= 100  # the share is real

--- a/plugin/tests/test_request_briefing.py
+++ b/plugin/tests/test_request_briefing.py
@@ -94,6 +94,32 @@ def test_panel_survives_budget_pressure(tmp_checkpoint_dir, sample_checkpoint,
     assert "publish the schema" in out
 
 
+def test_panel_rides_the_llm_opt_in_render_path(tmp_checkpoint_dir,
+                                                sample_checkpoint,
+                                                monkeypatch):
+    # #694: the request panel, like #693's rulings, is prepended verbatim
+    # OUTSIDE the LLM's narrated text on the opt-in path — never re-narrated,
+    # never trusted to a generative pass. Mirrors test_briefing.py's
+    # _llm_briefing_env + faithful-quote idiom for the rulings equivalent.
+    from daimon_briefing import llm
+    sender = _seed_sender()
+    _ask(sender)
+    monkeypatch.setenv("DAIMON_LLM_BRIEFING", "1")
+    monkeypatch.setenv("DAIMON_LLM_BASE_URL", "http://127.0.0.1:9")
+    monkeypatch.setenv("DAIMON_LLM_API_KEY", "sk-test")
+    monkeypatch.setenv("DAIMON_LLM_MODEL", "test-model")
+    faithful = (
+        'Verify: "I\'ll merge it myself later from the GitHub UI". '
+        'Open: "do we chunk below 1200 lines or single-pass?". '
+        'Decided: "we adopt the D-007 prompt for the serializer".'
+    )
+    monkeypatch.setattr(llm, "chat", lambda *a, **k: faithful)
+    out = briefing.render(sample_checkpoint, project_dir=RECIPIENT,
+                          worldcheck_project=RECIPIENT)
+    assert "publish the schema" in out
+    assert faithful in out
+
+
 def test_render_with_no_checkpoint_still_shows_the_panel(tmp_checkpoint_dir):
     # #693's rulings precedent: a day-one ratification must not wait for a
     # session to end. Same posture here — the FIRST thing this project ever

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -995,3 +995,318 @@ def test_cli_done_on_a_rejected_request_refuses(project, recipient,
     assert rc == 1
     assert "request done refused" in capsys.readouterr().out
     assert requests.get(q_id, project_dir=project)["state"] == "rejected"
+
+
+# ---- PR 2: the join composer -----------------------------------------------
+#
+# Verdict/suppress/done rows land in the RECIPIENT's own bucket, referencing a
+# foreign request id — orphans in that bucket's per-bucket fold (PR 1's
+# `records()`). The composer is the read-time join that pairs them with their
+# origin (D0), in both directions: sender_join (a sender's asks, joined with
+# whatever the recipient decided) and recipient_join (everything addressed to
+# this project, scanning every other bucket for the origin row).
+
+
+def _seed_bucket(project_dir, session="S-bucket"):
+    """A real checkpoint bucket, so store.list_buckets() can discover it —
+    recipient_join's scan enumerates buckets the same way `daimon projects`
+    does. Only SENDER buckets need this; a recipient need not have a
+    checkpoint of its own to read its own inbox."""
+    store.write_checkpoint(session, {
+        "session_id": session, "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "something happened here", "trust": "inferred"}]},
+    }, project_dir=project_dir)
+    return store.project_slug(project_dir)
+
+
+def test_sender_join_pulls_in_the_recipients_verdict(project):
+    recipient_slug = _seed_bucket("/p/req-recipient-a")
+    q_id = _open(project, to=recipient_slug)
+    requests.needs_info(q_id, channel="cli-tty", note="which release?",
+                        project_dir=recipient_slug)
+    joined = requests.sender_join(project_dir=project)
+    assert joined[q_id]["state"] == "needs-info"
+    # The sender's OWN per-bucket fold never sees it — PR 1 shape, unchanged:
+    # the verdict row lives in a different bucket entirely.
+    assert requests.get(q_id, project_dir=project)["state"] == "open"
+
+
+def test_sender_join_filters_suppression_d5(project):
+    """D5: to the sender, a suppressed request reads "surfaced, undecided" —
+    the recipient's own panel-attention housekeeping never crosses the join."""
+    recipient_slug = _seed_bucket("/p/req-recipient-b")
+    q_id = _open(project, to=recipient_slug)
+    requests.suppress(q_id, channel="cli-tty", project_dir=recipient_slug)
+    joined = requests.sender_join(project_dir=project)
+    assert joined[q_id]["suppressed"] is False
+    assert joined[q_id]["state"] == "open"
+
+
+def test_sender_join_a_later_verdict_still_lands_after_suppression(project):
+    recipient_slug = _seed_bucket("/p/req-recipient-c")
+    q_id = _open(project, to=recipient_slug)
+    requests.suppress(q_id, channel="cli-tty", project_dir=recipient_slug)
+    requests.accept(q_id, channel="cli-tty", project_dir=recipient_slug)
+    joined = requests.sender_join(project_dir=project)
+    assert joined[q_id]["state"] == "accepted"
+
+
+def test_sender_join_on_an_unknown_project_is_empty(project):
+    assert requests.sender_join(project_dir=None) == {}
+
+
+def test_recipient_join_finds_asks_addressed_to_this_project(project):
+    sender_slug = _seed_bucket("/p/req-sender-a")
+    q_id = requests.open_request(to=store.project_slug(project), ask=ASK,
+                                 why=WHY, channel="cli-agent",
+                                 project_dir=sender_slug)
+    joined = requests.recipient_join(project_dir=project)
+    assert joined[q_id]["ask"] == ASK
+    assert joined[q_id]["state"] == "open"
+    assert joined[q_id]["from_slug"] == sender_slug
+
+
+def test_recipient_join_excludes_requests_this_project_sent(project):
+    """A project's own OUTGOING asks — opened rows in its own bucket whose
+    `to` points elsewhere — must never leak into its own inbox. Only
+    requests addressed BACK to this project belong there (D0's join is
+    directional: `to == my_slug`, not "any row this bucket ever wrote)."""
+    recipient_slug = _seed_bucket("/p/req-recipient-leak")
+    requests.open_request(to=recipient_slug, ask=ASK, why=WHY,
+                          channel="cli-agent", project_dir=project)
+    assert requests.recipient_join(project_dir=project) == {}
+    assert requests.inbox_renderable(project_dir=project)["rows"] == []
+    assert requests.inbox_listing(project_dir=project) == []
+
+
+def test_recipient_join_keeps_self_addressed_requests(project):
+    """A request addressed TO the sender's own slug (self-addressed — the
+    write-audit guard's drive recipes exercise exactly this) is a legitimate
+    inbox entry; only requests addressed ELSEWHERE are excluded."""
+    my_slug = store.project_slug(project)
+    q_id = requests.open_request(to=my_slug, ask=ASK, why=WHY,
+                                 channel="cli-agent", project_dir=project)
+    joined = requests.recipient_join(project_dir=project)
+    assert joined[q_id]["ask"] == ASK
+    assert joined[q_id]["state"] == "open"
+
+
+def test_sender_join_ignores_verdict_rows_this_project_wrote_as_a_recipient(
+        project):
+    """The symmetric case: verdict/attention rows this project wrote in its
+    OWN bucket while answering a FOREIGN ask (no local `opened` row for that
+    id) must stay inert in `sender_join` too — the fold's orphan rule
+    already guarantees this (no `opened` row, no record), pinned here so a
+    future refactor of the row-gathering loop cannot regress it silently."""
+    foreign = "q-0123456789ab"
+    requests.accept(foreign, channel="cli-tty", project_dir=project)
+    requests.done(foreign, channel="cli-tty", evidence="shipped it",
+                 project_dir=project)
+    joined = requests.sender_join(project_dir=project)
+    assert foreign not in joined
+    assert joined == {}
+    # ...but the rows are still on disk, per the orphan rule's other half.
+    assert any(r.get("request_id") == foreign
+              for r in requests.events(project_dir=project))
+
+
+def test_recipient_join_merges_local_verdict_rows(project):
+    sender_slug = _seed_bucket("/p/req-sender-b")
+    q_id = requests.open_request(to=store.project_slug(project), ask=ASK,
+                                 why=WHY, channel="cli-agent",
+                                 project_dir=sender_slug)
+    requests.accept(q_id, channel="cli-tty", project_dir=project)
+    joined = requests.recipient_join(project_dir=project)
+    assert joined[q_id]["state"] == "accepted"
+
+
+def test_recipient_join_orphan_rule_when_sender_bucket_is_gone(project):
+    """D0: a verdict/attention row whose origin bucket is unreadable or gone
+    is inert in the join but stays visible in the raw audit."""
+    foreign = "q-0123456789ab"
+    requests.accept(foreign, channel="cli-tty", project_dir=project)
+    joined = requests.recipient_join(project_dir=project)
+    assert foreign not in joined
+    assert any(r.get("request_id") == foreign
+              for r in requests.events(project_dir=project))
+
+
+def test_recipient_join_ignores_asks_addressed_elsewhere(project):
+    sender_slug = _seed_bucket("/p/req-sender-c")
+    requests.open_request(to="-p-someone-else", ask=ASK, why=WHY,
+                          channel="cli-agent", project_dir=sender_slug)
+    assert requests.recipient_join(project_dir=project) == {}
+
+
+def test_recipient_join_on_an_unknown_project_is_empty(project):
+    assert requests.recipient_join(project_dir=None) == {}
+
+
+def test_inbox_listing_keeps_suppressed_visible_with_a_state(project):
+    sender_slug = _seed_bucket("/p/req-sender-d")
+    q_id = requests.open_request(to=store.project_slug(project), ask=ASK,
+                                 why=WHY, channel="cli-agent",
+                                 project_dir=sender_slug)
+    requests.suppress(q_id, channel="cli-tty", project_dir=project)
+    rows = requests.inbox_listing(project_dir=project)
+    assert rows[0]["request_id"] == q_id
+    assert rows[0]["suppressed"] is True
+    assert rows[0]["state"] == "open"
+
+
+def test_inbox_renderable_drops_suppressed_and_settled(project):
+    sender_slug = _seed_bucket("/p/req-sender-e")
+    to = store.project_slug(project)
+    open_id = requests.open_request(to=to, ask=ASK, why=WHY,
+                                    channel="cli-agent", project_dir=sender_slug)
+    suppressed_id = requests.open_request(
+        to=to, ask="a second ask about the release", why=WHY,
+        channel="cli-agent", project_dir=sender_slug)
+    requests.suppress(suppressed_id, channel="cli-tty", project_dir=project)
+    done_id = requests.open_request(
+        to=to, ask="a third ask, already handled", why=WHY,
+        channel="cli-agent", project_dir=sender_slug)
+    requests.done(done_id, channel="cli-tty", evidence="shipped",
+                 project_dir=project)
+    entry = requests.inbox_renderable(project_dir=project)
+    ids = {r["request_id"] for r in entry["rows"]}
+    assert ids == {open_id}
+
+
+def test_inbox_renderable_caps_and_counts_the_overflow(project):
+    sender_slug = _seed_bucket("/p/req-sender-f")
+    to = store.project_slug(project)
+    for n in range(requests.RENDER_CAP + 2):
+        requests.open_request(to=to, ask=f"ask {n} about the release",
+                              why=WHY, channel="cli-agent",
+                              project_dir=sender_slug)
+    entry = requests.inbox_renderable(project_dir=project)
+    assert len(entry["rows"]) == requests.RENDER_CAP
+    assert entry["overflow"] == 2
+
+
+def test_needs_surfaced_stamp_and_dedup(project):
+    sender_slug = _seed_bucket("/p/req-sender-g")
+    q_id = requests.open_request(to=store.project_slug(project), ask=ASK,
+                                 why=WHY, channel="cli-agent",
+                                 project_dir=sender_slug)
+    record = requests.recipient_join(project_dir=project)[q_id]
+    assert requests.needs_surfaced_stamp(record) is True
+    assert requests.stamp_surfaced(q_id, project_dir=project) is True
+    record = requests.recipient_join(project_dir=project)[q_id]
+    assert requests.needs_surfaced_stamp(record) is False
+
+
+def test_stamp_dedup_earliest_wins_under_a_duplicate_write(project):
+    """Concurrent-brief TOCTOU may at worst duplicate a stamp row; the fold
+    already takes the earliest — pin it."""
+    sender_slug = _seed_bucket("/p/req-sender-h")
+    q_id = requests.open_request(to=store.project_slug(project), ask=ASK,
+                                 why=WHY, channel="cli-agent",
+                                 project_dir=sender_slug)
+    assert requests.stamp_surfaced(q_id, project_dir=project) is True
+    assert requests.stamp_surfaced(q_id, project_dir=project) is True
+    record = requests.recipient_join(project_dir=project)[q_id]
+    assert set(record["surfaced"]) == {0}
+
+
+def test_stamp_dedup_resets_on_a_new_revision_epoch(project):
+    sender_slug = _seed_bucket("/p/req-sender-i")
+    q_id = requests.open_request(to=store.project_slug(project), ask=ASK,
+                                 why=WHY, channel="cli-agent",
+                                 project_dir=sender_slug)
+    requests.stamp_surfaced(q_id, project_dir=project)
+    requests.revise(q_id, channel="cli-agent", ask="a sharper ask",
+                    project_dir=sender_slug)
+    record = requests.recipient_join(project_dir=project)[q_id]
+    assert requests.needs_surfaced_stamp(record) is True  # new epoch, unstamped
+
+
+def test_supersedes_label_names_a_forgotten_lineage(project):
+    sender_slug = _seed_bucket("/p/req-sender-j")
+    to = store.project_slug(project)
+    first = requests.open_request(to=to, ask=ASK, why=WHY,
+                                  channel="cli-agent", project_dir=sender_slug)
+    second = requests.open_request(
+        to=to, ask="review it again, with the new numbers", why=WHY,
+        channel="cli-agent", project_dir=sender_slug, supersedes=first)
+    record = requests.recipient_join(project_dir=project)[second]
+    assert requests.supersedes_label(record) == first
+    requests.forget_content_key(normalize.content_key(ASK),
+                                project_dir=sender_slug)
+    record = requests.recipient_join(project_dir=project)[second]
+    assert requests.supersedes_label(record) == f"{first} (record forgotten)"
+
+
+def test_supersedes_label_is_empty_when_there_is_no_lineage(project):
+    sender_slug = _seed_bucket("/p/req-sender-k")
+    q_id = requests.open_request(to=store.project_slug(project), ask=ASK,
+                                 why=WHY, channel="cli-agent",
+                                 project_dir=sender_slug)
+    record = requests.recipient_join(project_dir=project)[q_id]
+    assert requests.supersedes_label(record) == ""
+
+
+# ---- PR 2: `request inbox` -------------------------------------------------
+
+
+def test_cli_request_inbox_shows_addressed_asks(project, recipient, capsys):
+    from daimon_briefing import cli
+    assert _cli_open(project, recipient) == 0
+    capsys.readouterr()
+    rc = cli.main(["request", "inbox", "--project", OTHER])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert ASK in out
+    assert "From:" in out
+
+
+def test_cli_request_inbox_json_matches_inbox_listing(project, recipient,
+                                                       capsys):
+    from daimon_briefing import cli
+    assert _cli_open(project, recipient) == 0
+    capsys.readouterr()
+    rc = cli.main(["request", "inbox", "--json", "--project", OTHER])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == requests.inbox_listing(project_dir=OTHER)
+
+
+def test_cli_request_inbox_empty_says_so(recipient, capsys):
+    from daimon_briefing import cli
+    rc = cli.main(["request", "inbox", "--project", OTHER])
+    assert rc == 0
+    assert "no requests addressed to this project" in capsys.readouterr().out
+
+
+def test_cli_request_inbox_shows_the_suppressed_marker(project, recipient,
+                                                        monkeypatch, capsys):
+    from daimon_briefing import cli
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    assert _cli_open(project, recipient) == 0
+    q_id = next(iter(requests.recipient_join(project_dir=OTHER)))
+    assert cli.main(["request", "suppress", q_id, "--project", OTHER]) == 0
+    capsys.readouterr()
+    rc = cli.main(["request", "inbox", "--project", OTHER])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert q_id in out and "suppressed" in out.lower()
+
+
+def test_cli_request_inbox_renders_the_forgotten_supersedes_lineage(
+        project, recipient, capsys):
+    from daimon_briefing import cli, normalize
+    assert _cli_open(project, recipient) == 0
+    first = next(iter(requests.recipient_join(project_dir=OTHER)))
+    second = requests.open_request(
+        to=store.project_slug(OTHER), ask="review it again, new numbers",
+        why=WHY, channel="cli-agent", project_dir=project, supersedes=first)
+    requests.forget_content_key(normalize.content_key(ASK),
+                                project_dir=project)
+    capsys.readouterr()
+    rc = cli.main(["request", "inbox", "--project", OTHER])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert second in out
+    assert f"{first} (record forgotten)" in out

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -1056,6 +1056,29 @@ def test_sender_join_on_an_unknown_project_is_empty(project):
     assert requests.sender_join(project_dir=None) == {}
 
 
+def test_sender_join_folds_a_self_addressed_request_without_a_foreign_fetch(
+        project, monkeypatch):
+    """A self-addressed request (`to == sender_slug`) is entirely local — no
+    SECOND bucket exists to fetch, and `sender_join` must skip that fetch
+    rather than re-reading its own bucket a second time under a different
+    name."""
+    my_slug = store.project_slug(project)
+    q_id = requests.open_request(to=my_slug, ask=ASK, why=WHY,
+                                 channel="cli-agent", project_dir=project)
+    real_events = requests.events
+    calls = []
+
+    def _tracking(*a, **k):
+        calls.append((a, k))
+        return real_events(*a, **k)
+
+    monkeypatch.setattr(requests, "events", _tracking)
+    joined = requests.sender_join(project_dir=project)
+    assert joined[q_id]["ask"] == ASK
+    assert joined[q_id]["state"] == "open"
+    assert len(calls) == 1  # only the sender's own bucket, read once
+
+
 def test_recipient_join_finds_asks_addressed_to_this_project(project):
     sender_slug = _seed_bucket("/p/req-sender-a")
     q_id = requests.open_request(to=store.project_slug(project), ask=ASK,
@@ -1260,6 +1283,16 @@ def test_cli_request_inbox_shows_addressed_asks(project, recipient, capsys):
     out = capsys.readouterr().out
     assert ASK in out
     assert "From:" in out
+
+
+def test_cli_request_inbox_renders_evidence(project, recipient, capsys):
+    from daimon_briefing import cli
+    assert _cli_open(project, recipient, "--evidence", "issue:694") == 0
+    capsys.readouterr()
+    rc = cli.main(["request", "inbox", "--project", OTHER])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Evidence: issue:694" in out
 
 
 def test_cli_request_inbox_json_matches_inbox_listing(project, recipient,

--- a/plugin/tests/test_requests_scan_cost.py
+++ b/plugin/tests/test_requests_scan_cost.py
@@ -1,0 +1,87 @@
+"""#694 PR 2 deliverable 5: combined scan-cost measurement, with a stated
+budget, for the composer + panel + stamp `daimon brief` now performs.
+
+The inbox/panel scans every bucket's requests.jsonl (`requests._bucket_slugs`
+via `recipient_join`), and PR 3's stale derivation will scan each rendered
+card's session pointers (cap 3, D3) in the SAME brief cycle. PR 3 is not
+built here, so this measures what PR 2 actually adds to a brief — the
+composer scan, the panel's cap/sort, and the post-print surfaced stamp — over
+a realistic multi-bucket store, and folds in a STAND-IN per-card read of the
+same SHAPE the future stale scan will cost (one `store.list_buckets()` call
+per rendered card, capped at 3), so the budget is not measuring a rosier
+feature than the one that will actually ship once PR 3 lands.
+"""
+import time
+
+from daimon_briefing import requests, store
+
+RECIPIENT = "/p/scan-cost-recipient"
+N_BUCKETS = 50          # "a realistic multi-bucket store" per the PR brief
+N_ADDRESSED = 8         # buckets that actually address RECIPIENT
+
+# Budget reasoning: measured on this machine at ~35-45ms for 50 buckets (8
+# addressed) — see the printed line this test emits; dominated by the 50
+# individual file reads (`_bucket_slugs` + one `events()` read per matching
+# bucket), not by CPU work. `daimon brief` already pays several ledger reads
+# per section (withhold, corroboration, worldcheck, staleness) in the same
+# call, each bounded by project size rather than fleet size — this is the
+# first one that scales with the NUMBER OF PROJECTS on the machine, which is
+# exactly why it gets its own stated budget instead of riding along
+# unmeasured. 150ms is roughly 3.5x the observed cost: enough headroom for a
+# slower disk or CI runner that a healthy run never trips it, tight enough
+# that a regression (e.g. an accidental full-fold-and-refold per bucket
+# instead of one read) would still fail it.
+_BUDGET_MS = 150.0
+
+
+def _seed(n_buckets=N_BUCKETS, n_addressed=N_ADDRESSED):
+    to = store.project_slug(RECIPIENT)
+    for i in range(n_buckets):
+        project_dir = f"/p/scan-cost-sender-{i}"
+        store.write_checkpoint(f"S-scan-{i}", {
+            "session_id": f"S-scan-{i}", "created": "2026-08-16T00:00:00Z",
+            "working_context": {"recent_decisions": [
+                {"text": "x", "trust": "inferred"}]},
+        }, project_dir=project_dir)
+        slug = store.project_slug(project_dir)
+        if i < n_addressed:
+            requests.open_request(
+                to=to, ask=f"ask {i} about the release", why="because",
+                channel="cli-agent", project_dir=slug)
+        else:
+            # A bucket with SOME request traffic, none of it addressed to
+            # RECIPIENT — the composer must still open and skim it, the same
+            # cost profile as an unrelated project sending elsewhere.
+            requests.open_request(
+                to="-p-someone-else", ask=f"unrelated ask {i}", why="why",
+                channel="cli-agent", project_dir=slug)
+
+
+def _d3_shaped_stub_scan(rows) -> None:
+    """Stand-in for PR 3's per-card session-pointer scan (D3), capped at 3,
+    same SHAPE (one directory read per card). Not built here — folded in so
+    this measurement does not understate what the feature costs once PR 3
+    ships the real one."""
+    for _row in rows[:3]:
+        store.list_buckets()
+
+
+def test_combined_brief_time_cost_stays_within_budget(tmp_checkpoint_dir,
+                                                       capsys):
+    _seed()
+    start = time.perf_counter()
+    entry = requests.inbox_renderable(project_dir=RECIPIENT)
+    for row in entry["rows"]:
+        if requests.needs_surfaced_stamp(row):
+            requests.stamp_surfaced(row["request_id"], project_dir=RECIPIENT)
+    _d3_shaped_stub_scan(entry["rows"])
+    elapsed_ms = (time.perf_counter() - start) * 1000
+
+    assert entry["rows"], "measurement is void if nothing was addressed here"
+    with capsys.disabled():
+        print(f"\n#694 PR 2 combined scan cost: {elapsed_ms:.2f}ms over "
+             f"{N_BUCKETS} buckets ({N_ADDRESSED} addressed) — "
+             f"budget {_BUDGET_MS}ms")
+    assert elapsed_ms <= _BUDGET_MS, (
+        f"combined composer+panel+stamp cost {elapsed_ms:.2f}ms exceeds the "
+        f"{_BUDGET_MS}ms budget over {N_BUCKETS} buckets")

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -545,6 +545,11 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
     def r_request_list():
         run(["request", "list"], 0)
 
+    def r_request_inbox():
+        # Read-only pull, self-addressed like _open_request above so the one
+        # bucket the drive owns is both sender and recipient.
+        run(["request", "inbox"], 0)
+
     def _seed_relation():
         # Proposals are not CLI-exposed (lab/serializer writers only), so the
         # verdict drives seed one candidate through the module seam — the
@@ -722,6 +727,7 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
         ("request", "done"): r_request_done,
         ("request", "reject"): r_request_reject,
         ("request", "list"): r_request_list,
+        ("request", "inbox"): r_request_inbox,
         ("relations", "list"): r_relations_list,
         ("relations", "show"): r_relations_show,
         ("relations", "confirm"): r_relations_confirm,


### PR DESCRIPTION
Refs #694

## Summary

- Ships the inbox: the read-time **join composer** that pairs a request's origin rows (sender's bucket) with its verdict/attention rows (recipient's bucket) — PR 2 of the 3-PR arc (object → inbox → return path).
- **Recipient-side briefing panel**: ruling-shaped, always outside `_DROP_ORDER` (never budget-dropped, worst case pinned by test), `RENDER_CAP = 3` with a loud `+N more waiting — daimon request inbox` overflow line. Silent truncation of addressed asks is the one forbidden failure.
- **CLI-only gate**: panel + stamp inject only when the caller passes the same-project parameter (`worldcheck_project` pattern) — never keyed on route. `brief --slug`, the global-pointer fallback body, and MCP `daimon_brief` pass `None` and get neither. Hook-briefed agents shell to the CLI path and do receive the panel.
- **Post-print surfaced stamp**: the recipient's brief appends `surfaced` to its OWN bucket after the render+print pipeline completes — write-once per (request id, revision epoch), earliest-wins under concurrent-brief duplicates, fail-open so a broken composer can never take the briefing down.
- **`request inbox` verb + read-only MCP `requests_inbox`**: deliberate pull, never ambient push. Every write verb stays CLI-only.
- **Combined scan-cost measurement with budget** (design deliverable): 50 buckets, inbox scan + stamp writes + a stand-in per-card pointer read of the PR 3 stale-scan shape — measured ~40ms, budget 150ms, asserted in `test_requests_scan_cost.py`.

Composer semantics per the twice-refuted design: orphan rule (a verdict row whose origin bucket is gone is inert in the join, visible in raw audit), supersedes-after-forget lineage (`supersedes q-… (record forgotten)` renders from the new record's own row), and the named sender-side suppression filter — to the sender, a suppressed ask reads "surfaced, undecided".

**Found and fixed at review**: `recipient_join` initially folded the project's own outgoing `opened` rows, leaking its own sent requests into its own inbox/panel (and self-stamping them). Own-bucket groups are now filtered: outgoing asks dropped, self-addressed kept, orphan verdict rows kept — regression-pinned in three tests.

**Discovery mechanism**: bucket discovery scans `checkpoints/*/requests.jsonl` presence directly (`_bucket_slugs`) instead of `store.list_buckets()`, which requires a checkpoint pointer and would silently hide a project that sent a request before ever serializing a session.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/requests.py` | Join composer: `sender_join`/`recipient_join`, suppression filter, `_bucket_slugs`, `inbox_listing`/`inbox_renderable`, stamp write + epoch dedup, `supersedes_label` |
| `plugin/daimon_briefing/briefing.py` | `request_panel_lines` (ruling-shaped, fail-open, 160-char ask cap), threaded through `render_plain`/`_render_parts`/`render()` outside `_DROP_ORDER` |
| `plugin/daimon_briefing/render.py` | `render_brief` gains `worldcheck_project`; rich path renders the request panel |
| `plugin/daimon_briefing/cli/__init__.py` | Post-print stamp pass gated on `worldcheck_project`; `requests` re-export |
| `plugin/daimon_briefing/cli/request.py` | `request inbox` verb |
| `plugin/daimon_briefing/mcp_tools.py` / `mcp_server.py` | Read-only `requests_inbox`; `daimon_brief` untouched |
| `plugin/daimon_briefing/skill_content.py` | Teaches `request inbox` (guard test refuses untaught verbs) |
| `plugin/tests/test_requests.py` | +37 composer/inbox/stamp/regression tests |
| `plugin/tests/test_request_briefing.py` | 11 panel tests (drop-order exclusion, cap, overflow, provenance) |
| `plugin/tests/test_cli_brief_requests.py` | 7 gate tests (slug/fallback/MCP excluded, stamp timing) |
| `plugin/tests/test_requests_scan_cost.py` | Combined scan-cost budget test |
| `plugin/tests/test_mcp_server.py` | Tool descriptor + read-only coverage |
| `plugin/tests/test_render.py` | Rich-path panel rendering |
| `plugin/tests/test_write_audit_guard.py` | Drive recipe for `request inbox` |

## PR Type

- [x] New feature

## Test Plan

- [x] Full suite green: `uv run pytest -q` → 4013 passed, 2 skipped (run twice: implementer + independent verification)
- [x] `uv run ruff check .` → clean repo-wide
- [x] Scan-cost budget test: ~40ms measured vs 150ms budget, 50 buckets
- [x] MCP `daimon_brief` output verified panel-free; no MCP write verb exists

## Contributor Checklist

- [x] Linked an approved issue (#694, `status:approved`)
- [x] Added exactly one `type:*` label
- [x] Skills content updated (`request inbox` taught)
- [x] Docs: design doc updated in vault (internal)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
