### PR TITLE
feat(cli): help epilog points to docs and issue tracker

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -2812,7 +2812,10 @@ def build_parser() -> argparse.ArgumentParser:
         epilog="Examples:\n"
                "  daimon brief                 render the latest briefing\n"
                "  daimon status                checkpoint presence + last serialize\n"
-               "  daimon configure             detect/repair the LLM backend\n",
+               "  daimon configure             detect/repair the LLM backend\n"
+               "\n"
+               "Docs:   https://daily-nerd.github.io/daimon/\n"
+               "Issues: https://github.com/Daily-Nerd/daimon/issues\n",
         formatter_class=fmt,
     )
     parser.add_argument(

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2057,6 +2057,17 @@ def test_top_level_help_has_examples(capsys):
     assert "daimon brief" in out
 
 
+def test_top_level_help_points_home(capsys):
+    # #736: a pip/uv install's first touch is --help; it must carry the docs
+    # and issue-tracker URLs so terminal-only users have a pointer home.
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "https://daily-nerd.github.io/daimon/" in out
+    assert "https://github.com/Daily-Nerd/daimon/issues" in out
+
+
 def test_status_help_has_example(capsys):
     with pytest.raises(SystemExit) as exc:
         cli.main(["status", "--help"])


### PR DESCRIPTION
Closes #736

## Summary

- `daimon --help` now ends with the docs and issue-tracker URLs, so a terminal-only install has a pointer home
- `--version` unchanged (version string only); error output unchanged (stays quiet)

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/cli/__init__.py` | Top-level epilog gains a Docs / Issues block after the Examples |
| `plugin/tests/test_cli.py` | New test asserts both URLs render in `--help` output |

## Test Plan

- [x] New test red before the change, green after
- [x] Full suite: 4127 passed, 2 skipped
- [x] `ruff check` passed; mypy delta zero against main
- [x] Verified live: `daimon --help` tail shows both URLs
