### PR TITLE
fix(recall): record which writer produced superseded_by

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -823,9 +823,15 @@ def _cmd_recall(args) -> int:
     for r in results:
         age = _format_age(now - r["created"]) if r.get("created") else "?"
         sup = r.get("superseded_by")
+        # #865: name the WRITER, not just the value. A model-authored
+        # supersedes link and a human `daimon resolve` both land here and
+        # both can write a bare id, so the marker rendered a claim and an
+        # action identically. `resolved` is the one value that was already
+        # unambiguous, and only by accident of its spelling.
         superseded = ("" if not sup
                       else " [resolved]" if sup == "resolved"
-                      else f" [superseded by {sup}]")
+                      else f" [superseded by {sup}, "
+                           f"{_supersession_origin(r)}]")
         # #837: an independent axis gets an independent marker — a row can
         # carry both, and collapsing them would hide one fact behind the
         # other. recall owns the phrasing so this marker can never describe a
@@ -839,6 +845,24 @@ def _cmd_recall(args) -> int:
                      f"{contradicted}")
     render.render_recall_lines(lines)
     return 0
+
+
+def _supersession_origin(row) -> str:
+    """How this row's supersession was produced, in plain words (#865).
+
+    The two mechanisms carry different weight to a reader: a person recorded
+    an action, or a model asserted a relationship. The column stores the
+    mechanism rather than an evidential grade, because grading is vocabulary
+    the language contract governs; this renders the mechanism and lets the
+    reader do the grading.
+
+    An unknown source reads as unknown rather than defaulting to either. A row
+    written before the column existed is not evidence for either writer, and
+    guessing would invent exactly the certainty this change exists to stop."""
+    return {
+        "resolution": "from a recorded resolution",
+        "link": "from a model-authored link",
+    }.get(row.get("superseded_source"), "origin not recorded")
 
 
 def _cmd_why(args) -> int:

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -94,7 +94,7 @@ def _note_error(where: str, exc: BaseException) -> None:
 # ledger folds bind through — purely a performance object, but the bump
 # rolls every existing db onto it deterministically instead of waiting for
 # an unrelated fingerprint change.
