### PR TITLE
docs(reference): restate the request and relation verbs in plain terms

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -3075,7 +3075,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_relations = sub.add_parser(
         "relations",
-        help="inspect and adjudicate typed item relations (#678, shadow mode)",
+        help="inspect and decide typed item relations (#678, shadow mode)",
         epilog="Examples:\n"
                "  daimon relations list\n"
                "  daimon relations show rel-0123456789abcdef\n"

--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -50,14 +50,14 @@ NOT_AGENT_FACING = {
         "says so in as many words"
     ),
     "relations": (
-        "human adjudication surface (#678 shadow mode): verdicts require an "
+        "human decision surface (#678 shadow mode): deciding requires an "
         "interactive terminal and agents cannot confirm, reject, or retract "
         "at all; candidates are behaviorally inert, so there is nothing an "
         "agent should do here yet"
     ),
     "anchor": (
         "user curation: which claims deserve code-drift watching is a person's "
-        "judgement about their own memory, not an agent's"
+        "decision about their own memory, not an agent's"
     ),
     "log": "human bookkeeping: a freeform timeline entry, zero-LLM",
     "serve": (

--- a/website/blog/2026-08-09-daimon-0-29.md
+++ b/website/blog/2026-08-09-daimon-0-29.md
@@ -13,11 +13,11 @@ it. 0.29.0 adds that half.
 
 ## The refutation ledger
 
-`daimon refute add` records a scoped verdict against a subject, with evidence
+`daimon refute add` records a scoped refutation against a subject, with evidence
 cited at the point of assertion. An agent's assertion stays a candidate until a
 human runs `daimon refute ratify`. `daimon refute guard` checks a proposed
 action against the active ledger before you repeat something already settled,
-and `daimon refute overturn` is how a verdict comes back off the books when the
+and `daimon refute overturn` is how a refutation comes back off the books when the
 evidence changes.
 
 Two design choices are worth stating plainly.
@@ -27,7 +27,7 @@ age, not less: the fact that an approach failed eight months ago is exactly what
 you want surfaced when someone proposes it again. So `daimon refute search`
 reads the complete ledger with no age decay, unlike checkpoint recall.
 
-And the guard is advisory. It surfaces the prior verdict; it does not block the
+And the guard is advisory. It surfaces the prior refutation; it does not block the
 action. An agent can still proceed. What changes is that the record of what it
 was told exists either way, so a repeated mistake is now traceable to a decision
 rather than to ignorance.

--- a/website/blog/2026-08-15-daimon-0-31.md
+++ b/website/blog/2026-08-15-daimon-0-31.md
@@ -76,7 +76,7 @@ localhost viewer: briefing, ledger, per-session pages, search-as-recall,
 a check strip, and a print view. 0.31.0 adds the rulings lane beside the
 refutations lane, each polarity under its own vocabulary.
 
-**A typed relation ledger shipped in shadow mode**, with adjudication verbs
+**A typed relation ledger shipped in shadow mode**, with decision verbs
 and history rendering in the viewer.
 
 **0.30.2 fixed a real forget defect:** forget by value only matched a

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -37,7 +37,7 @@ Every daimon verb, grouped by what you are trying to do. Each command's
 | `daimon refute list\|show\|search\|guard` | Read the negative-knowledge ledger without decay. `guard` emits active exact-anchor/subject matches only; it is advisory and never blocks a command. `search` returns both polarities, labelled; `list` and `guard` stay refutation-only. Add `--json` for deliberation integrations. |
 | `daimon ruling list\|show` | Read the standing rulings: human-ratified positive constraints on the same ledger, never decayed, never re-extracted. `show` includes pending agent proposals. |
 | `daimon serve` | Open the [read-only local viewer](viewer.md) on localhost — search as recall, per-entry "why" pages, refutations, diff, check strip, print view. Nothing writes. |
-| `daimon relations list\|show\|confirm\|reject\|retract` | The [typed relation ledger](relations.md): machines propose, only a person confirms, and verdicts need an interactive terminal. Candidates never render on an entry surface. |
+| `daimon relations list\|show\|confirm\|reject\|retract` | The [typed relation ledger](relations.md): machines propose, only a person confirms, and deciding needs an interactive terminal. Candidates never render on an entry surface. |
 
 The auditors share one exit contract, so a script can act on the answer:
 
@@ -68,15 +68,15 @@ The auditors share one exit contract, so a script can act on the answer:
 ## Cross-project requests
 
 A request lives in the sender's own project bucket; the recipient answers
-with verdict rows in its own bucket. The folded record is a read-time join —
+with decision rows in its own bucket. The folded record is a read-time join —
 nobody ever writes into another project's ledger.
 
 | command | what it does |
 | --- | --- |
 | `daimon request open --to <dir> --ask "…" --why "…"` | Ask another project for something. `--to` takes the recipient's project **directory**, not its slug (a real slug starts with `-`, which argparse reads as an option — `--to=<slug>` also works). Validated against `daimon projects`, with near-match suggestions on a typo; `--anyway` records the ask against a project that has never serialized on this machine. `--blocking` and `--to-human` are flags on the record. Either channel. |
 | `daimon request revise <id> [--ask] [--why] [--evidence]` | Answer a needs-info, or sharpen an open ask. Either channel; capped at 3 revisions per record lifetime — past the cap, open a new request with `--supersedes <id>` to keep the lineage visible. |
-| `daimon request accept\|reject\|needs-info <id> [--note]` | Land a verdict. Human-only — requires an interactive terminal. `reject` is final for that record; the sender supersedes with a new request rather than asking again. |
-| `daimon request suppress <id> [--note]` | Drop a request out of the recipient's own briefing panel. Human-only; the record stays in `list`/`inbox`, and any later verdict reverses it. |
+| `daimon request accept\|reject\|needs-info <id> [--note]` | Land a decision. Human-only — requires an interactive terminal. `reject` is final for that record; the sender supersedes with a new request rather than asking again. |
+| `daimon request suppress <id> [--note]` | Drop a request out of the recipient's own briefing panel. Human-only; the record stays in `list`/`inbox`, and any later decision reverses it. |
 | `daimon request done <id> --evidence "<quote>"` | Report the ask as satisfied. Either channel; an agent's claim renders `done (claimed, unverified)` until the recipient's next session-end byte-checks the evidence quote against its transcript. A human `done` renders plainly. |
 | `daimon request list` | This project's own sent requests, undecided first. `--json` for machines. |
 | `daimon request inbox` | Requests addressed TO this project, from every sender, undecided first — including ones the briefing panel dropped for attention. `--json` for machines. |
@@ -88,7 +88,7 @@ cards with a loud `+N more …` overflow line naming the command that shows
 the rest — never a silent drop. Suppression is recipient-side attention
 only: the sender's panel still reads a suppressed request as "surfaced,
 undecided". An unanswered request renders `stale` after 3 recipient
-sessions pass with no verdict; a decided one leaves the sender's panel
+sessions pass with no decision; a decided one leaves the sender's panel
 after 2 sender sessions. Attention decays — records never delete, and both
 stay fully visible in `list`/`inbox`.
 

--- a/website/docs/reference/relations.md
+++ b/website/docs/reference/relations.md
@@ -6,9 +6,9 @@ shadow mode: relations exist alongside your memory and never change what any
 other surface does on their own.
 
 The authority boundary is the whole design: **machines may propose, and none
-may confirm.** A verdict requires an interactive terminal, and there is no
+may confirm.** A decision requires an interactive terminal, and there is no
 flag that delegates it to an agent. Candidates never render on an entry's
-surface — the adjudication list is the one place they are visible. A chain a
+surface — the decision list is the one place they are visible. A chain a
 reader sees in the viewer's History panel is one a person vouched for.
 
 ## Verbs
@@ -30,10 +30,10 @@ is the same, and it names no id. An endpoint that merely aged out of the
 checkpoint retention window is different: it renders as `[unresolved]` and
 stays a valid record.
 
-## Adjudication advice
+## Advice for deciding
 
 Read a chain whole before confirming its edges. Two items can look related
 pairwise because they share project vocabulary while being different thoughts —
-the honest verdicts are "this is the same thought evolving" (confirm),
+the honest decisions are "this is the same thought evolving" (confirm),
 "this edge is wrong" (reject), or leaving the candidate alone when you are
 not sure. An unconfirmed candidate is inert; a wrong confirmation is not.

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-08-09-daimon-0-29.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-08-09-daimon-0-29.md
@@ -13,12 +13,12 @@ redescubriéndolo. 0.29.0 agrega esa mitad.
 
 ## El ledger de refutaciones
 
-`daimon refute add` registra un veredicto acotado sobre un sujeto, con la
+`daimon refute add` registra una refutación acotada sobre un sujeto, con la
 evidencia citada en el momento de afirmarlo. La afirmación de un agente queda
 como candidata hasta que una persona ejecuta `daimon refute ratify`.
 `daimon refute guard` contrasta una acción propuesta contra el ledger activo
 antes de que repitas algo ya resuelto, y `daimon refute overturn` es la forma de
-dar de baja un veredicto cuando la evidencia cambia.
+dar de baja una refutación cuando la evidencia cambia.
 
 Hay dos decisiones de diseño que conviene decir sin rodeos.
 
@@ -28,7 +28,7 @@ que querés ver cuando alguien lo propone de nuevo. Por eso
 `daimon refute search` lee el ledger completo sin decaimiento por edad, a
 diferencia del recall de checkpoints.
 
-Y el guard es consultivo. Muestra el veredicto previo; no bloquea la acción. Un
+Y el guard es consultivo. Muestra la refutación previa; no bloquea la acción. Un
 agente puede seguir adelante igual. Lo que cambia es que queda registro de lo
 que se le advirtió, así que un error repetido ahora se puede rastrear hasta una
 decisión y no hasta el desconocimiento.

--- a/website/i18n/es/docusaurus-plugin-content-blog/2026-08-15-daimon-0-31.md
+++ b/website/i18n/es/docusaurus-plugin-content-blog/2026-08-15-daimon-0-31.md
@@ -81,7 +81,7 @@ carril de rulings junto al de refutaciones, cada polaridad con su propio
 vocabulario.
 
 **Un ledger tipado de relaciones llegó en modo sombra**, con verbos de
-adjudicación e historial renderizado en el visor.
+decisión e historial renderizado en el visor.
 
 **0.30.2 corrigió un defecto real de forget:** forget por valor solo
 comparaba contra el campo subject de una refutación, dejando cuatro de sus

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -37,7 +37,7 @@ comando trae la superficie completa de flags; esta página es el mapa.
 | `daimon refute list\|show\|search\|guard` | Lee el ledger de conocimiento negativo sin decaimiento. `guard` emite solo matches activos por ancla exacta o frase de sujeto; es consultivo y nunca bloquea un comando. `search` devuelve ambas polaridades, etiquetadas; `list` y `guard` quedan solo para refutaciones. Sumá `--json` para integraciones de deliberación. |
 | `daimon ruling list\|show` | Lee las reglas vigentes: restricciones positivas ratificadas por humanos en el mismo ledger, que nunca decaen ni se re-extraen. `show` incluye propuestas de agentes pendientes. |
 | `daimon serve` | Abre el [visor local de solo lectura](viewer.md) en localhost — búsqueda como recall, páginas "why" por entrada, refutaciones, diff, check strip, vista de impresión. Nada escribe. |
-| `daimon relations list\|show\|confirm\|reject\|retract` | El [ledger de relaciones tipadas](relations.md): las máquinas proponen, solo una persona confirma, y los veredictos necesitan una terminal interactiva. Los candidatos nunca se renderizan en la superficie de una entrada. |
+| `daimon relations list\|show\|confirm\|reject\|retract` | El [ledger de relaciones tipadas](relations.md): las máquinas proponen, solo una persona confirma, y decidir necesita una terminal interactiva. Los candidatos nunca se renderizan en la superficie de una entrada. |
 
 Los auditores comparten un mismo contrato de salida, para que un script pueda
 actuar sobre la respuesta:
@@ -69,7 +69,7 @@ actuar sobre la respuesta:
 ## Solicitudes entre proyectos
 
 Una solicitud vive en el bucket del proyecto que la envía; el destinatario
-responde con filas de veredicto en su propio bucket. El registro combinado
+responde con filas de decisión en su propio bucket. El registro combinado
 es un join en tiempo de lectura — nadie escribe jamás en el ledger de otro
 proyecto.
 
@@ -77,8 +77,8 @@ proyecto.
 | --- | --- |
 | `daimon request open --to <dir> --ask "…" --why "…"` | Pide algo a otro proyecto. `--to` toma el **directorio** del proyecto destinatario, no su slug (un slug real empieza con `-`, que argparse lee como una opción — `--to=<slug>` también funciona). Se valida contra `daimon projects`, con sugerencias por parecido ante un typo; `--anyway` registra el pedido igual contra un proyecto que nunca serializó en esta máquina. `--blocking` y `--to-human` son flags del registro. Cualquier canal. |
 | `daimon request revise <id> [--ask] [--why] [--evidence]` | Responde un needs-info, o afina una solicitud abierta. Cualquier canal; tope de 3 revisiones por registro — superado el tope, se abre una nueva solicitud con `--supersedes <id>` para mantener visible el linaje. |
-| `daimon request accept\|reject\|needs-info <id> [--note]` | Registra un veredicto. Solo humano — requiere una terminal interactiva. `reject` es definitivo para ese registro; el remitente reemplaza con una nueva solicitud en vez de volver a pedir. |
-| `daimon request suppress <id> [--note]` | Saca una solicitud del panel de briefing propio del destinatario. Solo humano; el registro sigue en `list`/`inbox`, y cualquier veredicto posterior lo revierte. |
+| `daimon request accept\|reject\|needs-info <id> [--note]` | Registra una decisión. Solo humano — requiere una terminal interactiva. `reject` es definitivo para ese registro; el remitente reemplaza con una nueva solicitud en vez de volver a pedir. |
+| `daimon request suppress <id> [--note]` | Saca una solicitud del panel de briefing propio del destinatario. Solo humano; el registro sigue en `list`/`inbox`, y cualquier decisión posterior lo revierte. |
 | `daimon request done <id> --evidence "<cita>"` | Reporta la solicitud como satisfecha. Cualquier canal; el reclamo de un agente se renderiza como `done (claimed, unverified)` hasta que el próximo fin de sesión del destinatario verifica byte a byte la cita de evidencia contra su transcripción. Un `done` humano se renderiza sin más. |
 | `daimon request list` | Las solicitudes enviadas por este proyecto, primero las que siguen sin decidir. `--json` para máquinas. |
 | `daimon request inbox` | Solicitudes que otros proyectos dirigieron a este, de cualquier remitente, primero las que siguen sin decidir — incluidas las que el panel de briefing dejó fuera de la atención. `--json` para máquinas. |
@@ -91,7 +91,7 @@ Cada uno tiene un tope de 3 tarjetas con una línea de desborde bien visible
 silencioso. La supresión es solo atención del lado del destinatario: el
 panel del remitente sigue mostrando una solicitud suprimida como publicada
 y sin decidir. Una solicitud sin responder pasa a `stale` después de 3
-sesiones del destinatario sin veredicto; una ya decidida sale del panel del
+sesiones del destinatario sin decisión; una ya decidida sale del panel del
 remitente después de 2 sesiones del remitente. La atención decae — los
 registros nunca se eliminan, y ambos siguen totalmente visibles en
 `list`/`inbox`.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/relations.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/relations.md
@@ -6,9 +6,9 @@ registro append-only en modo sombra: las relaciones existen junto a tu memoria
 y nunca cambian por sí solas lo que hace cualquier otra superficie.
 
 La frontera de autoridad es todo el diseño: **las máquinas pueden proponer, y
-ninguna puede confirmar.** Un veredicto requiere una terminal interactiva, y no
+ninguna puede confirmar.** Una decisión requiere una terminal interactiva, y no
 existe flag que lo delegue a un agente. Los candidatos nunca se renderizan en
-la superficie de una entrada — la lista de adjudicación es el único lugar
+la superficie de una entrada — la lista de decisión es el único lugar
 donde son visibles. Una cadena que un lector ve en el panel History del visor
 es una que una persona avaló.
 
@@ -32,11 +32,11 @@ endpoint que simplemente envejeció fuera de la ventana de retención de
 checkpoints es distinto: se renderiza como `[unresolved]` y sigue siendo un
 registro válido.
 
-## Consejo de adjudicación
+## Consejos para decidir
 
 Leé la cadena completa antes de confirmar sus edges. Dos items pueden parecer
 relacionados de a pares porque comparten vocabulario del proyecto siendo
-pensamientos distintos — los veredictos honestos son "es el mismo pensamiento
+pensamientos distintos — las decisiones honestas son "es el mismo pensamiento
 evolucionando" (confirm), "esta edge está mal" (reject), o dejar el candidato
 en paz cuando no estás seguro. Un candidato sin confirmar es inerte; una
 confirmación equivocada no.


### PR DESCRIPTION
Closes #761.

## What

Corrects the wording on two reference pages and two blog posts, plus the `relations` group help and its skill entry. English and the Spanish mirror move together.

- `website/docs/reference/cli.md` (5 rows) and its mirror
- `website/docs/reference/relations.md` (2 rows, one heading) and its mirror
- `website/blog/2026-08-09-daimon-0-29.md` and `2026-08-15-daimon-0-31.md`, both mirrors
- `cli/__init__.py` — the `relations` group help string
- `skill_content.py` — the `relations` and `anchor` entries

The replacement is the word the CLI help already uses for the act, so the reference now agrees with what a reader sees when they run the command.

## Why

These rows were signed off against a commit well behind HEAD. The request work merged since then brought the same term back in, including a row I added yesterday in #759 and corrected in #762. The sign-off is stale rather than wrong-at-the-time, which is why nothing flagged it.

The sweep this time ran over the whole set at current HEAD rather than the old commit, which is how the extra occurrences beyond the ones #761 listed turned up.

## Deliberately out of scope

Three findings from the same sweep are left alone on purpose, each for its own reason.

**`--verdict` stays.** It is a flag name on `refute add` and `ruling propose`, machine-facing, and renaming it breaks every caller. Already carried as naming debt.

**The sender-side briefing panel heading stays** (`briefing.py:849`). Briefing headings are governed public API and load-bearing in installed host skills, so renaming one is a decision to make deliberately, not something to fold into a wording pass. This is the most significant thing the sweep found and it is reported separately rather than fixed here.

**The claims page** uses the marketing sense of its term to deny the thing, not to claim it, which reads as the allowed form. Flagged, not changed.

## Tests

Full suite: 4198 passed, 2 skipped. `ruff check` clean.

No behavior change — the two code strings touched are help text and skill text, neither asserted by any test. Re-ran the sweep after the edits and confirmed the corrected rows are clean, with only the three deliberate exclusions above remaining.