### PR TITLE
feat(serializer): record cross-message and cross-role quote stitching on the verification receipt

### DIFF
--- a/docs/checkpoint-schema.json
+++ b/docs/checkpoint-schema.json
@@ -1,7 +1,7 @@
 {
   "document": "daimon-checkpoint-field-table",
   "document_version": 1,
-  "format_version": "D-018",
+  "format_version": "D-019",
   "dispositions": {
     "reject": "an out-of-contract value refuses the whole checkpoint",
     "clamp": "an out-of-range value is pulled into range or truncated",
@@ -628,7 +628,7 @@
           "outcome: enum[verified, not-verified]",
           "checked_at: string (ISO-8601 UTC, %Y-%m-%dT%H:%M:%SZ)",
           "binding: object {mode: enum[message-ids, transcript-scan], message_ids: array of string}",
-          "stitching?: object {cross_message: boolean, cross_role: boolean} — verified receipts only, when per-message attribution was possible (#829); true means NO single message (or single role) can account for all matched quote fragments, i.e. the quote was stitched across turns or speakers; absent = unknown (legacy receipts, transcript-less captures)"
+          "stitching?: object {cross_message: boolean, cross_role: boolean} — exists since format_version D-019 (#829); verified receipts only, when per-message attribution was possible; true means NO single message (or single role) can account for all matched quote fragments, i.e. the quote was stitched across turns or speakers; absent = unknown (pre-D-019 receipts, transcript-less captures)"
         ]
       },
       "notes": "Durable per-item evidence receipt (#594, provenance.quote_receipt). verifier is an OBJECT {id, version}: consumers normalizing it as a string rendered every verified claim's verifier as absent."

--- a/docs/checkpoint-schema.json
+++ b/docs/checkpoint-schema.json
@@ -627,7 +627,8 @@
           "verifier: OBJECT {id: string ('tier-f'), version: integer} — an object, never a string",
           "outcome: enum[verified, not-verified]",
           "checked_at: string (ISO-8601 UTC, %Y-%m-%dT%H:%M:%SZ)",
-          "binding: object {mode: enum[message-ids, transcript-scan], message_ids: array of string}"
+          "binding: object {mode: enum[message-ids, transcript-scan], message_ids: array of string}",
+          "stitching?: object {cross_message: boolean, cross_role: boolean} — verified receipts only, when per-message attribution was possible (#829); true means NO single message (or single role) can account for all matched quote fragments, i.e. the quote was stitched across turns or speakers; absent = unknown (legacy receipts, transcript-less captures)"
         ]
       },
       "notes": "Durable per-item evidence receipt (#594, provenance.quote_receipt). verifier is an OBJECT {id, version}: consumers normalizing it as a string rendered every verified claim's verifier as absent."

--- a/plugin/daimon_briefing/field_table.py
+++ b/plugin/daimon_briefing/field_table.py
@@ -198,7 +198,14 @@ ITEM_RULES: tuple[FieldRule, ...] = (
                   "outcome: enum[verified, not-verified]",
                   "checked_at: string (" + _TIMESTAMP + ")",
                   "binding: object {mode: enum[message-ids, "
-                  "transcript-scan], message_ids: array of string}")),
+                  "transcript-scan], message_ids: array of string}",
+                  "stitching?: object {cross_message: boolean, cross_role: "
+                  "boolean} — verified receipts only, when per-message "
+                  "attribution was possible (#829); true means NO single "
+                  "message (or single role) can account for all matched "
+                  "quote fragments, i.e. the quote was stitched across "
+                  "turns or speakers; absent = unknown (legacy receipts, "
+                  "transcript-less captures)")),
         "Durable per-item evidence receipt (#594, provenance.quote_receipt). "
         "verifier is an OBJECT {id, version}: consumers normalizing it as a "
         "string rendered every verified claim's verifier as absent."),

--- a/plugin/daimon_briefing/field_table.py
+++ b/plugin/daimon_briefing/field_table.py
@@ -200,12 +200,13 @@ ITEM_RULES: tuple[FieldRule, ...] = (
                   "binding: object {mode: enum[message-ids, "
                   "transcript-scan], message_ids: array of string}",
                   "stitching?: object {cross_message: boolean, cross_role: "
-                  "boolean} — verified receipts only, when per-message "
-                  "attribution was possible (#829); true means NO single "
-                  "message (or single role) can account for all matched "
-                  "quote fragments, i.e. the quote was stitched across "
-                  "turns or speakers; absent = unknown (legacy receipts, "
-                  "transcript-less captures)")),
+                  "boolean} — exists since format_version D-019 (#829); "
+                  "verified receipts only, when per-message attribution "
+                  "was possible; true means NO single message (or single "
+                  "role) can account for all matched quote fragments, i.e. "
+                  "the quote was stitched across turns or speakers; absent "
+                  "= unknown (pre-D-019 receipts, transcript-less "
+                  "captures)")),
         "Durable per-item evidence receipt (#594, provenance.quote_receipt). "
         "verifier is an OBJECT {id, version}: consumers normalizing it as a "
         "string rendered every verified claim's verifier as absent."),

--- a/plugin/daimon_briefing/provenance.py
+++ b/plugin/daimon_briefing/provenance.py
@@ -170,8 +170,16 @@ def source_digest(transcript_hash, rendered_transcript: str) -> dict:
 
 
 def quote_receipt(source_ref, digest, *, outcome: str, checked_at: str,
-                  binding_mode: str, message_ids=()) -> dict | None:
-    """Build a complete item receipt from code-derived inputs."""
+                  binding_mode: str, message_ids=(),
+                  stitching=None) -> dict | None:
+    """Build a complete item receipt from code-derived inputs.
+
+    `stitching` (#829, optional): the serializer's fragment-attribution
+    verdict — {"cross_message": bool, "cross_role": bool} — recorded only
+    for verified quotes where per-message attribution was possible. Absent
+    means unknown (legacy receipts, transcript-less callers), never False.
+    Additive under version 1: the field is optional, so every pre-#829
+    receipt stays valid."""
     if not valid_source_ref(source_ref) or outcome not in _OUTCOMES:
         return None
     if binding_mode not in _BINDING_MODES:
@@ -193,6 +201,11 @@ def quote_receipt(source_ref, digest, *, outcome: str, checked_at: str,
         "checked_at": checked_at,
         "binding": {"mode": binding_mode, "message_ids": ids},
     }
+    if isinstance(stitching, dict):
+        receipt["stitching"] = {
+            "cross_message": bool(stitching.get("cross_message")),
+            "cross_role": bool(stitching.get("cross_role")),
+        }
     return receipt if valid_quote_receipt(receipt) else None
 
 
@@ -235,6 +248,16 @@ def valid_quote_receipt(value) -> bool:
         return False
     if len(ids) != len(set(ids)):
         return False
+    stitching = value.get("stitching")
+    if stitching is not None:
+        # #829: optional (absent = unknown on every pre-#829 receipt); when
+        # present, exactly the two boolean verdicts — a non-bool would let a
+        # truthy junk value read as an attribution the code never derived.
+        if not isinstance(stitching, dict):
+            return False
+        for key in ("cross_message", "cross_role"):
+            if not isinstance(stitching.get(key), bool):
+                return False
     return binding["mode"] != "transcript-scan" or not ids
 
 

--- a/plugin/daimon_briefing/provenance.py
+++ b/plugin/daimon_briefing/provenance.py
@@ -201,11 +201,13 @@ def quote_receipt(source_ref, digest, *, outcome: str, checked_at: str,
         "checked_at": checked_at,
         "binding": {"mode": binding_mode, "message_ids": ids},
     }
-    if isinstance(stitching, dict):
-        receipt["stitching"] = {
-            "cross_message": bool(stitching.get("cross_message")),
-            "cross_role": bool(stitching.get("cross_role")),
-        }
+    if stitching is not None:
+        # #831 review: reject-not-coerce. The raw value is copied through for
+        # the trailing valid_quote_receipt gate to refuse — never coerced
+        # into a verdict the code did not derive (bool() would launder any
+        # truthy junk into True).
+        receipt["stitching"] = (dict(stitching) if isinstance(stitching, dict)
+                                else stitching)
     return receipt if valid_quote_receipt(receipt) else None
 
 
