### PR TITLE
chore(types): drop ledger from the mypy ratchet

### DIFF
--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -535,13 +535,21 @@ def _stats_capture(now=None) -> dict:
     This is NOT the last-of-kind collapse scar #9 forbids: it never reaches
     across sessions, so a failure buried under a later session's success still
     counts."""
-    win = {"days": _CAPTURE_WINDOW_DAYS, "success": 0, "skipped": 0,
-           "errors": 0, "fallback_attempts": 0, "fallback_serializes": 0,
-           "starved": 0, "error_rate_pct": None}
-    out = {"success": 0, "skipped": 0, "errors": 0, "fallback_serializes": 0,
-           "fallback_attempts": 0, "starved": 0,
-           "hosts": {}, "max_serialize_seconds": 0, "total_serialize_seconds": 0,
-           "window": win}
+    # Both literals are heterogeneous on purpose: `win` carries counters
+    # alongside an `error_rate_pct` that stays None until there is something
+    # to divide by, and `out` carries counters alongside a host map and the
+    # nested window. Without the annotation the inferred value types are
+    # `int | None` and `object`, and every counter increment below fails.
+    win: dict = {"days": _CAPTURE_WINDOW_DAYS, "success": 0, "skipped": 0,
+                 "errors": 0, "fallback_attempts": 0,
+                 "fallback_serializes": 0,
+                 "starved": 0, "error_rate_pct": None}
+    out: dict = {"success": 0, "skipped": 0, "errors": 0,
+                 "fallback_serializes": 0,
+                 "fallback_attempts": 0, "starved": 0,
+                 "hosts": {}, "max_serialize_seconds": 0,
+                 "total_serialize_seconds": 0,
+                 "window": win}
     try:
         text = (config.log_dir() / "serialize.log").read_text(encoding="utf-8")
     except OSError:

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -101,7 +101,6 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
     "daimon_briefing.cli",
-    "daimon_briefing.ledger",
     "daimon_briefing.privacy",
 ]
 ignore_errors = true


### PR DESCRIPTION
Refs #842

## What

Removes `daimon_briefing.ledger` from the mypy ratchet. All 23 errors come
from two dict literals and are fixed by annotating them.

## Why 23 errors have one cause

The count made this look like the first expensive module. It is not. Every
error sits between lines 567 and 619, and all of them trace to the inferred
value type of two literals in `capture_stats`:

```python
win = {"days": ..., "success": 0, ..., "error_rate_pct": None}
out = {"success": 0, ..., "hosts": {}, ..., "window": win}
```

`win` mixes counters with an `error_rate_pct` that stays `None` until there
is something to divide by, so it infers `dict[str, int | None]`. `out`
mixes counters with a host map and the nested window, so it infers
`dict[str, object]`. Every `+= 1` on either then fails, which is where 19
of the 23 `[operator]` errors come from, plus `max()` refusing an `object`,
the `out["hosts"]` index and attribute pair, and the `error_rate_pct`
assignment at the end.

Annotated both as `dict`, matching `teamsync` in #871 and the dominant
shape in the package.

## On the prediction I made before opening this

I said `ledger`, `cli` and `privacy` were where the `union-attr` mass lives
and where a real bug was still likely. For `ledger` that is wrong, and the
class histogram says so: 19 `[operator]`, and one each of `[index]`,
`[call-overload]`, `[attr-defined]` and `[assignment]`. Zero `union-attr`.
A high error count in a module is not evidence of a high defect count in
it, because one bad inference multiplies across every use site.

This is the collapse #842 anticipated for the big modules, the same shape
as `carry` going 183 to 181 from a single change.

Behavior preserving. Two annotations and a comment, no runtime change.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/ledger.py` | Annotate the `win` and `out` literals in `capture_stats` as `dict`, with a comment naming why they are heterogeneous |
| `plugin/pyproject.toml` | Drop the `daimon_briefing.ledger` ratchet entry |

## Tests

- `uv run mypy daimon_briefing` passes with the entry removed. Removing the
  entry first is the failing test: it reports all 23 until the annotations
  land.
- `uv run ruff check`: clean.
- Ledger and stats suites: **1617 passed**. These drive the counters that
  every failing line increments, including the window arithmetic and the
  `error_rate_pct` division that only runs when there were attempts.
- Full suite: **4712 passed, 2 skipped**.
- No new test. Two annotations with no runtime effect and no new branch.

Ratchet is 3 entries before this PR, 2 after: `cli` 34 and `privacy` 74.
