### PR TITLE
ci: pin the scar lint gate to an exact linter version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,5 +103,11 @@ jobs:
       # Dogfood: the repo's own scar graph must always parse and lint clean.
       # A malformed scar silently never fires — this gate makes that class
       # of rot unmergeable.
+      #
+      # PINNED (#774): unpinned, `uvx` resolves the newest release at run
+      # time, so this gate's DEFINITION could change with no commit here — a
+      # new check lands as a red build on whoever opens the next PR, about
+      # rot their change did not introduce. Bump this deliberately, in its
+      # own PR, where new findings are the subject rather than a surprise.
       - name: scar lint
-        run: uvx --from scar-cli scar lint
+        run: uvx --from scar-cli==0.19.0 scar lint


### PR DESCRIPTION
Closes #774

## What

Pins the scar lint gate to `scar-cli==0.19.0`, with the reasoning recorded at the step.

## Why

Unpinned, `uvx` resolves the newest release at run time, so the definition of this gate could change with no commit to this repository. A check added upstream arrives as a red build on whoever opens the next pull request, about rot their own change did not introduce, and the version is not the first thing anyone suspects.

Pinning does not give up what floating found. The check that surfaced this was correct and the rot was real, and a deliberate bump still surfaces it, just as the subject of its own pull request rather than as a surprise blocking unrelated work.

The issue proposed pinning to 0.18.0. 0.19.0 has published since it was written, which is the same drift arriving again while the fix was being written, so the pin is to 0.19.0.

The two alternatives the issue raised were considered. A minor range is cheaper to maintain but still admits a new check in a patch release, which is the exact failure being fixed. Leaving it floating is defensible on the argument that early rot detection is worth the occasional surprise, but it needs to be written down as a decision rather than left silent, and an exact pin plus a deliberate bump keeps the detection while making the moment it happens a choice.

This also matches how the rest of the workflow already treats its tools: `actions/checkout@v7` and `astral-sh/setup-uv@v9.0.0` are both pinned.

## Tests

`uvx --from scar-cli==0.19.0 scar lint` locally: 59 files, 0 errors, 0 orphans, 0 unreachable evidence, exit 0. One pre-existing partial-rot hint on an unrelated scar, unchanged by this and not a failure.

One line of workflow configuration. No behavior change to the linter and no change to any scar.
