### PR TITLE
fix(cli): the request cap refusal names where the overflow belongs

### DIFF
--- a/plugin/daimon_briefing/cli/request.py
+++ b/plugin/daimon_briefing/cli/request.py
@@ -33,6 +33,46 @@ _MARKS = {"open": "→", "needs-info": "?", "accepted": "✓",
 # Near-match budget for an unknown `--to`: enough to catch a typo, few
 # enough that the refusal stays a refusal rather than a project directory.
 _SUGGESTIONS = 3
+# #916: over-cap `ask`/`why`/`evidence` name where the overflow belongs, in
+# the voice of the #902 handoff refusal. Fields not listed here (`note`,
+# `from_label`, the verify_done `role`) get no destination sentence — they
+# are a verdict comment or an internal label, not authored request prose,
+# so naming a destination for them would be advice for a case that never
+# meaningfully arises. Deliberately never `daimon log`: nothing reads a
+# ref-less note back (scar carried from #902).
+_DESTINATION_BY_FIELD = {
+    "ask": (
+        " — the long form belongs in an artifact the recipient can open "
+        "(a file in the repo, an issue, a document); the request carries "
+        "the pointer and the one-paragraph version."
+    ),
+    "why": (
+        " — the long form belongs in an artifact the recipient can open "
+        "(a file in the repo, an issue, a document); the request carries "
+        "the pointer and the one-paragraph version."
+    ),
+    "evidence": (
+        " — evidence is a pointer to the proof (a commit, a PR, a path, a "
+        "verbatim line), not the proof itself."
+    ),
+}
+_CHECKPOINT_HINT = (
+    " Durable facts learned while composing this belong in a checkpoint "
+    "(the daimon-end skill, `daimon write-checkpoint`), not in the request."
+)
+
+
+def _refusal_message(prefix: str, exc: requests.RequestError) -> str:
+    """`prefix: str(exc)`, plus a destination sentence when `exc` is the
+    over-cap subclass on a field that has one. Every other RequestError
+    (required-but-empty, state, revision cap, unknown recipient shape...)
+    keeps exactly its old plain message."""
+    dest = ""
+    if isinstance(exc, requests.RequestTooLong):
+        dest = _DESTINATION_BY_FIELD.get(exc.field, "")
+        if dest:
+            dest += _CHECKPOINT_HINT
+    return f"{prefix}: {exc}{dest}"
 
 
 def _request_channel(args, *, human_only: bool = False) -> str:
@@ -314,7 +354,7 @@ def _cmd_request_open(args) -> int:
             project_dir=project)
     except requests.RequestError as exc:
         _cli._note_usage("request:open:refused")
-        print(f"request not recorded: {exc}")
+        print(_refusal_message("request not recorded", exc))
         return 1
     _cli._note_usage("request:open:agent"
                      if getattr(args, "by", None) == "agent"
@@ -339,7 +379,7 @@ def _cmd_request_revise(args) -> int:
                         project_dir=project)
     except requests.RequestError as exc:
         _cli._note_usage("request:revise:refused")
-        print(f"request not revised: {exc}")
+        print(_refusal_message("request not revised", exc))
         return 1
     _cli._note_usage("request:revise")
     # #857: `revise()` above read the record through _require, and this is a
@@ -373,7 +413,7 @@ def _cmd_request_verdict(args) -> int:
             project_dir=project)
     except requests.RequestError as exc:
         _cli._note_usage(f"request:{verb}:refused")
-        print(f"request {verb} refused: {exc}")
+        print(_refusal_message(f"request {verb} refused", exc))
         return 1
     _cli._note_usage(f"request:{verb}")
     _report(args.request_id, project, verb)
@@ -403,7 +443,7 @@ def _cmd_request_done(args) -> int:
                       evidence=args.evidence, project_dir=project)
     except requests.RequestError as exc:
         _cli._note_usage("request:done:refused")
-        print(f"request done refused: {exc}")
+        print(_refusal_message("request done refused", exc))
         return 1
     _cli._note_usage("request:done")
     _report(args.request_id, project, "done")

--- a/plugin/daimon_briefing/requests.py
+++ b/plugin/daimon_briefing/requests.py
@@ -170,6 +170,19 @@ class RequestError(ValueError):
     """A requested ledger transition is invalid or cannot be persisted."""
 
 
+class RequestTooLong(RequestError):
+    """The over-cap branch of `_text`, and ONLY that branch — a required-but-
+    empty field stays a plain `RequestError`. Carries `field` and `limit` so
+    the CLI boundary can name a field-appropriate destination (#916, mirrors
+    the #902 handoff refusal) without re-parsing the message string. A
+    caller matching on `RequestError` still catches this by construction."""
+
+    def __init__(self, message: str, *, field: str, limit: int):
+        super().__init__(message)
+        self.field = field
+        self.limit = limit
+
+
 def _path(project_dir=None):
     slug = store.project_slug(project_dir)
     if not slug:
