### PR TITLE
feat(recall): populate items.invalidated_by from worldcheck contradiction evidence

### DIFF
--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -16,11 +16,14 @@ project_slug/session_id/created), plus two Graphiti-inspired interval slots:
 `superseded_by` (populated — see below) and `invalidated_by` (#835: populated
 from DERIVED contradiction evidence only — the per-bucket verification
 ledger's worldcheck receipt-contradiction rows fold in at rebuild as
-"<check>:<reason>@<ts>", latest row per item winning. Replaced and disproven
-are independent axes: neither write ever touches the other. Authority
-precedent: model-flagged contradictions never mint the link — derived world
-evidence writes it, or nothing does). A contentless FTS5 table indexes
-text + quote for MATCH; rows join back to `items` by rowid.
+"<check>:<reason>@<ts>", latest by ts, author-scoped to this install. The
+value is EVIDENCE, not a verdict: "was contradicted by <evidence> at <ts>"
+— no confirmation rows or cure path exist yet, so it never means "is
+currently false". Replacement and contradiction are independent axes:
+neither write ever touches the other. Authority precedent: model-flagged
+contradictions never mint the link — derived world evidence writes it, or
+nothing does). A contentless FTS5 table indexes text + quote for MATCH;
+rows join back to `items` by rowid.
 
 Supersession v3 (#234) is ITEM-LEVEL evidence only: `superseded_by` is set by
 typed `supersedes` links (#14) — id-bound directly, free-text via never-guess
@@ -83,7 +86,11 @@ def _note_error(where: str, exc: BaseException) -> None:
 # v5 (#452): items grew pinned — the cli age gate exempts pinned standing
 # rules, so suggest()'s SELECT names the column and a v4 db would
 # OperationalError on it; the bump funnels that into the rebuild too.
-_SCHEMA_VERSION = "5"
+# v6 (#836): items grew the (item_id, project_slug) identity index the
+# ledger folds bind through — purely a performance object, but the bump
+# rolls every existing db onto it deterministically instead of waiting for
+# an unrelated fingerprint change.
+_SCHEMA_VERSION = "6"
 
 _FTS5_MISSING_MSG = (
     "sqlite3 has no FTS5 module — `daimon recall` needs an FTS5-enabled "
@@ -316,12 +323,13 @@ def _fingerprint() -> str:
                 # verification.jsonl joined the same club in #835
                 # (_apply_verification_invalidations folds it into
                 # invalidated_by): new contradiction evidence must rebuild,
-                # never serve stale NULLs.
+                # never serve stale NULLs. The name set is store's contract
+                # (INDEX_CONTENT_LEDGERS), so a third fold-able ledger
+                # cannot dodge this walk unnoticed.
                 paths.extend(p for p in e.iterdir()
                              if p.is_file()
                              and (p.suffix == ".json"
-                                  or p.name in ("events.jsonl",
-                                                "verification.jsonl")))
+                                  or p.name in store.INDEX_CONTENT_LEDGERS))
     except OSError:
         pass
     try:
@@ -377,6 +385,7 @@ def _init_schema(conn: sqlite3.Connection) -> None:
                 pinned INTEGER NOT NULL DEFAULT 0,
                 frontier INTEGER NOT NULL DEFAULT 0
             );
+            CREATE INDEX idx_items_identity ON items(item_id, project_slug);
             CREATE VIRTUAL TABLE items_fts USING fts5(text, quote, scene, content='');
             """
         )
@@ -595,26 +604,50 @@ _INVALIDATION_CHECKS = ("receipt",)
 
 def _apply_verification_invalidations(conn: sqlite3.Connection) -> None:
     """Fold each project bucket's verification ledger into invalidated_by