@@ -248,11 +250,16 @@ def valid_quote_receipt(value) -> bool:
         return False
     if len(ids) != len(set(ids)):
         return False
-    stitching = value.get("stitching")
-    if stitching is not None:
-        # #829: optional (absent = unknown on every pre-#829 receipt); when
-        # present, exactly the two boolean verdicts — a non-bool would let a
-        # truthy junk value read as an attribution the code never derived.
+    if "stitching" in value:
+        # #829/#831: optional (absent = unknown on every pre-D-019 receipt),
+        # but present means the published contract's exact shape: verified
+        # receipts only (a not-verified check matched no fragments to
+        # attribute), an object — explicit null is NOT "absent" — and
+        # exactly boolean verdicts, so truthy junk can never read as an
+        # attribution the code derived.
+        stitching = value["stitching"]
+        if value.get("outcome") != "verified":
+            return False
         if not isinstance(stitching, dict):
             return False
         for key in ("cross_message", "cross_role"):

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -541,26 +541,29 @@ def _message_id(m) -> str | None:
     return None
 
 
+def _render_line(i, m, content) -> str:
+    """One message's transcript line — the per-message unit of every rendered
+    surface (#831: factored out of _render_transcript so the stitching
+    attribution can see EXACTLY the line verification matched against)."""
+    role = m.get("role", "unknown")
+    # #359: a failed tool result renders its error status inline — the
+    # extractor must see WHICH way the signal points, not just that one
+    # exists. Only flagged tool rows (transcript.py's Claude Code branch)
+    # qualify; a markdown "tool:" role row renders exactly as before.
+    if m.get("tool_result") and m.get("tool_error"):
+        role = f"{role} (error)"
+    # #358: a bracketed [mN] marker names an identified message so the
+    # extractor can cite where each verbatim quote came from. Id-less
+    # messages (hosts without stable ids) render byte-identical to the
+    # pre-#358 format — no marker, no behavior change.
+    if _message_id(m) is not None:
+        return f"[m{i + 1}] {role}: {content}"
+    return f"{role}: {content}"
+
+
 def _render_transcript(messages) -> str:
-    lines = []
-    for i, m in enumerate(messages):
-        role = m.get("role", "unknown")
-        # #359: a failed tool result renders its error status inline — the
-        # extractor must see WHICH way the signal points, not just that one
-        # exists. Only flagged tool rows (transcript.py's Claude Code branch)
-        # qualify; a markdown "tool:" role row renders exactly as before.
-        if m.get("tool_result") and m.get("tool_error"):
-            role = f"{role} (error)"
-        content = _message_text(m)
-        # #358: a bracketed [mN] marker names an identified message so the
-        # extractor can cite where each verbatim quote came from. Id-less
-        # messages (hosts without stable ids) render byte-identical to the
-        # pre-#358 format — no marker, no behavior change.
-        if _message_id(m) is not None:
-            lines.append(f"[m{i + 1}] {role}: {content}")
-        else:
-            lines.append(f"{role}: {content}")
-    return "\n\n".join(lines)
+    return "\n\n".join(_render_line(i, m, _message_text(m))
+                       for i, m in enumerate(messages))
 
 
 def message_id_map(messages) -> dict[str, str]:
@@ -786,8 +789,22 @@ def scoped_haystack(item, texts_by_id, exclude=frozenset()) -> str | None:
     ids = [i for i in ids if not (isinstance(i, str) and i in exclude)]
     if not ids:
         return None
+    # #831 finding 8: a duplicated citation must not duplicate its message's
+    # text in the haystack — a quote repeating a sentence could otherwise
+    # verify against the duplication artifact, and the verification view
+    # would disagree with the receipt's deduped message_ids. First
+    # occurrence wins; non-str entries keep their existing behavior (the
+    # text lookup below refuses the whole binding).
+    seen: set = set()
+    deduped = []
+    for i in ids:
+        if isinstance(i, str):
+            if i in seen:
+                continue
+            seen.add(i)
+        deduped.append(i)
     parts = []
-    for mid in ids:
+    for mid in deduped:
         text = texts_by_id.get(mid) if isinstance(mid, str) else None
         if text is None:
             return None
@@ -898,33 +915,53 @@ def _fragments_in_order(fragments, hay: str) -> bool:
     return True
 
 
-def _stitching_flags(quote, candidates) -> dict | None:
+def _attribution_views(rows) -> tuple:
+    """(per_message, role_joins) attribution haystacks from (role, raw_text)
+    rows in transcript order: each message's raw view normalized alone, and
+    each role's raw views joined with the verification surfaces' own "\\n\\n"
+    and THEN normalized (#831: join-then-normalize, the same convention
+    scoped_haystack and stripped_transcript render with, so seam behavior is
+    exactly what the matcher itself would accept — never a seam the join
+    convention manufactured or destroyed)."""
+    per_message = [(role, _normalize_for_match(text)) for role, text in rows]
+    by_role: dict = {}
+    for role, text in rows:
+        by_role.setdefault(role, []).append(text)
+    role_joins = {role: _normalize_for_match("\n\n".join(texts))
+                  for role, texts in by_role.items()}
+    return per_message, role_joins
+
+
+def _stitching_flags(fragments, per_message, role_joins) -> dict | None:
     """The #829 stitching record for a VERIFIED quote, or None when
-    attribution is impossible (no usable fragments, or no per-message texts).
-    `candidates` is the ordered (role, normalized-stripped-text) view of the
-    messages the verification vouched against.
+    attribution is impossible (no usable fragments, or no per-message text
+    survived stripping). `fragments` is the SAME parsed fragment list the
+    match used (#831: passed in, never re-split); `per_message`/`role_joins`
+    come from _attribution_views over the views verification vouched
+    against.
 
     Necessity semantics, deliberately: a flag is True only when NO single
-    message (cross_message) or no single role's messages, joined in order
-    (cross_role), can account for every matched fragment — never merely
-    because the flat-haystack scan happened to satisfy a fragment across a
-    boundary it did not need to cross. Which occurrence a flat scan matched
-    is ambiguous by construction; whether ONE message could have said the
-    whole quote is not. Recording only: rule 17 (SERIALIZE_SYS) stays
-    doctrine, verification outcomes are untouched, and the follow-up
-    enforcement is gated on the violation rate this measures (#829)."""
-    fragments = _quote_fragments(quote) if isinstance(quote, str) else []
-    usable = [(role, text) for role, text in candidates if text]
+    message (cross_message) or no single role's messages, joined in
+    transcript order (cross_role), can account for every matched fragment —
+    never merely because the flat-haystack scan happened to satisfy a
+    fragment across a boundary it did not need to cross. Which occurrence a
+    flat scan matched is ambiguous by construction; whether ONE message
+    could have said the whole quote is not. cross_message=False is NOT
+    short-circuited into cross_role=False: containment of one message's
+    normalized view inside its role's join-then-normalized haystack is
+    near-certain but not provable across every seam normalization, and the
+    joins are cached, so both are computed. Recording only: rule 17
+    (SERIALIZE_SYS) stays doctrine, verification outcomes are untouched, and
+    the follow-up enforcement is gated on the violation rate this measures
+    (#829)."""
+    usable = [norm for _role, norm in per_message if norm]
     if not fragments or not usable:
         return None
     cross_message = not any(
-        _fragments_in_order(fragments, text) for _, text in usable)
-    by_role: dict = {}
-    for role, text in usable:
-        by_role.setdefault(role, []).append(text)
+        _fragments_in_order(fragments, norm) for norm in usable)
     cross_role = not any(
-        _fragments_in_order(fragments, " ".join(texts))
-        for texts in by_role.values())
+        _fragments_in_order(fragments, join)
+        for join in role_joins.values() if join)
     return {"cross_message": cross_message, "cross_role": cross_role}
 
 
@@ -1049,14 +1086,39 @@ def stripped_transcript(messages) -> str:
     through `_render_transcript` before verification runs, and that raises on
     any non-dict row — so a message list that reaches here has already proven
     itself dict-shaped. A guard would only move a crash that already
