### PR TITLE
fix(recall): a human resolution demotes a superseded item harder than a model link

### DIFF
--- a/.scars/candidates/suggest-select-feeds-the-weight.md
+++ b/.scars/candidates/suggest-select-feeds-the-weight.md
@@ -1,0 +1,33 @@
+---
+id: 0
+type: landmine
+title: A column _suggest_weight reads must also be SELECTed in suggest() itself; search() selecting it proves nothing
+severity: high
+confidence: 0.9
+created: 2026-09-02
+authors: ["claude-code"]
+anchors:
+  - pattern: "_suggest_weight"
+evidence:
+  - note: "#837 (2abf0c4): invalidated_by was written and selected in search() but not in suggest()'s own SELECT; the auto-inject path re-asserted contradicted claims. The fix left the comment 'the column MUST be selected here, not just written' at recall.py suggest()"
+  - note: "#907 (2026-09-02): superseded_source, selected in search() since #867, was absent from suggest()'s SELECT. A weight-level test on a dict passed; the end-to-end suggest test was red with KeyError: 'superseded_source'. Every human resolution would have demoted at the model-link rate"
+expires:
+  condition: "search() and suggest() share one column list (a single SELECT builder), so a column cannot be present in one and absent from the other"
+  review_after: 2027-03-02
+status: candidate
+---
+
+`recall.search()` and `recall.suggest()` build SEPARATE SELECT statements over the
+same `items` table. `_suggest_weight(row, ...)` ranks whatever dict suggest()
+hands it, and reads columns by `row.get(...)`, which returns None for a column the
+SELECT never named. So a new rank input that is written at rebuild, selected in
+search(), and read in `_suggest_weight` is silently dead on the suggest path: no
+error, no test failure at the weight level, the auto-inject surface just ranks as
+if the column were empty. Twice now (#837 invalidated_by, #907 superseded_source).
+
+When you add or start reading a column in `_suggest_weight`: (1) add it to
+suggest()'s SELECT too, next to the #837 comment; (2) write the proving test
+THROUGH `recall.suggest()` with two rows equal on relevance, importance and
+first_seen so only the new column differs; a dict-level test of `_suggest_weight`
+cannot catch the missing wire. Do not treat search() selecting the column as
+evidence that suggest() does.

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -1056,9 +1056,14 @@ def search(query: str, project_dir=None, all_projects: bool = False,
     # a claim is the stronger fact of the two, so a contradicted row sorts
     # below a merely-replaced one. Both stay ABOVE nothing — demoted, never
     # filtered out: the evidence is machine-local and has no cure path, so
-    # burial must remain visible and reversible rather than silent.
+    # burial must remain visible and reversible rather than silent. Within
+    # replaced rows (#907) a person's recorded resolution sorts below a
+    # model-authored link, the same order the write side already keeps; an
+    # unattributed row sorts with the links.
     sql += (" ORDER BY (i.invalidated_by IS NOT NULL) ASC,"
-            " (i.superseded_by IS NOT NULL) ASC, rank ASC,"
+            " CASE WHEN i.superseded_by IS NULL THEN 0"
+            " WHEN i.superseded_source = 'resolution' THEN 2"
+            " ELSE 1 END ASC, rank ASC,"
             " i.frontier DESC, i.created DESC LIMIT ?")
 
     want_n = max(1, int(limit))
@@ -1382,7 +1387,8 @@ def is_machine_prompt(prompt: str) -> bool:
 # Neither is a filter. #112's rule holds for both: an overturned item is still
 # evidence, and this evidence is machine-local with no cure path yet, so it
 # ranks down and renders flagged rather than disappearing.
-_SUPERSEDED_WEIGHT = 0.7
+_SUPERSEDED_WEIGHT = 0.7   # superseded_source 'link': a claim the model made
+_RESOLVED_WEIGHT = 0.5     # superseded_source 'resolution': a person's recorded act
 _INVALIDATED_WEIGHT = 0.4
 
 
@@ -1399,7 +1405,14 @@ def _suggest_weight(row, item_type: str, now: float) -> float:
          "trust": row.get("trust")},
         item_type, now)
     if row.get("superseded_by"):
-        weight *= _SUPERSEDED_WEIGHT
+        # #907: spend the mechanism #865 recorded. The write side already
+        # ranks a person's recorded action above a model's claim (the
+        # resolution fold overwrites the link fold); the read side demotes
+        # in the same order. An unattributed row (legacy, or a writer the
+        # fold could not name) is the weaker claim, never the person.
+        weight *= (_RESOLVED_WEIGHT
+                   if row.get("superseded_source") == "resolution"
+                   else _SUPERSEDED_WEIGHT)
     if row.get("invalidated_by"):
         weight *= _INVALIDATED_WEIGHT
     return weight
