### PR TITLE
feat(skill): daimon-end surfaces the handoff decision

### DIFF
--- a/skills/daimon-end/SKILL.md
+++ b/skills/daimon-end/SKILL.md
@@ -30,7 +30,22 @@ a `prev` pointer. So it does not need to be perfect to be useful.
    the resolution is a provisional claim, byte-checked against the transcript
    when the session ends.
 
-2. **Emit a checkpoint JSON** from your in-context knowledge of THIS session,
+2. **Decide whether to hand off.** The baton is a different instrument from the
+   checkpoint: the checkpoint captures full state, the baton is the ONE
+   deliberate message that leads the next briefing. If the next session should
+   start somewhere specific — a reply to check, a play whose timing matters, a
+   decision waiting on the human — write it now:
+
+   ```bash
+   daimon handoff "<where the next session should start, and why>"
+   ```
+
+   Skipping is a valid decision when the checkpoint alone suffices; a baton
+   that merely restates the checkpoint is noise. But make the decision
+   consciously — a session that captures everything and hands off nothing
+   leaves the next session to infer its own starting point.
+
+3. **Emit a checkpoint JSON** from your in-context knowledge of THIS session,
    conforming exactly to the schema:
 
    ```json
@@ -58,14 +73,14 @@ a `prev` pointer. So it does not need to be perfect to be useful.
 
    Volume: 5–10 items per list; prefer the ones a fresh session would get wrong.
 
-3. **HONESTY RULE (load-bearing).** Quote only what you can reproduce exactly —
+4. **HONESTY RULE (load-bearing).** Quote only what you can reproduce exactly —
    an honest quote helps the later merge with the automatic reconstruction, and
    this path has no transcript to check against, so the CLI records every item
    as `inferred` either way (#511). Anything from an earlier,
    **compacted/summarized** part of the session you can no longer quote verbatim →
    `trust: "inferred"`, no `quote`. Do not fabricate quotes.
 
-4. **Write it** via the CLI (reads JSON on stdin, validates the schema, routes to
+5. **Write it** via the CLI (reads JSON on stdin, validates the schema, routes to
    this project + global + a per-session file, atomically, with rotation). Write
    the JSON to a temp file and pipe it:
 
@@ -76,7 +91,7 @@ a `prev` pointer. So it does not need to be perfect to be useful.
    It prints `wrote checkpoint: <path> (source: introspection)`. If it reports a
    schema-validation error, fix the JSON and retry — do not store garbage.
 
-5. **Confirm** to the user with the printed checkpoint path.
+6. **Confirm** to the user with the printed checkpoint path.
 
 ## Rules
 


### PR DESCRIPTION
Closes #733

## Summary

- One file, skill text only: the daimon-end skill gains an explicit handoff-decision step between loop resolution and the checkpoint write. The skill previously walked a closing session through resolving briefed loops and writing the introspection checkpoint but never mentioned the baton, so a session following it to the letter captured full state and handed off nothing — silently skipping the surface designed to lead the next briefing. Found by dogfooding: a real session closed via the skill and the baton was only written because the human asked.
- The step frames the baton as a decision, not a mandate: write `daimon handoff "..."` when the next session should start somewhere specific; skipping is valid when the checkpoint alone suffices, since a baton that restates the checkpoint is noise. Remaining steps renumbered.

## Changes

| File | Change |
|------|--------|
| `skills/daimon-end/SKILL.md` | New step 2 (handoff decision + command example); steps renumbered |

## PR Type

- [x] New feature

## Test Plan

- [x] Full suite: 4126 passed, 2 skipped (skill-text-only diff)
- [x] Skill content and packaging guard tests green

## Contributor Checklist

- [x] Linked an approved issue (#733, `status:approved`)
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
