### PR TITLE
fix(serializer): derive stated_by from the transcript's per-message speaker

### DIFF
--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -541,6 +541,21 @@ def _message_id(m) -> str | None:
     return None
 
 
+def _message_said_by(m) -> str | None:
+    """WHO said this message, as the host recorded it (#893), or None.
+
+    Distinct from `role`, which is the transcript position (user/assistant).
+    A long-lived host observing several people sets this per message; a host
+    that has no such concept sets nothing and every item stays unattributed.
+    """
+    if not isinstance(m, dict):
+        return None
+    who = m.get("said_by")
+    if isinstance(who, str) and who.strip():
+        return who.strip()
+    return None
+
+
 def _render_line(i, m, content) -> str:
     """One message's transcript line — the per-message unit of every rendered
     surface (#831: factored out of _render_transcript so the stitching
@@ -588,6 +603,23 @@ def message_texts_by_id(messages) -> dict[str, str]:
         mid = _message_id(m)
         if mid is not None:
             out[mid] = _message_text(m)
+    return out
+
+
+def message_speakers_by_id(messages) -> dict[str, str]:
+    """Host message id -> speaker, for messages the host attributed (#893).
+
+    The host half of the `stated_by` join. It states a fact about an artifact
+    it received ("message u1 came from ana"), never a claim about an item's
+    content, which is what keeps this an observation rather than an assertion.
+    Empty for hosts that record no speaker, the same degradation
+    signal_message_ids has for hosts that surface no tool rows."""
+    out: dict[str, str] = {}
+    for m in messages or []:
+        mid = _message_id(m)
+        who = _message_said_by(m)
+        if mid is not None and who is not None:
+            out[mid] = who
     return out
 
 
@@ -718,6 +750,39 @@ def validate(checkpoint) -> bool:
 # receipt-machinery change.
 
 SOURCE_IDS_KEY = "source_message_ids"
+
+
+def derive_stated_by(checkpoint, speakers) -> None:
+    """Fill each item's `stated_by` from its validated bindings (#893).
+
+    Runs AFTER sanitize_source_ids (so every id is one the transcript vouched
+    for) and AFTER strip_code_owned_keys (so a model-supplied value is already
+    gone and cannot survive by being right). daimon owns this join: the host
+    supplies message-to-speaker, the code supplies item-to-message, and neither
+    side ever asserts the other's half.
+
+    ABSENT MEANS UNKNOWN, and ambiguity counts as absent. An item whose
+    bindings name two different speakers, or name one speaker and one unknown
+    message, gets nothing: picking a winner would manufacture exactly the
+    misattribution the field exists to prevent. Only unanimous, fully-known
+    attribution is recorded.
+
+    Never fatal, same philosophy as sanitize_source_ids: an advisory field must
+    never fail a serialize."""
+    if not isinstance(speakers, dict) or not speakers:
+        return
+    for item in iter_items(checkpoint):
+        ids = item.get(SOURCE_IDS_KEY)
+        if not isinstance(ids, list) or not ids:
+            continue
+        named = {speakers.get(i) for i in ids if isinstance(i, str)}
+        # A single non-None speaker across every binding, or nothing. `None` in
+        # the set means one cited message had no recorded speaker, which makes
+        # the whole attribution partial and therefore unknown.
+        if len(named) == 1:
+            who = named.pop()
+            if isinstance(who, str) and who:
+                item["stated_by"] = who
 
 
 def sanitize_source_ids(checkpoint, id_map, signal_ids=frozenset()) -> None:
@@ -2558,6 +2623,11 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
     # tool-result messages) survive on any item, evidence for outcome claims.
     sig_ids = signal_message_ids(messages)
     sanitize_source_ids(checkpoint, message_id_map(messages), sig_ids)
+    # #893: fill `stated_by` from the host's per-message speaker, joined
+    # through the bindings sanitize_source_ids just validated. Must run HERE:
+    # after that call (so every id is one the transcript vouched for) and after
+    # strip_code_owned_keys ran on the fresh parse (so a model value is gone).
+    derive_stated_by(checkpoint, message_speakers_by_id(messages))
     # #369: deterministic backstop for constraint pinning — hard-imperative
     # user sentences the model paraphrased away are force-pinned as verbatim
     # items here, AFTER id sanitization (host ids go in directly) and BEFORE

--- a/plugin/daimon_briefing/transcript.py
+++ b/plugin/daimon_briefing/transcript.py
@@ -350,6 +350,13 @@ def _from_jsonl(text: str) -> list[dict]:
             msg = {"role": role, "content": content}
             if mid is not None:
                 msg["id"] = mid
+            # #893: carry the host's per-message speaker through when the row
+            # names one. A discriminating FIELD, not a row shape (deadend #20):
+            # rows without a usable string keep their exact existing shape, so
+            # hosts that record no speaker stay byte-identical.
+            said = obj.get("said_by")
+            if isinstance(said, str) and said.strip():
+                msg["said_by"] = said.strip()
             messages.append(msg)
             continue
         # #359: a row whose ONLY payload is tool_result blocks used to be

--- a/plugin/tests/test_stated_by_derivation.py
+++ b/plugin/tests/test_stated_by_derivation.py
@@ -1,0 +1,186 @@
+"""#893: `stated_by` is DERIVED from the transcript, never accepted from a host.
+
+`#892` shipped `items.stated_by` readable, indexed and rendered, and unfillable:
+the field is code-owned and every path accepting a checkpoint payload strips it,
+so no host could ever put a value in.
+
+The fix is not a write channel. A host naming an ITEM's speaker asserts something
+about content it did not author. A host putting a speaker on a MESSAGE states a
+fact about an artifact it received. So the host supplies `said_by` per message,
+daimon owns the join through the already-validated `source_message_ids` binding,
+and the derivation runs AFTER `strip_code_owned_keys` so a model still cannot
+reach the field.
+
+The rule inherited from #892 and extended here: ABSENT MEANS UNKNOWN. An item
+with no binding, an unknown speaker, or bindings that DISAGREE all render
+nothing, because ambiguous is not known.
+"""
+
+from daimon_briefing import serializer
+
+
+def _cp_one_decision(item):
+    return {
+        "session_id": "S1",
+        "working_context": {
+            "active_topic": {"text": "t", "trust": "inferred"},
+            "open_questions": [],
+            "recent_decisions": [item],
+        },
+        "epistemic_snapshot": {
+            "strong_beliefs": [], "uncertainties": [],
+            "contradictions_flagged": [],
+        },
+    }
+
+
+def _item(cp):
+    return cp["working_context"]["recent_decisions"][0]
+
+
+# ---- the map ---------------------------------------------------------------
+
+
+def test_message_speakers_by_id_maps_host_id_to_speaker():
+    messages = [
+        {"id": "u1", "role": "user", "said_by": "ana", "content": "a"},
+        {"id": "u2", "role": "user", "said_by": "ben", "content": "b"},
+    ]
+    assert serializer.message_speakers_by_id(messages) == {"u1": "ana",
+                                                           "u2": "ben"}
+
+
+def test_message_speakers_by_id_skips_messages_without_a_speaker():
+    """A host with no speaker on its messages degrades to an empty map, the
+    same mode signal_message_ids documents for hosts with no tool rows."""
+    messages = [
+        {"id": "u1", "role": "user", "content": "a"},
+        {"id": "u2", "role": "user", "said_by": "  ", "content": "b"},
+        {"role": "user", "said_by": "ana", "content": "no id"},
+    ]
+    assert serializer.message_speakers_by_id(messages) == {}
+
+
+def test_message_speakers_by_id_tolerates_junk():
+    """Never fatal, same philosophy as sanitize_source_ids."""
+    assert serializer.message_speakers_by_id(None) == {}
+    assert serializer.message_speakers_by_id(["not a dict", 7]) == {}
+    assert serializer.message_speakers_by_id(
+        [{"id": "u1", "said_by": 7}]) == {}
+
+
+# ---- the join --------------------------------------------------------------
+
+
+def test_derives_stated_by_from_a_validated_binding():
+    cp = _cp_one_decision({"text": "d", "trust": "verbatim", "quote": "q",
+                           "source_message_ids": ["u1"]})
+    serializer.derive_stated_by(cp, {"u1": "ana"})
+    assert _item(cp)["stated_by"] == "ana"
+
+
+def test_an_item_with_no_binding_gets_nothing():
+    cp = _cp_one_decision({"text": "d", "trust": "inferred"})
+    serializer.derive_stated_by(cp, {"u1": "ana"})
+    assert "stated_by" not in _item(cp)
+
+
+def test_an_unknown_speaker_gets_nothing():
+    """The binding is valid but the host named no speaker for that message."""
+    cp = _cp_one_decision({"text": "d", "trust": "verbatim", "quote": "q",
+                           "source_message_ids": ["u9"]})
+    serializer.derive_stated_by(cp, {"u1": "ana"})
+    assert "stated_by" not in _item(cp)
+
+
+def test_agreeing_bindings_derive_the_shared_speaker():
+    cp = _cp_one_decision({"text": "d", "trust": "verbatim", "quote": "q",
+                           "source_message_ids": ["u1", "u2"]})
+    serializer.derive_stated_by(cp, {"u1": "ana", "u2": "ana"})
+    assert _item(cp)["stated_by"] == "ana"
+
+
+def test_disagreeing_bindings_derive_nothing():
+    """AMBIGUOUS IS NOT KNOWN. An item stitched from two speakers has no single
+    stater, and picking one would manufacture the misattribution the field
+    exists to prevent. Absent is the honest answer."""
+    cp = _cp_one_decision({"text": "d", "trust": "verbatim", "quote": "q",
+                           "source_message_ids": ["u1", "u2"]})
+    serializer.derive_stated_by(cp, {"u1": "ana", "u2": "ben"})
+    assert "stated_by" not in _item(cp)
+
+
+def test_a_partially_known_pair_derives_nothing():
+    """One binding names ana, the other names nobody. We cannot say the item is
+    ana's when part of it came from a message we cannot attribute."""
+    cp = _cp_one_decision({"text": "d", "trust": "verbatim", "quote": "q",
+                           "source_message_ids": ["u1", "u9"]})
+    serializer.derive_stated_by(cp, {"u1": "ana"})
+    assert "stated_by" not in _item(cp)
+
+
+def test_an_empty_speaker_map_derives_nothing_anywhere():
+    cp = _cp_one_decision({"text": "d", "trust": "verbatim", "quote": "q",
+                           "source_message_ids": ["u1"]})
+    serializer.derive_stated_by(cp, {})
+    assert "stated_by" not in _item(cp)
+
+
+# ---- the guard -------------------------------------------------------------
+
+
+def test_a_model_supplied_value_never_survives():
+    """The wedge principle. strip_code_owned_keys runs first and removes the
+    model's claim; derivation then fills from the transcript or not at all. A
+    forged value must not persist just because the item has no binding."""
+    cp = _cp_one_decision({"text": "d", "trust": "inferred",
+                           "stated_by": "someone-who-never-spoke"})
+    serializer.strip_code_owned_keys(cp)
+    serializer.derive_stated_by(cp, {"u1": "ana"})
+    assert "stated_by" not in _item(cp)
+
+
+def test_a_forged_value_is_replaced_by_the_derived_one():
+    """A model naming the RIGHT speaker still does not get credit for it: the
+    stored value comes from the transcript join, never from model output."""
+    cp = _cp_one_decision({"text": "d", "trust": "verbatim", "quote": "q",
+                           "source_message_ids": ["u1"], "stated_by": "ben"})
+    serializer.strip_code_owned_keys(cp)
+    serializer.derive_stated_by(cp, {"u1": "ana"})
+    assert _item(cp)["stated_by"] == "ana"
+
+
+# ---- the wiring ------------------------------------------------------------
+
+
+def test_the_pipeline_actually_calls_the_derivation():
+    """#892's defect was a field nothing could write. The mirror defect is a
+    derivation nothing calls, so this pins the call site rather than trusting
+    that it exists.
+
+    Same discipline as test_stripped_item_keys_match_the_serializer_strip_list:
+    two things that must agree, asserted rather than assumed."""
+    import inspect
+    src = inspect.getsource(serializer)
+    body = src[src.index("sanitize_source_ids(checkpoint, message_id_map"):]
+    head = body[:900]
+    assert "derive_stated_by(checkpoint, message_speakers_by_id(messages))" in head, (
+        "derive_stated_by is not called right after sanitize_source_ids in the "
+        "serialize pipeline; the field would ship unfillable again")
+
+
+def test_transcript_carries_a_host_speaker_through_normalization():
+    """transcript.py normalizes to a fixed key set, so an unrecognised key on
+    the host row is dropped. Without this pass-through the derivation joins
+    against an empty map forever."""
+    import json
+
+    from daimon_briefing import transcript
+    rows = [
+        {"type": "user", "uuid": "u1", "said_by": "ana",
+         "message": {"role": "user", "content": "hello"}},
+        {"type": "user", "uuid": "u2",
+         "message": {"role": "user", "content": "no speaker"}},
+    ]
+    msgs = transcript._from_jsonl("\n".join(json.dumps(r) for r in rows))
+    assert serializer.message_speakers_by_id(msgs) == {"u1": "ana"}


### PR DESCRIPTION
Closes #893

## What

`stated_by` is now derived from the transcript instead of being unfillable.

`#892` shipped `items.stated_by` readable, indexed and rendered on both
surfaces, and writable by nobody. A census outside tests returned 11 hits and
zero writers.

Three additions, the first two following a shape `serializer.py` already has
three of:

```
_message_said_by(m)                 host row field reader, mirrors _message_id
message_speakers_by_id(messages)    host message id to speaker
derive_stated_by(cp, speakers)      the join, after sanitize_source_ids
```

`transcript.py` carries `said_by` through normalization as a discriminating
field rather than a row shape (deadend 20), so hosts recording no speaker stay
byte-identical.

## Why

The design rested on an analogy stated in the code, that the host sets this
field the way `author` is set. The analogy does not hold. `author` is stripped
from model output too, but a second channel puts a value back afterward:
`config.author()` reads `DAIMON_AUTHOR` and `store.py:1180` stamps it. There is
no per-item equivalent of an environment variable, because the value varies per
item by definition.

A write channel was the wrong fix. A host naming an ITEM's speaker asserts
something about content it did not author. A host putting a speaker on a
MESSAGE states a fact about an artifact it received, checkable after the fact.
So the host supplies its half, daimon owns the join, and neither side supplies
the other's.

The model still cannot reach the field. Derivation runs after
`strip_code_owned_keys`, so a forged value is removed before the join and a
correct guess earns no credit.

**Ambiguous is not known.** An item whose bindings name two different speakers,
or name one speaker and one unknown message, derives nothing. Picking a winner
would manufacture the misattribution the field exists to prevent. This extends
`#892`'s absent-means-unknown rule rather than reinterpreting it.

## Limits, stated rather than discovered later

1. `source_message_ids` travels with an item's quote, so this reaches verbatim
   items plus the one inferred case at `serializer.py:215`. Unbound items get
   nothing.
2. That failure is safe: absent already means unknown, so consumers see gaps,
   never misattribution.
3. Serialize path only. `write-checkpoint` passes an empty id map and derives
   nothing.
4. Hosts with no speaker degrade to absent, the mode `signal_message_ids`
   already documents.

## Tests

14 new tests in `plugin/tests/test_stated_by_derivation.py`, all 14 red before
the change.

Three guards mutation-verified rather than assumed:

```
take the first speaker instead of requiring unanimity  -> 2 tests fail
drop the transcript pass-through                       -> 1 test fails
remove the pipeline call                               -> wiring test fails
```

The wiring test exists because `#892`'s defect was a field nothing could write,
and the mirror defect is a derivation nothing calls. It pins the call site next
to `sanitize_source_ids` instead of trusting that it is there.

```
4766 passed, 10 skipped
ruff check          All checks passed
mypy daimon_briefing   no issues found in 59 source files
```

Baselined against clean `main` before claiming the suite was green: an earlier
run showed 53 failures that turned out to be a missing `pretty` extra in my own
invocation, identical on `main` with the change stashed.
