### PR TITLE
fix(inspector): why answers recall-surfaced ids through an index fallback

### DIFF
--- a/plugin/daimon_briefing/inspector.py
+++ b/plugin/daimon_briefing/inspector.py
@@ -14,7 +14,8 @@ import json
 import re
 from pathlib import Path
 
-from . import config, provenance, redact, schema, serializer, store, transcript
+from . import (config, provenance, recall, redact, schema, serializer, store,
+               transcript)
 
 
 SCHEMA_VERSION = 1
@@ -247,20 +248,52 @@ def _bounded_source(item, receipt, resolution, messages) -> dict:
     }
 
 
+def _index_only_reason(row: dict) -> str:
+    """Why this row is index-backed rather than a local project surface
+    (#674): the two real divergence paths the investigation proved. A local
+    flat file named for the row's session_id existing on disk means recall
+    attributed it via the pointer-fallback (_bucket_slugs) that
+    project_surfaces's membership test does not honor; its absence means the
+    row can only have come from recall's team-dir scan. Display-only — never
+    a claim about forget/membership reach."""
+    session_id = row.get("session_id")
+    if isinstance(session_id, str) and session_id:
+        local_file = config.checkpoint_dir() / f"{session_id}.json"
+        if local_file.is_file():
+            return "pointer-attributed-legacy"
+    return "team-mirror"
+
+
 def inspect_item(project_dir, item_id: str, *, include_source: bool = False,
                  resolver=None) -> dict | None:
     """Inspect one exact item inside one explicit project scope."""
     occurrences = _item_occurrences(project_dir, item_id)
     resolutions = store.resolutions(project_dir=project_dir)
     event = resolutions.get(item_id)
+    index_row = None
     if not occurrences and event is None:
-        return None
+        # #674: recall's index reaches surfaces this project's own walk
+        # structurally cannot (team-mirrored checkpoints, pointer-attributed
+        # legacy files). Read-only display fallback only — never widens what
+        # forget/project_surfaces/the privacy audit treat as this project's
+        # surfaces, and never fires once a local resolution event exists
+        # (that branch below already answers, forgotten included).
+        index_row = recall.lookup_item(item_id, project_dir=project_dir)
+        if index_row is None:
+            return None
 
     if occurrences:
         selected = occurrences[0]
         checkpoint = selected["checkpoint"]
         item = selected["item"]
         kind = selected["kind"]
+    elif index_row is not None:
+        checkpoint = {"author": index_row.get("author"),
+                     "session_id": index_row.get("session_id")}
+        item = {"text": index_row.get("text"),
+                "trust": index_row.get("trust"),
+                "quote": index_row.get("quote") or None}
+        kind = index_row.get("kind") or "unknown"
     else:
         checkpoint = {}
         item = {}
@@ -332,6 +365,14 @@ def inspect_item(project_dir, item_id: str, *, include_source: bool = False,
             "source": event.get("source"),
         } if isinstance(event, dict) else None),
     }
+    if index_row is not None:
+        result["index_only"] = {
+            "reason": _index_only_reason(index_row),
+            "note": ("this project's own checkpoint surfaces do not hold "
+                     "this item; content is served from the recall index "
+                     "and its exact bytes cannot be independently verified "
+                     "on this machine"),
+        }
     if include_source:
         result["source_excerpt"] = _bounded_source(
             item, receipt, resolution, messages)
@@ -365,6 +406,10 @@ def human_lines(result: dict) -> list[str]:
         f"Verifier: {axes['verifier_comparison']}",
         f"Lifecycle: {axes['lifecycle']}",
     ]
