### PR TITLE
feat(briefing): request return path closes the cross-project arc — PR 3 of #694

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -844,15 +844,62 @@ def request_panel_lines(project_dir=None) -> list[str]:
     return lines
 
 
+# ---- #694 PR 3: the sender-side verdict panel -------------------------------
+
+_VERDICT_PANEL_HEADER = "Verdicts on requests you sent:"
+
+# Mirrors cli/request.py's _MARKS glyph-per-state — a separate small table
+# rather than an import, because briefing.py must not depend on the cli
+# package (the dependency runs the other way: cli imports briefing/render).
+_VERDICT_MARKS = {"needs-info": "?", "accepted": "✓", "rejected": "×",
+                  "done": "✔"}
+
+
+def verdict_panel_lines(project_dir=None) -> list[str]:
+    """The sender-side panel's rendered lines ([] when nothing this project
+    sent has been decided yet, or `project_dir` is None). Same posture as
+    `request_panel_lines`: fail-open, skeleton furniture, never silently
+    truncated over RENDER_CAP. `project_dir` is the CLI's
+    `worldcheck_project` — same D2 CLI-only gate, same caller contract."""
+    if project_dir is None:
+        return []
+    try:
+        entry = requests.verdict_renderable(project_dir=project_dir)
+    except Exception:
+        return []
+    rows = entry.get("rows") or []
+    if not rows:
+        return []
+    lines = [_VERDICT_PANEL_HEADER]
+    for row in rows:
+        state = str(row.get("state") or "")
+        mark = _VERDICT_MARKS.get(state, "?")
+        lines.append(f"{mark} {state}  {row['request_id']}  "
+                     f"{_truncate_request_ask(row.get('ask', ''))}")
+        lines.append(f"  To: {row.get('to') or '?'}")
+        note = str(row.get("note") or "").strip()
+        if note:
+            lines.append(f"  Note: {_truncate_request_ask(note)}")
+        done_evidence = str(row.get("done_evidence") or "").strip()
+        if done_evidence:
+            lines.append(f"  Done: {_truncate_request_ask(done_evidence)}")
+    overflow = entry.get("overflow") or 0
+    if overflow:
+        plural = "s" if overflow != 1 else ""
+        lines.append(f"  (+{overflow} more decided{plural} — "
+                     "daimon request list)")
+    return lines
+
+
 def render_plain(b: dict, degraded: bool = False, rulings=(),
-                 request_lines=()) -> str:
+                 request_lines=(), verdict_lines=()) -> str:
     """The deterministic briefing text. Under the #79 budget this is
     BYTE-IDENTICAL to the legacy render(); over it, long items truncate
     (sections preserved) and then whole items drop, lowest value first,
     each cut announced with a trim note. `degraded` (#204) downgrades every
     verbatim label and adds one header note when the receipt is unverifiable."""
     budget = config.brief_max_tokens()
-    text = _render_parts(b, {}, degraded, rulings, request_lines)
+    text = _render_parts(b, {}, degraded, rulings, request_lines, verdict_lines)
     if not budget or estimate_tokens(text) <= budget:
         return text
 
@@ -870,7 +917,8 @@ def render_plain(b: dict, degraded: bool = False, rulings=(),
             for i in (b.get(key) or [])
         ]
     trimmed = {key: 0 for key, _ in _DROP_ORDER}
-    text = _render_parts(b, trimmed, degraded, rulings, request_lines)
+    text = _render_parts(b, trimmed, degraded, rulings, request_lines,
+                         verdict_lines)
 
     # Stage 2: drop whole items, least valuable first, until the budget holds
     # or only the skeleton remains.
@@ -880,14 +928,15 @@ def render_plain(b: dict, degraded: bool = False, rulings=(),
             items.pop(-1 if end == "tail" else 0)
             b[key] = items
             trimmed[key] += 1
-            text = _render_parts(b, trimmed, degraded, rulings, request_lines)
+            text = _render_parts(b, trimmed, degraded, rulings, request_lines,
+                                 verdict_lines)
         if estimate_tokens(text) <= budget:
             break
     return text
 
 
 def _render_parts(b: dict, trimmed: dict, degraded: bool = False,
-                  rulings=(), request_lines=()) -> str:
+                  rulings=(), request_lines=(), verdict_lines=()) -> str:
     parts = ["While you were away — here's where we left off."]
     if degraded:
         # One header note (#204), embedded in the text so the hook-injected
