### PR TITLE
fix(cli): report a ruling or refutation whose record vanishes before its render

### DIFF
--- a/plugin/daimon_briefing/cli/_ledger.py
+++ b/plugin/daimon_briefing/cli/_ledger.py
@@ -12,6 +12,46 @@ import sys
 from .. import refutations, render
 
 
+def _report_vanished_write(record_id: str, verb: str, *,
+                           as_json: bool) -> None:
+    """Report a write whose record did not survive to the render, or False.
+
+    Every write verb in both families appends and then re-reads the record to
+    show it. The lookup verbs already check the read, because a user-supplied
+    id may name nothing; the write verbs rested on having just written it,
+    which holds right up until a competing writer removes it in the gap. That
+    window is the one #857 confirmed reachable in the request ledger, and both
+    render branches died on the None: the text path on `record["state"]`, the
+    JSON path on `{**record}` inside the stamper.
+
+    The wording reports the half that actually happened. The append landed and
+    is on the ledger; only the render could not resolve it. Saying the verb
+    failed would be false, and saying nothing would leave a user who just
+    changed a ruling with no confirmation that it took.
+
+    The caller owns the `is None` test rather than this helper returning a
+    flag: the guard then reads the same way the lookup verbs' guards already
+    do, and a checker can narrow the record on the line after it.
+
+    The JSON branch answers with a document rather than the text sentence,
+    because a consumer parsing `--json` needs something it can parse. It is
+    deliberately not shaped like a record: `record` is null and `outcome`
+    names the write, so nothing can mistake it for the thing that vanished.
+    """
+    if as_json:
+        print(json.dumps({"id": record_id, "outcome": f"{verb}-recorded",
+                          "record": None,
+                          "note": "the write is on the ledger; the record was "
+                                  "not readable from this project at render "
+                                  "time"},
+                         ensure_ascii=False, sort_keys=True))
+    else:
+        render.render_ledger_lines(
+            [f"{record_id}: {verb} recorded in this project's ledger",
+             "  the record was not readable here at render time — the write "
+             "landed and renders with the record"])
+
+
 def _refutation_json(record) -> str:
     """JSON for one folded record or a list of them.
 

--- a/plugin/daimon_briefing/cli/refute.py
+++ b/plugin/daimon_briefing/cli/refute.py
@@ -13,6 +13,7 @@ from .. import refutations, render
 from ._ledger import (
     _print_refutation,
     _refutation_json,
+    _report_vanished_write,
     _refutation_lines,
     _refuse_ruling_id,
     _refute_channel,
@@ -34,6 +35,9 @@ def _cmd_refute_add(args) -> int:
         return 1
     record = refutations.get(ref_id, project_dir=project)
     _cli._note_usage("refute:add")
+    if record is None:
+        _report_vanished_write(ref_id, "add", as_json=args.json)
+        return 0
     if args.json:
         print(_refutation_json(record))
     else:
@@ -65,6 +69,9 @@ def _cmd_refute_ratify(args) -> int:
         return 1
     record = refutations.get(args.refutation_id, project_dir=project)
     _cli._note_usage("refute:ratify")
+    if record is None:
+        _report_vanished_write(args.refutation_id, "ratify", as_json=args.json)
+        return 0
     if args.json:
         print(_refutation_json(record))
     else:
@@ -89,6 +96,9 @@ def _cmd_refute_revise(args) -> int:
         return 1
     record = refutations.get(args.refutation_id, project_dir=project)
     _cli._note_usage("refute:revise")
+    if record is None:
+        _report_vanished_write(args.refutation_id, "revise", as_json=args.json)
+        return 0
     if args.json:
         print(_refutation_json(record))
     else:
@@ -114,6 +124,9 @@ def _cmd_refute_overturn(args) -> int:
         return 1
     record = refutations.get(args.refutation_id, project_dir=project)
     _cli._note_usage("refute:overturn")
+    if record is None:
+        _report_vanished_write(args.refutation_id, "overturn", as_json=args.json)
+        return 0
     if args.json:
         print(_refutation_json(record))
     else:

--- a/plugin/daimon_briefing/cli/ruling.py
+++ b/plugin/daimon_briefing/cli/ruling.py
@@ -15,6 +15,7 @@ from .. import config, normalize, refutations, render
 from ._ledger import (
     _print_ruling,
     _refutation_json,
+    _report_vanished_write,
     _refute_channel,
     _ruling_lines,
 )
@@ -34,6 +35,9 @@ def _cmd_ruling_propose(args) -> int:
         return 1
     record = refutations.get(ruling_id, project_dir=project)
     _cli._note_usage("ruling:propose")
+    if record is None:
+        _report_vanished_write(ruling_id, "propose", as_json=args.json)
+        return 0
     if args.json:
         print(_refutation_json(record))
     else:
@@ -95,6 +99,9 @@ def _cmd_ruling_ratify(args) -> int:
         return 1
     record = refutations.get(args.ruling_id, project_dir=project)
     _cli._note_usage("ruling:ratify")
+    if record is None:
+        _report_vanished_write(args.ruling_id, "ratify", as_json=args.json)
+        return 0
     if record["state"] != "active":
         print("not activated: the text changed during confirmation; "
               "re-run to review the current text")
@@ -156,6 +163,9 @@ def _cmd_ruling_revise(args) -> int:
         return 1
     record = refutations.get(args.ruling_id, project_dir=project)
     _cli._note_usage("ruling:revise")
+    if record is None:
+        _report_vanished_write(args.ruling_id, "revise", as_json=args.json)
+        return 0
     if args.json:
         print(_refutation_json(record))
     else:
@@ -183,6 +193,9 @@ def _cmd_ruling_retire(args) -> int:
         return 1
     record = refutations.get(args.ruling_id, project_dir=project)
     _cli._note_usage("ruling:retire")
+    if record is None:
+        _report_vanished_write(args.ruling_id, "retire", as_json=args.json)
+        return 0
     if args.json:
         print(_refutation_json(record))
     else:

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -103,8 +103,6 @@ module = [
     "daimon_briefing.amendments",
     "daimon_briefing.cli",
     "daimon_briefing.cli.lifecycle",
-    "daimon_briefing.cli.refute",
-    "daimon_briefing.cli.ruling",
     "daimon_briefing.cli.skill",
     "daimon_briefing.ledger",
     "daimon_briefing.pending",

--- a/plugin/tests/test_refutations.py
+++ b/plugin/tests/test_refutations.py
@@ -878,3 +878,94 @@ def test_a_torn_trailing_line_never_swallows_the_next_event(tmp_checkpoint_dir):
     record = refutations.get(ref_id, project_dir=PROJECT)
     assert record is not None, "the torn line swallowed the overturn"
     assert record["state"] == "overturned"
+
+
+# --- #860: the post-write re-read ------------------------------------------
+#
+# Twin of the ruling-side coverage in test_rulings.py. Every refute verb that
+# WRITES then re-reads the record to render it. The lookup verbs already check
+# for absence, because a user-supplied id may name nothing; the write verbs
+# rested on the record having been written a moment earlier.
+#
+# That holds unless a competing writer removes it in between, which is the
+# window #857 confirmed reachable in the request ledger. The write SUCCEEDED
+# in that window, so the command reports it instead of dying on a None.
+
+
+def _vanishes_after_the_write(monkeypatch, write_name):
+    """Model a competing writer between a verb's write and its own re-read.
+
+    Pinned to the write actually completing rather than to a call count, so
+    it stays faithful however many reads a verb makes on the way there.
+    """
+    real_write = getattr(refutations, write_name)
+    real_get = refutations.get
+    state = {"written": False}
+
+    def wrapped_write(*args, **kwargs):
+        out = real_write(*args, **kwargs)
+        state["written"] = True
+        return out
+
+    def wrapped_get(*args, **kwargs):
+        return None if state["written"] else real_get(*args, **kwargs)
+
+    monkeypatch.setattr(refutations, write_name, wrapped_write)
+    monkeypatch.setattr(refutations, "get", wrapped_get)
+    return state
+
+
+_REFUTE_WRITE_VERBS = [
+    ("add", "assert_refutation", [
+        "refute", "add", "--subject", "content hashes",
+        "--verdict", "whole-file hashes do not prove span claims",
+        "--scope", "verification", "--anchor", "issue:502",
+        "--evidence", "measurement:566/623 origin misses", "--by", "agent"]),
+    ("ratify", "ratify", ["refute", "ratify", "REF_ID"]),
+    ("revise", "revise", [
+        "refute", "revise", "REF_ID",
+        "--verdict", "file hashes still do not prove individual claims",
+        "--evidence", "measurement:second corpus", "--ratify"]),
+    ("overturn", "overturn", [
+        "refute", "overturn", "REF_ID",
+        "--evidence", "measurement:contrary replay", "--by", "agent"]),
+]
+
+
+@pytest.mark.parametrize("verb,write_name,argv", _REFUTE_WRITE_VERBS,
+                         ids=[v[0] for v in _REFUTE_WRITE_VERBS])
+@pytest.mark.parametrize("as_json", [False, True], ids=["text", "json"])
+def test_cli_refute_write_verbs_survive_the_record_vanishing(
+        verb, write_name, argv, as_json, tmp_checkpoint_dir, monkeypatch,
+        capsys):
+    # `add` CREATES; pre-seeding the same subject/scope would collide and the
+    # verb would refuse before writing, which the `written` assertion catches
+    # rather than letting the test pass vacuously.
+    ref_id = ""
+    if verb != "add":
+        ref_id = refutations.assert_refutation(
+            subject="content hashes",
+            verdict="whole-file hashes do not prove span claims",
+            scope="verification",
+            evidence=["measurement:566/623 origin misses"],
+            channel="cli-agent", project_dir=PROJECT)
+        if verb in {"revise", "overturn"}:
+            # cli-tty is the human channel; ratification is deliberately
+            # not self-declarable by an agent channel (CHANNEL_AUTHORITY).
+            refutations.ratify(ref_id, channel="cli-tty",
+                               project_dir=PROJECT)
+    capsys.readouterr()
+
+    state = _vanishes_after_the_write(monkeypatch, write_name)
+    args = [ref_id if a == "REF_ID" else a for a in argv]
+    args += ["--project", PROJECT]
+    if as_json:
+        args.append("--json")
+
+    rc = cli.main(args)
+
+    assert state["written"], "the write never ran, so this proves nothing"
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Traceback" not in out
+    assert out.strip(), "a vanished record must still report what happened"

--- a/plugin/tests/test_rulings.py
+++ b/plugin/tests/test_rulings.py
@@ -851,3 +851,86 @@ def test_dry_run_warns_about_active_rulings(tmp_checkpoint_dir, _tty,
     assert rc == 0
     assert "removes ACTIVE ruling" in capsys.readouterr().out
     assert refutations.get(ruling_id, project_dir=PROJECT) is not None
+
+
+# --- #860: the post-write re-read ------------------------------------------
+#
+# Every ruling verb that WRITES then re-reads the record to render it. The
+# lookup verbs (show, and the pre-write guards) already check for absence,
+# because a user-supplied id may name nothing. The write verbs did not, and
+# the reason is a reasonable one: the record was written a moment earlier, so
+# it must be there.
+#
+# It must be there unless a competing writer removes it in between, which is
+# the window #857 confirmed reachable in the request ledger. In that window
+# the write SUCCEEDED and only the render could not resolve, so the command
+# has to report that rather than dying on a None.
+
+
+def _vanishes_after_the_write(monkeypatch, write_name):
+    """Model a competing writer between a verb's write and its own re-read.
+
+    Sharper than a call counter: it is pinned to the write actually
+    completing, so it stays faithful no matter how many reads a given verb
+    makes on its way there.
+    """
+    real_write = getattr(refutations, write_name)
+    real_get = refutations.get
+    state = {"written": False}
+
+    def wrapped_write(*args, **kwargs):
+        out = real_write(*args, **kwargs)
+        state["written"] = True
+        return out
+
+    def wrapped_get(*args, **kwargs):
+        return None if state["written"] else real_get(*args, **kwargs)
+
+    monkeypatch.setattr(refutations, write_name, wrapped_write)
+    monkeypatch.setattr(refutations, "get", wrapped_get)
+    return state
+
+
+_RULING_WRITE_VERBS = [
+    ("propose", "assert_ruling", [
+        "ruling", "propose", "--subject", "public posts",
+        "--verdict", "internal numbers never appear in public posts",
+        "--scope", "publishing", "--evidence", "issue:693", "--by", "agent"]),
+    ("ratify", "ratify", ["ruling", "ratify", "RULING_ID"]),
+    ("revise", "revise", [
+        "ruling", "revise", "RULING_ID",
+        "--verdict", "internal numbers never ship in public posts",
+        "--evidence", "issue:693"]),
+    ("retire", "retire", ["ruling", "retire", "RULING_ID"]),
+]
+
+
+@pytest.mark.parametrize("verb,write_name,argv", _RULING_WRITE_VERBS,
+                         ids=[v[0] for v in _RULING_WRITE_VERBS])
+@pytest.mark.parametrize("as_json", [False, True], ids=["text", "json"])
+def test_cli_ruling_write_verbs_survive_the_record_vanishing(
+        verb, write_name, argv, as_json, tmp_checkpoint_dir, _tty,
+        monkeypatch, capsys):
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+    # `propose` CREATES; pre-seeding the same subject/scope would collide and
+    # the verb would refuse before writing anything, which the `written`
+    # assertion below catches rather than letting the test pass vacuously.
+    ruling_id = ("" if verb == "propose"
+                 else _rule(ratified=(verb in {"revise", "retire"}),
+                            channel=("cli-tty" if verb in {"revise", "retire"}
+                                     else "cli-agent")))
+    capsys.readouterr()
+
+    state = _vanishes_after_the_write(monkeypatch, write_name)
+    args = [ruling_id if a == "RULING_ID" else a for a in argv]
+    args += ["--project", PROJECT]
+    if as_json:
+        args.append("--json")
+
+    rc = cli.main(args)
+
+    assert state["written"], "the write never ran, so this proves nothing"
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Traceback" not in out
+    assert out.strip(), "a vanished record must still report what happened"


### PR DESCRIPTION
Closes #860
Refs #842

Ratchet 15 to 13: both `cli.refute` and `cli.ruling` come off, because every one of their 14 findings was this pattern.

## What

Eight sites across the two verb families, four each. Every write verb appends and then re-reads the record to render it, and neither render branch tolerated an absent one: the text path died on `record["state"]`, the JSON path on `{**record}` inside the stamper.

They now report what happened. The append landed and is on the ledger; only the render could not resolve it.

## A correction to my own issue text

#860 says the guards were missing because nobody wrote the check. That was wrong, and unfair to whoever wrote this. The split is principled:

- the lookup verbs guard, because a user-supplied id may name nothing
- the write verbs did not, because they had just written the record

That reasoning is sound. It holds until a competing writer removes the record in the gap, which is the window #857 confirmed reachable in the request ledger. This is an assumption with one exception, not an oversight.

## Shape

The caller owns the `is None` test and the helper only reports, rather than the helper returning a flag. Two reasons: the guard then reads the way the lookup verbs' guards already do, and a checker can narrow the record on the line after it. The first version returned a bool and mypy still flagged all eight sites, which is what pointed at the better shape.

The JSON branch answers with a document rather than the text sentence, since a consumer parsing `--json` needs something parseable. It is deliberately not record-shaped: `record` is null and `outcome` names the write, so nothing can mistake it for the thing that vanished.

## Tests

16 new, 4 verbs by 2 families by 2 render branches, all watched failing first.

The simulation is pinned to the write completing rather than to a call count, so it stays faithful however many reads a verb makes on the way there. Each test asserts the write actually ran, and that assertion earned its place twice:

- `propose` and `add` CREATE, so pre-seeding the same subject and scope made the verb refuse before writing. The tests would have gone green after the fix while proving nothing.
- `ruling propose` writes through `assert_ruling`, not `assert_refutation`, so the first wrapper never intercepted and a full record printed instead of the vanish.

Third fixture correction worth noting because the code was right and the test was wrong: ratification requires `cli-tty`. `CHANNEL_AUTHORITY` refuses to let an agent channel ratify, which is the authority model working as designed.

Full suite: 4697 passed, 2 skipped. mypy clean with both entries gone, ruff clean.
