### PR TITLE
fix(worldcheck): count the aggregate stats once per item, not per claim

### DIFF
--- a/plugin/daimon_briefing/worldcheck.py
+++ b/plugin/daimon_briefing/worldcheck.py
@@ -742,12 +742,16 @@ def check(checkpoint, project_dir) -> dict:
     persisted).
 
     Returns {"confirmed": n, "contradicted": n, "skipped": n} counted per
-    ITEM, plus a "<class>:<outcome>" key for every outcome that actually
-    occurred (#397) — so the caller's usage counters measure the fires-true
-    rate per claim class while the aggregate three keep their slice-1
-    meaning. Zero-claim checkpoints return all-zeros and cost one iteration,
-    no probe of any kind. Confirmed items are untouched: only a contradiction
-    earns any surface at all.
+    ITEM — once per claim-bearing item, the FIRST claim's outcome deciding
+    which aggregate it lands in (#830; text claims are emitted before
+    receipt claims per item, the same ordering that decides the stamp
+    collision below, so a two-axis item rolls up under its text outcome) —
+    plus a "<class>:<outcome>" key for every outcome that actually occurred
+    (#397), counted per CLAIM, so the caller's usage counters measure the
+    fires-true rate per claim class while the aggregate three keep their
+    slice-1 meaning. Zero-claim checkpoints return all-zeros and cost one
+    iteration, no probe of any kind. Confirmed items are untouched: only a
+    contradiction earns any surface at all.
 
     #439 adds ONE non-counter key, `LEDGER_KEY`, present only when a receipt
     verification actually failed: [(item_ref, check, reason)] rows for the
@@ -796,6 +800,10 @@ def check(checkpoint, project_dir) -> dict:
     probes.update(_gh_probes(plan, project_dir))
     results.update(_run_probes(probes, cwd=project_dir, deadline=deadline))
     ledger = []
+    # #830: the aggregate three count once per ITEM (the docstring's promise,
+    # and what cli emits usage events under) — identity-keyed, because two
+    # items may be equal dicts yet distinct claims-bearers.
+    counted: set = set()
     for item, cls, claim in claims:
         value = results.get((cls, _target(cls, claim)))
         if value is None:
@@ -822,7 +830,9 @@ def check(checkpoint, project_dir) -> dict:
                 # An id-less item yields no row: a ledger entry nobody can
                 # trace back is noise (serializer.verification_rejections).
                 ledger.append((ref, _LEDGER_CHECK, _LEDGER_REASONS[value]))
-        stats[outcome] += 1
+        if id(item) not in counted:
+            counted.add(id(item))
+            stats[outcome] += 1
         stats[f"{cls}:{outcome}"] = stats.get(f"{cls}:{outcome}", 0) + 1
     if ledger:
         stats[LEDGER_KEY] = ledger

--- a/plugin/tests/test_worldcheck.py
+++ b/plugin/tests/test_worldcheck.py
@@ -1389,6 +1389,58 @@ def test_receipt_never_overwrites_a_text_class_stamp(receipts_on, proj,
     assert stats[worldcheck.LEDGER_KEY] == [("o-000001", "receipt", "receipt-invalid")]
 
 
+def test_two_axis_item_counts_once_in_the_aggregates(receipts_on, proj,
+                                                     monkeypatch, fake_gh):
+    """#830: the three aggregates are counted per ITEM (the docstring's
+    promise, and what cli's usage counters emit under), so an item carrying
+    BOTH a text claim and a receipt-validity claim increments them once —
+    while the per-class keys keep the per-claim detail."""
+    monkeypatch.setenv("FAKE_VITNI_VERDICT", "signature_invalid")
+    gh, _log = fake_gh("echo '{\"state\":\"MERGED\"}'")
+    _enable_probes(monkeypatch, gh)
+    _signed_origin("S-origin", proj)
+    cp = _cp_origins(["S-origin"], texts=["PR #60 awaiting review"])
+    stats = worldcheck.check(cp, proj)
+    assert (stats["confirmed"] + stats["contradicted"] + stats["skipped"]) == 1
+    assert stats["contradicted"] == 1
+    assert stats["pr-state:contradicted"] == 1
+    assert stats["receipt-validity:contradicted"] == 1
+
+
+def test_two_axis_rollup_first_outcome_wins(receipts_on, proj, monkeypatch,
+                                            fake_gh):
+    """#830: per-item rollup semantics aligned with the stamp collision rule
+    (text claims are emitted first per item, FIRST wins): a text-confirmed,
+    receipt-contradicted item aggregates as confirmed, while the receipt
+    axis keeps its per-class count, its stamp, and its ledger row."""
+    monkeypatch.setenv("FAKE_VITNI_VERDICT", "signature_invalid")
+    gh, _log = fake_gh("echo '{\"state\":\"OPEN\"}'")
+    _enable_probes(monkeypatch, gh)
+    _signed_origin("S-origin", proj)
+    cp = _cp_origins(["S-origin"], texts=["PR #60 awaiting review"])
+    stats = worldcheck.check(cp, proj)
+    assert stats["confirmed"] == 1
+    assert stats["contradicted"] == 0
+    assert stats["pr-state:confirmed"] == 1
+    assert stats["receipt-validity:contradicted"] == 1
+    assert stats[worldcheck.LEDGER_KEY] == [
+        ("o-000001", "receipt", "receipt-invalid")]
+    item = cp["working_context"]["open_questions"][0]
+    assert item["_worldcheck_confirmed"] is True
+    assert item["_worldcheck"]["status"] == "unverified"
+
+
+def test_single_axis_aggregates_are_unchanged(receipts_on, proj):
+    """#830 regression guard: items with ONE claim keep counting exactly as
+    before the per-item rollup."""
+    _signed_origin("S-origin", proj)
+    cp = _cp_origins(["S-origin", "S-origin"])
+    stats = worldcheck.check(cp, proj)
+    assert (stats["confirmed"], stats["contradicted"], stats["skipped"]) \
+        == (2, 0, 0)
+    assert stats["receipt-validity:confirmed"] == 2
+
+
 def test_receipt_claims_are_carried_only(receipts_on, proj):
     _signed_origin("S-origin", proj)
     cp = _cp_origins(["S-origin"])


### PR DESCRIPTION
Closes #830

## What

worldcheck.check() now counts its three aggregate stats (confirmed / contradicted / skipped) once per ITEM, as its docstring has always promised and as the cli consumer emits usage events under. Rollup semantics: the FIRST claim's outcome per item decides the bucket. Text claims are emitted before receipt-validity claims per item, the same ordering that already decides the contradiction-stamp collision (the existing first-stamp-wins rule), so a two-axis item rolls up under its text outcome. The rollup is identity-keyed (two equal item dicts are still distinct claim-bearers). The per-class `<class>:<outcome>` keys keep counting per CLAIM as designed, and `LEDGER_KEY` behavior is untouched. The docstring now states the first-outcome rollup explicitly.

## Why

The loop fired `stats[outcome] += 1` once per claim, so an item carrying both a text claim and a receipt-validity claim incremented the aggregates twice. Receipt-bearing items are not a random subset, so any rate computed from the aggregates was systematically inflated, not noisy. Two code surfaces (the docstring and the cli usage-event emitter's comment) already promise per-item meaning to consumers, so the code moves to the promise rather than the other way around.

Expected consequence, by design: emitted usage-counter volumes change. `worldcheck:confirmed` / `worldcheck:contradicted` / `worldcheck:skipped` events (surfaced by `daimon stats`) will be lower on checkpoints with two-axis items, because that IS the fix. Numbers previously derived from the old aggregates were inflated by exactly the items carrying two claim axes and should be re-read with the corrected denominator in mind. The per-class counters are unaffected.

One pinned nuance of the ruled semantics: a text-confirmed, receipt-contradicted item aggregates as confirmed while its receipt axis keeps the per-class count, the contradiction stamp, and the ledger row (the render already lets a contradiction on any axis outrank the confirmed ground marker, so nothing user-facing hides).

## Tests

Strict TDD, red first: `test_two_axis_item_counts_once_in_the_aggregates` (an item with both a text claim and a receipt-validity claim: aggregates sum to 1 item while both per-class keys count their claim) and `test_two_axis_rollup_first_outcome_wins` (text-confirmed + receipt-contradicted: aggregate confirmed, receipt axis keeps count, stamp, and ledger row) both failed before the change; `test_single_axis_aggregates_are_unchanged` guards the regression direction.

- `uv run pytest`: 4629 passed, 2 skipped (full suite; 122 in test_worldcheck.py)
- `uv run ruff check .`: clean
- `uv run --extra dev mypy daimon_briefing`: clean, 59 files (worldcheck stays in the frozen ratchet list untouched, per the burn-down lane rule)
- `scar lint`: 0 errors (1 pre-existing partial-rot hint, untouched)
- Local patch coverage (term-missing): every changed line in worldcheck.py covered; remaining misses are pre-existing lines outside this diff