### PR TITLE
chore(types): drop teamsync from the mypy ratchet

### DIFF
--- a/plugin/daimon_briefing/teamsync.py
+++ b/plugin/daimon_briefing/teamsync.py
@@ -468,8 +468,8 @@ def sync_remote(sidecar: Path) -> dict:
     (fetch+merge only on HEAD-hash mismatch) -> push, with a bounded
     reject->integrate->push retry loop (rejects are benign: another author won
     the race)."""
-    report = {"slug": sidecar.name, "committed": 0, "pushed": False,
-              "fetched": False, "warnings": [], "notes": []}
+    report: dict = {"slug": sidecar.name, "committed": 0, "pushed": False,
+                    "fetched": False, "warnings": [], "notes": []}
     if not _recover_wedge(sidecar, report):
         return report
     _commit_own(sidecar, report)

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -109,7 +109,6 @@ module = [
     "daimon_briefing.refutations",
     "daimon_briefing.relations",
     "daimon_briefing.requests",
-    "daimon_briefing.teamsync",
     "daimon_briefing.transcript",
 ]
 ignore_errors = true


### PR DESCRIPTION
Refs #842

## What

Removes `daimon_briefing.teamsync` from the mypy ratchet and fixes the two
errors it was silencing, both the same one.

`sync_sidecar` builds its report as an untyped literal:

```python
report = {"slug": sidecar.name, "committed": 0, "pushed": False,
          "fetched": False, "warnings": [], "notes": []}
```

The values are a str, two ints, a bool and two lists, so mypy joins the
value type to `object` and both later appends fail with
`"object" has no attribute "append"` (teamsync.py:479 and :494).

Annotated the literal as `report: dict`.

## Why

The annotation is not new information, it is information the file already
states elsewhere and then loses at the one place it is constructed.
`_recover_wedge(sidecar: Path, report: dict)` and `_commit_own` both
already declare `report: dict` for this exact object as they receive it, so
the literal was the only place carrying a narrower inferred type than the
code around it.

Bare `dict` rather than a parametrised form on purpose: it matches the two
helpers that already take this object, and it is the dominant shape in the
package (19 bare `: dict = {` against 8 for the next most common).

Typing only, no runtime change.

Stage of the #842 burn-down, so `Refs` rather than `Closes`. Ratchet is 11
entries before this PR, 10 after.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/teamsync.py` | Annotate the `sync_sidecar` report literal as `dict` |
| `plugin/pyproject.toml` | Drop the `daimon_briefing.teamsync` ratchet entry |

## Tests

- `uv run mypy daimon_briefing` passes with the entry removed. Removing the
  entry first is the failing test: it reports both `attr-defined` errors
  until the annotation lands.
- `uv run pytest` across the team suites: 158 passed. These cover the push,
  reject-and-retry, offline and wedge-recovery paths, which are the ones
  that write into `report["warnings"]` and `report["notes"]`.
- Full suite on the combined cheap-tier branch: 4710 passed, 2 skipped.
- No new test. An annotation on a dict literal has no runtime behavior to
  cover, and the branches that append to it are already exercised.
