### PR TITLE
docs: cite the Agent Memory Atlas reading, strong half and weak half together

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ That's it. End a session → a checkpoint is written; start the next → the bri
 - **The briefing UX** — memory that arrives as a session-*start* artifact you can skim in 30 seconds, ordered by what to verify first.
 - **Host-agnostic hooks** — Claude Code (live-validated daily), Windsurf (live-validated), Codex (live-validated capture since 2026-08-06); other hosts are reachable via the same thin adapter shape.
 
+## An independent reading
+
+[Agent Memory Atlas](https://neoneye.github.io/agent-memory-atlas/systems/daimon/), a commit-pinned survey of agent memory systems, has read this codebase several times since July 2026. From its latest executive summary:
+
+> This is one of the very few that treats the model's own trust label as a claim to be falsified before it is stored.
+
+It is not praise alone. The same summary names the weak half: "The retrieval half is much less proven." Both halves are checkable against the card's file and line citations, and every reading is recorded with the commit it was pinned to.
+
 ## Status
 
 | Surface | State |

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -45,6 +45,14 @@ never wear the verbatim badge. With [receipts](concepts/receipts.md) enabled,
 the checkpoint's exact bytes are signed — everything above is checkable
 offline, without trusting daimon, the model, or this page.
 
+## An independent reading
+
+[Agent Memory Atlas](https://neoneye.github.io/agent-memory-atlas/systems/daimon/), a commit-pinned survey of agent memory systems, has read this codebase several times since July 2026. From its latest executive summary:
+
+> This is one of the very few that treats the model's own trust label as a claim to be falsified before it is stored.
+
+It is not praise alone. The same summary names the weak half: "The retrieval half is much less proven." Both halves are checkable against the card's file and line citations, and every reading is recorded with the commit it was pinned to.
+
 ## The loop
 
 1. **A session ends** — a host hook serializes the transcript into a

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/index.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/index.md
@@ -47,6 +47,14 @@ acto, así que una cita alucinada nunca puede llevar la insignia verbatim. Con
 se firman — todo lo de arriba es verificable offline, sin confiar en daimon,
 en el modelo, ni en esta página.
 
+## Una lectura independiente
+
+[Agent Memory Atlas](https://neoneye.github.io/agent-memory-atlas/systems/daimon/), un catálogo de sistemas de memoria para agentes fijado a commits, ha leído esta base de código varias veces desde julio de 2026. De su último resumen ejecutivo, citado en inglés:
+
+> This is one of the very few that treats the model's own trust label as a claim to be falsified before it is stored.
+
+No es solo elogio. El mismo resumen nombra la mitad débil: "The retrieval half is much less proven." Las dos mitades se pueden contrastar con las citas de archivo y línea de la ficha, y cada lectura queda registrada con el commit al que se fijó.
+
 ## El ciclo
 
 1. **Una sesión termina** — un hook del host serializa la transcripción a un


### PR DESCRIPTION
Documentation only.

## What

A short "An independent reading" section in three places: the README below "What's net-new here", the site overview below "Why it's different", and the Spanish mirror of that page. It quotes one verbatim sentence from the Agent Memory Atlas card's executive summary, puts the card's own weak-half sentence beside it, and links the card.

## Why

The card is the first independent, commit-pinned technical reading of this codebase, and it is checkable line by line. Quoting only the strong sentence would read as cherry-picked, so the weak sentence sits next to it in the card's own words. The work is named and linked; no person is named, because the card carries no byline of its own and an analysis is not an endorsement. Below the fold on purpose: a third-party quote above the briefing sample would read as marketing.

Both sentences were verified verbatim against the live card on 2026-09-02.

## Tests

`test_reader_facing_vocabulary.py` and `test_pr_template_matches_gates.py` pass. No em-dash in any added line. No build run, per the repo rule.