@@ -1466,6 +1479,10 @@ def suggest(prompt: str, project_dir=None, current_session=None,
         "SELECT i.text, i.quote, i.trust, i.kind, i.author, i.stated_by,"
         " i.project_slug,"
         " i.session_id, i.created, i.importance, i.first_seen, i.superseded_by,"
+        # #907: same rule for the writer column — without it every human
+        # resolution reaches _suggest_weight as an unattributed row and
+        # demotes at the model-link rate, on this same surface.
+        " i.superseded_source,"
         # #837: the column MUST be selected here, not just written — this is
         # the auto-inject path, so a missing select re-asserts a claim this
         # install's own ledger contradicted, on the highest-leverage surface.

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -2089,6 +2089,133 @@ def test_an_unsuperseded_item_has_no_mechanism(tmp_checkpoint_dir,
     assert hits[0]["superseded_source"] is None
 
 
+# --- #907: the read side spends superseded_source, not only the display ---
+#
+# #865 recorded the mechanism and the write side already ranks it (the
+# resolution fold overwrites the link fold: "a person's recorded action
+# outranks a model's claim"). Both spenders of superseded_by then ignored
+# the source: one multiplier, one sort predicate. A model's guess that B
+# replaced A and a person's recorded decision that it did demoted A at one
+# rate. These pin the read side to the mechanism the row already carries.
+# No vocabulary moves: link/resolution stay machine keys.
+
+
+def test_suggest_demotes_a_human_resolution_harder_than_a_model_link():
+    now = 1756468800.0
+    row = {"importance": 5, "first_seen": "2026-08-01T00:00:00Z",
+           "trust": "inferred", "invalidated_by": None}
+    clean = recall._suggest_weight(
+        {**row, "superseded_by": None, "superseded_source": None},
+        "recent_decision", now)
+    linked = recall._suggest_weight(
+        {**row, "superseded_by": "S-newer", "superseded_source": "link"},
+        "recent_decision", now)
+    resolved = recall._suggest_weight(
+        {**row, "superseded_by": "o-new222",
+         "superseded_source": "resolution"},
+        "recent_decision", now)
+    contradicted = recall._suggest_weight(
+        {**row, "superseded_by": None, "superseded_source": None,
+         "invalidated_by": "receipt:receipt-invalid@2026-08-29T10:00:00Z"},
+        "recent_decision", now)
+    # A person's recorded act sits between a model claim and world evidence
+    # that the claim is false: stronger than a guess, weaker than a probe.
+    assert contradicted < resolved < linked < clean
+
+
+def test_suggest_treats_an_unattributed_superseded_row_as_a_model_link():
+    # A legacy row (indexed before #865) or one whose writer the fold could
+    # not attribute carries superseded_by with no source. Absence is not a
+    # person: it ranks as the weaker claim, never as the stronger one.
+    now = 1756468800.0
+    row = {"importance": 5, "first_seen": "2026-08-01T00:00:00Z",
+           "trust": "inferred", "invalidated_by": None}
+    unattributed = recall._suggest_weight(
+        {**row, "superseded_by": "S-newer", "superseded_source": None},
+        "recent_decision", now)
+    linked = recall._suggest_weight(
+        {**row, "superseded_by": "S-newer", "superseded_source": "link"},
+        "recent_decision", now)
+    assert unattributed == linked
+
+
+def test_suggest_ranks_a_resolved_item_below_a_linked_one_end_to_end(
+        tmp_checkpoint_dir, monkeypatch):
+    # The weight function is only as good as the row it is handed. suggest
+    # runs its own SELECT (the auto-inject path), so the column has to be
+    # selected there too or every human resolution ranks as a model link and
+    # the weight-level test above passes on a dict the wire never carries.
+    # Same #837 lesson, same surface. suggest scores relevance x weight, so
+    # the two rows share text length, query terms, importance and birth
+    # stamp: the only thing that differs is who recorded the supersession.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint(
+        "S-linked", _cp125("S-linked", decisions=[{
+            "text": "pin the litellm gateway cache for bad responses "
+                    "until the retry path is measured",
+            "trust": "verbatim", "quote": "pin it", "id": "o-55ee66ff",
+            "importance": 9, "first_seen": "2026-06-20T00:00:00Z",
+        }], created="2026-06-20T00:00:00Z"), project_dir="/repo/x")
+    store.write_checkpoint(
+        "S-resolved", _cp125("S-resolved", decisions=[{
+            "text": "pin the litellm gateway cache for bad answers "
+                    "until the retry path is measured",
+            "trust": "verbatim", "quote": "pin it", "id": "o-77aa88bb",
+            "importance": 9, "first_seen": "2026-06-20T00:00:00Z",
+        }], created="2026-06-21T00:00:00Z"), project_dir="/repo/x")
+    store.write_checkpoint(
+        "S-newer", _cp125("S-newer", decisions=[{
+            "text": "unpinned the gateway cache, old diagnosis wrong",
+            "trust": "inferred",
+            "links": [{"type": "supersedes", "target": "o-55ee66ff"}],
+        }], created="2026-06-25T00:00:00Z"), project_dir="/repo/x")
+    store.append_event("o-77aa88bb", "superseded-by:o-h999", source="cli",
+                       project_dir="/repo/x")
+
+    out = recall.suggest("debugging the litellm gateway cache pinning again",
+                         project_dir="/repo/x", current_session="S-now",
+                         limit=5)
+    by_sid = {r["session_id"]: r for r in out}
+    assert by_sid["S-resolved"]["superseded_source"] == "resolution"
+    assert by_sid["S-linked"]["superseded_source"] == "link"
+    sids = [r["session_id"] for r in out]
+    assert sids.index("S-linked") < sids.index("S-resolved")
+
+
+def test_search_sorts_a_resolved_item_below_a_linked_one(tmp_checkpoint_dir,
+                                                         monkeypatch):
+    # Rigged against the fix: the human-resolved row is the SHORTER document,
+    # so bm25 alone puts it first. The link-superseded row must still lead,
+    # because a person recorded that the other one is replaced.
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint(
+        "S-linked", _cp125("S-linked", decisions=[{
+            "text": "pin the litellm gateway cache for bad responses "
+                    "until the retry path is measured",
+            "trust": "verbatim", "quote": "pin it", "id": "o-11aa22bb",
+        }], created="2026-06-20T00:00:00Z"), project_dir="/repo/x")
+    store.write_checkpoint(
+        "S-resolved", _cp125("S-resolved", decisions=[{
+            "text": "litellm gateway cache pinned",
+            "trust": "verbatim", "quote": "pinned", "id": "o-33cc44dd",
+        }], created="2026-06-21T00:00:00Z"), project_dir="/repo/x")
+    store.write_checkpoint(
+        "S-newer", _cp125("S-newer", decisions=[{
+            "text": "unpinned the gateway cache, old diagnosis wrong",
+            "trust": "inferred",
+            "links": [{"type": "supersedes", "target": "o-11aa22bb"}],
+        }], created="2026-06-25T00:00:00Z"), project_dir="/repo/x")
+    store.append_event("o-33cc44dd", "superseded-by:o-h333", source="cli",
+                       project_dir="/repo/x")
+
+    hits = recall.search("litellm gateway cache", project_dir="/repo/x")
+    order = [h["session_id"] for h in hits if h["superseded_by"]]
+    assert order[:2] == ["S-linked", "S-resolved"]
+    by_sid = {h["session_id"]: h for h in hits}
+    assert by_sid["S-linked"]["superseded_source"] == "link"
+    assert by_sid["S-resolved"]["superseded_source"] == "resolution"
+
+
 # ---- #899: host allowlist fans every single-scope read, and only those ----
 #
 # The caller never names a scope here. The host declares extra READ slugs out


### PR DESCRIPTION
Closes #907

## What

Both spenders of `superseded_by` now branch on the mechanism #867 recorded in `superseded_source`, and `suggest`'s own SELECT now carries that column, which it never did. In `suggest`, a row a person resolved takes 0.5 and a row a model link replaced keeps 0.7. In `search`, replaced rows sort unsuperseded first, then link, then resolution, ahead of the existing relevance term. A row with `superseded_by` set and no source ranks as a link. No public word moves; `link` and `resolution` stay machine keys.

## Why

The write side already ranked them: the resolution fold overwrites the link fold, with the comment that a person's recorded action outranks a model's claim. The read side never learned. One multiplier and one sort predicate for both writers meant a model's guess that B replaced A and a person's recorded decision that it did demoted A at one rate, and `superseded_source` was display-only.

Naming an evidential grade for these edges is deliberately out of scope. The language contract freezes trust literals as a closed set consumed by installed host skills, so that is a contract amendment first, and it is registered there as naming debt.

## Tests

Four new tests in `tests/test_recall.py`, each checked against the code it guards:

- `test_suggest_demotes_a_human_resolution_harder_than_a_model_link` pins the weight order contradicted < resolved < linked < clean. Red before the change.
- `test_search_sorts_a_resolved_item_below_a_linked_one` rigs the resolved row as the shorter document so bm25 alone puts it first, and asserts the linked row still leads. Red before the change.
- `test_suggest_ranks_a_resolved_item_below_a_linked_one_end_to_end` goes through `suggest` itself with two rows equal in text length, query terms, importance and birth stamp. Red before the change with `KeyError: 'superseded_source'`: the weight function was correct and the SELECT feeding it never carried the column, so every human resolution would have ranked as a model link. Same lesson #837 recorded on the same surface.
- `test_suggest_treats_an_unattributed_superseded_row_as_a_model_link` passes on main by construction and fails when the fallback is flipped to treat a missing source as a person. Kept as the guard for that fallback.

Full suite from `plugin/` with `uv run --extra dev --extra pretty pytest -q`, ruff and mypy clean.
