### PR TITLE
fix(requests): give the recipient its own attention filter

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -864,6 +864,47 @@ def request_panel_lines(project_dir=None) -> list[str]:
     return lines
 
 
+# ---- #885: the recipient-side owed panel ------------------------------------
+
+# Registered and frozen the same way the two headings above are (§3 amendment
+# 2026-08-27). The wording says OWE deliberately: an item here is not a
+# decision waiting on the human, it is work this project already agreed to.
+_OWED_PANEL_HEADER = "Requests you accepted and still owe:"
+
+
+def owed_panel_lines(project_dir=None) -> list[str]:
+    """#885: the recipient's OWED panel ([] when this project owes nothing,
+    or `project_dir` is None). Same posture as the two panels around it:
+    fail-open, skeleton furniture, never silently truncated over RENDER_CAP.
+
+    A third panel rather than more rows in `request_panel_lines`, because the
+    verb differs and the reader must not have to infer which from a glyph: an
+    undecided ask offers accept and reject, an owed one offers `done`. The
+    closing line names that verb for the same reason the inbox panel names
+    its own surface."""
+    if project_dir is None:
+        return []
+    try:
+        entry = requests.owed_renderable(project_dir=project_dir)
+    except Exception:
+        return []
+    rows = entry.get("rows") or []
+    if not rows:
+        return []
+    lines = [_OWED_PANEL_HEADER]
+    for row in rows:
+        marker = "  [blocking]" if row.get("blocking") else ""
+        lines.append(f"✓ {row['request_id']}  "
+                     f"{_truncate_request_ask(row.get('ask', ''))}{marker}")
+        lines.append(f"  From: {row.get('from_label') or 'an unnamed project'}")
+    overflow = entry.get("overflow") or 0
+    if overflow:
+        lines.append(f"  (+{overflow} more owed — "
+                     "daimon request inbox)")
+    lines.append("  Close one with: daimon request done <id> --evidence …")
+    return lines
+
+
 # ---- #694 PR 3: the sender-side verdict panel -------------------------------
 
 _VERDICT_PANEL_HEADER = "Decisions on requests you sent:"
@@ -912,14 +953,15 @@ def verdict_panel_lines(project_dir=None) -> list[str]:
 
 
 def render_plain(b: dict, degraded: bool = False, rulings=(),
-                 request_lines=(), verdict_lines=()) -> str:
+                 request_lines=(), verdict_lines=(), owed_lines=()) -> str:
     """The deterministic briefing text. Under the #79 budget this is
     BYTE-IDENTICAL to the legacy render(); over it, long items truncate
     (sections preserved) and then whole items drop, lowest value first,
     each cut announced with a trim note. `degraded` (#204) downgrades every
     verbatim label and adds one header note when the receipt is unverifiable."""
     budget = config.brief_max_tokens()
-    text = _render_parts(b, {}, degraded, rulings, request_lines, verdict_lines)
+    text = _render_parts(b, {}, degraded, rulings, request_lines,
+                         verdict_lines, owed_lines)
     if not budget or estimate_tokens(text) <= budget:
         return text
 
@@ -938,7 +980,7 @@ def render_plain(b: dict, degraded: bool = False, rulings=(),
         ]
     trimmed = {key: 0 for key, _ in _DROP_ORDER}
     text = _render_parts(b, trimmed, degraded, rulings, request_lines,
-                         verdict_lines)
+                         verdict_lines, owed_lines)
 
     # Stage 2: drop whole items, least valuable first, until the budget holds
     # or only the skeleton remains.
@@ -948,15 +990,16 @@ def render_plain(b: dict, degraded: bool = False, rulings=(),
             items.pop(-1 if end == "tail" else 0)
             b[key] = items
             trimmed[key] += 1
-            text = _render_parts(b, trimmed, degraded, rulings, request_lines,
-                                 verdict_lines)
+            text = _render_parts(b, trimmed, degraded, rulings,
+                                 request_lines, verdict_lines, owed_lines)
         if estimate_tokens(text) <= budget:
             break
     return text
 
 
 def _render_parts(b: dict, trimmed: dict, degraded: bool = False,
-                  rulings=(), request_lines=(), verdict_lines=()) -> str:
+                  rulings=(), request_lines=(), verdict_lines=(),
+                  owed_lines=()) -> str:
     parts = ["While you were away — here's where we left off."]
     if degraded:
         # One header note (#204), embedded in the text so the hook-injected
@@ -979,6 +1022,12 @@ def _render_parts(b: dict, trimmed: dict, degraded: bool = False,
         # #694 PR 3: same posture — skeleton furniture, outside _DROP_ORDER.
         parts.append("")
         parts.extend(verdict_lines)
+    if owed_lines:
+        # #885: same posture — skeleton furniture, outside _DROP_ORDER. Last
+        # of the four so the reader meets decisions owed TO them before work
+        # owed BY them.
+        parts.append("")
+        parts.extend(owed_lines)
 
     def _section(header: str, key: str) -> None:
         items = b.get(key) or []
@@ -1069,8 +1118,10 @@ def render(checkpoint: dict, project_dir=None, worldcheck_project=None) -> str |
                      if worldcheck_project is not None else [])
     verdict_lines = (verdict_panel_lines(worldcheck_project)
                      if worldcheck_project is not None else [])
