### PR TITLE
test(store): migrate the test and research call sites to the scoped readers

### DIFF
--- a/plugin/tests/bench/adapter.py
+++ b/plugin/tests/bench/adapter.py
@@ -215,7 +215,8 @@ def serialize_question(question: dict, *, chat, cache: cache_mod.CheckpointCache
             # this checkpoint's deterministic stamp, knobs from config (pinned in
             # _question_env), resolutions folded the same way (empty in the
             # isolated bench store, read anyway for fidelity).
-            prev = store.read_latest(project_dir, fallback=False)
+            prev = store.read_latest_body(project_dir, route=store.Route.OWN,
+                                          admit=store.Admit.ANY)
             now = store._created_epoch(cp["created"]) or 0.0
             events = store.resolutions(project_dir=project_dir)
             resolved = frozenset(ref for ref, evt in events.items()

--- a/plugin/tests/test_agent_resolution_verification.py
+++ b/plugin/tests/test_agent_resolution_verification.py
@@ -52,7 +52,9 @@ def _agent_candidate(project, sample_checkpoint, quote,
     first open question — the standard setup every test below shares.
     Returns the target item dict (with its stable id)."""
     store.write_checkpoint(prev_session, sample_checkpoint, project_dir=project)
-    written = store.read_latest(project_dir=project)
+    written = store.read_latest_body(project_dir=project,
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     item = written["working_context"]["open_questions"][0]
     rc = cli.main(["resolve", item["id"], "--by", "agent",
                    "--evidence", quote, "--project", project])

--- a/plugin/tests/test_bench_forbidden.py
+++ b/plugin/tests/test_bench_forbidden.py
@@ -101,7 +101,8 @@ def test_case_c_trust_downgraded_item_is_withheld_from_the_brief(tmp_path):
             "c1", _cp("deployment notes overview", decisions=[stale]),
             project_dir=proj)
         # recover the stamped item id, then downgrade its standing (superseded)
-        cp = store.read_latest(proj)
+        cp = store.read_latest_body(proj, route=store.Route.OWN_ELSE_GLOBAL,
+                                    admit=store.Admit.ANY)
         item_id = cp["working_context"]["recent_decisions"][0]["id"]
         store.append_event(item_id, "superseded-by:d-newid1", project_dir=proj)
         results = recall.search(query, project_dir=proj, limit=50)

--- a/plugin/tests/test_carry_forget_adversarial.py
+++ b/plugin/tests/test_carry_forget_adversarial.py
@@ -95,7 +95,8 @@ def _arm_adversarial_state():
     value-keyed tombstone against the never-present sibling id. Returns the
     prev item id under which the forgotten value survives on disk."""
     store.write_checkpoint(_PREV_SID, _prev_checkpoint(), project_dir=_P)
-    prev = store.read_latest(project_dir=_P, fallback=False)
+    prev = store.read_latest_body(project_dir=_P, route=store.Route.OWN,
+                                  admit=store.Admit.ANY)
     x_id = next(d["id"] for d in prev["working_context"]["recent_decisions"]
                 if d["text"] == _S)
 
@@ -160,7 +161,8 @@ def _serialize_new_session(tmp_path, monkeypatch):
     monkeypatch.setattr(cli, "_chat", FakeChat(_extraction_json()))
     monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
     assert cli.main(["serialize", str(_transcript_file(tmp_path))]) == 0
-    return store.read_latest(project_dir=_P, fallback=False)
+    return store.read_latest_body(project_dir=_P, route=store.Route.OWN,
+                                  admit=store.Admit.ANY)
 
 
 # ---- read-side probes (mirror #400/#407 helpers, fixed clock) -------------
@@ -200,7 +202,8 @@ def test_ungated_prev_cannot_resurrect_forgotten_value_through_carry(
     # the forgotten value in memory — its id-keyed suppression cannot see a
     # value-keyed tombstone recorded under a sibling id. Only the write
     # boundary stands between this merged dict and disk.
-    prev = store.read_latest(project_dir=_P, fallback=False)
+    prev = store.read_latest_body(project_dir=_P, route=store.Route.OWN,
+                                  admit=store.Admit.ANY)
     resolved = frozenset(ref for ref, evt in
                          store.resolutions(project_dir=_P).items()
                          if store.is_resolved(evt))

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -65,7 +65,8 @@ def test_cli_serialize_writes_checkpoint(tmp_checkpoint_dir, fake_chat_factory, 
     # checkpoint file exists, keyed by the transcript stem
     ckpt = store.read_checkpoint("sample_transcript")
     assert ckpt is not None
-    assert store.read_latest()["session_id"] == "sample_transcript"
+    assert store.read_latest_body(route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY)["session_id"] == "sample_transcript"
 
 
 def test_cli_brief_prints_briefing(tmp_checkpoint_dir, sample_checkpoint, capsys,
@@ -1910,7 +1911,8 @@ def test_cli_write_checkpoint_routes_and_stamps_source(tmp_checkpoint_dir, monke
     _stdin(monkeypatch, _valid_json("S-intro"))
     rc = cli.main(["write-checkpoint", "--project", "/p/A"])
     assert rc == 0
-    ck = store.read_latest(project_dir="/p/A")
+    ck = store.read_latest_body(project_dir="/p/A", route=store.Route.OWN_ELSE_GLOBAL,
+                                admit=store.Admit.ANY)
     assert ck["session_id"] == "S-intro"
     assert ck["source"] == "introspection"  # default provenance stamp
     assert (tmp_checkpoint_dir / "-p-A" / "latest.json").exists()
@@ -1922,7 +1924,8 @@ def test_cli_write_checkpoint_source_override(tmp_checkpoint_dir, monkeypatch):
     _stdin(monkeypatch, _valid_json("S-x"))
     rc = cli.main(["write-checkpoint", "--project", "/p/A", "--source", "reconstruction"])
     assert rc == 0
-    assert store.read_latest(project_dir="/p/A")["source"] == "reconstruction"
+    assert store.read_latest_body(project_dir="/p/A", route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY)["source"] == "reconstruction"
 
 
 def test_cli_write_checkpoint_invalid_json(tmp_checkpoint_dir, monkeypatch, capsys):
@@ -1968,7 +1971,8 @@ def test_cli_write_checkpoint_strips_model_supplied_code_owned_keys(
     _stdin(monkeypatch, json.dumps(spoofed))
     rc = cli.main(["write-checkpoint", "--project", "/p/A"])
     assert rc == 0
-    ck = store.read_latest(project_dir="/p/A")
+    ck = store.read_latest_body(project_dir="/p/A", route=store.Route.OWN_ELSE_GLOBAL,
+                                admit=store.Admit.ANY)
     assert ck["format_version"] == serializer.PROMPT_VERSION
     assert ck["author"] != "not-the-real-author"
     assert ck["created"] != "1999-01-01T00:00:00Z"
@@ -1989,7 +1993,8 @@ def test_cli_write_checkpoint_drops_model_claimed_source_ids(
     _stdin(monkeypatch, json.dumps(cp))
     rc = cli.main(["write-checkpoint", "--project", "/p/A"])
     assert rc == 0
-    ck = store.read_latest(project_dir="/p/A")
+    ck = store.read_latest_body(project_dir="/p/A", route=store.Route.OWN_ELSE_GLOBAL,
+                                admit=store.Admit.ANY)
     dec = ck["working_context"]["recent_decisions"][0]
     assert "source_message_ids" not in dec
 
@@ -2008,7 +2013,8 @@ def test_cli_write_checkpoint_strips_model_claimed_grounded(
     _stdin(monkeypatch, json.dumps(cp))
     rc = cli.main(["write-checkpoint", "--project", "/p/A"])
     assert rc == 0
-    ck = store.read_latest(project_dir="/p/A")
+    ck = store.read_latest_body(project_dir="/p/A", route=store.Route.OWN_ELSE_GLOBAL,
+                                admit=store.Admit.ANY)
     dec = ck["working_context"]["recent_decisions"][0]
     assert "grounded" not in dec
 
@@ -2029,7 +2035,8 @@ def test_cli_write_checkpoint_strips_model_claimed_pinned(
     _stdin(monkeypatch, json.dumps(cp))
     rc = cli.main(["write-checkpoint", "--project", "/p/A"])
     assert rc == 0
-    ck = store.read_latest(project_dir="/p/A")
+    ck = store.read_latest_body(project_dir="/p/A", route=store.Route.OWN_ELSE_GLOBAL,
+                                admit=store.Admit.ANY)
     belief = ck["epistemic_snapshot"]["strong_beliefs"][0]
     assert "pinned" not in belief
 
@@ -2066,7 +2073,8 @@ def test_cli_write_checkpoint_downgrades_unverifiable_verbatim(
     _stdin(monkeypatch, json.dumps(cp))
     rc = cli.main(["write-checkpoint", "--project", "/p/A"])
     assert rc == 0
-    ck = store.read_latest(project_dir="/p/A")
+    ck = store.read_latest_body(project_dir="/p/A", route=store.Route.OWN_ELSE_GLOBAL,
+                                admit=store.Admit.ANY)
     dec = ck["working_context"]["recent_decisions"][0]
     assert dec["trust"] == "inferred"
     assert "quote_verified" not in dec
@@ -2090,7 +2098,8 @@ def test_cli_write_checkpoint_does_not_stamp_extraction_version(
     _stdin(monkeypatch, json.dumps(cp))
     rc = cli.main(["write-checkpoint", "--project", "/p/A"])
     assert rc == 0
-    ck = store.read_latest(project_dir="/p/A")
+    ck = store.read_latest_body(project_dir="/p/A", route=store.Route.OWN_ELSE_GLOBAL,
+                                admit=store.Admit.ANY)
     assert "extraction_version" not in ck
 
 
@@ -2402,7 +2411,8 @@ def test_cli_anchor_attach_single_match_persists(
     assert "pkg/m.py::foo" in out
 
     # The attach persisted through the normal store path: read_latest sees it.
-    latest = store.read_latest(project_dir=proj)
+    latest = store.read_latest_body(project_dir=proj, route=store.Route.OWN_ELSE_GLOBAL,
+                                    admit=store.Admit.ANY)
     belief = latest["epistemic_snapshot"]["strong_beliefs"][0]
     anchored = belief["anchored_to"]
     assert anchored["file"] == "pkg/m.py" and anchored["symbol"] == "foo"
@@ -2429,7 +2439,8 @@ def test_cli_anchor_attach_zero_matches_exits_nonzero(
     err = capsys.readouterr().err.lower()
     assert "no cognitive item" in err and "no-such-text" in err
     # Nothing was re-written: latest is untouched.
-    latest = store.read_latest(project_dir=proj)
+    latest = store.read_latest_body(project_dir=proj, route=store.Route.OWN_ELSE_GLOBAL,
+                                    admit=store.Admit.ANY)
     assert "anchored_to" not in latest["epistemic_snapshot"]["strong_beliefs"][0]
 
 
@@ -2447,7 +2458,8 @@ def test_cli_anchor_attach_multiple_matches_lists_candidates(
     err = capsys.readouterr().err
     assert "Chunk threshold for the serializer" in err
     assert "Adopt the D-007 prompt for the serializer" in err
-    latest = store.read_latest(project_dir=proj)
+    latest = store.read_latest_body(project_dir=proj, route=store.Route.OWN_ELSE_GLOBAL,
+                                    admit=store.Admit.ANY)
     for item in latest["working_context"]["open_questions"]:
         assert "anchored_to" not in item
 
@@ -2485,7 +2497,8 @@ def test_cli_anchor_attach_refuses_another_projects_checkpoint(
     # No bucket minted for proj out of another project's content.
     assert not (tmp_checkpoint_dir / store.project_slug(proj) / "latest.json").exists()
     # And the owning project's checkpoint is untouched.
-    owner = store.read_latest(project_dir=other, fallback=False)
+    owner = store.read_latest_body(project_dir=other, route=store.Route.OWN,
+                                   admit=store.Admit.ANY)
     assert "anchored_to" not in owner["epistemic_snapshot"]["strong_beliefs"][0]
 
 
@@ -2526,7 +2539,8 @@ def test_cli_anchor_attach_preserves_existing_code_owned_stamps(
                    "--project", str(proj)])
     assert rc == 0
 
-    latest = store.read_latest(project_dir=proj)
+    latest = store.read_latest_body(project_dir=proj, route=store.Route.OWN_ELSE_GLOBAL,
+                                    admit=store.Admit.ANY)
     assert latest["format_version"] == "D-000"
     assert latest["format_version"] != serializer.PROMPT_VERSION
     assert latest["created"] == "2020-01-01T00:00:00Z"
@@ -3723,7 +3737,8 @@ def test_cli_heal_of_old_session_does_not_steal_latest(
     ])
     assert cli.main(["serialize", str(older)]) == 0
 
-    assert store.read_latest()["session_id"] == "S-newer"
+    assert store.read_latest_body(route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY)["session_id"] == "S-newer"
     assert store.read_checkpoint("S-older") is not None
 
 
@@ -4425,7 +4440,9 @@ def test_serialize_carry_folds_prev_open_question(
     rc = cli.main(["serialize", str(p)])
     assert rc == 0
 
-    written = store.read_latest(project_dir=project)
+    written = store.read_latest_body(project_dir=project,
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     carried = [q for q in written["working_context"]["open_questions"]
                if q.get("text") == "quorint reconciliation loop unresolved"]
     assert len(carried) == 1
@@ -4452,7 +4469,9 @@ def test_serialize_carry_kill_switch(
     rc = cli.main(["serialize", str(p)])
     assert rc == 0
 
-    written = store.read_latest(project_dir=project)
+    written = store.read_latest_body(project_dir=project,
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     texts = {q.get("text") for q in written["working_context"]["open_questions"]}
     assert "quorint reconciliation loop unresolved" not in texts
 
@@ -4481,7 +4500,9 @@ def test_serialize_carry_ignores_other_projects_checkpoint(
     rc = cli.main(["serialize", str(p)])
     assert rc == 0
 
-    written = store.read_latest(project_dir="/p/fresh-project")
+    written = store.read_latest_body(project_dir="/p/fresh-project",
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     texts = {q.get("text") for q in written["working_context"]["open_questions"]}
     assert "quorint reconciliation loop unresolved" not in texts
 
@@ -4512,7 +4533,9 @@ def test_serialize_carry_failure_still_writes_checkpoint(
     rc = cli.main(["serialize", str(p)])
     assert rc == 0
 
-    written = store.read_latest(project_dir=project)
+    written = store.read_latest_body(project_dir=project,
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     assert written["session_id"] == "S-new"
 
 
@@ -4716,7 +4739,8 @@ def test_serialize_supersede_candidate_never_leaks_forgotten_text(
                                "contradictions_flagged": []},
     }
     store.write_checkpoint("S-prev", prev, project_dir=project)
-    stored = store.read_latest(project_dir=project, fallback=False)
+    stored = store.read_latest_body(project_dir=project, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     forgotten_id = next(
         d["id"] for d in stored["working_context"]["recent_decisions"]
         if d["text"] == _FORGOTTEN_TEXT)
@@ -4954,7 +4978,9 @@ def test_brief_withholds_resolved_item_and_notes_suppression(
     # real checkpoint's items are id-bearing by the time brief reads them —
     # resolve that exact id (the id-less fuzzy path is for legacy checkpoints
     # predating id-stamping, covered by the pure-function tests).
-    written = store.read_latest(project_dir="/repo/x")
+    written = store.read_latest_body(project_dir="/repo/x",
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     item_id = written["working_context"]["open_questions"][1]["id"]
     store.append_event(item_id, "resolved", project_dir="/repo/x")
     rc = cli.main(["brief", "--project", "/repo/x"])
@@ -5047,7 +5073,9 @@ def test_status_suppressed_lists_withheld_item(tmp_checkpoint_dir, sample_checkp
     # rather than reimplementing the classification.
     from daimon_briefing import store
     store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
-    written = store.read_latest(project_dir="/repo/x")
+    written = store.read_latest_body(project_dir="/repo/x",
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     item = written["working_context"]["open_questions"][1]
     item_id = item["id"]
     store.append_event(item_id, "resolved", project_dir="/repo/x")
@@ -5068,7 +5096,9 @@ def test_status_suppressed_lists_withheld_strong_belief(tmp_checkpoint_dir, samp
     # resolved strong_beliefs id never suppressed. Cover the gap end-to-end.
     from daimon_briefing import store
     store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
-    written = store.read_latest(project_dir="/repo/x")
+    written = store.read_latest_body(project_dir="/repo/x",
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     item = written["epistemic_snapshot"]["strong_beliefs"][0]
     item_id = item["id"]
     store.append_event(item_id, "resolved", project_dir="/repo/x")
@@ -5100,7 +5130,9 @@ def test_brief_shows_annotation_and_status_lists_subsection(
         tmp_checkpoint_dir, sample_checkpoint, capsys):
     from daimon_briefing import store
     store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
-    written = store.read_latest(project_dir="/repo/x")
+    written = store.read_latest_body(project_dir="/repo/x",
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     item = written["working_context"]["recent_decisions"][0]
     item_id = item["id"]
     # new-id must be serializer-shaped (kind initial + hex slice) — withhold's
@@ -5131,7 +5163,9 @@ def test_transient_field_never_persisted(tmp_checkpoint_dir, sample_checkpoint, 
     # re-read the checkpoint straight off disk and confirm it never appears.
     from daimon_briefing import store
     store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
-    written = store.read_latest(project_dir="/repo/x")
+    written = store.read_latest_body(project_dir="/repo/x",
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     item_id = written["working_context"]["recent_decisions"][0]["id"]
     store.append_event(item_id, "supersede-candidate:r-9f3a2b", project_dir="/repo/x")
 
@@ -6757,7 +6791,9 @@ def test_stats_resolutions_counts_all_four_states(
         {"text": "agent claims and it stays pending"},
     ]}}
     store.write_checkpoint("S1", cp, project_dir="/repo/x")
-    written = store.read_latest(project_dir="/repo/x")
+    written = store.read_latest_body(project_dir="/repo/x",
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     human_item, verified_item, pending_item = written["working_context"]["open_questions"]
 
     assert cli.main(["resolve", human_item["id"], "--project", "/repo/x"]) == 0
@@ -6813,7 +6849,9 @@ def test_reverify_records_a_usage_tag(
     monkeypatch.setenv("DAIMON_PROJECT_DIR", "/repo/rv")
     cp = {"working_context": {"open_questions": [{"text": "close then reopen"}]}}
     store.write_checkpoint("S1", cp, project_dir="/repo/rv")
-    item = store.read_latest(project_dir="/repo/rv")[
+    item = store.read_latest_body(project_dir="/repo/rv",
+                                  route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY)[
         "working_context"]["open_questions"][0]
     assert cli.main(["resolve", item["id"], "--project", "/repo/rv"]) == 0
     assert cli.main(["reverify", item["id"], "--evidence", "checked the release page",
@@ -7930,7 +7968,8 @@ def test_loops_skips_idless_and_empty_text_items(tmp_checkpoint_dir, capsys, mon
     store.write_checkpoint("S1", cp, project_dir="/p/A")
     # Strip the id write_checkpoint stamped on the first item, blank the text
     # path via a raw edit of the stored checkpoint.
-    stored = store.read_latest(project_dir="/p/A", fallback=False)
+    stored = store.read_latest_body(project_dir="/p/A", route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     items = stored["working_context"]["open_questions"]
     items[0].pop("id", None)
     items[1]["text"] = "   "
@@ -8044,7 +8083,9 @@ def test_resolve_by_agent_candidate_never_withholds_human_resolve_still_does(
     # of item withholds exactly as it always has.
     from daimon_briefing import store
     store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
-    written = store.read_latest(project_dir="/repo/x")
+    written = store.read_latest_body(project_dir="/repo/x",
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     agent_item = written["working_context"]["open_questions"][0]
     human_item = written["working_context"]["open_questions"][1]
 
@@ -8156,7 +8197,9 @@ def test_brief_shows_agent_claim_annotation_unverified(
         tmp_checkpoint_dir, sample_checkpoint, capsys):
     from daimon_briefing import store
     store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
-    written = store.read_latest(project_dir="/repo/x")
+    written = store.read_latest_body(project_dir="/repo/x",
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     item = written["working_context"]["open_questions"][0]
     quote = "the user merged PR #6 from the GitHub UI"
     rc = cli.main(["resolve", item["id"], "--by", "agent",
@@ -8176,7 +8219,9 @@ def test_brief_ordinary_item_unaffected_by_agent_claim_render(
         tmp_checkpoint_dir, sample_checkpoint, capsys):
     from daimon_briefing import store
     store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
-    written = store.read_latest(project_dir="/repo/x")
+    written = store.read_latest_body(project_dir="/repo/x",
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     claimed = written["working_context"]["open_questions"][0]
     untouched = written["working_context"]["open_questions"][1]
     rc = cli.main(["resolve", claimed["id"], "--by", "agent",
@@ -8199,7 +8244,9 @@ def test_brief_agent_verified_item_shows_no_claim_annotation(
     # not even the item's own text.
     from daimon_briefing import capture, store
     store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
-    written = store.read_latest(project_dir="/repo/x")
+    written = store.read_latest_body(project_dir="/repo/x",
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     item = written["working_context"]["open_questions"][0]
     quote = "the user merged PR #6 from the GitHub UI"
     rc = cli.main(["resolve", item["id"], "--by", "agent",
@@ -8221,7 +8268,9 @@ def test_agent_claim_stamp_never_persisted(tmp_checkpoint_dir, sample_checkpoint
     # test): the `_agent_claim` stamp lives ONLY on withhold's returned copy.
     from daimon_briefing import store
     store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
-    written = store.read_latest(project_dir="/repo/x")
+    written = store.read_latest_body(project_dir="/repo/x",
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     item_id = written["working_context"]["open_questions"][0]["id"]
     rc = cli.main(["resolve", item_id, "--by", "agent",
                    "--evidence", "the deploy finished clean",
@@ -8555,7 +8604,8 @@ def test_cli_brief_slug_withholds_resolved_items(tmp_checkpoint_dir, sample_chec
     cp = json.loads(json.dumps(sample_checkpoint))
     cp["session_id"] = "S-b"
     store.write_checkpoint("S-b", cp, project_dir="/p/B")
-    written = store.read_latest(project_dir="/p/B", fallback=False)
+    written = store.read_latest_body(project_dir="/p/B", route=store.Route.OWN,
+                                     admit=store.Admit.ANY)
     iid = written["working_context"]["open_questions"][0]["id"]
     q_text = written["working_context"]["open_questions"][0]["text"]
     store.append_event(iid, "resolved", project_dir="/p/B")
@@ -8730,7 +8780,8 @@ def test_forget_removes_item_from_live_checkpoint(tmp_checkpoint_dir, capsys, mo
     cp = _write_cp_with_ids(store)
     iid = cp["working_context"]["open_questions"][0]["id"]
     assert cli.main(["forget", iid, "--reason", "user request"]) == 0
-    after = store.read_latest(project_dir="/p/A", fallback=False)
+    after = store.read_latest_body(project_dir="/p/A", route=store.Route.OWN,
+                                   admit=store.Admit.ANY)
     ids = [i.get("id") for i in after["working_context"]["open_questions"]]
     assert iid not in ids
 
@@ -8757,7 +8808,8 @@ def test_forget_ambiguous_refuses_without_write(tmp_checkpoint_dir, capsys, monk
     _write_cp_with_ids(store)
     assert cli.main(["forget", "the"]) == 1
     assert store.resolutions(project_dir="/p/A") == {}
-    before = store.read_latest(project_dir="/p/A", fallback=False)
+    before = store.read_latest_body(project_dir="/p/A", route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     assert len(before["working_context"]["open_questions"]) >= 1
 
 
@@ -8766,11 +8818,13 @@ def test_forget_dry_run_writes_nothing(tmp_checkpoint_dir, capsys, monkeypatch):
     monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
     cp = _write_cp_with_ids(store)
     iid = cp["working_context"]["open_questions"][0]["id"]
-    n_before = len(store.read_latest(project_dir="/p/A", fallback=False)
+    n_before = len(store.read_latest_body(project_dir="/p/A", route=store.Route.OWN,
+                                          admit=store.Admit.ANY)
                    ["working_context"]["open_questions"])
     assert cli.main(["forget", iid, "--dry-run"]) == 0
     assert store.resolutions(project_dir="/p/A") == {}
-    after = store.read_latest(project_dir="/p/A", fallback=False)
+    after = store.read_latest_body(project_dir="/p/A", route=store.Route.OWN,
+                                   admit=store.Admit.ANY)
     assert len(after["working_context"]["open_questions"]) == n_before
 
 
@@ -8824,7 +8878,8 @@ def test_forget_by_unique_fuzzy_query(tmp_checkpoint_dir, capsys, monkeypatch):
     iid = cp["working_context"]["open_questions"][0]["id"]
     assert cli.main(["forget", "release pipeline manual approval",
                      "--reason", "example"]) == 0
-    after = store.read_latest(project_dir="/p/A", fallback=False)
+    after = store.read_latest_body(project_dir="/p/A", route=store.Route.OWN,
+                                   admit=store.Admit.ANY)
     ids = [i.get("id") for i in after["working_context"]["open_questions"]]
     assert iid not in ids
     assert store.resolutions(project_dir="/p/A")[iid]["status"].startswith("forgotten:")
@@ -8867,7 +8922,8 @@ def test_forget_cache_purge_failure_warns_but_still_succeeds(
 
     monkeypatch.setattr(cli.serializer, "purge_chunk_cache", boom)
     assert cli.main(["forget", iid]) == 0  # forget itself still succeeds
-    after = store.read_latest(project_dir="/p/A", fallback=False)
+    after = store.read_latest_body(project_dir="/p/A", route=store.Route.OWN,
+                                   admit=store.Admit.ANY)
     assert iid not in [i.get("id")
                        for i in after["working_context"]["open_questions"]]
     out = capsys.readouterr().out
@@ -9567,7 +9623,9 @@ def test_write_checkpoint_carries_prev_open_question(tmp_checkpoint_dir, monkeyp
     rc = cli.main(["write-checkpoint", "--project", project])
     assert rc == 0
 
-    written = store.read_latest(project_dir=project)
+    written = store.read_latest_body(project_dir=project,
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     carried = [q for q in written["working_context"]["open_questions"]
                if q.get("text") == "quorint reconciliation loop unresolved"]
     assert len(carried) == 1
@@ -9589,7 +9647,8 @@ def test_write_checkpoint_carry_survives_a_concurrent_session(
     _stdin(monkeypatch, _valid_json("S-session-B"))
     assert cli.main(["write-checkpoint", "--project", project]) == 0
 
-    written = store.read_latest(project_dir=project, fallback=False)
+    written = store.read_latest_body(project_dir=project, route=store.Route.OWN,
+                                     admit=store.Admit.ANY)
     assert written["session_id"] == "S-session-B"
     origins = {q.get("origin_session")
                for q in written["working_context"]["open_questions"]}
@@ -9611,7 +9670,8 @@ def test_write_checkpoint_carry_ignores_other_projects_checkpoint(
     rc = cli.main(["write-checkpoint", "--project", "/p/fresh-intro"])
     assert rc == 0
 
-    written = store.read_latest(project_dir="/p/fresh-intro", fallback=False)
+    written = store.read_latest_body(project_dir="/p/fresh-intro",
+                                     route=store.Route.OWN, admit=store.Admit.ANY)
     texts = {q.get("text") for q in written["working_context"]["open_questions"]}
     assert "quorint reconciliation loop unresolved" not in texts
 
@@ -9627,7 +9687,9 @@ def test_write_checkpoint_carry_kill_switch(tmp_checkpoint_dir, monkeypatch):
     _stdin(monkeypatch, _valid_json("S-intro"))
     assert cli.main(["write-checkpoint", "--project", project]) == 0
 
-    written = store.read_latest(project_dir=project)
+    written = store.read_latest_body(project_dir=project,
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     texts = {q.get("text") for q in written["working_context"]["open_questions"]}
     assert "quorint reconciliation loop unresolved" not in texts
 
@@ -9649,7 +9711,9 @@ def test_write_checkpoint_carry_failure_still_writes_checkpoint(
     _stdin(monkeypatch, _valid_json("S-intro"))
     assert cli.main(["write-checkpoint", "--project", project]) == 0
 
-    written = store.read_latest(project_dir=project)
+    written = store.read_latest_body(project_dir=project,
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     assert written["session_id"] == "S-intro"
 
 

--- a/plugin/tests/test_corroboration.py
+++ b/plugin/tests/test_corroboration.py
@@ -231,7 +231,8 @@ def _seed_origin(project=PROJECT, session=ORIGIN, text=_TEXT):
         },
         "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []},
     }, project_dir=project)
-    stored = store.read_latest(project_dir=project, fallback=False)
+    stored = store.read_latest_body(project_dir=project, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     return stored["working_context"]["open_questions"][0]["id"]
 
 
@@ -429,7 +430,8 @@ def _corroborated_checkpoint(session="S-old", text=_TEXT, project=PROJECT):
         },
         "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []},
     }, project_dir=project)
-    stored = store.read_latest(project_dir=project, fallback=False)
+    stored = store.read_latest_body(project_dir=project, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     item_id = stored["working_context"]["open_questions"][0]["id"]
     assert store.append_event(store.corroboration_ref(item_id),
                               f"corroborated-by:{OBSERVER}",
@@ -631,7 +633,8 @@ def test_corroboration_survives_carry_and_accumulates_across_sessions(
     assert entry["latest_demotion_ts"] is None
     # The claim is still a live, single item — never resolved by its own
     # corroboration, never duplicated by the rewording.
-    latest = store.read_latest(project_dir=E2E_PROJECT, fallback=False)
+    latest = store.read_latest_body(project_dir=E2E_PROJECT, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     questions = latest["working_context"]["open_questions"]
     assert len(questions) == 1
     assert questions[0]["id"] == next(iter(fold))
@@ -702,7 +705,8 @@ def test_carry_merge_still_runs_when_corroboration_emission_explodes(
                         fake_chat_factory(_extraction(session, _PREV_TEXT)))
     assert cli.main(["serialize", str(_transcript_for(tmp_path, session))]) == 0
 
-    written = store.read_latest(project_dir=E2E_PROJECT, fallback=False)
+    written = store.read_latest_body(project_dir=E2E_PROJECT, route=store.Route.OWN,
+                                     admit=store.Admit.ANY)
     assert written["session_id"] == session
     texts = [q["text"] for q in written["working_context"]["open_questions"]]
     assert "an unrelated prior loop about zephyr batching" in texts
@@ -832,7 +836,8 @@ def test_the_stamp_is_transient_and_never_reaches_disk(tmp_checkpoint_dir):
     assert marked["working_context"]["open_questions"][0]["_corroborated"] == 2
     # Pure: the caller's own dict is untouched, and so is the file.
     assert "_corroborated" not in stored["working_context"]["open_questions"][0]
-    fresh = store.read_latest(project_dir=PROJECT, fallback=False)
+    fresh = store.read_latest_body(project_dir=PROJECT, route=store.Route.OWN,
+                                   admit=store.Admit.ANY)
     assert "_corroborated" not in fresh["working_context"]["open_questions"][0]
 
 
@@ -1016,7 +1021,8 @@ def test_an_echoed_briefing_item_never_self_corroborates_end_to_end(
     # refusal and not a capture that never happened. And the reason it refused
     # is on the record: the quote lived only in daimon's own output, so the
     # item is inferred and flagged, never a fresh verbatim.
-    written = store.read_latest(project_dir=_ECHO_PROJECT, fallback=False)
+    written = store.read_latest_body(project_dir=_ECHO_PROJECT, route=store.Route.OWN,
+                                     admit=store.Admit.ANY)
     item = next(q for q in written["working_context"]["open_questions"]
                 if q["text"] == _PREV_TEXT)
     assert item["trust"] == "inferred"
@@ -1247,7 +1253,8 @@ def test_ledger_rows_on_disk_do_not_reorder_a_briefing(tmp_checkpoint_dir):
             "recent_decisions": []},
         "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []},
     }, project_dir=PROJECT)
-    stored = store.read_latest(project_dir=PROJECT, fallback=False)
+    stored = store.read_latest_body(project_dir=PROJECT, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     weak = stored["working_context"]["open_questions"][0]["id"]
 
     def _order():

--- a/plugin/tests/test_crash_log_privacy.py
+++ b/plugin/tests/test_crash_log_privacy.py
@@ -359,7 +359,8 @@ def test_forget_survives_a_purge_that_raises(tmp_checkpoint_dir, monkeypatch,
     assert cli.main(["forget", CANARY, "--project", PROJECT]) == 0
     out = capsys.readouterr().out
     assert "purge exploded" in out, "a swallowed failure is an invisible leak"
-    latest = store.read_latest(project_dir=PROJECT, fallback=False)
+    latest = store.read_latest_body(project_dir=PROJECT, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     texts = [i["text"] for i
              in latest["working_context"]["recent_decisions"]]
     assert texts == [KEEPER], "the checkpoint scrub must survive the blowup"

--- a/plugin/tests/test_deletion_durability_protocol.py
+++ b/plugin/tests/test_deletion_durability_protocol.py
@@ -166,7 +166,8 @@ def _resolved():
 
 
 def _carry_decisions(new_created):
-    prev = store.read_latest(project_dir=_P, fallback=False)
+    prev = store.read_latest_body(project_dir=_P, route=store.Route.OWN,
+                                  admit=store.Admit.ANY)
     new_cp = {
         "session_id": "carry-probe",
         "created": new_created,
@@ -238,7 +239,8 @@ def test_deletion_durability_protocol(tmp_checkpoint_dir, monkeypatch,
 
     # --- Step 1: write a distinctive fact through the serializer -----------
     _serialize_and_write("S1", "2026-07-01T00:00:00Z", fake_chat_factory)
-    stored1 = store.read_latest(project_dir=_P, fallback=False)
+    stored1 = store.read_latest_body(project_dir=_P, route=store.Route.OWN,
+                                     admit=store.Admit.ANY)
     x_id = next(d["id"] for d in stored1["working_context"]["recent_decisions"]
                 if d["text"] == _S)
 
@@ -268,7 +270,8 @@ def test_deletion_durability_protocol(tmp_checkpoint_dir, monkeypatch,
     res = store.resolutions(project_dir=_P)
     assert x_id in res and res[x_id]["status"].startswith("forgotten:")
 
-    stored2 = store.read_latest(project_dir=_P, fallback=False)
+    stored2 = store.read_latest_body(project_dir=_P, route=store.Route.OWN,
+                                     admit=store.Admit.ANY)
     assert _S not in _brief_decisions(stored2)          # gone
     assert _T in _brief_decisions(stored2)              # liveness
     c2 = _carry_decisions("2026-07-03T00:00:00Z")
@@ -294,7 +297,8 @@ def test_deletion_durability_protocol(tmp_checkpoint_dir, monkeypatch,
     refed_texts = [d["text"] for d in refed["working_context"]["recent_decisions"]]
     assert _S in refed_texts and _T in refed_texts      # extractor re-produced both
 
-    stored3 = store.read_latest(project_dir=_P, fallback=False)
+    stored3 = store.read_latest_body(project_dir=_P, route=store.Route.OWN,
+                                     admit=store.Admit.ANY)
     assert _S not in _latest_raw()                       # dropped at the boundary
     assert _T in _latest_raw()                           # twin persisted to disk
     assert _S not in _brief_decisions(stored3) and _T in _brief_decisions(stored3)
@@ -320,7 +324,8 @@ def test_deletion_durability_protocol(tmp_checkpoint_dir, monkeypatch,
     monkeypatch.delenv("DAIMON_TEAM", raising=False)
 
     # --- Step 7: derived artifact — the rendered brief STRING ------------
-    stored7 = store.read_latest(project_dir=_P, fallback=False)
+    stored7 = store.read_latest_body(project_dir=_P, route=store.Route.OWN,
+                                     admit=store.Admit.ANY)
     rendered = briefing.render(stored7)
     assert rendered is not None
     assert _S not in rendered and _T in rendered
@@ -389,7 +394,8 @@ def test_step3_transcript_refeed_never_resurrects(tmp_checkpoint_dir, monkeypatc
     monkeypatch.setenv("DAIMON_PROJECT_DIR", _P)
 
     _serialize_and_write("A1", "2026-07-01T00:00:00Z", fake_chat_factory)
-    stored = store.read_latest(project_dir=_P, fallback=False)
+    stored = store.read_latest_body(project_dir=_P, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     x_id = next(d["id"] for d in stored["working_context"]["recent_decisions"]
                 if d["text"] == _S)
     assert cli.main(["forget", x_id]) == 0
@@ -412,7 +418,8 @@ def test_step9_receipt_binds_post_deletion_bytes(tmp_checkpoint_dir, monkeypatch
     monkeypatch.setenv("DAIMON_PROJECT_DIR", _P)
 
     _serialize_and_write("R1", "2026-07-01T00:00:00Z", fake_chat_factory)
-    stored = store.read_latest(project_dir=_P, fallback=False)
+    stored = store.read_latest_body(project_dir=_P, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     x_id = next(d["id"] for d in stored["working_context"]["recent_decisions"]
                 if d["text"] == _S)
 

--- a/plugin/tests/test_forget_field_residue.py
+++ b/plugin/tests/test_forget_field_residue.py
@@ -48,7 +48,8 @@ def _forget_canary():
 
 
 def _live_decisions():
-    cp = store.read_latest(project_dir=PROJECT, fallback=False)
+    cp = store.read_latest_body(project_dir=PROJECT, route=store.Route.OWN,
+                                admit=store.Admit.ANY)
     return (cp.get("working_context") or {}).get("recent_decisions") or []
 
 
@@ -159,7 +160,8 @@ def test_forget_drops_active_topic_carrying_the_value(tmp_checkpoint_dir):
                                  {"text": KEEPER, "trust": "inferred"}]},
     }, project_dir=PROJECT)
     _forget_canary()
-    cp = store.read_latest(project_dir=PROJECT, fallback=False)
+    cp = store.read_latest_body(project_dir=PROJECT, route=store.Route.OWN,
+                                admit=store.Admit.ANY)
     assert "active_topic" not in (cp.get("working_context") or {})
     residue = [str(p) for p in store.project_surfaces(PROJECT)
                if CANARY in p.read_text()]
@@ -175,7 +177,8 @@ def test_forget_scrubs_active_topic_quote(tmp_checkpoint_dir):
             "recent_decisions": [{"text": CANARY, "trust": "inferred"}]},
     }, project_dir=PROJECT)
     _forget_canary()
-    cp = store.read_latest(project_dir=PROJECT, fallback=False)
+    cp = store.read_latest_body(project_dir=PROJECT, route=store.Route.OWN,
+                                admit=store.Admit.ANY)
     topic = (cp.get("working_context") or {}).get("active_topic")
     assert topic and topic["text"] == KEEPER
     assert "quote" not in topic

--- a/plugin/tests/test_forget_hits.py
+++ b/plugin/tests/test_forget_hits.py
@@ -36,7 +36,8 @@ def _forget_S(monkeypatch):
     monkeypatch.setenv("DAIMON_PROJECT_DIR", _A)
     store.write_checkpoint("S1", _cp("S1", "2026-07-01T00:00:00Z", [_S, _T]),
                            project_dir=_A)
-    stored = store.read_latest(project_dir=_A, fallback=False)
+    stored = store.read_latest_body(project_dir=_A, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     x_id = next(d["id"] for d in stored["working_context"]["recent_decisions"]
                 if d["text"] == _S)
     assert cli.main(["forget", x_id]) == 0
@@ -170,7 +171,8 @@ def test_forgotten_key_lifted_by_reopen(tmp_checkpoint_dir, monkeypatch):
     monkeypatch.setenv("DAIMON_PROJECT_DIR", _A)
     store.write_checkpoint("S1", _cp("S1", "2026-07-01T00:00:00Z", [_S]),
                            project_dir=_A)
-    stored = store.read_latest(project_dir=_A, fallback=False)
+    stored = store.read_latest_body(project_dir=_A, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     x_id = stored["working_context"]["recent_decisions"][0]["id"]
     assert cli.main(["forget", x_id]) == 0
     key = normalize.content_key(_S)

--- a/plugin/tests/test_forget_reassertion_e2e.py
+++ b/plugin/tests/test_forget_reassertion_e2e.py
@@ -84,7 +84,8 @@ def test_forgotten_value_stays_gone_across_reassertion(tmp_checkpoint_dir, monke
     # --- Block 1: pre-state positive control (serialize #1) -----------------
     store.write_checkpoint("S1", _cp("S1", "2026-07-01T00:00:00Z", [_S, _T]),
                            project_dir=_A)
-    stored1 = store.read_latest(project_dir=_A, fallback=False)
+    stored1 = store.read_latest_body(project_dir=_A, route=store.Route.OWN,
+                                     admit=store.Admit.ANY)
     x_id = next(d["id"] for d in stored1["working_context"]["recent_decisions"]
                 if d["text"] == _S)
 
@@ -103,7 +104,8 @@ def test_forgotten_value_stays_gone_across_reassertion(tmp_checkpoint_dir, monke
     # A fresh session re-extracts S and T verbatim into the same field.
     store.write_checkpoint("S2", _cp("S2", "2026-07-03T00:00:00Z", [_S, _T]),
                            project_dir=_A)
-    stored2 = store.read_latest(project_dir=_A, fallback=False)
+    stored2 = store.read_latest_body(project_dir=_A, route=store.Route.OWN,
+                                     admit=store.Admit.ANY)
 
     # id stability is the guarantee: the re-extracted S keys to the SAME id.
     probe = _cp("probe", "2026-07-03T00:00:00Z", [_S])
@@ -149,7 +151,8 @@ def test_forgotten_value_stays_gone_across_reassertion(tmp_checkpoint_dir, monke
     recall.rebuild()
     store.write_checkpoint("S3", _cp("S3", "2026-07-06T00:00:00Z", [_S, _T]),
                            project_dir=_A)
-    stored3 = store.read_latest(project_dir=_A, fallback=False)
+    stored3 = store.read_latest_body(project_dir=_A, route=store.Route.OWN,
+                                     admit=store.Admit.ANY)
     assert _S not in _brief_decisions(stored3) and _T in _brief_decisions(stored3)
     c3 = _carry_decisions("2026-07-07T00:00:00Z", stored3, _A)
     assert _S not in c3 and _T in c3
@@ -171,7 +174,8 @@ def test_forget_dual_write_copy_never_carries_forgotten_value(tmp_checkpoint_dir
 
     store.write_checkpoint("T1", _cp("T1", "2026-07-01T00:00:00Z", [_S, _T]),
                            project_dir=_A)
-    stored = store.read_latest(project_dir=_A, fallback=False)
+    stored = store.read_latest_body(project_dir=_A, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     x_id = next(d["id"] for d in stored["working_context"]["recent_decisions"]
                 if d["text"] == _S)
     assert cli.main(["forget", x_id]) == 0

--- a/plugin/tests/test_forget_refutations.py
+++ b/plugin/tests/test_forget_refutations.py
@@ -93,7 +93,8 @@ def _fuzzy_arm(project, with_refutations):
             _refute(subject=subject, scope=f"scope-{index}",
                     project_dir=project)
     rc = cli.main(["forget", _FUZZY_QUERY, "--project", project])
-    stored = store.read_latest(project_dir=project, fallback=False) or {}
+    stored = store.read_latest_body(project_dir=project, route=store.Route.OWN,
+                                    admit=store.Admit.ANY) or {}
     survivors = [i.get("text") for i in
                  stored.get("working_context", {}).get("recent_decisions", [])]
     return rc, survivors
@@ -143,13 +144,15 @@ def test_a_contaminating_ledger_still_leaves_exact_id_forget_working(
                 project_dir=project)
     for index, subject in enumerate(_NOISE):
         _refute(subject=subject, scope=f"scope-{index}", project_dir=project)
-    stored = store.read_latest(project_dir=project, fallback=False)
+    stored = store.read_latest_body(project_dir=project, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     item_id = stored["working_context"]["recent_decisions"][0]["id"]
 
     assert cli.main(["forget", item_id, "--project", project]) == 0
 
     left = [i.get("text") for i in
-            (store.read_latest(project_dir=project, fallback=False) or {})
+            (store.read_latest_body(project_dir=project, route=store.Route.OWN,
+                                    admit=store.Admit.ANY) or {})
             .get("working_context", {}).get("recent_decisions", [])]
     assert _FUZZY_TARGET not in left
 
@@ -216,7 +219,8 @@ def test_forget_takes_the_checkpoint_item_and_the_matching_refutation_together(
 
     assert cli.main(["forget", SUBJECT, "--project", PROJECT]) == 0
 
-    stored = store.read_latest(project_dir=PROJECT, fallback=False)
+    stored = store.read_latest_body(project_dir=PROJECT, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     assert not stored["working_context"]["recent_decisions"]
     assert SUBJECT not in _ledger_text()
     assert refutations.get(ref_id, project_dir=PROJECT) is None
@@ -229,7 +233,8 @@ def test_forget_refuses_when_an_id_matches_a_decision_and_a_refutation(
     # picking either surface silently would delete the wrong thing.
     monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
     _checkpoint("an unrelated decision about logging")
-    stored = store.read_latest(project_dir=PROJECT, fallback=False)
+    stored = store.read_latest_body(project_dir=PROJECT, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     decision_id = stored["working_context"]["recent_decisions"][0]["id"]
     assert decision_id.startswith("r-")
 
@@ -257,7 +262,8 @@ def test_forget_refuses_when_an_id_matches_a_decision_and_a_refutation(
     # Nothing was removed from either surface.
     assert refutations.get(collided, project_dir=PROJECT) is not None
     assert refutations.get(ref_id, project_dir=PROJECT) is not None
-    stored = store.read_latest(project_dir=PROJECT, fallback=False)
+    stored = store.read_latest_body(project_dir=PROJECT, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     assert stored["working_context"]["recent_decisions"]
 
 
@@ -686,7 +692,8 @@ def test_dry_run_names_amendments_keyed_to_the_doomed_item(
     from daimon_briefing import amendments
     monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
     _checkpoint("we ship the queue rewrite before the freeze")
-    stored = store.read_latest(project_dir=PROJECT, fallback=False)
+    stored = store.read_latest_body(project_dir=PROJECT, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     item_id = stored["working_context"]["recent_decisions"][0]["id"]
     a_id = amendments.propose(
         item_id=item_id, change="progressed",
@@ -714,7 +721,8 @@ def test_dry_run_names_spliced_checkpoint_siblings(
             "recent_decisions": [{"text": shared, "trust": "inferred"}],
             "open_questions": [{"text": shared, "trust": "inferred"}]},
     }, project_dir=PROJECT)
-    stored = store.read_latest(project_dir=PROJECT, fallback=False)
+    stored = store.read_latest_body(project_dir=PROJECT, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     ids = {stored["working_context"]["recent_decisions"][0]["id"],
            stored["working_context"]["open_questions"][0]["id"]}
 
@@ -735,7 +743,8 @@ def test_dry_run_previews_amendments_of_a_superseded_item(
     monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
     doomed_text = "we ship the queue rewrite before the freeze"
     _checkpoint(doomed_text)
-    stored = store.read_latest(project_dir=PROJECT, fallback=False)
+    stored = store.read_latest_body(project_dir=PROJECT, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     item_id = stored["working_context"]["recent_decisions"][0]["id"]
     a_id = amendments.propose(
         item_id=item_id, change="progressed",

--- a/plugin/tests/test_forget_sibling_ids.py
+++ b/plugin/tests/test_forget_sibling_ids.py
@@ -43,7 +43,8 @@ def _latest_raw(project_dir):
 
 
 def _build_blob(project_dir):
-    cp = store.read_latest(project_dir=project_dir, fallback=False)
+    cp = store.read_latest_body(project_dir=project_dir, route=store.Route.OWN,
+                                admit=store.Admit.ANY)
     return json.dumps(briefing.build(cp, now=_NOW))
 
 
@@ -76,7 +77,8 @@ def test_forget_scrubs_same_value_sibling_in_another_section(tmp_checkpoint_dir,
             "open_questions": [_item(_S)],
         },
     }, project_dir=_P)
-    stored = store.read_latest(project_dir=_P, fallback=False)
+    stored = store.read_latest_body(project_dir=_P, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     d_id = next(i["id"] for i in stored["working_context"]["recent_decisions"]
                 if i["text"] == _S)
     q_id = next(i["id"] for i in stored["working_context"]["open_questions"]
@@ -100,7 +102,8 @@ def test_forget_scrubs_widened_hash_sibling_within_one_section(tmp_checkpoint_di
             "recent_decisions": [_item(_S), _item(_S), _item(_T)],
         },
     }, project_dir=_P)
-    stored = store.read_latest(project_dir=_P, fallback=False)
+    stored = store.read_latest_body(project_dir=_P, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     ids = [i["id"] for i in stored["working_context"]["recent_decisions"]
            if i["text"] == _S]
     assert len(ids) == 2 and ids[0] != ids[1]   # widened-hash siblings
@@ -124,7 +127,8 @@ def test_forget_sibling_path_keeps_tombstone_and_normal_output(tmp_checkpoint_di
             "open_questions": [_item(_S)],
         },
     }, project_dir=_P)
-    stored = store.read_latest(project_dir=_P, fallback=False)
+    stored = store.read_latest_body(project_dir=_P, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     d_id = next(i["id"] for i in stored["working_context"]["recent_decisions"]
                 if i["text"] == _S)
 

--- a/plugin/tests/test_hooks.py
+++ b/plugin/tests/test_hooks.py
@@ -92,7 +92,8 @@ def test_on_session_end_writes_checkpoint(tmp_checkpoint_dir, fake_chat_factory,
         session_id="S-end", completed=True, interrupted=False, model="m", platform="cli"
     )
     assert store.read_checkpoint("S-end") is not None
-    assert store.read_latest()["session_id"] == "S-end"
+    assert store.read_latest_body(route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY)["session_id"] == "S-end"
 
 
 def test_on_session_end_strips_model_supplied_format_version(
@@ -601,7 +602,9 @@ def test_pre_llm_call_withholds_resolved_item(tmp_checkpoint_dir, sample_checkpo
 
     monkeypatch.setenv("DAIMON_PROJECT_DIR", "/repo/x")
     store.write_checkpoint("S-prev", sample_checkpoint, project_dir="/repo/x")
-    written = store.read_latest(project_dir="/repo/x")
+    written = store.read_latest_body(project_dir="/repo/x",
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
     item_id = written["working_context"]["open_questions"][1]["id"]
     store.append_event(item_id, "resolved", project_dir="/repo/x")
     out = hooks.pre_llm_call(

--- a/plugin/tests/test_policy.py
+++ b/plugin/tests/test_policy.py
@@ -82,14 +82,16 @@ def test_write_checkpoint_drops_reasserted_secret_via_redacted_tombstone(
     monkeypatch.setenv("DAIMON_PROJECT_DIR", _A)
     store.write_checkpoint("S1", _cp("S1", "2026-07-01T00:00:00Z", [_SECRET_RAW]),
                            project_dir=_A)
-    stored = store.read_latest(project_dir=_A, fallback=False)
+    stored = store.read_latest_body(project_dir=_A, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     item = stored["working_context"]["recent_decisions"][0]
     assert "[redacted:aws-key]" in item["text"]  # the tombstone keys on THIS form
     assert cli.main(["forget", item["id"]]) == 0
 
     store.write_checkpoint("S2", _cp("S2", "2026-07-03T00:00:00Z", [_SECRET_RAW, _T]),
                            project_dir=_A)
-    latest = store.read_latest(project_dir=_A, fallback=False)
+    latest = store.read_latest_body(project_dir=_A, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     assert latest["session_id"] == "S2"
     assert [d["text"] for d in latest["working_context"]["recent_decisions"]] == [_T]
 
@@ -144,7 +146,8 @@ def test_disabled_forget_still_removes_value_and_appends_tombstone(
     monkeypatch.setenv("DAIMON_PROJECT_DIR", _A)
     store.write_checkpoint("S1", _cp("S1", "2026-07-01T00:00:00Z", [_S, _T]),
                            project_dir=_A)
-    stored = store.read_latest(project_dir=_A, fallback=False)
+    stored = store.read_latest_body(project_dir=_A, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     x_id = next(d["id"] for d in stored["working_context"]["recent_decisions"]
                 if d["text"] == _S)
 
@@ -152,7 +155,8 @@ def test_disabled_forget_still_removes_value_and_appends_tombstone(
     assert cli.main(["forget", x_id]) == 0
 
     # the value left the live checkpoint on disk (latest AND per-session file)
-    latest = store.read_latest(project_dir=_A, fallback=False)
+    latest = store.read_latest_body(project_dir=_A, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     texts = [d["text"] for d in latest["working_context"]["recent_decisions"]]
     assert _S not in texts and _T in texts
     per_session = store.read_checkpoint("S1")
@@ -460,8 +464,8 @@ def test_write_checkpoint_binds_origin_to_the_writing_session_and_author(
     monkeypatch.setenv("DAIMON_AUTHOR", "ada")
     store.write_checkpoint("S1", _cp("S1", "2026-07-01T00:00:00Z", [_S]),
                            project_dir=_A)
-    item = store.read_latest(project_dir=_A,
-                             fallback=False)["working_context"]["recent_decisions"][0]
+    item = store.read_latest_body(project_dir=_A, route=store.Route.OWN,
+                                  admit=store.Admit.ANY)["working_context"]["recent_decisions"][0]
     assert item["origin_session"] == "S1"
     assert item["origin_author"] == "ada"
 
@@ -481,7 +485,8 @@ def test_origin_survives_two_carry_hops_while_carried_from_only_names_the_last(
 
     def _write_with_carry(sid, created, texts):
         cp = _cp(sid, created, texts)
-        prev = _store.read_latest(project_dir=_A, fallback=False)
+        prev = _store.read_latest_body(project_dir=_A, route=store.Route.OWN,
+                                       admit=store.Admit.ANY)
         cp = carry.merge(cp, prev, _store._created_epoch(created),
                          floor=config.carry_floor(), cap=config.carry_max(),
                          resolved=frozenset())
@@ -493,7 +498,8 @@ def test_origin_survives_two_carry_hops_while_carried_from_only_names_the_last(
                       ["adopt sqlite for the recall index cache layer"])
     _write_with_carry("S-C", "2026-07-03T00:00:00Z", [_T])
 
-    latest = _store.read_latest(project_dir=_A, fallback=False)
+    latest = _store.read_latest_body(project_dir=_A, route=store.Route.OWN,
+                                     admit=store.Admit.ANY)
     sqlite_item = next(d for d in latest["working_context"]["recent_decisions"]
                        if "sqlite" in d["text"])
     assert sqlite_item.get("carried_from") in ("S-B", "S-C")

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -1435,7 +1435,8 @@ def test_resolve_event_invalidates_index_without_manual_rebuild(tmp_checkpoint_d
     hits = recall.search("walrus", project_dir="/repo/x")
     assert hits and hits[0]["superseded_by"] is None  # indexed live
 
-    iid = store.read_latest(project_dir="/repo/x", fallback=False)[
+    iid = store.read_latest_body(project_dir="/repo/x", route=store.Route.OWN,
+                                 admit=store.Admit.ANY)[
         "working_context"]["open_questions"][0]["id"]
     store.append_event(iid, "resolved", project_dir="/repo/x")
 
@@ -1448,7 +1449,8 @@ def test_reopen_event_revives_item_without_manual_rebuild(tmp_checkpoint_dir, mo
     cp = {"working_context": {"open_questions": [
         {"text": "narwhal question pending", "trust": "inferred"}]}}
     store.write_checkpoint("S-fp2", cp, project_dir="/repo/x")
-    iid = store.read_latest(project_dir="/repo/x", fallback=False)[
+    iid = store.read_latest_body(project_dir="/repo/x", route=store.Route.OWN,
+                                 admit=store.Admit.ANY)[
         "working_context"]["open_questions"][0]["id"]
     store.append_event(iid, "resolved", project_dir="/repo/x")
     hits = recall.search("narwhal", project_dir="/repo/x")
@@ -1506,7 +1508,8 @@ def _one_question_bucket(text, sid, project="/repo/x"):
     cp = {"working_context": {"open_questions": [
         {"text": text, "trust": "inferred"}]}}
     store.write_checkpoint(sid, cp, project_dir=project)
-    return store.read_latest(project_dir=project, fallback=False)[
+    return store.read_latest_body(project_dir=project, route=store.Route.OWN,
+                                  admit=store.Admit.ANY)[
         "working_context"]["open_questions"][0]["id"]
 
 
@@ -1677,7 +1680,8 @@ def test_rebuild_drops_forgotten_items_from_index(tmp_checkpoint_dir, monkeypatc
                               "trust": "inferred"}]),
         project_dir="/repo/x",
     )
-    cp = store.read_latest(project_dir="/repo/x", fallback=False)
+    cp = store.read_latest_body(project_dir="/repo/x", route=store.Route.OWN,
+                                admit=store.Admit.ANY)
     iid = cp["working_context"]["recent_decisions"][0]["id"]
     store.append_event(iid, "forgotten:deadbeef1234", kind="tombstone",
                        project_dir="/repo/x")
@@ -1815,7 +1819,8 @@ def test_rebuild_scrubs_forgotten_value_sibling_id_in_older_session(
         _cp("S2", questions=[{"text": s, "trust": "inferred"}],
             created="2026-07-31T00:00:00Z"),
         project_dir="/repo/x")
-    latest = store.read_latest(project_dir="/repo/x", fallback=False)
+    latest = store.read_latest_body(project_dir="/repo/x", route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     q_id = next(i["id"] for i in latest["working_context"]["open_questions"]
                 if i["text"] == s)
     old_file = config.checkpoint_dir() / "S1.json"

--- a/plugin/tests/test_relations.py
+++ b/plugin/tests/test_relations.py
@@ -701,7 +701,8 @@ def test_cli_forget_scrubs_relations_and_reports_them(
                 {"text": "adopt sqlite for the relations cache",
                  "trust": "inferred"}]},
     }, project_dir=project)
-    stored = store.read_latest(project_dir=project, fallback=False)
+    stored = store.read_latest_body(project_dir=project, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     item_id = stored["working_context"]["recent_decisions"][0]["id"]
     rel_id = relations.propose(
         type_="revision-of",

--- a/plugin/tests/test_relations_cli.py
+++ b/plugin/tests/test_relations_cli.py
@@ -26,7 +26,8 @@ def seeded(tmp_checkpoint_dir, monkeypatch):
                 {"text": "adjudicate candidates through the tty path",
                  "trust": "inferred"}]},
     }, project_dir=PROJECT)
-    stored = store.read_latest(project_dir=PROJECT, fallback=False)
+    stored = store.read_latest_body(project_dir=PROJECT, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     ids = [i["id"] for i in stored["working_context"]["recent_decisions"]]
     rel_id = relations.propose(
         type_="revision-of",

--- a/plugin/tests/test_ruling_echo.py
+++ b/plugin/tests/test_ruling_echo.py
@@ -312,7 +312,8 @@ def test_anchor_attach_rewrite_never_echo_drops(tmp_checkpoint_dir, tmp_path,
                    "--attach", "unrelated belief survives",
                    "--project", str(proj)])
     assert rc == 0
-    out = store.read_latest(project_dir=proj)
+    out = store.read_latest_body(project_dir=proj, route=store.Route.OWN_ELSE_GLOBAL,
+                                 admit=store.Admit.ANY)
     beliefs = [i["text"] for i in out["epistemic_snapshot"]["strong_beliefs"]]
     assert VERDICT in beliefs
 
@@ -325,12 +326,15 @@ def test_forget_rewrite_never_echo_drops(tmp_checkpoint_dir, monkeypatch,
     store.write_checkpoint("S-echo", _checkpoint(), project_dir=PROJECT)
     _active_ruling()
     monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
-    stored = store.read_latest(project_dir=PROJECT)
+    stored = store.read_latest_body(project_dir=PROJECT,
+                                    route=store.Route.OWN_ELSE_GLOBAL,
+                                    admit=store.Admit.ANY)
     doomed = next(i["id"] for i in
                   stored["epistemic_snapshot"]["strong_beliefs"]
                   if i["text"] == "an unrelated belief survives")
     assert cli.main(["forget", doomed]) == 0
-    out = store.read_latest(project_dir=PROJECT)
+    out = store.read_latest_body(project_dir=PROJECT, route=store.Route.OWN_ELSE_GLOBAL,
+                                 admit=store.Admit.ANY)
     beliefs = [i["text"] for i in out["epistemic_snapshot"]["strong_beliefs"]]
     assert VERDICT in beliefs  # the ruling echo was NOT the forget target
 
@@ -346,6 +350,7 @@ def test_write_checkpoint_stdin_path_admits(tmp_checkpoint_dir, monkeypatch,
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(cp)))
     rc = cli.main(["write-checkpoint", "--project", PROJECT])
     assert rc == 0
-    out = store.read_latest(project_dir=PROJECT)
+    out = store.read_latest_body(project_dir=PROJECT, route=store.Route.OWN_ELSE_GLOBAL,
+                                 admit=store.Admit.ANY)
     beliefs = [i["text"] for i in out["epistemic_snapshot"]["strong_beliefs"]]
     assert VERDICT not in beliefs

--- a/plugin/tests/test_serialize_brief_e2e.py
+++ b/plugin/tests/test_serialize_brief_e2e.py
@@ -55,7 +55,9 @@ def test_every_schema_field_survives_serialize_to_brief(tmp_checkpoint_dir):
     serializer.sanitize_importance(cp)
     store.write_checkpoint("S-e2e", cp, project_dir=_PROJECT)
 
-    stored = store.read_latest(project_dir=_PROJECT)
+    stored = store.read_latest_body(project_dir=_PROJECT,
+                                    route=store.Route.OWN_ELSE_GLOBAL,
+                                    admit=store.Admit.ANY)
     assert stored is not None
 
     for f in schema.ITEM_FIELDS:

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -21,7 +21,8 @@ def test_write_then_read_round_trip(tmp_checkpoint_dir, sample_checkpoint):
 
 def test_latest_pointer_updated_on_write(tmp_checkpoint_dir, sample_checkpoint):
     store.write_checkpoint("S-prev", sample_checkpoint)
-    latest = store.read_latest()
+    latest = store.read_latest_body(route=store.Route.OWN_ELSE_GLOBAL,
+                                    admit=store.Admit.ANY)
     assert latest is not None
     assert latest["session_id"] == "S-prev"
 
@@ -29,12 +30,14 @@ def test_latest_pointer_updated_on_write(tmp_checkpoint_dir, sample_checkpoint):
 def test_latest_reflects_most_recent_write(tmp_checkpoint_dir, sample_checkpoint):
     store.write_checkpoint("S-old", {**sample_checkpoint, "session_id": "S-old"})
     store.write_checkpoint("S-new", {**sample_checkpoint, "session_id": "S-new"})
-    latest = store.read_latest()
+    latest = store.read_latest_body(route=store.Route.OWN_ELSE_GLOBAL,
+                                    admit=store.Admit.ANY)
     assert latest["session_id"] == "S-new"
 
 
 def test_read_latest_none_when_empty(tmp_checkpoint_dir):
-    assert store.read_latest() is None
+    assert store.read_latest_body(route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY) is None
 
 
 def test_read_checkpoint_none_when_missing(tmp_checkpoint_dir):
@@ -307,19 +310,26 @@ def test_read_latest_prefers_project(tmp_checkpoint_dir, sample_checkpoint):
     # The original bug: session in A, then B; returning to A must NOT see B's checkpoint.
     store.write_checkpoint("S-a", {**sample_checkpoint, "session_id": "S-a"}, project_dir="/p/A")
     store.write_checkpoint("S-b", {**sample_checkpoint, "session_id": "S-b"}, project_dir="/p/B")
-    assert store.read_latest(project_dir="/p/A")["session_id"] == "S-a"
-    assert store.read_latest(project_dir="/p/B")["session_id"] == "S-b"
+    assert store.read_latest_body(project_dir="/p/A", route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY)["session_id"] == "S-a"
+    assert store.read_latest_body(project_dir="/p/B", route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY)["session_id"] == "S-b"
     # global latest still points at the most recent write (any project)
-    assert store.read_latest()["session_id"] == "S-b"
+    assert store.read_latest_body(route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY)["session_id"] == "S-b"
 
 
 def test_read_latest_falls_back_to_global(tmp_checkpoint_dir, sample_checkpoint):
     store.write_checkpoint("S-g", {**sample_checkpoint, "session_id": "S-g"})
-    assert store.read_latest(project_dir="/p/never-seen")["session_id"] == "S-g"
+    assert store.read_latest_body(project_dir="/p/never-seen",
+                                  route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY)["session_id"] == "S-g"
 
 
 def test_read_latest_none_when_both_absent(tmp_checkpoint_dir):
-    assert store.read_latest(project_dir="/p/never-seen") is None
+    assert store.read_latest_body(project_dir="/p/never-seen",
+                                  route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY) is None
 
 
 def test_read_latest_no_fallback_skips_global(tmp_checkpoint_dir, sample_checkpoint):
@@ -327,13 +337,15 @@ def test_read_latest_no_fallback_skips_global(tmp_checkpoint_dir, sample_checkpo
     # the global pointer — a fresh project reads None, not a foreign session.
     store.write_checkpoint("S-other", {**sample_checkpoint, "session_id": "S-other"},
                            project_dir="/p/other")
-    assert store.read_latest(project_dir="/p/fresh", fallback=False) is None
+    assert store.read_latest_body(project_dir="/p/fresh", route=store.Route.OWN,
+                                  admit=store.Admit.ANY) is None
 
 
 def test_read_latest_no_fallback_still_reads_own_project(tmp_checkpoint_dir, sample_checkpoint):
     store.write_checkpoint("S-a", {**sample_checkpoint, "session_id": "S-a"},
                            project_dir="/p/A")
-    assert store.read_latest(project_dir="/p/A", fallback=False)["session_id"] == "S-a"
+    assert store.read_latest_body(project_dir="/p/A", route=store.Route.OWN,
+                                  admit=store.Admit.ANY)["session_id"] == "S-a"
 
 
 # ---- checkpoint rotation: keep last N pointers per dir (#33 Phase 1) ----
@@ -646,7 +658,8 @@ def test_dual_write_failure_does_not_break_serialize(tmp_checkpoint_dir, sample_
     monkeypatch.setattr(config, "team_dir", lambda: blocker / "team")
     out = store.write_checkpoint("S-a", sample_checkpoint)  # must NOT raise
     assert out.exists()  # local write intact
-    assert store.read_latest() is not None
+    assert store.read_latest_body(route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY) is not None
 
 
 def test_gc_ignores_team_dir(tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
@@ -1013,7 +1026,8 @@ def test_read_team_own_synced_copy_not_clamped(tmp_checkpoint_dir, sample_checkp
 def test_write_older_checkpoint_does_not_steal_global_latest(tmp_checkpoint_dir, sample_checkpoint):
     store.write_checkpoint("S-new", _stamped(sample_checkpoint, "S-new", 0))
     store.write_checkpoint("S-old", _stamped(sample_checkpoint, "S-old", 2))
-    assert store.read_latest()["session_id"] == "S-new"
+    assert store.read_latest_body(route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY)["session_id"] == "S-new"
     # the per-session checkpoint itself still lands — only the pointer is guarded
     assert store.read_checkpoint("S-old") is not None
 
@@ -1021,8 +1035,10 @@ def test_write_older_checkpoint_does_not_steal_global_latest(tmp_checkpoint_dir,
 def test_write_older_checkpoint_does_not_steal_project_latest(tmp_checkpoint_dir, sample_checkpoint):
     store.write_checkpoint("S-new", _stamped(sample_checkpoint, "S-new", 0), project_dir="/p/A")
     store.write_checkpoint("S-old", _stamped(sample_checkpoint, "S-old", 2), project_dir="/p/A")
-    assert store.read_latest(project_dir="/p/A")["session_id"] == "S-new"
-    assert store.read_latest()["session_id"] == "S-new"
+    assert store.read_latest_body(project_dir="/p/A", route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY)["session_id"] == "S-new"
+    assert store.read_latest_body(route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY)["session_id"] == "S-new"
 
 
 def test_write_older_checkpoint_guards_pointers_independently(tmp_checkpoint_dir, sample_checkpoint):
@@ -1030,14 +1046,17 @@ def test_write_older_checkpoint_guards_pointers_independently(tmp_checkpoint_dir
     # the global pointer is newer and stays put.
     store.write_checkpoint("S-new", _stamped(sample_checkpoint, "S-new", 0), project_dir="/p/A")
     store.write_checkpoint("S-old", _stamped(sample_checkpoint, "S-old", 2), project_dir="/p/B")
-    assert store.read_latest()["session_id"] == "S-new"
-    assert store.read_latest(project_dir="/p/B")["session_id"] == "S-old"
+    assert store.read_latest_body(route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY)["session_id"] == "S-new"
+    assert store.read_latest_body(project_dir="/p/B", route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY)["session_id"] == "S-old"
 
 
 def test_write_newer_checkpoint_still_takes_latest(tmp_checkpoint_dir, sample_checkpoint):
     store.write_checkpoint("S-old", _stamped(sample_checkpoint, "S-old", 2))
     store.write_checkpoint("S-new", _stamped(sample_checkpoint, "S-new", 0))
-    assert store.read_latest()["session_id"] == "S-new"
+    assert store.read_latest_body(route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY)["session_id"] == "S-new"
 
 
 def test_write_over_legacy_pointer_without_created_takes_latest(tmp_checkpoint_dir, sample_checkpoint):
@@ -1048,7 +1067,8 @@ def test_write_over_legacy_pointer_without_created_takes_latest(tmp_checkpoint_d
     legacy.pop("created", None)
     (d / "latest.json").write_text(json.dumps(legacy), encoding="utf-8")
     store.write_checkpoint("S-old", _stamped(sample_checkpoint, "S-old", 2))
-    assert store.read_latest()["session_id"] == "S-old"
+    assert store.read_latest_body(route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY)["session_id"] == "S-old"
 
 
 # ---- first_seen: per-item birth stamp, exact-text carry-over (#126) ----
@@ -1894,14 +1914,17 @@ def test_read_latest_corrupt_project_pointer_falls_through_to_global(
     pdir = tmp_checkpoint_dir / slug
     pdir.mkdir(parents=True, exist_ok=True)
     (pdir / "latest.json").write_text("{not json", encoding="utf-8")  # torn project pointer
-    got = store.read_latest(project_dir="/p/torn", fallback=True)
+    got = store.read_latest_body(project_dir="/p/torn",
+                                 route=store.Route.OWN_ELSE_GLOBAL,
+                                 admit=store.Admit.ANY)
     assert got is not None and got["session_id"] == "S-g"  # fell through, no raise
 
 
 def test_read_latest_corrupt_global_pointer_returns_none(tmp_checkpoint_dir):
     tmp_checkpoint_dir.mkdir(parents=True, exist_ok=True)
     (tmp_checkpoint_dir / "latest.json").write_text("{not json", encoding="utf-8")
-    assert store.read_latest() is None  # tolerant, no raise
+    assert store.read_latest_body(route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY) is None  # tolerant, no raise
 
 
 # ---- non-object pointer payloads (#817): valid JSON that is not a dict is absent ----
@@ -1919,7 +1942,9 @@ def test_read_latest_non_object_project_pointer_falls_through_to_global(
     pdir = tmp_checkpoint_dir / slug
     pdir.mkdir(parents=True, exist_ok=True)
     (pdir / "latest.json").write_text(payload, encoding="utf-8")
-    got = store.read_latest(project_dir="/p/nonobj", fallback=True)
+    got = store.read_latest_body(project_dir="/p/nonobj",
+                                 route=store.Route.OWN_ELSE_GLOBAL,
+                                 admit=store.Admit.ANY)
     assert got is not None and got["session_id"] == "S-g"  # absent, like torn (#139)
 
 
@@ -1931,21 +1956,25 @@ def test_read_latest_non_object_project_pointer_no_fallback_returns_none(
     pdir = tmp_checkpoint_dir / slug
     pdir.mkdir(parents=True, exist_ok=True)
     (pdir / "latest.json").write_text(payload, encoding="utf-8")
-    assert store.read_latest(project_dir="/p/nonobj", fallback=False) is None
+    assert store.read_latest_body(project_dir="/p/nonobj", route=store.Route.OWN,
+                                  admit=store.Admit.ANY) is None
 
 
 @pytest.mark.parametrize("payload", _NON_OBJECT_PAYLOADS)
 def test_read_latest_non_object_global_pointer_returns_none(tmp_checkpoint_dir, payload):
     tmp_checkpoint_dir.mkdir(parents=True, exist_ok=True)
     (tmp_checkpoint_dir / "latest.json").write_text(payload, encoding="utf-8")
-    assert store.read_latest() is None
+    assert store.read_latest_body(route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY) is None
 
 
 def test_read_latest_agrees_with_reportable_on_non_object_pointer(tmp_checkpoint_dir):
     tmp_checkpoint_dir.mkdir(parents=True, exist_ok=True)
     (tmp_checkpoint_dir / "latest.json").write_text('["x"]', encoding="utf-8")
-    assert store.read_latest() is None
-    assert store.read_latest_reportable() is None  # the two readers agree (#817)
+    assert store.read_latest_body(route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY) is None
+    assert store.read_latest_body(route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.OWN_OR_UNROUTED) is None  # the two readers agree (#817)
 
 
 # ---- transcript_unchanged (#185): identical-bytes guard ----
@@ -2282,7 +2311,8 @@ def test_read_latest_reportable_returns_the_projects_own_checkpoint(tmp_checkpoi
     mine = (tmp_path / "rlr-mine").resolve()
     mine.mkdir()
     store.write_checkpoint("S-mine", {"session_id": "S-mine"}, project_dir=str(mine))
-    got = store.read_latest_reportable(str(mine))
+    got = store.read_latest_body(str(mine), route=store.Route.OWN_ELSE_GLOBAL,
+                                 admit=store.Admit.OWN_OR_UNROUTED)
     assert (got or {}).get("session_id") == "S-mine"
 
 
@@ -2293,8 +2323,11 @@ def test_read_latest_reportable_refuses_another_projects_checkpoint(tmp_checkpoi
     mine = (tmp_path / "rlr-mine2").resolve()
     mine.mkdir()
     # read_latest WOULD hand this project the other one's checkpoint.
-    assert store.read_latest(project_dir=str(mine))["session_id"] == "S-other"
-    assert store.read_latest_reportable(str(mine)) is None
+    assert store.read_latest_body(project_dir=str(mine),
+                                  route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.ANY)["session_id"] == "S-other"
+    assert store.read_latest_body(str(mine), route=store.Route.OWN_ELSE_GLOBAL,
+                                  admit=store.Admit.OWN_OR_UNROUTED) is None
 
 
 def test_read_latest_reportable_allows_an_unrouted_checkpoint(tmp_checkpoint_dir, tmp_path):
@@ -2303,5 +2336,6 @@ def test_read_latest_reportable_allows_an_unrouted_checkpoint(tmp_checkpoint_dir
     store.write_checkpoint("S-unrouted", {"session_id": "S-unrouted"})
     mine = (tmp_path / "rlr-mine3").resolve()
     mine.mkdir()
-    got = store.read_latest_reportable(str(mine))
+    got = store.read_latest_body(str(mine), route=store.Route.OWN_ELSE_GLOBAL,
+                                 admit=store.Admit.OWN_OR_UNROUTED)
     assert (got or {}).get("session_id") == "S-unrouted"

--- a/plugin/tests/test_team_tombstone_propagation.py
+++ b/plugin/tests/test_team_tombstone_propagation.py
@@ -228,7 +228,8 @@ def test_opt_in_scrubs_local_copies(tmp_checkpoint_dir, monkeypatch):
     residue = [str(p) for p in store.project_surfaces(PROJECT)
                if THEIRS in p.read_text()]
     assert residue == [], f"plaintext survives in {residue}"
-    kept = store.read_latest(project_dir=PROJECT, fallback=False)
+    kept = store.read_latest_body(project_dir=PROJECT, route=store.Route.OWN,
+                                  admit=store.Admit.ANY)
     texts = [i["text"] for i in
              kept["working_context"]["recent_decisions"]]
     assert texts == [MINE], "only the tombstoned value goes"

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -328,7 +328,8 @@ def _setup_env(tmp_path, monkeypatch):
 
 
 def _ids_by_text(proj):
-    cp = store.read_latest(project_dir=str(proj), fallback=False)
+    cp = store.read_latest_body(project_dir=str(proj), route=store.Route.OWN,
+                                admit=store.Admit.ANY)
     out = {}
     for section, key in store._ITEM_LISTS:
         for item in ((cp or {}).get(section) or {}).get(key) or []:

--- a/plugin/tests/ui/test_server_relations.py
+++ b/plugin/tests/ui/test_server_relations.py
@@ -36,7 +36,8 @@ def rel_proj(tmp_checkpoint_dir, tmp_path, monkeypatch):
     proj = tmp_path / PROJECT_NAME
     proj.mkdir()
     store.write_checkpoint("S1", _cp("S1"), project_dir=proj)
-    stored = store.read_latest(project_dir=proj, fallback=False)
+    stored = store.read_latest_body(project_dir=proj, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
     ids = [i["id"] for i in stored["working_context"]["recent_decisions"]]
     confirmed = relations.propose(
         type_="revision-of",

--- a/research/experiments/multicycle/run_multicycle.py
+++ b/research/experiments/multicycle/run_multicycle.py
@@ -96,7 +96,9 @@ def run_arm(arm: str, cycles: int, chat, run_dir) -> list[dict]:
                 # Mirror cli.py's serialize wiring: prev read before the write
                 # rotates it; clock = the cycle's simulated stamp (scar:
                 # simulated-clock-must-thread-into-every-now-consumer).
-                prev_latest = store.read_latest(project_dir)
+                prev_latest = store.read_latest_body(project_dir,
+                                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                                     admit=store.Admit.ANY)
                 out = carry.merge(out, prev_latest,
                                   store._created_epoch(out["created"]),
                                   floor=dconfig.carry_floor(),

--- a/research/experiments/recall-replay-ab/replay_ab.py
+++ b/research/experiments/recall-replay-ab/replay_ab.py
@@ -316,8 +316,11 @@ def run(dataset_path, daimon_home, sweep_tokens, out_dir,
                 # Briefing-session exclusion, from the SNAPSHOT's synthesized
                 # pointers — what read_latest would have returned at prompt ts.
                 exclude = set()
-                for cp in (store.read_latest(row["project"]),
-                           store.read_latest()):
+                for cp in (store.read_latest_body(row["project"],
+                                                  route=store.Route.OWN_ELSE_GLOBAL,
+                                                  admit=store.Admit.ANY),
+                           store.read_latest_body(route=store.Route.OWN_ELSE_GLOBAL,
+                                                  admit=store.Admit.ANY)):
                     sid = (cp or {}).get("session_id")
                     if sid:
                         exclude.add(str(sid))


### PR DESCRIPTION
Refs #795

## What

Stage 3 of #795: the 141 test-suite call sites and 3 research-script call sites move off the legacy `fallback=` surface onto `read_latest_body` with explicit route and admit. Mapping is the byte-equivalence one the contract table pins: `fallback=False` becomes `(Route.OWN, Admit.ANY)`, default and `fallback=True` become `(Route.OWN_ELSE_GLOBAL, Admit.ANY)`, and `read_latest_reportable` becomes `(Route.OWN_ELSE_GLOBAL, Admit.OWN_OR_UNROUTED)`. Bare no-project calls mean `(OWN_ELSE_GLOBAL, ANY)` with no reader slug, which the identity-less-reader rule makes the same read under either admit.

The three wrapper-equivalence calls in `tests/test_read_contract.py` stay on the legacy surface deliberately: they are the tests pinning the wrappers, and they are deleted with the wrappers in stage 4.

## Why

After stage 2 the production tree is fully on the scoped readers while the suite still exercised them through the legacy wrappers. Moving the suite over is what turns stage 4 into a deletion of dead surface: nothing will still call what it removes.

## How

Rewritten by AST span, not regex: each call's exact source extent is replaced, the `fallback` keyword dropped, route and admit appended, and every file re-parsed after rewriting. No production file changes; the diff shows tests and research only.

## Tests

Full suite: 4500 passed, 2 skipped, 0 failed. Ruff clean on the gated paths and both touched research files.
