### PR TITLE
fix(skill): the session-end skill closes every store it opens, not only loops

### DIFF
--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -196,6 +196,12 @@ that is world-check territory, not a resolve claim: run
 `daimon reverify <id> --evidence "<what you checked>"` to assert a carried
 item is still true and reset its staleness clock. `forget` stays human-only.
 
+Work also moves stores `resolve` cannot close, and an unclosed store rides
+into the next briefing as work. An item that advanced but did not close
+takes `daimon amend` (next section); an accepted request another project
+sent, satisfied here, takes `daimon request done <id> --evidence "<quote>"
+--by agent`, and `daimon request inbox` lists the ones still owed.
+
 ## Amending loops
 
 Advanced-but-open loops take `daimon amend`:

--- a/plugin/tests/test_packaging.py
+++ b/plugin/tests/test_packaging.py
@@ -79,3 +79,32 @@ def test_the_end_skill_names_every_store_and_says_which_surface():
     assert "daimon log" in section
     assert "nothing reads" in section.lower()
     assert "never decay" in section.lower() or "never decays" in section.lower()
+
+
+def test_the_end_skill_teaches_a_close_for_every_store_it_opens():
+    """#904: step 1 taught `daimon resolve` alone, so a session that shipped
+    a fix satisfying an accepted inbound request wrote its checkpoint,
+    handed off, resolved its loops and left the request owed. Three such
+    requests sat accepted for days after #836/#838 landed. The close step
+    must be a checklist naming every close verb, and the routing table must
+    carry the request row it lacked."""
+    text = (_REPO_ROOT / "skills" / "daimon-end" / "SKILL.md").read_text(
+        encoding="utf-8")
+    step_one = text.split("## What to do when invoked")[1].split("\n2. ")[0]
+    for verb in ("daimon resolve", "daimon amend", "daimon request done",
+                 "daimon reverify"):
+        assert verb in step_one, f"daimon-end step 1 never names {verb}"
+    assert "daimon request inbox" in step_one
+    table = text.split("## Where things go")[1].split("\n## ")[0]
+    assert "daimon request done" in table
+
+
+def test_the_briefing_skill_closing_loops_names_the_request_close():
+    """#904: the plugin briefing skill's "Closing loops" section covered
+    `resolve` and `reverify` and never said `request`, so the two shipped
+    skills disagreed on what closing means."""
+    text = (_REPO_ROOT / "skills" / "daimon-briefing" / "SKILL.md").read_text(
+        encoding="utf-8")
+    closing = text.split("## Closing loops")[1].split("\n## ")[0]
+    assert "daimon request done" in closing
+    assert "daimon request inbox" in closing

--- a/plugin/tests/test_skill_content.py
+++ b/plugin/tests/test_skill_content.py
@@ -84,8 +84,16 @@ def test_full_fits_size_budget():
     # deliberate-review size is 10,951 (2026-08-16); 11,400 keeps the same
     # ~4% slack. Nothing was added to the compact body (already at its
     # 2,000-char hard cap since #579).
+    #
+    # RAISED 11,400 -> 11,900 on 2026-09-02 (#904). The addition is ~330
+    # chars in "Closing loops": `resolve` closes one store, and a session
+    # that shipped a fix satisfying an accepted inbound request left the
+    # request owed for days because the section never named `request done`.
+    # Trimmed once before raising (the first draft was ~470 chars). New
+    # deliberate-review size is 11,463 (2026-09-02); 11,900 keeps the same
+    # ~4% slack. Nothing was added to the compact body.
     full = skill_content.render_full()
-    assert len(full) <= 11400, f"full body is {len(full)} chars (cap 11400)"
+    assert len(full) <= 11900, f"full body is {len(full)} chars (cap 11900)"
 
 
 def test_full_has_trigger_only_frontmatter():
@@ -473,3 +481,14 @@ def test_skill_points_the_handed_over_command_at_decide():
     section = section.split("\n## ")[0]
     assert "human-only: print the command, never run it" in section
     assert "daimon decide" in section
+
+
+# ---- #904: closing loops names every close verb, not only resolve ----
+
+
+def test_full_closing_loops_names_the_request_close():
+    full = skill_content.render_full()
+    closing = full.split("## Closing loops")[1].split("\n## ")[0]
+    assert "daimon request done" in closing
+    assert "daimon request inbox" in closing
+    assert "daimon amend" in closing

--- a/skills/daimon-briefing/SKILL.md
+++ b/skills/daimon-briefing/SKILL.md
@@ -52,6 +52,15 @@ is still pending that check.
 Do not resolve what you merely believe is stale — that is `reverify`/
 worldcheck territory, not a resolve claim. `forget` stays human-only.
 
