### PR TITLE
feat(cli): daimon slug <path> prints the checkpoint directory name

### DIFF
--- a/.scars/candidates/docs-tree-lacks-reference-section.md
+++ b/.scars/candidates/docs-tree-lacks-reference-section.md
@@ -1,0 +1,34 @@
+---
+id: 0
+type: deadend
+title: top-level docs/ is not a mirror of website/docs/ — it has no reference/ section, so relative .md links assuming parity point at nothing
+severity: low
+confidence: 0.8
+created: 2026-09-02
+authors: ["claude-code"]
+anchors:
+  - path: docs/
+  - path: website/docs/
+evidence:
+  - note: "#913: docs/hosts/claude-code.md and website/docs/hosts/claude-code.md carry the SAME stale 'Claude Code style' slug claim and were fixed in the same PR, which reads as if the two trees mirror each other page-for-page. They do not: website/docs/reference/cli.md exists, docs/reference/ does not exist at all (docs/ only has ARCHITECTURE.md, PITCH.md, hosts/, team.md, trust-inspector.md, etc. — internal working notes and validation records, confirmed by test_reader_facing_vocabulary.py's own comment: 'docs/ is deliberately absent — it holds working notes and validation records, not published prose'). A first attempt linked docs/hosts/claude-code.md to ../reference/cli.md#status, which resolves to nothing on GitHub."
+expires:
+  condition: "docs/ grows a reference/ section, or the two trees are formally declared independent (e.g. a README note) so no editor assumes parity again"
+  review_after: 2027-03-01
+status: candidate
+---
+
+`docs/` and `website/docs/` both describe hosts and both got edited in #913 for
+the same stale-claim fix, which looks like two synced copies of one doc set.
+They are not synced: `website/docs/` is the full Docusaurus site (getting-started,
+reference, concepts, hosts, viewer, blog) with an ES mirror under
+`website/i18n/`; `docs/` is a much smaller, GitHub-only set of internal/founder
+docs (architecture, pitch, problem, RFC, validation, hosts/, team, trust
+inspector) with no `reference/` section and no i18n mirror at all.
+
+Before adding a cross-link from a page under `docs/` to another doc, check the
+target actually exists in that tree (`fd -t f <name> docs/`) rather than
+assuming the `website/docs/` layout carries over. A `.md`-relative link into a
+nonexistent path fails silently on GitHub (renders as a dead link, no build
+error — unlike the `website/` es-locale hazard in scar #24, which at least
+throws at build time). Prefer describing the command in plain prose in
+`docs/`, or point at a URL if a page there truly needs an inbound link.

--- a/docs/hosts/claude-code.md
+++ b/docs/hosts/claude-code.md
@@ -50,7 +50,10 @@ registers them:
   stdin and shells out to the installed `daimon brief` CLI (single source of
   truth for rendering); prints the briefing to stdout, which Claude Code
   injects as session context. **Per-project routing:** the payload `cwd` is
