### PR TITLE
fix(config): silent misconfiguration reads as healthy across rescue, configure, and the capture gate

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -2065,9 +2065,35 @@ def _run_backend_test() -> int:
     return 0
 
 
+def _configure_write_flags(args) -> list:
+    """The value flags of a non-interactive configure write, as (name, value)
+    pairs — one list so the #749 --test guard, the no---backend guard, and the
+    cross-backend warning can never disagree about what counts as a write flag."""
+    return [(name, value) for name, value in (
+        ("--api-key", args.api_key),
+        ("--model", args.model),
+        ("--base-url", args.base_url),
+        ("--command", args.command),
+        ("--output", args.output),
+        ("--input", args.input),
+    ) if value]
+
+
+def _configure_wizard_flags(args) -> list:
+    """Flags consumed ONLY by the --init wizard, as (name, value) pairs — same
+    shared-list pattern as _configure_write_flags, so the --test guard and the
+    ignored-without---init warning can never drift (#749)."""
+    return [(name, value) for name, value in (
+        ("--timeout", getattr(args, "timeout", None)),
+        ("--author", getattr(args, "author", None)),
+        ("--team-remote", getattr(args, "team_remote", None)),
+    ) if value]
+
+
 def _configure_flag_updates(args) -> dict:
     """Backend flags -> env updates (the non-interactive write path)."""
     updates = {"DAIMON_LLM_BACKEND": args.backend}
+    litellm_flags = ("--api-key", "--model", "--base-url")
     if args.backend == "litellm":
         if args.api_key:
             updates["DAIMON_LLM_API_KEY"] = args.api_key
@@ -2075,6 +2101,7 @@ def _configure_flag_updates(args) -> dict:
             updates["DAIMON_LLM_MODEL"] = args.model
         if args.base_url:
             updates["DAIMON_LLM_BASE_URL"] = args.base_url
+        applies = litellm_flags
     elif args.backend == "command":
         if args.command:
             updates["DAIMON_LLM_COMMAND"] = args.command
@@ -2082,7 +2109,16 @@ def _configure_flag_updates(args) -> dict:
             updates["DAIMON_LLM_COMMAND_OUTPUT"] = args.output
         if args.input:
             updates["DAIMON_LLM_COMMAND_INPUT"] = args.input
-    # claude-cli: just pin the backend, no credentials needed.
+        applies = ("--command", "--output", "--input")
+    else:
+        # claude-cli: just pin the backend, no credentials needed.
+        applies = ()
+    # #749(c): a flag belonging to another backend was dropped without a word,
+    # so `--backend command --model x` looked like it configured a model.
+    for name, _ in _configure_write_flags(args):
+        if name not in applies:
+            print(f"warning: {name} ignored for backend {args.backend}",
+                  file=sys.stderr)
     return updates
 
 
@@ -2210,8 +2246,34 @@ def _cmd_configure(args) -> int:
     """
     if getattr(args, "init", False):
         return _configure_wizard(args)
+    wizard_flags = _configure_wizard_flags(args)
     if getattr(args, "test", False):
+        # #749(b): --test used to short-circuit BEFORE the write branch —
+        # `--backend litellm --model x --test` tested the OLD config and
+        # silently discarded the write flags. Wizard-only flags (--timeout/
+        # --author/--team-remote) would drop the same way. Refuse both.
+        other_flags = ([("--backend", args.backend)] if args.backend else []) \
+            + _configure_write_flags(args) + wizard_flags
+        if other_flags:
+            names = ", ".join(name for name, _ in other_flags)
+            print(f"error: --test cannot be combined with other flags "
+                  f"({names}) — apply them first (write flags via --backend, "
+                  "wizard flags via --init), then run `daimon configure "
+                  "--test` against the new config.",
+                  file=sys.stderr)
+            return 2
         return _run_backend_test()
+    if _configure_write_flags(args) and not args.backend:
+        # #749: the third silent-drop door — a value flag without --backend
+        # fell through every branch below untouched.
+        names = ", ".join(name for name, _ in _configure_write_flags(args))
+        print(f"error: value flags ({names}) require --backend "
+              "{litellm,command,claude-cli}", file=sys.stderr)
+        return 2
+    for name, _ in wizard_flags:
+        # Consumed only by the --init wizard; anywhere else it would drop
+        # silently (#749).
+        print(f"warning: {name} ignored without --init", file=sys.stderr)
 
     st = configure.status()
     render.render_configure(st)
@@ -2219,7 +2281,15 @@ def _cmd_configure(args) -> int:
     if args.backend:
         path = configure.write_env(_configure_flag_updates(args))
         render.render_configure_lines([f"wrote {path}"])
-        render.render_configure(configure.status())  # reprint the new resolved state
+        st = configure.status()
+        render.render_configure(st)  # reprint the new resolved state
+        if not st["ready"]:
+            # #749(a): a write that lands not-ready must fail loud — scripts
+            # read the rc, not the panel. The no-flag doctor path above keeps
+            # returning 0; only the WRITE claims an outcome.
+            print("not ready after write — see the doctor line above",
+                  file=sys.stderr)
+            return 1
         return 0
 
     if st["ready"]:

--- a/plugin/daimon_briefing/configure.py
+++ b/plugin/daimon_briefing/configure.py
@@ -59,6 +59,13 @@ def status() -> dict:
         # child fails minutes later.
         "fallback_command": fb[0] if fb else None,
         "fallback_input": fb[2] if fb else None,
+        # #747: a binary that RESOLVES but does not exist read as working
+        # everywhere (field case: DAIMON_LLM_COMMAND_FALLBACK=1). Name it here
+        # so the doctor can say so before a detached hook child discovers it.
+        # Advisory only — ready semantics unchanged; both fields come from
+        # llm's own seams so this view can never disagree with the runtime.
+        "command_missing_binary": llm.command_missing_binary(),
+        "fallback_missing_binary": llm.fallback_missing_binary(),
         "fallback_source": (
             "explicit" if config.llm_command_fallback()
             else ("legacy-command" if fb else None)

--- a/plugin/daimon_briefing/hooks.py
+++ b/plugin/daimon_briefing/hooks.py
@@ -13,8 +13,8 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-from . import (amendments, briefing, capture, config, harvest, llm, recall,
-               serializer, store, transcript)
+from . import (amendments, briefing, capture, config, harvest, ledger, llm,
+               recall, serializer, store, transcript)
 
 log = logging.getLogger("daimon_briefing")
 
@@ -91,7 +91,23 @@ def on_session_end(session_id, completed=None, interrupted=None, model=None, pla
                 )
                 return
         messages = transcript.from_session(session_id)
-        if not messages or len(messages) < config.min_messages():
+        if not messages:
+            # scar 0045: 0 parsed messages is the host-format-drift signature,
+            # never a short session — the official skip line would legitimize
+            # the loss as a policy outcome. Bare return, no skip record.
+            return
+        # #750: the SAME non-tool count serialize_strict gates on — raw len()
+        # here let a tool-heavy transcript pass this door only to be refused
+        # inside the pipeline. And a genuine skip is RECORDED, the way the CLI
+        # door records its (cli.__init__ TooShortError branch): a bare return
+        # left the session invisible to `daimon stats`. n == 0 stays scar-0045
+        # territory (rows parsed, zero conversation) — no skip line either.
+        n = serializer.conversation_message_count(messages)
+        if n < config.min_messages():
+            if n >= 1:
+                ledger._append_serialize_log(
+                    f"skipped serialize for {session_id}: transcript too short "
+                    f"({n} < {config.min_messages()} messages)")
             return
         root = config.resolve_project_root(config.project_dir())
         try:
@@ -114,6 +130,9 @@ def on_session_end(session_id, completed=None, interrupted=None, model=None, pla
                 transcript_sha=transcript_sha, capture_host=platform,
             )
         except serializer.TooShortError:
+            # Unreachable while both doors share conversation_message_count
+            # (#750); kept defensive. No ledger append here — a drift could
+            # carry n == 0, and scar 0045 forbids recording that as a skip.
             log.info("daimon: no checkpoint produced for session %s (skip)", session_id)
             return
         if out is None:

--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -602,7 +602,11 @@ def _stats_capture(now=None) -> dict:
                 # #742: the budget died before the command backend ran a
                 # single call — an error still, but its own class: nothing
                 # about the backend failed, the shared deadline starved it.
-                if "deadline exhausted before command backend" in line:
+                # #748's chained shape ("rescue failed: ...; primary: LLM
+                # deadline exhausted before command backend") carries the
+                # substring for a rescue that RAN and failed — never starved.
+                if ("deadline exhausted before command backend" in line
+                        and "rescue failed:" not in line):
                     out["starved"] += 1
                     if in_window:
                         win["starved"] += 1

--- a/plugin/daimon_briefing/llm.py
+++ b/plugin/daimon_briefing/llm.py
@@ -416,6 +416,12 @@ def rescue_posture() -> str:
     """
     resolved = resolve_backend()
     fallback = _resolve_fallback_command()
