### PR TITLE
ci(pr-validation): allow approved maintenance PRs to skip issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,11 @@ Closes #
 CI gates on this PR (pr-validation.yml):
 - body links an issue labeled status:approved (Closes/Fixes/Resolves #N;
   use "Refs #N" for a stage of a multi-PR issue so merging doesn't close it —
-  the final stage uses Closes)
+  the final stage uses Closes), except:
+  - allowlisted documentation-only PRs labeled type:docs
+  - allowlisted CI-only PRs labeled type:ci AND status:approved on the PR
+  - scars-only PRs, whose human sign-off happened at promotion
+  Mixed changes never receive an issue bypass.
 - exactly one type:* label on the PR
 - conventional title — squash-merge makes it the commit subject on main
 - branch named type/description (lowercase), where type is one of:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -20,26 +20,60 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       REPO: ${{ github.repository }}
       PR: ${{ github.event.pull_request.number }}
+      # Issue-free documentation is deliberately narrower than "any Markdown":
+      # SKILL.md and other agent instructions are executable behavior, not docs.
+      DOCS_ONLY_PATH_RE: '^(README\.md|(plugin|hook|benchmark)/README\.md|research/(.*/)?README\.md|docs/.*\.(md|png|gif|jpe?g|webp|ico)|website/(docs|blog)/.*\.md|website/static/img/.*\.(png|gif|jpe?g|webp|ico))$'
+      # CI changes can alter credentials, releases, and publishing. They bypass
+      # an issue only with explicit PR approval; this allowlist merely defines
+      # what may ASK for that bypass. Exact policy-test path is included so the
+      # gate and its regression contract can change together.
+      CI_ONLY_PATH_RE: '^(\.github/(workflows/[^/]+\.ya?ml|actions/.+|dependabot\.ya?ml|PULL_REQUEST_TEMPLATE\.md)|\.pre-commit-config\.yaml|codecov\.ya?ml|release-please-config\.json|\.release-please-manifest\.json|plugin/tests/test_pr_template_matches_gates\.py)$'
     steps:
-      # scar promotions move a reviewed candidate into .scars/ — the human
-      # sign-off already happened at `scar promote` (reviewer recorded in the
-      # scar's authors). The issue-first gate governs code contributions, so
-      # scars-only PRs skip the two issue steps; label/title/branch still apply.
-      - name: Detect scars-only change
-        id: scars_only
+      # Three narrowly-defined paths may skip a separate issue:
+      #   scars: human sign-off already happened at `scar promote`;
+      #   docs: prose-only changes carrying type:docs;
+      #   CI: allowlisted governance changes carrying BOTH type:ci and the
+      #       explicit status:approved PR label.
+      # Everything else remains issue-first. A mixed PR is always "other".
+      - name: Classify issue policy
+        id: issue_policy
         run: |
-          files="$(gh pr view "$PR" --repo "$REPO" --json files -q '.files[].path')"
+          # REST + --paginate is deliberate: a GraphQL files connection may
+          # expose only its first page. One omitted code path could otherwise
+          # misclassify a large mixed PR as docs-only or CI-only.
+          files="$(gh api "repos/$REPO/pulls/$PR/files?per_page=100" \
+                    --paginate --jq '.[].filename')"
+          labels="$(gh pr view "$PR" --repo "$REPO" --json labels -q '.labels[].name')"
+
+          kind=other
           if [ -n "$files" ] && ! grep -qvE '^\.scars/' <<<"$files"; then
-            echo "scars_only=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "scars_only=false" >> "$GITHUB_OUTPUT"
+            kind=scars
+          elif [ -n "$files" ] && ! grep -qvE "$DOCS_ONLY_PATH_RE" <<<"$files"; then
+            kind=docs
+          elif [ -n "$files" ] && ! grep -qvE "$CI_ONLY_PATH_RE" <<<"$files"; then
+            kind=ci
           fi
+
+          exempt=false
+          if [ "$kind" = scars ]; then
+            exempt=true
+          elif [ "$kind" = docs ] && grep -qx 'type:docs' <<<"$labels"; then
+            exempt=true
+          elif [ "$kind" = ci ] \
+               && grep -qx 'type:ci' <<<"$labels" \
+               && grep -qx 'status:approved' <<<"$labels"; then
+            exempt=true
+          fi
+
+          echo "kind=$kind" >> "$GITHUB_OUTPUT"
+          echo "exempt=$exempt" >> "$GITHUB_OUTPUT"
+          echo "Issue policy: kind=$kind exempt=$exempt"
 
       # `refs` links a staged issue (one issue, several sequential PRs) without
       # GitHub's auto-close-on-merge; `closes`/`fixes`/`resolves` stay the verbs
       # for a PR that finishes its issue.
       - name: Check Issue Reference
-        if: steps.scars_only.outputs.scars_only != 'true'
+        if: steps.issue_policy.outputs.exempt != 'true'
         run: |
           body="$(gh pr view "$PR" --repo "$REPO" --json body -q .body)"
           if ! grep -qiE '(closes|fixes|resolves|refs) #[0-9]+' <<<"$body"; then
@@ -48,7 +82,7 @@ jobs:
           fi
 
       - name: Check Issue Has status:approved
