### PR TITLE
fix(requests): a verdict after a revise now gets its own first look

### DIFF
--- a/plugin/daimon_briefing/requests.py
+++ b/plugin/daimon_briefing/requests.py
@@ -367,7 +367,14 @@ def fold(rows: list[dict]) -> dict[str, dict]:
                 # every session running in that epoch, so the session id is
                 # part of the write-once key rather than a field beside it.
                 "delivered": {},
-                "verdict_surfaced_at": None,
+                # #803: {revision epoch: earliest verdict_surfaced ts}, the
+                # same shape as `surfaced` above. It was a single timestamp on
+                # the premise that "a verdict is terminal once it lands", but
+                # needs-info is a verdict state and is not terminal: answering
+                # it with a revise and receiving a real verdict afterwards is
+                # the ordinary path, and the decay clock kept running from the
+                # needs-info, so the acceptance expired before it was shown.
+                "verdict_surfaced": {},
                 "revision": 0,
                 "created_at": row.get("ts"),
                 "updated_at": row.get("ts"),
@@ -396,8 +403,11 @@ def fold(rows: list[dict]) -> dict[str, dict]:
             continue
         if event == "verdict_surfaced":
             current["history_count"] += 1
-            if current["verdict_surfaced_at"] is None:
-                current["verdict_surfaced_at"] = row.get("ts")
+            # Keyed by the epoch the row was written IN: the stream is ordered,
+            # so `current["revision"]` here is the revision at that moment. Old
+            # rows therefore replay into their own epoch with no migration.
+            current["verdict_surfaced"].setdefault(current["revision"],
+                                                   row.get("ts"))
             continue
         if event == "delivered":
             # Same attention-row posture as `surfaced`: counted in history,
@@ -988,7 +998,8 @@ def deliverable(session: str, project_dir=None) -> dict:
 STALE_AFTER_SESSIONS = 3
 # Sender side: a decided record (accepted/rejected/needs-info/done) leaves
 # the sender's verdict PANEL after this many distinct non-introspection
-# SENDER sessions have serialized past `verdict_surfaced_at`. The record
+# SENDER sessions have serialized past THIS EPOCH's `verdict_surfaced`
+# stamp (#803). The record
 # itself never changes — only ambient panel placement.
 VERDICT_PANEL_SESSIONS = 2
 # States the sender-side verdict panel surfaces: everything settled enough
