### PR TITLE
ci(scar-lint): bump the pinned linter from 0.19.0 to 0.21.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,4 +110,4 @@ jobs:
       # rot their change did not introduce. Bump this deliberately, in its
       # own PR, where new findings are the subject rather than a surprise.
       - name: scar lint
-        run: uvx --from scar-cli==0.19.0 scar lint
+        run: uvx --from scar-cli==0.21.0 scar lint


### PR DESCRIPTION
CI-only, single line. The pin comment at `.github/workflows/ci.yml:107-111` asks for exactly this shape: deliberate, in its own PR, with new findings as the subject rather than a surprise.

## No new findings

0.19.0 and 0.21.0 produce **byte-identical** output on this tree. Verified locally by running both and diffing, not taken on trust:

```
$ uvx --from scar-cli==0.19.0 scar lint > a.txt
$ uvx --from scar-cli==0.21.0 scar lint > b.txt
$ diff a.txt b.txt && echo IDENTICAL
IDENTICAL
$ wc -c a.txt b.txt
     759 a.txt
     759 b.txt

lint: 64 file(s), 0 with errors, 0 orphan(s), 1 partial-rot, 0 unreachable-evidence
```

So this changes the gate's implementation without changing its verdict, which is the condition the pin comment set for a bump.

## Why take it

A bug fixed in this range was aimed at repositories shaped like this one. Pattern-anchor liveness truncated at 64 KiB, a bound sized for diff excerpts on the read hot path and then reused to scan whole file bodies. Any pattern anchor whose only match sat past byte 65,536 reported as a DEAD anchor while the code was plainly present, and lint then advised re-anchoring, so following its advice would have deleted live anchors.

This tree is well inside that range, and by more than the report that prompted the bump suggested:

- `plugin/tests/test_cli.py` is **418,051 bytes**, over six times the old horizon.
- It is not alone. **Ten files** under the anchored paths are past 64 KiB, including `cli/__init__.py`, `store.py`, `serializer.py` and `render.py`.
- Those paths carry **37 pattern anchors across 35 scar files**.

Nothing is mis-reported today, which the byte-identical result above confirms. The exposure is forward-looking: the next pattern anchor landing deep in a large file would have rotted silently, and these files only grow. Two of them grew in this session.

The release also publishes a stability contract for the `--json` payloads and adds `--since`/`--until` to `stats`. Neither is load-bearing here; the truncation fix is the reason.

## Scope

One line. No workflow structure, no job, no other pin touched.

The one remaining `partial-rot` is pre-existing on scar #54 (`inspect.getsource`, genuinely gone from the tree) and reports identically under both versions. It wants re-anchoring or a move to `violation:`, which is a separate call and deliberately not folded in here.
