### PR TITLE
feat(schema): published machine-readable checkpoint schema from one declarative field table

### DIFF
--- a/docs/checkpoint-schema.json
+++ b/docs/checkpoint-schema.json
@@ -13,6 +13,32 @@
     "model": "extracted content, policed by the validator and normalizers",
     "code": "stamped by daimon's own write pipeline"
   },
+  "columns": {
+    "type": "the JSON type the producer writes when it writes the field",
+    "optional": "whether a stored checkpoint may lack the field",
+    "nullable": "whether an explicit null is tolerated where the field is present; false on a reject row means an explicit null is rejected like any other out-of-contract value",
+    "owner": "see owners",
+    "disposition": "see dispositions",
+    "constraints": "see constraint_semantics; keys not listed there are documentation for consumers, not runtime checks"
+  },
+  "constraint_semantics": {
+    "validate": "the structural check the runtime validator performs on this envelope field: presence, object, item-required, item-list-required (absence rejects), item-list-optional (absence = empty list)",
+    "enum": "closed set of accepted values; anything else rejects with reject_reason",
+    "required_if_eq": "[field, value]: this field must be a non-empty string ONLY when the named sibling field equals the value; otherwise it is unconstrained and any shape passes (so a reject disposition with this key is conditional, not unconditional)",
+    "object_keys": "sub-keys that must each be a non-empty string when the field is present and non-null; a non-object rejects, a missing/empty sub-key rejects with reject_reason_missing",
+    "reject_reason": "the exact reason string the validator returns when this row rejects",
+    "reject_reason_missing": "the reason string when a required sub-key is absent or empty",
+    "min": "inclusive lower clamp bound for in-type integers; non-integers (booleans included) drop the field",
+    "max": "inclusive upper clamp bound for in-type integers",
+    "strip_whitespace": "leading/trailing whitespace is removed before storing",
+    "max_chars": "the stored string is truncated to this many characters",
+    "stripped_at_serialize": "a model-emitted value for this field is discarded at the serialize boundary; the persisted value is always code-derived",
+    "pattern": "regex the code-stamped value matches (documentation, not a runtime check)",
+    "format": "timestamp format of the code-stamped value (documentation)",
+    "element": "shape of array elements (documentation)",
+    "shape": "shape of the object's sub-fields (documentation)",
+    "link_types": "link `type` values the producer emits (documentation)"
+  },
   "envelope": [
     {
       "field": "session_id",
@@ -79,14 +105,14 @@
       "field": "working_context.active_topic",
       "type": "object",
       "optional": false,
-      "nullable": true,
+      "nullable": false,
       "owner": "model",
       "disposition": "reject",
       "constraints": {
         "validate": "item-required",
         "reject_reason": "missing working_context.active_topic"
       },
-      "notes": "Singleton item; per-session, never carried, never id-stamped. Presence is checked before the working_context lists, its item shape after them. May be deleted by a forget rewrite."
+      "notes": "Singleton item; per-session, never carried, never id-stamped. Presence is checked before the working_context lists, its item shape after them; an explicit null rejects (item shape applies). May be deleted by a forget rewrite."
     },
     {
       "field": "epistemic_snapshot.strong_beliefs",

--- a/docs/checkpoint-schema.json
+++ b/docs/checkpoint-schema.json
@@ -1,0 +1,642 @@
+{
+  "document": "daimon-checkpoint-field-table",
+  "document_version": 1,
+  "format_version": "D-018",
+  "dispositions": {
+    "reject": "an out-of-contract value refuses the whole checkpoint",
+    "clamp": "an out-of-range value is pulled into range or truncated",
+    "drop": "an out-of-contract value removes the field, never fails the write",
+    "pass": "stored as written; consumers must tolerate any shape",
+    "strip": "a model-emitted value is discarded at the serialize boundary; the persisted value is always code-derived"
+  },
+  "owners": {
+    "model": "extracted content, policed by the validator and normalizers",
+    "code": "stamped by daimon's own write pipeline"
+  },
+  "envelope": [
+    {
+      "field": "session_id",
+      "type": "string",
+      "optional": false,
+      "nullable": true,
+      "owner": "code",
+      "disposition": "reject",
+      "constraints": {
+        "validate": "presence",
+        "reject_reason": "missing session_id"
+      },
+      "notes": "Host session id, assigned by the serialize pipeline after stripping model output. Only PRESENCE is validated."
+    },
+    {
+      "field": "working_context",
+      "type": "object",
+      "optional": false,
+      "nullable": false,
+      "owner": "model",
+      "disposition": "reject",
+      "constraints": {
+        "validate": "object"
+      },
+      "notes": "Section holding active_topic, open_questions, recent_decisions."
+    },
+    {
+      "field": "epistemic_snapshot",
+      "type": "object",
+      "optional": false,
+      "nullable": false,
+      "owner": "model",
+      "disposition": "reject",
+      "constraints": {
+        "validate": "object"
+      },
+      "notes": "Section holding strong_beliefs, uncertainties, contradictions_flagged."
+    },
+    {
+      "field": "working_context.open_questions",
+      "type": "array",
+      "optional": false,
+      "nullable": false,
+      "owner": "model",
+      "disposition": "reject",
+      "constraints": {
+        "validate": "item-list-required"
+      },
+      "notes": "List of item objects; a non-list (absence included) rejects."
+    },
+    {
+      "field": "working_context.recent_decisions",
+      "type": "array",
+      "optional": false,
+      "nullable": false,
+      "owner": "model",
+      "disposition": "reject",
+      "constraints": {
+        "validate": "item-list-required"
+      },
+      "notes": "List of item objects; a non-list (absence included) rejects."
+    },
+    {
+      "field": "working_context.active_topic",
+      "type": "object",
+      "optional": false,
+      "nullable": true,
+      "owner": "model",
+      "disposition": "reject",
+      "constraints": {
+        "validate": "item-required",
+        "reject_reason": "missing working_context.active_topic"
+      },
+      "notes": "Singleton item; per-session, never carried, never id-stamped. Presence is checked before the working_context lists, its item shape after them. May be deleted by a forget rewrite."
+    },
+    {
+      "field": "epistemic_snapshot.strong_beliefs",
+      "type": "array",
+      "optional": true,
+      "nullable": false,
+      "owner": "model",
+      "disposition": "reject",
+      "constraints": {
+        "validate": "item-list-optional"
+      },
+      "notes": "List of item objects; absence is tolerated (treated as empty), a present non-list rejects."
+    },
+    {
+      "field": "epistemic_snapshot.uncertainties",
+      "type": "array",
+      "optional": true,
+      "nullable": false,
+      "owner": "model",
+      "disposition": "reject",
+      "constraints": {
+        "validate": "item-list-optional"
+      },
+      "notes": "List of item objects; absence is tolerated (treated as empty), a present non-list rejects."
+    },
+    {
+      "field": "epistemic_snapshot.contradictions_flagged",
+      "type": "array",
+      "optional": true,
+      "nullable": true,
+      "owner": "model",
+      "disposition": "pass",
+      "constraints": {
+        "element": [
+          "free-form: bare strings and objects both occur"
+        ]
+      },
+      "notes": "Never validated or normalized; item-shaped entries share the item fields but the shape varies by design (schema.py #146)."
+    },
+    {
+      "field": "worker_queue",
+      "type": "array",
+      "optional": true,
+      "nullable": true,
+      "owner": "model",
+      "disposition": "pass",
+      "constraints": {},
+      "notes": "Prompt-schema artifact; the producer emits an empty list. Never read or validated."
+    },
+    {
+      "field": "format_version",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "pattern": "^D-[0-9]+$",
+        "stripped_at_serialize": true
+      },
+      "notes": "Envelope schema version (serializer.PROMPT_VERSION); this document versions with it. Stamped at write when absent; pre-#93 legacy checkpoints may lack it."
+    },
+    {
+      "field": "created",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "format": "ISO-8601 UTC, %Y-%m-%dT%H:%M:%SZ",
+        "stripped_at_serialize": true
+      },
+      "notes": "Session-end stamp (capture path) or write-time fallback. Readers prefer it over file mtime, which pointer rotation rewrites (#93)."
+    },
+    {
+      "field": "author",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "stripped_at_serialize": true
+      },
+      "notes": "Team author (#111), resolved by config at write time."
+    },
+    {
+      "field": "transcript_hash",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "pattern": "^[0-9a-f]{64}$",
+        "stripped_at_serialize": true
+      },
+      "notes": "sha256 of the raw transcript file; absent when no transcript file exists (introspection path)."
+    },
+    {
+      "field": "source_ref",
+      "type": "object",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "stripped_at_serialize": true,
+        "shape": [
+          "version: integer (1)",
+          "host: enum[claude-code, codex, windsurf, gemini, hermes, manual]",
+          "session_id: string (^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$)",
+          "locator: enum[managed, host-api, unsupported]",
+          "author?: string (non-empty)"
+        ]
+      },
+      "notes": "Capture source descriptor (#594, provenance.capture_source_ref)."
+    },
+    {
+      "field": "project_slug",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "stripped_at_serialize": true
+      },
+      "notes": "Project attribution, stamped only when the project is known (absent = unknown, never empty)."
+    },
+    {
+      "field": "project_name",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "pass",
+      "constraints": {},
+      "notes": "#672 display name (the slug is a lossy flattening). Stamped only when absent and the project is known; a pre-existing value is kept."
+    },
+    {
+      "field": "git_branch",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "stripped_at_serialize": true
+      },
+      "notes": "Branch at capture time (#222); absent when unknown or detached."
+    },
+    {
+      "field": "receipts",
+      "type": "boolean",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "stripped_at_serialize": true
+      },
+      "notes": "#204 era marker: true when a signed provenance receipt sidecar was planned for this write; absent otherwise."
+    },
+    {
+      "field": "extraction_version",
+      "type": "integer",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "stripped_at_serialize": true
+      },
+      "notes": "#514 extraction-semantics version, stamped only by paths that ran the extractor; introspection checkpoints stay absent = unknown."
+    },
+    {
+      "field": "llm_backend",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "pass",
+      "constraints": {},
+      "notes": "#230 backend that produced this checkpoint; assignment always overwrites any model-emitted value at serialize."
+    },
+    {
+      "field": "llm_model",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "pass",
+      "constraints": {},
+      "notes": "Requested model alias, stamped only when config knows one; absent otherwise (a bare command backend stays honest-absent)."
+    },
+    {
+      "field": "llm_model_served",
+      "type": "string | array",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "pass",
+      "constraints": {
+        "element": [
+          "string served-model name; array when more than one model served the run (#458)"
+        ]
+      },
+      "notes": "Per-call served-model truth; popped from model output unconditionally before the serialize-path stamp."
+    },
+    {
+      "field": "redactions",
+      "type": "object",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "pass",
+      "constraints": {
+        "shape": [
+          "map of redaction kind -> integer count"
+        ]
+      },
+      "notes": "#104 visible counter, present only when capture-time redaction scrubbed something; merged (never overwritten) across re-writes."
+    },
+    {
+      "field": "source",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "pass",
+      "constraints": {},
+      "notes": "write-checkpoint provenance stamp (default 'introspection'); absent on serialize-path checkpoints."
+    },
+    {
+      "field": "team_project",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "pass",
+      "constraints": {},
+      "notes": "Team-mirror copies only (#111): the shared project path segments."
+    },
+    {
+      "field": "origin_session",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "stripped_at_serialize": true
+      },
+      "notes": "Reserved: stripped from model output and never stamped at the top level — origin binds per item only (#268)."
+    },
+    {
+      "field": "origin_author",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "stripped_at_serialize": true
+      },
+      "notes": "Reserved: stripped from model output and never stamped at the top level — origin binds per item only (#268)."
+    }
+  ],
+  "item": [
+    {
+      "field": "text",
+      "type": "string",
+      "optional": false,
+      "nullable": false,
+      "owner": "model",
+      "disposition": "reject",
+      "constraints": {
+        "reject_reason": "text is not a str"
+      },
+      "notes": "The claim. Empty string is valid (active_topic may be empty; briefing skips the empty section). Non-str rejects the checkpoint."
+    },
+    {
+      "field": "trust",
+      "type": "string",
+      "optional": false,
+      "nullable": false,
+      "owner": "model",
+      "disposition": "reject",
+      "constraints": {
+        "enum": [
+          "verbatim",
+          "inferred"
+        ],
+        "reject_reason": "trust is not a known trust class"
+      },
+      "notes": "D-006 trust class. verify_quotes and the grounding/foreign gates may downgrade verbatim to inferred after extraction; they never upgrade."
+    },
+    {
+      "field": "quote",
+      "type": "string",
+      "optional": true,
+      "nullable": true,
+      "owner": "model",
+      "disposition": "reject",
+      "constraints": {
+        "required_if_eq": [
+          "trust",
+          "verbatim"
+        ],
+        "reject_reason": "trust=verbatim item has no quote"
+      },
+      "notes": "Exact transcript span. Required non-empty when trust=verbatim (rejects otherwise); unconstrained on inferred items. A quote whose canonical value was forgotten is scrubbed and trust downgraded."
+    },
+    {
+      "field": "because",
+      "type": "string",
+      "optional": true,
+      "nullable": true,
+      "owner": "model",
+      "disposition": "reject",
+      "constraints": {
+        "reject_reason": "because is not a str"
+      },
+      "notes": "D-018 stated-reasoning clause. Explicit null is tolerated; any other non-str rejects the checkpoint."
+    },
+    {
+      "field": "anchored_to",
+      "type": "object",
+      "optional": true,
+      "nullable": true,
+      "owner": "model",
+      "disposition": "reject",
+      "constraints": {
+        "object_keys": [
+          "file",
+          "symbol",
+          "body_hash"
+        ],
+        "reject_reason_missing": "anchored_to is missing file, symbol, or body_hash"
+      },
+      "notes": "Code anchor (daimon anchor --attach): file, symbol, and body_hash must all be non-empty strings. Explicit null is tolerated."
+    },
+    {
+      "field": "importance",
+      "type": "integer",
+      "optional": true,
+      "nullable": false,
+      "owner": "model",
+      "disposition": "clamp",
+      "constraints": {
+        "min": 1,
+        "max": 10
+      },
+      "notes": "Producer scores 1-10 (serializer.py rule 14). Out-of-range ints clamp to the range; bool and every non-int (str, float, null) drop the field. Consumers clamping to any other range delete real data."
+    },
+    {
+      "field": "scene",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "model",
+      "disposition": "clamp",
+      "constraints": {
+        "strip_whitespace": true,
+        "max_chars": 500
+      },
+      "notes": "#317 episodic scene trace. Stripped and truncated to max_chars; empty/whitespace and every non-str drop the field."
+    },
+    {
+      "field": "external_state",
+      "type": "boolean",
+      "optional": true,
+      "nullable": true,
+      "owner": "model",
+      "disposition": "pass",
+      "constraints": {},
+      "notes": "Flags an answer that may have changed outside the session. Never validated or normalized: stored as emitted."
+    },
+    {
+      "field": "links",
+      "type": "array",
+      "optional": true,
+      "nullable": true,
+      "owner": "model",
+      "disposition": "pass",
+      "constraints": {
+        "element": [
+          "object with string fields: type, target"
+        ],
+        "link_types": [
+          "supersedes"
+        ]
+      },
+      "notes": "Supersession links; target names the OLD decision's stored text. Pass-through at admission; an element whose target was forgotten is removed, and the key is dropped when no element remains."
+    },
+    {
+      "field": "source_message_ids",
+      "type": "array",
+      "optional": true,
+      "nullable": false,
+      "owner": "model",
+      "disposition": "drop",
+      "constraints": {
+        "element": [
+          "string host message id"
+        ]
+      },
+      "notes": "#358 quote binding. A bare string coerces to a one-entry list; entries the transcript cannot vouch for are dropped (on inferred or quote-less items only tool-result signal ids survive, #359), and the key is removed when nothing valid remains."
+    },
+    {
+      "field": "id",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "pattern": "^[a-z]-[0-9a-f]{6,40}(-[0-9]+)?$",
+        "stripped_at_serialize": true
+      },
+      "notes": "Stable project-global item id (#102/#487), stamped at admission for non-empty-text list items; active_topic never carries one. Model-emitted values are stripped."
+    },
+    {
+      "field": "first_seen",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "format": "ISO-8601 UTC, %Y-%m-%dT%H:%M:%SZ",
+        "stripped_at_serialize": true
+      },
+      "notes": "Per-item birth stamp (#126), inherited across carries; feeds decay age. Model-emitted values are stripped (#725)."
+    },
+    {
+      "field": "origin_session",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "stripped_at_serialize": true
+      },
+      "notes": "Session that first wrote the item (#268); carried copies keep their binding. Model-emitted values are stripped."
+    },
+    {
+      "field": "origin_author",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "stripped_at_serialize": true
+      },
+      "notes": "Author that first wrote the item (#268). Model-emitted values are stripped."
+    },
+    {
+      "field": "carried_from",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "stripped_at_serialize": true
+      },
+      "notes": "Session id of the LAST carry hop (#33); absent on native items. Model-emitted values are stripped (#725)."
+    },
+    {
+      "field": "quote_verified",
+      "type": "boolean",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "stripped_at_serialize": true
+      },
+      "notes": "verify_quotes verdict (#125): true on a byte-verified quote, false only where a verbatim claim was downgraded. Inferred items carry neither this nor last_verified."
+    },
+    {
+      "field": "last_verified",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "format": "ISO-8601 UTC, %Y-%m-%dT%H:%M:%SZ",
+        "stripped_at_serialize": true
+      },
+      "notes": "Stamped with quote_verified=true at serialize; checkpoint-append-only (#215). Model-emitted values are stripped."
+    },
+    {
+      "field": "quote_provenance",
+      "type": "object",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "stripped_at_serialize": true,
+        "shape": [
+          "version: integer (1)",
+          "source: object {version: 1, host: enum[claude-code, codex, windsurf, gemini, hermes, manual], session_id: string, locator: enum[managed, host-api, unsupported], author?: string}",
+          "digest: object {algorithm: 'sha256', scope: enum[raw-file, rendered-transcript], value: string (64 hex)}",
+          "verifier: OBJECT {id: string ('tier-f'), version: integer} — an object, never a string",
+          "outcome: enum[verified, not-verified]",
+          "checked_at: string (ISO-8601 UTC, %Y-%m-%dT%H:%M:%SZ)",
+          "binding: object {mode: enum[message-ids, transcript-scan], message_ids: array of string}"
+        ]
+      },
+      "notes": "Durable per-item evidence receipt (#594, provenance.quote_receipt). verifier is an OBJECT {id, version}: consumers normalizing it as a string rendered every verified claim's verifier as absent."
+    },
+    {
+      "field": "grounded",
+      "type": "boolean",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "pass",
+      "constraints": {},
+      "notes": "#359 outcome-grounding verdict, re-derived every serialize: any model-emitted value is popped before ground_outcomes re-stamps."
+    },
+    {
+      "field": "pinned",
+      "type": "boolean",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "stripped_at_serialize": true
+      },
+      "notes": "#369 auto-pin marker on force-pinned hard-imperative constraints; always true when present. Model-emitted values are stripped."
+    },
+    {
+      "field": "quote_echo_only",
+      "type": "boolean",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "pass",
+      "constraints": {},
+      "notes": "#440: quote existed only inside daimon's own injected output; the item is downgraded and this marker set. Model-emitted values are popped before verify_quotes re-derives."
+    }
+  ]
+}

