### PR TITLE
chore(types): annotate the codex path accumulator, shrinking the ratchet by one

### DIFF
--- a/plugin/daimon_briefing/provenance.py
+++ b/plugin/daimon_briefing/provenance.py
@@ -312,7 +312,7 @@ class SourceResolver:
                 return list(self._indexes[host].get(sid, ()))
             if host == "codex":
                 if host not in self._indexes:
-                    paths = []
+                    paths: list[Path] = []
                     for root in self._roots(host) or ():
                         if root.exists():
                             paths.extend(root.rglob("*.jsonl"))

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -116,7 +116,6 @@ module = [
     "daimon_briefing.pending",
     "daimon_briefing.policy",
     "daimon_briefing.privacy",
-    "daimon_briefing.provenance",
     "daimon_briefing.recall",
     "daimon_briefing.refutations",
     "daimon_briefing.relations",


### PR DESCRIPTION
Refs #842

Sixth slice. Independent of the other open burn-down PRs.

## What

`SourceResolver._transcripts` accumulates codex transcript paths into a list built empty and filled by `rglob`, so there was nothing at the assignment for mypy to infer an element type from. Annotated `list[Path]`.

## Why that type

`Path` is what both ends already agree on: `root.rglob("*.jsonl")` yields `Path`, and `_build_index` consumes paths the same way the claude-code branch's `glob` result does. The annotation records the agreement rather than introducing one.

Annotation only. No behavior change, no new guard.

## Verification

Removing the ratchet entry first produced:

```
daimon_briefing/provenance.py:315: error: Need type annotation for "paths" (hint: "paths: list[<type>] = ...")  [var-annotated]
Found 1 error in 1 file (checked 59 source files)
```

Full suite: 4676 passed, 2 skipped. mypy clean with the entry gone, ruff clean.
