### PR TITLE
fix(briefing): stop the session-start injection at the project boundary

### DIFF
--- a/.scars/candidates/global-fallback-detection-misses-torn-pointer.md
+++ b/.scars/candidates/global-fallback-detection-misses-torn-pointer.md
@@ -1,0 +1,42 @@
+---
+id: 0
+type: landmine
+title: Detecting read_latest's global fallback by path existence misses the torn own-pointer
+severity: high
+confidence: 0.95
+created: 2026-08-28
+authors: ["claude-code"]
+anchors:
+  - path: plugin/daimon_briefing/store.py
+  - path: plugin/daimon_briefing/hooks.py
+  - path: plugin/daimon_briefing/cli/__init__.py
+  - pattern: "fallback_used|project_latest_path\\([^)]*\\)[^\\n]*exists\\(\\)"
+evidence:
+  - note: "#784 — the SessionStart injection rendered another project's checkpoint"
+expires:
+  condition: "read_latest reports whether it fell back, instead of callers inferring it"
+  review_after: 2027-02-28
+status: candidate
+---
+
+`store.read_latest()` falls back to the global pointer (the most recent checkpoint
+of ANY project) in TWO different cases, and they do not look alike from outside.
+The obvious one is a project with no bucket, where its `latest.json` does not
+exist. The second is a project whose own pointer EXISTS but fails to parse: the
+torn-pointer branch treats it as absent and falls through to the global pointer
+anyway (`store.py:1376-1403`).
+
+So the natural detection, comparing `store.project_latest_path(project)` against
+`.exists()`, is blind to the second case. It concludes the checkpoint is local
+while the caller is in fact holding another project's data. `daimon brief` still
+computes `fallback_used` exactly that way (`cli/__init__.py:665-667`), which means
+its #96 foreign-body suppression does not fire on a torn own-pointer.
+
+Do NOT copy that detection into a new caller. Ask `read_latest` not to fall back
+in the first place, by passing `fallback=` computed from policy, which is what the
+injection hook does after #784. Deciding before the read cannot be fooled by
+either case. Note the policy has a second half: when the project is UNKNOWN the
+fallback must stay ON, because there is no per-project pointer to prefer and
+nothing is foreign to a session with no project identity. A fix that suppresses
+the fallback unconditionally passes the leak test and silently removes the
+briefing from every pre-routing host; the full suite caught exactly that.

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -1406,13 +1406,18 @@ def _cmd_recall_inject(args) -> int:
             return 0
         project = _resolve_project(args.project)
         session = str(args.session or "")
-        # Never re-suggest what the SessionStart briefing already carried: the
-        # project's latest and the global latest are briefed by definition.
+        # Never re-suggest what the SessionStart briefing already carried.
+        # #784: that is ONE checkpoint, and which one depends on the same gate the
+        # injection hook reads — the project's own, and the global pointer only when
+        # the operator opted into the foreign body. Excluding the global latest
+        # unconditionally suppressed recall of a session that was never briefed.
         exclude = set()
-        for cp in (store.read_latest(project), store.read_latest()):
-            sid = (cp or {}).get("session_id")
-            if sid:
-                exclude.add(str(sid))
+        briefed = store.read_latest(
+            project_dir=project,
+            fallback=project is None or config.brief_global_fallback())
+        sid = (briefed or {}).get("session_id")
+        if sid:
+            exclude.add(str(sid))
         seen_file = _seen_path(session)
         origin_counts, seen_keys = (_load_seen(seen_file) if seen_file
                                     else ({}, set()))