@@ -1022,10 +1033,14 @@ def render_state(record: dict, project_dir=None) -> str:
 
 def needs_verdict_surfaced_stamp(record: dict) -> bool:
     """D1, sender side: whether a `verdict_surfaced` row already exists for
-    this record. Write-once per RECORD, not per revision epoch — unlike the
-    recipient's `surfaced` stamp, a verdict is terminal once it lands, so
-    there is only ever one thing to stamp."""
-    return record.get("verdict_surfaced_at") is None
+    this record's CURRENT revision epoch — the same key the recipient's
+    `surfaced` stamp uses (#803).
+
+    It was write-once per RECORD, on the premise that a verdict is terminal
+    once it lands. `needs-info` is a verdict state and is not terminal, so a
+    record can carry a verdict, a revise, and then a second verdict; keying
+    per record meant the second one was never owed a look."""
+    return record.get("revision") not in (record.get("verdict_surfaced") or {})
 
 
 def stamp_verdict_surfaced(request_id: str, project_dir=None) -> bool:
@@ -1041,9 +1056,12 @@ def stamp_verdict_surfaced(request_id: str, project_dir=None) -> bool:
 def verdict_panel_expired(record: dict, project_dir=None) -> bool:
     """D3 sender side: True once VERDICT_PANEL_SESSIONS distinct non-
     introspection sessions have serialized for `project_dir` (the SENDER's
-    own bucket) past `verdict_surfaced_at`. Never stamped yet -> never
-    expired — the panel still owes the sender its first look."""
-    anchor = record.get("verdict_surfaced_at")
+    own bucket) past this record's CURRENT epoch stamp. This epoch never
+    stamped -> never expired: the panel still owes the sender its first
+    look at THIS verdict, even if an earlier one was seen and decayed."""
+    # The anchor is THIS epoch's stamp: a verdict that arrives after a revise
+    # decays from when IT was seen, never from when an earlier one was (#803).
+    anchor = (record.get("verdict_surfaced") or {}).get(record.get("revision"))
     if not anchor:
         return False
     return (store.sessions_since_count(anchor, project_dir)

--- a/plugin/tests/test_cli_brief_verdicts.py
+++ b/plugin/tests/test_cli_brief_verdicts.py
@@ -74,7 +74,7 @@ def test_cli_brief_stamps_verdict_surfaced_after_the_print(
     capsys.readouterr()
     record = requests.sender_join(project_dir=sender)[q_id]
     assert requests.needs_verdict_surfaced_stamp(record) is False
-    assert record["verdict_surfaced_at"]
+    assert record["verdict_surfaced"][record["revision"]]
 
 
 def test_cli_brief_verdict_stamp_is_write_once_across_repeated_briefs(

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -587,7 +587,7 @@ def test_attention_rows_never_move_the_records_age(project):
                         project_dir=project)
     after = requests.get(q_id, project_dir=project)
     assert after["updated_at"] == before
-    assert after["verdict_surfaced_at"]
+    assert after["verdict_surfaced"][after["revision"]]
 
 
 def test_renderable_caps_and_counts_the_overflow(project):
@@ -1587,7 +1587,7 @@ def test_needs_verdict_surfaced_stamp_and_dedup(project):
     assert requests.stamp_verdict_surfaced(q_id, project_dir=project) is True
     record = requests.sender_join(project_dir=project)[q_id]
     assert requests.needs_verdict_surfaced_stamp(record) is False
-    assert record["verdict_surfaced_at"]
+    assert record["verdict_surfaced"][record["revision"]]
 
 
 def test_stamp_verdict_surfaced_is_write_once_earliest_wins(project):
@@ -1600,7 +1600,7 @@ def test_stamp_verdict_surfaced_is_write_once_earliest_wins(project):
             if r.get("event") == "verdict_surfaced"]
     assert len(rows) == 2  # both written…
     record = requests.sender_join(project_dir=project)[q_id]
-    assert record["verdict_surfaced_at"] == rows[0]["ts"]  # …fold takes earliest
+    assert record["verdict_surfaced"][record["revision"]] == rows[0]["ts"]  # …earliest
 
 
 def test_verdict_panel_expired_after_two_sender_sessions(project):
@@ -1623,7 +1623,7 @@ def test_verdict_panel_never_expires_before_the_first_stamp(project):
     q_id = _open(project, to=recipient_slug)
     requests.accept(q_id, channel="cli-tty", project_dir=recipient_slug)
     record = requests.sender_join(project_dir=project)[q_id]
-    assert record["verdict_surfaced_at"] is None
+    assert record["verdict_surfaced"] == {}
     assert requests.verdict_panel_expired(record, project_dir=project) is False
 
 
@@ -2229,3 +2229,79 @@ def test_inject_adds_no_overflow_line_when_it_withheld_nothing(
     assert _inject(project) == 0
     out = capsys.readouterr().out
     assert "more waiting" not in out, out
+
+
+# ---- #803: a second verdict must get its own first look --------------------
+#
+# The sender stamp was write-once per RECORD, on the premise that "a verdict is
+# terminal once it lands". needs-info is a verdict state and is NOT terminal:
+# answering it with `revise` and receiving a real verdict afterwards is the
+# ordinary negotiation path. The decay clock started on the needs-info and kept
+# running, so the acceptance that followed expired before it was ever shown.
+
+
+def _sender_session(project, sid, created):
+    store.write_checkpoint(sid, {
+        "session_id": sid, "created": created,
+        "working_context": {"recent_decisions": [
+            {"text": "something happened", "trust": "inferred"}]},
+    }, project_dir=project)
+
+
+def _fut(minutes):
+    import datetime
+    return (datetime.datetime.now(datetime.timezone.utc)
+            + datetime.timedelta(minutes=minutes)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_a_verdict_after_a_revise_gets_its_own_first_look(project):
+    """#803: needs-info, answered, then accepted. The acceptance must still be
+    renderable after VERDICT_PANEL_SESSIONS later sender sessions, because its
+    own epoch has never been surfaced."""
+    recipient = _seed_bucket("/p/verdict-epoch-a")
+    _sender_session(project, "S-before", _fut(-60))
+    q_id = _open(project, to=recipient)
+
+    requests.needs_info(q_id, channel="cli-tty", note="which release?",
+                        project_dir=recipient)
+    assert requests.stamp_verdict_surfaced(q_id, project_dir=project)
+
+    requests.revise(q_id, channel="cli-agent", why="clarified",
+                    project_dir=project)
+    requests.accept(q_id, channel="cli-tty", note="ok", project_dir=recipient)
+
+    for n in range(requests.VERDICT_PANEL_SESSIONS + 1):
+        _sender_session(project, f"S-after-{n}", _fut(10 * (n + 1)))
+
+    record = requests.sender_join(project_dir=project)[q_id]
+    assert record["state"] == "accepted"
+    assert not requests.verdict_panel_expired(record, project_dir=project)
+    assert [r["request_id"] for r in
+            requests.verdict_renderable(project_dir=project)["rows"]] == [q_id]
+
+
+def test_the_new_epoch_is_owed_a_stamp_even_though_an_older_one_exists(project):
+    recipient = _seed_bucket("/p/verdict-epoch-b")
+    q_id = _open(project, to=recipient)
+    requests.needs_info(q_id, channel="cli-tty", note="?", project_dir=recipient)
+    requests.stamp_verdict_surfaced(q_id, project_dir=project)
+    record = requests.sender_join(project_dir=project)[q_id]
+    assert not requests.needs_verdict_surfaced_stamp(record), "epoch 0 is stamped"
+
+    requests.revise(q_id, channel="cli-agent", why="clarified",
+                    project_dir=project)
+    requests.reject(q_id, channel="cli-tty", note="no", project_dir=recipient)
+    record = requests.sender_join(project_dir=project)[q_id]
+    assert requests.needs_verdict_surfaced_stamp(record), \
+        "the rejection is a new epoch and is owed its own first look"
+
+
+def test_the_same_epoch_is_still_stamped_only_once(project):
+    """The write-once property that made the original shape correct must
+    survive: within one epoch, a second stamp is not owed."""
+    recipient = _seed_bucket("/p/verdict-epoch-c")
+    q_id = _open(project, to=recipient)
+    requests.accept(q_id, channel="cli-tty", note="ok", project_dir=recipient)
+    requests.stamp_verdict_surfaced(q_id, project_dir=project)
+    record = requests.sender_join(project_dir=project)[q_id]
+    assert not requests.needs_verdict_surfaced_stamp(record)


### PR DESCRIPTION
Closes #803

## What

The sender-side verdict stamp was write-once per RECORD. It is now keyed per revision
epoch, the same shape the recipient's `surfaced` stamp already uses, with the decay
anchor read from the record's CURRENT epoch.

## Why

The old shape rested on a premise its own docstring stated:

> Write-once per RECORD, not per revision epoch: unlike the recipient's `surfaced`
> stamp, a verdict is terminal once it lands, so there is only ever one thing to stamp.

`_VERDICT_STATES` is `{needs-info, accepted, rejected, done}`. `needs-info` is not
terminal. Answering it with a revise and receiving a real verdict afterwards is the
ordinary negotiation path, not an edge case.

So the decay clock started on the first verdict a record ever received and kept
running. A sender asked for more information, who answers and is then accepted, never
saw the acceptance: two sender sessions after the needs-info was rendered,
`verdict_panel_expired` filtered the acceptance out before it had been shown once.

Reproduced before the change against a real store: after one later sender session the
record was still renderable; after two it was gone, in the accepted state, having never
been rendered in that state.

The recipient side never had this, because its stamp is epoch-keyed and a revise bumps
the revision, so a sharpened ask re-surfaces. Two keying decisions for the same
negotiation, and only one survived a second round.

## No migration, contrary to what the issue said

I wrote in the issue that the stored field shape changes and needs a read-tolerant
migration. That was wrong and is worth correcting here rather than quietly.

The epoch is assigned at fold time from the ordered event stream, exactly as `surfaced`
does it: when the fold reaches a `verdict_surfaced` row, `current["revision"]` is
already the revision at that point in the stream. An existing row therefore replays
into whatever epoch it was written during, with no migration and no compatibility
branch.

It also unsticks records that are currently hidden: a record sitting behind an expired
first verdict has no stamp for its later epoch, so the panel owes it a look again.

## Tests

`4301 passed, 2 skipped`; ruff clean.

Three new tests: a verdict after a revise stays renderable past
`VERDICT_PANEL_SESSIONS` later sender sessions; a new epoch is owed a stamp even though
an older epoch already has one; and the write-once property within a single epoch still
holds. The third passed before the change and is there to hold the property most likely
to regress when a key changes.

Five existing assertions read the field directly and were updated to the epoch key.

## Note for the follow-up

This is upstream of #801. Live sender-side delivery reads `verdict_renderable` and
would have inherited this expiry filter, so it would have silently skipped exactly the
verdicts a sender most needs. #801's dedup key can now mirror `delivered` as
`{revision epoch: {session: ts}}` rather than inventing a third shape.