-    skeleton_blocks = [blk for blk in (rulings, request_lines, verdict_lines)
-                       if blk]
+    owed_lines = (owed_panel_lines(worldcheck_project)
+                  if worldcheck_project is not None else [])
+    skeleton_blocks = [blk for blk in (rulings, request_lines, verdict_lines,
+                                       owed_lines) if blk]
     if b is None:
         # #693/#694: a ruling ratified, a request addressed, or a verdict
         # decided before the first real checkpoint (a day-one action) must
@@ -1097,7 +1148,8 @@ def render(checkpoint: dict, project_dir=None, worldcheck_project=None) -> str |
                 return "\n\n".join(parts)
             log.warning("llm briefing dropped a verbatim quote — "
                         "falling back to the deterministic render")
-    return render_plain(b, degraded, rulings, request_lines, verdict_lines)
+    return render_plain(b, degraded, rulings, request_lines, verdict_lines,
+                        owed_lines)
 
 
 # Seeded from research/experiments/track-a/prompts/02-reconstruct.md, tuned for a

--- a/plugin/daimon_briefing/cli/request.py
+++ b/plugin/daimon_briefing/cli/request.py
@@ -180,6 +180,23 @@ def _verdict_inject_lines(record: dict) -> list[str]:
     return lines
 
 
