### PR TITLE
fix(decide): source the request lane from the cross-bucket inbox join

### DIFF
--- a/.scars/candidates/per-bucket-fold-cannot-see-your-inbox.md
+++ b/.scars/candidates/per-bucket-fold-cannot-see-your-inbox.md
@@ -1,0 +1,46 @@
+---
+id: 0
+type: landmine
+title: A per-bucket requests fold reads your OUTGOING asks, never your inbox — an ask is stored in the sender's bucket
+severity: high
+confidence: 0.95
+created: 2026-08-28
+authors: ["claude-code"]
+anchors:
+  - path: plugin/daimon_briefing/pending.py
+  - pattern: "requests\.records\("
+evidence:
+  - commit: 8cdbede
+  - note: "daimon decide shipped listing 4 outgoing asks and omitting 2 asks addressed to this project, verified against real ledgers 2026-08-28"
+  - note: "requests.py:472 records() == fold(events(project_dir)) reads ONE file; requests.py:845 recipient_join() is the cross-bucket join and drops outgoing at :872-874"
+expires:
+  condition: "requests grow a recipient-side index, or open_request dual-writes an addressed-to row into the recipient's bucket, so a per-bucket fold can see an inbox"
+  review_after: 2027-02-28
+status: candidate
+---
+
+`requests.records(project_dir=X)` is `fold(events(X))` (requests.py:472): it reads exactly
+one file, `checkpoints/X/requests.jsonl`. That file holds the `opened` rows X WROTE, which
+are the asks X SENT to other projects. It cannot contain an ask addressed TO X, because
+`open_request` writes the row into the SENDER's bucket.
+
+So `records()` reads like "this project's requests" and is in fact "this project's OUTBOX".
+The two readings differ by 180 degrees and nothing in the name or signature says which one
+you get. `daimon decide` shipped on this mistake (#766 slice 1, commit 8cdbede) and looked
+correct in tests, because a test that opens a request locally and reads it back locally is
+exercising a self-addressed ask, the one case where both readings agree.
+
+If you want asks addressed to this project, call `requests.recipient_join(project_dir=)`
+(requests.py:845). It joins across every bucket holding a requests ledger and already
+excludes this project's own outgoing asks (:872-874). `requests.inbox_listing` (:894) is
+the shipped consumer to copy, including its `state not in _SENDER_MOVABLE` filter.
+
+Two consequences that bite downstream. First, any "local only, no cross-bucket read" scope
+claim is unavailable for an inbox surface: the data is not where it is addressed, so the
+join is not a cost you can defer behind a flag. Second, ordering that breaks ties on append
+position must take that position from the ORIGIN bucket's event order (the record's
+`from_slug`), because a foreign ask has no index in the local event list and silently
+falls back to 0.
+
+This is not scar 0055's cross-bucket render problem. An ask addressed to you is your own
+mail. What 0055 still forbids is another project's OWN record text.

--- a/plugin/daimon_briefing/cli/lifecycle.py
+++ b/plugin/daimon_briefing/cli/lifecycle.py
@@ -859,10 +859,13 @@ def _cmd_decide(args) -> int:
     can never age an ask out of the agent's panel (`is_stale` measures against
     the `surfaced` anchor, and this never writes one).
 
