### PR TITLE
fix(cli): forget never counts a ruling hit as an item hit

### DIFF
--- a/plugin/daimon_briefing/cli/lifecycle.py
+++ b/plugin/daimon_briefing/cli/lifecycle.py
@@ -307,7 +307,8 @@ def _cmd_forget(args) -> int:
         # are dropped: forgetting the item removes its amendments anyway
         # (forget_item_id below), so nothing becomes unreachable.
         item_hit_ids = {it["id"] for _, k, it, _ in hits
-                        if k not in ("refutation", "amendment", "request")}
+                        if k not in ("refutation", "ruling", "amendment",
+                                     "request")}
         if item_hit_ids:
             hits = [(s, k, it, m) for s, k, it, m in hits
                     if not (k == "amendment"

--- a/plugin/tests/test_amendments.py
+++ b/plugin/tests/test_amendments.py
@@ -523,6 +523,45 @@ def test_cli_forget_reaches_amendments_of_spliced_siblings(project, capsys):
     assert amendments.get(a_id, project_dir=project) is None
 
 
+def test_forget_does_not_cascade_an_amendment_via_a_ruling_id_collision(
+        project, capsys):
+    """#715: `item_hit_ids` (cli/lifecycle.py) excludes "refutation"/
+    "amendment"/"request" kinds from counting as checkpoint-item hits, but
+    NOT "ruling" — the #693 polarity that shares the refutation ledger's
+    `r-<12hex>` id shape, which is ALSO a valid amendment item-id shape
+    (`_ITEM_ID_RE` admits `r-...`). An amendment whose target happens to be
+    a ruling's id is real prose about that ruling, not a checkpoint item —
+    forgetting the ruling must never silently cascade-delete it.
+
+    Pre-fix: the ruling's id lands in `item_hit_ids`, the amendment hit is
+    dropped as "orbiting an item hit", the ruling becomes the sole
+    unambiguous target, forget SUCCEEDS, and `forget_item_id(ruling_id)`
+    deletes the amendment as a side effect. Post-fix: the ruling is
+    excluded, the amendment hit survives, two DISTINCT values remain, and
+    forget REFUSES (ambiguous) — nothing is deleted."""
+    from daimon_briefing import amendments, cli, refutations
+    ref_id = refutations.assert_ruling(
+        subject="the quokka migration protocol",
+        verdict="always stage before prod",
+        scope="this project",
+        evidence=["issue:715"],
+        channel="cli-agent",  # candidate, not active — no confirm prompt
+        project_dir=project,
+    )
+    a_id = amendments.propose(
+        item_id=ref_id, change="progressed",
+        evidence="the quokka migration protocol landed last night",
+        channel="cli-agent", project_dir=project)
+    rc = cli.main(["forget", "the quokka migration protocol",
+                   "--project", project])
+    out = capsys.readouterr().out
+    assert rc == 1, out
+    assert "ambiguous" in out
+    assert a_id in out
+    assert refutations.get(ref_id, project_dir=project) is not None
+    assert amendments.get(a_id, project_dir=project) is not None
+
+
 def test_cli_forget_item_text_not_made_ambiguous_by_its_amendment(
         project, capsys):
     from daimon_briefing import cli, store


### PR DESCRIPTION
Closes #715

## Summary

- Adds `"ruling"` to forget's `item_hit_ids` exclusion tuple (`cli/lifecycle.py`), so a ruling hit is classified as a ledger record like every other ledger kind, never as a checkpoint item.
- Building the regression test showed the defect is worse than the issue's filed impact assessment: it is a reachable cascade-deletion, not a latent misclassification. Ruling ids (`r-<12hex>`) are a valid amendment item-id shape (`_ITEM_ID_RE` admits the `r-` prefix), and module-level `amendments.propose` shape-checks its target without resolving it — so an amendment whose `item_id` equals a ruling's id needs no hash collision to exist. Pre-fix, a forget query matching both that ruling and that amendment dropped the amendment hit as "orbiting an item hit", made the ruling the sole unambiguous target, let the forget succeed, and the deletion cascade (`forget_item_id`) removed the amendment as a side effect of forgetting an unrelated ruling.
- Post-fix the never-guess contract holds: two distinct matched values, forget refuses as ambiguous, both records survive. Pinned by `test_forget_does_not_cascade_an_amendment_via_a_ruling_id_collision`, which was watched failing pre-fix with the cascade output (`rc == 0`, amendment deleted) and passing post-fix (`rc == 1`, both records intact).

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/cli/lifecycle.py` | `"ruling"` added to the exclusion tuple (one logical line) |
| `plugin/tests/test_amendments.py` | Regression test pinning the refusal and both records' survival |

## PR Type

- [x] Bug fix

## Test Plan

- [x] Full suite green: `uv run pytest -q` → 4089 passed, 2 skipped (run twice: implementer + independent verification)
- [x] `uv run ruff check .` → clean repo-wide
- [x] New test observed failing pre-fix with the actual cascade-deletion output, passing post-fix
- [x] Changed line exercised by the new test and pre-existing forget tests (no patch-coverage risk)

## Contributor Checklist

- [x] Linked an approved issue (#715, `status:approved`)
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
