### PR TITLE
chore(types): guard the OR fallback on emptiness, shrinking the ratchet by one

### DIFF
--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -950,7 +950,13 @@ def search(query: str, project_dir=None, all_projects: bool = False,
         rows = _run(expr)
         if not rows:
             or_expr = _match_expr(query, " OR ")
-            if or_expr != expr:  # differs only when there are >=2 tokens
+            # Truthiness, not just inequality (#842): _match_expr answers None
+            # when nothing searchable remains, and `or_expr != expr` is true
+            # for None as well, so the old guard would have handed None to the
+            # query. Unreachable, because emptiness depends on the tokens
+            # rather than the join and the AND form above already answered
+            # non-None for this same query, but the guard never said so.
+            if or_expr and or_expr != expr:  # differs only when >=2 tokens
                 rows = _run(or_expr)
         return _dedupe_rows(rows, want_n)
 

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -113,7 +113,6 @@ module = [
     "daimon_briefing.ledger",
     "daimon_briefing.pending",
     "daimon_briefing.privacy",
-    "daimon_briefing.recall",
     "daimon_briefing.refutations",
     "daimon_briefing.relations",
     "daimon_briefing.render",


### PR DESCRIPTION
Refs #842

Eighth slice. Non-adjacent ratchet line, so it merges independently of the others.

## What

`search`'s #25 OR fallback guarded the retry with `or_expr != expr`:

```python
or_expr = _match_expr(query, " OR ")
if or_expr != expr:  # differs only when there are >=2 tokens
```

`_match_expr` returns `str | None`, and `None != expr` is true, so that guard would have handed `None` into the FTS5 query. Now guarded on truthiness, which is what emptiness means here.

## Is it reachable

No, and the reason is worth stating rather than assuming.

`_match_expr` answers `None` only when `query.split()` yields no tokens. That depends on the tokens, not on the join operator, so the OR form is `None` exactly when the AND form is. `search` returns early when the AND form is `None`, so by the time the fallback runs the query has tokens and both forms are non-None.

The comment on that line explains what the inequality is FOR, which is skipping a pointless second query for a single-token search. It was never about None, and the type is what noticed.

## Verification

Removing the ratchet entry first produced:

```
daimon_briefing/recall.py:954: error: Argument 1 to "_run" has incompatible type "str | None"; expected "str"  [arg-type]
Found 1 error in 1 file (checked 59 source files)
```

Same branches for every reachable input, so behavior preservation is the existing suite's job, and search is heavily covered: 4680 passed, 2 skipped. mypy clean with the entry gone, ruff clean.
