### PR TITLE
fix(cli): carry the previous checkpoint forward on the write-checkpoint path

### DIFF
--- a/plugin/daimon_briefing/capture.py
+++ b/plugin/daimon_briefing/capture.py
@@ -79,63 +79,9 @@ def run(session_id: str, messages, *, project, chat, deadline,
         checkpoint["transcript_hash"] = transcript_sha
     if source_ref is not None:
         checkpoint["source_ref"] = source_ref
-    if config.carry_enabled():
-        # Deterministic carry (#33 Phase 2): fold the previous checkpoint's
-        # unresolved items in BEFORE the write rotates it away. Clock = this
-        # checkpoint's own stamp (scar: never default to wall clock when a
-        # stamp exists), wall time only as fallback for stampless paths.
-        # Advisory feature — a raise here must never cost us the checkpoint
-        # itself (a briefing missing carried items is strictly better than
-        # no briefing at all; same idiom as the rejection-ledger swallow below).
-        try:
-            # fallback=False (#94): on a project's first serialize there is no
-            # per-project pointer, and the global pointer is another project's
-            # checkpoint — carrying from it would write foreign items into
-            # this project's bucket permanently. No prev -> no carry.
-            prev = store.read_latest(project, fallback=False)
-            now = store._created_epoch(checkpoint.get("created")) or time.time()
-            events = store.resolutions(project_dir=project)
-            resolved = frozenset(ref for ref, evt in events.items()
-                                 if store.is_resolved(evt))
-            # #268: merge's observation sink — every prev/native pair that
-            # clears the corroboration predicate, as (item_id, origin_session,
-            # origin_author). merge only DECIDES; the ledger write is ours.
-            observed: list = []
-            checkpoint = carry.merge(checkpoint, prev, now,
-                                     floor=config.carry_floor(),
-                                     cap=config.carry_max(),
-                                     resolved=resolved,
-                                     observed=observed)
-            # #14: text-target supersession links bound to prev-item ids ->
-            # candidate events, gated so a human verdict is never overridden
-            # (see _emit_supersede_candidates). Same fail-open try as merge
-            # itself — a broken emission must never cost the checkpoint.
-            # Stamp ids BEFORE binding: fresh natives are only stamped inside
-            # write_checkpoint (after this block), so without this every new
-            # item binds with new_id="" and the event carries no target.
-            # Setdefault-idempotent — write_checkpoint's re-stamp no-ops.
-            store._stamp_item_ids(checkpoint)
-            pairs = carry.bind_links(checkpoint, prev)
-            # ONE forgotten-keys read for both emitters (#268): each writes to
-            # the same append-only log, each must refuse a tombstoned value,
-            # and both must see the same ledger the `resolved` set above was
-            # computed from. A raise here aborts BOTH emissions and keeps the
-            # checkpoint — the fail-safe direction either emitter would take
-            # on its own.
-            forgotten = store.forgotten_content_keys(project_dir=project)
-            _emit_supersede_candidates(pairs, events, project,
-                                       forgotten=forgotten)
-            # Corroboration rows land AFTER the candidates, deliberately: the
-            # same capture can suggest a supersession and record an agreement
-            # about the same item, and the corroboration reader measures its
-            # count against the LATEST contradiction — so the candidate has to
-            # be on the log first for that comparison to be honest.
-            _emit_corroborations(
-                observed, events,
-                _forgotten_item_ids(forgotten, checkpoint, prev),
-                project, str(checkpoint.get("session_id") or ""))
-        except Exception:  # keep the unmerged checkpoint, proceed to write
-            pass
+    # #811: carry is part of writing a checkpoint, not a step capture happens
+    # to perform. Shared with the introspection path via capture.carry_forward.
+    checkpoint = carry_forward(checkpoint, project)
     # admit=True (#693): capture is one of the two admission paths — new
     # cognitive content passes the ruling echo filter here.
     out = store.write_checkpoint(session_id, checkpoint, project_dir=project,
@@ -558,3 +504,88 @@ def _session_end_stamp(path) -> str:
     except OSError:
         mtime = time.time()
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(mtime))
+
+
+def carry_forward(checkpoint: dict, project) -> dict:
+    """Fold the project's previous checkpoint forward into `checkpoint` and
+    emit the ledger rows that decision produces (#33 Phase 2, #14, #268).
+
+    Extracted from `run` so it can be shared (#811). EVERY write path rotates
+    the pointer chain (`store._rotate_pointers`), and `brief` renders `latest`
+    alone and never walks prev-N, so a write that rotates without carrying
+    silently ends the reachable history of whatever it displaced. With one
+    session that is harmless — the displaced checkpoint is the same session's
+    own earlier state. With two sessions sharing a bucket it orphans the other
+    session's record outright, which is the field case #811 was filed from.
+    Carry belongs with the rotation, not with one of its callers.
+
+    Advisory: any raise inside costs the carried items and never the
+    checkpoint (a briefing missing carried items beats no briefing at all).
+    Returns the merged checkpoint, or `checkpoint` unchanged when carry is
+    disabled or fails.
+
+    Callers must run this AFTER their own provenance stripping. On the
+    introspection path in particular, #511: carry's freeze prefers `verbatim`,
+    so a model-claimed verbatim reaching this function before
+    `serializer.downgrade_unverifiable_verbatim` would be preferred over
+    genuinely extracted content.
+    """
+    if not config.carry_enabled():
+        return checkpoint
+    # Deterministic carry (#33 Phase 2): fold the previous checkpoint's
+    # unresolved items in BEFORE the write rotates it away. Clock = this
+    # checkpoint's own stamp (scar: never default to wall clock when a
+    # stamp exists), wall time only as fallback for stampless paths.
+    # Advisory feature — a raise here must never cost us the checkpoint
+    # itself (a briefing missing carried items is strictly better than
+    # no briefing at all; same idiom as `run`'s rejection-ledger swallow).
+    try:
+        # fallback=False (#94): on a project's first serialize there is no
+        # per-project pointer, and the global pointer is another project's
+        # checkpoint — carrying from it would write foreign items into
+        # this project's bucket permanently. No prev -> no carry.
+        prev = store.read_latest(project, fallback=False)
+        now = store._created_epoch(checkpoint.get("created")) or time.time()
+        events = store.resolutions(project_dir=project)
+        resolved = frozenset(ref for ref, evt in events.items()
+                             if store.is_resolved(evt))
+        # #268: merge's observation sink — every prev/native pair that
+        # clears the corroboration predicate, as (item_id, origin_session,
+        # origin_author). merge only DECIDES; the ledger write is ours.
+        observed: list = []
+        checkpoint = carry.merge(checkpoint, prev, now,
+                                 floor=config.carry_floor(),
+                                 cap=config.carry_max(),
+                                 resolved=resolved,
+                                 observed=observed)
+        # #14: text-target supersession links bound to prev-item ids ->
+        # candidate events, gated so a human verdict is never overridden
+        # (see _emit_supersede_candidates). Same fail-open try as merge
+        # itself — a broken emission must never cost the checkpoint.
+        # Stamp ids BEFORE binding: fresh natives are only stamped inside
+        # write_checkpoint (after this block), so without this every new
+        # item binds with new_id="" and the event carries no target.
+        # Setdefault-idempotent — write_checkpoint's re-stamp no-ops.
+        store._stamp_item_ids(checkpoint)
+        pairs = carry.bind_links(checkpoint, prev)
+        # ONE forgotten-keys read for both emitters (#268): each writes to
+        # the same append-only log, each must refuse a tombstoned value,
+        # and both must see the same ledger the `resolved` set above was
+        # computed from. A raise here aborts BOTH emissions and keeps the
+        # checkpoint — the fail-safe direction either emitter would take
+        # on its own.
+        forgotten = store.forgotten_content_keys(project_dir=project)
+        _emit_supersede_candidates(pairs, events, project,
+                                   forgotten=forgotten)
+        # Corroboration rows land AFTER the candidates, deliberately: the
+        # same capture can suggest a supersession and record an agreement
+        # about the same item, and the corroboration reader measures its
+        # count against the LATEST contradiction — so the candidate has to
+        # be on the log first for that comparison to be honest.
+        _emit_corroborations(
+            observed, events,
+            _forgotten_item_ids(forgotten, checkpoint, prev),
+            project, str(checkpoint.get("session_id") or ""))
+    except Exception:  # keep the unmerged checkpoint, proceed to write
+        pass
+    return checkpoint

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -404,10 +404,23 @@ def _cmd_write_checkpoint(args) -> int:
     serializer.downgrade_unverifiable_verbatim(checkpoint)
     checkpoint["source"] = args.source  # provenance: introspection vs reconstruction
     session_id = str(checkpoint["session_id"])
+    project = _resolve_project(args.project)
+    # #811: this write rotates the pointer chain exactly like a serialize, and
+    # `brief` reads `latest` alone (never prev-N). Without carry it therefore
+    # ENDS the reachable history of whatever it displaces. The docstring above
+    # reasons that is safe because a later reconstruction supersedes it — true
+    # only while `latest` holds this session's own earlier state. Two sessions
+    # in one bucket break that assumption and the earlier one is orphaned.
+    #
+    # Placement is load-bearing: strictly AFTER the four provenance strips, and
+    # #511 in particular. Carry's #22 freeze prefers `verbatim`, so carrying
+    # before downgrade_unverifiable_verbatim would let a model-claimed verbatim
+    # this path can never check beat genuinely extracted prev content.
+    checkpoint = capture.carry_forward(checkpoint, project)
     # admit=True (#693): the stdin path is the second admission caller — a
     # model-authored checkpoint passes the ruling echo filter like capture's.
     out = store.write_checkpoint(session_id, checkpoint,
-                                 project_dir=_resolve_project(args.project),
+                                 project_dir=project,
                                  admit=True)
     if out is None:  # #421: write boundary refused (kill switch)
         print("error: daimon disabled (DAIMON_DISABLE) — checkpoint not written",

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -9548,3 +9548,213 @@ def test_projects_human_render_shows_name_when_present(tmp_checkpoint_dir, capsy
         "project_name": "My Proj", "created": "2026-07-11T00:00:00Z"}))
     assert cli.main(["projects"]) == 0
     assert "My Proj" in capsys.readouterr().out
