### PR TITLE
chore(types): drop cli.skill from the mypy ratchet

### DIFF
--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -13,6 +13,7 @@ import logging
 import os
 import subprocess
 from pathlib import Path
+from typing import overload
 
 log = logging.getLogger(__name__)
 
@@ -422,6 +423,13 @@ def claude_projects_dir() -> Path:
     return Path.home() / ".claude" / "projects"
 
 
+# `None` is returned for exactly one input — `None` itself. Every str, `""`
+# included, comes back as a str (the git failure path returns `raw` unchanged),
+# so a caller passing a definite str never has to narrow the result.
+@overload
+def resolve_project_root(raw: str) -> str: ...
+@overload
+def resolve_project_root(raw: None) -> None: ...
 def resolve_project_root(raw: str | None) -> str | None:
     """Normalize a project dir to its git toplevel so a subdir session maps to the
     ONE repo bucket (#74).

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -103,7 +103,6 @@ module = [
     "daimon_briefing.amendments",
     "daimon_briefing.cli",
     "daimon_briefing.cli.lifecycle",
-    "daimon_briefing.cli.skill",
     "daimon_briefing.ledger",
     "daimon_briefing.pending",
     "daimon_briefing.privacy",


### PR DESCRIPTION
Refs #842

## What

Removes `daimon_briefing.cli.skill` from the mypy ratchet in
`plugin/pyproject.toml` and fixes the one error that entry was silencing.

The error: `_resolve_project_cwd` calls
`Path(config.resolve_project_root(str(Path.cwd())))`, and
`resolve_project_root` is declared `(str | None) -> str | None`, so `Path()`
was reported as receiving an optional.

The fix is a pair of `@overload` signatures on `resolve_project_root`, not a
cast or an `or` fallback at the call site. `cli/skill.py` is unchanged.

## Why

The declared return is wider than the function's actual contract.
`resolve_project_root` returns `None` for exactly one input, `None` itself.
Every `str` comes back a `str`, `""` included, because the git failure path
returns `raw` unchanged. `tests/test_config.py:309-310` already pins both
halves of that:

```python
assert config.resolve_project_root(None) is None
assert config.resolve_project_root("") == ""
```

Encoding it as overloads rather than narrowing at the one call site means
every present and future caller holding a definite `str` gets a definite
`str` back, so this error class cannot reappear at a new call site.

No runtime change. Overloads are erased at run time and the implementation
signature is untouched.

Stage of the #842 burn-down, so `Refs` rather than `Closes`. Ratchet is 13
entries before this PR, 12 after.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/config.py` | Two `@overload` stubs on `resolve_project_root` plus a comment naming why `None` is unreachable from a `str` input |
| `plugin/pyproject.toml` | Drop the `daimon_briefing.cli.skill` ratchet entry |

## Tests

- `uv run mypy daimon_briefing` passes with the entry removed, which is the
  failing test for this change: restoring the entry is what made it pass
  before, and mypy reports the `arg-type` error at `cli/skill.py:21` if the
  overloads are reverted.
- `uv run pytest tests/test_config.py tests/test_skill_cli.py
  tests/test_skill_content.py tests/test_skill_install.py`, 139 passed.
  The two contract assertions above are the ones that make the overloads
  provable rather than asserted.
- No new test: this is a typing-only change with no runtime behavior to
  cover, and the contract it encodes is already under test.
