### PR TITLE
fix(status): warn about the global fallback only when the opt-in is active

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -1579,11 +1579,16 @@ def _checkpoint_info(path, now) -> dict:
 
 
 def _status_health(proj, glob, outstanding, siblings, *, now,
-                   disabled: bool = False) -> dict:
+                   disabled: bool = False,
+                   global_fallback: bool = False) -> dict:
     """Objective health verdict for `status`. Pure — `now` is injected. Warns only
     on data-driven signals: a NEWER phantom-child bucket (the #74 split), a missing
     project checkpoint, outstanding serialize failures, or the kill switch being
-    set. No age thresholds."""
+    set. No age thresholds.
+
+    `global_fallback` is the opt-in's state (#793), injected for the same
+    reason `now` and `disabled` are: it is environment, and a verdict that
+    reads its own environment cannot be tested at the verdict level."""
     warnings: list[str] = []
 
     # #28: a stuck DAIMON_DISABLE=1 silently stops all capture — the single
@@ -1608,9 +1613,24 @@ def _status_health(proj, glob, outstanding, siblings, *, now,
         )
 
     if not proj.get("exists"):
+        # #793: this said the briefing falls back to the global pointer,
+        # possibly another project's. That behavior is gone by default —
+        # `brief` has suppressed the foreign body since #96 and SessionStart
+        # injection stopped falling back for a known project in #785, both
+        # now behind an explicit opt-in. status is the surface an operator
+        # reads to learn what the system WILL do, so a warning naming a risk
+        # the system no longer takes costs twice: it sends someone hunting a
+        # closed leak, and it teaches them to discount the warnings beside it,
+        # which are load bearing. The old sentence is kept for the case where
+        # it is true, which is the case an operator most needs to hear.
         warnings.append(
             "no checkpoint for this project — briefing falls back to the "
-            "global pointer (possibly another project) or nothing"
+            "global pointer (possibly another project), because "
+            "DAIMON_BRIEF_GLOBAL_FALLBACK is set"
+            if global_fallback else
+            "no checkpoint for this project — its briefing will be empty "
+            "(the global pointer is not used unless "
+            "DAIMON_BRIEF_GLOBAL_FALLBACK=full is set)"
         )
 
     # Format drift on the checkpoint that would back a briefing (proj, else the
@@ -1919,7 +1939,8 @@ def _status_world(project_arg=None) -> dict:
     # it means there.
     rescue_window_errors = _stats_capture()["window"]["errors"]
     health = _status_health(proj, glob, outstanding, siblings, now=now,
-                            disabled=disabled)
+                            disabled=disabled,
+                            global_fallback=config.brief_global_fallback())
     # ONE objective team line (#113), only when a team remote exists — the #84
     # health-line rule: no line, no false alarms when the team feature is unused.
     team = teamsync.status_line()

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -543,6 +543,34 @@ def test_cli_status_global_fallback_labeled(
     assert "fallback" in out.lower()
     assert "S-global" in out
 
+    # #793 guard: the labeled "global checkpoint (fallback)" PAIRING above is
+    # deliberate transparency (#785, #788, #790, #792) and is NOT what that
+    # issue changed. What changed is the health WARNING, which must not claim
+    # the briefing will use that pointer when the opt-in is off.
+    assert "briefing falls back to the global pointer" not in out
+
+
+def test_cli_status_warning_tracks_the_global_fallback_opt_in(
+    tmp_checkpoint_dir, tmp_log_dir, sample_checkpoint, capsys, monkeypatch
+):
+    # End to end over the wiring the unit tests cannot see: status must read
+    # the opt-in and hand it to the verdict, or the corrected wording is right
+    # in _status_health and still wrong on the surface an operator reads.
+    from daimon_briefing import store
+
+    store.write_checkpoint("S-global", _with_session(sample_checkpoint, "S-global"))
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/never-seen")
+
+    monkeypatch.delenv("DAIMON_BRIEF_GLOBAL_FALLBACK", raising=False)
+    assert cli.main(["status"]) == 0
+    off = capsys.readouterr().out
+    assert "its briefing will be empty" in off
+
+    monkeypatch.setenv("DAIMON_BRIEF_GLOBAL_FALLBACK", "full")
+    assert cli.main(["status"]) == 0
+    on = capsys.readouterr().out
+    assert "possibly another project" in on
+
 
 def test_cli_status_same_session_dedup_noted(
     tmp_checkpoint_dir, tmp_log_dir, sample_checkpoint, capsys, monkeypatch
@@ -2783,6 +2811,46 @@ def test_status_health_fresh():
     h = cli._status_health(_proj(), {"exists": True, "session_id": "P", "same_session_as_project": True},
                            [], [], now=1000.0)
     assert h["ok"] is True and h["verdict"].startswith("✓")
+
+
+def test_status_health_missing_checkpoint_states_the_default_not_the_opt_in(
+        monkeypatch):
+    # #793: the warning described a fallback the code stopped doing. `brief`
+    # has suppressed the foreign body since #96 and SessionStart injection
+    # stopped falling back for a known project in #785, so by DEFAULT an
+    # unbriefed project gets nothing, not a stranger's checkpoint. status is
+    # where an operator goes to learn what the system will do, so a warning
+    # naming a risk the system no longer takes trains readers to discount the
+    # warnings around it, which are load bearing.
+    h = cli._status_health(_proj(exists=False), {"exists": True}, [], [],
+                           now=1000.0, global_fallback=False)
+    warn = [w for w in h["warnings"] if "no checkpoint for this project" in w]
+    assert len(warn) == 1
+    assert "falls back to the global pointer" not in warn[0]
+    assert "DAIMON_BRIEF_GLOBAL_FALLBACK" in warn[0]  # names the opt-in
+
+
+def test_status_health_missing_checkpoint_warns_when_the_opt_in_is_active():
+    # The interesting case for an operator is the one where the opt-in IS on,
+    # because then a foreign checkpoint really can appear. That is when the
+    # original wording becomes true, so that is when it is said.
+    h = cli._status_health(_proj(exists=False), {"exists": True}, [], [],
+                           now=1000.0, global_fallback=True)
+    warn = [w for w in h["warnings"] if "no checkpoint for this project" in w]
+    assert len(warn) == 1
+    assert "global pointer" in warn[0]
+    assert "possibly another project" in warn[0]
+
+
+def test_status_health_fallback_flag_is_injected_not_read():
+    # _status_health is pure by contract (`now` injected, no I/O), and the
+    # opt-in is environment state. Reading config here would make the verdict
+    # untestable in the same way an un-injected clock does, so it arrives as
+    # a kwarg like `disabled` does.
+    import inspect as _inspect
+
+    sig = _inspect.signature(cli._status_health)
+    assert sig.parameters["global_fallback"].default is False
 
 
 def test_status_health_flags_newer_sibling():


### PR DESCRIPTION
Closes #793

## What

`_status_health` now conditions the missing-checkpoint warning on the global-fallback opt-in instead of asserting a fallback that no longer happens.

- opt-in off (the default): "no checkpoint for this project, its briefing will be empty (the global pointer is not used unless DAIMON_BRIEF_GLOBAL_FALLBACK=full is set)"
- opt-in on: the original sentence, which is true exactly then, with the reason named

The flag arrives as an injected kwarg beside `disabled` rather than being read inside the function. `_status_health` is pure by contract, and a verdict that reads its own environment is untestable at the verdict level for the same reason an un-injected clock is. `_cmd_status` does the `config.brief_global_fallback()` read.

## Why

`brief` has suppressed the foreign body since #96 and the SessionStart injection stopped falling back for a known project in #785, both now behind `--global-fallback` or the env var. The warning outlived the behavior.

`status` is the surface an operator reads to learn what the system will do, so a warning naming a risk the system no longer takes costs twice: it sends someone hunting a leak that is closed, and it teaches them to discount the warnings beside it, which are load bearing.

Conditioned rather than reworded, per the issue's own reasoning: the case where the sentence is true is the case an operator most needs to hear.

## Tests

Four tests. The three unit tests were watched failing first:

- the default states the default and names the opt-in, and specifically does not say "falls back to the global pointer"
- the opt-in path still says "possibly another project"
- the flag is an injected kwarg, pinning the purity contract rather than trusting it

The fourth is end to end over the wiring the unit tests cannot see, and it was verified the hard way: it passed on first write because it was added after the fix, so the caller was unwired by hand and the test re-run to confirm it goes red. It does. A corrected string in `_status_health` that never reaches `status` output would otherwise be a green suite and an unfixed bug.

Also added a regression guard on the neighbour the issue explicitly says is correct: the labeled `global checkpoint (fallback): session <id>` pairing is deliberate transparency from #785, #788, #790 and #792. It looks like the same defect without being one, so it is now pinned as untouched.

Full suite: 4657 passed, 2 skipped. ruff clean, mypy clean.
