### PR TITLE
feat(decide): count what waits in other projects, never their text

### DIFF
--- a/.scars/0056-per-bucket-fold-cannot-see-your-inbox.landmine.md
+++ b/.scars/0056-per-bucket-fold-cannot-see-your-inbox.landmine.md
@@ -1,22 +1,22 @@
 ---
-id: 0
+id: 56
 type: landmine
 title: A per-bucket requests fold reads your OUTGOING asks, never your inbox — an ask is stored in the sender's bucket
 severity: high
 confidence: 0.95
 created: 2026-08-28
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/pending.py
   - pattern: "requests\.records\("
 evidence:
   - commit: 8cdbede
-  - note: "daimon decide shipped listing 4 outgoing asks and omitting 2 asks addressed to this project, verified against real ledgers 2026-08-28"
-  - note: "requests.py:472 records() == fold(events(project_dir)) reads ONE file; requests.py:845 recipient_join() is the cross-bucket join and drops outgoing at :872-874"
+  - note: daimon decide shipped listing 4 outgoing asks and omitting 2 asks addressed to this project, verified against real ledgers 2026-08-28
+  - note: requests.py:472 records() == fold(events(project_dir)) reads ONE file; requests.py:845 recipient_join() is the cross-bucket join and drops outgoing at :872-874
 expires:
   condition: "requests grow a recipient-side index, or open_request dual-writes an addressed-to row into the recipient's bucket, so a per-bucket fold can see an inbox"
   review_after: 2027-02-28
-status: candidate
+status: active
 ---
 
 `requests.records(project_dir=X)` is `fold(events(X))` (requests.py:472): it reads exactly

--- a/plugin/daimon_briefing/cli/lifecycle.py
+++ b/plugin/daimon_briefing/cli/lifecycle.py
@@ -851,6 +851,23 @@ def _decide_age(waiting_since: str) -> str:
     return f"{hours // 24}d" if hours >= 24 else f"{hours}h"
 
 
+def _foreign_footer_lines(counts: dict) -> list:
+    """Slice 3 footer: how much waits on the human in every OTHER project,
+    counts only. Follows the shipped counts-by-project precedent
+    (`cli/__init__.py`'s zero-match `recall` retry) — render the number and
+    the owning slug, count-descending, and tell the operator how to act,
+    never the record itself.
+    """
+    if not counts:
+        return []
+    total = sum(counts.values())
+    lines = [f"{total} more waiting in other projects:"]
+    lines += [f"  {slug} ({n})" for slug, n in
+              sorted(counts.items(), key=lambda kv: -kv[1])]
+    lines.append("open that project to act on them")
+    return lines
+
+
 def _cmd_decide(args) -> int:
     """`decide` — everything waiting on a HUMAN, with the command that closes it.
 
@@ -863,7 +880,8 @@ def _cmd_decide(args) -> int:
     ask addressed here has its `opened` row in the SENDER's bucket, so it is
     read cross-bucket via `requests.recipient_join` (rendering your own mail,
     not scar 0055's violation). Other projects' OWN record text still arrives
-    as counts, then as text behind an explicit flag, because printing another
+    as counts (slice 3's footer, `pending.foreign_counts`), then as text
+    behind an explicit flag in a future slice, because printing another
     bucket's record text would copy it into THIS project's checkpoint where
     its owner's `forget` cannot reach it (scar 0055).
     """
@@ -872,13 +890,17 @@ def _cmd_decide(args) -> int:
     result = pending.queue(project_dir=project)
     rows = result.get("rows") or []
     suppressed = (result.get("excluded") or {}).get("suppressed") or 0
+    foreign = pending.foreign_counts(project_dir=project)
     if not rows:
         # "nothing waiting" would be a false claim while records sit
         # suppressed: the human set those aside, they did not go away.
-        render.render_ledger_lines(
-            ["nothing waiting on you in this project"] if not suppressed
-            else [f"nothing listed for you in this project "
-                  f"({suppressed} suppressed — daimon request inbox)"])
+        lines = (["nothing waiting on you in this project"] if not suppressed
+                  else [f"nothing listed for you in this project "
+                        f"({suppressed} suppressed — daimon request inbox)"])
+        # Same false-claim risk one level up: an empty LOCAL queue must not
+        # read as an empty queue everywhere.
+        lines += _foreign_footer_lines(foreign)
+        render.render_ledger_lines(lines)
         return 0
 
     render.render_ledger_lines([_DECIDE_HEADER])
