### PR TITLE
fix(relations): contradiction fold catches item-level cycles

### DIFF
--- a/plugin/daimon_briefing/relations.py
+++ b/plugin/daimon_briefing/relations.py
@@ -383,10 +383,21 @@ def fold(rows: list[dict]) -> dict[str, dict]:
     # A confirmed directional edge whose confirmed INVERSE also exists is a
     # cycle asserting each item revises the other — invented continuity in
     # its most literal form.  Surfaced on both records, never auto-resolved.
+    # #683: self-edges are excluded here too — a confirmed X-to-X edge's
+    # inverse hashes to its OWN id (make_id(type, to, from) degenerates to
+    # make_id(type, from, to) when from == to), so an unguarded lookup finds
+    # itself and flags a lone record against itself. Discovered while adding
+    # the item-level pass below, which needs the identical guard; fixed here
+    # too so a self-edge never flags regardless of which pass would
+    # otherwise have caught it.
     for record in out.values():
         if record["state"] != "confirmed":
             continue
         if record["type"] in SYMMETRIC_TYPES or record["type"] not in TYPES:
+            continue
+        from_item = record["from"].get("item_id")
+        to_item = record["to"].get("item_id")
+        if not from_item or not to_item or from_item == to_item:
             continue
         try:
             inverse = make_id(record["type"], record["to"], record["from"])
@@ -396,6 +407,54 @@ def fold(rows: list[dict]) -> dict[str, dict]:
         if twin is not None and twin["state"] == "confirmed":
             record["contradiction"] = True
             twin["contradiction"] = True
+    # #683: the pass above is SESSION-exact (make_id hashes (session_id,
+    # item_id) per endpoint), so a genuine item-level cycle confirmed
+    # through two DIFFERENT session pairs never matches its inverse id and
+    # slips through unflagged — the docstring's own intent ("a cycle
+    # asserting each item revises the other") is item-level, not
+    # occurrence-level. This second pass restates the same check at item
+    # granularity: index confirmed directional edges by
+    # (type, from.item_id, to.item_id), then flag a confirmed record whose
+    # REVERSED item-id key is also confirmed — regardless of which
+    # session/occurrence carried each side. Same self-edge and symmetric-
+    # type guards as the pass above, for the same reasons; "distinct
+    # relation id" is checked explicitly too, though the item-id guard
+    # already makes a self-match structurally unreachable.
+    #
+    # Deliberately no oscillation guard: item ids are content-derived (a
+    # sha1 of kind+text), so an id names a text, not a moment. A verbatim
+    # A->B->A-restated chain is three legitimate revisions that also forms
+    # an item-level cycle, and it flags exactly like any other cycle — the
+    # marker is attention for human review, not a claim about how the cycle
+    # arose, and suppressing it here would hide invented continuity behind
+    # a plausible-sounding explanation.
+    by_item_key: dict[tuple, list[dict]] = {}
+    for record in out.values():
+        if record["state"] != "confirmed":
+            continue
+        if record["type"] in SYMMETRIC_TYPES or record["type"] not in TYPES:
+            continue
+        from_item = record["from"].get("item_id")
+        to_item = record["to"].get("item_id")
+        if not from_item or not to_item or from_item == to_item:
+            continue
+        by_item_key.setdefault(
+            (record["type"], from_item, to_item), []).append(record)
+    for (type_, from_item, to_item), records_here in by_item_key.items():
+        twins = by_item_key.get((type_, to_item, from_item))
+        if not twins:
+            continue
+        for record in records_here:
+            for twin in twins:
+                if twin["relation_id"] == record["relation_id"]:
+                    continue  # pragma: no cover — structurally unreachable:
+                    # from_item != to_item (checked above) already means a
+                    # record's own key can never equal its reversed key, so
+                    # `twins` can never contain `record` itself. Kept as the
+                    # explicit "distinct relation id" guard #683 names,
+                    # belt for the item-id guard rather than a reachable path.
+                record["contradiction"] = True
+                twin["contradiction"] = True
     return out
 
 

--- a/plugin/tests/test_relations.py
+++ b/plugin/tests/test_relations.py
@@ -197,6 +197,153 @@ def test_inverse_confirmed_revisions_are_flagged_never_resolved(bucket):
     assert folded[a]["state"] == "confirmed"  # surfaced, not auto-resolved
 
 