@@ -183,8 +196,9 @@ def _text(name: str, value, *, required: bool = True,
     if required and not out:
         raise RequestError(f"{name} is required")
     if len(out) > limit:
-        raise RequestError(
-            f"{name} is too long ({len(out)} > {limit} characters)")
+        raise RequestTooLong(
+            f"{name} is too long ({len(out)} > {limit} characters)",
+            field=name, limit=limit)
     return out
 
 

--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -256,6 +256,9 @@ unverified claim until the quote is byte-checked. `accept`, `reject`,
 `needs-info`, `suppress` are human-only: print the command, never run it.
 `daimon decide` lists every such command still waiting on a person, across
 this project's ledgers, so say it lands there and stop repeating the ask.
+`ask`, `why` and `evidence` cap at 2000 characters: long content belongs in
+an artifact the request points at (a file, an issue, a PR), with the
+request carrying the pointer, not the full text.
 
 Requests OTHER projects addressed to this one surface automatically at the
 top of `daimon brief` (capped at 3, with an overflow count). `daimon request

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -124,6 +124,25 @@ def test_ask_and_why_are_required_and_capped(project):
         _open(project, ask="x" * (requests._MAX_TEXT + 1))
 
 
+def test_over_cap_raises_the_subclass_with_field_and_limit(project):
+    """#916: the CLI names a destination by inspecting which field tripped
+    the cap, so the exception must carry that field rather than the caller
+    re-parsing the message string."""
+    with pytest.raises(requests.RequestTooLong) as exc_info:
+        _open(project, ask="x" * (requests._MAX_TEXT + 1))
+    assert exc_info.value.field == "ask"
+    assert exc_info.value.limit == requests._MAX_TEXT
+
+
+def test_non_length_failures_still_raise_plain_request_error(project):
+    """A required-but-empty field is a different failure than over-cap —
+    it must not carry a `field`/`limit` pair or trip the CLI's destination
+    text, which is over-cap-only."""
+    with pytest.raises(requests.RequestError) as exc_info:
+        _open(project, ask="")
+    assert not isinstance(exc_info.value, requests.RequestTooLong)
+
+
 def test_unresolvable_project_writes_nothing(project):
     assert requests._path(None) is None
     assert requests.append({"event": "opened"}, project_dir=None) is False
@@ -801,6 +820,106 @@ def test_cli_revise_refuses_past_the_cap(project, recipient, capsys):
     assert "--supersedes" in out
     assert requests.get(q_id, project_dir=project)["revision"] == \
         requests.MAX_REVISIONS
+
+
+def test_cli_open_refusal_over_cap_names_the_ask_destination(project,
+                                                              recipient,
+                                                              capsys):
+    """#916: an over-cap `ask` on `request open` names an artifact pointer
+    and the checkpoint, mirroring the #902 handoff refusal — but never
+    `daimon log` (nothing reads a ref-less note back)."""
+    from daimon_briefing import cli
+    long_ask = "x" * (requests._MAX_TEXT + 1)
+    rc = cli.main(["request", "open", "--to", OTHER, "--ask", long_ask,
+                   "--why", WHY, "--by", "agent", "--project", project])
+    assert rc == 1
+    assert not requests.records(project_dir=project)
+    out = capsys.readouterr().out
+    assert "is too long" in out
+    assert "pointer" in out
+    assert "write-checkpoint" in out
+    assert "daimon-end" in out
+    assert "daimon log" not in out
+
+
+def test_cli_open_refusal_over_cap_evidence_names_the_proof_destination(
+        project, recipient, capsys):
+    from daimon_briefing import cli
+    long_evidence = "x" * (requests._MAX_TEXT + 1)
+    rc = cli.main(["request", "open", "--to", OTHER, "--ask", ASK,
+                   "--why", WHY, "--evidence", long_evidence, "--by", "agent",
+                   "--project", project])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "is too long" in out
+    assert "pointer" in out
+    assert "write-checkpoint" in out
+    assert "daimon log" not in out
+
+
+def test_cli_revise_refusal_over_cap_names_the_why_destination(project,
+                                                                recipient,
+                                                                capsys):
+    from daimon_briefing import cli
+    assert _cli_open(project, recipient) == 0
+    q_id = next(iter(requests.records(project_dir=project)))
+    long_why = "x" * (requests._MAX_TEXT + 1)
+    rc = cli.main(["request", "revise", q_id, "--why", long_why, "--by",
+                   "agent", "--project", project])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "is too long" in out
+    assert "pointer" in out
+    assert "write-checkpoint" in out
+    assert "daimon log" not in out
+
+
+def test_cli_done_refusal_over_cap_names_the_proof_destination(project,
+                                                                recipient,
+                                                                capsys):
+    from daimon_briefing import cli
+    assert _cli_open(project, recipient) == 0
+    q_id = next(iter(requests.records(project_dir=project)))
+    long_evidence = "x" * (requests._MAX_TEXT + 1)
+    rc = cli.main(["request", "done", q_id, "--evidence", long_evidence,
+                   "--by", "agent", "--project", project])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "is too long" in out
+    assert "pointer" in out
+    assert "write-checkpoint" in out
+    assert "daimon-end" in out
+    assert "daimon log" not in out
+
+
+def test_cli_open_normal_length_records_with_no_destination_text(project,
+                                                                  recipient,
+                                                                  capsys):
+    """The negative case: a normal-length request still records cleanly,
+    with no destination text on stdout — the sentence is over-cap-only."""
+    assert _cli_open(project, recipient) == 0
+    out = capsys.readouterr().out
+    assert "write-checkpoint" not in out
+    assert "pointer" not in out
+
+
+def test_cli_verdict_over_cap_note_names_no_destination(project, recipient,
+                                                         monkeypatch, capsys):
+    """`note` is a verdict comment, not authored request prose — it shares
+    `_text`'s cap but is deliberately absent from `_DESTINATION_BY_FIELD`,
+    so its over-cap refusal stays exactly its old plain message."""
+    from daimon_briefing import cli
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    assert _cli_open(project, recipient) == 0
+    q_id = next(iter(requests.records(project_dir=project)))
+    long_note = "x" * (requests._MAX_TEXT + 1)
+    rc = cli.main(["request", "needs-info", q_id, "--note", long_note,
+                   "--project", project])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "is too long" in out
+    assert "pointer" not in out
+    assert "write-checkpoint" not in out
 
 
 def test_cli_list_renders_records_and_json(project, recipient, monkeypatch,

--- a/skills/daimon-briefing/SKILL.md
+++ b/skills/daimon-briefing/SKILL.md
@@ -61,6 +61,10 @@ An accepted request another project sent, satisfied by this session's work
 "<quote>" --by agent`; `daimon request inbox` lists every one still owed.
 Same quote discipline, same byte-check at session end.
 
+Request text fields (`ask`, `why`, `evidence`) cap at 2000 characters. Long
+content belongs in an artifact the request points at (a file, an issue, a
+PR), with the request itself carrying the pointer, not the full text.
+
 ## Automatic behavior
 
 You do not need to invoke anything. The plugin wires the host's native session


### PR DESCRIPTION
Closes #916

## What

The over-cap refusal on `request open`, `request revise`, and `request done` now names where the content belongs, in the voice of the `handoff` refusal #902 shipped. An `ask` or `why` that runs long belongs in an artifact the recipient can open (a file in the repo, an issue, a document), with the request carrying the pointer and the one-paragraph version. `evidence` is a pointer to the proof (a commit, a PR, a path, a verbatim line), not the proof itself. Every over-cap refusal adds that durable facts learned while composing belong in a checkpoint, via the session-end skill or `daimon write-checkpoint`. `daimon log` is never named: nothing reads a ref-less note back.

The seam is a `RequestTooLong` subclass of `RequestError`, raised only on the length branch of the scrubber and carrying the field name and limit. The four CLI handlers format the destination through one helper keyed by field. Every other refusal (required-but-empty, state, revision cap) keeps its exact message, and a caller matching on `RequestError` still catches the subclass by construction. A decision `note` or a `from_label` over cap gets no destination sentence: those are a decision comment and an internal label, not authored request prose. Refusals print where they always did; no exit code changes.

Both skill surfaces gain one sentence stating the cap and the pointer rule, so an agent reads it before hitting the wall: the plugin-discovered `skills/daimon-briefing/SKILL.md` and the installed skill that `daimon skill install` renders from `skill_content.py`.

## Why

A refusal that names no destination sends the trimmed content to whatever store is nearest, and for an agent that is the harness's own memory file, where daimon never sees it. #902 fixed exactly this on `handoff`. The request verbs never learned, and they are where a long answer to another project most often lands. The cap itself is right; the missing piece was the sentence at the moment an agent has a long answer in hand and a refusal on screen.

## Tests

Eight new tests in `tests/test_requests.py`:

- `_scrub` over cap raises `RequestTooLong` with `field` and `limit` set; a required-but-empty field still raises plain `RequestError`, not the subclass.
- `open` with an over-cap `ask`, `open` with an over-cap `evidence`, `revise` with an over-cap `why`, `done` with an over-cap `evidence`: each exits 1, records nothing, and the output carries `is too long`, `pointer`, `write-checkpoint`, and never `daimon log`.
- A normal-length `open` records with no destination text in the output.
- A decision `note` over cap refuses with no destination sentence.

Full suite from `plugin/` with `uv run --extra dev --extra pretty pytest -q`: 4902 passed, 2 skipped. ruff and mypy clean. Manual run: `daimon request open` with a 2001-character ask prints the refusal followed by both destination sentences, exit 1.
