### PR TITLE
docs(site): document the cross-project request family

### DIFF
--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -65,6 +65,40 @@ The auditors share one exit contract, so a script can act on the answer:
 | --- | --- |
 | `daimon forget <id or text>` | Remove one item's content from disk and index, leaving a hash-only tombstone. The deletion survives re-serialization of the original transcript. |
 
+## Cross-project requests
+
+A request lives in the sender's own project bucket; the recipient answers
+with verdict rows in its own bucket. The folded record is a read-time join —
+nobody ever writes into another project's ledger.
+
+| command | what it does |
+| --- | --- |
+| `daimon request open --to <dir> --ask "…" --why "…"` | Ask another project for something. `--to` takes the recipient's project **directory**, not its slug (a real slug starts with `-`, which argparse reads as an option — `--to=<slug>` also works). Validated against `daimon projects`, with near-match suggestions on a typo; `--anyway` records the ask against a project that has never serialized on this machine. `--blocking` and `--to-human` are flags on the record. Either channel. |
+| `daimon request revise <id> [--ask] [--why] [--evidence]` | Answer a needs-info, or sharpen an open ask. Either channel; capped at 3 revisions per record lifetime — past the cap, open a new request with `--supersedes <id>` to keep the lineage visible. |
+| `daimon request accept\|reject\|needs-info <id> [--note]` | Land a verdict. Human-only — requires an interactive terminal. `reject` is final for that record; the sender supersedes with a new request rather than asking again. |
+| `daimon request suppress <id> [--note]` | Drop a request out of the recipient's own briefing panel. Human-only; the record stays in `list`/`inbox`, and any later verdict reverses it. |
+| `daimon request done <id> --evidence "<quote>"` | Report the ask as satisfied. Either channel; an agent's claim renders `done (claimed, unverified)` until the recipient's next session-end byte-checks the evidence quote against its transcript. A human `done` renders plainly. |
+| `daimon request list` | This project's own sent requests, undecided first. `--json` for machines. |
+| `daimon request inbox` | Requests addressed TO this project, from every sender, undecided first — including ones the briefing panel dropped for attention. `--json` for machines. |
+
+Two panels ride the same-project CLI `brief` only — never `--slug`, the
+global-pointer fallback, or MCP. The recipient sees "Requests waiting on
+you"; the sender sees "Verdicts on requests you sent". Each is capped at 3
+cards with a loud `+N more …` overflow line naming the command that shows
+the rest — never a silent drop. Suppression is recipient-side attention
+only: the sender's panel still reads a suppressed request as "surfaced,
+undecided". An unanswered request renders `stale` after 3 recipient
+sessions pass with no verdict; a decided one leaves the sender's panel
+after 2 sender sessions. Attention decays — records never delete, and both
+stay fully visible in `list`/`inbox`.
+
+`daimon status` adds a one-line summary, `requests: N open sent, M
+awaiting you`, silent when both are zero.
+
+The [MCP server](mcp.md) exposes the recipient-side view as the read-only
+`requests_inbox` tool. `daimon_brief` never carries request content, and no
+request write verb is reachable over MCP.
+
 ## Status
 
 | command | what it does |

--- a/website/docs/reference/mcp.md
+++ b/website/docs/reference/mcp.md
@@ -2,7 +2,7 @@
 
 `daimon mcp serve` exposes daimon's memory as an MCP tool surface over stdio —
 for hosts that speak MCP but have no hook system daimon can attach to. It is
-opt-in (nothing registers it for you), read-only (four tools, no writes), and
+opt-in (nothing registers it for you), read-only (five tools, no writes), and
 pure standard library (no extra dependency, same as the rest of daimon).
 
 ```bash
@@ -17,8 +17,9 @@ daimon mcp serve   # blocks, serves JSON-RPC on stdio until EOF
 | `daimon_brief` | The latest briefing for the current project — deterministic render, trust-tagged, resolutions withheld |
 | `daimon_projects` | Every project daimon has memory for: slug, session, branch, last topic |
 | `daimon_status` | Capture health: checkpoint freshness, last serialize result, outstanding failures, alarms — same payload as `daimon status --json` |
+| `requests_inbox` | Requests other projects have addressed to this one — the read-only pull side of the [cross-project request ledger](cli.md#cross-project-requests). `daimon_brief` never carries this content; opening, answering, or deciding a request is CLI-only. |
 
-All four carry `readOnlyHint`. Tool-level failures (bad arguments, missing
+All five carry `readOnlyHint`. Tool-level failures (bad arguments, missing
 FTS5) come back as `isError` results the agent can read; they never kill the
 server.
 


### PR DESCRIPTION
Closes #719

## Summary

- Docs-only, two files. `cli.md` gains a "Cross-project requests" section between Forget and Status: the two-bucket read-through shape in two sentences, a verb table with the channel-authority split (verdict verbs and suppress are human-only; done takes either channel with required evidence), the `--to` directory gotcha with validation and `--anyway`, the `done (claimed, unverified)` label and the session-end byte-check that clears it, both briefing panels with their caps and loud overflow, the `stale` and panel-decay thresholds (attention decays, records never delete), and the `daimon status` summary line.
- `mcp.md` was stale since the inbox shipped: tool count corrected to five and `requests_inbox` added to the tools table, with the read-only / no-write-verbs note.
- Every behavioral claim was verified against source literals, not memory — panel headers, overflow line text, status line wording, thresholds, and the MCP handler table all byte-match the code.
- Docs build run locally via the CI equivalent (`npm run build` in `website/`): both locales generate clean, cross-links resolve.

Known follow-up, deliberately out of scope: the `i18n/es` tree has no translation for the new section; existing pages keep rendering, nothing breaks.

## Changes

| File | Change |
|------|--------|
| `website/docs/reference/cli.md` | New Cross-project requests section |
| `website/docs/reference/mcp.md` | `requests_inbox` row; tool count five |

## PR Type

- [x] Documentation

## Test Plan

- [x] `npm run build` in `website/` — both locales green, links resolve
- [x] Full suite unchanged: 4089 passed, 2 skipped (docs-only diff confirmed)

## Contributor Checklist

- [x] Linked an approved issue (#719, `status:approved`)
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
