### PR TITLE
chore(types): empty the mypy ratchet

### DIFF
--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -423,7 +423,7 @@ def claude_projects_dir() -> Path:
     return Path.home() / ".claude" / "projects"
 
 
-# `None` is returned for exactly one input — `None` itself. Every str, `""`
+# `None` is returned for exactly one input, `None` itself. Every str, `""`
 # included, comes back as a str (the git failure path returns `raw` unchanged),
 # so a caller passing a definite str never has to narrow the result.
 @overload

--- a/plugin/daimon_briefing/privacy.py
+++ b/plugin/daimon_briefing/privacy.py
@@ -316,9 +316,13 @@ def _scan_team_dir(slug: str, keys: set[str], project_dir,
 def audit_project(project_dir=None) -> dict:
     slug = store.project_slug(project_dir)
     keys = store.forgotten_content_keys(project_dir=project_dir)
-    result = {"slug": slug, "findings": [], "informational": [],
-              "unscannable": [], "surfaces_scanned": 0,
-              "zero_surfaces": False}
+    # Heterogeneous by design: the slug, two finding lists, a scan counter,
+    # a flag, and a per-surface stats dict added for every surface below.
+    # Unannotated it infers `int | list | str | None`, which every
+    # `.append` and every stats assignment then contradicts.
+    result: dict = {"slug": slug, "findings": [], "informational": [],
+                    "unscannable": [], "surfaces_scanned": 0,
+                    "zero_surfaces": False}
     if not slug:
         result["zero_surfaces"] = True
         result["cache"] = {"entries": 0, "oldest_days": None}

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -86,23 +86,14 @@ select = ["E4", "E7", "E9", "F"]
 
 [tool.mypy]
 # BLOCKING in CI (#823). ignore_missing_imports absorbs the optional rich /
-# host-provided imports. Modules that predate enforcement carry their debt in
-# the overrides list below.
+# host-provided imports. Every module is enforced: the per-module debt list
+# that shipped with #823 was burned down to nothing in #842.
 python_version = "3.10"
 ignore_missing_imports = true
 
-# #823 ratchet: the modules with type errors on the day mypy became blocking.
-# THE LIST ONLY SHRINKS — clean a module, remove its entry in the same PR;
-# nothing is ever added. Every module absent from this list (and every future
-# module) is enforced from its first commit. Note ignore_errors also silences
-# the CI ReadResult-containment grep INSIDE these modules; that guard returns
-# per module as the list shrinks (the migration manifest test and scar 0063
-# hold the line in the interim).
-[[tool.mypy.overrides]]
-module = [
-    "daimon_briefing.privacy",
-]
-ignore_errors = true
+# The #823 ratchet is EMPTY as of #842: every module is enforced, and there
+# is no longer an overrides block to add one back to. Nothing is ever added
+# here again. A module with type errors does not ship, it gets fixed.
 
 [tool.coverage.run]
 source = ["daimon_briefing", "daimon_ui"]


### PR DESCRIPTION
Closes #842

## What

The last ratchet entry. `daimon_briefing.privacy` carried 74 errors, the
single largest block, and all 74 come from one unannotated dict literal.

`audit_project` builds `result` from a slug, two finding lists, a scan
counter and a flag, then adds a per-surface stats dict for every surface it
scans. Unannotated it infers `int | list[Any] | str | None`, which every
later `.append` and every stats assignment contradicts. mypy says so
directly at line 319: `Need type annotation for "result"`.

Annotated `result: dict`. That is one annotation for 74 errors.

Since this was the final entry, the `[[tool.mypy.overrides]]` block is
removed entirely rather than left empty, and the two comments that
described the ratchet now say it is gone. There is no longer a block to add
a module back into, which is the point: a module with type errors does not
ship, it gets fixed.

## The class histogram, which is the interesting part

60 of the 74 are `union-attr`, the class #842 singled out as "the class most
likely to be hiding a real latent bug rather than a missing annotation".
This module was the last and largest place that prediction could land.

It did not. All 60 are `result["findings"].append(...)` and its siblings
against one bad inference. Zero real defects.

That closes the pattern across the whole burn-down: **92 errors across 12
modules, and not one real bug.** Every module that looked expensive by
error count collapsed to a small number of causes, because one bad
inference multiplies across every use site rather than indicating many
faults. `ledger` was 23 errors from two literals; `cli` was 33 from six
causes with 25 of them from three literals; `privacy` is 74 from one.

The corollary is worth writing down for whoever reads this later: an error
COUNT is not a risk signal. I predicted a real defect three separate times
from counts and was wrong three times. The two `union-attr` in `cli` (#878)
were the only findings in the whole run that needed chasing rather than
annotating, and both proved unreachable.

## One correction included

`plugin/daimon_briefing/config.py` carries a one-character comment fix. The
overload comment I added in #869 used an em-dash, which the repo's own
voice rule forbids on every surface including code comments. Fixing it here
rather than leaving a known violation in the tree to keep this PR tidy.

Pre-existing em-dashes elsewhere in the package are untouched: they are not
mine to sweep, and doing so would be a large unrelated diff.

## Changes

| File | Change |
|------|--------|
| `plugin/daimon_briefing/privacy.py` | Annotate the `audit_project` result literal as `dict`, with a comment naming why it is heterogeneous |
| `plugin/daimon_briefing/config.py` | Replace an em-dash in the comment added by #869 |
| `plugin/pyproject.toml` | Remove the `[[tool.mypy.overrides]]` block entirely; update both comments that described the ratchet |

## Tests

- `uv run mypy daimon_briefing` passes with no overrides block at all.
  Removing the entry first is the failing test: it reports all 74 until the
  annotation lands.
- `uv run ruff check`: clean.
- Full suite: **4712 passed, 2 skipped**.
- Removing the last entry also returns the CI ReadResult-containment grep
  to `privacy`, which `ignore_errors` had been silencing. Suite is green
  with that guard active.
- No new test. One annotation, one comment fix, no new branch and no
  runtime behavior to pin.

## Ratchet

13 entries at the start of this run, 0 after this PR. Modules cleaned:
`cli.skill`, `render`, `teamsync`, `pending`, `relations`, `requests`,
`cli.lifecycle`, `transcript`, `amendments`, `refutations`, `ledger`,
`cli`, `privacy`.

Two tests were added along the way, both verified by breaking the behavior
first and confirming they fail: `test_rows_with_no_order_key_are_dropped_by_reader`
(#873) and `test_reopened_proposal_keeps_its_original_created_at` (#875).
