### PR TITLE
chore(research): record the ungated-arm replay and size the README verifiability trade

### DIFF
--- a/.scars/candidates/bench-cache-legacy-entries-are-dead.md
+++ b/.scars/candidates/bench-cache-legacy-entries-are-dead.md
@@ -1,0 +1,32 @@
+---
+id: 0
+type: deadend
+title: benchmark/.cache warm-looking legacy entries are unreplayable; offline replays must use .work stores
+severity: medium
+confidence: 0.9
+created: 2026-08-26
+authors: ["claude-code"]
+anchors:
+  - path: plugin/tests/bench/cache.py
+  - pattern: "cache\.get|CheckpointCache"
+evidence:
+  - note: "2026-08-26 ungated-arm replay: 7521 of 7723 entries in benchmark/.cache are pre-#343 raw checkpoints (no envelope); cache.get counts every one as legacy_misses and returns None"
+expires:
+  condition: "the .cache is re-warmed with #343 envelope entries (each carries served_model), or the legacy entries are purged"
+  review_after: 2027-02-26
+status: candidate
+---
+
+Tried to build a zero-LLM benchmark replay on top of the serialized-checkpoint
+cache: 7723 entries, 42MB, looks fully warm. Dead end. 7521 of them are
+pre-#343 raw checkpoint dicts with no `{"served_model": ..., "checkpoint": ...}`
+envelope, and `cache.get` refuses those by design (the #343 poison guard:
+unattributable producer, `legacy_misses`). The remaining 202 envelopes carry
+`served_model: null` (command backend), replayable only into a receiptless run.
+So a "cache-only" run with the current harness re-pays the LLM call for nearly
+every session — exactly what an offline replay must not do. Do not weaken the
+guard to admit legacy entries; it exists because a gateway silently substituted
+models mid-run (scar 0032 territory). The working substrate for offline replay
+is `benchmark/.work/<qid>/` (written checkpoints + recall.db from completed
+runs): copy the store, rebuild the index, run `recall.search` against the copy.
+Proven 2026-08-26: reproduced interim-317-baseline-first54.json exactly.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -26,6 +26,14 @@ This is the part that matters more than any single figure:
   verifiability (provenance, trust tags, quote-checking). The honest framing
   publishes both the recall number and that trade — including the efficiency
   story (`avg_injected_tokens`), which is what the recall buys you at answer time.
+  Measured (`research/experiments/ungated-arm/`, replayed over the frozen
+  interim-54 stores): the trust gate's downgrades cost **zero** raw recall on
+  this instrument — reverting all 726 downgraded labels (2.9% of indexed items)
+  leaves every ranking identical, because downgrades rewrite trust labels, not
+  the indexed text. The trade is paid in metadata honesty, not recall; what
+  recall gap remains is ranking and content selection on accepted sessions.
+  Unmeasured there, stated plainly: whether a lenient serializer would accept
+  or phrase sessions differently (that arm needs LLM runs).
 
 ## What is measured
 

