### PR TITLE
fix(echo): recognise the module and timeout invocation forms

### DIFF
--- a/plugin/daimon_briefing/transcript.py
+++ b/plugin/daimon_briefing/transcript.py
@@ -92,14 +92,31 @@ _TOOL_RESULT_MAX_CHARS = 500
 _DAIMON_CMD_RE = re.compile(
     r"(?:^|[|;&(`]|\&\&|\|\|)\s*"
     r"(?:\S+=\S+\s+)*(?:sudo\s+)?"
+    # #778: `timeout` is the only wrapper with measured field usage, and the
+    # case that earns it is `timeout N daimon handoff`, whose output is the
+    # densest memory content daimon renders. Flags and the duration are both
+    # consumed (`timeout -k 5 30s daimon ...`). Env assignments repeat after
+    # it because both `timeout 60 FOO=1 daimon` and `FOO=1 timeout 60 daimon`
+    # are real orderings. The wider wrapper family (`nice`, `xargs`, `env`,
+    # `time`) is deliberately NOT enumerated: measured usage is zero and each
+    # one adds prose-matching surface next to a repo whose own directory is
+    # named `daimon`.
+    r"(?:timeout\s+(?:-\S+\s+|\d+[a-z]*\s+)*)?"
+    r"(?:\S+=\S+\s+)*"
     # #585: a shell wrapper puts a QUOTE immediately before the command, and
     # quotes are deliberately absent from the delimiter class above — adding
     # them there would match `rg "daimon" cli.py`, which greps ABOUT daimon and
     # whose output is a genuine witness. Recognise the wrapper explicitly
     # instead, the same way `uv run` is handled below.
     r"(?:(?:\S*/)?(?:ba|z|da|k)?sh\s+-[a-z]*c\s+['\"]?)?"
-    r"(?:uv\s+run\s+(?:--?[\w-]+(?:[= ]\S+)?\s+)*(?:python\s+-m\s+)?)?"
-    r"(?:\S*/)?daimon(?:\s|$)", re.MULTILINE)
+    r"(?:uv\s+run\s+(?:--?[\w-]+(?:[= ]\S+)?\s+)*)?"
+    # #778: the module spelling gets its own branch. The old inline
+    # `(?:python\s+-m\s+)?` could never fire: it required a following bare
+    # `daimon`, and the module is `daimon_briefing`. This is how the CLI runs
+    # from a source checkout, so it is what anyone testing a branch produces,
+    # and it appears in no manifest section at all.
+    r"(?:(?:\S*/)?python[\d.]*\s+-m\s+daimon_briefing(?:\.[\w.]+)?(?:\s|$)"
+    r"|(?:\S*/)?daimon(?:\s|$))", re.MULTILINE)
 
 
 def _is_daimon_tool_use(block: dict) -> bool:

