### PR TITLE
chore(scars): promote 0061 and 0062, correcting evidence sha and an over-escaped pattern

### DIFF
--- a/.scars/0061-heartbeat-keyed-by-transcript-stem.landmine.md
+++ b/.scars/0061-heartbeat-keyed-by-transcript-stem.landmine.md
@@ -1,23 +1,23 @@
 ---
-id: 0
+id: 61
 type: landmine
 title: Serialize heartbeats are keyed by transcript STEM, never a host payload session id
 severity: high
 confidence: 0.9
 created: 2026-08-29
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: hook/_daimon_hook_lib.py
   - path: plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
   - pattern: "_in_flight_stems|touch_heartbeat|heartbeat_age"
 evidence:
-  - commit: 681c234
+  - commit: bb3d2dd
   - pr: 814
-  - note: "#813 field trace: hook logged `spawned serialize for 01a04bd2-...` while the checkpoint landed as `rollout-2026-08-28T22-41-50-01a04bd2-....json`"
+  - note: #813 field trace: hook logged `spawned serialize for 01a04bd2-...` while the checkpoint landed as `rollout-2026-08-28T22-41-50-01a04bd2-....json`
 expires:
   condition: "cli/__init__.py stops deriving session_id from the transcript filename (`session_id = path.stem`), or hooks start passing their session id through to `daimon serialize`"
   review_after: 2027-02-28
-status: candidate
+status: active
 ---
 
 `daimon serialize <transcript>` derives its session id from the FILENAME

--- a/.scars/0062-spawn-serialize-is-false-sentinel.fence.md
+++ b/.scars/0062-spawn-serialize-is-false-sentinel.fence.md
@@ -1,22 +1,22 @@
 ---
-id: 0
+id: 62
 type: fence
 title: spawn_serialize callers test `is False`, not falsiness, because ~16 test fakes return None
 severity: medium
 confidence: 0.85
 created: 2026-08-29
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
 anchors:
   - path: hook/
   - path: plugin/daimon_briefing/_hooks/
-  - pattern: "spawn_serialize\\(.*\\) is False|lib\\.spawn_serialize"
+  - pattern: "spawn_serialize"
 evidence:
-  - commit: 681c234
+  - commit: bb3d2dd
   - pr: 814
 expires:
   condition: "every `monkeypatch.setattr(lib, 'spawn_serialize', ...)` fake in plugin/tests returns an explicit bool, at which point plain falsiness is safe"
   review_after: 2027-02-28
-status: candidate
+status: active
 ---
 
 `spawn_serialize` returns `False` when it skipped the spawn because a serialize


### PR DESCRIPTION
Scars-only. Human sign-off happened at promotion (`scar promote`, reviewer recorded in both files).

## What

Promote the two candidates from #813 / #814 to active, and fix two defects that only surfaced once lint ran against them as active files.

**0061, landmine** - serialize heartbeats are keyed by the transcript STEM, never a host payload session id. `cli/__init__.py:233` derives `session_id` from the filename and that derived id is what `ledger.touch_heartbeat` stamps. A Codex payload's `session_id` is a different string. A liveness check keyed on the payload id matches no heartbeat, ever: it does not raise, does not log, and fails no test, so it reads as an implemented guard and is a no-op. That is the obvious way to write it, because the hook code has `session_id` in scope and the transcript path is the less convenient value.

**0062, fence** - `spawn_serialize` callers compare `is False` rather than falsiness. Around sixteen test fakes are `lambda cli, path, env: calls.append(path)` and return `None`; under a truthiness check every one silently flips its caller into the skip branch. The sentinel makes anything still returning `None` keep the old spawn-and-log path, so the contract change is safe by construction rather than safe only if every fake was found. It looks like an over-careful identity comparison a tidying pass would simplify, which is exactly what a fence is for.

## Two fixes on top of the promotion

**Evidence pointed at a commit that no longer exists.** Both candidates cited `681c234`, the pre-squash commit on the feature branch. Squash-merge replaced it with `bb3d2dd`, so lint reported `evidence-unreachable` on both. Re-pointed at the commit actually on main. Worth noting as a general trap for candidates authored before their own PR merges: the sha you have while writing is not the sha that survives.

**0062's pattern anchor was over-escaped and matched nothing.** It carried `"spawn_serialize\\(.*\\) is False|lib\\.spawn_serialize"`, and the doubled backslashes reached the matcher as literal backslashes rather than escapes, so lint classified it as a dead anchor. Every live pattern anchor in this directory is plain regex with no escaping. The pattern is now just `spawn_serialize`, which matches the definition and all six call sites.

The lint hint on that one suggested moving it to `violation:`, which would have been the wrong fix. A `violation:` pattern is for something that is healthy when ABSENT; this anchor is meant to fire on live code that is present and should stay present. The anchor was right and the escaping was wrong.

## Verification

```
scar lint: 64 file(s), 0 with errors, 0 orphan(s), 1 partial-rot, 0 unreachable-evidence
```

Both `unreachable-evidence` warnings cleared and the partial-rot count went from 2 back to 1. The remaining one is pre-existing on scar #54 (`inspect.getsource`, genuinely gone from the tree) and is untouched here - it wants re-anchoring or a move to `violation:`, which is a separate call.