--- a/research/experiments/ungated-arm/measurements.json
+++ b/research/experiments/ungated-arm/measurements.json
@@ -1,0 +1,1897 @@
+{
+ "issue": 754,
+ "summary": {
+  "questions": 54,
+  "scored": 52,
+  "rank_identical": 54,
+  "flipped_items": 726,
+  "gated_recall_at_5": 0.581,
+  "ungated_recall_at_5": 0.581,
+  "questions_with_metric_delta": 0
+ },
+ "per_question": [
+  {
+   "question_id": "e47becba",
+   "question_type": "single-session-user",
+   "abstention": false,
+   "n_sessions": 53,
+   "accounting": {
+    "indexed": 53,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_280352e9": "indexed_unretrieved"
+   },
+   "gated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.0,
+    "first_gold_rank": null
+   },
+   "ungated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.0,
+    "first_gold_rank": null
+   },
+   "n_flipped_items": 7,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.0
+   }
+  },
+  {
+   "question_id": "6f9b354f",
+   "question_type": "single-session-user",
+   "abstention": false,
+   "n_sessions": 50,
+   "accounting": {
+    "indexed": 50,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_feb5200f": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 51,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "66f24dbb",
+   "question_type": "single-session-user",
+   "abstention": false,
+   "n_sessions": 50,
+   "accounting": {
+    "indexed": 50,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_fea2e4d3": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 16,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "dccbc061",
+   "question_type": "single-session-user",
+   "abstention": false,
+   "n_sessions": 49,
+   "accounting": {
+    "indexed": 49,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_8f276838": "indexed_unretrieved"
+   },
+   "gated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.0,
+    "first_gold_rank": null
+   },
+   "ungated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.0,
+    "first_gold_rank": null
+   },
+   "n_flipped_items": 6,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.0
+   }
+  },
+  {
+   "question_id": "c8c3f81d",
+   "question_type": "single-session-user",
+   "abstention": false,
+   "n_sessions": 52,
+   "accounting": {
+    "indexed": 50,
+    "too_short": 2,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_761acef8": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 5,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "d52b4f67",
+   "question_type": "single-session-user",
+   "abstention": false,
+   "n_sessions": 52,
+   "accounting": {
+    "indexed": 50,
+    "too_short": 2,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_0df6aa4b": "indexed_deep"
+   },
+   "gated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.08333333333333333,
+    "first_gold_rank": 12
+   },
+   "ungated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.08333333333333333,
+    "first_gold_rank": 12
+   },
+   "n_flipped_items": 39,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.08333333333333333
+   }
+  },
+  {
+   "question_id": "25e5aa4f",
+   "question_type": "single-session-user",
+   "abstention": false,
+   "n_sessions": 45,
+   "accounting": {
+    "indexed": 45,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_986de8c3": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 38,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "60d45044",
+   "question_type": "single-session-user",
+   "abstention": false,
+   "n_sessions": 51,
+   "accounting": {
+    "indexed": 51,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_9cddca88": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 0.5,
+    "first_gold_rank": 2
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 0.5,
+    "first_gold_rank": 2
+   },
+   "n_flipped_items": 8,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 0.5
+   }
+  },
+  {
+   "question_id": "86b68151",
+   "question_type": "single-session-user",
+   "abstention": false,
+   "n_sessions": 47,
+   "accounting": {
+    "indexed": 47,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_dc11c1eb": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 4,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "e01b8e2f",
+   "question_type": "single-session-user",
+   "abstention": false,
+   "n_sessions": 53,
+   "accounting": {
+    "indexed": 53,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_5ca6cd28": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 20,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "b320f3f8",
+   "question_type": "single-session-user",
+   "abstention": false,
+   "n_sessions": 46,
+   "accounting": {
+    "indexed": 46,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_5cc9b056": "indexed_unretrieved"
+   },
+   "gated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.0,
+    "first_gold_rank": null
+   },
+   "ungated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.0,
+    "first_gold_rank": null
+   },
+   "n_flipped_items": 11,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.0
+   }
+  },
+  {
+   "question_id": "19b5f2b3",
+   "question_type": "single-session-user",
+   "abstention": false,
+   "n_sessions": 43,
+   "accounting": {
+    "indexed": 43,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_5ff494b9": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 0.5,
+    "first_gold_rank": 2
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 0.5,
+    "first_gold_rank": 2
+   },
+   "n_flipped_items": 6,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 0.5
+   }
+  },
+  {
+   "question_id": "4fd1909e",
+   "question_type": "single-session-user",
+   "abstention": false,
+   "n_sessions": 55,
+   "accounting": {
+    "indexed": 55,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_2952aee4": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 17,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "545bd2b5",
+   "question_type": "single-session-user",
+   "abstention": false,
+   "n_sessions": 44,
+   "accounting": {
+    "indexed": 44,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_47ffab4c": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 7,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "76d63226",
+   "question_type": "single-session-user",
+   "abstention": false,
+   "n_sessions": 48,
+   "accounting": {
+    "indexed": 47,
+    "too_short": 0,
+    "missing": 1
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_bbdc7b0a": "indexed_deep"
+   },
+   "gated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.041666666666666664,
+    "first_gold_rank": 24
+   },
+   "ungated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.041666666666666664,
+    "first_gold_rank": 24
+   },
+   "n_flipped_items": 8,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.041666666666666664
+   }
+  },
+  {
+   "question_id": "86f00804",
+   "question_type": "single-session-user",
+   "abstention": false,
+   "n_sessions": 43,
+   "accounting": {
+    "indexed": 43,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_96b8c9ee": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 7,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "4100d0a0",
+   "question_type": "single-session-user",
+   "abstention": false,
+   "n_sessions": 50,
+   "accounting": {
+    "indexed": 50,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_83c13ff9": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 12,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "a82c026e",
+   "question_type": "single-session-user",
+   "abstention": false,
+   "n_sessions": 47,
+   "accounting": {
+    "indexed": 47,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_787e6a6d": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 0.3333333333333333,
+    "first_gold_rank": 3
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 0.3333333333333333,
+    "first_gold_rank": 3
+   },
+   "n_flipped_items": 9,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 0.3333333333333333
+   }
+  },
+  {
+   "question_id": "bc8a6e93_abs",
+   "question_type": "single-session-user",
+   "abstention": true,
+   "n_sessions": 47,
+   "accounting": {
+    "indexed": 47,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_e6143162_abs": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 12,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "6d550036",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 47,
+   "accounting": {
+    "indexed": 47,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 4,
+   "gold_states": {
+    "answer_ec904b3c_4": "indexed_unretrieved",
+    "answer_ec904b3c_1": "indexed_deep",
+    "answer_ec904b3c_2": "indexed_unretrieved",
+    "answer_ec904b3c_3": "indexed_unretrieved"
+   },
+   "gated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.037037037037037035,
+    "first_gold_rank": 27
+   },
+   "ungated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.037037037037037035,
+    "first_gold_rank": 27
+   },
+   "n_flipped_items": 31,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.037037037037037035
+   }
+  },
+  {
+   "question_id": "gpt4_59c863d7",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 47,
+   "accounting": {
+    "indexed": 47,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 4,
+   "gold_states": {
+    "answer_593bdffd_3": "indexed_unretrieved",
+    "answer_593bdffd_1": "indexed_deep",
+    "answer_593bdffd_4": "hit_top5",
+    "answer_593bdffd_2": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 0.5,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 0.5,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 15,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.5,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "3a704032",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 48,
+   "accounting": {
+    "indexed": 47,
+    "too_short": 1,
+    "missing": 0
+   },
+   "n_gold": 3,
+   "gold_states": {
+    "answer_c2204106_2": "hit_top5",
+    "answer_c2204106_3": "hit_top5",
+    "answer_c2204106_1": "indexed_deep"
+   },
+   "gated": {
+    "recall_at_5": 0.6666666666666666,
+    "hit_at_5": true,
+    "mrr": 0.5,
+    "first_gold_rank": 2
+   },
+   "ungated": {
+    "recall_at_5": 0.6666666666666666,
+    "hit_at_5": true,
+    "mrr": 0.5,
+    "first_gold_rank": 2
+   },
+   "n_flipped_items": 7,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.6666666666666666,
+    "hit_at_5": true,
+    "mrr": 0.5
+   }
+  },
+  {
+   "question_id": "gpt4_d84a3211",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 48,
+   "accounting": {
+    "indexed": 48,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 4,
+   "gold_states": {
+    "answer_2880eb6c_3": "indexed_unretrieved",
+    "answer_2880eb6c_2": "hit_top5",
+    "answer_2880eb6c_1": "indexed_deep",
+    "answer_2880eb6c_4": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 0.5,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 0.5,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 10,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.5,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "7024f17c",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 47,
+   "accounting": {
+    "indexed": 47,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 3,
+   "gold_states": {
+    "answer_a21f3697_3": "hit_top5",
+    "answer_a21f3697_2": "indexed_deep",
+    "answer_a21f3697_1": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 0.6666666666666666,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 0.6666666666666666,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 20,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.6666666666666666,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "gpt4_5501fe77",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 45,
+   "accounting": {
+    "indexed": 45,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 3,
+   "gold_states": {
+    "answer_203bf3fa_1": "hit_top5",
+    "answer_203bf3fa_3": "hit_top5",
+    "answer_203bf3fa_2": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 5,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "gpt4_2ba83207",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 53,
+   "accounting": {
+    "indexed": 53,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 4,
+   "gold_states": {
+    "answer_6a3b5c13_3": "indexed_deep",
+    "answer_6a3b5c13_4": "indexed_deep",
+    "answer_6a3b5c13_1": "indexed_unretrieved",
+    "answer_6a3b5c13_2": "indexed_deep"
+   },
+   "gated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.16666666666666666,
+    "first_gold_rank": 6
+   },
+   "ungated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.16666666666666666,
+    "first_gold_rank": 6
+   },
+   "n_flipped_items": 8,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.16666666666666666
+   }
+  },
+  {
+   "question_id": "2318644b",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 41,
+   "accounting": {
+    "indexed": 41,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 2,
+   "gold_states": {
+    "answer_eaa8e3ef_1": "hit_top5",
+    "answer_eaa8e3ef_2": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 18,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "2788b940",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 47,
+   "accounting": {
+    "indexed": 47,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 4,
+   "gold_states": {
+    "answer_8f6b938d_3": "indexed_deep",
+    "answer_8f6b938d_2": "hit_top5",
+    "answer_8f6b938d_4": "hit_top5",
+    "answer_8f6b938d_1": "indexed_deep"
+   },
+   "gated": {
+    "recall_at_5": 0.5,
+    "hit_at_5": true,
+    "mrr": 0.5,
+    "first_gold_rank": 2
+   },
+   "ungated": {
+    "recall_at_5": 0.5,
+    "hit_at_5": true,
+    "mrr": 0.5,
+    "first_gold_rank": 2
+   },
+   "n_flipped_items": 14,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.5,
+    "hit_at_5": true,
+    "mrr": 0.5
+   }
+  },
+  {
+   "question_id": "a9f6b44c",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 45,
+   "accounting": {
+    "indexed": 45,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 3,
+   "gold_states": {
+    "answer_cc021f81_3": "indexed_deep",
+    "answer_cc021f81_1": "indexed_unretrieved",
+    "answer_cc021f81_2": "indexed_unretrieved"
+   },
+   "gated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.08333333333333333,
+    "first_gold_rank": 12
+   },
+   "ungated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.08333333333333333,
+    "first_gold_rank": 12
+   },
+   "n_flipped_items": 22,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.08333333333333333
+   }
+  },
+  {
+   "question_id": "d851d5ba",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 46,
+   "accounting": {
+    "indexed": 46,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 4,
+   "gold_states": {
+    "answer_5cdf9bd2_1": "hit_top5",
+    "answer_5cdf9bd2_3": "hit_top5",
+    "answer_5cdf9bd2_2": "hit_top5",
+    "answer_5cdf9bd2_4": "indexed_deep"
+   },
+   "gated": {
+    "recall_at_5": 0.75,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 0.75,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 5,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.75,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "gpt4_ab202e7f",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 46,
+   "accounting": {
+    "indexed": 46,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 5,
+   "gold_states": {
+    "answer_728deb4d_3": "indexed_deep",
+    "answer_728deb4d_4": "hit_top5",
+    "answer_728deb4d_1": "indexed_deep",
+    "answer_728deb4d_5": "indexed_unretrieved",
+    "answer_728deb4d_2": "indexed_deep"
+   },
+   "gated": {
+    "recall_at_5": 0.2,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 0.2,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 10,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.2,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "1a8a66a6",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 51,
+   "accounting": {
+    "indexed": 51,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 4,
+   "gold_states": {
+    "answer_2bd23659_4": "indexed_deep",
+    "answer_2bd23659_1": "hit_top5",
+    "answer_2bd23659_2": "indexed_unretrieved",
+    "answer_2bd23659_3": "indexed_deep"
+   },
+   "gated": {
+    "recall_at_5": 0.25,
+    "hit_at_5": true,
+    "mrr": 0.5,
+    "first_gold_rank": 2
+   },
+   "ungated": {
+    "recall_at_5": 0.25,
+    "hit_at_5": true,
+    "mrr": 0.5,
+    "first_gold_rank": 2
+   },
+   "n_flipped_items": 4,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.25,
+    "hit_at_5": true,
+    "mrr": 0.5
+   }
+  },
+  {
+   "question_id": "bf659f65",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 52,
+   "accounting": {
+    "indexed": 52,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 3,
+   "gold_states": {
+    "answer_7726e7e9_3": "indexed_deep",
+    "answer_7726e7e9_2": "hit_top5",
+    "answer_7726e7e9_1": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 0.6666666666666666,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 0.6666666666666666,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 25,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.6666666666666666,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "gpt4_372c3eed",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 45,
+   "accounting": {
+    "indexed": 45,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 3,
+   "gold_states": {
+    "answer_35c5419d_1": "indexed_unretrieved",
+    "answer_35c5419d_2": "indexed_unretrieved",
+    "answer_35c5419d_3": "indexed_deep"
+   },
+   "gated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.14285714285714285,
+    "first_gold_rank": 7
+   },
+   "ungated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.14285714285714285,
+    "first_gold_rank": 7
+   },
+   "n_flipped_items": 40,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.14285714285714285
+   }
+  },
+  {
+   "question_id": "gpt4_2f91af09",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 53,
+   "accounting": {
+    "indexed": 53,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 3,
+   "gold_states": {
+    "answer_669318cf_1": "hit_top5",
+    "answer_669318cf_3": "hit_top5",
+    "answer_669318cf_2": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 55,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "eeda8a6d_abs",
+   "question_type": "multi-session",
+   "abstention": true,
+   "n_sessions": 49,
+   "accounting": {
+    "indexed": 49,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 2,
+   "gold_states": {
+    "answer_3e5fea0e_abs_1": "hit_top5",
+    "answer_3e5fea0e_abs_2": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 10,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "8a2466db",
+   "question_type": "single-session-preference",
+   "abstention": false,
+   "n_sessions": 50,
+   "accounting": {
+    "indexed": 50,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_edb03329": "indexed_deep"
+   },
+   "gated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.1111111111111111,
+    "first_gold_rank": 9
+   },
+   "ungated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.1111111111111111,
+    "first_gold_rank": 9
+   },
+   "n_flipped_items": 7,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.1111111111111111
+   }
+  },
+  {
+   "question_id": "06878be2",
+   "question_type": "single-session-preference",
+   "abstention": false,
+   "n_sessions": 48,
+   "accounting": {
+    "indexed": 47,
+    "too_short": 1,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_555dfb94": "indexed_deep"
+   },
+   "gated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.09090909090909091,
+    "first_gold_rank": 11
+   },
+   "ungated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.09090909090909091,
+    "first_gold_rank": 11
+   },
+   "n_flipped_items": 10,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.09090909090909091
+   }
+  },
+  {
+   "question_id": "caf03d32",
+   "question_type": "single-session-preference",
+   "abstention": false,
+   "n_sessions": 51,
+   "accounting": {
+    "indexed": 51,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_2fc6aabb": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 11,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "54026fce",
+   "question_type": "single-session-preference",
+   "abstention": false,
+   "n_sessions": 49,
+   "accounting": {
+    "indexed": 49,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_f7b22c66": "indexed_unretrieved"
+   },
+   "gated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.0,
+    "first_gold_rank": null
+   },
+   "ungated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.0,
+    "first_gold_rank": null
+   },
+   "n_flipped_items": 8,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.0
+   }
+  },
+  {
+   "question_id": "1a1907b4",
+   "question_type": "single-session-preference",
+   "abstention": false,
+   "n_sessions": 48,
+   "accounting": {
+    "indexed": 48,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_719502eb": "indexed_deep"
+   },
+   "gated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.07692307692307693,
+    "first_gold_rank": 13
+   },
+   "ungated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.07692307692307693,
+    "first_gold_rank": 13
+   },
+   "n_flipped_items": 8,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.07692307692307693
+   }
+  },
+  {
+   "question_id": "d24813b1",
+   "question_type": "single-session-preference",
+   "abstention": false,
+   "n_sessions": 44,
+   "accounting": {
+    "indexed": 43,
+    "too_short": 1,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_7c0ade93": "indexed_deep"
+   },
+   "gated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.07142857142857142,
+    "first_gold_rank": 14
+   },
+   "ungated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.07142857142857142,
+    "first_gold_rank": 14
+   },
+   "n_flipped_items": 6,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.07142857142857142
+   }
+  },
+  {
+   "question_id": "57f827a0",
+   "question_type": "single-session-preference",
+   "abstention": false,
+   "n_sessions": 51,
+   "accounting": {
+    "indexed": 51,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_1bde8d3b": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 0.2,
+    "first_gold_rank": 5
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 0.2,
+    "first_gold_rank": 5
+   },
+   "n_flipped_items": 11,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 0.2
+   }
+  },
+  {
+   "question_id": "95228167",
+   "question_type": "single-session-preference",
+   "abstention": false,
+   "n_sessions": 49,
+   "accounting": {
+    "indexed": 49,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_5e613445": "indexed_deep"
+   },
+   "gated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.05263157894736842,
+    "first_gold_rank": 19
+   },
+   "ungated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.05263157894736842,
+    "first_gold_rank": 19
+   },
+   "n_flipped_items": 4,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.05263157894736842
+   }
+  },
+  {
+   "question_id": "fca70973",
+   "question_type": "single-session-preference",
+   "abstention": false,
+   "n_sessions": 45,
+   "accounting": {
+    "indexed": 44,
+    "too_short": 0,
+    "missing": 1
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_a1e169b1": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 11,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "b6025781",
+   "question_type": "single-session-preference",
+   "abstention": false,
+   "n_sessions": 47,
+   "accounting": {
+    "indexed": 46,
+    "too_short": 0,
+    "missing": 1
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_8414cc57": "indexed_unretrieved"
+   },
+   "gated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.0,
+    "first_gold_rank": null
+   },
+   "ungated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.0,
+    "first_gold_rank": null
+   },
+   "n_flipped_items": 8,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.0
+   }
+  },
+  {
+   "question_id": "1d4e3b97",
+   "question_type": "single-session-preference",
+   "abstention": false,
+   "n_sessions": 45,
+   "accounting": {
+    "indexed": 45,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_e6b6353d": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 0.3333333333333333,
+    "first_gold_rank": 3
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 0.3333333333333333,
+    "first_gold_rank": 3
+   },
+   "n_flipped_items": 8,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 0.3333333333333333
+   }
+  },
+  {
+   "question_id": "0a34ad58",
+   "question_type": "single-session-preference",
+   "abstention": false,
+   "n_sessions": 42,
+   "accounting": {
+    "indexed": 42,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 1,
+   "gold_states": {
+    "answer_cebb7159": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 0.25,
+    "first_gold_rank": 4
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 0.25,
+    "first_gold_rank": 4
+   },
+   "n_flipped_items": 2,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 0.25
+   }
+  },
+  {
+   "question_id": "d3ab962e",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 49,
+   "accounting": {
+    "indexed": 48,
+    "too_short": 1,
+    "missing": 0
+   },
+   "n_gold": 2,
+   "gold_states": {
+    "answer_5237bb0b_1": "indexed_deep",
+    "answer_5237bb0b_2": "indexed_deep"
+   },
+   "gated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.1,
+    "first_gold_rank": 10
+   },
+   "ungated": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.1,
+    "first_gold_rank": 10
+   },
+   "n_flipped_items": 2,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.0,
+    "hit_at_5": false,
+    "mrr": 0.1
+   }
+  },
+  {
+   "question_id": "2311e44b",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 50,
+   "accounting": {
+    "indexed": 50,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 2,
+   "gold_states": {
+    "answer_bf633415_2": "hit_top5",
+    "answer_bf633415_1": "indexed_deep"
+   },
+   "gated": {
+    "recall_at_5": 0.5,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 0.5,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 9,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 0.5,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "4f54b7c9",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 45,
+   "accounting": {
+    "indexed": 45,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 2,
+   "gold_states": {
+    "answer_50940cb7_2": "hit_top5",
+    "answer_50940cb7_1": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 13,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "1f2b8d4f",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 51,
+   "accounting": {
+    "indexed": 51,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 2,
+   "gold_states": {
+    "answer_d8454588_1": "hit_top5",
+    "answer_d8454588_2": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 11,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "e6041065",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 45,
+   "accounting": {
+    "indexed": 44,
+    "too_short": 1,
+    "missing": 0
+   },
+   "n_gold": 2,
+   "gold_states": {
+    "answer_4eb6d671_1": "hit_top5",
+    "answer_4eb6d671_2": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 2,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  },
+  {
+   "question_id": "4adc0475",
+   "question_type": "multi-session",
+   "abstention": false,
+   "n_sessions": 45,
+   "accounting": {
+    "indexed": 45,
+    "too_short": 0,
+    "missing": 0
+   },
+   "n_gold": 2,
+   "gold_states": {
+    "answer_6efce493_2": "hit_top5",
+    "answer_6efce493_1": "hit_top5"
+   },
+   "gated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "ungated": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0,
+    "first_gold_rank": 1
+   },
+   "n_flipped_items": 13,
+   "rank_identical": true,
+   "ref": {
+    "recall_at_5": 1.0,
+    "hit_at_5": true,
+    "mrr": 1.0
+   }
+  }
+ ]
+}

--- a/research/experiments/ungated-arm/replay.py
+++ b/research/experiments/ungated-arm/replay.py
@@ -1,0 +1,258 @@
+"""Ungated-arm replay (#754): measure the trust gate's retrieval cost.
+
+The benchmark README asserts that daimon "trades some raw recall for
+verifiability". This runner measures that trade with zero LLM calls by
+replaying the frozen per-question stores a completed bench run leaves under
+`benchmark/.work/` (the stores behind a committed `results/*.json` file):
+
+  gated arm    rebuild the recall index from each store's checkpoints as
+               written, run `recall.search`, score with the bench metrics
+  ungated arm  in a copy of the store, revert every trust-gate downgrade
+               (see `should_flip`), rebuild, re-run the same searches
+
+Registered prediction (frozen in #754 before the run): identical rankings,
+because `verify_quotes` / `ground_outcomes` only rewrite labels — `text` and
+`quote`, the only fields FTS5 indexes, survive a downgrade untouched — and
+`search()` does not rank on trust.
+
+Copy-on-read: the `.work` originals are never written; both arms run against
+copies (current `recall._ensure_fresh` rebuilds any index it is pointed at).
+Run from the repo root:
+
+  cd plugin && uv run python ../research/experiments/ungated-arm/replay.py
+
+Requires a completed bench run's `.work` stores for every question in the
+reference results file; sessions are never re-serialized (no LLM).
+"""
+
+import json
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+REPO = _HERE.parents[3]
+PLUGIN = REPO / "plugin"
+sys.path.insert(0, str(PLUGIN))
+
+from daimon_briefing import recall, serializer  # noqa: E402
+from tests.bench import dataset, metrics  # noqa: E402
+
+WORK = REPO / "benchmark" / ".work"
+DATA = REPO / "benchmark" / ".data" / dataset.DATASET_FILENAME
+REFERENCE = REPO / "benchmark" / "results" / "interim-317-baseline-first54.json"
+OUT = _HERE.parent / "measurements.json"
+K = 5
+DEPTH = 50
+MIN_MESSAGES = 2  # the reference run's bench floor
+
+_ENV_KEYS = (
+    "DAIMON_CHECKPOINT_DIR", "DAIMON_RECALL_DB", "DAIMON_LOG_DIR",
+    "DAIMON_RECALL_SEEN_DIR", "DAIMON_TEAM_DIR", "DAIMON_PROJECT_DIR",
+    "DAIMON_CARRY", "DAIMON_MIN_MESSAGES", "DAIMON_TEAM", "DAIMON_DISABLE",
+    "DAIMON_RECEIPTS", "DAIMON_SCAR_HARVEST", "DAIMON_SCENE_TRACES",
+)
+
+
+def _env_for(home: Path) -> dict:
+    return {
+        "DAIMON_CHECKPOINT_DIR": str(home / "checkpoints"),
+        "DAIMON_RECALL_DB": str(home / "recall.db"),
+        "DAIMON_LOG_DIR": str(home / "logs"),
+        "DAIMON_RECALL_SEEN_DIR": str(home / "recall_seen"),
+        "DAIMON_TEAM_DIR": str(home / "team"),
+        "DAIMON_PROJECT_DIR": str(home / "project"),
+        "DAIMON_CARRY": "0",
+        "DAIMON_MIN_MESSAGES": str(MIN_MESSAGES),
+        "DAIMON_TEAM": "0",
+        "DAIMON_DISABLE": "0",
+        "DAIMON_RECEIPTS": "0",
+        "DAIMON_SCAR_HARVEST": "0",
+        "DAIMON_SCENE_TRACES": "0",
+    }
+
+
+class _Env:
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    def __enter__(self):
+        self.saved = {k: os.environ.get(k) for k in _ENV_KEYS}
+        for k in _ENV_KEYS:
+            os.environ.pop(k, None)
+        os.environ.update(self.mapping)
+
+    def __exit__(self, *a):
+        for k, v in self.saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def should_flip(item: dict) -> bool:
+    """True when the trust gate downgraded this item from verbatim.
+
+    Both downgrade paths leave a code-owned marker no model output carries
+    into a fresh item: `verify_quotes` stamps `quote_verified: false`,
+    `ground_outcomes` stamps `grounded: false` (and only ever on items that
+    WERE trust=verbatim). Natively-inferred items carry neither marker.
+    """
+    if item.get("trust") != "inferred":
+        return False
+    return item.get("quote_verified") is False or item.get("grounded") is False
+
+
+def flip_downgrades(home: Path) -> int:
+    """Revert trust-gate downgrades in every checkpoint file. Returns flips."""
+    flipped = 0
+    for p in (home / "checkpoints").rglob("*.json"):
+        try:
+            cp = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(cp, dict):
+            continue
+        changed = False
+        for item in serializer.iter_items(cp):
+            if should_flip(item):
+                item["trust"] = "verbatim"
+                flipped += 1
+                changed = True
+        if changed:
+            p.write_text(json.dumps(cp, ensure_ascii=False), encoding="utf-8")
+    db = home / "recall.db"
+    if db.exists():
+        db.unlink()
+    return flipped
+
+
+def indexed_sessions(db_path: Path) -> set:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return {r[0] for r in
+                conn.execute("SELECT DISTINCT session_id FROM items")}
+    finally:
+        conn.close()
+
+
+def replay_store(home: Path, question: dict) -> dict:
+    with _Env(_env_for(home)):
+        recall.rebuild()
+        idx = indexed_sessions(home / "recall.db")
+        results = recall.search(question["question"], all_projects=True,
+                                limit=DEPTH)
+    ranked = metrics.attributed_sessions(results, {})
+    gold = dataset.gold_sessions(question)
+    first_gold_rank = next(
+        (i + 1 for i, sid in enumerate(ranked) if sid in gold), None)
+    return {
+        "indexed": idx,
+        "ranked": ranked,
+        "recall_at_5": metrics.recall_at_k(ranked, gold, K),
+        "hit_at_5": metrics.hit_at_k(ranked, gold, K),
+        "mrr": metrics.reciprocal_rank(ranked, gold),
+        "first_gold_rank": first_gold_rank,
+    }
+
+
+def classify_gold(sid, ranked, gold_state):
+    """One gold session's fate under an arm's ranking."""
+    if sid in ranked[:K]:
+        return "hit_top5"
+    if sid in ranked:
+        return "indexed_deep"
+    if gold_state == "indexed":
+        return "indexed_unretrieved"
+    if gold_state == "too_short":
+        return "absent_too_short"
+    return "absent_missing"
+
+
+def main():
+    questions = {q["question_id"]: q for q in dataset.load(DATA)}
+    ref = {q["question_id"]: q
+           for q in json.load(open(REFERENCE))["per_question"]}
+
+    scratch = Path(tempfile.mkdtemp(prefix="ungated-arm-"))
+    rows = []
+    for n, qid in enumerate(ref, 1):
+        q = questions[qid]
+        src = WORK / qid
+        if not src.is_dir():
+            raise SystemExit(f"{qid}: no .work store; run the bench first")
+        gated_home = scratch / qid / "gated"
+        flip_home = scratch / qid / "ungated"
+        for dst in (gated_home, flip_home):
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(src, dst)
+
+        sessions = dataset.sessions_of(q)
+        gold = dataset.gold_sessions(q)
+
+        gated = replay_store(gated_home, q)
+        n_flips = flip_downgrades(flip_home)
+        ungated = replay_store(flip_home, q)
+
+        idx = gated["indexed"]
+        acct = {"indexed": 0, "too_short": 0, "missing": 0}
+        gold_state = {}
+        for sid, messages in sessions:
+            if sid in idx:
+                state = "indexed"
+            elif len(messages) < MIN_MESSAGES:
+                state = "too_short"
+            else:
+                state = "missing"
+            acct[state] += 1
+            if sid in gold:
+                gold_state[sid] = state
+
+        rows.append({
+            "question_id": qid,
+            "question_type": q.get("question_type"),
+            "abstention": dataset.is_abstention(q),
+            "n_sessions": len(sessions),
+            "accounting": acct,
+            "n_gold": len(gold),
+            "gold_states": {sid: classify_gold(sid, gated["ranked"],
+                                               gold_state.get(sid))
+                            for sid in gold},
+            "gated": {k: gated[k] for k in
+                      ("recall_at_5", "hit_at_5", "mrr", "first_gold_rank")},
+            "ungated": {k: ungated[k] for k in
+                        ("recall_at_5", "hit_at_5", "mrr", "first_gold_rank")},
+            "n_flipped_items": n_flips,
+            "rank_identical": gated["ranked"] == ungated["ranked"],
+            "ref": {k: ref[qid].get(k) for k in
+                    ("recall_at_5", "hit_at_5", "mrr")},
+        })
+        print(f"[{n:2d}/{len(ref)}] {qid} gated R@5={gated['recall_at_5']} "
+              f"ungated R@5={ungated['recall_at_5']} flips={n_flips} "
+              f"identical={rows[-1]['rank_identical']}", flush=True)
+
+    scored = [r for r in rows if not r["abstention"]]
+    summary = {
+        "questions": len(rows),
+        "scored": len(scored),
+        "rank_identical": sum(r["rank_identical"] for r in rows),
+        "flipped_items": sum(r["n_flipped_items"] for r in rows),
+        "gated_recall_at_5": round(sum(r["gated"]["recall_at_5"]
+                                       for r in scored) / len(scored), 3),
+        "ungated_recall_at_5": round(sum(r["ungated"]["recall_at_5"]
+                                         for r in scored) / len(scored), 3),
+        "questions_with_metric_delta": sum(r["gated"] != r["ungated"]
+                                           for r in rows),
+    }
+    OUT.write_text(json.dumps(
+        {"issue": 754, "summary": summary, "per_question": rows},
+        indent=1), encoding="utf-8")
+    print("summary:", json.dumps(summary))
+    print("wrote", OUT)
+
+
+if __name__ == "__main__":
+    main()

--- a/research/experiments/ungated-arm/test_replay.py
+++ b/research/experiments/ungated-arm/test_replay.py
@@ -1,0 +1,40 @@
+"""Unit tests for the pure logic in replay.py (#754). Run manually:
+
+  cd plugin && uv run python -m pytest ../research/experiments/ungated-arm/
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from replay import classify_gold, should_flip  # noqa: E402
+
+
+def test_flip_targets_quote_verification_downgrade():
+    assert should_flip({"trust": "inferred", "quote_verified": False})
+
+
+def test_flip_targets_grounding_downgrade():
+    assert should_flip({"trust": "inferred", "grounded": False})
+
+
+def test_natively_inferred_items_never_flip():
+    # No code-owned downgrade marker: the model emitted inferred directly.
+    assert not should_flip({"trust": "inferred"})
+    assert not should_flip({"trust": "inferred", "quote_verified": True})
+
+
+def test_verbatim_items_never_flip():
+    # A verified verbatim item must not be touched, whatever its markers.
+    assert not should_flip({"trust": "verbatim", "quote_verified": True})
+    assert not should_flip({"trust": "verbatim"})
+
+
+def test_classify_gold_orders_by_visibility():
+    ranked = ["s1", "s2", "s3", "s4", "s5", "s6"]
+    assert classify_gold("s1", ranked, "indexed") == "hit_top5"
+    assert classify_gold("s6", ranked, "indexed") == "indexed_deep"
+    assert classify_gold("s9", ranked, "indexed") == "indexed_unretrieved"
+    assert classify_gold("s9", ranked, "too_short") == "absent_too_short"
+    assert classify_gold("s9", ranked, "missing") == "absent_missing"


### PR DESCRIPTION
Closes #754

## What

Records the ungated-arm experiment #754 approved: the measured size of the "trades some raw recall for verifiability" claim in `benchmark/README.md`.

- `research/experiments/ungated-arm/replay.py`: zero-LLM replay runner: gated arm (stores as written) vs ungated arm (every trust-gate downgrade reverted) over the frozen per-question stores behind `results/interim-317-baseline-first54.json`, plus session accounting and gold-state classification.
- `research/experiments/ungated-arm/measurements.json`: per-question results and summary, regenerated by the committed runner.
- `benchmark/README.md`: the trade bullet now cites the measured size instead of asserting one.
- `.scars/candidates/bench-cache-legacy-entries-are-dead.md`: candidate scar: the pre-#343 legacy cache entries are unreplayable by design; offline replays must use `.work` stores.

## Why

Result, registered as a prediction in #754 before the run: reverting all 726 downgraded labels (2.9% of 24,748 indexed items) leaves 54/54 rankings identical: delta R@5 = delta Hit@5 = delta MRR = 0. Downgrades rewrite trust labels, never the indexed text, and `search()` does not rank on trust. The gated replay also reproduces the committed interim metrics exactly per question (R@5 0.581, Hit@5 0.673, MRR 0.590), and the miss decomposition shows every miss sits on an accepted, indexed session (12 ranking, 5 content, 0 lost to acceptance). A repository whose thesis is checkable memory should not carry an unchecked claim about its own trade-off.

## Tests

- `uv run --extra dev python -m pytest research/experiments/ungated-arm/`: 5 passed (flip predicate: both downgrade markers flip, natively-inferred and verbatim items never flip; gold-state classifier ordering).
- Full replay run from the committed runner: summary `{"questions": 54, "scored": 52, "rank_identical": 54, "flipped_items": 726, "gated_recall_at_5": 0.581, "ungated_recall_at_5": 0.581, "questions_with_metric_delta": 0}`: matches the committed `measurements.json`.
- `ruff check research/experiments/ungated-arm/` clean.
