### PR TITLE
docs(store): state project_slug's real rule and drop the parity claim

### DIFF
--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -50,10 +50,35 @@ _POINTER_RE = re.compile(r"^(?:latest|prev-\d+)\.json$")
 def project_slug(project_dir) -> str | None:
     """Filesystem-safe slug for a project working directory, or None if unknown.
 
-    Same munging scheme Claude Code uses for its project dirs: every char that
-    is not a word char or '-' becomes '-' (slashes, dots, spaces). Unicode word
-    chars survive. The result can never contain a path separator, so it cannot
-    escape the checkpoint dir.
+    THE RULE, stated exactly: every char that is not a Python `\\w` char or '-'
+    becomes '-'. Python's `\\w` is Unicode-aware, so underscores, accented
+    letters and non-Latin scripts all survive; slashes, dots and spaces fold.
+    The result can never contain a path separator, so it cannot escape the
+    checkpoint dir.
+
+    This is NOT the same scheme the Claude CLI uses for `~/.claude/projects`,
+    which the docstring claimed until #884. The two agree on slashes, dots and
+    spaces and disagree on underscores: daimon keeps `_`, the CLI folds it.
+    Measured, not inferred: 0 of 711 directories under `~/.claude/projects` on
+    the machine this was written on contain an underscore, and 19 of them carry
+    a doubled hyphen of the form `...-daimon-cli--2y36i7g`. `mkdtemp` draws its
+    suffix from `[a-z0-9_]` and can never emit '-', so a `--` there can only be
+    a folded `_`. Unicode is a second, untested divergence in the same
+    direction: `-a-café` and `-a-日本` survive here whatever the CLI does.
+
+    DO NOT "fix" the divergence by folding '_' to match. This function names
+    checkpoint BUCKET directories, so re-slugging any project path containing
+    an underscore orphans that bucket: no error, no migration, the prior
+    history simply stops being found. Two slugs is the correct end state, not
+    one. The CLI's locates a transcript directory, this one locates a
+    checkpoint bucket, and they are different functions that happen to agree
+    on most inputs.
+
+    Nothing here joins on the CLI's slug. `provenance.py` takes
+    `transcript_path` from the host and tests containment, or globs
+    `*/*.jsonl`; it never computes a CLI slug and compares. The divergence is
+    therefore a documentation defect rather than a live one, which is why #884
+    changed only this text.
     """
     if not project_dir:
         return None

--- a/plugin/tests/test_store.py
+++ b/plugin/tests/test_store.py
@@ -132,7 +132,14 @@ def test_read_escaping_path_returns_none(tmp_checkpoint_dir, monkeypatch):
 # ---- per-project routing: cwd-slugged latest with global fallback ----
 
 
-def test_project_slug_matches_claude_code_scheme():
+def test_project_slug_folds_every_non_word_char_to_a_hyphen():
+    """#884: renamed from test_project_slug_matches_claude_code_scheme.
+
+    The old name asserted a parity with the Claude CLI that does not hold,
+    and its body could never have caught that: `/Users/x/proj` contains no
+    character the two schemes disagree about, so the test proved the claim
+    its name made in exactly zero cases. The docstring carried the same false
+    sentence, and a downstream consumer implemented against it."""
     assert store.project_slug("/Users/x/proj") == "-Users-x-proj"
 
 
@@ -140,8 +147,41 @@ def test_project_slug_spaces_and_dots():
     assert store.project_slug("/Users/x/My Proj.app") == "-Users-x-My-Proj-app"
 
 
+def test_project_slug_keeps_underscores_unlike_the_claude_cli():
+    """#884, the divergence the old name hid. The regex is `[^\\w-]` and
+    Python's `\\w` includes `_`, so daimon KEEPS underscores where the CLI
+    folds them.
+
+    Measured, not inferred: 0 of 711 directories under `~/.claude/projects`
+    on the machine this was written on contain an underscore, and 19 carry a
+    doubled hyphen of the form `...-daimon-cli--2y36i7g`. `mkdtemp` draws its
+    suffix from `[a-z0-9_]` and can never emit '-', so that `--` can only be
+    a collapsed `_`."""
+    assert store.project_slug("/a/b_c") == "-a-b_c"
+
+
+def test_project_slug_never_folds_underscores_to_match_the_cli():
+    """The guard a docstring warning cannot enforce on its own.
+
+    This is the dangerous reading of #884 and the reason that issue rejected
+    it explicitly. `project_slug` names checkpoint BUCKET directories, so
+    folding '_' re-slugs every project path containing one and orphans its
+    bucket: no error, no migration, the prior history simply stops being
+    found. Safe today only because no current bucket contains an underscore,
+    which is luck about one machine rather than a property of the code.
+
+    A future reader who takes the CLI-parity idea seriously and "corrects"
+    the regex to `[^A-Za-z0-9-]` fails HERE, loudly, instead of silently
+    orphaning history in the field."""
+    assert store.project_slug("/home/user/my_project") == "-home-user-my_project"
+
+
 def test_project_slug_unicode_preserved():