--- a/plugin/tests/test_echo_invocation_recognition.py
+++ b/plugin/tests/test_echo_invocation_recognition.py
@@ -42,6 +42,23 @@ RECOGNISED = [
     "zsh -c 'daimon recall foo'",
     "/bin/sh -c 'daimon brief'",
     "bash -lc 'daimon brief'",
+    # #778: the module spelling, which is how the CLI runs from a source
+    # checkout and is therefore what anyone testing a branch produces. It is
+    # in no manifest section — `daimon_briefing.cli` is reachable because
+    # `cli/__main__.py` exists — so a test driven off `[project.scripts]`
+    # would not have covered it.
+    "python -m daimon_briefing.cli decide",
+    "python3 -m daimon_briefing.cli brief",
+    "uv run --project plugin python -m daimon_briefing.cli decide",
+    "uv run --quiet python -m daimon_briefing refute ratify r-0123456789ab",
+    "/usr/bin/python3.12 -m daimon_briefing.cli status",
+    # #778: `timeout` is the one wrapper with real field usage, and the case
+    # that matters is `timeout N daimon handoff`, whose output is the densest
+    # memory content daimon renders.
+    "timeout 120 daimon handoff \"clear the backup volume\"",
+    "timeout 60 daimon loops",
+    "timeout -k 5 30s daimon brief",
+    "timeout 60 DAIMON_ENV_FILE=/tmp/e daimon status",
 ]
 
 NOT_RECOGNISED = [
@@ -54,6 +71,18 @@ NOT_RECOGNISED = [
     "echo daimon",
     "cat daimon.log",
     "ls ~/.daimon",
+    # #778: measured against the real corpus rather than invented. This repo's
+    # own directory is named `daimon` and its slug is `Daily-Nerd/daimon`, so
+    # prose and paths mentioning it vastly outnumber invocations. Every line
+    # below is a real corpus shape, and each one must keep its witness value.
+    "git status",
+    "gh issue create --repo Daily-Nerd/daimon --title 'fix: x'",
+    "gh run watch --repo Daily-Nerd/daimon 12345",
+    "bat plugin/daimon_briefing/cli/__init__.py",
+    "git commit -m 'fix: create workdir before daimon brief spawn'",
+    # A commit heredoc quoting a skill name. Observed as a real false positive
+    # while measuring, which is why it is pinned here rather than imagined.
+    "git commit -F - <<'EOF'\nchore(readme): document daimon-briefing\nEOF",
 ]
 
 


### PR DESCRIPTION
Refs #778

## What

Recognises two invocation forms that produced tool rows with no `daimon_output` flag: `python -m daimon_briefing[.module]` and `timeout N ...`.

## Why

An unflagged row keeps its place in the verification haystack, where daimon's own rendered output can satisfy a quote check, and it reaches the extractor as ordinary session content rather than being blanked.

The module spelling is how the CLI runs from a source checkout, so it is what anyone testing a branch produces. It is worth noting that the existing pattern already reached for this case: the inline `(?:python\s+-m\s+)?` branch was there, and it required a following bare `daimon` while the module is `daimon_briefing`, so it could not fire. The intent was right and the module name moved past it.

`timeout` earns its place on one case in particular. `timeout N daimon handoff` is a real and repeated form, and handoff output is the densest memory content daimon renders.

## Measurement

Replayed over the local transcript corpus, 13503 distinct commands mentioning daimon:

| | |
|---|---|
| flagged before | 772 |
| flagged after | 855 |
| gained | 83 |
| **lost** | **0** |

Of 29 distinct match spans in the gained set, 28 are genuine invocations. The remaining one is a string literal inside a probe script written while taking this measurement, which belongs to the pattern's existing prose-matching behaviour rather than to either new branch. Reported rather than rounded away.

## What is deliberately not here

**`daimon-briefing`.** The issue leads with it, and the corpus does not support adding it: zero true positives, and the single thing a matcher for it catches is a commit heredoc quoting the name. Its own manifest comment marks it for removal a release after the rename, so the alias closing this gap by going away is the cheaper path. If field evidence ever shows real use, it can be added on that evidence.

**The wider wrapper family** (`nice`, `xargs`, `env`, `time`, `command`). Measured usage is zero, and each one adds prose-matching surface next to a repository whose own directory is named `daimon`. That narrowness is load-bearing rather than cautious: over 1600 corpus occurrences of the word sit in `cd .../daimon` and `--repo Daily-Nerd/daimon`.

**`uvx` and `pipx run`.** Also absent, but their zero count is explicitly not the reason. A develop-from-source corpus cannot contain them, so this defer rests on no evidence and should be revisited the first time someone reports one.

## On the approach

A shell-aware tokenizer was designed and tested against this, and is not what shipped. Falling back to the pattern when the tokenizer raises does make it additive over unparseable input, but over parseable input the walker replaces the pattern entirely, and it silently drops the `sh -c` branch (#585) and the command-substitution branch. Extending the pattern keeps both.

## Tests

`uv run --project plugin pytest plugin/tests` : 4265 passed, 2 skipped.

`test_echo_invocation_recognition.py` gains nine recognised forms and six that must stay unrecognised. The negatives are real corpus shapes rather than invented ones, including a commit message mentioning a daimon command and a heredoc quoting the alias, because those are the families that actually threaten a widening here.

## One thing this does not tell you

`daimon audit quotes --all --top 0` was run before and after, and also with detection disabled entirely. All three produce identical output: 3196 checked, 3110 verified, 97.3%. The gate is insensitive to this mechanism on this corpus, so it is reported as run rather than as a passing check, and it should not be read as evidence either way. It also only exercises the verification half; the extractor half has no equivalent instrument today.