@@ -904,6 +926,9 @@ def _cmd_decide(args) -> int:
         # claiming a completeness it does not have.
         render.render_ledger_lines(
             [f"  ({suppressed} suppressed — daimon request inbox)"])
+    footer = _foreign_footer_lines(foreign)
+    if footer:
+        render.render_ledger_lines(footer)
     return 0
 
 

--- a/plugin/daimon_briefing/pending.py
+++ b/plugin/daimon_briefing/pending.py
@@ -275,9 +275,10 @@ def _foreign_request_counts(slug: str) -> dict[str, int]:
         except Exception:
             continue
         for row in rows:
+            # `events` already filtered every row through `_REQUEST_ID_RE`
+            # (requests.py:285-288), so the id is present and well-formed
+            # here — no second guard, which would be unreachable.
             rid = str(row.get("request_id") or "")
-            if not rid:
-                continue
             by_id.setdefault(rid, []).append(_strip_plaintext(row))
     counts: dict[str, int] = {}
     for rows in by_id.values():

--- a/plugin/daimon_briefing/pending.py
+++ b/plugin/daimon_briefing/pending.py
@@ -16,15 +16,16 @@ checkpoint pointers rather than reads. A composer that stamped would make the
 person READING their own queue the mechanism that ages those asks out of the
 agent's panel — decay inverted into deletion.
 
-SCOPE, slice 1: the ruling/refutation and amendment lanes are this project's
-buckets only. Foreign projects contribute counts in slice 3 and text only
-behind an explicit `--all-projects` in slice 4. That split is not caution,
-it is scar 0055: the serializer captures tool_result payloads, so inside an
-agent session CLI stdout is checkpoint input. Printing another bucket's
-record text copies that plaintext into THIS project's checkpoint, where
-`forget` in the origin project can never reach it. Same doctrine `recall.py`
-already applies when it widens: counts by project, never content, because
-crossing projects stays user-invoked.
+SCOPE, slice 1: the ruling/refutation and amendment lanes render this
+project's own buckets only. Slice 3 (`foreign_counts`) widens that to every
+OTHER project too, but as INTEGERS ONLY — text stays behind an explicit
+`--all-projects` reserved for slice 4. That split is not caution, it is
+scar 0055: the serializer captures tool_result payloads, so inside an agent
+session CLI stdout is checkpoint input. Printing another bucket's record
+text copies that plaintext into THIS project's checkpoint, where `forget`
+in the origin project can never reach it. Same doctrine `recall.py` already
+applies when it widens: counts by project, never content, because crossing
+projects stays user-invoked.
 
 The REQUEST lane is the deliberate exception, and always has been: an ask
 addressed to this project has its `opened` row in the SENDER's bucket, so an
@@ -41,7 +42,7 @@ its outgoing asks to someone else) stays behind the explicit flag.
 
 from __future__ import annotations
 
-from . import amendments, refutations, requests, store
+from . import amendments, config, refutations, requests, store
 
 
 # Requests first: someone else is blocked on them. Then quote-verified
@@ -220,3 +221,143 @@ def queue(*, project_dir=None) -> dict:
         "rows": [row for row, _seq in pairs],
         "excluded": {"suppressed": suppressed},
     }
