### PR TITLE
fix(requests): the live nudge now names the ask its cap withheld

### DIFF
--- a/plugin/daimon_briefing/cli/request.py
+++ b/plugin/daimon_briefing/cli/request.py
@@ -176,12 +176,20 @@ def _cmd_request_inject(args) -> int:
     _cli._note_usage("request-inject")
     try:
         project = _cli._resolve_project(args.project)
-        rows = requests.deliverable(session, project_dir=project)
+        entry = requests.deliverable(session, project_dir=project)
+        rows = entry["rows"]
         if not rows:
             return 0
         out = []
         for record in rows:
             out.extend(_inject_lines(record))
+        # #800: name what the cap withheld, in the panel's own words. Without
+        # it a fourth addressed ask is dropped and reads as an absence, which
+        # is the one failure this feature cannot have.
+        overflow = entry["overflow"]
+        if overflow:
+            plural = "s" if overflow != 1 else ""
+            out.append(f"(+{overflow} more waiting{plural}, not shown here)")
         # The verbs that decide are human-only (D8); the line names the
         # surface that lists them rather than a verb the agent cannot run.
         out.append("Undecided. Full records: `daimon request inbox`")

--- a/plugin/daimon_briefing/requests.py
+++ b/plugin/daimon_briefing/requests.py
@@ -950,27 +950,33 @@ def inbox_renderable(project_dir=None) -> dict:
     return {"rows": rows[:RENDER_CAP], "overflow": max(0, len(rows) - RENDER_CAP)}
 
 
-def deliverable(session: str, project_dir=None) -> list[dict]:
+def deliverable(session: str, project_dir=None) -> dict:
     """#756: the asks addressed to this project that `session` has not yet
     been delivered THIS revision epoch — the panel's own filter, narrowed by
-    what this one session has already seen.
+    what this one session has already seen. `{"rows": [...], "overflow": N}`.
 
     Ordering and cap follow the panel deliberately (newest first, RENDER_CAP)
     so a live nudge and the next brief agree about which asks matter. The
     dedup filter runs BEFORE the cap: capping first would let three
     already-delivered asks hide a fourth that nobody has seen.
 
+    #800: the remainder is COUNTED, the same shape and for the same reason as
+    `renderable()` above — silently dropping an addressed ask is the one
+    failure this feature cannot have, and this path inherited the cap without
+    the signal that made it safe. The count is taken AFTER the dedup filter,
+    so it never reports asks this session has already been shown.
+
     No session id means no dedup key, and re-nudging every turn forever is
     worse than not nudging — so it returns nothing rather than everything."""
     session = str(session or "").strip()
     if not session:
-        return []
+        return {"rows": [], "overflow": 0}
     rows = [r for r in recipient_join(project_dir=project_dir).values()
             if _deserves_attention(r, project_dir=project_dir)
             and needs_delivered_stamp(r, session)]
     rows.sort(key=lambda r: (r.get("updated_at") or "", r["request_id"]),
               reverse=True)
-    return rows[:RENDER_CAP]
+    return {"rows": rows[:RENDER_CAP], "overflow": max(0, len(rows) - RENDER_CAP)}
 
 
 # ---- #694 PR 3: D3 — consumption-based expiry, derived, never written -----

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -1950,13 +1950,13 @@ def test_deliverable_is_the_panel_filter_plus_this_session(project):
     q_id = requests.open_request(to=store.project_slug(project), ask=ASK,
                                  why=WHY, channel="cli-agent",
                                  project_dir=sender)
-    rows = requests.deliverable("S-alpha", project_dir=project)
+    rows = requests.deliverable("S-alpha", project_dir=project)["rows"]
     assert [r["request_id"] for r in rows] == [q_id]
     # Delivered once, gone for THIS session, still owed to the next one.
     assert requests.stamp_delivered(q_id, "S-alpha", project_dir=project)
