### PR TITLE
feat(requests): deliver a verdict back to the sender at its next turn boundary

### DIFF
--- a/plugin/daimon_briefing/cli/request.py
+++ b/plugin/daimon_briefing/cli/request.py
@@ -157,6 +157,29 @@ def _inject_lines(record: dict) -> list[str]:
     return lines
 
 
+_INJECT_VERDICT_MARKS = {"needs-info": "?", "accepted": "✓",
+                         "rejected": "×", "done": "✔"}
+
+
+def _verdict_inject_lines(record: dict) -> list[str]:
+    """One delivered verdict, compressed to what the sender acts on. Same
+    posture as `_inject_lines`: this lands mid-session on the agent's context
+    budget. The note is the recipient's answer to THIS project's own ask, so
+    it is this project's mail rather than a foreign record being rendered."""
+    state = str(record.get("state") or "")
+    mark = _INJECT_VERDICT_MARKS.get(state, "?")
+    lines = [f"daimon verdict: {mark} {state}  {record['request_id']} "
+             f"(to {record.get('to') or '?'})"]
+    lines.append(f"  Ask: {record.get('ask', '')}")
+    note = str(record.get("note") or "").strip()
+    if note:
+        lines.append(f"  Note: {note}")
+    evidence = str(record.get("done_evidence") or "").strip()
+    if evidence:
+        lines.append(f"  Done: {evidence}")
+    return lines
+
+
 def _cmd_request_inject(args) -> int:
     """Print the undecided asks this session has not been shown, or nothing.
 
@@ -177,10 +200,17 @@ def _cmd_request_inject(args) -> int:
     try:
         project = _cli._resolve_project(args.project)
         entry = requests.deliverable(session, project_dir=project)
+        verdicts = requests.verdict_deliverable(session, project_dir=project)
         rows = entry["rows"]
-        if not rows:
+        if not rows and not verdicts["rows"]:
             return 0
         out = []
+        for record in verdicts["rows"]:
+            out.extend(_verdict_inject_lines(record))
+        if verdicts["overflow"]:
+            plural = "s" if verdicts["overflow"] != 1 else ""
+            out.append(f"(+{verdicts['overflow']} more decided{plural}, "
+                       "not shown here)")
         for record in rows:
             out.extend(_inject_lines(record))
         # #800: name what the cap withheld, in the panel's own words. Without
@@ -192,8 +222,14 @@ def _cmd_request_inject(args) -> int:
             out.append(f"(+{overflow} more waiting{plural}, not shown here)")
         # The verbs that decide are human-only (D8); the line names the
         # surface that lists them rather than a verb the agent cannot run.
-        out.append("Undecided. Full records: `daimon request inbox`")
+        # Only when there ARE undecided asks: a delivery carrying nothing but
+        # verdicts has nothing awaiting a decision to point at.
+        if rows:
+            out.append("Undecided. Full records: `daimon request inbox`")
         print("\n".join(out))
+        for record in verdicts["rows"]:
+            requests.stamp_verdict_delivered(record["request_id"], session,
+                                             project_dir=project)
         for record in rows:
             requests.stamp_delivered(record["request_id"], session,
                                      project_dir=project)

--- a/plugin/daimon_briefing/requests.py
+++ b/plugin/daimon_briefing/requests.py
@@ -71,9 +71,14 @@ VERSION = 1
 # direction on an older reader — the row drops, the record reads as
 # undelivered, and the worst case is a repeated nudge rather than a
 # swallowed ask. It is an attention row like `surfaced`, never a state.
+# #801 widens it a third time, on the same terms, with `verdict_delivered`:
+# the live-delivery render stamped this VERDICT into a running SENDER session.
+# Same safe direction on an older reader — the row drops, the record reads as
+# undelivered, and the worst case is a repeated nudge rather than a swallowed
+# verdict. An attention row like `surfaced`, never a state.
 EVENTS = frozenset({
     "opened", "revised",
-    "surfaced", "verdict_surfaced", "delivered",
+    "surfaced", "verdict_surfaced", "delivered", "verdict_delivered",
     "needs_info", "accepted", "rejected", "done",
     "suppressed", "done_verified",
 })
@@ -114,6 +119,7 @@ _EVENT_RANK = {
     "surfaced": 2,
     "verdict_surfaced": 2,
     "delivered": 2,
+    "verdict_delivered": 2,
     "suppressed": 3,
     "done": 4,
     "needs_info": 5,
@@ -375,6 +381,12 @@ def fold(rows: list[dict]) -> dict[str, dict]:
                 # the ordinary path, and the decay clock kept running from the
                 # needs-info, so the acceptance expired before it was shown.
                 "verdict_surfaced": {},
+                # #801: {revision epoch: {session id: earliest ts}} — the same
+                # shape as `delivered`, one level deeper than `verdict_surfaced`
+                # for the same reason: a brief renders the verdict card once per
+                # epoch, but a live nudge owes it to every session running in
+                # that epoch.
+                "verdict_delivered": {},
                 "revision": 0,
                 "created_at": row.get("ts"),
                 "updated_at": row.get("ts"),
@@ -408,6 +420,16 @@ def fold(rows: list[dict]) -> dict[str, dict]:
             # rows therefore replay into their own epoch with no migration.
             current["verdict_surfaced"].setdefault(current["revision"],
                                                    row.get("ts"))
+            continue
+        if event == "verdict_delivered":
+            # Same posture as `delivered`, sender side. A row that lost its
+            # session id is inert rather than epoch-wide, so one malformed row
+            # cannot starve every live session of a verdict it never reached.
+            current["history_count"] += 1
+            session = str(row.get("session") or "").strip()
+            if session:
+                current["verdict_delivered"].setdefault(current["revision"], {}) \
+                    .setdefault(session, row.get("ts"))
             continue
         if event == "delivered":
             # Same attention-row posture as `surfaced`: counted in history,
@@ -1066,6 +1088,59 @@ def verdict_panel_expired(record: dict, project_dir=None) -> bool:
         return False
     return (store.sessions_since_count(anchor, project_dir)
             >= VERDICT_PANEL_SESSIONS)
+
+
+def needs_verdict_delivered_stamp(record: dict, session: str) -> bool:
+    """#801: whether THIS session has already been nudged with this record's
+    verdict in its CURRENT revision epoch. Write-once per (request id, epoch,
+    session), the recipient path's key exactly — a revise opens a new epoch, so
+    a verdict that lands after one gets its own delivery rather than being
+    swallowed by the stamp of an earlier one (#803's lesson, same shape)."""
+    epoch = (record.get("verdict_delivered") or {}).get(record.get("revision")) or {}
+    return str(session or "").strip() not in epoch
+
+
+def stamp_verdict_delivered(request_id: str, session: str,
+                            project_dir=None) -> bool:
+    """Write a `verdict_delivered` row to THIS project's own bucket (the
+    SENDER's), recording that the live surface nudged this verdict into
+    `session`. Channel `mechanical`, same posture as `stamp_delivered`.
+
+    Deliberately distinct from `verdict_surfaced`: that one records the BRIEF
+    rendering the verdict card, and one surface must never suppress the other
+    or a live nudge would cost the sender its fuller view at next session."""
+    session = str(session or "").strip()
+    if not session:
+        raise RequestError("verdict_delivered stamp requires a session id")
+    row = _stamp("verdict_delivered", request_id, "mechanical")
+    row["session"] = session
+    return append(row, project_dir=project_dir)
+
+
+def verdict_deliverable(session: str, project_dir=None) -> dict:
+    """#801: the verdicts on asks THIS project sent that `session` has not yet
+    been nudged with. `{"rows": [...], "overflow": N}`.
+
+    The sender-side counterpart to `deliverable`, over `sender_join` rather
+    than `recipient_join` — a verdict on an ask this project SENT is
+    structurally unreachable from the recipient path, which is why live
+    delivery was one-directional. Same filters as the sender's panel (verdict
+    states, not expired), the same dedup-before-cap ordering, and the same
+    counted remainder (#800): capping first would let three already-nudged
+    verdicts hide a fourth nobody has seen.
+
+    No session id means no dedup key, so it returns nothing rather than
+    re-nudging every turn forever."""
+    session = str(session or "").strip()
+    if not session:
+        return {"rows": [], "overflow": 0}
+    rows = [r for r in sender_join(project_dir=project_dir).values()
+            if r["state"] in _VERDICT_STATES
+            and not verdict_panel_expired(r, project_dir=project_dir)
+            and needs_verdict_delivered_stamp(r, session)]
+    rows.sort(key=lambda r: (r.get("updated_at") or "", r["request_id"]),
+              reverse=True)
+    return {"rows": rows[:RENDER_CAP], "overflow": max(0, len(rows) - RENDER_CAP)}
 
 
 def verdict_renderable(project_dir=None) -> dict:

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -908,9 +908,14 @@ def test_the_event_vocabulary_is_frozen():
     row and keeps rendering "done (claimed, unverified)" — the safe
     direction). #756 widens it a second time, on the same terms, with
     `delivered`: an older reader drops the row, reads the record as