-    happened."""
-    stripped = []
-    for m in messages or []:
-        copy = dict(m)
-        copy["content"] = ("" if m.get("daimon_output")
-                           else strip_injected(_message_text(m)))
-        stripped.append(copy)
-    return _render_transcript(stripped)
+    happened.
+
+    #831: derived from stripped_message_views — the ONE per-message builder
+    every verification surface (this haystack, the id-scoped map, and the
+    #829 stitching attribution) reads, so the surfaces cannot hand-sync
+    apart."""
+    return "\n\n".join(
+        line for _mid, _role, _text, line in stripped_message_views(messages))
+
+
+def stripped_message_views(messages) -> list:
+    """Per-message stripped views: [(mid, role, text, line)] in transcript
+    order — the ONE builder behind every per-message verification surface
+    (#831 review). `text` is the bare stripped flattened text (what
+    message_texts_by_id + strip_injected produced for the id-scoped checks);
+    `line` is the message's rendered transcript line with the SAME stripping
+    applied (what stripped_transcript joins into the whole-transcript
+    haystack). The #829 stitching attribution reads these same views, so its
+    verdicts are computed against exactly what verification witnessed —
+    never a third hand-synced spelling of the strip.
+
+    `role` is str()-coerced: the render path tolerates any role shape via
+    f-string, and attribution GROUPS by role, so grouping must tolerate it
+    the same way instead of raising on an unhashable value at
+    receipt-stamping time. #512: a daimon-output row is blanked, never
+    dropped. Same no-non-dict-guard contract as stripped_transcript."""
+    views = []
+    for i, m in enumerate(messages or []):
+        text = ("" if m.get("daimon_output")
+                else strip_injected(_message_text(m)))
+        views.append((_message_id(m), str(m.get("role", "unknown")), text,
+                      _render_line(i, m, text)))
+    return views
 
 
 def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
@@ -1112,12 +1174,14 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
     # #512: daimon-output tool rows are blanked in the STRIPPED map (their
     # bytes are daimon's own, not a witness) but kept raw, so a quote living
     # only there downgrades under the honest `echo-only` reason code.
+    # #831: both stripped surfaces derive from stripped_message_views — ONE
+    # strip pass, and the same views the stitching attribution reads.
     raw_texts_by_id = message_texts_by_id(messages) if messages else {}
-    daimon_ids = daimon_output_ids(messages) if messages else set()
-    texts_by_id = {mid: "" if mid in daimon_ids else strip_injected(text)
-                   for mid, text in raw_texts_by_id.items()}
-    haystack = (stripped_transcript(messages) if messages
-                else strip_injected(transcript_text))
+    views = stripped_message_views(messages) if messages else []
+    texts_by_id = {mid: text for mid, _role, text, _line in views
+                   if mid is not None}
+    haystack = ("\n\n".join(line for _mid, _role, _text, line in views)
+                if messages else strip_injected(transcript_text))
     # #359: signal pointers (tool-result ids) are outcome evidence, not
     # quote-source claims — they never scope the quote check, and a scoped
     # MISS must not execute them for the quote-id's crime.
@@ -1133,69 +1197,94 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
     # stays the fallback for callers with no transcript stamp to thread.
     stamp = now or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    def stamp_receipt(item, outcome, checked_at, binding_mode, message_ids=(),
-                      stitching=None):
+    # #829/#831: stitching attribution, derived lazily from the SAME
+    # per-message views the verification haystacks above are built from,
+    # per path: a transcript-scan hit matched the rendered LINES, a scoped
+    # hit matched the bare cited TEXTS. Role haystacks join in TRANSCRIPT
+    # order (never citation order — byte-identical quotes must get
+    # byte-identical verdicts) with the surfaces' own "\n\n" join. A session
+    # with no verbatim hit never pays the normalization pass. Without
+    # `messages` there is no per-message view, so receipts stay
+    # stitching-less — absent = unknown, the project convention.
+    view_at = {mid: idx for idx, (mid, _r, _t, _l) in enumerate(views)
+               if mid is not None}
+    scan_attr: tuple | None = None
+
+    def _scan_attribution():
+        nonlocal scan_attr
+        if scan_attr is None:
+            scan_attr = _attribution_views(
+                [(role, line) for _mid, role, _text, line in views])
+        return scan_attr
+
+    def _scoped_attribution(ids):
+        rows = [views[i] for i in sorted({view_at[mid] for mid in ids
+                                          if mid in view_at})]
+        return _attribution_views(
+            [(role, text) for _mid, role, text, _line in rows])
+
+    def stamp_receipt(item, outcome, checked_at, binding_mode, message_ids=()):
+        # #831 finding 10: stitching is derived HERE, keyed on the outcome,
+        # fully self-contained — the fragments are re-parsed from the item's
+        # own quote with the same _quote_fragments parse the match used, so
+        # no call site can opt out or silently shrink the measurement
+        # denominator by forgetting an argument. The re-parse is a few regex
+        # splits on one short quote, once per verified receipt; the costly
+        # haystack normalization is what the attribution caches hold.
+        stitching = None
+        if outcome == "verified" and messages:
+            fragments = _quote_fragments(item.get("quote") or "")
+            per_message, role_joins = (
+                _scoped_attribution(message_ids)
+                if binding_mode == "message-ids" else _scan_attribution())
+            stitching = _stitching_flags(fragments, per_message, role_joins)
         receipt = provenance.quote_receipt(
             source_ref, digest, outcome=outcome, checked_at=checked_at,
             binding_mode=binding_mode, message_ids=message_ids,
             stitching=stitching)
         if receipt is not None:
             item["quote_provenance"] = receipt
-
-    # #829: fragment-to-message attribution for the receipt's stitching
-    # record — built from the SAME stripped view the verification haystacks
-    # vouch for (daimon-output rows blanked, injected spans removed),
-    # normalized once per message. Lazy: a session with no verbatim hit
-    # never pays the normalization pass. Without `messages` there is no
-    # per-message view, so receipts stay stitching-less — absent = unknown,
-    # the project convention, never a guessed False.
-    _attr_rows: list | None = None
-    _attr_by_id: dict = {}
-
-    def _attribution(ids=None):
-        nonlocal _attr_rows
-        if _attr_rows is None:
-            _attr_rows = []
-            # No non-dict guard, same reasoning as stripped_transcript: a
-            # message list that reaches here already rendered through
-            # _render_transcript, which raises on any non-dict row.
-            for m in messages or []:
-                text = ("" if m.get("daimon_output")
-                        else strip_injected(_message_text(m)))
-                mid = _message_id(m)
-                if mid is not None:
-                    _attr_by_id[mid] = len(_attr_rows)
-                _attr_rows.append((m.get("role", "unknown"),
-                                   _normalize_for_match(text)))
-        if ids is None:
-            return _attr_rows
-        # Cited order, mirroring scoped_haystack's join order.
-        return [_attr_rows[_attr_by_id[i]] for i in ids if i in _attr_by_id]
     # The model never gets a vote on the echo verdict (#292 discipline, same
     # as `grounded`/`pinned`): any model-emitted value is dropped before the
     # checker re-derives it.
     for item in iter_items(checkpoint):
         item.pop(ECHO_ONLY_KEY, None)
         item.pop("quote_provenance", None)
+    # #831: the whole-transcript haystacks are constant across items —
+    # normalize each once, not once per verbatim item inside quote_matches.
+    norm_haystack = _normalize_for_match(haystack)
+    norm_raw = (_normalize_for_match(transcript_text)
+                if isinstance(transcript_text, str) else None)
     for item in iter_items(checkpoint):
         if item.get("trust") != "verbatim":
             continue
         quote = item.get("quote")
         if not isinstance(quote, str) or not quote.strip():
             continue
+        # One fragment parse per item (#831): every match check below and
+        # the stitching attribution share it. `_matches` is quote_matches
+        # with the parse hoisted — verdicts stay byte-identical.
+        fragments = _quote_fragments(quote)
+
+        def _matches(hay, _fragments=fragments) -> bool:
+            return (bool(_fragments) and isinstance(hay, str)
+                    and _fragments_in_order(_fragments,
+                                            _normalize_for_match(hay)))
+
+        # #831 finding 8: dedup the cited ids ONCE, first occurrence wins —
+        # scoped_haystack dedups identically, so the verification view, the
+        # attribution view, and the receipt's message_ids agree on one set.
+        quote_ids = list(dict.fromkeys(
+            i for i in item.get(SOURCE_IDS_KEY) or []
+            if isinstance(i, str) and i not in signals))
         scoped = scoped_haystack(item, texts_by_id, exclude=signals)
