### PR TITLE
refactor(store): migrate the 17 production call sites to the scoped readers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,17 @@ jobs:
         continue-on-error: true
         run: uv run --extra dev mypy daimon_briefing
 
+      # #795: a ReadResult reaching a body-only call site is a SILENT wrong
+      # answer (a frozen dataclass is truthy, not None and not a dict), so
+      # this step is blocking while mypy above stays advisory: any mypy
+      # finding that mentions ReadResult outside store.py fails the build.
+      # Scoped by symbol, not path, so it needs no baseline and survives
+      # until the #795 stage 4 cleanup.
+      - name: mypy ReadResult containment
+        run: |
+          uv run --extra dev mypy daimon_briefing > mypy-out.txt || true
+          ! grep "ReadResult" mypy-out.txt | grep -v "^daimon_briefing/store.py"
+
   scar-lint:
     name: scar lint
     runs-on: ubuntu-latest

--- a/.scars/0058-global-fallback-detection-misses-torn-pointer.landmine.md
+++ b/.scars/0058-global-fallback-detection-misses-torn-pointer.landmine.md
@@ -15,7 +15,7 @@ evidence:
   - note: #787 — brief rendered a foreign body on a torn own pointer
   - note: #784 — the SessionStart injection rendered another project's checkpoint
 expires:
-  condition: "read_latest reports whether it fell back, instead of callers inferring it"
+  condition: "no caller reconstructs the route; read_latest_result is the only source of fell_back, and the legacy fallback= surface is deleted (#795 stage 4)"
   review_after: 2027-02-28
 status: active
 ---
