### PR TITLE
chore(types): clean teamproject and shrink the mypy ratchet by one

### DIFF
--- a/plugin/daimon_briefing/teamproject.py
+++ b/plugin/daimon_briefing/teamproject.py
@@ -215,8 +215,20 @@ def _candidates(project_dir) -> list[tuple[str, ...]]:
             if derived:
                 out.append(derived)
     # Tier 4: nothing resolved → [] → flat era. Dedupe preserves tier order.
+    #
+    # Spelled as a loop rather than the `not (s in seen or seen.add(s))`
+    # comprehension idiom (#842). The idiom is correct — set.add returns None,
+    # which is falsy, so the filter keeps first occurrences — but it works by
+    # relying on the return value of a call that is documented to have none,
+    # which is exactly what mypy objects to. The loop says the same thing
+    # without asking a reader to verify a falsy-None trick.
     seen: set[tuple[str, ...]] = set()
-    return [s for s in out if not (s in seen or seen.add(s))]
+    unique: list[tuple[str, ...]] = []
+    for segments in out:
+        if segments not in seen:
+            seen.add(segments)
+            unique.append(segments)
+    return unique
 
 
 # ---- #279: per-remote scope — default-closed membership for synced remotes ----

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -126,7 +126,6 @@ module = [
     "daimon_briefing.serializer",
     "daimon_briefing.skill_install",
     "daimon_briefing.store",
-    "daimon_briefing.teamproject",
     "daimon_briefing.teamsync",
     "daimon_briefing.transcript",
 ]


### PR DESCRIPTION
Refs #842

First module off the burn-down list. 28 ratchet entries left.

## What

`teamproject.logical_candidates` deduped with the `not (s in seen or seen.add(s))` comprehension idiom. Spelled as an explicit loop instead. Same order, same dedupe, nothing else touched.

The ratchet entry for `daimon_briefing.teamproject` is removed in this commit, per the burn-down rule: an entry that outlives its errors silences a module that is already passing, including the CI ReadResult containment grep inside it.

## Why this is a rewrite and not an annotation

The idiom is correct. `set.add` returns `None`, `None` is falsy, so the filter keeps first occurrences in tier order. It is correct by relying on the return value of a call documented to have none, which is what mypy objects to and what makes a reader stop to verify a falsy-None trick before trusting the line. The loop states the same intent without the trick.

## Verification

The failing test here is mypy itself. Removing the ratchet entry first produced:

```
daimon_briefing/teamproject.py:219: error: "add" of "set" does not return a value (it only ever returns None)  [func-returns-value]
Found 1 error in 1 file (checked 59 source files)
```

After the change, mypy is clean with the entry gone. Behavior preservation is the existing suite's job: 4676 passed, 2 skipped. ruff clean.

## Triage note for the rest of the tail

While picking a first module I read all 13 single-error findings. One looked like a real bug and turned out not to be, which is worth recording because the first reading was mine and it was wrong.

`serializer.py:1678` reports a missing return statement on `_call_and_parse`, which is declared to return a dict and ends with `return parsed` inside its retry loop. A run where every attempt takes a `continue` would fall off the end and hand `None` to a caller expecting a dict.

It cannot happen. All three `continue` statements are guarded by `_can_retry()`, which is false on the final attempt, so the last attempt raises rather than continuing. The only way to exit the loop without returning is `attempts < 1`, which needs `parse_retries < 0`, and no caller passes the parameter at all: all four call sites take the default of 1.

So it is an invariant mypy cannot prove rather than a defect, and it belongs in the burn-down after all, with an explicit terminal raise that states the invariant instead of leaving the function implicitly partial. No separate issue is warranted.