--- a/plugin/daimon_briefing/field_table.py
+++ b/plugin/daimon_briefing/field_table.py
@@ -1,0 +1,557 @@
+"""#827: the declarative checkpoint field table — one source of truth.
+
+Checkpoint consumers cannot import daimon, so every consumer-side normalizer
+used to be a guess about the producer shape, and two guesses silently deleted
+real data (importance clamped 1-5 against the producer's 1-10 range;
+quote_provenance.verifier read as a string where the producer writes an
+object). This module states, per field of the checkpoint envelope and of a
+checkpoint item, exactly what the producer writes and what happens to an
+out-of-contract value — and everything else derives from that one table:
+
+  * the runtime validator (`item_reason` / `checkpoint_reason` — the functions
+    serializer's `_item_reason` / `validation_reason` now delegate to),
+  * the runtime normalizers (`normalize_field` — the per-item body of
+    serializer's `sanitize_importance` / `sanitize_scene`),
+  * the published machine-readable schema document
+    (`schema_document` / `render_document` -> docs/checkpoint-schema.json),
+    versioned with the envelope's `format_version`, so an external consumer
+    can test its own normalizers against the producer contract without
+    importing daimon.
+
+NO BEHAVIOR CHANGE is the hard requirement: the table encodes today's
+dispositions exactly, the generated reason strings are byte-identical to the
+predicates they replace, and tests/test_field_table*.py pin the table against
+the live serializer constants and the real on-disk corpus, so divergence is a
+test failure instead of a silent consumer-side data loss.
+
+Deliberately import-free (the schema.py discipline, #146): serializer imports
+this module for the generated validator/normalizers, so this module sits below
+the whole chain and imports nothing from the package. `format_version` is
+therefore a PARAMETER of the document builders — the one caller-owned value —
+and the `python -m daimon_briefing.field_table` entry point resolves it from
+serializer lazily, outside the import graph.
+
+Column semantics:
+  * type       — the JSON type the producer writes when it writes the field.
+  * optional   — whether a stored checkpoint may lack the field.
+  * nullable   — whether an explicit null is tolerated where the field exists.
+  * owner      — "model": extracted content the validator/normalizers police;
+                 "code": stamped by daimon's own write pipeline (a model-
+                 emitted value is stripped or overwritten, per the notes).
+  * disposition — what happens to an out-of-contract value:
+                 "reject" (the checkpoint is refused), "clamp" (pulled into
+                 range / truncated), "drop" (the field is removed), "pass"
+                 (stored as-is), "strip" (discarded at the serialize boundary;
+                 the persisted value is always code-derived).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, NamedTuple
+
+
+SCHEMA_DOCUMENT_VERSION = 1
+
+# Constraint keys the runtime engine executes (everything else is
+# documentation for consumers): "validate", "enum", "reject_reason",
+# "required_if_eq", "object_keys", "min", "max", "strip_whitespace",
+# "max_chars".
+Constraints = tuple[tuple[str, Any], ...]
+
+
+class FieldRule(NamedTuple):
+    """One row: a field of the checkpoint envelope or of a checkpoint item."""
+
+    scope: str          # "envelope" | "item"
+    name: str           # field name; envelope section fields are dotted paths
+    type: str           # JSON type produced ("string", "integer", ...)
+    optional: bool
+    nullable: bool
+    owner: str          # "model" | "code"
+    disposition: str    # "reject" | "clamp" | "drop" | "pass" | "strip"
+    constraints: Constraints
+    notes: str
+
+
+def _c(**kv: Any) -> Constraints:
+    return tuple(kv.items())
+
+
+_TIMESTAMP = "ISO-8601 UTC, %Y-%m-%dT%H:%M:%SZ"
+
+# Row order is load-bearing: the generated validator applies reject rows in
+# table order, reproducing the live predicate order (and therefore which
+# reason a multiply-invalid input is rejected with) byte-for-byte.
+ITEM_RULES: tuple[FieldRule, ...] = (
+    FieldRule(
+        "item", "text", "string", False, False, "model", "reject",
+        _c(reject_reason="text is not a str"),
+        "The claim. Empty string is valid (active_topic may be empty; "
+        "briefing skips the empty section). Non-str rejects the checkpoint."),
+    FieldRule(
+        "item", "trust", "string", False, False, "model", "reject",
+        _c(enum=("verbatim", "inferred"),
+           reject_reason="trust is not a known trust class"),
+        "D-006 trust class. verify_quotes and the grounding/foreign gates may "
+        "downgrade verbatim to inferred after extraction; they never upgrade."),
+    FieldRule(
+        "item", "quote", "string", True, True, "model", "reject",
+        _c(required_if_eq=("trust", "verbatim"),
+           reject_reason="trust=verbatim item has no quote"),
+        "Exact transcript span. Required non-empty when trust=verbatim "
+        "(rejects otherwise); unconstrained on inferred items. A quote whose "
+        "canonical value was forgotten is scrubbed and trust downgraded."),
+    FieldRule(
+        "item", "because", "string", True, True, "model", "reject",
+        _c(reject_reason="because is not a str"),
+        "D-018 stated-reasoning clause. Explicit null is tolerated; any other "
+        "non-str rejects the checkpoint."),
+    FieldRule(
+        "item", "anchored_to", "object", True, True, "model", "reject",
+        _c(object_keys=("file", "symbol", "body_hash"),
+           reject_reason_missing=(
+               "anchored_to is missing file, symbol, or body_hash")),
+        "Code anchor (daimon anchor --attach): file, symbol, and body_hash "
+        "must all be non-empty strings. Explicit null is tolerated."),
+    FieldRule(
+        "item", "importance", "integer", True, False, "model", "clamp",
+        _c(min=1, max=10),
+        "Producer scores 1-10 (serializer.py rule 14). Out-of-range ints "
+        "clamp to the range; bool and every non-int (str, float, null) drop "
+        "the field. Consumers clamping to any other range delete real data."),
+    FieldRule(
+        "item", "scene", "string", True, False, "model", "clamp",
+        _c(strip_whitespace=True, max_chars=500),
+        "#317 episodic scene trace. Stripped and truncated to max_chars; "
+        "empty/whitespace and every non-str drop the field."),
+    FieldRule(
+        "item", "external_state", "boolean", True, True, "model", "pass",
+        _c(),
+        "Flags an answer that may have changed outside the session. Never "
+        "validated or normalized: stored as emitted."),
+    FieldRule(
+        "item", "links", "array", True, True, "model", "pass",
+        _c(element=("object with string fields: type, target",),
+           link_types=("supersedes",)),
+        "Supersession links; target names the OLD decision's stored text. "
+        "Pass-through at admission; an element whose target was forgotten is "
+        "removed, and the key is dropped when no element remains."),
+    FieldRule(
+        "item", "source_message_ids", "array", True, False, "model", "drop",
+        _c(element=("string host message id",)),
+        "#358 quote binding. A bare string coerces to a one-entry list; "
+        "entries the transcript cannot vouch for are dropped (on inferred or "
+        "quote-less items only tool-result signal ids survive, #359), and "
+        "the key is removed when nothing valid remains."),
+    FieldRule(
+        "item", "id", "string", True, False, "code", "strip",
+        _c(pattern=r"^[a-z]-[0-9a-f]{6,40}(-[0-9]+)?$",
+           stripped_at_serialize=True),
+        "Stable project-global item id (#102/#487), stamped at admission for "
+        "non-empty-text list items; active_topic never carries one. Model-"
+        "emitted values are stripped."),
+    FieldRule(
+        "item", "first_seen", "string", True, False, "code", "strip",
+        _c(format=_TIMESTAMP, stripped_at_serialize=True),
+        "Per-item birth stamp (#126), inherited across carries; feeds decay "
+        "age. Model-emitted values are stripped (#725)."),
+    FieldRule(
+        "item", "origin_session", "string", True, False, "code", "strip",
+        _c(stripped_at_serialize=True),
+        "Session that first wrote the item (#268); carried copies keep their "
+        "binding. Model-emitted values are stripped."),
+    FieldRule(
+        "item", "origin_author", "string", True, False, "code", "strip",
+        _c(stripped_at_serialize=True),
+        "Author that first wrote the item (#268). Model-emitted values are "
+        "stripped."),
+    FieldRule(
+        "item", "carried_from", "string", True, False, "code", "strip",
+        _c(stripped_at_serialize=True),
+        "Session id of the LAST carry hop (#33); absent on native items. "
+        "Model-emitted values are stripped (#725)."),
+    FieldRule(
+        "item", "quote_verified", "boolean", True, False, "code", "strip",
+        _c(stripped_at_serialize=True),
+        "verify_quotes verdict (#125): true on a byte-verified quote, false "
+        "only where a verbatim claim was downgraded. Inferred items carry "
+        "neither this nor last_verified."),
+    FieldRule(
+        "item", "last_verified", "string", True, False, "code", "strip",
+        _c(format=_TIMESTAMP, stripped_at_serialize=True),
+        "Stamped with quote_verified=true at serialize; checkpoint-append-"
+        "only (#215). Model-emitted values are stripped."),
+    FieldRule(
+        "item", "quote_provenance", "object", True, False, "code", "strip",
+        _c(stripped_at_serialize=True,
+           shape=("version: integer (1)",
+                  "source: object {version: 1, host: enum[claude-code, "
+                  "codex, windsurf, gemini, hermes, manual], session_id: "
+                  "string, locator: enum[managed, host-api, unsupported], "
+                  "author?: string}",
+                  "digest: object {algorithm: 'sha256', scope: "
+                  "enum[raw-file, rendered-transcript], value: string "
+                  "(64 hex)}",
+                  "verifier: OBJECT {id: string ('tier-f'), version: "
+                  "integer} — an object, never a string",
+                  "outcome: enum[verified, not-verified]",
+                  "checked_at: string (" + _TIMESTAMP + ")",
+                  "binding: object {mode: enum[message-ids, "
+                  "transcript-scan], message_ids: array of string}")),
+        "Durable per-item evidence receipt (#594, provenance.quote_receipt). "
+        "verifier is an OBJECT {id, version}: consumers normalizing it as a "
+        "string rendered every verified claim's verifier as absent."),
+    FieldRule(
+        "item", "grounded", "boolean", True, False, "code", "pass",
+        _c(),
+        "#359 outcome-grounding verdict, re-derived every serialize: any "
+        "model-emitted value is popped before ground_outcomes re-stamps."),
+    FieldRule(
+        "item", "pinned", "boolean", True, False, "code", "strip",
+        _c(stripped_at_serialize=True),
+        "#369 auto-pin marker on force-pinned hard-imperative constraints; "
+        "always true when present. Model-emitted values are stripped."),
+    FieldRule(
+        "item", "quote_echo_only", "boolean", True, False, "code", "pass",
+        _c(),
+        "#440: quote existed only inside daimon's own injected output; the "
+        "item is downgraded and this marker set. Model-emitted values are "
+        "popped before verify_quotes re-derives."),
+)
+
+ENVELOPE_RULES: tuple[FieldRule, ...] = (
+    FieldRule(
+        "envelope", "session_id", "string", False, True, "code", "reject",
+        _c(validate="presence", reject_reason="missing session_id"),
+        "Host session id, assigned by the serialize pipeline after stripping "
+        "model output. Only PRESENCE is validated."),
+    FieldRule(
+        "envelope", "working_context", "object", False, False, "model",
+        "reject",
+        _c(validate="object"),
+        "Section holding active_topic, open_questions, recent_decisions."),
+    FieldRule(
+        "envelope", "epistemic_snapshot", "object", False, False, "model",
+        "reject",
+        _c(validate="object"),
+        "Section holding strong_beliefs, uncertainties, "
+        "contradictions_flagged."),
+    FieldRule(
+        "envelope", "working_context.open_questions", "array", False, False,
+        "model", "reject",
+        _c(validate="item-list-required"),
+        "List of item objects; a non-list (absence included) rejects."),
+    FieldRule(
+        "envelope", "working_context.recent_decisions", "array", False, False,
+        "model", "reject",
+        _c(validate="item-list-required"),
+        "List of item objects; a non-list (absence included) rejects."),
+    FieldRule(
+        "envelope", "working_context.active_topic", "object", False, True,
+        "model", "reject",
+        _c(validate="item-required",
+           reject_reason="missing working_context.active_topic"),
+        "Singleton item; per-session, never carried, never id-stamped. "
+        "Presence is checked before the working_context lists, its item "
+        "shape after them. May be deleted by a forget rewrite."),
+    FieldRule(
+        "envelope", "epistemic_snapshot.strong_beliefs", "array", True, False,
+        "model", "reject",
+        _c(validate="item-list-optional"),
+        "List of item objects; absence is tolerated (treated as empty), a "
+        "present non-list rejects."),
+    FieldRule(
+        "envelope", "epistemic_snapshot.uncertainties", "array", True, False,
+        "model", "reject",
+        _c(validate="item-list-optional"),
+        "List of item objects; absence is tolerated (treated as empty), a "
+        "present non-list rejects."),
+    FieldRule(
+        "envelope", "epistemic_snapshot.contradictions_flagged", "array",
+        True, True, "model", "pass",
+        _c(element=("free-form: bare strings and objects both occur",)),
+        "Never validated or normalized; item-shaped entries share the item "
+        "fields but the shape varies by design (schema.py #146)."),
+    FieldRule(
+        "envelope", "worker_queue", "array", True, True, "model", "pass",
+        _c(),
+        "Prompt-schema artifact; the producer emits an empty list. Never "
+        "read or validated."),
+    FieldRule(
+        "envelope", "format_version", "string", True, False, "code", "strip",
+        _c(pattern=r"^D-[0-9]+$", stripped_at_serialize=True),
+        "Envelope schema version (serializer.PROMPT_VERSION); this document "
+        "versions with it. Stamped at write when absent; pre-#93 legacy "
+        "checkpoints may lack it."),
+    FieldRule(
+        "envelope", "created", "string", True, False, "code", "strip",
+        _c(format=_TIMESTAMP, stripped_at_serialize=True),
+        "Session-end stamp (capture path) or write-time fallback. Readers "
+        "prefer it over file mtime, which pointer rotation rewrites (#93)."),
+    FieldRule(
+        "envelope", "author", "string", True, False, "code", "strip",
+        _c(stripped_at_serialize=True),
+        "Team author (#111), resolved by config at write time."),
+    FieldRule(
+        "envelope", "transcript_hash", "string", True, False, "code", "strip",
+        _c(pattern=r"^[0-9a-f]{64}$", stripped_at_serialize=True),
+        "sha256 of the raw transcript file; absent when no transcript file "
+        "exists (introspection path)."),
+    FieldRule(
+        "envelope", "source_ref", "object", True, False, "code", "strip",
+        _c(stripped_at_serialize=True,
+           shape=("version: integer (1)",
+                  "host: enum[claude-code, codex, windsurf, gemini, hermes, "
+                  "manual]",
+                  "session_id: string (^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$)",
+                  "locator: enum[managed, host-api, unsupported]",
+                  "author?: string (non-empty)")),
+        "Capture source descriptor (#594, provenance.capture_source_ref)."),
+    FieldRule(
+        "envelope", "project_slug", "string", True, False, "code", "strip",
+        _c(stripped_at_serialize=True),
+        "Project attribution, stamped only when the project is known "
+        "(absent = unknown, never empty)."),
+    FieldRule(
+        "envelope", "project_name", "string", True, False, "code", "pass",
+        _c(),
+        "#672 display name (the slug is a lossy flattening). Stamped only "
+        "when absent and the project is known; a pre-existing value is kept."),
+    FieldRule(
+        "envelope", "git_branch", "string", True, False, "code", "strip",
+        _c(stripped_at_serialize=True),
+        "Branch at capture time (#222); absent when unknown or detached."),
+    FieldRule(
+        "envelope", "receipts", "boolean", True, False, "code", "strip",
+        _c(stripped_at_serialize=True),
+        "#204 era marker: true when a signed provenance receipt sidecar was "
+        "planned for this write; absent otherwise."),
+    FieldRule(
+        "envelope", "extraction_version", "integer", True, False, "code",
+        "strip",
+        _c(stripped_at_serialize=True),
+        "#514 extraction-semantics version, stamped only by paths that ran "
+        "the extractor; introspection checkpoints stay absent = unknown."),
+    FieldRule(
+        "envelope", "llm_backend", "string", True, False, "code", "pass",
+        _c(),
+        "#230 backend that produced this checkpoint; assignment always "
+        "overwrites any model-emitted value at serialize."),
+    FieldRule(
+        "envelope", "llm_model", "string", True, False, "code", "pass",
+        _c(),
+        "Requested model alias, stamped only when config knows one; absent "
+        "otherwise (a bare command backend stays honest-absent)."),
+    FieldRule(
+        "envelope", "llm_model_served", "string | array", True, False, "code",
+        "pass",
+        _c(element=("string served-model name; array when more than one "
+                    "model served the run (#458)",)),
+        "Per-call served-model truth; popped from model output "
+        "unconditionally before the serialize-path stamp."),
+    FieldRule(
+        "envelope", "redactions", "object", True, False, "code", "pass",
+        _c(shape=("map of redaction kind -> integer count",)),
+        "#104 visible counter, present only when capture-time redaction "
+        "scrubbed something; merged (never overwritten) across re-writes."),
+    FieldRule(
+        "envelope", "source", "string", True, False, "code", "pass",
+        _c(),
+        "write-checkpoint provenance stamp (default 'introspection'); "
+        "absent on serialize-path checkpoints."),
+    FieldRule(
+        "envelope", "team_project", "string", True, False, "code", "pass",
+        _c(),
+        "Team-mirror copies only (#111): the shared project path segments."),
+    FieldRule(
+        "envelope", "origin_session", "string", True, False, "code", "strip",
+        _c(stripped_at_serialize=True),
+        "Reserved: stripped from model output and never stamped at the top "
+        "level — origin binds per item only (#268)."),
+    FieldRule(
+        "envelope", "origin_author", "string", True, False, "code", "strip",
+        _c(stripped_at_serialize=True),
+        "Reserved: stripped from model output and never stamped at the top "
+        "level — origin binds per item only (#268)."),
+)
+
+_ITEM_BY_NAME = {r.name: r for r in ITEM_RULES}
+_ENVELOPE_BY_NAME = {r.name: r for r in ENVELOPE_RULES}
+
+# Required-always item fields, in table order, for the combined missing-keys
+# predicate ("missing text or trust") the live validator reports.
+_ITEM_REQUIRED = tuple(
+    r.name for r in ITEM_RULES if not r.optional and r.disposition == "reject")
+
+
+def rule(scope: str, name: str) -> FieldRule:
+    """The table row for one field; KeyError on an unknown field."""
+    table = _ITEM_BY_NAME if scope == "item" else _ENVELOPE_BY_NAME
+    return table[name]
+
+
+def item_reason(item: object) -> str | None:
+    """None when the item is valid, else WHICH predicate rejected it — the
+    generated twin of the checks serializer._item_reason performs, driven by
+    ITEM_RULES rows with disposition "reject", reproducing the live reason
+    strings byte-for-byte (#555 named-predicate contract)."""
+    if not isinstance(item, dict):
+        return "not a dict"
+    if any(name not in item for name in _ITEM_REQUIRED):
+        return "missing " + " or ".join(_ITEM_REQUIRED)
+    for r in ITEM_RULES:
+        if r.disposition != "reject":
+            continue
+        c = dict(r.constraints)
+        value = item.get(r.name)
+        if "required_if_eq" in c:
+            dep, expected = c["required_if_eq"]
+            if item.get(dep) == expected and (
+                    not isinstance(value, str) or not value.strip()):
+                return str(c["reject_reason"])
+            continue
+        if "enum" in c:
+            if value not in c["enum"]:
+                return str(c["reject_reason"])
+            continue
+        if "object_keys" in c:
+            if value is None:
+                continue
+            if not isinstance(value, dict):
+                return f"{r.name} is not a dict"
+            if not all(isinstance(value.get(k), str) and value.get(k)
+                       for k in c["object_keys"]):
+                return str(c["reject_reason_missing"])
+            continue
+        # plain string field: required rows reject any non-str; optional
+        # rows tolerate an explicit null (the `because` posture).
+        if r.optional and value is None:
+            continue
+        if not isinstance(value, str):
+            return str(c["reject_reason"])
+    return None
+
+
+def checkpoint_reason(checkpoint: object) -> str | None:
+    """None when the checkpoint is valid, else WHICH predicate rejected it —
+    the generated twin of serializer.validation_reason, driven by
+    ENVELOPE_RULES. Two phases, like the live validator: presence/type of the
+    top-level keys first (in table order), then the item-bearing sections (in
+    table order) — so a multiply-invalid checkpoint is rejected with the same
+    reason string the live predicate order produced."""
+    if not isinstance(checkpoint, dict):
+        return "checkpoint is not a dict"
+    for r in ENVELOPE_RULES:
+        c = dict(r.constraints)
+        validate = c.get("validate")
+        if validate == "presence":
+            if r.name not in checkpoint:
+                return str(c["reject_reason"])
+        elif validate == "object":
+            if not isinstance(checkpoint.get(r.name), dict):
+                return f"{r.name} is not a dict"
+        elif validate == "item-required":
+            section, key = r.name.split(".", 1)
+            if key not in checkpoint[section]:
+                return str(c["reject_reason"])
+    for r in ENVELOPE_RULES:
+        validate = dict(r.constraints).get("validate")
+        if validate == "item-required":
+            section, key = r.name.split(".", 1)
+            reason = item_reason(checkpoint[section][key])
+            if reason is not None:
+                return f"{r.name}: {reason}"
+        elif validate in ("item-list-required", "item-list-optional"):
+            section, key = r.name.split(".", 1)
+            if validate == "item-list-optional":
+                items = checkpoint[section].get(key, [])
+            else:
+                items = checkpoint[section].get(key)
+            if not isinstance(items, list):
+                return f"{r.name} is not a list"
+            for i, item in enumerate(items):
+                reason = item_reason(item)
+                if reason is not None:
+                    return f"{r.name}[{i}]: {reason}"
+    return None
+
+
+def normalize_field(item: dict, name: str) -> None:
+    """Apply one clamp/drop row's disposition to `item` in place — the
+    generated per-item body of serializer.sanitize_importance /
+    sanitize_scene. Absent fields stay absent; a malformed advisory field is
+    removed, never fatal (#119 posture)."""
+    r = _ITEM_BY_NAME[name]
+    if r.disposition not in ("clamp", "drop") or name not in item:
+        return
+    c = dict(r.constraints)
+    value = item[name]
+    if r.type == "integer":
+        # bool is an int subclass — True must not become importance 1.
+        if isinstance(value, int) and not isinstance(value, bool):
+            item[name] = min(int(c["max"]), max(int(c["min"]), value))
+        else:
+            del item[name]
+    elif r.type == "string":
+        if isinstance(value, str) and value.strip():
+            out = value.strip() if c.get("strip_whitespace") else value
+            item[name] = out[:int(c["max_chars"])]
+        else:
+            del item[name]
+
+
+def _row_document(r: FieldRule) -> dict:
+    return {
+        "field": r.name,
+        "type": r.type,
+        "optional": r.optional,
+        "nullable": r.nullable,
+        "owner": r.owner,
+        "disposition": r.disposition,
+        "constraints": {k: list(v) if isinstance(v, tuple) else v
+                        for k, v in r.constraints},
+        "notes": r.notes,
+    }
+
+
+def schema_document(format_version: str) -> dict:
+    """The published machine-readable schema document, as a dict. Versioned
+    with the envelope's `format_version` (the caller passes
+    serializer.PROMPT_VERSION); deterministic by construction — fixed key
+    order, no clocks, no environment."""
+    return {
+        "document": "daimon-checkpoint-field-table",
+        "document_version": SCHEMA_DOCUMENT_VERSION,
+        "format_version": format_version,
+        "dispositions": {
+            "reject": "an out-of-contract value refuses the whole checkpoint",
+            "clamp": "an out-of-range value is pulled into range or truncated",
+            "drop": "an out-of-contract value removes the field, never fails "
+                    "the write",
+            "pass": "stored as written; consumers must tolerate any shape",
+            "strip": "a model-emitted value is discarded at the serialize "
+                     "boundary; the persisted value is always code-derived",
+        },
+        "owners": {
+            "model": "extracted content, policed by the validator and "
+                     "normalizers",
+            "code": "stamped by daimon's own write pipeline",
+        },
+        "envelope": [_row_document(r) for r in ENVELOPE_RULES],
+        "item": [_row_document(r) for r in ITEM_RULES],
+    }
+
+
+def render_document(format_version: str) -> str:
+    """schema_document as deterministic, newline-terminated JSON text — the
+    exact bytes of docs/checkpoint-schema.json."""
+    return json.dumps(schema_document(format_version), indent=2,
+                      ensure_ascii=False) + "\n"
+
+
+if __name__ == "__main__":  # pragma: no cover — the regeneration entry point
+    # Lazy: keeps the module import-free (serializer imports it).
+    from daimon_briefing import serializer as _serializer
+
+    print(render_document(_serializer.PROMPT_VERSION), end="")

--- a/plugin/daimon_briefing/field_table.py
+++ b/plugin/daimon_briefing/field_table.py
@@ -248,13 +248,14 @@ ENVELOPE_RULES: tuple[FieldRule, ...] = (
         _c(validate="item-list-required"),
         "List of item objects; a non-list (absence included) rejects."),
     FieldRule(
-        "envelope", "working_context.active_topic", "object", False, True,
+        "envelope", "working_context.active_topic", "object", False, False,
         "model", "reject",
         _c(validate="item-required",
            reject_reason="missing working_context.active_topic"),
         "Singleton item; per-session, never carried, never id-stamped. "
         "Presence is checked before the working_context lists, its item "
-        "shape after them. May be deleted by a forget rewrite."),
+        "shape after them; an explicit null rejects (item shape applies). "
+        "May be deleted by a forget rewrite."),
     FieldRule(
         "envelope", "epistemic_snapshot.strong_beliefs", "array", True, False,
         "model", "reject",
@@ -478,27 +479,116 @@ def checkpoint_reason(checkpoint: object) -> str | None:
 
 
 def normalize_field(item: dict, name: str) -> None:
-    """Apply one clamp/drop row's disposition to `item` in place — the
-    generated per-item body of serializer.sanitize_importance /
-    sanitize_scene. Absent fields stay absent; a malformed advisory field is
-    removed, never fatal (#119 posture)."""
+    """Apply one clamp row's disposition to `item` in place — the generated
+    per-item body of serializer.sanitize_importance / sanitize_scene. Absent
+    fields stay absent; a malformed advisory field is removed, never fatal
+    (#119 posture).
+
+    Only clamp rows are implemented HERE: the `drop` disposition of
+    source_message_ids needs transcript context and lives in
+    sanitize_source_ids, and reject rows belong to the validator. Calling
+    this on any other row RAISES instead of silently no-opping (#828 review:
+    a silent no-op would leave a malformed value in place while reading as
+    normalization at the call site)."""
     r = _ITEM_BY_NAME[name]
-    if r.disposition not in ("clamp", "drop") or name not in item:
-        return
     c = dict(r.constraints)
-    value = item[name]
-    if r.type == "integer":
+    if r.disposition == "clamp" and r.type == "integer":
+        if name not in item:
+            return
+        value = item[name]
         # bool is an int subclass — True must not become importance 1.
         if isinstance(value, int) and not isinstance(value, bool):
             item[name] = min(int(c["max"]), max(int(c["min"]), value))
         else:
             del item[name]
-    elif r.type == "string":
+    elif r.disposition == "clamp" and r.type == "string":
+        if name not in item:
+            return
+        value = item[name]
         if isinstance(value, str) and value.strip():
             out = value.strip() if c.get("strip_whitespace") else value
             item[name] = out[:int(c["max_chars"])]
         else:
             del item[name]
+    else:
+        raise ValueError(
+            f"normalize_field has no branch for {r.type}/{r.disposition} "
+            f"(field {name!r})")
+
+
+_ENGINE_VALIDATES = ("presence", "object", "item-required",
+                     "item-list-required", "item-list-optional")
+
+
+def engine_coverage_errors(
+        item_rules: tuple[FieldRule, ...] = ITEM_RULES,
+        envelope_rules: tuple[FieldRule, ...] = ENVELOPE_RULES) -> list[str]:
+    """Rows the runtime engine has no branch for, as human-readable errors.
+
+    #828 review: the validator dispatches on a row's constraint keys, not its
+    `type` column, so a reject row of a shape the engine never anticipated
+    (say an integer field with only a reject_reason) would fall through to
+    the plain-string branch or KeyError deep inside a serialize. This guard
+    runs at import, so a malformed row fails the first thing that touches
+    the module — never a capture at the write boundary."""
+    errors: list[str] = []
+    for r in item_rules:
+        c = dict(r.constraints)
+        if r.disposition == "reject":
+            if "required_if_eq" in c or "enum" in c:
+                if "reject_reason" not in c:
+                    errors.append(
+                        f"item.{r.name}: reject row lacks reject_reason")
+            elif "object_keys" in c:
+                if "reject_reason_missing" not in c:
+                    errors.append(
+                        f"item.{r.name}: object_keys row lacks "
+                        "reject_reason_missing")
+            elif r.type == "string":
+                if "reject_reason" not in c:
+                    errors.append(
+                        f"item.{r.name}: reject row lacks reject_reason")
+            else:
+                errors.append(
+                    f"item.{r.name}: reject row of type {r.type!r} has no "
+                    "engine branch")
+        elif r.disposition == "clamp":
+            if r.type == "integer":
+                if not {"min", "max"} <= set(c):
+                    errors.append(
+                        f"item.{r.name}: integer clamp row lacks min/max")
+            elif r.type == "string":
+                if "max_chars" not in c:
+                    errors.append(
+                        f"item.{r.name}: string clamp row lacks max_chars")
+            else:
+                errors.append(
+                    f"item.{r.name}: clamp row of type {r.type!r} has no "
+                    "engine branch")
+    for r in envelope_rules:
+        c = dict(r.constraints)
+        validate = c.get("validate")
+        if r.disposition == "reject":
+            if validate not in _ENGINE_VALIDATES:
+                errors.append(
+                    f"envelope.{r.name}: reject row validate={validate!r} "
+                    "has no engine branch")
+            elif (validate in ("presence", "item-required")
+                    and "reject_reason" not in c):
+                errors.append(
+                    f"envelope.{r.name}: validate={validate!r} row lacks "
+                    "reject_reason")
+        elif validate is not None:
+            errors.append(
+                f"envelope.{r.name}: validate={validate!r} on a "
+                f"non-reject row ({r.disposition})")
+    return errors
+
+
+_COVERAGE_ERRORS = engine_coverage_errors()
+if _COVERAGE_ERRORS:  # pragma: no cover — a table bug fails every import
+    raise AssertionError(
+        "field_table engine coverage: " + "; ".join(_COVERAGE_ERRORS))
 
 
 def _row_document(r: FieldRule) -> dict:
@@ -537,6 +627,62 @@ def schema_document(format_version: str) -> dict:
             "model": "extracted content, policed by the validator and "
                      "normalizers",
             "code": "stamped by daimon's own write pipeline",
+        },
+        "columns": {
+            "type": "the JSON type the producer writes when it writes the "
+                    "field",
+            "optional": "whether a stored checkpoint may lack the field",
+            "nullable": "whether an explicit null is tolerated where the "
+                        "field is present; false on a reject row means an "
+                        "explicit null is rejected like any other "
+                        "out-of-contract value",
+            "owner": "see owners",
+            "disposition": "see dispositions",
+            "constraints": "see constraint_semantics; keys not listed there "
+                           "are documentation for consumers, not runtime "
+                           "checks",
+        },
+        "constraint_semantics": {
+            "validate": "the structural check the runtime validator "
+                        "performs on this envelope field: presence, object, "
+                        "item-required, item-list-required (absence "
+                        "rejects), item-list-optional (absence = empty "
+                        "list)",
+            "enum": "closed set of accepted values; anything else rejects "
+                    "with reject_reason",
+            "required_if_eq": "[field, value]: this field must be a "
+                              "non-empty string ONLY when the named sibling "
+                              "field equals the value; otherwise it is "
+                              "unconstrained and any shape passes (so a "
+                              "reject disposition with this key is "
+                              "conditional, not unconditional)",
+            "object_keys": "sub-keys that must each be a non-empty string "
+                           "when the field is present and non-null; a "
+                           "non-object rejects, a missing/empty sub-key "
+                           "rejects with reject_reason_missing",
+            "reject_reason": "the exact reason string the validator returns "
+                             "when this row rejects",
+            "reject_reason_missing": "the reason string when a required "
+                                     "sub-key is absent or empty",
+            "min": "inclusive lower clamp bound for in-type integers; "
+                   "non-integers (booleans included) drop the field",
+            "max": "inclusive upper clamp bound for in-type integers",
+            "strip_whitespace": "leading/trailing whitespace is removed "
+                                "before storing",
+            "max_chars": "the stored string is truncated to this many "
+                         "characters",
+            "stripped_at_serialize": "a model-emitted value for this field "
+                                     "is discarded at the serialize "
+                                     "boundary; the persisted value is "
+                                     "always code-derived",
+            "pattern": "regex the code-stamped value matches "
+                       "(documentation, not a runtime check)",
+            "format": "timestamp format of the code-stamped value "
+                      "(documentation)",
+            "element": "shape of array elements (documentation)",
+            "shape": "shape of the object's sub-fields (documentation)",
+            "link_types": "link `type` values the producer emits "
+                          "(documentation)",
         },
         "envelope": [_row_document(r) for r in ENVELOPE_RULES],
         "item": [_row_document(r) for r in ITEM_RULES],

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -21,7 +21,8 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 
-from . import (config, configure, ledger, llm, normalize, provenance, schema)
+from . import (config, configure, field_table, ledger, llm, normalize,
+               provenance, schema)
 
 # No handlers/basicConfig here — the library stays silent unless the caller
 # configures logging. Multi-hour serialize runs need this heartbeat to be killable.
