### PR TITLE
fix(request): revise survives its record vanishing between two reads

### DIFF
--- a/plugin/daimon_briefing/cli/request.py
+++ b/plugin/daimon_briefing/cli/request.py
@@ -304,7 +304,21 @@ def _cmd_request_revise(args) -> int:
         print(f"request not revised: {exc}")
         return 1
     _cli._note_usage("request:revise")
+    # #857: `revise()` above read the record through _require, and this is a
+    # SECOND read. A writer between the two makes it None, and rendering a
+    # card from None dies inside render_state rather than saying anything.
+    # Both sibling paths already handle this; only revise did not.
+    #
+    # The revision itself landed before the record went, so the line reports
+    # that. Saying nothing, or failing, would describe the wrong half of what
+    # happened.
     record = requests.get(args.request_id, project_dir=project)
+    if record is None:
+        render.render_ledger_lines(
+            [f"{args.request_id}: revision recorded in this project's ledger",
+             "  the record is not readable from this bucket right now — the "
+             "revision is on the ledger and renders with the request"])
+        return 0
     render.render_ledger_lines(_request_lines(record, project_dir=project))
     return 0
 

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -106,7 +106,6 @@ module = [
     "daimon_briefing.cli.hooks",
     "daimon_briefing.cli.lifecycle",
     "daimon_briefing.cli.refute",
-    "daimon_briefing.cli.request",
     "daimon_briefing.cli.ruling",
     "daimon_briefing.cli.skill",
     "daimon_briefing.inspector",

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -2440,3 +2440,43 @@ def test_inject_names_the_verdict_it_withheld(project, capsys, monkeypatch):
     assert _inject(project) == 0
     out = capsys.readouterr().out
     assert "+2 more decided" in out, out
+
+
+def test_cli_revise_survives_the_record_vanishing_between_its_two_reads(
+        project, recipient, monkeypatch, capsys):
+    """#857: revise re-reads the record it just revised and rendered it
+    without the None check both sibling paths already have.
+
+    `revise()` reads once through `_require`, the CLI reads again to render
+    the card, and `requests.get` answers `dict | None`. A concurrent writer
+    between those two reads made the second answer None, and `_request_lines`
+    calls `.get()` on its first line, so the command died with an
+    AttributeError instead of saying the revision landed.
+
+    The revision itself SUCCEEDED in that window, so the command must report
+    that rather than implying it failed. `request open` and the verdict verbs
+    both already do exactly this; only revise omitted it.
+    """
+    from daimon_briefing import cli
+
+    assert _cli_open(project, recipient) == 0
+    q_id = next(iter(requests.records(project_dir=project)))
+
+    real_get = requests.get
+    reads = {"n": 0}
+
+    def vanishes_after_the_first_read(*args, **kwargs):
+        # Call 1 is revise's own _require; call 2 is the CLI's re-read.
+        reads["n"] += 1
+        return real_get(*args, **kwargs) if reads["n"] == 1 else None
+
+    monkeypatch.setattr(requests, "get", vanishes_after_the_first_read)
+
+    rc = cli.main(["request", "revise", q_id, "--ask", "sharpened ask text",
+                   "--by", "agent", "--project", project])
+
+    assert reads["n"] >= 2, "the CLI must re-read, or this test proves nothing"
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert q_id in out
+    assert "Traceback" not in out


### PR DESCRIPTION
Closes #857
Refs #842

## What

`_cmd_request_revise` re-read the record it had just revised and rendered it with no check for absence:

```python
record = requests.get(args.request_id, project_dir=project)   # dict | None
render.render_ledger_lines(_request_lines(record, project_dir=project))
```

It now renders a recorded line when the record does not resolve, matching what its two siblings already do.

## Why it is a defect and not a narrowing

`revise()` reads the record once through `_require`, and this is a second read. `requests.get` answers `dict | None`, so a writer between the two reads makes the second answer None. Concurrent sessions writing one bucket is a case this project already treats as real (#811, #812, #814).

Both sibling paths in the same file handle it. `request open` renders `_request_lines(record) if record else [f"request {q_id} recorded"]`. The verdict verbs check `if record is None:` explicitly and explain why the record may be unreadable from this bucket. Only revise omitted it, so the one path that could crash was the one nobody would predict from reading the other two.

The revision itself lands before the record goes, so the message says so. Reporting failure, or saying nothing, would describe the wrong half of what happened.

## The crash is one frame deeper than it looks

Worth recording, because it changes where a reader would go looking. The traceback does not come from `_request_lines`, which takes the record. It comes from `requests.render_state` at `requests.py:1040`, the first thing `_request_lines` calls:

```
E       AttributeError: 'NoneType' object has no attribute 'get'
daimon_briefing/requests.py:1040: AttributeError
```

## Provenance

Found while burning down the mypy ratchet. `daimon_briefing.cli.request` had exactly one reported error and it was this line:

```
daimon_briefing/cli/request.py:308: error: Argument 1 to "_request_lines" has incompatible type "dict[Any, Any] | None"; expected "dict[Any, Any]"  [arg-type]
```

A narrowing assert would have satisfied the checker and kept the crash, which is why it was held back for its own issue and its own failing test rather than swept into a chore PR. The ratchet entry is removed here, now that the finding is genuinely gone rather than silenced.

## Tests

One new test, watched failing first with the AttributeError above. It patches `requests.get` to answer truthfully once and None afterwards, which is a faithful simulation: `revise()` was measured to call `get` exactly once, so call one is its `_require` and call two is the CLI re-read. The test asserts the read actually happened twice, because a simulation that never reaches the second read would pass against the unfixed code.

Full suite: 4681 passed, 2 skipped. mypy clean with the entry gone, ruff clean.