-    undelivered, and at worst repeats a nudge."""
+    undelivered, and at worst repeats a nudge. #801 widens it a third time,
+    on identical terms, with `verdict_delivered`: the sender-side counterpart,
+    where an older reader drops the row, reads the verdict as undelivered, and
+    at worst repeats a nudge. Every widening so far fails the same safe way,
+    which is the property this test exists to keep true."""
     assert set(requests.EVENTS) == {
         "opened", "revised", "surfaced", "verdict_surfaced", "delivered",
+        "verdict_delivered",
         "needs_info", "accepted", "rejected", "done", "suppressed",
         "done_verified"}
 
@@ -2305,3 +2310,107 @@ def test_the_same_epoch_is_still_stamped_only_once(project):
     requests.stamp_verdict_surfaced(q_id, project_dir=project)
     record = requests.sender_join(project_dir=project)[q_id]
     assert not requests.needs_verdict_surfaced_stamp(record)
+
+
+# ---- #801: the sender learns a verdict at its next turn boundary ------------
+#
+# Live delivery was one-directional. A recipient learned about a new ask on its
+# next prompt turn; a sender learned the verdict only at its next SessionStart,
+# because `deliverable()` reads recipient_join and a verdict on an ask this
+# project SENT is structurally unreachable from that path.
+
+
+def test_verdict_deliverable_offers_a_verdict_on_an_ask_we_sent(project):
+    recipient = _seed_bucket("/p/verdict-live-a")
+    q_id = _open(project, to=recipient)
+    requests.reject(q_id, channel="cli-tty", note="not this quarter",
+                    project_dir=recipient)
+    entry = requests.verdict_deliverable("S-alpha", project_dir=project)
+    assert [r["request_id"] for r in entry["rows"]] == [q_id]
+    assert entry["rows"][0]["state"] == "rejected"
+
+
+def test_verdict_deliverable_is_write_once_per_session(project):
+    recipient = _seed_bucket("/p/verdict-live-b")
+    q_id = _open(project, to=recipient)
+    requests.accept(q_id, channel="cli-tty", note="ok", project_dir=recipient)
+    assert requests.verdict_deliverable("S-alpha", project_dir=project)["rows"]
+    assert requests.stamp_verdict_delivered(q_id, "S-alpha", project_dir=project)
+    assert requests.verdict_deliverable("S-alpha", project_dir=project)["rows"] == []
+    # …and still owed to a session that never saw it.
+    assert [r["request_id"] for r in
+            requests.verdict_deliverable("S-beta", project_dir=project)["rows"]] == [q_id]
+
+
+def test_verdict_deliverable_re_offers_after_a_revise_opens_a_new_epoch(project):
+    """The #803 key, reused: needs-info delivered, answered, then rejected. The
+    rejection is a new epoch and is owed its own delivery."""
+    recipient = _seed_bucket("/p/verdict-live-c")
+    q_id = _open(project, to=recipient)
+    requests.needs_info(q_id, channel="cli-tty", note="?", project_dir=recipient)
+    requests.stamp_verdict_delivered(q_id, "S-alpha", project_dir=project)
+    assert requests.verdict_deliverable("S-alpha", project_dir=project)["rows"] == []
+    requests.revise(q_id, channel="cli-agent", why="clarified", project_dir=project)
+    requests.reject(q_id, channel="cli-tty", note="no", project_dir=recipient)
+    assert [r["request_id"] for r in
+            requests.verdict_deliverable("S-alpha", project_dir=project)["rows"]] == [q_id]
+
+
+def test_verdict_deliverable_never_offers_an_ask_addressed_to_us(project):
+    """The sender lane is the sender lane: an inbound ask, even once decided
+    here, belongs to the recipient path."""
+    sender = _seed_bucket("/p/verdict-live-d")
+    q_id = requests.open_request(to=store.project_slug(project), ask=ASK, why=WHY,
+                                 channel="cli-agent", project_dir=sender)
+    requests.accept(q_id, channel="cli-tty", note="ok", project_dir=project)
+    assert requests.verdict_deliverable("S-alpha", project_dir=project)["rows"] == []
+
+
+def test_verdict_deliverable_offers_nothing_while_undecided(project):
+    recipient = _seed_bucket("/p/verdict-live-e")
+    _open(project, to=recipient)
+    assert requests.verdict_deliverable("S-alpha", project_dir=project)["rows"] == []
+
+
+def test_verdict_deliverable_without_a_session_offers_nothing(project):
+    recipient = _seed_bucket("/p/verdict-live-f")
+    q_id = _open(project, to=recipient)
+    requests.accept(q_id, channel="cli-tty", note="ok", project_dir=recipient)
+    assert requests.verdict_deliverable("", project_dir=project)["rows"] == []
+
+
+def test_verdict_deliverable_reports_what_the_cap_withheld(project):
+    recipient = _seed_bucket("/p/verdict-live-g")
+    for i in range(requests.RENDER_CAP + 2):
+        q = requests.open_request(to=recipient, ask=f"ask {i}", why=WHY,
+                                  channel="cli-agent", project_dir=project)
+        requests.accept(q, channel="cli-tty", note="ok", project_dir=recipient)
+    entry = requests.verdict_deliverable("S-alpha", project_dir=project)
+    assert len(entry["rows"]) == requests.RENDER_CAP
+    assert entry["overflow"] == 2
+
+
+def test_the_live_stamp_does_not_suppress_the_brief_stamp(project):
+    """Two surfaces, two stamps. A live nudge must not make the brief think it
+    already rendered the verdict card, or the sender loses the fuller view."""
+    recipient = _seed_bucket("/p/verdict-live-h")
+    q_id = _open(project, to=recipient)
+    requests.accept(q_id, channel="cli-tty", note="ok", project_dir=recipient)
+    requests.stamp_verdict_delivered(q_id, "S-alpha", project_dir=project)
+    record = requests.sender_join(project_dir=project)[q_id]
+    assert requests.needs_verdict_surfaced_stamp(record), \
+        "the brief still owes this verdict its card"
+
+
+def test_inject_delivers_a_verdict_to_the_sender(project, capsys, monkeypatch):
+    monkeypatch.setenv("DAIMON_LIVE_DELIVERY", "1")
+    recipient = _seed_bucket("/p/verdict-live-i")
+    q_id = _open(project, to=recipient)
+    requests.reject(q_id, channel="cli-tty", note="not this quarter",
+                    project_dir=recipient)
+    assert _inject(project) == 0
+    out = capsys.readouterr().out
+    assert q_id in out and "rejected" in out, out
+    # write-once: the same session is not told twice
+    assert _inject(project) == 0
+    assert q_id not in capsys.readouterr().out

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -2414,3 +2414,29 @@ def test_inject_delivers_a_verdict_to_the_sender(project, capsys, monkeypatch):
     # write-once: the same session is not told twice
     assert _inject(project) == 0
     assert q_id not in capsys.readouterr().out
