### PR TITLE
chore(types): make valid_session_id a TypeGuard, shrinking the ratchet by one

### DIFF
--- a/plugin/daimon_briefing/provenance.py
+++ b/plugin/daimon_briefing/provenance.py
@@ -17,6 +17,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from typing import TypeGuard
 
 
 SOURCE_REF_VERSION = 1
@@ -42,8 +43,14 @@ class SourceResolution:
     path: Path | None = None
 
 
-def valid_session_id(value) -> bool:
-    """Bounded, glob/path-safe host session identifier."""
+def valid_session_id(value) -> TypeGuard[str]:
+    """Bounded, glob/path-safe host session identifier.
+
+    A TypeGuard rather than a plain bool (#842): the body already establishes
+    `isinstance(value, str)`, and every caller reads a session id out of an
+    untyped checkpoint dict and passes it straight into something that wants
+    a str. Returning bool made each of those call sites re-prove, or skip
+    proving, what this function had just checked."""
     return isinstance(value, str) and _SESSION_RE.fullmatch(value) is not None
 
 

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -109,7 +109,6 @@ module = [
     "daimon_briefing.cli.request",
     "daimon_briefing.cli.ruling",
     "daimon_briefing.cli.skill",
-    "daimon_briefing.inspector",
     "daimon_briefing.ledger",
     "daimon_briefing.pending",
     "daimon_briefing.privacy",


### PR DESCRIPTION
Refs #842

Ninth slice. Non-adjacent ratchet line.

## What

`_legacy_source` reads `origin_session` out of an untyped item dict, validates it, and passes it to `store.read_checkpoint`, which wants a `str`:

```python
session_id = item.get("origin_session")
if not provenance.valid_session_id(session_id):
    return None
origin = store.read_checkpoint(session_id)
```

`valid_session_id` is now declared `TypeGuard[str]`.

## Why at the validator rather than the call site

The validator's body is `isinstance(value, str) and _SESSION_RE.fullmatch(value) is not None`. It already establishes the thing the caller needs; returning `bool` threw that away at the boundary, so every caller had to re-prove it or skip proving it.

An assert or a cast at this one call site would have silenced the same error while leaving the other six calls in the same position, and leaving the next caller to make the same choice. Declaring what the function has always proved fixes the class.

`TypeGuard` is typing-only. The returned value is unchanged, and the runtime behavior of all seven call sites is identical.

## Verification

Removing the ratchet entry first produced:

```
daimon_briefing/inspector.py:93: error: Argument 1 to "read_checkpoint" has incompatible type "Any | None"; expected "str"  [arg-type]
Found 1 error in 1 file (checked 59 source files)
```

Full suite: 4680 passed, 2 skipped. mypy clean with the entry gone, ruff clean.

Note this touches `provenance.py`, whose own ratchet entry was already removed in #851, so the file stays checked either way.