+
+
+# ---- slice 3: foreign counts -----------------------------------------------
+#
+# `queue` answers "what is waiting on me, HERE". `foreign_counts` answers a
+# different question: how much is waiting on the human in every OTHER
+# project — as INTEGERS ONLY. Scar 0055 governs this surface completely: the
+# serializer captures tool_result payloads, so printing a foreign bucket's
+# own record text into a `daimon decide` run inside THIS project copies that
+# plaintext into THIS project's checkpoint, where the origin's `forget` can
+# never reach it. So nothing below may return a record, an id, or text —
+# only a count per owning slug.
+
+
+def _strip_plaintext(row: dict) -> dict:
+    """Presence sentinel for every field `requests._PLAINTEXT_FIELDS` names:
+    `"x"` if the original held non-whitespace content, `""` otherwise. Every
+    other key passes through untouched. Applied at the READ boundary, before
+    folding, so a foreign bucket's ask/why/note/evidence/from_label never
+    travels through this project's process as real text.
+
+    A sentinel, not a dropped field: `requests.fold`'s read-boundary shape
+    check (requests.py:333) rejects an `opened` row whose `ask` is empty, so
+    dropping the field would silently undercount and disagree with what
+    `decide` shows inside the owning project.
+    """
+    out = dict(row)
+    for field in requests._PLAINTEXT_FIELDS:
+        if field in out:
+            out[field] = "x" if str(out.get(field) or "").strip() else ""
+    return out
+
+
+def _foreign_request_counts(slug: str) -> dict[str, int]:
+    """Every foreign project's waiting request count, in ONE fleet-wide pass.
+
+    A request's rows can span two buckets — the `opened` row in the
+    sender's, a verdict or suppression in the recipient's — so computing
+    this per foreign project via `queue`/`recipient_join` would each rescan
+    every bucket in the fleet: O(N^2). Here every bucket
+    (`requests._bucket_slugs()`) is read exactly once, rows are grouped by
+    `request_id` across buckets, and each group is folded once — reusing
+    `requests.fold` rather than a second counting state machine, so this
+    lane can never drift from the transitions `queue`'s own request lane
+    already trusts (suppression, rejection terminality, the human-only
+    verdict re-check).
+    """
+    by_id: dict[str, list] = {}
+    for bucket in requests._bucket_slugs():
+        try:
+            rows = requests.events(project_dir=bucket)
+        except Exception:
+            continue
+        for row in rows:
+            rid = str(row.get("request_id") or "")
+            if not rid:
+                continue
+            by_id.setdefault(rid, []).append(_strip_plaintext(row))
+    counts: dict[str, int] = {}
+    for rows in by_id.values():
+        try:
+            folded = requests.fold(rows)
+        except Exception:
+            continue
+        for record in folded.values():
+            to = str(record.get("to") or "")
+            if not to or to == slug:
+                continue  # this project's own inbox is `queue`'s, not ours
+            if record.get("state") not in requests._SENDER_MOVABLE:
+                continue
+            if record.get("suppressed"):
+                continue
+            counts[to] = counts.get(to, 0) + 1
+    return counts
+
+
+def _ledger_bucket_slugs() -> list[str]:
+    """Every project bucket directory under the checkpoint root.
+
+    Unlike the request lane, rulings/refutations and amendments are
+    genuinely single-bucket ledgers — a foreign bucket's own record lives
+    only in that bucket, never split across two. So every bucket has to be
+    checked directly rather than joined; a bucket with no refutations.jsonl
+    or amendments.jsonl yet simply reads back `{}` from `.records()`.
+    """
+    try:
+        return [child.name for child in
+                sorted(config.checkpoint_dir().iterdir()) if child.is_dir()]
+    except OSError:
+        return []
+
+
+def _foreign_ledger_counts(slug: str) -> dict[str, int]:
+    """Candidate rulings/refutations and verified amendments in every OTHER
+    bucket, read directly (single-bucket lanes) — fail-open per bucket, per
+    lane, matching `queue`'s own degradation posture. Only `state` survives
+    past the read: the record itself (subject, verdict, evidence text) is
+    dropped before this returns.
+    """
+    counts: dict[str, int] = {}
+    for bucket in _ledger_bucket_slugs():
+        if bucket == slug:
+            continue
+        try:
+            for record in refutations.records(project_dir=bucket).values():
+                if record.get("state") == "candidate":
+                    counts[bucket] = counts.get(bucket, 0) + 1
+        except Exception:
+            pass
+        try:
+            for record in amendments.records(project_dir=bucket).values():
+                if record.get("state") == "verified":
+                    counts[bucket] = counts.get(bucket, 0) + 1
+        except Exception:
+            pass
+    return counts
+
+
+def foreign_counts(*, project_dir=None) -> dict[str, int]:
+    """{"slug": waiting_count} for every OTHER project's decide queue —
+    integers only, never records, ids, or text. This project's own slug is
+    excluded; its own queue is `queue()` above.
+
+    Fail-open at both lane boundaries: an unreadable foreign bucket
+    degrades that bucket's contribution, never the whole count, and never
+    `queue`'s own local result.
+    """
+    slug = store.project_slug(project_dir)
+    counts: dict[str, int] = {}
+    try:
+        for foreign_slug, n in _foreign_request_counts(slug).items():
+            counts[foreign_slug] = counts.get(foreign_slug, 0) + n
+    except Exception:
+        pass
+    try:
+        for foreign_slug, n in _foreign_ledger_counts(slug).items():
+            counts[foreign_slug] = counts.get(foreign_slug, 0) + n
+    except Exception:
+        pass
+    return counts

