### PR TITLE
chore(types): enforce the carried-field scoring invariant, shrinking the ratchet by one

### DIFF
--- a/plugin/daimon_briefing/schema.py
+++ b/plugin/daimon_briefing/schema.py
@@ -59,8 +59,17 @@ KIND_SOURCES: tuple[tuple[str, str, str], ...] = tuple(
     (f.section, f.key, f.kind) for f in ITEM_FIELDS)
 
 # (section, key, scoring TYPE_RULES type) — carry's view: carried fields only.
+#
+# Filters on scoring_type as well as carries (#842). Every carried field has
+# one today and the field table is the single source that decides, but the
+# filter previously trusted an invariant nothing enforced: a carried field
+# added without a scoring type would have put None into a tuple typed str,
+# and carry would have used it as a TYPE_RULES key and silently fallen back
+# to the default rules. The invariant is now pinned by test, so this filter
+# can never quietly DROP a field either.
 CARRIED_KINDS: tuple[tuple[str, str, str], ...] = tuple(
-    (f.section, f.key, f.scoring_type) for f in ITEM_FIELDS if f.carries)
+    (f.section, f.key, f.scoring_type) for f in ITEM_FIELDS
+    if f.carries and f.scoring_type)
 
 # recall index kind -> scoring.TYPE_RULES key (#78 composition). Kinds without
 # dedicated rules (contradiction) are absent; lookups .get their own default.

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -122,7 +122,6 @@ module = [
     "daimon_briefing.relations",
     "daimon_briefing.render",
     "daimon_briefing.requests",
-    "daimon_briefing.schema",
     "daimon_briefing.serializer",
     "daimon_briefing.skill_install",
     "daimon_briefing.store",

--- a/plugin/tests/test_field_table.py
+++ b/plugin/tests/test_field_table.py
@@ -585,3 +585,19 @@ def test_published_artifact_matches_the_table():
         "`uv run python -m daimon_briefing.field_table` from plugin/")
     expected = field_table.render_document(serializer.PROMPT_VERSION)
     assert _ARTIFACT.read_text(encoding="utf-8") == expected
+
+
+def test_every_carried_field_declares_a_scoring_type():
+    """#842: carry keys its TYPE_RULES lookup off CARRIED_KINDS, so a carried
+    field with no scoring type would silently score under the default rules
+    rather than its own. The old comprehension trusted that invariant without
+    enforcing it and would have shipped a None inside a tuple typed str; the
+    new one filters on scoring_type, which makes the same field vanish from
+    carry instead. Both failure modes are silent, so the invariant is pinned
+    here rather than left to whichever of them happens to bite first."""
+    missing = [f.key for f in schema.ITEM_FIELDS if f.carries and not f.scoring_type]
+    assert missing == [], (
+        f"carried field(s) {missing} declare no scoring_type; either give them "
+        f"one in the field table or stop carrying them")
+    # and the derived view agrees, so the filter cannot be silently dropping one
+    assert len(schema.CARRIED_KINDS) == sum(1 for f in schema.ITEM_FIELDS if f.carries)


### PR DESCRIPTION
Refs #842

Seventh slice, and the first where the finding pointed at something real rather than only at a missing annotation.

## What mypy actually found

`CARRIED_KINDS` is typed `(str, str, str)` and was filtered on `carries` alone, while `scoring_type` is optional on the field table:

```python
CARRIED_KINDS: tuple[tuple[str, str, str], ...] = tuple(
    (f.section, f.key, f.scoring_type) for f in ITEM_FIELDS if f.carries)
```

I checked the live table before touching it. All three carried fields declare a scoring type, and the only field without one, `contradictions_flagged`, does not carry. So the tuple is well formed today.

Nothing enforced that. A carried field added without a scoring type would have put `None` into a slot typed `str`, and carry keys its `TYPE_RULES` lookup off this view, so that field would have scored under the default rules instead of its own. Silently, because a missing key resolves to a default rather than raising.

## Why the filter alone was not enough

Filtering on `scoring_type` makes the comprehension provable, but on its own it trades one silent failure for another: the offending field would vanish from carry entirely instead of mis-scoring. Neither failure announces itself.

So the invariant is pinned by a test rather than left to whichever failure happens to bite first: every carried field declares a scoring type, and the derived view holds exactly as many entries as there are carried fields, so the filter cannot be quietly dropping one.

## Verification

Removing the ratchet entry first produced:

```
daimon_briefing/schema.py:63: error: Generator has incompatible item type "tuple[str, str, str | None]"; expected "tuple[str, str, str]"  [misc]
Found 1 error in 1 file (checked 59 source files)
```

The new test was verified by flipping `uncertainties` to a null scoring type in the field table and watching it fail, then restoring. An invariant test that has never failed has not been shown to hold anything.

No behavior change today: the field table is untouched and all three carried fields keep their types. Full suite: 4677 passed, 2 skipped. mypy clean with the entry gone, ruff clean.
