### PR TITLE
chore(ci): make mypy blocking via a frozen per-module ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,19 +84,19 @@ jobs:
       - name: ruff check
         run: uv run --extra dev ruff check daimon_briefing tests ../scripts
 
-      # Non-blocking: mypy currently reports pre-existing errors that are a
-      # deliberate follow-up. continue-on-error keeps them visible in the log
-      # without blocking merges; tightened to blocking in a later slice.
+      # BLOCKING (#823): pre-enforcement debt lives in pyproject's
+      # tool.mypy.overrides ratchet list, which only shrinks. Every module
+      # outside that list, and every new module, is enforced here.
       - name: mypy
-        continue-on-error: true
         run: uv run --extra dev mypy daimon_briefing
 
       # #795: a ReadResult reaching a body-only call site is a SILENT wrong
-      # answer (a frozen dataclass is truthy, not None and not a dict), so
-      # this step is blocking while mypy above stays advisory: any mypy
-      # finding that mentions ReadResult outside store.py fails the build.
-      # Scoped by symbol, not path, so it needs no baseline and survives
-      # until the #795 stage 4 cleanup.
+      # answer (a frozen dataclass is truthy, not None and not a dict): any
+      # mypy finding that mentions ReadResult outside store.py fails the
+      # build. Scoped by symbol, not path. NOTE (#823): the ratchet's
+      # ignore_errors silences findings INSIDE listed debt modules, so this
+      # guard covers a debt module only once it leaves the list; the
+      # migration manifest test and scar 0063 hold that line meanwhile.
       - name: mypy ReadResult containment
         run: |
           uv run --extra dev mypy daimon_briefing > mypy-out.txt || true

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -85,11 +85,52 @@ line-length = 88
 select = ["E4", "E7", "E9", "F"]
 
 [tool.mypy]
-# Non-blocking in CI (continue-on-error). ignore_missing_imports absorbs the
-# optional rich / host-provided imports; strict mode and the remaining errors
-# are a deliberate follow-up, not this slice.
+# BLOCKING in CI (#823). ignore_missing_imports absorbs the optional rich /
+# host-provided imports. Modules that predate enforcement carry their debt in
+# the overrides list below.
 python_version = "3.10"
 ignore_missing_imports = true
+
+# #823 ratchet: the modules with type errors on the day mypy became blocking.
+# THE LIST ONLY SHRINKS — clean a module, remove its entry in the same PR;
+# nothing is ever added. Every module absent from this list (and every future
+# module) is enforced from its first commit. Note ignore_errors also silences
+# the CI ReadResult-containment grep INSIDE these modules; that guard returns
+# per module as the list shrinks (the migration manifest test and scar 0063
+# hold the line in the interim).
+[[tool.mypy.overrides]]
+module = [
+    "daimon_briefing.amendments",
+    "daimon_briefing.briefing",
+    "daimon_briefing.carry",
+    "daimon_briefing.cli",
+    "daimon_briefing.cli.amend",
+    "daimon_briefing.cli.hooks",
+    "daimon_briefing.cli.lifecycle",
+    "daimon_briefing.cli.refute",
+    "daimon_briefing.cli.request",
+    "daimon_briefing.cli.ruling",
+    "daimon_briefing.cli.skill",
+    "daimon_briefing.inspector",
+    "daimon_briefing.ledger",
+    "daimon_briefing.pending",
+    "daimon_briefing.policy",
+    "daimon_briefing.privacy",
+    "daimon_briefing.provenance",
+    "daimon_briefing.recall",
+    "daimon_briefing.refutations",
+    "daimon_briefing.relations",
+    "daimon_briefing.render",
+    "daimon_briefing.requests",
+    "daimon_briefing.schema",
+    "daimon_briefing.serializer",
+    "daimon_briefing.skill_install",
+    "daimon_briefing.store",
+    "daimon_briefing.teamproject",
+    "daimon_briefing.teamsync",
+    "daimon_briefing.transcript",
+]
+ignore_errors = true
 
 [tool.coverage.run]
 source = ["daimon_briefing", "daimon_ui"]


### PR DESCRIPTION
Closes #823

## What

Flips the CI mypy step to blocking and adds the frozen `tool.mypy.overrides` ratchet: the 29 modules carrying the 198 pre-enforcement errors get `ignore_errors = true`, with the rule stated beside the list: it only shrinks. Clean modules and all future modules are enforced from their first commit. One naming trap found by the verification probe: a package `__init__` is addressed as the package (`daimon_briefing.cli`), not `.cli.__init__` — the wrong form silently leaves the module enforced.

## Documented narrowing

`ignore_errors` also silences the ReadResult-containment grep inside listed debt modules; that guard returns per module as the list shrinks, and the migration manifest test plus scar 0063 hold the line meanwhile. Noted in both the pyproject comment and the CI step comment.

## Verification

Clean tree: mypy exits 0 (58 files). Planted type error in a clean module (`anchor.py`): run fails with 1 error, then reverted. The ReadResult containment step is unchanged and still blocking.