--- a/plugin/daimon_briefing/hooks.py
+++ b/plugin/daimon_briefing/hooks.py
@@ -179,7 +179,20 @@ def pre_llm_call(session_id=None, user_message=None, conversation_history=None,
         if not is_first_turn:
             return None
         project = config.resolve_project_root(config.project_dir())
-        checkpoint = store.read_latest(project_dir=project)
+        # #784: read_latest's global pointer is the most recent checkpoint of ANY
+        # project, so a project with no bucket of its own was injected with a
+        # foreign briefing on its first session. `daimon brief` already suppresses
+        # that body by default (#96); this path did not, and it is the path with no
+        # human reader. Same gate, same env var, so the two surfaces state the same
+        # world. Asking read_latest not to fall back (rather than detecting after
+        # the fact that it did) also covers the torn own-pointer, which falls
+        # through to the global pointer while the project's path still exists.
+        # The fallback stays ON when the project is UNKNOWN: there is no per-project
+        # pointer to prefer, the global one is the only briefing that exists, and
+        # nothing is foreign to a session with no project identity (pre-routing
+        # hosts that do not pass a cwd). The leak needs a KNOWN project.
+        allow_foreign = project is None or config.brief_global_fallback()
+        checkpoint = store.read_latest(project_dir=project, fallback=allow_foreign)
         if checkpoint is None:
             # #693: standing rulings exist before the first checkpoint does —
             # a day-one ratification must reach the very next session.

--- a/plugin/tests/test_hooks.py
+++ b/plugin/tests/test_hooks.py
@@ -512,8 +512,9 @@ def test_pre_llm_call_routes_project_through_resolve_project_root(
 
     captured = {}
 
-    def _spy(project_dir=None):
+    def _spy(project_dir=None, fallback=True):
         captured["project_dir"] = project_dir
+        captured["fallback"] = fallback
         return None
 
     monkeypatch.setattr(hooks.store, "read_latest", _spy)
@@ -891,3 +892,85 @@ def test_on_session_end_warms_index_after_write(tmp_checkpoint_dir, fake_chat_fa
         session_id="S-warm", completed=True, interrupted=False, model="m", platform="cli"
     )
     assert calls == [1]
+
+
+# ---- #784: the injection path must not render another project's checkpoint ----
+
+
+def _foreign_checkpoint_with_project_b(tmp_path, monkeypatch, sample_checkpoint):
+    """Project A holds the only checkpoint, so the GLOBAL pointer points at A.
+    Project B has no bucket at all. Returns B's path, routed as the session's
+    project."""
+    from daimon_briefing import store
+
+    project_a = tmp_path / "project-a"
+    project_b = tmp_path / "project-b"
+    project_a.mkdir()
+    project_b.mkdir()
+    store.write_checkpoint("S-a", sample_checkpoint, project_dir=str(project_a))
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", str(project_b))
+    return project_a, project_b
+
+
+def test_pre_llm_call_does_not_inject_another_projects_checkpoint(
+    tmp_checkpoint_dir, sample_checkpoint, tmp_path, monkeypatch
+):
+    """A fresh project's first session must not receive project A's briefing."""
+    _foreign_checkpoint_with_project_b(tmp_path, monkeypatch, sample_checkpoint)
+    out = hooks.pre_llm_call(
+        session_id="S-b", user_message="hi", conversation_history=[], is_first_turn=True,
+        model="m", platform="cli",
+    )
+    text = (out or {}).get("context", "")
+    assert "PR #6" not in text, "another project's checkpoint body was injected"
+
+
+def test_pre_llm_call_global_fallback_is_opt_in(
+    tmp_checkpoint_dir, sample_checkpoint, tmp_path, monkeypatch
+):
+    """Single-project users who opted in keep today's behavior, same env var
+    that governs `daimon brief`."""
+    _foreign_checkpoint_with_project_b(tmp_path, monkeypatch, sample_checkpoint)
+    monkeypatch.setenv("DAIMON_BRIEF_GLOBAL_FALLBACK", "full")
+    out = hooks.pre_llm_call(
+        session_id="S-b", user_message="hi", conversation_history=[], is_first_turn=True,
+        model="m", platform="cli",
+    )
+    assert "PR #6" in (out or {}).get("context", "")
+
+
+def test_pre_llm_call_torn_project_pointer_does_not_fall_through_to_foreign_body(
+    tmp_checkpoint_dir, sample_checkpoint, tmp_path, monkeypatch
+):
+    """A torn own-pointer is not the same as 'no data'. read_latest treats it as
+    absent and falls through, so a project WITH a bucket can still be handed a
+    foreign body. Detecting the fallback by path existence cannot see this."""
+    from daimon_briefing import store
+
+    _project_a, project_b = _foreign_checkpoint_with_project_b(
+        tmp_path, monkeypatch, sample_checkpoint)
+    torn = store.project_latest_path(str(project_b))
+    torn.parent.mkdir(parents=True, exist_ok=True)
+    torn.write_text("{not json", encoding="utf-8")
+    out = hooks.pre_llm_call(
+        session_id="S-b", user_message="hi", conversation_history=[], is_first_turn=True,
+        model="m", platform="cli",
+    )
+    assert "PR #6" not in (out or {}).get("context", "")
+
+
+def test_pre_llm_call_unknown_project_still_reads_the_global_pointer(
+    tmp_checkpoint_dir, sample_checkpoint, monkeypatch
+):
+    """#784 must not cost pre-routing hosts their briefing. With no project
+    identity there is no per-project pointer to prefer and nothing is foreign,
+    so the global pointer stays the briefing of record."""
+    from daimon_briefing import store
+
+    monkeypatch.delenv("DAIMON_PROJECT_DIR", raising=False)
+    store.write_checkpoint("S-prev", sample_checkpoint)
+    out = hooks.pre_llm_call(
+        session_id="S2", user_message="hi", conversation_history=[], is_first_turn=True,
+        model="m", platform="cli",
+    )
+    assert "PR #6" in (out or {}).get("context", "")


### PR DESCRIPTION
Closes #784

## What

The SessionStart briefing injection no longer renders another project's
checkpoint. `store.read_latest()` is now asked not to fall back to the global
pointer when the session's project is known, rather than being allowed to fall
back and then inspected afterwards.

Two conditions shape the gate:

- The project is UNKNOWN: the fallback stays ON. There is no per-project pointer
  to prefer and nothing is foreign to a session with no project identity, so
  pre-routing hosts keep the only briefing they have.
- The project is KNOWN: the fallback is OFF unless the operator opted in through
  `DAIMON_BRIEF_GLOBAL_FALLBACK`, the same gate that already governs
  `daimon brief`.

`recall-inject` excluded the global latest from its suggestions on the grounds
that SessionStart had briefed it. That exclusion now reads the same gate, so it
no longer suppresses recall of a session that was never briefed.

## Why

`read_latest`'s global pointer holds the most recent checkpoint of ANY project.
The injection hook called it with the default fallback, so a project with no
bucket of its own received another project's full briefing on its first session.

`daimon brief` already suppresses that body by default (#96), on the reasoning
that a fresh project's briefing which is entirely another project's content
reads as contamination no matter how it is labeled. The injection path never got
that gate, and it is the path that fires automatically with no human reader.

Deciding before the read, rather than detecting afterwards, also closes a case
the CLI's detection cannot see. A torn own-pointer falls through to the global
pointer while the project's own path still exists, so comparing
`project_latest_path()` against `.exists()` concludes the data is local while
holding another project's. That is recorded as a scar candidate.

## Tests

`plugin/tests/test_hooks.py`, four new tests, three of which failed before the
change:

- a fresh project's first session is not injected with another project's body
  (failed before)
- a torn own-pointer does not fall through to a foreign body (failed before)
- an unknown project still reads the global pointer, which locks in the
  pre-routing behavior (this one is the regression guard: an earlier revision of
  this change suppressed the fallback unconditionally, and the full suite caught
  it)
- the opt-in restores the previous behavior

Full suite: 4274 passed, 2 skipped. Also verified outside the test harness by
writing a checkpoint for one project, routing a session to a second project with
no bucket, and confirming the first project's topic does not appear in the
injected context, then that the opt-in restores it.

`scar lint`: 0 errors.
