### PR TITLE
chore(types): guard the container the delete touches, shrinking the ratchet by one

### DIFF
--- a/plugin/daimon_briefing/policy.py
+++ b/plugin/daimon_briefing/policy.py
@@ -140,15 +140,21 @@ def scrub_forgotten_payload(checkpoint: dict,
         if len(kept) != len(lst):
             block[key] = kept
             changed = True
+    # The dict guard leads (#842). It was expressed on `topic`, which implies
+    # the same thing to a reader (topic is non-None only when wc is a dict)
+    # but not to a checker, so the `del wc[...]` below read as a delete on a
+    # possible None. Guarding the container the delete actually touches is
+    # both provable and the narrower claim.
     wc = checkpoint.get("working_context")
-    topic = wc.get("active_topic") if isinstance(wc, dict) else None
-    if isinstance(topic, dict):
-        if normalize.content_key(topic.get("text") or "") in forgotten_keys:
-            del wc["active_topic"]
-            dropped.append(topic)
-            changed = True
-        elif scrub_forgotten_fields(topic, forgotten_keys):
-            changed = True
+    if isinstance(wc, dict):
+        topic = wc.get("active_topic")
+        if isinstance(topic, dict):
+            if normalize.content_key(topic.get("text") or "") in forgotten_keys:
+                del wc["active_topic"]
+                dropped.append(topic)
+                changed = True
+            elif scrub_forgotten_fields(topic, forgotten_keys):
+                changed = True
     return dropped, changed
 
 

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -114,7 +114,6 @@ module = [
     "daimon_briefing.inspector",
     "daimon_briefing.ledger",
     "daimon_briefing.pending",
-    "daimon_briefing.policy",
     "daimon_briefing.privacy",
     "daimon_briefing.provenance",
     "daimon_briefing.recall",


### PR DESCRIPTION
Refs #842

Fourth slice. Independent of #848; different module, non-adjacent ratchet line.

## What

`drop_forgotten` guarded on `topic` and then deleted from `wc`:

```python
wc = checkpoint.get("working_context")
topic = wc.get("active_topic") if isinstance(wc, dict) else None
if isinstance(topic, dict):
    ...
    del wc["active_topic"]
```

The isinstance check now leads on `wc`, with the `topic` check nested inside it. Same branches, same behavior.

## Why

The two guards are equivalent to a reader: `topic` is non-None only when `wc` is a dict. But that reasoning lives in a conditional expression on the line above rather than in the type, so `del wc["active_topic"]` reads as a delete on a possible None, which is what mypy reported.

Guarding the container the delete actually touches is the narrower claim as well as the provable one. The old form asserted something about `topic` and relied on the reader to carry it back to `wc`.

## Verification

Removing the ratchet entry first produced:

```
daimon_briefing/policy.py:147: error: Item "None" of "Any | None" has no attribute "__delitem__"  [union-attr]
Found 1 error in 1 file (checked 59 source files)
```

Behavior preservation is the existing suite's job, and this function is well covered by the forget and privacy-audit tests: 4676 passed, 2 skipped. mypy clean with the entry gone, ruff clean.
