### PR TITLE
fix(receipts): report only on a checkpoint this project may claim

### DIFF
--- a/.scars/candidates/blanket-fallback-false-breaks-unrouted-checkpoints.md
+++ b/.scars/candidates/blanket-fallback-false-breaks-unrouted-checkpoints.md
@@ -1,0 +1,35 @@
+---
+id: 0
+type: deadend
+title: Blanket fallback=False on a reporting surface refuses UN-ROUTED checkpoints too
+severity: medium
+confidence: 0.9
+created: 2026-08-28
+authors: ["claude-code"]
+anchors:
+  - path: plugin/daimon_briefing/receipts.py
+  - path: plugin/daimon_briefing/store.py
+evidence:
+  - note: "#791 — tried, broke test_cli_verify_receipt_default_uses_latest, replaced"
+expires:
+  condition: "un-routed (project_slug-less) checkpoints no longer exist in any store"
+  review_after: 2027-02-28
+status: candidate
+---
+
+Fixing a cross-project read by passing `fallback=False` is right for callers that
+PERSIST (#94, #789) and for display callers that can fall back to a rulings-only
+or header-only path (#785, #788). It was tried at the two receipt surfaces and is
+WRONG there.
+
+`read_latest`'s global pointer holds three different things, not two. Besides the
+project's own checkpoint and another project's, there are UN-ROUTED checkpoints,
+written before a project was known, carrying no `project_slug` stamp. They belong
+to nobody. `fallback=False` refuses those as well, so a pre-routing store loses
+`verify-receipt` and the receipts status line entirely, and the surface reports
+"no checkpoint for this project yet" while a usable file sits in the store.
+
+The distinction is available: decide by the payload's own `project_slug`, which
+is what team fan-in already does, not by which pointer the read came through.
+That is `store.read_latest_reportable`. Every new test written for the defect
+passed under the blunt version; only the pre-existing suite caught it.

--- a/.scars/candidates/reused-checkpoint-dict-keeps-first-project-stamp.md
+++ b/.scars/candidates/reused-checkpoint-dict-keeps-first-project-stamp.md
@@ -1,0 +1,44 @@
+---
+id: 0
+type: landmine
+title: write_checkpoint stamps project_slug with setdefault, so a reused dict keeps the FIRST project's stamp
+severity: medium
+confidence: 0.95
+created: 2026-08-28
+authors: ["claude-code"]
+anchors:
+  - path: plugin/daimon_briefing/store.py
+  - path: plugin/daimon_briefing/receipts.py
+  - pattern: "setdefault.*project_slug"
+evidence:
+  - note: "#791 — read_latest_reportable decides membership by the payload stamp"
+expires:
+  condition: "write_checkpoint re-stamps project_slug from project_dir on every write"
+  review_after: 2027-02-28
+status: candidate
+---
+
+`write_checkpoint` MUTATES the dict it is handed, in place, and stamps identity
+fields with `setdefault` (`store.py:1142-1190`): `project_slug`, `project_name`,
+`author`, `created`, `format_version`, `git_branch`. The idempotence is
+deliberate, because some callers stamp before calling (#123), and team fan-in
+decides membership by the payload's own `project_slug` rather than by which
+directory the file sits in (`store.py:274`, `store.py:291`).
+
+The edge: `setdefault` does NOT re-stamp. Write a checkpoint dict to project A,
+then hand the SAME dict to `write_checkpoint(..., project_dir=B)`, and the file
+lands in B's bucket still claiming A's slug. Verified: the second write leaves
+`project_slug` unchanged.
+
+That matters more since #791, because `store.read_latest_reportable` refuses a
+checkpoint whose stamped slug names a different project. A checkpoint carrying a
+stale stamp is therefore foreign to the very bucket it lives in, and the surfaces
+that use it will report "no checkpoint for this project yet" while a file sits
+right there. Team fan-in reads it the same way.
+
+Two rules. Never reuse a checkpoint dict across projects: re-read it, or delete
+the identity keys before the second write. And when a probe or test builds a
+payload by copying one that has already been written, it is carrying a stamp it
+did not ask for. That is a real failure mode and it produced a false negative in
+a manual check before it was understood: the code was correct and the probe was
+not.

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -1770,7 +1770,10 @@ def _cmd_verify_receipt(args) -> int:
     session_id = getattr(args, "session_id", None)
     if not session_id:
         project = _resolve_project(args.project)
-        checkpoint = store.read_latest(project_dir=project)
+        # #791: the docstring above says the default target is THIS project's
+        # latest checkpoint, and the fallback let it be another project's. An
+        # un-routed checkpoint is still this project's to verify.
+        checkpoint = store.read_latest_reportable(project)
         if not isinstance(checkpoint, dict) or not checkpoint.get("session_id"):
             print("no checkpoint for this project yet — nothing to verify")
             return 2

--- a/plugin/daimon_briefing/receipts.py
+++ b/plugin/daimon_briefing/receipts.py
@@ -527,7 +527,10 @@ def status_line(project_dir=None) -> str | None:
     if not config.receipts_enabled():
         return None
     from . import store
-    checkpoint = store.read_latest(project_dir=project_dir)
+    # #791: this line names the session it reports on, so it must not answer
+    # with another project's record. An un-routed checkpoint still counts as
+    # reportable, which keeps pre-routing stores working.
+    checkpoint = store.read_latest_reportable(project_dir)
     if not isinstance(checkpoint, dict) or not checkpoint.get("session_id"):
         return "receipts: on — no checkpoint to sign yet"
     sid = str(checkpoint["session_id"])

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -1403,6 +1403,32 @@ def read_latest(project_dir=None, fallback: bool = True) -> dict | None:
         return None
 
 
+def read_latest_reportable(project_dir=None) -> dict | None:
+    """The latest checkpoint a surface may REPORT ON as this project's, or None.
+
+    #791: a surface scoped to one project must not answer with another project's
+    record, but refusing every fallback is too blunt. `read_latest`'s global
+    pointer holds three different things, and only one of them is foreign:
+
+    - the project's own checkpoint, which is always fine;
+    - an UN-ROUTED checkpoint, written before a project was known and carrying
+      no `project_slug` stamp, which belongs to nobody and stays readable so
+      pre-routing stores keep working;
+    - another project's checkpoint, which is the one to refuse.
+
+    Membership is decided by the payload's own `project_slug`, the same way
+    team fan-in decides it, rather than by which pointer the read came through.
+    """
+    checkpoint = read_latest(project_dir=project_dir)
+    if not isinstance(checkpoint, dict):
+        return None
+    slug = project_slug(project_dir)
+    stamped = str(checkpoint.get("project_slug") or "").strip()
+    if slug and stamped and stamped != slug:
+        return None
+    return checkpoint
+
+
 # ---- team memory (#111): opt-in shared mirror, derive-never-write shared state ----
 
 # Phase 1 has a single local remote-slug; Phase 3 (#113) adds synced remotes as

--- a/plugin/tests/test_receipts.py
+++ b/plugin/tests/test_receipts.py
@@ -771,6 +771,52 @@ def test_status_line_no_checkpoint(tmp_checkpoint_dir, monkeypatch):
     assert receipts.status_line() == "receipts: on — no checkpoint to sign yet"
 
 
+def test_status_line_never_reports_another_projects_session(
+        tmp_checkpoint_dir, tmp_path, monkeypatch):
+    # #791: a surface scoped to one project must not answer with another
+    # project's record. read_latest falls back to the global pointer, so a
+    # project with no bucket reported on, and NAMED, the most recent session of
+    # any project.
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    other = (tmp_path / "other").resolve()
+    other.mkdir()
+    store.write_checkpoint("S-FOREIGN", {"session_id": "S-FOREIGN"},
+                           project_dir=str(other))
+    mine = (tmp_path / "mine").resolve()
+    mine.mkdir()
+    line = receipts.status_line(project_dir=str(mine))
+    assert "S-FOREIGN" not in line, "another project's session id was rendered"
+    assert "no checkpoint to sign yet" in line
+
+
+def test_status_line_unknown_project_still_reads_the_global_pointer(
+        tmp_checkpoint_dir, monkeypatch):
+    # #791 must not cost the pre-routing case its line: with no project identity
+    # there is no per-project pointer to prefer and nothing is foreign (#784).
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    store.write_checkpoint("S-global", {"session_id": "S-global"})
+    assert "S-global" in receipts.status_line()
+
+
+def test_cli_verify_receipt_never_targets_another_projects_session(
+        tmp_checkpoint_dir, tmp_path, capsys):
+    # #791: the docstring says the default target is the CURRENT project's
+    # latest checkpoint. With the fallback on it verified, and named, another
+    # project's session instead.
+    other = (tmp_path / "vr-other").resolve()
+    other.mkdir()
+    store.write_checkpoint("S-FOREIGN", {"session_id": "S-FOREIGN"},
+                           project_dir=str(other))
+    mine = (tmp_path / "vr-mine").resolve()
+    mine.mkdir()
+    capsys.readouterr()
+    rc = cli.main(["verify-receipt", "--project", str(mine)])
+    out = capsys.readouterr().out
+    assert "S-FOREIGN" not in out, "another project's session id was rendered"
+    assert rc == 2
+    assert "no checkpoint for this project yet" in out
+
+
 def test_status_line_marked_but_missing(tmp_checkpoint_dir, monkeypatch):
     monkeypatch.setenv("DAIMON_RECEIPTS", "1")
     # A receipt-era marker but no sidecar (mint failed) -> MISSING line.

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -2227,3 +2227,35 @@ def test_write_does_not_overwrite_existing_project_name(tmp_checkpoint_dir, samp
     store.write_checkpoint("S1", pre, project_dir="/Users/x/projA")
     blob = json.loads((tmp_checkpoint_dir / "S1.json").read_text(encoding="utf-8"))
     assert blob["project_name"] == "original"
+
+
+# ---- #791: what a project-scoped surface may report on ----
+
+
+def test_read_latest_reportable_returns_the_projects_own_checkpoint(tmp_checkpoint_dir, tmp_path):
+    mine = (tmp_path / "rlr-mine").resolve()
+    mine.mkdir()
+    store.write_checkpoint("S-mine", {"session_id": "S-mine"}, project_dir=str(mine))
+    got = store.read_latest_reportable(str(mine))
+    assert (got or {}).get("session_id") == "S-mine"
+
+
+def test_read_latest_reportable_refuses_another_projects_checkpoint(tmp_checkpoint_dir, tmp_path):
+    other = (tmp_path / "rlr-other").resolve()
+    other.mkdir()
+    store.write_checkpoint("S-other", {"session_id": "S-other"}, project_dir=str(other))
+    mine = (tmp_path / "rlr-mine2").resolve()
+    mine.mkdir()
+    # read_latest WOULD hand this project the other one's checkpoint.
+    assert store.read_latest(project_dir=str(mine))["session_id"] == "S-other"
+    assert store.read_latest_reportable(str(mine)) is None
+
+
+def test_read_latest_reportable_allows_an_unrouted_checkpoint(tmp_checkpoint_dir, tmp_path):
+    # Written before a project was known, so it carries no project_slug stamp
+    # and belongs to nobody. Pre-routing stores must keep working.
+    store.write_checkpoint("S-unrouted", {"session_id": "S-unrouted"})
+    mine = (tmp_path / "rlr-mine3").resolve()
+    mine.mkdir()
+    got = store.read_latest_reportable(str(mine))
+    assert (got or {}).get("session_id") == "S-unrouted"


### PR DESCRIPTION
Closes #791

## What

`receipts.status_line` and `daimon verify-receipt` now report only on a
checkpoint this project may claim, through a new `store.read_latest_reportable`.

## Why the issue's suggested one-flag fix was not the right one

The issue proposed `fallback=False` at both sites, matching #788 and #790. That
was written before the pre-routing case was checked, and it is too blunt: the
global pointer holds three different things and only one of them is foreign.

- the project's own checkpoint, always fine
- an UN-ROUTED checkpoint, written before a project was known and carrying no
  `project_slug` stamp, which belongs to nobody
- another project's checkpoint, which is the one to refuse

Membership is decided by the payload's own `project_slug`, the same way team
fan-in already decides it, rather than by which pointer the read came through.
That refuses the foreign case and leaves pre-routing stores working.

This was not a judgement call made in advance. The blunt version passed every new
test in this PR and broke `test_cli_verify_receipt_default_uses_latest`, which
covers exactly the un-routed shape. The suite named the case.

## What was wrong

Both surfaces read with the fallback on, so a project with no bucket reported on,
and NAMED, the most recent session of any project. `verify-receipt` states the
contract in its own docstring, that the default target is the current project's
latest checkpoint, and the read did not honour it.

A session id is another bucket's identifier and CLI output is captured, so
printing one puts it where this project's own records can pick it up. Both lines
also asserted about THIS project using another's state: that the latest
checkpoint is unsigned, or that there is nothing to verify, when the honest
answer is that this project has no checkpoint at all. A reader could not tell
those apart from the output.

## Tests

Six new. Two reproduce the defect and failed before the change; one pins a case
the fix must not cost; three cover the new helper directly:

- `status_line` does not name another project's session and says there is no
  checkpoint to sign yet (failed before)
- `verify-receipt` does not name another project's session, exits 2, and says
  there is no checkpoint for this project yet (failed before)
- `status_line` with an unknown project still reads the global pointer
- three direct tests of `read_latest_reportable`, which is new in this PR so
  they pin behaviour rather than reproduce a defect: own checkpoint returned,
  another project's refused, un-routed one allowed. The middle one first asserts
  that plain `read_latest` WOULD hand over the foreign checkpoint, so it fails if
  the helper is ever reduced to a passthrough.

Full suite: 4283 passed, 2 skipped. Also verified outside the harness for all
three cases, including that an un-routed checkpoint stays reachable.

## Scars

Two scar candidates are included. One records the approach this PR abandoned:
a blanket `fallback=False` at a reporting surface refuses un-routed checkpoints
as well as foreign ones, and every test written for the defect passed under it.

The other: `write_checkpoint` mutates the dict it is given and
stamps identity with `setdefault`, so a dict written to one project and then to
another keeps the FIRST project's `project_slug`. That is deliberate, and it now
couples to this change: a checkpoint carrying a stale stamp is foreign to the
bucket it sits in. It also produced a false negative in a manual check here
before it was understood, where the code was right and the probe was not.

## Note

This is the last of the five call sites in this family, after #785, #788 and
#790. All five came from the same default: `read_latest` falls back unless a
caller opts out. Whether that default is the thing to change, rather than the
call sites, is left open in #791 and is a larger question than this PR.
