### PR TITLE
chore(scars): promote 0066 and 0067, the docs tree split and the suggest SELECT weight

### DIFF
--- a/.scars/0066-docs-tree-lacks-reference-section.deadend.md
+++ b/.scars/0066-docs-tree-lacks-reference-section.deadend.md
@@ -1,20 +1,22 @@
 ---
-id: 0
+id: 66
 type: deadend
 title: top-level docs/ is not a mirror of website/docs/ — it has no reference/ section, so relative .md links assuming parity point at nothing
 severity: low
 confidence: 0.8
 created: 2026-09-02
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
+promoted_by: Kibukx
+promoted_by_source: git-config
 anchors:
   - path: docs/
   - path: website/docs/
 evidence:
-  - note: "#913: docs/hosts/claude-code.md and website/docs/hosts/claude-code.md carry the SAME stale 'Claude Code style' slug claim and were fixed in the same PR, which reads as if the two trees mirror each other page-for-page. They do not: website/docs/reference/cli.md exists, docs/reference/ does not exist at all (docs/ only has ARCHITECTURE.md, PITCH.md, hosts/, team.md, trust-inspector.md, etc. — internal working notes and validation records, confirmed by test_reader_facing_vocabulary.py's own comment: 'docs/ is deliberately absent — it holds working notes and validation records, not published prose'). A first attempt linked docs/hosts/claude-code.md to ../reference/cli.md#status, which resolves to nothing on GitHub."
+  - note: #913: docs/hosts/claude-code.md and website/docs/hosts/claude-code.md carry the SAME stale 'Claude Code style' slug claim and were fixed in the same PR, which reads as if the two trees mirror each other page-for-page. They do not: website/docs/reference/cli.md exists, docs/reference/ does not exist at all (docs/ only has ARCHITECTURE.md, PITCH.md, hosts/, team.md, trust-inspector.md, etc. — internal working notes and validation records, confirmed by test_reader_facing_vocabulary.py's own comment: 'docs/ is deliberately absent — it holds working notes and validation records, not published prose'). A first attempt linked docs/hosts/claude-code.md to ../reference/cli.md#status, which resolves to nothing on GitHub.
 expires:
   condition: "docs/ grows a reference/ section, or the two trees are formally declared independent (e.g. a README note) so no editor assumes parity again"
   review_after: 2027-03-01
-status: candidate
+status: active
 ---
 
 `docs/` and `website/docs/` both describe hosts and both got edited in #913 for

--- a/.scars/0067-suggest-select-feeds-the-weight.landmine.md
+++ b/.scars/0067-suggest-select-feeds-the-weight.landmine.md
@@ -1,20 +1,22 @@
 ---
-id: 0
+id: 67
 type: landmine
 title: A column _suggest_weight reads must also be SELECTed in suggest() itself; search() selecting it proves nothing
 severity: high
 confidence: 0.9
 created: 2026-09-02
-authors: ["claude-code"]
+authors: ["claude-code", "Kibukx"]
+promoted_by: Kibukx
+promoted_by_source: git-config
 anchors:
   - pattern: "_suggest_weight"
 evidence:
-  - note: "#837 (2abf0c4): invalidated_by was written and selected in search() but not in suggest()'s own SELECT; the auto-inject path re-asserted contradicted claims. The fix left the comment 'the column MUST be selected here, not just written' at recall.py suggest()"
-  - note: "#907 (2026-09-02): superseded_source, selected in search() since #867, was absent from suggest()'s SELECT. A weight-level test on a dict passed; the end-to-end suggest test was red with KeyError: 'superseded_source'. Every human resolution would have demoted at the model-link rate"
+  - note: #837 (2abf0c4): invalidated_by was written and selected in search() but not in suggest()'s own SELECT; the auto-inject path re-asserted contradicted claims. The fix left the comment 'the column MUST be selected here, not just written' at recall.py suggest()
+  - note: #907 (2026-09-02): superseded_source, selected in search() since #867, was absent from suggest()'s SELECT. A weight-level test on a dict passed; the end-to-end suggest test was red with KeyError: 'superseded_source'. Every human resolution would have demoted at the model-link rate
 expires:
   condition: "search() and suggest() share one column list (a single SELECT builder), so a column cannot be present in one and absent from the other"
   review_after: 2027-03-02
-status: candidate
+status: active
 ---
 
 `recall.search()` and `recall.suggest()` build SEPARATE SELECT statements over the


### PR DESCRIPTION
Scars only, promoted by the maintainer with `scar promote`; no linked issue by the gate's own rule.

## What

Promotes two candidates to active scars, reviewer added to `authors` per the existing convention.

- **0066, deadend:** `docs/` is not a mirror of `website/docs/` and has no `reference/` section. A relative link written as if the two trees matched resolves to nothing on GitHub, with no build error to catch it.
- **0067, landmine:** `suggest()` and `search()` carry separate SELECTs. A rank column the weight function consumes must be present in both, or the weight silently reads a missing key.

## Why

Both were caught in the last two merged changes (#908 and #914) and would recur without an anchored warning.

## Tests

`scar lint` in CI. No code changes.
