### PR TITLE
chore(types): drop refutations from the mypy ratchet

### DIFF
--- a/plugin/daimon_briefing/refutations.py
+++ b/plugin/daimon_briefing/refutations.py
@@ -81,6 +81,20 @@ CHANNEL_LABEL = {
     "signed": "ratified (signed)",
     "mechanical": "mechanically-activated",
 }
+
+
+def _channel_of(row: dict) -> str:
+    """A row's channel as a lookup key for CHANNEL_AUTHORITY / CHANNEL_LABEL.
+
+    Rows are read off disk, so the field can be absent or non-str. Neither map
+    carries an empty-string key, so an unusable channel misses on "" exactly
+    as a None missed before, and the lookup still yields None. Deriving the
+    key here keeps that reasoning in one place rather than at twelve call
+    sites.
+    """
+    return str(row.get("channel") or "")
+
+
 _EVENT_RANK = {
     # Same-order ambiguity fails toward less authority: ratification before a
     # revision leaves the revision candidate; overturn remains last.
@@ -529,7 +543,7 @@ def fold(rows: list[dict]) -> dict[str, dict]:
                 continue  # duplicate logical assertion, first writer wins
             state = (
                 "active" if row.get("ratified") is True
-                and CHANNEL_AUTHORITY.get(row.get("channel")) == "human" else "candidate")
+                and CHANNEL_AUTHORITY.get(_channel_of(row)) == "human" else "candidate")
             out[ref_id] = {
                 "refutation_id": ref_id,
                 # #693: polarity is DERIVED from the founding event name at
@@ -548,8 +562,8 @@ def fold(rows: list[dict]) -> dict[str, dict]:
                 # so human-ratified agent prose renders as exactly that.
                 # DERIVED from the channel, never read from the row's own
                 # authority claim: this is a rendered authority label.
-                "text_authored_by": CHANNEL_AUTHORITY.get(row.get("channel")),
-                "activation": (CHANNEL_LABEL.get(row.get("channel"))
+                "text_authored_by": CHANNEL_AUTHORITY.get(_channel_of(row)),
+                "activation": (CHANNEL_LABEL.get(_channel_of(row))
                                if state == "active" else None),
                 "activation_channel": (row.get("channel")
                                        if state == "active" else None),
@@ -571,7 +585,7 @@ def fold(rows: list[dict]) -> dict[str, dict]:
         # resurrected by revise; both stay visible in the raw audit.
         if is_ruling and event == "revised" and (
                 (current["state"] == "active"
-                 and CHANNEL_AUTHORITY.get(row.get("channel")) != "human")
+                 and CHANNEL_AUTHORITY.get(_channel_of(row)) != "human")
                 or current["state"] == "overturned"):
             continue
         # #693: a content-bound ratify whose displayed text no longer matches
@@ -594,9 +608,9 @@ def fold(rows: list[dict]) -> dict[str, dict]:
             # carrying a verdict_key activates only the text it displayed; a
             # row with NO key is unbound and activates normally (every
             # pre-existing ledger row is absent-key).
-            if current["state"] != "overturned" and CHANNEL_AUTHORITY.get(row.get("channel")) == "human":
+            if current["state"] != "overturned" and CHANNEL_AUTHORITY.get(_channel_of(row)) == "human":
                 current["state"] = "active"
-                current["activation"] = CHANNEL_LABEL.get(row.get("channel"))
+                current["activation"] = CHANNEL_LABEL.get(_channel_of(row))
                 current["activation_channel"] = row.get("channel")
                 current["activation_author"] = row.get("author")
                 current["activated_at"] = row.get("ts")
@@ -605,7 +619,7 @@ def fold(rows: list[dict]) -> dict[str, dict]:
             # a mechanical row on a ruling stays in the raw audit, inert.
             if (current["state"] != "overturned"
                     and current.get("polarity") != "ruling"
-                    and CHANNEL_AUTHORITY.get(row.get("channel")) == "mechanical"):
+                    and CHANNEL_AUTHORITY.get(_channel_of(row)) == "mechanical"):
                 current["state"] = "active"
                 current["activation"] = "mechanically-activated"
                 current["activation_channel"] = "mechanical"