+
+
+def test_stamp_verdict_delivered_requires_a_session_id(project):
+    """The session id is half the dedup key. A stamp without one would read as
+    "delivered" to sessions that never saw the verdict, so it refuses rather
+    than writing a row that silences everybody."""
+    recipient = _seed_bucket("/p/verdict-live-j")
+    q_id = _open(project, to=recipient)
+    requests.accept(q_id, channel="cli-tty", note="ok", project_dir=recipient)
+    with pytest.raises(requests.RequestError):
+        requests.stamp_verdict_delivered(q_id, "", project_dir=project)
+    # …and nothing was recorded, so the verdict is still owed.
+    assert [r["request_id"] for r in
+            requests.verdict_deliverable("S-alpha", project_dir=project)["rows"]] == [q_id]
+
+
+def test_inject_names_the_verdict_it_withheld(project, capsys, monkeypatch):
+    monkeypatch.setenv("DAIMON_LIVE_DELIVERY", "1")
+    recipient = _seed_bucket("/p/verdict-live-k")
+    for i in range(requests.RENDER_CAP + 2):
+        q = requests.open_request(to=recipient, ask=f"ask {i}", why=WHY,
+                                  channel="cli-agent", project_dir=project)
+        requests.accept(q, channel="cli-tty", note="ok", project_dir=recipient)
+    assert _inject(project) == 0
+    out = capsys.readouterr().out
+    assert "+2 more decided" in out, out