+`resolve` closes one store. Work in a session moves others, and each has its
+own close verb; a store moved and never closed rides into the next briefing
+as work. A briefed item that advanced but did not close takes `daimon amend
+<id> --change progressed|blocked|changed --evidence "<quote>" --by agent`.
+An accepted request another project sent, satisfied by this session's work
+(a shipped fix, a merged PR), takes `daimon request done <id> --evidence
+"<quote>" --by agent`; `daimon request inbox` lists every one still owed.
+Same quote discipline, same byte-check at session end.
+
 ## Automatic behavior
 
 You do not need to invoke anything. The plugin wires the host's native session

--- a/skills/daimon-end/SKILL.md
+++ b/skills/daimon-end/SKILL.md
@@ -17,18 +17,31 @@ a `prev` pointer. So it does not need to be perfect to be useful.
 
 ## What to do when invoked
 
-1. **Resolve closed loops FIRST.** If any briefed loop was closed this session,
-   record it before writing the checkpoint:
+1. **Close what this session moved, FIRST.** Every store daimon reads back
+   has its own close verb, and a store you moved but never closed rides into
+   the next briefing as work. Walk `daimon loops` and `daimon request inbox`
+   and record each close before writing the checkpoint:
 
    ```bash
+   # a briefed loop this session closed
    daimon resolve <id> --by agent --evidence "<exact contiguous transcript quote>"
+   # a briefed item that moved but did not close
+   daimon amend <id> --change progressed|blocked|changed --evidence "<quote>" --by agent
+   # an accepted inbound request this session satisfied (a shipped fix, a merged PR)
+   daimon request done <id> --evidence "<quote>" --by agent
+   # a carried item this session re-checked against the world and found still true
+   daimon reverify <id> --evidence "<what you checked>"
    ```
 
    (See the daimon-briefing skill's "Closing loops" section for the full
    quote-discipline rule.) The CLI answers `claim recorded ... pending
    verification at session end` — that is the expected output, not a failure:
-   the resolution is a provisional claim, byte-checked against the transcript
-   when the session ends.
+   each claim is provisional, byte-checked against the transcript when the
+   session ends. A `request done` on an ask another project sent prints
+   `no matching request in this bucket`; that is the read-time join, not a
+   miss. Skipping this step never errors: the checkpoint validates, the
+   briefing renders, and the satisfied request stays `[✓ accepted]` until
+   someone notices.
 
 2. **Decide whether to hand off.** The baton is a different instrument from the
    checkpoint: the checkpoint captures full state, the baton is the ONE
@@ -105,6 +118,7 @@ never reads it, so a fact placed there is lost to every other host.
 | Facts, decisions, beliefs, open loops from THIS session | the checkpoint, step 3 above (`daimon write-checkpoint`) | the next briefing, `daimon recall`, carry |
 | The ONE thing the next session should do first | `daimon handoff "<do X first, beware Y>"` (2000 chars max) | the top of the next briefing |
 | A briefed loop this session closed | `daimon resolve <id> --by agent --evidence "<quote>"` | the briefing withholds it once byte-checked |
+| An accepted inbound request this session satisfied | `daimon request done <id> --evidence "<quote>" --by agent` | the sender's brief and `daimon request inbox`, as a claim until byte-checked |
 | A rule that must never decay (a threshold, a boundary, a standing constraint) | `daimon ruling propose --subject ... --verdict ... --scope ... --evidence ... --by agent` | every briefing, once a human ratifies; 7 active per project by default |
 | An approach that was tried and failed | `daimon refute add ... --by agent` | `daimon refute guard` before anyone revives it |
 | A briefed item that moved but did not close | `daimon amend <id> --change progressed|blocked|changed --evidence "<quote>" --by agent` | the briefing, as an unconfirmed claim until a human settles it |


### PR DESCRIPTION
Closes #904

## What

The session-end skill's first step becomes a close checklist instead of a single verb. It now walks `daimon loops` and `daimon request inbox` and names the close for each store a session can move: `resolve`, `amend`, `request done`, `reverify`. The "Where things go" table gains the `request done` row it lacked. The plugin briefing skill and the portable skill teach the same thing in their "Closing loops" sections, so the three no longer disagree on what closing means.

## Why

An agent uses what its loaded skill names. Step 1 named `daimon resolve` alone, so a session that shipped a fix satisfying an accepted inbound request wrote its checkpoint, handed off, resolved its loops and left the request owed. Three such requests sat accepted for days after #836 and #838 landed. Nothing errors on that path: the checkpoint validates, the briefing renders, and the request stays `[✓ accepted]` until someone notices.

The portable skill's size budget moves from 11,400 to 11,900 with the dated note the test carries for every prior raise. The addition was trimmed once first.

## Tests

Three new tests, each red before the change:

- `test_the_end_skill_teaches_a_close_for_every_store_it_opens` pins all four verbs in step 1 and the `request done` row in the table.
- `test_the_briefing_skill_closing_loops_names_the_request_close` pins the plugin briefing skill's section.
- `test_full_closing_loops_names_the_request_close` pins the portable skill's rendered section.

Full suite from `plugin/` with `uv run --extra dev --extra pretty pytest -q`, ruff and mypy clean.