+def _owed_inject_lines(record: dict) -> list[str]:
+    """#885: one delivered OWED ask — work this project accepted and has not
+    closed. Same thinness as `_inject_lines`, different verb: the undecided
+    lane points at `daimon request inbox` because the verbs that decide are
+    human-only (D8), but `done` is the one either-channel move, so an agent
+    reading this can actually close it."""
+    lines = [f"daimon owed: {record['request_id']} to "
+             f"{record.get('from_label') or '?'}"
+             + (" [blocking: the sender is waiting]"
+                if record.get("blocking") else "")]
+    lines.append(f"  Ask: {record.get('ask', '')}")
+    note = str(record.get("note") or "").strip()
+    if note:
+        lines.append(f"  Accepted with: {note}")
+    return lines
+
+
 def _cmd_request_inject(args) -> int:
     """Print the undecided asks this session has not been shown, or nothing.
 
@@ -201,8 +218,9 @@ def _cmd_request_inject(args) -> int:
         project = _cli._resolve_project(args.project)
         entry = requests.deliverable(session, project_dir=project)
         verdicts = requests.verdict_deliverable(session, project_dir=project)
+        owed = requests.owed_deliverable(session, project_dir=project)
         rows = entry["rows"]
-        if not rows and not verdicts["rows"]:
+        if not rows and not verdicts["rows"] and not owed["rows"]:
             return 0
         out = []
         for record in verdicts["rows"]:
@@ -226,6 +244,15 @@ def _cmd_request_inject(args) -> int:
         # verdicts has nothing awaiting a decision to point at.
         if rows:
             out.append("Undecided. Full records: `daimon request inbox`")
+        for record in owed["rows"]:
+            out.extend(_owed_inject_lines(record))
+        if owed["overflow"]:
+            out.append(f"(+{owed['overflow']} more owed, not shown here)")
+        # `done` is the one either-channel state move (D8), so unlike the
+        # undecided lane above this names a verb the agent can actually run.
+        if owed["rows"]:
+            out.append("Accepted and owed. Close one with: "
+                       "`daimon request done <id> --evidence …`")
         print("\n".join(out))
         for record in verdicts["rows"]:
             requests.stamp_verdict_delivered(record["request_id"], session,
@@ -233,6 +260,9 @@ def _cmd_request_inject(args) -> int:
         for record in rows:
             requests.stamp_delivered(record["request_id"], session,
                                      project_dir=project)
+        for record in owed["rows"]:
+            requests.stamp_owed_delivered(record["request_id"], session,
+                                          project_dir=project)
     except Exception:  # noqa: BLE001 — per-prompt path: never block a prompt
         return 0
     return 0

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -182,7 +182,10 @@ def render_brief(checkpoint, drift=None, teammates=None, handoff=None,
                          if worldcheck_project is not None else [])
         verdict_lines = (briefing.verdict_panel_lines(worldcheck_project)
                          if worldcheck_project is not None else [])
-        blocks = [blk for blk in (rulings, request_lines, verdict_lines) if blk]
+        owed_lines = (briefing.owed_panel_lines(worldcheck_project)
+                      if worldcheck_project is not None else [])
+        blocks = [blk for blk in (rulings, request_lines, verdict_lines,
+                                  owed_lines) if blk]
         if blocks:
             # #693/#694: standing rulings, addressed requests, and decided
             # verdicts exist before the first checkpoint does — a day-one
@@ -218,14 +221,17 @@ def render_brief(checkpoint, drift=None, teammates=None, handoff=None,
                      if worldcheck_project is not None else [])
     verdict_lines = (briefing.verdict_panel_lines(worldcheck_project)
                      if worldcheck_project is not None else [])
+    owed_lines = (briefing.owed_panel_lines(worldcheck_project)
+                  if worldcheck_project is not None else [])
     # #204: degrade verbatim labels when the receipt can't be locally confirmed.
     # Cheap check (sidecar + byte match), computed once for both render paths.
     degraded = briefing.receipt_degraded(checkpoint)
     if not supports_rich():
         print(briefing.render_plain(b, degraded, rulings, request_lines,
-                                    verdict_lines))
+                                    verdict_lines, owed_lines))
     else:
-        _rich_brief(b, degraded, rulings, request_lines, verdict_lines)
+        _rich_brief(b, degraded, rulings, request_lines, verdict_lines,
+                    owed_lines)
     _print_drift(drift)
     _print_teammates(teammates)
 
@@ -259,7 +265,7 @@ def _print_drift(drift) -> None:
 
 
 def _rich_brief(b: dict, degraded: bool = False, rulings=(),
-                request_lines=(), verdict_lines=()) -> None:
+                request_lines=(), verdict_lines=(), owed_lines=()) -> None:
     from rich.console import Console
     from rich.panel import Panel
     from rich.text import Text
@@ -293,6 +299,15 @@ def _rich_brief(b: dict, degraded: bool = False, rulings=(),
             body.append(f"{line}\n", style="bold")
         console.print(Panel(body, title=verdict_lines[0],
                             border_style="green", title_align="left"))
+    if owed_lines:
+        # #885: the fourth skeleton section, its own border color for the
+        # same reason the three above have theirs — each must read as
+        # distinct at a glance.
+        body = Text()
+        for line in owed_lines[1:]:
+            body.append(f"{line}\n", style="bold")
+        console.print(Panel(body, title=owed_lines[0],
+                            border_style="magenta", title_align="left"))
     for key, title, style in _SECTIONS:
         items = b.get(key) or []
         if not items:

--- a/plugin/daimon_briefing/requests.py
+++ b/plugin/daimon_briefing/requests.py
@@ -79,6 +79,7 @@ VERSION = 1
 EVENTS = frozenset({
     "opened", "revised",
     "surfaced", "verdict_surfaced", "delivered", "verdict_delivered",
+    "owed_delivered",
     "needs_info", "accepted", "rejected", "done",
     "suppressed", "done_verified",
 })
@@ -101,6 +102,16 @@ _HUMAN_ONLY = frozenset({"needs_info", "accepted", "rejected", "suppressed"})
 # human verdict or by a completion claim, and re-opening it from the sender
 # side would be exactly the assertion the wedge principle forbids.
 _SENDER_MOVABLE = frozenset({"open", "needs-info"})
+# #885. States in which the RECIPIENT owes work. Deliberately NOT folded into
+# `_SENDER_MOVABLE`: widening that set would let a sender-side `revised` event
+# reopen an accepted record, which is exactly the assertion the wedge
+# principle forbids and which the frozenset above exists to prevent. The two
+# sets answer different questions and diverge at exactly one state — for the
+# SENDER `accepted` settles the ask, for the RECIPIENT it is where the work
+# starts and `done` is the close. Sharing one frozenset made `accept`
+# indistinguishable from `suppress` from the recipient's side while meaning
+# the opposite thing.
+_RECIPIENT_OWED = frozenset({"accepted"})
 # Per-brief render budget (D2). Over-cap renders a loud "+N more waiting"
 # line in PR 2; silent truncation of addressed asks is the one forbidden
 # failure, so the cap lives beside the overflow count it produces.
@@ -120,6 +131,7 @@ _EVENT_RANK = {
     "verdict_surfaced": 2,
     "delivered": 2,
     "verdict_delivered": 2,
+    "owed_delivered": 2,
     "suppressed": 3,
     "done": 4,
     "needs_info": 5,
@@ -387,6 +399,15 @@ def fold(rows: list[dict]) -> dict[str, dict]:
                 # epoch, but a live nudge owes it to every session running in
                 # that epoch.
                 "verdict_delivered": {},
+                # #885: {revision epoch: {session id: earliest ts}} — the
+                # recipient's OWED lane, the same shape as `delivered` and
+                # distinct from it for the same reason `verdict_delivered` is
+                # distinct from `verdict_surfaced`. Accepting never bumps the
+                # revision (only `revise` does, and it refuses a decided
+                # state), so an ask already delivered while `open` carries a
+                # `delivered` stamp for this very epoch. Reusing that key
+                # would drop the accepted card with no error and no log line.
+                "owed_delivered": {},
                 "revision": 0,
                 "created_at": row.get("ts"),
                 "updated_at": row.get("ts"),
@@ -429,6 +450,16 @@ def fold(rows: list[dict]) -> dict[str, dict]:
             session = str(row.get("session") or "").strip()
             if session:
                 current["verdict_delivered"].setdefault(current["revision"], {}) \
+                    .setdefault(session, row.get("ts"))
+            continue
+        if event == "owed_delivered":
+            # #885, same posture as `delivered` and `verdict_delivered`: an
+            # attention row, counted in history, never moving `updated_at`,
+            # and inert rather than epoch-wide when it lost its session id.
+            current["history_count"] += 1
+            session = str(row.get("session") or "").strip()
+            if session:
+                current["owed_delivered"].setdefault(current["revision"], {}) \
                     .setdefault(session, row.get("ts"))
             continue
         if event == "delivered":
@@ -966,6 +997,80 @@ def _deserves_attention(record: dict, project_dir=None) -> bool:
     about an ask the other already decided was not worth attention."""
     return (record["state"] in _SENDER_MOVABLE and not record["suppressed"]
             and not is_stale(record, project_dir=project_dir))