-        if scoped is not None and quote_matches(quote, scoped):
+        if scoped is not None and _matches(scoped):
             checked_at = stamp
             item["quote_verified"] = True
             item["last_verified"] = checked_at
-            quote_ids = [i for i in item.get(SOURCE_IDS_KEY) or []
-                         if isinstance(i, str) and i not in signals]
             stamp_receipt(item, "verified", checked_at, "message-ids",
-                          quote_ids,
-                          stitching=(_stitching_flags(
-                              quote, _attribution(quote_ids))
-                              if messages else None))
-        elif quote_matches(quote, haystack):
+                          quote_ids)
+        elif fragments and _fragments_in_order(fragments, norm_haystack):
             if scoped is not None:
                 # Resolved AND mismatched: the quote is real but not in its
                 # cited message — drop the disproven QUOTE binding (signal
@@ -1212,9 +1301,7 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
             checked_at = stamp
             item["quote_verified"] = True
             item["last_verified"] = checked_at
-            stamp_receipt(item, "verified", checked_at, "transcript-scan",
-                          stitching=(_stitching_flags(quote, _attribution())
-                                     if messages else None))
+            stamp_receipt(item, "verified", checked_at, "transcript-scan")
         else:
             # #440: a second pass over the UNSTRIPPED text separates "present
             # only in daimon's own injected output" from "absent entirely".
@@ -1222,8 +1309,9 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
             # distinct reason code turns the echo rate into something the
             # rejection ledger can count.
             raw_scoped = scoped_haystack(item, raw_texts_by_id, exclude=signals)
-            if ((raw_scoped is not None and quote_matches(quote, raw_scoped))
-                    or quote_matches(quote, transcript_text)):
+            if ((raw_scoped is not None and _matches(raw_scoped))
+                    or (norm_raw is not None and fragments
+                        and _fragments_in_order(fragments, norm_raw))):
                 item[ECHO_ONLY_KEY] = True
                 echoed += 1
             item["trust"] = "inferred"

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -858,15 +858,30 @@ def quote_matches(quote, haystack) -> bool:
     contract the docstring described was only ever met at the quote's edges."""
     if not isinstance(quote, str) or not isinstance(haystack, str):
         return False
-    hay = _normalize_for_match(haystack)
+    fragments = _quote_fragments(quote)
+    if not fragments:
+        return False
+    return _fragments_in_order(fragments, _normalize_for_match(haystack))
+
+
+def _quote_fragments(quote: str) -> list:
+    """The ordered, normalized, length-filtered fragments quote_matches scans
+    for — split on ellipsis and redaction markers (#505). Factored out (#829)
+    so stitching attribution replays the SAME fragment view the matcher used,
+    never a second parse that could drift."""
     fragments = []
     for raw in _ELLIPSIS_RE.split(quote):
         for piece in _REDACTED_RE.split(raw):
             frag = _normalize_for_match(piece)
             if len(frag) >= _MIN_FRAGMENT:
                 fragments.append(frag)
-    if not fragments:
-        return False
+    return fragments
+
+
+def _fragments_in_order(fragments, hay: str) -> bool:
+    """Every fragment appears in `hay` IN ORDER, each searched from the
+    previous fragment's match end — quote_matches' scan, over an
+    already-normalized haystack."""
     pos = 0
     for frag in fragments:
         idx = hay.find(frag, pos)
@@ -874,6 +889,36 @@ def quote_matches(quote, haystack) -> bool:
             return False
         pos = idx + len(frag)
     return True
+
+
+def _stitching_flags(quote, candidates) -> dict | None:
+    """The #829 stitching record for a VERIFIED quote, or None when
+    attribution is impossible (no usable fragments, or no per-message texts).
+    `candidates` is the ordered (role, normalized-stripped-text) view of the
+    messages the verification vouched against.
+
+    Necessity semantics, deliberately: a flag is True only when NO single
+    message (cross_message) or no single role's messages, joined in order
+    (cross_role), can account for every matched fragment — never merely
+    because the flat-haystack scan happened to satisfy a fragment across a
+    boundary it did not need to cross. Which occurrence a flat scan matched
+    is ambiguous by construction; whether ONE message could have said the
+    whole quote is not. Recording only: rule 17 (SERIALIZE_SYS) stays
+    doctrine, verification outcomes are untouched, and the follow-up
+    enforcement is gated on the violation rate this measures (#829)."""
+    fragments = _quote_fragments(quote) if isinstance(quote, str) else []
+    usable = [(role, text) for role, text in candidates if text]
+    if not fragments or not usable:
+        return None
+    cross_message = not any(
+        _fragments_in_order(fragments, text) for _, text in usable)
+    by_role: dict = {}
+    for role, text in usable:
+        by_role.setdefault(role, []).append(text)
+    cross_role = not any(
+        _fragments_in_order(fragments, " ".join(texts))
+        for texts in by_role.values())
+    return {"cross_message": cross_message, "cross_role": cross_role}
 
 
 # ---- #440: daimon's own injected output is not a witness ----
@@ -1047,7 +1092,14 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
     (see strip_injected) — a quote copied out of a recall line or a briefing
     block is an echo, not a witness, and must never earn `verbatim`. A miss
     is re-checked against the unstripped text so an echoed quote is ledgered
-    under `echo-only` rather than the generic absent-quote reason."""
+    under `echo-only` rather than the generic absent-quote reason.
+
+    #829: every verified receipt additionally records a `stitching` verdict —
+    whether the matched fragments could have come from one message / one role
+    (_stitching_flags' necessity semantics) — when `messages` provides a
+    per-message view. Recording only, never an outcome change: rule 17's
+    no-stitching doctrine (SERIALIZE_SYS) gains a measurement, not an
+    enforcement; the follow-up enforcement is gated on the measured rate."""
     # #440: the RAW pair survives alongside the stripped haystacks, read on
     # the failure path only — to tell an echoed quote from an absent one.
     # #512: daimon-output tool rows are blanked in the STRIPPED map (their
@@ -1074,12 +1126,44 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
     # stays the fallback for callers with no transcript stamp to thread.
     stamp = now or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    def stamp_receipt(item, outcome, checked_at, binding_mode, message_ids=()):
+    def stamp_receipt(item, outcome, checked_at, binding_mode, message_ids=(),
+                      stitching=None):
         receipt = provenance.quote_receipt(
             source_ref, digest, outcome=outcome, checked_at=checked_at,
-            binding_mode=binding_mode, message_ids=message_ids)
+            binding_mode=binding_mode, message_ids=message_ids,
+            stitching=stitching)
         if receipt is not None:
             item["quote_provenance"] = receipt
+
+    # #829: fragment-to-message attribution for the receipt's stitching
+    # record — built from the SAME stripped view the verification haystacks
+    # vouch for (daimon-output rows blanked, injected spans removed),
+    # normalized once per message. Lazy: a session with no verbatim hit
+    # never pays the normalization pass. Without `messages` there is no
+    # per-message view, so receipts stay stitching-less — absent = unknown,
+    # the project convention, never a guessed False.
+    _attr_rows: list | None = None
+    _attr_by_id: dict = {}
+
+    def _attribution(ids=None):
+        nonlocal _attr_rows
+        if _attr_rows is None:
+            _attr_rows = []
+            # No non-dict guard, same reasoning as stripped_transcript: a
+            # message list that reaches here already rendered through
+            # _render_transcript, which raises on any non-dict row.
+            for m in messages or []:
+                text = ("" if m.get("daimon_output")
+                        else strip_injected(_message_text(m)))
+                mid = _message_id(m)
+                if mid is not None:
+                    _attr_by_id[mid] = len(_attr_rows)
+                _attr_rows.append((m.get("role", "unknown"),
+                                   _normalize_for_match(text)))
+        if ids is None:
+            return _attr_rows
+        # Cited order, mirroring scoped_haystack's join order.
+        return [_attr_rows[_attr_by_id[i]] for i in ids if i in _attr_by_id]
     # The model never gets a vote on the echo verdict (#292 discipline, same
     # as `grounded`/`pinned`): any model-emitted value is dropped before the
     # checker re-derives it.
