### PR TITLE
fix(recall): let an item name whose statement it records

### DIFF
--- a/docs/checkpoint-schema.json
+++ b/docs/checkpoint-schema.json
@@ -575,6 +575,18 @@
       "notes": "Author that first wrote the item (#268). Model-emitted values are stripped."
     },
     {
+      "field": "stated_by",
+      "type": "string",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "stripped_at_serialize": true
+      },
+      "notes": "#890. WHOSE STATEMENT this item records, as distinct from `author`, which is the machine identity that wrote the checkpoint. A long-lived host observing several people has one author and many staters, and without this every item inherits the one author, so a foreign claim reads as the reader's own memory. Rendered only: never a dedup key, never a directory name, never an admission input, which is what keeps it from accumulating the load `author` carries. ABSENT MEANS UNKNOWN, never the reader — defaulting to the author would make every legacy item a first-person claim. Code-owned and stripped from model output like `author`: a model naming who said something is an agent asserting an identity it cannot verify."
+    },
+    {
       "field": "carried_from",
       "type": "string",
       "optional": true,

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -856,9 +856,14 @@ def _cmd_recall(args) -> int:
         # so a foreign hit and a local one rendered identically.
         scope = recall.describe_scope(r, store.project_slug(project))
         scope_mark = f" ({scope})" if scope else ""
+        # #890: whose STATEMENT this is, when the record names one. Absent
+        # means unknown and renders as nothing — never a guess and never a
+        # placeholder, because a default would read as the reader's own claim.
+        stated = str(r.get("stated_by") or "").strip()
+        stated_mark = f" (stated by {stated})" if stated else ""
         lines.append(f"[{r['author']}] [{trust}] [{r['kind']}]{item_id} {r['text']} "
-                     f"({r['session_id']}, {age} ago){scope_mark}{superseded}"
-                     f"{contradicted}")
+                     f"({r['session_id']}, {age} ago){stated_mark}{scope_mark}"
+                     f"{superseded}{contradicted}")
     render.render_recall_lines(lines)
     return 0
 
@@ -1473,9 +1478,13 @@ def _suggest_line(r: dict, terms, now: float, own_slug=None) -> str:
     # search can never describe a different origin for one row.
     scope = recall.describe_scope(r, own_slug)
     scope_mark = f" ({scope})" if scope else ""
+    # #890: same posture as the recall surface, same phrasing.
+    stated = str(r.get("stated_by") or "").strip()
+    stated_mark = f" (stated by {stated})" if stated else ""
     more = " ".join(terms[:3])
     return (f"daimon recall: prior work — {r['kind']} from {r['session_id']} "
-            f"({age} ago): \"{text}\" [{trust}]{scope_mark}{superseded}"
+            f"({age} ago): \"{text}\" [{trust}]{stated_mark}{scope_mark}"
+            f"{superseded}"
             f"{contradicted}. "
             f"More: daimon recall \"{more}\"")
 

