### PR TITLE
feat(recall): honor invalidated_by in suggest, search ranking and the CLI markers

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -827,10 +827,17 @@ def _cmd_recall(args) -> int:
         superseded = ("" if not sup
                       else " [resolved]" if sup == "resolved"
                       else f" [superseded by {sup}]")
+        # #837: an independent axis gets an independent marker — a row can
+        # carry both, and collapsing them would hide one fact behind the
+        # other. recall owns the phrasing so this marker can never describe a
+        # different view than the fold recorded.
+        inv = recall.describe_invalidation(r.get("invalidated_by"))
+        contradicted = f" [{inv}]" if inv else ""
         trust = r.get("trust") or "untagged"
         item_id = f" [{r['item_id']}]" if r.get("item_id") else ""
         lines.append(f"[{r['author']}] [{trust}] [{r['kind']}]{item_id} {r['text']} "
-                     f"({r['session_id']}, {age} ago){superseded}")
+                     f"({r['session_id']}, {age} ago){superseded}"
+                     f"{contradicted}")
     render.render_recall_lines(lines)
     return 0
 
@@ -1411,9 +1418,17 @@ def _suggest_line(r: dict, terms, now: float) -> str:
     superseded = ("" if not sup
                   else " (resolved)" if sup == "resolved"
                   else " (superseded by later work)")
+    # #837: suggest() ranks a contradicted item DOWN, and a demotion alone is
+    # silent burial — one that still clears the gate has to arrive flagged.
+    # The evidence is named in full here, unlike the supersession marker's
+    # vaguer wording, because there is no `daimon why` follow-up that would
+    # surface it and no cure path that would retract it.
+    inv = recall.describe_invalidation(r.get("invalidated_by"))
+    contradicted = f" ({inv})" if inv else ""
     more = " ".join(terms[:3])
     return (f"daimon recall: prior work — {r['kind']} from {r['session_id']} "
-            f"({age} ago): \"{text}\" [{trust}]{superseded}. "
+            f"({age} ago): \"{text}\" [{trust}]{superseded}"
+            f"{contradicted}. "
             f"More: daimon recall \"{more}\"")
 
 

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -22,8 +22,12 @@ value is EVIDENCE, not a verdict: "was contradicted by <evidence> at <ts>"
 currently false". Replacement and contradiction are independent axes:
 neither write ever touches the other. Authority precedent: model-flagged
 contradictions never mint the link — derived world evidence writes it, or
-nothing does). A contentless FTS5 table indexes text + quote for MATCH;
-rows join back to `items` by rowid.
+nothing does. #837 made the read surfaces honor it: search sorts a
+contradicted row below a merely-replaced one, suggest demotes it harder than
+supersession does, and both CLI renderers mark it. None of them filters —
+the evidence is machine-local and cure-less, so burial stays visible and
+reversible rather than silent). A contentless FTS5 table indexes text +
+quote for MATCH; rows join back to `items` by rowid.
 
 Supersession v3 (#234) is ITEM-LEVEL evidence only: `superseded_by` is set by
 typed `supersedes` links (#14) — id-bound directly, free-text via never-guess
@@ -680,6 +684,32 @@ def _apply_verification_invalidations(conn: sqlite3.Connection) -> None:
                  ref, bucket.name, author))
 
 
+def describe_invalidation(value) -> str | None:
+    """Render one stored `invalidated_by` value as a marker phrase, or None.
+
+    The ONE parse of the encoding the fold above writes, deliberately living
+    beside that write (#837): a renderer that re-split the value on its own
+    would be free to drift into describing a different view than the one the
+    verifier recorded. Every read surface calls this.
+
+    Wording is bound by the field's semantics, not by convenience: the slot
+    holds the latest contradiction EVIDENCE, so the phrase names the evidence
+    and its timestamp and stops there. It never says "false" and never says
+    "invalid" — no confirmation row and no cure path exist yet, so a
+    present-tense verdict would claim more than the record can carry. Tense
+    belongs to the caller's sentence, not to this fragment.
+
+    Tolerant by construction: a value this module could not have written
+    (hand-edited db, a future encoding) still renders as evidence rather than
+    raising on a user's read path — a marker is never worth a traceback."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    evidence, sep, ts = value.rpartition("@")
+    if not (sep and evidence and ts):
+        return f"contradicted by {value}"
+    return f"contradicted by {evidence} at {ts}"
+
+
 def rebuild() -> int:
     """Drop + rebuild the whole index by scanning local + team checkpoints.
     Atomic: builds into a sibling temp file, then os.replace — a concurrent