@@ -604,39 +605,17 @@ def _item_reason(item) -> str | None:
     Names the predicate only. Never the item's text, quote, or trust value —
     the reason is logged verbatim and the payload is exactly what the boundary
     is refusing to vouch for.
+
+    #827: the predicates (and their exact strings — they ship in
+    SchemaValidationError and the #743 retry note) are generated from
+    field_table.ITEM_RULES, the declarative source of truth this function's
+    hand-written checks moved into. The per-predicate history lives on the
+    table rows: #134 (present-but-null text crashed briefing.render — reject
+    at the boundary; empty str stays valid, active_topic MAY carry empty
+    text), D-006 (a verbatim claim without a real quote is an unpinned
+    claim), F4/#527 (because), and the anchored_to shape.
     """
-    if not isinstance(item, dict):
-        return "not a dict"
-    if "text" not in item or "trust" not in item:
-        return "missing text or trust"
-    # #134: presence != a usable value. A present-but-null (or non-str) text
-    # passed this check, reached disk, then crashed briefing.render on the next
-    # session. Reject at the boundary. Empty str stays valid — active_topic MAY
-    # carry empty text (test_validate_allows_empty_active_topic_text).
-    if not isinstance(item["text"], str):
-        return "text is not a str"
-    if item["trust"] not in _TRUST_CLASSES:
-        return "trust is not a known trust class"
-    if item["trust"] == "verbatim":
-        quote = item.get("quote")
-        # D-006: a verbatim claim without a real quote is an unpinned claim.
-        if not isinstance(quote, str) or not quote.strip():
-            return "trust=verbatim item has no quote"
-    because = item.get("because")
-    if because is not None and not isinstance(because, str):
-        # F4 (#527), same #134 lesson as text: present-but-non-str would
-        # reach disk and crash a later render — reject at the boundary.
-        return "because is not a str"
-    anchor = item.get("anchored_to")
-    if anchor is not None:
-        if not isinstance(anchor, dict):
-            return "anchored_to is not a dict"
-        if not all(
-            isinstance(anchor.get(k), str) and anchor.get(k)
-            for k in ("file", "symbol", "body_hash")
-        ):
-            return "anchored_to is missing file, symbol, or body_hash"
-    return None
+    return field_table.item_reason(item)
 
 
 def _valid_item(item) -> bool:
@@ -669,15 +648,11 @@ def sanitize_importance(checkpoint) -> None:
     else (strings, floats, bools, None) is dropped. Malformed importance must
     NEVER fail a serialize — a new failure class here would recreate the #119
     heal-starvation incident for a purely advisory field."""
