### PR TITLE
chore(types): drop render from the mypy ratchet

### DIFF
--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -375,9 +375,9 @@ def _rich_brief(b: dict, degraded: bool = False, rulings=(),
                               if amend.get("by") == "agent" else "")
                         flag = (f'    ↷ amended — {change} '
                                 f'({amend.get("label")}{by}): "{aq}"\n')
-                        note = str(amend.get("note") or "").strip()
-                        if note:
-                            nq = briefing._truncate_agent_claim(note)
+                        amend_note = str(amend.get("note") or "").strip()
+                        if amend_note:
+                            nq = briefing._truncate_agent_claim(amend_note)
                             flag += f"    note: {nq}\n"
                         body.append(flag, style="cyan")
                     else:

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -108,7 +108,6 @@ module = [
     "daimon_briefing.privacy",
     "daimon_briefing.refutations",
     "daimon_briefing.relations",
-    "daimon_briefing.render",
     "daimon_briefing.requests",
     "daimon_briefing.teamsync",
     "daimon_briefing.transcript",


### PR DESCRIPTION
Refs #842

## What

Removes `daimon_briefing.render` from the mypy ratchet and fixes the one
error it was silencing.

`_rich_brief` bound the local `note` twice, to two unrelated values:

```python
note = str(amend.get("note") or "").strip()      # amendment note, always str
...
note = briefing._overflow_note(b.get("decisions_overflow", 0))   # str | None
```

mypy inferred `str` from the first binding and rejected the second as
`assignment`. Renamed the amendment-local to `amend_note`. The overflow
marker keeps `note`.

## Why

Two different concepts sharing one name inside one function. The typing
error is the visible half; the readability trap is the other half, and
renaming fixes both at once rather than widening the annotation to
`str | None` and leaving the collision in place.

Behavior preserving. Each value keeps its own truthiness guard, so both
render exactly as before.

Stage of the #842 burn-down, so `Refs` rather than `Closes`. Ratchet is 12
entries before this PR, 11 after.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/render.py` | Rename the amendment-note local to `amend_note` at its binding and both uses |
| `plugin/pyproject.toml` | Drop the `daimon_briefing.render` ratchet entry |

## Tests

- `uv run mypy daimon_briefing` passes with the entry removed. Removing the
  entry first is the failing test: it reports the `assignment` error at
  `render.py:398` until the rename lands.
- An incomplete rename is caught rather than silent. Renaming only the
  binding and not the two uses produced `Cannot determine type of "note"`
  at `render.py:379-380`, which is how I found the second and third
  occurrences.
- `tests/test_amendments.py::test_rich_brief_renders_ratified_amendment_settled`
  is the behavior proof already in the tree. It renders a ratified
  amendment carrying `note="took the alternate route"` and asserts that
  string reaches the output, so a rename that broke the note path would
  fail it.
- `uv run pytest tests/test_amendments.py tests/test_render.py
  tests/test_briefing.py` and the other brief suites: 404 passed.
- Full suite on the combined cheap-tier branch: 4710 passed, 2 skipped.
- No new test. This is a rename with no new behavior, and the branch it
  touches was already covered.