@@ -1100,7 +1184,10 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
             quote_ids = [i for i in item.get(SOURCE_IDS_KEY) or []
                          if isinstance(i, str) and i not in signals]
             stamp_receipt(item, "verified", checked_at, "message-ids",
-                          quote_ids)
+                          quote_ids,
+                          stitching=(_stitching_flags(
+                              quote, _attribution(quote_ids))
+                              if messages else None))
         elif quote_matches(quote, haystack):
             if scoped is not None:
                 # Resolved AND mismatched: the quote is real but not in its
@@ -1118,7 +1205,9 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
             checked_at = stamp
             item["quote_verified"] = True
             item["last_verified"] = checked_at
-            stamp_receipt(item, "verified", checked_at, "transcript-scan")
+            stamp_receipt(item, "verified", checked_at, "transcript-scan",
+                          stitching=(_stitching_flags(quote, _attribution())
+                                     if messages else None))
         else:
             # #440: a second pass over the UNSTRIPPED text separates "present
             # only in daimon's own injected output" from "absent entirely".

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -49,10 +49,17 @@ log = logging.getLogger(__name__)
 # cached extractions, which never tried to keep a date, can never satisfy a
 # post-#416 request — a later re-measurement of the citable-date rate must
 # reflect the new behavior, not stale accidental survival.)
+# D-018 -> D-019 (#829: verified quote receipts additionally record a
+# stitching span verdict — quote_provenance.stitching {cross_message,
+# cross_role}. A persisted checkpoint-format change, the same class D-014
+# (#290) and D-015 (#358) bumped for: the #827 published schema names its
+# shape per format_version, so two different receipt shapes must never
+# share the name D-018. Recording only; EXTRACTION_VERSION stays at 3 —
+# what a chunk pass extracts is unchanged, only what verification records.)
 # Checkpoints are only comparable across runs sharing this version (scar
 # landmine #4); pre-bump checkpoints firing the #93 format_version mismatch
 # warning is desired, not a bug.
-PROMPT_VERSION = "D-018"
+PROMPT_VERSION = "D-019"
 
 # #367: the chunk-cache rotation lever, deliberately SEPARATE from
 # PROMPT_VERSION. Bump ONLY when extraction semantics change — the output

--- a/plugin/daimon_ui/reader.py
+++ b/plugin/daimon_ui/reader.py
@@ -190,6 +190,19 @@ def _norm_provenance(raw):
                             and not isinstance(version, bool) else None)
     else:
         verifier_id, verifier_version = _norm_str(verifier), None
+    # D-019 (#829): the stitching span verdict — the field that defines the
+    # format bump — passes through per-key, unknown-shaped values reading as
+    # None rather than a guessed verdict.
+    stitching = raw.get("stitching")
+    if isinstance(stitching, dict):
+        cm = stitching.get("cross_message")
+        cr = stitching.get("cross_role")
+        stitching_norm = {
+            "cross_message": cm if isinstance(cm, bool) else None,
+            "cross_role": cr if isinstance(cr, bool) else None,
+        }
+    else:
+        stitching_norm = None
     return {
         "verifier": verifier_id,
         "verifier_version": verifier_version,
@@ -197,6 +210,7 @@ def _norm_provenance(raw):
         "checked_at": _norm_str(raw.get("checked_at")),
         "digest_algorithm": _norm_str(digest.get("algorithm")),
         "message_ids": _norm_str_list(binding.get("message_ids")),
+        "stitching": stitching_norm,
     }
 
 def _norm_item(raw):

--- a/plugin/daimon_ui/reader.py
+++ b/plugin/daimon_ui/reader.py
@@ -151,7 +151,7 @@ def list_recent(bucket: Path):
         out.append({"ref": ref, "created": created, "active_topic": topic})
     return out
 
-KNOWN_FORMAT = "D-018"
+KNOWN_FORMAT = "D-019"
 
 _SECTIONS = [  # (ui key, label, checkpoint container, checkpoint key)
     ("decisions", "Decisions", "working_context", "recent_decisions"),

--- a/plugin/daimon_ui/static/render.js
+++ b/plugin/daimon_ui/static/render.js
@@ -389,6 +389,15 @@ export const ACT_ITEM_ID_RE = /^[a-z]-[0-9a-f]{6,40}(-\d+)?$/;   // mirror of re
         " · checked " + taVal(r.checked_at) + " · digest " + taVal(r.digest_algorithm) +
         " · bound to " + (r.message_ids ? r.message_ids.length + " message" +
           (r.message_ids.length === 1 ? "" : "s") : '<span class="ta-none">not recorded</span>');
+      // D-019 (#829): the stitching span verdict. Only definite booleans
+      // render; absent or unknown-shaped reads as "not recorded".
+      if (r.stitching && r.stitching.cross_message !== null) {
+        var span = r.stitching.cross_message ? "cross-message" : "single-message";
+        if (r.stitching.cross_role === true) span += ", cross-role";
+        receipt += " · span " + escapeHtml(span);
+      } else {
+        receipt += ' · span <span class="ta-none">not recorded</span>';
+      }
     } else {
       receipt = '<span class="ta-none">not recorded</span>';
     }