--- a/plugin/daimon_briefing/field_table.py
+++ b/plugin/daimon_briefing/field_table.py
@@ -167,6 +167,20 @@ ITEM_RULES: tuple[FieldRule, ...] = (
         "Author that first wrote the item (#268). Model-emitted values are "
         "stripped."),
     FieldRule(
+        "item", "stated_by", "string", True, False, "code", "strip",
+        _c(stripped_at_serialize=True),
+        "#890. WHOSE STATEMENT this item records, as distinct from `author`, "
+        "which is the machine identity that wrote the checkpoint. A "
+        "long-lived host observing several people has one author and many "
+        "staters, and without this every item inherits the one author, so a "
+        "foreign claim reads as the reader's own memory. Rendered only: never "
+        "a dedup key, never a directory name, never an admission input, which "
+        "is what keeps it from accumulating the load `author` carries. "
+        "ABSENT MEANS UNKNOWN, never the reader — defaulting to the author "
+        "would make every legacy item a first-person claim. Code-owned and "
+        "stripped from model output like `author`: a model naming who said "
+        "something is an agent asserting an identity it cannot verify."),
+    FieldRule(
         "item", "carried_from", "string", True, False, "code", "strip",
         _c(stripped_at_serialize=True),
         "Session id of the LAST carry hop (#33); absent on native items. "

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -97,7 +97,7 @@ def _note_error(where: str, exc: BaseException) -> None:
 # ledger folds bind through — purely a performance object, but the bump
 # rolls every existing db onto it deterministically instead of waiting for
 # an unrelated fingerprint change.
-_SCHEMA_VERSION = "8"   # #866 added items.cured_by
+_SCHEMA_VERSION = "9"   # #890 added items.stated_by
 
 _FTS5_MISSING_MSG = (
     "sqlite3 has no FTS5 module — `daimon recall` needs an FTS5-enabled "
@@ -169,9 +169,14 @@ def _items(cp: dict):
                             and isinstance(link.get("target"), str)
                             and link["target"].strip()):
                         targets.append(link["target"].strip())
+            # #890: absent stays None, never the checkpoint's author — a
+            # default would make every legacy item a first-person claim,
+            # which is the collapse the field exists to prevent.
+            stated = str(item.get("stated_by") or "").strip() or None
             yield (kind, text, str(item.get("trust") or ""),
                    str(item.get("quote") or ""), str(item.get("scene") or ""),
-                   imp, fs, item_id, 1 if item.get("pinned") else 0, targets)
+                   imp, fs, item_id, 1 if item.get("pinned") else 0, targets,
+                   stated)
 
 
 def _bucket_slugs(d: Path) -> dict[str, str]:
@@ -381,6 +386,14 @@ def _init_schema(conn: sqlite3.Connection) -> None:
                 trust TEXT,
                 kind TEXT,
                 author TEXT,
+                -- #890: WHOSE STATEMENT this item records, distinct from
+                -- `author` (the machine identity that wrote the checkpoint).
+                -- A long-lived host observing several people has one author
+                -- and many staters. Rendered only: never a dedup key, never a
+                -- directory name, never an admission input, which is what
+                -- keeps it from accumulating the load `author` carries.
+                -- NULL means UNKNOWN, never the reader.
+                stated_by TEXT,
                 project_slug TEXT,
                 session_id TEXT,
                 created REAL,
