### PR TITLE
chore(types): annotate the optional fcntl import, shrinking the ratchet by one

### DIFF
--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -35,6 +35,7 @@ import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
+from types import ModuleType
 
 from . import config, normalize, policy, receipts, redact, schema, serializer, teamproject
 
@@ -90,6 +91,11 @@ _LOCK_NAME = ".pointer.lock"   # dotfile: invisible to _session_files (.json
 _LOCK_TRIES = 50               # x 20ms = ~1s bounded wait, then fail open
 _LOCK_INTERVAL = 0.02
 
+# Annotated before the import (#842): the try branch alone infers a Module, so
+# the except branch's None reads as a type error rather than as the degrade it
+# is. The annotation states the actual contract, which every use site already
+# honors with an `if _fcntl` guard.
+_fcntl: ModuleType | None
 try:
     import fcntl as _fcntl
 except ImportError:            # non-POSIX: lock degrades to a no-op

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -125,7 +125,6 @@ module = [
     "daimon_briefing.schema",
     "daimon_briefing.serializer",
     "daimon_briefing.skill_install",
-    "daimon_briefing.store",
     "daimon_briefing.teamsync",
     "daimon_briefing.transcript",
 ]


### PR DESCRIPTION
Refs #842

Fifth slice. Independent of the other open burn-down PRs; different module, non-adjacent ratchet line.

## What

`store` degrades its pointer lock to a no-op on non-POSIX hosts:

```python
try:
    import fcntl as _fcntl
except ImportError:            # non-POSIX: lock degrades to a no-op
    _fcntl = None
```

The try branch alone infers `Module`, so the except branch's `None` reads as an incompatible assignment. Annotated as `ModuleType | None` before the import.

## Why an annotation rather than a restructure

There is nothing wrong with the code. The optional-import-with-None-fallback is the standard shape for a capability that may not exist on a host, and every use site already guards with `if _fcntl`. The type simply could not see the fallback, so the annotation states the contract the guards already keep.

Worth noting what this does NOT do: it does not add a guard, change the degrade, or touch the lock. A silent behavior change inside a chore PR is the thing the burn-down rules exist to prevent, and this one carries none.

## Verification

Removing the ratchet entry first produced:

```
daimon_briefing/store.py:96: error: Incompatible types in assignment (expression has type "None", variable has type Module)  [assignment]
Found 1 error in 1 file (checked 59 source files)
```

Full suite: 4676 passed, 2 skipped. mypy clean with the entry gone, ruff clean.
