### PR TITLE
chore(scars): promote 0057-0060 and re-anchor 0058 to a violation guard

### DIFF
--- a/.scars/0057-blanket-fallback-false-breaks-unrouted-checkpoints.deadend.md
+++ b/.scars/0057-blanket-fallback-false-breaks-unrouted-checkpoints.deadend.md
@@ -1,20 +1,20 @@
 ---
-id: 0
+id: 57
 type: deadend
 title: Blanket fallback=False on a reporting surface refuses UN-ROUTED checkpoints too
 severity: medium
 confidence: 0.9
 created: 2026-08-28
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/receipts.py
   - path: plugin/daimon_briefing/store.py
 evidence:
-  - note: "#791 — tried, broke test_cli_verify_receipt_default_uses_latest, replaced"
+  - note: #791 — tried, broke test_cli_verify_receipt_default_uses_latest, replaced
 expires:
   condition: "un-routed (project_slug-less) checkpoints no longer exist in any store"
   review_after: 2027-02-28
-status: candidate
+status: active
 ---
 
 Fixing a cross-project read by passing `fallback=False` is right for callers that

--- a/.scars/0058-global-fallback-detection-misses-torn-pointer.landmine.md
+++ b/.scars/0058-global-fallback-detection-misses-torn-pointer.landmine.md
@@ -1,23 +1,23 @@
 ---
-id: 0
+id: 58
 type: landmine
 title: Detecting read_latest's global fallback by path existence misses the torn own-pointer
 severity: high
 confidence: 0.95
 created: 2026-08-28
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/store.py
   - path: plugin/daimon_briefing/hooks.py
   - path: plugin/daimon_briefing/cli/__init__.py
-  - pattern: "fallback_used|project_latest_path\\([^)]*\\)[^\\n]*exists\\(\\)"
+violation: "project_latest_path\([^)]*\)[^\n]*exists\(\)"
 evidence:
-  - note: "#787 — brief rendered a foreign body on a torn own pointer"
-  - note: "#784 — the SessionStart injection rendered another project's checkpoint"
+  - note: #787 — brief rendered a foreign body on a torn own pointer
+  - note: #784 — the SessionStart injection rendered another project's checkpoint
 expires:
   condition: "read_latest reports whether it fell back, instead of callers inferring it"
   review_after: 2027-02-28
-status: candidate
+status: active
 ---
 
 `store.read_latest()` falls back to the global pointer (the most recent checkpoint

--- a/.scars/0059-reused-checkpoint-dict-keeps-first-project-stamp.landmine.md
+++ b/.scars/0059-reused-checkpoint-dict-keeps-first-project-stamp.landmine.md
@@ -1,21 +1,21 @@
 ---
-id: 0
+id: 59
 type: landmine
 title: write_checkpoint stamps project_slug with setdefault, so a reused dict keeps the FIRST project's stamp
 severity: medium
 confidence: 0.95
 created: 2026-08-28
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/daimon_briefing/store.py
   - path: plugin/daimon_briefing/receipts.py
   - pattern: "setdefault.*project_slug"
 evidence:
-  - note: "#791 — read_latest_reportable decides membership by the payload stamp"
+  - note: #791 — read_latest_reportable decides membership by the payload stamp
 expires:
   condition: "write_checkpoint re-stamps project_slug from project_dir on every write"
   review_after: 2027-02-28
-status: candidate
+status: active
 ---
 
 `write_checkpoint` MUTATES the dict it is handed, in place, and stamps identity

--- a/.scars/0060-bench-cache-legacy-entries-are-dead.deadend.md
+++ b/.scars/0060-bench-cache-legacy-entries-are-dead.deadend.md
@@ -1,20 +1,20 @@
 ---
-id: 0
+id: 60
 type: deadend
 title: benchmark/.cache warm-looking legacy entries are unreplayable; offline replays must use .work stores
 severity: medium
 confidence: 0.9
 created: 2026-08-26
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: plugin/tests/bench/cache.py
-  - pattern: "cache\.get|CheckpointCache"
+  - pattern: "CheckpointCache"
 evidence:
-  - note: "2026-08-26 ungated-arm replay: 7521 of 7723 entries in benchmark/.cache are pre-#343 raw checkpoints (no envelope); cache.get counts every one as legacy_misses and returns None"
+  - note: 2026-08-26 ungated-arm replay: 7521 of 7723 entries in benchmark/.cache are pre-#343 raw checkpoints (no envelope); cache.get counts every one as legacy_misses and returns None
 expires:
   condition: "the .cache is re-warmed with #343 envelope entries (each carries served_model), or the legacy entries are purged"
   review_after: 2027-02-26
-status: candidate
+status: active
 ---
 
 Tried to build a zero-LLM benchmark replay on top of the serialized-checkpoint


### PR DESCRIPTION
Scars-only change, so the issue-first gate does not apply (pr-validation.yml:24-28: the human sign-off already happened at `scar promote`, reviewer recorded in the scar's authors).

## What

Promotes the four reviewed candidates.

| Scar | Type | What it protects |
|---|---|---|
| `0057` | deadend | Blanket `fallback=False` at a reporting surface refuses UN-ROUTED checkpoints too |
| `0058` | landmine | Detecting the global fallback by path existence is blind to the torn own-pointer |
| `0059` | landmine | `write_checkpoint` stamps with `setdefault`, so a reused dict keeps the FIRST project's stamp |
| `0060` | deadend | `benchmark/.cache` looks warm; 7521 of 7723 entries are unreplayable |

## Why

0057 and 0058 fall out of the read_latest arc (#785, #788, #790, #792). 0059 is the probe that produced a false negative while auditing it — the code was correct and the probe was not. 0060 is the 2026-08-26 ungated-arm replay dead end; the 42MB cache is still on disk, so the trap is still armed.

Two anchors were repaired before promotion, both the same defect: a pattern branch widening coverage the path anchors already had, matching unrelated code instead.

0058 anchored on `fallback_used`, which is ambiguous: it matches the LLM retry flag (`llm.py:291`, `serializer.py:1847`, `cli/__init__.py:321`) as well as `brief`'s own fallback-detection local (`cli/__init__.py:682-738`), which is the scar's actual subject. Dropping it loses no coverage, because the `path: cli/__init__.py` anchor already reaches 682-738, and it stops the scar firing at LLM retry edits. Its second branch, `project_latest_path(...).exists()`, guards against reintroducing a detection the fix removed, so it is healthy when absent and belongs in `violation:` rather than `anchors:` — and it was double-escaped (scar 0019), reaching the regex engine as a literal backslash and matching nothing. `scar lint` reported it as partial rot on the day it was promoted.

0060 anchored on `cache\.get|CheckpointCache`. The `cache\.get` branch matched `render.py:1715`, where `cache` is a stats dict, so a benchmark-replay scar would have fired at someone editing render output. Narrowed to `CheckpointCache`, whose every hit is bench code.

## Tests

No code change. `scar lint` under the CI-pinned `scar-cli==0.19.0`: 62 files, 0 errors, 0 orphans, 0 unreachable evidence. The remaining partial-rot is `0054`, pre-existing and untouched by this PR.
