### PR TITLE
fix(anchor): refuse to attach to a checkpoint this project does not own

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -432,7 +432,14 @@ def _cmd_anchor(args) -> int:
     # matching cognitive item and re-write through the NORMAL store path, so
     # rotation + stamping apply — the attached state becomes latest, the
     # pre-attach state is retained as prev-1.
-    checkpoint = store.read_latest(project_dir=project)
+    # #789: this caller PERSISTS what it reads, so it takes the fallback=False
+    # branch read_latest documents for exactly that class (#94). With the global
+    # fallback left on, a project with no bucket of its own re-wrote ANOTHER
+    # project's checkpoint into its bucket under that project's session_id, and
+    # the project that owns the item never received the anchor while the command
+    # reported success. Refusing is the correct outcome: there is nothing here to
+    # attach to, and the message below already says so.
+    checkpoint = store.read_latest(project_dir=project, fallback=False)
     if checkpoint is None:
         print(f"error: no checkpoint found for {project} — nothing to attach to",
               file=sys.stderr)

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2462,6 +2462,33 @@ def test_cli_anchor_attach_no_checkpoint_exits_nonzero(
     assert "no checkpoint" in capsys.readouterr().err.lower()
 
 
+def test_cli_anchor_attach_refuses_another_projects_checkpoint(
+    tmp_checkpoint_dir, capsys, monkeypatch, tmp_path, sample_checkpoint
+):
+    # #789: --attach PERSISTS what it reads, and read_latest's docstring says
+    # such callers must never see the global pointer (#94). With the fallback
+    # left on, a project with no checkpoint of its own re-wrote ANOTHER
+    # project's checkpoint into its own bucket, while the project that actually
+    # owns the item never received the anchor.
+    from daimon_briefing import store
+
+    other = (tmp_path / "other").resolve()
+    other.mkdir()
+    store.write_checkpoint("S-other", sample_checkpoint, project_dir=other)
+    proj = _anchor_proj(tmp_path, monkeypatch)  # no bucket of its own
+    capsys.readouterr()
+
+    rc = cli.main(["anchor", "pkg/m.py", "foo", "--attach", "PINNING",
+                   "--project", str(proj)])
+    assert rc != 0
+    assert "no checkpoint" in capsys.readouterr().err.lower()
+    # No bucket minted for proj out of another project's content.
+    assert not (tmp_checkpoint_dir / store.project_slug(proj) / "latest.json").exists()
+    # And the owning project's checkpoint is untouched.
+    owner = store.read_latest(project_dir=other, fallback=False)
+    assert "anchored_to" not in owner["epistemic_snapshot"]["strong_beliefs"][0]
+
+
 def test_cli_anchor_attach_missing_session_id_exits_nonzero(
     tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch, tmp_path
 ):


### PR DESCRIPTION
Closes #789

## What

`daimon anchor --attach` now reads the project's own pointer only:

```python
checkpoint = store.read_latest(project_dir=project, fallback=False)
```

When the project has no checkpoint of its own the existing branch refuses and
says there is nothing to attach to. No new message, no new flag, one line of
behaviour change.

## Why

`--attach` re-writes what it reads back through the normal store path, so it is a
caller that PERSISTS. `read_latest` documents that class and the rule for it:

> `fallback=False` reads ONLY the project's own pointer (#94): the global
> pointer holds the most recent checkpoint of ANY project, so callers that
> PERSIST what they read (carry) must never see it

This caller did not pass it. With the fallback on, a project holding no
checkpoint read another project's, attached the anchor to an item in it, and
wrote the result into its own bucket under the other project's session id.

Two things followed, and the second is the one an operator would hit first:

1. The bucket held content that project never produced, in a place scoped to it.
2. The project that owns the item never received the anchor, while the command
   exited 0 and printed that it had attached, so nothing signalled that the write
   had landed on a copy.

Refusing is correct rather than conservative. Attaching an anchor resolved from
THIS repo's source to an item that belongs to a different project has no reading
under which it is the intended operation.

## Tests

`plugin/tests/test_cli.py`, one new test beside the existing attach cases:

- with a checkpoint owned by another project and none of its own, `--attach`
  exits non-zero, mints no bucket for this project, and leaves the owning
  project's checkpoint un-anchored (failed before the change: it exited 0 and
  reported attaching to the other project's item)

The existing attach tests all write with an explicit project, so they pin that
the ordinary path is unchanged. Full suite: 4277 passed, 2 skipped.

Also verified outside the harness by replaying the reproduction from the issue:
the command now exits 1, no bucket is created for the project that has none, and
the owning project's checkpoint is untouched.

## Note

This is the third call site corrected in this family, after #785 and #788, and
the only one that persisted rather than displayed. One member is left and is
read-only: `receipts.status_line` and `cli._cmd_verify_receipt` take a
`session_id` from a possibly foreign checkpoint and then report on or verify that
session. It needs its own issue.
