### PR TITLE
refactor(store): delete the legacy fallback read surface

### DIFF
--- a/.scars/0058-global-fallback-detection-misses-torn-pointer.landmine.md
+++ b/.scars/0058-global-fallback-detection-misses-torn-pointer.landmine.md
@@ -17,8 +17,15 @@ evidence:
 expires:
   condition: "no caller reconstructs the route; read_latest_result is the only source of fell_back, and the legacy fallback= surface is deleted (#795 stage 4)"
   review_after: 2027-02-28
-status: active
+status: archived
 ---
+
+> Archived at #795 stage 4 (2026-08-29): the rewritten expiry is met. brief
+> reads `fell_back` off `read_latest_result` (the only source), no caller
+> reconstructs the route, and the legacy `fallback=` surface is deleted. The
+> route-reconstruction hazard for body-only callers is carried forward by the
+> candidate scar `own-else-global-banned-in-own-only-modules` and the frozen
+> migration manifest test.
 
 `store.read_latest()` falls back to the global pointer (the most recent checkpoint
 of ANY project) in TWO different cases, and they do not look alike from outside.

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -445,8 +445,8 @@ def _cmd_anchor(args) -> int:
     # matching cognitive item and re-write through the NORMAL store path, so
     # rotation + stamping apply — the attached state becomes latest, the
     # pre-attach state is retained as prev-1.
-    # #789: this caller PERSISTS what it reads, so it takes the fallback=False
-    # branch read_latest documents for exactly that class (#94). With the global
+    # #789: this caller PERSISTS what it reads, so it takes Route.OWN, the
+    # route named for exactly that class (#94). With the global
     # fallback left on, a project with no bucket of its own re-wrote ANOTHER
     # project's checkpoint into its bucket under that project's session_id, and
     # the project that owns the item never received the anchor while the command