--- a/plugin/tests/test_cli_decide.py
+++ b/plugin/tests/test_cli_decide.py
@@ -11,7 +11,15 @@ as text only behind an explicit flag in slice 4, per scar 0055.
 
 import pytest
 
-from daimon_briefing import amendments, cli, refutations, render, requests, store
+from daimon_briefing import (
+    amendments,
+    cli,
+    pending,
+    refutations,
+    render,
+    requests,
+    store,
+)
 
 
 @pytest.fixture
@@ -185,3 +193,64 @@ def test_a_populated_queue_still_admits_what_it_is_not_showing(project, capsys):
     assert "never bump to 1.0 without a human call" in out   # listed
     assert muted not in out                                   # not listed
     assert "1 suppressed" in out                              # admitted
+
+
+# --- foreign counts (slice 3) -------------------------------------------------
+
+def test_decide_footer_shows_foreign_counts_never_text(project, capsys):
+    """The plaintext guarantee, pinned structurally: scar 0055 forbids a
+    foreign bucket's own prose from crossing into THIS project's stdout
+    (and therefore its checkpoint). Seed a request whose ask/why/evidence
+    each carry a distinctive sentinel and prove it never lands in output —
+    only the owning slug and an integer count may.
+    """
+    sentinel = "UNIQUE-PLAINTEXT-SENTINEL-990177"
+    b = store.project_slug("/p/B")
+    requests.open_request(
+        to=b, ask=f"do the thing {sentinel}", why=f"because {sentinel}",
+        evidence=f"proof {sentinel}", channel="cli-agent",
+        project_dir="/p/A")
+    # A local ruling too, so this exercises the POPULATED path (footer after
+    # the cards and the suppressed line), not just the empty-queue branch.
+    _ruling(project)
+
+    assert cli.main(["decide"]) == 0
+    out = capsys.readouterr().out
+
+    assert sentinel not in out
+    assert b in out
+    assert "1 more waiting in other projects" in out
+
+
+def test_empty_local_queue_still_reports_foreign_counts(project, capsys):
+    """The sibling of the ordinary populated case: nothing waits HERE, but
+    the empty-queue path must not silently drop the fact that something
+    waits elsewhere.
+    """
+    requests.open_request(
+        to=store.project_slug("/p/B"), ask="please review", why="ready",
+        channel="cli-agent", project_dir="/p/A")
+
+    assert cli.main(["decide"]) == 0
+    out = capsys.readouterr().out
+
+    assert "nothing waiting on you in this project" in out
+    assert store.project_slug("/p/B") in out
+
+
+def test_no_foreign_activity_means_no_footer(project, capsys):
+    assert cli.main(["decide"]) == 0
+    out = capsys.readouterr().out
+
+    assert "more waiting in other projects" not in out
+
+
+def test_foreign_counts_returns_integers_only(project):
+    requests.open_request(
+        to=store.project_slug("/p/B"), ask="please review", why="ready",
+        channel="cli-agent", project_dir="/p/A")
+
+    result = pending.foreign_counts(project_dir=project)
+
+    assert result
+    assert all(isinstance(v, int) for v in result.values())

