### PR TITLE
test(worldcheck): semantic tests own a controlled probe budget

### DIFF
--- a/plugin/tests/test_worldcheck.py
+++ b/plugin/tests/test_worldcheck.py
@@ -64,6 +64,25 @@ def _cp(texts, carried=True, with_ids=True):
     }
 
 
+@pytest.fixture(autouse=True)
+def _generous_worldcheck_budget(monkeypatch):
+    """#718: `check()`'s aggregate wall-clock budget (BUDGET_SECONDS, 0.8s in
+    production) races REAL elapsed time — under a loaded or coverage-
+    instrumented run, a probe that would ordinarily return well inside the
+    budget can still get killed mid-flight by `_run_probes`'s deadline check,
+    failing a test for a reason that has nothing to do with the semantics
+    under test (observed: test_check_dedup_same_ref_probes_once_stamps_all).
+
+    Every test in this module gets an effectively-infinite budget by
+    default, so the deadline can never bind here. Tests that deliberately
+    exercise the deadline CONTRACT ITSELF (search this file for
+    `BUDGET_SECONDS`) set their own small value or a negative
+    already-exhausted one inside the test body — that call simply overrides
+    this fixture's default, the same monkeypatch-layering every other
+    per-test override in this suite already relies on."""
+    monkeypatch.setattr(worldcheck, "BUDGET_SECONDS", 300.0)
+
+
 @pytest.fixture
 def proj(tmp_path):
     """A real directory to act as the project root — Popen(cwd=...) needs it


### PR DESCRIPTION
Closes #718

## Summary

- Tests-only, one file: an autouse fixture in `tests/test_worldcheck.py` monkeypatches `worldcheck.BUDGET_SECONDS` to an effectively infinite value, so semantic tests (dedup, stamping, probe classes) can no longer lose a race against real machine load. Observed failure mode: a coverage-instrumented full-suite run pushed a probe past the 0.8s production budget and `test_check_dedup_same_ref_probes_once_stamps_all` failed on the stamped count; the same test passes standalone and on plain reruns — the signature of the budget race, not a semantics regression.
- The six tests that exercise the deadline contract itself already set their own explicit small or already-exhausted budgets inside the test body; those `monkeypatch.setattr` calls run after the fixture's and simply win. Verified they remain genuinely bound: the full deadline-test set completes in under a second, which a masked override would have turned into multi-second sleeps.
- The flake mechanism was demonstrated deterministically before fixing (probe forced slow with the budget forced to zero reproduces the exact reported assertion failure), and the diagnostic edit was reverted before the fix landed.
- No production behavior change; nothing outside `tests/test_worldcheck.py` is in the diff.

## Changes

| File | Change |
|------|--------|
| `plugin/tests/test_worldcheck.py` | Autouse `_generous_worldcheck_budget` fixture (+19 lines) |

## PR Type

- [x] Bug fix

## Test Plan

- [x] Full suite green: `uv run pytest -q` → 4089 passed, 2 skipped (run twice: implementer + independent verification)
- [x] `uv run ruff check .` → clean repo-wide
- [x] Deadline-contract tests verified still bound by their own budgets after the fixture
- [x] Flake reproduced deterministically pre-fix, deterministic pass post-fix

## Contributor Checklist

- [x] Linked an approved issue (#718, `status:approved`)
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