-    assert requests.deliverable("S-alpha", project_dir=project) == []
+    assert requests.deliverable("S-alpha", project_dir=project)["rows"] == []
     assert [r["request_id"] for r in
-            requests.deliverable("S-beta", project_dir=project)] == [q_id]
+            requests.deliverable("S-beta", project_dir=project)["rows"]] == [q_id]
 
 
 def test_deliverable_excludes_decided_suppressed_and_stale(project):
@@ -1977,7 +1977,7 @@ def test_deliverable_excludes_decided_suppressed_and_stale(project):
         _serialize(project, f"S-deliver-stale-{n}", _iso(n + 1))
     live = ask("the live ask, still owed a decision")
     ids = {r["request_id"] for r in
-           requests.deliverable("S-alpha", project_dir=project)}
+           requests.deliverable("S-alpha", project_dir=project)["rows"]}
     assert ids == {live}
 
 
@@ -1987,11 +1987,11 @@ def test_deliverable_re_offers_a_revised_ask_to_a_delivered_session(project):
                                  why=WHY, channel="cli-agent",
                                  project_dir=sender)
     assert requests.stamp_delivered(q_id, "S-alpha", project_dir=project)
-    assert requests.deliverable("S-alpha", project_dir=project) == []
+    assert requests.deliverable("S-alpha", project_dir=project)["rows"] == []
     requests.revise(q_id, channel="cli-agent", ask="the sharpened ask",
                     project_dir=sender)
     assert [r["request_id"] for r in
-            requests.deliverable("S-alpha", project_dir=project)] == [q_id]
+            requests.deliverable("S-alpha", project_dir=project)["rows"]] == [q_id]
 
 
 def test_deliverable_caps_at_the_render_budget(project):
@@ -2000,13 +2000,13 @@ def test_deliverable_caps_at_the_render_budget(project):
         requests.open_request(to=store.project_slug(project),
                               ask=f"ask number {n} about the release",
                               why=WHY, channel="cli-agent", project_dir=sender)
-    assert len(requests.deliverable("S-alpha", project_dir=project)) \
+    assert len(requests.deliverable("S-alpha", project_dir=project)["rows"]) \
         == requests.RENDER_CAP
 
 
 def test_deliverable_never_offers_this_projects_own_outgoing_ask(project):
     _open(project)
-    assert requests.deliverable("S-alpha", project_dir=project) == []
+    assert requests.deliverable("S-alpha", project_dir=project)["rows"] == []
 
 
 def test_deliverable_without_a_session_offers_nothing(project):
@@ -2015,7 +2015,7 @@ def test_deliverable_without_a_session_offers_nothing(project):
     sender = _seed_bucket("/p/deliver-sender-e")
     requests.open_request(to=store.project_slug(project), ask=ASK, why=WHY,
                           channel="cli-agent", project_dir=sender)
-    assert requests.deliverable("", project_dir=project) == []
+    assert requests.deliverable("", project_dir=project)["rows"] == []
 
 
 # ---- the hook backend -----------------------------------------------------
@@ -2167,3 +2167,65 @@ def test_listing_keeps_the_sent_lane_out_of_the_inbox(project):
     assert q_id not in {r["request_id"] for r in requests.listing(project_dir=project)}
     # ...and it is still reachable where it belongs, the inbox.
     assert requests.recipient_join(project_dir=project)[q_id]["suppressed"] is True