--- a/plugin/tests/test_quote_stitching.py
+++ b/plugin/tests/test_quote_stitching.py
@@ -1,0 +1,235 @@
+"""#829: record cross-message / cross-role quote stitching on the receipt.
+
+SERIALIZE_SYS rule 17 forbids stitching a quote from different speakers or
+turns, but quote_matches scans one flattened haystack, so a stitched quote
+verifies and earns trust=verbatim. This slice is recording only, additive and
+behavior-preserving: the receipt says whether the matched fragments could have
+come from one message / one role, verification outcomes stay untouched, and
+the violation rate becomes measurable before any semantics change.
+
+Necessity semantics (pinned here): a flag is True only when NO single message
+(or no single role's messages, joined in transcript order) can account for
+every matched fragment — never merely because the flat scan happened to cross
+a boundary it did not need to cross.
+"""
+from daimon_briefing import field_table, provenance, serializer
+
+_HASH = "a" * 64
+
+
+def _source(session="S-new"):
+    return {
+        "version": provenance.SOURCE_REF_VERSION,
+        "host": "claude-code",
+        "session_id": session,
+        "locator": "managed",
+        "author": "alice",
+    }
+
+
+def _checkpoint(item):
+    return {
+        "session_id": "S-new",
+        "working_context": {
+            "active_topic": {"text": "topic", "trust": "inferred"},
+            "open_questions": [item],
+            "recent_decisions": [],
+        },
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []},
+    }
+
+
+def _verify(item, messages):
+    cp = _checkpoint(item)
+    serializer.verify_quotes(
+        cp, serializer._render_transcript(messages), messages,
+        source_ref=_source(), transcript_hash=_HASH)
+    return item
+
+
+# ---- single-source quotes carry an explicit all-clear ----
+
+def test_single_message_quote_records_no_stitching():
+    messages = [
+        {"role": "user", "content": "please keep the invariant intact", "id": "u-1"},
+        {"role": "assistant", "content": "the invariant holds after the change",
+         "id": "a-2"},
+    ]
+    item = {"text": "claim", "trust": "verbatim",
+            "quote": "the invariant holds after the change"}
+    _verify(item, messages)
+
+    assert item["quote_verified"] is True
+    assert item["quote_provenance"]["stitching"] == {
+        "cross_message": False, "cross_role": False}
+
+
+def test_scoped_single_message_binding_records_no_stitching():
+    messages = [
+        {"role": "user", "content": "the durable sentence we agreed on", "id": "u-1"},
+        {"role": "assistant", "content": "unrelated follow-up prose", "id": "a-2"},
+    ]
+    item = {"text": "claim", "trust": "verbatim",
+            "quote": "the durable sentence we agreed on",
+            "source_message_ids": ["u-1"]}
+    _verify(item, messages)
+
+    receipt = item["quote_provenance"]
+    assert receipt["binding"]["mode"] == "message-ids"
+    assert receipt["stitching"] == {"cross_message": False, "cross_role": False}
+
+
+# ---- stitched quotes are recorded, and still verify (recording only) ----
+
+def test_cross_message_same_role_stitch_is_recorded():
+    messages = [
+        {"role": "user", "content": "the first constraint half lives here",
+         "id": "u-1"},
+        {"role": "assistant", "content": "acknowledged, moving on", "id": "a-2"},
+        {"role": "user", "content": "the second constraint half arrives now",
+         "id": "u-3"},
+    ]
+    item = {"text": "claim", "trust": "verbatim",
+            "quote": "first constraint half ... second constraint half"}
+    _verify(item, messages)
+
+    # Behavior preserved: the stitched quote still verifies (rule 17 stays
+    # doctrine; enforcement is the measured follow-up, not this slice).
+    assert item["trust"] == "verbatim"
+    assert item["quote_verified"] is True
+    assert item["quote_provenance"]["stitching"] == {
+        "cross_message": True, "cross_role": False}
+
+
+def test_cross_role_stitch_is_recorded():
+    messages = [
+        {"role": "user", "content": "the alpha premise stands firm", "id": "u-1"},
+        {"role": "assistant", "content": "the omega conclusion follows cleanly",
+         "id": "a-2"},
+    ]
+    item = {"text": "claim", "trust": "verbatim",
+            "quote": "alpha premise stands ... omega conclusion follows"}
+    _verify(item, messages)
+
+    assert item["quote_verified"] is True
+    assert item["quote_provenance"]["stitching"] == {
+        "cross_message": True, "cross_role": True}
+
+
+def test_scoped_two_message_binding_attributes_within_the_cited_set():
+    messages = [
+        {"role": "user", "content": "the alpha premise stands firm", "id": "u-1"},
+        {"role": "assistant", "content": "the omega conclusion follows cleanly",
+         "id": "a-2"},
+    ]
+    item = {"text": "claim", "trust": "verbatim",
+            "quote": "alpha premise stands ... omega conclusion follows",
+            "source_message_ids": ["u-1", "a-2"]}
+    _verify(item, messages)
+
+    receipt = item["quote_provenance"]
+    assert receipt["binding"]["mode"] == "message-ids"
+    assert receipt["stitching"] == {"cross_message": True, "cross_role": True}
+
+
+# ---- honest absence everywhere attribution is impossible or meaningless ----
+
+def test_not_verified_receipt_carries_no_stitching():
+    messages = [
+        {"role": "user", "content": "nothing that matches lives here", "id": "u-1"},
+    ]
+    item = {"text": "claim", "trust": "verbatim",
+            "quote": "a sentence the transcript never said"}
+    _verify(item, messages)
+
+    assert item["quote_verified"] is False
+    assert "stitching" not in item["quote_provenance"]
+
+
+def test_legacy_two_arg_call_records_no_stitching():
+    """Without `messages` there is no per-message view to attribute against —
+    absent = unknown, the project convention, never a guessed False."""
+    item = {"text": "claim", "trust": "verbatim",
+            "quote": "the durable sentence we agreed on"}
+    cp = _checkpoint(item)
+    serializer.verify_quotes(
+        cp, "user: the durable sentence we agreed on",
+        source_ref=_source(), transcript_hash=_HASH)
+
+    assert item["quote_verified"] is True
+    assert "stitching" not in item["quote_provenance"]
+
+
+def test_stitched_receipt_round_trips_the_validator():
+    messages = [
+        {"role": "user", "content": "the alpha premise stands firm", "id": "u-1"},
+        {"role": "assistant", "content": "the omega conclusion follows cleanly",
+         "id": "a-2"},
+    ]
+    item = {"text": "claim", "trust": "verbatim",
+            "quote": "alpha premise stands ... omega conclusion follows"}
+    _verify(item, messages)
+
+    assert provenance.valid_quote_receipt(item["quote_provenance"])
+
+
+# ---- attribution is impossible: the helper answers None, never a guess ----
+
+def test_stitching_flags_are_none_when_attribution_is_impossible():
+    candidates = [("user", "the alpha premise stands firm")]
+    # No usable fragment (below _MIN_FRAGMENT after normalization).
+    assert serializer._stitching_flags("short", candidates) is None
+    # Non-str quote fails closed the same way quote_matches does.
+    assert serializer._stitching_flags(None, candidates) is None
+    # No candidate carries any text (all blanked/stripped).
+    assert serializer._stitching_flags(
+        "a proper long fragment", [("user", ""), ("assistant", "")]) is None
+
+
+# ---- validator shape rules for the new optional member ----
+
+def _receipt(**kw):
+    return provenance.quote_receipt(
+        _source(), {"algorithm": "sha256", "scope": "raw-file", "value": _HASH},
+        outcome="verified", checked_at="2026-08-29T10:00:00Z",
+        binding_mode="transcript-scan", **kw)
+
+
+def test_quote_receipt_emits_normalized_stitching():
+    receipt = _receipt(stitching={"cross_message": True, "cross_role": False})
+    assert receipt is not None
+    assert receipt["stitching"] == {"cross_message": True, "cross_role": False}
+
+
+def test_quote_receipt_without_stitching_stays_bare():
+    receipt = _receipt()
+    assert receipt is not None
+    assert "stitching" not in receipt
+
+
+def test_valid_quote_receipt_rejects_malformed_stitching():
+    good = _receipt(stitching={"cross_message": False, "cross_role": False})
+    assert provenance.valid_quote_receipt(good)
+
+    for bad in ("yes", 1, [], {"cross_message": True},
+                {"cross_message": "yes", "cross_role": False},
+                {"cross_message": True, "cross_role": None}):
+        receipt = _receipt()
+        receipt["stitching"] = bad
+        assert not provenance.valid_quote_receipt(receipt), bad
+
+
+def test_receipt_without_stitching_is_still_valid_for_legacy_checkpoints():
+    receipt = _receipt()
+    receipt.pop("stitching", None)
+    assert provenance.valid_quote_receipt(receipt)
+
+
+# ---- the published contract learns the new shape (#827 table) ----
+
+def test_field_table_documents_the_stitching_shape():
+    row = field_table.rule("item", "quote_provenance")
+    shape = " ".join(dict(row.constraints)["shape"])
+    assert "stitching" in shape
+    assert "cross_message" in shape
+    assert "cross_role" in shape

--- a/plugin/tests/test_quote_stitching.py
+++ b/plugin/tests/test_quote_stitching.py
@@ -173,17 +173,120 @@ def test_stitched_receipt_round_trips_the_validator():
     assert provenance.valid_quote_receipt(item["quote_provenance"])
 
 
