### PR TITLE
feat(cli): status reports a waiting handoff baton

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -1864,6 +1864,18 @@ def _status_world(project_arg=None) -> dict:
         request_counts = requests.status_counts(project_dir=project)
     except Exception:
         request_counts = {"open_sent": 0, "awaiting_you": 0}
+    # #662: a waiting handoff baton, or None once consumed/absent — the same
+    # optional-fact convention as recall_index (dict-or-None, never a
+    # fabricated zero-shape). store.active_handoff already encodes "waiting
+    # only" (None once two sessions have serialized past it, #523); the
+    # note text stays OUT of status by the issue's own instruction — it
+    # belongs to `brief`, not here. Fail-open like every other best-effort
+    # status fact: a broken reader must never take status down with it.
+    try:
+        _baton = store.active_handoff(project)
+        handoff = {"written_at": _baton["ts"]} if _baton else None
+    except Exception:
+        handoff = None
     identity = {
         "cwd": str(Path(project_arg or ".").expanduser().resolve()),
         "git_root": project,
@@ -1882,7 +1894,8 @@ def _status_world(project_arg=None) -> dict:
         "hook_drift": hook_drift, "plugin_drift": plugin_drift,
         "rescue_gap": rescue_gap,
         "rescue_posture": rescue_posture, "rescue_window_errors": rescue_window_errors,
-        "forget_hits": forget_hits, "requests": request_counts, "rc": rc,
+        "forget_hits": forget_hits, "requests": request_counts,
+        "handoff": handoff, "rc": rc,
     }
 
 
@@ -1903,6 +1916,7 @@ def status_payload(project_arg=None) -> tuple:
         "rescue_posture": w["rescue_posture"],
         "forget_hits": w["forget_hits"],
         "requests": w["requests"],
+        "handoff": w["handoff"],
     }
     return payload, w["rc"]
 
@@ -1929,6 +1943,7 @@ def _cmd_status(args) -> int:
         "rescue_window_errors": w["rescue_window_errors"],
         "forget_hits": w["forget_hits"],
         "requests": w["requests"],
+        "handoff": w["handoff"],
     })
     return w["rc"]
 

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -750,6 +750,21 @@ def _ruling_echo_line(data: dict) -> str | None:
             "at admission")
 
 
