### PR TITLE
chore(scars): promote 0055 rendering cross-bucket content is a write

### DIFF
--- a/.scars/0001-llm-judge-grounding-reference.deadend.md
+++ b/.scars/0001-llm-judge-grounding-reference.deadend.md
@@ -15,6 +15,7 @@ evidence:
 expires:
   condition: "FMR scoring no longer uses LLM-as-judge"
   review_after: 2027-06-09
+status: active
 ---
 
 The first probe judge defined `grounded` as "supported by the ground truth

--- a/.scars/0005-uv-run-daimon-resolves-stale-global-tool.landmine.md
+++ b/.scars/0005-uv-run-daimon-resolves-stale-global-tool.landmine.md
@@ -17,6 +17,7 @@ evidence:
 expires:
   condition: "pyproject.toml moves to the repo root, or the global `daimon` uv tool is installed --editable"
   review_after: 2027-01-01
+status: active
 ---
 
 The package's `pyproject.toml` lives in `plugin/`, not the repo root. `uv run daimon`

--- a/.scars/0055-rendering-cross-bucket-content-is-a-write.landmine.md
+++ b/.scars/0055-rendering-cross-bucket-content-is-a-write.landmine.md
@@ -1,0 +1,47 @@
+---
+id: 55
+type: landmine
+title: Printing another bucket's record text writes that text into THIS project's checkpoint, where forget can never reach it
+severity: high
+confidence: 0.9
+created: 2026-08-27
+authors: ["claude-code", "Kibukx"]
+anchors:
+  - path: plugin/daimon_briefing/cli/
+  - pattern: "_bucket_slugs"
+evidence:
+  - note: transcript.py:138 _tool_result_of flattens tool_result payloads; transcript.py:302 gives them their own row shape (#359) — so CLI stdout in an agent session is checkpoint input
+  - note: recall.py:760-766 already implements the safe pattern and states the doctrine: counts by project, never content, because crossing projects stays user-invoked (#94/#95)
+  - note: daimon#766 design review 2026-08-27 — caught before any code was written
+expires:
+  condition: "capture excludes daimon's own CLI output from serialization, OR surfaces.py can map a deletion into checkpoint item text that originated as captured tool output"
+  review_after: 2027-02-27
+status: active
+---
+
+daimon serializes the host transcript INCLUDING tool_result payloads (`_tool_result_of`,
+transcript.py:138; row shape at :302, #359). So inside an agent session **CLI stdout is
+checkpoint input: printing is writing.**
+
+A command that enumerates buckets and prints their record text therefore copies that
+plaintext into the checkpoint of whichever project it was RUN in. `forget` in the origin
+project can never reach the copy: surfaces.py maps deletion per file shape per bucket, and
+there is no shape for "project B's plaintext inside project A's item text". Both projects
+then audit clean while A holds text B deleted. This is the defect class surfaces.py:4-12
+was built to end (#583, #599 twice, #600), reappearing as a CONTENT path rather than a
+FILE path, which is why the write-audit registry cannot see it. It is recursive: A's
+briefing can re-emit the copy. And it ships green, because that guard watches file writes,
+not render content.
+
+**The safe pattern already exists — copy it.** recall.py:760-766 auto-widens across
+projects and deliberately reports counts by project and never content, because "crossing
+projects stays user-invoked (#94/#95), the system just stops hiding that crossing would
+pay". `recall --all-projects` does cross with content, but only when a human explicitly
+asks for it. The bounded exposure comes from that user-invoked gate, not from luck.
+
+So: render ids, counts and the owning slug by default, and make the operator open the
+owning project to read the text. A surface that crosses with content by default removes
+the only thing keeping this bounded. If foreign text must be rendered, the deletion story
+has to exist BEFORE the render does. The shipped request panel is not a precedent for
+skipping this: it shows only asks addressed to THIS project, capped at 3
+(requests.py:102) and truncated to 160 chars (briefing.py:806).


### PR DESCRIPTION
Scars-only change, so the issue-first gate does not apply (pr-validation.yml:24-28: the human sign-off already happened at `scar promote`, reviewer recorded in the scar's authors).

## What

Promotes candidate `rendering-cross-bucket-content-is-a-write` to `0055`, a landmine anchored to `plugin/daimon_briefing/cli/` and the `_bucket_slugs` pattern.

The constraint: the serializer captures tool_result payloads (`transcript.py:138` flattens them, `:302` gives them their own row shape, #359), so inside an agent session CLI stdout is checkpoint input. A command that enumerates buckets and prints their record text copies that plaintext into the checkpoint of whichever project it ran in. `forget` in the origin project can never reach the copy, because `surfaces.py` maps deletion per file shape per bucket and no shape covers one project's text living inside another's item text. Both projects then audit clean while one holds text the other deleted.

## Why

Found during the design pass on #766, before any code was written. The design there described itself as a pure render surface; in a system whose capture loop reads its own output, rendering foreign content is a write, and the write-audit guard cannot see it because it watches file writes rather than render content. The whole class would ship green and surface months later.

The scar does not invent a rule. `recall.py:760-766` already implements the safe pattern and states the reason, reporting counts by project and never content because crossing projects stays user-invoked. `recall --all-projects` does cross with content, but only when a person explicitly asks. That gate is what keeps the exposure bounded, and it was never generalized beyond recall.

Anchors were narrowed before promotion on churn evidence: `render.py` (60 commits in 90 days) and `briefing.py` (23) were dropped as too noisy to discriminate, leaving `cli/` (14) where a new surface command is actually written, and a `_bucket_slugs` pattern that matches 3 source files rather than the 15 matched by the original pattern.

## Tests

No code change, so no behavior to test. `scar lint` passes on the promoted file: 58 files, 0 orphans, 0 unreachable evidence. The two reported errors and one partial-rot are pre-existing in `0001`, `0005` and `0054` and are untouched by this PR.
