### PR TITLE
fix(briefing): rename the sender-side request panel heading

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -846,7 +846,7 @@ def request_panel_lines(project_dir=None) -> list[str]:
 
 # ---- #694 PR 3: the sender-side verdict panel -------------------------------
 
-_VERDICT_PANEL_HEADER = "Verdicts on requests you sent:"
+_VERDICT_PANEL_HEADER = "Decisions on requests you sent:"
 
 # Mirrors cli/request.py's _MARKS glyph-per-state — a separate small table
 # rather than an import, because briefing.py must not depend on the cli

--- a/plugin/tests/test_cli_brief_verdicts.py
+++ b/plugin/tests/test_cli_brief_verdicts.py
@@ -40,6 +40,31 @@ def test_cli_brief_shows_the_verdict_panel_on_the_normal_path(
     assert "accepted" in out
 
 
+def test_the_two_request_panel_headings_render_verbatim(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    """Both request-panel headings are registered public strings, frozen the
+    same way the four older briefing headings are.
+
+    Nothing pinned them before this: the panel tests assert the ASK text, and
+    the only line that named a heading was a negative assertion, so a heading
+    could have been renamed, mistyped, or dropped and the whole suite would
+    still pass. That is how the sender-side heading carried the wrong word
+    long enough to reach a reference page and its translation.
+
+    Rename either string and this fails — deliberately. The fix is to change
+    the registration first and this assertion second, never the reverse."""
+    from daimon_briefing import briefing
+    assert briefing._REQUEST_PANEL_HEADER == \
+        "Requests waiting on you (from other projects):"
+    assert briefing._VERDICT_PANEL_HEADER == "Decisions on requests you sent:"
+
+    sender = "/p/cbv-sender-headings"
+    _accepted_ask(sender, recipient_dir="/p/cbv-recipient-headings")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", sender)
+    assert cli.main(["brief"]) == 0
+    assert briefing._VERDICT_PANEL_HEADER in capsys.readouterr().out
+
+
 def test_cli_brief_stamps_verdict_surfaced_after_the_print(
         tmp_checkpoint_dir, monkeypatch, capsys):
     sender = "/p/cbv-sender-b"
@@ -129,7 +154,7 @@ def test_cli_brief_no_decided_requests_shows_no_verdict_panel(
     monkeypatch.setenv("DAIMON_PROJECT_DIR", sender)
     rc = cli.main(["brief"])
     assert rc == 0
-    assert "Verdicts on requests you sent" not in capsys.readouterr().out
+    assert "Decisions on requests you sent" not in capsys.readouterr().out
 
 
 def test_cli_brief_shows_both_panels_together(tmp_checkpoint_dir,

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -83,7 +83,7 @@ nobody ever writes into another project's ledger.
 
 Two panels ride the same-project CLI `brief` only — never `--slug`, the
 global-pointer fallback, or MCP. The recipient sees "Requests waiting on
-you"; the sender sees "Verdicts on requests you sent". Each is capped at 3
+you"; the sender sees "Decisions on requests you sent". Each is capped at 3
 cards with a loud `+N more …` overflow line naming the command that shows
 the rest — never a silent drop. Suppression is recipient-side attention
 only: the sender's panel still reads a suppressed request as "surfaced,

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -85,7 +85,7 @@ proyecto.
 
 Dos paneles viajan solo con el `brief` de CLI del mismo proyecto — nunca con
 `--slug`, el fallback al puntero global, ni por MCP. El destinatario ve
-"Requests waiting on you"; el remitente ve "Verdicts on requests you sent".
+"Requests waiting on you"; el remitente ve "Decisions on requests you sent".
 Cada uno tiene un tope de 3 tarjetas con una línea de desborde bien visible
 (`+N more …`) que nombra el comando para ver el resto — nunca un descarte
 silencioso. La supresión es solo atención del lado del destinatario: el


### PR DESCRIPTION
Closes #764.

## What

```
Verdicts on requests you sent:  ->  Decisions on requests you sent:
```

- `plugin/daimon_briefing/briefing.py:849` — the constant
- `website/docs/reference/cli.md:86` and its Spanish mirror `:88`, both of which quote the literal
- `plugin/tests/test_cli_brief_verdicts.py` — the assertion that names it, plus a new one

The recipient-side sibling at `briefing.py:797` was already clean and does not move.

## Why

The heading used a term this project keeps out of prose, in one of the most-read strings daimon produces.

The replacement is also the more accurate word, which is the reason to prefer it over any other rewording. The panel renders `needs-info`, `accepted`, `rejected` and `done` only; `open` is deliberately excluded, because an ask nobody has acted on has nothing to report. The panel lists decided requests, and "decision" is already the word the CLI help uses for that act.

Rejected alternatives: "Answers to requests you sent" introduces a new word where an existing one works, and "Requests you sent" over-promises, since the panel shows only the decided ones.

## Tests

Adds `test_the_two_request_panel_headings_render_verbatim`, which pins both panel headings.

Nothing pinned either one before now. The panel tests assert the ask text, and the only line that named a heading was a negative assertion, so a heading could have been renamed, mistyped or dropped and the suite would still have passed. That is how the wrong word survived long enough to reach a reference page and its translation.

The new test was checked by reverting the rename and confirming it fails, then restoring it and confirming it passes. Rename either heading and it fails deliberately.

Full suite: 4199 passed, 2 skipped. `ruff check` clean.

No installed skill consumes these strings, so host integrations are unaffected.