+    # #747: resolving is not existing. DAIMON_LLM_COMMAND_FALLBACK=1 made the
+    # rescue binary a program named `1` and posture read "covered" — an exec
+    # that can only fail is no rescue, so both edges below must see no
+    # fallback. The doctor names the missing binary (configure.status()).
+    if fallback is not None and _missing_binary(fallback[0]):
+        fallback = None
     if resolved["backend"] in ("command", "claude-cli"):
         # #475: a command primary DOES have a rescue direction now, but only
         # when one is configured. Absent a fallback this must still read
@@ -443,6 +449,15 @@ def _rescue(messages, deadline, exc, primary_label):
     fallback = _resolve_fallback_command()
     if not (config.llm_fallback() and fallback is not None):
         raise exc
+    missing = _missing_binary(fallback[0])
+    if missing:
+        # #747 coherence: posture already reads this config as none/gap, so
+        # runtime must not attempt the doomed exec — that would log the
+        # ledger-counted attempt literal, set _fallback_used, and bury the
+        # primary's diagnostic under "binary not found" (#748 field case).
+        # The primary error surfaces untouched instead.
+        log.warning("llm.rescue skipped: fallback binary not found (%s)", missing)
+        raise exc
     # #533: budget expiry is daimon's own clock, not a backend error — the
     # label decides which of two very different things gets debugged.
     reason = ("serialize deadline expired"
@@ -460,7 +475,20 @@ def _rescue(messages, deadline, exc, primary_label):
         # floor; a healthy remaining budget is never shrunk.
         deadline = max(deadline,
                        time.monotonic() + config.fallback_min_seconds())
-    return _chat_command(messages, deadline, resolved=fallback)
+    try:
+        return _chat_command(messages, deadline, resolved=fallback)
+    except ChatError as rescue_exc:
+        # #748: the rescue's own failure must not destroy the primary's
+        # diagnostic (field case: "binary not found: 1" buried the real "No
+        # LLM model" error). Chain both — exception TEXT only, never payloads
+        # (#744 redaction rule). Re-raised as the SAME type so
+        # EmptyOutputError keeps its serializer retry class. `exc` is a
+        # NoRescueAvailable placeholder on the rescue_unparseable path, where
+        # `reason` is the honest primary description.
+        primary = reason if isinstance(exc, NoRescueAvailable) else str(exc)
+        raise type(rescue_exc)(
+            f"rescue failed: {rescue_exc}; primary: {primary}"
+        ) from rescue_exc
 
 
 def rescue_unparseable(messages, deadline):
@@ -618,6 +646,41 @@ def _resolve_fallback_command():
     if resolve_backend()["backend"] not in ("command", "claude-cli"):
         return _resolve_command()
     return None
+
+
+def _missing_binary(command_str) -> str | None:
+    """argv[0] of `command_str` when exec would refuse it, else None (#747).
+
+    Splits with the same shlex.split _chat_command execs through, so this can
+    never disagree with the exec about what argv[0] IS. shutil.which honours
+    both PATH lookups and explicit paths; an unsplittable or empty command
+    string cannot exec either, so it reports as its own missing name.
+
+    ADVISORY: the check runs under the CALLING process's PATH — a detached
+    hook child's PATH can differ, so exec can still fail after a None here
+    (accepted limitation; the #748 chain covers that path)."""
+    try:
+        argv = shlex.split(command_str)
+    except ValueError:
+        return command_str
+    if not argv:
+        return command_str
+    return None if shutil.which(argv[0]) else argv[0]
+
+
+def fallback_missing_binary() -> str | None:
+    """The resolved rescue's argv[0] when it does not exist, else None —
+    the doctor's #747 surface, derived from the same resolution _rescue runs."""
+    fallback = _resolve_fallback_command()
+    return _missing_binary(fallback[0]) if fallback else None
+
+
+def command_missing_binary() -> str | None:
+    """#747 half two: the resolved PRIMARY command's argv[0] when it does not
+    exist, else None. Same advisory seam as fallback_missing_binary — the
+    doctor warns, ready semantics stay untouched (changing them ripples)."""
+    cmd = _resolve_command()
+    return _missing_binary(cmd[0]) if cmd else None
 
 
 def _extract_output(stdout, output_spec):

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -526,11 +526,46 @@ def render_configure(st: dict) -> None:
         _plain_configure(st)
 
 
+def _command_binary_warning(st: dict) -> str | None:
+    """#747 half two: the PRIMARY command's binary can be missing too — the
+    doctor warns and names it; ready semantics stay untouched in this slice.
+    A missing primary implies an explicit DAIMON_LLM_COMMAND: the claude-cli
+    preset only resolves when its binary is on PATH."""
+    missing = st.get("command_missing_binary")
+    if not missing:
+        return None
+    return (f"⚠ command binary not found: {missing} — the configured backend "
+            f"({st.get('command')}) cannot run; fix DAIMON_LLM_COMMAND")
+
+
+def _fallback_binary_warning(st: dict) -> str | None:
+    """#747: the doctor line for a rescue whose binary does not exist — the
+    posture already refuses to read "covered", but only this view can NAME the
+    binary (field case: DAIMON_LLM_COMMAND_FALLBACK=1). The fix advice names
+    the knob the rescue actually resolved from: the #475 legacy shim reads
+    DAIMON_LLM_COMMAND, not the fallback variable."""
+    missing = st.get("fallback_missing_binary")
+    if not missing:
+        return None
+    knob = ("DAIMON_LLM_COMMAND"
+            if st.get("fallback_source") == "legacy-command"
+            else "DAIMON_LLM_COMMAND_FALLBACK")
+    return (f"⚠ fallback binary not found: {missing} — the configured rescue "
+            f"({st.get('fallback_command')}) cannot run; fix {knob}")
+
+
+def _configure_warnings(st: dict) -> list:
+    return [w for w in (_command_binary_warning(st),
+                        _fallback_binary_warning(st)) if w]
+
+
 def _plain_configure(st: dict) -> None:
     mark = "✓" if st["ready"] else "✗"
     state = "ready" if st["ready"] else "not ready"
     print(f"{mark} {state} — {_explain(st)}")
     print(f"  env file: {st['env_file']}")
+    for warning in _configure_warnings(st):
+        print(f"  {warning}")
 
 
 def _rich_configure(st: dict) -> None:
@@ -541,6 +576,8 @@ def _rich_configure(st: dict) -> None:
     style = "green" if st["ready"] else "red"
     state = "ready" if st["ready"] else "not ready"
     body = f"[{style}]{state}[/{style}] — {_explain(st)}\nenv file: [dim]{st['env_file']}[/dim]"
+    for warning in _configure_warnings(st):
+        body += f"\n[yellow]{warning}[/yellow]"
     console.print(Panel(body, title="daimon configure", border_style=style, title_align="left"))
 
 

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -2171,6 +2171,18 @@ def _stamp_llm_provenance(checkpoint: dict) -> None:
             pass
 
 
+def conversation_message_count(messages) -> int:
+    """Non-tool rows — THE too-short count, for BOTH capture doors (#750).
+
+    #359: tool rows are evidence, not conversation — they never count toward
+    the too-short gate, so surfacing them cannot let a two-turn session sneak
+    past it. hooks.on_session_end gated on raw len() while serialize_strict
+    counted this way, so a tool-heavy transcript passed one door and was
+    refused by the other."""
+    return sum(1 for m in messages or []
+               if not (isinstance(m, dict) and m.get("tool_result")))
+
+
 def serialize_strict(session_id: str, messages, chat=None, deadline=None,
                      escalate=False, source_ref=None, transcript_hash=None,
                      now=None) -> dict:
@@ -2194,11 +2206,7 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
     """
     if chat is None:
         chat = llm.chat
-    # #359: tool rows are evidence, not conversation — they never count
-    # toward the too-short gate, so surfacing them cannot let a two-turn
-    # session sneak past it.
-    n = sum(1 for m in messages or []
-            if not (isinstance(m, dict) and m.get("tool_result")))
+    n = conversation_message_count(messages)
     if n < config.min_messages():
         raise TooShortError(
             f"transcript too short ({n} < {config.min_messages()} messages)"

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -5985,6 +5985,7 @@ def test_status_no_rescue_warning_when_command_resolves(tmp_checkpoint_dir,
     monkeypatch.setenv("DAIMON_LLM_API_KEY", "k")
     monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
     monkeypatch.setattr(llm, "_resolve_command", lambda: ("claude -p", "text", "stdin"))
+    monkeypatch.setattr(llm, "_missing_binary", lambda c: None)  # #747: CI has no claude
     cli.main(["status"])   # rc reflects checkpoint health, not this warning
     out = capsys.readouterr().out
     assert "no fallback backend resolves" not in out
@@ -6100,6 +6101,7 @@ def test_stats_plain_fallback_line_suffix_covered(
     monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
     monkeypatch.setattr(config, "llm_api_key", lambda: "k")
     monkeypatch.setattr(llm, "_resolve_command", lambda: ("claude -p", "text", "stdin"))
+    monkeypatch.setattr(llm, "_missing_binary", lambda c: None)  # #747: CI has no claude
     store.write_checkpoint("S1", sample_checkpoint)
     assert cli.main(["stats"]) == 0
     out = capsys.readouterr().out
@@ -6114,6 +6116,7 @@ def test_stats_rich_fallback_line_suffix_covered(
     monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
     monkeypatch.setattr(config, "llm_api_key", lambda: "k")
     monkeypatch.setattr(llm, "_resolve_command", lambda: ("claude -p", "text", "stdin"))
+    monkeypatch.setattr(llm, "_missing_binary", lambda c: None)  # #747: CI has no claude
     store.write_checkpoint("S1", sample_checkpoint)
     assert cli.main(["stats"]) == 0
     out = capsys.readouterr().out

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1610,6 +1610,178 @@ def test_cli_configure_not_ready_non_tty_prints_guidance(
     assert not env_file.exists()
 
 
+def test_cli_configure_doctor_names_missing_fallback_binary(
+    capsys, monkeypatch, tmp_path
+):
+    # #747 field case: DAIMON_LLM_COMMAND_FALLBACK=1 made the rescue a program
+    # named `1`; the doctor is the one surface built to catch that before a
+    # detached hook child fails minutes later.
+    env_file = tmp_path / "env"
+    monkeypatch.setenv("DAIMON_ENV_FILE", str(env_file))
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "claude-cli")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND_FALLBACK", "1")
+    _set_claude(monkeypatch, True)
+
+    rc = cli.main(["configure"])
+    assert rc == 0  # primary is ready; the fallback problem is a warning
+    out = capsys.readouterr().out
+    assert "fallback binary not found: 1" in out
+
+
+def test_cli_configure_doctor_silent_when_fallback_binary_exists(
+    capsys, monkeypatch, tmp_path
+):
+    env_file = tmp_path / "env"
+    monkeypatch.setenv("DAIMON_ENV_FILE", str(env_file))
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "claude-cli")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND_FALLBACK", "claude -p")
+    _set_claude(monkeypatch, True)
+
+    rc = cli.main(["configure"])
+    assert rc == 0
+    assert "fallback binary not found" not in capsys.readouterr().out
+
+
+# ---- #749: the non-interactive write path must fail loud, not lie with rc 0 ----
+
+
+def test_cli_configure_flag_write_not_ready_returns_1(capsys, monkeypatch, tmp_path):
+    # A --backend write that lands on ready=False used to return 0 — scripts
+    # read rc, not the panel.
+    env_file = tmp_path / "env"
+    monkeypatch.setenv("DAIMON_ENV_FILE", str(env_file))
+    _clear_llm_env(monkeypatch)
+    _set_claude(monkeypatch, False)
+
+    rc = cli.main(["configure", "--backend", "litellm", "--api-key", "K"])
+    assert rc == 1  # no model -> litellm not ready
+    err = capsys.readouterr().err
+    assert "not ready" in err
+    # The write itself still happened — rc 1 reports the state, not a rollback.
+    from daimon_briefing import config
+    assert config._file_values()["DAIMON_LLM_BACKEND"] == "litellm"
+
+
+def test_cli_configure_test_with_write_flags_is_an_error(capsys, monkeypatch, tmp_path):
+    # --test used to short-circuit BEFORE the write branch: it tested the OLD
+    # config and silently discarded the write flags.
+    env_file = tmp_path / "env"
+    monkeypatch.setenv("DAIMON_ENV_FILE", str(env_file))
+    _clear_llm_env(monkeypatch)
+    _set_claude(monkeypatch, False)
+
+    rc = cli.main(["configure", "--backend", "litellm", "--model", "M", "--test"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "--test" in err
+    assert not env_file.exists()  # nothing written, nothing tested — no half-state
+
+
+def test_cli_configure_warns_on_cross_backend_flags(capsys, monkeypatch, tmp_path):
+    # litellm value flags on a command-backend write were silently dropped.
+    env_file = tmp_path / "env"
+    monkeypatch.setenv("DAIMON_ENV_FILE", str(env_file))
+    _clear_llm_env(monkeypatch)
+    _set_claude(monkeypatch, False)
+
+    rc = cli.main([
+        "configure", "--backend", "command", "--command", "mycli -p",
+        "--model", "M", "--api-key", "K",
+    ])
+    assert rc == 0  # command backend with a command is ready
+    err = capsys.readouterr().err
+    assert "--model" in err and "--api-key" in err
+    assert "ignored" in err
+    from daimon_briefing import config
+    values = config._file_values()
+    assert "DAIMON_LLM_MODEL" not in values
+    assert "DAIMON_LLM_API_KEY" not in values
+
+
+def test_cli_configure_warns_on_value_flags_with_claude_cli(capsys, monkeypatch, tmp_path):
+    env_file = tmp_path / "env"
+    monkeypatch.setenv("DAIMON_ENV_FILE", str(env_file))
+    _clear_llm_env(monkeypatch)
+    _set_claude(monkeypatch, True)
+
+    rc = cli.main(["configure", "--backend", "claude-cli", "--command", "mycli -p"])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "--command" in err and "ignored" in err
+    from daimon_briefing import config
+    assert "DAIMON_LLM_COMMAND" not in config._file_values()
+
+
+def test_cli_configure_value_flags_without_backend_error(capsys, monkeypatch, tmp_path):
+    # #749: the third silent-drop door — a value flag without --backend fell
+    # through every branch untouched, so `--model M` looked like it configured
+    # a model.
+    env_file = tmp_path / "env"
+    monkeypatch.setenv("DAIMON_ENV_FILE", str(env_file))
+    _clear_llm_env(monkeypatch)
+    _set_claude(monkeypatch, False)
+
+    rc = cli.main(["configure", "--model", "M"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "--model" in err and "--backend" in err
+    assert not env_file.exists()
+
+
+def test_cli_configure_test_refuses_wizard_flags(capsys, monkeypatch, tmp_path):
+    # #749: --timeout/--author/--team-remote are consumed only by the --init
+    # wizard; `--timeout 600 --test` silently tested with the flag dropped.
+    env_file = tmp_path / "env"
+    monkeypatch.setenv("DAIMON_ENV_FILE", str(env_file))
+    _clear_llm_env(monkeypatch)
+    _set_claude(monkeypatch, False)
+
+    rc = cli.main(["configure", "--timeout", "600", "--test"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "--timeout" in err
+    assert not env_file.exists()
+
+
+def test_cli_configure_warns_on_wizard_flags_without_init(capsys, monkeypatch, tmp_path):
+    env_file = tmp_path / "env"
+    monkeypatch.setenv("DAIMON_ENV_FILE", str(env_file))
+    _clear_llm_env(monkeypatch)
+    _set_claude(monkeypatch, True)
+
+    rc = cli.main([
+        "configure", "--backend", "claude-cli",
+        "--timeout", "600", "--author", "al",
+    ])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "--timeout" in err and "--author" in err
+    assert "--init" in err
+    from daimon_briefing import config
+    assert "DAIMON_TIMEOUT" not in config._file_values()
+
+
+def test_cli_configure_doctor_names_missing_primary_binary(
+    capsys, monkeypatch, tmp_path
+):
+    # #747 half two: the PRIMARY command backend gets the same existence
+    # check as the fallback — advisory warning only, ready semantics
+    # unchanged in this slice.
+    env_file = tmp_path / "env"
+    monkeypatch.setenv("DAIMON_ENV_FILE", str(env_file))
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "ghostcli -p")
+    _set_claude(monkeypatch, False)  # which() resolves nothing
+
+    rc = cli.main(["configure"])
+    assert rc == 0  # ready stays ready; the warning is the honest floor
+    out = capsys.readouterr().out
+    assert "command binary not found: ghostcli" in out
+
+
 def test_cli_configure_interactive_litellm(capsys, monkeypatch, tmp_path):
     # Not ready + TTY + no flags -> interactive prompt path via the _prompt seam.
     env_file = tmp_path / "env"
@@ -5708,6 +5880,24 @@ def test_stats_capture_window_counts_starved(tmp_log_dir):
     assert cap["window"]["starved"] == 1
 
 
+def test_stats_capture_chained_rescue_failure_is_not_starved(tmp_log_dir):
+    # #748 chains "...; primary: LLM deadline exhausted before command
+    # backend" into the rescue's own error line — that rescue RAN and failed,
+    # so the bare-substring starved match must not fire on the chained shape.
+    # Only a bare primary starved line is a starved call.
+    from daimon_briefing import ledger
+    _write_log(tmp_log_dir, [
+        "error: LLM call failed on transcript: ChatError: rescue failed: "
+        "command backend exited 2 (stderr: /x); primary: LLM deadline "
+        "exhausted before command backend (transcript: /t/S1.jsonl) after 840s",
+        "error: LLM deadline exhausted before command backend "
+        "(transcript: /t/S2.jsonl) after 840s",
+    ])
+    cap = ledger._stats_capture()
+    assert cap["errors"] == 2
+    assert cap["starved"] == 1
+
+
 def test_cli_mcp_serve_registered_and_honors_kill_switch(monkeypatch):
     # #261: `daimon mcp serve` exists; disabled daimon refuses to serve but
     # exits 0 — it must never break a host's MCP startup.
@@ -5827,6 +6017,9 @@ def test_cli_status_rescue_gap_matches_posture_across_all_rows(
     monkeypatch.setenv("DAIMON_LLM_FALLBACK", fallback)
     monkeypatch.setattr(config, "llm_api_key", lambda: api_key)
     monkeypatch.setattr(llm, "_resolve_command", lambda: command)
+    # #747: posture now checks the fallback binary exists — pin which() so
+    # the "covered" row does not depend on a real `claude` on PATH.
+    monkeypatch.setattr(llm.shutil, "which", lambda b: f"/usr/bin/{b}")
     payload, _ = cli.status_payload(None)
     assert payload["rescue_posture"] == expected_posture
     assert payload["rescue_gap"] == (expected_posture == "gap")
@@ -5881,6 +6074,7 @@ def test_status_covered_disabled_no_backend_stay_silent(
     monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
     monkeypatch.setattr(config, "llm_api_key", lambda: "k")
     monkeypatch.setattr(llm, "_resolve_command", lambda: ("claude -p", "text", "stdin"))
+    monkeypatch.setattr(llm.shutil, "which", lambda b: f"/usr/bin/{b}")  # #747
     now = datetime.now(timezone.utc)
     _write_log(tmp_log_dir, [
         f"{_iso(now - timedelta(days=1))} session-end: spawned serialize for A "

--- a/plugin/tests/test_configure.py
+++ b/plugin/tests/test_configure.py
@@ -11,6 +11,8 @@ _LLM_VARS = (
     "DAIMON_LLM_MODEL", "LITELLM_MODEL",
     "DAIMON_LLM_BASE_URL", "LITELLM_BASE_URL",
     "DAIMON_LLM_COMMAND", "DAIMON_LLM_COMMAND_OUTPUT", "DAIMON_LLM_COMMAND_INPUT",
+    "DAIMON_LLM_COMMAND_FALLBACK", "DAIMON_LLM_COMMAND_FALLBACK_OUTPUT",
+    "DAIMON_LLM_COMMAND_FALLBACK_INPUT",
 )
 
 
@@ -170,6 +172,55 @@ def test_status_input_none_when_no_backend_resolves(clean_llm_env):
     st = configure.status()
     assert st["command"] is None
     assert st["input"] is None
+
+
+# ---- #747: the doctor names a fallback binary that does not exist ----
+
+
+def test_status_names_a_missing_fallback_binary(clean_llm_env):
+    # Field case: DAIMON_LLM_COMMAND_FALLBACK=1 — the rescue binary is a
+    # program named `1`, which exists nowhere.
+    clean_llm_env.setenv("DAIMON_LLM_BACKEND", "claude-cli")
+    clean_llm_env.setenv("DAIMON_LLM_COMMAND_FALLBACK", "1")
+    _set_claude(clean_llm_env, True)
+    st = configure.status()
+    assert st["fallback_command"] == "1"
+    assert st["fallback_missing_binary"] == "1"
+
+
+def test_status_fallback_missing_binary_none_when_it_exists(clean_llm_env):
+    clean_llm_env.setenv("DAIMON_LLM_BACKEND", "litellm")
+    clean_llm_env.setenv("DAIMON_LLM_COMMAND_FALLBACK", "claude -p")
+    _set_claude(clean_llm_env, True)  # which() resolves only `claude`
+    st = configure.status()
+    assert st["fallback_missing_binary"] is None
+
+
+def test_status_fallback_missing_binary_none_without_a_fallback(clean_llm_env):
+    _set_claude(clean_llm_env, False)
+    st = configure.status()
+    assert st["fallback_command"] is None
+    assert st["fallback_missing_binary"] is None
+
+
+def test_status_names_a_missing_primary_command_binary(clean_llm_env):
+    # #747 half two: the PRIMARY command backend gets the same existence
+    # check — ready semantics unchanged (that ripples), the field is the
+    # honest floor for the doctor to warn from.
+    clean_llm_env.setenv("DAIMON_LLM_BACKEND", "command")
+    clean_llm_env.setenv("DAIMON_LLM_COMMAND", "ghostcli -p")
+    _set_claude(clean_llm_env, False)  # which() resolves nothing
+    st = configure.status()
+    assert st["ready"] is True
+    assert st["command_missing_binary"] == "ghostcli"
+
+
+def test_status_command_missing_binary_none_when_it_exists(clean_llm_env):
+    clean_llm_env.setenv("DAIMON_LLM_BACKEND", "command")
+    clean_llm_env.setenv("DAIMON_LLM_COMMAND", "claude -p")
+    _set_claude(clean_llm_env, True)  # which() resolves only `claude`
+    st = configure.status()
+    assert st["command_missing_binary"] is None
 
 
 # ---- write_env: merge, preserve, chmod 600, no-empty-file ----

--- a/plugin/tests/test_hooks.py
+++ b/plugin/tests/test_hooks.py
@@ -144,6 +144,88 @@ def test_on_session_end_too_short_noop(tmp_checkpoint_dir, fake_chat_factory, mo
     assert store.read_checkpoint("S-end") is None
 
 
+def test_on_session_end_gate_counts_non_tool_rows_like_the_cli_door(
+        _isolate_daimon_home, tmp_checkpoint_dir, fake_chat_factory, monkeypatch):
+    # #750: 12 raw rows but only 5 conversation rows — the raw len() gate let
+    # this through, only for serialize_strict's #359 count to refuse it later.
+    # The hook door must trip the SAME gate, before the pipeline is entered.
+    from daimon_briefing import capture, store, transcript
+
+    msgs = make_messages(5) + [
+        {"role": "tool", "content": "ok", "id": f"t-{i}", "tool_result": True}
+        for i in range(7)
+    ]
+    chat = fake_chat_factory(_valid_json("S-end"))
+    monkeypatch.setattr(transcript, "from_session", lambda sid: msgs)
+    monkeypatch.setattr(hooks, "_chat", chat)
+
+    def boom(*a, **k):
+        raise AssertionError("capture.run reached despite a too-short gate")
+
+    monkeypatch.setattr(capture, "run", boom)
+    hooks.on_session_end(
+        session_id="S-end", completed=True, interrupted=False, model="m", platform="cli"
+    )
+    assert store.read_checkpoint("S-end") is None
+    log = _isolate_daimon_home / "logs" / "serialize.log"
+    text = log.read_text(encoding="utf-8")
+    assert "skipped serialize for S-end: transcript too short (5 < 10 messages)" in text
+    assert "error:" not in text  # a skip, never a lying failure
+
+
+def test_on_session_end_zero_parsed_transcript_gets_no_skip_line(
+        _isolate_daimon_home, tmp_checkpoint_dir, fake_chat_factory, monkeypatch):
+    # scar 0045: a transcript that parses to 0 messages is the host-format-
+    # drift signature (a 13MB Codex session parsed to 0 and was skipped as
+    # "too short" 9 times) — the official skip line would legitimize the loss
+    # as a policy outcome. No line at all: never a skip record.
+    from daimon_briefing import transcript
+
+    chat = fake_chat_factory(_valid_json("S-end"))
+    monkeypatch.setattr(transcript, "from_session", lambda sid: [])
+    monkeypatch.setattr(hooks, "_chat", chat)
+    hooks.on_session_end(
+        session_id="S-end", completed=True, interrupted=False, model="m", platform="cli"
+    )
+    log = _isolate_daimon_home / "logs" / "serialize.log"
+    assert not log.exists() or "skipped serialize" not in log.read_text(encoding="utf-8")
+
+
+def test_on_session_end_all_tool_rows_transcript_gets_no_skip_line(
+        _isolate_daimon_home, tmp_checkpoint_dir, fake_chat_factory, monkeypatch):
+    # Same scar posture for the n == 0 shape: many raw records, zero
+    # conversation rows reads as a parse/format problem, not a short session.
+    from daimon_briefing import transcript
+
+    msgs = [{"role": "tool", "content": "ok", "id": f"t-{i}", "tool_result": True}
+            for i in range(12)]
+    chat = fake_chat_factory(_valid_json("S-end"))
+    monkeypatch.setattr(transcript, "from_session", lambda sid: msgs)
+    monkeypatch.setattr(hooks, "_chat", chat)
+    hooks.on_session_end(
+        session_id="S-end", completed=True, interrupted=False, model="m", platform="cli"
+    )
+    log = _isolate_daimon_home / "logs" / "serialize.log"
+    assert not log.exists() or "skipped serialize" not in log.read_text(encoding="utf-8")
+
+
+def test_on_session_end_too_short_skip_lands_in_the_ledger(
+        _isolate_daimon_home, tmp_checkpoint_dir, fake_chat_factory, monkeypatch):
+    # #750: the CLI door prints AND ledger-logs its too-short skip; the hook
+    # door returned bare, so the skip was invisible to `daimon stats`.
+    from daimon_briefing import transcript
+
+    chat = fake_chat_factory(_valid_json("S-end"))
+    monkeypatch.setattr(transcript, "from_session", lambda sid: make_messages(3))
+    monkeypatch.setattr(hooks, "_chat", chat)
+    hooks.on_session_end(
+        session_id="S-end", completed=True, interrupted=False, model="m", platform="cli"
+    )
+    log = _isolate_daimon_home / "logs" / "serialize.log"
+    text = log.read_text(encoding="utf-8")
+    assert "skipped serialize for S-end: transcript too short (3 < 10 messages)" in text
+
+
 def test_on_session_end_never_raises_when_serializer_explodes(tmp_checkpoint_dir, monkeypatch):
     from daimon_briefing import transcript
 

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -1984,6 +1984,17 @@ def test_fallback_missing_binary_none_when_no_fallback_resolves(monkeypatch):
     assert llm.fallback_missing_binary() is None
 
 
+def test_missing_binary_unsplittable_command_reports_itself():
+    # An unbalanced quote cannot shlex.split, so it cannot exec either —
+    # the whole string IS the missing name (#747).
+    assert llm._missing_binary("'unbalanced") == "'unbalanced"
+
+
+def test_missing_binary_empty_command_reports_itself():
+    assert llm._missing_binary("") == ""
+    assert llm._missing_binary("   ") == "   "
+
+
 # ---- #748: a failed rescue exec must not destroy the primary's diagnostic ----
 
 

--- a/plugin/tests/test_llm.py
+++ b/plugin/tests/test_llm.py
@@ -649,6 +649,7 @@ def test_chat_litellm_falls_back_on_error(monkeypatch):
         raise llm.ChatError("gateway down")
     monkeypatch.setattr(llm, "_chat_litellm", boom)
     monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text"))
+    monkeypatch.setattr(llm, "_missing_binary", lambda c: None)  # #747: binary "exists"
     monkeypatch.setattr(llm, "_chat_command", lambda m, deadline, resolved=None: "FALLBACK")
     assert llm.chat([{"role": "user", "content": "x"}]) == "FALLBACK"
 
@@ -833,6 +834,7 @@ def test_rescue_posture_keyless_litellm_with_a_command_is_covered(monkeypatch):
     monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
     monkeypatch.setattr(config, "llm_api_key", lambda: None)
     monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text", "stdin"))
+    monkeypatch.setattr(llm.shutil, "which", lambda b: f"/usr/bin/{b}")  # #747
     assert llm.rescue_posture() == "covered"
 
 
@@ -869,6 +871,7 @@ def test_rescue_posture_covered(monkeypatch):
     monkeypatch.setattr(config, "llm_api_key", lambda: "sk-key")
     monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
     monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text", "stdin"))
+    monkeypatch.setattr(llm.shutil, "which", lambda b: f"/usr/bin/{b}")  # #747
     assert llm.rescue_posture() == "covered"
 
 
@@ -891,6 +894,7 @@ def test_rescue_posture_unknown_backend_string_joins_litellm_family(monkeypatch)
     # joins, and this test would be asking two questions at once.
     monkeypatch.setattr(config, "llm_api_key", lambda: "sk-key")
     monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text", "stdin"))
+    monkeypatch.setattr(llm.shutil, "which", lambda b: f"/usr/bin/{b}")  # #747
     assert llm.rescue_posture() == "covered"
     monkeypatch.setattr(llm, "_resolve_command", lambda: None)
     assert llm.rescue_posture() == "gap"
@@ -908,6 +912,7 @@ def test_chat_fallback_sets_flag(monkeypatch):
         raise llm.ChatError("gateway down")
     monkeypatch.setattr(llm, "_chat_litellm", boom)
     monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text"))
+    monkeypatch.setattr(llm, "_missing_binary", lambda c: None)  # #747: binary "exists"
     monkeypatch.setattr(llm, "_chat_command", lambda m, deadline, resolved=None: "FALLBACK")
     llm.reset_fallback()
     assert llm.fallback_used() is False
@@ -1228,6 +1233,7 @@ def test_chat_fallback_extends_drained_deadline(monkeypatch):
     monkeypatch.setattr(llm, "_chat_litellm",
                         lambda *a, **k: (_ for _ in ()).throw(llm.ChatError("down")))
     monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text", "stdin"))
+    monkeypatch.setattr(llm, "_missing_binary", lambda c: None)  # #747: binary "exists"
     seen = {}
 
     def fake_command(messages, deadline, resolved=None):
@@ -1248,6 +1254,7 @@ def test_chat_fallback_keeps_larger_remaining_budget(monkeypatch):
     monkeypatch.setattr(llm, "_chat_litellm",
                         lambda *a, **k: (_ for _ in ()).throw(llm.ChatError("down")))
     monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text", "stdin"))
+    monkeypatch.setattr(llm, "_missing_binary", lambda c: None)  # #747: binary "exists"
     seen = {}
 
     def fake_command(messages, deadline, resolved=None):
@@ -1267,6 +1274,7 @@ def test_chat_fallback_no_deadline_stays_none(monkeypatch):
     monkeypatch.setattr(llm, "_chat_litellm",
                         lambda *a, **k: (_ for _ in ()).throw(llm.ChatError("down")))
     monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text", "stdin"))
+    monkeypatch.setattr(llm, "_missing_binary", lambda c: None)  # #747: binary "exists"
     seen = {}
 
     def fake_command(messages, deadline, resolved=None):
@@ -1568,6 +1576,7 @@ def test_chat_fallback_log_names_deadline_expiry(monkeypatch, caplog):
 
     monkeypatch.setattr(llm, "_chat_litellm", budget_gone)
     monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text"))
+    monkeypatch.setattr(llm, "_missing_binary", lambda c: None)  # #747: binary "exists"
     monkeypatch.setattr(llm, "_chat_command", lambda m, deadline, resolved=None: "FALLBACK")
     llm.reset_fallback()
     with caplog.at_level(logging.WARNING, logger="daimon_briefing.llm"):
@@ -1586,6 +1595,7 @@ def test_chat_fallback_log_still_names_backend_failure(monkeypatch, caplog):
 
     monkeypatch.setattr(llm, "_chat_litellm", boom)
     monkeypatch.setattr(llm, "_resolve_command", lambda: ("mycli", "text"))
+    monkeypatch.setattr(llm, "_missing_binary", lambda c: None)  # #747: binary "exists"
     monkeypatch.setattr(llm, "_chat_command", lambda m, deadline, resolved=None: "FALLBACK")
     llm.reset_fallback()
     with caplog.at_level(logging.WARNING, logger="daimon_briefing.llm"):
@@ -1717,6 +1727,7 @@ def test_chat_command_primary_falls_back_on_error(monkeypatch):
     monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
     monkeypatch.setattr(llm, "_resolve_fallback_command",
                         lambda: ("rescuecli", "text", "stdin"))
+    monkeypatch.setattr(llm, "_missing_binary", lambda c: None)  # #747: binary "exists"
 
     def dispatch(messages, deadline, resolved=None):
         if resolved is None:
@@ -1736,6 +1747,7 @@ def test_chat_command_primary_fallback_sets_the_flag(monkeypatch):
     monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
     monkeypatch.setattr(llm, "_resolve_fallback_command",
                         lambda: ("rescuecli", "text", "stdin"))
+    monkeypatch.setattr(llm, "_missing_binary", lambda c: None)  # #747: binary "exists"
     monkeypatch.setattr(llm, "_chat_command",
                         lambda m, deadline, resolved=None: (
                             "OK" if resolved else (_ for _ in ()).throw(llm.ChatError("x"))))
@@ -1775,6 +1787,7 @@ def test_chat_command_primary_fallback_rearms_a_drained_deadline(monkeypatch):
     monkeypatch.setattr(config, "fallback_min_seconds", lambda: 300)
     monkeypatch.setattr(llm, "_resolve_fallback_command",
                         lambda: ("rescuecli", "text", "stdin"))
+    monkeypatch.setattr(llm, "_missing_binary", lambda c: None)  # #747: binary "exists"
     seen = {}
 
     def dispatch(messages, deadline, resolved=None):
@@ -1797,6 +1810,7 @@ def test_chat_command_primary_fallback_log_keeps_the_ledger_literal(monkeypatch,
     monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
     monkeypatch.setattr(llm, "_resolve_fallback_command",
                         lambda: ("rescuecli", "text", "stdin"))
+    monkeypatch.setattr(llm, "_missing_binary", lambda c: None)  # #747: binary "exists"
     monkeypatch.setattr(llm, "_chat_command",
                         lambda m, deadline, resolved=None: (
                             "OK" if resolved else (_ for _ in ()).throw(llm.ChatError("x"))))
@@ -1814,6 +1828,7 @@ def test_chat_command_uses_the_resolved_fallback_triple(monkeypatch):
     monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
     triple = ("rescuecli --json", "json:answer", "arg")
     monkeypatch.setattr(llm, "_resolve_fallback_command", lambda: triple)
+    monkeypatch.setattr(llm, "_missing_binary", lambda c: None)  # #747: binary "exists"
     seen = {}
 
     def dispatch(messages, deadline, resolved=None):
@@ -1848,6 +1863,7 @@ def test_rescue_posture_command_backend_is_covered_with_a_fallback(monkeypatch):
     monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
     monkeypatch.setattr(llm, "_resolve_fallback_command",
                         lambda: ("rescuecli", "text", "stdin"))
+    monkeypatch.setattr(llm.shutil, "which", lambda b: f"/usr/bin/{b}")  # #747
     assert llm.rescue_posture() == "covered"
 
 
@@ -1877,6 +1893,7 @@ def test_rescue_posture_reresolves_liveness_every_call(monkeypatch):
     live = {"resolves": True}
     monkeypatch.setattr(llm, "_resolve_fallback_command",
                         lambda: ("rescuecli", "text", "stdin") if live["resolves"] else None)
+    monkeypatch.setattr(llm.shutil, "which", lambda b: f"/usr/bin/{b}")  # #747
     assert llm.rescue_posture() == "covered"
     live["resolves"] = False
     assert llm.rescue_posture() == "none"
@@ -1892,6 +1909,7 @@ def test_rescue_unparseable_routes_to_the_fallback(monkeypatch, caplog):
     monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
     monkeypatch.setattr(llm, "_resolve_fallback_command",
                         lambda: ("rescuecli", "text", "stdin"))
+    monkeypatch.setattr(llm, "_missing_binary", lambda c: None)  # #747: binary "exists"
     seen = {}
 
     def fake_command(messages, deadline, resolved=None):
@@ -1919,4 +1937,122 @@ def test_rescue_unparseable_without_a_fallback_raises_no_rescue(monkeypatch):
     llm.reset_fallback()
     with pytest.raises(llm.NoRescueAvailable):
         llm.rescue_unparseable([{"role": "user", "content": "x"}], None)
+    assert llm.fallback_used() is False
+
+
+# ---- #747: a fallback whose binary does not exist is not a rescue ----
+
+
+def test_rescue_posture_command_edge_not_covered_for_missing_fallback_binary(monkeypatch):
+    # Field case: DAIMON_LLM_COMMAND_FALLBACK=1 made the rescue binary a
+    # program named `1`; posture read "covered" for an exec that can only fail.
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND", "primarycli -x")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND_FALLBACK", "1")
+    monkeypatch.setattr(llm.shutil, "which", lambda b: None)
+    assert llm.rescue_posture() == "none"
+
+
+def test_rescue_posture_litellm_edge_not_covered_for_missing_fallback_binary(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setattr(config, "llm_api_key", lambda: "sk-key")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND_FALLBACK", "1")
+    monkeypatch.setattr(llm.shutil, "which", lambda b: None)
+    assert llm.rescue_posture() == "gap"
+
+
+def test_fallback_missing_binary_names_argv0(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND_FALLBACK", "1 --flag value")
+    monkeypatch.setattr(llm.shutil, "which", lambda b: None)
+    assert llm.fallback_missing_binary() == "1"
+
+
+def test_fallback_missing_binary_none_when_binary_exists(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND_FALLBACK", "rescuecli -p")
+    monkeypatch.setattr(llm.shutil, "which", lambda b: f"/usr/bin/{b}")
+    assert llm.fallback_missing_binary() is None
+
+
+def test_fallback_missing_binary_none_when_no_fallback_resolves(monkeypatch):
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "command")
+    monkeypatch.delenv("DAIMON_LLM_COMMAND_FALLBACK", raising=False)
+    monkeypatch.setattr(llm.shutil, "which", lambda b: None)
+    assert llm.fallback_missing_binary() is None
+
+
+# ---- #748: a failed rescue exec must not destroy the primary's diagnostic ----
+
+
+def test_rescue_exec_failure_preserves_primary_diagnostic(monkeypatch, caplog):
+    # Field case: the real error was the missing model, but the surfaced error
+    # was "command backend binary not found: 1" — the rescue's own failure
+    # overwrote the one diagnostic worth acting on. which() is pinned to say
+    # the binary exists while exec still refuses it: the advisory pre-check
+    # runs under THIS process's PATH, and the exec's view can differ — the
+    # chain is exactly for the failures the pre-check cannot see.
+    primary = "No LLM model (set DAIMON_LLM_MODEL or LITELLM_MODEL)."
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND_FALLBACK", "1")
+
+    def boom(*a, **k):
+        raise llm.ChatError(primary)
+
+    def missing(argv, stdin_text, timeout, env, cwd):
+        raise FileNotFoundError(argv[0])
+
+    monkeypatch.setattr(llm.shutil, "which", lambda b: f"/usr/bin/{b}")
+    monkeypatch.setattr(llm, "_chat_litellm", boom)
+    monkeypatch.setattr(llm, "_run_command", missing)
+    with caplog.at_level(logging.WARNING, logger="daimon_briefing.llm"):
+        with pytest.raises(llm.ChatError) as exc:
+            llm.chat([{"role": "user", "content": "x"}])
+    text = str(exc.value)
+    assert "command backend binary not found: 1" in text
+    assert primary in text
+    # The ledger literal must survive the new failure path (ledger.py counts
+    # attempts by matching it).
+    assert any(r.getMessage().startswith("llm.fallback backend=command")
+               for r in caplog.records)
+
+
+def test_rescue_empty_output_keeps_retry_class_and_primary_text(monkeypatch):
+    # EmptyOutputError is the serializer's cache-buster retry class — chaining
+    # the primary's text must not demote it to a plain ChatError.
+    primary = "gateway down"
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND_FALLBACK", "fbcli")
+    monkeypatch.setattr(llm, "_chat_litellm",
+                        lambda *a, **k: (_ for _ in ()).throw(llm.ChatError(primary)))
+    monkeypatch.setattr(llm.shutil, "which", lambda b: f"/usr/bin/{b}")
+    monkeypatch.setattr(llm, "_run_command", lambda *a, **k: (0, "", ""))
+    with pytest.raises(llm.EmptyOutputError) as exc:
+        llm.chat([{"role": "user", "content": "x"}])
+    assert primary in str(exc.value)
+
+
+def test_rescue_not_attempted_when_fallback_binary_is_missing(monkeypatch, caplog):
+    # Runtime must agree with posture (#747 reads this config as none/gap):
+    # attempting the doomed exec would log the ledger-counted attempt literal,
+    # set _fallback_used, and bury the primary's diagnostic. The primary error
+    # surfaces verbatim instead — the honest read of the field case.
+    primary = "No LLM model (set DAIMON_LLM_MODEL or LITELLM_MODEL)."
+    monkeypatch.setenv("DAIMON_LLM_BACKEND", "litellm")
+    monkeypatch.setenv("DAIMON_LLM_FALLBACK", "1")
+    monkeypatch.setenv("DAIMON_LLM_COMMAND_FALLBACK", "1")
+    monkeypatch.setattr(llm, "_chat_litellm",
+                        lambda *a, **k: (_ for _ in ()).throw(llm.ChatError(primary)))
+    monkeypatch.setattr(llm.shutil, "which", lambda b: None)
+    llm.reset_fallback()
+    with caplog.at_level(logging.WARNING, logger="daimon_briefing.llm"):
+        with pytest.raises(llm.ChatError) as exc:
+            llm.chat([{"role": "user", "content": "x"}])
+    assert str(exc.value) == primary
+    assert not any(r.getMessage().startswith("llm.fallback backend=command")
+                   for r in caplog.records)
     assert llm.fallback_used() is False

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -660,6 +660,19 @@ def test_render_configure_rich_smoke(monkeypatch, capsys):
     assert "ready" in out.lower()
 
 
+def test_render_configure_rich_carries_binary_warnings(monkeypatch, capsys):
+    # #747: the rich doctor must carry the missing-binary warnings the plain
+    # view prints — same content-only bar as the smoke test above.
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    st = _cfg_ready()
+    st["fallback_missing_binary"] = "1"
+    st["fallback_command"] = "1"
+    st["fallback_source"] = "explicit"
+    render.render_configure(st)
+    out = capsys.readouterr().out
+    assert "fallback binary not found" in out
+
+
 # --- _explain(): one-line backend explanation, all branches -----------------
 
 @pytest.mark.parametrize("st, expected", [

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -719,6 +719,36 @@ def test_explain_omits_note_for_default_stdin_input():
     assert render._explain(st) == "backend: command (devin -p)"
 
 
+# ---- #747: the doctor's missing-binary warnings name the RIGHT env knob ----
+
+
+def test_fallback_binary_warning_names_the_knob_by_source():
+    # The rescue can resolve from two different knobs: an explicit
+    # DAIMON_LLM_COMMAND_FALLBACK, or the #475 legacy shim from
+    # DAIMON_LLM_COMMAND — the fix advice must name the one actually set.
+    explicit = render._fallback_binary_warning({
+        "fallback_missing_binary": "1", "fallback_command": "1",
+        "fallback_source": "explicit"})
+    assert "DAIMON_LLM_COMMAND_FALLBACK" in explicit
+    legacy = render._fallback_binary_warning({
+        "fallback_missing_binary": "ghostcli", "fallback_command": "ghostcli -p",
+        "fallback_source": "legacy-command"})
+    assert "DAIMON_LLM_COMMAND" in legacy
+    assert "DAIMON_LLM_COMMAND_FALLBACK" not in legacy
+
+
+def test_fallback_binary_warning_none_when_nothing_is_missing():
+    assert render._fallback_binary_warning({"fallback_missing_binary": None}) is None
+
+
+def test_command_binary_warning_names_the_primary_knob():
+    warning = render._command_binary_warning({
+        "command_missing_binary": "ghostcli", "command": "ghostcli -p"})
+    assert "command binary not found: ghostcli" in warning
+    assert "DAIMON_LLM_COMMAND" in warning
+    assert render._command_binary_warning({"command_missing_binary": None}) is None
+
+
 def test_render_brief_honors_llm_briefing_when_present(monkeypatch, sample_checkpoint, capsys):
     # When DAIMON_LLM_BRIEFING is opted in, the CLI brief must surface the LLM
     # narrative (same source of truth as the hermes hook), not the deterministic text.

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -2993,6 +2993,22 @@ def test_serialize_strict_min_messages_ignores_tool_rows(
     assert chat.calls == []
 
 
+def test_conversation_message_count_excludes_tool_rows():
+    # #750: THE too-short count, shared by both capture doors — hooks.py gated
+    # on raw len() while serialize_strict counted non-tool rows (#359), so the
+    # two doors disagreed on any tool-heavy transcript.
+    msgs = make_messages(4) + [
+        {"role": "tool", "content": "ok", "id": f"t-{i}", "tool_result": True}
+        for i in range(3)
+    ]
+    assert serializer.conversation_message_count(msgs) == 4
+
+
+def test_conversation_message_count_handles_empty_and_none():
+    assert serializer.conversation_message_count([]) == 0
+    assert serializer.conversation_message_count(None) == 0
+
+
 # ---- #360: perspective-diverse escalation (heal-path only) ----
 #
 # Escalation is the heal tier for failed serializes: N extraction passes over

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -138,14 +138,18 @@ Serialize-throttle knobs for hosts that lack a clean session-end event. See
 
 Serialization needs an LLM endpoint. `daimon configure` is the intended way to
 set these. The URL, key, and model each fall back to a `LITELLM_*` variable if
-the `DAIMON_*` form is unset.
+the `DAIMON_*` form is unset. The `litellm` backend needs **both**
+`DAIMON_LLM_MODEL` and `DAIMON_LLM_API_KEY`; while either is missing,
+`daimon configure` reports `backend: litellm — missing: ...` naming exactly
+what is absent — that line means the config is incomplete, not that the
+endpoint is down.
 
 | Variable | Default | What it does |
 |---|---|---|
 | `DAIMON_LLM_BACKEND` | `auto` | Transport: `auto` (litellm if credentials exist, else a named command CLI if one resolves), `litellm`, `command`, or `claude-cli`. `claude-cli` is the zero-config option: it runs a `claude` found on PATH with a built-in preset and needs nothing else set. `command` requires `DAIMON_LLM_COMMAND`. |
 | `DAIMON_LLM_BASE_URL` | `http://localhost:4000` | OpenAI-compatible endpoint URL (trailing slash trimmed). Falls back to `LITELLM_BASE_URL`. |
-| `DAIMON_LLM_API_KEY` | unset | API key for the endpoint. Falls back to `LITELLM_API_KEY`. |
-| `DAIMON_LLM_MODEL` | unset | Model name to send. Falls back to `LITELLM_MODEL`. |
+| `DAIMON_LLM_API_KEY` | unset | API key for the endpoint. **Required for the `litellm` backend.** Falls back to `LITELLM_API_KEY`. |
+| `DAIMON_LLM_MODEL` | unset | Model name to send. **Required for the `litellm` backend.** Falls back to `LITELLM_MODEL`. |
 | `DAIMON_LLM_TEMPERATURE` | `0.0` | Sampling temperature for every chat call. `0.0` for deterministic extraction; some upstreams reject anything but a fixed value. |
 | `DAIMON_LLM_FALLBACK` | on | When the primary backend fails, auto-fall-back to the rescue command (`DAIMON_LLM_COMMAND_FALLBACK`). Applies to both a litellm and a `command` primary. Set to `0` to disable. |
 | `DAIMON_FALLBACK_MIN_SECONDS` | `DAIMON_TIMEOUT` | Minimum budget the rescue command is guaranteed on entry. The primary may have drained the shared serialize deadline retrying the very failure the rescue exists to fix, which would kill the rescue on arrival; a healthy remaining budget is never shrunk. |

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
@@ -149,14 +149,18 @@ de sesión. Mira [Hosts](../hosts/) para la configuración por host.
 
 La serialización necesita un endpoint de LLM. `daimon configure` es la vía
 prevista para definir estas variables. La URL, la key y el modelo caen cada
-uno a una variable `LITELLM_*` si la forma `DAIMON_*` no está definida.
+uno a una variable `LITELLM_*` si la forma `DAIMON_*` no está definida. El
+backend `litellm` necesita **ambas** `DAIMON_LLM_MODEL` y
+`DAIMON_LLM_API_KEY`; mientras falte alguna, `daimon configure` reporta
+`backend: litellm — missing: ...` nombrando exactamente qué falta — esa línea
+significa que la configuración está incompleta, no que el endpoint esté caído.
 
 | Variable | Default | Qué hace |
 |---|---|---|
 | `DAIMON_LLM_BACKEND` | `auto` | Transporte: `auto` (litellm si hay credenciales, si no un CLI de comando **nombrado** si alguno resuelve), `litellm`, `command` o `claude-cli`. `claude-cli` es la opción sin configuración: ejecuta un `claude` encontrado en el PATH con un preset incorporado y no necesita nada más. `command` requiere `DAIMON_LLM_COMMAND`. |
 | `DAIMON_LLM_BASE_URL` | `http://localhost:4000` | URL del endpoint compatible con OpenAI (se recorta la barra final). Cae a `LITELLM_BASE_URL`. |
-| `DAIMON_LLM_API_KEY` | sin definir | API key del endpoint. Cae a `LITELLM_API_KEY`. |
-| `DAIMON_LLM_MODEL` | sin definir | Nombre de modelo a enviar. Cae a `LITELLM_MODEL`. |
+| `DAIMON_LLM_API_KEY` | sin definir | API key del endpoint. **Obligatoria para el backend `litellm`.** Cae a `LITELLM_API_KEY`. |
+| `DAIMON_LLM_MODEL` | sin definir | Nombre de modelo a enviar. **Obligatorio para el backend `litellm`.** Cae a `LITELLM_MODEL`. |
 | `DAIMON_LLM_TEMPERATURE` | `0.0` | Temperatura de muestreo de cada llamada de chat. `0.0` para extracción determinista; algunos upstreams rechazan cualquier valor que no sea uno fijo. |
 | `DAIMON_LLM_FALLBACK` | on | Cuando el backend primario falla, cae automáticamente al comando de rescate (`DAIMON_LLM_COMMAND_FALLBACK`). Aplica tanto a un primario litellm como a uno `command`. Ponlo en `0` para desactivarlo. |
 | `DAIMON_FALLBACK_MIN_SECONDS` | `DAIMON_TIMEOUT` | Presupuesto mínimo garantizado al comando de rescate al entrar. El primario pudo haber agotado el deadline compartido reintentando la misma falla que el rescate existe para resolver, lo que lo mataría al llegar; un presupuesto restante sano nunca se recorta. |


### PR DESCRIPTION
Closes #747
Closes #748
Closes #749
Closes #750
Closes #751

## What

Five fixes for one failure class: a misconfigured install reading as healthy.

- `rescue_posture()` no longer reports "covered" for a fallback whose binary does not exist; resolution and existence are now separate questions, answered by the same `shlex.split` argv the exec uses (#747). The configure doctor names the missing binary, for the rescue and now also for a primary `command` backend (review depth finding; `ready` semantics unchanged).
- `_rescue()` refuses to attempt a fallback whose binary is missing and re-raises the primary error verbatim; when a rescue with an existing binary does run and fails, the raised error chains both reasons ("rescue failed: ...; primary: ..."), exception text only, type preserved so the retry classification survives (#748). The ledger's starved classifier no longer matches the primary clause of a chained line, so a rescue that ran and failed cannot land in the starved bucket.
- The non-interactive `configure` write path stops failing silently four ways (#749): a flag write that lands not-ready returns 1 with an explicit line; `--test` combined with write or wizard flags returns 2 instead of testing the old config; flags the chosen backend does not consume warn by name; value flags without `--backend` error instead of vanishing through the doctor branch. The fallback-binary warning names the env var that is actually set (`DAIMON_LLM_COMMAND` when the rescue comes from the legacy shim).
- The too-short gate counts the same thing on both capture doors: the in-process hook door now uses the serializer's non-tool count and records its skip in the ledger the way the CLI door does (#750). A transcript parsing to zero messages gets no skip record; per scar 0045 that is a parse failure, never a short session.
- Docs mark `DAIMON_LLM_MODEL` and `DAIMON_LLM_API_KEY` as required for the litellm backend and show the doctor's `missing:` line, in both locales (#751).

## Why

A field install ran for days with no model configured and a rescue binary that could not exist, and every surface said fine: configure exited 0, posture read "covered", the surfaced error named a phantom binary instead of the real one-line fix, and short-session skips never reached the ledger. Each fix moves one silent state to a loud one without changing any healthy path.

## Tests

`uv run --extra dev pytest -q` in `plugin/`: 4169 passed, 2 skipped (both pre-existing). 30+ new tests, one per behavior change, each confirmed failing before its fix (TDD). An adversarial review pass ran between the first implementation round and this final state; its confirmed findings (scar-0045 regression in the hook-door skip, starved-classifier miscount on chained errors, posture/runtime disagreement on a missing-binary fallback, two further silent-drop doors in configure) are fixed and tested here. Pre-existing rescue-flow tests that faked fallback binaries now pin the existence seam explicitly, preserving their original intent. `ruff check` clean.