+    index_only = result.get("index_only")
+    if isinstance(index_only, dict):
+        lines.append(
+            f"Index-only ({index_only['reason']}): {index_only['note']}")
     corroboration = result["corroboration"]
     refs = ", ".join(corroboration["references"])
     lines.append(

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -840,6 +840,52 @@ def search(query: str, project_dir=None, all_projects: bool = False,
             return []
 
 
+def lookup_item(item_id: str, project_dir=None, slug: str | None = None) -> dict | None:
+    """Single-id read against the (auto-refreshed) index (#674).
+
+    `why`'s own walk (store.project_surfaces) only ever sees this project's
+    local flat/pointer surfaces — never the team dir, and only a stampless
+    legacy file that happens to sit inside its project's bucket directory.
+    The index is deliberately more permissive (team ingestion, #158
+    _bucket_slugs pointer-derived attribution for legacy files), so a row
+    can exist here for an id `why`'s walk structurally cannot reach.
+
+    This is a companion to search(), never a substitute for its scoping:
+    same project_slug equality (never team_project/granted-segments), same
+    fail-open posture (any index trouble degrades to None, not a raise —
+    the caller's own "not found" refusal is the safe default already).
+    Read-only. Callers must never treat a hit here as license to widen what
+    forget/project_surfaces/the privacy audit consider this project's own
+    surfaces — this only ever feeds a DISPLAY fallback.
+
+    Returns the newest matching row (ties broken by `created`), or None."""
+    want = slug if slug else store.project_slug(project_dir)
+    if want is None:
+        return None
+    try:
+        _ensure_fresh()
+    except (OSError, sqlite3.Error, RecallError) as exc:
+        _note_error("lookup_item.refresh", exc)
+    try:
+        conn = sqlite3.connect(str(config.recall_db()))
+        try:
+            cur = conn.execute(
+                "SELECT text, quote, trust, kind, author, project_slug,"
+                " session_id, created, superseded_by, item_id, frontier"
+                " FROM items WHERE item_id = ? AND project_slug = ?"
+                " ORDER BY created DESC LIMIT 1",
+                (item_id, want),
+            )
+            cols = [c[0] for c in cur.description]
+            row = cur.fetchone()
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        _note_error("lookup_item", exc)
+        return None
+    return dict(zip(cols, row)) if row is not None else None
+
+
 # ---- #125: proactive suggestion — "you worked on this before" ----
 
 # Words that carry no retrieval signal in a work prompt: English function words

--- a/plugin/tests/test_inspector.py
+++ b/plugin/tests/test_inspector.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 import pytest
 
-from daimon_briefing import cli, inspector, provenance, recall, redact, store, transcript
+from daimon_briefing import (cli, config, inspector, provenance, recall,
+                              redact, store, transcript)
 
 
 _PROJECT = "/p/A"
@@ -74,6 +75,40 @@ def _write_checkpoint(session_id, items, *, project=_PROJECT,
                       created="2026-08-05T10:00:00Z"):
     checkpoint = _checkpoint(session_id, items, created)
     assert store.write_checkpoint(session_id, checkpoint, project_dir=project)
+    return checkpoint
+
+
+def _write_team_checkpoint(session_id, items, *, project=_PROJECT,
+                           author="alice", created="2026-08-05T10:00:00Z"):
+    """A checkpoint that exists ONLY in the team mirror (#674) — no local flat
+    file, no local bucket — the shape `why`'s own walk (store.project_surfaces)
+    structurally cannot reach, but recall's index (team-scan, #111) does."""
+    checkpoint = _checkpoint(session_id, items, created)
+    checkpoint["author"] = author
+    checkpoint["project_slug"] = store.project_slug(project)
+    d = config.team_dir() / "local" / "authors" / author
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{session_id}.json").write_text(
+        json.dumps(checkpoint), encoding="utf-8")
+    return checkpoint
+
+
+def _write_stampless_pointer_checkpoint(session_id, items, *, project=_PROJECT,
+                                        created="2026-08-05T10:00:00Z"):
+    """A LOCAL flat checkpoint with no embedded project_slug stamp, attributed
+    to `project` only via the per-project bucket pointer (#674) — the exact
+    legacy shape recall._bucket_slugs resolves but project_surfaces's
+    membership test (physical bucket residence or an OWN stamp) does not."""
+    checkpoint = _checkpoint(session_id, items, created)
+    d = config.checkpoint_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{session_id}.json").write_text(
+        json.dumps(checkpoint), encoding="utf-8")
+    slug = store.project_slug(project)
+    bucket = d / slug
+    bucket.mkdir(parents=True, exist_ok=True)
+    (bucket / "latest.json").write_text(
+        json.dumps({"session_id": session_id}), encoding="utf-8")
     return checkpoint
 
 
@@ -589,3 +624,111 @@ def test_recall_exposes_item_id_in_json_and_human_output(
         project_dir=_PROJECT, current_session="S-now")
     assert suggestions
     assert all("item_id" not in row for row in suggestions)