@@ -1736,7 +1736,7 @@ def _print_suppressed(project) -> int:
     --suppressed` to list"). Reuses briefing.withhold for the classification
     rather than reimplementing it — the resolved/live split must stay in
     exactly one place. Reads ONLY this project's own latest checkpoint
-    (fallback=False, same rule as carry #94): listing another project's
+    (Route.OWN, same rule as carry #94): listing another project's
     withheld items under this project's status would be worse than listing
     none. Fails open like brief's withhold call — a broken events.jsonl
     must not crash `status`, it should just report nothing suppressed."""

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -1383,7 +1383,15 @@ class Route(enum.Enum):
 class Admit(enum.Enum):
     """Which payloads a latest-read may return as a body (#795). Ownership is
     a PAYLOAD fact decided by the `project_slug` stamp, independent of which
-    pointer produced the value — that split is the whole point (#784/#791)."""
+    pointer produced the value — that split is the whole point (#784/#791).
+
+    #791's taxonomy, which OWN_OR_UNROUTED encodes: the global pointer holds
+    three different things and only one is foreign — the project's own
+    checkpoint (always fine), an UN-ROUTED checkpoint written before a project
+    was known and stamped with nobody (stays readable so pre-routing stores
+    keep working), and another project's checkpoint (the one to refuse).
+    Membership is decided the way team fan-in decides it, by the payload's own
+    stamp, never by which pointer the read came through."""
 
     ANY = "any"
     OWN_OR_UNROUTED = "own_or_unrouted"    # + checkpoints belonging to nobody (#791)
@@ -1491,41 +1499,10 @@ def read_own_stream_latest(project_dir=None) -> dict | None:
     return read_latest_body(project_dir=project_dir, route=route, admit=Admit.ANY)
 
 
-def read_latest(project_dir=None, fallback: bool = True) -> dict | None:
-    """Latest checkpoint, preferring the project's own pointer when known;
-    falls back to the global pointer (pre-routing checkpoints, fresh projects).
-
-    fallback=False reads ONLY the project's own pointer (#94): the global
-    pointer holds the most recent checkpoint of ANY project, so callers that
-    PERSIST what they read (carry) must never see it — display callers (brief)
-    keep the fallback and label it.
-
-    Thin wrapper over the scoped read (#795): fallback=True is
-    (OWN_ELSE_GLOBAL, ANY), fallback=False is (OWN, ANY), byte-for-byte."""
-    route = Route.OWN_ELSE_GLOBAL if fallback else Route.OWN
-    return read_latest_body(project_dir=project_dir, route=route, admit=Admit.ANY)
-
-
-def read_latest_reportable(project_dir=None) -> dict | None:
-    """The latest checkpoint a surface may REPORT ON as this project's, or None.
-
-    #791: a surface scoped to one project must not answer with another project's
-    record, but refusing every fallback is too blunt. `read_latest`'s global
-    pointer holds three different things, and only one of them is foreign:
-
-    - the project's own checkpoint, which is always fine;
-    - an UN-ROUTED checkpoint, written before a project was known and carrying
-      no `project_slug` stamp, which belongs to nobody and stays readable so
-      pre-routing stores keep working;
-    - another project's checkpoint, which is the one to refuse.
-
-    Membership is decided by the payload's own `project_slug`, the same way
-    team fan-in decides it, rather than by which pointer the read came through.
-
-    Thin wrapper over the scoped read (#795): exactly
-    (OWN_ELSE_GLOBAL, OWN_OR_UNROUTED), body projection."""
-    return read_latest_body(project_dir=project_dir, route=Route.OWN_ELSE_GLOBAL,
-                            admit=Admit.OWN_OR_UNROUTED)
+# The legacy surface — read_latest(fallback=) and read_latest_reportable —
+# was deleted at #795 stage 4. fallback named a mechanism while callers
+# reasoned about a policy; four defects shipped from its default (#785 #788
+# #790 #792). Route and Admit above are the replacement, both required.
 
 
 # ---- team memory (#111): opt-in shared mirror, derive-never-write shared state ----

--- a/plugin/tests/test_migration_manifest.py
+++ b/plugin/tests/test_migration_manifest.py
@@ -57,11 +57,9 @@ MANIFEST = {
     ("store.py", "write_checkpoint", "read_own_stream_latest", None, None),
 }
 
-# Wrapper-internal calls in store.py: the legacy surface is re-expressed over
-# the scoped read (stage 1) and is not a migration site.
+# Wrapper-internal calls in store.py that are not migration sites. The two
+# legacy wrappers were deleted at stage 4; only the persist-path reader remains.
 WRAPPER_SITES = {
-    ("store.py", "read_latest", "read_latest_body"),
-    ("store.py", "read_latest_reportable", "read_latest_body"),
     ("store.py", "read_own_stream_latest", "read_latest_body"),
 }
 

--- a/plugin/tests/test_read_contract.py
+++ b/plugin/tests/test_read_contract.py
@@ -24,10 +24,10 @@ PROJ = "/p/contract"
 OTHER = "someone-elses-project"
 CREATED = "2026-08-29T00:00:00Z"
 
-C1 = (Route.OWN, Admit.ANY)                        # today's fallback=False
+C1 = (Route.OWN, Admit.ANY)                        # the old fallback=False
 C2 = (Route.OWN, Admit.OWN_OR_UNROUTED)            # no caller today
-C3 = (Route.OWN_ELSE_GLOBAL, Admit.ANY)            # today's fallback=True
-C4 = (Route.OWN_ELSE_GLOBAL, Admit.OWN_OR_UNROUTED)  # today's read_latest_reportable
+C3 = (Route.OWN_ELSE_GLOBAL, Admit.ANY)            # the old fallback=True
+C4 = (Route.OWN_ELSE_GLOBAL, Admit.OWN_OR_UNROUTED)  # the old read_latest_reportable
 COMBOS = [C1, C2, C3, C4]
 
 # "Yields nothing" is one state with three faces (#139 torn, #817 non-object).
@@ -213,36 +213,9 @@ def test_slug_string_as_project_dir_reads_the_bucket(tmp_checkpoint_dir):
     assert got.checkpoint == body
 
 
-# ---- the wrappers are projections of the same read path --------------------
-
-
-@pytest.mark.parametrize("own,global_,reader", [
-    (_ck("SELF"), None, PROJ),
-    (_ck(), None, PROJ),
-    (_ck(OTHER), None, PROJ),
-    (None, _ck(OTHER), PROJ),
-    (None, _ck(), PROJ),
-    (None, _ck(OTHER), None),
-    (None, None, PROJ),
-], ids=["own-self", "own-unstamped", "own-other", "global-other", "global-unstamped",
-        "no-slug-global-other", "empty"])
-def test_legacy_readers_are_wrappers(tmp_checkpoint_dir, own, global_, reader):
-    if own is not None and own.get("project_slug") == "SELF":
-        own = _ck(_self_slug())
-    if own is not None:
-        _write_own(tmp_checkpoint_dir, own)
-    elif reader is not None:
-        _write_own(tmp_checkpoint_dir, None)
-    if global_ is not None:
-        _write_global(tmp_checkpoint_dir, global_)
-    assert store.read_latest(project_dir=reader, fallback=False) == \
-        store.read_latest_body(project_dir=reader, route=Route.OWN, admit=Admit.ANY)
-    assert store.read_latest(project_dir=reader, fallback=True) == \
-        store.read_latest_body(project_dir=reader, route=Route.OWN_ELSE_GLOBAL,
-                               admit=Admit.ANY)
-    assert store.read_latest_reportable(project_dir=reader) == \
-        store.read_latest_body(project_dir=reader, route=Route.OWN_ELSE_GLOBAL,
-                               admit=Admit.OWN_OR_UNROUTED)
+# ---- the two entry points are projections of the same read path ------------
+# (The legacy-wrapper equivalence tests lived here through stages 1-3 and
+# were deleted with the wrappers at stage 4.)
 
 
 def test_body_is_the_result_projection(tmp_checkpoint_dir):


### PR DESCRIPTION
Closes #795

## What

Stage 4 of #795, the close: `read_latest(fallback=)` and `read_latest_reportable` are deleted, and `Route` and `Admit` are the only way to read the latest checkpoint. The #791 taxonomy that lived on reportable's docstring moves onto `Admit.OWN_OR_UNROUTED`, where the behavior now lives. The wrapper-equivalence tests that pinned the legacy surface through stages 1-3 are deleted with the wrappers they pinned; the manifest's legacy-surface test stays as the reintroduction guard, and two comments still describing sites in `fallback=False` vocabulary are reworded to the route they actually pass.

Scar 0058 is archived in this PR: its rewritten expiry is met, since `brief` reads `fell_back` off `read_latest_result` (the only source), no caller reconstructs the route, and the `fallback=` surface is gone. The route-reconstruction hazard for body-only callers carries forward in the candidate scar and the frozen migration manifest.

## Why

`fallback` named a mechanism while every caller reasoned about a policy, and four defects shipped from its harmless-sounding default (#785, #788, #790, #792). After stages 0-3 nothing in production, tests, or research called it; this removes dead surface.

## Tests

AST census: zero calls to either legacy name anywhere (production 0, test 0). Full suite: 4493 passed, 2 skipped, 0 failed; the seven-test drop from stage 3 is exactly the deleted wrapper-equivalence pins. Scar lint: 65 files, 0 errors. Ruff clean.
