### PR TITLE
fix(cli): brief renders the handoff baton when the project has no checkpoint

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -674,6 +674,11 @@ def _cmd_brief(args) -> int:
         slug = str(checkpoint.get("project_slug") or "").strip() or "another project"
         epoch = store._created_epoch(checkpoint.get("created"))
         age = f"{_format_age(time.time() - epoch)} ago" if epoch else "age unknown"
+        # #740: a baton left for a checkpoint-less project is the only
+        # orientation it has — status says "waiting baton"; brief must not
+        # swallow it on the header-only path. Read-only: consumption stays
+        # serialize-count-based in store.active_handoff.
+        render.render_handoff(store.active_handoff(project))
         render.render_brief_note([
             "No briefing for this project yet — the first serialized session "
             "will create one.",

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -153,6 +153,13 @@ def _print_handoff(handoff) -> None:
     print("")
 
 
+def render_handoff(handoff) -> None:
+    """Public seam for the baton block alone (#740): the no-checkpoint brief
+    path never reaches render_brief, but a baton left for a fresh project is
+    the only orientation that project has and must still lead the output."""
+    _print_handoff(handoff)
+
+
 def render_brief(checkpoint, drift=None, teammates=None, handoff=None,
                  project_dir=None, worldcheck_project=None) -> None:
     """`worldcheck_project` (#694 PR 2/3) is a SEPARATE gate from

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -4596,6 +4596,27 @@ def test_brief_fallback_header_only_by_default(
     assert "D-007" not in out
 
 
+def test_brief_fallback_header_still_renders_handoff_baton(
+        tmp_checkpoint_dir, sample_checkpoint, capsys):
+    # #740: a baton left for a checkpoint-less project is the ONLY orientation
+    # that project has, and the header-only early return dropped it while
+    # `daimon status` said "waiting baton". The baton must lead even the
+    # no-briefing note.
+    from daimon_briefing import store
+    store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
+    assert cli.main(["handoff", "Wire the gateway first. Beware rate limits.",
+                     "--project", "/repo/fresh"]) == 0
+    capsys.readouterr()
+    rc = cli.main(["brief", "--project", "/repo/fresh"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "HANDOFF" in out
+    assert "Wire the gateway first" in out
+    assert "no briefing for this project yet" in out.lower()
+    # still header-only: the foreign checkpoint's body stays suppressed
+    assert "PR #6 state" not in out
+
+
 def test_brief_fallback_full_via_flag(
         tmp_checkpoint_dir, sample_checkpoint, capsys):
     from daimon_briefing import store


### PR DESCRIPTION
Closes #740

## Summary

- A handoff baton left for a project with no checkpoint now renders in `daimon brief`, leading the "No briefing yet" note
- Root cause: the header-only early return exited before `store.active_handoff` was ever consulted; `status` showed the baton, `brief` swallowed it
- Read-only fix: baton consumption stays serialize-count-based

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/cli/__init__.py` | No-checkpoint path loads and renders the baton before the note |
| `plugin/daimon_briefing/render.py` | Public `render_handoff` seam delegating to the existing block renderer |
| `plugin/tests/test_cli.py` | New test: baton visible without checkpoint, foreign body still suppressed |

## Test Plan

- [x] New test red before, green after
- [x] Full suite: 4128 passed, 2 skipped
- [x] ruff clean
- [x] Field-verified against a real fresh project: baton leads the output
