### PR TITLE
feat(requests): ledger layer for live request delivery

### DIFF
--- a/plugin/daimon_briefing/requests.py
+++ b/plugin/daimon_briefing/requests.py
@@ -65,9 +65,15 @@ VERSION = 1
 # the transcript. The format is frozen PER-PR, not for the whole arc (the
 # design's own implementation note): an older reader drops the unknown row
 # and keeps rendering "done (claimed, unverified)" — the safe direction.
+#
+# #756 widens it a second time, on the same terms, with `delivered`: the
+# live-delivery render stamped this ask into a running session. Same safe
+# direction on an older reader — the row drops, the record reads as
+# undelivered, and the worst case is a repeated nudge rather than a
+# swallowed ask. It is an attention row like `surfaced`, never a state.
 EVENTS = frozenset({
     "opened", "revised",
-    "surfaced", "verdict_surfaced",
+    "surfaced", "verdict_surfaced", "delivered",
     "needs_info", "accepted", "rejected", "done",
     "suppressed", "done_verified",
 })
@@ -107,6 +113,7 @@ _EVENT_RANK = {
     "revised": 1,
     "surfaced": 2,
     "verdict_surfaced": 2,
+    "delivered": 2,
     "suppressed": 3,
     "done": 4,
     "needs_info": 5,
@@ -354,6 +361,12 @@ def fold(rows: list[dict]) -> dict[str, dict]:
                 # {revision epoch: earliest surfaced ts} — D1's write-once
                 # dedup key, consulted by the stamp PR 2 adds.
                 "surfaced": {},
+                # #756: {revision epoch: {session id: earliest delivered ts}}.
+                # One level deeper than `surfaced` on purpose — a brief
+                # renders an ask once per epoch, but live delivery owes it to
+                # every session running in that epoch, so the session id is
+                # part of the write-once key rather than a field beside it.
+                "delivered": {},
                 "verdict_surfaced_at": None,
                 "revision": 0,
                 "created_at": row.get("ts"),
@@ -385,6 +398,18 @@ def fold(rows: list[dict]) -> dict[str, dict]:
             current["history_count"] += 1
             if current["verdict_surfaced_at"] is None:
                 current["verdict_surfaced_at"] = row.get("ts")
+            continue
+        if event == "delivered":
+            # Same attention-row posture as `surfaced`: counted in history,
+            # never moving `updated_at`. A row that lost its session id is
+            # inert rather than epoch-wide — deduping every session at once
+            # off one malformed row would silently starve the live sessions
+            # it never actually reached.
+            current["history_count"] += 1
+            session = str(row.get("session") or "").strip()
+            if session:
+                current["delivered"].setdefault(current["revision"], {}) \
+                    .setdefault(session, row.get("ts"))
             continue
         if event == "suppressed":
             current["history_count"] += 1
@@ -994,6 +1019,34 @@ def stamp_surfaced(request_id: str, project_dir=None) -> bool:
     duplicate is at worst a second row the fold's earliest-wins tie-break
     absorbs for free."""
     row = _stamp("surfaced", request_id, "mechanical")
+    return append(row, project_dir=project_dir)
+
+
+def needs_delivered_stamp(record: dict, session: str) -> bool:
+    """#756: whether THIS session has already been delivered this record's
+    CURRENT revision epoch. Write-once per (request id, epoch, session) — a
+    revise opens a new epoch, so every live session re-receives the
+    sharpened ask, which is the behaviour the design asked for."""
+    epoch = (record.get("delivered") or {}).get(record.get("revision")) or {}
+    return str(session or "").strip() not in epoch
+
+
+def stamp_delivered(request_id: str, session: str, project_dir=None) -> bool:
+    """Write a `delivered` row to THIS project's own bucket (the
+    RECIPIENT's), recording that the live-delivery surface rendered this ask
+    into `session`. Channel `mechanical`, same posture as `stamp_surfaced`:
+    nobody asserted anything, the render pipeline stamped what it did.
+    Write-once is the caller's job (`needs_delivered_stamp` first); the
+    fold's earliest-wins tie-break absorbs a concurrent duplicate for free.
+
+    The session id is required, not optional: it is half the dedup key, and
+    a stamp without it would read as "delivered" to sessions that never saw
+    the ask."""
+    session = str(session or "").strip()
+    if not session:
+        raise RequestError("delivered stamp requires a session id")
+    row = _stamp("delivered", request_id, "mechanical")
+    row["session"] = session
     return append(row, project_dir=project_dir)
 
 

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -906,9 +906,11 @@ def test_the_event_vocabulary_is_frozen():
     #694 PR 3 widens it ONCE, deliberately, with `done_verified` (the
     design's own implementation note 2: an older reader drops the unknown
     row and keeps rendering "done (claimed, unverified)" — the safe
-    direction)."""
+    direction). #756 widens it a second time, on the same terms, with
+    `delivered`: an older reader drops the row, reads the record as
+    undelivered, and at worst repeats a nudge."""
     assert set(requests.EVENTS) == {
-        "opened", "revised", "surfaced", "verdict_surfaced",
+        "opened", "revised", "surfaced", "verdict_surfaced", "delivered",
         "needs_info", "accepted", "rejected", "done", "suppressed",
         "done_verified"}
 
@@ -1815,3 +1817,120 @@ def test_cli_request_inbox_renders_the_forgotten_supersedes_lineage(
     out = capsys.readouterr().out
     assert second in out
     assert f"{first} (record forgotten)" in out
+
+
+# ---- live delivery (#756, PR 1 — the ledger layer) -------------------------
+#
+# The design's invariant: the ledger stays store-and-forward and only the
+# render surface gains a second door. Delivery adds zero assertion power, so
+# `delivered` is an attention row exactly like `surfaced` — mechanical
+# channel, never moves the record's age, never touches its state. What it
+# does NOT share with `surfaced` is the dedup key: a brief renders a request
+# once per revision epoch, but delivery renders it once per epoch PER LIVE
+# SESSION, because two sessions running side by side each need the ask.
+
+
+def test_delivered_is_in_the_event_vocabulary():
+    """The second deliberate widening (after #694 PR 3's `done_verified`).
+    An older reader drops the unknown row and keeps rendering the request as
+    undelivered — a duplicate nudge, never a swallowed ask."""
+    assert "delivered" in requests.EVENTS
+
+
+def test_delivered_rows_fold_per_session_within_a_revision_epoch(project):
+    """Write-once per (request id, revision epoch, session id): two live
+    sessions each receive the ask, and a second stamp for a session already
+    delivered to is absorbed earliest-wins."""
+    q_id = _open(project)
+    rows = requests.events(project_dir=project)
+    base = rows[0]["order"]
+
+    def at(seconds, session):
+        row = requests._stamp("delivered", q_id, "mechanical",
+                              now_ns=base + seconds * 10 ** 9)
+        row["session"] = session
+        return row
+
+    rows.append(at(10, "S-alpha"))
+    rows.append(at(20, "S-alpha"))
+    rows.append(at(30, "S-beta"))
+    record = requests.fold(rows)[q_id]
+    assert set(record["delivered"]) == {0}
+    assert set(record["delivered"][0]) == {"S-alpha", "S-beta"}
+    # Earliest row for a session wins: the 20s stamp never overwrote the 10s.
+    assert record["delivered"][0]["S-alpha"] == requests._ts(base + 10 * 10 ** 9)
+
+
+def test_a_revise_reopens_delivery_for_every_session(project):
+    """D3: a revise clears the stamp so the sharpened ask re-delivers — the
+    same epoch mechanism `surfaced` uses, so a session that already saw the
+    old ask sees the new one."""
+    q_id = _open(project)
+    rows = requests.events(project_dir=project)
+    base = rows[0]["order"]
+
+    def at(seconds, session):
+        row = requests._stamp("delivered", q_id, "mechanical",
+                              now_ns=base + seconds * 10 ** 9)
+        row["session"] = session
+        return row
+
+    rows.append(at(10, "S-alpha"))
+    revised = requests._stamp("revised", q_id, "cli-agent",
+                              now_ns=base + 20 * 10 ** 9)
+    revised["ask"] = "the sharpened ask, after a revise"
+    rows.append(revised)
+    rows.append(at(30, "S-alpha"))
+    record = requests.fold(rows)[q_id]
+    assert set(record["delivered"]) == {0, 1}
+    assert record["delivered"][1]["S-alpha"] == requests._ts(base + 30 * 10 ** 9)
+
+
+def test_a_delivered_row_without_a_session_is_inert(project):
+    """The session id IS the dedup key. A row that lost it (hand-edited, or
+    written by a future path that forgot) must not silently dedup every
+    session at once — it folds away instead."""
+    q_id = _open(project)
+    rows = requests.events(project_dir=project)
+    rows.append(requests._stamp("delivered", q_id, "mechanical"))
+    assert requests.fold(rows)[q_id]["delivered"] == {}
+
+
+def test_delivered_never_moves_the_records_age(project):
+    """An attention row, like `surfaced`: a session that merely received the
+    nudge must not make an untouched ask sort as freshly updated."""
+    q_id = _open(project)
+    before = requests.get(q_id, project_dir=project)["updated_at"]
+    assert requests.stamp_delivered(q_id, "S-alpha", project_dir=project)
+    after = requests.get(q_id, project_dir=project)
+    assert after["updated_at"] == before
+    assert after["state"] == "open"
+
+
+def test_needs_delivered_stamp_is_per_session(project):
+    sender_slug = _seed_bucket("/p/req-sender-deliver")
+    q_id = requests.open_request(to=store.project_slug(project), ask=ASK,
+                                 why=WHY, channel="cli-agent",
+                                 project_dir=sender_slug)
+    record = requests.recipient_join(project_dir=project)[q_id]
+    assert requests.needs_delivered_stamp(record, "S-alpha") is True
+    assert requests.stamp_delivered(q_id, "S-alpha", project_dir=project)
+    record = requests.recipient_join(project_dir=project)[q_id]
+    assert requests.needs_delivered_stamp(record, "S-alpha") is False
+    # A second live session still owes the ask.
+    assert requests.needs_delivered_stamp(record, "S-beta") is True
+
+
+def test_stamp_delivered_carries_the_session_and_stays_mechanical(project):
+    q_id = _open(project)
+    assert requests.stamp_delivered(q_id, "S-alpha", project_dir=project)
+    row = [r for r in _rows(project) if r["event"] == "delivered"][0]
+    assert row["session"] == "S-alpha"
+    assert row["channel"] == "mechanical"
+    assert row["authority"] == requests.CHANNEL_AUTHORITY["mechanical"]
+
+
+def test_stamp_delivered_refuses_a_blank_session(project):
+    q_id = _open(project)
+    with pytest.raises(requests.RequestError):
+        requests.stamp_delivered(q_id, "   ", project_dir=project)


### PR DESCRIPTION
Refs #756.

Stage 1 of 3. Ledger layer only; the selection, CLI, and hook surfaces land in follow-up PRs against the same issue.

## What

Adds the `delivered` attention row to the request ledger: the record that a live-delivery render placed an undecided ask into a running session.

- Widens the frozen event vocabulary with `delivered`, ranked with the other attention rows.
- Folds it as `{revision epoch: {session id: earliest ts}}` on the record.
- Adds `needs_delivered_stamp(record, session)` and `stamp_delivered(request_id, session)`, mirroring the `surfaced` pair.

No surface consumes it yet, so behavior is unchanged for every existing caller.

## Why

A request opened with `request open --to Y` only surfaces in Y's next SessionStart brief, so a session already running when the request arrives never learns it exists. For an always-on consumer that is hours of invisible latency. The accepted design delivers at the next turn boundary as a render-surface addition only; the ledger stays store-and-forward and delivery adds zero assertion power.

Freezing the format before any surface reads it keeps the vocabulary from drifting as the later stages land, the same staging the #694 arc used.

Two details worth review attention:

**The vocabulary widens a second time.** #694 PR 3 widened it once for `done_verified`. This is the same trade on the same terms: an older reader drops the unknown row, reads the record as undelivered, and at worst repeats a nudge rather than swallowing an ask.

**The dedup key is one level deeper than `surfaced`.** A brief renders an ask once per revision epoch. Live delivery owes it to every session running in that epoch, so the session id is part of the write-once key rather than a field beside it. Two consequences, both intended: a revise opens a new epoch and re-delivers to every session, and a row that lost its session id folds away inert rather than deduping the whole epoch, so one malformed row can never starve the sessions it never reached.

Row growth is per session that receives an ask rather than per request. Bounded in practice, but it is the first stamp in this ledger with that shape.

## Tests

8 new tests in `plugin/tests/test_requests.py`, all written before the implementation and confirmed failing against it:

- `delivered` is in the event vocabulary
- rows fold per session within a revision epoch, earliest wins per session
- a revise reopens delivery for every session
- a row without a session id is inert
- delivery never moves the record's age
- `needs_delivered_stamp` is per session
- the stamp carries the session and stays on the mechanical channel
- the stamp refuses a blank session

The frozen-vocabulary guard is updated deliberately rather than silently, carrying the reason in its docstring.

Full suite: 4180 passed, 2 skipped. `ruff check` clean.