### PR TITLE
refactor(store): add the scoped latest-reader with route and admit

### DIFF
--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -24,6 +24,8 @@ one a live pointer still references. The default is generous on purpose so #33's
 merged checkpoint history keeps a deep well of files to reconstruct from.
 """
 
+import dataclasses
+import enum
 import json
 import logging
 import os
@@ -1373,32 +1375,51 @@ def read_checkpoint(session_id: str) -> dict | None:
         return None
 
 
-def read_latest(project_dir=None, fallback: bool = True) -> dict | None:
-    """Latest checkpoint, preferring the project's own pointer when known;
-    falls back to the global pointer (pre-routing checkpoints, fresh projects).
+class Route(enum.Enum):
+    """Which pointers a latest-read may consult (#795). Deliberately not a
+    str mixin: a bare route="own" must raise, never silently match."""
 
-    fallback=False reads ONLY the project's own pointer (#94): the global
-    pointer holds the most recent checkpoint of ANY project, so callers that
-    PERSIST what they read (carry) must never see it — display callers (brief)
-    keep the fallback and label it."""
-    d = config.checkpoint_dir()
-    slug = project_slug(project_dir)
-    if slug:
-        path = d / slug / _LATEST
-        if path.exists():
-            # A torn project pointer is treated as absent and falls through to the
-            # global fallback below (#139) — not the same as "no data". Valid JSON
-            # that is not an object gets the same treatment (#817): consumers
-            # assume a dict, and read_latest_reportable already refuses it.
-            try:
-                got = json.loads(path.read_text(encoding="utf-8"))
-                if isinstance(got, dict):
-                    return got
-            except (OSError, json.JSONDecodeError):
-                pass
-    if not fallback:
-        return None
-    path = d / _LATEST
+    OWN = "own"                            # the project's own bucket pointer only
+    OWN_ELSE_GLOBAL = "own_else_global"    # own first, global if own yields nothing
+
+
+class Admit(enum.Enum):
+    """Which payloads a latest-read may return as a body (#795). Ownership is
+    a PAYLOAD fact decided by the `project_slug` stamp, independent of which
+    pointer produced the value — that split is the whole point (#784/#791)."""
+
+    ANY = "any"
+    OWN_OR_UNROUTED = "own_or_unrouted"    # + checkpoints belonging to nobody (#791)
+
+
+@dataclasses.dataclass(frozen=True)
+class Marker:
+    """What a refused payload leaves behind: the two header fields `brief`
+    already prints, and NOTHING more. Stdout is a write (scar 0055) — a wider
+    marker would copy foreign content into this project's checkpoint."""
+
+    slug: str | None
+    created: str | None
+
+
+@dataclasses.dataclass(frozen=True)
+class ReadResult:
+    """One read, both facts. `fell_back` is a pure ROUTE fact: the global
+    pointer yielded an OBJECT (never "parseable", never "produced the value" —
+    a refused payload still sets it). `refused` is the PAYLOAD fact: set iff
+    ADMIT rejected a payload the route found. This type must never reach the
+    17 body-only call sites: it is truthy, not None and not a dict, so a
+    dropped `.checkpoint` there is a clean wrong answer, not an error."""
+
+    checkpoint: dict | None
+    fell_back: bool
+    refused: Marker | None
+
+
+def _read_pointer_object(path) -> dict | None:
+    """The pointer's payload iff it is a JSON object. Absent, torn (#139) and
+    valid-but-non-object (#817) all read as None: "yields nothing" is ONE
+    state with three faces, and the contract table asserts them identical."""
     if not path.exists():
         return None
     try:
@@ -1406,6 +1427,74 @@ def read_latest(project_dir=None, fallback: bool = True) -> dict | None:
     except (OSError, json.JSONDecodeError):
         return None
     return got if isinstance(got, dict) else None
+
+
+def _admit_payload(checkpoint: dict, slug, admit: "Admit", fell_back: bool) -> "ReadResult":
+    if admit is Admit.OWN_OR_UNROUTED:
+        # Verbatim the shipped comparison: None / "" / whitespace / falsy
+        # stamps all read as un-routed, and a non-string stamp is coerced
+        # before comparing. Refuse only when BOTH sides are truthy and
+        # unequal — an identity-less reader (falsy slug) refuses nothing,
+        # because nothing is foreign to a session with no project identity.
+        stamped = str(checkpoint.get("project_slug") or "").strip()
+        if slug and stamped and stamped != slug:
+            created = str(checkpoint.get("created") or "").strip() or None
+            return ReadResult(None, fell_back, Marker(slug=stamped, created=created))
+    return ReadResult(checkpoint, fell_back, None)
+
+
+def _scoped_read(project_dir, route: "Route", admit: "Admit") -> "ReadResult":
+    """THE latest-read (#795): every projection below goes through here, so
+    there is exactly one implementation of route and admit."""
+    if not isinstance(route, Route):
+        raise TypeError(f"route must be a Route, got {route!r}")
+    if not isinstance(admit, Admit):
+        raise TypeError(f"admit must be an Admit, got {admit!r}")
+    d = config.checkpoint_dir()
+    slug = project_slug(project_dir)
+    if slug:
+        got = _read_pointer_object(d / slug / _LATEST)
+        if got is not None:
+            return _admit_payload(got, slug, admit, fell_back=False)
+    if route is Route.OWN:
+        return ReadResult(None, False, None)
+    got = _read_pointer_object(d / _LATEST)
+    if got is None:
+        return ReadResult(None, False, None)
+    return _admit_payload(got, slug, admit, fell_back=True)
+
+
+def read_latest_body(project_dir=None, *, route: "Route", admit: "Admit") -> dict | None:
+    """The latest checkpoint BODY under an explicit route and admit, or None.
+
+    Same return type as `read_latest`, for the call sites that only want the
+    body. Both keywords are required with no default so an omitted argument is
+    a TypeError instead of a silently unsafe answer. Callers that need to know
+    HOW the value arrived use `read_latest_result` instead — the choice is
+    "do I reference `fell_back`?", nothing else."""
+    return _scoped_read(project_dir, route, admit).checkpoint
+
+
+def read_latest_result(project_dir=None, *, route: "Route", admit: "Admit") -> "ReadResult":
+    """`read_latest_body` plus the route fact, as a `ReadResult` — for the one
+    caller (`brief`) that must LABEL a fallback rather than infer it (#787,
+    scar 0058). Everyone else takes the body projection above."""
+    return _scoped_read(project_dir, route, admit)
+
+
+def read_latest(project_dir=None, fallback: bool = True) -> dict | None:
+    """Latest checkpoint, preferring the project's own pointer when known;
+    falls back to the global pointer (pre-routing checkpoints, fresh projects).
+
+    fallback=False reads ONLY the project's own pointer (#94): the global
+    pointer holds the most recent checkpoint of ANY project, so callers that
+    PERSIST what they read (carry) must never see it — display callers (brief)
+    keep the fallback and label it.
+
+    Thin wrapper over the scoped read (#795): fallback=True is
+    (OWN_ELSE_GLOBAL, ANY), fallback=False is (OWN, ANY), byte-for-byte."""
+    route = Route.OWN_ELSE_GLOBAL if fallback else Route.OWN
+    return read_latest_body(project_dir=project_dir, route=route, admit=Admit.ANY)
 
 
 def read_latest_reportable(project_dir=None) -> dict | None:
@@ -1423,15 +1512,11 @@ def read_latest_reportable(project_dir=None) -> dict | None:
 
     Membership is decided by the payload's own `project_slug`, the same way
     team fan-in decides it, rather than by which pointer the read came through.
-    """
-    checkpoint = read_latest(project_dir=project_dir)
-    if not isinstance(checkpoint, dict):
-        return None
-    slug = project_slug(project_dir)
-    stamped = str(checkpoint.get("project_slug") or "").strip()
-    if slug and stamped and stamped != slug:
-        return None
-    return checkpoint
+
+    Thin wrapper over the scoped read (#795): exactly
+    (OWN_ELSE_GLOBAL, OWN_OR_UNROUTED), body projection."""
+    return read_latest_body(project_dir=project_dir, route=Route.OWN_ELSE_GLOBAL,
+                            admit=Admit.OWN_OR_UNROUTED)
 
 
 # ---- team memory (#111): opt-in shared mirror, derive-never-write shared state ----

--- a/plugin/tests/test_read_contract.py
+++ b/plugin/tests/test_read_contract.py
@@ -1,0 +1,287 @@
+"""The scoped-reader contract table (#795 stage 1).
+
+Forty cells: ten store states x four (route, admit) combinations, each cell
+marked by why it holds — FORCED by shipped behaviour, PARTIAL (body forced,
+route fact unobservable today), DEFINITIONAL (no caller exists), or ADDITIVE
+(the Marker payload is new). Torn and non-object pointer variants must be
+indistinguishable from absent (#139, #817): "yields nothing" is one state.
+
+`fell_back` means "the global pointer yielded an OBJECT" — never "parseable",
+never "produced the value" (spec v3.2 S1). Columns 3 and 4 agree on it in
+every row because it is a pure route fact (v3.1 amendment 2).
+"""
+
+import dataclasses
+import json
+from pathlib import Path
+
+import pytest
+
+from daimon_briefing import store
+from daimon_briefing.store import Admit, Marker, ReadResult, Route
+
+PROJ = "/p/contract"
+OTHER = "someone-elses-project"
+CREATED = "2026-08-29T00:00:00Z"
+
+C1 = (Route.OWN, Admit.ANY)                        # today's fallback=False
+C2 = (Route.OWN, Admit.OWN_OR_UNROUTED)            # no caller today
+C3 = (Route.OWN_ELSE_GLOBAL, Admit.ANY)            # today's fallback=True
+C4 = (Route.OWN_ELSE_GLOBAL, Admit.OWN_OR_UNROUTED)  # today's read_latest_reportable
+COMBOS = [C1, C2, C3, C4]
+
+# "Yields nothing" is one state with three faces (#139 torn, #817 non-object).
+NOTHING = {"absent": None, "torn": "{not json", "nonobject": '["x"]'}
+
+
+def _ck(stamp=None):
+    body = {"session_id": "S-contract", "created": CREATED}
+    if stamp is not None:
+        body["project_slug"] = stamp
+    return body
+
+
+def _write_own(tmp_checkpoint_dir, payload):
+    pdir = tmp_checkpoint_dir / store.project_slug(PROJ)
+    pdir.mkdir(parents=True, exist_ok=True)
+    if payload is not None:
+        text = payload if isinstance(payload, str) else json.dumps(payload)
+        (pdir / "latest.json").write_text(text, encoding="utf-8")
+
+
+def _write_global(tmp_checkpoint_dir, payload):
+    tmp_checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    if payload is not None:
+        text = payload if isinstance(payload, str) else json.dumps(payload)
+        (tmp_checkpoint_dir / "latest.json").write_text(text, encoding="utf-8")
+
+
+def _cell(project_dir, route, admit):
+    got = store.read_latest_result(project_dir=project_dir, route=route, admit=admit)
+    return (got.checkpoint, got.fell_back,
+            got.refused.slug if got.refused is not None else None)
+
+
+# ---- the 40 cells ---------------------------------------------------------
+# Expected tuples are (checkpoint-or-None, fell_back, refused-slug-or-None);
+# SELF/BODY placeholders are resolved inside the test against the state.
+
+
+def _self_slug():
+    return store.project_slug(PROJ)
+
+
+# S1 own=self, S2 own=unstamped: every combo returns the body. All FORCED.
+@pytest.mark.parametrize("route,admit", COMBOS)
+@pytest.mark.parametrize("stamp", ["SELF", None], ids=["S1-own-self", "S2-own-unstamped"])
+def test_own_bucket_admitted_bodies(tmp_checkpoint_dir, stamp, route, admit):
+    body = _ck(_self_slug() if stamp == "SELF" else None)
+    _write_own(tmp_checkpoint_dir, body)
+    assert _cell(PROJ, route, admit) == (body, False, None)
+
+
+# S3 own=other (#789 poisoned bucket): the PATH decides under ANY (scar 0059,
+# R2 — FORCED at C1/C3); OWN_OR_UNROUTED refuses with a marker (C2 is the one
+# genuinely DEFINITIONAL design choice; C4's marker payload is ADDITIVE).
+@pytest.mark.parametrize("route,admit,expect", [
+    (*C1, "body"), (*C2, "marker"), (*C3, "body"), (*C4, "marker"),
+], ids=["C1-forced", "C2-definitional", "C3-forced", "C4-marker-additive"])
+def test_s3_own_stamped_other(tmp_checkpoint_dir, route, admit, expect):
+    body = _ck(OTHER)
+    _write_own(tmp_checkpoint_dir, body)
+    got = store.read_latest_result(project_dir=PROJ, route=route, admit=admit)
+    assert got.fell_back is False
+    if expect == "body":
+        assert (got.checkpoint, got.refused) == (body, None)
+    else:
+        assert got.checkpoint is None
+        assert (got.refused.slug, got.refused.created) == (OTHER, CREATED)
+
+
+# S4 own yields nothing, global absent: every combo empty. FORCED.
+# Asserted across all three "yields nothing" faces of the OWN pointer.
+@pytest.mark.parametrize("route,admit", COMBOS)
+@pytest.mark.parametrize("own", NOTHING.values(), ids=NOTHING.keys())
+def test_s4_nothing_anywhere(tmp_checkpoint_dir, own, route, admit):
+    _write_own(tmp_checkpoint_dir, own)
+    assert _cell(PROJ, route, admit) == (None, False, None)
+
+
+# S5 global=self, S6 global=unstamped: OWN routes see nothing (FORCED);
+# OWN_ELSE_GLOBAL returns the body with fell_back=True (FORCED — S6 under C4
+# is #791's "belongs to nobody and stays readable").
+@pytest.mark.parametrize("own", NOTHING.values(), ids=NOTHING.keys())
+@pytest.mark.parametrize("stamp", ["SELF", None], ids=["S5-global-self", "S6-global-unstamped"])
+@pytest.mark.parametrize("route,admit", COMBOS)
+def test_global_admitted_bodies(tmp_checkpoint_dir, stamp, own, route, admit):
+    body = _ck(_self_slug() if stamp == "SELF" else None)
+    _write_own(tmp_checkpoint_dir, own)
+    _write_global(tmp_checkpoint_dir, body)
+    expected = (body, True, None) if route is Route.OWN_ELSE_GLOBAL else (None, False, None)
+    assert _cell(PROJ, route, admit) == expected
+
+
+# S7 global=other: C3 admits it (FORCED — today's fallback body, brief labels
+# it); C4 refuses with a marker, fell_back STILL True — an object was yielded,
+# ADMIT refused it (v3.2 S1). Marker payload ADDITIVE.
+@pytest.mark.parametrize("route,admit,expect", [
+    (*C1, (None, False, None)), (*C2, (None, False, None)),
+    (*C3, "body-fb"), (*C4, (None, True, OTHER)),
+], ids=["C1", "C2", "C3-forced-body", "C4-refused-fb-true"])
+def test_s7_global_stamped_other(tmp_checkpoint_dir, route, admit, expect):
+    body = _ck(OTHER)
+    _write_own(tmp_checkpoint_dir, None)
+    _write_global(tmp_checkpoint_dir, body)
+    got = _cell(PROJ, route, admit)
+    assert got == ((body, True, None) if expect == "body-fb" else expect)
+
+
+# S8-S10: reader identity UNKNOWN. OWN routes have no pointer to read — every
+# column-1/2 cell is empty and NO production site may ever land there. Columns
+# 3-4: nothing is foreign to a session with no project identity (R3,
+# store's shipped identity-less branch), so even a stamped body is admitted,
+# and fell_back=True because the value came off the global pointer (v3.1
+# amendment 2 — PARTIAL: bodies forced, the route fact has no reader today).
+@pytest.mark.parametrize("reader", [None, "", "   "], ids=["none", "empty", "whitespace"])
+@pytest.mark.parametrize("route,admit", COMBOS)
+@pytest.mark.parametrize("stamp", ["S8", None, OTHER],
+                         ids=["S8-global-absent", "S9-unstamped", "S10-stamped"])
+def test_identity_less_reader(tmp_checkpoint_dir, stamp, route, admit, reader):
+    if stamp == "S8":
+        body = None
+    else:
+        body = _ck(stamp)
+        _write_global(tmp_checkpoint_dir, body)
+    if body is None or route is Route.OWN:
+        assert _cell(reader, route, admit) == (None, False, None)
+    else:
+        assert _cell(reader, route, admit) == (body, True, None)
+
+
+# Torn/non-object GLOBAL pointer: S5-S7 collapse to S4, S9-S10 collapse to S8,
+# and fell_back stays False — no OBJECT was yielded (v3.2 S1 pins fb here).
+@pytest.mark.parametrize("route,admit", COMBOS)
+@pytest.mark.parametrize("payload", [NOTHING["torn"], NOTHING["nonobject"]],
+                         ids=["global-torn", "global-nonobject"])
+@pytest.mark.parametrize("reader", [PROJ, None], ids=["slug-known", "slug-none"])
+def test_global_yields_nothing_collapses(tmp_checkpoint_dir, reader, payload, route, admit):
+    if reader is not None:
+        _write_own(tmp_checkpoint_dir, None)
+    _write_global(tmp_checkpoint_dir, payload)
+    assert _cell(reader, route, admit) == (None, False, None)
+
+
+# ---- coercion edges (v3.2 S3: the ADMIT comparison goes in verbatim) -------
+
+
+@pytest.mark.parametrize("stamp", ["", "   ", 0, False, []],
+                         ids=["empty", "whitespace", "zero", "false", "list"])
+def test_falsy_stamps_read_as_unrouted(tmp_checkpoint_dir, stamp):
+    body = _ck(stamp)
+    _write_own(tmp_checkpoint_dir, None)
+    _write_global(tmp_checkpoint_dir, body)
+    got = store.read_latest_result(project_dir=PROJ, route=Route.OWN_ELSE_GLOBAL,
+                                   admit=Admit.OWN_OR_UNROUTED)
+    assert (got.checkpoint, got.refused) == (body, None)
+
+
+def test_non_string_stamp_is_coerced_before_comparing(tmp_checkpoint_dir):
+    body = _ck(123)  # str-coerced to "123": truthy, unequal, refused
+    _write_own(tmp_checkpoint_dir, None)
+    _write_global(tmp_checkpoint_dir, body)
+    got = store.read_latest_result(project_dir=PROJ, route=Route.OWN_ELSE_GLOBAL,
+                                   admit=Admit.OWN_OR_UNROUTED)
+    assert got.checkpoint is None
+    assert got.refused.slug == "123"
+
+
+def test_path_and_str_project_dir_agree(tmp_checkpoint_dir):
+    body = _ck(_self_slug())
+    _write_own(tmp_checkpoint_dir, body)
+    for route, admit in COMBOS:
+        assert (_cell(PROJ, route, admit)
+                == _cell(Path(PROJ), route, admit))
+
+
+def test_slug_string_as_project_dir_reads_the_bucket(tmp_checkpoint_dir):
+    # cli passes a bare slug as project_dir and survives because project_slug
+    # is idempotent — the scoped reader must keep that property.
+    body = _ck(_self_slug())
+    _write_own(tmp_checkpoint_dir, body)
+    got = store.read_latest_result(project_dir=_self_slug(), route=Route.OWN,
+                                   admit=Admit.ANY)
+    assert got.checkpoint == body
+
+
+# ---- the wrappers are projections of the same read path --------------------
+
+
+@pytest.mark.parametrize("own,global_,reader", [
+    (_ck("SELF"), None, PROJ),
+    (_ck(), None, PROJ),
+    (_ck(OTHER), None, PROJ),
+    (None, _ck(OTHER), PROJ),
+    (None, _ck(), PROJ),
+    (None, _ck(OTHER), None),
+    (None, None, PROJ),
+], ids=["own-self", "own-unstamped", "own-other", "global-other", "global-unstamped",
+        "no-slug-global-other", "empty"])
+def test_legacy_readers_are_wrappers(tmp_checkpoint_dir, own, global_, reader):
+    if own is not None and own.get("project_slug") == "SELF":
+        own = _ck(_self_slug())
+    if own is not None:
+        _write_own(tmp_checkpoint_dir, own)
+    elif reader is not None:
+        _write_own(tmp_checkpoint_dir, None)
+    if global_ is not None:
+        _write_global(tmp_checkpoint_dir, global_)
+    assert store.read_latest(project_dir=reader, fallback=False) == \
+        store.read_latest_body(project_dir=reader, route=Route.OWN, admit=Admit.ANY)
+    assert store.read_latest(project_dir=reader, fallback=True) == \
+        store.read_latest_body(project_dir=reader, route=Route.OWN_ELSE_GLOBAL,
+                               admit=Admit.ANY)
+    assert store.read_latest_reportable(project_dir=reader) == \
+        store.read_latest_body(project_dir=reader, route=Route.OWN_ELSE_GLOBAL,
+                               admit=Admit.OWN_OR_UNROUTED)
+
+
+def test_body_is_the_result_projection(tmp_checkpoint_dir):
+    body = _ck(_self_slug())
+    _write_own(tmp_checkpoint_dir, body)
+    for route, admit in COMBOS:
+        assert (store.read_latest_body(project_dir=PROJ, route=route, admit=admit)
+                == store.read_latest_result(project_dir=PROJ, route=route,
+                                            admit=admit).checkpoint)
+
+
+# ---- API guards ------------------------------------------------------------
+
+
+def test_route_and_admit_are_required():
+    with pytest.raises(TypeError):
+        store.read_latest_body(project_dir=PROJ)
+    with pytest.raises(TypeError):
+        store.read_latest_result(project_dir=PROJ)
+    with pytest.raises(TypeError):
+        store.read_latest_body(project_dir=PROJ, route=Route.OWN)
+    with pytest.raises(TypeError):
+        store.read_latest_body(project_dir=PROJ, admit=Admit.ANY)
+
+
+@pytest.mark.parametrize("route,admit", [
+    ("own", Admit.ANY), (Route.OWN, "any"), (True, Admit.ANY), (Route.OWN, None),
+], ids=["route-str", "admit-str", "route-bool", "admit-none"])
+def test_bare_values_raise_instead_of_matching(route, admit):
+    with pytest.raises(TypeError):
+        store.read_latest_body(project_dir=PROJ, route=route, admit=admit)
+
+
+def test_read_result_is_frozen():
+    got = ReadResult(checkpoint=None, fell_back=False, refused=None)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        got.checkpoint = {}
+
+
+def test_marker_carries_exactly_slug_and_created():
+    # Stdout is a write (scar 0055): the marker must never widen to a body.
+    assert [f.name for f in dataclasses.fields(Marker)] == ["slug", "created"]


### PR DESCRIPTION
Refs #795

## What

Stage 1 of #795, additive only. `Route` (OWN | OWN_ELSE_GLOBAL) and `Admit` (ANY | OWN_OR_UNROUTED) as plain enums, `Marker` (slug + created, nothing more, ever), `ReadResult`, and ONE read path with two projections: `read_latest_body` returning `dict | None` for body-only callers, and `read_latest_result` returning `ReadResult` for the caller that needs the route fact. `read_latest` and `read_latest_reportable` are re-expressed as thin wrappers (`fallback=True` maps to `(OWN_ELSE_GLOBAL, ANY)`, `fallback=False` to `(OWN, ANY)`, reportable to `(OWN_ELSE_GLOBAL, OWN_OR_UNROUTED)`). Zero call sites change.

Two properties not visible in the diff: `fell_back` means "the global pointer yielded an OBJECT": a refused payload still sets it, a non-object payload never does; and under `Admit.ANY` nothing is ever refused, so `fell_back=True` implies `checkpoint is not None`, which is what lets stage 2 gate on the bare field.

## Why

`fallback` names a mechanism while every caller reasons about a policy; four shipped defects (#785/#788/#790/#792) and the census in #795 show the translation keeps being done by hand. Naming both knobs, requiring them with no defaults, and returning the route fact ends the route reconstruction (#787's class). Entry points are named for the RETURN, not the scope, so the migration choice per site is only "does it reference `fell_back`?".

## Tests

New `tests/test_read_contract.py`: 127 tests covering the 40 contract cells (marked FORCED / PARTIAL / DEFINITIONAL / ADDITIVE) with torn and non-object pointer variants asserted identical to absent, coercion edges over the admit comparison (falsy/whitespace/non-string stamps, Path vs str project_dir, slug string as project_dir), wrapper-equivalence over both legacy readers, and API guards (required kwargs, bare strings raise, frozen results, Marker field freeze). Written first and watched fail. Two deliberate mutations (non-object passthrough; refusing unstamped payloads) each turned the table red (16 and 10 failures) and were reverted.

Existing suite: green and unedited. Full run: 4494 passed (4367 existing + 127 new), 2 skipped, 0 failed.