@@ -898,7 +928,14 @@ def search(query: str, project_dir=None, all_projects: bool = False,
         sql += " AND i.project_slug = ?"
     # frontier is a TIEBREAK after relevance (#234): equally-relevant rows
     # from the newest checkpoint edge out older ones — silently, no label.
-    sql += (" ORDER BY (i.superseded_by IS NOT NULL) ASC, rank ASC,"
+    # Contradiction leads the demotion keys (#837): "at least as strongly as
+    # superseded" is the issue's floor, and evidence that a probe contradicted
+    # a claim is the stronger fact of the two, so a contradicted row sorts
+    # below a merely-replaced one. Both stay ABOVE nothing — demoted, never
+    # filtered out: the evidence is machine-local and has no cure path, so
+    # burial must remain visible and reversible rather than silent.
+    sql += (" ORDER BY (i.invalidated_by IS NOT NULL) ASC,"
+            " (i.superseded_by IS NOT NULL) ASC, rank ASC,"
             " i.frontier DESC, i.created DESC LIMIT ?")
 
     want_n = max(1, int(limit))
@@ -1205,6 +1242,39 @@ def is_machine_prompt(prompt: str) -> bool:
     return any(line.startswith(_MACHINE_MARKERS) for line in head.split("\n"))
 
 
+# Interval-slot demotions for the auto-inject path. Multiplicative and
+# INDEPENDENT, because the two facts are (#836): "replaced by later work" and
+# "a probe contradicted this" can hold together, separately, or not at all, so
+# an item carrying both is demoted by both. Contradiction is the heavier of
+# the two — a replaced decision was still the right call at the time, whereas
+# contradiction evidence says a check disagreed with the claim itself.
+#
+# Neither is a filter. #112's rule holds for both: an overturned item is still
+# evidence, and this evidence is machine-local with no cure path yet, so it
+# ranks down and renders flagged rather than disappearing.
+_SUPERSEDED_WEIGHT = 0.7
+_INVALIDATED_WEIGHT = 0.4
+
+
+def _suggest_weight(row, item_type: str, now: float) -> float:
+    """One row's suggest() rank weight: #78 effective_weight, then the
+    interval-slot demotions. Extracted so the penalties are testable at the
+    weight level rather than only through a rigged end-to-end fixture."""
+    weight = scoring.effective_weight(
+        {"importance": row.get("importance"),
+         "first_seen": row.get("first_seen"),
+         # trust is part of the record's authority (#408): drop it here and
+         # the trust ceiling never applies to recall ranking, letting an
+         # inferred item ride relevance x recency to a verbatim item's band.
+         "trust": row.get("trust")},
+        item_type, now)
+    if row.get("superseded_by"):
+        weight *= _SUPERSEDED_WEIGHT
+    if row.get("invalidated_by"):
+        weight *= _INVALIDATED_WEIGHT
+    return weight
+
+
 def suggest(prompt: str, project_dir=None, current_session=None,
             exclude_sessions=(), limit: int = 2, now=None) -> list[dict]:
     """Proactive matches for a user prompt, or [] — silence is the default and
@@ -1226,6 +1296,13 @@ def suggest(prompt: str, project_dir=None, current_session=None,
     flag means item-level evidence (a typed supersedes link or a logged
     resolution, #234), so it is rare and load-bearing; it still never hides
     a result (an overturned decision is still evidence, #112).
+
+    Items carrying contradiction evidence (#837) are included on the same
+    terms and demoted harder, the two penalties stacking because the axes
+    are independent. This is the path that mattered most: everything here
+    lands in the user's next prompt unasked, so an unconsumed invalidated_by
+    meant re-asserting a claim this install's own ledger contradicted, at
+    full weight, on the one surface nobody chose to read.
 
     Each returned row also carries `term_hits` (its own distinct-term match
     count) and `pinned` (the #369 standing-rule flag) — inputs to the cli
@@ -1255,6 +1332,10 @@ def suggest(prompt: str, project_dir=None, current_session=None,
     sql = (
         "SELECT i.text, i.quote, i.trust, i.kind, i.author, i.project_slug,"
         " i.session_id, i.created, i.importance, i.first_seen, i.superseded_by,"
+        # #837: the column MUST be selected here, not just written — this is
+        # the auto-inject path, so a missing select re-asserts a claim this
+        # install's own ledger contradicted, on the highest-leverage surface.
+        " i.invalidated_by,"
         # pinned rides out for the #452 age gate (standing rules are
         # age-independent); it is NOT a rank input here.
         " i.pinned,"
@@ -1309,15 +1390,8 @@ def suggest(prompt: str, project_dir=None, current_session=None,
         # the existing len(hit) tiebreak below.
         r["term_hits"] = len(hit)
         relevance = max(0.0, -float(r["rank"]))  # FTS5 bm25(): smaller = better
-        weight = scoring.effective_weight(
-            {"importance": r["importance"], "first_seen": r["first_seen"],
-             # trust is part of the record's authority (#408): drop it here and
-             # the trust ceiling never applies to recall ranking, letting an
-             # inferred item ride relevance x recency to a verbatim item's band.
-             "trust": r["trust"]},
-            _KIND_TO_TYPE.get(r["kind"], "recent_decision"), now)
-        if r["superseded_by"]:
-            weight *= 0.7  # flagged and ranked down, never hidden (#112)
+        weight = _suggest_weight(
+            r, _KIND_TO_TYPE.get(r["kind"], "recent_decision"), now)
         scored.append((relevance * weight, len(hit), r))
 
     scored.sort(key=lambda s: (-s[0], -s[1]))

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3584,6 +3584,51 @@ def test_cli_recall_flags_typed_supersession_only(
     assert "superseded by S-new" in lines[1]  # link evidence renders
 
 
+def _write_verification_ledger(slug, rows):
+    from daimon_briefing import config
+    path = config.checkpoint_dir() / slug / "verification.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows),
+                    encoding="utf-8")
+
+
+def test_cli_recall_marks_contradiction_evidence(
+        tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):
+    # #837: invalidated_by had no renderer, so a contradicted item printed
+    # identically to a live trusted one. The marker mirrors the supersession
+    # one and stays faithful to the field: EVIDENCE, never a verdict.
+    from daimon_briefing import store
+
+    proj = str((tmp_path / "proj").resolve())
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    cp = _recall_checkpoint("S-bad", "meerkat burrow mapping plan colony")
+    cp["working_context"]["recent_decisions"][0]["id"] = "o-bad111"
+    store.write_checkpoint("S-bad", cp, project_dir=proj)
+    _write_verification_ledger(store.project_slug(proj), [
+        {"ts": "2026-08-29T10:00:00Z", "check": "receipt",
+         "item_ref": "o-bad111", "reason": "receipt-invalid"}])
+
+    rc = cli.main(["recall", "meerkat", "--project", proj])
+    assert rc == 0
+    line = [ln for ln in capsys.readouterr().out.splitlines()
+            if "meerkat" in ln][0]
+    assert ("[contradicted by receipt:receipt-invalid "
+            "at 2026-08-29T10:00:00Z]") in line
+    assert "false" not in line.lower()
+
+
+def test_suggest_line_marks_contradiction_evidence():
+    # The auto-inject line is the highest-leverage surface: a demoted item
+    # still reaching the prompt must arrive flagged, not silently ranked down.
+    r = {"kind": "decision", "session_id": "S-1", "created": 1000.0,
+         "trust": "verbatim", "text": "the exporter caches limbs",
+         "invalidated_by": "receipt:receipt-invalid@2026-08-29T10:00:00Z"}
+    line = cli._suggest_line(r, ["exporter"], 2000.0)
+    assert ("(contradicted by receipt:receipt-invalid "
+            "at 2026-08-29T10:00:00Z)") in line
+    assert "false" not in line.lower()
+
+
 def test_cli_recall_json(tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):
     from daimon_briefing import store
 

--- a/plugin/tests/test_recall_invalidated_by.py
+++ b/plugin/tests/test_recall_invalidated_by.py
@@ -295,3 +295,162 @@ def test_invalidation_check_names_match_worldchecks_ledger():
     check name are pinned equal rather than imported (recall's import graph
     stays free of worldcheck's probe machinery)."""
     assert recall._INVALIDATION_CHECKS == (worldcheck._LEDGER_CHECK,)
+
+
+# --- #837: the READ surfaces ------------------------------------------------
+#
+# #835 populated the slot and #836 shipped it; nothing consumed it, so the
+# record existed and changed nothing a user saw. suggest() did not even select
+# the column, which is the sharp edge: the auto-inject path re-asserted a claim
+# this install's own verification ledger contradicted, at FULL weight, while a
+# merely-superseded item was downweighted. These tests pin the invariant the
+# issue names: a contradicted item never outranks and never out-renders its
+# clean equivalent, on any surface.
+#
+# The semantics ride along unchanged. The slot holds contradiction EVIDENCE,
+# so every surface says "contradicted by <evidence> at <ts>" and no surface
+# says "false" — there is no confirmation row and no cure path yet, so a
+# present-tense verdict would overclaim what the field can know.
+
+
+def _decision(text, ref, **extra):
+    return {"text": text, "trust": "inferred", "id": ref, **extra}
+
+
+def test_suggest_ranks_a_contradicted_item_below_its_clean_equivalent(
+        tmp_checkpoint_dir, monkeypatch):
+    # The fixture is rigged AGAINST the penalty: the contradicted item is the
+    # more important one (9 vs 5), so without a demotion it wins outright.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    common = {"first_seen": "2026-08-01T00:00:00Z"}
+    store.write_checkpoint("S-bad", _cp("S-bad", decisions=[
+        _decision("the axolotl exporter caches every regenerated limb",
+                  "o-bad111", importance=9, **common)],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+    store.write_checkpoint("S-clean", _cp("S-clean", decisions=[
+        _decision("the axolotl exporter caches every regenerated limb",
+                  "o-clean1", importance=5, **common)],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+    _write_ledger(store.project_slug("/repo/x"), [_receipt_row("o-bad111")])
+
+    out = recall.suggest("what did the axolotl exporter do with limb caches",
+                         project_dir="/repo/x", current_session="S-now",
+                         limit=5, now=1756468800.0)
+    sids = [r["session_id"] for r in out]
+    assert "S-bad" in sids and "S-clean" in sids
+    assert sids.index("S-clean") < sids.index("S-bad")
+
+
+def test_suggest_carries_the_evidence_out_so_the_line_can_render_it(
+        tmp_checkpoint_dir, monkeypatch):
+    # Demoting silently is not enough: burial stays VISIBLE, so the row must
+    # carry the evidence to the emitter.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-bad", _cp("S-bad", decisions=[
+        _decision("the axolotl exporter caches every regenerated limb",
+                  "o-bad111")], created="2026-08-01T00:00:00Z"),
+        project_dir="/repo/x")
+    _write_ledger(store.project_slug("/repo/x"), [_receipt_row("o-bad111")])
+
+    out = recall.suggest("what did the axolotl exporter do with limb caches",
+                         project_dir="/repo/x", current_session="S-now")
+    assert out
+    assert out[0]["invalidated_by"] == \
+        "receipt:receipt-invalid@2026-08-29T10:00:00Z"
+
+
+def test_suggest_penalties_stack_because_the_axes_are_independent(
+        tmp_checkpoint_dir, monkeypatch):
+    # superseded_by and invalidated_by are independent facts (#836), so an
+    # item carrying BOTH is demoted below one carrying either alone.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    now = 1756468800.0
+    row = {"importance": 5, "first_seen": "2026-08-01T00:00:00Z",
+           "trust": "inferred"}
+    both = recall._suggest_weight(
+        {**row, "superseded_by": "S-newer",
+         "invalidated_by": "receipt:receipt-invalid@2026-08-29T10:00:00Z"},
+        "recent_decision", now)
+    superseded_only = recall._suggest_weight(
+        {**row, "superseded_by": "S-newer", "invalidated_by": None},
+        "recent_decision", now)
+    contradicted_only = recall._suggest_weight(
+        {**row, "superseded_by": None,
+         "invalidated_by": "receipt:receipt-invalid@2026-08-29T10:00:00Z"},
+        "recent_decision", now)
+    clean = recall._suggest_weight(
+        {**row, "superseded_by": None, "invalidated_by": None},
+        "recent_decision", now)
+    assert both < contradicted_only < superseded_only < clean
+
+
+def test_search_ranks_a_contradicted_item_below_its_clean_equivalent(
+        tmp_checkpoint_dir, monkeypatch):
+    # Rigged against the fix again: the contradicted row is the SHORTER
+    # document, so bm25 alone puts it first.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-bad", _cp("S-bad", decisions=[
+        _decision("axolotl exporter", "o-bad111")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+    store.write_checkpoint("S-clean", _cp("S-clean", decisions=[
+        _decision("axolotl exporter for the regenerated limb cache pipeline",
+                  "o-clean1")], created="2026-08-01T00:00:00Z"),
+        project_dir="/repo/x")
+    _write_ledger(store.project_slug("/repo/x"), [_receipt_row("o-bad111")])
+
+    hits = recall.search("axolotl exporter", project_dir="/repo/x")
+    sids = [h["session_id"] for h in hits]
+    assert "S-bad" in sids and "S-clean" in sids
+    assert sids.index("S-clean") < sids.index("S-bad")
+
+
+def test_search_demotes_contradiction_at_least_as_hard_as_supersession(
+        tmp_checkpoint_dir, monkeypatch):
+    # #837's wording: "at least as strongly as superseded ones". Contradiction
+    # evidence is the stronger claim of the two, so it sorts last.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    # Distinct texts on purpose: _dedupe_rows keys on (kind, author, text),
+    # so two items worded identically collapse into one result and the
+    # comparison this test exists to make disappears.
+    store.write_checkpoint("S-old", _cp("S-old", decisions=[
+        _decision("axolotl exporter limb cache rollout", "o-old111")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+    store.write_checkpoint("S-newer", _cp("S-newer", decisions=[
+        {"text": "axolotl exporter limb cache rewritten", "trust": "inferred",
+         "links": [{"type": "supersedes",
+                    "target": "axolotl exporter limb cache rollout"}]}],
+        created="2026-08-02T00:00:00Z"), project_dir="/repo/x")
+    store.write_checkpoint("S-bad", _cp("S-bad", decisions=[
+        _decision("axolotl exporter limb cache probe", "o-bad111")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+    _write_ledger(store.project_slug("/repo/x"), [_receipt_row("o-bad111")])
+
+    hits = recall.search("axolotl exporter limb cache", project_dir="/repo/x")
+    sids = [h["session_id"] for h in hits]
+    assert "S-bad" in sids and "S-old" in sids
+    assert sids.index("S-old") < sids.index("S-bad")
+
+
+def test_describe_invalidation_reads_the_stored_encoding():
+    # One parse, shared by every renderer, so a marker can never describe a
+    # different view than the one the fold wrote.
+    assert recall.describe_invalidation(
+        "receipt:receipt-invalid@2026-08-29T10:00:00Z") == \
+        "contradicted by receipt:receipt-invalid at 2026-08-29T10:00:00Z"
+
+
+def test_describe_invalidation_never_says_false():
+    # The slot is EVIDENCE, not a verdict: no cure path exists, so a
+    # present-tense claim would overclaim what the field can know.
+    phrase = recall.describe_invalidation(
+        "receipt:receipt-invalid@2026-08-29T10:00:00Z")
+    assert "false" not in phrase.lower()
+    assert "was contradicted" not in phrase  # tense belongs to the caller
+
+
+def test_describe_invalidation_tolerates_a_malformed_value():
+    # A value the fold could not have written still renders as evidence
+    # rather than raising on a user's read path.
+    assert recall.describe_invalidation("garbage") == "contradicted by garbage"
+    assert recall.describe_invalidation(None) is None
+    assert recall.describe_invalidation("") is None


### PR DESCRIPTION
Closes #837

## What

Three read surfaces now consume `items.invalidated_by`:

- `suggest()` selects the column and scores through a new `_suggest_weight`.
  The supersession penalty (0.7x) and the new contradiction penalty (0.4x)
  stack multiplicatively, because the axes are independent facts: an item can
  carry both, either, or neither.
- `search()` leads its ORDER BY with `(i.invalidated_by IS NOT NULL) ASC`, so
  a contradicted row sorts below a merely replaced one. The issue's floor was
  "at least as strongly as superseded"; contradiction is the stronger claim of
  the two, so it takes the leading key.
- `daimon recall` and the auto-inject line both mark the row through one new
  `recall.describe_invalidation`, which owns the parse of the encoding the
  fold writes, so a marker cannot describe a different view than the verifier
  recorded.

No surface filters. A contradicted item is demoted and flagged, never hidden.

## Why

#835 populated the slot and #836 shipped it, but nothing read it, so the
record existed and changed nothing a user saw. `suggest()` did not even select
the column, which is the sharp edge: the auto-inject path re-asserted a claim
this install's own verification ledger contradicted, at full weight, on the
one surface nobody chooses to read.

Wording is bound by the field's semantics rather than by convenience. The slot
holds the latest contradiction evidence, and no confirmation row or cure path
exists yet, so every marker names the evidence and its timestamp and stops
there. No surface says "false", and none states a present tense verdict.

## Tests

10 new tests, each watched failing before the change:

- suggest ranks a contradicted item below its clean equivalent, on a fixture
  rigged against the fix (the contradicted item is importance 9 vs 5)
- suggest carries the evidence out so the emitter can render it
- the two penalties stack: both < contradicted only < superseded only < clean
- search ranks a contradicted item below its clean equivalent, on a fixture
  where bm25 alone puts the contradicted row first
- search demotes contradiction at least as hard as supersession
- describe_invalidation reads the stored encoding, never says "false", and
  tolerates a value this module could not have written
- both CLI markers render, and neither says "false"

Full suite: 4653 passed, 2 skipped. ruff clean, mypy clean.
