### PR TITLE
chore(types): finish the provenance TypeGuards, shrinking the ratchet by one

### DIFF
--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -350,7 +350,7 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
         generic = _generic_terms(
             [str(i.get("text") or "") for i in native if isinstance(i, dict)]
             + [str(i.get("text") or "") for i in prev_items if isinstance(i, dict)])
-        carried = []
+        carried: list[dict] = []
         for item in prev_items:
             if not isinstance(item, dict) or not str(item.get("text") or "").strip():
                 continue

--- a/plugin/daimon_briefing/provenance.py
+++ b/plugin/daimon_briefing/provenance.py
@@ -151,7 +151,10 @@ def capture_source_ref(session_id: str, transcript_path=None, *, author=None,
     return source
 
 
-def valid_source_ref(value) -> bool:
+def valid_source_ref(value) -> TypeGuard[dict]:
+    """A TypeGuard for the same reason valid_session_id is one (#842): the
+    body opens with isinstance(value, dict), and every caller reads a source
+    ref out of an untyped checkpoint and then subscripts it."""
     if not isinstance(value, dict) or value.get("version") != SOURCE_REF_VERSION:
         return False
     if value.get("host") not in _HOSTS or value.get("locator") not in _LOCATORS:
@@ -218,7 +221,11 @@ def quote_receipt(source_ref, digest, *, outcome: str, checked_at: str,
     return receipt if valid_quote_receipt(receipt) else None
 
 
-def valid_quote_receipt(value) -> bool:
+def valid_quote_receipt(value) -> TypeGuard[dict]:
+    """A TypeGuard, matching the two validators above (#842). carry's
+    _capture_verified is the case that shows why: it calls this and then
+    immediately reads receipt["outcome"], which only holds because this
+    function proved the dict and then discarded the proof at its return."""
     if not isinstance(value, dict) or value.get("version") != QUOTE_PROVENANCE_VERSION:
         return False
     if not valid_source_ref(value.get("source")):

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -101,7 +101,6 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
     "daimon_briefing.amendments",
-    "daimon_briefing.carry",
     "daimon_briefing.cli",
     "daimon_briefing.cli.lifecycle",
     "daimon_briefing.cli.refute",


### PR DESCRIPTION
Refs #842

Twelfth slice. Ratchet 16 to 15.

## What

Two findings in `carry`, one of which was not really carry's.

`_capture_verified` calls `provenance.valid_quote_receipt(receipt)` and then reads `receipt["outcome"]`:

```python
receipt = item.get("quote_provenance")
if provenance.valid_quote_receipt(receipt):
    return receipt["outcome"] == "verified"
```

That is only safe because the validator's first line is `isinstance(value, dict)`. Returning `bool` threw the proof away at the boundary, so the subscript on the next line looked unfounded.

`valid_quote_receipt` and `valid_source_ref` now declare `TypeGuard[dict]`, finishing what #854 started with `valid_session_id`. Ten call sites read the receipt validator.

carry's second finding is an accumulator with nothing at its assignment to infer an element type from; annotated `list[dict]`.

## Why at the validators again

Same reasoning as #854, and the repeat is the point. An assert or a cast in `_capture_verified` would have silenced this one site and left the other nine callers exactly where they were, waiting to be silenced one at a time. The provenance validators are the boundary where untyped checkpoint data becomes trusted, so that is where the proof belongs.

This is now the second module whose finding dissolved at a validator rather than at its own call site, which suggests the remaining `union-attr` and `arg-type` counts are smaller than they look.

## Measured effect

Removing all overrides and counting: 183 findings before, 181 after. Two disappeared, both in carry, so the TypeGuards did not accidentally paper over anything elsewhere.

## Verification

Full suite: 4681 passed, 2 skipped. mypy clean with the entry gone, ruff clean.

`provenance` and `inspector` are already off the ratchet, so both are checked at the point this change is written as well as where it is read.