+
+
+# ---- #674: why falls back to the recall index when its own walk misses ----
+
+
+def test_why_answers_a_team_mirror_only_item_from_the_index(
+    tmp_checkpoint_dir, monkeypatch
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    _write_team_checkpoint("S-team-only", [_item(quote=None)])
+
+    result = inspector.inspect_item(_PROJECT, _ITEM_ID)
+
+    assert result is not None
+    assert result["item"]["text"] == "durable trust decision"
+    assert result["item"]["session_id"] == "S-team-only"
+    assert result["item"]["occurrences"] == 0
+    assert result["axes"]["provenance"] == "legacy-unbound"
+    assert result["axes"]["bytes"] == "unknown"
+    assert result["axes"]["current_support"] == "not-checked"
+    assert result["index_only"]["reason"] == "team-mirror"
+    human = "\n".join(inspector.human_lines(result))
+    assert "recall index" in human.lower()
+
+
+def test_why_answers_a_stampless_pointer_attributed_item_from_the_index(
+    tmp_checkpoint_dir, monkeypatch
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    _write_stampless_pointer_checkpoint("S-stampless", [_item(quote=None)])
+    # Sanity per the investigation: why's own walk sees only the bucket's
+    # pointer file (no item content), never the stampless flat file.
+    surfaces = store.project_surfaces(_PROJECT)
+    assert all(p.name != "S-stampless.json" for p in surfaces)
+
+    result = inspector.inspect_item(_PROJECT, _ITEM_ID)
+
+    assert result is not None
+    assert result["item"]["session_id"] == "S-stampless"
+    assert result["index_only"]["reason"] == "pointer-attributed-legacy"
+
+
+def test_why_still_refuses_an_id_in_neither_surfaces_nor_index(
+    tmp_checkpoint_dir, monkeypatch, capsys
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    # A populated index for this SAME project, but never for this id — proves
+    # the fallback is precise, not "any index activity counts as a hit".
+    _write_team_checkpoint("S-other", [_item(item_id="o-other000000", quote=None)])
+
+    assert inspector.inspect_item(_PROJECT, _ITEM_ID) is None
+    assert cli.main(["why", _ITEM_ID, "--project", _PROJECT]) == 1
+    assert "no item" in capsys.readouterr().err
+
+
+def test_forgotten_team_only_item_is_not_resurrected(
+    tmp_checkpoint_dir, monkeypatch
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    _write_team_checkpoint("S-team-forgotten", [_item(quote=None)])
+    assert store.append_event(
+        _ITEM_ID, "forgotten:" + "a" * 64,
+        project_dir=_PROJECT, allow_disabled=True)
+
+    result = inspector.inspect_item(_PROJECT, _ITEM_ID)
+
+    assert result is not None
+    assert result["axes"]["lifecycle"] == "forgotten"
+    assert "index_only" not in result
+    # The row itself is gone too (recall's own rebuild-time scrub) — the
+    # fallback finding nothing is not what protects this; the scrub is.
+    hits = recall.search("durable trust", project_dir=_PROJECT, all_projects=True)
+    assert not any(h.get("item_id") == _ITEM_ID for h in hits)
+
+
+def test_local_surface_answer_is_unperturbed_by_the_index_fallback(
+    tmp_checkpoint_dir, monkeypatch, tmp_path, capsys
+):
+    # Parity: an item why already answers from its own surfaces must never
+    # gain the new index_only key or otherwise change shape. This mirrors
+    # test_why_json_matches_golden_and_command_is_read_only_except_usage,
+    # which already asserts full dict equality against the golden file —
+    # that test staying green after this change IS the parity proof; this
+    # test adds the explicit negative assertion for readability.
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    monkeypatch.setenv(
+        "DAIMON_CLAUDE_PROJECTS_DIR", str(tmp_path / "no-transcripts"))
+    _write_checkpoint("S-bound", [
+        _item(receipt=_receipt(_source(), "a" * 64)),
+    ])
+
+    result = inspector.inspect_item(_PROJECT, _ITEM_ID)
+
+    assert "index_only" not in result
+
+
+def test_index_fallback_answers_a_freshly_synced_item_without_manual_rebuild(
+    tmp_checkpoint_dir, monkeypatch
+):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+
+    assert inspector.inspect_item(_PROJECT, _ITEM_ID) is None
+
+    _write_team_checkpoint("S-fresh", [_item(quote=None)])
+
+    result = inspector.inspect_item(_PROJECT, _ITEM_ID)
+    assert result is not None
+    assert result["item"]["session_id"] == "S-fresh"

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -207,6 +207,53 @@ def test_local_and_team_copies_not_double_indexed(tmp_checkpoint_dir, monkeypatc
     assert len(hits) == 1
 
 
+# ---- #674: lookup_item — single-id read for why's index fallback ----
+
+
+def test_lookup_item_finds_team_only_row_scoped_to_project(
+    tmp_checkpoint_dir, monkeypatch
+):
+    _write_team_file("grace", "S-g", _cp("S-g", decisions=[
+        {"id": "d-aaaaaa111111", "text": "pelican decision", "trust": "inferred"}]),
+        project_dir="/repo/x")
+
+    row = recall.lookup_item("d-aaaaaa111111", project_dir="/repo/x")
+
+    assert row is not None
+    assert row["session_id"] == "S-g"
+    assert row["author"] == "grace"
+    assert row["text"] == "pelican decision"
+
+
+def test_lookup_item_never_crosses_project_scope(tmp_checkpoint_dir, monkeypatch):
+    _write_team_file("grace", "S-g", _cp("S-g", decisions=[
+        {"id": "d-aaaaaa111111", "text": "pelican decision", "trust": "inferred"}]),
+        project_dir="/repo/x")
+
+    # Same id, wrong project: scoping must be project_slug equality, exactly
+    # what search() enforces — never a looser team_project/segments match.
+    assert recall.lookup_item("d-aaaaaa111111", project_dir="/repo/y") is None
+    # Right project, wrong id: never fuzzy.
+    assert recall.lookup_item("d-does-not-exist", project_dir="/repo/x") is None
+    # No scope at all: nothing to check against, always None.
+    assert recall.lookup_item("d-aaaaaa111111", project_dir=None) is None
+
+
+def test_lookup_item_freshens_without_a_manual_rebuild(tmp_checkpoint_dir, monkeypatch):
+    # Mirrors search()'s own contract: the fingerprint mechanism notices a
+    # newly-written source file with no separate recall.rebuild() call.
+    assert recall.lookup_item("d-bbbbbb222222", project_dir="/repo/x") is None
+
+    _write_team_file("grace", "S-fresh", _cp("S-fresh", decisions=[
+        {"id": "d-bbbbbb222222", "text": "fresh pelican decision",
+         "trust": "inferred"}]),
+        project_dir="/repo/x")
+
+    row = recall.lookup_item("d-bbbbbb222222", project_dir="/repo/x")
+    assert row is not None
+    assert row["session_id"] == "S-fresh"
+
+
 # ---- supersession v3 (#234): item-level evidence flags, recency only ranks ----
 
 
@@ -1007,6 +1054,47 @@ def test_search_happy_path_writes_no_breadcrumb(tmp_checkpoint_dir, monkeypatch)
     store.write_checkpoint("S1", _cp("S1", decisions=[
         {"text": "pelican decision", "trust": "inferred"}]), project_dir="/repo/x")
     assert recall.search("pelican", all_projects=True)
+    assert not (config.log_dir() / "recall-error.log").exists()
+
+
+def test_lookup_item_refresh_error_writes_breadcrumb(tmp_checkpoint_dir, monkeypatch):
+    # Same #28 fail-open contract as search()'s own refresh-error path: a
+    # broken _ensure_fresh() must never raise or block the fallback read.
+    from daimon_briefing import config
+
+    def boom():
+        raise OSError("disk full")
+    monkeypatch.setattr(recall, "_ensure_fresh", boom)
+    assert recall.lookup_item("d-aaaaaa111111", project_dir="/repo/x") is None
+    breadcrumb = config.log_dir() / "recall-error.log"
+    assert breadcrumb.exists()
+    assert "disk full" in breadcrumb.read_text(encoding="utf-8")
+
+
+def test_lookup_item_query_error_returns_none_and_writes_breadcrumb(
+    tmp_checkpoint_dir, monkeypatch
+):
+    import sqlite3 as sq
+    from daimon_briefing import config, store
+    store.write_checkpoint("S1", _cp("S1", decisions=[
+        {"id": "d-aaaaaa111111", "text": "pelican decision",
+         "trust": "inferred"}]), project_dir="/repo/x")
+
+    def bad_connect(*a, **k):
+        raise sq.OperationalError("database is locked")
+    monkeypatch.setattr(recall.sqlite3, "connect", bad_connect)
+    assert recall.lookup_item("d-aaaaaa111111", project_dir="/repo/x") is None
+    breadcrumb = config.log_dir() / "recall-error.log"
+    assert breadcrumb.exists()
+    assert "database is locked" in breadcrumb.read_text(encoding="utf-8")
+
+
+def test_lookup_item_happy_path_writes_no_breadcrumb(tmp_checkpoint_dir, monkeypatch):
+    from daimon_briefing import config, store
+    store.write_checkpoint("S1", _cp("S1", decisions=[
+        {"id": "d-aaaaaa111111", "text": "pelican decision",
+         "trust": "inferred"}]), project_dir="/repo/x")
+    assert recall.lookup_item("d-aaaaaa111111", project_dir="/repo/x")
     assert not (config.log_dir() / "recall-error.log").exists()
 
 


### PR DESCRIPTION
Closes #674

## Summary

- `daimon recall` and `daimon why` could disagree about whether an item exists. The investigation proved two real divergence paths and ruled out the third: (a) an item living only in a team-mirrored checkpoint, which recall's index ingests but `why`'s local walk structurally never visits; (b) a stampless legacy flat file attributed to the project only through a bucket pointer, which recall's documented fallback honors and `project_surfaces`' membership test does not. The stale-index path (c) does not exist — forget tombstones and GC both scrub the index correctly, proven by reproduction.
- The first fix direction (teach `why` a team-dir walk; widen `project_surfaces` membership with the pointer fallback) was put through an independent adversarial review and refuted: widening membership would have widened forget's deletion reach through an ambiguity-blind pointer resolution, reversed `project_surfaces`' own written design intent, and desynced the privacy audit's hand-mirrored membership test.
- Shipped design instead: `inspect_item` falls back to a read-only single-id lookup against the persisted recall index — only on the branch that returned `None` before. The lookup (`recall.lookup_item`) applies the same `project_slug` equality `search()` enforces, freshens through recall's own mechanism, and fails open to the existing refusal. The answer renders honestly: degraded capture/bytes/support axes (the axis model already never claims what it cannot verify) plus an `index_only` provenance note naming which divergence path served the row and that its bytes cannot be independently verified on this machine.
- What deliberately did not change: `store.project_surfaces`, `items_for_project`, `scrub_content_key`, and the privacy audit are untouched — zero change to forget's reach. No `team_dir()` reference enters inspector or store. A locally-forgotten team-only item stays unanswerable (pinned: the index row is scrubbed and lifecycle reports forgotten). Local-surface answers are byte-identical to before, pinned by the existing golden test plus an explicit negative.
- The issue reported rc 0 for the "no item" refusal; the refusal returns 1 on current main and could not be reproduced at 0. Unchanged.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/recall.py` | `lookup_item`: read-only, project-scoped, fail-open single-id index read |
| `plugin/daimon_briefing/inspector.py` | Index fallback on the former `None` branch; `index_only` provenance; reason heuristic documented as display-only |
| `plugin/tests/test_recall.py` | Six `lookup_item` tests: scoping, misses, freshness, error breadcrumbs |
| `plugin/tests/test_inspector.py` | Six integration tests: both divergence paths answer, refusal precision, no resurrection of forgotten content, local-path parity, freshness |

## PR Type

- [x] Bug fix

## Test Plan

- [x] Full suite: 4116 passed, 2 skipped (run twice: implementer + independent verification; the single local failure both runs saw is the known environmental plugin-version-drift check, untouched by this diff and clean in CI)
- [x] `uv run ruff check .` → clean repo-wide
- [x] Six tests observed failing pre-fix (missing symbol + `None` answers); the four precision/parity/no-resurrection pins passed pre-fix, confirming they guard pre-existing behavior
- [x] Coverage: `inspector.py` 100%; `lookup_item`'s span fully covered including both error branches; remaining `recall.py` gaps verified pre-existing with zero overlap

## Contributor Checklist

- [x] Linked an approved issue (#674, `status:approved`)
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