@@ -33,12 +33,19 @@ while the caller is in fact holding another project's data. `daimon brief` shipp
 that detection and its #96 foreign-body suppression therefore did not fire on a
 torn own-pointer (#787); both call sites now decide before the read instead.
 
-Do NOT reintroduce that detection in a new caller. Ask `read_latest` not to fall
-back in the first place, by passing `fallback=` computed from policy (the injection
-hook after #784), or read the own pointer with `fallback=False` first and let its
-absence be the answer (`brief` after #787). Deciding before the read cannot be fooled by
-either case. Note the policy has a second half: when the project is UNKNOWN the
-fallback must stay ON, because there is no per-project pointer to prefer and
-nothing is foreign to a session with no project identity. A fix that suppresses
-the fallback unconditionally passes the leak test and silently removes the
-briefing from every pre-routing host; the full suite caught exactly that.
+Do NOT reintroduce that detection in a new caller. Since #795 stage 2 the route
+fact is RETURNED: `store.read_latest_result(...).fell_back` is the only honest
+source, and `brief` reads it instead of reconstructing it. Every other caller
+holds a body with no route fact ON PURPOSE — a body-only caller that suddenly
+needs to know how its value arrived must switch to `read_latest_result`, never
+reach for `project_latest_path(...).exists()`, which is this scar's violation
+pattern verbatim. Route policy is named per caller (`Route.OWN` /
+`Route.OWN_ELSE_GLOBAL`, or `briefing.injection_read_route` on the injection
+surfaces). The policy's second half still binds: when the project is UNKNOWN
+the fallback must stay ON, because there is no per-project pointer to prefer
+and nothing is foreign to a session with no project identity. A fix that
+suppresses the fallback unconditionally passes the leak test and silently
+removes the briefing from every pre-routing host; the full suite caught
+exactly that. This scar stays ACTIVE until #795 stage 4 deletes the legacy
+`fallback=` surface — the split fix leaves 17 body-only callers for whom the
+path-existence check is the cheapest wrong answer on the shelf.

--- a/.scars/candidates/own-else-global-banned-in-own-only-modules.md
+++ b/.scars/candidates/own-else-global-banned-in-own-only-modules.md
@@ -1,0 +1,34 @@
+---
+id: 0
+type: landmine
+title: Route.OWN_ELSE_GLOBAL in capture/lifecycle/amend/mcp_tools returns another project's dict with no exception
+severity: high
+confidence: 0.9
+created: 2026-08-29
+authors: ["claude-code"]
+anchors:
+  - path: plugin/daimon_briefing/capture.py
+  - path: plugin/daimon_briefing/cli/lifecycle.py
+  - path: plugin/daimon_briefing/cli/amend.py
+  - path: plugin/daimon_briefing/mcp_tools.py
+  - pattern: "Route\.OWN_ELSE_GLOBAL"
+evidence:
+  - note: "#784 tenant leak; #795 stage 2 migration — every read in these four modules is Route.OWN by decision (persist paths and project-scoped surfaces)"
+  - note: "pinned by tests/test_migration_manifest.py::test_own_else_global_never_appears_in_own_only_modules"
+expires:
+  condition: "one of these modules legitimately gains a labeled global-fallback display surface, reviewed against scar 0057 (un-routed checkpoints) and 0058 (route reconstruction)"
+  review_after: 2027-02-28
+status: candidate
+---
+
+Every `read_latest_body` call in these four modules is `Route.OWN` on purpose:
+capture and amend PERSIST what they read (a foreign body would be carried into
+this project's bucket permanently, #784's failure mode), and lifecycle and
+mcp_tools are project-scoped surfaces where an un-routed or foreign body hands
+out ids no scoped write can act on. A wrong `Route.OWN_ELSE_GLOBAL` here
+raises nothing and type-checks clean — it returns another project's dict, the
+exact silent failure the enum migration was built to prevent. If you need the
+global pointer in one of these files, you are on the wrong surface: display
+callers live in cli/__init__.py and hooks.py, where the route is labeled and
+gated. The manifest test pins today's sites; this scar guards the ones added
+after it.

--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -339,7 +339,22 @@ def build(checkpoint, now=None) -> dict | None:
 _CANDIDATE_ID_SHAPE = re.compile(r"[a-z]-[0-9a-f]{6,40}(-\d+)?")
 
 
-def withhold(checkpoint, resolutions: dict,
+def injection_read_route(project) -> "store.Route":
+    """The ONE display-policy route shared by the two briefing-injection
+    surfaces (#784, #795): fall back to the global pointer only when the
+    project is unknown — nothing is foreign to a session with no project
+    identity — or the operator opted in. The `project is None` term is live
+    on the hook path (resolve_project_root propagates None) and dead on the
+    CLI path (_resolve_project always returns a str); folding them is safe,
+    citing the duplication as a shared cause is not. Display callers only:
+    the persist path (store.write_checkpoint) must never consult this, or an
+    env var could change what carry writes (#126)."""
+    if project is None or config.brief_global_fallback():
+        return store.Route.OWN_ELSE_GLOBAL
+    return store.Route.OWN
+
+
+def withhold(checkpoint: dict, resolutions: dict,
              amendments=None) -> tuple[dict, list, list]:
     """Drop items the world has already resolved, at RENDER time only — the
     checkpoint on disk (and carry's copy of it) is never touched. `resolutions`
@@ -1027,7 +1042,7 @@ def _validate_llm_render(rendered: str, checkpoint) -> bool:
     return True
 
 
-def render(checkpoint, project_dir=None, worldcheck_project=None) -> str | None:
+def render(checkpoint: dict, project_dir=None, worldcheck_project=None) -> str | None:
     """Render the briefing, or None if there is nothing worth surfacing.
     LLM rendering is opt-in (DAIMON_LLM_BRIEFING), post-validated for verbatim
     quote integrity, and falls back to deterministic on any doubt.

--- a/plugin/daimon_briefing/capture.py
+++ b/plugin/daimon_briefing/capture.py
@@ -540,11 +540,12 @@ def carry_forward(checkpoint: dict, project) -> dict:
     # itself (a briefing missing carried items is strictly better than
     # no briefing at all; same idiom as `run`'s rejection-ledger swallow).
     try:
-        # fallback=False (#94): on a project's first serialize there is no
+        # Route.OWN (#94): on a project's first serialize there is no
         # per-project pointer, and the global pointer is another project's
         # checkpoint — carrying from it would write foreign items into
         # this project's bucket permanently. No prev -> no carry.
-        prev = store.read_latest(project, fallback=False)
+        prev = store.read_latest_body(project, route=store.Route.OWN,
+                                      admit=store.Admit.ANY)
         now = store._created_epoch(checkpoint.get("created")) or time.time()
         events = store.resolutions(project_dir=project)
         resolved = frozenset(ref for ref, evt in events.items()

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -452,7 +452,8 @@ def _cmd_anchor(args) -> int:
     # the project that owns the item never received the anchor while the command
     # reported success. Refusing is the correct outcome: there is nothing here to
     # attach to, and the message below already says so.
-    checkpoint = store.read_latest(project_dir=project, fallback=False)
+    checkpoint = store.read_latest_body(project_dir=project, route=store.Route.OWN,
+                                        admit=store.Admit.ANY)
     if checkpoint is None:
         print(f"error: no checkpoint found for {project} — nothing to attach to",
               file=sys.stderr)
@@ -669,7 +670,10 @@ def _cmd_brief(args) -> int:
             print("error: --team routes by project path and cannot combine "
                   "with --slug", file=sys.stderr)
             return 2
-        checkpoint = store.read_latest(project_dir=slug, fallback=False)
+        # `slug` is a bare slug string, not a path — this survives because
+        # project_slug is idempotent on slugs (pinned by its own test).
+        checkpoint = store.read_latest_body(project_dir=slug, route=store.Route.OWN,
+                                            admit=store.Admit.ANY)
         if not isinstance(checkpoint, dict):
             render.render_brief_note([
                 f"no checkpoint bucket for slug {slug} — "
@@ -681,19 +685,20 @@ def _cmd_brief(args) -> int:
     # Route like status/serialize: --project, else DAIMON_PROJECT_DIR, else cwd.
     # read_latest still falls back to the global pointer if the project has none.
     project = _resolve_project(args.project)
-    # #787: whether the fallback fired is what read_latest DID, not what the
-    # filesystem shows. It reaches the global pointer by TWO routes: an absent
-    # own pointer, and a TORN one, which falls through while its path still
-    # exists. Comparing project_latest_path() against exists() is blind to the
-    # second, so the #96 suppression did not fire and a foreign body rendered
-    # with no note and no opt-in. Ask for the project's own pointer first and
-    # let its absence BE the answer — that cannot be fooled by either route.
-    own = store.read_latest(project_dir=project, fallback=False)
-    checkpoint = own if own is not None else store.read_latest(project_dir=project)
-    # project_latest_path is None when the project is unknown, and nothing is
-    # foreign to a session with no project identity (#784).
-    fallback_used = (own is None and checkpoint is not None
-                     and store.project_latest_path(project) is not None)
+    # #787/#795: whether the fallback fired is what the read DID, not what the
+    # filesystem shows — and the route fact is now READ off the result, never
+    # reconstructed from a second look (scar 0058's class). Two invariants the
+    # diff does not show: under Admit.ANY nothing is ever refused, so
+    # fell_back=True implies checkpoint is not None (the old second conjunct
+    # is implied, not dropped); and brief cannot be identity-less, because
+    # _resolve_project returns str(Path(...).resolve()) — never empty — and
+    # resolve_project_root ends `return top or raw`, so the no-slug rows of
+    # the read contract are unreachable on this path.
+    got = store.read_latest_result(project_dir=project,
+                                   route=store.Route.OWN_ELSE_GLOBAL,
+                                   admit=store.Admit.ANY)
+    checkpoint = got.checkpoint
+    fallback_used = got.fell_back
     if fallback_used and not (getattr(args, "global_fallback", False)
                               or config.brief_global_fallback()):
         # Header-only fallback (#96): the foreign body is suppressed — one
@@ -1441,9 +1446,10 @@ def _cmd_recall_inject(args) -> int:
         # the operator opted into the foreign body. Excluding the global latest
         # unconditionally suppressed recall of a session that was never briefed.
         exclude = set()
-        briefed = store.read_latest(
+        briefed = store.read_latest_body(
             project_dir=project,
-            fallback=project is None or config.brief_global_fallback())
+            route=briefing.injection_read_route(project),
+            admit=store.Admit.ANY)
         sid = (briefed or {}).get("session_id")
         if sid:
             exclude.add(str(sid))
@@ -1734,7 +1740,13 @@ def _print_suppressed(project) -> int:
     withheld items under this project's status would be worse than listing
     none. Fails open like brief's withhold call — a broken events.jsonl
     must not crash `status`, it should just report nothing suppressed."""
-    checkpoint = store.read_latest(project_dir=project, fallback=False)
+    # Route.OWN is a DECISION here, not a leftover: this is a read-only
+    # reporting surface, and a pre-routing store is read-only for
+    # project-scoped commands — its content comes from briefing.withhold over
+    # store.resolutions(project), whose writers are all own-only, so an
+    # un-routed checkpoint can have nothing suppressed to report anyway.
+    checkpoint = store.read_latest_body(project_dir=project, route=store.Route.OWN,
+                                        admit=store.Admit.ANY)
     withheld = []
     candidates = []
     if checkpoint:
@@ -1786,7 +1798,9 @@ def _cmd_verify_receipt(args) -> int:
         # #791: the docstring above says the default target is THIS project's
         # latest checkpoint, and the fallback let it be another project's. An
         # un-routed checkpoint is still this project's to verify.
-        checkpoint = store.read_latest_reportable(project)
+        checkpoint = store.read_latest_body(project_dir=project,
+                                            route=store.Route.OWN_ELSE_GLOBAL,
+                                            admit=store.Admit.OWN_OR_UNROUTED)
         if not isinstance(checkpoint, dict) or not checkpoint.get("session_id"):
             print("no checkpoint for this project yet — nothing to verify")
             return 2

--- a/plugin/daimon_briefing/cli/amend.py
+++ b/plugin/daimon_briefing/cli/amend.py
@@ -39,7 +39,8 @@ def _cmd_amend_propose(args) -> int:
     # belief would invite exactly the state-rewriting on settled facts that
     # BRIEFABLE_ITEM_KEYS exists to fence off, and `daimon loops` — the
     # discovery surface this command's errors point at — lists only these.
-    checkpoint = store.read_latest(project_dir=project, fallback=False)
+    checkpoint = store.read_latest_body(project_dir=project, route=store.Route.OWN,
+                                        admit=store.Admit.ANY)
     live = {
         str(item.get("id") or "")
         for section, key in store._ITEM_LISTS

--- a/plugin/daimon_briefing/cli/lifecycle.py
+++ b/plugin/daimon_briefing/cli/lifecycle.py
@@ -72,7 +72,8 @@ def _cmd_resolve(args) -> int:
               "— refused, nothing written")
         return 1
     project = _cli._resolve_project(args.project)
-    checkpoint = store.read_latest(project_dir=project, fallback=False)
+    checkpoint = store.read_latest_body(project_dir=project, route=store.Route.OWN,
+                                        admit=store.Admit.ANY)
     if not isinstance(checkpoint, dict):
         print("no checkpoint for this project yet — nothing to resolve")
         return 1
@@ -147,7 +148,8 @@ def _cmd_forget(args) -> int:
     recall index deletion all inherit it with no new plumbing. The rewritten
     checkpoint re-mints its receipt, so the post-removal state is signed."""
     project = _cli._resolve_project(args.project)
-    checkpoint = store.read_latest(project_dir=project, fallback=False)
+    checkpoint = store.read_latest_body(project_dir=project, route=store.Route.OWN,
+                                        admit=store.Admit.ANY)
     # #578: the refutation ledger is a second plaintext store, so a value can
     # live there with no checkpoint at all. Bailing on a missing checkpoint
     # would leave that value permanently unreachable.
@@ -718,7 +720,8 @@ def _cmd_reverify(args) -> int:
     with no evidence — rejecting a suggestion is not vouching for a claim.
     The reopened event is a human verdict, so re-detection stays silent."""
     project = _cli._resolve_project(args.project)
-    checkpoint = store.read_latest(project_dir=project, fallback=False)
+    checkpoint = store.read_latest_body(project_dir=project, route=store.Route.OWN,
+                                        admit=store.Admit.ANY)
     if not isinstance(checkpoint, dict):
         print("no checkpoint for this project yet — nothing to reverify")
         return 1
@@ -784,7 +787,14 @@ def _cmd_loops(args) -> int:
     (#480 scope guard, mirrors briefing._line's new suffix)."""
     _cli._note_usage("loops")
     project = _cli._resolve_project(args.project)
-    checkpoint = store.read_latest(project_dir=project, fallback=False)
+    # Route.OWN is a DECISION here, not a leftover: a pre-routing store is
+    # read-only for project-scoped commands. If loops listed items off an
+    # un-routed checkpoint, the user would copy an id, run `daimon resolve`,
+    # and be refused — every scoped WRITE is own-only, and a listing that
+    # hands out handles nothing can act on is worse than an honest refusal.
+    # (Making un-routed checkpoints adoptable is a feature, out of #795's scope.)
+    checkpoint = store.read_latest_body(project_dir=project, route=store.Route.OWN,
+                                        admit=store.Admit.ANY)
     if not isinstance(checkpoint, dict):
         print("no checkpoint for this project yet — nothing to list")
         return 0

--- a/plugin/daimon_briefing/hooks.py
+++ b/plugin/daimon_briefing/hooks.py
@@ -190,9 +190,13 @@ def pre_llm_call(session_id=None, user_message=None, conversation_history=None,
         # The fallback stays ON when the project is UNKNOWN: there is no per-project
         # pointer to prefer, the global one is the only briefing that exists, and
         # nothing is foreign to a session with no project identity (pre-routing
-        # hosts that do not pass a cwd). The leak needs a KNOWN project.
-        allow_foreign = project is None or config.brief_global_fallback()
-        checkpoint = store.read_latest(project_dir=project, fallback=allow_foreign)
+        # hosts that do not pass a cwd). The leak needs a KNOWN project. The
+        # policy lives once, in briefing.injection_read_route, shared with the
+        # recall-inject surface so the two cannot drift (#795).
+        checkpoint = store.read_latest_body(
+            project_dir=project,
+            route=briefing.injection_read_route(project),
+            admit=store.Admit.ANY)
         if checkpoint is None:
             # #693: standing rulings exist before the first checkpoint does —
             # a day-one ratification must reach the very next session.

--- a/plugin/daimon_briefing/mcp_tools.py
+++ b/plugin/daimon_briefing/mcp_tools.py
@@ -63,7 +63,12 @@ def _brief(arguments: dict) -> str:
     # no-content returns carry them too.
     rulings = briefing.ruling_lines(target)
     ruling_text = ("\n".join(rulings) + "\n\n") if rulings else ""
-    checkpoint = store.read_latest(project_dir=target, fallback=False)
+    # Route.OWN is a DECISION here, not a leftover: an agent tool result
+    # carrying another project's briefing is contamination, and a pre-routing
+    # store stays read-only for project-scoped surfaces — an un-routed body
+    # would hand the agent handles no scoped write could act on.
+    checkpoint = store.read_latest_body(project_dir=target, route=store.Route.OWN,
+                                        admit=store.Admit.ANY)
     if checkpoint is None:
         # Orientation without content: name the explicit path, leak nothing
         # (#96, machine edition — an agent tool result carrying another

--- a/plugin/daimon_briefing/receipts.py
+++ b/plugin/daimon_briefing/receipts.py
@@ -530,7 +530,9 @@ def status_line(project_dir=None) -> str | None:
     # #791: this line names the session it reports on, so it must not answer
     # with another project's record. An un-routed checkpoint still counts as
     # reportable, which keeps pre-routing stores working.
-    checkpoint = store.read_latest_reportable(project_dir)
+    checkpoint = store.read_latest_body(project_dir=project_dir,
+                                        route=store.Route.OWN_ELSE_GLOBAL,
+                                        admit=store.Admit.OWN_OR_UNROUTED)
     if not isinstance(checkpoint, dict) or not checkpoint.get("session_id"):
         return "receipts: on — no checkpoint to sign yet"
     sid = str(checkpoint["session_id"])

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -1192,13 +1192,10 @@ def write_checkpoint(session_id: str, checkpoint: dict, project_dir=None,
         checkpoint.setdefault("git_branch", branch)
     # Birth stamps (#126) need the previous latest BEFORE this write moves it.
     # read_latest never raises (returns None on absent/torn pointers). When the
-    # project is KNOWN, suppress the global fallback (#139): _stamp_first_seen
-    # PERSISTS what it reads, and the global pointer holds the most recent
-    # checkpoint of ANY project — a known project's first write must inherit
-    # nothing (None → all items fresh), never a foreign first_seen. When the
-    # project is UNKNOWN, the global pointer IS this stream's own prior
-    # checkpoint, so the fallback stays on (same-stream carry, #126 legacy).
-    _stamp_first_seen(checkpoint, read_latest(project_dir, fallback=not slug))
+    # _stamp_first_seen PERSISTS what it reads (#139), so this read is the
+    # own-stream one: a known project inherits nothing foreign, an unknown
+    # project keeps the global pointer as its own prior (#126 legacy).
+    _stamp_first_seen(checkpoint, read_own_stream_latest(project_dir))
     # Signed provenance receipt (#204): decide + prep key material BEFORE the blob
     # is serialized, so the `receipts` era marker rides INSIDE the signed bytes
     # (outputs_hash covers the exact blob). plan_mint returns None (and stamps
@@ -1480,6 +1477,18 @@ def read_latest_result(project_dir=None, *, route: "Route", admit: "Admit") -> "
     caller (`brief`) that must LABEL a fallback rather than infer it (#787,
     scar 0058). Everyone else takes the body projection above."""
     return _scoped_read(project_dir, route, admit)
+
+
+def read_own_stream_latest(project_dir=None) -> dict | None:
+    """The previous checkpoint of THIS stream, for the persist path (#126).
+
+    A KNOWN project inherits only its own bucket (a foreign `first_seen` must
+    never be carried); an UNKNOWN project keeps the global fallback because
+    the global pointer IS that stream's own prior checkpoint (pre-routing
+    legacy). Takes NO policy argument on purpose: nothing an env var can
+    reach may change what write_checkpoint persists."""
+    route = Route.OWN if project_slug(project_dir) else Route.OWN_ELSE_GLOBAL
+    return read_latest_body(project_dir=project_dir, route=route, admit=Admit.ANY)
 
 
 def read_latest(project_dir=None, fallback: bool = True) -> dict | None:

--- a/plugin/tests/test_hooks.py
+++ b/plugin/tests/test_hooks.py
@@ -422,7 +422,11 @@ def test_pre_llm_call_never_raises_when_config_raises(tmp_checkpoint_dir, monkey
 
 
 def test_pre_llm_call_never_raises_when_read_latest_raises(tmp_checkpoint_dir, monkeypatch):
-    monkeypatch.setattr(hooks.store, "read_latest", _raiser)
+    # Installed over the symbol pre_llm_call ACTUALLY calls (#795 stage 2):
+    # left on read_latest, this fake would sit on a symbol nobody calls, the
+    # injected failure would never fire, and the fail-open guard would stop
+    # being tested in a green suite.
+    monkeypatch.setattr(hooks.store, "read_latest_body", _raiser)
     out = hooks.pre_llm_call(
         session_id="S2", user_message="hi", conversation_history=[], is_first_turn=True,
         model="m", platform="cli",
@@ -512,18 +516,75 @@ def test_pre_llm_call_routes_project_through_resolve_project_root(
 
     captured = {}
 
-    def _spy(project_dir=None, fallback=True):
+    def _spy(project_dir=None, *, route, admit):
         captured["project_dir"] = project_dir
-        captured["fallback"] = fallback
+        captured["route"] = route
+        captured["admit"] = admit
         return None
 
-    monkeypatch.setattr(hooks.store, "read_latest", _spy)
+    monkeypatch.setattr(hooks.store, "read_latest_body", _spy)
     out = hooks.pre_llm_call(
         session_id="S2", user_message="hi", conversation_history=[], is_first_turn=True,
         model="m", platform="cli",
     )
-    assert out is None  # read_latest returned None
+    assert out is None  # the read returned None
     assert captured["project_dir"] == "/git/top"
+
+
+# ---- #795 stage 2: the injection read's ROUTE argument, asserted (#784) ----
+# No test anywhere asserted the foreign-suppression argument at the injection
+# site — the tenant-leak fix shipped with no unit-level guard on the one line
+# that carries it. After the enum migration a wrong Route returns another
+# project's dict with the right type and no exception, so this argument test
+# is the only thing between a bad edit and the #784 leak.
+
+
+def _route_spy(captured):
+    def _spy(project_dir=None, *, route, admit):
+        captured.update(project_dir=project_dir, route=route, admit=admit)
+        return None
+    return _spy
+
+
+def test_pre_llm_call_reads_own_route_for_a_known_project(tmp_checkpoint_dir, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setattr(hooks.config, "resolve_project_root", lambda raw: "/git/top")
+    captured = {}
+    monkeypatch.setattr(hooks.store, "read_latest_body", _route_spy(captured))
+    out = hooks.pre_llm_call(
+        session_id="S2", user_message="hi", conversation_history=[], is_first_turn=True,
+        model="m", platform="cli",
+    )
+    assert out is None
+    assert captured["route"] is store.Route.OWN
+    assert captured["admit"] is store.Admit.ANY
+    assert captured["project_dir"] == "/git/top"
+
+
+def test_pre_llm_call_falls_back_only_when_project_is_unknown(tmp_checkpoint_dir, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setattr(hooks.config, "resolve_project_root", lambda raw: None)
+    captured = {}
+    monkeypatch.setattr(hooks.store, "read_latest_body", _route_spy(captured))
+    hooks.pre_llm_call(
+        session_id="S2", user_message="hi", conversation_history=[], is_first_turn=True,
+        model="m", platform="cli",
+    )
+    assert captured["route"] is store.Route.OWN_ELSE_GLOBAL
+    assert captured["admit"] is store.Admit.ANY
+
+
+def test_pre_llm_call_env_opt_in_restores_the_global_fallback(tmp_checkpoint_dir, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setattr(hooks.config, "resolve_project_root", lambda raw: "/git/top")
+    monkeypatch.setenv("DAIMON_BRIEF_GLOBAL_FALLBACK", "full")
+    captured = {}
+    monkeypatch.setattr(hooks.store, "read_latest_body", _route_spy(captured))
+    hooks.pre_llm_call(
+        session_id="S2", user_message="hi", conversation_history=[], is_first_turn=True,
+        model="m", platform="cli",
+    )
+    assert captured["route"] is store.Route.OWN_ELSE_GLOBAL
 
 
 # ---- #103 I1: pre_llm_call must withhold resolved items before injecting ----

--- a/plugin/tests/test_migration_manifest.py
+++ b/plugin/tests/test_migration_manifest.py
@@ -1,0 +1,131 @@
+"""#795 stage 2: the frozen migration manifest.
+
+A wrong Route at a migrated site returns another project's dict with the right
+type and no exception (#784's failure mode), so the migration itself is pinned:
+every production call to the scoped readers is enumerated by AST walk, keyed by
+enclosing-function qualname (lines move, qualnames survive), and compared to
+this frozen manifest. A site added, dropped, or migrated to the wrong route
+fails here by name.
+
+Part A of the same defense: four modules hold ONLY own-route reads, so the
+token OWN_ELSE_GLOBAL must never appear in them at all — scoped to those
+paths the rule has no false positives and keeps guarding sites added later.
+"""
+
+import ast
+from pathlib import Path
+
+PKG = Path(__file__).parent.parent / "daimon_briefing"
+
+SCOPED = {"read_latest_body", "read_latest_result", "read_own_stream_latest"}
+LEGACY = {"read_latest", "read_latest_reportable"}
+
+# (file, qualname, callee, route source, admit source); route/admit are None
+# for read_own_stream_latest, which takes no policy argument ON PURPOSE (#126:
+# nothing an env var can reach may change what the persist path carries).
+MANIFEST = {
+    ("capture.py", "carry_forward", "read_latest_body",
+     "store.Route.OWN", "store.Admit.ANY"),
+    ("cli/__init__.py", "_cmd_anchor", "read_latest_body",
+     "store.Route.OWN", "store.Admit.ANY"),
+    ("cli/__init__.py", "_cmd_brief", "read_latest_body",
+     "store.Route.OWN", "store.Admit.ANY"),
+    ("cli/__init__.py", "_cmd_brief", "read_latest_result",
+     "store.Route.OWN_ELSE_GLOBAL", "store.Admit.ANY"),
+    ("cli/__init__.py", "_cmd_recall_inject", "read_latest_body",
+     "briefing.injection_read_route(project)", "store.Admit.ANY"),
+    ("cli/__init__.py", "_print_suppressed", "read_latest_body",
+     "store.Route.OWN", "store.Admit.ANY"),
+    ("cli/__init__.py", "_cmd_verify_receipt", "read_latest_body",
+     "store.Route.OWN_ELSE_GLOBAL", "store.Admit.OWN_OR_UNROUTED"),
+    ("cli/amend.py", "_cmd_amend_propose", "read_latest_body",
+     "store.Route.OWN", "store.Admit.ANY"),
+    ("cli/lifecycle.py", "_cmd_resolve", "read_latest_body",
+     "store.Route.OWN", "store.Admit.ANY"),
+    ("cli/lifecycle.py", "_cmd_forget", "read_latest_body",
+     "store.Route.OWN", "store.Admit.ANY"),
+    ("cli/lifecycle.py", "_cmd_reverify", "read_latest_body",
+     "store.Route.OWN", "store.Admit.ANY"),
+    ("cli/lifecycle.py", "_cmd_loops", "read_latest_body",
+     "store.Route.OWN", "store.Admit.ANY"),
+    ("hooks.py", "pre_llm_call", "read_latest_body",
+     "briefing.injection_read_route(project)", "store.Admit.ANY"),
+    ("mcp_tools.py", "_brief", "read_latest_body",
+     "store.Route.OWN", "store.Admit.ANY"),
+    ("receipts.py", "status_line", "read_latest_body",
+     "store.Route.OWN_ELSE_GLOBAL", "store.Admit.OWN_OR_UNROUTED"),
+    ("store.py", "write_checkpoint", "read_own_stream_latest", None, None),
+}
+
+# Wrapper-internal calls in store.py: the legacy surface is re-expressed over
+# the scoped read (stage 1) and is not a migration site.
+WRAPPER_SITES = {
+    ("store.py", "read_latest", "read_latest_body"),
+    ("store.py", "read_latest_reportable", "read_latest_body"),
+    ("store.py", "read_own_stream_latest", "read_latest_body"),
+}
+
+OWN_ONLY_MODULES = ["capture.py", "cli/lifecycle.py", "cli/amend.py", "mcp_tools.py"]
+
+
+def _callee(node):
+    f = node.func
+    if isinstance(f, ast.Name):
+        return f.id
+    if isinstance(f, ast.Attribute):
+        return f.attr
+    return None
+
+
+def _kw_src(node, name, src):
+    for kw in node.keywords:
+        if kw.arg == name:
+            return ast.get_source_segment(src, kw.value)
+    return None
+
+
+def _walk(names):
+    for path in sorted(PKG.rglob("*.py")):
+        src = path.read_text(encoding="utf-8")
+        rel = str(path.relative_to(PKG))
+        stack = []
+
+        def visit(node):
+            scoped = isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+            if scoped:
+                stack.append(node.name)
+            if isinstance(node, ast.Call) and _callee(node) in names:
+                yield rel, ".".join(stack) or "<module>", node, src
+            for child in ast.iter_child_nodes(node):
+                yield from visit(child)
+            if scoped:
+                stack.pop()
+
+        yield from visit(ast.parse(src))
+
+
+def test_no_production_call_on_the_legacy_surface():
+    hits = [(rel, qual) for rel, qual, node, src in _walk(LEGACY)]
+    assert hits == [], f"legacy read_latest calls remain in production: {hits}"
+
+
+def test_every_scoped_call_matches_the_frozen_manifest():
+    found = set()
+    for rel, qual, node, src in _walk(SCOPED):
+        if (rel, qual, _callee(node)) in WRAPPER_SITES:
+            continue
+        found.add((rel, qual, _callee(node),
+                   _kw_src(node, "route", src), _kw_src(node, "admit", src)))
+    assert found == MANIFEST, (
+        f"missing: {sorted(MANIFEST - found)}\nunexpected: {sorted(found - MANIFEST)}")
+
+
+def test_own_else_global_never_appears_in_own_only_modules():
+    # AST, not text: a comment MENTIONING the route must not trip the rule
+    # (scar 0054's shape — text matches are satisfied by their own prose).
+    for rel in OWN_ONLY_MODULES:
+        tree = ast.parse((PKG / rel).read_text(encoding="utf-8"))
+        hits = [n.lineno for n in ast.walk(tree)
+                if (isinstance(n, ast.Attribute) and n.attr == "OWN_ELSE_GLOBAL")
+                or (isinstance(n, ast.Name) and n.id == "OWN_ELSE_GLOBAL")]
+        assert hits == [], f"{rel}:{hits} must stay own-route only"


### PR DESCRIPTION
Refs #795

## What

Stage 2 of #795: the 17 production call sites move to the scoped readers; the legacy `fallback=` surface is untouched and the 144 test-suite call sites still use it, by design. Ten behaviour-neutral renames to `(Route.OWN, Admit.ANY)`; `brief` is the one rewrite, replacing its two non-atomic reads and hand-built `fallback_used` with a single `read_latest_result` whose `fell_back` gates all three of its surfaces; the two reportable sites take `(OWN_ELSE_GLOBAL, OWN_OR_UNROUTED)` explicitly; the two computed-policy sites (SessionStart injection, recall-inject) share one named helper, `briefing.injection_read_route`, so the duplicated expression that predicted the next #784-class bug cannot drift; and `write_checkpoint` reads its carry input through `read_own_stream_latest`, which takes no policy argument so nothing an env var can reach changes what the persist path carries.

Three sites (`mcp _brief`, `status --suppressed`, `loops`) carry comments recording WHY own-only is a decision rather than a leftover, per the migration map's laundering note.

## Defense in depth for the wrong-enum hazard

A wrong `Route` returns another project's dict with the right type and no exception, so the migration itself is pinned:

- A frozen manifest test enumerates every scoped-reader call by AST walk, keyed by enclosing-function qualname, and compares route and admit sources against the expected set. It caught one real miss during this migration (`amend.py`, reported by name).
- Four own-only modules (`capture`, `lifecycle`, `amend`, `mcp_tools`) ban `Route.OWN_ELSE_GLOBAL` at the AST level, with a candidate scar guarding sites added after the manifest froze.
- CI gains a blocking step that fails any mypy `ReadResult` finding outside `store.py` (symbol-scoped, no baseline, survives to stage 4).
- Three new tests pin the injection read's route argument, previously unguarded anywhere: own for a known project, global only when the project is unknown, or on explicit operator opt-in.

Scar 0058 stays active with its expiry rewritten for the split-reader world: 17 callers now hold a body with no route fact, and the cheapest wrong recovery is exactly the path-existence check the scar forbids. It retires when stage 4 deletes the legacy surface.

## Tests

The 144 test-suite call sites still exercise the legacy wrappers, so any red in this stage would have been a real production regression: full suite 4500 passed (4494 + 3 route-argument pins + 3 manifest), 2 skipped, 0 failed. The nine brief fallback guards passed unedited, including the byte-identical output assertion. The two fakes installed over the store symbol in `test_hooks.py` move with the call they fake; left behind, the variadic raiser would have sat on a symbol nobody calls and passed silently forever. Scar lint: 65 files, 0 errors. Local mypy containment probe: zero `ReadResult` findings outside `store.py`.