+    # #827: the 1..10 clamp and the drop-everything-else disposition are
+    # generated from field_table's `importance` row — the same row the
+    # published schema document renders for consumers.
     for item in iter_items(checkpoint):
-        if "importance" not in item:
-            continue
-        v = item["importance"]
-        # bool is an int subclass — True must not become importance 1.
-        if isinstance(v, int) and not isinstance(v, bool):
-            item["importance"] = min(10, max(1, v))
-        else:
-            del item["importance"]
+        field_table.normalize_field(item, "importance")
 
 
 def sanitize_scene(checkpoint) -> None:
@@ -686,14 +661,10 @@ def sanitize_scene(checkpoint) -> None:
     empty/whitespace) is dropped. Same philosophy as sanitize_importance: a
     malformed advisory field must NEVER fail a serialize — and it runs flag or
     no flag, because a model can hallucinate the key without being asked."""
+    # #827: strip/cap/drop dispositions generated from field_table's `scene`
+    # row (its max_chars is pinned equal to _SCENE_MAX_CHARS by test).
     for item in iter_items(checkpoint):
-        if "scene" not in item:
-            continue
-        v = item["scene"]
-        if isinstance(v, str) and v.strip():
-            item["scene"] = v.strip()[:_SCENE_MAX_CHARS]
-        else:
-            del item["scene"]
+        field_table.normalize_field(item, "scene")
 
 
 def validation_reason(checkpoint) -> str | None:
@@ -711,39 +682,14 @@ def validation_reason(checkpoint) -> str | None:
     caught a genuinely unpinned claim (the machinery working), a non-str text
     means junk arrived from upstream. Predicate order is unchanged, so the
     accept/reject verdict is byte-identical to the bool version.
+
+    #827: generated from field_table.ENVELOPE_RULES — the declarative source
+    of truth the hand-written section walk moved into, and the same rows the
+    published schema document renders. Predicate order and reason strings
+    are pinned byte-identical by tests/test_field_table.py (matrix) and
+    tests/test_field_table_corpus.py (the real on-disk corpus).
     """