+
+
+def _is_owed(record: dict, project_dir=None) -> bool:
+    """#885: whether an addressed ask is work this project has AGREED to and
+    not yet closed. The recipient-side twin of `_deserves_attention`, and the
+    reason the two are separate functions rather than one widened frozenset.
+
+    Suppression still reaches here — it is the human's one lever over ambient
+    placement, and an accepted ask ignoring it would make `suppress` the only
+    verb the owed lane refuses. Staleness deliberately does NOT: `is_stale`
+    measures an ask AWAITING a decision decaying out of attention, and an
+    accepted one is not waiting on anybody, it is owed. Work does not expire
+    by being ignored. `is_stale` already returns False for every state
+    outside `_SENDER_MOVABLE`; not calling it says so at this level too."""
+    return record["state"] in _RECIPIENT_OWED and not record["suppressed"]
+
+
+def owed_renderable(project_dir=None) -> dict:
+    """#885: the recipient-side OWED panel data: {"rows": [...],
+    "overflow": N} — asks this project accepted and has not closed with
+    `done`, newest first, capped at RENDER_CAP with the remainder COUNTED.
+
+    Deliberately a second panel rather than more rows in `inbox_renderable`:
+    these are not a decision the human owes, they are work the project owes,
+    and the verb differs. An undecided ask offers accept and reject; an
+    accepted one offers `done`. Mixing them would ask the reader to sort out
+    which is which from the state glyph alone."""
+    rows = [r for r in recipient_join(project_dir=project_dir).values()
+            if _is_owed(r, project_dir=project_dir)]
+    rows.sort(key=lambda r: (r.get("updated_at") or "", r["request_id"]),
+              reverse=True)
+    return {"rows": rows[:RENDER_CAP], "overflow": max(0, len(rows) - RENDER_CAP)}
+
+
+def needs_owed_delivered_stamp(record: dict, session: str) -> bool:
+    """#885: whether THIS session has already been nudged about this OWED
+    ask this revision epoch. Its own namespace, never `delivered`: see the
+    fold's `owed_delivered` comment for why sharing that key silently
+    swallows every ask the session saw before it was accepted."""
+    epoch = (record.get("owed_delivered") or {}).get(record.get("revision")) or {}
+    return str(session or "").strip() not in epoch
+
+
+def stamp_owed_delivered(request_id: str, session: str,
+                         project_dir=None) -> bool:
+    """Write an `owed_delivered` row to THIS project's own bucket (the
+    RECIPIENT's), recording that the live surface nudged this owed ask into
+    `session`. Channel `mechanical`, same posture as `stamp_delivered`: the
+    render pipeline stamped what it did, nobody asserted anything."""
+    session = str(session or "").strip()
+    if not session:
+        raise RequestError("owed_delivered stamp requires a session id")
+    row = _stamp("owed_delivered", request_id, "mechanical")
+    row["session"] = session
+    return append(row, project_dir=project_dir)
+
+
+def owed_deliverable(session: str, project_dir=None) -> dict:
+    """#885: the asks this project has ACCEPTED and not closed that `session`
+    has not yet been nudged with. `{"rows": [...], "overflow": N}`.
+
+    Ordering, cap, dedup-before-cap and the counted remainder all follow
+    `deliverable` deliberately, so a live nudge and the next brief agree
+    about which owed work matters. No session id means no dedup key, and
+    re-nudging every turn forever is worse than not nudging."""
+    session = str(session or "").strip()
+    if not session:
+        return {"rows": [], "overflow": 0}
+    rows = [r for r in recipient_join(project_dir=project_dir).values()
+            if _is_owed(r, project_dir=project_dir)
+            and needs_owed_delivered_stamp(r, session)]
+    rows.sort(key=lambda r: (r.get("updated_at") or "", r["request_id"]),
+              reverse=True)
+    return {"rows": rows[:RENDER_CAP], "overflow": max(0, len(rows) - RENDER_CAP)}
 
 
 def inbox_renderable(project_dir=None) -> dict:

