### PR TITLE
feat(decide): add the human decision queue, scoped to this project

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -962,6 +962,7 @@ from .request import (  # noqa: E402
 )
 from .lifecycle import (  # noqa: E402
     _cmd_forget,  # noqa: F401 — re-exported for compat
+    _cmd_decide,  # noqa: F401 — re-exported for compat
     _cmd_loops,  # noqa: F401 — re-exported for compat
     _cmd_resolve,  # noqa: F401 — re-exported for compat
     _cmd_reverify,  # noqa: F401 — re-exported for compat

--- a/plugin/daimon_briefing/cli/lifecycle.py
+++ b/plugin/daimon_briefing/cli/lifecycle.py
@@ -1,10 +1,11 @@
-"""Item lifecycle verbs — `resolve`, `forget`, `reverify`, and `loops` (#708 move).
+"""Item lifecycle verbs — `resolve`, `forget`, `reverify`, `loops`, `decide`.
 
 Shared helpers that remain in the package `__init__` are reached through the
 module object (`_cli.<name>`) so the `cli.<name>` seam tests and hosts patch
 keeps working on moved code.
 """
 
+import datetime
 import sys
 
 import daimon_briefing.cli as _cli
@@ -16,6 +17,7 @@ from .. import (
     carry,
     config,
     normalize,
+    pending,
     refutations,
     relations,
     render,
@@ -828,6 +830,80 @@ def _cmd_loops(args) -> int:
     return 0
 
 
+# Pinned by tests/test_cli_decide.py, deliberately: this is the string a
+# reader learns to scan for, and the sibling of the brief's already-registered
+# "Decisions on requests you sent:". Change the registration before the string.
+_DECIDE_HEADER = "Decisions waiting on you:"
+
+
+def _decide_age(waiting_since: str) -> str:
+    """Coarse age for the header bracket. Days once there is a day to show,
+    hours before that: a backlog is read in days, and false precision on a
+    record that has waited three weeks helps nobody."""
+    try:
+        started = datetime.datetime.strptime(
+            waiting_since, "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=datetime.timezone.utc)
+    except (ValueError, TypeError):
+        return ""
+    delta = datetime.datetime.now(datetime.timezone.utc) - started
+    hours = int(delta.total_seconds() // 3600)
+    return f"{hours // 24}d" if hours >= 24 else f"{hours}h"
+
+
+def _cmd_decide(args) -> int:
+    """`decide` — everything waiting on a HUMAN, with the command that closes it.
+
+    The mirror of `loops`: that lists what the agent still owes, this lists what
+    you still owe. A pure reader — it stamps nothing, so opening your own queue
+    can never age an ask out of the agent's panel (`is_stale` measures against
+    the `surfaced` anchor, and this never writes one).
+
+    Scoped to this project. Other projects arrive as counts, then as text behind
+    an explicit flag, because printing another bucket's record text would copy
+    it into THIS project's checkpoint where its owner's `forget` cannot reach
+    it (scar 0055).
+    """
+    _cli._note_usage("decide")
+    project = _cli._resolve_project(args.project)
+    result = pending.queue(project_dir=project)
+    rows = result.get("rows") or []
+    suppressed = (result.get("excluded") or {}).get("suppressed") or 0
+    if not rows:
+        # "nothing waiting" would be a false claim while records sit
+        # suppressed: the human set those aside, they did not go away.
+        render.render_ledger_lines(
+            ["nothing waiting on you in this project"] if not suppressed
+            else [f"nothing listed for you in this project "
+                  f"({suppressed} suppressed — daimon request inbox)"])
+        return 0
+
+    render.render_ledger_lines([_DECIDE_HEADER])
+    cards = []
+    for row in rows:
+        age = _decide_age(row.get("waiting_since") or "")
+        tag = row["kind"] + (f" · {age}" if age else "")
+        blocking = " [blocking: the sender says it is waiting]" if row.get(
+            "blocking") else ""
+        # Two spaces after the id: `render._LEDGER_HEADER_RE` reads that shape
+        # to give the id its own span, because it is what a human copies.
+        card = [f"[{tag}] {row['id']}  {row['headline']}{blocking}"]
+        if row.get("context"):
+            card.append(f"  {row['context']}")
+        card += [f"    {label}: {command}"
+                 for label, command in row.get("commands") or []]
+        cards.append(card)
+    render.render_ledger_records(cards)
+
+    if suppressed:
+        # Counted, never listed: `suppress` is human-only, so this is the
+        # owner's own "not now" — but a queue that hid the fact would be
+        # claiming a completeness it does not have.
+        render.render_ledger_lines(
+            [f"  ({suppressed} suppressed — daimon request inbox)"])
+    return 0
+
+
 def register(sub, fmt) -> None:
     """Register the `lifecycle` parser family on the top-level subparsers."""
     p_resolve = sub.add_parser(
@@ -890,3 +966,11 @@ def register(sub, fmt) -> None:
     )
     p_loops.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
     p_loops.set_defaults(func=_cli._cmd_loops)
+
+    p_decide = sub.add_parser(
+        "decide", help="list what is waiting on YOU with the command that "
+        "closes each (#766) — the human-side mirror of daimon loops",
+        epilog="Examples:\n  daimon decide\n  daimon decide --project .\n",
+    )
+    p_decide.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    p_decide.set_defaults(func=_cli._cmd_decide)

--- a/plugin/daimon_briefing/pending.py
+++ b/plugin/daimon_briefing/pending.py
@@ -1,0 +1,186 @@
+"""The `decide` queue composer (#766) — what is waiting on a HUMAN.
+
+daimon tracks the agent's open loops as first-class records; the human's half
+has never had a surface. This module composes one, over records that already
+exist, and it is a pure reader: it writes nothing at all.
+
+WHAT QUALIFIES is structural, never editorial. A record belongs here only when
+some verb's write path REFUSES a non-human channel — `requests._HUMAN_ONLY`,
+the `CHANNEL_AUTHORITY` guards in `refutations.ratify` and `amendments`. No
+guard, no entry. That test is checkable rather than a matter of taste, and it
+is why an agent's own proposal can never promote itself onto this queue.
+
+WHY IT WRITES NOTHING, including no `surfaced` stamp. That stamp is the anchor
+`is_stale` measures against, and `store.sessions_since_count` counts serialized
+checkpoint pointers rather than reads. A composer that stamped would make the
+person READING their own queue the mechanism that ages those asks out of the
+agent's panel — decay inverted into deletion.
+
+SCOPE, slice 1: this project's buckets only. Foreign projects contribute counts
+in slice 3 and text only behind an explicit `--all-projects` in slice 4. That
+split is not caution, it is scar 0055: the serializer captures tool_result
+payloads, so inside an agent session CLI stdout is checkpoint input. Printing
+another bucket's record text copies that plaintext into THIS project's
+checkpoint, where `forget` in the origin project can never reach it. Same
+doctrine `recall.py` already applies when it widens: counts by project, never
+content, because crossing projects stays user-invoked.
+"""
+
+from __future__ import annotations
+
+from . import amendments, refutations, requests, store
+
+
+# Requests first: someone else is blocked on them. Then quote-verified
+# amendments, which are already rendering in briefings as unconfirmed claims.
+# Ledger candidates last: nothing renders them yet, so nothing is misleading
+# while they wait.
+_KIND_RANK = {"request": 0, "amendment": 1, "ruling": 2, "refutation": 2}
+
+
+def _row(*, kind, record_id, slug, headline, waiting_since,
+         commands, context="", blocking=False) -> dict:
+    return {
+        "kind": kind,
+        "id": record_id,
+        "slug": slug,
+        "headline": headline,
+        # What the headline alone cannot carry: who is waiting, or which
+        # item a claim is about. A decision needs both, and neither belongs
+        # in the header line a reader scans.
+        "context": context,
+        "waiting_since": waiting_since,
+        "blocking": blocking,
+        "commands": commands,
+    }
+
+
+def _order_key(row: dict, seq: int) -> tuple:
+    # Blocking first, then OLDEST first — a deliberate inversion of the
+    # panels' newest-first (`requests.inbox_renderable`). Those are a capped
+    # attention feed; this is a backlog, and the oldest undecided item is the
+    # one rotting. `created_at` is second-resolution and ties routinely, so
+    # append order in the ledger breaks it: in an append-only log, first
+    # written IS first waiting.
+    return (not row["blocking"], row["waiting_since"] or "", seq,
+            _KIND_RANK.get(row["kind"], 9), row["id"])
+
+
+def _request_rows(project_dir, slug) -> tuple[list, int]:
+    """Asks addressed to this project that no human has answered."""
+    records = requests.records(project_dir=project_dir)
+    seen = [row.get("request_id") for row in requests.events(
+        project_dir=project_dir)]
+    rows, suppressed = [], 0
+    for rid, record in records.items():
+        if record.get("state") not in requests._SENDER_MOVABLE:
+            continue
+        if record.get("suppressed"):
+            # `suppress` is human-only, so a suppressed ask is already the
+            # owner's own "not now". Counted, never listed.
+            suppressed += 1
+            continue
+        rows.append((_row(
+            kind="request", record_id=rid, slug=slug,
+            headline=record.get("ask") or "",
+            context=(f"from {record['from_label']}"
+                     if record.get("from_label") else ""),
+            waiting_since=record.get("created_at") or "",
+            blocking=bool(record.get("blocking")),
+            commands=[
+                ("accept", f"daimon request accept {rid}"),
+                ("reject", f"daimon request reject {rid} --note \"<why>\""),
+                ("needs-info", f"daimon request needs-info {rid}"),
+            ]),
+            seen.index(rid) if rid in seen else 0))
+    return rows, suppressed
+
+
+def _ledger_rows(project_dir, slug) -> list:
+    """Agent-proposed rulings and refutations awaiting ratification.
+
+    Polarity decides the verb family AND the header field: a ruling is read by
+    its rule text, a refutation by what it refutes. `cli/_ledger.py` makes the
+    same split for the same reason.
+    """
+    records = refutations.records(project_dir=project_dir)
+    seen = [row.get("refutation_id") for row in refutations.events(
+        project_dir=project_dir)]
+    rows = []
+    for rid, record in records.items():
+        if record.get("state") != "candidate":
+            continue
+        ruling = record.get("polarity") == "ruling"
+        family = "ruling" if ruling else "refute"
+        rows.append((_row(
+            kind="ruling" if ruling else "refutation",
+            record_id=rid, slug=slug,
+            headline=(record.get("verdict") if ruling
+                      else record.get("subject")) or "",
+            waiting_since=record.get("created_at") or "",
+            commands=[
+                ("ratify", f"daimon {family} ratify {rid}"),
+                ("retire" if ruling else "overturn",
+                 f"daimon {family} "
+                 f"{'retire' if ruling else 'overturn'} {rid}"),
+            ]),
+            seen.index(rid) if rid in seen else 0))
+    return rows
+
+
+def _amendment_rows(project_dir, slug) -> list:
+    """Quote-verified amendments only.
+
+    A candidate has not passed the session-end byte-check, so nothing is owed
+    yet — `amendments.py` forbids surfacing one outright, because an unverified
+    annotation would let an agent assert state with no transcription check.
+    `verified` is exactly the set the briefing already renders with a
+    confirm/reject pair.
+    """
+    records = amendments.records(project_dir=project_dir)
+    seen = [row.get("amendment_id") for row in amendments.events(
+        project_dir=project_dir)]
+    rows = []
+    for aid, record in records.items():
+        if record.get("state") != "verified":
+            continue
+        rows.append((_row(
+            kind="amendment", record_id=aid, slug=slug,
+            headline=record.get("evidence") or "",
+            # An amendment is a claim ABOUT an item: the quote alone is not
+            # decidable without knowing what it is claimed to change.
+            context=(f"on {record.get('item_id') or '?'} "
+                     f"· claims {record.get('change') or '?'}"),
+            waiting_since=record.get("created_at") or "",
+            commands=[
+                ("confirm", f"daimon amend ratify {aid}"),
+                ("reject", f"daimon amend reject {aid}"),
+            ]),
+            seen.index(aid) if aid in seen else 0))
+    return rows
+
+
+def queue(*, project_dir=None) -> dict:
+    """{"rows": [...], "excluded": {...}} for this project.
+
+    Fail-open per source: one unreadable ledger degrades that lane rather than
+    emptying the queue, because a human-facing backlog that silently renders
+    nothing is worse than one that renders less.
+    """
+    slug = store.project_slug(project_dir)
+    pairs, suppressed = [], 0
+    try:
+        request_pairs, suppressed = _request_rows(project_dir, slug)
+        pairs += request_pairs
+    except Exception:
+        pass
+    for source in (_ledger_rows, _amendment_rows):
+        try:
+            pairs += source(project_dir, slug)
+        except Exception:
+            pass
+    pairs.sort(key=lambda pair: _order_key(pair[0], pair[1]))
+    return {
+        "rows": [row for row, _seq in pairs],
+        "excluded": {"suppressed": suppressed},
+    }

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -1255,7 +1255,10 @@ def _ledger_style(ln: str) -> str | None:
 # refutations, q- requests): the three-span header is a per-LINE shape, not
 # a per-ledger one, and a request card that fell back to whole-line styling
 # would bury the id a human copies.
-_LEDGER_HEADER_RE = re.compile(r"^(\[[^\]]*\]) ([rq]-[0-9a-f]{12})  (.*)$")
+# #766 adds a- (amendments), which `decide` renders beside the other two.
+# The failure this prevents is silent: the plain path is byte-identical
+# either way, so only the rich path loses the id it was meant to highlight.
+_LEDGER_HEADER_RE = re.compile(r"^(\[[^\]]*\]) ([rqa]-[0-9a-f]{12})  (.*)$")
 
 
 def _ledger_header_spans(ln: str):

--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -241,6 +241,8 @@ daimon request open --to <dir> --ask "<what>" --why "<why>" --by agent
 `--supersedes <id>`). `request done --evidence "<quote>"` renders as an
 unverified claim until the quote is byte-checked. `accept`, `reject`,
 `needs-info`, `suppress` are human-only: print the command, never run it.
+`daimon decide` lists every such command still waiting on a person, across
+this project's ledgers, so say it lands there and stop repeating the ask.
 
 Requests OTHER projects addressed to this one surface automatically at the
 top of `daimon brief` (capped at 3, with an overflow count). `daimon request

--- a/plugin/tests/test_cli_decide.py
+++ b/plugin/tests/test_cli_decide.py
@@ -165,3 +165,23 @@ def test_an_unreadable_timestamp_costs_the_age_and_nothing_else():
     assert lifecycle._decide_age("not a timestamp") == ""
     assert lifecycle._decide_age("") == ""
     assert lifecycle._decide_age(None) == ""
+
+
+def test_a_populated_queue_still_admits_what_it_is_not_showing(project, capsys):
+    """The sibling of the empty-queue case, and the ordinary one: items ARE
+    listed and something is also set aside. The footer is what stops the queue
+    claiming a completeness it does not have, so it has to survive a refactor
+    that only ever looks at the populated path.
+    """
+    _ruling(project)
+    muted = requests.open_request(
+        to=store.project_slug(project), ask="a muted ask",
+        why="why", channel="cli-agent", project_dir=project)
+    requests.suppress(muted, channel="cli-tty", project_dir=project)
+
+    assert cli.main(["decide"]) == 0
+    out = capsys.readouterr().out
+
+    assert "never bump to 1.0 without a human call" in out   # listed
+    assert muted not in out                                   # not listed
+    assert "1 suppressed" in out                              # admitted

--- a/plugin/tests/test_cli_decide.py
+++ b/plugin/tests/test_cli_decide.py
@@ -136,3 +136,32 @@ def test_an_amendment_names_the_item_it_amends(project, capsys):
 
     assert "o-1234567890ab" in out
     assert "progressed" in out
+
+
+# --- age formatting -----------------------------------------------------------
+
+def test_age_reads_in_days_once_there_is_a_day_to_show():
+    """A backlog is read in days. False precision on something that has waited
+    three weeks helps nobody, so hours only appear below one day."""
+    import datetime
+
+    from daimon_briefing.cli import lifecycle
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    fmt = "%Y-%m-%dT%H:%M:%SZ"
+
+    assert lifecycle._decide_age(
+        (now - datetime.timedelta(hours=3)).strftime(fmt)) == "3h"
+    assert lifecycle._decide_age(
+        (now - datetime.timedelta(days=21)).strftime(fmt)) == "21d"
+
+
+def test_an_unreadable_timestamp_costs_the_age_and_nothing_else():
+    """A row whose stamp cannot be parsed still has a decision attached to it.
+    Dropping the row would hide work; dropping the age loses nothing that
+    matters."""
+    from daimon_briefing.cli import lifecycle
+
+    assert lifecycle._decide_age("not a timestamp") == ""
+    assert lifecycle._decide_age("") == ""
+    assert lifecycle._decide_age(None) == ""

--- a/plugin/tests/test_cli_decide.py
+++ b/plugin/tests/test_cli_decide.py
@@ -1,0 +1,138 @@
+"""`daimon decide` — the human's queue (#766), slice 2.
+
+`loops` is what the agent still owes; `decide` is what you still owe. The
+command is a pure reader over `pending.queue`: it prints ids, the record's own
+text, and the one command that closes each entry. It writes nothing, so running
+it can never change what the agent's panels show.
+
+Slice 2 is this project only. Foreign projects arrive as counts in slice 3 and
+as text only behind an explicit flag in slice 4, per scar 0055.
+"""
+
+import pytest
+
+from daimon_briefing import amendments, cli, refutations, render, requests, store
+
+
+@pytest.fixture
+def project(tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    return "/p/A"
+
+
+def _ruling(project, verdict="never bump to 1.0 without a human call"):
+    return refutations.assert_ruling(
+        subject="release", verdict=verdict, scope="repo",
+        evidence=["issue:766"], channel="cli-agent", project_dir=project)
+
+
+def test_empty_queue_says_so_and_exits_zero(project, capsys):
+    assert cli.main(["decide"]) == 0
+    assert "nothing waiting on you" in capsys.readouterr().out.lower()
+
+
+def test_a_candidate_ruling_shows_its_text_and_its_command(project, capsys):
+    r_id = _ruling(project)
+
+    assert cli.main(["decide"]) == 0
+    out = capsys.readouterr().out
+
+    assert r_id in out
+    assert "never bump to 1.0 without a human call" in out
+    assert f"daimon ruling ratify {r_id}" in out
+
+
+def test_a_decided_request_is_absent(project, capsys):
+    q_id = requests.open_request(
+        to=store.project_slug(project), ask="bump before the docs change",
+        why="the tag is referenced", channel="cli-agent", project_dir=project)
+    requests.accept(q_id, channel="cli-tty", project_dir=project)
+
+    assert cli.main(["decide"]) == 0
+    assert q_id not in capsys.readouterr().out
+
+
+def test_suppressed_asks_are_counted_not_listed(project, capsys):
+    q_id = requests.open_request(
+        to=store.project_slug(project), ask="a muted ask",
+        why="why", channel="cli-agent", project_dir=project)
+    requests.suppress(q_id, channel="cli-tty", project_dir=project)
+
+    assert cli.main(["decide"]) == 0
+    out = capsys.readouterr().out
+
+    # Suppression is the owner's own "not now": it takes away placement,
+    # never visibility of the fact that something was set aside.
+    assert q_id not in out
+    assert "1 suppressed" in out
+
+
+def test_decide_writes_nothing(project, capsys):
+    requests.open_request(
+        to=store.project_slug(project), ask="an ask",
+        why="why", channel="cli-agent", project_dir=project)
+    before = requests.events(project_dir=project)
+
+    assert cli.main(["decide"]) == 0
+    capsys.readouterr()
+
+    assert requests.events(project_dir=project) == before
+
+
+def test_an_amendment_id_gets_the_ledger_header_treatment(project):
+    """#766: amendment ids are `a-`, and the ledger header span regex was
+    widened for `q-` requests (#694) but never for `a-`. An amendment card
+    would fall back to whole-line styling and bury the id a human copies —
+    silently, because the plain path stays byte-identical either way.
+    """
+    spans = render._ledger_header_spans(
+        "[? candidate] a-0f1e2d3c4b5a  the quote the agent proposed")
+
+    assert spans is not None
+    assert spans[1] == "a-0f1e2d3c4b5a"
+
+
+def test_a_verified_amendment_reaches_the_queue(project, capsys):
+    a_id = amendments.propose(
+        item_id="o-1234567890ab", change="progressed",
+        evidence="the PR merged this morning", channel="cli-agent",
+        project_dir=project)
+    amendments.verify(a_id, role="assistant", project_dir=project)
+
+    assert cli.main(["decide"]) == 0
+    out = capsys.readouterr().out
+
+    assert a_id in out
+    assert f"daimon amend ratify {a_id}" in out
+
+
+def test_the_queue_names_itself(project, capsys):
+    """The header is pinned the way the brief panels are (see
+    test_cli_brief_verdicts). Rename it and this fails deliberately: the
+    string is what a reader learns to scan for, and it is the sibling of
+    "Decisions on requests you sent:" already registered for the brief.
+    """
+    from daimon_briefing.cli import lifecycle
+
+    assert lifecycle._DECIDE_HEADER == "Decisions waiting on you:"
+
+    _ruling(project)
+    assert cli.main(["decide"]) == 0
+    assert lifecycle._DECIDE_HEADER in capsys.readouterr().out
+
+
+def test_an_amendment_names_the_item_it_amends(project, capsys):
+    """The quote alone cannot be decided on. An amendment is a claim ABOUT a
+    checkpoint item, so the target id has to travel with it or the reader has
+    to go find out what the sentence refers to."""
+    a_id = amendments.propose(
+        item_id="o-1234567890ab", change="progressed",
+        evidence="the PR merged this morning", channel="cli-agent",
+        project_dir=project)
+    amendments.verify(a_id, role="assistant", project_dir=project)
+
+    assert cli.main(["decide"]) == 0
+    out = capsys.readouterr().out
+
+    assert "o-1234567890ab" in out
+    assert "progressed" in out

--- a/plugin/tests/test_pending.py
+++ b/plugin/tests/test_pending.py
@@ -167,3 +167,48 @@ def test_every_row_carries_its_project(project):
     row = pending.queue(project_dir=project)["rows"][0]
 
     assert row["slug"] == store.project_slug(project)
+
+
+# --- degradation --------------------------------------------------------------
+
+def test_one_unreadable_ledger_degrades_its_own_lane_only(project, monkeypatch):
+    """Fail-open per source, not per queue.
+
+    A human-facing backlog that silently renders nothing is worse than one that
+    renders less: an empty queue reads as "you owe nothing", which is the one
+    false claim this surface must never make. So a source that blows up costs
+    its own lane and nothing else.
+    """
+    refutations.assert_ruling(
+        subject="release", verdict="a standing rule", scope="repo",
+        evidence=["issue:766"], channel="cli-agent", project_dir=project)
+    requests.open_request(
+        to=store.project_slug(project), ask="an ask", why="why",
+        channel="cli-agent", project_dir=project)
+
+    def boom(*_args, **_kwargs):
+        raise OSError("ledger unreadable")
+
+    monkeypatch.setattr(pending.refutations, "records", boom)
+
+    result = pending.queue(project_dir=project)
+
+    assert _kinds(result) == ["request"]
+
+
+def test_an_unreadable_request_ledger_does_not_empty_the_queue(project,
+                                                               monkeypatch):
+    refutations.assert_ruling(
+        subject="release", verdict="a standing rule", scope="repo",
+        evidence=["issue:766"], channel="cli-agent", project_dir=project)
+
+    def boom(*_args, **_kwargs):
+        raise OSError("ledger unreadable")
+
+    monkeypatch.setattr(pending.requests, "records", boom)
+
+    result = pending.queue(project_dir=project)
+
+    assert _kinds(result) == ["ruling"]
+    # The suppressed count is unknown rather than zero when its source failed.
+    assert result["excluded"]["suppressed"] == 0

--- a/plugin/tests/test_pending.py
+++ b/plugin/tests/test_pending.py
@@ -1,0 +1,169 @@
+"""The `decide` queue composer (#766), slice 1: this project's buckets only.
+
+`pending.queue` answers one question: what is waiting on a HUMAN here. A record
+qualifies only when some verb's write path refuses a non-human channel, so the
+test is structural rather than editorial. Slice 1 is deliberately single-bucket
+— foreign counts land in slice 3 and foreign text only behind `--all-projects`
+in slice 4, because printing another bucket's text into this project's
+checkpoint is what scar 0055 forbids.
+
+The composer writes nothing. In particular it never stamps `surfaced`: that
+anchor drives `is_stale`, so a stamping reader would make the person reading
+their own queue the mechanism that ages their asks out of the agent's panel.
+"""
+
+import pytest
+
+from daimon_briefing import amendments, pending, refutations, requests, store
+
+
+@pytest.fixture
+def project(tmp_checkpoint_dir):
+    # conftest's autouse fixture already isolates DAIMON_CHECKPOINT_DIR.
+    return "/p/A"
+
+
+def _kinds(result):
+    return [row["kind"] for row in result["rows"]]
+
+
+def _ids(result):
+    return [row["id"] for row in result["rows"]]
+
+
+def _commands(row):
+    return [command for _label, command in row["commands"]]
+
+
+# --- rulings and refutations -------------------------------------------------
+
+def test_candidate_ruling_waits_on_a_human(project):
+    r_id = refutations.assert_ruling(
+        subject="release", verdict="never bump to 1.0 without a human call",
+        scope="repo", evidence=["issue:766"], channel="cli-agent",
+        project_dir=project)
+
+    result = pending.queue(project_dir=project)
+
+    assert _ids(result) == [r_id]
+    row = result["rows"][0]
+    assert row["kind"] == "ruling"
+    # The rule text is the header a human reads, never the subject.
+    assert row["headline"] == "never bump to 1.0 without a human call"
+
+
+def test_an_active_ruling_owes_nothing(project):
+    refutations.assert_ruling(
+        subject="release", verdict="never bump to 1.0 without a human call",
+        scope="repo", evidence=["issue:766"], channel="cli-tty",
+        ratified=True, project_dir=project)
+
+    assert pending.queue(project_dir=project)["rows"] == []
+
+
+def test_candidate_refutation_waits_and_carries_its_own_verb(project):
+    r_id = refutations.assert_refutation(
+        subject="idf recall", verdict="does not improve recall",
+        scope="repo", evidence=["measurement:n=50"], channel="cli-agent",
+        project_dir=project)
+
+    row = pending.queue(project_dir=project)["rows"][0]
+
+    assert row["kind"] == "refutation"
+    assert row["id"] == r_id
+    # A refutation is not retired, and a ruling is not overturned.
+    assert any("refute ratify" in c for c in _commands(row))
+    assert not any("ruling ratify" in c for c in _commands(row))
+
+
+# --- amendments --------------------------------------------------------------
+
+def test_an_amendment_candidate_is_not_yet_owed(project):
+    # amendments.py:64 — candidates render nowhere, because an unverified
+    # annotation would let an agent assert state with no transcription check.
+    amendments.propose(
+        item_id="o-1234567890ab", change="progressed",
+        evidence="the PR merged this morning", channel="cli-agent",
+        project_dir=project)
+
+    assert pending.queue(project_dir=project)["rows"] == []
+
+
+def test_a_quote_verified_amendment_is_owed(project):
+    a_id = amendments.propose(
+        item_id="o-1234567890ab", change="progressed",
+        evidence="the PR merged this morning", channel="cli-agent",
+        project_dir=project)
+    amendments.verify(a_id, role="assistant", project_dir=project)
+
+    row = pending.queue(project_dir=project)["rows"][0]
+
+    assert row["kind"] == "amendment"
+    assert row["id"] == a_id
+    assert any("amend ratify" in c for c in _commands(row))
+    assert any("amend reject" in c for c in _commands(row))
+
+
+# --- requests ----------------------------------------------------------------
+
+def test_an_addressed_undecided_request_is_owed(project):
+    q_id = requests.open_request(
+        to=store.project_slug(project), ask="bump before the docs change",
+        why="the tag is referenced", channel="cli-agent", project_dir=project)
+
+    row = pending.queue(project_dir=project)["rows"][0]
+
+    assert row["kind"] == "request"
+    assert row["id"] == q_id
+    assert any("request accept" in c for c in _commands(row))
+
+
+def test_a_decided_request_is_not_owed(project):
+    q_id = requests.open_request(
+        to=store.project_slug(project), ask="bump before the docs change",
+        why="the tag is referenced", channel="cli-agent", project_dir=project)
+    requests.accept(q_id, channel="cli-tty", project_dir=project)
+
+    assert pending.queue(project_dir=project)["rows"] == []
+
+
+# --- ordering and posture ----------------------------------------------------
+
+def test_oldest_waits_first(project):
+    """`decide` is a backlog, not the panels' capped attention feed: the
+    oldest undecided item is the one rotting, so this deliberately inverts
+    `inbox_renderable`'s newest-first."""
+    first = refutations.assert_ruling(
+        subject="a", verdict="the older rule", scope="repo",
+        evidence=["issue:1"], channel="cli-agent", project_dir=project)
+    second = refutations.assert_ruling(
+        subject="b", verdict="the newer rule", scope="repo",
+        evidence=["issue:2"], channel="cli-agent", project_dir=project)
+
+    assert _ids(pending.queue(project_dir=project)) == [first, second]
+
+
+def test_the_composer_writes_nothing(project):
+    """No `surfaced` stamp, no ledger row, nothing. `is_stale` counts
+    serialized pointers against that anchor, so a stamping reader would
+    decay the asks of the person reading them."""
+    requests.open_request(
+        to=store.project_slug(project), ask="bump before the docs change",
+        why="the tag is referenced", channel="cli-agent", project_dir=project)
+    before = requests.events(project_dir=project)
+
+    pending.queue(project_dir=project)
+
+    assert requests.events(project_dir=project) == before
+
+
+def test_every_row_carries_its_project(project):
+    """Slice 3 adds other projects' counts; the field has to exist from the
+    start so a row can never be read as belonging to wherever it was run."""
+    refutations.assert_ruling(
+        subject="release", verdict="a rule", scope="repo",
+        evidence=["issue:766"], channel="cli-agent", project_dir=project)
+
+    row = pending.queue(project_dir=project)["rows"][0]
+
+    assert row["slug"] == store.project_slug(project)

--- a/plugin/tests/test_skill_content.py
+++ b/plugin/tests/test_skill_content.py
@@ -453,3 +453,23 @@ def test_full_teaches_the_briefing_rulings_section():
     from daimon_briefing import briefing
     full = skill_content.render_full()
     assert briefing._RULING_HEADER in full
+
+
+# ---- #766: the handed-over command needs somewhere to land ----
+
+def test_skill_points_the_handed_over_command_at_decide():
+    """The skill tells an agent twice to print a human-only command and never
+    run it. Before `decide` those commands landed in a chat message and
+    scrolled away, which is why the agent ended up acting as the human's
+    reminder system. Naming the queue lets it say where the command went once
+    instead of repeating itself.
+    """
+    full = skill_content.render_full()
+
+    assert "daimon decide" in full
+    # Named where the human-only verbs are actually taught, not in some
+    # distant section an agent reading about requests would never reach.
+    section = full.split("## Asking another project for something")[1]
+    section = section.split("\n## ")[0]
+    assert "human-only: print the command, never run it" in section
+    assert "daimon decide" in section

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -623,6 +623,15 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
         # (e.g. it starts writing) trips this guard immediately.
         run(["loops"], 0)
 
+    def r_decide():
+        # #766: pure read — the human's queue, composed over ledgers that
+        # already exist. Driven here for the same reason as `loops`, and for
+        # one more: `decide` must never stamp `surfaced`. That anchor drives
+        # `is_stale`, so a stamping reader would age an ask out of the agent's
+        # panel because a human looked at it. This guard is where that
+        # regression surfaces.
+        run(["decide"], 0)
+
     def r_recall_inject():
         run(["recall-inject", "--session", "S-live"], 0,
             stdin="anything about the gateway seam?")
@@ -749,6 +758,7 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
         ("log",): r_log,
         ("handoff",): r_handoff,
         ("loops",): r_loops,
+        ("decide",): r_decide,
         ("recall-inject",): r_recall_inject,
         ("request-inject",): r_request_inject,
         ("status",): r_status,

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -107,6 +107,7 @@ request write verb is reachable over MCP.
 | `daimon stats` | Local usage and capture aggregates — nothing is transmitted; sharing the output is a deliberate paste. `--json` for machines. |
 | `daimon log --text "…"` | Append a freeform timeline event to the project's event log — zero-LLM, audit-trail only. |
 | `daimon loops` | List open, addressable loop items with their ids — the read counterpart to `resolve`'s write path. |
+| `daimon decide` | List what is waiting on YOU, each with the one command that closes it — the human-side mirror of `loops`. Reads records that already exist and writes nothing at all, so opening it never changes what the agent is shown. Scoped to this project. |
 | `daimon projects` | List every project daimon holds a checkpoint for, with topic teasers. |
 | `daimon team init\|sync\|status` | Shared team memory via a sidecar repo — default-closed routing, shape-redacted before anything syncs. |
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -112,6 +112,7 @@ alcanzable por MCP.
 | `daimon stats` | Agregados locales de uso y captura — nada se transmite; compartir la salida es un pegado deliberado. `--json` para máquinas. |
 | `daimon log --text "…"` | Agrega un evento libre a la línea de tiempo del proyecto — cero LLM, solo rastro de auditoría. |
 | `daimon loops` | Lista los loops abiertos direccionables con sus ids — la contraparte de lectura del camino de escritura de `resolve`. |
+| `daimon decide` | Lista lo que está esperando por VOS, cada cosa con el único comando que la cierra — el espejo del lado humano de `loops`. Lee registros que ya existen y no escribe nada, así que abrirlo nunca cambia lo que el agente ve. Acotado a este proyecto. |
 | `daimon projects` | Lista cada proyecto con checkpoint, con un adelanto del tema. |
 | `daimon team init\|sync\|status` | Memoria de equipo compartida vía repo sidecar — ruteo cerrado por defecto, redacción por forma antes de sincronizar nada. |
 


### PR DESCRIPTION
Refs #766

## What

`daimon decide` lists what is waiting on a person, each entry with the one command that closes it. `loops` is what the agent still owes; this is what you still owe.

Three commits: a render defect this exposed, the feature, and the reference docs with the Spanish mirror.

Scoped to this project. Other projects arrive as counts in the next slice and as text only behind an explicit flag in the one after, because printing another bucket's record text copies it into this project's checkpoint where its owner's `forget` cannot reach it (scar 0055, merged separately). That split follows the doctrine `recall.py` already applies when it widens: counts by project, never content, because crossing projects stays user invoked.

## Why

The human-only verbs are real: `accept`, `reject`, `needs-info`, `suppress`, `amend ratify`, `ruling ratify`. The skill tells an agent twice to print those commands and never run them, and until now the printed command landed in a chat message and scrolled away. That is what left the agent acting as the person's reminder system.

Three design points worth review:

**Sources are chosen structurally, not editorially.** A record qualifies only where some verb's write path refuses a non-human channel. Amendments therefore enter at `verified` and never at `candidate`: a candidate has not passed the byte check, so nothing is owed yet, and `amendments.py` forbids surfacing one outright.

**It never stamps `surfaced`.** That anchor drives `is_stale`, which counts serialized checkpoint pointers rather than reads. A stamping reader would make the person opening their own queue the mechanism that ages those asks out of the agent's panel. The write audit recipe drives the command and observes no writes, so this is enforced rather than asserted.

**Suppressed records are counted, never listed.** `suppress` is human only, so a suppressed ask is already the owner's own "not now". An empty queue with suppressed records says so rather than claiming nothing is waiting.

## Tests

`plugin/tests/test_pending.py` (10) covers the composer: candidate versus active, amendment `verified` versus `candidate`, decided requests dropping off, oldest first ordering, and an explicit assertion that the event stream is byte identical before and after a read.

`plugin/tests/test_cli_decide.py` (9) covers the command, including an empty queue with suppressed records, and pins the header string the way `test_cli_brief_verdicts` pins the brief panels.

Two existing gates failed the moment the command registered and are now satisfied with content rather than exemptions: `test_write_audit_guard` needed a recipe, and `test_every_shipped_command_is_taught_or_declared_not_agent_facing` needed the skill to teach it.

The render fix has its own test: the header regex covered `r-` and `q-` but not `a-`, so an amendment card fell back to whole line styling and buried the id a person copies. That failure is silent by construction, since the plain path is byte identical either way.

Full suite: 4222 passed, 2 skipped. Ordering ties on `created_at`, which is second resolution, so ties break on append order in the ledger. In an append only log the first written is the first waiting, and the comment says so to stop a later change replacing it with a timestamp sort.

## Not in this change

Foreign counts, `--all-projects`, and the one line briefing count, which needs a contract amendment before any code. The design pass and its correction are recorded on the issue.
