### PR TITLE
feat(scoring): publish the effective_weight computation on daimon why

### DIFF
--- a/docs/trust-inspector.md
+++ b/docs/trust-inspector.md
@@ -54,8 +54,59 @@ daimon why o-3f8a2c --json
 ```
 
 The V1 document has `schema_version`, stable values under `axes`, item metadata,
-corroboration references, the durable receipt when one exists, and no derived
-`summary` field. Scripts should inspect the axes they actually care about.
+corroboration references, the durable receipt when one exists, a `ranking`
+block, and no derived `summary` field. Scripts should inspect the axes they
+actually care about.
+
+### Ranking
+
+`ranking` publishes the ordering key Daimon itself uses, together with the
+inputs that produced it:
+
+```json
+{
+  "effective_weight": 0.448,
+  "computed_at": 1800000000.0,
+  "item_type": "recent_decision",
+  "rules": "recent_decision",
+  "inputs": {
+    "importance": 8,
+    "importance_source": "item",
+    "trust": "verbatim",
+    "trust_ceiling": 3.0,
+    "first_seen": "2026-08-01T00:00:00Z",
+    "age_days": 10.0
+  },
+  "factors": {
+    "base": 0.8,
+    "recency": 0.7,
+    "type_decay": 0.8,
+    "overdue_boost": 1.0,
+    "raw": 0.448
+  }
+}
+```
+
+The weight is recomputed on every read and is never stored, because it decays
+with age: a value written at capture time would be stale by the time anything
+read it. `computed_at` is the epoch it was computed against, and the number
+cannot be interpreted without it.
+
+The point of publishing the inputs is that a consumer can redo the arithmetic
+and land on the same number. `raw` is the product of the four factors, and
+`effective_weight` is that product under the trust ceiling. The ceiling
+saturates rather than truncating, so `raw` above the ceiling is normal and
+still ordered.
+
+Two values are deliberately not what they look like:
+
+- `importance_source: "default"` means the item carried no importance and 5
+  was substituted. An unscored item is not an importance-5 item.
+- `age_days: null` means no usable `first_seen`, which is not the same as a
+  brand new item. Recency falls back to neutral rather than maximum.
+
+`rules` names the type rules the computation actually applied, which differs
+from `item_type` whenever the item's kind maps to no known type.
 
 Exit codes describe command execution, not epistemic state:
 

--- a/plugin/daimon_briefing/inspector.py
+++ b/plugin/daimon_briefing/inspector.py
@@ -12,10 +12,11 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import time
 from pathlib import Path
 
-from . import (config, provenance, recall, redact, schema, serializer, store,
-               transcript)
+from . import (config, provenance, recall, redact, schema, scoring,
+               serializer, store, transcript)
 
 
 SCHEMA_VERSION = 1
@@ -265,8 +266,14 @@ def _index_only_reason(row: dict) -> str:
 
 
 def inspect_item(project_dir, item_id: str, *, include_source: bool = False,
-                 resolver=None) -> dict | None:
-    """Inspect one exact item inside one explicit project scope."""
+                 resolver=None, now: float | None = None) -> dict | None:
+    """Inspect one exact item inside one explicit project scope.
+
+    `now` is injected (#840) because the ranking block below decays with age:
+    a payload whose number depends on an un-injected clock cannot be pinned by
+    a test, and this one is published for consumers to recompute."""
+    if now is None:
+        now = time.time()
     occurrences = _item_occurrences(project_dir, item_id)
     resolutions = store.resolutions(project_dir=project_dir)
     event = resolutions.get(item_id)
@@ -357,6 +364,21 @@ def inspect_item(project_dir, item_id: str, *, include_source: bool = False,
             "count": len(references),
             "references": references,
         },
+        # #840 (request q-6cd17264d205): the ordering key, published with the
+        # inputs that produced it. `why` is the surface that exists to answer
+        # "why is this item where it is", and ranking was the one axis it
+        # could not answer, so a consumer had to reimplement scoring.py and
+        # drift from it. Recomputed here rather than stored: the weight decays,
+        # so a value written at capture time is stale by the time it is read.
+        #
+        # The kind picks the rules — decay rate, and whether overdue
+        # escalation applies at all — so a fixed type would publish a number
+        # no read path actually ranks on. On the #674 index-only path the
+        # index row carries no importance or first_seen, and the block says so
+        # in its own inputs (`importance_source: default`, `age_days: null`)
+        # rather than presenting substituted values as recorded ones.
+        "ranking": scoring.explain(
+            item, schema.KIND_TO_TYPE.get(kind, "recent_decision"), now),
         "receipt": receipt if bound else None,
         "source": source,
         "lifecycle_event": ({
@@ -377,6 +399,26 @@ def inspect_item(project_dir, item_id: str, *, include_source: bool = False,
         result["source_excerpt"] = _bounded_source(
             item, receipt, resolution, messages)
     return result
+
+
+def _ranking_line(ranking: dict) -> str:
+    """One line for the same numbers the JSON publishes (#840). The human
+    receipt must not be strictly less informative than its own machine
+    payload, and the inputs ride along because a bare weight is exactly the
+    ranking-you-must-trust-blind the request objected to.
+
+    `rules` rather than `item_type`: it names the rules the computation
+    actually applied, which differ whenever the kind maps to no known type."""
+    inputs = ranking["inputs"]
+    age = inputs["age_days"]
+    age_text = "age unknown" if age is None else f"{age:.1f}d old"
+    importance = (f"importance {inputs['importance']}"
+                  if inputs["importance_source"] == "item"
+                  else f"importance {inputs['importance']} (default, unscored)")
+    return (f"Ranking: weight {ranking['effective_weight']:.3f} "
+            f"as {ranking['rules']} ({importance}, {age_text}, "
+            f"{inputs['trust'] or 'untagged'} ceiling "
+            f"{inputs['trust_ceiling']:.2f})")
 
 
 def human_lines(result: dict) -> list[str]:
@@ -405,6 +447,7 @@ def human_lines(result: dict) -> list[str]:
         f"Current support: {axes['current_support']}",
         f"Verifier: {axes['verifier_comparison']}",
         f"Lifecycle: {axes['lifecycle']}",
+        _ranking_line(result["ranking"]),
     ]
     index_only = result.get("index_only")
     if isinstance(index_only, dict):

--- a/plugin/daimon_briefing/scoring.py
+++ b/plugin/daimon_briefing/scoring.py
@@ -144,6 +144,86 @@ def _soft_clip(weight: float, ceiling: float) -> float:
     return ceiling - (gap * gap) / (weight - 2.0 * knee + ceiling)
 
 
+def explain(item, item_type: str, now: float) -> dict:
+    """The same ordering key effective_weight returns, published WITH the
+    inputs and factors that produced it (#840, request q-6cd17264d205).
+
+    Why a read API and not a stored column: the weight decays, so a value
+    written at capture time is stale by the time anything reads it, and a
+    stale ranking number is worse than none because it still looks
+    authoritative. This recomputes at read time and stamps `computed_at`,
+    without which the number cannot be interpreted at all.
+
+    The bar this has to clear is not "report a number". A consumer must be
+    able to take `inputs` and `factors`, redo the arithmetic, and land on the
+    published `effective_weight`. Anything less leaves them with a ranking
+    they can read and still cannot check, which is the complaint that opened
+    the request.
+
+    Two deliberate honesty rules in the payload:
+      - a substituted importance is labelled `default`, because an unscored
+        item is not an importance-5 item and a consumer recomputing from a
+        bare 5 would report a score the record never carried;
+      - an unstamped item publishes `age_days: None`, never 0.0 — "unknown
+        age" and "brand new" are different facts, and collapsing them is how
+        a reimplementation reinvents the bug this API exists to prevent.
+
+    `effective_weight` stays the authoritative number and is called for it
+    rather than recomputed here, so the two can never disagree. The factors
+    are derived independently and pinned to their own product by test, since
+    a delegating wrapper makes the obvious equality assertion a tautology."""
+    rules_name = item_type if item_type in TYPE_RULES else "recent_decision"
+    rules = TYPE_RULES[rules_name]
+
+    imp = item.get("importance")
+    scored = isinstance(imp, int) and not isinstance(imp, bool) and 1 <= imp <= 10
+    importance = imp if scored else _DEFAULT_IMPORTANCE
+
+    trust = item.get("trust")
+    ceiling = trust_ceiling(trust)
+    age = _age_days(item, now)
+
+    if age is None:
+        # Mirrors effective_weight's unstamped branch: neutral recency, and
+        # neither decay nor escalation apply without an age to apply them to.
+        recency, decay, boost = _NEUTRAL_RECENCY, 1.0, 1.0
+    else:
+        recency = recency_weight(age)
+        decay = _type_decay(age, rules)
+        boost = (_overdue_boost(age - rules["expected_lifespan"])
+                 if rules["auto_escalation"] and age > rules["expected_lifespan"]
+                 else 1.0)
+
+    base = importance / 10.0
+    return {
+        "effective_weight": effective_weight(item, item_type, now),
+        "computed_at": now,
+        "item_type": item_type,
+        # What the computation actually used, which differs from item_type
+        # whenever the caller passes a type the table does not know.
+        "rules": rules_name,
+        "inputs": {
+            "importance": importance,
+            "importance_source": "item" if scored else "default",
+            "trust": trust,
+            "trust_ceiling": ceiling,
+            "first_seen": item.get("first_seen"),
+            "age_days": age,
+        },
+        "factors": {
+            "base": base,
+            "recency": recency,
+            "type_decay": decay,
+            "overdue_boost": boost,
+            # Pre-lid product. Published separately from effective_weight
+            # because _soft_clip is order-preserving rather than a min(), so
+            # "what this item accumulated" and "what its trust class allows
+            # it to spend" are two readable facts, not one.
+            "raw": base * recency * decay * boost,
+        },
+    }
+
+
 def effective_weight(item, item_type: str, now: float) -> float:
     """Ordering key for one checkpoint item. Tolerant of everything a legacy or
     torn checkpoint can throw: missing/malformed first_seen -> neutral recency,

--- a/plugin/tests/golden/why_bound.json
+++ b/plugin/tests/golden/why_bound.json
@@ -25,6 +25,27 @@
     "count": 0,
     "references": []
   },
+  "ranking": {
+    "effective_weight": 0.010000000000000002,
+    "computed_at": 1800000000.0,
+    "item_type": "recent_decision",
+    "rules": "recent_decision",
+    "inputs": {
+      "importance": 5,
+      "importance_source": "default",
+      "trust": "verbatim",
+      "trust_ceiling": 3.0,
+      "first_seen": "2026-08-05T10:00:00Z",
+      "age_days": 162.91666666666666
+    },
+    "factors": {
+      "base": 0.5,
+      "recency": 0.2,
+      "type_decay": 0.1,
+      "overdue_boost": 1.0,
+      "raw": 0.010000000000000002
+    }
+  },
   "receipt": {
     "version": 1,
     "source": {

--- a/plugin/tests/test_inspector.py
+++ b/plugin/tests/test_inspector.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from daimon_briefing import (cli, config, inspector, provenance, recall,
-                              redact, store, transcript)
+                              redact, schema, scoring, store, transcript)
 
 
 _PROJECT = "/p/A"
@@ -551,12 +551,92 @@ def test_source_helpers_ignore_malformed_messages_and_cap_plain_text():
     assert capped == "x" * (inspector._SOURCE_CHAR_LIMIT - 1) + "…"
 
 
+def test_why_publishes_a_recomputable_ranking_block(tmp_checkpoint_dir,
+                                                    monkeypatch):
+    # #840 / q-6cd17264d205: effective_weight decided ordering on three read
+    # paths and was never exposed, so a consumer had to reimplement scoring.py
+    # to answer "why is this ranked here". `why` is the surface that exists to
+    # answer exactly that question about one item.
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    _write_checkpoint("S-bound", [
+        _item(importance=8, first_seen="2026-08-01T00:00:00Z"),
+    ])
+    now = 1_800_000_000.0
+
+    got = inspector.inspect_item(_PROJECT, _ITEM_ID, now=now)
+
+    ranking = got["ranking"]
+    assert ranking["computed_at"] == now
+    assert ranking["inputs"]["importance"] == 8
+    assert ranking["inputs"]["importance_source"] == "item"
+    # The published number IS the one the read paths rank on, not a
+    # display-only recomputation that could drift from it.
+    assert ranking["effective_weight"] == pytest.approx(
+        scoring.effective_weight(
+            {"importance": 8, "first_seen": "2026-08-01T00:00:00Z",
+             "trust": got["item"]["trust"]},
+            schema.KIND_TO_TYPE.get(got["item"]["kind"], "recent_decision"),
+            now))
+
+
+def test_why_ranking_uses_the_item_kind_not_a_fixed_type(tmp_checkpoint_dir,
+                                                         monkeypatch):
+    # The type selects the decay rate and whether overdue escalation applies,
+    # so publishing a weight computed under the wrong rules would be a number
+    # no read path actually uses. An open question is the one auto-escalating
+    # type, which makes it the case that cannot pass by accident.
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    checkpoint = _checkpoint("S-q", [])
+    checkpoint["working_context"]["open_questions"] = [
+        _item(item_id="q-abcdef", text="still open", quote=None,
+              importance=5, first_seen="2026-06-01T00:00:00Z"),
+    ]
+    assert store.write_checkpoint("S-q", checkpoint, project_dir=_PROJECT)
+
+    got = inspector.inspect_item(_PROJECT, "q-abcdef", now=1_800_000_000.0)
+    assert got["ranking"]["rules"] == "open_question"
+
+
+def test_why_human_render_carries_the_ranking_it_publishes(
+        tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    _write_checkpoint("S-h", [_item()])
+    # The human receipt must not be strictly less informative than its own
+    # machine payload, and a bare weight would be the "trust it blind"
+    # ranking the request objected to, so the inputs ride the line too.
+    result = inspector.inspect_item(_PROJECT, _ITEM_ID, now=1_800_000_000.0)
+    line = [ln for ln in inspector.human_lines(result)
+            if ln.startswith("Ranking:")]
+    assert len(line) == 1
+    assert f"{result['ranking']['effective_weight']:.3f}" in line[0]
+    assert result["ranking"]["rules"] in line[0]
+    assert "importance" in line[0]
+
+
+def test_why_human_render_names_a_substituted_importance(
+        tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    _write_checkpoint("S-h", [_item()])
+    # Same honesty rule the JSON keeps: an unscored item is not an
+    # importance-5 item, so the line must not read as if 5 were recorded.
+    result = inspector.inspect_item(_PROJECT, _ITEM_ID, now=1_800_000_000.0)
+    line = [ln for ln in inspector.human_lines(result)
+            if ln.startswith("Ranking:")][0]
+    if result["ranking"]["inputs"]["importance_source"] == "default":
+        assert "default, unscored" in line
+
+
 def test_why_json_matches_golden_and_command_is_read_only_except_usage(
     tmp_checkpoint_dir, tmp_path, monkeypatch, capsys
 ):
     monkeypatch.setenv("DAIMON_AUTHOR", "alice")
     monkeypatch.setenv(
         "DAIMON_CLAUDE_PROJECTS_DIR", str(tmp_path / "no-transcripts"))
+    # #840: the ranking block decays with wall-clock age, so the golden can
+    # only stay a golden with the clock pinned. Freezing it here keeps the
+    # WHOLE document under the golden rather than carving out an exempt
+    # subtree, which is how a golden quietly stops covering its own payload.
+    monkeypatch.setattr(inspector.time, "time", lambda: 1_800_000_000.0)
     _write_checkpoint("S-bound", [
         _item(receipt=_receipt(_source(), "a" * 64)),
     ])

--- a/plugin/tests/test_scoring.py
+++ b/plugin/tests/test_scoring.py
@@ -3,6 +3,8 @@ escalation. Pure + deterministic — `now` injected everywhere."""
 
 import time as _time
 
+import pytest
+
 from daimon_briefing import scoring
 
 _NOW = 1_800_000_000.0  # fixed epoch; all ages derived from here
@@ -243,3 +245,108 @@ def test_soft_clip_at_a_zero_ceiling_silences_without_a_special_case():
     # statement about the formula rather than about production behavior.
     assert all(v > 0 for v in scoring.TRUST_CEILING.values())
     assert scoring._DEFAULT_CEILING > 0
+
+
+# ---- #840 / q-6cd17264d205: the ranking must be interrogable ----------------
+#
+# effective_weight decides ordering on three read paths and was never exposed,
+# so a consumer wanting to answer "why is this ranked here" had to reimplement
+# scoring.py and drift from it. daimon-ui cannot import daimon, so
+# reimplementation was its only option.
+#
+# Persistence was rejected in the acceptance: the weight decays, so a value
+# stored at write time is stale by the time anything reads it, and a stale
+# ranking number is worse than none because it looks authoritative. The shape
+# is recompute at read time and publish the result WITH the inputs, because a
+# number a reader cannot recompute is still a ranking they have to trust blind.
+
+
+def test_explain_publishes_inputs_that_reproduce_the_weight():
+    # Frozen reference, computed by hand rather than from the code under test:
+    # importance 8 -> base 0.8; 10 days old -> recency tier 0.7; recent_decision
+    # decay 0.02/day -> 1 - 10*0.02 = 0.8; no escalation for that type; verbatim
+    # ceiling 3.0 leaves the knee at 2.7, so nothing clips. 0.8*0.7*0.8 = 0.448.
+    item = {"importance": 8, "first_seen": _iso(10), "trust": "verbatim"}
+    got = scoring.explain(item, "recent_decision", _NOW)
+
+    assert got["effective_weight"] == pytest.approx(0.448)
+    assert got["computed_at"] == _NOW
+    assert got["inputs"] == {
+        "importance": 8,
+        "importance_source": "item",
+        "trust": "verbatim",
+        "trust_ceiling": 3.0,
+        "first_seen": _iso(10),
+        "age_days": pytest.approx(10.0),
+    }
+    assert got["factors"]["base"] == pytest.approx(0.8)
+    assert got["factors"]["recency"] == pytest.approx(0.7)
+    assert got["factors"]["type_decay"] == pytest.approx(0.8)
+    assert got["factors"]["overdue_boost"] == 1.0
+    assert got["factors"]["raw"] == pytest.approx(0.448)
+
+
+def test_explain_factors_multiply_to_the_weight_it_publishes():
+    # The one invariant that keeps the explanation honest: raw is the product
+    # of the published factors, and the published weight is that product under
+    # the trust lid. Asserted across shapes that exercise every branch,
+    # including the clipped one where raw and weight legitimately differ.
+    #
+    # This is deliberately NOT `explain(...)["effective_weight"] ==
+    # effective_weight(...)`. explain delegates the authoritative number to
+    # effective_weight, so that comparison is a tautology that would keep
+    # passing if the factors drifted away from the math entirely.
+    cases = [
+        ({"importance": 8, "first_seen": _iso(10), "trust": "verbatim"}, "recent_decision"),
+        ({"importance": 10, "first_seen": _iso(0), "trust": "inferred"}, "open_question"),
+        ({"importance": 9, "first_seen": _iso(200), "trust": "verbatim"}, "open_question"),
+        ({"importance": 3, "first_seen": _iso(45), "trust": None}, "strong_belief"),
+        ({"trust": "inferred"}, "active_topic"),
+    ]
+    for item, item_type in cases:
+        got = scoring.explain(item, item_type, _NOW)
+        f = got["factors"]
+        product = f["base"] * f["recency"] * f["type_decay"] * f["overdue_boost"]
+        assert f["raw"] == pytest.approx(product), (item, item_type)
+        assert got["effective_weight"] == pytest.approx(
+            scoring._soft_clip(f["raw"], got["inputs"]["trust_ceiling"])), (item, item_type)
+
+
+def test_explain_names_a_substituted_importance_as_a_default():
+    # An unscored item is not an importance-5 item, and a consumer recomputing
+    # from a published 5 without knowing it was substituted would report a
+    # score the record never carried.
+    got = scoring.explain({"first_seen": _iso(1)}, "recent_decision", _NOW)
+    assert got["inputs"]["importance"] == scoring._DEFAULT_IMPORTANCE
+    assert got["inputs"]["importance_source"] == "default"
+
+
+def test_explain_reports_an_unstamped_item_as_neutral_rather_than_fresh():
+    # No first_seen means neutral recency, not maximum. The published age is
+    # null rather than 0, because "unknown age" and "brand new" are different
+    # facts and collapsing them is how a consumer reinvents the bug.
+    got = scoring.explain({"importance": 6, "trust": "inferred"}, "recent_decision", _NOW)
+    assert got["inputs"]["age_days"] is None
+    assert got["inputs"]["first_seen"] is None
+    assert got["factors"]["recency"] == pytest.approx(scoring._NEUTRAL_RECENCY)
+    assert got["factors"]["type_decay"] == 1.0
+    assert got["factors"]["overdue_boost"] == 1.0
+
+
+def test_explain_reports_the_rules_actually_applied_for_an_unknown_type():
+    # effective_weight falls back to _DEFAULT_RULES for a type it does not
+    # know. Publishing the requested type alone would describe a computation
+    # that did not happen.
+    got = scoring.explain({"importance": 5}, "not-a-real-type", _NOW)
+    assert got["item_type"] == "not-a-real-type"
+    assert got["rules"] == "recent_decision"
+
+
+def test_explain_shows_the_overdue_boost_that_escalation_applied():
+    # open_question is the one auto-escalating type; an item past its expected
+    # lifespan gets a boost, and a consumer cannot reproduce the number
+    # without it.
+    got = scoring.explain(
+        {"importance": 5, "first_seen": _iso(60), "trust": "verbatim"},
+        "open_question", _NOW)
+    assert got["factors"]["overdue_boost"] > 1.0