-    if not isinstance(checkpoint, dict):
-        return "checkpoint is not a dict"
-    if "session_id" not in checkpoint:
-        return "missing session_id"
-    wc = checkpoint.get("working_context")
-    es = checkpoint.get("epistemic_snapshot")
-    if not isinstance(wc, dict):
-        return "working_context is not a dict"
-    if not isinstance(es, dict):
-        return "epistemic_snapshot is not a dict"
-    if "active_topic" not in wc:
-        return "missing working_context.active_topic"
-    for key in ("open_questions", "recent_decisions"):
-        items = wc.get(key)
-        if not isinstance(items, list):
-            return f"working_context.{key} is not a list"
-        for i, item in enumerate(items):
-            reason = _item_reason(item)
-            if reason is not None:
-                return f"working_context.{key}[{i}]: {reason}"
-    reason = _item_reason(wc["active_topic"])
-    if reason is not None:
-        return f"working_context.active_topic: {reason}"
-    for key in ("strong_beliefs", "uncertainties"):
-        items = es.get(key, [])
-        if not isinstance(items, list):
-            return f"epistemic_snapshot.{key} is not a list"
-        for i, item in enumerate(items):
-            reason = _item_reason(item)
-            if reason is not None:
-                return f"epistemic_snapshot.{key}[{i}]: {reason}"
-    return None
+    return field_table.checkpoint_reason(checkpoint)
 
 
 def validate(checkpoint) -> bool:

--- a/plugin/tests/test_field_table.py
+++ b/plugin/tests/test_field_table.py
@@ -1,0 +1,359 @@
+"""#827: the declarative field table is the single source of truth.
+
+Three guarantees, each pinned here:
+
+1. The generated validator's verdict AND reason string are byte-identical to
+   the live serializer validator's, across a matrix that exercises every
+   predicate branch — so table-vs-code divergence is a test failure, never a
+   silent consumer-side data loss.
+2. The generated normalizers reproduce sanitize_importance / sanitize_scene
+   exactly (the #827 motivating bug was a consumer guessing importance 1-5
+   against the producer's 1-10).
+3. The published schema document (docs/checkpoint-schema.json) is exactly what
+   the table renders, versioned with the envelope's format_version — a stale
+   committed artifact fails CI.
+"""
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from daimon_briefing import field_table, schema, serializer
+
+_REPO = Path(__file__).resolve().parents[2]
+_ARTIFACT = _REPO / "docs" / "checkpoint-schema.json"
+
+
+def _item(**over):
+    base = {"text": "t", "trust": "inferred"}
+    base.update(over)
+    return base
+
+
+def _checkpoint(**over):
+    base = {
+        "session_id": "S1",
+        "working_context": {
+            "active_topic": {"text": "topic", "trust": "inferred"},
+            "open_questions": [{"text": "q", "trust": "inferred"}],
+            "recent_decisions": [
+                {"text": "d", "trust": "verbatim", "quote": "the quote"}],
+        },
+        "epistemic_snapshot": {
+            "strong_beliefs": [],
+            "uncertainties": [{"text": "u", "trust": "inferred"}],
+            "contradictions_flagged": [],
+        },
+        "worker_queue": [],
+    }
+    base.update(over)
+    return base
+
+
+# ---- 1. generated item validator == live item validator ----
+
+_ITEM_CASES = (
+    _item(),
+    _item(trust="verbatim", quote="q"),
+    _item(text=""),                          # empty text stays valid (#134)
+    "not a dict",
+    None,
+    42,
+    {"trust": "inferred"},                   # missing text
+    {"text": "t"},                           # missing trust
+    {},                                      # missing both
+    _item(text=None),
+    _item(text=7),
+    _item(trust="gospel"),
+    _item(trust=None),
+    _item(trust="verbatim"),                 # verbatim without quote
+    _item(trust="verbatim", quote=""),
+    _item(trust="verbatim", quote="   "),
+    _item(trust="verbatim", quote=None),
+    _item(trust="verbatim", quote=3),
+    _item(because="stated reasoning"),
+    _item(because=None),                     # null because is tolerated
+    _item(because=5),
+    _item(because=["x"]),
+    _item(anchored_to={"file": "f", "symbol": "s", "body_hash": "h"}),
+    _item(anchored_to=None),                 # null anchored_to is tolerated
+    _item(anchored_to="f:s"),
+    _item(anchored_to={"file": "f", "symbol": "s"}),
+    _item(anchored_to={"file": "f", "symbol": "s", "body_hash": ""}),
+    _item(anchored_to={"file": "f", "symbol": "s", "body_hash": 9}),
+    # out-of-contract values on pass/clamp fields never reject an item
+    _item(importance="high", scene=7, external_state="yes", links="x",
+          source_message_ids=13),
+)
+
+
+@pytest.mark.parametrize("item", _ITEM_CASES,
+                         ids=[f"case{i}" for i in range(len(_ITEM_CASES))])
+def test_item_reason_matches_the_live_validator(item):
+    assert field_table.item_reason(item) == serializer._item_reason(item)
+
+
+def test_item_reason_strings_are_the_live_predicate_names():
+    """The exact strings ship in SchemaValidationError and retry notes (#743),
+    so the generated validator must reproduce them byte-for-byte."""
+    assert field_table.item_reason("x") == "not a dict"
+    assert field_table.item_reason({}) == "missing text or trust"
+    assert field_table.item_reason(_item(text=None)) == "text is not a str"
+    assert (field_table.item_reason(_item(trust="gospel"))
+            == "trust is not a known trust class")
+    assert (field_table.item_reason(_item(trust="verbatim"))
+            == "trust=verbatim item has no quote")
+    assert field_table.item_reason(_item(because=5)) == "because is not a str"
+    assert (field_table.item_reason(_item(anchored_to="x"))
+            == "anchored_to is not a dict")
+    assert (field_table.item_reason(_item(anchored_to={}))
+            == "anchored_to is missing file, symbol, or body_hash")
+
+
+# ---- 2. generated checkpoint validator == live checkpoint validator ----
+
+def _without(key):
+    def mutate(cp):
+        del cp[key]
+        return cp
+    return mutate
+
+
+def _set(path, value):
+    def mutate(cp):
+        node = cp
+        for part in path[:-1]:
+            node = node[part]
+        node[path[-1]] = value
+        return cp
+    return mutate
+
+
+def _del(path):
+    def mutate(cp):
+        node = cp
+        for part in path[:-1]:
+            node = node[part]
+        del node[path[-1]]
+        return cp
+    return mutate
+
+
+_CHECKPOINT_MUTATIONS = (
+    lambda cp: cp,
+    lambda cp: "not a dict",
+    lambda cp: None,
+    _without("session_id"),
+    _set(("working_context",), "junk"),
+    _without("working_context"),
+    _set(("epistemic_snapshot",), None),
+    _without("epistemic_snapshot"),
+    _del(("working_context", "active_topic")),
+    _set(("working_context", "active_topic"), {"trust": "inferred"}),
+    _set(("working_context", "open_questions"), "junk"),
+    _del(("working_context", "open_questions")),
+    _set(("working_context", "open_questions"), [{"text": "q"}]),
+    _set(("working_context", "recent_decisions"), None),
+    _set(("working_context", "recent_decisions"),
+         [{"text": "d", "trust": "verbatim"}]),
+    _set(("epistemic_snapshot", "strong_beliefs"), "junk"),
+    _del(("epistemic_snapshot", "strong_beliefs")),   # optional: absent is valid
+    _set(("epistemic_snapshot", "uncertainties"), [{"text": "u", "trust": "x"}]),
+    _set(("epistemic_snapshot", "contradictions_flagged"), "anything"),
+    _del(("working_context", "active_topic")),
+    # active_topic missing AND a bad list: presence is checked first
+    lambda cp: (_set(("working_context", "open_questions"), "junk")(
+        _del(("working_context", "active_topic"))(cp))),
+    # bad wc list AND bad active_topic item: the wc lists are checked first
+    lambda cp: (_set(("working_context", "active_topic"), {"text": 1, "trust": "inferred"})(
+        _set(("working_context", "recent_decisions"), [{"text": "d", "trust": "z"}])(cp))),
+    _without("worker_queue"),
+)
+
+
+@pytest.mark.parametrize(
+    "mutate", _CHECKPOINT_MUTATIONS,
+    ids=[f"case{i}" for i in range(len(_CHECKPOINT_MUTATIONS))])
+def test_checkpoint_reason_matches_the_live_validator(mutate):
+    ours = field_table.checkpoint_reason(mutate(_checkpoint()))
+    live = serializer.validation_reason(mutate(_checkpoint()))
+    assert ours == live
+
+
+def test_checkpoint_reason_names_paths_like_the_live_validator():
+    cp = _checkpoint()
+    cp["working_context"]["open_questions"] = [
+        {"text": "q", "trust": "inferred"}, {"text": None, "trust": "inferred"}]
+    assert (field_table.checkpoint_reason(cp)
+            == "working_context.open_questions[1]: text is not a str")
+
+
+# ---- 3. generated normalizers reproduce today's dispositions exactly ----
+
+@pytest.mark.parametrize("value,expected", [
+    (5, 5),
+    (1, 1),
+    (10, 10),
+    (0, 1),        # clamp low (the producer range is 1-10; serializer.py:678)
+    (-3, 1),
+    (11, 10),      # clamp high
+    (9999, 10),
+    (True, None),  # bool is an int subclass — dropped, never importance 1
+    (False, None),
+    ("5", None),
+    (3.7, None),
+    (None, None),
+])
+def test_normalize_importance_disposition(value, expected):
+    item = _item(importance=value)
+    field_table.normalize_field(item, "importance")
+    assert item.get("importance", None) == expected
+    if expected is None:
+        assert "importance" not in item
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("a scene", "a scene"),
+    ("  padded  ", "padded"),
+    ("x" * 600, "x" * 500),
+    ("", None),
+    ("   ", None),
+    (7, None),
+    (["s"], None),
+    (None, None),
+])
+def test_normalize_scene_disposition(value, expected):
+    item = _item(scene=value)
+    field_table.normalize_field(item, "scene")
+    assert item.get("scene", None) == expected
+    if expected is None:
+        assert "scene" not in item
+
+
+def test_normalize_field_leaves_an_absent_field_absent():
+    item = _item()
+    field_table.normalize_field(item, "importance")
+    field_table.normalize_field(item, "scene")
+    assert item == _item()
+
+
+def test_sanitize_importance_and_scene_still_behave_at_the_checkpoint_level():
+    """The serializer entry points (now wired through the table) keep their
+    contract: normalize every schema item in place, never raise."""
+    cp = _checkpoint()
+    cp["working_context"]["active_topic"]["importance"] = 12
+    cp["working_context"]["open_questions"][0]["importance"] = True
+    cp["epistemic_snapshot"]["uncertainties"][0]["scene"] = "  s  "
+    serializer.sanitize_importance(cp)
+    serializer.sanitize_scene(cp)
+    assert cp["working_context"]["active_topic"]["importance"] == 10
+    assert "importance" not in cp["working_context"]["open_questions"][0]
+    assert cp["epistemic_snapshot"]["uncertainties"][0]["scene"] == "s"
+
+
+# ---- 4. the table agrees with the code it describes ----
+
+def test_scene_cap_matches_the_serializer_constant():
+    row = field_table.rule("item", "scene")
+    assert dict(row.constraints)["max_chars"] == serializer._SCENE_MAX_CHARS
+
+
+def test_importance_bounds_are_the_producer_range():
+    row = field_table.rule("item", "importance")
+    c = dict(row.constraints)
+    assert (c["min"], c["max"]) == (1, 10)
+
+
+def test_trust_enum_matches_the_serializer_trust_classes():
+    row = field_table.rule("item", "trust")
+    assert set(dict(row.constraints)["enum"]) == serializer._TRUST_CLASSES
+
+
+def test_stripped_envelope_keys_match_the_serializer_strip_list():
+    stripped = {r.name for r in field_table.ENVELOPE_RULES
+                if dict(r.constraints).get("stripped_at_serialize")}
+    assert stripped == set(serializer._CODE_OWNED_KEYS)
+
+
+def test_stripped_item_keys_match_the_serializer_strip_list():
+    stripped = {r.name for r in field_table.ITEM_RULES
+                if dict(r.constraints).get("stripped_at_serialize")}
+    assert stripped == set(serializer._CODE_OWNED_ITEM_KEYS)
+
+
+def test_every_schema_item_field_has_an_envelope_row():
+    """schema.ITEM_FIELDS (#146) and the table must name the same sections."""
+    rows = {r.name: r for r in field_table.ENVELOPE_RULES}
+    for f in schema.ITEM_FIELDS:
+        row = rows[f"{f.section}.{f.key}"]
+        validate = dict(row.constraints).get("validate")
+        if f.singleton:
+            assert validate == "item-required"
+        else:
+            assert validate in ("item-list-required", "item-list-optional", None)
+
+
+def test_no_duplicate_rows_and_scopes_are_coherent():
+    for rules, scope in ((field_table.ENVELOPE_RULES, "envelope"),
+                        (field_table.ITEM_RULES, "item")):
+        names = [r.name for r in rules]
+        assert len(names) == len(set(names))
+        assert all(r.scope == scope for r in rules)
+        assert all(r.owner in ("model", "code") for r in rules)
+        assert all(r.disposition in ("reject", "clamp", "drop", "pass", "strip")
+                   for r in rules)
+
+
+# ---- 5. the published document ----
+
+def test_schema_document_is_versioned_with_format_version():
+    doc = field_table.schema_document(serializer.PROMPT_VERSION)
+    assert doc["format_version"] == serializer.PROMPT_VERSION
+    assert doc["document"] == "daimon-checkpoint-field-table"
+    assert doc["document_version"] == field_table.SCHEMA_DOCUMENT_VERSION
+    assert {row["field"] for row in doc["item"]} == {
+        r.name for r in field_table.ITEM_RULES}
+    assert {row["field"] for row in doc["envelope"]} == {
+        r.name for r in field_table.ENVELOPE_RULES}
+    for row in doc["envelope"] + doc["item"]:
+        assert set(row) == {"field", "type", "optional", "nullable", "owner",
+                            "disposition", "constraints", "notes"}
+
+
+def test_render_document_is_deterministic_json():
+    a = field_table.render_document("D-999")
+    b = field_table.render_document("D-999")
+    assert a == b
+    assert a.endswith("\n")
+    assert json.loads(a)["format_version"] == "D-999"
+
+
+def test_published_artifact_matches_the_table():
+    """docs/checkpoint-schema.json is generated, never hand-edited: a table
+    change without `python -m daimon_briefing.field_table` fails here."""
+    assert _ARTIFACT.is_file(), (
+        "docs/checkpoint-schema.json is missing — regenerate it with "
+        "`uv run python -m daimon_briefing.field_table` from plugin/")
+    expected = field_table.render_document(serializer.PROMPT_VERSION)
+    assert _ARTIFACT.read_text(encoding="utf-8") == expected
+
+
+# ---- 6. normalizer equivalence holds on arbitrary shapes ----
+
+def test_normalizers_and_sanitizers_agree_on_adversarial_checkpoints():
+    cases = []
+    for imp in (5, 0, 11, True, "5", None, 3.5):
+        for scn in ("s", "", "  y  ", 9, None, "z" * 600):
+            cases.append(_checkpoint(working_context={
+                "active_topic": {"text": "t", "trust": "inferred",
+                                 "importance": imp, "scene": scn},
+                "open_questions": [], "recent_decisions": []}))
+    for cp in cases:
+        a, b = copy.deepcopy(cp), copy.deepcopy(cp)
+        serializer.sanitize_importance(a)
+        serializer.sanitize_scene(a)
+        for item in serializer.iter_items(b):
+            field_table.normalize_field(item, "importance")
+            field_table.normalize_field(item, "scene")
+        assert a == b

