### PR TITLE
fix(serializer): stats classifies starved rescues and gates rescue effectiveness

### DIFF
--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -496,6 +496,8 @@ def _is_result_line(line: str) -> bool:
 # it means the foundation the whole product sits on is failing too often.
 _CAPTURE_WINDOW_DAYS = 14
 _CAPTURE_ERROR_GATE_PCT = 10
+# #742: rescue success below this share of windowed attempts reopens that issue.
+_RESCUE_GATE_PCT = 50
 
 
 def _stats_capture(now=None) -> dict:
@@ -535,9 +537,9 @@ def _stats_capture(now=None) -> dict:
     counts."""
     win = {"days": _CAPTURE_WINDOW_DAYS, "success": 0, "skipped": 0,
            "errors": 0, "fallback_attempts": 0, "fallback_serializes": 0,
-           "error_rate_pct": None}
+           "starved": 0, "error_rate_pct": None}
     out = {"success": 0, "skipped": 0, "errors": 0, "fallback_serializes": 0,
-           "fallback_attempts": 0,
+           "fallback_attempts": 0, "starved": 0,
            "hosts": {}, "max_serialize_seconds": 0, "total_serialize_seconds": 0,
            "window": win}
     try:
@@ -597,6 +599,13 @@ def _stats_capture(now=None) -> dict:
                 out["errors"] += 1
                 if in_window:
                     win["errors"] += 1
+                # #742: the budget died before the command backend ran a
+                # single call — an error still, but its own class: nothing
+                # about the backend failed, the shared deadline starved it.
+                if "deadline exhausted before command backend" in line:
+                    out["starved"] += 1
+                    if in_window:
+                        win["starved"] += 1
             continue
         hm = _STATS_HOST_RE.match(line)
         if hm:

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -1337,18 +1337,29 @@ def _capture_window_lines(c: dict) -> list[str]:
     """#364: the rolling-window capture-rate line(s), shared verbatim by the
     plain and rich stats renderers. Second line only when the rolling error
     rate trips the reopen gate recorded on #364."""
-    from .ledger import _CAPTURE_ERROR_GATE_PCT
+    from .ledger import _CAPTURE_ERROR_GATE_PCT, _RESCUE_GATE_PCT
     w = c.get("window")
     if not w:
         return []
     rate = w["error_rate_pct"]
+    # #742: starved appears only when nonzero — a healthy window keeps the
+    # line shape every existing reader knows.
+    starved = w.get("starved", 0)
+    starved_part = f"starved {starved}  " if starved else ""
     lines = [f"last {w['days']}d: serialized {w['success']}  "
              f"errors {w['errors']}  rescued {w['fallback_serializes']}  "
+             f"{starved_part}"
              f"error rate: {'n/a' if rate is None else f'{rate}%'}"]
     if rate is not None and rate > _CAPTURE_ERROR_GATE_PCT:
         lines.append(f"⚠ capture error rate {rate}% (last {w['days']}d) "
                      f"exceeds the {_CAPTURE_ERROR_GATE_PCT}% gate — see "
                      "`daimon status` for failing serializes")
+    attempts = w.get("fallback_attempts", 0)
+    rescued = w.get("fallback_serializes", 0)
+    if attempts and rescued * 100 < attempts * _RESCUE_GATE_PCT:
+        lines.append(f"⚠ rescue succeeded {rescued} of {attempts} attempts "
+                     f"(last {w['days']}d) — below the {_RESCUE_GATE_PCT}% "
+                     "gate recorded on #742")
     return lines
 
 

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -5677,6 +5677,37 @@ def test_stats_capture_counts_fallback_attempts(tmp_log_dir):
     assert cap["errors"] == 1
 
 
+def test_stats_capture_counts_starved_before_backend(tmp_log_dir):
+    # #742: a deadline that dies before the command backend runs a single call
+    # is its own class — the budget starved the call, the backend never failed.
+    # It stays an error (capture should have worked) AND is tagged starved.
+    from daimon_briefing import ledger
+    _write_log(tmp_log_dir, [
+        "error: LLM call failed on merge level 1, group 1 of 1: ChatError: "
+        "LLM deadline exhausted before command backend "
+        "(transcript: /t/S1.jsonl) after 840s",
+        "error: LLM call failed on transcript: ChatError: unreachable "
+        "(transcript: /t/S2.jsonl) after 12s",
+    ])
+    cap = ledger._stats_capture()
+    assert cap["errors"] == 2
+    assert cap["starved"] == 1
+
+
+def test_stats_capture_window_counts_starved(tmp_log_dir):
+    from datetime import datetime, timezone
+    from daimon_briefing import ledger
+    _write_log(tmp_log_dir, [
+        "2026-07-16T01:00:00Z session-end: spawn serialize for S1",
+        "error: LLM call failed on chunk 1 of 2: ChatError: "
+        "LLM deadline exhausted before command backend "
+        "(transcript: /t/S1.jsonl) after 420s",
+    ])
+    cap = ledger._stats_capture(
+        now=datetime(2026, 7, 17, tzinfo=timezone.utc))
+    assert cap["window"]["starved"] == 1
+
+
 def test_cli_mcp_serve_registered_and_honors_kill_switch(monkeypatch):
     # #261: `daimon mcp serve` exists; disabled daimon refuses to serve but
     # exits 0 — it must never break a host's MCP startup.
