### PR TITLE
chore(types): make _call_and_parse total and shrink the mypy ratchet by one

### DIFF
--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -1811,6 +1811,16 @@ def _call_and_parse(chat, system, user_content, deadline, what: str,
                 f"model output on {what} is not a JSON object after {attempt} attempts"
             )
         return parsed
+    # Unreachable while attempts >= 1, which holds for every caller: all four
+    # call sites take the default parse_retries=1, and each `continue` above
+    # is guarded by _can_retry(), which is false on the final attempt so that
+    # attempt raises instead of looping. Stated rather than left implicit
+    # (#842): the annotation promises a dict, and a function that can fall off
+    # its own loop and hand back None promises something it does not keep.
+    # A negative parse_retries is the only way here, and it is a caller bug,
+    # so it fails loudly rather than returning None into a dict-shaped hole.
+    raise LLMCallError(
+        f"LLM call on {what} ran no attempts (parse_retries={parse_retries})")
 
 
 def _plan_waves(n_chunks: int, workers: int, k: int) -> int:

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -123,7 +123,6 @@ module = [
     "daimon_briefing.render",
     "daimon_briefing.requests",
     "daimon_briefing.schema",
-    "daimon_briefing.serializer",
     "daimon_briefing.skill_install",
     "daimon_briefing.store",
     "daimon_briefing.teamproject",

--- a/plugin/tests/test_serializer.py
+++ b/plugin/tests/test_serializer.py
@@ -691,6 +691,24 @@ def test_serialize_parse_retry_skipped_when_deadline_exhausted():
 # --- #225: command-backend empty output retries like an empty 200 body ------
 
 
+def test_call_and_parse_never_returns_none_from_a_zero_attempt_loop(
+        fake_chat_factory):
+    # #842: the function is annotated to return a dict and its only `return`
+    # sits INSIDE the retry loop, so a loop that runs zero times fell off the
+    # end and handed None to a caller expecting a dict.
+    #
+    # Unreachable for every real caller: all four take the default
+    # parse_retries=1, and each `continue` is guarded by _can_retry(), which
+    # is false on the final attempt so that attempt raises. A negative
+    # parse_retries is the only route, and it is a caller bug, so it fails
+    # loudly rather than returning None into a dict-shaped hole.
+    chat = fake_chat_factory(['{"ok": 1}'])
+    with pytest.raises(serializer.LLMCallError):
+        serializer._call_and_parse(chat, "sys", "user", None, "a-thing",
+                                   parse_retries=-1)
+    assert chat.calls == []  # no attempt was ever made, which is the point
+
+
 def test_call_and_parse_retries_empty_output_error_once(fake_chat_factory, caplog):
     # rc=0 + empty stdout raises llm.EmptyOutputError instead of parsing to
     # nothing — it must get the SAME cache-buster retry treatment as an


### PR DESCRIPTION
Refs #842

Second module off the burn-down list. 27 ratchet entries left.

Depends on nothing in #846; the two touch different modules and different ratchet lines.

## What

`_call_and_parse` is annotated to return a dict and its only `return` sits inside the retry loop, so a loop that runs zero times fell off the end and handed `None` to a caller expecting a dict. The function now raises on that path instead.

## Why this is a chore and not a bug fix

I first read this as a live defect and it is not, which is worth stating because the first reading was mine.

All three `continue` statements are guarded by `_can_retry()`, which is false on the final attempt, so the last attempt raises rather than looping. The only remaining route out of the loop without returning is `attempts < 1`, which needs `parse_retries < 0`. No caller passes the parameter at all: the four call sites take the default of 1.

That makes it an invariant mypy cannot prove rather than a hole in behavior. The fix states the invariant instead of leaving the function implicitly partial, and a negative `parse_retries` now fails loudly rather than returning `None` into a dict-shaped hole, since that would be a caller bug worth hearing about.

## Verification

Removing the ratchet entry first produced:

```
daimon_briefing/serializer.py:1678: error: Missing return statement  [return]
Found 1 error in 1 file (checked 59 source files)
```

The new test pins the invariant and was verified the hard way: the terminal raise was removed and the test re-run, which fails with DID NOT RAISE. A test for an unreachable path is worth nothing unless you have watched it fail.

Full suite: 4677 passed, 2 skipped. mypy clean with the entry gone, ruff clean.