+# -- #683: item-level cycle detection (the exact-inverse pass is SESSION- --
+# -- exact; a genuine item-level cycle confirmed through different       --
+# -- occurrences must still flag)                                       --
+
+
+def test_item_level_cycle_flags_through_different_sessions(bucket):
+    """#683's exact repro: X revision-of Y confirmed entirely within S1, Y
+    revision-of X confirmed entirely within S2 — different session PAIRS on
+    each edge, so make_id's (session_id, item_id) hash never matches its own
+    inverse and the old exact-inverse pass misses it. Item level, both items
+    are confirmed as revising each other — the docstring's own intent."""
+    a = _propose(bucket,
+                 frm=_endpoint("S1", item="r-abc123456789"),
+                 to=_endpoint("S1", item="r-def123456789"))
+    b = _propose(bucket,
+                 frm=_endpoint("S2", item="r-def123456789"),
+                 to=_endpoint("S2", item="r-abc123456789"))
+    relations.confirm(a, channel="cli-tty", project_dir=bucket)
+    relations.confirm(b, channel="cli-tty", project_dir=bucket)
+    folded = relations.records(project_dir=bucket)
+    assert folded[a]["contradiction"] is True
+    assert folded[b]["contradiction"] is True
+    assert folded[a]["state"] == "confirmed"  # surfaced, not auto-resolved
+
+
+def test_item_level_pass_still_flags_a_same_session_reversal(bucket):
+    """Existing behavior preserved: a reversal confirmed within the SAME
+    session pair (what the exact-inverse pass already caught) still flags
+    under the new item-level pass too."""
+    a = _propose(bucket,
+                 frm=_endpoint("S1", item="r-abc123456789"),
+                 to=_endpoint("S1", item="r-def123456789"))
+    b = _propose(bucket,
+                 frm=_endpoint("S1", item="r-def123456789"),
+                 to=_endpoint("S1", item="r-abc123456789"))
+    relations.confirm(a, channel="cli-tty", project_dir=bucket)
+    relations.confirm(b, channel="cli-tty", project_dir=bucket)
+    folded = relations.records(project_dir=bucket)
+    assert folded[a]["contradiction"] is True
+    assert folded[b]["contradiction"] is True
+
+
+def test_item_level_pass_skips_self_edges_across_occurrences(bucket):
+    """propose() does not require from.item_id != to.item_id. A confirmed
+    X-to-X edge's reversed item key equals its own key, and a SECOND
+    occurrence of the identical self-edge (different session, same item on
+    both sides) must not cross-flag it either."""
+    a = _propose(bucket,
+                 frm=_endpoint("S1", item="r-abc123456789"),
+                 to=_endpoint("S1", item="r-abc123456789"))
+    b = _propose(bucket,
+                 frm=_endpoint("S2", item="r-abc123456789"),
+                 to=_endpoint("S2", item="r-abc123456789"))
+    relations.confirm(a, channel="cli-tty", project_dir=bucket)
+    relations.confirm(b, channel="cli-tty", project_dir=bucket)
+    folded = relations.records(project_dir=bucket)
+    assert folded[a]["contradiction"] is False
+    assert folded[b]["contradiction"] is False
+
+
+def test_item_level_pass_skips_symmetric_type_even_hand_reversed(bucket):
+    """propose() canonicalizes endpoint order for symmetric types so one
+    fact mints one record — such a pair cannot form a cycle by
+    construction. Hand-crafted rows bypass that canonicalization (the same
+    raw-row idiom test_contradiction_pass_skips_symmetric_and_forged_types
+    uses for the exact-inverse pass), so the item-level pass needs its own
+    explicit skip too, not a free ride on propose()'s guarantee."""
+    x = _endpoint("S1", item="r-abc123456789")
+    y = _endpoint("S2", item="r-def123456789")
+    a = relations._stamp("proposed", "rel-" + "d" * 16, "lab-import")
+    a.update({"type": "same-arc", "from": x, "to": y,
+             "matched_by": ["carry-absolute"], "matcher_version": "lineage-v1"})
+    assert relations._append(a, project_dir=bucket)
+    assert relations._append(
+        relations._stamp("confirmed", "rel-" + "d" * 16, "cli-tty"),
+        project_dir=bucket)
+    b = relations._stamp("proposed", "rel-" + "e" * 16, "lab-import")
+    b.update({"type": "same-arc", "from": y, "to": x,
+             "matched_by": ["carry-absolute"], "matcher_version": "lineage-v1"})
+    assert relations._append(b, project_dir=bucket)
+    assert relations._append(
+        relations._stamp("confirmed", "rel-" + "e" * 16, "cli-tty"),
+        project_dir=bucket)
+    folded = relations.records(project_dir=bucket)
+    assert folded["rel-" + "d" * 16]["contradiction"] is False
+    assert folded["rel-" + "e" * 16]["contradiction"] is False
+
+
+def test_item_level_pass_ignores_an_unconfirmed_twin(bucket):
+    """Only a CONFIRMED pair is a cycle worth surfacing — a rejected or
+    still-candidate reversal is not."""
+    a = _propose(bucket,
+                 frm=_endpoint("S1", item="r-abc123456789"),
+                 to=_endpoint("S1", item="r-def123456789"))
+    b = _propose(bucket,
+                 frm=_endpoint("S2", item="r-def123456789"),
+                 to=_endpoint("S2", item="r-abc123456789"))
+    relations.confirm(a, channel="cli-tty", project_dir=bucket)
+    relations.reject(b, channel="cli-tty", project_dir=bucket)
+    folded = relations.records(project_dir=bucket)
+    assert folded[a]["contradiction"] is False
+    assert folded[b]["contradiction"] is False
+
+
+def test_item_level_pass_flags_the_oscillation_shape_deliberately(bucket):
+    """#683's decided posture: item ids are content-derived (sha1 of kind +
+    text), so an id names a text, not a moment. A→B revised, then B revised
+    back into a word-for-word restatement of A (same item id as the
+    original, by construction) is three legitimate revisions that ALSO
+    forms an item-level cycle — and it flags regardless, exactly like any
+    other cycle. No oscillation guard: the marker is attention for human
+    review, and suppressing it here would hide invented continuity behind
+    a plausible-sounding explanation."""
+    a = _propose(bucket,
+                 frm=_endpoint("S2", item="r-abc123456789"),  # A revised into B
+                 to=_endpoint("S2", item="r-def123456789"))
+    b = _propose(bucket,
+                 frm=_endpoint("S3", item="r-def123456789"),  # B revised back
+                 to=_endpoint("S3", item="r-abc123456789"))   # to restated A
+    relations.confirm(a, channel="cli-tty", project_dir=bucket)
+    relations.confirm(b, channel="cli-tty", project_dir=bucket)
+    folded = relations.records(project_dir=bucket)
+    assert folded[a]["contradiction"] is True
+    assert folded[b]["contradiction"] is True
+
+
+def test_exact_inverse_pass_survives_an_endpoint_missing_session_id(bucket):
+    """#683: the self-edge guard added to the exact-inverse pass short-
+    circuits on an ABSENT item_id before `make_id` ever runs — so the
+    pre-existing `except (RelationError, KeyError)` guard is now reached
+    only by a row whose item_id survives that check (present, distinct)
+    but whose endpoint dict is missing `session_id` entirely, which
+    `make_id` cannot hash. Still must not raise."""
+    damaged_from = relations._stamp("proposed", "rel-" + "f" * 16, "lab-import")
+    damaged_from.update({"type": "revision-of",
+                         "from": {"item_id": "r-abc123456789"},
+                         "to": {"item_id": "r-def123456789"},
+                         "matched_by": ["carry-absolute"],
+                         "matcher_version": "lineage-v1"})
+    assert relations._append(damaged_from, project_dir=bucket)
+    assert relations._append(
+        relations._stamp("confirmed", "rel-" + "f" * 16, "cli-tty"),
+        project_dir=bucket)
+    folded = relations.records(project_dir=bucket)
+    assert folded["rel-" + "f" * 16]["contradiction"] is False
+
+
 def test_torn_append_costs_exactly_the_torn_row(bucket):
     rel_id = _propose(bucket)
     path = relations._path(bucket)


