### PR TITLE
fix(recall): name the origin project on a cross-scope hit

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -850,8 +850,14 @@ def _cmd_recall(args) -> int:
         contradicted += f" [{cured}]" if cured else ""
         trust = r.get("trust") or "untagged"
         item_id = f" [{r['item_id']}]" if r.get("item_id") else ""
+        # #889: [author] reads like attribution and is not — config.author()
+        # is a machine identity, one constant across every project here. The
+        # row has always known its origin project; only --json ever showed it,
+        # so a foreign hit and a local one rendered identically.
+        scope = recall.describe_scope(r, store.project_slug(project))
+        scope_mark = f" ({scope})" if scope else ""
         lines.append(f"[{r['author']}] [{trust}] [{r['kind']}]{item_id} {r['text']} "
-                     f"({r['session_id']}, {age} ago){superseded}"
+                     f"({r['session_id']}, {age} ago){scope_mark}{superseded}"
                      f"{contradicted}")
     render.render_recall_lines(lines)
     return 0
@@ -1434,7 +1440,7 @@ def age_gate_blocks(m, now: float, age_days=_UNSET) -> bool:
     return isinstance(hits, int) and hits < _STALE_MIN_HITS
 
 
-def _suggest_line(r: dict, terms, now: float) -> str:
+def _suggest_line(r: dict, terms, now: float, own_slug=None) -> str:
     """One compact, attributed, trust-preserving injection line (#125).
 
     ONE line is a contract, not a hope (#512): the echo strip that removes
@@ -1462,9 +1468,14 @@ def _suggest_line(r: dict, terms, now: float) -> str:
     # as though nothing had happened.
     cured = recall.describe_cure(r.get("cured_by"))
     contradicted += f" ({cured})" if cured else ""
+    # #889: name the origin project when it is not this reader's own. Same
+    # phrasing function as the recall surface, so a live nudge and a hand-run
+    # search can never describe a different origin for one row.
+    scope = recall.describe_scope(r, own_slug)
+    scope_mark = f" ({scope})" if scope else ""
     more = " ".join(terms[:3])
     return (f"daimon recall: prior work — {r['kind']} from {r['session_id']} "
-            f"({age} ago): \"{text}\" [{trust}]{superseded}"
+            f"({age} ago): \"{text}\" [{trust}]{scope_mark}{superseded}"
             f"{contradicted}. "
             f"More: daimon recall \"{more}\"")
 
@@ -1567,7 +1578,8 @@ def _cmd_recall_inject(args) -> int:
             return 0
         terms = recall.salient_terms(prompt)
         for m in chosen:
-            print(_suggest_line(m, terms, now))
+            print(_suggest_line(m, terms, now,
+                                own_slug=store.project_slug(project)))
         if seen_file:
             # #500: count what each origin supplied instead of retiring it
             # outright, so a later, stronger row from the same session stays

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -713,6 +713,39 @@ def _apply_verification_invalidations(conn: sqlite3.Connection) -> None:
                  ref, bucket.name, author))
 
 
+def describe_scope(row, own_slug) -> str | None:
+    """#889: name the project a row came from when it is not the reader's own,
+    else None.
+
+    Lives here for the same reason `describe_invalidation` below does: every
+    read surface calls one function, so two surfaces can never describe a
+    different origin for the same row. `search` has always SELECTed
+    `i.project_slug`; only `--json` ever showed it, so a foreign row and a
+    local row rendered identically everywhere a human actually reads.
+
+    `author` is not a substitute and looks like one. `config.author()` resolves
+    an env var, then git's user name, then the OS user, all process-level, so
+    on one workstation every row in every project carries the same string.
+
+    Silent in three cases, each deliberate:
+
+      - same slug: the common case pays no noise, and a label that never
+        varies is read as furniture and stops being seen, which would
+        reintroduce this defect wearing a fix;
+      - the reader has no slug: an unknown project cannot say what is foreign
+        to it, and guessing would label every row of an all-projects search;
+      - the row has no slug: rotated-out pre-stamp checkpoints index NULL-slug
+        on purpose, and a row that never claimed a project must not be
+        described as coming from somewhere else.
+    """
+    if not own_slug:
+        return None
+    slug = (row or {}).get("project_slug")
+    if not slug or slug == own_slug:
+        return None
+    return f"from {slug}"
+
+
 def describe_invalidation(value) -> str | None:
     """Render one stored `invalidated_by` value as a marker phrase, or None.
 