-_SCHEMA_VERSION = "6"
+_SCHEMA_VERSION = "7"   # #865 added items.superseded_source
 
 _FTS5_MISSING_MSG = (
     "sqlite3 has no FTS5 module — `daimon recall` needs an FTS5-enabled "
@@ -382,6 +382,18 @@ def _init_schema(conn: sqlite3.Connection) -> None:
                 session_id TEXT,
                 created REAL,
                 superseded_by TEXT,
+                -- #865: WHICH writer produced superseded_by. Two folds write
+                -- that column and mean different things: "link" is a claim the
+                -- MODEL made (serializer instructs it to attach a supersedes
+                -- link on "we changed from X to Y"), "resolution" is a HUMAN
+                -- action recorded in events.jsonl. Both can write a bare id,
+                -- so the value alone could not tell them apart, and the column
+                -- is a rank input, so the ambiguity was acted on rather than
+                -- merely displayed. Mechanism, deliberately, not an evidential
+                -- grade: naming the grade is a vocabulary change that routes
+                -- through the language contract first, and the mechanism is
+                -- the checkable fact a reader needs to derive a grade.
+                superseded_source TEXT,
                 invalidated_by TEXT,
                 importance INTEGER,
                 first_seen TEXT,
@@ -425,7 +437,7 @@ def _apply_typed_supersession(conn: sqlite3.Connection, links: list) -> None:
          owner_item_id, owner_text, target) in links:
         if _ID_SHAPE.fullmatch(target):
             conn.execute(
-                "UPDATE items SET superseded_by = ?"
+                "UPDATE items SET superseded_by = ?, superseded_source = 'link'"
                 " WHERE item_id = ? AND author = ? AND project_slug IS ?"
                 " AND session_id != ?",
                 (owner_sid, target, author, slug, owner_sid),
@@ -453,7 +465,10 @@ def _apply_typed_supersession(conn: sqlite3.Connection, links: list) -> None:
             continue  # unbound or ambiguous — never guess
         (rowids,) = by_text.values()
         conn.executemany(
-            "UPDATE items SET superseded_by = ? WHERE id = ?",
+            # Free-text branch of the SAME model-authored link, so it
+            # records the same mechanism as the id-shape branch above (#865).
+            "UPDATE items SET superseded_by = ?, superseded_source = 'link'"
+            " WHERE id = ?",
             [(owner_sid, rid) for rid in rowids],
         )
 
@@ -493,8 +508,13 @@ def _apply_event_resolutions(conn: sqlite3.Connection) -> None:
             value = "resolved"
             if status.lower().startswith("superseded-by:"):
                 value = status.split(":", 1)[1].strip() or "resolved"
+            # Runs AFTER the link fold and overwrites it, which is the
+            # right precedence: a person's recorded action outranks a
+            # model's claim. #865 makes the surviving writer visible, so a
+            # reader can tell the value came from the person.
             conn.execute(
-                "UPDATE items SET superseded_by = ?"
+                "UPDATE items SET superseded_by = ?,"
+                " superseded_source = 'resolution'"
                 " WHERE item_id = ? AND project_slug IS ?",
                 (value, ref, bucket.name),
             )
@@ -906,7 +926,8 @@ def search(query: str, project_dir=None, all_projects: bool = False,
 
     sql = (
         "SELECT i.text, i.quote, i.trust, i.kind, i.author, i.project_slug,"
-        " i.session_id, i.created, i.superseded_by, i.invalidated_by,"
+        " i.session_id, i.created, i.superseded_by, i.superseded_source,"
+        " i.invalidated_by,"
         " i.importance, i.first_seen, i.item_id, i.frontier,"
         " bm25(items_fts) AS rank"
         " FROM items_fts JOIN items i ON i.id = items_fts.rowid"

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3684,6 +3684,54 @@ def _write_verification_ledger(slug, rows):
                     encoding="utf-8")
 
 
+def test_cli_recall_says_which_writer_superseded_an_item(
+        tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):
+    # #865: a model-authored supersedes link and a human `daimon resolve`
+    # both land in superseded_by and both can write a bare id. The marker
+    # rendered them identically, so a reader could not tell whether a person
+    # decided this or a model claimed it.
+    from daimon_briefing import store
+
+    proj = str((tmp_path / "proj").resolve())
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    cp = _recall_checkpoint("S-linked", "meerkat burrow mapping plan colony")
+    store.write_checkpoint("S-linked", cp, project_dir=proj)
+    newer = _recall_checkpoint(
+        "S-new", "abandoned meerkat burrow mapping plan colony too unstable",
+        "2025-06-01T00:00:00Z")
+    newer["working_context"]["recent_decisions"][0]["links"] = [
+        {"type": "supersedes", "target": "meerkat burrow mapping plan colony"}]
+    store.write_checkpoint("S-new", newer, project_dir=proj)
+
+    assert cli.main(["recall", "meerkat", "--project", proj]) == 0
+    line = [ln for ln in capsys.readouterr().out.splitlines()
+            if "meerkat burrow mapping plan colony" in ln
+            and "abandoned" not in ln][0]
+    assert "superseded by S-new" in line
+    assert "model-authored link" in line
+
+
+def test_cli_recall_marks_a_human_resolution_as_recorded(
+        tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):
+    # The other writer, and the one that must not read as a model's claim.
+    from daimon_briefing import store
+
+    proj = str((tmp_path / "proj").resolve())
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    cp = _recall_checkpoint("S-res", "meerkat burrow mapping plan colony")
+    cp["working_context"]["recent_decisions"][0]["id"] = "o-mee111"
+    store.write_checkpoint("S-res", cp, project_dir=proj)
+    store.append_event("o-mee111", "superseded-by:o-later22", source="cli",
+                       project_dir=proj)
+
+    assert cli.main(["recall", "meerkat", "--project", proj]) == 0
+    line = [ln for ln in capsys.readouterr().out.splitlines()
+            if "meerkat" in ln][0]
+    assert "superseded by o-later22" in line
+    assert "recorded resolution" in line
+    assert "model-authored" not in line
+
+
 def test_cli_recall_marks_contradiction_evidence(
         tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):
     # #837: invalidated_by had no renderer, so a contradicted item printed

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -1990,3 +1990,100 @@ def test_suggest_still_credits_a_compound_identifier(tmp_checkpoint_dir,
                          project_dir="/repo/x", current_session="S-now")
     assert out and out[0]["session_id"] == "S-comp"
     assert out[0]["term_hits"] >= 2
+
+
+# --- #865: superseded_by must say which writer produced it ------------------
+#
+# Two folds write the same column and mean different things. A typed
+# `supersedes` link is a claim the MODEL made (serializer.py instructs it to
+# attach one when it detects "we changed from X to Y"). An events.jsonl
+# resolution is a HUMAN action (`daimon resolve`). Both can write a bare id,
+# so a reader seeing one could not tell which produced it.
+#
+# The column is a rank input and a rendered marker, so the ambiguity was being
+# acted on, not merely displayed. These pin the mechanism that produced the
+# value, not an evidential grade: naming the grade is a vocabulary change that
+# routes through the language contract first, and the mechanism is the
+# checkable fact a reader needs to derive a grade for themselves.
+
+
+def test_a_model_authored_link_records_its_mechanism(tmp_checkpoint_dir,
+                                                     monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint(
+        "S-old", _cp125("S-old", decisions=[{
+            "text": "pin the litellm gateway cache for bad responses",
+            "trust": "verbatim", "quote": "pin it",
+        }], created="2026-06-20T00:00:00Z"), project_dir="/repo/x")
+    store.write_checkpoint(
+        "S-newer", _cp125("S-newer", decisions=[{
+            "text": "unpinned the litellm gateway cache, old diagnosis wrong",
+            "trust": "inferred",
+            "links": [{"type": "supersedes",
+                       "target": "pin litellm gateway cache bad responses"}],
+        }], created="2026-06-25T00:00:00Z"), project_dir="/repo/x")
+
+    hits = recall.search("pin litellm gateway cache", project_dir="/repo/x")
+    old = [h for h in hits if h["session_id"] == "S-old"]
+    assert old and old[0]["superseded_by"] == "S-newer"
+    assert old[0]["superseded_source"] == "link"
+
+
+def test_a_human_resolution_records_its_mechanism(tmp_checkpoint_dir,
+                                                  monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint(
+        "S-old", _cp125("S-old", decisions=[{
+            "text": "pin the litellm gateway cache for bad responses",
+            "trust": "verbatim", "quote": "pin it", "id": "o-pin111",
+        }], created="2026-06-20T00:00:00Z"), project_dir="/repo/x")
+    store.append_event("o-pin111", "superseded-by:o-new222", source="cli",
+                       project_dir="/repo/x")
+
+    hits = recall.search("pin litellm gateway cache", project_dir="/repo/x")
+    assert hits and hits[0]["superseded_by"] == "o-new222"
+    assert hits[0]["superseded_source"] == "resolution"
+
+
+def test_a_human_resolution_outranks_a_model_link_and_says_so(
+        tmp_checkpoint_dir, monkeypatch):
+    # The event fold already runs after the link fold and overwrites it, so a
+    # human action already wins. That precedence was invisible; a reader could
+    # not tell the surviving value came from the person rather than the model.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint(
+        "S-old", _cp125("S-old", decisions=[{
+            "text": "pin the litellm gateway cache for bad responses",
+            "trust": "verbatim", "quote": "pin it", "id": "o-pin111",
+        }], created="2026-06-20T00:00:00Z"), project_dir="/repo/x")
+    store.write_checkpoint(
+        "S-newer", _cp125("S-newer", decisions=[{
+            "text": "unpinned the litellm gateway cache, old diagnosis wrong",
+            "trust": "inferred",
+            "links": [{"type": "supersedes",
+                       "target": "pin litellm gateway cache bad responses"}],
+        }], created="2026-06-25T00:00:00Z"), project_dir="/repo/x")
+    store.append_event("o-pin111", "superseded-by:o-human333", source="cli",
+                       project_dir="/repo/x")
+
+    hits = recall.search("pin litellm gateway cache", project_dir="/repo/x")
+    old = [h for h in hits if h["session_id"] == "S-old"]
+    assert old and old[0]["superseded_by"] == "o-human333"
+    assert old[0]["superseded_source"] == "resolution"
+
+
+def test_an_unsuperseded_item_has_no_mechanism(tmp_checkpoint_dir,
+                                               monkeypatch):
+    # Absence stays absence: a live item must not read as superseded by an
+    # unnamed mechanism.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint(
+        "S-live", _cp125("S-live", decisions=[{
+            "text": "pin the litellm gateway cache for bad responses",
+            "trust": "verbatim", "quote": "pin it",
+        }], created="2026-06-20T00:00:00Z"), project_dir="/repo/x")
+
+    hits = recall.search("pin litellm gateway cache", project_dir="/repo/x")
+    assert hits
+    assert hits[0]["superseded_by"] is None
+    assert hits[0]["superseded_source"] is None


### PR DESCRIPTION
Closes #865

## What

`items` gains `superseded_source`. All three writers of `superseded_by` now record which one they are:

- both branches of the typed-link fold record `link`, a claim the model made
- the resolution fold records `resolution`, a human action through `daimon resolve`

The resolution fold already ran second and overwrote the link fold. That precedence is right, a person's recorded action outranking a model's claim, and it was invisible. It is visible now.

The `daimon recall` marker reads `[superseded by S-new, from a model-authored link]` or `[superseded by o-later22, from a recorded resolution]`.

Schema 6 to 7, so an existing index rebuilds rather than serving rows without the column.

## Why this is not tidying

The column drives a 0.7x demotion in `suggest`, a leading key in `search`'s ORDER BY, and a rendered marker. A model's claim and a person's action carried identical weight and identical rendering, so the ambiguity was being acted on rather than displayed. Only the literal `"resolved"` was ever unambiguous, and only by accident of its spelling: an event carrying `superseded-by:<id>` writes a bare id, and so does a typed link.

## Three deliberate limits

**Mechanism, not an evidential grade.** The column says which writer produced the value, not whether it is attested or observed. Grading is vocabulary the language contract governs, and the scope question on `q-eca06df3ba39` is still open, so naming a grade here would pre-empt a ruling with a schema. The mechanism is the checkable fact a reader needs to do the grading themselves.

**Ranking is unchanged.** Whether a model's claim should demote as hard as a person's action is a real question and a separate one. It needs its own evidence, and this change is what makes answering it possible. Changing weights here would have been a behavior change smuggled inside a provenance change.

**An unknown source reads as unknown.** `origin not recorded`, never a default to either writer. A row written before the column existed is not evidence for either, and defaulting would invent the certainty this change exists to remove. That is the same rule the codebase already keeps for a missing key against an empty one.

## Tests

Six new, all watched failing first. Four on the index, covering both mechanisms, the precedence case where a human resolution overwrites a model link and the source follows, and the negative case where a live item has neither. Two on the CLI marker, including one asserting a human resolution does not read as a model's claim.

One thing the tests caught: the typed-link fold has two UPDATE statements, an id-shape branch and a free-text branch. Patching only the first left the free-text path writing a null source, and the model-link test failed on exactly that. The free-text branch is the one that fires in practice, since carry-time binding rarely lands.

Full suite: 4703 passed, 2 skipped. mypy clean, ruff clean.

## Context

Filed after reading the r/AI_Agents thread that produced `q-eca06df3ba39`, where the general form is that a state indistinguishable from its neighbour will be acted on as its neighbour. #866 is the same shape in `invalidated_by` and is not addressed here.