-    (#835): a worldcheck receipt-contradiction row marks every indexed row
-    of the referenced item with "<check>:<reason>@<ts>" — a scalar evidence
+    (#835): the LATEST worldcheck receipt-contradiction row per item marks
+    that item's rows with "<check>:<reason>@<ts>" — a scalar evidence
     reference, the same convention superseded_by keeps (a bare TEXT value,
-    never a JSON blob). Rows fold in file order, so the LATEST evidence for
-    an item wins: the most recent probe is the current world's answer.
+    never a JSON blob).
 
-    Independent axis by contract: superseded_by is never read or written
-    here — an item can be both replaced and disproven. Malformed rows
-    (missing ref/reason/ts) are skipped, the same fail-open bias as every
-    ledger fold: a wrong invalidation fabricates distrust, a missed one
-    just stays quiet."""
+    SEMANTICS (#836 review): the field records the latest contradiction
+    EVIDENCE — "was contradicted by <evidence> at <ts>" — never a
+    present-tense verdict. worldcheck appends no confirmation rows and no
+    cure path exists yet (human resolve / confirmation rows are the named
+    follow-up), so a populated value means "a probe once contradicted
+    this", not "this is currently false".
+
+    Latest by TS, NEVER line order — store.resolutions' documented contract,
+    mirrored: the ledger interleaves concurrent writers and clock-skewed
+    appends (the cli re-appends rows every briefing), so rows validate,
+    dedup to one per item_ref by parsed-ts maximum (an unstamped row never
+    displaces a stamped one; equal stamps fall to canonical-JSON order,
+    deterministic under any line order), then ONE UPDATE per item through
+    the (item_id, project_slug) identity index.
+
+    Binding, each choice deliberate (#836 review):
+    - the SAME bucket directory is read and bound (bucket=): bucket names
+      are not slug-idempotent (dots munge to '-'), so re-slugging the name
+      could read a sibling bucket's ledger;
+    - author-scoped to this install's author: receipt evidence is machine-
+      local (vitni verified THIS install's origin checkpoint bytes), so it
+      must never brand a teammate's mirrored copy of the same item id —
+      the same direct-id author binding _apply_typed_supersession uses;
+    - superseded_by is an independent axis, never read or written here.
+
+    Known limitations, accepted and documented: rows under a NULL slug
+    (unattributed sessions have no bucket), rows a project left behind
+    under a moved/renamed slug (the ledger lives with the old bucket), and
+    rows captured under a different local author name (an install whose
+    author changed) all stay unmarked. Malformed rows are skipped — a
+    wrong invalidation fabricates distrust, a missed one stays quiet."""
+    author = config.author()
     try:
         buckets = [d for d in config.checkpoint_dir().iterdir() if d.is_dir()]
     except OSError:
         return
     for bucket in buckets:
-        # The bucket dir NAME routes store.verification_rows exactly like a
-        # project dir — slug munging is idempotent on slugs, the same trick
-        # _apply_event_resolutions leans on.
-        for row in store.verification_rows(project_dir=bucket.name):
+        latest: dict[str, dict] = {}
+        for row in store.verification_rows(bucket=bucket):
             if row.get("check") not in _INVALIDATION_CHECKS:
                 continue
             ref = row.get("item_ref")
@@ -624,10 +657,27 @@ def _apply_verification_invalidations(conn: sqlite3.Connection) -> None:
                     and isinstance(reason, str) and reason
                     and isinstance(ts, str) and ts):
                 continue
+            cur = latest.get(ref)
+            if cur is None:
+                latest[ref] = row
+                continue
+            new_e = store._created_epoch(ts)
+            if new_e is None:
+                continue  # an unstamped row never displaces a stamped one
+            cur_e = store._created_epoch(cur.get("ts"))
+            if (cur_e is None or new_e > cur_e
+                    or (new_e == cur_e
+                        and json.dumps(row, sort_keys=True,
+                                       ensure_ascii=False)
+                        > json.dumps(cur, sort_keys=True,
+                                     ensure_ascii=False))):
+                latest[ref] = row
+        for ref, row in latest.items():
             conn.execute(
                 "UPDATE items SET invalidated_by = ?"
-                " WHERE item_id = ? AND project_slug IS ?",
-                (f"{row['check']}:{reason}@{ts}", ref, bucket.name))
+                " WHERE item_id = ? AND project_slug IS ? AND author IS ?",
+                (f"{row['check']}:{row['reason']}@{row['ts']}",
+                 ref, bucket.name, author))
 
 
 def rebuild() -> int:

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -13,8 +13,13 @@ small JSON files; correctness over cleverness (no incremental upserts).
 
 Schema: `items` carries one row per cognitive item (text/trust/kind/author/
 project_slug/session_id/created), plus two Graphiti-inspired interval slots:
-`superseded_by` (populated — see below) and `invalidated_by` (schema slot ONLY,
-no logic yet; future contradiction intervals). A contentless FTS5 table indexes
+`superseded_by` (populated — see below) and `invalidated_by` (#835: populated
+from DERIVED contradiction evidence only — the per-bucket verification
+ledger's worldcheck receipt-contradiction rows fold in at rebuild as
+"<check>:<reason>@<ts>", latest row per item winning. Replaced and disproven
+are independent axes: neither write ever touches the other. Authority
+precedent: model-flagged contradictions never mint the link — derived world
+evidence writes it, or nothing does). A contentless FTS5 table indexes
 text + quote for MATCH; rows join back to `items` by rowid.
 
 Supersession v3 (#234) is ITEM-LEVEL evidence only: `superseded_by` is set by
@@ -308,9 +313,15 @@ def _fingerprint() -> str:
                 # it into superseded_by), so it must be fingerprint INPUT too —
                 # else a resolve/reopen serves stale rows until an unrelated
                 # checkpoint write happens to invalidate the db (#245).
+                # verification.jsonl joined the same club in #835
+                # (_apply_verification_invalidations folds it into
+                # invalidated_by): new contradiction evidence must rebuild,
+                # never serve stale NULLs.
                 paths.extend(p for p in e.iterdir()
-                             if p.is_file() and (p.suffix == ".json"
-                                                 or p.name == "events.jsonl"))
+                             if p.is_file()
+                             and (p.suffix == ".json"
+                                  or p.name in ("events.jsonl",
+                                                "verification.jsonl")))
     except OSError:
         pass
     try:
@@ -572,6 +583,53 @@ def reap_dead_snapshots(now: float | None = None, apply: bool = True) -> list:
     return reaped
 
 
