### PR TITLE
ci(website): fail the build on a link to a heading that does not exist

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -26,6 +26,11 @@ const config: Config = {
   projectName: 'daimon', // Usually your repo name.
 
   onBrokenLinks: 'throw',
+  // A link to a heading that no longer exists resolves to the page and
+  // silently drops the reader at the top, so the default 'warn' is one
+  // line in a build log nobody reads. #767 orphaned two such links by
+  // renaming one heading; the diff caught them, the build did not.
+  onBrokenAnchors: 'throw',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you


### PR DESCRIPTION
Closes #768.

## What

```ts
onBrokenLinks: 'throw',
onBrokenAnchors: 'throw',   // added
```

## Why

`onBrokenLinks` catches links to pages that do not exist. It does not cover links to headings that do not exist, and `onBrokenAnchors` was unset, so Docusaurus defaulted to warning.

The failure mode is quiet by construction. A stale anchor loads the target page and drops the reader at the top with no error, so nothing looks wrong to a reviewer clicking through, and the warning is one line in a long build log.

#767 orphaned two links by renaming a single reference heading. Reading the diff caught them; the build would not have.

## Tests

Built both locales locally with the setting on, and both succeeded:

```
[INFO] [en] Creating an optimized production build...
[SUCCESS] Generated static files in "build".
[INFO] [es] Creating an optimized production build...
[SUCCESS] Generated static files in "build/es".
```

That is the check that matters. A static scan had already suggested all 11 same-repo anchor links across 54 files resolve, but it reproduced heading-to-slug conversion approximately rather than using Docusaurus's resolver, so it was evidence rather than proof. The build is the proof.

Note this branch is cut from `main`, so it validates the tree as it stands today, before #770 lands. #770 changes a heading and both links that point at it together, so the tree is consistent at either commit.