### PR TITLE
fix(worldcheck): roll up per-item aggregates by outcome precedence

### DIFF
--- a/plugin/daimon_briefing/worldcheck.py
+++ b/plugin/daimon_briefing/worldcheck.py
@@ -42,9 +42,12 @@ fair rather than first-come-lucky:
 - EXECUTION runs the on-disk classes BEFORE the `gh` fan-out, so a hanging
   network probe can never starve a probe that costs microseconds.
 
-Counters now also land per class (worldcheck:<class>:<outcome>) while the
-aggregate three keep their slice-1 meaning, so the fires-true rate is
-readable per class before any further expansion. Content-hash — the strongest
+Counters land per class (worldcheck:<class>:<outcome>, counted per CLAIM) so
+the fires-true rate is readable per class before any further expansion, while
+the aggregate three count once per ITEM (#830) under a precedence rollup —
+contradicted > confirmed > skipped (#833): an item is what its strongest
+outcome says it is, so a probe-cap- or deadline-starved claim's "skipped"
+never swallows a real answer on the item's other axis. Content-hash — the strongest
 form — is deliberately NOT here: it would have to capture a hash at serialize
 time, which changes the serializer contract, so it is its own issue.
 
@@ -82,6 +85,12 @@ BUDGET_SECONDS = 0.8
 # across ALL classes: cheap disk probes spend from the same allowance as `gh`,
 # which is why allocation follows checkpoint order rather than class.
 MAX_PROBES = 5
+
+# #833: per-item aggregate rollup precedence — an item is what its strongest
+# outcome says it is, and "skipped" never decides when another outcome
+# exists (a probe-cap- or deadline-starved claim must not swallow a real
+# answer on the item's other axis).
+_OUTCOME_RANK = {"skipped": 0, "confirmed": 1, "contradicted": 2}
 
 # Claim classes, in the fixed priority order claim_for tries them. The order
 # is part of the contract: it keeps an item's reading stable as classes are
@@ -742,16 +751,18 @@ def check(checkpoint, project_dir) -> dict:
     persisted).
 
     Returns {"confirmed": n, "contradicted": n, "skipped": n} counted per
-    ITEM — once per claim-bearing item, the FIRST claim's outcome deciding
-    which aggregate it lands in (#830; text claims are emitted before
-    receipt claims per item, the same ordering that decides the stamp
-    collision below, so a two-axis item rolls up under its text outcome) —
-    plus a "<class>:<outcome>" key for every outcome that actually occurred
-    (#397), counted per CLAIM, so the caller's usage counters measure the
-    fires-true rate per claim class while the aggregate three keep their
-    slice-1 meaning. Zero-claim checkpoints return all-zeros and cost one
-    iteration, no probe of any kind. Confirmed items are untouched: only a
-    contradiction earns any surface at all.
+    ITEM — once per claim-bearing item, under a precedence rollup:
+    contradicted > confirmed > skipped (#830/#833). An item is what its
+    strongest outcome says it is; "skipped" never decides when another
+    outcome exists, so a probe-cap- or deadline-starved claim cannot
+    swallow a real answer on the item's other axis, and the aggregate
+    always agrees with the strongest stamp/ledger surface the item earned.
+    Additionally a "<class>:<outcome>" key for every outcome that actually
+    occurred (#397), counted per CLAIM, so the caller's usage counters
+    measure the fires-true rate per claim class. Zero-claim checkpoints
+    return all-zeros and cost one iteration, no probe of any kind.
+    Confirmed items are untouched: only a contradiction earns any surface
+    at all.
 
     #439 adds ONE non-counter key, `LEDGER_KEY`, present only when a receipt
     verification actually failed: [(item_ref, check, reason)] rows for the
@@ -800,10 +811,13 @@ def check(checkpoint, project_dir) -> dict:
     probes.update(_gh_probes(plan, project_dir))
     results.update(_run_probes(probes, cwd=project_dir, deadline=deadline))
     ledger = []
-    # #830: the aggregate three count once per ITEM (the docstring's promise,
-    # and what cli emits usage events under) — identity-keyed, because two
-    # items may be equal dicts yet distinct claims-bearers.
-    counted: set = set()
+    # #830/#833: the aggregate three count once per ITEM (the docstring's
+    # promise, and what cli emits usage events under), under the precedence
+    # rollup — a starved claim's "skipped" must never swallow a real answer
+    # on the item's other axis (the undercount fired exactly when the probe
+    # cap bound, i.e. on the largest checkpoints). Identity-keyed, because
+    # two items may be equal dicts yet distinct claims-bearers.
+    rollup: dict[int, str] = {}
     for item, cls, claim in claims:
         value = results.get((cls, _target(cls, claim)))
         if value is None:
@@ -830,10 +844,12 @@ def check(checkpoint, project_dir) -> dict:
                 # An id-less item yields no row: a ledger entry nobody can
                 # trace back is noise (serializer.verification_rejections).
                 ledger.append((ref, _LEDGER_CHECK, _LEDGER_REASONS[value]))
-        if id(item) not in counted:
-            counted.add(id(item))
-            stats[outcome] += 1
+        prev = rollup.get(id(item))
+        if prev is None or _OUTCOME_RANK[outcome] > _OUTCOME_RANK[prev]:
+            rollup[id(item)] = outcome
         stats[f"{cls}:{outcome}"] = stats.get(f"{cls}:{outcome}", 0) + 1
+    for outcome in rollup.values():
+        stats[outcome] += 1
     if ledger:
         stats[LEDGER_KEY] = ledger
     return stats

--- a/plugin/tests/test_worldcheck.py
+++ b/plugin/tests/test_worldcheck.py
@@ -1100,6 +1100,26 @@ def _cp_origins(origins, texts=None):
     return cp
 
 
+def _two_axis_check(proj, monkeypatch, fake_gh, *, gh_state,
+                    vitni_verdict=None, n=1):
+    """Run check() over `n` carried items that each carry BOTH a text claim
+    (PR #6<i> awaiting review — distinct probe targets) and a
+    receipt-validity claim on ONE shared signed origin. The caller's
+    `receipts_on` fixture supplies the vitni side; `gh_state` drives the
+    text-claim probes and `vitni_verdict` (None = valid) the receipt one.
+    Returns (stats, checkpoint). With n >= 6 the probe plan fills at
+    MAX_PROBES before items 5+ plant their text probes — the #833
+    starvation shape."""
+    if vitni_verdict is not None:
+        monkeypatch.setenv("FAKE_VITNI_VERDICT", vitni_verdict)
+    gh, _log = fake_gh(f"echo '{{\"state\":\"{gh_state}\"}}'")
+    _enable_probes(monkeypatch, gh)
+    _signed_origin("S-origin", proj)
+    cp = _cp_origins(["S-origin"] * n,
+                     texts=[f"PR #6{i} awaiting review" for i in range(n)])
+    return worldcheck.check(cp, proj), cp
+
+
 def _pubkey_dir(tmp_path, monkeypatch):
     """A keys dir holding only the cached PUBLIC key — worldcheck verifies, it
     never signs, so the seed is deliberately absent."""
@@ -1376,12 +1396,8 @@ def test_receipt_never_overwrites_a_text_class_stamp(receipts_on, proj,
     # is the more actionable one (it names what changed and drives a `daimon
     # resolve --status`), so it WINS — but the receipt outcome still counts and
     # still reaches the rejection ledger.
-    monkeypatch.setenv("FAKE_VITNI_VERDICT", "signature_invalid")
-    gh, _log = fake_gh("echo '{\"state\":\"MERGED\"}'")
-    _enable_probes(monkeypatch, gh)
-    _signed_origin("S-origin", proj)
-    cp = _cp_origins(["S-origin"], texts=["PR #60 awaiting review"])
-    stats = worldcheck.check(cp, proj)
+    stats, cp = _two_axis_check(proj, monkeypatch, fake_gh, gh_state="MERGED",
+                                vitni_verdict="signature_invalid")
     item = cp["working_context"]["open_questions"][0]
     assert item["_worldcheck"] == {"note": "#60 merged", "status": "merged"}
     assert stats["pr-state:contradicted"] == 1
@@ -1395,32 +1411,27 @@ def test_two_axis_item_counts_once_in_the_aggregates(receipts_on, proj,
     promise, and what cli's usage counters emit under), so an item carrying
     BOTH a text claim and a receipt-validity claim increments them once —
     while the per-class keys keep the per-claim detail."""
-    monkeypatch.setenv("FAKE_VITNI_VERDICT", "signature_invalid")
-    gh, _log = fake_gh("echo '{\"state\":\"MERGED\"}'")
-    _enable_probes(monkeypatch, gh)
-    _signed_origin("S-origin", proj)
-    cp = _cp_origins(["S-origin"], texts=["PR #60 awaiting review"])
-    stats = worldcheck.check(cp, proj)
+    stats, _cp_out = _two_axis_check(proj, monkeypatch, fake_gh,
+                                     gh_state="MERGED",
+                                     vitni_verdict="signature_invalid")
     assert (stats["confirmed"] + stats["contradicted"] + stats["skipped"]) == 1
     assert stats["contradicted"] == 1
     assert stats["pr-state:contradicted"] == 1
     assert stats["receipt-validity:contradicted"] == 1
 
 
-def test_two_axis_rollup_first_outcome_wins(receipts_on, proj, monkeypatch,
-                                            fake_gh):
-    """#830: per-item rollup semantics aligned with the stamp collision rule
-    (text claims are emitted first per item, FIRST wins): a text-confirmed,
-    receipt-contradicted item aggregates as confirmed, while the receipt
-    axis keeps its per-class count, its stamp, and its ledger row."""
-    monkeypatch.setenv("FAKE_VITNI_VERDICT", "signature_invalid")
-    gh, _log = fake_gh("echo '{\"state\":\"OPEN\"}'")
-    _enable_probes(monkeypatch, gh)
-    _signed_origin("S-origin", proj)
-    cp = _cp_origins(["S-origin"], texts=["PR #60 awaiting review"])
-    stats = worldcheck.check(cp, proj)
-    assert stats["confirmed"] == 1
-    assert stats["contradicted"] == 0
+def test_two_axis_rollup_contradiction_takes_precedence(receipts_on, proj,
+                                                        monkeypatch, fake_gh):
+    """#833 precedence rollup (supersedes the #832 first-outcome pin): a
+    text-confirmed, receipt-contradicted item aggregates as CONTRADICTED —
+    the aggregate agrees with the surface the item renders with, since a
+    contradiction on any axis outranks the ground marker at render time.
+    Per-claim surfaces are unchanged: per-class keys, both stamps, and the
+    ledger row all stay."""
+    stats, cp = _two_axis_check(proj, monkeypatch, fake_gh, gh_state="OPEN",
+                                vitni_verdict="signature_invalid")
+    assert stats["contradicted"] == 1
+    assert stats["confirmed"] == 0
     assert stats["pr-state:confirmed"] == 1
     assert stats["receipt-validity:contradicted"] == 1
     assert stats[worldcheck.LEDGER_KEY] == [
@@ -1428,6 +1439,40 @@ def test_two_axis_rollup_first_outcome_wins(receipts_on, proj, monkeypatch,
     item = cp["working_context"]["open_questions"][0]
     assert item["_worldcheck_confirmed"] is True
     assert item["_worldcheck"]["status"] == "unverified"
+
+
+def test_starved_text_claim_does_not_swallow_a_receipt_contradiction(
+        receipts_on, proj, monkeypatch, fake_gh):
+    """#833: six items share one origin, so the probe plan fills at
+    MAX_PROBES (items 1-4's text probes + the shared receipt key) and items
+    5-6's text claims starve to "skipped" — while the shared receipt answer
+    still lands and comes back invalid. Those items are stamped, rendered,
+    and ledgered as contradicted; the aggregate must agree, never count
+    them under the starved axis."""
+    stats, _cp_out = _two_axis_check(proj, monkeypatch, fake_gh,
+                                     gh_state="OPEN",
+                                     vitni_verdict="signature_invalid", n=6)
+    assert stats["pr-state:confirmed"] == 4
+    assert stats["pr-state:skipped"] == 2          # the starved text claims
+    assert stats["receipt-validity:contradicted"] == 6
+    assert stats["contradicted"] == 6
+    assert stats["confirmed"] == 0
+    assert stats["skipped"] == 0
+
+
+def test_starved_text_claim_does_not_swallow_a_receipt_confirmation(
+        receipts_on, proj, monkeypatch, fake_gh):
+    """#833 mirror case: text starved to "skipped", receipt confirmed — the
+    item carries the solid-ground stamp, so the aggregate says confirmed,
+    never skipped."""
+    stats, cp = _two_axis_check(proj, monkeypatch, fake_gh, gh_state="OPEN",
+                                n=6)
+    assert stats["pr-state:skipped"] == 2
+    assert stats["receipt-validity:confirmed"] == 6
+    assert stats["confirmed"] == 6
+    assert stats["skipped"] == 0
+    for item in cp["working_context"]["open_questions"]:
+        assert item["_worldcheck_confirmed"] is True
 
 
 def test_single_axis_aggregates_are_unchanged(receipts_on, proj):


### PR DESCRIPTION
Closes #833

## What

The per-item aggregate rollup in worldcheck.check() moves from first-claim-outcome-wins (#832) to a precedence rollup: contradicted > confirmed > skipped. An item is what its strongest outcome says it is, and skipped never decides when another outcome exists on the item, so the aggregate always agrees with the strongest stamp/ledger surface the item earned. Per-class `<class>:<outcome>` keys keep counting per claim, LEDGER_KEY and the first-stamp-wins contradiction-stamp rule are untouched.

Bundled from the same review, per the issue: the module-level docstring header no longer teaches the pre-#830 per-claim aggregate meaning; the rollup map is typed `dict[int, str]` (the module is mypy-enforced); the triplicated two-axis test setup is now one helper (`_two_axis_check`, following the file's `_cp_origins` helper conventions) with every test keeping its own name, docstring, and assertions.

## Why

First-outcome-wins let a starved claim swallow a real one. When the probe cap (MAX_PROBES) or the deadline starves an item's text claim, that claim is skipped; if the item's receipt claim was still answered (its shared probe key planned via an earlier item), a genuine receipt contradiction stamped, rendered, and ledgered the item while `stats["contradicted"]` stayed 0. The undercount fired exactly when the probe budget binds, i.e. on the largest checkpoints. The mirror case (text skipped, receipt confirmed) undercounted confirmed the same way.

## Superseded pinned outcome

One pinned #832 semantics deliberately changes: a text-confirmed, receipt-contradicted item now aggregates CONTRADICTED (was: confirmed under first-outcome-wins). The old pin produced an aggregate that disagreed with the item's own render, since a contradiction on any axis already outranks the solid-ground marker at render time; precedence makes the aggregate agree with the surface. The test is renamed `test_two_axis_rollup_contradiction_takes_precedence` and its docstring names the supersession.

## Stats epoch

The aggregate worldcheck usage counters changed unit on 2026-08-29 (#832 introduced per-item counting; this PR refines the rollup rule). Lifetime `daimon stats` therefore mixes per-claim (before) and per-item (after) regimes across that boundary; usage lines carry timestamps, so the epoch is recoverable. The repo's release notes are generated by release-please from commit messages, so the epoch note rides this commit's body.

## Tests

Strict TDD, red first: `test_starved_text_claim_does_not_swallow_a_receipt_contradiction` (6 items share one origin so the probe plan fills at MAX_PROBES and items 5-6's text claims starve; the shared receipt key answers invalid; aggregate must say contradicted 6, skipped 0), `test_starved_text_claim_does_not_swallow_a_receipt_confirmation` (mirror: confirmed 6, skipped 0), and `test_two_axis_rollup_contradiction_takes_precedence` — all three failed before the change. `test_two_axis_item_counts_once_in_the_aggregates`, `test_single_axis_aggregates_are_unchanged`, and `test_receipt_never_overwrites_a_text_class_stamp` passed on both sides, guarding the unchanged semantics.

- `uv run pytest`: 4631 passed, 2 skipped (124 in test_worldcheck.py)
- `uv run ruff check .`: clean
- `uv run --extra dev mypy daimon_briefing`: clean, 59 files
- `scar lint`: 0 errors (1 pre-existing partial-rot hint, untouched)
- Local patch coverage (term-missing): every changed worldcheck.py line covered; remaining misses are pre-existing lines outside this diff