-        if: steps.scars_only.outputs.scars_only != 'true'
+        if: steps.issue_policy.outputs.exempt != 'true'
         run: |
           body="$(gh pr view "$PR" --repo "$REPO" --json body -q .body)"
           issue="$(grep -oiE '(closes|fixes|resolves|refs) #[0-9]+' <<<"$body" | head -1 | grep -oE '[0-9]+')"

--- a/plugin/tests/test_pr_template_matches_gates.py
+++ b/plugin/tests/test_pr_template_matches_gates.py
@@ -27,6 +27,14 @@ def _gate_types():
     return m.group(1).split("|")
 
 
+def _policy_regex(name):
+    """Compile one single-quoted path policy from the workflow env."""
+    body = WORKFLOW.read_text(encoding="utf-8")
+    m = re.search(rf"^\s+{re.escape(name)}: '([^']+)'$", body, re.MULTILINE)
+    assert m, f"{name} not found; the policy test is measuring nothing"
+    return re.compile(m.group(1))
+
+
 def test_the_regex_is_still_shaped_the_way_this_test_assumes():
     # Guard against the test silently passing if the workflow is restructured.
     types = _gate_types()
@@ -52,3 +60,71 @@ def test_the_template_does_not_invent_types_the_gate_rejects():
     assert set(documented) <= set(_gate_types()), (
         f"template documents types the gate rejects: "
         f"{sorted(set(documented) - set(_gate_types()))}")
+
+
+@pytest.mark.parametrize("path", [
+    "README.md",
+    "plugin/README.md",
+    "research/experiments/README.md",
+    "docs/ARCHITECTURE.md",
+    "docs/demo/daimon-demo.gif",
+    "website/docs/concepts/architecture.md",
+    "website/blog/2026-08-29-architecture.md",
+    "website/static/img/architecture.png",
+])
+def test_docs_issue_bypass_accepts_only_declared_public_docs(path):
+    assert _policy_regex("DOCS_ONLY_PATH_RE").fullmatch(path)
+
+
+@pytest.mark.parametrize("path", [
+    "skills/daimon-briefing/SKILL.md",
+    "docs/demo/daimon-demo.tape",
+    "website/docs/concepts/interactive.mdx",
+    "website/static/img/active-content.svg",
+    ".github/PULL_REQUEST_TEMPLATE.md",
+    "website/docusaurus.config.ts",
+    "website/package.json",
+    "plugin/daimon_briefing/briefing.py",
+])
+def test_docs_issue_bypass_rejects_executable_or_governance_surfaces(path):
+    assert not _policy_regex("DOCS_ONLY_PATH_RE").fullmatch(path)
+
+
+@pytest.mark.parametrize("path", [
+    ".github/workflows/ci.yml",
+    ".github/workflows/release.yaml",
+    ".github/actions/setup/action.yml",
+    ".github/dependabot.yml",
+    ".github/PULL_REQUEST_TEMPLATE.md",
+    ".pre-commit-config.yaml",
+    "release-please-config.json",
+    ".release-please-manifest.json",
+    "plugin/tests/test_pr_template_matches_gates.py",
+])
+def test_ci_issue_bypass_accepts_only_declared_governance_files(path):
+    assert _policy_regex("CI_ONLY_PATH_RE").fullmatch(path)
+
+
+@pytest.mark.parametrize("path", [
+    ".github/ISSUE_TEMPLATE/feature_request.yml",
+    "scripts/sync_hooks.py",
+    "plugin/uv.lock",
+    "website/package-lock.json",
+    "plugin/daimon_briefing/store.py",
+])
+def test_ci_issue_bypass_rejects_code_dependencies_and_issue_forms(path):
+    assert not _policy_regex("CI_ONLY_PATH_RE").fullmatch(path)
+
+
+def test_issue_bypasses_keep_their_required_labels_and_mixed_pr_guard():
+    body = WORKFLOW.read_text(encoding="utf-8")
+    assert "[ \"$kind\" = docs ] && grep -qx 'type:docs'" in body
+    assert "grep -qx 'type:ci'" in body
+    assert "grep -qx 'status:approved'" in body
+    assert 'kind=other' in body
+    assert "--paginate --jq '.[].filename'" in body
+
+    template = TEMPLATE.read_text(encoding="utf-8")
+    assert "documentation-only PRs labeled type:docs" in template
+    assert "CI-only PRs labeled type:ci AND status:approved" in template
+    assert "Mixed changes never receive an issue bypass" in template


### PR DESCRIPTION
Closes #805

## What

- Classify the complete pull request file set as scars-only, documentation-only,
  CI-only, or mixed.
- Let documentation-only changes skip a separate issue when labeled `type:docs`.
- Let CI-only changes skip a separate issue only when labeled both `type:ci` and
  `status:approved`.
- Keep mixed changes on the existing approved-issue path.
- Document the exceptions in the pull request template and pin their allowlists with
  regression tests.

## Why

Documentation changes often repeat their full context in an issue without creating a
separate product decision. CI maintenance has similar overhead, but workflow changes
can alter publishing and repository authority, so they retain an explicit approval
gate on the pull request itself.

The classifier reads every changed-file page and uses narrow allowlists. Agent skills,
active document formats, dependencies, source code, and arbitrary scripts do not
qualify as documentation-only maintenance.

## Tests

- Focused policy contract: 44 passed.
- Ruff on the changed test module: clean.
- Diff whitespace check: clean.
- Pre-commit Ruff and hook-mirror checks: passed.