+
+
+# ---- #811: write-checkpoint rotates the pointer, so it must carry too ----
+
+
+def test_write_checkpoint_carries_prev_open_question(tmp_checkpoint_dir, monkeypatch):
+    """#811: `daimon end` rotates the pointer chain like every other write, so
+    a checkpoint it does not fold forward is one the briefing can never reach
+    again (brief renders `latest` only and never walks prev-N). Parity with
+    test_serialize_carry_folds_prev_open_question, one path over."""
+    from daimon_briefing import store
+
+    project = "/p/intro-carry"
+    _prev_with_open_question(project, "2026-06-25T08:00:00Z", "2026-06-28T00:00:00Z")
+
+    _stdin(monkeypatch, _valid_json("S-intro"))
+    rc = cli.main(["write-checkpoint", "--project", project])
+    assert rc == 0
+
+    written = store.read_latest(project_dir=project)
+    carried = [q for q in written["working_context"]["open_questions"]
+               if q.get("text") == "quorint reconciliation loop unresolved"]
+    assert len(carried) == 1
+    assert carried[0]["carried_from"] == "S-prev"
+
+
+def test_write_checkpoint_carry_survives_a_concurrent_session(
+    tmp_checkpoint_dir, monkeypatch
+):
+    """The field case #811 was filed from: two sessions share one bucket and
+    neither knows the other exists. Session A serializes, then session B runs
+    `daimon end`. B's write must not orphan A's record — after B, the bucket's
+    own pointer still answers for A."""
+    from daimon_briefing import store
+
+    project = "/p/two-sessions"
+    _prev_with_open_question(project, "2026-06-25T08:00:00Z", "2026-06-28T00:00:00Z")
+
+    _stdin(monkeypatch, _valid_json("S-session-B"))
+    assert cli.main(["write-checkpoint", "--project", project]) == 0
+
+    written = store.read_latest(project_dir=project, fallback=False)
+    assert written["session_id"] == "S-session-B"
+    origins = {q.get("origin_session")
+               for q in written["working_context"]["open_questions"]}
+    assert "S-prev" in origins
+
+
+def test_write_checkpoint_carry_ignores_other_projects_checkpoint(
+    tmp_checkpoint_dir, monkeypatch
+):
+    """#94 parity on the introspection path: a project's first write has no own
+    pointer, and the global pointer is somebody else's checkpoint. Carrying
+    from it would write foreign items into this bucket permanently."""
+    from daimon_briefing import store
+
+    _prev_with_open_question("/p/other-project", "2026-06-25T08:00:00Z",
+                             "2026-06-28T00:00:00Z")
+
+    _stdin(monkeypatch, _valid_json("S-intro"))
+    rc = cli.main(["write-checkpoint", "--project", "/p/fresh-intro"])
+    assert rc == 0
+
+    written = store.read_latest(project_dir="/p/fresh-intro", fallback=False)
+    texts = {q.get("text") for q in written["working_context"]["open_questions"]}
+    assert "quorint reconciliation loop unresolved" not in texts
+
+
+def test_write_checkpoint_carry_kill_switch(tmp_checkpoint_dir, monkeypatch):
+    """DAIMON_CARRY=0 turns carry off on this path too, same as serialize."""
+    from daimon_briefing import store
+
+    project = "/p/intro-carry-off"
+    _prev_with_open_question(project, "2026-06-25T08:00:00Z", "2026-06-28T00:00:00Z")
+    monkeypatch.setenv("DAIMON_CARRY", "0")
+
+    _stdin(monkeypatch, _valid_json("S-intro"))
+    assert cli.main(["write-checkpoint", "--project", project]) == 0
+
+    written = store.read_latest(project_dir=project)
+    texts = {q.get("text") for q in written["working_context"]["open_questions"]}
+    assert "quorint reconciliation loop unresolved" not in texts
+
+
+def test_write_checkpoint_carry_failure_still_writes_checkpoint(
+    tmp_checkpoint_dir, monkeypatch
+):
+    """Carry is advisory here exactly as it is in capture: a raise must cost
+    the carried items, never the checkpoint."""
+    from daimon_briefing import carry, store
+
+    project = "/p/intro-carry-broken"
+    _prev_with_open_question(project, "2026-06-25T08:00:00Z", "2026-06-28T00:00:00Z")
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("carry exploded")
+
+    monkeypatch.setattr(carry, "merge", _boom)
+    _stdin(monkeypatch, _valid_json("S-intro"))
+    assert cli.main(["write-checkpoint", "--project", project]) == 0
+
+    written = store.read_latest(project_dir=project)
+    assert written["session_id"] == "S-intro"
+
+
+def _events(project):
+    """Every event row in a project's bucket, as dicts."""
+    import json
+    from daimon_briefing import store
+
+    path = store._events_path(project)
+    if path is None or not path.exists():
+        return []
+    out = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def test_write_checkpoint_carry_emits_no_corroboration(
+    tmp_checkpoint_dir, monkeypatch
+):
+    """#811 gave the introspection path a carry, and carry's #268 observation
+    sink rides along with it. It must stay empty here, and G3 is the reason:
+    corroboration requires the NATIVE item to be this session's own VERIFIED
+    verbatim, and this path has no transcript, so downgrade_unverifiable_
+    verbatim has already stripped every claim a receipt could have backed.
+
+    Pinned rather than assumed. If the carry call is ever moved above those
+    strips, corroboration starts minting trust boosts out of unverifiable
+    model claims, and this test is what says so."""
+    project = "/p/intro-corroborate"
+    _prev_with_open_question(project, "2026-06-25T08:00:00Z", "2026-06-28T00:00:00Z")
+
+    _stdin(monkeypatch, _valid_json("S-intro"))
+    assert cli.main(["write-checkpoint", "--project", project]) == 0
+
+    statuses = [e.get("status", "") for e in _events(project)]
+    assert not [s for s in statuses if s.startswith("corroborated-by:")]
+
+
+def test_write_checkpoint_carry_can_emit_a_supersede_candidate(
+    tmp_checkpoint_dir, monkeypatch
+):
+    """The other half of the same boundary, and it goes the OTHER way on
+    purpose. `links` is not in _CODE_OWNED_ITEM_KEYS, so a model authoring a
+    checkpoint may claim a supersedes link on this path exactly as the
+    serializer's own model does on the other. The row is a machine SUGGESTION,
+    source "serializer", and #14's gate still refuses to write over a human
+    verdict — so admitting it here is consistent, not a new trust hole.
+
+    The native text here is deliberately unlike the prev item's. See the twin
+    case below for what happens when it is not."""
+    import json
+
+    project = "/p/intro-supersede"
+    _prev_with_open_question(project, "2026-06-25T08:00:00Z", "2026-06-28T00:00:00Z")
+
+    ck = json.loads(_valid_json("S-intro"))
+    ck["working_context"]["open_questions"] = [{
+        "text": "postgres replaces the old lookup store",
+        "trust": "inferred",
+        "importance": 7,
+        "links": [{"type": "supersedes",
+                   "target": "quorint reconciliation loop unresolved"}],
+    }]
+    _stdin(monkeypatch, json.dumps(ck))
+    assert cli.main(["write-checkpoint", "--project", project]) == 0
+
+    statuses = [e.get("status", "") for e in _events(project)]
+    assert [s for s in statuses if s.startswith("supersede-candidate")]
+
+
+def test_write_checkpoint_supersede_of_a_near_identical_item_is_suppressed(
+    tmp_checkpoint_dir, monkeypatch
+):
+    """The introspection path is STRICTER than serialize about supersession,
+    and not by anything #811 added — by #167 meeting a path with no transcript.
+
+    A reversal signature needs BOTH a supersedes link and the item's own
+    VERIFIED quote. This path has no transcript, so downgrade_unverifiable_
+    verbatim guarantees the second leg can never be present. A native item
+    whose text is close enough to twin with its target therefore reads as a
+    re-statement, inherits the prev id in merge, and bind_links' self-guard
+    drops the candidate rather than letting an item supersede itself.
+
+    That is the safe direction (a missed candidate costs a suggestion; a forged
+    one corrupts provenance), but it is a real asymmetry between the two write
+    paths and it should fail loudly if it ever silently changes."""
+    import json
+
+    project = "/p/intro-supersede-twin"
+    _prev_with_open_question(project, "2026-06-25T08:00:00Z", "2026-06-28T00:00:00Z")
+
+    ck = json.loads(_valid_json("S-intro"))
+    ck["working_context"]["open_questions"] = [{
+        "text": "quorint reconciliation loop unresolved on the retry path",
+        "trust": "inferred",
+        "importance": 7,
+        "links": [{"type": "supersedes",
+                   "target": "quorint reconciliation loop unresolved"}],
+    }]
+    _stdin(monkeypatch, json.dumps(ck))
+    assert cli.main(["write-checkpoint", "--project", project]) == 0
+
+    statuses = [e.get("status", "") for e in _events(project)]
+    assert not [s for s in statuses if s.startswith("supersede-candidate")]