-    Scoped to this project. Other projects arrive as counts, then as text behind
-    an explicit flag, because printing another bucket's record text would copy
-    it into THIS project's checkpoint where its owner's `forget` cannot reach
-    it (scar 0055).
+    Scoped to this project — except the request lane, which is an inbox: an
+    ask addressed here has its `opened` row in the SENDER's bucket, so it is
+    read cross-bucket via `requests.recipient_join` (rendering your own mail,
+    not scar 0055's violation). Other projects' OWN record text still arrives
+    as counts, then as text behind an explicit flag, because printing another
+    bucket's record text would copy it into THIS project's checkpoint where
+    its owner's `forget` cannot reach it (scar 0055).
     """
     _cli._note_usage("decide")
     project = _cli._resolve_project(args.project)

--- a/plugin/daimon_briefing/pending.py
+++ b/plugin/daimon_briefing/pending.py
@@ -16,14 +16,27 @@ checkpoint pointers rather than reads. A composer that stamped would make the
 person READING their own queue the mechanism that ages those asks out of the
 agent's panel — decay inverted into deletion.
 
-SCOPE, slice 1: this project's buckets only. Foreign projects contribute counts
-in slice 3 and text only behind an explicit `--all-projects` in slice 4. That
-split is not caution, it is scar 0055: the serializer captures tool_result
-payloads, so inside an agent session CLI stdout is checkpoint input. Printing
-another bucket's record text copies that plaintext into THIS project's
-checkpoint, where `forget` in the origin project can never reach it. Same
-doctrine `recall.py` already applies when it widens: counts by project, never
-content, because crossing projects stays user-invoked.
+SCOPE, slice 1: the ruling/refutation and amendment lanes are this project's
+buckets only. Foreign projects contribute counts in slice 3 and text only
+behind an explicit `--all-projects` in slice 4. That split is not caution,
+it is scar 0055: the serializer captures tool_result payloads, so inside an
+agent session CLI stdout is checkpoint input. Printing another bucket's
+record text copies that plaintext into THIS project's checkpoint, where
+`forget` in the origin project can never reach it. Same doctrine `recall.py`
+already applies when it widens: counts by project, never content, because
+crossing projects stays user-invoked.
+
+The REQUEST lane is the deliberate exception, and always has been: an ask
+addressed to this project has its `opened` row in the SENDER's bucket, so an
+inbox is inherently cross-bucket — there is no single-bucket reading of "asks
+addressed to me" any more than `requests.inbox_listing` (its shipped panel
+precedent) has one. That is not scar 0055's violation, it is the sentence
+right after it: the scar's own closing lines say the shipped request panel
+"shows only asks addressed to THIS project" and is bounded by exactly that.
+Rendering an ask addressed to you is rendering your own mail, not a foreign
+bucket's plaintext. What scar 0055 still forbids stands untouched: a FOREIGN
+project's own record text (its rulings, its refutations, its amendments, or
+its outgoing asks to someone else) stays behind the explicit flag.
 """
 
 from __future__ import annotations
@@ -67,10 +80,33 @@ def _order_key(row: dict, seq: int) -> tuple:
 
 
 def _request_rows(project_dir, slug) -> tuple[list, int]:
-    """Asks addressed to this project that no human has answered."""
-    records = requests.records(project_dir=project_dir)
-    seen = [row.get("request_id") for row in requests.events(
-        project_dir=project_dir)]
+    """Asks addressed to this project that no human has answered.
+
+    Sourced from `requests.recipient_join`, the cross-bucket inbox join —
+    never `requests.records`, which folds only this bucket's own file. An
+    ask addressed here has its `opened` row in the SENDER's bucket, so a
+    per-bucket fold cannot see it; `recipient_join` already keeps the two
+    directions apart (requests.py:871-874), excluding this project's own
+    outgoing asks. `requests.inbox_listing` is the shipped precedent for
+    consuming it, including this same `state not in _SENDER_MOVABLE` filter.
+    """
+    records = requests.recipient_join(project_dir=project_dir)
+    # `seq` breaks the `waiting_since` tie on append order (see
+    # `_order_key`), and that order lives in whichever bucket actually wrote
+    # the `opened` row — the record's own `from_slug`, or this bucket itself
+    # for a self-addressed ask (`from_slug` is empty for those). Cache each
+    # origin bucket's event order so a bucket with several addressed asks is
+    # read once, not once per record.
+    seq_cache: dict[str, list] = {}
+
+    def _seq(record, rid) -> int:
+        origin = record.get("from_slug") or slug
+        if origin not in seq_cache:
+            seq_cache[origin] = [row.get("request_id") for row in
+                                 requests.events(project_dir=origin)]
+        seen = seq_cache[origin]
+        return seen.index(rid) if rid in seen else 0
+
     rows, suppressed = [], 0
     for rid, record in records.items():
         if record.get("state") not in requests._SENDER_MOVABLE:
@@ -92,7 +128,7 @@ def _request_rows(project_dir, slug) -> tuple[list, int]:
                 ("reject", f"daimon request reject {rid} --note \"<why>\""),
                 ("needs-info", f"daimon request needs-info {rid}"),
             ]),
-            seen.index(rid) if rid in seen else 0))
+            _seq(record, rid)))
     return rows, suppressed
 
 

--- a/plugin/tests/test_pending.py
+++ b/plugin/tests/test_pending.py
@@ -127,6 +127,28 @@ def test_a_decided_request_is_not_owed(project):
     assert pending.queue(project_dir=project)["rows"] == []
 
 