--- a/plugin/tests/test_cli_brief_owed.py
+++ b/plugin/tests/test_cli_brief_owed.py
@@ -1,0 +1,129 @@
+"""#885: the recipient-side OWED panel + owed_delivered stamp.
+
+The third request panel. PR 2 gave the recipient its undecided asks and PR 3
+gave the sender its verdicts; neither surface showed a recipient the work it
+had already AGREED to, because both filters ran off a sender-side frozenset
+that treats `accepted` as settled. For the recipient `accepted` is where the
+work starts and `done` is the close.
+
+Mirrors test_cli_brief_requests.py and test_cli_brief_verdicts.py: same D2
+same-project gate, same post-print stamp timing.
+"""
+
+from daimon_briefing import briefing, cli, requests, store
+
+
+def _seed_checkpoint(project_dir, session):
+    store.write_checkpoint(session, {
+        "session_id": session, "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": "x", "trust": "inferred"}]},
+    }, project_dir=project_dir)
+    return store.project_slug(project_dir)
+
+
+def _owed_ask(recipient_dir, ask="port the corroboration model",
+              sender_dir="/p/cbo-sender"):
+    """An ask addressed to `recipient_dir` and accepted by it — the state in
+    which the recipient owes work and nothing surfaced it."""
+    _seed_checkpoint(recipient_dir, "S-cbo-recipient")
+    sender_slug = _seed_checkpoint(sender_dir, "S-cbo-sender")
+    q_id = requests.open_request(to=store.project_slug(recipient_dir), ask=ask,
+                                 why="because", channel="cli-agent",
+                                 project_dir=sender_slug)
+    requests.accept(q_id, channel="cli-tty", project_dir=recipient_dir)
+    return q_id
+
+
+def test_cli_brief_shows_the_owed_panel_on_the_normal_path(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    recipient = "/p/cbo-recipient-a"
+    _owed_ask(recipient, sender_dir="/p/cbo-sender-a")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", recipient)
+    assert cli.main(["brief"]) == 0
+    out = capsys.readouterr().out
+    assert briefing._OWED_PANEL_HEADER in out
+    assert "port the corroboration model" in out
+
+
+def test_the_owed_panel_heading_renders_verbatim(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    """Registered the same way the other two request headings are (§3
+    amendment 2026-08-27). Rename it and this fails deliberately: change the
+    registration first and this assertion second, never the reverse."""
+    assert briefing._OWED_PANEL_HEADER == \
+        "Requests you accepted and still owe:"
+    recipient = "/p/cbo-recipient-headings"
+    _owed_ask(recipient, sender_dir="/p/cbo-sender-headings")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", recipient)
+    assert cli.main(["brief"]) == 0
+    assert briefing._OWED_PANEL_HEADER in capsys.readouterr().out
+
+
+def test_the_owed_panel_is_absent_when_nothing_is_owed(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    """Skeleton furniture, but empty furniture is noise — same posture as
+    the other two panels."""
+    recipient = "/p/cbo-recipient-empty"
+    _seed_checkpoint(recipient, "S-cbo-empty")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", recipient)
+    assert cli.main(["brief"]) == 0
+    assert briefing._OWED_PANEL_HEADER not in capsys.readouterr().out
+
+
+def test_the_owed_panel_disappears_once_done(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    recipient = "/p/cbo-recipient-done"
+    q_id = _owed_ask(recipient, sender_dir="/p/cbo-sender-done")
+    requests.done(q_id, channel="cli-tty", evidence="shipped it",
+                  project_dir=recipient)
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", recipient)
+    assert cli.main(["brief"]) == 0
+    assert briefing._OWED_PANEL_HEADER not in capsys.readouterr().out
+
+
+def test_owed_panel_lines_are_empty_without_a_project(tmp_checkpoint_dir):
+    """The D2 gate: no worldcheck project, no panel — same contract as
+    `request_panel_lines` and `verdict_panel_lines`."""
+    assert briefing.owed_panel_lines(None) == []
+
+
+def test_owed_panel_lines_fail_open(tmp_checkpoint_dir, monkeypatch):
+    """ANY composer error costs the panel, never the briefing."""
+    def _boom(*a, **k):
+        raise RuntimeError("ledger unreadable")
+    monkeypatch.setattr(requests, "owed_renderable", _boom)
+    assert briefing.owed_panel_lines("/p/cbo-boom") == []
+
+
+def test_owed_panel_names_the_verb_that_closes_it(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    """The whole reason this is a second panel and not more rows in the
+    inbox one: an undecided ask offers accept and reject, an owed one offers
+    `done`, and the reader must not have to infer which from a glyph."""
+    recipient = "/p/cbo-recipient-verb"
+    _owed_ask(recipient, sender_dir="/p/cbo-sender-verb")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", recipient)
+    assert cli.main(["brief"]) == 0
+    assert "daimon request done" in capsys.readouterr().out
+
+
+def test_owed_overflow_line_does_not_pluralise_owed(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    """"owed" is not a count noun. The sibling panels count nouns ("+2 more
+    waiting", "+2 more decided") and copying their `plural` idiom here
+    produced "+4 more oweds" on the live ledger."""
+    recipient = "/p/cbo-recipient-plural"
+    _seed_checkpoint(recipient, "S-cbo-plural")
+    sender_slug = _seed_checkpoint("/p/cbo-sender-plural", "S-cbo-sp")
+    for n in range(requests.RENDER_CAP + 2):
+        q_id = requests.open_request(to=store.project_slug(recipient),
+                                     ask=f"owed ask number {n}", why="because",
+                                     channel="cli-agent",
+                                     project_dir=sender_slug)
+        requests.accept(q_id, channel="cli-tty", project_dir=recipient)
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", recipient)
+    assert cli.main(["brief"]) == 0
+    out = capsys.readouterr().out
+    assert "(+2 more owed —" in out
+    assert "oweds" not in out

--- a/plugin/tests/test_cli_brief_owed.py
+++ b/plugin/tests/test_cli_brief_owed.py
@@ -127,3 +127,20 @@ def test_owed_overflow_line_does_not_pluralise_owed(
     out = capsys.readouterr().out
     assert "(+2 more owed —" in out
     assert "oweds" not in out
+
+
+def test_cli_rich_brief_carries_the_owed_panel(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    """The rich path renders its own Panel per skeleton section, so the plain
+    path passing proves nothing about it. Same coverage posture as the three
+    sibling panels."""
+    from daimon_briefing import render
+    recipient = "/p/cbo-recipient-rich"
+    _owed_ask(recipient, ask="rich brief carries this",
+              sender_dir="/p/cbo-sender-rich")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", recipient)
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    assert cli.main(["brief"]) == 0
+    out = capsys.readouterr().out
+    assert "rich brief carries this" in out
+    assert "Requests you accepted" in out

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -2707,3 +2707,20 @@ def test_request_inject_owed_overflow_is_counted(project, capsys, monkeypatch):
     capsys.readouterr()
     assert _inject(project, session="S-owed-overflow") == 0
     assert "+1 more owed" in capsys.readouterr().out
+
+
+def test_request_inject_owed_carries_the_acceptance_note(
+        project, capsys, monkeypatch):
+    """A verdict note is the recipient's own record of WHY it took the work
+    on, so the owed nudge carries it. Without this the agent sees the ask it
+    agreed to but not the terms it agreed to."""
+    monkeypatch.setenv("DAIMON_LIVE_DELIVERY", "1")
+    sender = _seed_bucket("/p/req-owed-inject-e")
+    q_id = requests.open_request(to=store.project_slug(project), ask=ASK,
+                                 why=WHY, channel="cli-agent",
+                                 project_dir=sender)
+    requests.accept(q_id, channel="cli-tty", note="only the read half",
+                    project_dir=project)
+    capsys.readouterr()
+    assert _inject(project, session="S-owed-note") == 0
+    assert "Accepted with: only the read half" in capsys.readouterr().out

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -911,11 +911,16 @@ def test_the_event_vocabulary_is_frozen():
     undelivered, and at worst repeats a nudge. #801 widens it a third time,
     on identical terms, with `verdict_delivered`: the sender-side counterpart,
     where an older reader drops the row, reads the verdict as undelivered, and
-    at worst repeats a nudge. Every widening so far fails the same safe way,
-    which is the property this test exists to keep true."""
+    at worst repeats a nudge. #885 widens it a fourth time, on identical terms,
+    with `owed_delivered`: the recipient's owed lane needs its own delivery
+    window because accepting never bumps the revision, so the `delivered` key
+    for this epoch is already spent; an older reader drops the row, reads the
+    owed ask as undelivered, and at worst repeats a nudge. Every widening so
+    far fails the same safe way, which is the property this test exists to
+    keep true."""
     assert set(requests.EVENTS) == {
         "opened", "revised", "surfaced", "verdict_surfaced", "delivered",
-        "verdict_delivered",
+        "verdict_delivered", "owed_delivered",
         "needs_info", "accepted", "rejected", "done", "suppressed",
         "done_verified"}
 
@@ -2480,3 +2485,225 @@ def test_cli_revise_survives_the_record_vanishing_between_its_two_reads(
     out = capsys.readouterr().out
     assert q_id in out
     assert "Traceback" not in out
+
+
+# ---- #885: the recipient's owed lane ---------------------------------------
+# `_deserves_attention` used a SENDER-side frozenset as the RECIPIENT's
+# attention filter. The two questions diverge at exactly one state: for the
+# sender `accepted` settles the ask, for the recipient it is where the work
+# STARTS and `done` is the close. Both the brief panel and live delivery
+# closed at acceptance, so the asks that had already cleared the human gate
+# were the ones that stopped being surfaced.
+
+
+def _owed_ask(project, sender_dir="/p/req-owed-sender", ask=ASK):
+    """A foreign ask addressed to `project` and ACCEPTED by it — the state
+    the recipient owes work in."""
+    sender_slug = _seed_bucket(sender_dir)
+    q_id = requests.open_request(to=store.project_slug(project), ask=ask,
+                                 why=WHY, channel="cli-agent",
+                                 project_dir=sender_slug)
+    requests.accept(q_id, channel="cli-tty", project_dir=project)
+    return q_id
+
+
+def test_owed_renderable_surfaces_an_accepted_ask(project):
+    """The whole bug in one assertion: acceptance is where the recipient's
+    obligation begins, so the panel must show it."""
+    q_id = _owed_ask(project, sender_dir="/p/req-owed-a")
+    rows = requests.owed_renderable(project_dir=project)["rows"]
+    assert [r["request_id"] for r in rows] == [q_id]
+    assert rows[0]["state"] == "accepted"
+
+
+def test_owed_renderable_drops_it_once_done(project):
+    """`done` is the recipient's close, and the only one."""
+    q_id = _owed_ask(project, sender_dir="/p/req-owed-b")
+    requests.done(q_id, channel="cli-tty", evidence="shipped it",
+                  project_dir=project)
+    assert requests.owed_renderable(project_dir=project)["rows"] == []
+
+
+def test_owed_renderable_excludes_undecided_and_rejected(project):
+    """The two lanes do not overlap: an undecided ask is a decision the
+    human owes and belongs in the inbox panel, a rejected one is closed."""
+    sender_slug = _seed_bucket("/p/req-owed-c")
+    open_id = requests.open_request(to=store.project_slug(project), ask=ASK,
+                                    why=WHY, channel="cli-agent",
+                                    project_dir=sender_slug)
+    rejected = requests.open_request(to=store.project_slug(project),
+                                     ask="a second ask", why=WHY,
+                                     channel="cli-agent",
+                                     project_dir=sender_slug)
+    requests.reject(rejected, channel="cli-tty", project_dir=project)
+    owed = [r["request_id"]
+            for r in requests.owed_renderable(project_dir=project)["rows"]]
+    assert owed == []
+    inbox = [r["request_id"]
+             for r in requests.inbox_renderable(project_dir=project)["rows"]]
+    assert inbox == [open_id]
+
+
+def test_inbox_renderable_still_excludes_the_accepted_one(project):
+    """The sender lane is untouched: widening `_SENDER_MOVABLE` would have
+    let a sender-side event reopen an accepted record, which is exactly the
+    assertion the wedge principle forbids."""
+    _owed_ask(project, sender_dir="/p/req-owed-d")
+    assert requests.inbox_renderable(project_dir=project)["rows"] == []
+    assert requests._SENDER_MOVABLE == frozenset({"open", "needs-info"})
+
+
+def test_owed_renderable_honours_suppress(project):
+    """Suppression is the human's one lever over ambient placement, and it
+    must reach this panel too — otherwise `suppress` would be the only verb
+    an accepted ask ignores."""
+    q_id = _owed_ask(project, sender_dir="/p/req-owed-e")
+    requests.suppress(q_id, channel="cli-tty", project_dir=project)
+    assert requests.owed_renderable(project_dir=project)["rows"] == []
+
+
+def test_an_owed_ask_never_goes_stale(project):
+    """Staleness is consumption-based decay on an ask AWAITING a decision.
+    An accepted one is not waiting on anybody's attention, it is owed work,
+    and work does not expire by being ignored."""
+    q_id = _owed_ask(project, sender_dir="/p/req-owed-f")
+    for n in range(requests.STALE_AFTER_SESSIONS + 2):
+        _serialize(project, f"S-owed-stale-{n}", _iso(n))
+    record = requests.recipient_join(project_dir=project)[q_id]
+    assert requests.is_stale(record, project_dir=project) is False
+    assert [r["request_id"] for r in
+            requests.owed_renderable(project_dir=project)["rows"]] == [q_id]
+
+
+def test_owed_renderable_caps_and_counts_the_remainder(project):
+    """Same posture as every other panel: silently dropping an addressed ask
+    is the one failure this feature cannot have."""
+    sender_slug = _seed_bucket("/p/req-owed-g")
+    for n in range(requests.RENDER_CAP + 2):
+        q_id = requests.open_request(to=store.project_slug(project),
+                                     ask=f"owed ask number {n}", why=WHY,
+                                     channel="cli-agent",
+                                     project_dir=sender_slug)
+        requests.accept(q_id, channel="cli-tty", project_dir=project)
+    entry = requests.owed_renderable(project_dir=project)
+    assert len(entry["rows"]) == requests.RENDER_CAP
+    assert entry["overflow"] == 2
+
+
+# ---- #885: live delivery of the owed lane ----------------------------------
+# The trap the predicate split alone does NOT fix. `needs_delivered_stamp`
+# dedups on (request id, revision epoch, session), and accepting does not
+# bump the revision — only `revise` does, and `revise` refuses a decided
+# state. So an ask already delivered to a live session while `open` is
+# stamped for that epoch, and re-entering the filter after acceptance is
+# dropped by the stamp with no error and no log line. The owed lane gets its
+# own stamp namespace, the same shape and for the same reason as
+# `verdict_delivered` (#801) beside `delivered`.
+
+
+def test_owed_deliverable_reaches_a_session_that_already_saw_it_open(project):
+    """The regression this whole namespace exists to prevent."""
+    q_id = _owed_ask(project, sender_dir="/p/req-owed-h")
+    session = "S-owed-live"
+    record = requests.recipient_join(project_dir=project)[q_id]
+    requests.stamp_delivered(q_id, session, project_dir=project)
+    record = requests.recipient_join(project_dir=project)[q_id]
+    assert requests.needs_delivered_stamp(record, session) is False
+    rows = requests.owed_deliverable(session, project_dir=project)["rows"]
+    assert [r["request_id"] for r in rows] == [q_id]
+
+
+def test_owed_deliverable_is_write_once_per_session(project):
+    q_id = _owed_ask(project, sender_dir="/p/req-owed-i")
+    session = "S-owed-once"
+    assert requests.owed_deliverable(session, project_dir=project)["rows"]
+    requests.stamp_owed_delivered(q_id, session, project_dir=project)
+    assert requests.owed_deliverable(session, project_dir=project)["rows"] == []
+
+
+def test_owed_deliverable_still_reaches_a_second_session(project):
+    q_id = _owed_ask(project, sender_dir="/p/req-owed-j")
+    requests.stamp_owed_delivered(q_id, "S-owed-first", project_dir=project)
+    rows = requests.owed_deliverable("S-owed-second", project_dir=project)["rows"]
+    assert [r["request_id"] for r in rows] == [q_id]
+
+
+def test_owed_deliverable_without_a_session_delivers_nothing(project):
+    """Same posture as `deliverable`: no session id means no dedup key, and
+    re-nudging every turn forever is worse than not nudging."""
+    _owed_ask(project, sender_dir="/p/req-owed-k")
+    assert requests.owed_deliverable("", project_dir=project)["rows"] == []
+
+
+def test_stamp_owed_delivered_requires_a_session_id(project):
+    q_id = _owed_ask(project, sender_dir="/p/req-owed-l")
+    with pytest.raises(requests.RequestError):
+        requests.stamp_owed_delivered(q_id, "", project_dir=project)
+
+
+def test_owed_delivered_is_a_registered_event(project):
+    assert "owed_delivered" in requests.EVENTS
+
+
+# ---- #885: live delivery of the owed lane, end to end ----------------------
+
+
+def test_request_inject_delivers_an_owed_ask(project, capsys, monkeypatch):
+    monkeypatch.setenv("DAIMON_LIVE_DELIVERY", "1")
+    q_id = _owed_ask(project, sender_dir="/p/req-owed-inject-a")
+    capsys.readouterr()
+    assert _inject(project, session="S-owed-inject") == 0
+    out = capsys.readouterr().out
+    assert q_id in out
+    assert ASK in out
+    assert "daimon request done" in out
+
+
+def test_request_inject_stamps_the_owed_lane_after_the_print(
+        project, capsys, monkeypatch):
+    monkeypatch.setenv("DAIMON_LIVE_DELIVERY", "1")
+    q_id = _owed_ask(project, sender_dir="/p/req-owed-inject-b")
+    capsys.readouterr()
+    assert _inject(project, session="S-owed-stamp") == 0
+    capsys.readouterr()
+    record = requests.recipient_join(project_dir=project)[q_id]
+    assert requests.needs_owed_delivered_stamp(record, "S-owed-stamp") is False
+    # Write-once: a second turn in the same session says nothing.
+    assert _inject(project, session="S-owed-stamp") == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_request_inject_reaches_a_session_that_saw_the_ask_before_accept(
+        project, capsys, monkeypatch):
+    """The end-to-end form of the trap. The session was nudged while the ask
+    was still `open`, so the `delivered` stamp for this epoch is already
+    written. Accepting does not bump the revision, so a shared stamp would
+    swallow the owed nudge with no error and no log line."""
+    monkeypatch.setenv("DAIMON_LIVE_DELIVERY", "1")
+    sender = _seed_bucket("/p/req-owed-inject-c")
+    q_id = requests.open_request(to=store.project_slug(project), ask=ASK,
+                                 why=WHY, channel="cli-agent",
+                                 project_dir=sender)
+    session = "S-owed-before-accept"
+    assert _inject(project, session=session) == 0
+    capsys.readouterr()
+    # Same session, same epoch: the undecided lane is now silent.
+    assert _inject(project, session=session) == 0
+    assert capsys.readouterr().out == ""
+    requests.accept(q_id, channel="cli-tty", project_dir=project)
+    assert _inject(project, session=session) == 0
+    out = capsys.readouterr().out
+    assert q_id in out, "the owed nudge was swallowed by the delivered stamp"
+
+
+def test_request_inject_owed_overflow_is_counted(project, capsys, monkeypatch):
+    monkeypatch.setenv("DAIMON_LIVE_DELIVERY", "1")
+    sender = _seed_bucket("/p/req-owed-inject-d")
+    for n in range(requests.RENDER_CAP + 1):
+        q_id = requests.open_request(to=store.project_slug(project),
+                                     ask=f"owed ask number {n}", why=WHY,
+                                     channel="cli-agent", project_dir=sender)
+        requests.accept(q_id, channel="cli-tty", project_dir=project)
+    capsys.readouterr()
+    assert _inject(project, session="S-owed-overflow") == 0
+    assert "+1 more owed" in capsys.readouterr().out


### PR DESCRIPTION
Closes #885

## What

Splits the recipient's attention filter off the sender's.

`_deserves_attention` filtered on `_SENDER_MOVABLE`, a sender-side frozenset,
and used it as the recipient's filter too. The two questions diverge at exactly
one state. For the sender `accepted` settles the ask. For the recipient it is
where the work starts and `done` is the close.

- `_RECIPIENT_OWED` is a new frozenset, deliberately separate. Widening
  `_SENDER_MOVABLE` would have let a sender-side `revised` event reopen an
  accepted record, which is the assertion the wedge principle forbids and which
  that frozenset exists to prevent. A test pins it unchanged.
- `owed_renderable` and `owed_deliverable` are the recipient's two surfaces,
  mirroring `inbox_renderable` and `deliverable` in ordering, cap, and counted
  overflow.
- `owed_delivered` is a new stamp namespace with its own fold field and event.
- A fourth briefing panel, "Requests you accepted and still owe:", registered
  and frozen the same way the other three headings are.
- The live-delivery surface gains an owed section that names `daimon request
  done`, the one either-channel move an agent can actually run.

## Why

Accepting an addressed request made it invisible to the project expected to
carry it out. The asks that had already cleared the human gate were the ones
that stopped surfacing, which inverts the signal. `suppress` is documented as
dropping an item out of the panel; `accept` was doing the same thing without
being asked to, making the two verbs indistinguishable from the recipient's
side while meaning opposite things.

Measured on one real ledger before the change: seven accepted asks were
surfacing nowhere.

The second half is the part a predicate split alone does not fix.
`needs_delivered_stamp` dedups on request id, revision epoch, and session, and
accepting never bumps the revision, since only `revise` does and it refuses a
decided state. An ask already nudged into a live session while open therefore
carries a `delivered` stamp for that same epoch, so reusing that key would drop
the accepted card with no error and no log line. The owed lane gets its own
namespace for the same reason, and in the same shape, as `verdict_delivered`
beside `delivered`.

Rendered as a fourth panel rather than more rows in the inbox one because the
verb differs. An undecided ask offers accept and reject; an owed one offers
`done`, and the reader should not have to infer which from a glyph.

The frozen event vocabulary widens a fourth time on the same terms as the three
before it: an older reader drops the unknown row, reads the ask as undelivered,
and at worst repeats a nudge.

Not built here: whether an accepted and owed item should also surface on the
sender's side. The issue flags it as a second panel needing a deliberate
ruling, so it is left for one.

## Tests

`plugin/tests/test_requests.py` gains the data and live-delivery lanes,
`plugin/tests/test_cli_brief_owed.py` is new and covers the panel. All 20 fail
before the change.

The one that matters most is
`test_request_inject_reaches_a_session_that_saw_the_ask_before_accept`. It
nudges a session while the ask is open, asserts the second nudge is silent, then
accepts and asserts the owed nudge still arrives. On a shared stamp namespace it
does not, silently, which is what makes the predicate split alone look like a
working fix.

Also pinned: `_SENDER_MOVABLE` is unchanged; an owed ask never goes stale, since
staleness measures an ask awaiting a decision and work does not expire by being
ignored; suppression still reaches the owed panel; the overflow line does not
pluralise "owed", which the live run caught after the sibling panels' idiom was
copied one step too far.

Full suite 4737 passed, 2 skipped. `ruff check` clean. `mypy` clean across 59
source files.

The frozen-vocabulary test failed first and correctly, since it exists to make
widening `EVENTS` deliberate. It is updated with the fail-safe argument rather
than loosened.