### PR DESCRIPTION
Closes #683

## Summary

- The confirmed-inverse contradiction check in `relations.fold()` was session-exact: `make_id` hashes each endpoint as `(session_id, item_id)`, so `X revision-of Y` and `Y revision-of X` confirmed through different session pairs minted unrelated ids, the lookup missed, and a genuine item-level cycle sat confirmed and unflagged — against the check's own documented intent.
- A second pass now restates the check at item granularity: confirmed directional edges indexed by `(type, from.item_id, to.item_id)`, a confirmed record whose reversed item-id key is also confirmed flags on both sides. Both guards from the issue: self-edges skipped (distinct item ids required, distinct relation id kept as an explicit belt), symmetric types skipped (canonicalized at propose, no cycle possible). Flag lifecycle unchanged — derived at fold, recomputed every call, never persisted (verified before building).
- **Disclosed in-scope extension**: writing the self-edge invariant test exposed that the existing exact-inverse pass has the same self-edge bug on its own — a lone confirmed self-edge's inverse id hashes to its own id (`make_id(type, to, from)` degenerates when `from == to`), so the unguarded lookup retrieved itself and a single record flagged itself as contradicting itself, today, on main. The identical guard now protects both passes; it is the issue's "require distinct item ids" guard applied where the bug actually lives, and the invariant test could not pass without it.
- The issue's named judgment call is decided and pinned by test: verbatim oscillation (A revised to B, B later revised back to a word-for-word A) deliberately flags. Item ids name a text, not a moment; the marker is attention for human review, and an oscillation guard would hide exactly the invented-continuity shape the check exists to surface. Documented at the pass.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/relations.py` | Item-level pass after the exact-inverse pass; self-edge guard on both |
| `plugin/tests/test_relations.py` | Seven tests: the cross-session repro, same-session preserved, self-edge and symmetric and unconfirmed negatives, oscillation posture pin, damaged-endpoint coverage for the guarded old pass |

## PR Type

- [x] Bug fix

## Test Plan

- [x] Full suite: 4104 passed, 2 skipped (run twice: implementer + independent verification; the one local failure both runs saw is the known environmental plugin-version-drift check, untouched by this diff and clean in CI)
- [x] `uv run ruff check .` → clean repo-wide
- [x] Cross-session repro and self-edge tests observed failing pre-fix
- [x] Coverage diffed against a stash baseline: zero new gaps; the one defensive branch structurally unreachable by construction carries an explanatory pragma per repo convention

## Contributor Checklist

- [x] Linked an approved issue (#683, `status:approved`)
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