+def test_a_foreign_addressed_request_is_owed_but_our_own_outgoing_ask_is_not(
+        project):
+    """The request lane is an INBOX: the `opened` row for an ask addressed
+    to this project lives in the SENDER's bucket, not ours, so the lane has
+    to be sourced from `requests.recipient_join` (the cross-bucket join),
+    never the per-bucket `requests.records` (this bucket's own file only).
+    Both directions matter: a foreign ask addressed HERE must appear, and
+    this project's own OUTGOING ask to someone else must never appear —
+    exactly the split `recipient_join` already keeps (requests.py:871-874)."""
+    inbound_id = requests.open_request(
+        to=store.project_slug(project), ask="please review the PR",
+        why="ready to merge", channel="cli-agent", project_dir="/p/B")
+    outbound_id = requests.open_request(
+        to=store.project_slug("/p/B"), ask="please look at this later",
+        why="fyi", channel="cli-agent", project_dir=project)
+
+    result = pending.queue(project_dir=project)
+
+    assert _ids(result) == [inbound_id]
+    assert outbound_id not in _ids(result)
+
+
 # --- ordering and posture ----------------------------------------------------
 
 def test_oldest_waits_first(project):
@@ -139,6 +161,27 @@ def test_oldest_waits_first(project):
     second = refutations.assert_ruling(
         subject="b", verdict="the newer rule", scope="repo",
         evidence=["issue:2"], channel="cli-agent", project_dir=project)
+
+    assert _ids(pending.queue(project_dir=project)) == [first, second]
+
+
+def test_two_foreign_asks_with_identical_timestamps_keep_append_order(
+        project, monkeypatch):
+    """`_order_key`'s append-order tiebreak (pending.py:58) is deliberate:
+    `created_at` is second-resolution and ties routinely, so in an
+    append-only log the first WRITTEN is first waiting. Sourcing the lane
+    from `recipient_join` must not lose this — the `seq` used to break the
+    tie has to come from the ORIGIN bucket's event order (via the record's
+    `from_slug`), not a local index that does not exist for a foreign ask.
+    Two asks from the same foreign sender, same second, pin it."""
+    monkeypatch.setattr(requests.time, "time_ns",
+                        lambda: 1_786_000_000 * 10 ** 9)
+    first = requests.open_request(
+        to=store.project_slug(project), ask="review the first PR",
+        why="ready", channel="cli-agent", project_dir="/p/B")
+    second = requests.open_request(
+        to=store.project_slug(project), ask="review the second PR",
+        why="ready too", channel="cli-agent", project_dir="/p/B")
 
     assert _ids(pending.queue(project_dir=project)) == [first, second]
 