### PR DESCRIPTION
Closes #811

## What

Extract capture's carry block into `capture.carry_forward(checkpoint, project)` and call it from both checkpoint write paths. The introspection path (`daimon end` / `write-checkpoint`, `cli/__init__.py:358`) previously wrote through `store.write_checkpoint` directly, with no `carry.merge` and no `carry.bind_links`.

On that path the call sits deliberately AFTER the four provenance strips, `#511` in particular. Carry's `#22` freeze prefers `verbatim`, so carrying before `downgrade_unverifiable_verbatim` would let a model-claimed verbatim this path can never check beat genuinely extracted prev content.

## Why

Every write path rotates the pointer chain (`store._rotate_pointers`), and `brief` renders `latest` alone and never walks prev-N (`cli/__init__.py:678-679`). A write that rotates without carrying therefore ends the reachable history of whatever it displaces.

With one session that is harmless, and the existing docstring says so:

> Provisional by design: a later SessionEnd reconstruction supersedes it and rotation keeps this as a prev pointer

That reasoning assumes whatever sits at `latest` is the same session's own earlier state. Two sessions sharing a bucket break the assumption, and the earlier session's record is orphaned. Full field trace is in #811.

The shape of the defect is that carry lived in one caller rather than with the rotation it has to accompany. Extracting it means a future third write path inherits the behaviour instead of inheriting the bug.

