### PR TITLE
fix(serializer): strip model-supplied item ids; id is code-owned

### DIFF
--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -1991,11 +1991,20 @@ _CODE_OWNED_KEYS = (
 # on the introspection path, so without this entry a piped checkpoint keeps a
 # self-issued pin that the recall index then honors as a #452 age-gate
 # exemption. On the serialize path pin_imperatives re-pins after this strip.
+# #684: `id` is the highest-stakes entry in this set — the PROJECT-GLOBAL key
+# recall, resolve/forget tombstones, supersede-candidates, corroboration, and
+# relation-ledger endpoints all bind identity to. `policy.stamp_item_ids`
+# trusts ANY present id as authoritative (`if item.get("id"): seen.add(...);
+# continue`), so an un-stripped model-emitted value is either a self-chosen
+# identity the code never derived, or — if it happens to match another
+# item's id — a silent inheritance of that item's entire lifecycle and
+# corroboration history. Same #292 discipline as every entry above: stripped
+# from freshly authored model output only.
 # Safe to strip on both paths because carry.merge folds prev items in AFTER
 # serialize_strict returns — a carried item's genuine stamps never pass here.
 _CODE_OWNED_ITEM_KEYS = ("origin_session", "origin_author",
                          "quote_verified", "last_verified",
-                         "quote_provenance", "pinned")
+                         "quote_provenance", "pinned", "id")
 
 
 def strip_code_owned_keys(checkpoint: dict) -> None:

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -1625,6 +1625,71 @@ def test_strip_code_owned_keys_clears_item_origin_on_the_introspection_path():
     assert item["text"] == "q"  # nothing else disturbed
 
 
+def test_serialize_strips_model_supplied_item_id(fake_chat_factory):
+    """#684: `id` is load-bearing identity — it keys the recall index,
+    lifecycle events (resolve, forget tombstones, supersede-candidates),
+    corroboration, and relation-ledger endpoints. `policy.stamp_item_ids`
+    trusts ANY present id as authoritative, so a model-chosen id names an
+    identity the code never derived. Stripped at the same boundary as
+    `origin_session`/`origin_author`: freshly parsed model output, before
+    stamp_item_ids (or carry.merge) ever sees it."""
+    spoofed = json.loads(_valid_checkpoint_json("S1"))
+    for item in [spoofed["working_context"]["active_topic"],
+                 spoofed["working_context"]["open_questions"][0],
+                 spoofed["working_context"]["recent_decisions"][0]]:
+        item["id"] = "o-modelchosenid"
+    chat = fake_chat_factory(json.dumps(spoofed))
+
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+
+    assert ckpt is not None
+    for item in serializer.iter_items(ckpt):
+        assert "id" not in item
+
+
+def test_strip_code_owned_keys_clears_item_id_on_the_introspection_path():
+    """`daimon write-checkpoint` takes a dict a live model authored directly
+    — the same spoofing surface, one level down (cli calls this function for
+    exactly that reason)."""
+    ckpt = json.loads(_valid_checkpoint_json("S1"))
+    ckpt["working_context"]["open_questions"][0]["id"] = "o-forgedforged1"
+
+    serializer.strip_code_owned_keys(ckpt)
+
+    item = ckpt["working_context"]["open_questions"][0]
+    assert "id" not in item
+    assert item["text"] == "q"  # nothing else disturbed
+
+
+def test_serialize_strips_a_model_emitted_id_that_collides_across_items(
+        fake_chat_factory):
+    """#684: `stamp_item_ids`' setdefault-shaped check (`if item.get("id"):
+    seen.add(...); continue`) trusts ANY present id, so two different items
+    sharing one model-supplied value would keep sharing it forever — the
+    second item silently inheriting the first's lifecycle and corroboration
+    history. Stripping removes the shared value from BOTH before
+    stamp_item_ids ever runs, so each item earns its own text-derived id
+    instead of colliding into one identity."""
+    from daimon_briefing import policy
+
+    spoofed = json.loads(_valid_checkpoint_json("S1"))
+    spoofed["working_context"]["open_questions"][0]["id"] = "o-collideddddd1"
+    spoofed["working_context"]["recent_decisions"][0]["id"] = "o-collideddddd1"
+    chat = fake_chat_factory(json.dumps(spoofed))
+
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+
+    assert ckpt is not None
+    q = ckpt["working_context"]["open_questions"][0]
+    d = ckpt["working_context"]["recent_decisions"][0]
+    assert "id" not in q
+    assert "id" not in d
+    policy.stamp_item_ids(ckpt)
+    assert q["id"] != "o-collideddddd1"
+    assert d["id"] != "o-collideddddd1"
+    assert q["id"] != d["id"]  # never silently share one identity
+
+
 def test_validate_accepts_decision_with_because():
     """#525 follow-on (F4): decisions may carry a `because` clause — the
     stated reasoning, extracted only when the transcript states it."""


### PR DESCRIPTION
Closes #684

## Summary

- Adds `id` to `_CODE_OWNED_ITEM_KEYS`, so `strip_code_owned_keys` removes a model-emitted id on both capture doors before `policy.stamp_item_ids` runs. The stamper trusts any present id as authoritative (`if item.get("id"): seen.add(...); continue`), so an un-stripped value was either a self-chosen identity the code never derived, or — on collision with an existing item's id — a silent inheritance of that item's entire lifecycle and corroboration history. Item ids key the recall index, resolve/forget tombstones, supersede candidates, corroboration references, and relation-ledger endpoints.
- The strip is safe for the same reason as every existing entry: `carry.merge` folds prev items in after `serialize_strict` returns, so a genuinely carried id never passes through this path (claim re-verified in code, not taken from the issue).
- Three tests, each watched failing pre-fix: model-emitted id stripped on the serialize door; stripped on the introspection door; and the cross-item collision shape — two different items forging the identical id both get distinct, code-derived ids.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/serializer.py` | `id` added to `_CODE_OWNED_ITEM_KEYS` with rationale comment |
| `plugin/tests/test_serializer.py` | Three door/collision tests, mirroring the existing origin-binding test idiom |

## PR Type

- [x] Bug fix

## Test Plan

- [x] Full suite green: `uv run pytest -q` → 4092 passed, 2 skipped (run twice: implementer + independent verification)
- [x] `uv run ruff check .` → clean repo-wide
- [x] All three new tests observed failing pre-fix with the forged ids surviving, passing post-fix
- [x] Coverage diffed against a stash baseline: zero new gaps in `serializer.py`

## Contributor Checklist

- [x] Linked an approved issue (#684, `status:approved`)
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
