### PR TITLE
fix(requests): join a verdict recorded from a third project directory

### DIFF
--- a/plugin/daimon_briefing/cli/request.py
+++ b/plugin/daimon_briefing/cli/request.py
@@ -35,13 +35,21 @@ _MARKS = {"open": "→", "needs-info": "?", "accepted": "✓",
 _SUGGESTIONS = 3
 
 
-def _request_channel(args) -> str:
+def _request_channel(args, *, human_only: bool = False) -> str:
     """The channel this invocation actually arrived through — the
     `_refute_channel` contract restated for the request ledger (same
-    doctrine, its own error type so refusals stay per-surface)."""
+    doctrine, its own error type so refusals stay per-surface).
+
+    #895: a verdict verb refuses `--by agent` by design, so its refusal must
+    not name that flag as the remedy; the only path that can succeed there
+    is a terminal."""
     if getattr(args, "by", None) == "agent":
         return "cli-agent"
     if not sys.stdin.isatty():
+        if human_only:
+            raise requests.RequestError(
+                "this verb is human-only and there is no interactive "
+                "terminal; run it from a terminal")
         raise requests.RequestError(
             "this is the human path and there is no interactive terminal; "
             "pass --by agent to record it as an agent, or run it from a "
@@ -357,7 +365,7 @@ def _cmd_request_verdict(args) -> int:
     project = _cli._resolve_project(args.project)
     verb = args.request_cmd
     try:
-        channel = _request_channel(args)
+        channel = _request_channel(args, human_only=True)
         getattr(requests, _VERDICT_CALLS[verb])(
             args.request_id, channel=channel, note=args.note or "",
             project_dir=project)

--- a/plugin/daimon_briefing/requests.py
+++ b/plugin/daimon_briefing/requests.py
@@ -684,9 +684,11 @@ def _require(request_id: str, project_dir) -> dict:
 def _verdict(event: str, request_id: str, *, channel: str, note: str = "",
              project_dir=None) -> None:
     if CHANNEL_AUTHORITY.get(channel) != "human":
+        state = _STATE_BY_EVENT.get(event, event)
+        article = "an" if state[:1] in "aeiou" else "a"
         raise RequestError(
-            f"a {_STATE_BY_EVENT.get(event, event)} verdict requires a human "
-            f"channel; this call arrived through {channel!r}")
+            f"{article} {state} verdict requires a human channel; this call "
+            f"arrived through {channel!r}")
     current = _answering(request_id, project_dir)
     if current is not None and current["state"] == "rejected":
         raise RequestError(
@@ -878,26 +880,33 @@ def _sender_rows(project_dir) -> dict[str, list]:
     and must never cross the join (D5). Local rows are returned untouched, so a
     record THIS project suppressed keeps its visibility.
 
-    One recipient bucket is read once per distinct `to` target, not once per
-    record."""
+    #895: the verdict is not necessarily in the recipient's bucket. A human
+    decides from whatever directory they are standing in, and the row lands
+    THERE, so every bucket with a ledger is read once and its rows for the
+    ids this project sent abroad are joined. A project with nothing sent
+    abroad (only self-addressed asks, or only answers to foreign asks) reads
+    its own bucket and nothing else."""
     sender_slug = store.project_slug(project_dir)
     if not sender_slug:
         return {}
     by_id: dict[str, list] = {}
-    to_by_id: dict[str, str] = {}
+    abroad: set[str] = set()
     for row in events(project_dir=sender_slug):
         rid = str(row.get("request_id") or "")
         by_id.setdefault(rid, []).append(row)
         if row.get("event") == "opened":
-            to_by_id[rid] = str(row.get("to") or "")
-    cache: dict[str, list] = {}
-    for rid, to_slug in to_by_id.items():
-        if not to_slug or to_slug == sender_slug:
+            to_slug = str(row.get("to") or "")
+            if to_slug and to_slug != sender_slug:
+                abroad.add(rid)
+    if not abroad:
+        return by_id
+    for slug in _bucket_slugs():
+        if slug == sender_slug:
             continue  # already covered by this bucket's own rows above
-        if to_slug not in cache:
-            cache[to_slug] = events(project_dir=to_slug)
-        by_id[rid] = by_id[rid] + _without_suppression(
-            [row for row in cache[to_slug] if row.get("request_id") == rid])
+        foreign = [row for row in events(project_dir=slug)
+                   if str(row.get("request_id") or "") in abroad]
+        for row in _without_suppression(foreign):
+            by_id[str(row.get("request_id") or "")].append(row)
     return by_id
 
 
@@ -944,7 +953,16 @@ def recipient_join(project_dir=None) -> dict[str, dict]:
 
     Every folded record carries a transient `from_slug` — the bucket whose
     `opened` row founded it — so a supersedes reference can be resolved back
-    to its origin (`supersedes_label`) without a second scan."""
+    to its origin (`supersedes_label`) without a second scan.
+
+    #895: a verdict does not necessarily live in this bucket either. A human
+    decides from whatever directory they are standing in, so the row can sit
+    in a THIRD bucket that holds no `opened` for the id: an orphan in that
+    bucket's own fold. The scan already reads every bucket; it now keeps such
+    orphan groups when the id is one addressed here. A bucket's rows for an
+    id this project is not party to are still discarded, and a row claiming
+    an agent channel is still refused by the fold's authority re-check, so
+    widening the read adds no write reach anywhere."""
     my_slug = store.project_slug(project_dir)
     if not my_slug:
         return {}
@@ -958,6 +976,7 @@ def recipient_join(project_dir=None) -> dict[str, dict]:
             continue  # this project's own OUTGOING ask — never its own inbox
         by_id[rid] = rows
     origin_of: dict[str, str] = {}
+    orphans: list[tuple[str, list]] = []
     for slug in _bucket_slugs():
         if slug == my_slug:
             continue
@@ -967,9 +986,14 @@ def recipient_join(project_dir=None) -> dict[str, dict]:
         for rid, rows in grouped.items():
             opened = next((r for r in rows if r.get("event") == "opened"),
                          None)
-            if opened is not None and str(opened.get("to") or "") == my_slug:
+            if opened is None:
+                orphans.append((rid, rows))  # decided elsewhere, maybe ours
+            elif str(opened.get("to") or "") == my_slug:
                 by_id.setdefault(rid, []).extend(rows)
                 origin_of[rid] = slug
+    for rid, rows in orphans:
+        if rid in origin_of:
+            by_id[rid].extend(rows)
     all_rows = [row for group in by_id.values() for row in group]
     out = fold(all_rows)
     for rid, record in out.items():

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -2724,3 +2724,127 @@ def test_request_inject_owed_carries_the_acceptance_note(
     capsys.readouterr()
     assert _inject(project, session="S-owed-note") == 0
     assert "Accepted with: only the read half" in capsys.readouterr().out
+
+
+# ---- #895: a verdict recorded from a THIRD bucket -------------------------
+#
+# A human decides from whatever directory they are standing in. Their verdict
+# row lands in THAT bucket, which holds no `opened` row for the id: an orphan
+# in its own fold, and before #895 reachable by neither side of the join. The
+# fix widens both joins to collect rows for ids the project is party to from
+# EVERY bucket, keeping the header invariant: nobody writes a foreign ledger.
+
+
+def test_recipient_join_sees_a_verdict_recorded_from_a_third_bucket(project):
+    sender_slug = _seed_bucket("/p/req-sender-third")
+    elsewhere = _seed_bucket("/p/req-elsewhere")
+    q_id = requests.open_request(to=store.project_slug(project), ask=ASK,
+                                 why=WHY, channel="cli-agent",
+                                 project_dir=sender_slug)
+    requests.accept(q_id, channel="cli-tty", note="go ahead",
+                    project_dir=elsewhere)
+    joined = requests.recipient_join(project_dir=project)
+    assert joined[q_id]["state"] == "accepted"
+    assert joined[q_id]["note"] == "go ahead"
+    assert joined[q_id]["from_slug"] == sender_slug
+    # ...and it lands in the OWED lane #885 added, which is the point: the
+    # addressee begins work on acceptance, wherever the human was standing.
+    owed = requests.owed_renderable(project_dir=project)["rows"]
+    assert [r["request_id"] for r in owed] == [q_id]
+
+
+def test_sender_join_sees_a_verdict_recorded_from_a_third_bucket(project):
+    recipient_slug = _seed_bucket("/p/req-recipient-third")
+    elsewhere = _seed_bucket("/p/req-elsewhere-b")
+    q_id = _open(project, to=recipient_slug)
+    requests.reject(q_id, channel="cli-tty", project_dir=elsewhere)
+    joined = requests.sender_join(project_dir=project)
+    assert joined[q_id]["state"] == "rejected"
+
+
+def test_a_third_bucket_suppression_never_reaches_the_sender(project):
+    """D5 holds across the widened join: suppression is panel attention,
+    and the sender must not learn its ask was muted, whichever bucket the
+    human muted it from."""
+    recipient_slug = _seed_bucket("/p/req-recipient-third-b")
+    elsewhere = _seed_bucket("/p/req-elsewhere-c")
+    q_id = _open(project, to=recipient_slug)
+    requests.suppress(q_id, channel="cli-tty", project_dir=elsewhere)
+    joined = requests.sender_join(project_dir=project)
+    assert joined[q_id]["state"] == "open"
+    assert joined[q_id]["suppressed"] is False
+
+
+def test_third_bucket_rows_for_ids_this_project_is_not_party_to_stay_out(
+        project):
+    """Widening collects rows for ids this project SENT or was ADDRESSED; a
+    stranger's verdict on a stranger's ask must not appear on either side."""
+    sender_slug = _seed_bucket("/p/req-sender-third-c")
+    elsewhere = _seed_bucket("/p/req-elsewhere-d")
+    other_id = requests.open_request(to="-p-someone-else", ask=ASK, why=WHY,
+                                     channel="cli-agent",
+                                     project_dir=sender_slug)
+    requests.accept(other_id, channel="cli-tty", project_dir=elsewhere)
+    requests.accept("q-0123456789ab", channel="cli-tty",
+                    project_dir=elsewhere)
+    assert requests.recipient_join(project_dir=project) == {}
+    assert requests.sender_join(project_dir=project) == {}
+
+
+def test_a_third_bucket_verdict_on_an_agent_channel_stays_inert(project):
+    """The fold's authority re-check is the guard that matters here: a row
+    appended off-path in some bucket claiming an agent channel is a verdict
+    nobody can mint, and the widened join must not give it a path in."""
+    sender_slug = _seed_bucket("/p/req-sender-third-d")
+    elsewhere = _seed_bucket("/p/req-elsewhere-e")
+    q_id = requests.open_request(to=store.project_slug(project), ask=ASK,
+                                 why=WHY, channel="cli-agent",
+                                 project_dir=sender_slug)
+    requests.append(requests._stamp("accepted", q_id, "cli-agent"),
+                    project_dir=elsewhere)
+    assert requests.recipient_join(project_dir=project)[q_id]["state"] == "open"
+
+
+def test_sender_join_reads_no_other_bucket_when_nothing_was_sent_abroad(
+        project, monkeypatch):
+    """The widened sender scan is paid only by a project with an outgoing
+    ask: a bucket with only its own answers to foreign asks stays at one
+    read, the same budget the self-addressed test above pins."""
+    _seed_bucket("/p/req-elsewhere-f")
+    requests.accept("q-0123456789ab", channel="cli-tty", project_dir=project)
+    real_events = requests.events
+    calls = []
+
+    def _tracking(*a, **k):
+        calls.append((a, k))
+        return real_events(*a, **k)
+
+    monkeypatch.setattr(requests, "events", _tracking)
+    assert requests.sender_join(project_dir=project) == {}
+    assert len(calls) == 1
+
+
+def test_an_agent_channel_verdict_refusal_reads_as_english(project):
+    with pytest.raises(requests.RequestError,
+                       match="an accepted verdict requires a human channel"):
+        requests.accept("q-0123456789ab", channel="cli-agent",
+                        project_dir=project)
+
+
+@pytest.mark.parametrize("verb", ["accept", "reject", "needs-info",
+                                  "suppress"])
+def test_cli_verdict_refusal_without_a_terminal_names_no_dead_end(
+        project, recipient, verb, monkeypatch, capsys):
+    """The non-interactive refusal used to send the caller to `--by agent`,
+    which these verbs refuse by design. The remedy it names must be one that
+    can succeed."""
+    from daimon_briefing import cli
+    assert _cli_open(project, recipient) == 0
+    q_id = next(iter(requests.records(project_dir=project)))
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False)
+    rc = cli.main(["request", verb, q_id, "--project", project])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "--by agent" not in out
+    assert "terminal" in out
+    assert requests.get(q_id, project_dir=project)["state"] == "open"


### PR DESCRIPTION
Closes #895

## What

A verdict recorded from a third project directory now reaches both parties.

- `recipient_join` already reads every bucket with a ledger and discarded orphan groups (rows with no `opened` beside them). It now keeps an orphan group when the id was addressed to this project.
- `_sender_rows` gains the same bucket walk for ids this project sent abroad. A project with nothing sent abroad still reads only its own bucket; the self-addressed one-read guarantee is unchanged and a new test pins the answers-only case too.
- The fold's authority re-check is untouched, so a row in any bucket claiming an agent channel stays inert. D5 also holds across the widened join: a third-bucket `suppressed` row never reaches the sender.
- The non-interactive refusal on `accept`, `reject`, `needs-info` and `suppress` no longer names `--by agent` as the remedy, since those verbs refuse it by design. It says to run the verb from a terminal.
- The agent-channel refusal reads "an accepted verdict", not "a accepted verdict".

## Why

The human decides from wherever they are standing, and the row lands there. When that is neither the sender's nor the addressee's bucket, nobody collected it: the accept succeeded and the addressee kept showing the ask as undecided, with no signal that a human had already approved it.

The issue listed two shapes. Widening the join was chosen over also writing the verdict into the addressee's bucket. Dual-write would break the header invariant of `requests.py` that nobody writes a foreign ledger, give forget-by-value a second copy to chase, and need a rule about which bucket is canonical. The read cost on the recipient side was already being paid; the scan-cost budget tests cover the sender side and stayed well inside budget.

## Tests

New tests in `tests/test_requests.py`, the first two and the two message tests failing before the change:

- recipient sees a third-bucket accept, with its note and `from_slug`, and the ask lands in the owed lane
- sender sees a third-bucket reject
- a third-bucket suppression never reaches the sender
- third-bucket rows for ids this project is not party to stay out of both joins
- a third-bucket verdict row on an agent channel stays inert
- a project with only answers to foreign asks still reads one bucket
- the verdict refusal text, both the article and the non-interactive remedy, parametrized over the four human-only verbs

Run from `plugin/` with `uv run --extra dev --extra pretty pytest -q`: 4802 passed, 2 skipped. `uv run --extra dev mypy daimon_briefing`: clean. ruff: clean.