## Tests

8 new tests in `plugin/tests/test_cli.py`. Two of them fail before the change:

- `test_write_checkpoint_carries_prev_open_question` - parity with the existing `test_serialize_carry_folds_prev_open_question`, one path over. RED before: no `carried_from`.
- `test_write_checkpoint_carry_survives_a_concurrent_session` - the field case. RED before: `assert 'S-prev' in {'S-session-B'}`.

Three more were vacuous before the change and are load-bearing now: the `DAIMON_CARRY=0` kill switch, the `#94` foreign-project guard, and the fail-open case where a raising `carry.merge` must cost the carried items and never the checkpoint.

Three pin the trust boundary this moves, because extraction also gave the introspection path the two ledger emitters that ride along with carry:

- `test_write_checkpoint_carry_emits_no_corroboration` - corroboration's G3 requires the native item to be this session's own VERIFIED verbatim, which this path can never have. Verified empty rather than assumed. If the carry call is ever moved above the strips, this is what says so.
- `test_write_checkpoint_carry_can_emit_a_supersede_candidate` - `links` is not code-owned, so a model may claim a supersedes link here exactly as the serializer's model does on the other path. The row is a machine suggestion and `#14`'s gate still refuses to write over a human verdict.
- `test_write_checkpoint_supersede_of_a_near_identical_item_is_suppressed` - documents a real asymmetry, and one this PR did not introduce. `#167`'s reversal signature needs BOTH a supersedes link and the item's own verified quote; with no transcript the second leg is impossible, so a near-identical native twins with its target, inherits its id in merge, and bind_links' self-guard drops the candidate. Safe direction, but it should fail loudly if it ever silently changes.

Full suite: 4351 passed, 2 skipped. `ruff check`: clean. Commit is GPG-signed.
