### PR TITLE
fix(store): treat a pointer holding valid non-object JSON as absent

### DIFF
--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -1387,9 +1387,13 @@ def read_latest(project_dir=None, fallback: bool = True) -> dict | None:
         path = d / slug / _LATEST
         if path.exists():
             # A torn project pointer is treated as absent and falls through to the
-            # global fallback below (#139) — not the same as "no data".
+            # global fallback below (#139) — not the same as "no data". Valid JSON
+            # that is not an object gets the same treatment (#817): consumers
+            # assume a dict, and read_latest_reportable already refuses it.
             try:
-                return json.loads(path.read_text(encoding="utf-8"))
+                got = json.loads(path.read_text(encoding="utf-8"))
+                if isinstance(got, dict):
+                    return got
             except (OSError, json.JSONDecodeError):
                 pass
     if not fallback:
@@ -1398,9 +1402,10 @@ def read_latest(project_dir=None, fallback: bool = True) -> dict | None:
     if not path.exists():
         return None
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        got = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
+    return got if isinstance(got, dict) else None
 
 
 def read_latest_reportable(project_dir=None) -> dict | None:

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -3,6 +3,8 @@ import re
 import time as _time
 from pathlib import Path
 
+import pytest
+
 from daimon_briefing import config, normalize, serializer, store
 
 _ISO_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
@@ -1900,6 +1902,50 @@ def test_read_latest_corrupt_global_pointer_returns_none(tmp_checkpoint_dir):
     tmp_checkpoint_dir.mkdir(parents=True, exist_ok=True)
     (tmp_checkpoint_dir / "latest.json").write_text("{not json", encoding="utf-8")
     assert store.read_latest() is None  # tolerant, no raise
+
+
+# ---- non-object pointer payloads (#817): valid JSON that is not a dict is absent ----
+
+
+_NON_OBJECT_PAYLOADS = ['["x"]', '"str"', "42"]
+
+
+@pytest.mark.parametrize("payload", _NON_OBJECT_PAYLOADS)
+def test_read_latest_non_object_project_pointer_falls_through_to_global(
+    tmp_checkpoint_dir, sample_checkpoint, payload
+):
+    store.write_checkpoint("S-g", {**sample_checkpoint, "session_id": "S-g"})  # global
+    slug = store.project_slug("/p/nonobj")
+    pdir = tmp_checkpoint_dir / slug
+    pdir.mkdir(parents=True, exist_ok=True)
+    (pdir / "latest.json").write_text(payload, encoding="utf-8")
+    got = store.read_latest(project_dir="/p/nonobj", fallback=True)
+    assert got is not None and got["session_id"] == "S-g"  # absent, like torn (#139)
+
+
+@pytest.mark.parametrize("payload", _NON_OBJECT_PAYLOADS)
+def test_read_latest_non_object_project_pointer_no_fallback_returns_none(
+    tmp_checkpoint_dir, payload
+):
+    slug = store.project_slug("/p/nonobj")
+    pdir = tmp_checkpoint_dir / slug
+    pdir.mkdir(parents=True, exist_ok=True)
+    (pdir / "latest.json").write_text(payload, encoding="utf-8")
+    assert store.read_latest(project_dir="/p/nonobj", fallback=False) is None
+
+
+@pytest.mark.parametrize("payload", _NON_OBJECT_PAYLOADS)
+def test_read_latest_non_object_global_pointer_returns_none(tmp_checkpoint_dir, payload):
+    tmp_checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_checkpoint_dir / "latest.json").write_text(payload, encoding="utf-8")
+    assert store.read_latest() is None
+
+
+def test_read_latest_agrees_with_reportable_on_non_object_pointer(tmp_checkpoint_dir):
+    tmp_checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_checkpoint_dir / "latest.json").write_text('["x"]', encoding="utf-8")
+    assert store.read_latest() is None
+    assert store.read_latest_reportable() is None  # the two readers agree (#817)
 
 
 # ---- transcript_unchanged (#185): identical-bytes guard ----


### PR DESCRIPTION
Fixes #817
Refs #795

## What

`isinstance(got, dict)` gate on both pointer reads in `read_latest`: a project pointer holding valid non-object JSON now falls through to the global fallback, exactly like a torn pointer (#139), and a non-object global pointer reads as `None`. No signature change, no call-site change.

## Why

`read_latest` returned whatever `json.loads` produced, so a pointer file holding a list, a string, or a number reached four consumers that assume a dict and die on `AttributeError` (`cli/__init__.py:455`, `:691-692`, `:1444`, `cli/amend.py:42`), while `read_latest_reportable` refused the same value through its `isinstance` guard. The two readers disagreed on the same input. This is stage 0 of the #795 staging plan: stage 1 re-expresses `read_latest` as a wrapper over the scoped read path, and its equivalence claim is only exactly true once that disagreement is gone.

## Tests

Ten new tests in `tests/test_store.py`, written first and watched fail (`assert ['x'] is None`): list/string/number payloads per pointer, the `fallback=False` case, and one asserting `read_latest` and `read_latest_reportable` agree. Full plugin suite: 4367 passed, 2 skipped, 0 failed.