@@ -906,6 +955,10 @@ def _render_parts(b: dict, trimmed: dict, degraded: bool = False,
         # sections below.
         parts.append("")
         parts.extend(request_lines)
+    if verdict_lines:
+        # #694 PR 3: same posture — skeleton furniture, outside _DROP_ORDER.
+        parts.append("")
+        parts.extend(verdict_lines)
 
     def _section(header: str, key: str) -> None:
         items = b.get(key) or []
@@ -984,21 +1037,28 @@ def render(checkpoint, project_dir=None, worldcheck_project=None) -> str | None:
     unknown project resolves to no ledger path and reads nothing, so the
     guard saves a pointless call rather than preventing a leak.
 
-    `worldcheck_project` (#694 PR 2) scopes the incoming-request panel — a
-    SEPARATE parameter from `project_dir`, never reused, because the panel's
-    gate is narrower than the rulings section's: rulings render on every
-    route (including `--slug`), the panel only on the CLI same-project
-    path (`cli._render_briefing_body`'s own `worldcheck_project`, D2)."""
+    `worldcheck_project` (#694 PR 2/3) scopes the incoming-request panel AND
+    the sender-side verdict panel — a SEPARATE parameter from `project_dir`,
+    never reused, because both panels' gate is narrower than the rulings
+    section's: rulings render on every route (including `--slug`), the
+    panels only on the CLI same-project path (`cli._render_briefing_body`'s
+    own `worldcheck_project`, D2)."""
     b = build(checkpoint)
     rulings = ruling_lines(project_dir) if project_dir is not None else []
     request_lines = (request_panel_lines(worldcheck_project)
                      if worldcheck_project is not None else [])
+    verdict_lines = (verdict_panel_lines(worldcheck_project)
+                     if worldcheck_project is not None else [])
+    skeleton_blocks = [blk for blk in (rulings, request_lines, verdict_lines)
+                       if blk]
     if b is None:
-        # #693: a ruling ratified before the first real checkpoint (a day-one
-        # action) must still reach context — "nothing worth surfacing" is no
-        # longer true when active rulings or addressed requests exist.
-        skeleton = rulings + ([""] if rulings and request_lines else []) + request_lines
-        return "\n".join(skeleton) if skeleton else None
+        # #693/#694: a ruling ratified, a request addressed, or a verdict
+        # decided before the first real checkpoint (a day-one action) must
+        # still reach context — "nothing worth surfacing" is no longer true
+        # when any of the three exist.
+        if not skeleton_blocks:
+            return None
+        return "\n\n".join("\n".join(blk) for blk in skeleton_blocks)
     degraded = receipt_degraded(checkpoint)
     if config.llm_briefing():
         rendered = _render_llm(checkpoint)
@@ -1007,20 +1067,17 @@ def render(checkpoint, project_dir=None, worldcheck_project=None) -> str | None:
                 # The LLM render carries no per-item marks to degrade; the one
                 # header note stays FIRST on every path (#204 — the loudest
                 # line never moves below another section). #693/#694: the LLM
-                # narrates the CHECKPOINT; rulings and the request panel live
-                # outside it, so the deterministic sections are prepended
-                # verbatim after the note — never re-narrated, never trusted
-                # to a generative pass.
+                # narrates the CHECKPOINT; rulings and both request panels
+                # live outside it, so the deterministic sections are
+                # prepended verbatim after the note — never re-narrated,
+                # never trusted to a generative pass.
                 parts = ([DEGRADE_NOTE] if degraded else [])
-                if rulings:
-                    parts.append("\n".join(rulings))
-                if request_lines:
-                    parts.append("\n".join(request_lines))
+                parts.extend("\n".join(blk) for blk in skeleton_blocks)
                 parts.append(rendered)
                 return "\n\n".join(parts)
             log.warning("llm briefing dropped a verbatim quote — "
                         "falling back to the deterministic render")
-    return render_plain(b, degraded, rulings, request_lines)
+    return render_plain(b, degraded, rulings, request_lines, verdict_lines)
 
 
 # Seeded from research/experiments/track-a/prompts/02-reconstruct.md, tuned for a

--- a/plugin/daimon_briefing/capture.py
+++ b/plugin/daimon_briefing/capture.py
@@ -32,8 +32,8 @@ import logging
 import time
 from pathlib import Path
 
-from . import (amendments, carry, config, normalize, provenance, serializer,
-               store, transcript)
+from . import (amendments, carry, config, normalize, provenance, requests,
+               serializer, store, transcript)
 
 log = logging.getLogger(__name__)
 
@@ -163,6 +163,16 @@ def run(session_id: str, messages, *, project, chat, deadline,
         _verify_agent_amendments(project, messages)
     except Exception:
         log.warning("agent amendment verification pass failed", exc_info=True)
+    # #694 PR 3 (D8): same posture again — its own pass, deliberately NOT
+    # folded into either pass above (each ledger's pending population must
+    # stay honestly apart, same reasoning as the amendments/resolutions
+    # split). Same independence from carry, same never-cost-the-checkpoint
+    # try/except.
+    try:
+        _verify_agent_request_done(project, messages)
+    except Exception:
+        log.warning("agent request-done verification pass failed",
+                    exc_info=True)
     # #376: record what the checkers REJECTED, after write_checkpoint because
     # that is where item ids are guaranteed stamped (the merge branch above
     # only stamps when it runs). Its own append-only stream, never events.jsonl
@@ -480,6 +490,59 @@ def _verify_agent_amendments(project, messages) -> int:
             confirmed += 1
         except amendments.AmendmentError:
             continue
+    return confirmed
+
+
+def _verify_agent_request_done(project, messages) -> int:
+    """#694 PR 3 (D8): byte-check every un-verified agent `done` row's
+    evidence quote against THIS session's transcript — the same matching
+    stack the resolve candidates and amendments are held to (#125/#480/
+    #691), reused, not duplicated.
+
+    Reads RAW EVENTS, not `requests.records(project_dir=project)`: a `done`
+    row this project wrote as the RECIPIENT of a FOREIGN ask (#694's mutual
+    read-through — the recipient answers in its own bucket) is an ORPHAN in
+    its own per-bucket fold, invisible to `records()`. The raw row is what
+    this pass verifies; the sender's join is what makes the flag meaningful
+    on the other side, with no foreign write.
+
+    Quote found -> `requests.verify_done` appends a mechanical-channel
+    `done_verified` row recording the speaker role; the fold clears
+    `done_claimed` and the render drops the "(claimed, unverified)"
+    qualifier. Quote not found -> nothing written; the claim stands exactly
+    as before, for a human verdict or a future serialize to settle. Human
+    `done` never reaches here: it was never claimed in the first place, and
+    the pending filter below keys on the observed agent authority, never on
+    a caller's claim."""
+    rows = requests.events(project_dir=project)
+    already_verified = {
+        str(row.get("request_id") or "") for row in rows
+        if row.get("event") == "done_verified"}
+    pending: dict[str, str] = {}
+    for row in rows:
+        if row.get("event") != "done":
+            continue
+        rid = str(row.get("request_id") or "")
+        if not rid or rid in already_verified:
+            continue
+        if requests.CHANNEL_AUTHORITY.get(str(row.get("channel") or "")) \
+                != "agent":
+            continue
+        evidence = str(row.get("evidence") or "").strip()
+        if evidence:
+            pending[rid] = evidence
+    if not pending:
+        return 0
+    haystack = serializer.stripped_transcript(messages) if messages else ""
+    confirmed = 0
+    for rid, evidence in sorted(pending.items()):
+        found, role = serializer.verify_agent_evidence(
+            evidence, messages, haystack=haystack)
+        if not found:
+            continue
+        if requests.verify_done(rid, role=str(role or "unknown"),
+                                project_dir=project):
+            confirmed += 1
     return confirmed
 
 

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -599,6 +599,17 @@ def _render_briefing_body(checkpoint, route, *, drift_project, teammates,
                                             project_dir=worldcheck_project)
         except Exception:
             pass
+        # #694 PR 3 (D1, sender side): same posture, same gate, same
+        # post-print timing — a crash before this line just re-renders the
+        # verdict card next brief instead of a false "verdict_surfaced".
+        try:
+            for row in requests.verdict_renderable(
+                    project_dir=worldcheck_project).get("rows") or []:
+                if requests.needs_verdict_surfaced_stamp(row):
+                    requests.stamp_verdict_surfaced(
+                        row["request_id"], project_dir=worldcheck_project)
+        except Exception:
+            pass
     if withheld:
         render.render_brief_note([
             f"{len(withheld)} resolved item(s) withheld — "
@@ -1846,6 +1857,13 @@ def _status_world(project_arg=None) -> dict:
     # surfaced only when non-zero (same "quiet by default" rule). Claim
     # snapshots stay in the ledger; status shows only the number.
     forget_hits = store.forget_hit_stats(project)
+    # #694 PR 3: the requests summary — {open_sent, awaiting_you}. Fail-open,
+    # same posture as every other best-effort status fact: a broken composer
+    # must never take `status` down with it.
+    try:
+        request_counts = requests.status_counts(project_dir=project)
+    except Exception:
+        request_counts = {"open_sent": 0, "awaiting_you": 0}
     identity = {
         "cwd": str(Path(project_arg or ".").expanduser().resolve()),
         "git_root": project,
@@ -1864,7 +1882,7 @@ def _status_world(project_arg=None) -> dict:
         "hook_drift": hook_drift, "plugin_drift": plugin_drift,
         "rescue_gap": rescue_gap,
         "rescue_posture": rescue_posture, "rescue_window_errors": rescue_window_errors,
-        "forget_hits": forget_hits, "rc": rc,
+        "forget_hits": forget_hits, "requests": request_counts, "rc": rc,
     }
 
 
@@ -1884,6 +1902,7 @@ def status_payload(project_arg=None) -> tuple:
         "rescue_gap": w["rescue_gap"],
         "rescue_posture": w["rescue_posture"],
         "forget_hits": w["forget_hits"],
+        "requests": w["requests"],
     }
     return payload, w["rc"]
 
@@ -1909,6 +1928,7 @@ def _cmd_status(args) -> int:
         "rescue_posture": w["rescue_posture"],
         "rescue_window_errors": w["rescue_window_errors"],
         "forget_hits": w["forget_hits"],
+        "requests": w["requests"],
     })
     return w["rc"]
 

--- a/plugin/daimon_briefing/cli/request.py
+++ b/plugin/daimon_briefing/cli/request.py
@@ -29,7 +29,7 @@ _VERDICT_CALLS = {
     "suppress": "suppress",
 }
 _MARKS = {"open": "→", "needs-info": "?", "accepted": "✓",
-          "rejected": "×", "done": "✔"}
+          "rejected": "×", "done": "✔", "stale": "⏳"}
 # Near-match budget for an unknown `--to`: enough to catch a typo, few
 # enough that the refusal stays a refusal rather than a project directory.
 _SUGGESTIONS = 3
@@ -49,22 +49,26 @@ def _request_channel(args) -> str:
     return "cli-tty"
 
 
-def _state_label(record: dict) -> str:
-    """#694 D8: an agent's completion claim is never rendered as fact. The
-    session-end byte-check (PR 3) is what drops the qualifier."""
+def _state_label(record: dict, project_dir=None) -> str:
+    """#694 D8: an agent's completion claim is never rendered as fact — the
+    session-end byte-check drops the qualifier once `verify_done` clears
+    `done_claimed`. D3: an open/needs-info record whose surfaced anchor has
+    aged past STALE_AFTER_SESSIONS renders `stale` instead — never written
+    to disk, recomputed fresh on every call via `requests.render_state`."""
     if record.get("state") == "done" and record.get("done_claimed"):
         return "done (claimed, unverified)"
-    return str(record.get("state") or "open")
+    return requests.render_state(record, project_dir=project_dir)
 
 
-def _request_lines(record: dict) -> list:
+def _request_lines(record: dict, project_dir=None) -> list:
     """One request as a record card. The header follows the #711 three-span
     shape (state bracket, id, prose); the body carries the two-party facts a
     one-liner would drop — who it is addressed to, why, and whether the
     sender is blocked on it."""
-    state = str(record.get("state") or "open")
+    state = requests.render_state(record, project_dir=project_dir)
     who = record.get("verdict_label") or f"{record.get('opened_by', '?')}-asked"
-    lines = [f"[{_MARKS.get(state, '?')} {_state_label(record)} · {who}] "
+    lines = [f"[{_MARKS.get(state, '?')} "
+             f"{_state_label(record, project_dir=project_dir)} · {who}] "
              f"{record['request_id']}  {record.get('ask', '')}"]
     to = record.get("to", "")
     lines.append(f"  To: {to}" + (" (for a human)" if record.get("to_human")
@@ -93,12 +97,13 @@ def _request_lines(record: dict) -> list:
     return lines
 
 
-def _inbox_lines(record: dict) -> list:
+def _inbox_lines(record: dict, project_dir=None) -> list:
     """One inbox entry as a record card — same three-span header shape as
     `_request_lines`, labeled with the foreign SENDER (`From:`) instead of
     the local `to`, since every row here was addressed to THIS project."""
-    state = str(record.get("state") or "open")
-    lines = [f"[{_MARKS.get(state, '?')} {_state_label(record)}] "
+    state = requests.render_state(record, project_dir=project_dir)
+    lines = [f"[{_MARKS.get(state, '?')} "
+             f"{_state_label(record, project_dir=project_dir)}] "
              f"{record['request_id']}  {record.get('ask', '')}"]
     lines.append(f"  From: {record.get('from_label') or '?'}"
                  + (" (for a human)" if record.get("to_human") else ""))
@@ -132,7 +137,8 @@ def _cmd_request_inbox(args) -> int:
     if not rows:
         render.render_ledger_lines(["no requests addressed to this project"])
         return 0
-    render.render_ledger_records([_inbox_lines(row) for row in rows])
+    render.render_ledger_records(
+        [_inbox_lines(row, project_dir=project) for row in rows])
     return 0
 
 
@@ -185,8 +191,9 @@ def _cmd_request_open(args) -> int:
              "never surfaced there and never decays; it stays in "
              "`daimon request list` until that project serializes a session"])
     record = requests.get(q_id, project_dir=project)
-    render.render_ledger_lines(_request_lines(record) if record else
-                               [f"request {q_id} recorded"])
+    render.render_ledger_lines(
+        _request_lines(record, project_dir=project) if record else
+        [f"request {q_id} recorded"])
     return 0
 
 
@@ -202,7 +209,7 @@ def _cmd_request_revise(args) -> int:
         return 1
     _cli._note_usage("request:revise")
     record = requests.get(args.request_id, project_dir=project)
-    render.render_ledger_lines(_request_lines(record))
+    render.render_ledger_lines(_request_lines(record, project_dir=project))
     return 0
 
 
@@ -236,7 +243,7 @@ def _report(request_id: str, project, verb: str) -> None:
              "project's ask joins its origin at read time, and until then "
              "it renders nowhere"])
         return
-    render.render_ledger_lines(_request_lines(record))
+    render.render_ledger_lines(_request_lines(record, project_dir=project))
 
 
 def _cmd_request_done(args) -> int:
@@ -263,7 +270,8 @@ def _cmd_request_list(args) -> int:
     if not rows:
         render.render_ledger_lines(["no requests for this project"])
         return 0
-    render.render_ledger_records([_request_lines(row) for row in rows])
+    render.render_ledger_records(
+        [_request_lines(row, project_dir=project) for row in rows])
     return 0
 
 

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -155,11 +155,12 @@ def _print_handoff(handoff) -> None:
 
 def render_brief(checkpoint, drift=None, teammates=None, handoff=None,
                  project_dir=None, worldcheck_project=None) -> None:
-    """`worldcheck_project` (#694 PR 2) is a SEPARATE gate from `project_dir`
-    — the request panel's own `worldcheck_project` pattern (D2), never keyed
-    on route: the caller passes it only on the CLI same-project brief path
+    """`worldcheck_project` (#694 PR 2/3) is a SEPARATE gate from
+    `project_dir` — the incoming-request panel's AND the sender-side
+    verdict panel's `worldcheck_project` pattern (D2), never keyed on
+    route: the caller passes it only on the CLI same-project brief path
     (`cli._render_briefing_body`), never for `--slug`, the global-pointer
-    fallback body, or MCP. None here means no panel, full stop."""
+    fallback body, or MCP. None here means neither panel, full stop."""
     _print_handoff(handoff)
     b = briefing.build(checkpoint)
     # #693/#694: each path below performs exactly one ledger read per
@@ -172,13 +173,15 @@ def render_brief(checkpoint, drift=None, teammates=None, handoff=None,
                    if project_dir is not None else [])
         request_lines = (briefing.request_panel_lines(worldcheck_project)
                          if worldcheck_project is not None else [])
-        if rulings or request_lines:
-            # #693/#694: standing rulings and addressed requests exist before
-            # the first checkpoint does — a day-one ratification, or the
-            # first ask ever addressed to this project, must not wait for a
-            # session to end.
-            print("\n".join(rulings + (([""] if rulings and request_lines
-                                        else []) + request_lines)))
+        verdict_lines = (briefing.verdict_panel_lines(worldcheck_project)
+                         if worldcheck_project is not None else [])
+        blocks = [blk for blk in (rulings, request_lines, verdict_lines) if blk]
+        if blocks:
+            # #693/#694: standing rulings, addressed requests, and decided
+            # verdicts exist before the first checkpoint does — a day-one
+            # ratification, or the first ask/verdict this project ever sees,
+            # must not wait for a session to end.
+            print("\n\n".join("\n".join(blk) for blk in blocks))
             print("")
         # Point at the real flow (#29): checkpoints come from the hooks; bare
         # `serialize` dead-ends (it needs a transcript path).
@@ -193,7 +196,7 @@ def render_brief(checkpoint, drift=None, teammates=None, handoff=None,
     # it is active we print its narrative regardless of TTY.
     if config.llm_briefing():
         # Tries LLM, falls back to deterministic; #693 rulings and #694's
-        # request panel both ride inside. Unconditional return: `b` is
+        # two request panels all ride inside. Unconditional return: `b` is
         # non-None here, so render() always yields text — a fall-through
         # would double the ledger reads below, and structure beats a comment
         # at keeping that invariant.
@@ -206,13 +209,16 @@ def render_brief(checkpoint, drift=None, teammates=None, handoff=None,
                if project_dir is not None else [])
     request_lines = (briefing.request_panel_lines(worldcheck_project)
                      if worldcheck_project is not None else [])
+    verdict_lines = (briefing.verdict_panel_lines(worldcheck_project)
+                     if worldcheck_project is not None else [])
     # #204: degrade verbatim labels when the receipt can't be locally confirmed.
     # Cheap check (sidecar + byte match), computed once for both render paths.
     degraded = briefing.receipt_degraded(checkpoint)
     if not supports_rich():
-        print(briefing.render_plain(b, degraded, rulings, request_lines))
+        print(briefing.render_plain(b, degraded, rulings, request_lines,
+                                    verdict_lines))
     else:
-        _rich_brief(b, degraded, rulings, request_lines)
+        _rich_brief(b, degraded, rulings, request_lines, verdict_lines)
     _print_drift(drift)
     _print_teammates(teammates)
 
@@ -246,7 +252,7 @@ def _print_drift(drift) -> None:
 
 
 def _rich_brief(b: dict, degraded: bool = False, rulings=(),
-                request_lines=()) -> None:
+                request_lines=(), verdict_lines=()) -> None:
     from rich.console import Console
     from rich.panel import Panel
     from rich.text import Text
@@ -272,6 +278,14 @@ def _rich_brief(b: dict, degraded: bool = False, rulings=(),
             body.append(f"{line}\n", style="bold")
         console.print(Panel(body, title=request_lines[0],
                             border_style="blue", title_align="left"))
+    if verdict_lines:
+        # #694 PR 3: same shape, its own border color — three skeleton
+        # sections must each read as distinct at a glance.
+        body = Text()
+        for line in verdict_lines[1:]:
+            body.append(f"{line}\n", style="bold")
+        console.print(Panel(body, title=verdict_lines[0],
+                            border_style="green", title_align="left"))
     for key, title, style in _SECTIONS:
         items = b.get(key) or []
         if not items:
@@ -705,6 +719,22 @@ def _forget_hits_line(data: dict) -> str | None:
             f"re-assertion{'s' if n != 1 else ''}, most recent {ts}")
 
 
+def _requests_line(data: dict) -> str | None:
+    """#694 PR 3: one line summarizing the cross-project ask ledger — open
+    sent / awaiting-you counts, read through the composer so the numbers
+    agree with both ambient panels. Silent when both are zero (same "quiet
+    by default" rule as the team/receipts/forget-hits lines)."""
+    counts = data.get("requests")
+    if not isinstance(counts, dict):
+        return None
+    sent = counts.get("open_sent") or 0
+    awaiting = counts.get("awaiting_you") or 0
+    if not sent and not awaiting:
+        return None
+    return (f"requests: {sent} open sent, {awaiting} awaiting you — "
+            "daimon request list / inbox")
+
+
 def _ruling_echo_line(data: dict) -> str | None:
     """#693: one line when the admission filter has dropped a ruling echo on
     this install; silent otherwise. Its own counter, never folded into the
@@ -772,6 +802,9 @@ def _plain_status(data: dict) -> None:
     re_line = _ruling_echo_line(data)
     if re_line:
         print(re_line)  # #693: one line, only when an echo was dropped
+    rq_line = _requests_line(data)
+    if rq_line:
+        print(rq_line)  # #694 PR 3: one line, only when non-zero
     proj, glob, last = data["proj"], data["glob"], data["last"]
     print(f"project: {data['project']}")
     if proj["exists"]:
@@ -868,6 +901,9 @@ def _rich_status(data: dict) -> None:
     re_line = _ruling_echo_line(data)
     if re_line:
         console.print(re_line)  # #693: one line, only when an echo was dropped
+    rq_line = _requests_line(data)
+    if rq_line:
+        console.print(rq_line)  # #694 PR 3: one line, only when non-zero
     proj, glob, last = data["proj"], data["glob"], data["last"]
     table = Table(title=f"daimon status — {data['project']}", title_justify="left",
                   show_header=True, header_style="bold")

--- a/plugin/daimon_briefing/requests.py
+++ b/plugin/daimon_briefing/requests.py
@@ -59,11 +59,17 @@ VERSION = 1
 # `verdict_surfaced` (the sender's brief stamped the answer) are written by
 # the inbox and return-path PRs, but their fold handling ships here — an
 # older reader that dropped them would silently re-render decided work.
+#
+# #694 PR 3 widens it ONCE, deliberately, with `done_verified` — the
+# session-end byte-check confirming an agent's `done` evidence quote against
+# the transcript. The format is frozen PER-PR, not for the whole arc (the
+# design's own implementation note): an older reader drops the unknown row
+# and keeps rendering "done (claimed, unverified)" — the safe direction.
 EVENTS = frozenset({
     "opened", "revised",
     "surfaced", "verdict_surfaced",
     "needs_info", "accepted", "rejected", "done",
-    "suppressed",
+    "suppressed", "done_verified",
 })
 # What a folded record may render as. `stale` is derived from consumption
 # (PR 3's baton count), never appended — an expiry that writes a row would
@@ -106,6 +112,9 @@ _EVENT_RANK = {
     "needs_info": 5,
     "accepted": 6,
     "rejected": 7,
+    # Verification always answers a `done` row that already landed; ranked
+    # last so a same-`order` tie (test clocks) can never process it first.
+    "done_verified": 8,
 }
 _REQUEST_ID_RE = re.compile(r"q-[0-9a-f]{12}")
 # store.project_slug's output: every non-word char munged to '-'. Validated
@@ -116,6 +125,9 @@ _SLUG_RE = re.compile(r"[\w-]{1,255}")
 _SPACE_RE = re.compile(r"\s+")
 _MAX_TEXT = 2000
 _LABEL_MAX = 64
+# The verify_done transcript-speaker role, same bound amendments.py's
+# _ROLE_MAX uses for the identical session-end byte-check shape.
+_ROLE_MAX = 64
 
 # Every field of a ledger row that can hold plaintext (#645 discipline).
 # One declaration, two consumers: `forget_content_key` decides which records
@@ -334,6 +346,10 @@ def fold(rows: list[dict]) -> dict[str, dict]:
                 "done_by": None,
                 "done_claimed": False,
                 "done_evidence": "",
+                # #694 PR 3 (D8): set only by a `done_verified` row landing
+                # on a currently-claimed completion — never on disk, the
+                # session-end byte-check's own timestamp.
+                "done_verified_at": None,
                 "suppressed": False,
                 # {revision epoch: earliest surfaced ts} — D1's write-once
                 # dedup key, consulted by the stamp PR 2 adds.
@@ -393,6 +409,19 @@ def fold(rows: list[dict]) -> dict[str, dict]:
         if event == "done" and not str(row.get("evidence") or "").strip():
             # D8: `done` is the one either-channel state move, and its price
             # is evidence. A row without it never lands.
+            continue
+        if event == "done_verified":
+            # #694 PR 3 (D8): the session-end byte-check confirmed the
+            # agent's `done` evidence quote. Certifies TRANSCRIPTION, not
+            # truth — clears the "claimed, unverified" qualifier without
+            # moving state or any verdict field. Inert unless the record is
+            # CURRENTLY a claimed completion: a stray/duplicate row, one
+            # answering a human `done` (never claimed), or one that arrived
+            # before any `done` at all changes nothing.
+            if current["state"] == "done" and current["done_claimed"]:
+                current["history_count"] += 1
+                current["done_claimed"] = False
+                current["done_verified_at"] = row.get("ts")
             continue
         current["history_count"] += 1
         current["updated_at"] = row.get("ts") or current["updated_at"]
@@ -631,6 +660,25 @@ def done(request_id: str, *, channel: str, evidence: str,
         raise RequestError("completion not written")
 
 
+def verify_done(request_id: str, *, role: str, project_dir=None) -> bool:
+    """Record the session-end byte-check outcome for an agent's `done`
+    evidence quote (channel `mechanical`), written to THIS bucket — where
+    the `done` row it verifies lives (#694 PR 3, D8).
+
+    No `get()` gate, unlike `amendments.verify`: a `done` row this pass
+    verifies may be an ORPHAN in this bucket's own per-bucket fold above (a
+    foreign ask this project answered as the recipient — its `opened` row
+    lives in the sender's bucket). The raw row is what matters; the fold's
+    `done_verified` handling and the composer's read-through are what make
+    the flag meaningful to whichever side is watching. The role is the
+    transcript speaker the quote was found under, bounded to _ROLE_MAX —
+    verification certifies transcription, not truth, and the render never
+    drops that qualifier just because a role was recorded."""
+    row = _stamp("done_verified", request_id, "mechanical")
+    row["evidence_role"] = _text("role", role)[:_ROLE_MAX]
+    return append(row, project_dir=project_dir)
+
+
 def plaintext_values(row: dict) -> list[str]:
     """Every plaintext value this row carries, in declaration order.
 
@@ -831,11 +879,100 @@ def inbox_listing(project_dir=None) -> list[dict]:
 def inbox_renderable(project_dir=None) -> dict:
     """The recipient-side panel data: {"rows": [...], "overflow": N} —
     requests addressed to this project still awaiting a decision, newest
-    first, capped at RENDER_CAP with the remainder COUNTED. Suppressed
-    records are filtered here and only here (mirrors `renderable` above):
-    that is the entire effect suppress is allowed to have."""
+    first, capped at RENDER_CAP with the remainder COUNTED. Suppressed AND
+    stale records are filtered here and only here (mirrors `renderable`
+    above, extended by D3): that is the entire effect suppress/staleness is
+    allowed to have on the ambient panel — both stay fully visible in
+    `inbox_listing`."""
     rows = [r for r in recipient_join(project_dir=project_dir).values()
-            if r["state"] in _SENDER_MOVABLE and not r["suppressed"]]
+            if r["state"] in _SENDER_MOVABLE and not r["suppressed"]
+            and not is_stale(r, project_dir=project_dir)]
+    rows.sort(key=lambda r: (r.get("updated_at") or "", r["request_id"]),
+              reverse=True)
+    return {"rows": rows[:RENDER_CAP], "overflow": max(0, len(rows) - RENDER_CAP)}
+
+
+# ---- #694 PR 3: D3 — consumption-based expiry, derived, never written -----
+
+# Recipient side: an open/needs-info record goes `stale` once this many
+# distinct non-introspection RECIPIENT sessions have serialized past the
+# surfaced anchor with no verdict. Named, not the baton's inlined 2
+# (store.sessions_since_count's threshold is caller-chosen).
+STALE_AFTER_SESSIONS = 3
+# Sender side: a decided record (accepted/rejected/needs-info/done) leaves
+# the sender's verdict PANEL after this many distinct non-introspection
+# SENDER sessions have serialized past `verdict_surfaced_at`. The record
+# itself never changes — only ambient panel placement.
+VERDICT_PANEL_SESSIONS = 2
+# States the sender-side verdict panel surfaces: everything settled enough
+# for the sender to be told about it. "open" is deliberately absent — an
+# ask nobody has acted on yet has nothing to report.
+_VERDICT_STATES = frozenset({"needs-info", "accepted", "rejected", "done"})
+
+
+def is_stale(record: dict, project_dir=None) -> bool:
+    """D3 recipient side: True once an open/needs-info record's surfaced
+    anchor — the first `surfaced` ts of its LATEST revision epoch — has aged
+    past STALE_AFTER_SESSIONS distinct non-introspection sessions serialized
+    for `project_dir` (the RECIPIENT's own bucket) with no verdict landing
+    in between. Never surfaced -> no anchor -> never decays. Every other
+    state is a permanent fact — a verdict or a completion never goes stale."""
+    if record.get("state") not in _SENDER_MOVABLE:
+        return False
+    anchor = (record.get("surfaced") or {}).get(record.get("revision"))
+    if not anchor:
+        return False
+    return store.sessions_since_count(anchor, project_dir) >= STALE_AFTER_SESSIONS
+
+
+def render_state(record: dict, project_dir=None) -> str:
+    """The state LABEL for `request list`/`inbox` (D3): `stale` in place of
+    `open`/`needs-info` once `is_stale`, else the record's real state.
+    Recomputed fresh on every call — `stale` is never written to disk."""
+    return "stale" if is_stale(record, project_dir=project_dir) \
+        else str(record.get("state") or "open")
+
+
+def needs_verdict_surfaced_stamp(record: dict) -> bool:
+    """D1, sender side: whether a `verdict_surfaced` row already exists for
+    this record. Write-once per RECORD, not per revision epoch — unlike the
+    recipient's `surfaced` stamp, a verdict is terminal once it lands, so
+    there is only ever one thing to stamp."""
+    return record.get("verdict_surfaced_at") is None
+
+
+def stamp_verdict_surfaced(request_id: str, project_dir=None) -> bool:
+    """Write a `verdict_surfaced` row to THIS project's own bucket (the
+    SENDER's) — its brief observed and rendered the verdict card. Channel
+    `mechanical`, same posture as `stamp_surfaced`. Write-once is the
+    caller's job (`needs_verdict_surfaced_stamp` first) — the fold's
+    earliest-wins tie-break absorbs a concurrent-brief duplicate for free."""
+    row = _stamp("verdict_surfaced", request_id, "mechanical")
+    return append(row, project_dir=project_dir)
+
+
+def verdict_panel_expired(record: dict, project_dir=None) -> bool:
+    """D3 sender side: True once VERDICT_PANEL_SESSIONS distinct non-
+    introspection sessions have serialized for `project_dir` (the SENDER's
+    own bucket) past `verdict_surfaced_at`. Never stamped yet -> never
+    expired — the panel still owes the sender its first look."""
+    anchor = record.get("verdict_surfaced_at")
+    if not anchor:
+        return False
+    return (store.sessions_since_count(anchor, project_dir)
+            >= VERDICT_PANEL_SESSIONS)
+
+
+def verdict_renderable(project_dir=None) -> dict:
+    """The sender-side verdict panel data: {"rows": [...], "overflow": N} —
+    requests THIS project SENT whose recipient gave a verdict or completion
+    claim, read through `sender_join` (so suppression stays hidden, D5),
+    newest first, capped at RENDER_CAP with the remainder COUNTED. Expired
+    verdicts (D3) are filtered here and only here — the record stays fully
+    readable through `sender_join`, only ambient panel attention decays."""
+    rows = [r for r in sender_join(project_dir=project_dir).values()
+            if r["state"] in _VERDICT_STATES
+            and not verdict_panel_expired(r, project_dir=project_dir)]
     rows.sort(key=lambda r: (r.get("updated_at") or "", r["request_id"]),
               reverse=True)
     return {"rows": rows[:RENDER_CAP], "overflow": max(0, len(rows) - RENDER_CAP)}
@@ -874,6 +1011,22 @@ def supersedes_label(record: dict) -> str:
     if origin and get(target, project_dir=origin) is None:
         return f"{target} (record forgotten)"
     return target
+
+
+def status_counts(project_dir=None) -> dict:
+    """{"open_sent": N, "awaiting_you": N} for `daimon status`'s one-line
+    summary (#694 PR 3). Read through the composer (`sender_join`/
+    `recipient_join`) rather than the per-bucket fold, so the counts agree
+    with the two ambient panels rather than the pre-PR-2 per-bucket view.
+
+    A full honest count, not an attention-filtered one: suppressed and
+    stale records still await a decision, so they count here even though
+    neither panel renders them."""
+    sent = sum(1 for r in sender_join(project_dir=project_dir).values()
+              if r["state"] in _SENDER_MOVABLE)
+    awaiting = sum(1 for r in recipient_join(project_dir=project_dir).values()
+                  if r["state"] in _SENDER_MOVABLE)
+    return {"open_sent": sent, "awaiting_you": awaiting}
 
 
 def forget_content_key(content_key: str, *, project_dir=None) -> list[str]:

--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -245,6 +245,12 @@ top of `daimon brief` (capped at 3, with an overflow count). `daimon request
 inbox` lists every one, including any the panel dropped for attention —
 `--suppress` hides a card from the panel, never from `list`/`inbox`.
 
+Decisions on requests THIS project sent also surface in your own brief
+(accepted/rejected/needs-info/done) — no need to poll `request list` for
+them. An agent's `done` claim renders "claimed, unverified" until the
+next session-end byte-checks the evidence quote; a `stale` label in
+`list`/`inbox` means unanswered too long, not invalid — still act on it.
+
 ## When memory looks wrong
 
 | Symptom | Command |

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -1655,6 +1655,50 @@ def _events_path(project_dir=None):
     return config.checkpoint_dir() / slug / "events.jsonl"
 
 
+def sessions_since_count(ts: str, project_dir=None) -> int:
+    """Count of distinct non-introspection sessions that have serialized a
+    checkpoint POINTER (latest.json / prev-N.json) for `project_dir` with a
+    `created` stamp strictly AFTER `ts`.
+
+    Extracted from `active_handoff`'s baton consumption count (#523,
+    store.py — this WAS the inline block at its old line 1698-1721): a
+    crashed session never serializes, so it never counts; an introspection
+    checkpoint (a /daimon-end provisional, superseded by its own
+    reconstruction) is excluded so one real session is never counted twice.
+    Distinct SESSION IDS are the unit, not pointer files — rotation can
+    leave more than one pointer from a single re-serialize or heal.
+    Fail-open: an unreadable bucket, a torn pointer, or an empty `ts`
+    contributes nothing, never raises.
+
+    Shared by `active_handoff`'s 2-session threshold and #694 PR 3's
+    request staleness derivation (D3) — the SAME counting shape at a
+    caller-chosen threshold, never a hardcoded 2."""
+    ts = str(ts or "")
+    if not ts:
+        return 0
+    slug = project_slug(project_dir)
+    if not slug:
+        return 0
+    d = config.checkpoint_dir() / slug
+    try:
+        entries = list(d.iterdir())
+    except OSError:
+        return 0
+    consumers = set()
+    for p in entries:
+        if not _POINTER_RE.match(p.name):
+            continue
+        try:
+            ck = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(ck, dict) or ck.get("source") == "introspection":
+            continue
+        if str(ck.get("created") or "") > ts and ck.get("session_id"):
+            consumers.add(str(ck["session_id"]))
+    return len(consumers)
+
+
 def active_handoff(project_dir=None) -> dict | None:
     """The project's active baton (#523), or None.
 
@@ -1696,28 +1740,7 @@ def active_handoff(project_dir=None) -> dict | None:
             or not str(latest.get("note") or "").strip()):
         return None
     ts = str(latest.get("ts") or "")
-    slug = project_slug(project_dir)
-    consumers = set()
-    if slug:
-        d = config.checkpoint_dir() / slug
-        try:
-            entries = list(d.iterdir())
-        except OSError:  # pragma: no cover — TOCTOU only: the events file
-            # was just read from this dir, so it exists; the guard is for a
-            # bucket deleted mid-call, and the fail-open promise must hold.
-            entries = []
-        for p in entries:
-            if not _POINTER_RE.match(p.name):
-                continue
-            try:
-                ck = json.loads(p.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError):
-                continue
-            if not isinstance(ck, dict) or ck.get("source") == "introspection":
-                continue
-            if str(ck.get("created") or "") > ts and ck.get("session_id"):
-                consumers.add(str(ck["session_id"]))
-    if len(consumers) >= 2:
+    if sessions_since_count(ts, project_dir) >= 2:
         return None
     return {"ts": ts, "note": str(latest["note"])}
 

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -717,7 +717,10 @@ def test_cli_status_json_shape(
                          "skipped_recent", "recall_error", "recall_index",
                          "receipts", "capture_alarm", "hook_drift",
                          "plugin_drift", "rescue_gap", "rescue_posture",
-                         "forget_hits"}
+                         "forget_hits", "requests"}
+    # #694 PR 3: the requests summary — {open_sent, awaiting_you}, always
+    # present (zeros when nothing is recorded, never absent/null).
+    assert data["requests"] == {"open_sent": 0, "awaiting_you": 0}
     assert data["plugin_drift"] is None  # #554 no plugin installed -> null
     assert data["capture_alarm"] is None  # #265 FAIL-only probe silent by default
     assert data["forget_hits"]["count"] == 0  # #404 nothing suppressed yet
@@ -732,6 +735,72 @@ def test_cli_status_json_shape(
     assert data["last_serialize"]["result"]["outcome"] == "success"
     assert data["last_serialize"]["result"]["duration_seconds"] == 7
     assert data["last_serialize"]["spawn"]["session_id"] == "S-prev"
+
+
+def test_cli_status_json_reflects_real_request_counts(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    from daimon_briefing import requests, store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/status-req-a")
+    store.write_checkpoint("S-recipient", {
+        "session_id": "S-recipient", "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "x", "trust": "inferred"}]},
+    }, project_dir="/p/status-req-a-recipient")
+    requests.open_request(
+        to=store.project_slug("/p/status-req-a-recipient"), ask="hey",
+        why="because", channel="cli-agent", project_dir="/p/status-req-a")
+    rc = cli.main(["status", "--json"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["requests"] == {"open_sent": 1, "awaiting_you": 0}
+
+
+def test_cli_status_plain_shows_the_requests_line_when_nonzero(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    from daimon_briefing import requests, store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/status-req-b")
+    store.write_checkpoint("S-recipient-b", {
+        "session_id": "S-recipient-b", "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "x", "trust": "inferred"}]},
+    }, project_dir="/p/status-req-b-recipient")
+    requests.open_request(
+        to=store.project_slug("/p/status-req-b-recipient"), ask="hey",
+        why="because", channel="cli-agent", project_dir="/p/status-req-b")
+    rc = cli.main(["status"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "1 open sent" in out
+
+
+def test_cli_status_survives_a_broken_requests_status_counts(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    from daimon_briefing import requests
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/status-req-broken")
+
+    def boom(project_dir=None):
+        raise RuntimeError("composer broke")
+
+    monkeypatch.setattr(requests, "status_counts", boom)
+    rc = cli.main(["status", "--json"])
+    assert rc == 1  # no checkpoint at all here, unrelated to the composer
+    data = json.loads(capsys.readouterr().out)
+    assert data["requests"] == {"open_sent": 0, "awaiting_you": 0}
+
+
+def test_cli_status_plain_silent_when_nothing_recorded(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/status-req-c")
+    store.write_checkpoint("S-c", {
+        "session_id": "S-c", "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "x", "trust": "inferred"}]},
+    }, project_dir="/p/status-req-c")
+    cli.main(["status"])
+    out = capsys.readouterr().out
+    assert "open sent" not in out
+    assert "awaiting you" not in out
 
 
 def test_cli_status_json_exit_1_when_nothing(tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):

--- a/plugin/tests/test_cli_brief_verdicts.py
+++ b/plugin/tests/test_cli_brief_verdicts.py
@@ -1,0 +1,156 @@
+"""#694 PR 3: the sender-side verdict panel + verdict_surfaced stamp on the
+CLI `brief` path. Mirrors test_cli_brief_requests.py (PR 2's incoming panel)
+exactly — same D2 gate, same D1 post-print stamp timing.
+"""
+
+from daimon_briefing import cli, requests, store
+
+
+def _seed_checkpoint(project_dir, session):
+    store.write_checkpoint(session, {
+        "session_id": session, "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "x", "trust": "inferred"}]},
+    }, project_dir=project_dir)
+    return store.project_slug(project_dir)
+
+
+def _accepted_ask(sender_dir, ask="publish the schema",
+                  recipient_dir="/p/cbv-recipient", seed_sender=True):
+    """Seeds the RECIPIENT's bucket, opens an ask FROM sender_dir, and
+    accepts it — the sender's brief has a verdict to show."""
+    if seed_sender:
+        _seed_checkpoint(sender_dir, "S-cbv-sender")
+    recipient_slug = _seed_checkpoint(recipient_dir, "S-cbv-recipient")
+    q_id = requests.open_request(to=recipient_slug, ask=ask, why="because",
+                                 channel="cli-agent", project_dir=sender_dir)
+    requests.accept(q_id, channel="cli-tty", project_dir=recipient_dir)
+    return q_id
+
+
+def test_cli_brief_shows_the_verdict_panel_on_the_normal_path(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    sender = "/p/cbv-sender-a"
+    _accepted_ask(sender, recipient_dir="/p/cbv-recipient-a")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", sender)
+    rc = cli.main(["brief"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "publish the schema" in out
+    assert "accepted" in out
+
+
+def test_cli_brief_stamps_verdict_surfaced_after_the_print(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    sender = "/p/cbv-sender-b"
+    q_id = _accepted_ask(sender, recipient_dir="/p/cbv-recipient-b")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", sender)
+    assert cli.main(["brief"]) == 0
+    capsys.readouterr()
+    record = requests.sender_join(project_dir=sender)[q_id]
+    assert requests.needs_verdict_surfaced_stamp(record) is False
+    assert record["verdict_surfaced_at"]
+
+
+def test_cli_brief_verdict_stamp_is_write_once_across_repeated_briefs(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    sender = "/p/cbv-sender-c"
+    q_id = _accepted_ask(sender, recipient_dir="/p/cbv-recipient-c")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", sender)
+    assert cli.main(["brief"]) == 0
+    assert cli.main(["brief"]) == 0
+    capsys.readouterr()
+    rows = [r for r in requests.events(project_dir=sender)
+            if r.get("event") == "verdict_surfaced" and r.get("request_id") == q_id]
+    assert len(rows) == 1
+
+
+def test_cli_brief_slug_path_never_stamps_or_shows_the_verdict_panel(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    sender = "/p/cbv-sender-d"
+    _accepted_ask(sender, recipient_dir="/p/cbv-recipient-d")
+    slug = store.project_slug(sender)
+
+    def _boom(*a, **k):
+        raise AssertionError("--slug briefs must never touch the composer")
+
+    monkeypatch.setattr(requests, "verdict_renderable", _boom)
+    monkeypatch.setattr(requests, "stamp_verdict_surfaced", _boom)
+    rc = cli.main(["brief", "--slug", slug])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "publish the schema" not in out
+
+
+def test_cli_brief_global_fallback_never_stamps_or_shows_the_verdict_panel(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    sender = "/p/cbv-sender-e"
+    _accepted_ask(sender, recipient_dir="/p/cbv-recipient-e",
+                 seed_sender=False)
+    store.write_checkpoint("S-other-v", {
+        "session_id": "S-other-v", "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "y", "trust": "inferred"}]},
+    })  # no project_dir -> global pointer only
+    monkeypatch.setenv("DAIMON_BRIEF_GLOBAL_FALLBACK", "full")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/cbv-never-seen")
+
+    def _boom(*a, **k):
+        raise AssertionError("global-fallback briefs must never touch the "
+                             "composer")
+
+    monkeypatch.setattr(requests, "verdict_renderable", _boom)
+    monkeypatch.setattr(requests, "stamp_verdict_surfaced", _boom)
+    rc = cli.main(["brief"])
+    assert rc == 0
+
+
+def test_cli_brief_a_crash_before_the_verdict_stamp_leaves_it_unstamped(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    sender = "/p/cbv-sender-f"
+    q_id = _accepted_ask(sender, recipient_dir="/p/cbv-recipient-f")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", sender)
+
+    def _boom(*a, **k):
+        raise RuntimeError("simulated crash between print and stamp")
+
+    monkeypatch.setattr(requests, "stamp_verdict_surfaced", _boom)
+    rc = cli.main(["brief"])
+    assert rc == 0
+    assert "publish the schema" in capsys.readouterr().out
+    record = requests.sender_join(project_dir=sender)[q_id]
+    assert requests.needs_verdict_surfaced_stamp(record) is True
+
+
+def test_cli_brief_no_decided_requests_shows_no_verdict_panel(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    sender = "/p/cbv-sender-g"
+    _seed_checkpoint(sender, "S-cbv-g")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", sender)
+    rc = cli.main(["brief"])
+    assert rc == 0
+    assert "Verdicts on requests you sent" not in capsys.readouterr().out
+
+
+def test_cli_brief_shows_both_panels_together(tmp_checkpoint_dir,
+                                              monkeypatch, capsys):
+    # #694: PR 2's incoming panel and PR 3's verdict panel are independent
+    # sections on the SAME project — a project can be both sender and
+    # recipient at once.
+    project = "/p/cbv-both"
+    _seed_checkpoint(project, "S-cbv-both")
+    sent_id = _accepted_ask(project, ask="the sent ask",
+                            recipient_dir="/p/cbv-both-recipient",
+                            seed_sender=False)
+    incoming_sender = "/p/cbv-both-incoming-sender"
+    _seed_checkpoint(incoming_sender, "S-cbv-both-incoming")
+    requests.open_request(to=store.project_slug(project),
+                          ask="the incoming ask", why="because",
+                          channel="cli-agent", project_dir=incoming_sender)
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", project)
+    rc = cli.main(["brief"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "the sent ask" in out
+    assert "the incoming ask" in out
+    assert sent_id  # keeps the linter from flagging an unused id

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -159,6 +159,64 @@ def test_render_brief_no_checkpoint_still_shows_the_panel(
     assert "publish the schema" in out
 
 
+# ---- #694 PR 3: the sender-side verdict panel's worldcheck_project gate ----
+
+
+def _seed_verdict(sender_dir, ask="publish the schema"):
+    from daimon_briefing import requests, store
+    recipient_dir = sender_dir + "-recipient"
+    store.write_checkpoint("S-render-verdict-recipient", {
+        "session_id": "S-render-verdict-recipient",
+        "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "x", "trust": "inferred"}]},
+    }, project_dir=recipient_dir)
+    to = store.project_slug(recipient_dir)
+    q_id = requests.open_request(to=to, ask=ask, why="because",
+                                 channel="cli-agent", project_dir=sender_dir)
+    requests.accept(q_id, channel="cli-tty", project_dir=recipient_dir)
+    return q_id
+
+
+def test_render_brief_shows_the_verdict_panel_when_worldcheck_project_given(
+        tmp_checkpoint_dir, sample_checkpoint, capsys):
+    _seed_verdict("/p/render-verdict-sender-a")
+    render.render_brief(sample_checkpoint,
+                        worldcheck_project="/p/render-verdict-sender-a")
+    out = capsys.readouterr().out
+    assert "publish the schema" in out
+    assert "accepted" in out
+
+
+def test_render_brief_hides_the_verdict_panel_without_worldcheck_project(
+        tmp_checkpoint_dir, sample_checkpoint, capsys):
+    _seed_verdict("/p/render-verdict-sender-b")
+    render.render_brief(sample_checkpoint,
+                        project_dir="/p/render-verdict-sender-b")
+    out = capsys.readouterr().out
+    assert "publish the schema" not in out
+
+
+def test_render_brief_no_checkpoint_still_shows_the_verdict_panel(
+        tmp_checkpoint_dir, capsys):
+    _seed_verdict("/p/render-verdict-sender-c")
+    render.render_brief({}, worldcheck_project="/p/render-verdict-sender-c")
+    out = capsys.readouterr().out
+    assert "publish the schema" in out
+
+
+def test_render_brief_rich_smoke_shows_the_verdict_panel(
+        monkeypatch, tmp_checkpoint_dir, sample_checkpoint, capsys):
+    # Rich path: content-only (see test_render_brief_rich_smoke for rationale).
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    _seed_verdict("/p/render-verdict-sender-rich")
+    render.render_brief(sample_checkpoint,
+                        worldcheck_project="/p/render-verdict-sender-rich")
+    out = capsys.readouterr().out
+    assert "publish the schema" in out
+    assert "accepted" in out
+
+
 def _serialize_status_data(last):
     return {
         "project": "/repo/x",
@@ -282,6 +340,29 @@ def _status_data():
         "last": {"result": {"outcome": "success", "line": "wrote checkpoint: /c/x.json (took 1s)"},
                  "spawn": {"session_id": "S-proj", "age": "1m"}},
     }
+
+
+def test_render_status_shows_requests_line_when_nonzero(capsys):
+    data = _status_data()
+    data["requests"] = {"open_sent": 2, "awaiting_you": 1}
+    render.render_status(data)
+    out = capsys.readouterr().out
+    assert "requests: 2 open sent, 1 awaiting you" in out
+
+
+def test_render_status_requests_line_silent_when_zero(capsys):
+    data = _status_data()
+    data["requests"] = {"open_sent": 0, "awaiting_you": 0}
+    render.render_status(data)
+    assert "requests:" not in capsys.readouterr().out
+
+
+def test_render_status_requests_rich_smoke(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    data = _status_data()
+    data["requests"] = {"open_sent": 2, "awaiting_you": 1}
+    render.render_status(data)
+    assert "open sent" in capsys.readouterr().out
 
 
 def test_render_status_plain_exact_format(capsys):

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -8,10 +8,24 @@ is the object, its fold, and its deletion contract.
 """
 
 import json
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
 from daimon_briefing import config, normalize, redact, requests, store
+
+
+def _iso(offset_seconds=0):
+    return (datetime.now(timezone.utc)
+            + timedelta(seconds=offset_seconds)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _serialize(project_dir, session_id, created):
+    store.write_checkpoint(session_id, {
+        "session_id": session_id, "created": created,
+        "working_context": {"recent_decisions": [
+            {"text": "x", "trust": "inferred"}]},
+    }, project_dir=project_dir)
 
 
 @pytest.fixture
@@ -266,6 +280,208 @@ def test_done_without_evidence_is_inert_in_the_fold(project):
     assert requests.append(requests._stamp("done", q_id, "cli-tty"),
                            project_dir=project)
     assert requests.get(q_id, project_dir=project)["state"] == "open"
+
+
+# ---- #694 PR 3: done_verified — the session-end byte-check ----------------
+
+
+def test_verify_done_writes_a_mechanical_channel_row(project):
+    q_id = _open(project)
+    requests.done(q_id, channel="cli-agent", evidence="merged in PR #712",
+                 project_dir=project)
+    assert requests.get(q_id, project_dir=project)["done_claimed"] is True
+    assert requests.verify_done(q_id, role="assistant",
+                                project_dir=project) is True
+    record = requests.get(q_id, project_dir=project)
+    assert record["state"] == "done"
+    assert record["done_claimed"] is False
+    assert record["done_verified_at"]
+
+
+def test_verify_done_role_is_capped_and_recorded(project):
+    q_id = _open(project)
+    requests.done(q_id, channel="cli-agent", evidence="shipped it",
+                 project_dir=project)
+    requests.verify_done(q_id, role="x" * 200, project_dir=project)
+    rows = [r for r in requests.events(project_dir=project)
+            if r.get("event") == "done_verified"]
+    assert len(rows[0]["evidence_role"]) <= 64
+
+
+def test_done_verified_is_inert_on_a_human_done(project):
+    """A human `done` is never a claim (D8) — nothing to verify, and a
+    stray/duplicate `done_verified` row must not fabricate a verified flag
+    on a record that never carried the unverified qualifier."""
+    q_id = _open(project)
+    requests.done(q_id, channel="cli-tty", evidence="I did it myself",
+                 project_dir=project)
+    assert requests.get(q_id, project_dir=project)["done_claimed"] is False
+    requests.verify_done(q_id, role="human", project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["done_claimed"] is False
+    assert record["done_verified_at"] is None
+
+
+def test_done_verified_is_inert_without_a_done_first(project):
+    q_id = _open(project)
+    requests.verify_done(q_id, role="assistant", project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["state"] == "open"
+    assert record["done_verified_at"] is None
+
+
+def test_done_verified_on_an_orphan_id_is_written_but_inert(project):
+    """D8/PR 3: a `done` an agent completed for a FOREIGN ask is an orphan in
+    THIS bucket's own per-bucket fold (its `opened` row lives elsewhere) —
+    `verify_done` still writes the row here (where the `done` row lives),
+    and the composer's read-through is what makes it meaningful."""
+    foreign = "q-0123456789ab"
+    assert requests.verify_done(foreign, role="assistant",
+                                project_dir=project) is True
+    assert requests.records(project_dir=project) == {}
+    assert any(r.get("event") == "done_verified"
+              for r in requests.events(project_dir=project))
+
+
+def test_done_verified_is_deterministic_under_reorder(project):
+    q_id = _open(project)
+    requests.done(q_id, channel="cli-agent", evidence="shipped it",
+                 project_dir=project)
+    requests.verify_done(q_id, role="assistant", project_dir=project)
+    rows = requests.events(project_dir=project)
+    forward = requests.fold(rows)[q_id]
+    backward = requests.fold(list(reversed(rows)))[q_id]
+    assert forward == backward
+    assert forward["done_claimed"] is False
+
+
+# ---- #694 PR 3: _verify_agent_request_done() — the session-end pass -------
+
+
+def test_session_end_verifies_agent_request_done_quote(project):
+    from daimon_briefing import capture
+    q_id = _open(project)
+    requests.done(q_id, channel="cli-agent",
+                 evidence="the follow-up issue is filed", project_dir=project)
+    messages = [{"role": "user", "content": "ok, the follow-up issue is filed now"}]
+    confirmed = capture._verify_agent_request_done(project, messages)
+    assert confirmed == 1
+    record = requests.get(q_id, project_dir=project)
+    assert record["done_claimed"] is False
+    assert record["done_verified_at"]
+
+
+def test_session_end_leaves_unfound_done_quote_as_claimed(project):
+    from daimon_briefing import capture
+    q_id = _open(project)
+    requests.done(q_id, channel="cli-agent", evidence="something never said",
+                 project_dir=project)
+    confirmed = capture._verify_agent_request_done(
+        project, [{"role": "user", "content": "entirely different words"}])
+    assert confirmed == 0
+    assert requests.get(q_id, project_dir=project)["done_claimed"] is True
+
+
+def test_session_end_pass_skips_human_done(project):
+    from daimon_briefing import capture
+    q_id = _open(project)
+    requests.done(q_id, channel="cli-tty", evidence="the deploy target moved",
+                 project_dir=project)
+    confirmed = capture._verify_agent_request_done(
+        project, [{"role": "user", "content": "the deploy target moved"}])
+    assert confirmed == 0
+    record = requests.get(q_id, project_dir=project)
+    assert record["done_claimed"] is False   # never claimed to begin with
+    assert record["done_verified_at"] is None
+
+
+def test_session_end_verifies_a_foreign_asks_done_row_in_this_bucket(project):
+    """The recipient-side case (D8): a `done` row this project wrote
+    answering a FOREIGN ask is an orphan in its OWN per-bucket fold — the
+    pass reads raw events, not `records()`, so it still finds and verifies
+    it. The sender's join is what makes the flag meaningful."""
+    from daimon_briefing import capture
+    foreign = "q-0123456789ab"
+    requests.done(foreign, channel="cli-agent", evidence="the fix shipped",
+                 project_dir=project)
+    confirmed = capture._verify_agent_request_done(
+        project, [{"role": "assistant", "content": "the fix shipped in v2"}])
+    assert confirmed == 1
+    rows = [r for r in requests.events(project_dir=project)
+           if r.get("event") == "done_verified"]
+    assert rows and rows[0]["request_id"] == foreign
+
+
+def test_session_end_pass_is_idempotent(project):
+    from daimon_briefing import capture
+    q_id = _open(project)
+    requests.done(q_id, channel="cli-agent", evidence="shipped it",
+                 project_dir=project)
+    msgs = [{"role": "user", "content": "shipped it"}]
+    n1 = capture._verify_agent_request_done(project, msgs)
+    n2 = capture._verify_agent_request_done(project, msgs)
+    assert n1 == 1
+    assert n2 == 0  # already verified — no duplicate done_verified row
+
+
+def test_session_end_pass_survives_a_failing_verify(project, monkeypatch):
+    from daimon_briefing import capture
+    q_id = _open(project)
+    requests.done(q_id, channel="cli-agent", evidence="shipped it",
+                 project_dir=project)
+    monkeypatch.setenv("DAIMON_DISABLE", "1")
+    confirmed = capture._verify_agent_request_done(
+        project, [{"role": "user", "content": "shipped it"}])
+    assert confirmed == 0
+
+
+def test_capture_run_survives_a_broken_request_done_pass(
+        project, sample_checkpoint, fake_chat_factory, monkeypatch):
+    from tests.conftest import make_messages
+    from daimon_briefing import capture
+
+    def boom(proj, messages):
+        raise RuntimeError("pass broke")
+
+    monkeypatch.setattr(capture, "_verify_agent_request_done", boom)
+    store.write_checkpoint("S-prev", sample_checkpoint, project_dir=project)
+    chat = fake_chat_factory(json.dumps({
+        "session_id": "S-new",
+        "working_context": {
+            "active_topic": {"text": "t", "trust": "inferred"},
+            "open_questions": [], "recent_decisions": []},
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []},
+    }))
+    out = capture.run("S-new", make_messages(10), project=project,
+                      chat=chat, deadline=None)
+    assert out is not None  # a broken pass never costs the checkpoint
+
+
+def test_capture_run_wires_the_request_done_pass(
+        project, sample_checkpoint, fake_chat_factory, monkeypatch):
+    """Belt for the hand-wiring itself (#694 PR 3's named checklist item):
+    capture.run must actually CALL the pass, not just tolerate its absence."""
+    from tests.conftest import make_messages
+    from daimon_briefing import capture
+
+    calls = []
+
+    def spy(proj, messages):
+        calls.append((proj, messages))
+        return 0
+
+    monkeypatch.setattr(capture, "_verify_agent_request_done", spy)
+    store.write_checkpoint("S-prev", sample_checkpoint, project_dir=project)
+    chat = fake_chat_factory(json.dumps({
+        "session_id": "S-new",
+        "working_context": {
+            "active_topic": {"text": "t", "trust": "inferred"},
+            "open_questions": [], "recent_decisions": []},
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []},
+    }))
+    capture.run("S-new", make_messages(10), project=project, chat=chat,
+               deadline=None)
+    assert len(calls) == 1
 
 
 # ---- suppress: attention, never state -------------------------------------
@@ -686,10 +902,15 @@ def test_audit_privacy_no_slug_shape_includes_requests():
 
 def test_the_event_vocabulary_is_frozen():
     """PR 1 freezes the format so PR 2/3 cannot widen it by accident: rows
-    an older reader drops are rows it silently re-renders as undecided."""
+    an older reader drops are rows it silently re-renders as undecided.
+    #694 PR 3 widens it ONCE, deliberately, with `done_verified` (the
+    design's own implementation note 2: an older reader drops the unknown
+    row and keeps rendering "done (claimed, unverified)" — the safe
+    direction)."""
     assert set(requests.EVENTS) == {
         "opened", "revised", "surfaced", "verdict_surfaced",
-        "needs_info", "accepted", "rejected", "done", "suppressed"}
+        "needs_info", "accepted", "rejected", "done", "suppressed",
+        "done_verified"}
 
 
 def test_the_fold_reaches_every_render_state_but_never_stale(project):
@@ -1271,6 +1492,223 @@ def test_supersedes_label_is_empty_when_there_is_no_lineage(project):
     assert requests.supersedes_label(record) == ""
 
 
+# ---- #694 PR 3: D3 stale derivation (recipient side, K=3) ------------------
+
+
+def test_is_stale_never_surfaced_never_decays(project):
+    sender_slug = _seed_bucket("/p/req-sender-stale-a")
+    recipient = "/p/req-recipient-stale-a"
+    q_id = requests.open_request(to=store.project_slug(recipient), ask=ASK,
+                                 why=WHY, channel="cli-agent",
+                                 project_dir=sender_slug)
+    record = requests.recipient_join(project_dir=recipient)[q_id]
+    assert record["surfaced"] == {}
+    for n in range(5):
+        _serialize(recipient, f"S-never-{n}", _iso(n + 1))
+    record = requests.recipient_join(project_dir=recipient)[q_id]
+    assert requests.is_stale(record, project_dir=recipient) is False
+
+
+def test_is_stale_after_three_recipient_sessions_past_the_anchor(project):
+    sender_slug = _seed_bucket("/p/req-sender-stale-b")
+    recipient = "/p/req-recipient-stale-b"
+    q_id = requests.open_request(to=store.project_slug(recipient), ask=ASK,
+                                 why=WHY, channel="cli-agent",
+                                 project_dir=sender_slug)
+    requests.stamp_surfaced(q_id, project_dir=recipient)
+    record = requests.recipient_join(project_dir=recipient)[q_id]
+    assert requests.is_stale(record, project_dir=recipient) is False
+    for n in range(requests.STALE_AFTER_SESSIONS - 1):
+        _serialize(recipient, f"S-b{n}", _iso(n + 1))
+    record = requests.recipient_join(project_dir=recipient)[q_id]
+    assert requests.is_stale(record, project_dir=recipient) is False  # 2 of 3
+    _serialize(recipient, "S-b-last",
+              _iso(requests.STALE_AFTER_SESSIONS + 1))
+    record = requests.recipient_join(project_dir=recipient)[q_id]
+    assert requests.is_stale(record, project_dir=recipient) is True
+
+
+def test_is_stale_never_applies_to_a_decided_state(project):
+    sender_slug = _seed_bucket("/p/req-sender-stale-c")
+    recipient = "/p/req-recipient-stale-c"
+    q_id = requests.open_request(to=store.project_slug(recipient), ask=ASK,
+                                 why=WHY, channel="cli-agent",
+                                 project_dir=sender_slug)
+    requests.stamp_surfaced(q_id, project_dir=recipient)
+    requests.accept(q_id, channel="cli-tty", project_dir=recipient)
+    for n in range(requests.STALE_AFTER_SESSIONS + 1):
+        _serialize(recipient, f"S-c{n}", _iso(n + 1))
+    record = requests.recipient_join(project_dir=recipient)[q_id]
+    assert record["state"] == "accepted"
+    assert requests.is_stale(record, project_dir=recipient) is False
+
+
+def test_render_state_labels_stale_without_writing_it(project):
+    sender_slug = _seed_bucket("/p/req-sender-stale-d")
+    recipient = "/p/req-recipient-stale-d"
+    q_id = requests.open_request(to=store.project_slug(recipient), ask=ASK,
+                                 why=WHY, channel="cli-agent",
+                                 project_dir=sender_slug)
+    requests.stamp_surfaced(q_id, project_dir=recipient)
+    for n in range(requests.STALE_AFTER_SESSIONS + 1):
+        _serialize(recipient, f"S-d{n}", _iso(n + 1))
+    before = requests.events(project_dir=recipient)
+    record = requests.recipient_join(project_dir=recipient)[q_id]
+    assert requests.render_state(record, project_dir=recipient) == "stale"
+    assert record["state"] == "open"  # never written to disk
+    assert requests.events(project_dir=recipient) == before  # no new row
+
+
+def test_inbox_renderable_drops_stale_but_inbox_listing_keeps_it(project):
+    sender_slug = _seed_bucket("/p/req-sender-stale-e")
+    recipient = "/p/req-recipient-stale-e"
+    q_id = requests.open_request(to=store.project_slug(recipient), ask=ASK,
+                                 why=WHY, channel="cli-agent",
+                                 project_dir=sender_slug)
+    requests.stamp_surfaced(q_id, project_dir=recipient)
+    for n in range(requests.STALE_AFTER_SESSIONS + 1):
+        _serialize(recipient, f"S-e{n}", _iso(n + 1))
+    assert requests.inbox_renderable(project_dir=recipient)["rows"] == []
+    rows = requests.inbox_listing(project_dir=recipient)
+    assert rows[0]["request_id"] == q_id
+
+
+# ---- #694 PR 3: sender-side verdict panel (D2/D3, K=2) ---------------------
+
+
+def test_needs_verdict_surfaced_stamp_and_dedup(project):
+    recipient_slug = _seed_bucket("/p/req-recipient-verdict-a")
+    q_id = _open(project, to=recipient_slug)
+    requests.accept(q_id, channel="cli-tty", project_dir=recipient_slug)
+    record = requests.sender_join(project_dir=project)[q_id]
+    assert requests.needs_verdict_surfaced_stamp(record) is True
+    assert requests.stamp_verdict_surfaced(q_id, project_dir=project) is True
+    record = requests.sender_join(project_dir=project)[q_id]
+    assert requests.needs_verdict_surfaced_stamp(record) is False
+    assert record["verdict_surfaced_at"]
+
+
+def test_stamp_verdict_surfaced_is_write_once_earliest_wins(project):
+    recipient_slug = _seed_bucket("/p/req-recipient-verdict-b")
+    q_id = _open(project, to=recipient_slug)
+    requests.accept(q_id, channel="cli-tty", project_dir=recipient_slug)
+    assert requests.stamp_verdict_surfaced(q_id, project_dir=project) is True
+    assert requests.stamp_verdict_surfaced(q_id, project_dir=project) is True
+    rows = [r for r in requests.events(project_dir=project)
+            if r.get("event") == "verdict_surfaced"]
+    assert len(rows) == 2  # both written…
+    record = requests.sender_join(project_dir=project)[q_id]
+    assert record["verdict_surfaced_at"] == rows[0]["ts"]  # …fold takes earliest
+
+
+def test_verdict_panel_expired_after_two_sender_sessions(project):
+    recipient_slug = _seed_bucket("/p/req-recipient-verdict-c")
+    q_id = _open(project, to=recipient_slug)
+    requests.accept(q_id, channel="cli-tty", project_dir=recipient_slug)
+    requests.stamp_verdict_surfaced(q_id, project_dir=project)
+    record = requests.sender_join(project_dir=project)[q_id]
+    assert requests.verdict_panel_expired(record, project_dir=project) is False
+    _serialize(project, "S-vp-0", _iso(1))
+    record = requests.sender_join(project_dir=project)[q_id]
+    assert requests.verdict_panel_expired(record, project_dir=project) is False
+    _serialize(project, "S-vp-1", _iso(requests.VERDICT_PANEL_SESSIONS + 1))
+    record = requests.sender_join(project_dir=project)[q_id]
+    assert requests.verdict_panel_expired(record, project_dir=project) is True
+
+
+def test_verdict_panel_never_expires_before_the_first_stamp(project):
+    recipient_slug = _seed_bucket("/p/req-recipient-verdict-d")
+    q_id = _open(project, to=recipient_slug)
+    requests.accept(q_id, channel="cli-tty", project_dir=recipient_slug)
+    record = requests.sender_join(project_dir=project)[q_id]
+    assert record["verdict_surfaced_at"] is None
+    assert requests.verdict_panel_expired(record, project_dir=project) is False
+
+
+def test_verdict_renderable_shows_decided_requests_only(project):
+    recipient_slug = _seed_bucket("/p/req-recipient-verdict-e")
+    open_id = _open(project, to=recipient_slug, ask="still open, no verdict")
+    accepted_id = _open(project, to=recipient_slug,
+                        ask="accepted, should show")
+    requests.accept(accepted_id, channel="cli-tty", project_dir=recipient_slug)
+    entry = requests.verdict_renderable(project_dir=project)
+    ids = {r["request_id"] for r in entry["rows"]}
+    assert ids == {accepted_id}
+    assert open_id not in ids
+
+
+def test_verdict_renderable_caps_and_counts_the_overflow(project):
+    recipient_slug = _seed_bucket("/p/req-recipient-verdict-f")
+    for n in range(requests.RENDER_CAP + 2):
+        q_id = _open(project, to=recipient_slug,
+                     ask=f"ask {n} about the release")
+        requests.accept(q_id, channel="cli-tty", project_dir=recipient_slug)
+    entry = requests.verdict_renderable(project_dir=project)
+    assert len(entry["rows"]) == requests.RENDER_CAP
+    assert entry["overflow"] == 2
+
+
+def test_verdict_renderable_excludes_expired_verdicts(project):
+    recipient_slug = _seed_bucket("/p/req-recipient-verdict-g")
+    q_id = _open(project, to=recipient_slug)
+    requests.accept(q_id, channel="cli-tty", project_dir=recipient_slug)
+    requests.stamp_verdict_surfaced(q_id, project_dir=project)
+    for n in range(requests.VERDICT_PANEL_SESSIONS + 1):
+        _serialize(project, f"S-vpe-{n}", _iso(n + 1))
+    entry = requests.verdict_renderable(project_dir=project)
+    assert entry["rows"] == []
+
+
+def test_verdict_renderable_still_visible_in_sender_join(project):
+    """D3: only ambient panel attention decays — the record itself stays
+    fully readable through the composer regardless of expiry."""
+    recipient_slug = _seed_bucket("/p/req-recipient-verdict-h")
+    q_id = _open(project, to=recipient_slug)
+    requests.accept(q_id, channel="cli-tty", project_dir=recipient_slug)
+    requests.stamp_verdict_surfaced(q_id, project_dir=project)
+    for n in range(requests.VERDICT_PANEL_SESSIONS + 1):
+        _serialize(project, f"S-vpv-{n}", _iso(n + 1))
+    assert requests.verdict_renderable(project_dir=project)["rows"] == []
+    record = requests.sender_join(project_dir=project)[q_id]
+    assert record["state"] == "accepted"
+
+
+# ---- #694 PR 3: status counts ----------------------------------------------
+
+
+def test_status_counts_open_sent_and_awaiting_you(project):
+    recipient_slug = _seed_bucket("/p/req-status-recipient-a")
+    _open(project, to=recipient_slug, ask="still open")
+    accepted_id = _open(project, to=recipient_slug, ask="decided already")
+    requests.accept(accepted_id, channel="cli-tty", project_dir=recipient_slug)
+    sender_slug = _seed_bucket("/p/req-status-sender-b")
+    requests.open_request(to=store.project_slug(project), ask="please look",
+                          why="because", channel="cli-agent",
+                          project_dir=sender_slug)
+    counts = requests.status_counts(project_dir=project)
+    assert counts == {"open_sent": 1, "awaiting_you": 1}
+
+
+def test_status_counts_zero_with_nothing_recorded(project):
+    assert requests.status_counts(project_dir=project) == \
+        {"open_sent": 0, "awaiting_you": 0}
+
+
+def test_status_counts_unknown_project_is_zero():
+    assert requests.status_counts(project_dir=None) == \
+        {"open_sent": 0, "awaiting_you": 0}
+
+
+def test_status_counts_include_suppressed_and_stale(project):
+    """Status is a full honest count, not an attention-filtered display:
+    suppressed/stale requests are still awaiting a decision."""
+    recipient_slug = _seed_bucket("/p/req-status-recipient-c")
+    q_id = _open(project, to=recipient_slug)
+    requests.suppress(q_id, channel="cli-tty", project_dir=recipient_slug)
+    assert requests.status_counts(project_dir=project) == \
+        {"open_sent": 1, "awaiting_you": 0}
+
+
 # ---- PR 2: `request inbox` -------------------------------------------------
 
 
@@ -1325,6 +1763,40 @@ def test_cli_request_inbox_shows_the_suppressed_marker(project, recipient,
     assert rc == 0
     out = capsys.readouterr().out
     assert q_id in out and "suppressed" in out.lower()
+
+
+def test_cli_request_inbox_shows_the_stale_label(project, recipient, capsys):
+    from daimon_briefing import cli
+    assert _cli_open(project, recipient) == 0
+    q_id = next(iter(requests.recipient_join(project_dir=OTHER)))
+    requests.stamp_surfaced(q_id, project_dir=OTHER)
+    for n in range(requests.STALE_AFTER_SESSIONS + 1):
+        _serialize(OTHER, f"S-cli-stale-{n}", _iso(n + 1))
+    capsys.readouterr()
+    rc = cli.main(["request", "inbox", "--project", OTHER])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "stale" in out
+    assert q_id in out
+
+
+def test_cli_request_list_shows_the_stale_label_when_self_addressed(
+        project, capsys):
+    from daimon_briefing import cli
+    my_slug = store.project_slug(project)
+    rc = cli.main(["request", "open", "--to", project, "--ask", ASK,
+                   "--why", WHY, "--by", "agent", "--anyway",
+                   "--project", project])
+    assert rc == 0
+    q_id = next(iter(requests.records(project_dir=project)))
+    requests.stamp_surfaced(q_id, project_dir=my_slug)
+    for n in range(requests.STALE_AFTER_SESSIONS + 1):
+        _serialize(project, f"S-list-stale-{n}", _iso(n + 1))
+    capsys.readouterr()
+    rc = cli.main(["request", "list", "--project", project])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "stale" in out
 
 
 def test_cli_request_inbox_renders_the_forgotten_supersedes_lineage(

--- a/plugin/tests/test_skill_content.py
+++ b/plugin/tests/test_skill_content.py
@@ -62,20 +62,30 @@ def test_full_fits_size_budget():
     # 9,502 (2026-08-15, after review folded the proposal-verb teaching in);
     # 9,900 keeps ~4% slack. Nothing was added to the compact body.
     #
-    # RAISED 9,900 -> 10,700 on 2026-08-16 (#694), same discipline and the
-    # same subject. `request` ships an agent-facing verb family — an agent
-    # opens, revises, and completes asks — and the alternative was declaring
-    # it NOT_AGENT_FACING, which would have been false rather than economical.
-    # The addition is ~500 chars in the cross-project section, where an agent
-    # already goes to read another project: the doctrine line (never write
-    # into another project's memory), the one command that matters, and the
-    # human-only verb list, which is the wedge rule again. What was NOT
-    # taught: the verdict flow and the inbox, because neither exists until
-    # PR 2/3 — teaching a surface before it renders is how a skill starts
-    # lying. New deliberate-review size is 10,301 (2026-08-16); 10,700 keeps
-    # the same ~4% slack. Nothing was added to the compact body.
+    # RAISED 9,900 -> 10,700 on 2026-08-16 (#694 PR 2), same discipline and
+    # the same subject. `request` ships an agent-facing verb family — an
+    # agent opens, revises, and completes asks — and the alternative was
+    # declaring it NOT_AGENT_FACING, which would have been false rather than
+    # economical. The addition is ~500 chars in the cross-project section,
+    # where an agent already goes to read another project: the doctrine line
+    # (never write into another project's memory), the one command that
+    # matters, and the human-only verb list, which is the wedge rule again.
+    # What was NOT taught: the verdict flow and the inbox, because neither
+    # exists until PR 2/3 — teaching a surface before it renders is how a
+    # skill starts lying. New deliberate-review size is 10,301 (2026-08-16);
+    # 10,700 keeps the same ~4% slack. Nothing was added to the compact body.
+    #
+    # RAISED 10,700 -> 11,400 on 2026-08-16 (#694 PR 3), closing the arc: the
+    # gap PR 2's note named is now real. The addition is ~350 chars in the
+    # SAME cross-project section: decisions on requests this project sent
+    # now surface in its own brief too (not just incoming asks), the `done`
+    # claim's byte-check qualifier, and what a `stale` label means — an
+    # agent seeing "stale" must not read it as invalid and stop. New
+    # deliberate-review size is 10,951 (2026-08-16); 11,400 keeps the same
+    # ~4% slack. Nothing was added to the compact body (already at its
+    # 2,000-char hard cap since #579).
     full = skill_content.render_full()
-    assert len(full) <= 10700, f"full body is {len(full)} chars (cap 10700)"
+    assert len(full) <= 11400, f"full body is {len(full)} chars (cap 11400)"
 
 
 def test_full_has_trigger_only_frontmatter():

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1307,6 +1307,72 @@ def _bucket_ckpt(tmp_checkpoint_dir, slug, name, created, session_id,
     (d / name).write_text(json.dumps(ck))
 
 
+# ---- sessions_since_count: the baton's counting shape, extracted (#694 PR 3) ----
+
+
+def test_sessions_since_count_counts_distinct_sessions_after_ts(
+        tmp_checkpoint_dir):
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    _bucket_ckpt(tmp_checkpoint_dir, slug, "latest.json",
+                 "2026-08-02T11:00:00Z", "S-1")
+    assert store.sessions_since_count("2026-08-02T10:00:00Z", "/p/A") == 1
+    assert store.sessions_since_count("2026-08-02T12:00:00Z", "/p/A") == 0
+
+
+def test_sessions_since_count_excludes_introspection(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    _bucket_ckpt(tmp_checkpoint_dir, slug, "latest.json",
+                 "2026-08-02T11:00:00Z", "S-1", source="introspection")
+    assert store.sessions_since_count("2026-08-02T10:00:00Z", "/p/A") == 0
+
+
+def test_sessions_since_count_same_session_counts_once(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    _bucket_ckpt(tmp_checkpoint_dir, slug, "prev-1.json",
+                 "2026-08-02T10:05:00Z", "S-1")
+    _bucket_ckpt(tmp_checkpoint_dir, slug, "latest.json",
+                 "2026-08-02T10:06:00Z", "S-1")
+    assert store.sessions_since_count("2026-08-02T10:00:00Z", "/p/A") == 1
+
+
+def test_sessions_since_count_zero_without_a_ts(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    _bucket_ckpt(tmp_checkpoint_dir, slug, "latest.json",
+                 "2026-08-02T11:00:00Z", "S-1")
+    assert store.sessions_since_count("", "/p/A") == 0
+
+
+def test_sessions_since_count_unknown_project_is_zero(tmp_checkpoint_dir):
+    from daimon_briefing import store
+    assert store.sessions_since_count("2026-08-02T10:00:00Z", None) == 0
+
+
+def test_sessions_since_count_survives_an_unreadable_bucket(
+        tmp_checkpoint_dir):
+    # The bucket directory itself is unreadable (occupied by a file, or a
+    # permissions/TOCTOU failure) — iterdir() raises, and the count degrades
+    # to 0 rather than propagating.
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    tmp_checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_checkpoint_dir / slug).write_text("not a directory")
+    assert store.sessions_since_count("2026-08-02T10:00:00Z", "/p/A") == 0
+
+
+def test_sessions_since_count_survives_an_unreadable_pointer(
+        tmp_checkpoint_dir):
+    from daimon_briefing import store
+    slug = store.project_slug("/p/A")
+    _bucket_ckpt(tmp_checkpoint_dir, slug, "latest.json",
+                 "2026-08-02T11:00:00Z", "S-1")
+    (tmp_checkpoint_dir / slug / "prev-1.json").write_text("{torn")
+    assert store.sessions_since_count("2026-08-02T10:00:00Z", "/p/A") == 1
+
+
 def test_active_handoff_none_without_events(tmp_checkpoint_dir):
     from daimon_briefing import store
     assert store.active_handoff("/p/A") is None

--- a/plugin/tests/test_verdict_briefing.py
+++ b/plugin/tests/test_verdict_briefing.py
@@ -1,0 +1,128 @@
+"""#694 PR 3: the sender-side verdict panel — verdicts on requests THIS
+project sent, surfaced in its own briefing. Mirrors test_request_briefing.py
+(PR 2's incoming panel) and test_ruling_briefing.py's shape: fail-open,
+always present, never budget-dropped. The CLI-only gate (worldcheck_project)
+is exercised in test_cli_brief_requests.py, not here.
+"""
+
+from daimon_briefing import briefing, requests, store
+
+SENDER = "/p/verdict-brief-sender"
+RECIPIENT = "/p/verdict-brief-recipient"
+
+
+def _ask(ask="publish the schema", **kw):
+    return requests.open_request(
+        to=store.project_slug(RECIPIENT), ask=ask, why="the client needs it",
+        channel="cli-agent", project_dir=SENDER, **kw)
+
+
+def test_panel_lists_verdicts_on_requests_this_project_sent(
+        tmp_checkpoint_dir):
+    q_id = _ask()
+    requests.accept(q_id, channel="cli-tty", project_dir=RECIPIENT)
+    lines = briefing.verdict_panel_lines(SENDER)
+    assert any("publish the schema" in ln for ln in lines)
+    assert any("accepted" in ln for ln in lines)
+
+
+def test_panel_names_the_recipient(tmp_checkpoint_dir):
+    q_id = _ask()
+    requests.accept(q_id, channel="cli-tty", project_dir=RECIPIENT)
+    lines = briefing.verdict_panel_lines(SENDER)
+    assert any(store.project_slug(RECIPIENT) in ln for ln in lines)
+
+
+def test_panel_shows_a_verdict_note(tmp_checkpoint_dir):
+    q_id = _ask()
+    requests.reject(q_id, channel="cli-tty", note="wrong project",
+                    project_dir=RECIPIENT)
+    lines = briefing.verdict_panel_lines(SENDER)
+    assert any("Note: wrong project" in ln for ln in lines)
+
+
+def test_panel_shows_done_evidence(tmp_checkpoint_dir):
+    q_id = _ask()
+    requests.done(q_id, channel="cli-tty", evidence="shipped in v2.1",
+                 project_dir=RECIPIENT)
+    lines = briefing.verdict_panel_lines(SENDER)
+    assert any("Done: shipped in v2.1" in ln for ln in lines)
+
+
+def test_panel_excludes_still_open_requests(tmp_checkpoint_dir):
+    _ask()  # no verdict yet
+    assert briefing.verdict_panel_lines(SENDER) == []
+
+
+def test_panel_never_silently_truncates_over_cap(tmp_checkpoint_dir):
+    for n in range(requests.RENDER_CAP + 2):
+        q_id = _ask(ask=f"ask number {n} about the release")
+        requests.accept(q_id, channel="cli-tty", project_dir=RECIPIENT)
+    lines = briefing.verdict_panel_lines(SENDER)
+    body = "\n".join(lines)
+    assert "+2 more decided" in body
+    assert "daimon request list" in body
+
+
+def test_panel_empty_when_no_project_dir(tmp_checkpoint_dir):
+    q_id = _ask()
+    requests.accept(q_id, channel="cli-tty", project_dir=RECIPIENT)
+    assert briefing.verdict_panel_lines(None) == []
+
+
+def test_panel_empty_with_nothing_decided(tmp_checkpoint_dir):
+    assert briefing.verdict_panel_lines(SENDER) == []
+
+
+def test_panel_fails_open_on_a_broken_composer(tmp_checkpoint_dir, monkeypatch):
+    def boom(project_dir=None):
+        raise RuntimeError("boom")
+    monkeypatch.setattr(requests, "verdict_renderable", boom)
+    q_id = _ask()
+    requests.accept(q_id, channel="cli-tty", project_dir=RECIPIENT)
+    assert briefing.verdict_panel_lines(SENDER) == []
+
+
+def test_panel_and_incoming_panel_coexist(tmp_checkpoint_dir):
+    # #694 PR 2's incoming panel and PR 3's verdict panel are independent
+    # sections — both must render together without interfering.
+    sent_id = _ask(ask="the sent ask")
+    requests.accept(sent_id, channel="cli-tty", project_dir=RECIPIENT)
+    incoming_id = requests.open_request(
+        to=store.project_slug(SENDER), ask="the incoming ask",
+        why="because", channel="cli-agent", project_dir=RECIPIENT)
+    out = briefing.render(None, project_dir=SENDER, worldcheck_project=SENDER)
+    assert "the sent ask" in out
+    assert "the incoming ask" in out
+    assert incoming_id  # keeps the linter from flagging an unused id
+
+
+def test_panel_survives_budget_pressure(tmp_checkpoint_dir, sample_checkpoint):
+    q_id = _ask()
+    requests.accept(q_id, channel="cli-tty", project_dir=RECIPIENT)
+    import os
+    os.environ["DAIMON_BRIEF_MAX_TOKENS"] = "40"
+    try:
+        out = briefing.render(sample_checkpoint, project_dir=SENDER,
+                              worldcheck_project=SENDER)
+    finally:
+        del os.environ["DAIMON_BRIEF_MAX_TOKENS"]
+    assert "publish the schema" in out
+
+
+def test_render_with_no_checkpoint_still_shows_the_panel(tmp_checkpoint_dir):
+    q_id = _ask()
+    requests.accept(q_id, channel="cli-tty", project_dir=RECIPIENT)
+    out = briefing.render(None, project_dir=SENDER, worldcheck_project=SENDER)
+    assert out is not None
+    assert "publish the schema" in out
+
+
+def test_full_cap_worst_case_stays_within_budget_share(tmp_checkpoint_dir):
+    for n in range(requests.RENDER_CAP):
+        q_id = _ask(ask=f"n{n} " + "x" * (requests._MAX_TEXT - 4))
+        requests.accept(q_id, channel="cli-tty", project_dir=RECIPIENT)
+    lines = briefing.verdict_panel_lines(SENDER)
+    section = "\n".join(lines)
+    assert briefing.estimate_tokens(section) <= 300
+    assert briefing.estimate_tokens(section) >= 100


### PR DESCRIPTION
Closes #694

## Summary

- Ships the return path — PR 3 of 3, closing the cross-project requests arc (object → inbox → return path).
- **Sender-side verdict panel**: a sender's CLI same-project brief shows verdicts and completion claims on requests it sent, read through `sender_join` (so suppression stays hidden: to the sender a suppressed ask reads "surfaced, undecided"). Same CLI-only gate as the recipient panel (`worldcheck_project` caller parameter, never route), same ruling-shaped posture outside `_DROP_ORDER`, capped with a loud overflow line.
- **`verdict_surfaced` stamp**: after the sender's brief prints, a write-once-per-record row lands in the sender's own bucket — verdicts are terminal, so record scope (not the recipient stamp's per-revision-epoch scope) is correct. Post-print timing, fail-open, earliest-wins under concurrent duplicates.
- **Stale derivation, derived never written**: recipient side, an open/needs-info record renders `stale` once `STALE_AFTER_SESSIONS = 3` distinct non-introspection sessions serialized past the surfaced anchor (first `surfaced` of the latest revision epoch) with no verdict; never-surfaced never decays. Sender side, a decided record leaves the verdict panel after `VERDICT_PANEL_SESSIONS = 2`. Both thresholds are named module constants; the baton's counting logic is extracted into `store.sessions_since_count` (behavior preserved, all pre-existing handoff tests pass unchanged). Stale and suppressed records stay fully visible in `request list` / `request inbox`; only ambient panel attention decays.
- **`done_verified` + session-end byte-check**: `EVENTS` widens with `done_verified` (older readers drop the unknown row and keep rendering `done (claimed, unverified)` — the safe direction). `_verify_agent_request_done()` joins capture's session-end pass beside the amendments verifier: agent-channel `done` evidence quotes are byte-checked against the transcript with the same matching stack, and a mechanical-channel verification row lands in the recipient's own bucket. The sender reads the verified flag through the join — the loop closes across buckets with no foreign write. Human `done` is never byte-checked; a cross-project agent claim never gets a lower bar than a same-project one.
- **`daimon status`** gains a one-line requests summary (`open sent` / `awaiting you`), counted through the composer so it agrees with the panels, honest (suppressed and stale still count), fail-open.
- Byte-check pass reads RAW events, not the per-bucket fold: a `done` row this project wrote answering a foreign ask is an orphan in its own fold and would otherwise silently never verify.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/requests.py` | `done_verified` fold handling, `verify_done`, stale + panel-expiry derivation, `verdict_renderable`, `status_counts`, `render_state` |
| `plugin/daimon_briefing/store.py` | `sessions_since_count` extracted from the handoff baton, threshold parameterized |
| `plugin/daimon_briefing/capture.py` | `_verify_agent_request_done()` hand-wired into the session-end pass |
| `plugin/daimon_briefing/briefing.py` | `verdict_panel_lines`, threaded as a third skeleton block beside rulings and the request panel |
| `plugin/daimon_briefing/render.py` | Verdict panel on plain + rich paths; status requests line |
| `plugin/daimon_briefing/cli/__init__.py` | Post-print `verdict_surfaced` stamp pass; status wiring (JSON + plain) |
| `plugin/daimon_briefing/cli/request.py` | `stale` label threading through list/inbox cards |
| `plugin/daimon_briefing/skill_content.py` | Teaches the verdict panel, stale label, done qualifier |
| `plugin/tests/` | +75 tests: fold/stale/verify/panel/status/CLI + `test_verdict_briefing.py`, `test_cli_brief_verdicts.py` |

## PR Type

- [x] New feature

## Test Plan

- [x] Full suite green: `uv run pytest -q` → 4088 passed, 2 skipped (run twice: implementer + independent verification)
- [x] `uv run ruff check .` → clean repo-wide
- [x] Patch coverage pre-closed: `requests.py`, `cli/request.py`, `capture.py` at 100%; remaining misses in touched files verified pre-existing line-for-line against a stash baseline
- [x] Byte-check verified against the orphan shape: a `done` row answering a foreign ask in this bucket is found and verified from raw events

## Contributor Checklist

- [x] Linked an approved issue (#694, `status:approved`)
- [x] Added exactly one `type:*` label
- [x] Skills content updated
- [x] Docs: design doc updated in vault (internal)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