@@ -205,7 +248,10 @@ def test_an_unreadable_request_ledger_does_not_empty_the_queue(project,
     def boom(*_args, **_kwargs):
         raise OSError("ledger unreadable")
 
-    monkeypatch.setattr(pending.requests, "records", boom)
+    # The request lane now sources from `recipient_join` (the cross-bucket
+    # inbox join), not `records` (the per-bucket fold) — see
+    # test_a_foreign_addressed_request_is_owed_but_our_own_outgoing_ask_is_not.
+    monkeypatch.setattr(pending.requests, "recipient_join", boom)
 
     result = pending.queue(project_dir=project)
 

--- a/plugin/tests/test_requests_scan_cost.py
+++ b/plugin/tests/test_requests_scan_cost.py
@@ -13,7 +13,7 @@ feature than the one that will actually ship once PR 3 lands.
 """
 import time
 
-from daimon_briefing import requests, store
+from daimon_briefing import pending, requests, store
 
 RECIPIENT = "/p/scan-cost-recipient"
 N_BUCKETS = 50          # "a realistic multi-bucket store" per the PR brief
@@ -85,3 +85,44 @@ def test_combined_brief_time_cost_stays_within_budget(tmp_checkpoint_dir,
     assert elapsed_ms <= _BUDGET_MS, (
         f"combined composer+panel+stamp cost {elapsed_ms:.2f}ms exceeds the "
         f"{_BUDGET_MS}ms budget over {N_BUCKETS} buckets")
+
+
+# The fix for the polarity bug: `daimon decide`'s request lane now sources
+# from `requests.recipient_join` (see `pending._request_rows`) instead of
+# the per-bucket `requests.records`, so it pays the same fleet-scan
+# `_bucket_slugs` walks. On top of that, the append-order tiebreak
+# (`pending._order_key`) reads each ADDRESSED bucket's `events()` a second
+# time to seat the `seq` a foreign record has no local index for — one extra
+# read per addressed bucket, not per fleet bucket.
+#
+# Budget reasoning: measured on this machine at ~3-4ms over the same
+# 50-bucket/8-addressed fleet (`_seed()`) — see the printed line this test
+# emits. Cheaper than the panel measurement above (~35-45ms) for a real
+# reason, not a fluke: `decide` is a pure reader (#8 of the fix that added
+# this test — see `pending.py`'s "WHY IT WRITES NOTHING"), so it never pays
+# `stamp_surfaced`'s per-row write, and it skips the PR-3-shaped stub scan
+# the panel test folds in. What it DOES pay is the same fleet walk
+# (`_bucket_slugs` + one `events()` read per bucket) plus one extra
+# `events()` read per ADDRESSED bucket for the append-order `seq` — bounded
+# by N_ADDRESSED (8), not N_BUCKETS (50). 150ms keeps the panel's budget
+# rather than tightening to the observed number: a slower disk or CI runner
+# should not trip this on a healthy run, while a regression (e.g. re-reading
+# every bucket, not just the addressed ones, for `seq`) still would.
+_DECIDE_BUDGET_MS = 150.0
+
+
+def test_decide_queue_time_cost_stays_within_budget(tmp_checkpoint_dir,
+                                                     capsys):
+    _seed()
+    start = time.perf_counter()
+    result = pending.queue(project_dir=RECIPIENT)
+    elapsed_ms = (time.perf_counter() - start) * 1000
+
+    assert result["rows"], "measurement is void if nothing was addressed here"
+    with capsys.disabled():
+        print(f"\n#766 decide request-lane scan cost: {elapsed_ms:.2f}ms "
+             f"over {N_BUCKETS} buckets ({N_ADDRESSED} addressed) — "
+             f"budget {_DECIDE_BUDGET_MS}ms")
+    assert elapsed_ms <= _DECIDE_BUDGET_MS, (
+        f"pending.queue cost {elapsed_ms:.2f}ms exceeds the "
+        f"{_DECIDE_BUDGET_MS}ms budget over {N_BUCKETS} buckets")


### PR DESCRIPTION
Refs #766

## What

`daimon decide`'s request lane now sources from `requests.recipient_join`, the cross-bucket inbox join, instead of `requests.records`, the per-bucket fold.

Before this change the lane listed the asks this project had SENT and omitted the asks addressed TO it. The other two lanes (candidate rulings/refutations, verified amendments) were correct and are untouched.

## Why

A request lives in the SENDER's bucket. `requests.records` is `fold(events(project_dir))`, so it reads one file: this project's own. That file holds this project's own `opened` rows, which are its outgoing asks. The `opened` row for an ask addressed here is in whichever project sent it.

So an inbox has no single-bucket reading. `requests.recipient_join` already draws that line, and already excludes this project's outgoing asks so the two directions never mix. `requests.inbox_listing` is the shipped precedent for consuming it, down to the same `state not in _SENDER_MOVABLE` filter.

This corrects a scoping claim in the #766 design as well: slices 1 and 2 were planned as purely local, and the request lane cannot be. That is a property of where an ask is stored, not a choice the surface gets to make.

It does not widen what scar 0055 guards. The scar's own closing lines note that the shipped request panel "shows only asks addressed to THIS project" and is bounded by that. Rendering an ask addressed to you is rendering your own mail. Another project's own record text, including its outgoing asks to someone else, stays behind the explicit flag that slice 4 adds.

The append-order tiebreak in `_order_key` is preserved. `created_at` is second-resolution and ties routinely, so the first row written is the first waiting. That order lives in the bucket that wrote the `opened` row, so `seq` is now derived from the origin bucket via the record's `from_slug`, with one cached read per origin rather than one per record.

`decide` remains a pure reader. No `surfaced` stamp, no ledger row.

## Tests

`uv run --project plugin pytest plugin/tests` : 4230 passed, 2 skipped.

Two new tests in `test_pending.py`, both failing before the change:

- `test_a_foreign_addressed_request_is_owed_but_our_own_outgoing_ask_is_not` asserts both directions in one place: an ask opened by another bucket addressed here appears, and this project's own outgoing ask does not.
- `test_two_foreign_asks_with_identical_timestamps_keep_append_order` freezes the clock and pins the tiebreak across the new origin-bucket lookup.

One existing test updated: `test_an_unreadable_request_ledger_does_not_empty_the_queue` now monkeypatches `recipient_join`, the function the lane actually calls, so the fail-open guarantee still covers the live path.

New scan-cost measurement in `test_requests_scan_cost.py`, following that file's convention of giving a fleet-scaling read its own stated budget: 3.77ms over 50 buckets (8 addressed), budget 150ms. The lane reads one file per bucket and writes nothing, so it costs well under the brief's existing combined 43ms.