@@ -828,14 +841,16 @@ def rebuild() -> int:
                 if key not in newest or (stamped, recency, sid) > newest[key]:
                     newest[key] = (stamped, recency, sid)
             for (kind, text, trust, quote, scene, importance, first_seen,
-                 item_id, pinned, targets) in _items(cp):
+                 item_id, pinned, targets, stated_by) in _items(cp):
                 cur = conn.execute(
                     "INSERT INTO items"
-                    " (text, quote, scene, trust, kind, author, project_slug,"
+                    " (text, quote, scene, trust, kind, author, stated_by,"
+                    "  project_slug,"
                     "  session_id, created, importance, first_seen, item_id,"
                     "  pinned)"
-                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    (text, quote, scene, trust, kind, author, slug, sid, recency,
+                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (text, quote, scene, trust, kind, author, stated_by, slug,
+                     sid, recency,
                      importance, first_seen, item_id, pinned),
                 )
                 conn.execute(
@@ -998,7 +1013,8 @@ def search(query: str, project_dir=None, all_projects: bool = False,
                               else store.project_slug(project_dir))
 
     sql = (
-        "SELECT i.text, i.quote, i.trust, i.kind, i.author, i.project_slug,"
+        "SELECT i.text, i.quote, i.trust, i.kind, i.author, i.stated_by,"
+        " i.project_slug,"
         " i.session_id, i.created, i.superseded_by, i.superseded_source,"
         " i.invalidated_by, i.cured_by,"
         " i.importance, i.first_seen, i.item_id, i.frontier,"
@@ -1418,7 +1434,8 @@ def suggest(prompt: str, project_dir=None, current_session=None,
     except (OSError, sqlite3.Error) as exc:
         _note_error("suggest.refresh", exc)
     sql = (
-        "SELECT i.text, i.quote, i.trust, i.kind, i.author, i.project_slug,"
+        "SELECT i.text, i.quote, i.trust, i.kind, i.author, i.stated_by,"
+        " i.project_slug,"
         " i.session_id, i.created, i.importance, i.first_seen, i.superseded_by,"
         # #837: the column MUST be selected here, not just written — this is
         # the auto-inject path, so a missing select re-asserts a claim this

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -2163,7 +2163,13 @@ _CODE_OWNED_KEYS = (
 _CODE_OWNED_ITEM_KEYS = ("origin_session", "origin_author",
                          "quote_verified", "last_verified",
                          "quote_provenance", "pinned", "id",
-                         "carried_from", "first_seen")
+                         "carried_from", "first_seen",
+                         # #890: a model naming who said something is an agent
+                         # asserting an identity it cannot verify, and the
+                         # field would carry more authority than any other
+                         # while being the least checkable. The host sets it
+                         # after the model is done, the way `author` is set.
+                         "stated_by")
 
 
 def strip_code_owned_keys(checkpoint: dict) -> None:

--- a/plugin/tests/test_stated_by.py
+++ b/plugin/tests/test_stated_by.py
@@ -1,0 +1,143 @@
+"""#890: an item can name whose statement it records, distinct from `author`.
+
+`author` is a machine identity and a KEY: it names a team sidecar directory,
+gates foreign-content admission, and is half of two dedup keys. A checkpoint
+written by a long-lived process that observed several people cannot say so,
+because every item inherits the one checkpoint-level value.
+
+`stated_by` is the subject identity and is rendered only. It is never a key,
+never a directory name, never an admission input, which is what keeps it from
+accumulating the load `author` carries.
+
+The rule most easily got wrong: an ABSENT `stated_by` means unknown, never
+"the reader". Implicit "no speaker equals mine" is the collapse this exists to
+fix, and it would be reintroduced for every legacy row by a fix that guessed.
+"""
+
+from daimon_briefing import cli, field_table, recall, store
+
+
+def _cp(sid, items):
+    return {
+        "session_id": sid,
+        "created": "2026-08-16T00:00:00Z",
+        "working_context": {"recent_decisions": items},
+    }
+
+
+# ---- the field rule --------------------------------------------------------
+
+
+def test_stated_by_is_a_registered_item_field():
+    rule = field_table._ITEM_BY_NAME.get("stated_by")
+    assert rule is not None, "stated_by is not in the generated field table"
+    assert rule.scope == "item"
+    assert rule.type == "string"
+    assert rule.optional is True
+
+
+def test_stated_by_is_code_owned_and_stripped_from_model_output():
+    """The wedge principle: no feature may let an agent assert.
+
+    A model emitting `stated_by` would be attributing a claim to a person who
+    may never have made it, and the field would carry more authority than any
+    other while being the least verifiable. So it matches `author`: code-owned,
+    stripped at serialize, set by the host after the model is done."""
+    rule = field_table._ITEM_BY_NAME["stated_by"]
+    assert rule.owner == "code"
+    assert rule.disposition == "strip"
+    assert dict(rule.constraints).get("stripped_at_serialize") is True
+
+
+# ---- the index -------------------------------------------------------------
+
+
+def test_an_item_carries_its_own_stated_by(tmp_checkpoint_dir, tmp_path,
+                                           monkeypatch):
+    """The whole point: one checkpoint, two speakers."""
+    proj = str((tmp_path / "p-two-speakers").resolve())
+    monkeypatch.setenv("DAIMON_AUTHOR", "the-host")
+    store.write_checkpoint("S-a", _cp("S-a", [
+        {"text": "lemurs are nocturnal", "trust": "inferred",
+         "stated_by": "ana"},
+        {"text": "lemurs are diurnal", "trust": "inferred",
+         "stated_by": "ben"},
+    ]), project_dir=proj)
+    rows = recall.search("lemurs", project_dir=proj, limit=10)
+    got = {r["text"]: r.get("stated_by") for r in rows}
+    assert got["lemurs are nocturnal"] == "ana"
+    assert got["lemurs are diurnal"] == "ben"
+    # `author` is untouched and still the machine identity for both.
+    assert {r["author"] for r in rows} == {"the-host"}
+
+
+def test_an_item_without_stated_by_is_null_not_the_author(
+        tmp_checkpoint_dir, tmp_path, monkeypatch):
+    """Absent means UNKNOWN. Defaulting to the checkpoint author would make
+    every legacy row a first-person claim, which is the bug this fixes."""
+    proj = str((tmp_path / "p-absent").resolve())
+    monkeypatch.setenv("DAIMON_AUTHOR", "the-host")
+    store.write_checkpoint("S-a", _cp("S-a", [
+        {"text": "lemur with no speaker", "trust": "inferred"},
+    ]), project_dir=proj)
+    row = recall.search("lemur", project_dir=proj, limit=10)[0]
+    assert row.get("stated_by") is None
+    assert row["author"] == "the-host"
+
+
+def test_stated_by_is_not_a_dedup_key():
+    """`author` is half the result dedup key on purpose: the same words from
+    two authors is attribution, not duplication. `stated_by` must NOT join
+    that key, or one speaker's echo of another would stop collapsing."""
+    rows = [{"kind": "decision", "author": "a", "text": "same words",
+             "stated_by": "ana", "created": 1.0},
+            {"kind": "decision", "author": "a", "text": "same words",
+             "stated_by": "ben", "created": 2.0}]
+    assert len(recall._dedupe_rows(rows, 10)) == 1
+
+
+def test_the_schema_version_moved(tmp_checkpoint_dir):
+    """A new column means every existing index rebuilds deterministically
+    rather than waiting for an unrelated fingerprint change."""
+    assert recall._SCHEMA_VERSION != "8"
+
+
+# ---- the render ------------------------------------------------------------
+
+
+def test_cli_recall_names_the_stater(tmp_checkpoint_dir, tmp_path,
+                                     monkeypatch, capsys):
+    proj = str((tmp_path / "p-render").resolve())
+    monkeypatch.setenv("DAIMON_AUTHOR", "the-host")
+    store.write_checkpoint("S-a", _cp("S-a", [
+        {"text": "lemur claim", "trust": "inferred", "stated_by": "ana"},
+    ]), project_dir=proj)
+    assert cli.main(["recall", "lemur", "--project", proj]) == 0
+    assert "stated by ana" in capsys.readouterr().out
+
+
+def test_cli_recall_says_nothing_when_no_one_is_named(
+        tmp_checkpoint_dir, tmp_path, monkeypatch, capsys):
+    """Silence, not a guess and not a placeholder. The common single-speaker
+    case pays no noise, same posture as the #889 scope marker."""
+    proj = str((tmp_path / "p-render-absent").resolve())
+    monkeypatch.setenv("DAIMON_AUTHOR", "the-host")
+    store.write_checkpoint("S-a", _cp("S-a", [
+        {"text": "lemur claim", "trust": "inferred"},
+    ]), project_dir=proj)
+    assert cli.main(["recall", "lemur", "--project", proj]) == 0
+    out = capsys.readouterr().out
+    assert "lemur claim" in out
+    assert "stated by" not in out
+
+
+def test_suggest_line_names_the_stater():
+    row = {"kind": "decision", "session_id": "S-x", "text": "a claim",
+           "trust": "inferred", "created": 0, "stated_by": "ana"}
+    assert "stated by ana" in cli._suggest_line(row, ["lemur"], 0.0)
+
+
+def test_suggest_line_is_silent_without_one():
+    row = {"kind": "decision", "session_id": "S-x", "text": "a claim",
+           "trust": "inferred", "created": 0}
+    assert "stated by" not in cli._suggest_line(row, ["lemur"], 0.0)


### PR DESCRIPTION
Closes #890

## What

An item can now name whose statement it records.

```
[the-host] [inferred] [decision] lemurs are nocturnal (S-a, 2h ago) (stated by ana)
[the-host] [inferred] [decision] lemurs are diurnal   (S-a, 2h ago) (stated by ben)
```

One checkpoint, one `author`, two staters. That was not expressible before.

| File | Change |
|---|---|
| `field_table.py` | new item rule, code-owned, `stripped_at_serialize` |
| `docs/checkpoint-schema.json` | regenerated, verified against the generator |
| `serializer.py` | `_CODE_OWNED_ITEM_KEYS` gains the name |
| `recall.py` | schema version 8 to 9, DDL column, `_items` yield, INSERT, both SELECTs |
| `cli/__init__.py` | both render surfaces |

## Why a separate field, not a widened `author`

`author` is a key, not a label. Five load-bearing uses:

- names a team sidecar directory, `authors/<slug(author)>/*.json`
- gates foreign-content admission, `if foreign and project_slug(author) != self_author`
- half the index dedup key, `(author, sid)`
- half the result dedup key, `(kind, author, text)`
- five `WHERE ... author = ?` clauses

The admission gate decides it. A non-matching author routes content through
`policy.admit_foreign`, which re-redacts and clamps `verbatim` to `inferred`.
Per-item authors would make a host's own observations read as a stranger's and
downgrade their trust on the machine that recorded them.

The result dedup key is the quieter argument, and its own docstring already
says it: "the same words from two authors is attribution, not duplication."
`author` is already carrying meaning there.

This is not a new pattern. `refutations.py` splits identity three ways on one
record rather than overloading any of them: `asserted_by` is the authority
class, `asserted_author` the machine identity, `text_authored_by` who wrote the
current text.

## The rule that is easy to get wrong

**Absent means unknown, never the reader.**

Implicit "no speaker equals mine" is the collapse this field exists to fix. If
absence read as the reader, every legacy item would become a first-person claim
and the fix would ship having reintroduced the bug for all existing data.

Verified by mutation, not by the tests passing. Defaulting an absent value to
the checkpoint author fails two tests:

```
FAILED test_an_item_without_stated_by_is_null_not_the_author
FAILED test_cli_recall_says_nothing_when_no_one_is_named
```

Restored, all ten pass. The guard is enforced rather than intended.

## Why the model cannot write it

`stated_by` is code-owned and stripped at serialize, exactly like `author`.

A model naming who said something is an agent asserting an identity it cannot
verify, and the field would carry more authority than any other field while
being the least checkable. That is the assertion the wedge principle forbids.

The field table and the serializer strip list must agree on this, and
`test_stripped_item_keys_match_the_serializer_strip_list` caught the omission
on the first run. That test exists because those two lists drifting is a known
failure here.

## Integration cost, stated up front

Because the field is stripped at serialize, a host cannot have it populated by
the serializer. It must attach `stated_by` to items itself after serialization,
which requires a mapping from item to source message that a host may not have.

That is the honest price of keeping assertion out of the model's hands. It
belongs here rather than being discovered by the first consumer.

## Schema version

`_SCHEMA_VERSION` moves from 8 to 9, so every existing index rebuilds
deterministically instead of waiting for an unrelated fingerprint change. The
rebuild is total, so no stale rows persist.

## Tests

`4760 passed, 2 skipped`. `ruff check` clean. `mypy` clean across 59 source
files. The regenerated schema artifact is byte-identical to the generator.

Ten new tests in `plugin/tests/test_stated_by.py`. Six fail before the change.
The four that pass on arrival are the guards: absent stays null, the field
stays out of the dedup key, and both render surfaces stay silent when no one is
named. The mutation above is what shows they can fail.

## Not in this change

Whether `stated_by` should also carry an evidential label, the attested versus
observed question. That asks whether the label is a new value on the existing
`trust` axis or a field of its own, and it routes through the language contract
before any surface change. Folding it in here would smuggle a contract change
into a bug fix.