-  slugged (Claude Code style: `/Users/x/proj` -> `-Users-x-proj`) and this
+  slugged with daimon's own rule (`/Users/x/proj` -> `-Users-x-proj`; run
+  `daimon slug <path>` to print it for any path). This is not the scheme
+  Claude Code itself uses for `~/.claude/projects`, which folds `_` where
+  daimon keeps it. This
   project's `<checkpoint-dir>/<slug>/latest.json` is preferred; if the
   project has no checkpoint of its own, the global `latest.json` is used and
   the briefing header is labeled `(global fallback — checkpoint may be from

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -1015,6 +1015,20 @@ def projects_rows(project_arg=None) -> list:
     return rows
 
 
+def _cmd_slug(args) -> int:
+    """Print the checkpoint bucket name daimon derives from a project path
+    (#913). No store, config, or ledger access — deliberately: a host that
+    wants this name before the first write (to lay out a fresh volume, or
+    start a watcher on a directory daimon has not touched yet) has no bucket
+    to list, so this must answer without one, unlike `projects` below."""
+    slug = store.project_slug(args.path)
+    if not slug:
+        print("error: path must not be empty or whitespace-only", file=sys.stderr)
+        return 2
+    print(slug)
+    return 0
+
+
 def _cmd_projects(args) -> int:
     """Read-only orientation for context switching — the crossing itself
     stays explicit (`brief --slug` / `recall --slug`), the #94/#95 lesson."""
@@ -3303,6 +3317,19 @@ def build_parser() -> argparse.ArgumentParser:
         "--json", action="store_true", help="machine-readable output"
     )
     p_projects.set_defaults(func=_cmd_projects)
+
+    p_slug = sub.add_parser(
+        "slug",
+        help="print the checkpoint directory name daimon derives from a project path",
+        description="Print the checkpoint directory name daimon derives from "
+                     "a project path. Read-only: no store, config, or ledger "
+                     "access.",
+        epilog="Examples:\n"
+               "  daimon slug /Users/x/my.proj\n"
+               "  daimon slug -- -Users-x        # '--' escapes a path starting with '-'\n",
+    )
+    p_slug.add_argument("path", help="project directory path to slug")
+    p_slug.set_defaults(func=_cmd_slug)
 
     lifecycle.register(sub, fmt)
 

--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -44,6 +44,13 @@ NOT_AGENT_FACING = {
     "recall-inject": "internal: the per-prompt recall hook",
     "request-inject": ("internal: the per-prompt live-delivery hook (#756); "
                        "agents receive its output, never run it"),
+    "slug": (
+        "internal: a host-integration primitive (#913) that names a "
+        "checkpoint bucket before any checkpoint exists — a HOST process "
+        "shells out to it once to lay out a volume or start a watcher; an "
+        "agent inside a session has no bucket-naming task and reads its own "
+        "project through brief/recall/why, never by slug arithmetic"
+    ),
     # -- deliberate product boundaries --
     "forget": (
         "human-only by design: deletion is the user's call, and the full body "

--- a/plugin/daimon_ui/reader.py
+++ b/plugin/daimon_ui/reader.py
@@ -83,7 +83,16 @@ def resolve_data_dir(env=None):
     return Path.home() / ".daimon" / "checkpoints"
 
 def project_slug(project_dir):
-    return re.sub(r"[^\w-]", "-", str(project_dir).strip())
+    """Behaviorally locked to daimon_briefing.store.project_slug by
+    test_reader_project_slug_stays_in_sync_with_store (#913) — no import
+    here on purpose, this module carries no daimon import (see file
+    docstring). Empty/None input returns None, matching store, not ''."""
+    if not project_dir:
+        return None
+    s = str(project_dir).strip()
+    if not s:
+        return None
+    return re.sub(r"[^\w-]", "-", s) or None
 
 def _pointer_files(bucket: Path):
     if not bucket.is_dir():

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -8735,6 +8735,121 @@ def test_projects_empty_store_says_so(tmp_checkpoint_dir, capsys, monkeypatch):
     assert "no project" in capsys.readouterr().out.lower()
 
 
+# ---- daimon slug <path>: the checkpoint-bucket-name rule, standalone (#913) ----
+
+
+def test_cli_slug_prints_project_slug_for_a_normal_path(capsys):
+    from daimon_briefing import store
+
+    path = "/tmp/a b.c_d"
+    assert cli.main(["slug", path]) == 0
+    out = capsys.readouterr().out
+    assert out == store.project_slug(path) + "\n"
+
+
+def test_cli_slug_keeps_underscore(capsys):
+    assert cli.main(["slug", "/tmp/a_b"]) == 0
+    assert capsys.readouterr().out == "-tmp-a_b\n"
+
+
+def test_cli_slug_matches_the_documented_example(capsys):
+    # #913: the worked example in website/docs/reference/cli.md and its
+    # Spanish mirror, pinned literally so drift there fails a test instead
+    # of only failing store.project_slug's own oracle.
+    assert cli.main(["slug", "/Users/x/my.proj"]) == 0
+    assert capsys.readouterr().out == "-Users-x-my-proj\n"
+
+
+def test_cli_slug_preserves_unicode(capsys):
+    from daimon_briefing import store
+
+    path = "/home/dev/ünïcode-プロジェクト"
+    assert cli.main(["slug", path]) == 0
+    out = capsys.readouterr().out
+    assert out == store.project_slug(path) + "\n"
+
+
+def test_cli_slug_empty_path_exits_2_with_no_stdout(capsys):
+    rc = cli.main(["slug", ""])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.strip() != ""
+
+
+def test_cli_slug_whitespace_only_path_exits_2_with_no_stdout(capsys):
+    rc = cli.main(["slug", "   "])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.strip() != ""
+
+
+def test_cli_slug_is_idempotent(capsys):
+    from daimon_briefing import store
+
+    path = "/Users/x/my.proj"
+    once = store.project_slug(path)
+    # a slug of an absolute path starts with '-' — needs '--' same as any
+    # other leading-dash positional (see test_cli_slug_leading_dash_path_...)
+    assert cli.main(["slug", "--", once]) == 0
+    twice = capsys.readouterr().out.strip()
+    assert twice == store.project_slug(once)
+    assert twice == once  # a slug re-slugged is unchanged: it's already \w or -
+
+
+def test_cli_slug_matches_store_project_slug_across_samples(capsys):
+    from daimon_briefing import store
+
+    samples = (
+        "/Users/dev/proj", "/tmp/a b/c.d", "/home/dev/ünïcode-プロジェクト",
+        "rel/path", "----", "...",
+    )
+    for sample in samples:
+        assert cli.main(["slug", "--", sample]) == 0
+        out = capsys.readouterr().out
+        assert out == store.project_slug(sample) + "\n", sample
+
+
+def test_cli_slug_leading_dash_path_needs_double_dash(capsys):
+    # argparse reads a bare leading-dash token as an unknown option; `--`
+    # is the documented escape (main()'s pre-parse fusion only rewrites
+    # `--slug`, not this command's positional).
+    rc = cli.main(["slug", "--", "-Users-x"])
+    assert rc == 0
+    assert capsys.readouterr().out == "-Users-x\n"
+
+
+def test_cli_slug_takes_no_slug_flag():
+    # #913: adding --slug here would break
+    # test_exactly_the_read_verbs_and_the_human_only_verbs_take_a_slug.
+    import argparse
+
+    parser = cli.build_parser()
+
+    def _find(parser, name):
+        for action in parser._actions:
+            if isinstance(action, argparse._SubParsersAction):
+                if name in action.choices:
+                    return action.choices[name]
+        return None
+
+    p_slug = _find(parser, "slug")
+    assert p_slug is not None
+    assert not any("--slug" in a.option_strings for a in p_slug._actions)
+    assert not any("--project" in a.option_strings for a in p_slug._actions)
+
+
+def test_cli_slug_does_not_touch_config_or_ledger(capsys, monkeypatch, tmp_path):
+    # spec: read-only, no store read, no config read, no ledger touch — a
+    # checkpoint dir daimon never created must stay absent after this
+    # command (config.checkpoint_dir() reads DAIMON_CHECKPOINT_DIR).
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
+    assert cli.main(["slug", "/tmp/x"]) == 0
+    capsys.readouterr()
+    assert not (tmp_path / "checkpoints").exists()
+
+
 # ---- recall --slug: bucket-identity scoping (#243) ----
 
 

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -407,6 +407,11 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
     def r_projects():
         run(["projects"], 0)
 
+    def r_slug():
+        # #913: drives the command so the audit proves it makes no
+        # ungoverned write, same as every other recipe here.
+        run(["slug", str(proj)], 0)
+
     def r_refute_add():
         subject = "The original receipt design"
         scope = "carried-item receipt tiers"
@@ -721,6 +726,7 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
         ("recall",): r_recall,
         ("why",): r_why,
         ("projects",): r_projects,
+        ("slug",): r_slug,
         ("refute", "add"): r_refute_add,
         ("refute", "ratify"): r_refute_ratify,
         ("refute", "revise"): r_refute_revise,

--- a/plugin/tests/ui/test_reader_discovery.py
+++ b/plugin/tests/ui/test_reader_discovery.py
@@ -12,6 +12,26 @@ def test_resolve_data_dir_default():
 def test_project_slug_munging():
     assert reader.project_slug("/Users/x/My Proj") == "-Users-x-My-Proj"
 
+
+def test_reader_project_slug_stays_in_sync_with_store():
+    # #913: reader.py is the 4th copy of the slug rule (the other three are
+    # store.project_slug, the hook-lib copy locked by
+    # test_hook_lib_slug_and_created_epoch_stay_in_sync_with_store, and the
+    # CLI verb, which calls store directly). Same risk class as #510: a
+    # drifted reader shows the wrong project's data with no error. Behavioral
+    # equality only — reader.py carries no daimon import by design (module
+    # docstring: "files are the seam"), so this asserts agreement rather than
+    # sharing code.
+    from daimon_briefing import store
+
+    samples = (
+        "/Users/dev/proj", "/Users/dev/proj/", "C:\\work\\repo",
+        "/tmp/a b/c.d", "/home/dev/ünïcode-プロジェクト", "rel/path",
+        "----", "...", "", "   ", None,
+    )
+    for sample in samples:
+        assert reader.project_slug(sample) == store.project_slug(sample), sample
+
 def test_list_recent_orders_and_filters(bucket):
     got = reader.list_recent(bucket)
     assert [g["ref"] for g in got] == ["latest", "prev-1", "prev-2"]

--- a/website/docs/hosts/claude-code.md
+++ b/website/docs/hosts/claude-code.md
@@ -51,7 +51,10 @@ registers them:
   stdin and shells out to the installed `daimon brief` CLI (single source of
   truth for rendering); prints the briefing to stdout, which Claude Code
   injects as session context. **Per-project routing:** the payload `cwd` is
-  slugged (Claude Code style: `/Users/x/proj` -> `-Users-x-proj`) and this
+  slugged with daimon's own rule (`/Users/x/proj` -> `-Users-x-proj`; run
+  [`daimon slug <path>`](../reference/cli#status) to print it for any path).
+  This is not the scheme Claude Code itself uses for `~/.claude/projects`,
+  which folds `_` where daimon keeps it. This
   project's `<checkpoint-dir>/<slug>/latest.json` is preferred; if the
   project has no checkpoint of its own, the global `latest.json` is used and
   the briefing header is labeled `(global fallback — checkpoint may be from

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -109,7 +109,19 @@ request write verb is reachable over MCP.
 | `daimon loops` | List open, addressable loop items with their ids — the read counterpart to `resolve`'s write path. |
 | `daimon decide` | List what is waiting on YOU, each with the one command that closes it — the human-side mirror of `loops`. Reads records that already exist and writes nothing at all, so opening it never changes what the agent is shown. Scoped to this project; other projects arrive as counts. `--all-projects` adds every other project's queue as text, composed per project, each command routed with `--slug=<slug>` so it runs from here. The ten human-only verbs (`request accept`, `reject`, `needs-info`, `suppress`; `amend ratify`, `reject`; `ruling ratify`, `retire`; `refute ratify`, `overturn`) take that flag as routing only. Both are refused while `DAIMON_TENANT_SCOPED` is set. |
 | `daimon projects` | List every project daimon holds a checkpoint for, with topic teasers. |
+| `daimon slug <path>` | Print the checkpoint directory name daimon derives from a project path. No store, config, or ledger access, so it answers even for a path daimon has never written to. |
 | `daimon team init\|sync\|status` | Shared team memory via a sidecar repo — default-closed routing, shape-redacted before anything syncs. |
+
+The slug rule, stated exactly: leading and trailing whitespace is stripped
+first, then every character that is not a Unicode word character or `-`
+becomes `-`. Underscores, accented letters, and non-Latin scripts survive the
+fold; an empty or whitespace-only input has no slug. Example: `/Users/x/my.proj`
+becomes `-Users-x-my-proj`. This is not the scheme Claude Code uses for
+`~/.claude/projects`. The two agree on slashes, dots, and spaces, and
+disagree on `_` (daimon keeps it, Claude Code folds it to `-`). A host that
+reimplements the rule can check its copy against `daimon slug` directly. A
+path that starts with `-` needs `--` before it (`daimon slug -- -Users-x`),
+the same escape any positional argument needs for a leading dash.
 
 ## Internals (invoked by hooks, documented for completeness)
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/claude-code.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/claude-code.md
@@ -53,8 +53,11 @@ instalación que los registre:
   y delega en el CLI `daimon brief` instalado (única fuente de verdad para el
   renderizado); imprime el briefing a stdout, que Claude Code inyecta como
   contexto de sesión. **Enrutamiento por proyecto:** el `cwd` del payload se
-  convierte en slug (estilo Claude Code: `/Users/x/proj` -> `-Users-x-proj`) y
-  se prefiere el `<checkpoint-dir>/<slug>/latest.json` de este proyecto; si el
+  convierte en slug con la regla propia de daimon (`/Users/x/proj` ->
+  `-Users-x-proj`; corré [`daimon slug <path>`](../reference/cli#estado) para
+  imprimirlo para cualquier ruta). Este no es el esquema que usa Claude Code
+  para `~/.claude/projects`, que pliega `_` donde daimon lo conserva. Se
+  prefiere el `<checkpoint-dir>/<slug>/latest.json` de este proyecto; si el
   proyecto no tiene checkpoint propio, se usa el `latest.json` global y el
   encabezado del briefing se etiqueta `(global fallback — checkpoint may be
   from another project)`. El cwd se reenvía al CLI vía `DAIMON_PROJECT_DIR`

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -114,7 +114,21 @@ alcanzable por MCP.
 | `daimon loops` | Lista los loops abiertos direccionables con sus ids — la contraparte de lectura del camino de escritura de `resolve`. |
 | `daimon decide` | Lista lo que está esperando por VOS, cada cosa con el único comando que la cierra — el espejo del lado humano de `loops`. Lee registros que ya existen y no escribe nada, así que abrirlo nunca cambia lo que el agente ve. Acotado a este proyecto; los demás proyectos llegan como conteos. `--all-projects` agrega la cola de cada otro proyecto como texto, compuesta por proyecto, con cada comando enrutado con `--slug=<slug>` para que corra desde acá. Los diez verbos solo para humanos (`request accept`, `reject`, `needs-info`, `suppress`; `amend ratify`, `reject`; `ruling ratify`, `retire`; `refute ratify`, `overturn`) toman esa bandera solo como ruteo. Ambos se rechazan mientras `DAIMON_TENANT_SCOPED` esté activo. |
 | `daimon projects` | Lista cada proyecto con checkpoint, con un adelanto del tema. |
+| `daimon slug <path>` | Imprime el nombre de directorio de checkpoint que daimon deriva de una ruta de proyecto. Sin acceso a store, config ni ledger, así que responde incluso para una ruta a la que daimon nunca escribió. |
 | `daimon team init\|sync\|status` | Memoria de equipo compartida vía repo sidecar — ruteo cerrado por defecto, redacción por forma antes de sincronizar nada. |
+
+La regla del slug, dicha con precisión: primero se recorta el espacio en
+blanco al principio y al final, y después cada carácter que no sea un
+carácter de palabra Unicode ni `-` se convierte en `-`. Los guiones bajos, las
+letras acentuadas y las escrituras no latinas sobreviven al pliegue; una
+entrada vacía o de solo espacios no tiene slug. Ejemplo: `/Users/x/my.proj` se
+convierte en `-Users-x-my-proj`. Este no es el esquema que usa Claude Code
+para `~/.claude/projects`. Los dos coinciden en barras, puntos y espacios, y
+difieren en `_` (daimon lo conserva, Claude Code lo pliega a `-`). Un host que
+prefiera reimplementar la regla puede chequear su copia contra `daimon slug`
+directamente. Una ruta que empieza con `-` necesita `--` antes (`daimon slug
+-- -Users-x`), el mismo escape que necesita cualquier argumento posicional con
+guion inicial.
 
 ## Internos (los invocan los hooks; documentados por completitud)
 


### PR DESCRIPTION
Closes #913

## What

A new read-only verb, `daimon slug <path>`, prints the checkpoint directory name `store.project_slug` derives from any path, with no store, config, or ledger access. Empty or whitespace-only input exits 2 with nothing on stdout. A path that starts with `-` takes the usual `--` escape. The rule itself is now stated in the CLI reference, EN and ES, in the same section as `daimon projects`: whitespace stripped first, then every character outside Unicode `\w` and `-` becomes `-`, and the one place it differs from Claude Code's `~/.claude/projects` naming is `_`, which daimon keeps.

Both host docs for Claude Code stop claiming "Claude Code style" slugging, the claim #884 already retracted from the docstring. The `daimon_ui` reader's copy of the rule now returns `None` on empty input like store does and is locked to store by a behavioral test, the way #510 locked the hook-lib copy. The verb is declared not agent-facing in the skill classifier and driven by the write-audit guard like every other command; both were red without those entries.

## Why

A host that lays out a fresh volume or starts a watcher on a project directory needs the bucket name before the first checkpoint exists. `daimon projects --json` prints slugs, but only for buckets already on disk, and under `DAIMON_TENANT_SCOPED` it filters to the current one. Until now the only other way was to copy the regex, and one out-of-process host that did so had already drifted: its copy folds only `/`. The two agree only while a work root stays inside `[A-Za-z0-9/-]`.

The rule is effectively frozen already, since changing it would orphan every checkpoint directory. A CLI verb plus a written rule is the smallest new promise that ends the copying. Declaring `store.project_slug` a public Python API was considered and set aside: it freezes an import path and forces an out-of-process host to import daimon to get one string, and a Python API can still be added later without breaking anything.

## Tests

Eleven new tests in `tests/test_cli.py` under the `daimon slug` block, one in `tests/ui/test_reader_discovery.py`:

- Output equals `store.project_slug(path)` plus newline for a path with a dot and a space, for a Unicode path, and across a sample set including `----` and `...`.
- Underscore is kept, asserted on the exact output `-tmp-a_b`.
- The worked example in the docs, `/Users/x/my.proj` to `-Users-x-my-proj`, is pinned literally so a drift in the rule fails a test instead of only moving its own oracle.
- Empty and whitespace-only input exit 2 with empty stdout and a non-empty stderr line.
- Idempotence: the slug of a slug is unchanged.
- A leading-dash path works behind `--`.
- The parser for `slug` carries neither `--slug` nor `--project`, so `test_exactly_the_read_verbs_and_the_human_only_verbs_take_a_slug` keeps its set.
- No checkpoint directory is created by the command when `DAIMON_CHECKPOINT_DIR` points at an absent path.
- `reader.project_slug` agrees with `store.project_slug` over eleven samples including `None`, `""`, whitespace, and a Windows path. Red before the reader change on `""` and `None`.

A scar candidate records that `docs/` is not a mirror of `website/docs/` and has no `reference/` section, caught when a relative link there resolved to nothing.

Full suite from `plugin/` with `uv run --extra dev --extra pretty pytest -q`: 4878 passed, 2 skipped. ruff and mypy clean.
