### PR TITLE
fix(brief): decide the global fallback before the read, not after it

### DIFF
--- a/.scars/candidates/global-fallback-detection-misses-torn-pointer.md
+++ b/.scars/candidates/global-fallback-detection-misses-torn-pointer.md
@@ -12,6 +12,7 @@ anchors:
   - path: plugin/daimon_briefing/cli/__init__.py
   - pattern: "fallback_used|project_latest_path\\([^)]*\\)[^\\n]*exists\\(\\)"
 evidence:
+  - note: "#787 — brief rendered a foreign body on a torn own pointer"
   - note: "#784 — the SessionStart injection rendered another project's checkpoint"
 expires:
   condition: "read_latest reports whether it fell back, instead of callers inferring it"
@@ -28,13 +29,14 @@ anyway (`store.py:1376-1403`).
 
 So the natural detection, comparing `store.project_latest_path(project)` against
 `.exists()`, is blind to the second case. It concludes the checkpoint is local
-while the caller is in fact holding another project's data. `daimon brief` still
-computes `fallback_used` exactly that way (`cli/__init__.py:665-667`), which means
-its #96 foreign-body suppression does not fire on a torn own-pointer.
+while the caller is in fact holding another project's data. `daimon brief` shipped
+that detection and its #96 foreign-body suppression therefore did not fire on a
+torn own-pointer (#787); both call sites now decide before the read instead.
 
-Do NOT copy that detection into a new caller. Ask `read_latest` not to fall back
-in the first place, by passing `fallback=` computed from policy, which is what the
-injection hook does after #784. Deciding before the read cannot be fooled by
+Do NOT reintroduce that detection in a new caller. Ask `read_latest` not to fall
+back in the first place, by passing `fallback=` computed from policy (the injection
+hook after #784), or read the own pointer with `fallback=False` first and let its
+absence be the answer (`brief` after #787). Deciding before the read cannot be fooled by
 either case. Note the policy has a second half: when the project is UNKNOWN the
 fallback must stay ON, because there is no per-project pointer to prefer and
 nothing is foreign to a session with no project identity. A fix that suppresses

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -661,10 +661,19 @@ def _cmd_brief(args) -> int:
     # Route like status/serialize: --project, else DAIMON_PROJECT_DIR, else cwd.
     # read_latest still falls back to the global pointer if the project has none.
     project = _resolve_project(args.project)
-    checkpoint = store.read_latest(project_dir=project)
-    proj_path = store.project_latest_path(project)
-    fallback_used = (checkpoint is not None and proj_path is not None
-                     and not proj_path.exists())
+    # #787: whether the fallback fired is what read_latest DID, not what the
+    # filesystem shows. It reaches the global pointer by TWO routes: an absent
+    # own pointer, and a TORN one, which falls through while its path still
+    # exists. Comparing project_latest_path() against exists() is blind to the
+    # second, so the #96 suppression did not fire and a foreign body rendered
+    # with no note and no opt-in. Ask for the project's own pointer first and
+    # let its absence BE the answer — that cannot be fooled by either route.
+    own = store.read_latest(project_dir=project, fallback=False)
+    checkpoint = own if own is not None else store.read_latest(project_dir=project)
+    # project_latest_path is None when the project is unknown, and nothing is
+    # foreign to a session with no project identity (#784).
+    fallback_used = (own is None and checkpoint is not None
+                     and store.project_latest_path(project) is not None)
     if fallback_used and not (getattr(args, "global_fallback", False)
                               or config.brief_global_fallback()):
         # Header-only fallback (#96): the foreign body is suppressed — one

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -344,6 +344,46 @@ def test_cli_brief_falls_back_to_global(tmp_checkpoint_dir, sample_checkpoint, c
     assert "PR #6" not in out
 
 
+def test_cli_brief_torn_own_pointer_still_suppresses_the_foreign_body(
+    tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch
+):
+    # #787: read_latest reaches the global pointer by TWO routes. The second is a
+    # torn own pointer: the path exists, the read raises, and it falls through
+    # anyway. Detecting the fallback by path existence cannot see that, so the
+    # #96 suppression did not fire and a foreign body rendered with no note.
+    from daimon_briefing import store
+
+    store.write_checkpoint("S-global", sample_checkpoint, project_dir="/p/A")
+    torn = store.project_latest_path("/p/B")
+    torn.parent.mkdir(parents=True, exist_ok=True)
+    torn.write_text("{not json", encoding="utf-8")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/B")
+    rc = cli.main(["brief"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "PR #6" not in out, "foreign body rendered on a torn own pointer"
+    assert "no briefing for this project yet" in out.lower()
+
+
+def test_cli_brief_torn_own_pointer_opt_in_still_shows_the_foreign_body(
+    tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch
+):
+    # The opt-in is unchanged by #787: an operator who asked for the foreign
+    # body still gets it, by the same env var that governs the absent-pointer
+    # route.
+    from daimon_briefing import store
+
+    store.write_checkpoint("S-global", sample_checkpoint, project_dir="/p/A")
+    torn = store.project_latest_path("/p/B")
+    torn.parent.mkdir(parents=True, exist_ok=True)
+    torn.write_text("{not json", encoding="utf-8")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/B")
+    monkeypatch.setenv("DAIMON_BRIEF_GLOBAL_FALLBACK", "full")
+    rc = cli.main(["brief"])
+    assert rc == 0
+    assert "PR #6" in capsys.readouterr().out
+
+
 def test_cli_brief_routes_to_cwd_when_no_env(
     tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch, tmp_path
 ):


### PR DESCRIPTION
Closes #787

## What

`brief` now determines whether the global fallback fired from what `read_latest`
actually did, rather than inferring it from the filesystem afterwards.

```python
own = store.read_latest(project_dir=project, fallback=False)
checkpoint = own if own is not None else store.read_latest(project_dir=project)
fallback_used = (own is None and checkpoint is not None
                 and store.project_latest_path(project) is not None)
```

The orientation note still needs the foreign checkpoint, so the second read
happens only once the own pointer is known to be missing. The opt-in path is
untouched.

## Why

`read_latest` reaches the global pointer by two routes. One is a project with no
pointer at all, where the path does not exist and the old check was correct. The
other is a torn pointer: the path exists, the read raises, and it falls through
anyway. Comparing `project_latest_path()` against `.exists()` can only see the
first, so on the second the check concluded the checkpoint was local, the #96
suppression did not fire, and another project's body rendered with no note and no
opt-in.

A torn pointer is the case that fallthrough was written for, and an interrupted
write produces one.

`project_latest_path` returns None when the project is unknown, which keeps the
unknown-project case out of the gate for the same reason as #784: nothing is
foreign to a session with no project identity, and the global pointer is the only
briefing that exists.

## Tests

`plugin/tests/test_cli.py`, two new tests beside the existing absent-pointer case:

- a torn own pointer suppresses the foreign body and prints the header-only note
  (failed before the change, rendering the foreign body)
- the opt-in still shows the foreign body on a torn pointer (passed before and
  after, pinning that this change does not narrow the opt-in)

Full suite: 4276 passed, 2 skipped. Also verified outside the harness by running
`brief` as a subprocess against a checkpoint in one project and a deliberately
corrupted pointer in another, confirming the first project's topic does not
appear, the note does, and the opt-in restores the body.

The scar candidate added in #785 is updated in this PR: it described this call
site as still carrying the unsafe detection, which is no longer true, and it now
records both safe shapes instead.
