### PR TITLE
feat(recall): let a later confirmation clear invalidated_by

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -583,9 +583,7 @@ def _render_briefing_body(checkpoint, route, *, drift_project, teammates,
             # A POINTER and a REASON CODE, never the item's text (#376) — the
             # same second stream capture writes, for the same reason: folded
             # into events.jsonl a rejection would HIDE the item it describes.
-            for item_ref, check, reason in ledger_rows:
-                store.append_verification(item_ref, check, reason,
-                                          project_dir=route)
+            _write_worldcheck_ledger(ledger_rows, route)
         except Exception:
             pass
     # NOTE: drift is checked against the resolved project root. If read_latest fell
@@ -1576,6 +1574,23 @@ def _checkpoint_info(path, now) -> dict:
         "age": _format_age(age),
         "path": str(path),
     }
+
+
+def _write_worldcheck_ledger(rows, route) -> None:
+    """Append worldcheck's reserved ledger rows at the write boundary (#439,
+    #839). A POINTER and a REASON CODE, never the item's text (#376).
+
+    Cure rows take the gated path. worldcheck emits them the same way it emits
+    contradictions, because it writes nothing to disk by contract, so this is
+    the first place that knows where the item currently stands. A cure for an
+    item nothing contradicted changes nothing, and writing it anyway would
+    turn a ledger of problems found into a ledger of work done."""
+    for item_ref, check, reason in rows:
+        if check == worldcheck.LEDGER_CONFIRM_CHECK:
+            store.append_receipt_cure(item_ref, project_dir=route)
+        else:
+            store.append_verification(item_ref, check, reason,
+                                      project_dir=route)
 
 
 def _status_health(proj, glob, outstanding, siblings, *, now,

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -604,6 +604,11 @@ def reap_dead_snapshots(now: float | None = None, apply: bool = True) -> list:
 # write; model-flagged contradictions have no path here at all — authority
 # precedent: derived world evidence writes the slot, or nothing does.
 _INVALIDATION_CHECKS = ("receipt",)
+# #839: the cure half. Derived evidence clears derived evidence, which needs
+# no widening of #836's authority model: the same probe that contradicted the
+# claim is the one now saying it holds. A HUMAN ruling channel is the other
+# half and stays deliberately unbuilt, because that WOULD widen the model.
+_CONFIRMATION_CHECKS = ("receipt-ok",)
 
 
 def _apply_verification_invalidations(conn: sqlite3.Connection) -> None:
@@ -650,38 +655,21 @@ def _apply_verification_invalidations(conn: sqlite3.Connection) -> None:
     except OSError:
         return
     for bucket in buckets:
-        latest: dict[str, dict] = {}
-        for row in store.verification_rows(bucket=bucket):
-            if row.get("check") not in _INVALIDATION_CHECKS:
-                continue
-            ref = row.get("item_ref")
-            reason = row.get("reason")
-            ts = row.get("ts")
-            if not (isinstance(ref, str) and ref
-                    and isinstance(reason, str) and reason
-                    and isinstance(ts, str) and ts):
-                continue
-            cur = latest.get(ref)
-            if cur is None:
-                latest[ref] = row
-                continue
-            new_e = store._created_epoch(ts)
-            if new_e is None:
-                continue  # an unstamped row never displaces a stamped one
-            cur_e = store._created_epoch(cur.get("ts"))
-            if (cur_e is None or new_e > cur_e
-                    or (new_e == cur_e
-                        and json.dumps(row, sort_keys=True,
-                                       ensure_ascii=False)
-                        > json.dumps(cur, sort_keys=True,
-                                     ensure_ascii=False))):
-                latest[ref] = row
-        for ref, row in latest.items():
+        # ONE resolution of latest-by-ts, shared with the cure gate that
+        # decides whether a confirmation is worth writing (#839). Two copies
+        # would drift, and the write side deciding "currently contradicted"
+        # differently from the read side is the recorder-and-verifier
+        # mismatch this codebase keeps paying for.
+        for ref, row in store.latest_receipt_verdicts(bucket=bucket).items():
+            # A confirmation CLEARS rather than stamping: the slot holds the
+            # latest contradiction evidence, and once the latest evidence is
+            # a confirmation there is no contradiction evidence to hold.
+            value = (f"{row['check']}:{row['reason']}@{row['ts']}"
+                     if row["verdict"] == "contradicted" else None)
             conn.execute(
                 "UPDATE items SET invalidated_by = ?"
                 " WHERE item_id = ? AND project_slug IS ? AND author IS ?",
-                (f"{row['check']}:{row['reason']}@{row['ts']}",
-                 ref, bucket.name, author))
+                (value, ref, bucket.name, author))
 
 
 def describe_invalidation(value) -> str | None:

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -1937,6 +1937,90 @@ def verification_rows(project_dir=None, *, bucket=None) -> list:
     return rows
 
 
