### PR TITLE
chore(types): drop amendments from the mypy ratchet

### DIFF
--- a/plugin/daimon_briefing/amendments.py
+++ b/plugin/daimon_briefing/amendments.py
@@ -235,9 +235,8 @@ def fold(rows: list[dict]) -> dict[str, dict]:
                 continue  # duplicate logical proposal, first writer wins
             state = (
                 "ratified" if row.get("ratified") is True
-                and CHANNEL_AUTHORITY.get(row.get("channel")) == "human"
+                and CHANNEL_AUTHORITY.get(str(row.get("channel") or "")) == "human"
                 else "candidate")
-            reopened = current is not None
             out[a_id] = {
                 "amendment_id": a_id,
                 "state": state,
@@ -249,13 +248,17 @@ def fold(rows: list[dict]) -> dict[str, dict]:
                 "proposed_by": row.get("authority"),
                 "proposed_channel": row.get("channel"),
                 "proposed_author": row.get("author"),
-                "verdict_label": (CHANNEL_LABEL.get(row.get("channel"))
+                "verdict_label": (CHANNEL_LABEL.get(str(row.get("channel") or ""))
                                   if state == "ratified" else None),
-                "created_at": (current["created_at"] if reopened
+                # Reopening a rejected proposal keeps the original creation
+                # stamp and extends its history rather than starting a second
+                # chain. Narrowed on `current` itself: a boolean copy of the
+                # same test reads the same but carries no narrowing.
+                "created_at": (current["created_at"] if current is not None
                                else row.get("ts")),
                 "updated_at": row.get("ts"),
-                "history_count": (current["history_count"] + 1 if reopened
-                                  else 1),
+                "history_count": (current["history_count"] + 1
+                                  if current is not None else 1),
             }
             continue
         if current is None:
@@ -267,18 +270,18 @@ def fold(rows: list[dict]) -> dict[str, dict]:
             # the quote in the transcript. It never overrides a verdict, and
             # it never yields a settled render — see RENDER_STATES.
             if (current["state"] == "candidate"
-                    and CHANNEL_AUTHORITY.get(row.get("channel")) == "mechanical"):
+                    and CHANNEL_AUTHORITY.get(str(row.get("channel") or "")) == "mechanical"):
                 current["state"] = "verified"
                 current["evidence_role"] = str(
                     row.get("evidence_role") or "")[:_ROLE_MAX]
                 current["verdict_label"] = "quote-verified"
         elif event == "ratified":
             if (current["state"] in ("candidate", "verified")
-                    and CHANNEL_AUTHORITY.get(row.get("channel")) == "human"):
+                    and CHANNEL_AUTHORITY.get(str(row.get("channel") or "")) == "human"):
                 current["state"] = "ratified"
-                current["verdict_label"] = CHANNEL_LABEL.get(row.get("channel"))
+                current["verdict_label"] = CHANNEL_LABEL.get(str(row.get("channel") or ""))
         elif event == "rejected":