+
+
+# ---- #800: the live nudge must report what its cap withheld ----------------
+#
+# `renderable()` returns {"rows", "overflow"} because, in its own words,
+# silently dropping an addressed ask is the one failure this feature cannot
+# have. `deliverable()` inherited that ordering and cap and dropped the
+# overflow signal that made the cap safe.
+
+
+def _addressed(project, sender, n):
+    return [requests.open_request(to=store.project_slug(project), ask=f"ask {i}",
+                                  why=WHY, channel="cli-agent", project_dir=sender)
+            for i in range(n)]
+
+
+def test_deliverable_reports_what_the_cap_withheld(project):
+    sender = _seed_bucket("/p/deliver-overflow-a")
+    _addressed(project, sender, requests.RENDER_CAP + 2)
+    entry = requests.deliverable("S-alpha", project_dir=project)
+    assert len(entry["rows"]) == requests.RENDER_CAP
+    assert entry["overflow"] == 2
+
+
+def test_deliverable_overflow_is_zero_when_nothing_is_withheld(project):
+    sender = _seed_bucket("/p/deliver-overflow-b")
+    _addressed(project, sender, 1)
+    entry = requests.deliverable("S-alpha", project_dir=project)
+    assert len(entry["rows"]) == 1 and entry["overflow"] == 0
+
+
+def test_deliverable_overflow_counts_after_dedup_not_before(project):
+    """The dedup filter runs BEFORE the cap, deliberately, so already-delivered
+    asks cannot hide an unseen one. The count has to be taken after that same
+    filter or it reports asks this session has already been shown."""
+    sender = _seed_bucket("/p/deliver-overflow-c")
+    ids = _addressed(project, sender, requests.RENDER_CAP + 2)
+    # Show this session everything except the two most recent.
+    for q in ids[:requests.RENDER_CAP]:
+        requests.stamp_delivered(q, "S-alpha", project_dir=project)
+    entry = requests.deliverable("S-alpha", project_dir=project)
+    assert len(entry["rows"]) == 2, "only the undelivered ones remain"
+    assert entry["overflow"] == 0, "nothing is withheld once dedup has run"
+
+
+def test_inject_names_the_ask_it_withheld(project, capsys, monkeypatch):
+    monkeypatch.setenv("DAIMON_LIVE_DELIVERY", "1")
+    sender = _seed_bucket("/p/deliver-overflow-d")
+    _addressed(project, sender, requests.RENDER_CAP + 2)
+    assert _inject(project) == 0
+    out = capsys.readouterr().out
+    assert "+2 more waiting" in out, out
+
+
+def test_inject_adds_no_overflow_line_when_it_withheld_nothing(
+        project, capsys, monkeypatch):
+    monkeypatch.setenv("DAIMON_LIVE_DELIVERY", "1")
+    sender = _seed_bucket("/p/deliver-overflow-e")
+    _addressed(project, sender, 1)
+    assert _inject(project) == 0
+    out = capsys.readouterr().out
+    assert "more waiting" not in out, out


### PR DESCRIPTION
Closes #800

## What

`deliverable()` returned `rows[:RENDER_CAP]` as a bare list with no count of what it
cut, and `RENDER_CAP` is 3. A project with four addressed asks was nudged about three
and told nothing about the fourth.

It now returns `{"rows": [...], "overflow": N}`, the same shape as `renderable()`, and
the injected text carries the count in the panel's own wording.

## Why

The panel this path was modelled on counts its remainder precisely because, in its own
words, silently dropping an addressed ask is the one failure this feature cannot have.
`deliverable()` inherited that panel's ordering and cap deliberately, so a live nudge
and the next brief agree about which asks matter, and then dropped the overflow signal
that made the cap safe.

The trailing pointer did not cover it:

```
Undecided. Full records: `daimon request inbox`
```

That reads identically whether one ask was shown or one was hidden. It points at a
fuller surface; it does not say this render was incomplete.

Observed live before the fix: four open addressed asks, three delivered. The fourth
passed every filter (open, not suppressed, deserving attention, not yet stamped for
this session) and was cut by the cap alone.

## The ordering that matters

The count is taken AFTER the dedup filter. That filter already runs before the cap, by
design, so three already-delivered asks cannot hide a fourth nobody has seen. Counting
before it would report asks this session has already been shown, which is a different
lie in the same place. There is a test for exactly this.

## Tests

`4298 passed, 2 skipped`; ruff clean.

Five new tests: the cap reports its remainder, a full-but-uncapped read reports zero,
the count is taken after dedup rather than before, the injected text names the withheld
ask, and it says nothing extra when nothing was withheld. The cap boundary on this path
had no test at all.

Six existing tests failed on the return type change and were updated. That breakage is
the intended property of a list-to-dict swap: it fails at every call site at once rather
than returning something plausible. There is one production caller.
