### PR TITLE
docs: state the single-live-checkpoint working-set trade

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ That's it. End a session → a checkpoint is written; start the next → the bri
 
 ## Beyond the briefing
 
-- **`daimon recall <terms>`** — full-text search over your whole checkpoint history (and your team's, if enabled).
+- **`daimon recall <terms>`** — full-text search over your whole checkpoint history (and your team's, if enabled). This is also the working-set boundary, stated plainly: one live checkpoint per project feeds the briefing, and an item that falls out of [carry](https://daily-nerd.github.io/daimon/docs/concepts/carry/) never re-enters a briefing on its own — it stays reachable here, permanently, but only when asked for.
 - **`daimon why <item-id>`** — inspect a recalled item's independent capture, provenance, source, byte-integrity, current-support, verifier, lifecycle, and corroboration evidence. Add `--source` for one bounded redacted source window. See the [Trust Inspector guide](docs/trust-inspector.md).
 - **Context switching** — `daimon projects`, `daimon brief --slug <slug>`: read another project's memory deliberately, provenance-labeled — never automatic.
 - **Proactive recall** — when a new prompt overlaps prior work from an older session, the briefing surfaces it, in English or Spanish.

--- a/website/docs/concepts/carry.md
+++ b/website/docs/concepts/carry.md
@@ -39,6 +39,17 @@ All knobs live in the
 [configuration reference](../getting-started/configuration.md), including
 `DAIMON_CARRY` (master switch, on by default).
 
+## What leaving carry means
+
+The live memory is one checkpoint per project, and a briefing renders only
+what carry keeps. When an item decays out — or the per-kind cap trims it —
+it is not deleted: it survives in the historical session files and the recall
+index, and `daimon recall <terms>` reaches it permanently. But it will never
+re-enter a briefing on its own. That is the deliberate trade of a briefing
+product: the working set stays skimmable precisely because everything outside
+it is reachable only when asked for. If silence in a briefing surprises you,
+`recall` is the answer, not a lost memory.
+
 ## The staleness warning
 
 Carry has a failure mode daimon warns about explicitly: an item can ride

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/carry.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/carry.md
@@ -43,6 +43,18 @@ Todas las perillas están en la
 [referencia de configuración](../getting-started/configuration), incluido
 `DAIMON_CARRY` (interruptor maestro, encendido por defecto).
 
+## Qué significa salir del arrastre
+
+La memoria viva es un checkpoint por proyecto, y un briefing muestra solo lo
+que el arrastre conserva. Cuando un ítem decae — o el tope por tipo lo
+recorta — no se borra: sobrevive en los archivos históricos de sesión y en el
+índice de recall, y `daimon recall <términos>` lo alcanza para siempre. Pero
+nunca volverá a entrar a un briefing por sí solo. Ese es el trade deliberado
+de un producto de briefing: el conjunto de trabajo se mantiene legible
+precisamente porque todo lo que queda afuera solo se alcanza cuando se pide.
+Si el silencio de un briefing te sorprende, la respuesta es `recall`, no una
+memoria perdida.
+
 ## La advertencia de desactualización
 
 El arrastre tiene un modo de falla del que daimon advierte explícitamente: un


### PR DESCRIPTION
Closes #738

## Summary

- States the single-live-checkpoint working-set trade in user-facing docs: briefings render only what carry keeps; everything else is reachable through `daimon recall`, permanently, but never re-enters a briefing on its own
- Spanish mirror ships in the same PR per docs convention

## Changes

| File | Change |
|------|--------|
| `README.md` | `recall` bullet now states the working-set boundary |
| `website/docs/concepts/carry.md` | New section "What leaving carry means" |
| `website/i18n/es/.../concepts/carry.md` | Mirror section "Que significa salir del arrastre" |

## Test Plan

- [x] Docs-only change, no code touched
- [x] Links verified against existing doc paths
