### PR TITLE
fix(recall): a cured item now says it survived a contradiction

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -838,6 +838,11 @@ def _cmd_recall(args) -> int:
         # different view than the fold recorded.
         inv = recall.describe_invalidation(r.get("invalidated_by"))
         contradicted = f" [{inv}]" if inv else ""
+        # #866: the release from burial is a fact too. A cured item read
+        # exactly like one nothing ever questioned, which is the same
+        # collapse the contradiction marker exists to prevent, inverted.
+        cured = recall.describe_cure(r.get("cured_by"))
+        contradicted += f" [{cured}]" if cured else ""
         trust = r.get("trust") or "untagged"
         item_id = f" [{r['item_id']}]" if r.get("item_id") else ""
         lines.append(f"[{r['author']}] [{trust}] [{r['kind']}]{item_id} {r['text']} "
@@ -1448,6 +1453,10 @@ def _suggest_line(r: dict, terms, now: float) -> str:
     # surface it and no cure path that would retract it.
     inv = recall.describe_invalidation(r.get("invalidated_by"))
     contradicted = f" ({inv})" if inv else ""
+    # #866: an item that survived a challenge arrives saying so, rather than
+    # as though nothing had happened.
+    cured = recall.describe_cure(r.get("cured_by"))
+    contradicted += f" ({cured})" if cured else ""
     more = " ".join(terms[:3])
     return (f"daimon recall: prior work — {r['kind']} from {r['session_id']} "
             f"({age} ago): \"{text}\" [{trust}]{superseded}"

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -25,8 +25,11 @@ contradictions never mint the link — derived world evidence writes it, or
 nothing does. #837 made the read surfaces honor it: search sorts a
 contradicted row below a merely-replaced one, suggest demotes it harder than
 supersession does, and both CLI renderers mark it. None of them filters —
-the evidence is machine-local and cure-less, so burial stays visible and
-reversible rather than silent). A contentless FTS5 table indexes text +
+the evidence is machine-local, so burial stays visible and reversible
+rather than silent. #839 gave it a cure: a later confirmation clears the
+slot. #866 gave the cure a record of its own in `cured_by`, because
+clearing the mark had made "challenged and survived" indistinguishable
+from "never questioned", which is the same collapse inverted). A contentless FTS5 table indexes text +
 quote for MATCH; rows join back to `items` by rowid.
 
 Supersession v3 (#234) is ITEM-LEVEL evidence only: `superseded_by` is set by
@@ -94,7 +97,7 @@ def _note_error(where: str, exc: BaseException) -> None:
 # ledger folds bind through — purely a performance object, but the bump
 # rolls every existing db onto it deterministically instead of waiting for
 # an unrelated fingerprint change.
-_SCHEMA_VERSION = "7"   # #865 added items.superseded_source
+_SCHEMA_VERSION = "8"   # #866 added items.cured_by
 
 _FTS5_MISSING_MSG = (
     "sqlite3 has no FTS5 module — `daimon recall` needs an FTS5-enabled "
@@ -395,6 +398,19 @@ def _init_schema(conn: sqlite3.Connection) -> None:
                 -- the checkable fact a reader needs to derive a grade.
                 superseded_source TEXT,
                 invalidated_by TEXT,
+                -- #866: the latest CONFIRMATION that cleared a prior
+                -- contradiction. #845 released the ratchet by writing NULL,
+                -- which is also what an item nothing ever questioned carries,
+                -- so "challenged and survived" and "never questioned" became
+                -- one state on every read surface. They are different facts
+                -- and the first is arguably the stronger one.
+                --
+                -- Depends on store.append_receipt_cure staying CONDITIONAL:
+                -- the fold sees only the latest verdict per item, so it can
+                -- read a confirmation as a cure only because a cure row is
+                -- never written unless the item currently stands
+                -- contradicted. Pinned by test, not just by this comment.
+                cured_by TEXT,
                 importance INTEGER,
                 first_seen TEXT,
                 item_id TEXT,
@@ -684,12 +700,17 @@ def _apply_verification_invalidations(conn: sqlite3.Connection) -> None:
             # A confirmation CLEARS rather than stamping: the slot holds the
             # latest contradiction evidence, and once the latest evidence is
             # a confirmation there is no contradiction evidence to hold.
-            value = (f"{row['check']}:{row['reason']}@{row['ts']}"
-                     if row["verdict"] == "contradicted" else None)
+            evidence = f"{row['check']}:{row['reason']}@{row['ts']}"
+            contradicted = row["verdict"] == "contradicted"
+            # The ratchet still releases: a cure clears invalidated_by. What
+            # it no longer does is erase the fact that there was something to
+            # clear (#866).
             conn.execute(
-                "UPDATE items SET invalidated_by = ?"
+                "UPDATE items SET invalidated_by = ?, cured_by = ?"
                 " WHERE item_id = ? AND project_slug IS ? AND author IS ?",
-                (value, ref, bucket.name, author))
+                (evidence if contradicted else None,
+                 None if contradicted else evidence,
+                 ref, bucket.name, author))
 
 
 def describe_invalidation(value) -> str | None:
@@ -716,6 +737,25 @@ def describe_invalidation(value) -> str | None:
     if not (sep and evidence and ts):
         return f"contradicted by {value}"
     return f"contradicted by {evidence} at {ts}"
+
+
+def describe_cure(value) -> str | None:
+    """Render one stored `cured_by` value as a marker phrase, or None (#866).
+
+    Twin of describe_invalidation, and the one parse of the same encoding, for
+    the same reason: a renderer that re-split the value could drift into
+    describing a different view than the fold recorded.
+
+    The wording says the contradiction was CLEARED, never that the claim is
+    true. The evidence semantics are unchanged: a confirmation is the latest
+    evidence, not a verdict, and an item that survived a challenge is not
+    thereby proven."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    evidence, sep, ts = value.rpartition("@")
+    if not (sep and evidence and ts):
+        return f"contradiction cleared by {value}"
+    return f"contradiction cleared by {evidence} at {ts}"
 
 
 def rebuild() -> int:
@@ -927,7 +967,7 @@ def search(query: str, project_dir=None, all_projects: bool = False,
     sql = (
         "SELECT i.text, i.quote, i.trust, i.kind, i.author, i.project_slug,"
         " i.session_id, i.created, i.superseded_by, i.superseded_source,"
-        " i.invalidated_by,"
+        " i.invalidated_by, i.cured_by,"
         " i.importance, i.first_seen, i.item_id, i.frontier,"
         " bm25(items_fts) AS rank"
         " FROM items_fts JOIN items i ON i.id = items_fts.rowid"
@@ -1350,7 +1390,7 @@ def suggest(prompt: str, project_dir=None, current_session=None,
         # #837: the column MUST be selected here, not just written — this is
         # the auto-inject path, so a missing select re-asserts a claim this
         # install's own ledger contradicted, on the highest-leverage surface.
-        " i.invalidated_by,"
+        " i.invalidated_by, i.cured_by,"
         # pinned rides out for the #452 age gate (standing rules are
         # age-independent); it is NOT a rank input here.
         " i.pinned,"

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -3757,6 +3757,41 @@ def test_cli_recall_marks_contradiction_evidence(
     assert "false" not in line.lower()
 
 
+def test_cli_recall_marks_a_cleared_contradiction(
+        tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):
+    # #866: a cured item rendered exactly like one nothing ever questioned.
+    from daimon_briefing import store
+
+    proj = str((tmp_path / "proj").resolve())
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    cp = _recall_checkpoint("S-cured", "meerkat burrow mapping plan colony")
+    cp["working_context"]["recent_decisions"][0]["id"] = "o-mee111"
+    store.write_checkpoint("S-cured", cp, project_dir=proj)
+    _write_verification_ledger(store.project_slug(proj), [
+        {"ts": "2026-08-29T10:00:00Z", "check": "receipt",
+         "item_ref": "o-mee111", "reason": "receipt-invalid"},
+        {"ts": "2026-08-29T12:00:00Z", "check": "receipt-ok",
+         "item_ref": "o-mee111", "reason": "receipt-valid"}])
+
+    assert cli.main(["recall", "meerkat", "--project", proj]) == 0
+    line = [ln for ln in capsys.readouterr().out.splitlines()
+            if "meerkat" in ln][0]
+    assert "contradiction cleared by receipt-ok:receipt-valid" in line
+    assert "contradicted by" not in line  # the ratchet released
+    assert "false" not in line.lower()
+    assert "true" not in line.lower()   # cleared is not proven
+
+
+def test_suggest_line_marks_a_cleared_contradiction():
+    # The auto-inject line carries it too: an item that survived a challenge
+    # arrives with that fact, not as though nothing had happened.
+    r = {"kind": "decision", "session_id": "S-1", "created": 1000.0,
+         "trust": "verbatim", "text": "the exporter caches limbs",
+         "cured_by": "receipt-ok:receipt-valid@2026-08-29T12:00:00Z"}
+    line = cli._suggest_line(r, ["exporter"], 2000.0)
+    assert "contradiction cleared by receipt-ok:receipt-valid" in line
+
+
 def test_suggest_line_marks_contradiction_evidence():
     # The auto-inject line is the highest-leverage surface: a demoted item
     # still reaching the prompt must arrive flagged, not silently ranked down.

--- a/plugin/tests/test_recall_invalidated_by.py
+++ b/plugin/tests/test_recall_invalidated_by.py
@@ -614,3 +614,91 @@ def test_a_cure_is_not_a_catch_in_the_rejection_counters(tmp_checkpoint_dir,
     counts = store.verification_counts(project_dir="/repo/x")
     assert counts == {"receipt": 1}
     assert sum(counts.values()) == 1
+
+
+# --- #866: a cured item is not a pristine one -------------------------------
+#
+# #845 cleared the slot on a confirmation, which released the ratchet but wrote
+# NULL, and NULL is also what an item that was never contradicted carries. On
+# every read surface "challenged and survived" and "never questioned" became
+# one state.
+#
+# That contradicts the rule #838 shipped in this same module: burial must stay
+# visible, not silent. It was enforced for the burial and dropped for the
+# release from it. An item that survived a contradiction has a different
+# standing from one nothing ever questioned, arguably a stronger one.
+
+
+def test_a_cured_item_records_what_cleared_it(tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-1", _cp("S-1", questions=[
+        _item("the axolotl exporter claim was verified", "o-111aaa")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+    _write_ledger(store.project_slug("/repo/x"), [
+        _receipt_row("o-111aaa", ts="2026-08-29T10:00:00Z"),
+        _cure_row("o-111aaa", ts="2026-08-29T12:00:00Z"),
+    ])
+
+    hits = recall.search("axolotl exporter claim", project_dir="/repo/x")
+    assert hits
+    assert hits[0]["invalidated_by"] is None  # the ratchet still releases
+    assert hits[0]["cured_by"] == "receipt-ok:receipt-valid@2026-08-29T12:00:00Z"
+
+
+def test_an_unchallenged_item_is_not_marked_cured(tmp_checkpoint_dir,
+                                                  monkeypatch):
+    # The whole point: absence of a contradiction is not the same fact as
+    # having survived one, so a pristine item must carry neither mark.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-1", _cp("S-1", questions=[
+        _item("the axolotl exporter claim was verified", "o-111aaa")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+
+    hits = recall.search("axolotl exporter claim", project_dir="/repo/x")
+    assert hits
+    assert hits[0]["invalidated_by"] is None
+    assert hits[0]["cured_by"] is None
+
+
+def test_a_standing_contradiction_is_not_also_cured(tmp_checkpoint_dir,
+                                                    monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-1", _cp("S-1", questions=[
+        _item("the axolotl exporter claim was verified", "o-111aaa")],
+        created="2026-08-01T00:00:00Z"), project_dir="/repo/x")
+    _write_ledger(store.project_slug("/repo/x"),
+                  [_receipt_row("o-111aaa", ts="2026-08-29T10:00:00Z")])
+
+    hits = recall.search("axolotl exporter claim", project_dir="/repo/x")
+    assert hits[0]["invalidated_by"] == \
+        "receipt:receipt-invalid@2026-08-29T10:00:00Z"
+    assert hits[0]["cured_by"] is None
+
+
+def test_the_cure_mark_depends_on_the_write_gate_staying_conditional():
+    """LANDMINE, pinned rather than left implicit.
+
+    `cured_by` means "was contradicted, and the latest evidence confirms". The
+    fold cannot see the earlier contradiction, because only the latest verdict
+    per item survives the dedup. It reads a confirmation as a CURE purely
+    because `store.append_receipt_cure` refuses to write one unless the item
+    currently stands contradicted.
+
+    Make that gate unconditional and `cured_by` silently starts appearing on
+    items nothing ever challenged, which is the exact confusion this column
+    was added to remove. The coupling lives in two modules, so it is pinned
+    here instead of in a comment nobody has to read.
+    """
+    import inspect as _inspect
+
+    body = _inspect.getsource(store.append_receipt_cure)
+    assert 'get("verdict") != "contradicted"' in body
+    assert "return False" in body
+
+
+def test_describe_cure_reads_the_stored_encoding():
+    assert recall.describe_cure(
+        "receipt-ok:receipt-valid@2026-08-29T12:00:00Z") == \
+        "contradiction cleared by receipt-ok:receipt-valid at 2026-08-29T12:00:00Z"
+    assert recall.describe_cure(None) is None
+    assert recall.describe_cure("garbage") == "contradiction cleared by garbage"


### PR DESCRIPTION
Closes #866

Twin of #867: a field that must say which state it is holding.

## What

`items` gains `cured_by`, holding the confirmation that cleared a prior contradiction, in the same `<check>:<reason>@<ts>` encoding `invalidated_by` uses. Both CLI renderers show it through one `describe_cure` parse.

The ratchet still releases. A cure still clears `invalidated_by`, and the read surfaces still stop demoting. What it no longer does is erase the fact that there was something to clear.

Schema 7 to 8.

## Why

#845 released the ratchet by writing NULL, and NULL is also what an item nothing ever questioned carries. So "challenged and survived" and "never questioned" became one state everywhere a reader looks.

That contradicts the rule #838 shipped in the same module and documents in its own docstring: burial must stay visible, not silent. It was enforced for the burial and dropped for the release from it.

## Wording, deliberately narrow

`contradiction cleared by <evidence> at <ts>`. It says the contradiction was CLEARED and never that the claim is true. A confirmation is the latest evidence rather than a verdict, and an item that survived a challenge is not thereby proven. A test asserts the line says neither "false" nor "true".

## A coupling worth naming

`cured_by` means "was contradicted, and the latest evidence confirms". The fold cannot see the earlier contradiction, because only the latest verdict per item survives the dedup. It reads a confirmation as a CURE purely because `store.append_receipt_cure` refuses to write one unless the item currently stands contradicted, which is the conditional write #845 introduced for an unrelated reason: keeping the ledger a record of problems found.

Make that gate unconditional and `cured_by` silently starts appearing on items nothing ever challenged, which is exactly the confusion this column was added to remove. The coupling spans two modules, so it is pinned by a test rather than left in a comment nobody has to read.

## Deliberately not in scope

`daimon why` still surfaces neither `invalidated_by` nor `cured_by`. That gap is recorded in #839 and unbuilt; adding an interrogation surface is a different change from making a write visible, and folding it in here would have hidden it inside a fix.

Ranking is unchanged, as in #867. A cured item is not demoted, which is the point of the cure.

## Tests

Seven new, five watched failing first. The index side covers the cure, a pristine item carrying neither mark, and a standing contradiction that must not read as cured. The CLI side covers both renderers.

The other two are guards rather than drivers: the coupling pin above, and the `describe_cure` malformed-value case.

Full suite: 4710 passed, 2 skipped. mypy clean, ruff clean.
