### PR TITLE
chore(types): type the hook host table per key, shrinking the ratchet by one

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -30,6 +30,7 @@ import time
 import traceback
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import TypedDict
 
 from .. import amendments, anchor, briefing, capture, carry, config, configure, harvest, inspector, ledger, llm, normalize, privacy, provenance, recall, receipts, redact, refutations, relations, render, requests, schema, serializer, store, teamsync, transcript, worldcheck  # noqa: F401 — several are re-exported for compat only (#708): `cli.<name>` is a stable seam
 from .. import __version__
@@ -2743,7 +2744,22 @@ def _cmd_stats(args) -> int:
 # copies live in daimon_briefing/_hooks/ and are drift-guarded against the
 # repo's hook/ dir by tests/test_hooks_install.py. Claude Code is absent on
 # purpose: the plugin marketplace owns that path.
-_HOOK_HOSTS = {
+class _HookHostSpec(TypedDict, total=False):
+    """Per-key types for the hook host table (#842).
+
+    A plain dict literal types this as a mapping to "tuple or str", so
+    `spec["files"]` came out as a union and `pkg / name` read as dividing a
+    Path by a sequence. The keys genuinely differ in type and genuinely differ
+    in presence (codex carries `register` and no `entry`), which is what a
+    TypedDict says and a value-type union cannot."""
+
+    files: tuple[str, ...]
+    entry: str
+    events: tuple[str, ...]
+    register: str
+
+
+_HOOK_HOSTS: dict[str, _HookHostSpec] = {
     "windsurf": {
         # redact.py ships alongside the scripts so the standalone hooks can
         # scrub secrets at their write sites (#109) without importing the

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -103,7 +103,6 @@ module = [
     "daimon_briefing.amendments",
     "daimon_briefing.carry",
     "daimon_briefing.cli",
-    "daimon_briefing.cli.hooks",
     "daimon_briefing.cli.lifecycle",
     "daimon_briefing.cli.refute",
     "daimon_briefing.cli.request",


### PR DESCRIPTION
Refs #842

Eleventh slice. Non-adjacent ratchet line.

## What

`_HOOK_HOSTS` maps a host to a spec whose keys genuinely differ in type and in presence:

- `files` and `events` are tuples of strings
- `entry` and `register` are strings
- codex carries `register` and no `entry`; windsurf carries `entry` and no `register`

A dict literal collapses all of that into a mapping to "tuple or str", so `spec["files"]` came out as a union and `(pkg / name)` read as dividing a `Path` by a `Sequence[str]`.

Declared as a `TypedDict` with `total=False`, which is the one construct that states both the per-key types and the optionality. The table itself is unchanged.

## Same defect family as #855

That PR split a read cap out of the host scope table because one mapping was answering two questions. This one keeps the mapping and names the questions instead, because here the keys are a genuine record rather than an accidental mixture: every hook host has files and events, and the differences are real per-host facts rather than a scalar that wandered in.

## One thing worth flagging

The definition lives in `cli/__init__.py`, which is still on the ratchet at 34 errors, so this change is unchecked where it is written and load-bearing where it is read in `cli/hooks.py`. That is the ratchet behaving as designed rather than a gap: `ignore_errors` suppresses diagnostics reported inside a module, and the types it exports still flow out of it.

## Verification

Removing the ratchet entry first produced:

```
daimon_briefing/cli/hooks.py:50: error: Unsupported operand types for / ("Path" and "Sequence[str]")  [operator]
Found 1 error in 1 file (checked 59 source files)
```

Full suite: 4680 passed, 2 skipped. mypy clean with the entry gone, ruff clean.