-            if CHANNEL_AUTHORITY.get(row.get("channel")) == "human":
+            if CHANNEL_AUTHORITY.get(str(row.get("channel") or "")) == "human":
                 current["state"] = "rejected"
                 current["verdict_label"] = None
                 current["note"] = str(row.get("note") or current["note"])

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -100,7 +100,6 @@ ignore_missing_imports = true
 # hold the line in the interim).
 [[tool.mypy.overrides]]
 module = [
-    "daimon_briefing.amendments",
     "daimon_briefing.cli",
     "daimon_briefing.ledger",
     "daimon_briefing.privacy",

--- a/plugin/tests/test_amendments.py
+++ b/plugin/tests/test_amendments.py
@@ -153,6 +153,22 @@ def test_reject_then_repropose_reopens_as_candidate(project):
     assert record["history_count"] == 3
 
 
+def test_reopened_proposal_keeps_its_original_created_at(project, monkeypatch):
+    # `ts` is second-resolution, so a same-second reject/repropose cannot
+    # tell a preserved stamp from a reset one and the assertion would pass
+    # either way. Pin three distinct seconds so it actually bites.
+    ticks = iter([1_700_000_000_000_000_000,
+                  1_700_000_060_000_000_000,
+                  1_700_000_120_000_000_000])
+    monkeypatch.setattr(amendments.time, "time_ns", lambda: next(ticks))
+    a_id = _propose(project)
+    amendments.reject(a_id, channel="cli-tty", project_dir=project)
+    assert _propose(project) == a_id
+    record = amendments.get(a_id, project_dir=project)
+    assert record["created_at"] == "2023-11-14T22:13:20Z"
+    assert record["updated_at"] == "2023-11-14T22:15:20Z"
+
+
 def test_ratify_after_reject_still_refused(project):
     a_id = _propose(project)
     amendments.reject(a_id, channel="cli-tty", project_dir=project)


### PR DESCRIPTION
Refs #842

## What

Removes `daimon_briefing.amendments` from the mypy ratchet and fixes the
eight errors it was silencing. Six are one recurring shape, two are a
narrowing that a boolean local was throwing away.

## Why, per class

**Channel lookups (:238, :252, :270, :277, :279, :281)**

Six `CHANNEL_AUTHORITY.get(row.get("channel"))` and
`CHANNEL_LABEL.get(row.get("channel"))` calls passing `Any | None` into a
`dict[str, str]`. Now `str(row.get("channel") or "")`, the same fix already
landed for `relations`, `requests` and `transcript` in #873 and #874.
Neither dict carries an empty-string key, so a missing or non-str channel
misses on `""` exactly where it missed on `None`.

**A boolean copy of a narrowing test (:254, :257)**

```python
reopened = current is not None
...
"created_at": (current["created_at"] if reopened else row.get("ts")),
"history_count": (current["history_count"] + 1 if reopened else 1),
```

mypy reports `Value of type "dict[Any, Any] | None" is not indexable`.

Not a live defect. `reopened` is exactly `current is not None`, computed
fourteen lines above with no rebinding of `current` in between, so both
index operations are safe at run time. mypy simply cannot carry a narrowing
through a boolean copy of the test.

Fixed by narrowing on `current` itself at both sites and dropping the
`reopened` local, which had no other reader. The intent `reopened` carried
moved into a comment on the branch it explains.

## The test, and why the obvious version of it was worthless

Reopening is covered by `test_reject_then_repropose_reopens_as_candidate`,
which asserts `history_count == 3`. That pins the `+1` half of the branch.
The `created_at` half, that a reopened proposal keeps its ORIGINAL creation
stamp rather than taking the new row's, was unpinned.

My first attempt captured `created_at` before the reject and asserted it
was unchanged after the repropose. **It passed with the preservation
deliberately broken**, so it proved nothing. `ts` is second-resolution
(`%Y-%m-%dT%H:%M:%SZ`), and a same-second reject/repropose produces an
identical stamp either way.

`test_reopened_proposal_keeps_its_original_created_at` replaces it and pins
three distinct seconds through `time.time_ns`, so the preserved stamp and
the reset stamp are actually different values. Verified both directions:
it FAILS when `created_at` is changed to `row.get("ts")`, and passes
against the real implementation.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/amendments.py` | `str(... or "")` on six channel lookups; narrow on `current` instead of the `reopened` boolean and drop that local |
| `plugin/tests/test_amendments.py` | Add `test_reopened_proposal_keeps_its_original_created_at` with a pinned clock |
| `plugin/pyproject.toml` | Drop the `daimon_briefing.amendments` ratchet entry |

## Tests

- `uv run mypy daimon_briefing` passes with the entry removed. Removing the
  entry first is the failing test: it reports all eight errors until the
  fixes land.
- Full suite: **4712 passed, 2 skipped**.
- `tests/test_amendments.py`: 77 passed.
- Behavior preserving. No runtime path changes; the new test pins an
  invariant that already held.

Ratchet is 5 entries before this PR, 4 after: `refutations` 12, `ledger`
23, `cli` 34, `privacy` 74.
