### PR TITLE
chore(website): apply semver-compatible npm audit fixes

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7173,9 +7173,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -9428,9 +9428,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",
@@ -11063,9 +11063,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",
@@ -14122,9 +14122,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -14778,9 +14778,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -14797,7 +14797,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
Refs #806

## What

Applies semver-compatible `npm audit fix` in `website/`. Lockfile-only change; `package.json` is untouched.

Advisories cleared (29 -> 24 vulnerabilities; high 22 -> 18, moderate 7 -> 6):

| Package | Version | Advisories |
|---------|---------|------------|
| brace-expansion | 1.1.16 -> 1.1.18 | GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895 |
| fast-uri | 3.1.3 -> 3.1.6 | GHSA-7p8r-x3mc-p8w7, GHSA-v2hh-gcrm-f6hx |
| js-yaml | 4.3.0 -> 4.3.2 | GHSA-5p4m-2wfm-xmqj |
| nanoid | 3.3.16 -> 3.3.18 | GHSA-2v37-7h3g-55p8 |
| postcss | 8.5.19 -> 8.5.26 | GHSA-fxqj-rqcc-2cmp |

Not fixed here, stays tracked in #806:

- image-size (CVE-2025-71329) stays pinned at 2.0.2: no patched release has been published upstream.
- serialize-javascript via the copy-webpack-plugin / css-minimizer-webpack-plugin chain: needs a Docusaurus upgrade.
- uuid 8.3.2 via sockjs / webpack-dev-server: sockjs pins uuid ^8 and the patched uuid is 11.1.1, so there is no semver-compatible path. npm's "fix available" hint for this tier requires `--force`, which was deliberately not used.

## Why

Dependency hygiene for the website: clear every advisory that has a semver-compatible patch, without forcing major bumps. The issue stays open to track the deps that cannot be fixed until upstream releases land.

## Tests

- `npm audit` before: 29 vulnerabilities (7 moderate, 22 high). After: 24 (6 moderate, 18 high). Ran `npm audit fix` twice to confirm convergence; the second pass changed nothing.
- `git diff --stat` confirms only `website/package-lock.json` changed (16 insertions, 16 deletions).
- No build run per repo policy; verification is the audit output itself.
