### PR TITLE
fix(ui): stop nulling the fields the producer actually writes

### DIFF
--- a/plugin/daimon_ui/reader.py
+++ b/plugin/daimon_ui/reader.py
@@ -178,8 +178,21 @@ def _norm_provenance(raw):
         return None
     digest = raw.get("digest") if isinstance(raw.get("digest"), dict) else {}
     binding = raw.get("binding") if isinstance(raw.get("binding"), dict) else {}
+    # The producer writes verifier as an OBJECT (provenance.py:188, {id, version}).
+    # A string normalizer nulled every one of them, so the field naming WHO checked
+    # the quote rendered as "not recorded" on every provenanced item. Bare strings
+    # stay readable: older receipts recorded the id alone.
+    verifier = raw.get("verifier")
+    if isinstance(verifier, dict):
+        verifier_id = _norm_str(verifier.get("id"))
+        version = verifier.get("version")
+        verifier_version = (version if isinstance(version, int)
+                            and not isinstance(version, bool) else None)
+    else:
+        verifier_id, verifier_version = _norm_str(verifier), None
     return {
-        "verifier": _norm_str(raw.get("verifier")),
+        "verifier": verifier_id,
+        "verifier_version": verifier_version,
         "outcome": _norm_str(raw.get("outcome")),
         "checked_at": _norm_str(raw.get("checked_at")),
         "digest_algorithm": _norm_str(digest.get("algorithm")),
@@ -203,7 +216,11 @@ def _norm_item(raw):
         "because": raw.get("because") or None,
         "id": raw.get("id") or None,
         "external_state": bool(raw.get("external_state")),
-        "importance": imp if isinstance(imp, int) and not isinstance(imp, bool) and 1 <= imp <= 5 else None,
+        # 1-10, matching the producer (serializer.py:151 instructs the range,
+        # :678 clamps to it). A 1-5 bound nulled 89% of rated items, and because
+        # the distribution is right-skewed it deleted precisely the load-bearing
+        # half, inverting every importance-sorted list.
+        "importance": imp if isinstance(imp, int) and not isinstance(imp, bool) and 1 <= imp <= 10 else None,
         "last_verified": _norm_str(raw.get("last_verified")),
         "origin_session": _norm_str(raw.get("origin_session")),
         "source_message_ids": _norm_str_list(raw.get("source_message_ids")),

--- a/plugin/tests/ui/test_producer_contract.py
+++ b/plugin/tests/ui/test_producer_contract.py
@@ -1,0 +1,104 @@
+"""Fixture-free contract: the reader must not null a field the producer wrote.
+
+Every other test in this directory builds its own checkpoint, which means it can
+only ever assert the shape its author IMAGINED. Two live bugs got in that way and
+were then pinned green: `importance` was normalized against a 1-5 bound while the
+producer scores 1-10 (serializer.py:151, :678), and `quote_provenance.verifier` was
+normalized as a string while the producer writes an object (provenance.py:188). A
+wrong guess resolves to None, and None is indistinguishable from honest absence, so
+nothing raised.
+
+This test takes no fixtures. It reads whatever real checkpoints exist on the machine
+and asserts the reader preserves what the producer actually wrote, so a future
+divergence is a test failure instead of a shipped lie.
+
+It skips when there is no store (CI, a fresh machine). That is deliberate: the value
+is on developer machines and in dogfooding, where real producer output lives.
+
+Failure messages carry field names and COUNTS only, never checkpoint content or
+paths. Real checkpoints hold private project data, and a pytest failure line can
+reach CI logs and pull request comments.
+"""
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from daimon_ui import reader
+
+# Resolved independently of DAIMON_CHECKPOINT_DIR: the root conftest redirects that
+# to an isolated tmp home for every test, which would make this one skip forever.
+_REAL_STORE = Path(os.path.expanduser("~")) / ".daimon" / "checkpoints"
+
+
+def _checkpoints(limit=400):
+    if not _REAL_STORE.is_dir():
+        return []
+    out = []
+    for path in sorted(_REAL_STORE.rglob("*.json"))[:limit]:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            continue  # torn or foreign file: the reader tolerates these too
+        if isinstance(data, dict):
+            out.append(data)
+    return out
+
+
+def _raw_items(checkpoint):
+    """Every raw item dict the producer wrote, from both blocks."""
+    for block in (checkpoint.get("working_context"), checkpoint.get("epistemic_snapshot")):
+        if not isinstance(block, dict):
+            continue
+        for value in block.values():
+            if isinstance(value, dict):
+                yield value
+            elif isinstance(value, list):
+                for entry in value:
+                    if isinstance(entry, dict):
+                        yield entry
+
+
+@pytest.fixture(scope="module")
+def real_items():
+    items = [item for cp in _checkpoints() for item in _raw_items(cp)]
+    if not items:
+        pytest.skip("no local checkpoint store to check the producer contract against")
+    return items
+
+
+def test_reader_preserves_every_importance_the_producer_wrote(real_items):
+    written = [i for i in real_items
+               if isinstance(i.get("importance"), int)
+               and not isinstance(i.get("importance"), bool)]
+    if not written:
+        pytest.skip("no rated items in the local store")
+    dropped = sum(1 for i in written if reader._norm_item(i)["importance"] is None)
+    assert dropped == 0, (
+        f"reader nulled 'importance' on {dropped} of {len(written)} items the "
+        "producer rated; the reader's accepted range disagrees with the producer's"
+    )
+
+
+def test_reader_preserves_every_quote_verifier_the_producer_wrote(real_items):
+    written = [i for i in real_items
+               if isinstance(i.get("quote_provenance"), dict)
+               and i["quote_provenance"].get("verifier")]
+    if not written:
+        pytest.skip("no provenanced items in the local store")
+    dropped = sum(1 for i in written
+                  if (reader._norm_item(i)["quote_provenance"] or {}).get("verifier") is None)
+    assert dropped == 0, (
+        f"reader nulled 'quote_provenance.verifier' on {dropped} of {len(written)} "
+        "items that carry one; the reader's expected shape disagrees with the producer's"
+    )
+
+
+def test_reader_never_invents_an_item_from_a_producer_item(real_items):
+    """Weaker but broader: a producer item must normalize to something, never None.
+    Catches a whole-item rejection the two field checks above would miss."""
+    dropped = sum(1 for i in real_items if reader._norm_item(i) is None)
+    assert dropped == 0, (
+        f"reader rejected {dropped} of {len(real_items)} items the producer wrote"
+    )

--- a/plugin/tests/ui/test_reader_normalize.py
+++ b/plugin/tests/ui/test_reader_normalize.py
@@ -81,8 +81,20 @@ def test_importance_non_int_string_is_none(bucket):
     got = reader.load_checkpoint(bucket.parent, bucket.name, "latest")
     assert got["sections"][0]["items"][0]["importance"] is None
 
+def test_importance_producer_range_passes_through(bucket):
+    """The producer scores 1-10 (serializer.py:151, :678). A reader that stops at 5
+    deletes the load-bearing half, and the deleted value is indistinguishable from
+    honest absence, so nothing raises."""
+    cp = make_checkpoint(open_questions=[
+        {"text": "seven", "importance": 7, "external_state": True},
+        {"text": "ten", "importance": 10, "external_state": True},
+    ])
+    _write(bucket, "latest.json", cp)
+    got = reader.load_checkpoint(bucket.parent, bucket.name, "latest")
+    assert [i["importance"] for i in got["sections"][0]["items"]] == [7, 10]
+
 def test_importance_out_of_range_is_none(bucket):
-    cp = make_checkpoint(open_questions=[{"text": "t", "importance": 7, "external_state": True}])
+    cp = make_checkpoint(open_questions=[{"text": "t", "importance": 11, "external_state": True}])
     _write(bucket, "latest.json", cp)
     got = reader.load_checkpoint(bucket.parent, bucket.name, "latest")
     assert got["sections"][0]["items"][0]["importance"] is None
@@ -123,7 +135,7 @@ def test_norm_item_passes_trust_anatomy_fields():
         "origin_session": "aaaa-1111",
         "source_message_ids": ["m1", "m2"],
         "quote_provenance": {
-            "verifier": "quote-v2", "outcome": "verified",
+            "verifier": {"id": "tier-f", "version": 1}, "outcome": "verified",
             "checked_at": "2026-08-06T10:00:00Z",
             "digest": {"algorithm": "sha256", "value": "ff"},
             "binding": {"message_ids": ["m1"]},
@@ -133,7 +145,7 @@ def test_norm_item_passes_trust_anatomy_fields():
     assert got["origin_session"] == "aaaa-1111"
     assert got["source_message_ids"] == ["m1", "m2"]
     assert got["quote_provenance"] == {
-        "verifier": "quote-v2", "outcome": "verified",
+        "verifier": "tier-f", "verifier_version": 1, "outcome": "verified",
         "checked_at": "2026-08-06T10:00:00Z",
         "digest_algorithm": "sha256", "message_ids": ["m1"],
     }
@@ -164,10 +176,26 @@ def test_norm_provenance_malformed_nested_shapes():
         "digest": "not-a-dict", "binding": {"message_ids": ["ok", 5]},
     }})
     assert got["quote_provenance"] == {
-        "verifier": None, "outcome": None, "checked_at": None,
-        "digest_algorithm": None, "message_ids": ["ok"],
+        "verifier": None, "verifier_version": None, "outcome": None,
+        "checked_at": None, "digest_algorithm": None, "message_ids": ["ok"],
     }
 
 def test_norm_item_source_message_ids_filters_non_strings():
     got = reader._norm_item({"text": "x", "source_message_ids": ["a", 1, "b"]})
     assert got["source_message_ids"] == ["a", "b"]
