### PR TITLE
feat(config): tenant-scoped mode refuses caller-chosen scope and takes a host allowlist

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,6 +69,15 @@ Deterministic cross-session carry-over of unresolved items.
 | `DAIMON_RECALL_DB` | `~/.daimon/recall.db` | Location of the derived recall index (SQLite FTS). Never a source of truth — safe to delete at any time; recall rebuilds it by scanning the checkpoint and team dirs. |
 | `DAIMON_RECALL_SEEN_DIR` | `~/.daimon/recall_seen` | Per-session suggestion-cooldown state so a repeated topic never re-injects. Disposable — deleting it only resets cooldowns. |
 
+## Tenant scope
+
+For a host that runs one daimon home with one project directory per person. A single person's machine never needs either variable. Both are read at process start, from the process env or the env file, never from prompt content, so a model cannot set them.
+
+| Variable | Default | What it does |
+|---|---|---|
+| `DAIMON_TENANT_SCOPED` | off | When truthy, a caller may not choose a scope. `--slug` and `--all-projects` on `recall`, `brief` and `why` are refused with a plain error, the MCP `daimon_recall` and `daimon_brief` tools refuse `slug` and `all_projects` the same way, and `daimon projects` lists only the caller's own bucket. Refused, never silently narrowed: a caller who asked for a scope and got their own instead would read the answer as complete. |
+| `DAIMON_EXTRA_READ_SLUGS` | unset | Comma-separated slugs this session may read beside its own, ambiently, with no caller argument involved. Reaches `recall`, `why` and the proactive suggestion path alike. Read only: no write path takes a slug and a session never writes to a listed scope. A hit from a listed scope names its origin project. Meant for a shared scope whose contents were already visible to everyone in it; set it only where one session is one person. |
+
 ## Team memory
 
 Opt-in shared-memory mirror. See [docs/team.md](./team.md) for the full workflow.

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -657,6 +657,8 @@ def _render_briefing_body(checkpoint, route, *, drift_project, teammates,
 def _cmd_brief(args) -> int:
     _note_usage("brief:auto" if getattr(args, "auto", False) else "brief")
     slug = getattr(args, "slug", None)
+    if _refuses_caller_scope(slug):
+        return 2
     if slug:
         # Deliberate cross-project read (#243). Explicit-never-automatic is
         # the #94/#95 lesson, so: no global-pointer fallback (the target was
@@ -764,6 +766,16 @@ def _cmd_brief(args) -> int:
 # ---- recall: FTS search over local + team checkpoint history (#112) ----
 
 
+def _refuses_caller_scope(slug=None, all_projects: bool = False) -> bool:
+    """#899: on a tenant-scoped home a caller-chosen scope is refused out
+    loud, rc 2, never narrowed in silence. One check for `recall`, `brief`
+    and `why`, the three read verbs that take an address."""
+    if config.tenant_scoped() and (slug or all_projects):
+        print(f"error: {config.TENANT_SCOPE_REFUSAL}", file=sys.stderr)
+        return True
+    return False
+
+
 def _cmd_recall(args) -> int:
     """Lexical search over the derived recall index. The index is disposable —
     recall.search auto-(re)builds it — so the only hard failure surfaced here is
@@ -781,6 +793,8 @@ def _cmd_recall(args) -> int:
     if slug and args.all_projects:
         print("error: --slug scopes to one project; drop it or drop "
               "--all-projects", file=sys.stderr)
+        return 2
+    if _refuses_caller_scope(slug, args.all_projects):
         return 2
     project = _resolve_project(args.project)
     try:
@@ -800,8 +814,10 @@ def _cmd_recall(args) -> int:
         # crossing would pay. Explicit scopes (--all-projects already
         # searched everything; --slug named its target) get no second-guess.
         # Same doctrine as the AND->OR retry (#25): a narrower scope must
-        # never mean a silent dead end.
-        if not args.all_projects and not slug:
+        # never mean a silent dead end. #899: except on a tenant-scoped
+        # home, where per-slug counts are enumeration and the remedy the
+        # signpost names is the refused flag.
+        if not args.all_projects and not slug and not config.tenant_scoped():
             try:
                 wide = recall.search(query, all_projects=True, limit=50)
             except recall.RecallError:
@@ -897,6 +913,8 @@ def _cmd_why(args) -> int:
         print("error: invalid item id — expected "
               "[a-z]-[0-9a-f]{6,40}(-N)?", file=sys.stderr)
         return 2
+    if _refuses_caller_scope(args.slug):
+        return 2
     project = args.slug or _resolve_project(args.project)
     result = inspector.inspect_item(
         project, args.item_id, include_source=args.source)
@@ -942,6 +960,10 @@ def projects_rows(project_arg=None) -> list:
     cur_slug = store.project_slug(_resolve_project(project_arg))
     rows = []
     for b in store.list_buckets():
+        # #899: enumeration is the other half of the exfiltration primitive;
+        # a tenant-scoped home lists the caller's own bucket and no other.
+        if config.tenant_scoped() and b["slug"] != cur_slug:
+            continue
         cp = b["checkpoint"] or {}
         created = cp.get("created")
         topic = ((cp.get("working_context") or {}).get("active_topic") or {})

--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -384,6 +384,52 @@ def session_speaker() -> str | None:
     return (_get("DAIMON_SESSION_SPEAKER") or "").strip() or None
 
 
+# ---- tenant scope (#899): the host, never the caller, chooses a read scope --
+
+
+def tenant_scoped() -> bool:
+    """When set, every caller-chosen cross-project address is refused: `--slug`
+    and `--all-projects` on the CLI, `slug` and `all_projects` on the MCP
+    tools, and `daimon projects` lists only the caller's own bucket.
+
+    For a host running one daimon home with one project directory per person,
+    those surfaces are cross-tenant read and enumerate primitives, one prompt
+    injection away from every tenant's memory. A single person's machine
+    never needs this. Read at process start through the same accessor as
+    every other flag: process env or env file, never prompt content."""
+    return _flag("DAIMON_TENANT_SCOPED")
+
+
+# One refusal, both surfaces (CLI and MCP): a caller who asked for a scope and
+# silently got their own instead would read the answer as complete.
+TENANT_SCOPE_REFUSAL = (
+    "this daimon home is tenant-scoped (DAIMON_TENANT_SCOPED): a caller may "
+    "not choose a scope (slug, all_projects); reads stay in this project's "
+    "own scope plus any host-declared DAIMON_EXTRA_READ_SLUGS")
+
+
+def extra_read_slugs() -> tuple[str, ...]:
+    """Slugs the host lets this session read AMBIENTLY, beside its own
+    (DAIMON_EXTRA_READ_SLUGS, comma separated), for a shared scope whose
+    contents were already visible to everyone in it. Read only: no write path
+    takes a slug, and a session never writes to a listed scope.
+
+    The dangerous half of cross-project reads was never that two scopes are
+    readable; it was that the CALLER picked the slug. This is the host
+    picking, out of band, in the trust class of DAIMON_AUTHOR. Stripped,
+    de-duplicated, order kept; an entry that is not slug-shaped is dropped
+    rather than widened into a path or a glob."""
+    out: list[str] = []
+    for raw in (_get("DAIMON_EXTRA_READ_SLUGS") or "").split(","):
+        tok = raw.strip()
+        if not tok or tok in out:
+            continue
+        if not all(ch.isalnum() or ch in "_-" for ch in tok):
+            continue
+        out.append(tok)
+    return tuple(out)
+
+
 # ---- signed provenance receipts (#204): opt-in vitni local-binding receipts ----
 
 

--- a/plugin/daimon_briefing/mcp_tools.py
+++ b/plugin/daimon_briefing/mcp_tools.py
@@ -12,7 +12,7 @@ distinguishably or the gate they measure goes blind.
 """
 import json
 
-from . import amendments, briefing, recall, requests, store
+from . import amendments, briefing, config, recall, requests, store
 
 
 class ToolError(Exception):
@@ -35,6 +35,9 @@ def _recall(arguments: dict) -> str:
         # Same guard as the CLI: slug scopes to ONE project.
         raise ToolError("slug scopes to one project; drop it or drop "
                         "all_projects")
+    if config.tenant_scoped() and (slug or all_projects):
+        # #899: refused out loud, never narrowed in silence.
+        raise ToolError(config.TENANT_SCOPE_REFUSAL)
     limit = arguments.get("limit")
     limit = 20 if not isinstance(limit, int) or limit < 1 else limit
     from . import cli
@@ -54,6 +57,8 @@ def _brief(arguments: dict) -> str:
     if slug and project_arg:
         raise ToolError('slug and project are two answers to "which bucket" '
                         "— pass one")
+    if config.tenant_scoped() and slug:
+        raise ToolError(config.TENANT_SCOPE_REFUSAL)
     from . import cli
     # Strictly scoped read (#94): never the global pointer. A named slug is
     # passed straight through; otherwise the resolved project's own bucket.
@@ -73,7 +78,9 @@ def _brief(arguments: dict) -> str:
         # Orientation without content: name the explicit path, leak nothing
         # (#96, machine edition — an agent tool result carrying another
         # project's briefing is contamination, not convenience).
-        others = len(store.list_buckets())
+        # #899: on a tenant-scoped home even the count is enumeration, and
+        # the remedy the hint names is the refused argument.
+        others = 0 if config.tenant_scoped() else len(store.list_buckets())
         hint = (f"daimon knows {others} project(s) — call daimon_projects "
                 "and pass a slug to read one explicitly."
                 if others else

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -986,6 +986,29 @@ def _dedupe_rows(rows: list[dict], want_n: int) -> list[dict]:
     return out[:want_n]
 
 
+def _ambient_scopes(project_dir) -> list[str] | None:
+    """The slugs an UNADDRESSED read may see (#899): this project's own plus
+    whatever the host declared in DAIMON_EXTRA_READ_SLUGS, own first. None
+    when the project is unknown, so each caller keeps its own "unknown"
+    rule (search: no filter; lookup_item: None; suggest: silence) and the
+    allowlist can never turn an unscoped read into a read of the listed
+    buckets. Explicit addressing (`slug`, `all_projects`) never comes here:
+    an explicit slug IS the scope (#243) and all_projects is already
+    everything."""
+    own = store.project_slug(project_dir)
+    if own is None:
+        return None
+    scopes = [own]
+    for extra in config.extra_read_slugs():
+        if extra not in scopes:
+            scopes.append(extra)
+    return scopes
+
+
+def _scope_clause(scopes: list[str], column: str = "i.project_slug") -> str:
+    return f" AND {column} IN ({', '.join('?' for _ in scopes)})"
+
+
 def search(query: str, project_dir=None, all_projects: bool = False,
            limit: int = 20, slug: str | None = None) -> list[dict]:
     """FTS5 MATCH over the (auto-refreshed) index. Live items first, then by
@@ -1009,8 +1032,10 @@ def search(query: str, project_dir=None, all_projects: bool = False,
         _ensure_fresh()
     except (OSError, sqlite3.Error) as exc:
         _note_error("search.refresh", exc)  # then try the query on what exists
-    want = slug if slug else (None if all_projects
-                              else store.project_slug(project_dir))
+    # #899: an unaddressed read fans across own + host-allowlisted scopes;
+    # an explicit slug or all_projects is exactly what it says.
+    scopes = ([slug] if slug else
+              None if all_projects else _ambient_scopes(project_dir))
 
     sql = (
         "SELECT i.text, i.quote, i.trust, i.kind, i.author, i.stated_by,"
@@ -1022,8 +1047,8 @@ def search(query: str, project_dir=None, all_projects: bool = False,
         " FROM items_fts JOIN items i ON i.id = items_fts.rowid"
         " WHERE items_fts MATCH ?"
     )
-    if want is not None:
-        sql += " AND i.project_slug = ?"
+    if scopes is not None:
+        sql += _scope_clause(scopes)
     # frontier is a TIEBREAK after relevance (#234): equally-relevant rows
     # from the newest checkpoint edge out older ones — silently, no label.
     # Contradiction leads the demotion keys (#837): "at least as strongly as
@@ -1040,8 +1065,8 @@ def search(query: str, project_dir=None, all_projects: bool = False,
 
     def _run(match_expr: str) -> list[dict]:
         params: list = [match_expr]
-        if want is not None:
-            params.append(want)
+        if scopes is not None:
+            params.extend(scopes)
         # #288 overfetch: a carried item occupies one row PER checkpoint that
         # carries it, and dedupe below collapses those — fetch headroom so the
         # deduped list can still fill the caller's limit. 4x covers typical
@@ -1109,8 +1134,8 @@ def lookup_item(item_id: str, project_dir=None, slug: str | None = None) -> dict
     surfaces — this only ever feeds a DISPLAY fallback.
 
     Returns the newest matching row (ties broken by `created`), or None."""
-    want = slug if slug else store.project_slug(project_dir)
-    if want is None:
+    scopes = [slug] if slug else _ambient_scopes(project_dir)
+    if scopes is None:
         return None
     try:
         _ensure_fresh()
@@ -1122,9 +1147,10 @@ def lookup_item(item_id: str, project_dir=None, slug: str | None = None) -> dict
             cur = conn.execute(
                 "SELECT text, quote, trust, kind, author, project_slug,"
                 " session_id, created, superseded_by, item_id, frontier"
-                " FROM items WHERE item_id = ? AND project_slug = ?"
-                " ORDER BY created DESC LIMIT 1",
-                (item_id, want),
+                " FROM items WHERE item_id = ?"
+                + _scope_clause(scopes, "project_slug")
+                + " ORDER BY created DESC LIMIT 1",
+                (item_id, *scopes),
             )
             cols = [c[0] for c in cur.description]
             row = cur.fetchone()
@@ -1412,8 +1438,11 @@ def suggest(prompt: str, project_dir=None, current_session=None,
     count) and `pinned` (the #369 standing-rule flag) — inputs to the cli
     age gate (#452), not rank inputs here.
     """
-    slug = store.project_slug(project_dir)
-    if slug is None:
+    # #899: the auto-inject path fans across own + host-allowlisted scopes
+    # too; a shared scope reached by `recall` but not here would exist when
+    # asked for and vanish when it would have helped.
+    scopes = _ambient_scopes(project_dir)
+    if scopes is None:
         return []
     terms = salient_terms(prompt)
     if not terms:
@@ -1449,13 +1478,13 @@ def suggest(prompt: str, project_dir=None, current_session=None,
         # Best-ranked candidates first (#31 item 4): without ORDER BY the LIMIT
         # window is arbitrary — on a busy project (>N matching rows) the
         # strongest rows could be truncated away, silencing prior work.
-        " WHERE items_fts MATCH ? AND i.project_slug = ?"
+        " WHERE items_fts MATCH ?" + _scope_clause(scopes) +
         " ORDER BY rank ASC LIMIT 256"
     )
     try:
         conn = sqlite3.connect(str(config.recall_db()))
         try:
-            cur = conn.execute(sql, (expr, slug))
+            cur = conn.execute(sql, (expr, *scopes))
             cols = [c[0] for c in cur.description]
             rows = [dict(zip(cols, row)) for row in cur.fetchall()]
         finally:

--- a/plugin/tests/conftest.py
+++ b/plugin/tests/conftest.py
@@ -35,6 +35,9 @@ def _isolate_daimon_home(tmp_path, monkeypatch):
     # #896: and the host-declared per-session speaker — a developer who exports
     # it in their own shell must not silently attribute every derived item.
     monkeypatch.delenv("DAIMON_SESSION_SPEAKER", raising=False)
+    # #899: a developer's own tenant flags must not narrow or widen the suite.
+    monkeypatch.delenv("DAIMON_TENANT_SCOPED", raising=False)
+    monkeypatch.delenv("DAIMON_EXTRA_READ_SLUGS", raising=False)
     # #200: a host DAIMON_TEAM_PROJECT would nest every team write; and the
     # resolver caches per (project_dir, team_dir, env) — clear it so no test
     # can see another test's resolution.

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import logging
 import os
@@ -10042,3 +10043,90 @@ def test_write_checkpoint_supersede_of_a_near_identical_item_is_suppressed(
 
     statuses = [e.get("status", "") for e in _events(project)]
     assert not [s for s in statuses if s.startswith("supersede-candidate")]
+
+
+# ---- #899: tenant scope refuses caller-chosen addressing at the CLI ------
+
+
+def _two_recall_buckets(monkeypatch, tmp_path):
+    from daimon_briefing import store
+    proj_a = str((tmp_path / "proj-a").resolve())
+    proj_b = str((tmp_path / "proj-b").resolve())
+    store.write_checkpoint("S-a", _recall_checkpoint("S-a", "marmot work in a"),
+                           project_dir=proj_a)
+    store.write_checkpoint("S-b", _recall_checkpoint("S-b", "marmot work in b"),
+                           project_dir=proj_b)
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", proj_a)
+    return proj_a, proj_b
+
+
+@pytest.mark.parametrize("argv", [
+    ["recall", "marmot", "--all-projects"],
+    ["recall", "marmot", "--slug", "-p-b"],
+    ["brief", "--slug", "-p-b"],
+    ["why", "o-3f8a2c", "--slug", "-p-b"],
+])
+def test_tenant_scope_refuses_caller_chosen_scope(tmp_checkpoint_dir, capsys,
+                                                  monkeypatch, tmp_path, argv):
+    """A plain refusal, never a silent narrowing: a caller who asked for a
+    scope and got their own instead would read the answer as complete."""
+    _two_recall_buckets(monkeypatch, tmp_path)
+    monkeypatch.setenv("DAIMON_TENANT_SCOPED", "1")
+    rc = cli.main(argv)
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "tenant-scoped" in err
+    assert "DAIMON_TENANT_SCOPED" in err
+
+
+def test_tenant_scope_leaves_the_scoped_read_alone(tmp_checkpoint_dir, capsys,
+                                                   monkeypatch, tmp_path):
+    _two_recall_buckets(monkeypatch, tmp_path)
+    monkeypatch.setenv("DAIMON_TENANT_SCOPED", "1")
+    assert cli.main(["recall", "marmot"]) == 0
+    out = capsys.readouterr().out
+    assert "marmot work in a" in out
+    assert "marmot work in b" not in out
+
+
+def test_tenant_scope_zero_match_never_teases_other_projects(
+        tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):
+    """#259's signpost counts matches per foreign slug. Counts are
+    enumeration, and the remedy it names is the refused flag."""
+    _, proj_b = _two_recall_buckets(monkeypatch, tmp_path)
+    from daimon_briefing import store
+    store.write_checkpoint("S-c", _recall_checkpoint("S-c", "narwhal only in b"),
+                           project_dir=proj_b)
+    monkeypatch.setenv("DAIMON_TENANT_SCOPED", "1")
+    assert cli.main(["recall", "narwhal"]) == 0
+    out = capsys.readouterr().out
+    assert "no matches" in out
+    assert "elsewhere" not in out
+    assert "--all-projects" not in out
+
+
+def test_tenant_scope_projects_lists_only_the_callers_own(
+        tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):
+    from daimon_briefing import store
+    proj_a, _ = _two_recall_buckets(monkeypatch, tmp_path)
+    monkeypatch.setenv("DAIMON_TENANT_SCOPED", "1")
+    assert cli.main(["projects", "--json"]) == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert [r["slug"] for r in rows] == [store.project_slug(proj_a)]
+    assert rows[0]["current"] is True
+
+
+def test_only_the_three_read_verbs_take_a_slug():
+    """No write path accepts a slug. Pinned structurally: walk the parser
+    and name every subcommand carrying --slug, so a future verb cannot grow
+    caller-chosen addressing without this list changing on purpose."""
+    import argparse
+    from daimon_briefing import store
+    parser = cli.build_parser()
+    subs = next(a for a in parser._actions
+                if isinstance(a, argparse._SubParsersAction))
+    with_slug = sorted(
+        name for name, sp in subs.choices.items()
+        if any("--slug" in a.option_strings for a in sp._actions))
+    assert with_slug == ["brief", "recall", "why"]
+    assert "slug" not in inspect.signature(store.write_checkpoint).parameters

--- a/plugin/tests/test_config.py
+++ b/plugin/tests/test_config.py
@@ -680,3 +680,39 @@ def test_live_delivery_defaults_off(monkeypatch):
 def test_live_delivery_flag_reads_the_env(monkeypatch):
     monkeypatch.setenv("DAIMON_LIVE_DELIVERY", "1")
     assert config.live_delivery_enabled() is True
+
+
+# ---- tenant scope (#899): host-declared, never caller-chosen ---------------
+
+
+def test_tenant_scoped_is_off_by_default(monkeypatch):
+    monkeypatch.delenv("DAIMON_TENANT_SCOPED", raising=False)
+    assert config.tenant_scoped() is False
+
+
+def test_tenant_scoped_reads_the_flag(monkeypatch):
+    monkeypatch.setenv("DAIMON_TENANT_SCOPED", "1")
+    assert config.tenant_scoped() is True
+    monkeypatch.setenv("DAIMON_TENANT_SCOPED", "0")
+    assert config.tenant_scoped() is False
+
+
+def test_extra_read_slugs_is_empty_by_default(monkeypatch):
+    monkeypatch.delenv("DAIMON_EXTRA_READ_SLUGS", raising=False)
+    assert config.extra_read_slugs() == ()
+    monkeypatch.setenv("DAIMON_EXTRA_READ_SLUGS", "  , ,")
+    assert config.extra_read_slugs() == ()
+
+
+def test_extra_read_slugs_parses_stripped_deduped_in_order(monkeypatch):
+    monkeypatch.setenv("DAIMON_EXTRA_READ_SLUGS", " -p-shared , -p-other,,-p-shared ")
+    assert config.extra_read_slugs() == ("-p-shared", "-p-other")
+
+
+def test_extra_read_slugs_drops_entries_that_are_not_slugs(monkeypatch):
+    """A slug is one path segment's worth of [\\w-]. Anything else (a path, a
+    glob, whitespace inside) is not an address daimon ever minted, and a
+    lenient parse here would be the one place a malformed host value could
+    widen a read."""
+    monkeypatch.setenv("DAIMON_EXTRA_READ_SLUGS", "-p-ok, /etc/x, a b, *, -p-also")
+    assert config.extra_read_slugs() == ("-p-ok", "-p-also")

--- a/plugin/tests/test_mcp_server.py
+++ b/plugin/tests/test_mcp_server.py
@@ -388,3 +388,50 @@ def test_serve_disabled_exits_clean_without_reading(monkeypatch):
     rc = mcp_server.serve(in_stream=fake_in, out_stream=fake_out)
     assert rc == 0
     assert fake_out.getvalue() == ""
+
+
+# ---- #899: tenant scope refuses caller-chosen addressing over MCP --------
+
+
+def _tenant_two_buckets(sample_checkpoint, monkeypatch):
+    from daimon_briefing import store
+    store.write_checkpoint("S-a", sample_checkpoint, project_dir="/p/A")
+    store.write_checkpoint("S-b", sample_checkpoint, project_dir="/p/B")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    monkeypatch.setenv("DAIMON_TENANT_SCOPED", "1")
+
+
+@pytest.mark.parametrize("tool,args", [
+    ("daimon_recall", {"query": "x", "slug": "-p-B"}),
+    ("daimon_recall", {"query": "x", "all_projects": True}),
+    ("daimon_brief", {"slug": "-p-B"}),
+])
+def test_tenant_scope_refuses_caller_chosen_scope_over_mcp(
+        tmp_checkpoint_dir, sample_checkpoint, monkeypatch, tool, args):
+    _tenant_two_buckets(sample_checkpoint, monkeypatch)
+    _, out = rpc(_init(), _call(tool, args))
+    text, is_err = _result(out)
+    assert is_err is True
+    assert "tenant-scoped" in text
+
+
+def test_tenant_scope_projects_tool_lists_only_the_callers_own(
+        tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
+    from daimon_briefing import store
+    _tenant_two_buckets(sample_checkpoint, monkeypatch)
+    _, out = rpc(_init(), _call("daimon_projects", {}))
+    text, is_err = _result(out)
+    assert is_err is False
+    assert [r["slug"] for r in json.loads(text)] == [store.project_slug("/p/A")]
+
+
+def test_tenant_scope_leaves_own_scope_reads_working_over_mcp(
+        tmp_checkpoint_dir, sample_checkpoint, monkeypatch):
+    _tenant_two_buckets(sample_checkpoint, monkeypatch)
+    _, out = rpc(_init(), _call("daimon_recall", {"query": "merge"}))
+    _, is_err = _result(out)
+    assert is_err is False
+    _, out = rpc(_init(), _call("daimon_brief", {}))
+    text, is_err = _result(out)
+    assert is_err is False
+    assert "daimon_projects" not in text  # no enumeration hint either

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -2087,3 +2087,76 @@ def test_an_unsuperseded_item_has_no_mechanism(tmp_checkpoint_dir,
     assert hits
     assert hits[0]["superseded_by"] is None
     assert hits[0]["superseded_source"] is None
+
+
+# ---- #899: host allowlist fans every single-scope read, and only those ----
+#
+# The caller never names a scope here. The host declares extra READ slugs out
+# of band and each of the three single-scope filters (search, lookup_item,
+# suggest) fans across own + listed. One filter reached and one missed gives
+# a shared memory that exists when asked for and vanishes when it would have
+# helped, so there is one test per filter and each must fail alone.
+
+
+def _two_buckets():
+    _write_team_file("grace", "S-x", _cp("S-x", decisions=[
+        {"id": "d-aaaaaa111111", "text": "toucan decision in x",
+         "trust": "inferred"}]), project_dir="/repo/x")
+    _write_team_file("grace", "S-y", _cp("S-y", decisions=[
+        {"id": "d-bbbbbb222222", "text": "toucan decision in y",
+         "trust": "inferred"}]), project_dir="/repo/y")
+
+
+def test_extra_read_slugs_reach_search(tmp_checkpoint_dir, monkeypatch):
+    _two_buckets()
+    assert [h["text"] for h in recall.search("toucan", project_dir="/repo/x")] \
+        == ["toucan decision in x"]
+    monkeypatch.setenv("DAIMON_EXTRA_READ_SLUGS", store.project_slug("/repo/y"))
+    hits = recall.search("toucan", project_dir="/repo/x")
+    assert sorted(h["text"] for h in hits) == ["toucan decision in x",
+                                               "toucan decision in y"]
+    # attribution survives: the foreign row still names its origin
+    by_text = {h["text"]: h["project_slug"] for h in hits}
+    assert by_text["toucan decision in y"] == store.project_slug("/repo/y")
+
+
+def test_extra_read_slugs_reach_lookup_item(tmp_checkpoint_dir, monkeypatch):
+    _two_buckets()
+    assert recall.lookup_item("d-bbbbbb222222", project_dir="/repo/x") is None
+    monkeypatch.setenv("DAIMON_EXTRA_READ_SLUGS", store.project_slug("/repo/y"))
+    row = recall.lookup_item("d-bbbbbb222222", project_dir="/repo/x")
+    assert row is not None and row["text"] == "toucan decision in y"
+    assert row["project_slug"] == store.project_slug("/repo/y")
+
+
+def test_extra_read_slugs_reach_suggest(tmp_checkpoint_dir, monkeypatch):
+    _seed_history(project="/repo/x")
+    prompt = "debugging the litellm gateway cache pinning again"
+    assert recall.suggest(prompt, project_dir="/repo/z",
+                          current_session="S-now") == []
+    monkeypatch.setenv("DAIMON_EXTRA_READ_SLUGS", store.project_slug("/repo/x"))
+    out = recall.suggest(prompt, project_dir="/repo/z", current_session="S-now")
+    assert out and out[0]["session_id"] == "S-old"
+    assert out[0]["project_slug"] == store.project_slug("/repo/x")
+
+
+def test_extra_read_slugs_never_widen_an_explicit_scope(tmp_checkpoint_dir,
+                                                        monkeypatch):
+    """An explicit slug IS the scope (#243) and all_projects is already
+    everything; the allowlist is the AMBIENT read set and touches neither."""
+    _two_buckets()
+    monkeypatch.setenv("DAIMON_EXTRA_READ_SLUGS", store.project_slug("/repo/y"))
+    hits = recall.search("toucan", slug=store.project_slug("/repo/x"))
+    assert [h["text"] for h in hits] == ["toucan decision in x"]
+    assert recall.lookup_item("d-bbbbbb222222",
+                              slug=store.project_slug("/repo/x")) is None
+
+
+def test_extra_read_slugs_with_an_unknown_project_stay_silent(
+        tmp_checkpoint_dir, monkeypatch):
+    """suggest's first gate is 'unknown project -> []' and the allowlist must
+    not turn an unscoped prompt into a read of the listed buckets."""
+    _seed_history(project="/repo/x")
+    monkeypatch.setenv("DAIMON_EXTRA_READ_SLUGS", store.project_slug("/repo/x"))
+    assert recall.suggest("debugging the litellm gateway cache pinning again",
+                          project_dir=None, current_session="S-now") == []


### PR DESCRIPTION
Closes #899

## What

Two host-declared variables, read at process start through the same accessor as every other flag, never from prompt content.

- `DAIMON_TENANT_SCOPED`: a caller may not choose a scope. `--slug` and `--all-projects` on `recall`, `brief` and `why` are refused with a plain error, rc 2. The MCP `daimon_recall` and `daimon_brief` tools refuse `slug` and `all_projects` as a tool error. `daimon projects` and the MCP projects tool list only the caller's own bucket, and the brief tool's orientation hint no longer counts other projects. The zero-match signpost in `recall`, which counts matches per foreign slug, is skipped, since counts are enumeration and the remedy it names is the refused flag. One refusal string lives in `config` so the CLI and MCP surfaces cannot drift.
- `DAIMON_EXTRA_READ_SLUGS`: the host's out-of-band allowlist. `recall.py`'s three single-scope filters, `search`, `lookup_item` and `suggest`, fan an unaddressed read across own plus listed slugs through one helper, `_ambient_scopes`. An explicit slug and `all_projects` are untouched. An unknown project stays unknown, so the allowlist can never turn an unscoped read into a read of the listed buckets. Malformed entries (paths, globs, inner whitespace) are dropped rather than widened.
- Read only: no write path takes a slug, pinned by a test that walks the parser and names the three read verbs carrying `--slug`, plus a signature check on `write_checkpoint`.
- `docs/configuration.md` gains a Tenant scope section with the host's obligation.

## Why

On a host running one daimon home with one project directory per person, every caller-addressable cross-project read is a cross-tenant primitive one prompt injection away from every tenant's memory, and isolation there was resting on two external controls staying exactly so. The same host needs a controlled form: a session reading its own scope plus a shared scope whose contents were already visible to everyone in it. The dangerous half was never that two scopes are readable. It was that the caller chose the scope. This separates the two halves.

Attribution across scopes already holds from #891, #894 and #897, so a hit from a listed scope renders as someone else's memory rather than collapsing into the reader's own.

Sequencing: this lands before #766 slice 4, which would add `--slug` to write verbs and must be gated by this refusal from its first day.

## Tests

New tests, red before the change (18 failing, 5 invariant guards already passing):

- `test_config.py`: flag default and parse, allowlist strip, dedupe, order, and malformed entries dropped
- `test_recall.py`: one test per filter proving the allowlist reaches `search`, `lookup_item` and `suggest`, each carrying the origin slug; an explicit scope is never widened; an unknown project stays silent
- `test_cli.py`: the four refused invocations parametrized, the scoped read left alone, the zero-match signpost silenced, `projects` limited to the caller's own, and the structural test that only `brief`, `recall` and `why` take `--slug`
- `test_mcp_server.py`: the three refused tool calls, `daimon_projects` limited, own-scope reads still working with no enumeration hint
- `conftest.py` clears both variables so a developer's shell export cannot narrow or widen the suite

Run from `plugin/` with `uv run --extra dev --extra pretty pytest -q`: 4825 passed, 2 skipped. `uv run --extra dev mypy daimon_briefing`: clean. ruff: clean.