### PR DESCRIPTION
Closes #801

## What

The sender-side counterpart to live delivery. A sender now learns a verdict on its next
turn boundary instead of waiting for its next session start.

## Why

`deliverable()` reads `recipient_join`, so it can only ever contain asks addressed TO
this project. A verdict on an ask this project SENT was structurally unreachable from
that path, not merely filtered out of it. The sender's side was stamped from the brief
instead, which runs at session start.

In a long working session a sender could be told nothing for hours after its ask was
accepted, rejected or completed, and had to be prompted by a human to go and look. That
is the coordination cost the feature exists to remove, still being paid in one
direction.

Verified in the field before this change: an ask sent to a second project appeared in
that project's deliverable set immediately, while the sending project's deliverable set
contained only asks addressed to it.

## Reusing rather than inventing

Everything here already existed and was already trusted:

- `sender_join` does the cross-bucket read and is what the verdict panel uses
- the verdict-state and expiry filters are the panel's own
- the dedup-before-cap ordering and counted remainder come from the recipient path,
  including #800's fix, so a fourth decided ask cannot vanish the way it could there

## The dedup key, and why it is not per record

Per (request id, revision epoch, session), which is the recipient path's key exactly.

Keying per record would have reintroduced #803: a verdict landing after a revise would
be swallowed by the stamp of an earlier one, and `needs-info` followed by a real verdict
is the ordinary negotiation path rather than an edge case. #803 had to land first for
this reason; built the other way round, this feature would have silently skipped
precisely the verdicts a sender most needs.