+
+def test_norm_provenance_accepts_a_legacy_string_verifier():
+    """Older receipts recorded the verifier as a bare string. A tolerant reader keeps
+    reading them; only the version is unavailable."""
+    got = reader._norm_item({"text": "x", "quote_provenance": {
+        "verifier": "quote-v2", "outcome": "verified",
+    }})
+    assert got["quote_provenance"]["verifier"] == "quote-v2"
+    assert got["quote_provenance"]["verifier_version"] is None
+
+def test_norm_provenance_verifier_object_without_version():
+    got = reader._norm_item({"text": "x", "quote_provenance": {
+        "verifier": {"id": "tier-f"}, "outcome": "verified",
+    }})
+    assert got["quote_provenance"]["verifier"] == "tier-f"
+    assert got["quote_provenance"]["verifier_version"] is None


### PR DESCRIPTION
Closes #796

## What

The viewer normalized two fields against a shape the producer does not emit, and both
mismatches resolved to `None`. `None` is indistinguishable from honest absence, so
nothing raised and the panel rendered a confident lie.

- `importance` was accepted only in 1-5 while the producer scores 1-10
  (`serializer.py:151` instructs the range, `:678` clamps to it). Now 1-10.
- `quote_provenance.verifier` was normalized as a string while the producer writes an
  object (`provenance.py:188`). Now read as an object, with the version exposed as its
  own key rather than folded into a display string, so `render.js` is untouched. Bare
  strings stay readable, because older receipts recorded the id alone.

