### PR TITLE
chore(types): drop transcript from the mypy ratchet

### DIFF
--- a/plugin/daimon_briefing/transcript.py
+++ b/plugin/daimon_briefing/transcript.py
@@ -257,7 +257,7 @@ def _from_jsonl(text: str) -> list[dict]:
             continue
         payload_type = payload.get("type")
         role = {"user_message": "user", "agent_message": "assistant"}.get(
-            payload_type
+            str(payload_type or "")
         )
         content = payload.get("message")
         if role and isinstance(content, str) and content.strip():
@@ -275,7 +275,7 @@ def _from_jsonl(text: str) -> list[dict]:
         if not isinstance(item, dict):
             continue
         role = {"UserMessage": "user", "AgentMessage": "assistant"}.get(
-            item.get("type")
+            str(item.get("type") or "")
         )
         if role is None:
             continue
@@ -288,9 +288,9 @@ def _from_jsonl(text: str) -> list[dict]:
                 continue
             if str(block.get("type") or "").lower() != "text":
                 continue
-            text = block.get("text")
-            if isinstance(text, str) and text.strip():
-                parts.append(text.strip())
+            block_text = block.get("text")
+            if isinstance(block_text, str) and block_text.strip():
+                parts.append(block_text.strip())
         joined = "\n".join(parts)
         if joined:
             codex_messages.append({"role": role, "content": joined})
@@ -321,9 +321,10 @@ def _from_jsonl(text: str) -> list[dict]:
         if not isinstance(payload, dict):
             continue
         text_key = "user_response" if obj_type == "user_input" else "response"
-        text = payload.get(text_key)
-        if isinstance(text, str) and text.strip():
-            windsurf_messages.append({"role": role, "content": text.strip()})
+        payload_text = payload.get(text_key)
+        if isinstance(payload_text, str) and payload_text.strip():
+            windsurf_messages.append(
+                {"role": role, "content": payload_text.strip()})
     if windsurf_messages:
         return windsurf_messages
 
@@ -362,9 +363,9 @@ def _from_jsonl(text: str) -> list[dict]:
         if mid is not None:
             tool = _tool_result_of(obj)
             if tool is not None:
-                text, is_error, use_ids = tool
-                tool_msg: dict = {"role": "tool", "content": text, "id": mid,
-                                  "tool_result": True}
+                tool_text, is_error, use_ids = tool
+                tool_msg: dict = {"role": "tool", "content": tool_text,
+                                  "id": mid, "tool_result": True}
                 if is_error:
                     tool_msg["tool_error"] = True
                 # #512: provenance flag, resolved via the tool_use pairing.

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -105,7 +105,6 @@ module = [
     "daimon_briefing.ledger",
     "daimon_briefing.privacy",
     "daimon_briefing.refutations",
-    "daimon_briefing.transcript",
 ]
 ignore_errors = true
 


### PR DESCRIPTION
Refs #842

## What

Removes `daimon_briefing.transcript` from the mypy ratchet and fixes the
four errors it was silencing. All four are in `_from_jsonl`, in two
classes.

## Why, per class

**Role maps keyed on `Any | None` (transcript.py:260, :278)**

The codex `event_msg` role map is keyed on `payload_type`, and the 0.147.0
`item_completed` map on `item.get("type")`, both `Any | None` into a
`dict[str, str]` lookup. Now `str(... or "")`.

Identical at run time. `{"user_message", "agent_message"}` and
`{"UserMessage", "AgentMessage"}` are the full key sets and neither has an
empty-string key, so a missing or non-str type misses on `""` exactly where
it previously missed on `None`, and `role` still comes out `None`.

**The function overwrites its own parameter (transcript.py:291, :324)**

`_from_jsonl(text: str)` rebinds `text` twice inside its body, once to a
content block's text in the codex branch and once to a windsurf payload's
text. mypy reports both as `assignment` against the parameter's declared
`str`. Renamed to `block_text` and `payload_text`.

**This is not a live defect, and I want to be precise about that rather
than sell it as a bug fix.** The parameter is consumed by
`text.splitlines()` at the top of the function, before either
reassignment, and is never read again. Nothing ever saw a clobbered value.
What it is, is one name meaning four different things in a 150-line
function, which is a readability trap that mypy happened to notice.

The fourth meaning is the `text` unpacked from `_tool_result_of` at :365.
mypy does not flag it, because that tuple element is already `str` and so
the assignment is compatible. Renamed it to `tool_text` anyway: leaving one
clobber of the parameter in place defeats the reason for fixing the other
two. After this change `text` occurs exactly twice in the function, its
declaration and its one legitimate read.

Behavior preserving throughout.

Stage of the #842 burn-down, so `Refs` rather than `Closes`. Ratchet is 6
entries before this PR, 5 after: `amendments` 8, `refutations` 12,
`ledger` 23, `cli` 34, `privacy` 74.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/transcript.py` | `str(... or "")` on both role-map lookups; rename the three locals shadowing the `text` parameter |
| `plugin/pyproject.toml` | Drop the `daimon_briefing.transcript` ratchet entry |

## Tests

- `uv run mypy daimon_briefing` passes with the entry removed. Removing the
  entry first is the failing test: it reports all four errors until the
  fixes land.
- Full suite: **4711 passed, 2 skipped**.
- `tests/test_transcript.py`, `tests/test_codex_session_end.py`,
  `tests/test_windsurf_hooks.py`, `tests/test_capture_parity.py` and
  `tests/test_quote_verification.py`: 179 passed. These are the suites that
  drive real host transcripts through `_from_jsonl`, so they cover both
  role-map branches, the windsurf branch and the tool-result branch, which
  are the four sites touched.
- No new test. Two lookups whose miss behavior is unchanged, and three
  renames of locals whose surrounding branches are already exercised. There
  is no new branch here to cover, unlike the `relations` order guard in
  #873.
