### PR TITLE
fix(cli): the handoff refusal names where the content belongs

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -1241,9 +1241,17 @@ def _cmd_handoff(args) -> int:
               file=sys.stderr)
         return 1
     if len(text) > _HANDOFF_MAX_CHARS:
+        # #902: a refusal that names no destination sends the trimmed content
+        # to whatever store is nearest, which for an agent is the harness's
+        # own memory file, where daimon never sees it. Name the daimon-side
+        # homes. NOT `daimon log`: nothing reads a ref-less note back, so it
+        # would be a void with a command name.
         print(f"error: baton exceeds {_HANDOFF_MAX_CHARS} chars "
               f"({len(text)}) — a handoff is \"do X first, beware Y\", not a "
-              "second checkpoint; trim it", file=sys.stderr)
+              "second checkpoint; trim it. The trimmed facts belong in a "
+              "checkpoint (the /daimon-end skill, `daimon write-checkpoint`), "
+              "and a rule that must never decay in "
+              "`daimon ruling propose --by agent`", file=sys.stderr)
         return 1
     # #571: latest-wins stays the contract, but replacing a baton no session
     # has consumed yet must not be silent — the superseded text never

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -10148,3 +10148,24 @@ def test_exactly_the_read_verbs_and_the_human_only_verbs_take_a_slug():
         "refute ratify", "refute overturn",
     ])
     assert "slug" not in inspect.signature(store.write_checkpoint).parameters
+
+# ---- #902: a refusal routes, it does not just reject ---------------------
+
+
+def test_cli_handoff_refusal_names_where_the_content_belongs(
+        tmp_checkpoint_dir, capsys):
+    """A gate that rejects without naming a destination sends the content
+    to whatever store is nearest, and for an agent that is the harness's
+    own memory file, which daimon never reads. The refusal must name the
+    daimon-side homes: the checkpoint for durable facts (the only store the
+    briefing and recall read back) and a ruling proposal for a rule that
+    must never decay. `daimon log` is deliberately NOT named: nothing reads
+    a ref-less note event back, so it would be a void with a command name."""
+    rc = cli.main(["handoff", "x" * 2001, "--project", "/p/A"])
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "trim it" in err
+    assert "daimon-end" in err
+    assert "write-checkpoint" in err
+    assert "daimon ruling propose --by agent" in err
+    assert "daimon log" not in err

--- a/plugin/tests/test_packaging.py
+++ b/plugin/tests/test_packaging.py
@@ -60,3 +60,22 @@ def test_every_shipped_skill_declares_a_name_and_description():
         front = text.split("---\n")[1]
         assert "name:" in front, f"{skill.name}: no name"
         assert "description:" in front, f"{skill.name}: no description"
+
+
+def test_the_end_skill_names_every_store_and_says_which_surface():
+    """#902: an agent uses what its loaded skill names and reads the skill
+    as complete. The session-end skill taught three of seven stores, so
+    durable facts went to the harness's own memory file instead. It must
+    now name all seven, and be honest that a `daimon log` note is an audit
+    trail nothing reads back, so the agent never routes a durable fact
+    there on the strength of the name."""
+    text = (_REPO_ROOT / "skills" / "daimon-end" / "SKILL.md").read_text(
+        encoding="utf-8")
+    for store in ("write-checkpoint", "daimon handoff", "daimon resolve",
+                  "daimon log", "daimon ruling propose", "daimon amend",
+                  "daimon refute"):
+        assert store in text, f"daimon-end skill never names {store}"
+    section = text.split("## Where things go")[1].split("\n## ")[0]
+    assert "daimon log" in section
+    assert "nothing reads" in section.lower()
+    assert "never decay" in section.lower() or "never decays" in section.lower()

--- a/skills/daimon-end/SKILL.md
+++ b/skills/daimon-end/SKILL.md
@@ -93,6 +93,27 @@ a `prev` pointer. So it does not need to be perfect to be useful.
 
 6. **Confirm** to the user with the printed checkpoint path.
 
+## Where things go
+
+Seven stores, each read by a different surface. Route by what the next
+session must see, and never by which command is nearest. The harness's own
+memory file (MEMORY.md, AGENTS.md, GEMINI.md) is not one of these: daimon
+never reads it, so a fact placed there is lost to every other host.
+
+| What you hold | Where it goes | Who reads it back |
+| --- | --- | --- |
+| Facts, decisions, beliefs, open loops from THIS session | the checkpoint, step 3 above (`daimon write-checkpoint`) | the next briefing, `daimon recall`, carry |
+| The ONE thing the next session should do first | `daimon handoff "<do X first, beware Y>"` (2000 chars max) | the top of the next briefing |
+| A briefed loop this session closed | `daimon resolve <id> --by agent --evidence "<quote>"` | the briefing withholds it once byte-checked |
+| A rule that must never decay (a threshold, a boundary, a standing constraint) | `daimon ruling propose --subject ... --verdict ... --scope ... --evidence ... --by agent` | every briefing, once a human ratifies; 7 active per project by default |
+| An approach that was tried and failed | `daimon refute add ... --by agent` | `daimon refute guard` before anyone revives it |
+| A briefed item that moved but did not close | `daimon amend <id> --change progressed|blocked|changed --evidence "<quote>" --by agent` | the briefing, as an unconfirmed claim until a human settles it |
+| A timeline fact worth an audit line and nothing more | `daimon log --text "..."` | nothing reads it back into a briefing or recall; it is an audit trail only |
+
+If `daimon handoff` refuses a baton as too long, the trimmed content is not
+homeless: facts go in the checkpoint, rules go to `ruling propose`. Do not
+move it to the harness memory file.
+
 ## Rules
 
 - **Write-only.** Do NOT exit/quit the session — that is the user's action.


### PR DESCRIPTION
Closes #902

## What

- The over-cap refusal on `daimon handoff` now names the daimon-side homes for the trimmed content: a checkpoint for durable facts (the daimon-end skill, `daimon write-checkpoint`) and `daimon ruling propose --by agent` for a rule that must never decay.
- `skills/daimon-end/SKILL.md` gains a "Where things go" section: all seven stores, what each holds, and who reads it back. The harness's own memory file is named as the one place daimon never reads.

## Why

A gate that rejects without naming a destination sends the content to whatever store is nearest, and for an agent that is the harness memory file. The skill taught three of seven stores and read as complete, so the agent never went looking for the rest. Both halves are verified against the code and the skill text, not taken from the report.

One deliberate departure from the issue's expected behavior: the refusal does not name `daimon log`. Nothing reads a ref-less note event back into any surface (briefing, recall, `why`, `loops`), and the CLI reference already calls it an audit trail only. Naming it would move the loss one store over and call it fixed. The skill lists it honestly as audit-only instead.

## Tests

Both new tests failed before the change:

- `test_cli_handoff_refusal_names_where_the_content_belongs`: the refusal still says "trim it", names `daimon-end`, `write-checkpoint` and `daimon ruling propose --by agent`, and never names `daimon log`
- `test_the_end_skill_names_every_store_and_says_which_surface`: the skill names all seven stores and the section states that nothing reads a log note back

Run from `plugin/` with `uv run --extra dev --extra pretty pytest -q`: 4855 passed, 2 skipped. mypy clean, ruff clean.
