### PR TITLE
feat(serializer): retries carry the failure diagnostic back to the model

### DIFF
--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -1577,13 +1577,16 @@ def _call_and_parse(chat, system, user_content, deadline, what: str,
     """
     attempts = 1 + parse_retries
     run_nonce = uuid.uuid4().hex[:12]
+    # #743: the marker names WHAT failed, not just that something did — exception
+    # text only (position info), never `raw` itself, which can echo request contents.
+    last_error = "unknown failure"
     for attempt in range(1, attempts + 1):
         content = user_content
         if attempt > 1:
             content += (
                 f"\n\n(retry attempt {attempt} [{run_nonce}] — the previous "
-                f"response was unparseable; output ONLY the JSON object, "
-                f"no prose, no reasoning)"
+                f"response failed with: {last_error}; output ONLY the JSON "
+                f"object, no prose, no reasoning)"
             )
 
         def _can_retry(_attempt=attempt):
@@ -1638,6 +1641,7 @@ def _call_and_parse(chat, system, user_content, deadline, what: str,
             )
         except llm.EmptyOutputError as exc:
             if _can_retry():
+                last_error = "the response was empty"
                 log.warning("empty output on %s (attempt %d/%d), "
                             "retrying with cache-buster", what, attempt, attempts)
                 continue
@@ -1650,6 +1654,7 @@ def _call_and_parse(chat, system, user_content, deadline, what: str,
         except (json.JSONDecodeError, ValueError, TypeError) as exc:
             if _can_retry():
                 # Never log `raw` — model output can echo request contents.
+                last_error = f"unparseable: {exc}"
                 log.warning("unparseable output on %s (attempt %d/%d), "
                             "retrying with cache-buster", what, attempt, attempts)
                 continue
@@ -1663,6 +1668,7 @@ def _call_and_parse(chat, system, user_content, deadline, what: str,
             ) from exc
         if not isinstance(parsed, dict):
             if _can_retry():
+                last_error = "parsed to a non-object (array or scalar)"
                 log.warning("unparseable output on %s (attempt %d/%d), "
                             "retrying with cache-buster", what, attempt, attempts)
                 continue
@@ -2242,9 +2248,12 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
     # but gateway response caches replay the SAME bad body for a byte-identical
     # retry — so heal could never recover. Same lesson _call_and_parse already
     # encodes for parse failures.
+    # #743: the note names the actual rejection — a static quote lecture let a
+    # missing-keys or bad-trust-class retry repeat the identical violation.
     _RETRY_NOTE = (
-        "\n\nattempt 2: the previous output failed schema validation — "
-        'every trust="verbatim" item MUST carry its exact transcript quote in '
+        "\n\nattempt 2: the previous output failed schema validation with: "
+        "{reason}. "
+        'Every trust="verbatim" item MUST carry its exact transcript quote in '
         "its `quote` field (never inlined into `text`). The quote must be "
         "copy-pasted exactly from the transcript, elisions marked with `...`. "
         "Re-emit the full corrected JSON."
@@ -2375,7 +2384,7 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
                 log.info("resample budget re-armed to %ds (#553)",
                          config.resample_min_seconds())
                 deadline = floor
-        checkpoint = _produce(_RETRY_NOTE)
+        checkpoint = _produce(_RETRY_NOTE.format(reason=first_reason))
         strip_code_owned_keys(checkpoint)
         checkpoint["session_id"] = session_id
     reason = validation_reason(checkpoint)

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -1175,6 +1175,36 @@ def test_validation_failure_retries_once_with_nonce(fake_chat_factory, monkeypat
     assert "quote" in second  # the reminder names the observed failure mode
 
 
+# ---- #743: retries carry the failure diagnostic back to the model ----
+
+
+def test_validation_resample_prompt_carries_the_rejection_reason(
+        fake_chat_factory, monkeypatch):
+    # #743: the resample note was a static quote lecture regardless of what
+    # the validator rejected — a missing-keys or bad-trust-class rejection got
+    # an irrelevant reminder and the retry repeated the identical violation.
+    # The resample prompt must name the actual rejection.
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    chat = fake_chat_factory([_invalid_checkpoint_json(), _valid_checkpoint_json("S1")])
+    serializer.serialize_strict("S1", make_messages(6), chat=chat)
+    assert len(chat.calls) == 2
+    second = chat.calls[1]["messages"][-1]["content"]
+    assert ("working_context.recent_decisions[0]: trust=verbatim item has "
+            "no quote") in second
+
+
+def test_parse_retry_marker_carries_the_parse_diagnostic(fake_chat_factory):
+    # #743: the parse retry said only "the previous response was unparseable".
+    # The diagnostic (position info, never raw model output) tells the model
+    # what actually came back wrong.
+    chat = fake_chat_factory(["not json, just prose",
+                              _valid_checkpoint_json("S1")])
+    serializer.serialize_strict("S1", make_messages(20), chat=chat)
+    assert len(chat.calls) == 2
+    retry_user = chat.calls[1]["messages"][1]["content"]
+    assert "no JSON object/array found in response" in retry_user
+
+
 # ---- #555: validation reports WHICH predicate rejected the checkpoint ----
 
 


### PR DESCRIPTION
Closes #743

## What

Retries carry the failure diagnostic back to the model. The parse retry marker now names what failed (exception text only, position info, never raw model output) instead of a generic "was unparseable"; the schema resample note interpolates the validator's named rejection ahead of the standing quote contract; empty-output and non-object retries get their own named reasons through the same marker.

## Why

Both retry paths were blind. A schema-rejected checkpoint repeated the identical violation on attempt 2 because the resample note was a static quote lecture regardless of what the validator rejected, and parse retries re-asked with no signal about what came back. On the #364 field install, parse plus schema classes are 30% of real capture errors.

## Tests

- `test_validation_resample_prompt_carries_the_rejection_reason` and `test_parse_retry_marker_carries_the_parse_diagnostic`: both watched failing before the change, both pass after.
- Full suite: 4130 passed, 2 skipped. ruff clean on both changed files.