Also corrects the tests that pinned both shapes, and adds a fixture-free producer
contract test.

## Why

Measured against a real store, the 1-5 bound nulled 89 percent of rated items. The
distribution is right-skewed, so it deleted precisely the load-bearing half and any
importance-sorted list ranked the most important claims last, behind the least
important ones that happened to survive. Every receipt carrying a verifier rendered it
as not recorded, which is the worst field to blank, because it names who checked the
quote.

The reason it survived is the part worth fixing properly: the suite encoded the same
fiction. `test_importance_out_of_range_is_none` asserted that `7` normalizes to `None`,
and 7 is a valid producer value. The provenance tests used a string verifier the
producer never emits. A fixture written from an imagined producer cannot detect a
disagreement with the real one, so the one-line bound was the symptom rather than the
defect.

## Tests

`4289 passed, 2 skipped` on the full suite; `ruff` clean; `scar lint` reports 0 errors.

The new `tests/ui/test_producer_contract.py` takes no fixtures. It reads real
checkpoints and asserts the reader never nulls a field the producer wrote. Against the
old bound it fails with 9995 and 3128 dropped, so it would have caught both bugs. Five
tests in `test_reader_normalize.py` failed before the change and pass after.

Two details that matter for review. It resolves the store independently of
`DAIMON_CHECKPOINT_DIR`, because the root conftest redirects that to an isolated tmp
home for every test and the check would otherwise skip forever. Its failure messages
carry field names and counts only, never checkpoint content or paths, because a pytest
failure line can reach CI logs and pull request comments.

Publishing a machine readable checkpoint schema is the general fix for this whole class
and is left to its own issue. This repairs the two live fields and installs the test
that would have caught them.