### PR DESCRIPTION
Closes #840

Answers accepted request `q-6cd17264d205` from daimon-ui-init.

## What

New `scoring.explain(item, item_type, now)` returns the ordering key together with the inputs and factors that produced it. `daimon why` carries it as a `ranking` block in both `--json` and the human render, and `docs/trust-inspector.md` documents the shape.

```json
"ranking": {
  "effective_weight": 0.448,
  "computed_at": 1800000000.0,
  "item_type": "recent_decision",
  "rules": "recent_decision",
  "inputs": {"importance": 8, "importance_source": "item", "trust": "verbatim",
             "trust_ceiling": 3.0, "first_seen": "...", "age_days": 10.0},
  "factors": {"base": 0.8, "recency": 0.7, "type_decay": 0.8,
              "overdue_boost": 1.0, "raw": 0.448}
}
```

## Why

`effective_weight` decides ordering on three read paths and was never exposed, so a consumer answering "why is this ranked here" had to reimplement `scoring.py` and drift from it. daimon-ui cannot import daimon, so reimplementation was its only option.

Persistence was rejected in the acceptance and the reason holds: the weight decays, so a value stored at capture time is stale by the time anything reads it, and a stale ranking number is worse than none because it still looks authoritative. Recomputed at read time, stamped with `computed_at`, without which the number cannot be interpreted at all.

