### PR TITLE
fix(request): fold the sender lane in request list, like the panels already do

### DIFF
--- a/plugin/daimon_briefing/requests.py
+++ b/plugin/daimon_briefing/requests.py
@@ -480,9 +480,17 @@ def get(request_id: str, project_dir=None) -> dict | None:
 def listing(project_dir=None) -> list[dict]:
     """Every record in this bucket, undecided first — the `request list`
     order. Suppressed records are HERE by construction (D5): suppression
-    takes away panel placement, never visibility."""
+    takes away panel placement, never visibility.
+
+    #798: read through the sender join, not the bucket-local fold. A request's
+    rows span two buckets — `opened` here, the verdict in the recipient's — so
+    folding only this bucket reported every ask this project SENT as `open`
+    forever after it was decided, while `inbox` and the verdict panel (which do
+    join) reported it correctly. The panel's own overflow line points here.
+    Local suppression survives the join; the recipient's never crosses it."""
+    rows = [row for group in _sender_rows(project_dir).values() for row in group]
     return sorted(
-        records(project_dir=project_dir).values(),
+        fold(rows).values(),
         key=lambda r: (r["state"] not in _SENDER_MOVABLE,
                        r.get("updated_at") or "", r["request_id"]))
 
@@ -797,12 +805,17 @@ def _without_suppression(rows: list[dict]) -> list[dict]:
     return [row for row in rows if row.get("event") != "suppressed"]
 
 
-def sender_join(project_dir=None) -> dict[str, dict]:
-    """Every request this project SENT, joined with whatever its recipient
-    decided (D0) — the per-bucket `records()` above only ever sees this
-    project's OWN rows, and a verdict lives in the recipient's bucket. One
-    recipient bucket is read once per distinct `to` target, not once per
-    record. Suppression is filtered before the fold runs (D5)."""
+def _sender_rows(project_dir) -> dict[str, list]:
+    """This bucket's rows, plus the recipient's rows for every request it SENT,
+    grouped by request id. The traversal both sender-side surfaces share (#798).
+
+    Foreign suppression is dropped HERE, not by the callers: a `suppressed` row
+    in the recipient's bucket is that project's own panel-attention housekeeping
+    and must never cross the join (D5). Local rows are returned untouched, so a
+    record THIS project suppressed keeps its visibility.
+
+    One recipient bucket is read once per distinct `to` target, not once per
+    record."""
     sender_slug = store.project_slug(project_dir)
     if not sender_slug:
         return {}
@@ -819,10 +832,19 @@ def sender_join(project_dir=None) -> dict[str, dict]:
             continue  # already covered by this bucket's own rows above
         if to_slug not in cache:
             cache[to_slug] = events(project_dir=to_slug)