@@ -633,13 +647,13 @@ def fold(rows: list[dict]) -> dict[str, dict]:
             # only scope must not relabel agent-authored text as human.
             if "verdict" in row or "subject" in row:
                 current["text_authored_by"] = CHANNEL_AUTHORITY.get(
-                    row.get("channel"))
+                    _channel_of(row))
             was_active = current["state"] == "active"
             current["state"] = (
                 "active" if row.get("ratified") is True
-                and CHANNEL_AUTHORITY.get(row.get("channel")) == "human" else "candidate")
+                and CHANNEL_AUTHORITY.get(_channel_of(row)) == "human" else "candidate")
             current["activation"] = (
-                CHANNEL_LABEL.get(row.get("channel"))
+                CHANNEL_LABEL.get(_channel_of(row))
                 if current["state"] == "active" else None)
             current["activation_channel"] = (
                 row.get("channel") if current["state"] == "active" else None)
@@ -670,7 +684,7 @@ def fold(rows: list[dict]) -> dict[str, dict]:
                     "note": str(row.get("note") or ""),
                 }
         elif event == "overturned":
-            if CHANNEL_AUTHORITY.get(row.get("channel")) == "human":
+            if CHANNEL_AUTHORITY.get(_channel_of(row)) == "human":
                 current["state"] = "overturned"
                 current["activation"] = None
                 current["activation_channel"] = None
@@ -777,7 +791,7 @@ def _guard_open_proposals(refutation_id: str, event: str,
     if record is not None:
         current_key = normalize.content_key(record.get("verdict") or "")
     verdicts = [r for r in rows
-                if CHANNEL_AUTHORITY.get(r.get("channel")) == "human"
+                if CHANNEL_AUTHORITY.get(_channel_of(r)) == "human"
                 and r.get("event") in ("ratified", "overturned", "revised")
                 and not (r.get("event") == "ratified"
                          and str(r.get("verdict_key") or "")

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -103,7 +103,6 @@ module = [
     "daimon_briefing.cli",
     "daimon_briefing.ledger",
     "daimon_briefing.privacy",
-    "daimon_briefing.refutations",
 ]
 ignore_errors = true
 


### PR DESCRIPTION
Refs #842

## What

Removes `daimon_briefing.refutations` from the mypy ratchet and fixes the
twelve errors it was silencing.

All twelve are one shape: `CHANNEL_AUTHORITY.get(row.get("channel"))` or
`CHANNEL_LABEL.get(...)`, passing `Any | None` into a `dict[str, str]`.
Accounted for exactly: 7 single-line authority lookups, 3 single-line label
lookups, 1 line-wrapped authority lookup, and 1 written against a row bound
as `r` rather than `row`.

Introduces a module-private `_channel_of(row)` returning
`str(row.get("channel") or "")` and routes all twelve through it.

## Why a helper here, when #873 and #874 inlined the same fix

Worth naming the inconsistency rather than leaving it to be discovered.
`relations`, `requests` and `transcript` each had one or two of these and
took an inline `str(... or "")`. At twelve sites in one module that stops
being reasonable: the argument for why `""` is a safe substitute for `None`
is a real argument, and it deserves one home rather than twelve copies of a
bare expression a future reader has to re-derive.

The reasoning, stated once in the helper docstring: rows are read off disk,
so `channel` can be absent or non-str; neither map carries an empty-string
key, so an unusable channel misses on `""` exactly as it missed on `None`
and the lookup still yields `None`.

The module already carries a dozen small `_` helpers, so this reads like
its neighbours.

## Why this module did not bite

I said before starting that `refutations` was the one I expected to hide a
real defect, on the grounds that it decides who may assert what and that
`union-attr` is the class most likely to hide a latent bug. That was wrong,
and the measurement says so plainly: all twelve errors are `arg-type`, and
there is not a single `union-attr` or `index` among them. Every site is a
lookup whose miss behavior is unchanged.

Checked each of the twelve individually rather than trusting the shared
error code, since the same code can still mean different fixes.

Behavior preserving.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/refutations.py` | Add `_channel_of`; route all twelve channel lookups through it |
| `plugin/pyproject.toml` | Drop the `daimon_briefing.refutations` ratchet entry |

## Tests

- `uv run mypy daimon_briefing` passes with the entry removed. Removing the
  entry first is the failing test: it reports all twelve until the helper
  lands.
- `uv run ruff check`: clean.
- Refutation, refute and ruling suites: **1056 passed**. These are the
  suites that drive authority derivation, activation labels and the
  candidate/active/overturned transitions, which is every branch the twelve
  sites sit in.
- Full suite: **4712 passed, 2 skipped**.
- No new test. Twelve lookups whose miss behavior is unchanged, with no new
  branch to cover.

Ratchet is 4 entries before this PR, 3 after: `ledger` 23, `cli` 34,
`privacy` 74.