@@ -6098,7 +6129,7 @@ def test_stats_json_includes_capture_window(tmp_checkpoint_dir, tmp_log_dir,
     data = json.loads(capsys.readouterr().out)
     assert set(data["capture"]["window"]) == {
         "days", "success", "skipped", "errors", "fallback_attempts",
-        "fallback_serializes", "error_rate_pct"}
+        "fallback_serializes", "starved", "error_rate_pct"}
 
 
 def test_stats_plain_renders_capture_window_line(tmp_checkpoint_dir,

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -1741,3 +1741,39 @@ def test_lifecycle_style_map():
     assert style("warning: purge failed: boom") == "yellow"
     assert style("forgot o-1 (content hash k) — removed") is None
     assert style("  o-1  [open_questions] [?] text") is None
+
+
+# ---- #742: rescue effectiveness on the stats window line -------------------
+
+
+def _window(**overrides):
+    w = {"days": 14, "success": 10, "skipped": 0, "errors": 2,
+         "fallback_attempts": 0, "fallback_serializes": 0, "starved": 0,
+         "error_rate_pct": 16.7}
+    w.update(overrides)
+    return {"window": w}
+
+
+def test_capture_window_line_shows_starved_when_nonzero():
+    lines = render._capture_window_lines(_window(starved=2))
+    assert any("starved 2" in ln for ln in lines)
+
+
+def test_capture_window_line_omits_starved_when_zero():
+    lines = render._capture_window_lines(_window())
+    assert not any("starved" in ln for ln in lines)
+
+
+def test_rescue_gate_warns_below_half_of_attempts():
+    lines = render._capture_window_lines(
+        _window(fallback_attempts=3, fallback_serializes=1))
+    assert any("rescue succeeded 1 of 3" in ln and "50%" in ln
+               for ln in lines)
+
+
+def test_rescue_gate_silent_with_no_attempts_or_healthy_rate():
+    assert not any("rescue succeeded" in ln
+                   for ln in render._capture_window_lines(_window()))
+    assert not any("rescue succeeded" in ln
+                   for ln in render._capture_window_lines(
+                       _window(fallback_attempts=2, fallback_serializes=1)))


### PR DESCRIPTION
Refs #742

## What

The capture fold tags `deadline exhausted before command backend` errors as their own `starved` class (still counted as errors: capture should have worked), the stats window line surfaces `starved N` when nonzero, and a rescue sub-gate warns when windowed rescue successes fall below 50% of attempts (`_RESCUE_GATE_PCT`, the threshold recorded on the issue).

## Why

The fallback counters could not tell a rescue that ran and died from one the shared deadline starved before a single call, and rescue success had no gate: the field install reads 11 of 36 lifetime attempts succeeded, 0 in the current window, and nothing surfaces that unless someone diffs the log by hand.

Deadline-handoff audit (issue item 2): the reservation IS applied on the rescue edge. `_rescue` re-arms to at least `fallback_min_seconds` before invoking the fallback, so a configured rescue cannot start with a dead budget. The observed starved errors occur on the PRIMARY command-backend edge, where no reservation applies by design (the primary gets the honest remaining budget; re-arming it would break deadline semantics). That class is budget exhaustion upstream, which is the incremental-serialization lane's territory; the new counter makes its population visible per install instead of anecdotal.

## Tests

- `test_stats_capture_counts_starved_before_backend`, `test_stats_capture_window_counts_starved`, `test_capture_window_line_shows_starved_when_nonzero`, `test_capture_window_line_omits_starved_when_zero`, `test_rescue_gate_warns_below_half_of_attempts`, `test_rescue_gate_silent_with_no_attempts_or_healthy_rate`: all watched failing first.
- The stats JSON window contract test extends its key set with `starved` (intended surface change).
- Full suite: 4136 passed, 2 skipped. ruff clean.