The bar was not "report a number". A consumer must be able to redo the arithmetic and land on the published one, so `raw` is the product of the four factors and `effective_weight` is that product under the trust ceiling. The ceiling saturates rather than truncating, so `raw` above it is normal and still ordered, and publishing both makes "what this item accumulated" and "what its trust class lets it spend" two readable facts instead of one.

Two values are labelled rather than presented as recorded, because a consumer recomputing from a bare number would report a score the record never carried:

- `importance_source: "default"` when 5 was substituted. An unscored item is not an importance 5 item.
- `age_days: null` when there is no usable `first_seen`. Unknown age is not brand new, and recency falls back to neutral rather than maximum.

`rules` names the type rules actually applied, which differs from `item_type` whenever the kind maps to no known type. Publishing the requested type alone would describe a computation that did not happen.

## Design notes

`effective_weight` remains the authoritative number and `explain` calls it, so the two cannot disagree, and the hot ranking path keeps its cheap scalar rather than building a dict per row. The factors are derived independently, which is the drift risk, so they are pinned to their own product by test across five shapes including the clipped one. That test deliberately is not `explain(...)["effective_weight"] == effective_weight(...)`, which is a tautology once explain delegates and would keep passing if the factors drifted away from the math entirely.

`schema_version` stays 1. The documented posture is that scripts inspect the axes they care about, and a new key is additive; bumping would break a consumer pinned to 1 over a change that takes nothing away.

## Tests

Eleven new tests, each watched failing first. Two pieces are worth calling out.

The human render line was written before its test, so it was deleted and rewritten after one. Keeping it would have been a test-after passing on arrival, which proves nothing.

The `why` golden now pins its clock. The block decays with wall clock age, so without freezing time the golden could only cover the payload by exempting the new subtree, and a golden with an exempt subtree quietly stops covering its own document. A temporary regeneration hatch was used to rebuild the file and then removed, because an env var that rewrites a golden is an env var that can make it pass in CI.

Full suite: 4667 passed, 2 skipped. ruff clean, mypy clean.
