### PR TITLE
chore(types): make _truncate_agent_claim's signature honest, shrinking the ratchet by two

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -114,7 +114,12 @@ def corroboration_badge(item) -> str:
 _AGENT_CLAIM_EVIDENCE_CHARS = 120
 
 
-def _truncate_agent_claim(evidence: str) -> str:
+def _truncate_agent_claim(evidence: str | None) -> str:
+    # The annotation was the lie, not the callers (#842). Every call site
+    # feeds this a `.get()` result, and the body has always coped with a
+    # missing one through `or ""` — an absent claim renders as empty, which is
+    # the behavior three render paths depend on. Declaring `str` described a
+    # contract the function never enforced and no caller ever kept.
     text = str(evidence or "").strip()
     if len(text) <= _AGENT_CLAIM_EVIDENCE_CHARS:
         return text

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -101,10 +101,8 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
     "daimon_briefing.amendments",
-    "daimon_briefing.briefing",
     "daimon_briefing.carry",
     "daimon_briefing.cli",
-    "daimon_briefing.cli.amend",
     "daimon_briefing.cli.hooks",
     "daimon_briefing.cli.lifecycle",
     "daimon_briefing.cli.refute",

--- a/plugin/tests/test_briefing.py
+++ b/plugin/tests/test_briefing.py
@@ -1192,3 +1192,21 @@ def test_render_never_prints_scene():
     }
     out = briefing.render(cp)
     assert "SCENE-MARKER-NEVER-RENDERED" not in out
+
+
+def test_truncate_agent_claim_renders_an_absent_claim_as_empty():
+    # #842: the annotation said `str` while every call site fed it a `.get()`
+    # result. Widening it to `str | None` makes the signature honest, and this
+    # pins the behavior that makes the widening safe: an absent claim renders
+    # as empty rather than as the string "None", which is what three render
+    # paths have always relied on.
+    assert briefing._truncate_agent_claim(None) == ""
+    assert briefing._truncate_agent_claim("") == ""
+    assert briefing._truncate_agent_claim("  spaced  ") == "spaced"
+
+
+def test_truncate_agent_claim_caps_a_long_claim_with_an_ellipsis():
+    long_claim = "x" * (briefing._AGENT_CLAIM_EVIDENCE_CHARS + 50)
+    out = briefing._truncate_agent_claim(long_claim)
+    assert len(out) == briefing._AGENT_CLAIM_EVIDENCE_CHARS + 1
+    assert out.endswith("…")


### PR DESCRIPTION
Refs #842

Third slice. Ratchet down to 25.

## Why this one pairs two modules

The burn-down plan says one PR per module and this is the case it does not fit. `briefing.py:240` and `cli/amend.py:126` are the same finding from the same root: both pass a `.get()` result into `briefing._truncate_agent_claim`. One annotation fixes both, so splitting them would have put the fix in one PR and its reasoning in the other, and left whichever merged second looking unmotivated.

## What

`_truncate_agent_claim` was annotated to take a `str`. All five call sites feed it a `.get()` result, and the body has always coped through `or ""`, so an absent claim renders as empty. The annotation described a contract the function never enforced and no caller ever kept.

Widened to `str | None`, which is the type it always accepted in practice. `object` would also silence mypy but would claim it takes anything; `str | None` says what it means, a claim string that may be absent.

No behavior change.

## Verification

Removing both ratchet entries first produced:

```
daimon_briefing/briefing.py:240: error: Argument 1 to "_truncate_agent_claim" has incompatible type "Any | None"; expected "str"  [arg-type]
daimon_briefing/cli/amend.py:126: error: Argument 1 to "_truncate_agent_claim" has incompatible type "Any | None"; expected "str"  [arg-type]
Found 2 errors in 2 files (checked 59 source files)
```

The `None` contract that makes the widening safe had no direct test, which is why the annotation could stay wrong. It has one now, verified by removing the `or ""` and watching it render the string "None" into a briefing.

Full suite: 4678 passed, 2 skipped. mypy clean with both entries gone, ruff clean.
