### PR TITLE
ci(pr-validation): gate on the release-please parser

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,12 @@ CI gates on this PR (pr-validation.yml):
   NOT the content area: `research/foo` fails. A PR's head branch cannot be
   retargeted, so a wrong name means closing and reopening the PR, not renaming
   it. Pick the name from the KIND of change before the first push.
+- the body must PARSE as a conventional commit. Squash makes title+body the
+  commit release-please reads, and one it cannot parse is dropped from the
+  changelog and from the version bump while the release still succeeds. The
+  usual cause is a body line whose first token is immediately followed by an
+  open paren containing another open paren; indent that line two spaces or put
+  a word before it. Fences and backticks do not help (scar 0065).
 - breaking change? put the `!` in the TITLE (`feat!:` / `fix(scope)!:`).
   Local commit footers do NOT survive the squash; a body that says
   "breaking change" without a title `!` or a `BREAKING CHANGE:` body

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -126,6 +126,43 @@ jobs:
             exit 1
           fi
 
+      # #880: squash composes main's commit from the PR title and body, so the
+      # body IS what release-please parses. A body it cannot parse is dropped
+      # from the changelog AND from the version bump while the Release workflow
+      # exits zero (scar 0065). Running the real parser instead of matching
+      # known-bad shapes is deliberate: two prose rules were derived for this
+      # failure and both turned out to be wrong.
+      - name: Check Release-Please Can Parse
+        run: |
+          d="$RUNNER_TEMP/rp"; mkdir -p "$d"
+          {
+            printf '%s (#%s)\n\n' \
+              "$(gh pr view "$PR" --repo "$REPO" --json title -q .title)" "$PR"
+            gh pr view "$PR" --repo "$REPO" --json body -q .body | tr -d '\r'
+          } > "$d/msg.txt"
+          # Pinned to release-please 17.x's own dependency so this gate cannot
+          # test a different grammar than the release does.
+          npm install --prefix "$d" --no-save --no-audit --no-fund --silent \
+            '@conventional-commits/parser@0.4.1'
+          cd "$d" && node --input-type=module -e '
+            import {parser} from "@conventional-commits/parser";
+            import {readFileSync} from "fs";
+            try {
+              parser(readFileSync("msg.txt", "utf8"));
+            } catch (e) {
+              console.log("::error::release-please cannot parse the commit this "
+                + "PR will squash into: " + e.message
+                + ". Such a commit is dropped from the changelog and from the "
+                + "version bump while the Release workflow still reports success. "
+                + "Usual cause: a body line whose first token is immediately "
+                + "followed by an open paren containing another open paren, for "
+                + "example a line starting with foo(bar(x)). Indent that line two "
+                + "spaces, or put a word before it. Fences and backticks do not "
+                + "help. See scar 0065.");
+              process.exit(1);
+            }
+          '
+
       - name: Check Branch Name
         run: |
           branch="${{ github.head_ref }}"


### PR DESCRIPTION
Closes #880

## What

Adds one step to the `PR convention` job that runs the real release-please
parser over the commit this PR will squash into, and fails when it throws.
Documents the gate in the PR template.

## Why a parser and not a rule

`squash_merge_commit_message` is PR_BODY, so the PR body IS the commit message
release-please parses. A body it cannot parse is dropped from the changelog AND
from the version bump, silently, while the Release workflow exits zero. Nothing
checked that today.

Two prose rules have now been derived for this failure and both were wrong.
Scar 0065 first blamed a double issue footer; that was correlation, corrected
in #882. My own next guess, nested parens anywhere in prose, was also wrong.
The real trigger is narrow: a body line whose first token is immediately
followed by an open paren containing another open paren. Fences and inline
backticks do not protect it; leading whitespace does.

Running the parser tests the real thing and cannot drift from what the release
does. A pattern list would need a third revision the first time someone finds
trigger number three.

## Validation

Composed title plus body from seven real PRs and compared the verdict against
what release-please actually did in the run that produced release PR #864:

```
PR #876  FAILS      release-please: could not parse e901d3b
PR #875  FAILS      release-please: could not parse 657d832
PR #873  FAILS      release-please: could not parse 8493159
PR #869  FAILS      release-please: could not parse 1a54677
PR #877  PARSES     release-please: parsed
PR #878  PARSES     release-please: parsed
PR #879  PARSES     release-please: parsed
```

Seven for seven. Line and column shift by the composition offset; the verdict
does not, which is what the gate needs.

Then extracted the step's shell straight out of the YAML and ran it locally
against a known-bad and a known-good PR:

```
simulating gate on PR #876 -> RESULT: FAIL (exit 1), with the actionable message
simulating gate on PR #879 -> RESULT: pass (exit 0)
```

The parser is pinned to `@conventional-commits/parser@0.4.1`, which is what
release-please 17.6.0 depends on, so the gate cannot test a different grammar
than the release uses.

## Why server-side and not a hook

The step reads the title and body through `gh`, the way the neighbouring
marker check from #561 does. That makes it blind to how the body was produced. It matters: all eleven PRs in the #842 ratchet run were opened
with `gh pr create --body-file`, so a check inspecting the shell command would
have seen zero of them. That constraint is already accepted in the
cross-project request ledger as q-9bf219663559.

A scar cannot cover this either. The dangerous artifact is a commit body, which
is not a file, so no anchor fires at the moment one is written.

## No release was harmed

The four unparsed commits above are all `chore:`, which is hidden from the
changelog and does not bump the version. Seven sibling `chore:` commits parsed
fine and are equally absent from #864, which is the control showing the parse
failures were not the reason they are missing. Under `fix:` or `feat:` the same
bodies would have vanished from both the notes and the bump.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/pr-validation.yml` | Add `Check Release-Please Can Parse` |
| `.github/PULL_REQUEST_TEMPLATE.md` | Document the gate and the usual cause |

## Tests

- `plugin/tests/test_pr_template_matches_gates.py`: 44 passed. The template and
  the workflow are pinned to each other, so the doc line cannot drift from the
  gate.
- Step extracted from the YAML and executed locally: fails #876, passes #879.
- This PR body was run through the same parser before posting.