-        by_id[rid] = by_id[rid] + [row for row in cache[to_slug]
-                                   if row.get("request_id") == rid]
+        by_id[rid] = by_id[rid] + _without_suppression(
+            [row for row in cache[to_slug] if row.get("request_id") == rid])
+    return by_id
+
+
+def sender_join(project_dir=None) -> dict[str, dict]:
+    """Every request this project SENT, joined with whatever its recipient
+    decided (D0) — the per-bucket `records()` above only ever sees this
+    project's OWN rows, and a verdict lives in the recipient's bucket.
+    Suppression is filtered before the fold runs (D5), local rows included:
+    this feeds the verdict PANEL, and suppression is exactly panel attention."""
     rows = _without_suppression(
-        [row for group in by_id.values() for row in group])
+        [row for group in _sender_rows(project_dir).values() for row in group])
     return fold(rows)
 
 

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -2111,3 +2111,59 @@ def test_request_inject_needs_no_session_to_stay_quiet(
     capsys.readouterr()
     assert cli.main(["request-inject", "--project", project]) == 0
     assert capsys.readouterr().out == ""
+
+
+# ---- #798: `request list` must fold the sender lane, like the panels do ------
+#
+# A request's rows span two buckets: `opened` in the sender's, the verdict in the
+# recipient's. `inbox` joins across buckets (recipient_join) and the verdict panel
+# joins across buckets (sender_join), but `listing` folded only the local bucket, so
+# every ask a project SENT read `open` forever after it was decided.
+
+
+def _listed(project, q_id):
+    return {r["request_id"]: r for r in requests.listing(project_dir=project)}[q_id]
+
+
+def test_listing_reports_the_recipients_verdict(project):
+    """#798: the surface the verdict panel's overflow line points at
+    ("+N more decided — daimon request list") must be able to show them."""
+    recipient_slug = _seed_bucket("/p/req-list-verdict")
+    q_id = _open(project, to=recipient_slug)
+    requests.done(q_id, channel="cli-agent", evidence="shipped in abc1234",
+                  project_dir=recipient_slug)
+    assert _listed(project, q_id)["state"] == "done"
+
+
+def test_listing_reports_a_rejection_too(project):
+    recipient_slug = _seed_bucket("/p/req-list-reject")
+    q_id = _open(project, to=recipient_slug)
+    requests.reject(q_id, channel="cli-tty", note="not this quarter",
+                    project_dir=recipient_slug)
+    assert _listed(project, q_id)["state"] == "rejected"
+
+
+def test_listing_does_not_leak_the_recipients_suppression_d5(project):
+    """D5 runs the OTHER way here. Joining the recipient's rows must not teach the
+    sender that its ask was muted from the recipient's panel: it reads undecided and
+    goes stale on the normal schedule. The filter belongs on FOREIGN rows only."""
+    recipient_slug = _seed_bucket("/p/req-list-suppressed")
+    q_id = _open(project, to=recipient_slug)
+    requests.suppress(q_id, channel="cli-tty", project_dir=recipient_slug)
+    listed = _listed(project, q_id)
+    assert listed["suppressed"] is False
+    assert listed["state"] == "open"
+
+
+def test_listing_keeps_the_sent_lane_out_of_the_inbox(project):
+    """The property most likely to regress when the data source moves. `listing` is
+    the SENT lane: an ask addressed TO this project, opened elsewhere, has never
+    appeared here (verified against the pre-change behaviour) and must not start
+    appearing once foreign rows are joined in."""
+    sender_slug = _seed_bucket("/p/req-list-inbound")
+    q_id = requests.open_request(to=store.project_slug(project), ask=ASK, why=WHY,
+                                 channel="cli-agent", project_dir=sender_slug)
+    requests.suppress(q_id, channel="cli-tty", project_dir=project)
+    assert q_id not in {r["request_id"] for r in requests.listing(project_dir=project)}
+    # ...and it is still reachable where it belongs, the inbox.
+    assert requests.recipient_join(project_dir=project)[q_id]["suppressed"] is True


### PR DESCRIPTION
Closes #798

## What

`daimon request list` folded only the local bucket, so a request this project SENT
reported `open` forever after its recipient decided it. It now reads through the same
traversal the sender-side verdict panel already uses.

A request's rows span two buckets: `opened` in the sender's, the verdict or completion
in the recipient's. `inbox` joins across buckets through `recipient_join`, the verdict
panel joins through `sender_join`, and `listing` did neither.

Rather than add a third bucket walk that could drift from the two the panels trust,
this extracts the traversal `sender_join` already performs into `_sender_rows` and
reads `listing` through it.

## Why

Observed on a real cross-project request, same id and same moment:

```
sender_join   state : done
listing       state : open
verdict panel rows  : 1
```

Two surfaces, two answers. `request list` is the one command a sender runs to ask what
happened to its asks.

It compounds: the verdict panel's overflow line points at the broken surface, so past
`RENDER_CAP` a sender is told to read the remainder in the place that renders every one
of them as undecided. Reporting a completion also prints that an answer joins its
origin at read time, which was true of the panels and false of this surface.

## Suppression, which is the part worth reviewing

D5 runs in both directions here, and the two halves live in different buckets.

- A `suppressed` row in the RECIPIENT's bucket is that project's own panel-attention
  housekeeping. It must never cross the join, or a sender would learn its ask had been
  muted.
- A record THIS project suppressed must stay visible in its own list, because
  suppression takes away panel placement and never visibility.

So the filter moved onto foreign rows only, inside `_sender_rows`. `sender_join` still
filters local rows too, which stays correct for it: it feeds the panel, and suppression
is exactly panel attention.

## Tests

`4293 passed, 2 skipped`; ruff clean; `scar lint` 0 errors.

Four new tests. Two fail before the change (a verdict and a rejection, now reported by
`listing`). Two pass before it and exist to hold the properties most likely to regress
when a data source moves: the recipient's suppression still does not leak to the
sender, and an inbound ask is still absent from the sent lane.

That last one is worth a note for review. A first draft of it asserted that a record
this project suppressed appears in its own `request list`, which reads like the
documented rule. Checked against the pre-change code, inbound asks have never appeared
in `listing` at all, so the test was asserting a behaviour that never held and was
replaced with one that pins what is actually there.

Cost is bounded by distinct recipients rather than fleet size, since one recipient
bucket is read once per distinct target. Measured on a real store at 0.47ms for 6
records across 3 recipients, matching `sender_join` on the same data.

## Noted, not fixed here

`daimon request suppress --help` says a suppressed record "stays in `request list`". It
does not, and did not before this change either: an inbound ask is not in that lane at
all, and the record stays reachable through `inbox`. That is a separate wording or
scoping question and did not belong in a fix whose whole point is that these surfaces
should stop disagreeing.