## Two stamps, deliberately

`verdict_delivered` is distinct from `verdict_surfaced`. One records the BRIEF rendering
the verdict card, the other a live nudge. If either suppressed the other, a sender
nudged mid-session would lose its fuller view at the next session start. There is a test
for that.

## Frozen vocabulary

The event vocabulary is frozen per-PR so widening it is an explicit act rather than an
accident. `verdict_delivered` fails the same safe way as both widenings before it: an
older reader drops the row, reads the verdict as undelivered, and at worst repeats a
nudge. The guard test was updated deliberately, with the reasoning written into it.

## Tests

`4310 passed, 2 skipped`; ruff clean.

Nine new tests: a verdict on a sent ask is offered; write-once per session and still
owed to a session that never saw it; a new epoch re-offers after a revise; an inbound
ask never appears in the sender lane; nothing is offered while undecided; no session id
offers nothing; the cap reports its remainder; the live stamp does not suppress the
brief stamp; and the CLI delivers a verdict once and not twice.

## Field note, not fixed here

While testing this, a second project reported that the RECIPIENT nudge did not reach it
either. The cause is unrelated to this change and is a packaging gap rather than a code
one: the hook wiring that calls `request-inject` landed after the last release was cut,
so no installed copy has it. Worth a release rather than a code fix.