+    """#884 widened this: `\\w` is Unicode-aware, so the surviving class is
+    every Unicode word char, not only accented Latin. Whether the CLI agrees
+    is untested, which is why the docstring no longer claims it does."""
     assert store.project_slug("/Users/x/café") == "-Users-x-café"
+    assert store.project_slug("/Users/x/日本") == "-Users-x-日本"
 
 
 def test_project_slug_empty_is_none():
@@ -2339,3 +2379,4 @@ def test_read_latest_reportable_allows_an_unrouted_checkpoint(tmp_checkpoint_dir
     got = store.read_latest_body(str(mine), route=store.Route.OWN_ELSE_GLOBAL,
                                  admit=store.Admit.OWN_OR_UNROUTED)
     assert (got or {}).get("session_id") == "S-unrouted"
+


### PR DESCRIPTION
Closes #884

## What

Corrects `store.project_slug`'s docstring, and the test that carried the same
wrong claim.

The docstring said the function used "the same munging scheme Claude Code uses
for its project dirs". The two disagree on underscores. The regex is `[^\w-]`
and Python's `\w` includes `_`, so daimon keeps underscores where the CLI folds
them.

- The docstring now states daimon's rule exactly, names the divergence, and
  records why the algorithm must not be changed to match.
- `test_project_slug_matches_claude_code_scheme` is renamed to
  `test_project_slug_folds_every_non_word_char_to_a_hyphen`.
- Two cases added beside it: underscores survive, and the CLI-parity regex is
  refused.
- The unicode case is widened past accented Latin.

No behavior change. The regex is untouched.

## Why

It was a documented promise, and a consumer implemented against it. A
downstream reimplementation folds `/` only, so a dot, underscore or space in
its working root would point its memory directory where the CLI never reads and
its checkpoint watcher where daimon never writes, silently in both directions.
It is latent rather than live only because that root happens to sit in the
agreement set `[A-Za-z0-9/-]`.

Measured on the machine this was written on, not inferred: 0 of 711 directories
under `~/.claude/projects` contain an underscore, and 19 carry a doubled hyphen
of the form `...-daimon-cli--2y36i7g`. `mkdtemp` draws its suffix from
`[a-z0-9_]` and can never emit a hyphen, so that doubled hyphen can only be a
collapsed underscore.

The test is the part worth flagging. Its name asserted the parity, and its body
passed `/Users/x/proj`, an input containing no character the two schemes
disagree about. It could not have failed for the reason its name gave, so a
reader checking whether parity held would have found a green test named after
it.

The docstring also now records the trap, because this is the dangerous reading
of the issue. `project_slug` names checkpoint bucket directories, so folding an
underscore re-slugs any project path containing one and orphans its bucket: no
error, no migration, the prior history simply stops being found. Two slugs is
the correct end state. The CLI's locates a transcript directory, this one
locates a checkpoint bucket, and they are different functions that agree on
most inputs.

Nothing joins on the CLI's slug today. `provenance.py` takes `transcript_path`
from the host and tests containment, or globs for the transcript. So this is a
correction to the record with no behavior change anywhere.

## Tests

`4741 passed, 2 skipped`. `ruff check` clean. `mypy` clean across 59 source
files.

Verified by mutation rather than by the tests merely passing. Switching the
regex to `[^A-Za-z0-9-]`, which is the change this PR exists to prevent, fails
three of them:

```
FAILED test_project_slug_keeps_underscores_unlike_the_claude_cli
FAILED test_project_slug_never_folds_underscores_to_match_the_cli
FAILED test_project_slug_unicode_preserved
```

Restored, all pass. Characterization tests that pass on arrival prove nothing
until something shows they can fail.

Note on the label: this is `type:docs` because the deliverable is a corrected
documented rule, and the tests exist to keep that text true. It is not eligible
for the docs-only issue bypass, since a docstring lives in a `.py` file and
`DOCS_ONLY_PATH_RE` matches paths; the linked issue carries `status:approved`.
