### PR TITLE
chore(types): drop pending from the mypy ratchet

### DIFF
--- a/plugin/daimon_briefing/pending.py
+++ b/plugin/daimon_briefing/pending.py
@@ -254,7 +254,7 @@ def _strip_plaintext(row: dict) -> dict:
     return out
 
 
-def _foreign_request_counts(slug: str) -> dict[str, int]:
+def _foreign_request_counts(slug: str | None) -> dict[str, int]:
     """Every foreign project's waiting request count, in ONE fleet-wide pass.
 
     A request's rows can span two buckets — the `opened` row in the
@@ -314,7 +314,7 @@ def _ledger_bucket_slugs() -> list[str]:
         return []
 
 
-def _foreign_ledger_counts(slug: str) -> dict[str, int]:
+def _foreign_ledger_counts(slug: str | None) -> dict[str, int]:
     """Candidate rulings/refutations and verified amendments in every OTHER
     bucket, read directly (single-bucket lanes) — fail-open per bucket, per
     lane, matching `queue`'s own degradation posture. Only `state` survives

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -104,7 +104,6 @@ module = [
     "daimon_briefing.cli",
     "daimon_briefing.cli.lifecycle",
     "daimon_briefing.ledger",
-    "daimon_briefing.pending",
     "daimon_briefing.privacy",
     "daimon_briefing.refutations",
     "daimon_briefing.relations",


### PR DESCRIPTION
Refs #842

## What

Removes `daimon_briefing.pending` from the mypy ratchet and fixes the two
errors it was silencing.

`foreign_counts` resolves its slug and hands it to two helpers:

```python
slug = store.project_slug(project_dir)     # str | None
... _foreign_request_counts(slug)          # declared slug: str
... _foreign_ledger_counts(slug)           # declared slug: str
```

Both helpers are now declared `slug: str | None`.

## Why

Widening the helpers rather than guarding the call site, because the
helpers already handle `None` correctly and the narrow annotation was the
inaccurate part.

`slug` reaches exactly two expressions across both functions:

- `_foreign_request_counts`: `if not to or to == slug:` (skip this
  project's own inbox, which is `queue`'s job)
- `_foreign_ledger_counts`: `if bucket == slug: continue`

Both are equality tests. A `None` slug simply matches nothing, so the
"exclude my own bucket" step excludes nothing and the count degrades. No
attribute access, no path join, no string method, so there is nothing that
a `None` could crash.

A `None` guard was the alternative and was rejected: it would change
behavior on a path no production caller reaches. The only production caller
is the decide command in `cli/lifecycle.py:903`, which always passes a
resolved project dir. The `None` is reachable only through the keyword
default on `foreign_counts(*, project_dir=None)`, and no caller in the tree
or the tests uses it. Changing unreachable behavior inside a chore PR is
exactly what rule 2 on #842 rules out.

Typing only, no runtime change.

Stage of the #842 burn-down, so `Refs` rather than `Closes`. Ratchet is 10
entries before this PR, 9 after.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/pending.py` | Widen `_foreign_request_counts` and `_foreign_ledger_counts` to `slug: str \| None` |
| `plugin/pyproject.toml` | Drop the `daimon_briefing.pending` ratchet entry |

## Tests

- `uv run mypy daimon_briefing` passes with the entry removed. Removing the
  entry first is the failing test: it reports both `arg-type` errors at
  `pending.py:355` and `:360` until the signatures widen.
- `uv run pytest tests/test_pending.py tests/test_cli_decide.py
  tests/test_requests_scan_cost.py`: 48 passed. These pin the behavior the
  widened parameter is claimed not to touch, including
  `test_this_projects_own_waiting_decisions_are_not_in_the_foreign_counts`,
  which is the assertion that the own-bucket exclusion still works.
- Full suite on the combined cheap-tier branch: 4710 passed, 2 skipped.
- No new test. The signature change adds no reachable behavior, and adding
  a test for the unreachable `None` default would pin behavior this PR
  deliberately does not decide.