--- a/plugin/tests/test_field_table.py
+++ b/plugin/tests/test_field_table.py
@@ -2,10 +2,13 @@
 
 Three guarantees, each pinned here:
 
-1. The generated validator's verdict AND reason string are byte-identical to
-   the live serializer validator's, across a matrix that exercises every
-   predicate branch — so table-vs-code divergence is a test failure, never a
-   silent consumer-side data loss.
+1. The generated validator reproduces the ratified contract — verdicts AND
+   reason strings — across a matrix that exercises every predicate branch.
+   The contract lives in this file as FROZEN REFERENCE implementations
+   (transcribed from the pre-#827 serializer), NOT as calls through the live
+   code path: serializer now delegates to field_table, so comparing the two
+   live functions would be f(x) == f(x) (the scar-0042 tautology class).
+   Exactly one wiring test proves the delegation itself.
 2. The generated normalizers reproduce sanitize_importance / sanitize_scene
    exactly (the #827 motivating bug was a consumer guessing importance 1-5
    against the producer's 1-10).
@@ -51,7 +54,97 @@ def _checkpoint(**over):
     return base
 
 
-# ---- 1. generated item validator == live item validator ----
+# ---- The frozen contract (reference implementations) ----
+#
+# LITERAL transcriptions of serializer._item_reason / validation_reason /
+# sanitize_importance+sanitize_scene as they stood before #827 wired them
+# through the table. They deliberately never call the live code. ONE ratified
+# divergence from the pre-#827 bytes (#828 review, finding kept as an
+# improvement): trust membership is checked against a TUPLE, not a set, so an
+# unhashable trust value (e.g. a list) rejects cleanly as an unknown trust
+# class instead of raising TypeError out of serialize_strict.
+
+def _reference_item_reason(item):
+    if not isinstance(item, dict):
+        return "not a dict"
+    if "text" not in item or "trust" not in item:
+        return "missing text or trust"
+    if not isinstance(item["text"], str):
+        return "text is not a str"
+    if item["trust"] not in ("verbatim", "inferred"):
+        return "trust is not a known trust class"
+    if item["trust"] == "verbatim":
+        quote = item.get("quote")
+        if not isinstance(quote, str) or not quote.strip():
+            return "trust=verbatim item has no quote"
+    because = item.get("because")
+    if because is not None and not isinstance(because, str):
+        return "because is not a str"
+    anchor = item.get("anchored_to")
+    if anchor is not None:
+        if not isinstance(anchor, dict):
+            return "anchored_to is not a dict"
+        if not all(
+            isinstance(anchor.get(k), str) and anchor.get(k)
+            for k in ("file", "symbol", "body_hash")
+        ):
+            return "anchored_to is missing file, symbol, or body_hash"
+    return None
+
+
+def _reference_checkpoint_reason(checkpoint):
+    if not isinstance(checkpoint, dict):
+        return "checkpoint is not a dict"
+    if "session_id" not in checkpoint:
+        return "missing session_id"
+    wc = checkpoint.get("working_context")
+    es = checkpoint.get("epistemic_snapshot")
+    if not isinstance(wc, dict):
+        return "working_context is not a dict"
+    if not isinstance(es, dict):
+        return "epistemic_snapshot is not a dict"
+    if "active_topic" not in wc:
+        return "missing working_context.active_topic"
+    for key in ("open_questions", "recent_decisions"):
+        items = wc.get(key)
+        if not isinstance(items, list):
+            return f"working_context.{key} is not a list"
+        for i, item in enumerate(items):
+            reason = _reference_item_reason(item)
+            if reason is not None:
+                return f"working_context.{key}[{i}]: {reason}"
+    reason = _reference_item_reason(wc["active_topic"])
+    if reason is not None:
+        return f"working_context.active_topic: {reason}"
+    for key in ("strong_beliefs", "uncertainties"):
+        items = es.get(key, [])
+        if not isinstance(items, list):
+            return f"epistemic_snapshot.{key} is not a list"
+        for i, item in enumerate(items):
+            reason = _reference_item_reason(item)
+            if reason is not None:
+                return f"epistemic_snapshot.{key}[{i}]: {reason}"
+    return None
+
+
+def _reference_sanitize(item):
+    """importance + scene dispositions, per-item, as the pre-#827 serializer
+    checkpoint walks applied them."""
+    if "importance" in item:
+        v = item["importance"]
+        if isinstance(v, int) and not isinstance(v, bool):
+            item["importance"] = min(10, max(1, v))
+        else:
+            del item["importance"]
+    if "scene" in item:
+        v = item["scene"]
+        if isinstance(v, str) and v.strip():
+            item["scene"] = v.strip()[:500]
+        else:
+            del item["scene"]
+
+
+# ---- 1. generated item validator == the frozen contract ----
 
 _ITEM_CASES = (
     _item(),
@@ -67,6 +160,8 @@ _ITEM_CASES = (
     _item(text=7),
     _item(trust="gospel"),
     _item(trust=None),
+    _item(trust=["verbatim"]),               # unhashable: clean reject (#828)
+    _item(trust={"v": 1}),
     _item(trust="verbatim"),                 # verbatim without quote
     _item(trust="verbatim", quote=""),
     _item(trust="verbatim", quote="   "),
@@ -90,11 +185,11 @@ _ITEM_CASES = (
 
 @pytest.mark.parametrize("item", _ITEM_CASES,
                          ids=[f"case{i}" for i in range(len(_ITEM_CASES))])
-def test_item_reason_matches_the_live_validator(item):
-    assert field_table.item_reason(item) == serializer._item_reason(item)
+def test_item_reason_matches_the_frozen_contract(item):
+    assert field_table.item_reason(item) == _reference_item_reason(item)
 
 
-def test_item_reason_strings_are_the_live_predicate_names():
+def test_item_reason_strings_are_the_ratified_predicate_names():
     """The exact strings ship in SchemaValidationError and retry notes (#743),
     so the generated validator must reproduce them byte-for-byte."""
     assert field_table.item_reason("x") == "not a dict"
@@ -111,7 +206,15 @@ def test_item_reason_strings_are_the_live_predicate_names():
             == "anchored_to is missing file, symbol, or body_hash")
 
 
-# ---- 2. generated checkpoint validator == live checkpoint validator ----
+def test_unhashable_trust_rejects_cleanly_instead_of_raising():
+    """#828 review, ratified: pre-#827 an unhashable trust raised TypeError
+    out of serialize_strict; the table engine rejects it as an unknown trust
+    class, which routes it into the ordinary #118 resample instead."""
+    assert (field_table.item_reason(_item(trust=["verbatim"]))
+            == "trust is not a known trust class")
+
+
+# ---- 2. generated checkpoint validator == the frozen contract ----
 
 def _without(key):
     def mutate(cp):
@@ -151,6 +254,7 @@ _CHECKPOINT_MUTATIONS = (
     _without("epistemic_snapshot"),
     _del(("working_context", "active_topic")),
     _set(("working_context", "active_topic"), {"trust": "inferred"}),
+    _set(("working_context", "active_topic"), None),   # explicit null rejects
     _set(("working_context", "open_questions"), "junk"),
     _del(("working_context", "open_questions")),
     _set(("working_context", "open_questions"), [{"text": "q"}]),
@@ -161,7 +265,6 @@ _CHECKPOINT_MUTATIONS = (
     _del(("epistemic_snapshot", "strong_beliefs")),   # optional: absent is valid
     _set(("epistemic_snapshot", "uncertainties"), [{"text": "u", "trust": "x"}]),
     _set(("epistemic_snapshot", "contradictions_flagged"), "anything"),
-    _del(("working_context", "active_topic")),
     # active_topic missing AND a bad list: presence is checked first
     lambda cp: (_set(("working_context", "open_questions"), "junk")(
         _del(("working_context", "active_topic"))(cp))),
@@ -175,13 +278,13 @@ _CHECKPOINT_MUTATIONS = (
 @pytest.mark.parametrize(
     "mutate", _CHECKPOINT_MUTATIONS,
     ids=[f"case{i}" for i in range(len(_CHECKPOINT_MUTATIONS))])
-def test_checkpoint_reason_matches_the_live_validator(mutate):
+def test_checkpoint_reason_matches_the_frozen_contract(mutate):
     ours = field_table.checkpoint_reason(mutate(_checkpoint()))
-    live = serializer.validation_reason(mutate(_checkpoint()))
-    assert ours == live
+    ref = _reference_checkpoint_reason(mutate(_checkpoint()))
+    assert ours == ref
 
 
-def test_checkpoint_reason_names_paths_like_the_live_validator():
+def test_checkpoint_reason_names_paths_like_the_ratified_contract():
     cp = _checkpoint()
     cp["working_context"]["open_questions"] = [
         {"text": "q", "trust": "inferred"}, {"text": None, "trust": "inferred"}]
@@ -189,7 +292,38 @@ def test_checkpoint_reason_names_paths_like_the_live_validator():
             == "working_context.open_questions[1]: text is not a str")
 
 
-# ---- 3. generated normalizers reproduce today's dispositions exactly ----
+def test_explicit_null_active_topic_rejects():
+    """The published row says nullable=false; the validator must agree —
+    contract accuracy is the point of #827 (#828 review)."""
+    cp = _checkpoint()
+    cp["working_context"]["active_topic"] = None
+    assert (field_table.checkpoint_reason(cp)
+            == "working_context.active_topic: not a dict")
+    assert field_table.rule(
+        "envelope", "working_context.active_topic").nullable is False
+
+
+# ---- 3. the one wiring test: serializer delegates to the table ----
+
+def test_serializer_delegates_to_the_field_table(monkeypatch):
+    """The matrix above pins the ENGINE against the frozen contract without
+    touching the live path; this single test pins the WIRING — that the
+    serializer entry points actually route through the table engine."""
+    normalized = []
+    monkeypatch.setattr(field_table, "item_reason", lambda item: "ITEM-SENTINEL")
+    monkeypatch.setattr(field_table, "checkpoint_reason", lambda cp: "CP-SENTINEL")
+    monkeypatch.setattr(field_table, "normalize_field",
+                        lambda item, name: normalized.append(name))
+    assert serializer._item_reason(_item()) == "ITEM-SENTINEL"
+    assert serializer.validation_reason(_checkpoint()) == "CP-SENTINEL"
+    cp = _checkpoint()
+    serializer.sanitize_importance(cp)
+    serializer.sanitize_scene(cp)
+    assert "importance" in normalized
+    assert "scene" in normalized
+
+
+# ---- 4. generated normalizers reproduce today's dispositions exactly ----
 
 @pytest.mark.parametrize("value,expected", [
     (5, 5),
@@ -238,21 +372,37 @@ def test_normalize_field_leaves_an_absent_field_absent():
     assert item == _item()
 
 
-def test_sanitize_importance_and_scene_still_behave_at_the_checkpoint_level():
-    """The serializer entry points (now wired through the table) keep their
-    contract: normalize every schema item in place, never raise."""
-    cp = _checkpoint()
-    cp["working_context"]["active_topic"]["importance"] = 12
-    cp["working_context"]["open_questions"][0]["importance"] = True
-    cp["epistemic_snapshot"]["uncertainties"][0]["scene"] = "  s  "
-    serializer.sanitize_importance(cp)
-    serializer.sanitize_scene(cp)
-    assert cp["working_context"]["active_topic"]["importance"] == 10
-    assert "importance" not in cp["working_context"]["open_questions"][0]
-    assert cp["epistemic_snapshot"]["uncertainties"][0]["scene"] == "s"
+def test_normalize_field_raises_on_a_row_it_does_not_implement():
+    """#828 review: a silent no-op on an unimplemented (type, disposition)
+    combination would leave a malformed value in place while reading as
+    normalization at the call site — the drop of source_message_ids lives in
+    sanitize_source_ids (it needs transcript context), never here."""
+    with pytest.raises(ValueError):
+        field_table.normalize_field(_item(source_message_ids=13),
+                                    "source_message_ids")
+    with pytest.raises(ValueError):
+        field_table.normalize_field(_item(), "text")
 
 
-# ---- 4. the table agrees with the code it describes ----
+def test_normalizers_match_the_frozen_contract_on_adversarial_checkpoints():
+    cases = []
+    for imp in (5, 0, 11, True, "5", None, 3.5):
+        for scn in ("s", "", "  y  ", 9, None, "z" * 600):
+            cases.append(_checkpoint(working_context={
+                "active_topic": {"text": "t", "trust": "inferred",
+                                 "importance": imp, "scene": scn},
+                "open_questions": [], "recent_decisions": []}))
+    for cp in cases:
+        a, b = copy.deepcopy(cp), copy.deepcopy(cp)
+        for item in serializer.iter_items(a):
+            _reference_sanitize(item)
+        for item in serializer.iter_items(b):
+            field_table.normalize_field(item, "importance")
+            field_table.normalize_field(item, "scene")
+        assert a == b
+
+
+# ---- 5. the table agrees with the code it describes ----
 
 def test_scene_cap_matches_the_serializer_constant():
     row = field_table.rule("item", "scene")
@@ -282,16 +432,22 @@ def test_stripped_item_keys_match_the_serializer_strip_list():
     assert stripped == set(serializer._CODE_OWNED_ITEM_KEYS)
 
 
-def test_every_schema_item_field_has_an_envelope_row():
-    """schema.ITEM_FIELDS (#146) and the table must name the same sections."""
+def test_every_schema_item_field_has_a_walked_envelope_row():
+    """schema.ITEM_FIELDS (#146) and the table must name the same sections,
+    and every item-bearing section must actually be WALKED by the validator —
+    a list row without validate= would silently skip its items (the #134
+    incident shape). Free-form-by-design sections are exempt only via an
+    explicit disposition of pass (#828 review)."""
     rows = {r.name: r for r in field_table.ENVELOPE_RULES}
     for f in schema.ITEM_FIELDS:
         row = rows[f"{f.section}.{f.key}"]
         validate = dict(row.constraints).get("validate")
         if f.singleton:
             assert validate == "item-required"
+        elif row.disposition == "pass":
+            assert validate is None   # free-form by design (contradictions)
         else:
-            assert validate in ("item-list-required", "item-list-optional", None)
+            assert validate in ("item-list-required", "item-list-optional")
 
 
 def test_no_duplicate_rows_and_scopes_are_coherent():
@@ -305,7 +461,36 @@ def test_no_duplicate_rows_and_scopes_are_coherent():
                    for r in rules)
 
 
-# ---- 5. the published document ----
+def test_engine_coverage_guard_accepts_the_real_tables():
+    assert field_table.engine_coverage_errors() == []
+
+
+def test_engine_coverage_guard_names_rows_the_engine_cannot_run():
+    """#828 review: the validator dispatches on constraint keys, not the type
+    column, so a shape the engine never anticipated must fail at import —
+    not fall through to the wrong branch inside a serialize."""
+    bad_item = field_table.FieldRule(
+        "item", "count", "integer", True, False, "model", "reject",
+        (("reject_reason", "count is bad"),), "")
+    errors = field_table.engine_coverage_errors(
+        item_rules=(bad_item,), envelope_rules=())
+    assert errors and "count" in errors[0]
+
+    bad_envelope = field_table.FieldRule(
+        "envelope", "extra", "object", True, False, "model", "reject",
+        (("validate", "frobnicate"),), "")
+    errors = field_table.engine_coverage_errors(
+        item_rules=(), envelope_rules=(bad_envelope,))
+    assert errors and "frobnicate" in errors[0]
+
+    unclamped = field_table.FieldRule(
+        "item", "blob", "object", True, False, "model", "clamp", (), "")
+    errors = field_table.engine_coverage_errors(
+        item_rules=(unclamped,), envelope_rules=())
+    assert errors and "blob" in errors[0]
+
+
+# ---- 6. the published document ----
 
 def test_schema_document_is_versioned_with_format_version():
     doc = field_table.schema_document(serializer.PROMPT_VERSION)
@@ -319,6 +504,19 @@ def test_schema_document_is_versioned_with_format_version():
     for row in doc["envelope"] + doc["item"]:
         assert set(row) == {"field", "type", "optional", "nullable", "owner",
                             "disposition", "constraints", "notes"}
+
+
+def test_schema_document_glossaries_cover_every_constraint_key():
+    """#828 review: a column-driven consumer must be able to resolve every
+    constraint key it meets (required_if_eq especially — the quote row's
+    reject is conditional) from the document itself."""
+    doc = field_table.schema_document(serializer.PROMPT_VERSION)
+    used = {key
+            for rows in (field_table.ENVELOPE_RULES, field_table.ITEM_RULES)
+            for r in rows for key, _ in r.constraints}
+    assert used <= set(doc["constraint_semantics"])
+    assert set(doc["columns"]) >= {"type", "optional", "nullable", "owner",
+                                   "disposition", "constraints"}
 
 
 def test_render_document_is_deterministic_json():
@@ -337,23 +535,3 @@ def test_published_artifact_matches_the_table():
         "`uv run python -m daimon_briefing.field_table` from plugin/")
     expected = field_table.render_document(serializer.PROMPT_VERSION)
     assert _ARTIFACT.read_text(encoding="utf-8") == expected
-
-
-# ---- 6. normalizer equivalence holds on arbitrary shapes ----
-
-def test_normalizers_and_sanitizers_agree_on_adversarial_checkpoints():
-    cases = []
-    for imp in (5, 0, 11, True, "5", None, 3.5):
-        for scn in ("s", "", "  y  ", 9, None, "z" * 600):
-            cases.append(_checkpoint(working_context={
-                "active_topic": {"text": "t", "trust": "inferred",
-                                 "importance": imp, "scene": scn},
-                "open_questions": [], "recent_decisions": []}))
-    for cp in cases:
-        a, b = copy.deepcopy(cp), copy.deepcopy(cp)
-        serializer.sanitize_importance(a)
-        serializer.sanitize_scene(a)
-        for item in serializer.iter_items(b):
-            field_table.normalize_field(item, "importance")
-            field_table.normalize_field(item, "scene")
-        assert a == b

--- a/plugin/tests/test_field_table.py
+++ b/plugin/tests/test_field_table.py
@@ -490,6 +490,56 @@ def test_engine_coverage_guard_names_rows_the_engine_cannot_run():
     assert errors and "blob" in errors[0]
 
 
+def _bad_rule(scope, name, type_, disposition, constraints):
+    return field_table.FieldRule(
+        scope, name, type_, True, False, "model", disposition, constraints, "")
+
+
+@pytest.mark.parametrize("rule,fragment", [
+    # enum/required_if_eq reject row without its reason string
+    (_bad_rule("item", "f1", "string", "reject", (("enum", ("a",)),)),
+     "lacks reject_reason"),
+    (_bad_rule("item", "f2", "string", "reject",
+               (("required_if_eq", ("trust", "verbatim")),)),
+     "lacks reject_reason"),
+    # object_keys row without the missing-sub-key reason string
+    (_bad_rule("item", "f3", "object", "reject", (("object_keys", ("k",)),)),
+     "lacks reject_reason_missing"),
+    # plain string reject row without a reason string
+    (_bad_rule("item", "f4", "string", "reject", ()),
+     "lacks reject_reason"),
+    # clamp rows missing their bounds
+    (_bad_rule("item", "f5", "integer", "clamp", (("min", 1),)),
+     "lacks min/max"),
+    (_bad_rule("item", "f6", "string", "clamp", ()),
+     "lacks max_chars"),
+], ids=["enum-no-reason", "conditional-no-reason", "object-no-missing-reason",
+        "string-no-reason", "clamp-no-bounds", "clamp-no-max-chars"])
+def test_engine_coverage_guard_flags_every_incomplete_item_row(rule, fragment):
+    errors = field_table.engine_coverage_errors(
+        item_rules=(rule,), envelope_rules=())
+    assert errors and fragment in errors[0]
+
+
+@pytest.mark.parametrize("rule,fragment", [
+    # presence/item-required rows must carry the reason string they reject with
+    (_bad_rule("envelope", "e1", "string", "reject",
+               (("validate", "presence"),)),
+     "lacks reject_reason"),
+    (_bad_rule("envelope", "e2", "object", "reject",
+               (("validate", "item-required"),)),
+     "lacks reject_reason"),
+    # a validate= the engine would never walk (non-reject rows are phase-less)
+    (_bad_rule("envelope", "e3", "array", "pass", (("validate", "object"),)),
+     "non-reject row"),
+], ids=["presence-no-reason", "item-required-no-reason", "validate-on-pass"])
+def test_engine_coverage_guard_flags_every_incomplete_envelope_row(
+        rule, fragment):
+    errors = field_table.engine_coverage_errors(
+        item_rules=(), envelope_rules=(rule,))
+    assert errors and fragment in errors[0]
+
+
 # ---- 6. the published document ----
 
 def test_schema_document_is_versioned_with_format_version():

--- a/plugin/tests/test_field_table_corpus.py
+++ b/plugin/tests/test_field_table_corpus.py
@@ -2,14 +2,19 @@
 
 Fixture-free, like tests/ui/test_producer_contract.py: reads whatever real
 checkpoints exist on the machine and pits the table-generated validator and
-normalizers against the live serializer ones, so table-vs-code divergence
-surfaces on real producer output — not just on shapes a test author imagined.
+normalizers against the FROZEN REFERENCE contract (the pre-#827 predicates,
+transcribed in tests/test_field_table.py — never the live serializer, which
+now delegates to field_table and would make every comparison f(x) == f(x)).
+Divergence from the ratified contract therefore surfaces on real producer
+output — not just on shapes a test author imagined.
 
 The store is resolved independently of DAIMON_CHECKPOINT_DIR (the root conftest
 redirects that to an isolated tmp home per test, which would make this skip
-forever), and the `.chunk-cache/` wrapper blobs are excluded — they are LLM-call
-cache entries, not checkpoints. Skips when there is no store (CI, fresh
-machines): the value is on developer machines and in dogfooding.
+forever). The `.chunk-cache/` wrapper blobs are excluded BEFORE the file limit
+is applied — dot-dirs sort early, so filtering after truncation would let cache
+blobs eat census slots and silently shrink the real corpus under test (the
+never-truncate-a-census failure shape). Skips when there is no store (CI,
+fresh machines): the value is on developer machines and in dogfooding.
 
 Failure messages carry field names and COUNTS only, never checkpoint content or
 paths. Real checkpoints hold private project data, and a pytest failure line can
@@ -23,6 +28,10 @@ from pathlib import Path
 import pytest
 
 from daimon_briefing import field_table, serializer
+from tests.test_field_table import (
+    _reference_checkpoint_reason,
+    _reference_sanitize,
+)
 
 _REAL_STORE = Path(os.path.expanduser("~")) / ".daimon" / "checkpoints"
 
@@ -31,8 +40,11 @@ def _checkpoints(limit=400):
     if not _REAL_STORE.is_dir():
         return []
     out = []
-    for path in sorted(_REAL_STORE.rglob("*.json"))[:limit]:
-        if any(part.startswith(".") for part in path.relative_to(_REAL_STORE).parts):
+    for path in sorted(_REAL_STORE.rglob("*.json")):
+        if len(out) >= limit:
+            break
+        if any(part.startswith(".")
+               for part in path.relative_to(_REAL_STORE).parts):
             continue  # .chunk-cache wrappers are not checkpoints
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
@@ -43,6 +55,32 @@ def _checkpoints(limit=400):
     return out
 
 
+def _validated_items(checkpoint):
+    """Item dicts from exactly the sections the validator walks — the free-form
+    contradictions_flagged section is out of census scope by its own row's
+    contract, and ONLY that section (#828 review: a global key subtraction
+    would excuse unknown keys on validated items corpus-wide)."""
+    for r in field_table.ENVELOPE_RULES:
+        validate = dict(r.constraints).get("validate")
+        if validate not in ("item-required", "item-list-required",
+                            "item-list-optional"):
+            continue
+        section, key = r.name.split(".", 1)
+        block = checkpoint.get(section)
+        if not isinstance(block, dict):
+            continue
+        if validate == "item-required":
+            item = block.get(key)
+            if isinstance(item, dict):
+                yield item
+            continue
+        entries = block.get(key)
+        if isinstance(entries, list):
+            for item in entries:
+                if isinstance(item, dict):
+                    yield item
+
+
 @pytest.fixture(scope="module")
 def real_checkpoints():
     cps = _checkpoints()
@@ -51,28 +89,28 @@ def real_checkpoints():
     return cps
 
 
-def test_generated_validator_agrees_with_the_live_one_on_every_checkpoint(
+def test_generated_validator_agrees_with_the_frozen_contract_on_every_checkpoint(
         real_checkpoints):
     diverged = sum(
         1 for cp in real_checkpoints
-        if field_table.checkpoint_reason(cp) != serializer.validation_reason(cp))
+        if field_table.checkpoint_reason(cp) != _reference_checkpoint_reason(cp))
     assert diverged == 0, (
-        f"generated validator diverged from the live validator on {diverged} of "
-        f"{len(real_checkpoints)} real checkpoints"
+        f"generated validator diverged from the frozen contract on {diverged} "
+        f"of {len(real_checkpoints)} real checkpoints"
     )
 
 
-def test_generated_validator_accepts_everything_the_live_one_accepts(
+def test_generated_validator_accepts_everything_the_frozen_contract_accepts(
         real_checkpoints):
     accepted = [cp for cp in real_checkpoints
-                if serializer.validation_reason(cp) is None]
+                if _reference_checkpoint_reason(cp) is None]
     if not accepted:
-        pytest.skip("no live-valid checkpoints in the local store")
+        pytest.skip("no contract-valid checkpoints in the local store")
     rejected = sum(1 for cp in accepted
                    if field_table.checkpoint_reason(cp) is not None)
     assert rejected == 0, (
         f"generated validator rejected {rejected} of {len(accepted)} checkpoints "
-        "the live validator accepts — the no-behavior-change bar (#827)"
+        "the ratified contract accepts — the no-behavior-change bar (#827)"
     )
 
 
@@ -86,38 +124,33 @@ def test_every_envelope_key_in_the_corpus_is_in_the_table(real_checkpoints):
 
 
 def test_every_item_key_in_the_corpus_is_in_the_table(real_checkpoints):
-    """Validated item sections only: contradictions_flagged is free-form by
-    contract (its row says so), so its keys are not enumerable."""
     known = {r.name for r in field_table.ITEM_RULES}
     unknown = set()
     for cp in real_checkpoints:
-        for item in serializer.iter_items(cp):
+        for item in _validated_items(cp):
             unknown |= set(item) - known
-    for cp in real_checkpoints:
-        block = cp.get("epistemic_snapshot")
-        if isinstance(block, dict):
-            for entry in block.get("contradictions_flagged") or []:
-                if isinstance(entry, dict):
-                    unknown -= set(entry)
     assert not unknown, (
         f"{len(unknown)} item field(s) exist on real checkpoints but not in the "
         f"field table: {sorted(unknown)} — the table census is incomplete"
     )
 
 
-def test_generated_normalizers_are_noops_exactly_where_the_live_ones_are(
+def test_generated_normalizers_are_noops_exactly_where_the_contract_says(
         real_checkpoints):
+    # serializer.iter_items is the WALK the live sanitizers use (it includes
+    # dict-shaped contradiction entries); walking it on both sides keeps this
+    # a pure engine-vs-contract comparison over every item the producer wrote.
     diverged = 0
     for cp in real_checkpoints:
         a, b = copy.deepcopy(cp), copy.deepcopy(cp)
-        serializer.sanitize_importance(a)
-        serializer.sanitize_scene(a)
+        for item in serializer.iter_items(a):
+            _reference_sanitize(item)
         for item in serializer.iter_items(b):
             field_table.normalize_field(item, "importance")
             field_table.normalize_field(item, "scene")
         if a != b:
             diverged += 1
     assert diverged == 0, (
-        f"generated normalizers diverged from the live sanitizers on {diverged} "
+        f"generated normalizers diverged from the frozen contract on {diverged} "
         f"of {len(real_checkpoints)} real checkpoints"
     )

--- a/plugin/tests/test_field_table_corpus.py
+++ b/plugin/tests/test_field_table_corpus.py
@@ -1,0 +1,123 @@
+"""#827 hard requirement: the generated validator accepts today's corpus unchanged.
+
+Fixture-free, like tests/ui/test_producer_contract.py: reads whatever real
+checkpoints exist on the machine and pits the table-generated validator and
+normalizers against the live serializer ones, so table-vs-code divergence
+surfaces on real producer output — not just on shapes a test author imagined.
+
+The store is resolved independently of DAIMON_CHECKPOINT_DIR (the root conftest
+redirects that to an isolated tmp home per test, which would make this skip
+forever), and the `.chunk-cache/` wrapper blobs are excluded — they are LLM-call
+cache entries, not checkpoints. Skips when there is no store (CI, fresh
+machines): the value is on developer machines and in dogfooding.
+
+Failure messages carry field names and COUNTS only, never checkpoint content or
+paths. Real checkpoints hold private project data, and a pytest failure line can
+reach CI logs and pull request comments.
+"""
+import copy
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from daimon_briefing import field_table, serializer
+
+_REAL_STORE = Path(os.path.expanduser("~")) / ".daimon" / "checkpoints"
+
+
+def _checkpoints(limit=400):
+    if not _REAL_STORE.is_dir():
+        return []
+    out = []
+    for path in sorted(_REAL_STORE.rglob("*.json"))[:limit]:
+        if any(part.startswith(".") for part in path.relative_to(_REAL_STORE).parts):
+            continue  # .chunk-cache wrappers are not checkpoints
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            continue  # torn or foreign file: every reader tolerates these too
+        if isinstance(data, dict):
+            out.append(data)
+    return out
+
+
+@pytest.fixture(scope="module")
+def real_checkpoints():
+    cps = _checkpoints()
+    if not cps:
+        pytest.skip("no local checkpoint store to check the field table against")
+    return cps
+
+
+def test_generated_validator_agrees_with_the_live_one_on_every_checkpoint(
+        real_checkpoints):
+    diverged = sum(
+        1 for cp in real_checkpoints
+        if field_table.checkpoint_reason(cp) != serializer.validation_reason(cp))
+    assert diverged == 0, (
+        f"generated validator diverged from the live validator on {diverged} of "
+        f"{len(real_checkpoints)} real checkpoints"
+    )
+
+
+def test_generated_validator_accepts_everything_the_live_one_accepts(
+        real_checkpoints):
+    accepted = [cp for cp in real_checkpoints
+                if serializer.validation_reason(cp) is None]
+    if not accepted:
+        pytest.skip("no live-valid checkpoints in the local store")
+    rejected = sum(1 for cp in accepted
+                   if field_table.checkpoint_reason(cp) is not None)
+    assert rejected == 0, (
+        f"generated validator rejected {rejected} of {len(accepted)} checkpoints "
+        "the live validator accepts — the no-behavior-change bar (#827)"
+    )
+
+
+def test_every_envelope_key_in_the_corpus_is_in_the_table(real_checkpoints):
+    known = {r.name for r in field_table.ENVELOPE_RULES if "." not in r.name}
+    unknown = {k for cp in real_checkpoints for k in cp} - known
+    assert not unknown, (
+        f"{len(unknown)} envelope field(s) exist on real checkpoints but not in "
+        f"the field table: {sorted(unknown)} — the table census is incomplete"
+    )
+
+
+def test_every_item_key_in_the_corpus_is_in_the_table(real_checkpoints):
+    """Validated item sections only: contradictions_flagged is free-form by
+    contract (its row says so), so its keys are not enumerable."""
+    known = {r.name for r in field_table.ITEM_RULES}
+    unknown = set()
+    for cp in real_checkpoints:
+        for item in serializer.iter_items(cp):
+            unknown |= set(item) - known
+    for cp in real_checkpoints:
+        block = cp.get("epistemic_snapshot")
+        if isinstance(block, dict):
+            for entry in block.get("contradictions_flagged") or []:
+                if isinstance(entry, dict):
+                    unknown -= set(entry)
+    assert not unknown, (
+        f"{len(unknown)} item field(s) exist on real checkpoints but not in the "
+        f"field table: {sorted(unknown)} — the table census is incomplete"
+    )
+
+
+def test_generated_normalizers_are_noops_exactly_where_the_live_ones_are(
+        real_checkpoints):
+    diverged = 0
+    for cp in real_checkpoints:
+        a, b = copy.deepcopy(cp), copy.deepcopy(cp)
+        serializer.sanitize_importance(a)
+        serializer.sanitize_scene(a)
+        for item in serializer.iter_items(b):
+            field_table.normalize_field(item, "importance")
+            field_table.normalize_field(item, "scene")
+        if a != b:
+            diverged += 1
+    assert diverged == 0, (
+        f"generated normalizers diverged from the live sanitizers on {diverged} "
+        f"of {len(real_checkpoints)} real checkpoints"
+    )


### PR DESCRIPTION
Closes #827

## What

One declarative field table, `daimon_briefing.field_table`, is now the single source of truth for the checkpoint contract: per envelope and item field it states type, optionality, nullability, owner (model-extracted vs code-stamped), and the disposition for out-of-contract values (reject / clamp / drop / pass / strip). Generated from that one table:

1. the runtime validator: `serializer._item_reason` and `serializer.validation_reason` delegate to the table-driven `field_table.item_reason` / `checkpoint_reason`, which reproduce the live predicate order and reason strings byte-for-byte;
2. the runtime normalizers: `sanitize_importance` / `sanitize_scene` delegate their per-item bodies to `field_table.normalize_field` (importance clamps to the producer's 1-10 range, scene strips/caps at 500, wrong types drop the field);
3. `docs/checkpoint-schema.json`, the published machine-readable schema document, versioned with the envelope `format_version` (currently D-018), regenerated deterministically via `uv run python -m daimon_briefing.field_table` and pinned to the table by test, so a stale committed artifact fails CI. External consumers can test their normalizers against it without importing daimon.

The table census is exhaustive: 28 envelope rows and 21 item rows, cross-checked against `serializer._CODE_OWNED_KEYS` / `_CODE_OWNED_ITEM_KEYS`, `schema.ITEM_FIELDS`, and the real on-disk corpus (a corpus key that is missing from the table fails the census test). `contradictions_flagged` elements are declared free-form, matching the code. The new module is stdlib-only, import-free (sits below serializer like `schema.py`), mypy-clean, and is NOT added to the mypy ratchet list.

## Why

Checkpoint consumers cannot import daimon, so every consumer-side normalizer was a guess about the producer shape, and two guesses silently deleted real data (importance clamped 1-5 against the producer's 1-10; `quote_provenance.verifier` read as a string where the producer writes an object). A wrong guess resolves to None, indistinguishable from honest absence. With the table, divergence between the stated contract and the live code is a test failure instead of a silent consumer-side loss.

## No behavior change, and how that is proven

The validator and normalizers were implemented first as independent twins and proven equivalent BEFORE serializer was wired to them:

- a branch-complete matrix (30 item cases, 23 checkpoint mutations) asserts verdicts AND exact reason strings match the live implementations;
- a fixture-free corpus test (same conventions as `tests/ui/test_producer_contract.py`: real store resolved independently of `DAIMON_CHECKPOINT_DIR`, skips when absent, failure messages carry field names and counts only) asserts verdict equality on every real checkpoint, acceptance of everything the live validator accepts, census completeness, and normalizer no-op equivalence. Locally that ran against 320 real checkpoints, all agreeing.

Where rewiring was NOT provably safe, the call site was left alone and a divergence test holds the line instead: the code-owned strip lists stay in `serializer` (`_CODE_OWNED_KEYS` / `_CODE_OWNED_ITEM_KEYS`) with set-equality tests against the table's `stripped_at_serialize` rows, and `_SCENE_MAX_CHARS` / `_TRUST_CLASSES` stay as serializer constants with equality tests against the table rows.

## Tests

- `uv run pytest`: 4585 passed, 2 skipped (full suite, includes the 92 new tests; the new tests failed before the module existed)
- `uv run ruff check .`: clean
- `uv run --extra dev mypy daimon_briefing`: clean, 59 files; `field_table` is enforced (not in the ratchet)
- `scar lint`: 0 errors (1 pre-existing partial-rot hint, untouched by this PR)





## Review round (blind review, applied in 36fb022)

One deliberate behavior delta on a degenerate input, ratified in review: an unhashable `trust` value (for example a list) previously raised TypeError out of `serialize_strict`, because set membership hashes its probe. The table engine checks membership against a tuple, so the same input now rejects cleanly as "trust is not a known trust class" and routes into the ordinary #118 resample instead of crashing the serialize. Kept as an improvement; pinned by a dedicated matrix case and a literal test, and the frozen reference contract in the tests encodes the new posture with a comment naming the delta.

The review also converted the equivalence tests from live-path comparisons (tautological once serializer delegates) to frozen reference implementations, fixed the corpus loader to filter `.chunk-cache/` before the file limit, corrected the `active_topic` row to nullable=false, added column and constraint-key glossaries to the published document, made `normalize_field` raise on unimplemented rows, and added an import-time engine coverage guard.