+# ---- attribution must mirror what verification witnessed (#831 review) ----
+
+def test_quote_containing_rendered_scaffolding_is_not_flagged_as_stitched():
+    """The transcript-scan haystack is the RENDERED transcript — [mN]
+    markers, role prefixes, joins — so a quote that verified because it
+    matched rendered scaffolding must be attributed against the same
+    rendered per-message lines, or one-message quotes record false
+    cross_message/cross_role verdicts and poison the enforcement
+    measurement."""
+    messages = [
+        {"role": "user", "content": "did the deployment finish", "id": "u-1"},
+        {"role": "assistant", "content": "the fix landed cleanly", "id": "a-2"},
+    ]
+    item = {"text": "claim", "trust": "verbatim",
+            "quote": "assistant: the fix landed"}
+    _verify(item, messages)
+
+    assert item["quote_verified"] is True
+    assert item["quote_provenance"]["stitching"] == {
+        "cross_message": False, "cross_role": False}
+
+
+def test_scoped_attribution_is_citation_order_invariant():
+    """Pinned semantics say roles join in TRANSCRIPT order — byte-identical
+    quotes must get byte-identical verdicts regardless of citation order."""
+    def _receipt_for(ids):
+        messages = [
+            {"role": "user", "content": "the alpha premise stands firm",
+             "id": "u-1"},
+            {"role": "user", "content": "the omega conclusion follows cleanly",
+             "id": "u-2"},
+        ]
+        item = {"text": "claim", "trust": "verbatim",
+                "quote": "alpha premise stands ... omega conclusion follows",
+                "source_message_ids": list(ids)}
+        _verify(item, messages)
+        return item["quote_provenance"]
+
+    forward = _receipt_for(["u-1", "u-2"])
+    reverse = _receipt_for(["u-2", "u-1"])
+    assert forward["stitching"] == reverse["stitching"]
+    assert forward["stitching"] == {"cross_message": True, "cross_role": False}
+
+
+def test_duplicate_cited_ids_are_deduped_before_the_verification_view():
+    """A duplicated citation must not duplicate its message's text in the
+    scoped haystack: a quote repeating a sentence could otherwise verify
+    against the duplication artifact, and the verdict, the attribution view
+    and the receipt's message_ids would disagree."""
+    messages = [
+        {"role": "user", "content": "the durable sentence we agreed on",
+         "id": "u-1"},
+    ]
+    item = {"text": "claim", "trust": "verbatim",
+            "quote": "the durable sentence we agreed on",
+            "source_message_ids": ["u-1", "u-1"]}
+    _verify(item, messages)
+    receipt = item["quote_provenance"]
+    assert receipt["binding"]["message_ids"] == ["u-1"]
+    assert receipt["stitching"] == {"cross_message": False, "cross_role": False}
+
+    # The duplication artifact itself must not verify: a quote needing the
+    # sentence TWICE has no witness in a store that said it once.
+    messages = [
+        {"role": "user", "content": "the durable sentence we agreed on",
+         "id": "u-1"},
+    ]
+    twice = {"text": "claim", "trust": "verbatim",
+             "quote": ("the durable sentence we agreed on ... "
+                       "the durable sentence we agreed on"),
+             "source_message_ids": ["u-1", "u-1"]}
+    _verify(twice, messages)
+    assert twice["quote_verified"] is False
+
+
+def test_unhashable_role_never_crashes_the_capture_path():
+    """Pre-#829 rendering tolerated any role shape via f-string; attribution
+    grouping must tolerate it the same way, never raise at stamping time."""
+    messages = [
+        {"role": ["user"], "content": "the durable sentence we agreed on",
+         "id": "u-1"},
+    ]
+    item = {"text": "claim", "trust": "verbatim",
+            "quote": "the durable sentence we agreed on"}
+    _verify(item, messages)
+    assert item["quote_verified"] is True
+    assert item["quote_provenance"]["stitching"] == {
+        "cross_message": False, "cross_role": False}
+
+
+def test_verbatim_item_with_unusable_quote_is_left_untouched():
+    """The loop's guard, unchanged from pre-#829: a verbatim item whose quote
+    is not a usable string gets no verdict, no stamp, and no receipt."""
+    messages = [
+        {"role": "user", "content": "anything at all here", "id": "u-1"},
+    ]
+    item = {"text": "claim", "trust": "verbatim", "quote": "   "}
+    _verify(item, messages)
+    assert "quote_verified" not in item
+    assert "quote_provenance" not in item
+
+
 # ---- attribution is impossible: the helper answers None, never a guess ----
 
 def test_stitching_flags_are_none_when_attribution_is_impossible():
-    candidates = [("user", "the alpha premise stands firm")]
-    # No usable fragment (below _MIN_FRAGMENT after normalization).
-    assert serializer._stitching_flags("short", candidates) is None
-    # Non-str quote fails closed the same way quote_matches does.
-    assert serializer._stitching_flags(None, candidates) is None
+    per_message = [("user", "the alpha premise stands firm")]
+    role_joins = {"user": "the alpha premise stands firm"}
+    # No usable fragment survives (below _MIN_FRAGMENT after normalization).
+    assert serializer._stitching_flags(
+        serializer._quote_fragments("short"), per_message, role_joins) is None
     # No candidate carries any text (all blanked/stripped).
     assert serializer._stitching_flags(
-        "a proper long fragment", [("user", ""), ("assistant", "")]) is None
+        serializer._quote_fragments("a proper long fragment"),
+        [("user", ""), ("assistant", "")], {"user": "", "assistant": ""}) is None
 
 
 # ---- validator shape rules for the new optional member ----
@@ -217,6 +320,42 @@ def test_valid_quote_receipt_rejects_malformed_stitching():
         receipt = _receipt()
         receipt["stitching"] = bad
         assert not provenance.valid_quote_receipt(receipt), bad
+
+
+def test_valid_quote_receipt_holds_the_published_invariants():
+    """#831 review: the D-019 contract says verified receipts only, and
+    `stitching?: object` — an explicit null is not "absent", and a
+    not-verified receipt carrying the member is out of contract."""
+    explicit_null = _receipt()
+    explicit_null["stitching"] = None
+    assert not provenance.valid_quote_receipt(explicit_null)
+
+    not_verified = provenance.quote_receipt(
+        _source(), {"algorithm": "sha256", "scope": "raw-file", "value": _HASH},
+        outcome="not-verified", checked_at="2026-08-29T10:00:00Z",
+        binding_mode="transcript-scan")
+    not_verified["stitching"] = {"cross_message": False, "cross_role": False}
+    assert not provenance.valid_quote_receipt(not_verified)
+
+
+def test_quote_receipt_rejects_malformed_stitching_instead_of_coercing():
+    """#831 review: reject-not-coerce. A junk stitching input must refuse the
+    whole receipt, never launder truthy junk into a verdict the code did not
+    derive."""
+    for junk in ("junk", 7, ["x"],
+                 {"cross_message": "yes", "cross_role": False},
+                 {"cross_message": True},
+                 {"cross_message": None, "cross_role": None}):
+        assert _receipt(stitching=junk) is None, junk
+
+
+def test_quote_receipt_rejects_stitching_on_a_not_verified_outcome():
+    receipt = provenance.quote_receipt(
+        _source(), {"algorithm": "sha256", "scope": "raw-file", "value": _HASH},
+        outcome="not-verified", checked_at="2026-08-29T10:00:00Z",
+        binding_mode="transcript-scan",
+        stitching={"cross_message": False, "cross_role": False})
+    assert receipt is None
 
 
 def test_receipt_without_stitching_is_still_valid_for_legacy_checkpoints():

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -957,9 +957,14 @@ def test_prompt_version_history_and_current_pin():
     # reasoning — new schema field AND new extraction target, so
     # EXTRACTION_VERSION bumped alongside for the first time since the
     # #514 stamp made a lone bump visible).
+    # D-018 -> D-019 (#829: verified quote receipts record a stitching span
+    # verdict — quote_provenance.stitching {cross_message, cross_role}. A
+    # persisted receipt-surface change, the D-014/D-015 class, so the
+    # format version moves; EXTRACTION_VERSION stays 3 because extraction
+    # semantics are unchanged — only what verification records).
     # Pre-bump checkpoints firing the format_version mismatch warning (#93)
     # is DESIRED behavior.
-    assert serializer.PROMPT_VERSION == "D-018"
+    assert serializer.PROMPT_VERSION == "D-019"
     assert serializer.EXTRACTION_VERSION == 3
 
 

