### PR TITLE
fix(serializer): strip model-supplied carried_from and first_seen

### DIFF
--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -2000,11 +2000,24 @@ _CODE_OWNED_KEYS = (
 # item's id — a silent inheritance of that item's entire lifecycle and
 # corroboration history. Same #292 discipline as every entry above: stripped
 # from freshly authored model output only.
+# #725: `carried_from` is stamped only by carry.merge's setdefault, on a PREV
+# item read fresh off disk — never on a freshly parsed model output. A
+# model-forged value on its own fresh claim would make a brand-new, first-
+# time assertion masquerade as inherited from an earlier session: the
+# `[carried]` render marker, the #215 staleness budget, and corroboration's
+# native-vs-carried split would all read it as older and less scrutinized
+# than it actually is.
+# #725: `first_seen` is the per-item birth stamp store._stamp_first_seen
+# derives, guarded by the EXACT bug shape #684 fixed for `id` (`if
+# item.get("first_seen"): continue` — any present value is trusted forever).
+# A model-forged old timestamp would feed scoring.py's effective-weight/decay
+# calculation directly, letting a claim manufacture its own apparent age.
 # Safe to strip on both paths because carry.merge folds prev items in AFTER
 # serialize_strict returns — a carried item's genuine stamps never pass here.
 _CODE_OWNED_ITEM_KEYS = ("origin_session", "origin_author",
                          "quote_verified", "last_verified",
-                         "quote_provenance", "pinned", "id")
+                         "quote_provenance", "pinned", "id",
+                         "carried_from", "first_seen")
 
 
 def strip_code_owned_keys(checkpoint: dict) -> None:

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -78,6 +78,18 @@ def test_origin_provenance_survives_chains():
     assert out["working_context"]["open_questions"][0]["carried_from"] == "S-origin"
 
 
