### PR TITLE
docs(reference): name the request section for what the reader wants to do

### DIFF
--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -65,7 +65,7 @@ The auditors share one exit contract, so a script can act on the answer:
 | --- | --- |
 | `daimon forget <id or text>` | Remove one item's content from disk and index, leaving a hash-only tombstone. The deletion survives re-serialization of the original transcript. |
 
-## Cross-project requests
+## Coordinate
 
 A request lives in the sender's own project bucket; the recipient answers
 with decision rows in its own bucket. The folded record is a read-time join —

--- a/website/docs/reference/mcp.md
+++ b/website/docs/reference/mcp.md
@@ -17,7 +17,7 @@ daimon mcp serve   # blocks, serves JSON-RPC on stdio until EOF
 | `daimon_brief` | The latest briefing for the current project — deterministic render, trust-tagged, resolutions withheld |
 | `daimon_projects` | Every project daimon has memory for: slug, session, branch, last topic |
 | `daimon_status` | Capture health: checkpoint freshness, last serialize result, outstanding failures, alarms — same payload as `daimon status --json` |
-| `requests_inbox` | Requests other projects have addressed to this one — the read-only pull side of the [cross-project request ledger](cli.md#cross-project-requests). `daimon_brief` never carries this content; opening, answering, or deciding a request is CLI-only. |
+| `requests_inbox` | Requests other projects have addressed to this one — the read-only pull side of the [cross-project request ledger](cli.md#coordinate). `daimon_brief` never carries this content; opening, answering, or deciding a request is CLI-only. |
 
 All five carry `readOnlyHint`. Tool-level failures (bad arguments, missing
 FTS5) come back as `isError` results the agent can read; they never kill the

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -66,7 +66,7 @@ actuar sobre la respuesta:
 | --- | --- |
 | `daimon forget <id o texto>` | Elimina el contenido de un ítem del disco y del índice, dejando una lápida de solo-hash. La eliminación sobrevive a re-serializar la transcripción original. |
 
-## Solicitudes entre proyectos
+## Coordinar
 
 Una solicitud vive en el bucket del proyecto que la envía; el destinatario
 responde con filas de decisión en su propio bucket. El registro combinado

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/mcp.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/mcp.md
@@ -18,7 +18,7 @@ daimon mcp serve   # bloquea y sirve JSON-RPC por stdio hasta EOF
 | `daimon_brief` | El último briefing del proyecto actual — render determinista, etiquetado por confianza, con resoluciones retenidas |
 | `daimon_projects` | Cada proyecto del que daimon tiene memoria: slug, sesión, rama, último tema |
 | `daimon_status` | Salud de captura: frescura del checkpoint, resultado del último serialize, fallas pendientes, alarmas — el mismo payload que `daimon status --json` |
-| `requests_inbox` | Solicitudes que otros proyectos dirigieron a este — el lado de lectura del [ledger de solicitudes entre proyectos](cli.md#solicitudes-entre-proyectos). `daimon_brief` nunca lleva este contenido; abrir, responder o decidir una solicitud es exclusivo de la CLI. |
+| `requests_inbox` | Solicitudes que otros proyectos dirigieron a este — el lado de lectura del [ledger de solicitudes entre proyectos](cli.md#coordinar). `daimon_brief` nunca lleva este contenido; abrir, responder o decidir una solicitud es exclusivo de la CLI. |
 
 Las cinco llevan `readOnlyHint`. Las fallas a nivel de herramienta
 (argumentos inválidos, FTS5 ausente) vuelven como resultados `isError` que el


### PR DESCRIPTION
Closes #767.

## What

```
website/docs/reference/cli.md:68   ## Cross-project requests      ->  ## Coordinate
.../es/.../reference/cli.md:69     ## Solicitudes entre proyectos ->  ## Coordinar
```

Plus the two links that resolve against those anchors, in `mcp.md:20` and its Spanish mirror `:21`.

## Why

Every other heading in the reference names an intent: Set up, Brief, Check, Correct, Forget, Status. This one named the mechanism.

`Coordinate` matches the verb form of the other six and covers both halves of the feature: asking another project for something, and deciding on what it asked you.

Folding the section into an existing group was considered and rejected. None of the six fits — `Status` reports, and `request accept` is a decision rather than a report, so the section earns its own place. `Ask` was rejected as a name because it only covers the sender's half.

## The links are the interesting part

A heading rename changes the anchor a link resolves against. Two links pointed at the old anchors and move in the same change.

Left alone they would have broken silently: a stale anchor still loads the page and lands the reader at the top with no error. `onBrokenLinks: 'throw'` does not catch it, because that governs links to missing pages; `onBrokenAnchors` is unset and defaults to warning. Filed separately as #768.

## Tests

No code changed, so no test covers this. Verified by scanning every same-repo anchor link under `website/` — 11 across 54 files — and confirming each resolves to a heading that exists after the rename.

Correction worth noting: the issue originally claimed no inbound links existed. That was wrong, and finding the two is why this is four files rather than two.