### PR TITLE
ci(pr-validation): the docs-only allowlist admits the Spanish mirror

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -22,7 +22,7 @@ jobs:
       PR: ${{ github.event.pull_request.number }}
       # Issue-free documentation is deliberately narrower than "any Markdown":
       # SKILL.md and other agent instructions are executable behavior, not docs.
-      DOCS_ONLY_PATH_RE: '^(README\.md|(plugin|hook|benchmark)/README\.md|research/(.*/)?README\.md|docs/.*\.(md|png|gif|jpe?g|webp|ico)|website/(docs|blog)/.*\.md|website/static/img/.*\.(png|gif|jpe?g|webp|ico))$'
+      DOCS_ONLY_PATH_RE: '^(README\.md|(plugin|hook|benchmark)/README\.md|research/(.*/)?README\.md|docs/.*\.(md|png|gif|jpe?g|webp|ico)|website/(docs|blog)/.*\.md|website/i18n/.*\.md|website/static/img/.*\.(png|gif|jpe?g|webp|ico))$'
       # CI changes can alter credentials, releases, and publishing. They bypass
       # an issue only with explicit PR approval; this allowlist merely defines
       # what may ASK for that bypass. Exact policy-test path is included so the

--- a/plugin/tests/test_pr_template_matches_gates.py
+++ b/plugin/tests/test_pr_template_matches_gates.py
@@ -71,6 +71,11 @@ def test_the_template_does_not_invent_types_the_gate_rejects():
     "website/docs/concepts/architecture.md",
     "website/blog/2026-08-29-architecture.md",
     "website/static/img/architecture.png",
+    # The Spanish mirror ships in the same PR as the page it mirrors; a
+    # docs PR carrying it must stay docs-only or the mirror rule and the
+    # bypass contradict each other on every mirrored change.
+    "website/i18n/es/docusaurus-plugin-content-docs/current/index.md",
+    "website/i18n/es/docusaurus-plugin-content-blog/2026-08-29-architecture.md",
 ])
 def test_docs_issue_bypass_accepts_only_declared_public_docs(path):
     assert _policy_regex("DOCS_ONLY_PATH_RE").fullmatch(path)
@@ -84,6 +89,9 @@ def test_docs_issue_bypass_accepts_only_declared_public_docs(path):
     ".github/PULL_REQUEST_TEMPLATE.md",
     "website/docusaurus.config.ts",
     "website/package.json",
+    # Translation JSON under i18n/ configures the site; prose only bypasses.
+    "website/i18n/es/code.json",
+    "website/i18n/es/docusaurus-theme-classic/navbar.json",
     "plugin/daimon_briefing/briefing.py",
 ])
 def test_docs_issue_bypass_rejects_executable_or_governance_surfaces(path):


### PR DESCRIPTION
Closes #911

## What

`DOCS_ONLY_PATH_RE` in `pr-validation.yml` also matches `website/i18n/.*\.md`. Two positive regression cases (a docs mirror page, a blog mirror page) and two negative ones (translation JSON under the same tree) pin the widening in `test_pr_template_matches_gates.py`.

## Why

The repo rule says a docs change ships its Spanish mirror in the same PR. The docs-only bypass never listed the mirror path, so every mirrored docs PR was classified `other` and failed "Check Issue Reference" with an issue that would exist only to satisfy the gate. #910 hit it today. Prose only: the JSON files under `i18n/` configure the site and keep needing an issue.

## Tests

`test_pr_template_matches_gates.py`: the two new positive cases were red before the regex change and green after; the negative cases pass on both sides.