+def _handoff_line(data: dict) -> str | None:
+    """#662: one line when a handoff baton is waiting — this project wrote
+    one and no session has consumed it yet. `data["handoff"]` is already
+    "waiting only" (store.active_handoff returns None once two sessions
+    have serialized past it, #523); silent otherwise, same "quiet by
+    default" rule as the team/receipts/forget-hits/requests lines. Never
+    the baton TEXT — that belongs to `daimon brief`, not status (the issue
+    is explicit)."""
+    handoff = data.get("handoff")
+    if not isinstance(handoff, dict):
+        return None
+    written_at = handoff.get("written_at") or "unknown"
+    return f"handoff: waiting baton, written {written_at} — daimon brief"
+
+
 def _plugin_drift_line(pd: dict) -> str:
     """#554: name BOTH versions and the command that moves the stale half.
     "out of date" alone does not say which half, and the two are updated by
@@ -805,6 +820,9 @@ def _plain_status(data: dict) -> None:
     rq_line = _requests_line(data)
     if rq_line:
         print(rq_line)  # #694 PR 3: one line, only when non-zero
+    ho_line = _handoff_line(data)
+    if ho_line:
+        print(ho_line)  # #662: one line, only when a baton is waiting
     proj, glob, last = data["proj"], data["glob"], data["last"]
     print(f"project: {data['project']}")
     if proj["exists"]:
@@ -904,6 +922,9 @@ def _rich_status(data: dict) -> None:
     rq_line = _requests_line(data)
     if rq_line:
         console.print(rq_line)  # #694 PR 3: one line, only when non-zero
+    ho_line = _handoff_line(data)
+    if ho_line:
+        console.print(ho_line)  # #662: one line, only when a baton is waiting
     proj, glob, last = data["proj"], data["glob"], data["last"]
     table = Table(title=f"daimon status — {data['project']}", title_justify="left",
                   show_header=True, header_style="bold")

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -717,10 +717,13 @@ def test_cli_status_json_shape(
                          "skipped_recent", "recall_error", "recall_index",
                          "receipts", "capture_alarm", "hook_drift",
                          "plugin_drift", "rescue_gap", "rescue_posture",
-                         "forget_hits", "requests"}
+                         "forget_hits", "requests", "handoff"}
     # #694 PR 3: the requests summary — {open_sent, awaiting_you}, always
     # present (zeros when nothing is recorded, never absent/null).
     assert data["requests"] == {"open_sent": 0, "awaiting_you": 0}
+    # #662: no baton written -> explicit null, same optional-fact convention
+    # as recall_index/team/receipts (never absent, never a fabricated shape).
+    assert data["handoff"] is None
     assert data["plugin_drift"] is None  # #554 no plugin installed -> null
     assert data["capture_alarm"] is None  # #265 FAIL-only probe silent by default
     assert data["forget_hits"]["count"] == 0  # #404 nothing suppressed yet
@@ -771,6 +774,121 @@ def test_cli_status_plain_shows_the_requests_line_when_nonzero(
     assert rc == 0
     out = capsys.readouterr().out
     assert "1 open sent" in out
+
+
+# ---- #662: status reports a waiting handoff baton -----------------------
+
+
+def test_cli_status_json_reports_a_waiting_handoff_baton(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    # The second-order motive from the issue: an agent confirming its own
+    # handoff write via status, without rendering a full briefing. Drive the
+    # write through the real CLI, not a hand-built event.
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/status-baton-a")
+    store.write_checkpoint("S-a", {
+        "session_id": "S-a", "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "x", "trust": "inferred"}]},
+    }, project_dir="/p/status-baton-a")
+    assert cli.main(["handoff", "Ship the release next.",
+                     "--project", "/p/status-baton-a"]) == 0
+    capsys.readouterr()
+
+    rc = cli.main(["status", "--json"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["handoff"]["written_at"]
+    # The baton TEXT belongs to the briefing, not status (the issue is
+    # explicit) — the field must never carry the note.
+    assert "note" not in data["handoff"]
+    assert "Ship the release next." not in json.dumps(data)
+
+
+def test_cli_status_plain_shows_the_handoff_line_when_waiting(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/status-baton-b")
+    store.write_checkpoint("S-b", {
+        "session_id": "S-b", "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "x", "trust": "inferred"}]},
+    }, project_dir="/p/status-baton-b")
+    assert cli.main(["handoff", "Ship the release next.",
+                     "--project", "/p/status-baton-b"]) == 0
+    capsys.readouterr()
+
+    rc = cli.main(["status"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "handoff" in out.lower()
+    assert "Ship the release next." not in out
+
+
+def test_cli_status_silent_on_handoff_when_none_written(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/status-baton-c")
+    store.write_checkpoint("S-c", {
+        "session_id": "S-c", "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "x", "trust": "inferred"}]},
+    }, project_dir="/p/status-baton-c")
+    rc = cli.main(["status"])
+    assert rc == 0
+    assert "handoff" not in capsys.readouterr().out.lower()
+
+
+def test_cli_status_silent_on_handoff_once_consumed(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    # Consumed = two distinct non-introspection sessions serialized after the
+    # write (store.active_handoff's own rule, mirrored from
+    # test_cli_handoff_no_warning_after_baton_consumed) — a consumed baton
+    # must render exactly like no baton at all, never a stale "waiting" line.
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/status-baton-d")
+    slug = store.project_slug("/p/status-baton-d")
+    d = tmp_checkpoint_dir / slug
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "events.jsonl").write_text(json.dumps(
+        {"ts": "2026-08-02T10:00:00Z", "kind": "handoff", "item_ref": "",
+         "status": "active", "note": "old consumed baton",
+         "source": "cli"}) + "\n")
+    for name, created, sid in (("prev-1.json", "2026-08-02T10:05:00Z",
+                                "S-writer"),
+                               ("latest.json", "2026-08-02T12:00:00Z",
+                                "S-consumer")):
+        (d / name).write_text(json.dumps(
+            {"session_id": sid, "created": created,
+             "working_context": {}, "epistemic_snapshot": {}}))
+    assert store.active_handoff("/p/status-baton-d") is None
+
+    payload, rc = cli.status_payload("/p/status-baton-d")
+    assert rc == 0
+    assert payload["handoff"] is None
+    cli.main(["status", "--project", "/p/status-baton-d"])
+    assert "handoff" not in capsys.readouterr().out.lower()
+
+
+def test_cli_status_handoff_fails_open_on_a_broken_reader(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    # Same fail-open posture as the requests summary (#694 PR 3): a broken
+    # reader must never take `status` down with it.
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/status-baton-e")
+    store.write_checkpoint("S-e", {
+        "session_id": "S-e", "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "x", "trust": "inferred"}]},
+    }, project_dir="/p/status-baton-e")
+
+    def boom(project_dir=None):
+        raise RuntimeError("boom")
+    monkeypatch.setattr(store, "active_handoff", boom)
+    rc = cli.main(["status", "--json"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["handoff"] is None
 
 
 def test_cli_status_survives_a_broken_requests_status_counts(

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -365,6 +365,46 @@ def test_render_status_requests_rich_smoke(monkeypatch, capsys):
     assert "open sent" in capsys.readouterr().out
 
 
+# ---- #662: status's waiting-handoff-baton line ------------------------------
+
+
+def test_render_status_shows_handoff_line_when_waiting(capsys):
+    data = _status_data()
+    data["handoff"] = {"written_at": "2026-08-10T22:15:49Z"}
+    render.render_status(data)
+    out = capsys.readouterr().out
+    assert "handoff" in out.lower()
+    assert "2026-08-10T22:15:49Z" in out
+    assert "daimon brief" in out
+
+
+def test_render_status_handoff_line_silent_when_absent(capsys):
+    data = _status_data()
+    data["handoff"] = None
+    render.render_status(data)
+    assert "handoff" not in capsys.readouterr().out.lower()
+
+
+def test_render_status_handoff_line_never_shows_the_baton_text(capsys):
+    # #662: the issue is explicit — the note belongs to the briefing, not
+    # status. Pinned at the render function itself, not just the payload
+    # shape, so a future caller stuffing "note" in by mistake still cannot
+    # leak it through this line.
+    data = _status_data()
+    data["handoff"] = {"written_at": "2026-08-10T22:15:49Z",
+                       "note": "should never appear"}
+    render.render_status(data)
+    assert "should never appear" not in capsys.readouterr().out
+
+
+def test_render_status_handoff_rich_smoke(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    data = _status_data()
+    data["handoff"] = {"written_at": "2026-08-10T22:15:49Z"}
+    render.render_status(data)
+    assert "handoff" in capsys.readouterr().out.lower()
+
+
 def test_render_status_plain_exact_format(capsys):
     # Plain output is deterministic — assert exact lines, not substrings.
     render.render_status(_status_data())


### PR DESCRIPTION
Closes #662

## Summary

- `daimon status` now reports a waiting handoff baton: one payload field (`handoff`, dict-or-None per the `recall_index` optional-fact convention) and one quiet-by-default line naming the written-at timestamp and pointing at `daimon brief`. The baton's text stays out of status, per the issue's own scope.
- The issue's open question — whether to distinguish a consumed baton — is resolved by derivation, not new state: the field comes from `store.active_handoff`, the same waiting-only consumption reader the briefing uses, so a consumed or absent baton renders nothing. The issue's "is the omission intentional" question was settled by precedent: status already carries the requests-ledger summary, so it is the ledger-facts surface, not capture-health-only.
- Wired through `_status_world`, the `--json` payload contract, `_cmd_status`, and both plain and rich renderers, with the same fail-open posture as every other best-effort status fact.
- The issue's second-order motive is pinned by test: writing a handoff through the real path makes it visible in the status payload immediately, so an agent can confirm its write without rendering the full briefing.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/cli/__init__.py` | `handoff` fact in `_status_world`, `status_payload`, `_cmd_status` |
| `plugin/daimon_briefing/render.py` | `_handoff_line` on plain and rich status paths |
| `plugin/tests/test_cli.py` | Waiting/absent/consumed/JSON-contract/fail-open tests |
| `plugin/tests/test_render.py` | Line rendering + rich smoke tests |

## PR Type

- [x] New feature

## Test Plan

- [x] Full suite: 4125 passed, 2 skipped (run twice: implementer + independent verification; the single local failure is the known environmental plugin-version-drift check, untouched by this diff and clean in CI)
- [x] `uv run ruff check .` → clean repo-wide
- [x] Waiting-baton tests observed failing pre-fix; consumed-baton silence driven through the real consumption model
- [x] Coverage: new lines fully exercised, zero overlap with pre-existing gaps

## Contributor Checklist

- [x] Linked an approved issue (#662, `status:approved`)
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