+def test_725_carried_from_still_stamped_after_joining_the_strip_tuple():
+    """#725: `carried_from` joined serializer.py's `_CODE_OWNED_ITEM_KEYS`, so
+    a model can no longer forge it into fresh output. `carry.merge`'s own
+    setdefault stamp — the ONLY legitimate writer of this field — is
+    unaffected: `prev` is read fresh off disk, after serialize_strict's
+    strip has already returned, so a genuinely carried item must still gain
+    the stamp exactly as before the fix."""
+    prev = _cp("S-prev", 1, questions=[_item("zephyr ledger drop unresolved")])
+    out = carry.merge(_cp("S-new"), prev, NOW)
+    assert out["working_context"]["open_questions"][0]["carried_from"] == "S-prev"
+
+
 def test_weight_floor_drops_stale_low_importance():
     # imp-2 decision 60 days old: 0.2 * 0.4 * 0.1 = 0.008 < 0.05 -> falls off.
     # imp-7 open question 60 days old: escalated well above floor -> carries.

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -1690,6 +1690,78 @@ def test_serialize_strips_a_model_emitted_id_that_collides_across_items(
     assert q["id"] != d["id"]  # never silently share one identity
 
 
+def test_serialize_strips_model_supplied_carried_from(fake_chat_factory):
+    """#725: `carried_from` is stamped only by `carry.merge` (setdefault, on
+    a PREV item read fresh off disk — never a freshly parsed model output),
+    so a model-emitted value on its own claim is always a forgery. Left
+    un-stripped, it would make a brand-new, first-time assertion masquerade
+    as inherited from an earlier session: the `[carried]` render marker,
+    the #215 staleness budget, and corroboration's native-vs-carried split
+    would all read it as older and less scrutinized than it actually is."""
+    spoofed = json.loads(_valid_checkpoint_json("S1"))
+    for item in [spoofed["working_context"]["active_topic"],
+                 spoofed["working_context"]["open_questions"][0],
+                 spoofed["working_context"]["recent_decisions"][0]]:
+        item["carried_from"] = "S-forged-origin"
+    chat = fake_chat_factory(json.dumps(spoofed))
+
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+
+    assert ckpt is not None
+    for item in serializer.iter_items(ckpt):
+        assert "carried_from" not in item
+
+
+def test_strip_code_owned_keys_clears_carried_from_on_the_introspection_path():
+    """`daimon write-checkpoint` takes a dict a live model authored directly
+    — the same spoofing surface, one level down (cli calls this function for
+    exactly that reason)."""
+    ckpt = json.loads(_valid_checkpoint_json("S1"))
+    ckpt["working_context"]["open_questions"][0]["carried_from"] = "S-forged"
+
+    serializer.strip_code_owned_keys(ckpt)
+
+    item = ckpt["working_context"]["open_questions"][0]
+    assert "carried_from" not in item
+    assert item["text"] == "q"  # nothing else disturbed
+
+
+def test_serialize_strips_model_supplied_first_seen(fake_chat_factory):
+    """#725: `first_seen` is the per-item birth stamp `store._stamp_first_seen`
+    derives (verbatim carry-over on an exact-text match, otherwise this
+    checkpoint's own `created`) — its own idempotent guard (`if
+    item.get("first_seen"): continue`) is the EXACT bug shape #684 fixed for
+    `id`. A model-forged old timestamp would survive untouched and feed
+    `scoring.py`'s effective-weight/decay calculation directly, letting a
+    brand-new claim manufacture its own apparent age and ranking."""
+    spoofed = json.loads(_valid_checkpoint_json("S1"))
+    for item in [spoofed["working_context"]["active_topic"],
+                 spoofed["working_context"]["open_questions"][0],
+                 spoofed["working_context"]["recent_decisions"][0]]:
+        item["first_seen"] = "1999-01-01T00:00:00Z"
+    chat = fake_chat_factory(json.dumps(spoofed))
+
+    ckpt = serializer.serialize("S1", make_messages(20), chat=chat)
+
+    assert ckpt is not None
+    for item in serializer.iter_items(ckpt):
+        assert "first_seen" not in item
+
+
+def test_strip_code_owned_keys_clears_first_seen_on_the_introspection_path():
+    """`daimon write-checkpoint` takes a dict a live model authored directly
+    — the same spoofing surface, one level down (cli calls this function for
+    exactly that reason)."""
+    ckpt = json.loads(_valid_checkpoint_json("S1"))
+    ckpt["working_context"]["open_questions"][0]["first_seen"] = "1999-01-01T00:00:00Z"
+
+    serializer.strip_code_owned_keys(ckpt)
+
+    item = ckpt["working_context"]["open_questions"][0]
+    assert "first_seen" not in item
+    assert item["text"] == "q"  # nothing else disturbed
+
+
 def test_validate_accepts_decision_with_because():
     """#525 follow-on (F4): decisions may carry a `because` clause — the
     stated reasoning, extracted only when the transcript states it."""

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -1119,6 +1119,28 @@ def test_first_seen_idempotent_on_rewrite(tmp_checkpoint_dir, sample_checkpoint)
     assert _first_seens(back)[carried_text] == "2026-01-01T00:00:00Z"
 
 
+def test_725_first_seen_pipeline_unaffected_by_the_new_strip_entry(
+        tmp_checkpoint_dir, sample_checkpoint):
+    """#725: `first_seen` joined serializer.py's `_CODE_OWNED_ITEM_KEYS`, but
+    `_stamp_first_seen`'s own idempotent guard — the ONLY legitimate writer
+    of this field — never routes through that strip (write_checkpoint runs
+    downstream of serialize_strict, which has already returned). A fresh
+    item still gets stamped, and a legitimately re-written item keeps its
+    existing stamp, exactly as before the fix."""
+    import copy as _copy
+
+    fresh = _stamped(sample_checkpoint, "S-1", 3)
+    store.write_checkpoint("S-1", fresh, project_dir="/p/A")
+    back = store.read_checkpoint("S-1")
+    assert back["working_context"]["active_topic"].get("first_seen") == back["created"]
+
+    rewritten = _copy.deepcopy(back)
+    rewritten["working_context"]["open_questions"][0]["first_seen"] = "2026-01-01T00:00:00Z"
+    store.write_checkpoint("S-1", rewritten, project_dir="/p/A")
+    back2 = store.read_checkpoint("S-1")
+    assert back2["working_context"]["open_questions"][0]["first_seen"] == "2026-01-01T00:00:00Z"
+
+
 # ---- #31 audit tail: importance-pinned GC, tmp reaping, pointer lock --------
 
 


### PR DESCRIPTION
Closes #725

## Summary

- Completes the code-owned strip-set audit #684 started: `carried_from` and `first_seen` join `_CODE_OWNED_ITEM_KEYS`, each with a rationale comment.
- `carried_from`: the only legitimate writer is `carry.merge`'s `setdefault` on prev items read fresh off disk. A model-forged value on a freshly authored item survived the strip and made a first-time claim read as inherited lineage — affecting the carried render marker, the staleness budget, and corroboration's native-vs-carried treatment.
- `first_seen`: `store._stamp_first_seen` trusts any present value (`if item.get("first_seen"): continue` — the exact shape #684 fixed for `id`), so a forged old timestamp let a brand-new claim manufacture apparent age for scoring's effective-weight and decay calculation.
- Safety verified in code, not assumed: `strip_code_owned_keys` has exactly three call sites, all upstream of `carry.merge` and `store.write_checkpoint`'s stamping — rotated and carried items never pass through the strip. Pinned empirically by two writer-preservation tests that already passed pre-fix.
- Audit completeness re-checked: teamsync/harvest/teamproject stamp no per-item fields; the underscore-prefixed worldcheck/render annotations are transient in-memory marks a model never authors, categorically outside this threat model. The strip set is now complete against every per-item field the code stamps.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/serializer.py` | `carried_from` + `first_seen` into `_CODE_OWNED_ITEM_KEYS` with rationale |
| `plugin/tests/test_serializer.py` | Four door tests (serialize + introspection, per field), watched failing pre-fix |
| `plugin/tests/test_carry.py` | Writer-preservation pin: genuine carry still stamps lineage |
| `plugin/tests/test_store.py` | Writer-preservation pin: rotation keeps first_seen; fresh items get stamped |

## PR Type

- [x] Bug fix

## Test Plan

- [x] Full suite green: `uv run pytest -q` → 4098 passed, 2 skipped (run twice: implementer + independent verification)
- [x] `uv run ruff check .` → clean repo-wide
- [x] All four door tests observed failing pre-fix with forged values surviving
- [x] Coverage diffed against a stash baseline for all three modules: zero new gaps

## Contributor Checklist

- [x] Linked an approved issue (#725, `status:approved`)
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
