### PR TITLE
fix(echo): stop reading a markdown code span as a command substitution

### DIFF
--- a/plugin/daimon_briefing/transcript.py
+++ b/plugin/daimon_briefing/transcript.py
@@ -89,8 +89,21 @@ _TOOL_RESULT_MAX_CHARS = 500
 # `rg daimon cli.py` greps ABOUT daimon and its output is a genuine witness
 # (measured: a blanket tool-row strip costs 9.5% of the corpus's verifiable
 # quotes; this invocation-scoped rule costs 0.06%).
+#
+# #781: the backtick is NOT in the delimiter class, though it opens a command
+# substitution in shell. In a repository whose own directory is named `daimon`
+# and whose issue bodies, PR bodies, docstrings and commit messages discuss its
+# commands constantly, a backtick opens a markdown inline code span far more
+# often. Measured over the local corpus: 127 rows were flagged ONLY by that
+# delimiter and NOT ONE was a shell substitution — every one was prose a person
+# wrote, blanked from the extractor as though daimon had produced it.
+# The substitution it protected is still covered: `$(...)` reaches this pattern
+# through the `(` delimiter, which is the spelling anyone writes today. The
+# residual is legacy backtick substitution, which fails toward admitting an
+# echo rather than destroying a witness — a real trade, measured at zero here
+# and pinned by test_modern_command_substitution_still_matches.
 _DAIMON_CMD_RE = re.compile(
-    r"(?:^|[|;&(`]|\&\&|\|\|)\s*"
+    r"(?:^|[|;&(]|\&\&|\|\|)\s*"
     r"(?:\S+=\S+\s+)*(?:sudo\s+)?"
     # #778: `timeout` is the only wrapper with measured field usage, and the
     # case that earns it is `timeout N daimon handoff`, whose output is the

--- a/plugin/tests/test_echo_invocation_recognition.py
+++ b/plugin/tests/test_echo_invocation_recognition.py
@@ -83,6 +83,16 @@ NOT_RECOGNISED = [
     # A commit heredoc quoting a skill name. Observed as a real false positive
     # while measuring, which is why it is pinned here rather than imagined.
     "git commit -F - <<'EOF'\nchore(readme): document daimon-briefing\nEOF",
+    # #781: a backtick opens a command substitution in shell, but in this
+    # repository it far more often opens a markdown inline code span, because
+    # every issue body, PR body, docstring and commit message here discusses
+    # daimon's own commands. Measured: 127 rows were flagged ONLY by the
+    # backtick delimiter and NONE was a shell substitution. Each line below is
+    # a real corpus shape.
+    "git commit -m 'fix: `daimon status` explained every unsigned checkpoint'",
+    "cat > body.md <<'EOF'\n- `daimon --help` now ends with the docs URLs\nEOF",
+    "python3 - <<'PY'\n\"\"\"Do items trace to `daimon brief` output?\"\"\"\nPY",
+    "gh issue comment 1 --body 'the echo counter in `daimon status` is capped'",
 ]
 
 
@@ -96,6 +106,17 @@ def test_daimon_invocations_are_recognised(cmd):
 def test_commands_about_daimon_stay_witnesses(cmd):
     assert not transcript._is_daimon_tool_use(_use(cmd)), (
         f"over-broad match destroys a legitimate witness: {cmd!r}")
+
+
+def test_modern_command_substitution_still_matches():
+    """#781 removes the backtick from the delimiter class, so the substitution
+    it protected has to be covered by the spelling people actually write.
+    `$(...)` reaches the matcher through the `(` delimiter, which is why
+    dropping the backtick costs no genuine coverage."""
+    for cmd in ["V=$(daimon --version)",
+                "echo \"at $(daimon status --json | head -1)\"",
+                "test -n \"$(daimon loops)\""]:
+        assert transcript._is_daimon_tool_use(_use(cmd)), cmd
 
 
 def test_mcp_tool_names_still_match():


### PR DESCRIPTION
Closes #781

## What

Removes the backtick from the delimiter class in `_DAIMON_CMD_RE`, so a markdown inline code span is no longer read as a shell command substitution.

## Measurement, taken before the change

Replayed over the local transcript corpus:

| | |
|---|---|
| flagged before | 861 |
| flagged after | 733 |
| **removed** | **128** |
| added | 0 |

127 rows were flagged **only** by that delimiter. Every one is prose a person wrote: issue bodies, PR body heredocs, docstrings, commit messages, code comments. Not one is a shell substitution. Two candidates matched a substitution shape and turned out to be Python string assignments inside heredoc scripts.

Those rows were being blanked from the verification haystack and from what the extractor reads, as though daimon had produced them.

## Why the cheaper fix does not work

The obvious move is to require that a backtick match be followed by something invocation-shaped. It cannot discriminate: 129 of 132 backtick matches are exactly `` `daimon ``, because that is what the pattern requires in the first place. A markdown code span and a shell command substitution are byte-identical at that point. The only thing that separates them is whether the position sits inside prose, which the pattern cannot see.

## The trade, stated

The substitution the backtick protected is still covered. `$(...)` reaches the pattern through the `(` delimiter already in the class, and that is the spelling anyone writes today. It is now pinned by `test_modern_command_substitution_still_matches` rather than left implicit.

What is genuinely given up is legacy backtick substitution. If someone writes `` V=`daimon --version` ``, that row stops being flagged, and an unflagged row is the worse direction for this defense: it admits an echo rather than destroying a witness. Measured at zero occurrences in this corpus, against 128 measured rows of human-written evidence on the other side. Worth revisiting if a field report ever shows one.

## Out of scope, and named so it is not lost

521 rows still match at a line start through `re.MULTILINE`, and some of those are prose inside heredoc bodies. That is the second family the issue describes. It needs heredoc awareness rather than a delimiter change, because removing `re.MULTILINE` would lose ordinary multi-line shell, which is common and genuine.

## Relationship to the wider question

Both this and the recognition gap fixed in #780 are instances of what #591 already describes: inferring provenance from a command string puts a matcher in the trust path, and that is where the gaps live. This change makes the current matcher more accurate. It does not make it the right long-term mechanism, and nothing here should be read as closing that question.

## Tests

`uv run --project plugin pytest plugin/tests` : 4270 passed, 2 skipped.

Four new negative cases, all real corpus shapes rather than invented ones: a commit message quoting a daimon command, a PR body heredoc, a Python docstring, and a `gh issue comment` body. Plus the positive pin on `$(...)` in three spellings.

## The gate, reported honestly

`daimon audit quotes --all --top 0` is insensitive to this mechanism: it returns identical output with the rule as shipped, widened, and with detection disabled entirely. It is reported as run, not as a passing check. The extraction side, which is where these 128 rows actually cost something, has no equivalent instrument today.