--- a/plugin/tests/ui/conftest.py
+++ b/plugin/tests/ui/conftest.py
@@ -6,7 +6,7 @@ from daimon_ui import server
 def make_checkpoint(created="2026-08-06T08:05:12Z", topic="Scoping the inspector", **over):
     cp = {
         "session_id": over.get("session_id", "aaaa-bbbb"),
-        "format_version": over.get("format_version", "D-018"),
+        "format_version": over.get("format_version", "D-019"),
         "created": created,
         "author": "ada",
         "project_slug": "-tmp-proj",

--- a/plugin/tests/ui/test_reader_ledger.py
+++ b/plugin/tests/ui/test_reader_ledger.py
@@ -12,7 +12,7 @@ from daimon_ui import reader
 
 def _cp(sid, created, slug, items, topic="t"):
     return {
-        "session_id": sid, "format_version": "D-018", "created": created,
+        "session_id": sid, "format_version": "D-019", "created": created,
         "author": "ada", "project_slug": slug,
         "working_context": {"active_topic": {"text": topic},
                             "open_questions": items, "recent_decisions": []},

--- a/plugin/tests/ui/test_reader_normalize.py
+++ b/plugin/tests/ui/test_reader_normalize.py
@@ -148,6 +148,7 @@ def test_norm_item_passes_trust_anatomy_fields():
         "verifier": "tier-f", "verifier_version": 1, "outcome": "verified",
         "checked_at": "2026-08-06T10:00:00Z",
         "digest_algorithm": "sha256", "message_ids": ["m1"],
+        "stitching": None,
     }
 
 def test_norm_item_trust_anatomy_fields_default_none():
@@ -178,7 +179,35 @@ def test_norm_provenance_malformed_nested_shapes():
     assert got["quote_provenance"] == {
         "verifier": None, "verifier_version": None, "outcome": None,
         "checked_at": None, "digest_algorithm": None, "message_ids": ["ok"],
+        "stitching": None,
     }
+
+
+def test_norm_provenance_preserves_the_stitching_verdict():
+    """D-019 (#829/#831): the span verdict is the field that defines the
+    format bump — the inspector must surface it, never null it."""
+    got = reader._norm_item({"text": "x", "quote_provenance": {
+        "outcome": "verified",
+        "stitching": {"cross_message": True, "cross_role": False},
+    }})
+    assert got["quote_provenance"]["stitching"] == {
+        "cross_message": True, "cross_role": False}
+
+
+def test_norm_provenance_stitching_absent_or_junk_reads_as_unknown():
+    absent = reader._norm_item({"text": "x", "quote_provenance": {
+        "outcome": "verified"}})
+    assert absent["quote_provenance"]["stitching"] is None
+
+    junk = reader._norm_item({"text": "x", "quote_provenance": {
+        "outcome": "verified", "stitching": "yes"}})
+    assert junk["quote_provenance"]["stitching"] is None
+
+    partial = reader._norm_item({"text": "x", "quote_provenance": {
+        "outcome": "verified",
+        "stitching": {"cross_message": "junk", "cross_role": True}}})
+    assert partial["quote_provenance"]["stitching"] == {
+        "cross_message": None, "cross_role": True}
 
 def test_norm_item_source_message_ids_filters_non_strings():
     got = reader._norm_item({"text": "x", "source_message_ids": ["a", 1, "b"]})

--- a/plugin/tests/ui/test_receipts.py
+++ b/plugin/tests/ui/test_receipts.py
@@ -26,7 +26,7 @@ def _write_pair(root: Path, sid: str, claims: bool, sidecar: str | None):
     """Write a checkpoint and optionally a sidecar whose outputs_hash covers it.
     Returns the checkpoint path. sidecar: None = no file, "match" = true hash,
     "wrong" = a different hash, "garbage" = unparseable, "nokey" = no outputs_hash."""
-    cp = {"session_id": sid, "format_version": "D-018"}
+    cp = {"session_id": sid, "format_version": "D-019"}
     if claims:
         cp["receipts"] = True
     p = root / f"{sid}.json"
@@ -75,7 +75,7 @@ def test_tampering_one_byte_turns_match_into_mismatch(tmp_path):
     A state machine that reported "match" from the claim alone would stay green."""
     p = _write_pair(tmp_path, "aaaa-bbbb", True, "match")
     assert reader.receipt_state(tmp_path, json.loads(p.read_text()))["state"] == "match"
-    p.write_text(p.read_text().replace("D-018", "D-019"), encoding="utf-8")
+    p.write_text(p.read_text().replace("D-019", "D-020"), encoding="utf-8")
     assert reader.receipt_state(tmp_path, json.loads(p.read_text()))["state"] == "mismatch"
 
 def test_root_session_file_governs_even_when_a_pointer_copy_differs(tmp_path):
@@ -89,7 +89,7 @@ def test_root_session_file_governs_even_when_a_pointer_copy_differs(tmp_path):
     bucket = tmp_path / slug
     bucket.mkdir()
 
-    root_data = {"session_id": sid, "format_version": "D-018", "receipts": True,
+    root_data = {"session_id": sid, "format_version": "D-019", "receipts": True,
                  "working_context": {}, "epistemic_snapshot": {}}
     root = tmp_path / f"{sid}.json"
     root.write_text(json.dumps(root_data), encoding="utf-8")
@@ -134,7 +134,7 @@ def _bucket_with(root: Path, slug: str, claims_by_ref: dict):
     b = root / slug
     b.mkdir(parents=True, exist_ok=True)
     for ref, claims in claims_by_ref.items():
-        cp = {"session_id": f"sid-{ref}", "format_version": "D-018",
+        cp = {"session_id": f"sid-{ref}", "format_version": "D-019",
               "working_context": {}, "epistemic_snapshot": {}}
         if claims:
             cp["receipts"] = True


### PR DESCRIPTION
Closes #829

## What

Every VERIFIED quote receipt now records whether the matched fragments were stitched across turns or speakers: an optional `stitching` member, `{cross_message: boolean, cross_role: boolean}`, beside the existing `binding` on `quote_provenance`. Recording only, additive and behavior-preserving: verification outcomes, trust assignment, and `quote_verified` semantics are untouched, and the receipt version stays 1 so every existing receipt remains valid. Single-message enforcement stays the follow-up the issue names, gated on the violation rate this makes measurable.

Semantics (pinned by test): NECESSITY, not incident. A flag is true only when NO single message (`cross_message`) or no single role's messages joined in transcript order (`cross_role`) can account for every matched fragment. Fragment occurrences in a flattened haystack are ambiguous (which occurrence matched is unknowable), so the receipt answers the well-defined question instead: could one message have said this whole quote. That is conservative in the right direction: a quote is never flagged merely because the flat scan happened to cross a boundary it did not need to cross.

## How attribution works

`quote_matches` is factored into `_quote_fragments` + `_fragments_in_order` with a byte-identical composition (the matcher itself is untouched; the existing quote-verification suite pins it). `_stitching_flags` replays that exact fragment view over per-message texts: the same stripped view the verification haystacks vouch for (daimon-output rows blanked per #512, injected spans removed per #440), normalized once per message and built lazily inside `verify_quotes`, so a session with no verbatim hit pays nothing. Scoped (message-ids) hits attribute within the cited messages in cited order, mirroring `scoped_haystack`'s join; transcript-scan hits attribute across all messages. Where attribution is impossible the field is ABSENT, never a guessed false: legacy two-arg callers with no message list, not-verified receipts (there are no matched fragments), and quotes with no usable fragment.

## Contract surface

- `provenance.quote_receipt` gains an optional `stitching` parameter; `valid_quote_receipt` accepts the optional member (exactly two boolean keys when present, rejects malformed shapes) and still accepts every receipt without it.
- The #827 field table's `quote_provenance` row documents the new shape and `docs/checkpoint-schema.json` is regenerated in the same PR, so consumers learn the field from the published table.

## Tests

Strict TDD: `plugin/tests/test_quote_stitching.py` written first and red (16 tests) covering single-message and scoped all-clears, cross-message same-role, cross-role, scoped two-message attribution, honest absence (not-verified, legacy caller, unusable fragments), validator shape rules, round-trip validity, and the field-table documentation.

- `uv run pytest`: 4616 passed, 2 skipped (full suite)
- `uv run ruff check .`: clean
- `uv run --extra dev mypy daimon_briefing`: clean, 59 files
- `scar lint`: 0 errors (1 pre-existing partial-rot hint, untouched)
- Local patch coverage (term-missing over the touched modules): every added or changed line in `serializer.py`, `provenance.py`, and `field_table.py` is covered; the remaining misses in those files are pre-existing lines outside this diff.

## Format version ruling (applied in 4d53bed)

PROMPT_VERSION is bumped D-018 to D-019 in this PR, per the design ruling: the stitching member is a persisted checkpoint-format change, and PROMPT_VERSION versions the checkpoint format, with D-014 (#290) and D-015 (#358) as direct precedent for receipt/capture-surface additions. The #827 published schema names its shape per format_version, so two different receipt shapes must never share the name D-018. The version-history comment block carries the D-018 to D-019 entry.

EXTRACTION_VERSION stays at 3, considered and deliberate: extraction semantics did not change, only what verification records, and the #367 comment reserves that lever for extraction-semantics changes (keeping the #48 chunk cache warm is the point of the split).

Consequences handled: the daimon_ui reader KNOWN_FORMAT follows to D-019 (the additive member changes nothing it renders; left at D-018 it would banner every new checkpoint as unknown schema), ui fixtures follow, the receipts byte-mutation test now flips D-019 to D-020 so it keeps mutating, the serializer test pin was updated deliberately with a matching history comment, the field table notes the member exists since D-019, and docs/checkpoint-schema.json regenerates with format_version D-019. Pre-bump checkpoints firing the #93 format_version mismatch warning is desired, documented behavior.


Two distinct version levers move differently here, deliberately: format_version (PROMPT_VERSION) bumps to D-019 because the checkpoint format gained a field, while quote_provenance.version stays 1 because it names the receipt envelope shape and valid_quote_receipt rejects any receipt whose version differs, so bumping it would invalidate every receipt already on disk. The new member is optional under version 1; the published table records both facts.