+# #835/#839: the receipt-validity ledger vocabulary. Two check names rather
+# than one row type with an outcome field, because verification_counts is a
+# shipped surface documented as "how often the checkers actually CAUGHT
+# something here" and its total sums every check. Folding cures into the
+# rejection check would silently turn a problems-found counter into a
+# work-done counter, which is the #832 defect wearing different clothes.
+# Pinned equal to worldcheck's names by test rather than imported.
+RECEIPT_CHECK = "receipt"        # a contradiction: this receipt did not hold
+RECEIPT_CURE_CHECK = "receipt-ok"  # the same probe, later, saying it does
+
+
+def latest_receipt_verdicts(*, bucket=None, project_dir=None) -> dict:
+    """{item_ref: row} for the LATEST receipt-class verdict per item (#839).
+
+    The single resolution of "where does this item currently stand", shared by
+    the recall fold that writes invalidated_by and by the cure gate that
+    decides whether a confirmation is worth recording. Two copies of
+    latest-by-ts would drift, and a recorder deriving from a different view
+    than the verifier is the failure this codebase keeps paying for.
+
+    Latest by TS, NEVER line order (store.resolutions' contract, mirrored):
+    the ledger interleaves concurrent writers and clock-skewed appends, so an
+    unstamped row never displaces a stamped one and equal stamps fall to
+    canonical-JSON order, deterministic under any line order.
+
+    Rows whose check is neither name are skipped entirely rather than treated
+    as either verdict. A wrong invalidation fabricates distrust and a wrong
+    cure fabricates trust, so a row this module could not have written decides
+    neither. Each returned row carries a `verdict` of "contradicted" or
+    "confirmed"; callers never re-derive it from the check name."""
+    latest: dict = {}
+    for row in verification_rows(bucket=bucket, project_dir=project_dir):
+        check = row.get("check")
+        if check == RECEIPT_CHECK:
+            verdict = "contradicted"
+        elif check == RECEIPT_CURE_CHECK:
+            verdict = "confirmed"
+        else:
+            continue
+        ref, reason, ts = (row.get("item_ref"), row.get("reason"),
+                           row.get("ts"))
+        if not (isinstance(ref, str) and ref
+                and isinstance(reason, str) and reason
+                and isinstance(ts, str) and ts):
+            continue
+        cur = latest.get(ref)
+        if cur is None:
+            latest[ref] = {**row, "verdict": verdict}
+            continue
+        new_e = _created_epoch(ts)
+        if new_e is None:
+            continue  # an unstamped row never displaces a stamped one
+        cur_e = _created_epoch(cur.get("ts"))
+        if (cur_e is None or new_e > cur_e
+                or (new_e == cur_e
+                    and json.dumps(row, sort_keys=True, ensure_ascii=False)
+                    > json.dumps({k: v for k, v in cur.items()
+                                  if k != "verdict"},
+                                 sort_keys=True, ensure_ascii=False))):
+            latest[ref] = {**row, "verdict": verdict}
+    return latest
+
+
+def append_receipt_cure(item_ref: str, project_dir=None) -> bool:
+    """Record that a receipt-validity probe now PASSES for an item that
+    currently stands contradicted (#839). Returns whether a row was written.
+
+    Conditional on purpose, and the condition is the whole design. The
+    rejection ledger has always recorded problems found: measured on this
+    project it holds one row per rejection and stays sparse over a project's
+    whole life. Appending a row on every passing check would make it grow with
+    work done instead, which is both a different artifact and a much larger
+    one, for a cure nobody needed. So a confirmation is written only when it
+    changes something: when the item's latest verdict is a contradiction.
+
+    A duplicate cure is harmless if two writers race (the fold takes the
+    latest and both say the same thing), so the gate needs no lock."""
+    if latest_receipt_verdicts(project_dir=project_dir).get(
+            item_ref, {}).get("verdict") != "contradicted":
+        return False
+    return append_verification(item_ref, RECEIPT_CURE_CHECK, "receipt-valid",
+                               project_dir=project_dir)
+
+
 def verification_counts(project_dir=None) -> dict:
     """{check: count} over the rejection ledger. Answers the question the
     trust classes otherwise cannot: has verification ever caught anything on
@@ -1945,7 +2029,10 @@ def verification_counts(project_dir=None) -> dict:
     out: dict = {}
     for row in verification_rows(project_dir):
         check = str(row.get("check") or "")
-        if check:
+        # #839: a cure is not a catch. This counter and the `total` the CLI
+        # sums from it answer "has verification ever caught anything here",
+        # so a row recording that a check PASSED must not inflate it.
+        if check and check != RECEIPT_CURE_CHECK:
             out[check] = out.get(check, 0) + 1
     return out
 

--- a/plugin/daimon_briefing/worldcheck.py
+++ b/plugin/daimon_briefing/worldcheck.py
@@ -138,6 +138,15 @@ _TAMPERED = "TAMPERED"      # bytes no longer match the signed outputs_hash
 LEDGER_KEY = "_ledger"
 _LEDGER_CHECK = "receipt"
 _LEDGER_REASONS = {_TAMPERED: "receipt-tampered", _INVALID: "receipt-invalid"}
+# #839: the cure row. A SEPARATE check name, not the same check with a
+# passing reason, because verification_counts sums every check into a "has
+# verification ever caught anything here" total and a cure is not a catch.
+# Emitted unconditionally here, exactly like a contradiction row; whether it
+# is worth WRITING is decided at the write boundary (store.append_receipt_cure),
+# because that is where the current ledger state is already in hand and where
+# worldcheck's write-nothing-to-disk contract stays intact.
+LEDGER_CONFIRM_CHECK = "receipt-ok"
+_LEDGER_CONFIRM_REASON = "receipt-valid"
 
 # A probe: how to spawn it, what to feed its stdin, and how to read its answer.
 # The parser rides PER PROBE because the classes speak different dialects
@@ -829,6 +838,12 @@ def check(checkpoint, project_dir) -> dict:
             # solid ground with it; a contradiction on ANY axis outranks it
             # at render time, so stamping here stays unconditional.
             item.setdefault("_worldcheck_confirmed", True)
+            ref = item.get("id")
+            if cls == RECEIPT_VALIDITY and isinstance(ref, str) and ref:
+                # #839: the same id-less rule the contradiction row keeps — a
+                # cure nobody can trace back to an item cures nothing.
+                ledger.append((ref, LEDGER_CONFIRM_CHECK,
+                               _LEDGER_CONFIRM_REASON))
         else:
             outcome = "contradicted"
             note, status = _flag(cls, claim, value)

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2069,6 +2069,30 @@ def test_cli_write_checkpoint_strips_model_claimed_pinned(
     assert "pinned" not in belief
 
 
+def test_worldcheck_ledger_rows_route_cures_through_the_gate(
+        tmp_checkpoint_dir, monkeypatch):
+    # #839: worldcheck emits contradiction and cure rows the same way, because
+    # it writes nothing to disk by contract. The write boundary is where the
+    # current ledger state is in hand, so it is where a cure that would change
+    # nothing gets dropped.
+    from daimon_briefing import store
+
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    proj = "/p/wc"
+
+    # A cure for an item nothing contradicted is not worth a row.
+    cli._write_worldcheck_ledger(
+        [("o-clean", "receipt-ok", "receipt-valid")], proj)
+    assert store.verification_rows(project_dir=proj) == []
+
+    cli._write_worldcheck_ledger(
+        [("o-bad", "receipt", "receipt-invalid")], proj)
+    cli._write_worldcheck_ledger(
+        [("o-bad", "receipt-ok", "receipt-valid")], proj)
+    assert [r["check"] for r in store.verification_rows(project_dir=proj)] \
+        == ["receipt", "receipt-ok"]
+
+
 def test_suggest_line_collapses_multiline_item_text():
     # #512: the injection line's echo strip is line-scoped (`[^\n]*`), so item
     # text carrying a newline would leave its tail in the verification

--- a/plugin/tests/test_recall_invalidated_by.py
+++ b/plugin/tests/test_recall_invalidated_by.py
@@ -454,3 +454,163 @@ def test_describe_invalidation_tolerates_a_malformed_value():
     assert recall.describe_invalidation("garbage") == "contradicted by garbage"
     assert recall.describe_invalidation(None) is None
     assert recall.describe_invalidation("") is None
+
+
+# --- #839 Half 1: derived evidence can cure derived evidence -----------------
+#
+# invalidated_by was a one-way ratchet. worldcheck appended contradiction rows
+# only, so "the latest evidence for this item" could never become a
+# confirmation and the fold had no input that would clear the slot. A probe
+# that contradicted an item once buried it on every read surface forever, with
+# a receipt that was invalid because of a since-fixed bug indistinguishable
+# from a standing contradiction.
+#
+# Half 2 (a human ruling channel) is deliberately NOT here: it widens the
+# authority model #836 narrowed to "derived world evidence writes the slot, or
+# nothing does", and that is a ruling rather than an implementation detail.
+# This half stays entirely inside the ratified authority.
+
+
+def _cure_row(ref, *, ts="2026-08-29T12:00:00Z"):
+    return {"ts": ts, "check": "receipt-ok", "item_ref": ref,
+            "reason": "receipt-valid"}
+
+
+def test_a_later_confirmation_clears_the_contradiction(tmp_checkpoint_dir,
+                                                       monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-1", _cp("S-1", questions=[
+        _item("the axolotl exporter claim was verified", "o-111aaa")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+    _write_ledger(store.project_slug("/repo/x"), [
+        _receipt_row("o-111aaa", ts="2026-08-29T10:00:00Z"),
+        _cure_row("o-111aaa", ts="2026-08-29T12:00:00Z"),
+    ])
+
+    hits = recall.search("axolotl exporter claim", project_dir="/repo/x")
+    assert hits
+    assert hits[0]["invalidated_by"] is None
+
+
+def test_an_earlier_confirmation_does_not_clear_a_later_contradiction(
+        tmp_checkpoint_dir, monkeypatch):
+    # Latest by TS, never line order, and never "a confirmation wins": a cure
+    # that predates the contradiction cures nothing.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-1", _cp("S-1", questions=[
+        _item("the axolotl exporter claim was verified", "o-111aaa")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+    _write_ledger(store.project_slug("/repo/x"), [
+        _cure_row("o-111aaa", ts="2026-08-29T08:00:00Z"),
+        _receipt_row("o-111aaa", ts="2026-08-29T10:00:00Z"),
+    ])
+
+    hits = recall.search("axolotl exporter claim", project_dir="/repo/x")
+    assert hits
+    assert hits[0]["invalidated_by"] == \
+        "receipt:receipt-invalid@2026-08-29T10:00:00Z"
+
+
+def test_the_cure_is_visible_on_the_read_surfaces_it_unburies(
+        tmp_checkpoint_dir, monkeypatch):
+    # The point of the cure is that #838's demotions stop applying. A cure
+    # that cleared the column but left the item ranked last would be a
+    # different kind of permanent burial.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-bad", _cp("S-bad", decisions=[
+        _decision("axolotl exporter", "o-bad111")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+    store.write_checkpoint("S-clean", _cp("S-clean", decisions=[
+        _decision("axolotl exporter for the regenerated limb cache pipeline",
+                  "o-clean1")], created="2026-08-01T00:00:00Z"),
+        project_dir="/repo/x")
+    _write_ledger(store.project_slug("/repo/x"), [
+        _receipt_row("o-bad111", ts="2026-08-29T10:00:00Z"),
+        _cure_row("o-bad111", ts="2026-08-29T12:00:00Z"),
+    ])
+
+    hits = recall.search("axolotl exporter", project_dir="/repo/x")
+    sids = [h["session_id"] for h in hits]
+    # bm25 favours the shorter document, and with the mark gone nothing
+    # demotes it any more.
+    assert sids.index("S-bad") < sids.index("S-clean")
+
+
+def test_latest_receipt_verdicts_is_one_resolution_both_sides_share():
+    # The cure gate and the fold must agree about what "currently
+    # contradicted" means. Two implementations of latest-by-ts would drift,
+    # and a recorder that derives from a different view than the verifier is
+    # the defect this codebase keeps paying for.
+    assert callable(store.latest_receipt_verdicts)
+
+
+def test_an_unknown_check_neither_marks_nor_cures(tmp_checkpoint_dir,
+                                                  monkeypatch):
+    # A wrong invalidation fabricates distrust and a wrong cure fabricates
+    # trust, so a row this module could not have written decides neither.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-1", _cp("S-1", questions=[
+        _item("the axolotl exporter claim was verified", "o-111aaa")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+    _write_ledger(store.project_slug("/repo/x"), [
+        _receipt_row("o-111aaa", ts="2026-08-29T10:00:00Z"),
+        {"ts": "2026-08-29T23:00:00Z", "check": "receipt-someday",
+         "item_ref": "o-111aaa", "reason": "who-knows"},
+    ])
+
+    hits = recall.search("axolotl exporter claim", project_dir="/repo/x")
+    assert hits[0]["invalidated_by"] == \
+        "receipt:receipt-invalid@2026-08-29T10:00:00Z"
+
+
+def test_the_cure_check_names_match_worldchecks(monkeypatch):
+    """Divergence guard, mirroring the contradiction one: the three modules
+    pin equal names rather than importing each other."""
+    assert recall._CONFIRMATION_CHECKS == (worldcheck.LEDGER_CONFIRM_CHECK,)
+    assert store.RECEIPT_CURE_CHECK == worldcheck.LEDGER_CONFIRM_CHECK
+
+
+def test_a_cure_is_written_only_when_it_changes_something(tmp_checkpoint_dir,
+                                                          monkeypatch):
+    # The rejection ledger records problems FOUND. Measured on this project it
+    # holds roughly one row per rejection and stays sparse over the project's
+    # whole life. Writing a row on every passing check would make it grow with
+    # work DONE instead, which is a different artifact and a far larger one.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-1", _cp("S-1", questions=[
+        _item("the axolotl exporter claim was verified", "o-111aaa")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+
+    # Nothing stands contradicted: no row.
+    assert store.append_receipt_cure("o-111aaa", project_dir="/repo/x") is False
+    assert store.verification_rows(project_dir="/repo/x") == []
+
+    _write_ledger(store.project_slug("/repo/x"),
+                  [_receipt_row("o-111aaa", ts="2026-08-29T10:00:00Z")])
+    assert store.append_receipt_cure("o-111aaa", project_dir="/repo/x") is True
+    rows = store.verification_rows(project_dir="/repo/x")
+    assert [r["check"] for r in rows] == ["receipt", "receipt-ok"]
+
+    # Already cured: the next passing check writes nothing.
+    assert store.append_receipt_cure("o-111aaa", project_dir="/repo/x") is False
+    assert len(store.verification_rows(project_dir="/repo/x")) == 2
+
+
+def test_a_cure_is_not_a_catch_in_the_rejection_counters(tmp_checkpoint_dir,
+                                                         monkeypatch):
+    # verification_counts and the `total` the CLI sums from it answer "has
+    # verification ever caught anything on this install". A row saying a check
+    # PASSED must not inflate that, or a problems-found counter quietly
+    # becomes a work-done counter.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-1", _cp("S-1", questions=[
+        _item("the axolotl exporter claim was verified", "o-111aaa")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+    _write_ledger(store.project_slug("/repo/x"), [
+        _receipt_row("o-111aaa", ts="2026-08-29T10:00:00Z"),
+        _cure_row("o-111aaa", ts="2026-08-29T12:00:00Z"),
+    ])
+
+    counts = store.verification_counts(project_dir="/repo/x")
+    assert counts == {"receipt": 1}
+    assert sum(counts.values()) == 1

--- a/plugin/tests/test_worldcheck.py
+++ b/plugin/tests/test_worldcheck.py
@@ -1177,6 +1177,10 @@ def test_receipt_valid_confirms_and_leaves_item_untouched(receipts_on, proj):
     _signed_origin("S-origin", proj)
     cp = _cp_origins(["S-origin"])
     stats = worldcheck.check(cp, proj)
+    # #839: a confirmed receipt now also emits a cure CANDIDATE under the
+    # reserved key. Popped here exactly as the CLI pops it, so this stays an
+    # assertion about the counters.
+    stats.pop(worldcheck.LEDGER_KEY, None)
     assert stats == {"confirmed": 1, "contradicted": 0, "skipped": 0,
                      "receipt-validity:confirmed": 1}
     assert "_worldcheck" not in cp["working_context"]["open_questions"][0]
@@ -1354,6 +1358,7 @@ def test_receipt_probes_one_origin_per_day_by_rotation(receipts_on, proj,
     stats = worldcheck.check(_cp_origins(["S-a", "S-b"]), proj)
     assert len(_vitni_calls(receipts_on)) == 2
     # One probe per brief either way: the other origin makes no claim at all.
+    stats.pop(worldcheck.LEDGER_KEY, None)  # #839 cure candidate
     assert stats == {"confirmed": 1, "contradicted": 0, "skipped": 0,
                      "receipt-validity:confirmed": 1}
 
@@ -1496,12 +1501,23 @@ def test_receipt_claims_are_carried_only(receipts_on, proj):
     assert _vitni_calls(receipts_on) == []
 
 
-def test_receipt_ledger_key_absent_when_nothing_failed(receipts_on, proj):
-    # The reserved key only appears when there is something to write — the
-    # counter dict the CLI iterates stays all-ints on the happy path.
+def test_receipt_happy_path_emits_a_cure_candidate_and_all_int_counters(
+        receipts_on, proj):
+    # This asserted that the reserved key was ABSENT on the happy path, which
+    # was a proxy for the property that actually matters: the counter dict the
+    # CLI iterates stays all-ints. #839 made a confirmed receipt emit a cure
+    # candidate, so the proxy no longer holds while the property still does
+    # (the CLI pops the key before the counter loop, as this does).
+    #
+    # Emitting unconditionally is deliberate. worldcheck writes nothing to
+    # disk by contract, so it reports what it found and the write boundary
+    # decides whether a cure changes anything worth recording.
     _signed_origin("S-origin", proj)
     stats = worldcheck.check(_cp_origins(["S-origin"]), proj)
-    assert worldcheck.LEDGER_KEY not in stats
+    rows = stats.pop(worldcheck.LEDGER_KEY, ())
+    assert [(check, reason) for _ref, check, reason in rows] == [
+        (worldcheck.LEDGER_CONFIRM_CHECK, "receipt-valid")]
+    assert all(isinstance(v, int) for v in stats.values())
 
 
 def test_receipt_idless_item_yields_no_ledger_row(receipts_on, proj, monkeypatch):


### PR DESCRIPTION
Refs #839

Half 1 only. Half 2, the human ruling channel, widens the authority model #836 deliberately narrowed and is left for the ruling the issue asks for, so this PR uses `Refs` rather than `Closes`.

## What

A later confirmation now clears `invalidated_by`.

- `worldcheck` emits a cure row for a confirmed receipt-validity claim, under a separate check name (`receipt-ok`) rather than the rejection check with a passing reason.
- `store.append_receipt_cure` is the write boundary and records the row only when the item currently stands contradicted.
- `store.latest_receipt_verdicts` is one shared latest-by-ts resolution, used by both the cure gate and the recall fold.
- the fold sets the slot to NULL when the latest verdict is a confirmation.
- `verification_counts` excludes cure rows.

## Why the shape changed from the issue's sketch

The issue proposed appending a confirmation for every receipt check that passes. I measured the live ledgers before building and two things argued against that.

daimon's own `verification.jsonl` holds 463 rows across 453 distinct items, with 10 total repeats. The rejection ledger records problems FOUND and stays sparse over a project's whole life. Appending on every passing check would make it grow with work DONE instead, which is a different artifact and a much larger one, for a cure nobody needed.

`verification_counts` feeds a user-facing stat documented as "how often the checkers actually caught something here", and the CLI sums its values into a total. Confirmations under any check name inflate that total, so an unconditional write turns a problems-found counter into a work-done counter. That is the #832 defect wearing different clothes, so the check name is separate and the counter excludes it.

Also worth recording against the issue text: there are zero `receipt` rows on this machine across every bucket, so this write path has never fired here. Every existing row is a `quote` or `outcome` capture rejection.

## Design notes

worldcheck emits cure candidates unconditionally and the write boundary drops the ones that change nothing. That split keeps worldcheck's hardest contract intact, which is that it writes nothing to disk, and puts the "is this worth recording" decision where the current ledger state is already in hand.

An unknown check name decides neither verdict. A wrong invalidation fabricates distrust, a wrong cure fabricates trust, so a row this module could not have written is skipped rather than guessed at.

A duplicate cure is harmless under a race, since the fold takes the latest and both rows say the same thing, so the gate needs no lock.

## One changed assertion, stated plainly

`test_receipt_ledger_key_absent_when_nothing_failed` pinned the reserved ledger key ABSENT on the happy path. That was a proxy for the property it names in its own comment: the counter dict the CLI iterates stays all ints. A confirmed receipt now emits a cure candidate, so the proxy no longer holds while the property still does. The test now asserts the property directly, plus the new contract. Two other tests compared the whole stats dict for equality and now pop the reserved key first, exactly as the CLI does.

## Tests

Ten new tests. Six were watched failing first. The two covering the write gate and the counter exclusion were written after their implementation, so rather than claim a cycle I did not run, I removed both behaviors from `store.py`, confirmed both tests go red, and restored. A test that has never failed has not been shown to test anything.

Full suite: 4676 passed, 2 skipped. ruff clean, mypy clean.