--- a/plugin/tests/test_cross_scope_attribution.py
+++ b/plugin/tests/test_cross_scope_attribution.py
@@ -1,0 +1,121 @@
+"""#889: a cross-project recall hit must not render as the reader's own memory.
+
+`search` selects `i.project_slug` per row and the render line never printed it,
+so a foreign row and a local row looked identical on every surface except
+`--json`. `[author]` reads like the answer and is not: `config.author()` is a
+machine identity, one constant across every project on a workstation.
+
+The marker is deliberately absent on same-project rows. A label that never
+varies is read as furniture and stops being seen, which would reintroduce the
+defect wearing a fix.
+"""
+
+from daimon_briefing import cli, recall, store
+
+
+def _cp(sid, text):
+    return {
+        "session_id": sid,
+        "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": [
+            {"text": text, "trust": "inferred"}]},
+    }
+
+
+# ---- the shared phrasing ---------------------------------------------------
+
+
+def test_describe_scope_is_silent_for_the_readers_own_slug():
+    assert recall.describe_scope({"project_slug": "-p-mine"}, "-p-mine") is None
+
+
+def test_describe_scope_names_a_foreign_slug():
+    assert recall.describe_scope(
+        {"project_slug": "-p-theirs"}, "-p-mine") == "from -p-theirs"
+
+
+def test_describe_scope_is_silent_when_the_reader_has_no_slug():
+    """An unknown project cannot say what is foreign to it, and guessing would
+    label every row of an all-projects search."""
+    assert recall.describe_scope({"project_slug": "-p-theirs"}, None) is None
+
+
+def test_describe_scope_is_silent_on_a_row_with_no_slug():
+    """Rotated-out pre-stamp checkpoints index NULL-slug on purpose. A row
+    that never claimed a project must not be described as foreign."""
+    assert recall.describe_scope({"project_slug": None}, "-p-mine") is None
+    assert recall.describe_scope({}, "-p-mine") is None
+
+
+# ---- the recall surface ----------------------------------------------------
+
+
+def test_cli_recall_all_projects_marks_the_foreign_row(
+        tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):
+    """The live defect: before this, both lines rendered identically."""
+    proj_a = str((tmp_path / "proj-a").resolve())
+    proj_b = str((tmp_path / "proj-b").resolve())
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-a", _cp("S-a", "lemur work in a"),
+                           project_dir=proj_a)
+    store.write_checkpoint("S-b", _cp("S-b", "lemur work in b"),
+                           project_dir=proj_b)
+
+    assert cli.main(["recall", "lemur", "--project", proj_a,
+                     "--all-projects"]) == 0
+    out = capsys.readouterr().out
+    slug_b = store.project_slug(proj_b)
+    assert f"from {slug_b}" in out, "the foreign row is unmarked"
+    slug_a = store.project_slug(proj_a)
+    assert f"from {slug_a}" not in out, "the reader's own row was marked"
+
+
+def test_cli_recall_scoped_search_marks_nothing(
+        tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):
+    """The common case pays no noise: every row is the reader's own."""
+    proj = str((tmp_path / "proj-only").resolve())
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-a", _cp("S-a", "lemur work here"),
+                           project_dir=proj)
+    assert cli.main(["recall", "lemur", "--project", proj]) == 0
+    out = capsys.readouterr().out
+    assert "lemur work here" in out
+    assert "from " not in out
+
+
+def test_cli_recall_json_is_unchanged(
+        tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):
+    """--json already carried project_slug; the marker is a human-render
+    concern and must not become a second encoding of the same fact."""
+    proj = str((tmp_path / "proj-json").resolve())
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S-a", _cp("S-a", "lemur json"), project_dir=proj)
+    assert cli.main(["recall", "lemur", "--project", proj, "--json"]) == 0
+    out = capsys.readouterr().out
+    assert '"project_slug"' in out
+    assert "from " not in out
+
+
+# ---- the inject surface ----------------------------------------------------
+
+
+def test_inject_line_marks_a_foreign_row():
+    """The two surfaces share one phrasing so they can never disagree about
+    where a memory came from.
+
+    `suggest` cannot cross a scope today: it takes no `slug` parameter and
+    derives one from `project_dir`. This exercises the line builder directly,
+    because the guard has to exist BEFORE the capability that would need it,
+    which is the whole timing argument in #889."""
+    row = {"kind": "decision", "session_id": "S-x", "text": "a foreign claim",
+           "trust": "inferred", "created": 0, "project_slug": "-p-theirs"}
+    line = cli._suggest_line(row, ["lemur"], 0.0, own_slug="-p-mine")
+    assert "from -p-theirs" in line
+
+
+def test_inject_line_is_silent_for_the_readers_own_row():
+    row = {"kind": "decision", "session_id": "S-x", "text": "my own claim",
+           "trust": "inferred", "created": 0, "project_slug": "-p-mine"}
+    line = cli._suggest_line(row, ["lemur"], 0.0, own_slug="-p-mine")
+    assert "from -p-mine" not in line