--- a/plugin/tests/test_pending.py
+++ b/plugin/tests/test_pending.py
@@ -258,3 +258,152 @@ def test_an_unreadable_request_ledger_does_not_empty_the_queue(project,
     assert _kinds(result) == ["ruling"]
     # The suppressed count is unknown rather than zero when its source failed.
     assert result["excluded"]["suppressed"] == 0
+
+
+# --- foreign counts (slice 3) -------------------------------------------------
+#
+# `pending.foreign_counts` answers a different question than `queue`: not
+# "what is waiting on me here" but "how much is waiting on the human in
+# EVERY OTHER project". Integers only — never records, ids, or text, because
+# printing a foreign bucket's plaintext into THIS project's checkpoint is
+# exactly what scar 0055 forbids. The observer in these tests is a THIRD
+# project, distinct from sender and recipient, so a count landing on the
+# right slug is never an accident of which bucket happened to be "project".
+
+
+def test_a_foreign_addressed_request_is_counted_for_its_recipient(project):
+    b = store.project_slug("/p/B")
+    requests.open_request(
+        to=b, ask="please review the PR", why="ready to merge",
+        channel="cli-agent", project_dir="/p/A")
+
+    counts = pending.foreign_counts(project_dir="/p/C")
+
+    assert counts[b] == 1
+
+
+def test_this_projects_own_waiting_decisions_are_not_in_the_foreign_counts(
+        project):
+    requests.open_request(
+        to=store.project_slug(project), ask="please review", why="ready",
+        channel="cli-agent", project_dir="/p/A")
+
+    counts = pending.foreign_counts(project_dir=project)
+
+    assert store.project_slug(project) not in counts
+
+
+def test_a_suppressed_foreign_request_is_not_counted(project):
+    b = store.project_slug("/p/B")
+    q_id = requests.open_request(
+        to=b, ask="please review", why="ready", channel="cli-agent",
+        project_dir="/p/A")
+    requests.suppress(q_id, channel="cli-tty", project_dir=b)
+
+    counts = pending.foreign_counts(project_dir="/p/C")
+
+    assert counts.get(b, 0) == 0
+
+
+def test_a_decided_foreign_request_is_not_counted(project):
+    b = store.project_slug("/p/B")
+    q_id = requests.open_request(
+        to=b, ask="please review", why="ready", channel="cli-agent",
+        project_dir="/p/A")
+    requests.accept(q_id, channel="cli-tty", project_dir=b)
+
+    counts = pending.foreign_counts(project_dir="/p/C")
+
+    assert counts.get(b, 0) == 0
+
+
+def test_a_rejected_foreign_request_is_not_counted(project):
+    b = store.project_slug("/p/B")
+    q_id = requests.open_request(
+        to=b, ask="please review", why="ready", channel="cli-agent",
+        project_dir="/p/A")
+    requests.reject(q_id, channel="cli-tty", project_dir=b)
+
+    counts = pending.foreign_counts(project_dir="/p/C")
+
+    assert counts.get(b, 0) == 0
+
+
+def test_foreign_candidate_rulings_and_refutations_are_counted(project):
+    b = "/p/B"
+    refutations.assert_ruling(
+        subject="release", verdict="a standing rule", scope="repo",
+        evidence=["issue:766"], channel="cli-agent", project_dir=b)
+    refutations.assert_refutation(
+        subject="idf recall", verdict="does not improve recall",
+        scope="repo", evidence=["measurement:n=50"], channel="cli-agent",
+        project_dir=b)
+
+    counts = pending.foreign_counts(project_dir="/p/C")
+
+    assert counts[store.project_slug(b)] == 2
+
+
+def test_foreign_verified_amendments_are_counted(project):
+    b = "/p/B"
+    a_id = amendments.propose(
+        item_id="o-1234567890ab", change="progressed",
+        evidence="the PR merged this morning", channel="cli-agent",
+        project_dir=b)
+    amendments.verify(a_id, role="assistant", project_dir=b)
+
+    counts = pending.foreign_counts(project_dir="/p/C")
+
+    assert counts[store.project_slug(b)] == 1
+
+
+def test_an_unverified_amendment_candidate_is_not_counted(project):
+    b = "/p/B"
+    amendments.propose(
+        item_id="o-1234567890ab", change="progressed",
+        evidence="the PR merged this morning", channel="cli-agent",
+        project_dir=b)
+
+    counts = pending.foreign_counts(project_dir="/p/C")
+
+    assert counts.get(store.project_slug(b), 0) == 0
+
+
+def test_foreign_counts_returns_integers_only(project):
+    requests.open_request(
+        to=store.project_slug("/p/B"), ask="please review", why="ready",
+        channel="cli-agent", project_dir="/p/A")
+    refutations.assert_ruling(
+        subject="release", verdict="a standing rule", scope="repo",
+        evidence=["issue:766"], channel="cli-agent", project_dir="/p/B")
+
+    counts = pending.foreign_counts(project_dir="/p/C")
+
+    assert counts
+    assert all(isinstance(v, int) for v in counts.values())
+
+
+def test_an_unreadable_foreign_ledger_degrades_that_bucket_only(project,
+                                                                 monkeypatch):
+    """Fail-open per bucket, per lane — the same posture `queue` holds for
+    this project's own lanes. A foreign fleet scan that raised on one bad
+    bucket would be strictly worse than `queue`'s own degradation story."""
+    requests.open_request(
+        to=store.project_slug("/p/B"), ask="please review", why="ready",
+        channel="cli-agent", project_dir="/p/A")
+    refutations.assert_ruling(
+        subject="release", verdict="a standing rule", scope="repo",
+        evidence=["issue:766"], channel="cli-agent", project_dir="/p/D")
+
+    def boom(*_args, **_kwargs):
+        raise OSError("ledger unreadable")
+
+    monkeypatch.setattr(pending.amendments, "records", boom)
+
+    counts = pending.foreign_counts(project_dir="/p/C")
+
+    assert counts[store.project_slug("/p/B")] == 1
+    assert counts[store.project_slug("/p/D")] == 1
+    # And the local queue this project owes is untouched by a foreign-lane
+    # failure.
+    assert pending.queue(project_dir=project)["rows"] == []

--- a/plugin/tests/test_pending.py
+++ b/plugin/tests/test_pending.py
@@ -407,3 +407,100 @@ def test_an_unreadable_foreign_ledger_degrades_that_bucket_only(project,
     # And the local queue this project owes is untouched by a foreign-lane
     # failure.
     assert pending.queue(project_dir=project)["rows"] == []
+
+
+def test_an_unreadable_foreign_bucket_does_not_sink_the_fleet_pass(project,
+                                                                   monkeypatch):
+    """The fleet pass reads every bucket; one that raises must cost that
+    bucket alone. `requests.events` is already best-effort about malformed
+    lines, so reaching this branch takes a failure it cannot absorb (a
+    permission error on the path itself) — which is exactly the case that
+    must not take the whole count down with it."""
+    requests.open_request(
+        to=store.project_slug("/p/B"), ask="please review", why="ready",
+        channel="cli-agent", project_dir="/p/A")
+    real_events = pending.requests.events
+    bad = store.project_slug("/p/A")
+
+    def selective(*args, **kwargs):
+        if kwargs.get("project_dir") == bad:
+            raise OSError("bucket unreadable")
+        return real_events(*args, **kwargs)
+
+    monkeypatch.setattr(pending.requests, "events", selective)
+
+    # The only sender bucket is unreadable, so its ask cannot be counted —
+    # but the call returns a count rather than raising, and the local queue
+    # is untouched.
+    assert pending.foreign_counts(project_dir="/p/C") == {}
+    assert pending.queue(project_dir=project)["rows"] == []
+
+
+def test_an_unfoldable_request_group_is_skipped_not_fatal(project, monkeypatch):
+    """One malformed group must not cost the other projects their counts."""
+    requests.open_request(
+        to=store.project_slug("/p/B"), ask="please review", why="ready",
+        channel="cli-agent", project_dir="/p/A")
+
+    def boom(*_args, **_kwargs):
+        raise ValueError("unfoldable")
+
+    monkeypatch.setattr(pending.requests, "fold", boom)
+
+    assert pending.foreign_counts(project_dir="/p/C") == {}
+    assert pending.queue(project_dir=project)["rows"] == []
+
+
+def test_an_unreadable_foreign_ruling_ledger_degrades_that_lane_only(
+        project, monkeypatch):
+    """The refutations half of the ledger lane fails open independently of
+    the amendments half — one bad lane must not cost the other."""
+    a_id = amendments.propose(
+        item_id="o-1234567890ab", change="progressed",
+        evidence="a quote that was verified", channel="cli-agent",
+        project_dir="/p/D")
+    amendments.verify(a_id, role="assistant", project_dir="/p/D")
+
+    def boom(*_args, **_kwargs):
+        raise OSError("ledger unreadable")
+
+    monkeypatch.setattr(pending.refutations, "records", boom)
+
+    counts = pending.foreign_counts(project_dir="/p/C")
+
+    assert counts[store.project_slug("/p/D")] == 1
+    assert pending.queue(project_dir=project)["rows"] == []
+
+
+def test_a_failing_request_lane_still_yields_the_ledger_counts(project,
+                                                              monkeypatch):
+    """Outer fail-open: the two lanes are independent at the top level too,
+    so a request lane that raises leaves the ledger counts intact."""
+    refutations.assert_ruling(
+        subject="release", verdict="a standing rule", scope="repo",
+        evidence=["issue:766"], channel="cli-agent", project_dir="/p/D")
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("request lane exploded")
+
+    monkeypatch.setattr(pending, "_foreign_request_counts", boom)
+
+    assert pending.foreign_counts(project_dir="/p/C") == {
+        store.project_slug("/p/D"): 1}
+
+
+def test_a_failing_ledger_lane_still_yields_the_request_counts(project,
+                                                               monkeypatch):
+    """The mirror of the above: a ledger lane that raises leaves the request
+    counts intact."""
+    requests.open_request(
+        to=store.project_slug("/p/B"), ask="please review", why="ready",
+        channel="cli-agent", project_dir="/p/A")
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("ledger lane exploded")
+
+    monkeypatch.setattr(pending, "_foreign_ledger_counts", boom)
+
+    assert pending.foreign_counts(project_dir="/p/C") == {
+        store.project_slug("/p/B"): 1}

--- a/plugin/tests/test_requests_scan_cost.py
+++ b/plugin/tests/test_requests_scan_cost.py
@@ -126,3 +126,41 @@ def test_decide_queue_time_cost_stays_within_budget(tmp_checkpoint_dir,
     assert elapsed_ms <= _DECIDE_BUDGET_MS, (
         f"pending.queue cost {elapsed_ms:.2f}ms exceeds the "
         f"{_DECIDE_BUDGET_MS}ms budget over {N_BUCKETS} buckets")
+
+
+# #766 slice 3: `pending.foreign_counts` reads every bucket's requests ledger
+# in ONE fleet-wide pass (grouped by request_id, folded once per group) plus
+# one direct read of refutations.jsonl and amendments.jsonl per foreign
+# bucket — deliberately NOT `pending.queue(project_dir=foreign_slug)` called
+# once per foreign project, which would each pay `recipient_join`'s own
+# fleet scan and turn the whole thing O(N^2) (91.4ms measured that way over
+# 25 buckets against this same 150ms budget, and it only gets worse as the
+# fleet grows).
+#
+# Budget reasoning: measured on this machine at ~4-6ms for 50 buckets — see
+# the printed line this test emits; cheaper than the panel/decide numbers
+# above because most of the fleet has neither a requests, refutations, nor
+# amendments ledger for this test's foreign buckets, so each per-lane read
+# is a single `exists()`-and-return-empty rather than a parse. Same fleet as
+# the two measurements above (`_seed()`, 50 buckets), so 150ms keeps them
+# comparable rather than inventing a new number tuned to look good — tight
+# enough that a regression (e.g. a per-foreign-project `queue()` call
+# reintroducing the O(N^2) shape this function exists to avoid) would still
+# fail it well before the budget is reached.
+_FOREIGN_BUDGET_MS = 150.0
+
+
+def test_foreign_counts_time_cost_stays_within_budget(tmp_checkpoint_dir,
+                                                       capsys):
+    _seed()
+    start = time.perf_counter()
+    result = pending.foreign_counts(project_dir=RECIPIENT)
+    elapsed_ms = (time.perf_counter() - start) * 1000
+
+    assert result, "measurement is void if nothing waits elsewhere"
+    with capsys.disabled():
+        print(f"\n#766 slice 3 foreign-counts scan cost: {elapsed_ms:.2f}ms "
+             f"over {N_BUCKETS} buckets — budget {_FOREIGN_BUDGET_MS}ms")
+    assert elapsed_ms <= _FOREIGN_BUDGET_MS, (
+        f"pending.foreign_counts cost {elapsed_ms:.2f}ms exceeds the "
+        f"{_FOREIGN_BUDGET_MS}ms budget over {N_BUCKETS} buckets")


### PR DESCRIPTION
Refs #766

## What

Slice 3 of `daimon decide`: a footer counting what waits on the human in every OTHER project. Integers only, never a record, an id, or a line of text.

```
2 more waiting in other projects:
  <slug> (1)
  <slug> (1)
open that project to act on them
```

It also renders when the local queue is empty, because an empty local queue must not read as an empty queue everywhere.

Promotes the scar candidate from #776 to active scar 0056.

## Why

Scar 0055 governs this surface completely. The serializer captures tool_result payloads, so inside an agent session CLI stdout is checkpoint input, and printing a foreign bucket's record text copies that plaintext into THIS project's checkpoint where the origin's `forget` can never reach it. Counts are what can cross safely, which is the same doctrine `recall` already applies when it auto-widens.

Two design points worth stating, because both were arrived at the hard way.

**Plaintext is stripped at the read boundary, not filtered at the render.** Every field `requests._PLAINTEXT_FIELDS` names is replaced with a presence sentinel before folding: `"x"` when the original held content, `""` when it did not. A sentinel rather than a dropped field, because `fold`'s read-boundary shape check rejects an `opened` row whose `ask` is empty, so dropping it would silently undercount and disagree with what `decide` shows inside the owning project. The guarantee is then structural rather than conventional: foreign text never reaches the folded records, so there is nothing to print even if a later caller tried.

**One fleet-wide pass, not one pass per project.** A request's rows can span two buckets, the `opened` row in the sender's and a verdict or suppression in the recipient's. So computing this per foreign project through `queue` or `recipient_join` would rescan the whole fleet each time, which is quadratic: measured at 91.4ms over 25 real buckets, and worse from there. Instead every bucket is read once, rows are grouped by `request_id` across buckets, and each group is folded once.

That fold is `requests.fold` itself, deliberately, rather than a second counting state machine. Suppression and its reversal, rejection terminality, and the human-only verdict re-check are subtle enough that a parallel implementation would drift from the transitions the local lane already trusts, and drift there would be silent.

The ruling/refutation and amendment lanes need none of this. Those records are genuinely single-bucket, so they are counted per bucket directly.

Both lanes fail open per bucket, matching `queue`'s posture: one unreadable foreign ledger costs that bucket's contribution, never the count and never the local queue.

`decide` remains a pure reader. No `surfaced` stamp, no ledger row.

## Tests

`uv run --project plugin pytest plugin/tests` : 4244 passed, 2 skipped.

One unrelated pre-existing failure, `test_combined_brief_time_cost_stays_within_budget`. Confirmed on clean `main` at 159.24ms, then passing at 94.54ms on retry. It is a wall-clock budget calibrated at 35-45ms whose headroom has since gone; unrelated to this change and left alone here.

14 new tests. In `test_pending.py`: a foreign request counts for its recipient and not for its sender or a third observer; this project's own queue is excluded; suppressed, rejected and accepted foreign requests are not counted; foreign candidate rulings and refutations and verified amendments are counted while an unverified amendment candidate is not; the return is integers only; and each lane fails open without emptying the other or the local queue.

In `test_cli_decide.py`, the plaintext guarantee is pinned end to end rather than asserted: a foreign request is seeded whose ask, why and evidence carry a distinctive sentinel, the full CLI is run, and the sentinel must appear nowhere in stdout while the owning slug and its count do appear. Also covered: an empty local queue still reports foreign work, and no foreign activity renders no footer at all.

New budgeted measurement in `test_requests_scan_cost.py` following that file's convention: 4.13ms over the 50-bucket fleet against a 150ms budget. Cheaper than the request lane's own scan because most seeded buckets have no refutations or amendments ledger, so those reads cost a single `exists()` check.