+# #835: the ledger checks that may write invalidated_by — worldcheck's
+# receipt-validity contradiction evidence (worldcheck._LEDGER_CHECK; pinned
+# equal by test rather than imported, so recall's import graph stays free of
+# worldcheck's probe machinery). Capture-time rejection rows ("quote",
+# "outcome", #376) describe the CAPTURE, not later disproof, and never
+# write; model-flagged contradictions have no path here at all — authority
+# precedent: derived world evidence writes the slot, or nothing does.
+_INVALIDATION_CHECKS = ("receipt",)
+
+
+def _apply_verification_invalidations(conn: sqlite3.Connection) -> None:
+    """Fold each project bucket's verification ledger into invalidated_by
+    (#835): a worldcheck receipt-contradiction row marks every indexed row
+    of the referenced item with "<check>:<reason>@<ts>" — a scalar evidence
+    reference, the same convention superseded_by keeps (a bare TEXT value,
+    never a JSON blob). Rows fold in file order, so the LATEST evidence for
+    an item wins: the most recent probe is the current world's answer.
+
+    Independent axis by contract: superseded_by is never read or written
+    here — an item can be both replaced and disproven. Malformed rows
+    (missing ref/reason/ts) are skipped, the same fail-open bias as every
+    ledger fold: a wrong invalidation fabricates distrust, a missed one
+    just stays quiet."""
+    try:
+        buckets = [d for d in config.checkpoint_dir().iterdir() if d.is_dir()]
+    except OSError:
+        return
+    for bucket in buckets:
+        # The bucket dir NAME routes store.verification_rows exactly like a
+        # project dir — slug munging is idempotent on slugs, the same trick
+        # _apply_event_resolutions leans on.
+        for row in store.verification_rows(project_dir=bucket.name):
+            if row.get("check") not in _INVALIDATION_CHECKS:
+                continue
+            ref = row.get("item_ref")
+            reason = row.get("reason")
+            ts = row.get("ts")
+            if not (isinstance(ref, str) and ref
+                    and isinstance(reason, str) and reason
+                    and isinstance(ts, str) and ts):
+                continue
+            conn.execute(
+                "UPDATE items SET invalidated_by = ?"
+                " WHERE item_id = ? AND project_slug IS ?",
+                (f"{row['check']}:{reason}@{ts}", ref, bucket.name))
+
+
 def rebuild() -> int:
     """Drop + rebuild the whole index by scanning local + team checkpoints.
     Atomic: builds into a sibling temp file, then os.replace — a concurrent
@@ -642,6 +700,7 @@ def rebuild() -> int:
             )
         _apply_typed_supersession(conn, links)
         _apply_event_resolutions(conn)
+        _apply_verification_invalidations(conn)
         conn.execute("INSERT INTO meta VALUES ('schema_version', ?)",
                      (_SCHEMA_VERSION,))
         conn.execute("INSERT INTO meta VALUES ('fingerprint', ?)", (fingerprint,))

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -1895,6 +1895,30 @@ def append_verification(item_ref: str, check: str, reason: str,
         return False
 
 
+def verification_rows(project_dir=None) -> list:
+    """Parsed rejection-ledger rows, oldest first (#835) — the read half of
+    append_verification, for recall's invalidated_by fold. Fails open to []
+    (missing/corrupt ledger, unknown project) and skips torn lines, the same
+    posture as verification_counts: a ledger read must never take an index
+    rebuild down."""
+    path = _ledger_path(project_dir)
+    if path is None:
+        return []
+    rows: list = []
+    try:
+        with path.open(encoding="utf-8") as f:
+            for line in f:
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict):
+                    rows.append(row)
+    except OSError:
+        return []
+    return rows
+
+
 def verification_counts(project_dir=None) -> dict:
     """{check: count} over the rejection ledger. Answers the question the
     trust classes otherwise cannot: has verification ever caught anything on

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -1895,27 +1895,45 @@ def append_verification(item_ref: str, check: str, reason: str,
         return False
 
 
-def verification_rows(project_dir=None) -> list:
+# Ledgers recall's rebuild folds into index COLUMNS: events.jsonl ->
+# superseded_by (the resolutions fold, #234), verification.jsonl ->
+# invalidated_by (#835). Every name here must be fingerprint INPUT in
+# recall._fingerprint (#245's lesson) — a fold-able ledger missing from that
+# walk serves stale rows until an unrelated checkpoint write happens to
+# invalidate the db. recall references this tuple, so adding a third
+# fold-able ledger without wiring the fingerprint fails loudly in its tests
+# instead of dodging the walk.
+INDEX_CONTENT_LEDGERS = ("events.jsonl", "verification.jsonl")
+
+
+def verification_rows(project_dir=None, *, bucket=None) -> list:
     """Parsed rejection-ledger rows, oldest first (#835) — the read half of
-    append_verification, for recall's invalidated_by fold. Fails open to []
-    (missing/corrupt ledger, unknown project) and skips torn lines, the same
-    posture as verification_counts: a ledger read must never take an index
-    rebuild down."""
-    path = _ledger_path(project_dir)
-    if path is None:
+    append_verification, for recall's invalidated_by fold (and the parse
+    loop verification_counts folds over — one loop, one failure posture,
+    #836 review). `bucket` (a bucket DIRECTORY under the checkpoint dir)
+    bypasses slug re-derivation entirely: recall's fold reads and binds THE
+    SAME bucket, so a bucket whose name is not slug-idempotent (dots munge
+    to '-') can never read a sibling bucket's ledger. Fails open to []
+    (missing/corrupt/non-UTF-8 ledger, unknown project) and skips torn
+    lines: a ledger read must never take an index rebuild down."""
+    if bucket is not None:
+        path = Path(bucket) / "verification.jsonl"
+    else:
+        path = _ledger_path(project_dir)
+        if path is None:
+            return []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
         return []
     rows: list = []
-    try:
-        with path.open(encoding="utf-8") as f:
-            for line in f:
-                try:
-                    row = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if isinstance(row, dict):
-                    rows.append(row)
-    except OSError:
-        return []
+    for line in lines:
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(row, dict):
+            rows.append(row)
     return rows
 
 
@@ -1925,20 +1943,7 @@ def verification_counts(project_dir=None) -> dict:
     THIS install. Fails open to {} (missing/corrupt log, unknown project) —
     same posture as the resolutions fold."""
     out: dict = {}
-    path = _ledger_path(project_dir)
-    if path is None:
-        return out
-    try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-    except (OSError, UnicodeDecodeError):
-        return out
-    for line in lines:
-        try:
-            row = json.loads(line)
-        except ValueError:
-            continue
-        if not isinstance(row, dict):
-            continue
+    for row in verification_rows(project_dir):
         check = str(row.get("check") or "")
         if check:
             out[check] = out.get(check, 0) + 1

--- a/plugin/tests/test_recall_invalidated_by.py
+++ b/plugin/tests/test_recall_invalidated_by.py
@@ -1,0 +1,199 @@
+"""#835: items.invalidated_by is populated from worldcheck contradiction
+evidence — the derived-evidence-only write path.
+
+The slot records that a claim was DISPROVEN against repo reality, which is a
+different fact from superseded_by's "replaced": the axes are independent and
+neither write touches the other. Authority precedent, pinned here: only the
+verification ledger's worldcheck receipt-contradiction rows write the slot.
+Capture-time rejection rows (quote / outcome) describe the capture, not later
+disproof, and never write; model-flagged contradictions_flagged entries have
+no path to it at all.
+
+Like every recall test: the index is derived, so everything folds in at
+rebuild from durable sources (verification.jsonl), and the ledger is
+fingerprint INPUT so new evidence rebuilds the index instead of serving
+stale rows (#245's lesson, applied to a second ledger).
+"""
+
+import json
+
+from daimon_briefing import config, recall, store, worldcheck
+from tests.test_recall import _cp
+
+
+def _item(text, ref):
+    return {"text": text, "trust": "inferred", "id": ref}
+
+
+def _write_ledger(slug, rows):
+    path = config.checkpoint_dir() / slug / "verification.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(r, ensure_ascii=False) + "\n" for r in rows),
+        encoding="utf-8")
+
+
+def _receipt_row(ref, *, ts="2026-08-29T10:00:00Z", reason="receipt-invalid"):
+    return {"ts": ts, "check": "receipt", "item_ref": ref, "reason": reason}
+
+
+def test_receipt_contradiction_populates_invalidated_by(
+        tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-1", _cp("S-1", questions=[
+        _item("the axolotl exporter claim was verified", "o-111aaa")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+    _write_ledger(store.project_slug("/repo/x"), [_receipt_row("o-111aaa")])
+
+    hits = recall.search("axolotl exporter claim", project_dir="/repo/x")
+    assert hits
+    assert hits[0]["invalidated_by"] == \
+        "receipt:receipt-invalid@2026-08-29T10:00:00Z"
+
+
+def test_axes_are_independent_disproof_never_touches_supersession(
+        tmp_checkpoint_dir, monkeypatch):
+    """An item can be both replaced and disproven; populating one axis never
+    clears or writes the other."""
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-1", _cp("S-1", questions=[
+        _item("the axolotl exporter claim was verified", "o-111aaa"),
+        _item("an unrelated capybara pagination question", "o-222bbb")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+    slug = store.project_slug("/repo/x")
+    ev = config.checkpoint_dir() / slug / "events.jsonl"
+    ev.parent.mkdir(parents=True, exist_ok=True)
+    ev.write_text(
+        '{"ts": "2026-08-29T09:00:00Z", "kind": "resolution",'
+        ' "item_ref": "o-111aaa", "status": "resolved", "source": "cli"}\n',
+        encoding="utf-8")
+    _write_ledger(slug, [_receipt_row("o-111aaa")])
+
+    hits = recall.search("axolotl exporter claim", project_dir="/repo/x")
+    assert hits
+    assert hits[0]["superseded_by"] == "resolved"
+    assert hits[0]["invalidated_by"] == \
+        "receipt:receipt-invalid@2026-08-29T10:00:00Z"
+
+    other = recall.search("capybara pagination question", project_dir="/repo/x")
+    assert other
+    assert other[0]["superseded_by"] is None
+    assert other[0]["invalidated_by"] is None
+
+
+def test_capture_rejection_rows_never_write_invalidated_by(
+        tmp_checkpoint_dir, monkeypatch):
+    """quote/outcome rows (#376) are capture-time verification failures —
+    the item downgraded to inferred, not disproven against the world."""
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-1", _cp("S-1", questions=[
+        _item("the axolotl exporter claim was verified", "o-111aaa")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+    _write_ledger(store.project_slug("/repo/x"), [
+        {"ts": "2026-08-29T10:00:00Z", "check": "quote",
+         "item_ref": "o-111aaa", "reason": "quote-not-in-transcript"},
+        {"ts": "2026-08-29T10:00:01Z", "check": "outcome",
+         "item_ref": "o-111aaa", "reason": "no-signal-cited"},
+    ])
+
+    hits = recall.search("axolotl exporter claim", project_dir="/repo/x")
+    assert hits
+    assert hits[0]["invalidated_by"] is None
+
+
+def test_contradictions_flagged_never_writes_invalidated_by(
+        tmp_checkpoint_dir, monkeypatch):
+    """A model-flagged contradiction is a standalone claim with no authority
+    to mint a target link — self-assertion is the wedge the trust model
+    forbids (#835 authority precedent)."""
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    cp = _cp("S-1", questions=[
+        _item("the axolotl exporter claim was verified", "o-111aaa")],
+        created="2026-08-01T00:00:00Z")
+    cp["epistemic_snapshot"]["contradictions_flagged"] = [
+        {"text": "the axolotl exporter claim was verified is wrong",
+         "trust": "inferred"}]
+    store.write_checkpoint("S-1", cp, project_dir="/repo/x")
+
+    hits = recall.search("axolotl exporter claim", project_dir="/repo/x")
+    assert hits
+    assert all(h["invalidated_by"] is None for h in hits)
+
+
+def test_latest_evidence_wins(tmp_checkpoint_dir, monkeypatch):
+    """Rows fold in append order: the most recent probe is the current
+    world's answer."""
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-1", _cp("S-1", questions=[
+        _item("the axolotl exporter claim was verified", "o-111aaa")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+    _write_ledger(store.project_slug("/repo/x"), [
+        _receipt_row("o-111aaa", ts="2026-08-28T10:00:00Z",
+                     reason="receipt-tampered"),
+        _receipt_row("o-111aaa", ts="2026-08-29T10:00:00Z",
+                     reason="receipt-invalid"),
+    ])
+
+    hits = recall.search("axolotl exporter claim", project_dir="/repo/x")
+    assert hits
+    assert hits[0]["invalidated_by"] == \
+        "receipt:receipt-invalid@2026-08-29T10:00:00Z"
+
+
+def test_malformed_ledger_rows_are_skipped(tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-1", _cp("S-1", questions=[
+        _item("the axolotl exporter claim was verified", "o-111aaa")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+    slug = store.project_slug("/repo/x")
+    path = config.checkpoint_dir() / slug / "verification.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "{not json\n"
+        '{"ts": "2026-08-29T10:00:00Z", "check": "receipt"}\n'
+        '{"ts": null, "check": "receipt", "item_ref": "o-111aaa",'
+        ' "reason": "receipt-invalid"}\n',
+        encoding="utf-8")
+
+    hits = recall.search("axolotl exporter claim", project_dir="/repo/x")
+    assert hits
+    assert hits[0]["invalidated_by"] is None
+
+
+def test_verification_ledger_is_fingerprint_input(
+        tmp_checkpoint_dir, monkeypatch):
+    """#245's lesson for a second ledger: new contradiction evidence must
+    rebuild the index, never serve stale NULL rows until an unrelated
+    checkpoint write happens to invalidate the db."""
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-1", _cp("S-1", questions=[
+        _item("the axolotl exporter claim was verified", "o-111aaa")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+
+    hits = recall.search("axolotl exporter claim", project_dir="/repo/x")
+    assert hits and hits[0]["invalidated_by"] is None
+
+    _write_ledger(store.project_slug("/repo/x"), [_receipt_row("o-111aaa")])
+    hits = recall.search("axolotl exporter claim", project_dir="/repo/x")
+    assert hits
+    assert hits[0]["invalidated_by"] == \
+        "receipt:receipt-invalid@2026-08-29T10:00:00Z"
+
+
+def test_verification_rows_fail_open(tmp_checkpoint_dir):
+    """The reader's two guard branches: unknown project and an unreadable
+    ledger path both answer [] — a ledger read must never take a rebuild
+    down."""
+    assert store.verification_rows(project_dir=None) == []
+    slug = store.project_slug("/repo/x")
+    path = config.checkpoint_dir() / slug / "verification.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.mkdir()  # a directory where the file should be -> OSError on open
+    assert store.verification_rows(project_dir="/repo/x") == []
+
+
+def test_invalidation_check_names_match_worldchecks_ledger():
+    """Divergence guard: recall's filter constant and worldcheck's ledger
+    check name are pinned equal rather than imported (recall's import graph
+    stays free of worldcheck's probe machinery)."""
+    assert recall._INVALIDATION_CHECKS == (worldcheck._LEDGER_CHECK,)

--- a/plugin/tests/test_recall_invalidated_by.py
+++ b/plugin/tests/test_recall_invalidated_by.py
@@ -1,13 +1,17 @@
 """#835: items.invalidated_by is populated from worldcheck contradiction
 evidence — the derived-evidence-only write path.
 
-The slot records that a claim was DISPROVEN against repo reality, which is a
+The slot records the LATEST CONTRADICTION EVIDENCE for a claim ("was
+contradicted by <evidence> at <ts>") — never a present-tense verdict: no
+confirmation rows or cure path exist yet, so a populated value means a probe
+once contradicted the claim, not that it is currently false. That is a
 different fact from superseded_by's "replaced": the axes are independent and
 neither write touches the other. Authority precedent, pinned here: only the
-verification ledger's worldcheck receipt-contradiction rows write the slot.
-Capture-time rejection rows (quote / outcome) describe the capture, not later
-disproof, and never write; model-flagged contradictions_flagged entries have
-no path to it at all.
+verification ledger's worldcheck receipt-contradiction rows write the slot,
+scoped to THIS install's author (machine-local evidence never brands a
+teammate's mirrored copy). Capture-time rejection rows (quote / outcome)
+describe the capture and never write; model-flagged contradictions_flagged
+entries have no path to it at all.
 
 Like every recall test: the index is derived, so everything folds in at
 rebuild from durable sources (verification.jsonl), and the ledger is
@@ -16,9 +20,10 @@ stale rows (#245's lesson, applied to a second ledger).
 """
 
 import json
+import sqlite3
 
 from daimon_briefing import config, recall, store, worldcheck
-from tests.test_recall import _cp
+from tests.test_recall import _cp, _write_team_file
 
 
 def _item(text, ref):
@@ -51,10 +56,10 @@ def test_receipt_contradiction_populates_invalidated_by(
         "receipt:receipt-invalid@2026-08-29T10:00:00Z"
 
 
-def test_axes_are_independent_disproof_never_touches_supersession(
+def test_axes_are_independent_contradiction_never_touches_supersession(
         tmp_checkpoint_dir, monkeypatch):
-    """An item can be both replaced and disproven; populating one axis never
-    clears or writes the other."""
+    """An item can be both replaced and contradicted; populating one axis
+    never clears or writes the other."""
     monkeypatch.setenv("DAIMON_AUTHOR", "ada")
     store.write_checkpoint("S-1", _cp("S-1", questions=[
         _item("the axolotl exporter claim was verified", "o-111aaa"),
@@ -84,7 +89,7 @@ def test_axes_are_independent_disproof_never_touches_supersession(
 def test_capture_rejection_rows_never_write_invalidated_by(
         tmp_checkpoint_dir, monkeypatch):
     """quote/outcome rows (#376) are capture-time verification failures —
-    the item downgraded to inferred, not disproven against the world."""
+    the item downgraded to inferred, not later contradicted by the world."""
     monkeypatch.setenv("DAIMON_AUTHOR", "ada")
     store.write_checkpoint("S-1", _cp("S-1", questions=[
         _item("the axolotl exporter claim was verified", "o-111aaa")],
@@ -120,9 +125,12 @@ def test_contradictions_flagged_never_writes_invalidated_by(
     assert all(h["invalidated_by"] is None for h in hits)
 
 
-def test_latest_evidence_wins(tmp_checkpoint_dir, monkeypatch):
-    """Rows fold in append order: the most recent probe is the current
-    world's answer."""
+def test_latest_evidence_wins_by_timestamp_never_line_order(
+        tmp_checkpoint_dir, monkeypatch):
+    """store.resolutions' documented contract, mirrored (#836 review):
+    latest by TS, never line order — the ledger interleaves concurrent
+    writers and clock-skewed appends, so a LATER line with an EARLIER stamp
+    must not win."""
     monkeypatch.setenv("DAIMON_AUTHOR", "ada")
     store.write_checkpoint("S-1", _cp("S-1", questions=[
         _item("the axolotl exporter claim was verified", "o-111aaa")],
@@ -132,12 +140,82 @@ def test_latest_evidence_wins(tmp_checkpoint_dir, monkeypatch):
                      reason="receipt-tampered"),
         _receipt_row("o-111aaa", ts="2026-08-29T10:00:00Z",
                      reason="receipt-invalid"),
+        # Clock-skewed straggler: appended last, stamped earliest.
+        _receipt_row("o-111aaa", ts="2026-08-27T10:00:00Z",
+                     reason="receipt-tampered"),
+        # Unparseable stamp: never displaces a stamped row (the
+        # resolutions-fold posture, mirrored).
+        _receipt_row("o-111aaa", ts="not-a-timestamp",
+                     reason="receipt-tampered"),
     ])
 
     hits = recall.search("axolotl exporter claim", project_dir="/repo/x")
     assert hits
     assert hits[0]["invalidated_by"] == \
         "receipt:receipt-invalid@2026-08-29T10:00:00Z"
+
+
+def test_machine_local_evidence_never_brands_a_teammates_copy(
+        tmp_checkpoint_dir, monkeypatch):
+    """#836 review: receipt evidence is about THIS install's checkpoint
+    bytes, so the write is author-scoped — a teammate's mirrored row of the
+    SAME item id stays unmarked."""
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-1", _cp("S-1", questions=[
+        _item("the axolotl exporter claim was verified", "o-111aaa")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+    # A FRESH dict for the team copy: write_checkpoint stamps author/created
+    # into the dict it is handed, and _write_team_file's setdefault would
+    # keep those stamps. No `created` either — a stamped 08-01 date would
+    # age out of the #113 team retention window and never index.
+    _write_team_file("bea", "S-bea", _cp("S-bea", questions=[
+        _item("the axolotl exporter claim was verified", "o-111aaa")]),
+        project_dir="/repo/x")
+    _write_ledger(store.project_slug("/repo/x"), [_receipt_row("o-111aaa")])
+
+    recall.search("axolotl exporter claim", project_dir="/repo/x")  # fresh db
+    conn = sqlite3.connect(str(config.recall_db()))
+    try:
+        by_author = dict(conn.execute(
+            "SELECT author, invalidated_by FROM items"
+            " WHERE item_id = 'o-111aaa'").fetchall())
+    finally:
+        conn.close()
+    assert by_author["ada"] == "receipt:receipt-invalid@2026-08-29T10:00:00Z"
+    assert by_author["bea"] is None
+
+
+def test_fold_reads_and_binds_the_same_bucket(tmp_checkpoint_dir, monkeypatch):
+    """#836 review: bucket names are not slug-idempotent (dots munge to '-'),
+    so the fold must read THE bucket directory it binds — never re-derive a
+    slug from the name and read a sibling bucket's ledger."""
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    blob = _cp("S-dot", questions=[
+        _item("the quokka dotted bucket claim", "o-333ccc")],
+        created="2026-08-01T00:00:00Z")
+    blob["author"] = "ada"
+    blob["project_slug"] = "repo.x"
+    config.checkpoint_dir().mkdir(parents=True, exist_ok=True)
+    (config.checkpoint_dir() / "S-dot.json").write_text(
+        json.dumps(blob), encoding="utf-8")
+    _write_ledger("repo.x", [_receipt_row("o-333ccc")])
+    # The sibling the OLD re-slugging read ("repo.x" munges to "repo-x"):
+    # carries different evidence, which must NOT land on repo.x's rows.
+    _write_ledger("repo-x", [
+        _receipt_row("o-333ccc", reason="receipt-tampered")])
+
+    recall.search("quokka dotted bucket claim", all_projects=True)  # fresh db
+    conn = sqlite3.connect(str(config.recall_db()))
+    try:
+        rows = conn.execute(
+            "SELECT invalidated_by FROM items"
+            " WHERE item_id = 'o-333ccc' AND project_slug = 'repo.x'"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert rows
+    assert all(
+        v == "receipt:receipt-invalid@2026-08-29T10:00:00Z" for (v,) in rows)
 
 
 def test_malformed_ledger_rows_are_skipped(tmp_checkpoint_dir, monkeypatch):
@@ -181,15 +259,35 @@ def test_verification_ledger_is_fingerprint_input(
 
 
 def test_verification_rows_fail_open(tmp_checkpoint_dir):
-    """The reader's two guard branches: unknown project and an unreadable
-    ledger path both answer [] — a ledger read must never take a rebuild
-    down."""
+    """The reader's guard branches: unknown project and an unreadable ledger
+    path both answer [] — a ledger read must never take a rebuild down."""
     assert store.verification_rows(project_dir=None) == []
     slug = store.project_slug("/repo/x")
     path = config.checkpoint_dir() / slug / "verification.jsonl"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.mkdir()  # a directory where the file should be -> OSError on open
     assert store.verification_rows(project_dir="/repo/x") == []
+
+
+def test_non_utf8_ledger_never_kills_the_rebuild(tmp_checkpoint_dir,
+                                                 monkeypatch):
+    """#836 review crasher: one non-UTF-8 byte in a ledger raised
+    UnicodeDecodeError through the fold, killing rebuild() and every search
+    after. The reader now shares verification_counts' wider posture; the
+    fold survives and the item simply stays unmarked."""
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-1", _cp("S-1", questions=[
+        _item("the axolotl exporter claim was verified", "o-111aaa")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+    slug = store.project_slug("/repo/x")
+    path = config.checkpoint_dir() / slug / "verification.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\xff\xfe not utf-8 at all\n")
+
+    assert store.verification_rows(bucket=path.parent) == []
+    hits = recall.search("axolotl exporter claim", project_dir="/repo/x")
+    assert hits
+    assert hits[0]["invalidated_by"] is None
 
 
 def test_invalidation_check_names_match_worldchecks_ledger():


### PR DESCRIPTION
Closes #835

## What

items.invalidated_by moves from schema-slot-only (zero rows ever) to populated: when worldcheck contradicts a carried claim's origin receipt, the verification-ledger evidence for that contradiction now folds into the slot at index rebuild, so the trust store can finally distinguish a claim that was REPLACED (superseded_by) from one that was DISPROVEN (invalidated_by).

Reference format, mirroring superseded_by's bare-TEXT scalar convention (never a JSON blob): `<check>:<reason>@<ts>`, e.g. `receipt:receipt-invalid@2026-08-29T10:00:00Z` — check and reason from the ledger row, the row's own timestamp as the evidence time. Rows fold in append order, so the latest evidence per item wins (the most recent probe is the current world's answer).

## Where the write lives, and why

A new rebuild fold, `recall._apply_verification_invalidations`, reading the per-bucket `verification.jsonl` through a new fail-open reader `store.verification_rows` (the read half of `append_verification`). The indexer, not the ledger-append site, for three reasons:

1. recall.db is DERIVED state: the module contract is rebuild-from-durable-sources with no incremental upserts, so a write alongside the cli's ledger append would be silently wiped by the next rebuild. The durable truth is the ledger; the index derives.
2. Item identity resolves to rows exactly where the events fold already resolves it: `item_id` + bucket slug, the same idioms `_apply_event_resolutions` uses (the fold mirrors its shape line for line).
3. worldcheck writes nothing to disk by contract and stays untouched; the cli's existing ledger append remains the one durable write.

Consequence handled: `verification.jsonl` joins the rebuild fingerprint inputs, for the same reason `events.jsonl` did (#245) — new contradiction evidence must rebuild the index, never serve stale NULL rows until an unrelated checkpoint write happens to invalidate the db. A test pins this.

## Authority precedent (pinned by test)

Only derived world evidence writes the slot: the fold accepts exactly worldcheck's ledger check name (`recall._INVALIDATION_CHECKS`, pinned equal to `worldcheck._LEDGER_CHECK` by a divergence test rather than an import, keeping recall's import graph free of worldcheck's probe machinery). Capture-time rejection rows (quote/outcome, #376) describe the capture, not later disproof, and never write. `contradictions_flagged` entries have no path to the slot at all. The human-ruling path stays out of scope per the issue.

Independent axes: `superseded_by` is never read or written by the fold; a test pins an item carrying both values simultaneously. The module docstring moves from "schema slot ONLY, no logic yet" to the implemented meaning.

## Consumers

No rendering changes. The search SELECT already carried `i.invalidated_by` (rows built from cursor columns), so result dicts simply stop being always-None; nothing orders, filters, or weights on the column, and the full suite proves nothing assumed NULL.

## Tests

Strict TDD, red first (5 of 9 failed before the change): contradiction populates the slot with the exact reference; both axes set independently on one item; quote/outcome rows never write; contradictions_flagged never writes; latest evidence wins; malformed ledger rows are skipped; the ledger is fingerprint input (append after first search, second search sees the evidence); reader fail-open branches; the check-name divergence guard.

- `uv run pytest`: 4640 passed, 2 skipped
- `uv run ruff check .`: clean
- `uv run --extra dev mypy daimon_briefing`: clean, 59 files (recall/store stay in the frozen ratchet untouched)
- `scar lint`: 0 errors (1 pre-existing partial-rot hint, untouched)
- Local patch coverage (term-missing + json): every added line in recall.py and store.py covered; remaining misses are pre-existing lines outside this diff

## Review round (applied in 21aa44b)

Semantics sharpened per review: invalidated_by records the LATEST CONTRADICTION EVIDENCE ("was contradicted by <evidence> at <ts>"), never a present-tense verdict. worldcheck appends no confirmation rows and no cure mechanism exists yet, so a populated value means "a probe once contradicted this", not "this is currently false". The cure path (human resolve and/or future confirmation rows) is an explicit follow-up, not built here. The #827 published checkpoint schema does not cover recall.db columns, so there was no field-table note to update for this (checked).

Write-path hardening: verification_rows now shares verification_counts exact failure posture (OSError plus UnicodeDecodeError; a non-UTF-8 ledger byte previously killed rebuild and every search after) and counts is a fold over rows, one parse loop. The fold dedups to the latest row per item by parsed-ts maximum, mirroring store.resolutions documented latest-by-ts-never-line-order contract with its tie posture (unstamped never displaces stamped; equal stamps fall to canonical-JSON order), then issues one UPDATE per item through a new items(item_id, project_slug) index (schema v6, also speeds the pre-existing event fold). The cli re-appends identical ledger rows every briefing by design and stays untouched: fold-side dedup makes correctness independent of ledger growth; retention policy for the ledger is flagged separately as a human call.

Binding rules, decided deliberately: the write is author-scoped to this install (receipt evidence is about THIS install checkpoint bytes; vitni verified local origin files), so machine-local evidence never brands a teammate mirrored copy of the same item id — this CLOSES the cross-author concern (review finding 7). The fold reads and binds the same bucket directory (verification_rows grew a bucket= keyword; bucket names are not slug-idempotent since dots munge to "-"), which CLOSES the sibling-bucket cross-contamination half of finding 8; the moved-slug half (historical rows left under a renamed slug, whose ledger stays with the old bucket) REMAINS as a documented limitation in the fold docstring, alongside NULL-slug rows and rows captured under a changed local author name. Note: _apply_event_resolutions carries the same latent re-slug shape for events.jsonl; pre-existing, deliberately not touched in this PR.

Deferred by ruling, to a follow-up issue: consumer awareness of invalidated_by — suggest() currently injects contradicted items at full weight, search ranking does not demote them, and the CLI renders no marker. #835 ruled no consumer changes in this slice; the follow-up carries them.

Also added: store.INDEX_CONTENT_LEDGERS names the fold-able ledgers and the fingerprint walk references it, so a third fold-able ledger fails loudly instead of dodging the fingerprint.
