### PR TITLE
feat(decide): list every project's queue behind a flag, with routed commands

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -776,6 +776,33 @@ def _refuses_caller_scope(slug=None, all_projects: bool = False) -> bool:
     return False
 
 
+SLUG_ROUTE_HELP = ("route to another project's bucket by its slug, written "
+                   "--slug=<slug> (a slug starts with '-'); routing only, "
+                   "the channel gate is unchanged (#766)")
+
+
+def _slug_route(args) -> tuple:
+    """(project, rc) for the ten human-only decision verbs (#766 slice 4).
+
+    `--slug` is a ROUTING flag: `decide --all-projects` prints a command per
+    foreign entry, and `--project` cannot carry it (it resolves a path, and
+    the slug flattening is not invertible). The slug passes straight through
+    as the project, which works because `store.project_slug` is idempotent on
+    slugs, the same mechanism `brief --slug` relies on. It mints nothing and
+    leaves every channel gate where it was; on a tenant-scoped home (#899)
+    it is refused, since a caller choosing a bucket is the primitive that
+    mode removes. rc is 0 on success, else the exit code to return."""
+    slug = getattr(args, "slug", None)
+    project_arg = getattr(args, "project", None)
+    if slug and project_arg:
+        print("error: --slug and --project are two answers to \"which bucket\" "
+              "— pass one", file=sys.stderr)
+        return None, 2
+    if _refuses_caller_scope(slug):
+        return None, 2
+    return (slug or _resolve_project(project_arg)), 0
+
+
 def _cmd_recall(args) -> int:
     """Lexical search over the derived recall index. The index is disposable —
     recall.search auto-(re)builds it — so the only hard failure surfaced here is

--- a/plugin/daimon_briefing/cli/amend.py
+++ b/plugin/daimon_briefing/cli/amend.py
@@ -86,7 +86,9 @@ def _cmd_amend_propose(args) -> int:
 
 
 def _cmd_amend_verdict(args) -> int:
-    project = _cli._resolve_project(args.project)
+    project, rc = _cli._slug_route(args)
+    if rc:
+        return rc
     verb = args.amend_cmd
     try:
         channel = _amend_channel(args)
@@ -172,6 +174,7 @@ def register(sub, fmt) -> None:
                            help="declare yourself an agent; ratification then "
                                 "refuses, because it requires a human channel")
     pa_ratify.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    pa_ratify.add_argument("--slug", metavar="SLUG", help=_cli.SLUG_ROUTE_HELP)
     pa_ratify.set_defaults(func=_cli._cmd_amend_verdict)
 
     pa_reject = amend_sub.add_parser(
@@ -182,6 +185,7 @@ def register(sub, fmt) -> None:
                            help="declare yourself an agent; rejection then "
                                 "refuses, because it requires a human channel")
     pa_reject.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    pa_reject.add_argument("--slug", metavar="SLUG", help=_cli.SLUG_ROUTE_HELP)
     pa_reject.set_defaults(func=_cli._cmd_amend_verdict)
 
     pa_list = amend_sub.add_parser("list", help="list project amendments, candidates first")

--- a/plugin/daimon_briefing/cli/lifecycle.py
+++ b/plugin/daimon_briefing/cli/lifecycle.py
@@ -878,42 +878,9 @@ def _foreign_footer_lines(counts: dict) -> list:
     return lines
 
 
-def _cmd_decide(args) -> int:
-    """`decide` — everything waiting on a HUMAN, with the command that closes it.
-
-    The mirror of `loops`: that lists what the agent still owes, this lists what
-    you still owe. A pure reader — it stamps nothing, so opening your own queue
-    can never age an ask out of the agent's panel (`is_stale` measures against
-    the `surfaced` anchor, and this never writes one).
-
-    Scoped to this project — except the request lane, which is an inbox: an
-    ask addressed here has its `opened` row in the SENDER's bucket, so it is
-    read cross-bucket via `requests.recipient_join` (rendering your own mail,
-    not scar 0055's violation). Other projects' OWN record text still arrives
-    as counts (slice 3's footer, `pending.foreign_counts`), then as text
-    behind an explicit flag in a future slice, because printing another
-    bucket's record text would copy it into THIS project's checkpoint where
-    its owner's `forget` cannot reach it (scar 0055).
-    """
-    _cli._note_usage("decide")
-    project = _cli._resolve_project(args.project)
-    result = pending.queue(project_dir=project)
-    rows = result.get("rows") or []
-    suppressed = (result.get("excluded") or {}).get("suppressed") or 0
-    foreign = pending.foreign_counts(project_dir=project)
-    if not rows:
-        # "nothing waiting" would be a false claim while records sit
-        # suppressed: the human set those aside, they did not go away.
-        lines = (["nothing waiting on you in this project"] if not suppressed
-                  else [f"nothing listed for you in this project "
-                        f"({suppressed} suppressed — daimon request inbox)"])
-        # Same false-claim risk one level up: an empty LOCAL queue must not
-        # read as an empty queue everywhere.
-        lines += _foreign_footer_lines(foreign)
-        render.render_ledger_lines(lines)
-        return 0
-
-    render.render_ledger_lines([_DECIDE_HEADER])
+def _decide_cards(rows: list) -> list:
+    """One card per queue row: header line with the kind, age and id, an
+    optional context line, then the closing commands."""
     cards = []
     for row in rows:
         age = _decide_age(row.get("waiting_since") or "")
@@ -928,17 +895,77 @@ def _cmd_decide(args) -> int:
         card += [f"    {label}: {command}"
                  for label, command in row.get("commands") or []]
         cards.append(card)
-    render.render_ledger_records(cards)
+    return cards
 
-    if suppressed:
-        # Counted, never listed: `suppress` is human-only, so this is the
-        # owner's own "not now" — but a queue that hid the fact would be
-        # claiming a completeness it does not have.
-        render.render_ledger_lines(
-            [f"  ({suppressed} suppressed — daimon request inbox)"])
-    footer = _foreign_footer_lines(foreign)
-    if footer:
-        render.render_ledger_lines(footer)
+
+def _cmd_decide(args) -> int:
+    """`decide` — everything waiting on a HUMAN, with the command that closes it.
+
+    The mirror of `loops`: that lists what the agent still owes, this lists what
+    you still owe. A pure reader — it stamps nothing, so opening your own queue
+    can never age an ask out of the agent's panel (`is_stale` measures against
+    the `surfaced` anchor, and this never writes one).
+
+    Scoped to this project — except the request lane, which is an inbox: an
+    ask addressed here has its `opened` row in the SENDER's bucket, so it is
+    read cross-bucket via `requests.recipient_join` (rendering your own mail,
+    not scar 0055's violation). Other projects' OWN record text arrives as
+    counts by default (slice 3's footer, `pending.foreign_counts`), because
+    printing another bucket's record text would copy it into THIS project's
+    checkpoint where its owner's `forget` cannot reach it (scar 0055).
+
+    `--all-projects` (slice 4) is the person asking for that text: each
+    foreign bucket is composed by its own `pending.queue` and rendered under
+    its own heading, every command routed with `--slug=<slug>`. Refused on a
+    tenant-scoped home (#899), where a caller choosing a bucket is the
+    primitive that mode removes.
+    """
+    _cli._note_usage("decide")
+    everywhere = bool(getattr(args, "all_projects", False))
+    if everywhere and _cli._refuses_caller_scope(all_projects=True):
+        return 2
+    project = _cli._resolve_project(args.project)
+    result = pending.queue(project_dir=project)
+    rows = result.get("rows") or []
+    suppressed = (result.get("excluded") or {}).get("suppressed") or 0
+    # With the text itself on screen the counts footer is redundant.
+    foreign = {} if everywhere else pending.foreign_counts(project_dir=project)
+    abroad = pending.foreign_queues(project_dir=project) if everywhere else []
+    if not rows:
+        if everywhere and not abroad and not suppressed:
+            render.render_ledger_lines(["nothing waiting on you in any project"])
+            return 0
+        # "nothing waiting" would be a false claim while records sit
+        # suppressed: the human set those aside, they did not go away.
+        lines = (["nothing waiting on you in this project"] if not suppressed
+                  else [f"nothing listed for you in this project "
+                        f"({suppressed} suppressed — daimon request inbox)"])
+        # Same false-claim risk one level up: an empty LOCAL queue must not
+        # read as an empty queue everywhere.
+        lines += _foreign_footer_lines(foreign)
+        render.render_ledger_lines(lines)
+    else:
+        render.render_ledger_lines([_DECIDE_HEADER])
+        render.render_ledger_records(_decide_cards(rows))
+        if suppressed:
+            # Counted, never listed: `suppress` is human-only, so this is the
+            # owner's own "not now" — but a queue that hid the fact would be
+            # claiming a completeness it does not have.
+            render.render_ledger_lines(
+                [f"  ({suppressed} suppressed — daimon request inbox)"])
+        footer = _foreign_footer_lines(foreign)
+        if footer:
+            render.render_ledger_lines(footer)
+    for bucket, bucket_result in abroad:
+        render.render_ledger_lines([f"Decisions waiting on you in {bucket}:"])
+        bucket_rows = bucket_result.get("rows") or []
+        if bucket_rows:
+            render.render_ledger_records(_decide_cards(bucket_rows))
+        bucket_suppressed = (bucket_result.get("excluded") or {}).get(
+            "suppressed") or 0
+        if bucket_suppressed:
+            render.render_ledger_lines(
+                [f"  ({bucket_suppressed} suppressed there)"])
     return 0
 
 
@@ -1011,4 +1038,9 @@ def register(sub, fmt) -> None:
         epilog="Examples:\n  daimon decide\n  daimon decide --project .\n",
     )
     p_decide.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    p_decide.add_argument(
+        "--all-projects", action="store_true",
+        help="also list every other project's queue as text, composed per "
+             "project, each command routed with --slug=<slug> so it runs from "
+             "here; refused on a tenant-scoped home (#766, #899)")
     p_decide.set_defaults(func=_cli._cmd_decide)

--- a/plugin/daimon_briefing/cli/refute.py
+++ b/plugin/daimon_briefing/cli/refute.py
@@ -57,7 +57,9 @@ def _cmd_refute_add(args) -> int:
 
 
 def _cmd_refute_ratify(args) -> int:
-    project = _cli._resolve_project(args.project)
+    project, rc = _cli._slug_route(args)
+    if rc:
+        return rc
     if _refuse_ruling_id(refutations.get(args.refutation_id,
                                          project_dir=project), "ratify"):
         return 1
@@ -110,7 +112,9 @@ def _cmd_refute_revise(args) -> int:
 
 
 def _cmd_refute_overturn(args) -> int:
-    project = _cli._resolve_project(args.project)
+    project, rc = _cli._slug_route(args)
+    if rc:
+        return rc
     if _refuse_ruling_id(refutations.get(args.refutation_id,
                                          project_dir=project), "retire"):
         return 1
@@ -281,6 +285,7 @@ def register(sub, fmt) -> None:
              "activation requires a human channel")
     pr_ratify.add_argument("--note", help="optional ratification rationale")
     pr_ratify.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    pr_ratify.add_argument("--slug", metavar="SLUG", help=_cli.SLUG_ROUTE_HELP)
     pr_ratify.add_argument("--json", action="store_true", help="machine-readable output")
     pr_ratify.set_defaults(func=_cli._cmd_refute_ratify)
 
@@ -317,6 +322,7 @@ def register(sub, fmt) -> None:
     pr_overturn.add_argument("--note", help="optional explanation")
     pr_overturn.add_argument("--by", choices=["agent"], default=None)
     pr_overturn.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    pr_overturn.add_argument("--slug", metavar="SLUG", help=_cli.SLUG_ROUTE_HELP)
     pr_overturn.add_argument("--json", action="store_true", help="machine-readable output")
     pr_overturn.set_defaults(func=_cli._cmd_refute_overturn)
 

--- a/plugin/daimon_briefing/cli/request.py
+++ b/plugin/daimon_briefing/cli/request.py
@@ -362,7 +362,9 @@ def _cmd_request_revise(args) -> int:
 
 
 def _cmd_request_verdict(args) -> int:
-    project = _cli._resolve_project(args.project)
+    project, rc = _cli._slug_route(args)
+    if rc:
+        return rc
     verb = args.request_cmd
     try:
         channel = _request_channel(args, human_only=True)
@@ -507,6 +509,7 @@ def register(sub, fmt) -> None:
             help="declare yourself an agent; the call then refuses, because "
                  "this verb requires a human channel")
         _common(parser)
+        parser.add_argument("--slug", metavar="SLUG", help=_cli.SLUG_ROUTE_HELP)
         parser.set_defaults(func=_cli._cmd_request_verdict)
 
     rq_done = request_sub.add_parser(

--- a/plugin/daimon_briefing/cli/ruling.py
+++ b/plugin/daimon_briefing/cli/ruling.py
@@ -55,7 +55,9 @@ def _cmd_ruling_propose(args) -> int:
 
 
 def _cmd_ruling_ratify(args) -> int:
-    project = _cli._resolve_project(args.project)
+    project, rc = _cli._slug_route(args)
+    if rc:
+        return rc
     try:
         channel = _refute_channel(args)
     except refutations.RefutationError as exc:
@@ -182,7 +184,9 @@ def _cmd_ruling_revise(args) -> int:
 
 
 def _cmd_ruling_retire(args) -> int:
-    project = _cli._resolve_project(args.project)
+    project, rc = _cli._slug_route(args)
+    if rc:
+        return rc
     try:
         event = refutations.retire(
             args.ruling_id, channel=_refute_channel(args),
@@ -303,6 +307,7 @@ def register(sub, fmt) -> None:
                                 "then refuses")
     rl_ratify.add_argument("--note", help="optional ratification rationale")
     rl_ratify.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    rl_ratify.add_argument("--slug", metavar="SLUG", help=_cli.SLUG_ROUTE_HELP)
     rl_ratify.add_argument("--json", action="store_true", help="machine-readable output")
     rl_ratify.set_defaults(func=_cli._cmd_ruling_ratify)
 
@@ -345,6 +350,7 @@ def register(sub, fmt) -> None:
         help="declare yourself an agent; the call then records a retirement "
              "proposal and the ruling stands until a human verdict")
     rl_retire.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    rl_retire.add_argument("--slug", metavar="SLUG", help=_cli.SLUG_ROUTE_HELP)
     rl_retire.add_argument("--json", action="store_true", help="machine-readable output")
     rl_retire.set_defaults(func=_cli._cmd_ruling_retire)
 

--- a/plugin/daimon_briefing/pending.py
+++ b/plugin/daimon_briefing/pending.py
@@ -340,6 +340,57 @@ def _foreign_ledger_counts(slug: str | None) -> dict[str, int]:
     return counts
 
 
+def foreign_queues(*, project_dir=None) -> list[tuple[str, dict]]:
+    """Slice 4: every OTHER bucket's own queue, as TEXT, behind the explicit
+    `--all-projects` the caller typed. [(slug, queue-result), ...], buckets
+    with nothing waiting and nothing suppressed omitted.
+
+    Composed PER BUCKET, never as one global fold, and that is the whole
+    design: each bucket's request lane runs its own `recipient_join` (its
+    own orphan gate, its own suppression semantics) and its ledger lanes
+    read its own files, exactly as `queue` does for the local project. A
+    single fold across buckets would lose the recipient the staleness anchor
+    belongs to and delete the join that stops an agent from marking a foreign
+    ask done. Every printed command carries `--slug=<slug>` (the `=` form,
+    since a slug starts with '-'), so it runs from wherever the person is
+    standing. Fail-open per bucket, matching `foreign_counts`.
+
+    Scar 0055 still governs the DEFAULT surface: nothing here is reached
+    without the flag, and the caller typing it is the user-invoked crossing
+    `recall --all-projects` already is."""
+    own = store.project_slug(project_dir)
+    # A project can be waited on before it has ever written a bucket of its
+    # own: its mail sits in the SENDER's ledger, addressed by slug. So the
+    # candidates are every bucket directory plus every `to` an opened row
+    # names, ids only, no text read here.
+    candidates = {b for b in _ledger_bucket_slugs() if not b.startswith(".")}
+    for bucket in requests._bucket_slugs():
+        try:
+            rows = requests.events(project_dir=bucket)
+        except Exception:
+            continue
+        for row in rows:
+            if row.get("event") == "opened" and str(row.get("to") or ""):
+                candidates.add(str(row.get("to")))
+    out: list[tuple[str, dict]] = []
+    for bucket in sorted(candidates):
+        if bucket == own:
+            continue
+        try:
+            result = queue(project_dir=bucket)
+        except Exception:
+            continue
+        rows = result.get("rows") or []
+        suppressed = (result.get("excluded") or {}).get("suppressed") or 0
+        if not rows and not suppressed:
+            continue
+        for row in rows:
+            row["commands"] = [(label, f"{command} --slug={bucket}")
+                               for label, command in row.get("commands") or []]
+        out.append((bucket, result))
+    return out
+
+
 def foreign_counts(*, project_dir=None) -> dict[str, int]:
     """{"slug": waiting_count} for every OTHER project's decide queue —
     integers only, never records, ids, or text. This project's own slug is

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -10116,17 +10116,35 @@ def test_tenant_scope_projects_lists_only_the_callers_own(
     assert rows[0]["current"] is True
 
 
-def test_only_the_three_read_verbs_take_a_slug():
-    """No write path accepts a slug. Pinned structurally: walk the parser
-    and name every subcommand carrying --slug, so a future verb cannot grow
-    caller-chosen addressing without this list changing on purpose."""
+def test_exactly_the_read_verbs_and_the_human_only_verbs_take_a_slug():
+    """No write path an AGENT can complete accepts a slug. Pinned
+    structurally: walk the parser, nested families included, and name every
+    subcommand carrying --slug. The three read verbs take it as an address
+    (#243). The ten human-only decision verbs take it as a ROUTING flag
+    (#766 slice 4) so a command printed by `decide --all-projects` runs from
+    wherever the person stands; their channel gate refuses an agent with or
+    without it, and #899's tenant mode refuses the flag itself. `request
+    done`, the one either-channel state move, is deliberately absent."""
     import argparse
     from daimon_briefing import store
-    parser = cli.build_parser()
-    subs = next(a for a in parser._actions
-                if isinstance(a, argparse._SubParsersAction))
-    with_slug = sorted(
-        name for name, sp in subs.choices.items()
-        if any("--slug" in a.option_strings for a in sp._actions))
-    assert with_slug == ["brief", "recall", "why"]
+
+    def _walk(parser, prefix=""):
+        found = []
+        for action in parser._actions:
+            if isinstance(action, argparse._SubParsersAction):
+                for name, sub in action.choices.items():
+                    full = f"{prefix}{name}"
+                    if any("--slug" in a.option_strings for a in sub._actions):
+                        found.append(full)
+                    found += _walk(sub, full + " ")
+        return found
+
+    assert sorted(_walk(cli.build_parser())) == sorted([
+        "brief", "recall", "why",
+        "request accept", "request reject", "request needs-info",
+        "request suppress",
+        "amend ratify", "amend reject",
+        "ruling ratify", "ruling retire",
+        "refute ratify", "refute overturn",
+    ])
     assert "slug" not in inspect.signature(store.write_checkpoint).parameters

--- a/plugin/tests/test_cli_decide.py
+++ b/plugin/tests/test_cli_decide.py
@@ -351,3 +351,22 @@ def test_all_projects_writes_nothing(project, capsys, tmp_checkpoint_dir):
 
     after = {p: p.read_bytes() for p in root.rglob("*") if p.is_file()}
     assert after == before
+
+
+def test_all_projects_counts_a_foreign_suppression_never_lists_it(
+        project, capsys, monkeypatch):
+    """The owner's own "not now" in another bucket stays theirs: counted
+    under that bucket's heading, the record itself never printed."""
+    b = store.project_slug("/p/B")
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True, raising=False)
+    requests.open_request(to=b, ask="UNIQUE-SUPPRESSED-ASK-7731", why="w",
+                          channel="cli-agent", project_dir="/p/C")
+    q = next(iter(requests.recipient_join(project_dir="/p/B")))
+    requests.suppress(q, channel="cli-tty", project_dir="/p/B")
+
+    assert cli.main(["decide", "--all-projects"]) == 0
+    out = capsys.readouterr().out
+
+    assert f"waiting on you in {b}" in out
+    assert "1 suppressed there" in out
+    assert "UNIQUE-SUPPRESSED-ASK-7731" not in out

--- a/plugin/tests/test_cli_decide.py
+++ b/plugin/tests/test_cli_decide.py
@@ -254,3 +254,100 @@ def test_foreign_counts_returns_integers_only(project):
 
     assert result
     assert all(isinstance(v, int) for v in result.values())
+
+
+# ---- slice 4: text behind an explicit flag, composed per bucket -----------
+#
+# Scar 0055 governs the default: a foreign bucket's own prose never crosses
+# into this project's stdout unasked. `--all-projects` is the person asking,
+# the same user-invoked crossing `recall --all-projects` already is. Each
+# foreign bucket is composed by ITS OWN `pending.queue` (its own inbox join,
+# its own staleness anchor, its own suppression), never one global fold, and
+# every printed command carries `--slug=<slug>` so it runs from here.
+
+
+def _sentinel_ruling_in_b():
+    # A ruling id hashes subject and scope, so B's subject differs from the
+    # local `_ruling` helper's on purpose: two buckets, two ids.
+    return refutations.assert_ruling(
+        subject="release of B", verdict="UNIQUE-FOREIGN-RULING-SENTINEL-4471",
+        scope="repo", evidence=["issue:766"], channel="cli-agent",
+        project_dir="/p/B")
+
+
+def test_all_projects_shows_foreign_text_with_a_routed_command(project,
+                                                               capsys):
+    rid = _sentinel_ruling_in_b()
+    b = store.project_slug("/p/B")
+
+    assert cli.main(["decide", "--all-projects"]) == 0
+    out = capsys.readouterr().out
+
+    assert "UNIQUE-FOREIGN-RULING-SENTINEL-4471" in out
+    assert f"daimon ruling ratify {rid} --slug={b}" in out
+    assert f"waiting on you in {b}" in out
+    # the counts footer is redundant once the text itself is on screen
+    assert "more waiting in other projects" not in out
+
+
+def test_without_the_flag_the_default_stays_counts_only(project, capsys):
+    _sentinel_ruling_in_b()
+    assert cli.main(["decide"]) == 0
+    out = capsys.readouterr().out
+    assert "UNIQUE-FOREIGN-RULING-SENTINEL-4471" not in out
+    assert "1 more waiting in other projects" in out
+
+
+def test_all_projects_composes_each_foreign_inbox_by_its_own_join(project,
+                                                                  capsys):
+    """An ask from C to B is B's mail. Under one global fold it would be an
+    orphan with no owner; composed per bucket it lands under B, routed."""
+    b = store.project_slug("/p/B")
+    q = requests.open_request(to=b, ask="review the thing for B", why="w",
+                              channel="cli-agent", project_dir="/p/C")
+
+    assert cli.main(["decide", "--all-projects"]) == 0
+    out = capsys.readouterr().out
+
+    assert "review the thing for B" in out
+    assert f"daimon request accept {q} --slug={b}" in out
+
+
+def test_all_projects_local_commands_carry_no_slug(project, capsys):
+    r_local = _ruling(project)
+    _sentinel_ruling_in_b()
+
+    assert cli.main(["decide", "--all-projects"]) == 0
+    out = capsys.readouterr().out
+
+    assert f"daimon ruling ratify {r_local}\n" in out
+    assert f"daimon ruling ratify {r_local} --slug" not in out
+
+
+def test_all_projects_with_nothing_anywhere_says_so(project, capsys):
+    assert cli.main(["decide", "--all-projects"]) == 0
+    assert "nothing waiting on you in any project" in capsys.readouterr().out
+
+
+def test_all_projects_is_refused_on_a_tenant_scoped_home(project, capsys,
+                                                         monkeypatch):
+    _sentinel_ruling_in_b()
+    monkeypatch.setenv("DAIMON_TENANT_SCOPED", "1")
+    assert cli.main(["decide", "--all-projects"]) == 2
+    captured = capsys.readouterr()
+    assert "tenant-scoped" in captured.err
+    assert "UNIQUE-FOREIGN-RULING-SENTINEL-4471" not in captured.out
+
+
+def test_all_projects_writes_nothing(project, capsys, tmp_checkpoint_dir):
+    _sentinel_ruling_in_b()
+    requests.open_request(to=store.project_slug("/p/B"), ask="a", why="w",
+                          channel="cli-agent", project_dir="/p/C")
+    root = tmp_checkpoint_dir
+    before = {p: p.read_bytes() for p in root.rglob("*") if p.is_file()}
+
+    assert cli.main(["decide", "--all-projects"]) == 0
+    capsys.readouterr()
+
+    after = {p: p.read_bytes() for p in root.rglob("*") if p.is_file()}
+    assert after == before

--- a/plugin/tests/test_cli_slug_routing.py
+++ b/plugin/tests/test_cli_slug_routing.py
@@ -1,0 +1,169 @@
+"""#766 slice 4: `--slug` is a ROUTING flag on the ten human-only verbs.
+
+`decide --all-projects` prints the one command that closes each foreign
+entry, and that command has to be runnable from wherever the person is
+standing. `--project` cannot carry a slug (it resolves a path and the slug
+flattening is not invertible), so the four decision-writing families take
+`--slug=<slug>` exactly as `brief`, `recall` and `why` already do.
+
+Routing only. It mints nothing, adds no assertion power, and leaves every
+channel gate untouched: the same verb refuses `--by agent` with or without
+the flag. On a tenant-scoped home (#899) the flag is refused outright, since
+a caller choosing a bucket is the primitive that mode exists to remove.
+"""
+
+import json
+
+import pytest
+
+from daimon_briefing import cli, refutations, requests, store
+
+A, B, C = "/p/A", "/p/B", "/p/C"
+
+
+@pytest.fixture
+def project(tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", A)
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True, raising=False)
+    return A
+
+
+def _b() -> str:
+    return store.project_slug(B)
+
+
+def _open_to_b() -> str:
+    return requests.open_request(to=_b(), ask="do the thing", why="because",
+                                 channel="cli-agent", project_dir=C)
+
+
+def _ruling_in_b() -> str:
+    return refutations.assert_ruling(
+        subject="release", verdict="never bump to 1.0 without a human call",
+        scope="repo", evidence=["issue:766"], channel="cli-agent",
+        project_dir=B)
+
+
+def _refutation_in_b(capsys) -> str:
+    assert cli.main([
+        "refute", "add", "--subject", "whole-file receipt design",
+        "--verdict", "whole-file hashes do not prove spans",
+        "--scope", "carried receipt tiers", "--evidence", "measurement:1/2",
+        "--by", "agent", "--json", "--project", B]) == 0
+    return json.loads(capsys.readouterr().out)["refutation_id"]
+
+
+# ---- the four families route ---------------------------------------------
+
+
+def test_request_accept_routes_to_the_named_bucket(project, capsys):
+    q = _open_to_b()
+    assert cli.main(["request", "accept", q, f"--slug={_b()}"]) == 0
+    assert requests.recipient_join(project_dir=B)[q]["state"] == "accepted"
+    # nothing landed in the bucket the person was standing in
+    assert not any(r.get("request_id") == q
+                   for r in requests.events(project_dir=A))
+
+
+def test_request_suppress_routes_to_the_named_bucket(project, capsys):
+    q = _open_to_b()
+    assert cli.main(["request", "suppress", q, f"--slug={_b()}"]) == 0
+    assert requests.recipient_join(project_dir=B)[q]["suppressed"] is True
+
+
+def test_ruling_ratify_routes_to_the_named_bucket(project, capsys,
+                                                  monkeypatch):
+    rid = _ruling_in_b()
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+    assert cli.main(["ruling", "ratify", rid, f"--slug={_b()}",
+                     "--json"]) == 0
+    assert refutations.records(project_dir=B)[rid]["state"] == "active"
+    assert rid not in refutations.records(project_dir=A)
+
+
+def test_ruling_retire_routes_to_the_named_bucket(project, capsys,
+                                                  monkeypatch):
+    rid = _ruling_in_b()
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+    assert cli.main(["ruling", "ratify", rid, f"--slug={_b()}",
+                     "--json"]) == 0
+    capsys.readouterr()
+    assert cli.main(["ruling", "retire", rid, f"--slug={_b()}",
+                     "--json"]) == 0
+    assert refutations.records(project_dir=B)[rid]["state"] != "active"
+
+
+def test_refute_ratify_routes_to_the_named_bucket(project, capsys):
+    rid = _refutation_in_b(capsys)
+    assert cli.main(["refute", "ratify", rid, f"--slug={_b()}",
+                     "--json"]) == 0
+    assert refutations.records(project_dir=B)[rid]["state"] == "active"
+    assert rid not in refutations.records(project_dir=A)
+
+
+def test_refute_overturn_routes_to_the_named_bucket(project, capsys):
+    rid = _refutation_in_b(capsys)
+    assert cli.main(["refute", "ratify", rid, f"--slug={_b()}",
+                     "--json"]) == 0
+    capsys.readouterr()
+    assert cli.main(["refute", "overturn", rid, "--evidence", "issue:766",
+                     f"--slug={_b()}", "--json"]) == 0
+    assert refutations.records(project_dir=B)[rid]["state"] != "active"
+
+
+def test_amend_reject_routes_to_the_named_bucket(project, capsys):
+    """No verified amendment can be seeded without a session-end byte-check,
+    so the routing is pinned on the refusal path: an unknown id refused in
+    the NAMED bucket, with nothing written in either."""
+    from daimon_briefing import amendments
+    rc = cli.main(["amend", "reject", "a-0123456789ab", f"--slug={_b()}"])
+    assert rc == 1
+    assert amendments.events(project_dir=B) == []
+    assert amendments.events(project_dir=A) == []
+
+
+# ---- routing only: every gate stays where it was --------------------------
+
+
+def test_the_channel_gate_is_unchanged_under_slug(project, capsys):
+    q = _open_to_b()
+    rc = cli.main(["request", "accept", q, f"--slug={_b()}", "--by", "agent"])
+    assert rc == 1
+    assert requests.recipient_join(project_dir=B)[q]["state"] == "open"
+
+
+@pytest.mark.parametrize("argv", [
+    ["request", "accept", "q-0123456789ab"],
+    ["amend", "ratify", "a-0123456789ab"],
+    ["ruling", "ratify", "r-0123456789ab"],
+    ["refute", "overturn", "r-0123456789ab", "--evidence", "x"],
+])
+def test_slug_and_project_are_two_answers_to_which_bucket(project, capsys,
+                                                          argv):
+    rc = cli.main(argv + [f"--slug={_b()}", "--project", A])
+    assert rc == 2
+    assert "--slug" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("argv", [
+    ["request", "accept", "q-0123456789ab"],
+    ["amend", "reject", "a-0123456789ab"],
+    ["ruling", "retire", "r-0123456789ab"],
+    ["refute", "ratify", "r-0123456789ab"],
+])
+def test_a_tenant_scoped_home_refuses_the_routing_flag(project, capsys,
+                                                       monkeypatch, argv):
+    monkeypatch.setenv("DAIMON_TENANT_SCOPED", "1")
+    rc = cli.main(argv + [f"--slug={_b()}"])
+    assert rc == 2
+    assert "tenant-scoped" in capsys.readouterr().err
+
+
+def test_request_done_takes_no_slug(project, capsys):
+    """`done` is the one either-channel state move. Routing it by slug would
+    let an agent standing anywhere mark a foreign ask done; it stays
+    `--project` only, on purpose."""
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["request", "done", "q-0123456789ab", "--evidence", "x",
+                  f"--slug={_b()}", "--by", "agent"])
+    assert exc.value.code == 2

--- a/plugin/tests/test_pending.py
+++ b/plugin/tests/test_pending.py
@@ -504,3 +504,64 @@ def test_a_failing_ledger_lane_still_yields_the_request_counts(project,
 
     assert pending.foreign_counts(project_dir="/p/C") == {
         store.project_slug("/p/B"): 1}
+
+
+# ---- slice 4: foreign_queues, composed per bucket, fail-open per bucket ----
+
+
+def test_foreign_queues_route_every_command_with_the_bucket_slug(project):
+    b = store.project_slug("/p/B")
+    q = requests.open_request(to=b, ask="review B", why="w",
+                              channel="cli-agent", project_dir="/p/C")
+    queues = dict(pending.foreign_queues(project_dir=project))
+    assert list(queues) == [b]
+    row = queues[b]["rows"][0]
+    assert row["id"] == q
+    assert all(command.endswith(f" --slug={b}")
+               for _label, command in row["commands"])
+
+
+def test_foreign_queues_skip_a_bucket_whose_ledger_cannot_be_read(project,
+                                                                  monkeypatch):
+    """Candidate discovery reads every request ledger for `opened.to`; one
+    that raises costs that bucket's discoveries alone, never the pass."""
+    b = store.project_slug("/p/B")
+    refutations.assert_ruling(
+        subject="release of B", verdict="a ruling in B", scope="repo",
+        evidence=["issue:766"], channel="cli-agent", project_dir="/p/B")
+    requests.open_request(to=b, ask="review B", why="w",
+                          channel="cli-agent", project_dir="/p/C")
+    real_events = pending.requests.events
+    bad = store.project_slug("/p/C")
+
+    def selective(*args, **kwargs):
+        if kwargs.get("project_dir") == bad:
+            raise OSError("bucket unreadable")
+        return real_events(*args, **kwargs)
+
+    monkeypatch.setattr(pending.requests, "events", selective)
+    queues = dict(pending.foreign_queues(project_dir=project))
+    # B is still found through its own ledger directory, with its ruling
+    assert b in queues
+    assert [r["kind"] for r in queues[b]["rows"]] == ["ruling"]
+
+
+def test_foreign_queues_skip_a_bucket_whose_queue_raises(project, monkeypatch):
+    b = store.project_slug("/p/B")
+    c = store.project_slug("/p/C")
+    requests.open_request(to=b, ask="review B", why="w",
+                          channel="cli-agent", project_dir="/p/C")
+    refutations.assert_ruling(
+        subject="release of C", verdict="a ruling in C", scope="repo",
+        evidence=["issue:766"], channel="cli-agent", project_dir="/p/C")
+    real_queue = pending.queue
+
+    def selective(*, project_dir=None):
+        if project_dir == b:
+            raise RuntimeError("bucket exploded")
+        return real_queue(project_dir=project_dir)
+
+    monkeypatch.setattr(pending, "queue", selective)
+    queues = dict(pending.foreign_queues(project_dir=project))
+    assert b not in queues
+    assert c in queues

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -107,7 +107,7 @@ request write verb is reachable over MCP.
 | `daimon stats` | Local usage and capture aggregates — nothing is transmitted; sharing the output is a deliberate paste. `--json` for machines. |
 | `daimon log --text "…"` | Append a freeform timeline event to the project's event log — zero-LLM, audit-trail only. |
 | `daimon loops` | List open, addressable loop items with their ids — the read counterpart to `resolve`'s write path. |
-| `daimon decide` | List what is waiting on YOU, each with the one command that closes it — the human-side mirror of `loops`. Reads records that already exist and writes nothing at all, so opening it never changes what the agent is shown. Scoped to this project. |
+| `daimon decide` | List what is waiting on YOU, each with the one command that closes it — the human-side mirror of `loops`. Reads records that already exist and writes nothing at all, so opening it never changes what the agent is shown. Scoped to this project; other projects arrive as counts. `--all-projects` adds every other project's queue as text, composed per project, each command routed with `--slug=<slug>` so it runs from here. The ten human-only verbs (`request accept`, `reject`, `needs-info`, `suppress`; `amend ratify`, `reject`; `ruling ratify`, `retire`; `refute ratify`, `overturn`) take that flag as routing only. Both are refused while `DAIMON_TENANT_SCOPED` is set. |
 | `daimon projects` | List every project daimon holds a checkpoint for, with topic teasers. |
 | `daimon team init\|sync\|status` | Shared team memory via a sidecar repo — default-closed routing, shape-redacted before anything syncs. |
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -112,7 +112,7 @@ alcanzable por MCP.
 | `daimon stats` | Agregados locales de uso y captura — nada se transmite; compartir la salida es un pegado deliberado. `--json` para máquinas. |
 | `daimon log --text "…"` | Agrega un evento libre a la línea de tiempo del proyecto — cero LLM, solo rastro de auditoría. |
 | `daimon loops` | Lista los loops abiertos direccionables con sus ids — la contraparte de lectura del camino de escritura de `resolve`. |
-| `daimon decide` | Lista lo que está esperando por VOS, cada cosa con el único comando que la cierra — el espejo del lado humano de `loops`. Lee registros que ya existen y no escribe nada, así que abrirlo nunca cambia lo que el agente ve. Acotado a este proyecto. |
+| `daimon decide` | Lista lo que está esperando por VOS, cada cosa con el único comando que la cierra — el espejo del lado humano de `loops`. Lee registros que ya existen y no escribe nada, así que abrirlo nunca cambia lo que el agente ve. Acotado a este proyecto; los demás proyectos llegan como conteos. `--all-projects` agrega la cola de cada otro proyecto como texto, compuesta por proyecto, con cada comando enrutado con `--slug=<slug>` para que corra desde acá. Los diez verbos solo para humanos (`request accept`, `reject`, `needs-info`, `suppress`; `amend ratify`, `reject`; `ruling ratify`, `retire`; `refute ratify`, `overturn`) toman esa bandera solo como ruteo. Ambos se rechazan mientras `DAIMON_TENANT_SCOPED` esté activo. |
 | `daimon projects` | Lista cada proyecto con checkpoint, con un adelanto del tema. |
 | `daimon team init\|sync\|status` | Memoria de equipo compartida vía repo sidecar — ruteo cerrado por defecto, redacción por forma antes de sincronizar nada. |
 


### PR DESCRIPTION
Refs #766

Slice 4 of the human decision queue. Slice 5, the one-line briefing count, still needs its contract amendment and stays on the issue.

## What

- `daimon decide --all-projects` renders every other project's waiting decisions as text, each under its own heading. Each foreign bucket is composed by its own `pending.queue`, never one global fold: its own inbox join keeps the orphan gate, its own suppression stays its own, and a project that has never written a bucket of its own is still found through the `opened` rows addressed to it. The counts footer drops out once the text is on screen. Without the flag the default surface is unchanged.
- The ten human-only verbs take `--slug=<slug>` as a routing flag: `request accept`, `reject`, `needs-info`, `suppress`; `amend ratify`, `reject`; `ruling ratify`, `retire`; `refute ratify`, `overturn`. Every printed foreign command carries it, so it runs from wherever the person is standing. Routing only: the slug passes through as the project the same way `brief --slug` does, `--slug` with `--project` is refused as two answers to one question, and every channel gate is unchanged. `request done`, the one either-channel state move, deliberately takes no slug.
- Both the flag and the routing are refused while `DAIMON_TENANT_SCOPED` is set, since a caller choosing a bucket is the primitive that mode removes.
- The parser walk that pins which verbs take a slug now names all thirteen and says why each family is there.
- CLI reference updated in both languages.

## Why

`decide` promised the one command that closes each entry. For a foreign entry that command could not be printed: `--project` resolves a path and the slug flattening is not invertible. The issue's design pass ruled that `--slug` on the decision verbs and the cross-project view must land together, and that the merge be composed per bucket rather than as one global fold, because a single fold loses the recipient a staleness anchor belongs to and deletes the join that stops an agent from marking a foreign ask done.

Scar 0055 still governs the default: nothing foreign prints unasked. The flag is the person asking, the same user-invoked crossing `recall --all-projects` already is.

## Tests

New tests, red before the change (24 failing):

- `tests/test_cli_slug_routing.py`: each family routes to the named bucket and writes nothing where the person stood; the channel gate refuses an agent with the flag; `--slug` plus `--project` is refused across four families; a tenant-scoped home refuses the flag across four families; `request done` rejects the flag at the parser
- `tests/test_cli_decide.py`: foreign text with a routed command, the default staying counts only, a foreign inbox composed by its own join, local commands carrying no slug, the empty-everywhere line, tenant refusal, and a byte-level writes-nothing check over the whole checkpoint dir
- `tests/test_cli.py`: the parser walk now covers nested families and names the thirteen slug-taking verbs

Run from `plugin/` with `uv run --extra dev --extra pretty pytest -q`: 4849 passed, 2 skipped. `uv run --extra dev mypy daimon_briefing`: clean. ruff: clean. Scan-cost budgets unchanged.
