### PR TITLE
fix(hooks): skip a serialize spawn when one is already in flight for that transcript

### DIFF
--- a/.scars/candidates/heartbeat-keyed-by-transcript-stem.md
+++ b/.scars/candidates/heartbeat-keyed-by-transcript-stem.md
@@ -1,0 +1,46 @@
+---
+id: 0
+type: landmine
+title: Serialize heartbeats are keyed by transcript STEM, never a host payload session id
+severity: high
+confidence: 0.9
+created: 2026-08-29
+authors: ["claude-code"]
+anchors:
+  - path: hook/_daimon_hook_lib.py
+  - path: plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
+  - pattern: "_in_flight_stems|touch_heartbeat|heartbeat_age"
+evidence:
+  - commit: 681c234
+  - pr: 814
+  - note: "#813 field trace: hook logged `spawned serialize for 01a04bd2-...` while the checkpoint landed as `rollout-2026-08-28T22-41-50-01a04bd2-....json`"
+expires:
+  condition: "cli/__init__.py stops deriving session_id from the transcript filename (`session_id = path.stem`), or hooks start passing their session id through to `daimon serialize`"
+  review_after: 2027-02-28
+status: candidate
+---
+
+`daimon serialize <transcript>` derives its session id from the FILENAME
+(`cli/__init__.py:233`, `session_id = path.stem`), and that derived id is what
+`ledger.touch_heartbeat` stamps into `<log_dir>/heartbeats/`. A host hook's
+payload `session_id` is a DIFFERENT string. Codex is the clearest case: the
+payload carries `01a04bd2-...` while the transcript is
+`rollout-2026-08-28T22-41-50-01a04bd2-....jsonl`, so the stem and the payload
+id share a substring and are not equal.
+
+Any liveness check written against the payload `session_id` therefore matches
+no heartbeat, ever. It does not raise, does not log, and does not fail a test.
+It reads as an implemented guard and is a no-op. This is the obvious way to
+write it, because the surrounding hook code has `session_id` in scope and the
+transcript path is the less convenient value.
+
+`_in_flight_stems()` returns STEMS for exactly this reason, and its two
+consumers both respect it: `sweep_orphans` compares against `candidate.stem`,
+and `_serialize_in_flight` (added by PR #814) does `Path(transcript_path).stem`.
+Keep it that way. If you add a third consumer, key it on the transcript path
+you are about to hand to the CLI, never on whatever the host called the session.
+
+Pinned by `test_spawn_serialize_keys_the_guard_on_the_transcript_stem` and
+`test_codex_session_end_skips_when_a_stop_serialize_is_in_flight`, both of
+which deliberately use a payload id that differs from the stem. If you change
+the key, those are the tests that should go red.

--- a/.scars/candidates/spawn-serialize-is-false-sentinel.md
+++ b/.scars/candidates/spawn-serialize-is-false-sentinel.md
@@ -1,0 +1,46 @@
+---
+id: 0
+type: fence
+title: spawn_serialize callers test `is False`, not falsiness, because ~16 test fakes return None
+severity: medium
+confidence: 0.85
+created: 2026-08-29
+authors: ["claude-code"]
+anchors:
+  - path: hook/
+  - path: plugin/daimon_briefing/_hooks/
+  - pattern: "spawn_serialize\\(.*\\) is False|lib\\.spawn_serialize"
+evidence:
+  - commit: 681c234
+  - pr: 814
+expires:
+  condition: "every `monkeypatch.setattr(lib, 'spawn_serialize', ...)` fake in plugin/tests returns an explicit bool, at which point plain falsiness is safe"
+  review_after: 2027-02-28
+status: candidate
+---
+
+`spawn_serialize` returns `False` when it skipped the spawn because a serialize
+for that transcript is already in flight (#813). Every caller checks
+`if lib.spawn_serialize(...) is False:` rather than `if not lib.spawn_serialize(...)`.
+
+That looks like an over-careful identity comparison a linter or a tidying pass
+would want to simplify. Do not simplify it.
+
+The test suite replaces this function in roughly sixteen places with fakes
+shaped `lambda cli, path, env: calls.append(path)`, which return `None`. Under
+a truthiness check every one of those fakes flips its caller into the skip
+branch: the hook stops logging `spawned serialize` and starts logging
+`skipped serialize`, silently, in tests whose assertions are about spawn calls
+rather than log lines. The `is False` sentinel makes the un-updated case keep
+the OLD behaviour, so the contract change is safe by construction instead of
+safe only if you found every fake. The full suite passing unchanged across the
+migration is the evidence that it worked.
+
+Same hazard class the #795 review named for `read_latest`: a return-contract
+change that is SILENT at call sites which never inspect the value. There the
+answer was to keep the new type off the migration path entirely; here it is a
+sentinel that only an explicit value triggers.
+
+The honest log line is the reason this matters rather than being cosmetic.
+`ledger` parses `spawned serialize`, and a spawn line with no matching result
+classifies as hung, which invites `heal` to retry work that never started.

--- a/hook/_daimon_hook_lib.py
+++ b/hook/_daimon_hook_lib.py
@@ -318,6 +318,17 @@ def _in_flight_stems() -> set:
     return stems
 
 
+def _serialize_in_flight(transcript_path) -> bool:
+    """True when a LIVE serialize is already running for this transcript
+    (#813). Fails OPEN — an unreadable heartbeat dir must never block a
+    genuine capture, which is the same direction `_in_flight_stems` takes."""
+    try:
+        return Path(transcript_path).stem in _in_flight_stems()
+    except Exception:  # noqa: BLE001 — a broken guard must not cost a capture
+        return False
+
+
+
 def _failed_session_stems() -> set:
     """Transcript stems (session ids) whose LATEST serialize.log outcome is a
     recorded failure — a lightweight, read-only echo of
@@ -541,15 +552,46 @@ def trim_crash_log(path) -> None:
         pass
 
 
-def spawn_serialize(cli, transcript_path, env) -> None:
+def spawn_serialize(cli, transcript_path, env):
     """Spawn `daimon serialize <transcript>` DETACHED so the hook returns
     immediately (serialization is a 30s+ LLM call). Raises OSError on spawn
     failure so the caller can log its own host-tagged diagnostic.
 
+    Returns False when the spawn was SKIPPED because a serialize for this same
+    transcript is already in flight (#813); any other return means it spawned.
+    Callers must test `is False` and log a skip line instead of a spawn line —
+    see the note on the sentinel below.
+
     The CLI logs its result lines to serialize.log first-class (FR #27), so we
     DON'T capture the child's stdout here — that double-logged results. stderr
     goes to a SEPARATE crash log to preserve uncaught tracebacks without
-    duplicating the CLI's `error:` result lines in serialize.log."""
+    duplicating the CLI's `error:` result lines in serialize.log.
+
+    #813, the in-flight guard: #545 established that two serializes of one
+    transcript are last-writer-wins and uncorrelated with quality, built
+    `_in_flight_stems` for it, and wired it to `sweep_orphans` alone. The two
+    Codex hook spawn paths never consulted it, so a `Stop` child still running
+    when `SessionEnd` fires produced two full runs of the same transcript. The
+    check belongs HERE, with the spawn, so every caller inherits it rather than
+    each one having to remember.
+
+    Keyed on the transcript STEM, never on a host payload's session id. The CLI
+    derives its session id from the filename (`cli:233`, `session_id =
+    path.stem`) and that is the name `ledger.touch_heartbeat` stamps, while a
+    Codex payload's `session_id` is a different string entirely. Keying on the
+    payload id would match no heartbeat ever and leave a guard that looks
+    implemented and does nothing.
+
+    Known narrowing, not a total fix: the child stamps its first heartbeat
+    after interpreter start and its own preflight, so two spawns inside that
+    startup window both see an empty set and both run. Stamping from the PARENT
+    would close it and open something worse — a child that dies before its
+    first touch would leave a stamp that blocks the session for the whole
+    hung-after ceiling. The observed race is minutes wide; this narrows it to
+    seconds, and `heal` remains the answer for the rest.
+    """
+    if _serialize_in_flight(transcript_path):
+        return False
     crash = crash_log_path()
     crash.parent.mkdir(parents=True, exist_ok=True)
     trim_crash_log(crash)

--- a/hook/daimon-codex-session-end.py
+++ b/hook/daimon-codex-session-end.py
@@ -108,7 +108,16 @@ def main() -> int:
     cwd = str(payload.get("cwd") or "").strip()
     child_env = lib.project_env(cwd, "codex")
     try:
-        lib.spawn_serialize(cli, transcript_path, child_env)
+        if lib.spawn_serialize(cli, transcript_path, child_env) is False:
+        # #813: `is False` (not falsy) on purpose — only an explicit skip
+        # takes this branch, so any caller or fake still returning None
+        # keeps the old spawn-and-log path instead of silently flipping.
+        # The log line has to be honest: the ledger parses "spawned
+        # serialize", and a spawn with no result reads as hung and
+        # invites `heal` to retry work that never started.
+            lib.log(f"{TAG}: skipped serialize for {session_id} "
+                    f"(already in flight) (transcript: {transcript_path})")
+            return 0
         _mark_spawned(session_id)
         lib.log(f"{TAG}: spawned serialize for {session_id} "
                 f"(project: {cwd or '?'}) (transcript: {transcript_path})")

--- a/hook/daimon-codex-stop.py
+++ b/hook/daimon-codex-stop.py
@@ -125,7 +125,16 @@ def main() -> int:
     cwd = str(payload.get("cwd") or "").strip()
     child_env = lib.project_env(cwd, "codex")
     try:
-        lib.spawn_serialize(cli, transcript_path, child_env)
+        if lib.spawn_serialize(cli, transcript_path, child_env) is False:
+        # #813: `is False` (not falsy) on purpose — only an explicit skip
+        # takes this branch, so any caller or fake still returning None
+        # keeps the old spawn-and-log path instead of silently flipping.
+        # The log line has to be honest: the ledger parses "spawned
+        # serialize", and a spawn with no result reads as hung and
+        # invites `heal` to retry work that never started.
+            lib.log(f"codex-stop: skipped serialize for {session_id} "
+                    f"(already in flight) (transcript: {transcript_path})")
+            return 0
         _mark_spawned(session_id)
         lib.log(f"codex-stop: spawned serialize for {session_id} "
                 f"(project: {cwd or '?'}) (transcript: {transcript_path})")

--- a/hook/daimon-gemini-session-end.py
+++ b/hook/daimon-gemini-session-end.py
@@ -86,7 +86,17 @@ def main() -> int:
     cwd = str(payload.get("cwd") or "").strip()
     child_env = lib.project_env(cwd, "gemini")
     try:
-        lib.spawn_serialize(cli, transcript_path, child_env)
+        if lib.spawn_serialize(cli, transcript_path, child_env) is False:
+        # #813: `is False` (not falsy) on purpose — only an explicit skip
+        # takes this branch, so any caller or fake still returning None
+        # keeps the old spawn-and-log path instead of silently flipping.
+        # The log line has to be honest: the ledger parses "spawned
+        # serialize", and a spawn with no result reads as hung and
+        # invites `heal` to retry work that never started.
+            lib.log(
+                f"gemini-session-end: skipped serialize for {session_id} "
+                f"(already in flight) (transcript: {transcript_path})")
+            return 0
         lib.log(
             f"gemini-session-end: spawned serialize for {session_id} "
             f"(reason: {reason}, project: {cwd or '?'}) "

--- a/hook/daimon-session-end.py
+++ b/hook/daimon-session-end.py
@@ -76,7 +76,17 @@ def main() -> int:
     cwd = str(payload.get("cwd") or "").strip()
     child_env = lib.project_env(cwd, "claude-code")
     try:
-        lib.spawn_serialize(cli, transcript_path, child_env)
+        if lib.spawn_serialize(cli, transcript_path, child_env) is False:
+        # #813: `is False` (not falsy) on purpose — only an explicit skip
+        # takes this branch, so any caller or fake still returning None
+        # keeps the old spawn-and-log path instead of silently flipping.
+        # The log line has to be honest: the ledger parses "spawned
+        # serialize", and a spawn with no result reads as hung and
+        # invites `heal` to retry work that never started.
+            lib.log(
+                f"session-end: skipped serialize for {session_id} "
+                f"(already in flight) (transcript: {transcript_path})")
+            return 0
         # Trailing (transcript: ...) group (#28): if the child crashes before
         # writing any result line, this is the only surviving pointer to the
         # transcript — it makes the hung session healable instead of lost.

--- a/hook/daimon-windsurf-hooks.py
+++ b/hook/daimon-windsurf-hooks.py
@@ -361,8 +361,16 @@ def _spawn_serialize_for(trajectory_id: str, transcript_path, detail: str) -> No
         return
     cwd = _project_cwd()
     try:
-        lib.spawn_serialize(
-            cli, str(transcript_path), lib.project_env(cwd, "windsurf"))
+        if lib.spawn_serialize(
+                cli, str(transcript_path),
+                lib.project_env(cwd, "windsurf")) is False:
+        # #813: `is False` only — a None-returning fake keeps the old path.
+        # The ledger parses "spawned serialize"; a spawn line with no
+        # result reads as hung and invites a heal retry of work that
+        # never started, so the skip must log as a skip.
+            lib.log(f"windsurf-cascade: skipped serialize for {trajectory_id} "
+                    f"(already in flight) ({detail})")
+            return
         _mark_spawned(trajectory_id)
         lib.log(f"windsurf-cascade: spawned serialize for {trajectory_id} "
                 f"(project: {cwd or '?'}) ({detail})")
@@ -456,8 +464,16 @@ def _finalize(trajectory_id: str, transcript_path: str, armed_mtime_ns: str) -> 
         return 0
     cwd = _project_cwd()
     try:
-        lib.spawn_serialize(
-            cli, transcript_path, lib.project_env(cwd, "windsurf"))
+        if lib.spawn_serialize(
+                cli, transcript_path,
+                lib.project_env(cwd, "windsurf")) is False:
+        # #813: `is False` only — a None-returning fake keeps the old path.
+        # The ledger parses "spawned serialize"; a spawn line with no
+        # result reads as hung and invites a heal retry of work that
+        # never started, so the skip must log as a skip.
+            lib.log(f"windsurf-finalizer: skipped serialize for {trajectory_id} "
+                    f"(already in flight) (transcript: {transcript_path})")
+            return 0
         # Logged at FIRE time, not arm time: an arm-time spawn line would sit
         # unresolved for the whole quiet period and read as hung to the ledger.
         lib.log(f"windsurf-finalizer: spawned serialize for {trajectory_id} "

--- a/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
+++ b/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
@@ -318,6 +318,17 @@ def _in_flight_stems() -> set:
     return stems
 
 
+def _serialize_in_flight(transcript_path) -> bool:
+    """True when a LIVE serialize is already running for this transcript
+    (#813). Fails OPEN — an unreadable heartbeat dir must never block a
+    genuine capture, which is the same direction `_in_flight_stems` takes."""
+    try:
+        return Path(transcript_path).stem in _in_flight_stems()
+    except Exception:  # noqa: BLE001 — a broken guard must not cost a capture
+        return False
+
+
+
 def _failed_session_stems() -> set:
     """Transcript stems (session ids) whose LATEST serialize.log outcome is a
     recorded failure — a lightweight, read-only echo of
@@ -541,15 +552,46 @@ def trim_crash_log(path) -> None:
         pass
 
 
-def spawn_serialize(cli, transcript_path, env) -> None:
+def spawn_serialize(cli, transcript_path, env):
     """Spawn `daimon serialize <transcript>` DETACHED so the hook returns
     immediately (serialization is a 30s+ LLM call). Raises OSError on spawn
     failure so the caller can log its own host-tagged diagnostic.
 
+    Returns False when the spawn was SKIPPED because a serialize for this same
+    transcript is already in flight (#813); any other return means it spawned.
+    Callers must test `is False` and log a skip line instead of a spawn line —
+    see the note on the sentinel below.
+
     The CLI logs its result lines to serialize.log first-class (FR #27), so we
     DON'T capture the child's stdout here — that double-logged results. stderr
     goes to a SEPARATE crash log to preserve uncaught tracebacks without
-    duplicating the CLI's `error:` result lines in serialize.log."""
+    duplicating the CLI's `error:` result lines in serialize.log.
+
+    #813, the in-flight guard: #545 established that two serializes of one
+    transcript are last-writer-wins and uncorrelated with quality, built
+    `_in_flight_stems` for it, and wired it to `sweep_orphans` alone. The two
+    Codex hook spawn paths never consulted it, so a `Stop` child still running
+    when `SessionEnd` fires produced two full runs of the same transcript. The
+    check belongs HERE, with the spawn, so every caller inherits it rather than
+    each one having to remember.
+
+    Keyed on the transcript STEM, never on a host payload's session id. The CLI
+    derives its session id from the filename (`cli:233`, `session_id =
+    path.stem`) and that is the name `ledger.touch_heartbeat` stamps, while a
+    Codex payload's `session_id` is a different string entirely. Keying on the
+    payload id would match no heartbeat ever and leave a guard that looks
+    implemented and does nothing.
+
+    Known narrowing, not a total fix: the child stamps its first heartbeat
+    after interpreter start and its own preflight, so two spawns inside that
+    startup window both see an empty set and both run. Stamping from the PARENT
+    would close it and open something worse — a child that dies before its
+    first touch would leave a stamp that blocks the session for the whole
+    hung-after ceiling. The observed race is minutes wide; this narrows it to
+    seconds, and `heal` remains the answer for the rest.
+    """
+    if _serialize_in_flight(transcript_path):
+        return False
     crash = crash_log_path()
     crash.parent.mkdir(parents=True, exist_ok=True)
     trim_crash_log(crash)

--- a/plugin/daimon_briefing/_hooks/daimon-codex-session-end.py
+++ b/plugin/daimon_briefing/_hooks/daimon-codex-session-end.py
@@ -108,7 +108,16 @@ def main() -> int:
     cwd = str(payload.get("cwd") or "").strip()
     child_env = lib.project_env(cwd, "codex")
     try:
-        lib.spawn_serialize(cli, transcript_path, child_env)
+        if lib.spawn_serialize(cli, transcript_path, child_env) is False:
+        # #813: `is False` (not falsy) on purpose — only an explicit skip
+        # takes this branch, so any caller or fake still returning None
+        # keeps the old spawn-and-log path instead of silently flipping.
+        # The log line has to be honest: the ledger parses "spawned
+        # serialize", and a spawn with no result reads as hung and
+        # invites `heal` to retry work that never started.
+            lib.log(f"{TAG}: skipped serialize for {session_id} "
+                    f"(already in flight) (transcript: {transcript_path})")
+            return 0
         _mark_spawned(session_id)
         lib.log(f"{TAG}: spawned serialize for {session_id} "
                 f"(project: {cwd or '?'}) (transcript: {transcript_path})")

--- a/plugin/daimon_briefing/_hooks/daimon-codex-stop.py
+++ b/plugin/daimon_briefing/_hooks/daimon-codex-stop.py
@@ -125,7 +125,16 @@ def main() -> int:
     cwd = str(payload.get("cwd") or "").strip()
     child_env = lib.project_env(cwd, "codex")
     try:
-        lib.spawn_serialize(cli, transcript_path, child_env)
+        if lib.spawn_serialize(cli, transcript_path, child_env) is False:
+        # #813: `is False` (not falsy) on purpose — only an explicit skip
+        # takes this branch, so any caller or fake still returning None
+        # keeps the old spawn-and-log path instead of silently flipping.
+        # The log line has to be honest: the ledger parses "spawned
+        # serialize", and a spawn with no result reads as hung and
+        # invites `heal` to retry work that never started.
+            lib.log(f"codex-stop: skipped serialize for {session_id} "
+                    f"(already in flight) (transcript: {transcript_path})")
+            return 0
         _mark_spawned(session_id)
         lib.log(f"codex-stop: spawned serialize for {session_id} "
                 f"(project: {cwd or '?'}) (transcript: {transcript_path})")

--- a/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
+++ b/plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py
@@ -361,8 +361,16 @@ def _spawn_serialize_for(trajectory_id: str, transcript_path, detail: str) -> No
         return
     cwd = _project_cwd()
     try:
-        lib.spawn_serialize(
-            cli, str(transcript_path), lib.project_env(cwd, "windsurf"))
+        if lib.spawn_serialize(
+                cli, str(transcript_path),
+                lib.project_env(cwd, "windsurf")) is False:
+        # #813: `is False` only — a None-returning fake keeps the old path.
+        # The ledger parses "spawned serialize"; a spawn line with no
+        # result reads as hung and invites a heal retry of work that
+        # never started, so the skip must log as a skip.
+            lib.log(f"windsurf-cascade: skipped serialize for {trajectory_id} "
+                    f"(already in flight) ({detail})")
+            return
         _mark_spawned(trajectory_id)
         lib.log(f"windsurf-cascade: spawned serialize for {trajectory_id} "
                 f"(project: {cwd or '?'}) ({detail})")
@@ -456,8 +464,16 @@ def _finalize(trajectory_id: str, transcript_path: str, armed_mtime_ns: str) -> 
         return 0
     cwd = _project_cwd()
     try:
-        lib.spawn_serialize(
-            cli, transcript_path, lib.project_env(cwd, "windsurf"))
+        if lib.spawn_serialize(
+                cli, transcript_path,
+                lib.project_env(cwd, "windsurf")) is False:
+        # #813: `is False` only — a None-returning fake keeps the old path.
+        # The ledger parses "spawned serialize"; a spawn line with no
+        # result reads as hung and invites a heal retry of work that
+        # never started, so the skip must log as a skip.
+            lib.log(f"windsurf-finalizer: skipped serialize for {trajectory_id} "
+                    f"(already in flight) (transcript: {transcript_path})")
+            return 0
         # Logged at FIRE time, not arm time: an arm-time spawn line would sit
         # unresolved for the whole quiet period and read as hung to the ledger.
         lib.log(f"windsurf-finalizer: spawned serialize for {trajectory_id} "

--- a/plugin/tests/test_claude_hooks.py
+++ b/plugin/tests/test_claude_hooks.py
@@ -1415,3 +1415,102 @@ def test_prompt_hook_delivers_once_per_session(tmp_checkpoint_dir, tmp_path):
     assert q_id in first.stdout
     second = _run(PROMPT_HOOK, payload, tmp_path, extra_env=env)
     assert second.returncode == 0 and q_id not in second.stdout
+
+
+# ---- #813: the in-flight guard belongs with the spawn, not in one caller ----
+
+
+def _spy_popen(monkeypatch, calls):
+    """Replace Popen inside the lib so spawn_serialize is exercised for real."""
+    class _P:
+        def __init__(self, argv, **kw):
+            calls.append(argv[-1])
+    monkeypatch.setattr(lib.subprocess, "Popen", _P)
+
+
+def test_spawn_serialize_skips_when_that_transcript_is_already_in_flight(
+    tmp_path, monkeypatch
+):
+    """#813: Stop forks a detached child, SessionEnd fires seconds later, and
+    both serialize the same transcript. #545 built exactly this check
+    (_in_flight_stems) but wired it to sweep_orphans alone, so the two hook
+    spawn paths never consult it. Putting it in spawn_serialize means every
+    caller inherits it instead of each one remembering."""
+    monkeypatch.setattr(lib, "LOG_DIR", tmp_path / "logs")
+    transcript = tmp_path / "S-live.jsonl"
+    transcript.write_text("{}\n")
+
+    beats = tmp_path / "logs" / "heartbeats"
+    beats.mkdir(parents=True)
+    (beats / "S-live").write_text("some-project-slug")  # fresh: serialize live
+
+    calls = []
+    _spy_popen(monkeypatch, calls)
+    assert lib.spawn_serialize("daimon", str(transcript), {}) is False
+    assert calls == []
+
+
+def test_spawn_serialize_keys_the_guard_on_the_transcript_stem(
+    tmp_path, monkeypatch
+):
+    """The trap this guard dies on if it is written the obvious way.
+
+    `daimon serialize` derives its session id from the TRANSCRIPT FILENAME
+    (`cli/__init__.py:233`, `session_id = path.stem`), and that is the name
+    ledger.touch_heartbeat stamps. A Codex hook's payload `session_id` is a
+    DIFFERENT string: the field trace on #813 logs `spawned serialize for
+    01a04bd2-...` while the checkpoint lands as
+    `rollout-2026-08-28T22-41-50-01a04bd2-....json`.
+
+    Key the check on the payload id and it matches no heartbeat, ever, and the
+    guard is a silent no-op that still looks implemented."""
+    monkeypatch.setattr(lib, "LOG_DIR", tmp_path / "logs")
+    transcript = tmp_path / "rollout-2026-08-28T22-41-50-01a04bd2.jsonl"
+    transcript.write_text("{}\n")
+
+    beats = tmp_path / "logs" / "heartbeats"
+    beats.mkdir(parents=True)
+    # Stamped under the STEM, which is what the serializer actually writes.
+    (beats / "rollout-2026-08-28T22-41-50-01a04bd2").write_text("slug")
+    # The payload id a Codex hook would have used. Must not be what we consult.
+    (beats / "01a04bd2").write_text("slug")
+
+    calls = []
+    _spy_popen(monkeypatch, calls)
+    assert lib.spawn_serialize("daimon", str(transcript), {}) is False
+    assert calls == []
+
+
+def test_spawn_serialize_still_spawns_when_the_heartbeat_is_stale(
+    tmp_path, monkeypatch
+):
+    """A crashed serialize leaves its stamp behind. Treating a stale stamp as
+    in-flight would make that session permanently un-serializable, which is
+    strictly worse than the double spawn. Same liveness bar #545 set for the
+    sweep."""
+    monkeypatch.setattr(lib, "LOG_DIR", tmp_path / "logs")
+    transcript = tmp_path / "S-stale.jsonl"
+    transcript.write_text("{}\n")
+
+    beats = tmp_path / "logs" / "heartbeats"
+    beats.mkdir(parents=True)
+    stamp = beats / "S-stale"
+    stamp.write_text("slug")
+    _age(stamp, lib.hung_after_seconds() + 60)
+
+    calls = []
+    _spy_popen(monkeypatch, calls)
+    assert lib.spawn_serialize("daimon", str(transcript), {}) is not False
+    assert calls == [str(transcript)]
+
+
+def test_spawn_serialize_spawns_when_nothing_is_in_flight(tmp_path, monkeypatch):
+    """The liveness control: the guard must not swallow the ordinary case."""
+    monkeypatch.setattr(lib, "LOG_DIR", tmp_path / "logs")
+    transcript = tmp_path / "S-quiet.jsonl"
+    transcript.write_text("{}\n")
+
+    calls = []
+    _spy_popen(monkeypatch, calls)
+    assert lib.spawn_serialize("daimon", str(transcript), {}) is not False
+    assert calls == [str(transcript)]

--- a/plugin/tests/test_codex_hooks.py
+++ b/plugin/tests/test_codex_hooks.py
@@ -13,6 +13,7 @@ from daimon_briefing import store
 HOOK_DIR = Path(__file__).parents[2] / "hook"
 START_HOOK = HOOK_DIR / "daimon-codex-session-start.py"
 STOP_HOOK = HOOK_DIR / "daimon-codex-stop.py"
+SESSION_END_HOOK = HOOK_DIR / "daimon-codex-session-end.py"
 MANAGER = HOOK_DIR / "codex-hooks.py"
 LIB_NAME = "_daimon_hook_lib.py"
 VENV_BIN = Path(sys.executable).parent
@@ -471,3 +472,76 @@ def test_codex_hooks_install_copies_lib_uninstall_removes_it(tmp_path):
     assert _manager(tmp_path, "uninstall").returncode == 0
     assert not lib.exists()  # removed once no daimon hook remains
     assert not (hooks_dir / "daimon-codex-session-start.py").exists()
+
+
+# ---- #813: SessionEnd must not spawn over a live Stop child ----
+
+
+def test_codex_session_end_skips_when_a_stop_serialize_is_in_flight(
+    tmp_path, tmp_checkpoint_dir
+):
+    """The field case #813 reports, end to end.
+
+    Stop forks a detached serialize; SessionEnd fires 55s later, unthrottled,
+    and forked a second one over the still-running first. Both wrote. The
+    SessionEnd docstring argued this was covered because it writes the Stop
+    hook's marker, but that marker only stops a LATER Stop.
+
+    Two details this pins deliberately:
+
+    - The payload `session_id` and the transcript STEM are different strings
+      here, exactly as Codex produces them. `daimon serialize` keys its
+      heartbeat off the filename (`cli:233`), so a guard keyed on the payload
+      id would match nothing and silently never fire.
+    - The log line must say SKIPPED. `ledger` parses "spawned serialize", and a
+      spawn with no result classifies as hung and invites `heal` to retry work
+      that never started.
+    """
+    fake_bin, capture = _fake_cli(tmp_path)
+    transcript = tmp_path / "rollout-2026-08-28T22-41-50-01a04bd2.jsonl"
+    transcript.write_text("{}\n")
+
+    beats = tmp_path / ".daimon" / "logs" / "heartbeats"
+    beats.mkdir(parents=True)
+    (beats / transcript.stem).write_text("some-project-slug")  # Stop's child, live
+
+    payload = {
+        "session_id": "01a04bd2",  # NOT the stem — this is the trap
+        "transcript_path": str(transcript),
+        "cwd": "/Users/x/projA",
+        "hook_event_name": "SessionEnd",
+    }
+    result = _run(SESSION_END_HOOK, payload, tmp_path,
+                  extra_env={"PATH": str(fake_bin)})
+
+    assert result.returncode == 0
+    time.sleep(0.2)
+    assert not capture.exists()  # no second serialize forked
+
+    log = (tmp_path / ".daimon" / "logs" / "serialize.log").read_text(encoding="utf-8")
+    assert "skipped serialize" in log
+    assert "spawned serialize" not in log
+
+
+def test_codex_session_end_still_spawns_when_nothing_is_in_flight(
+    tmp_path, tmp_checkpoint_dir
+):
+    """Liveness control for the guard above: the ordinary graceful exit must
+    still serialize."""
+    fake_bin, capture = _fake_cli(tmp_path)
+    transcript = tmp_path / "rollout-2026-08-28T22-41-50-01a04bd2.jsonl"
+    transcript.write_text("{}\n")
+
+    payload = {
+        "session_id": "01a04bd2",
+        "transcript_path": str(transcript),
+        "cwd": "/Users/x/projA",
+        "hook_event_name": "SessionEnd",
+    }
+    result = _run(SESSION_END_HOOK, payload, tmp_path,
+                  extra_env={"PATH": str(fake_bin)})
+
+    assert result.returncode == 0
+    _wait_for(capture)
+    log = (tmp_path / ".daimon" / "logs" / "serialize.log").read_text(encoding="utf-8")
+    assert "spawned serialize" in log


### PR DESCRIPTION
Closes #813

## What

Move the in-flight check into `spawn_serialize` (`hook/_daimon_hook_lib.py`), so all six spawn paths inherit it, and make every caller log a skip as a skip.

`_in_flight_stems()` already existed for this, added by #545, and was consulted at exactly one place: `sweep_orphans`. The two Codex hook spawn paths never asked.

Two details that are load-bearing rather than incidental:

**Keyed on the transcript stem, not a payload session id.** `daimon serialize` derives its session id from the filename (`cli/__init__.py:233`, `session_id = path.stem`), and that is the name `ledger.touch_heartbeat` stamps. A Codex payload's `session_id` is a different string: the trace on #813 logs `spawned serialize for 01a04bd2-...` while the checkpoint lands as `rollout-2026-08-28T22-41-50-01a04bd2-....json`. Keying on the payload id would match no heartbeat, ever, and leave a guard that looks implemented and does nothing. There is a test whose only job is to fail if that changes.

**Callers test `is False`, not falsiness.** Around sixteen existing test fakes are `lambda cli, path, env: calls.append(path)` and return `None`. Under a truthiness check every one of them would silently flip its caller into the skip branch. With the explicit sentinel, anything still returning `None` keeps the old spawn-and-log path, so the migration direction is safe by construction rather than by having found all the fakes. The full suite passing unchanged is the evidence.

The skip has to log as a skip. `ledger` parses `spawned serialize`, and a spawn line with no result classifies as hung, which invites `heal` to retry work that never started.

## Why

Stop forks a detached serialize. SessionEnd fires seconds later, unthrottled by design, and forks a second one over the still-running first. Both complete, both write, both rotate the pointer chain.

The SessionEnd docstring argued the case was covered:

> It still writes the Stop hook's marker, so a Stop arriving moments earlier or later does not serialize the same transcript twice.

A start-time marker only stops a **later** Stop. It says nothing about an **earlier** Stop whose child is still running, which is the observed case: Stop forked a 151 second child, SessionEnd wrote the marker 55 seconds in.

#545 already recorded what two runs of one transcript cost: last-writer-wins, uncorrelated with quality, with a field case where the surviving checkpoint had 28 decisions against the discarded one's 32.

## Known narrowing, not a total fix

The child stamps its first heartbeat after interpreter start and its own preflight, so two spawns inside that startup window both see an empty set and both run. Stamping from the parent would close that window and open a worse one: a child dying before its first touch would leave a stamp blocking the session for the whole hung-after ceiling. The observed race is minutes wide and this narrows it to seconds. `heal` remains the answer for the rest.

`_in_flight_stems`' stale rule carries over unchanged, and there is a test for it: a stale stamp is a crashed serialize and heal's territory, never in-flight, or a crash would make a session permanently un-serializable.

## Scope

Six call sites across four hosts, all updated. Codex and Windsurf each have two spawning paths and are the exposed pair; Claude Code and Gemini have one each, so the guard is inert for them today and correct if they ever gain a second.

The Windsurf pair (throttled per-turn spawn plus an unthrottled finalizer) is the same shape as the Codex pair but was never field-observed, as #813 says. It is fixed here because the guard now lives with the spawn, not because a second defect was confirmed.

## Tests

6 new. Verified red before the change by reverting the source and re-running, not by assumption:

- `test_codex_session_end_skips_when_a_stop_serialize_is_in_flight` - the field case end to end, subprocess level. Before: `assert 'skipped serialize' in '... codex-session-end: spawned serialize for 01a04bd2 ...'`, i.e. it spawned straight over the live child.
- `test_spawn_serialize_skips_when_that_transcript_is_already_in_flight` and `test_spawn_serialize_keys_the_guard_on_the_transcript_stem` - unit level. Both failed with `assert None is False`.

Three are liveness and safety controls that must never go red: the ordinary graceful exit still spawns, a quiet transcript still spawns, and a stale heartbeat still spawns.

Full suite: 4357 passed, 2 skipped. `ruff check` clean, hook mirror drift check clean, commit GPG-signed.