### PR DESCRIPTION
Closes #889

## What

A cross-project recall hit now names the project it came from.

```
[ada] [inferred] [decision] lemur work in b (S-b, 2h ago) (from -tmp-proj-b)
[ada] [inferred] [decision] lemur work in a (S-a, 2h ago)
```

- `recall.describe_scope(row, own_slug)` is the one phrasing function, placed
  beside `describe_invalidation` for the reason that one already gives: every
  read surface calls it, so two surfaces cannot describe a different origin for
  the same row.
- `_cmd_recall` and `_suggest_line` both call it.
- `--json` is untouched. It already carried `project_slug` and the marker must
  not become a second encoding of the same fact.

## Why

The row has always known its origin. `search` selects `i.project_slug` per row,
and only `--json` ever showed it, so every surface a human reads printed a
foreign row and a local row identically.

`[author]` reads like the answer and is not. `config.author()` resolves
`DAIMON_AUTHOR`, then `git config user.name`, then the OS user, all
process-level, so on one workstation every row in every project carries the
same string. A reader looking for whose memory this is finds a field that
answers and always gives the same answer.

### The marker is silent three ways, each on purpose

Same slug, so the common case pays no noise. This is the one that matters: a
label that never varies is read as furniture and stops being seen, which would
reintroduce the defect wearing a fix. Two tests exist only to pin it, and both
pass before this change.

Reader has no slug, because an unknown project cannot say what is foreign to it
and guessing would label every row of an all-projects search.

Row has no slug, because rotated-out pre-stamp checkpoints index NULL-slug
deliberately, and a row that never claimed a project must not be described as
coming from somewhere else.

### Timing

Crossing a scope is user-invoked today. `--all-projects` and `--slug` are typed
by someone who knows they crossed, so the missing label has been a wart rather
than a hazard.

`suggest` is the prompt-time auto-inject path and it cannot cross a scope at
all: it takes no `slug` parameter and derives one from `project_dir`. Ambient
cross-scope injection is impossible by construction right now.

Any future second read scope changes that. Crossing would happen on every
prompt, with nobody asking and no label, and an agent would speak about another
scope's memory in the first person. The guard belongs before the capability.

## Tests

`4750 passed, 2 skipped`. `ruff check` clean. `mypy` clean across 59 source
files. Patch coverage clean: the changed ranges appear in neither file's
missing-lines list.

Nine new tests in `plugin/tests/test_cross_scope_attribution.py`. Seven fail
before the change; the two that pass are the over-fix guards described above.

One judgement call worth a reviewer's eye:
`test_inject_line_marks_a_foreign_row` calls `_suggest_line` directly instead
of driving `recall-inject` end to end. There is no end-to-end path that can
cross a scope, since `suggest` has no route to one, so an integration test
would have nothing to assert. It is a unit test standing in for an integration
test, which is honest for a guard that must exist before the capability, but it
is a stand-in and it should be read as one.

## Not in this change

Per-item author, which is filed separately. This makes the origin visible; it
does not make the speaker correct. For the existing `--all-projects` case that
is a complete fix, because one workstation means the single author genuinely is
one person. A scope holding several speakers needs both.
