### PR TITLE
test(cli): status shape test controls the plugin-drift probe

### DIFF
--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -702,6 +702,14 @@ def test_cli_status_json_shape(
 
     store.write_checkpoint("S-prev", sample_checkpoint, project_dir="/p/A")
     monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    # #731: _plugin_drift_present() reads Path.home()/.claude/plugins/... —
+    # the DEVELOPER'S REAL machine state, untouched by the checkpoint/log/
+    # team/recall isolation the autouse fixture provides. The shape test
+    # below asserts the documented no-plugin state as a controlled
+    # precondition, not an assumption about whoever's machine runs it (this
+    # failed on every dev box whose installed Claude Code plugin copy lags
+    # the daimon CLI version, #731).
+    monkeypatch.setattr(cli, "_plugin_drift_present", lambda: None)
     _write_log(
         tmp_log_dir,
         [


### PR DESCRIPTION
Closes #731

## Summary

- Tests-only, one file, eight lines: `test_cli_status_json_shape` asserted `plugin_drift is None` as an assumption about the host machine. `_plugin_drift_present()` reads the real `Path.home()`, which the autouse isolation fixture never redirects, so the test failed on any development machine whose installed Claude Code plugin copy lagged the repo version and self-healed when the marketplace caught up. It reproduced across three consecutive version windows this week.
- The probe is now monkeypatched to the documented no-plugin state inside the shape test, turning the assertion into a controlled precondition. The comment on the line names the trap for the next reader.
- Drift behavior keeps its real coverage untouched: `tests/test_plugin_drift.py` already drives the probe end to end with explicit installed/cli versions through a home-redirection fixture, including a status-surface test. No other test in the suite hard-codes a `plugin_drift` expectation; the payload-equality test compares two live computations and is safe by construction.
- Proof on the machine that motivated the issue: the shape test failed here pre-fix with real drift present (installed 0.32.0, cli 0.32.1) and passes post-fix; the full suite is fully green locally for the first time in four tasks (4126 passed, 0 failed).

## Changes

| File | Change |
|------|--------|
| `plugin/tests/test_cli.py` | Probe monkeypatched in the shape test, with rationale comment |

## PR Type

- [x] Bug fix

## Test Plan

- [x] Full suite: 4126 passed, 2 skipped, 0 failed (run twice: implementer + independent verification, both on a machine with real drift present)
- [x] `uv run ruff check .` → clean repo-wide
- [x] Shape test observed failing pre-fix with the real drift dict, passing post-fix
- [x] All 18 probe-level drift tests in test_plugin_drift.py untouched and green

## Contributor Checklist

- [x] Linked an approved issue (#731, `status:approved`)
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
