### PR TITLE
fix(cli): the refutation and amendment cap refusals name where the overflow belongs

### DIFF
--- a/plugin/daimon_briefing/amendments.py
+++ b/plugin/daimon_briefing/amendments.py
@@ -93,6 +93,20 @@ class AmendmentError(ValueError):
     """A requested ledger transition is invalid or cannot be persisted."""
 
 
+class AmendmentTooLong(AmendmentError):
+    """The over-cap branch of `_text`, and ONLY that branch — a required-but-
+    empty field stays a plain `AmendmentError`. Carries `field` and `limit`
+    so the CLI boundary can name a field-appropriate destination (#920,
+    mirrors the #916 request-ledger fix) without re-parsing the message
+    string. A caller matching on `AmendmentError` still catches this by
+    construction."""
+
+    def __init__(self, message: str, *, field: str, limit: int):
+        super().__init__(message)
+        self.field = field
+        self.limit = limit
+
+
 def _path(project_dir=None):
     slug = store.project_slug(project_dir)
     if not slug:
@@ -105,8 +119,9 @@ def _text(name: str, value, *, required: bool = True) -> str:
     if required and not out:
         raise AmendmentError(f"{name} is required")
     if len(out) > _MAX_TEXT:
-        raise AmendmentError(
-            f"{name} is too long ({len(out)} > {_MAX_TEXT} characters)")
+        raise AmendmentTooLong(
+            f"{name} is too long ({len(out)} > {_MAX_TEXT} characters)",
+            field=name, limit=_MAX_TEXT)
     return out
 
 

--- a/plugin/daimon_briefing/cli/_cap_refusal.py
+++ b/plugin/daimon_briefing/cli/_cap_refusal.py
@@ -1,0 +1,39 @@
+"""Shared formatter for the #916 over-cap destination sentence (#920).
+
+Three ledgers — requests, refutations/rulings, and amendments — each cap a
+handful of text fields at 2000 characters and want the SAME shape of
+refusal when a caller trips that cap: name where the long form belongs,
+then remind the caller that durable facts belong in a checkpoint, never in
+the ledger record. This module holds only that formatting. It imports
+nothing from any ledger module, so using it from more than one ledger's CLI
+boundary creates no import between the ledgers themselves — each ledger
+still owns its own `TooLong` exception type and its own
+`_DESTINATION_BY_FIELD` mapping; this is just the one place that turns
+`(prefix, exc, ...)` into the same sentence shape everywhere.
+
+`request.py` predates this module (#916) and was left as its own inline
+copy rather than retrofitted onto this — the smallest change for #920 was
+adding this helper for the two ledgers it covers, not going back to touch a
+working, tested surface that was never part of this request.
+"""
+
+_CHECKPOINT_HINT = (
+    " Durable facts learned while composing this belong in a checkpoint "
+    "(the daimon-end skill, `daimon write-checkpoint`), not in the record."
+)
+
+
+def format_cap_refusal(prefix: str, exc: Exception, too_long_type: type,
+                       destination_by_field: dict) -> str:
+    """`prefix: str(exc)`, plus a destination sentence when `exc` is an
+    instance of `too_long_type` on a field present in
+    `destination_by_field`. Every other error on the ledger (a
+    required-but-empty field, a state refusal, an unknown id shape...)
+    keeps exactly its old plain message — this only ever appends text, it
+    never replaces `str(exc)`."""
+    dest = ""
+    if isinstance(exc, too_long_type):
+        dest = destination_by_field.get(getattr(exc, "field", ""), "")
+        if dest:
+            dest += _CHECKPOINT_HINT
+    return f"{prefix}: {exc}{dest}"

--- a/plugin/daimon_briefing/cli/_ledger.py
+++ b/plugin/daimon_briefing/cli/_ledger.py
@@ -10,6 +10,39 @@ import json
 import sys
 
 from .. import refutations, render
+from . import _cap_refusal
+
+# #920: over-cap `subject`/`verdict`/`scope`/`evidence` name where the
+# overflow belongs, mirroring #916's request-ledger refusal. `anchor`,
+# `revisit_when` and `note` are absent on purpose: an anchor is an
+# identifier, not authored prose, and `revisit_when`/`note` are short
+# secondary annotations rather than the text a ruling or refutation
+# governs — naming a destination for them would be advice for a case that
+# does not meaningfully arise (the #916 reasoning for `request`'s `note`,
+# restated for this ledger).
+_ARTIFACT_DESTINATION = (
+    " — the long form belongs in the artifact it governs (the issue, the "
+    "design record, the file); the record carries the one-paragraph rule "
+    "and a pointer."
+)
+_DESTINATION_BY_FIELD = {
+    "subject": _ARTIFACT_DESTINATION,
+    "verdict": _ARTIFACT_DESTINATION,
+    "scope": _ARTIFACT_DESTINATION,
+    "evidence": (
+        " — evidence is a pointer to the proof (a commit, a PR, a path, a "
+        "verbatim line), not the proof itself."
+    ),
+}
+
+
+def _refusal_message(prefix: str, exc: refutations.RefutationError) -> str:
+    """`prefix: str(exc)`, plus a destination sentence when `exc` is the
+    over-cap subclass on a field that has one. Shared by both `cli.refute`
+    and `cli.ruling`, since both catch `refutations.RefutationError` off the
+    same ledger and the same `_text` cap."""
+    return _cap_refusal.format_cap_refusal(
+        prefix, exc, refutations.RefutationTooLong, _DESTINATION_BY_FIELD)
 
 
 def _report_vanished_write(record_id: str, verb: str, *,

--- a/plugin/daimon_briefing/cli/amend.py
+++ b/plugin/daimon_briefing/cli/amend.py
@@ -13,6 +13,28 @@ import sys
 import daimon_briefing.cli as _cli
 
 from .. import amendments, briefing, render, store
+from . import _cap_refusal
+
+# #920: over-cap `evidence` gets its OWN destination, distinct from the
+# request and refutation ledgers' "put it in an artifact" wording. `evidence`
+# here is the verbatim transcript quote itself — the thing being byte-checked
+# at session end, not a pointer to it — so redirecting it to a file would
+# make the byte-check meaningless. The fix over cap is a shorter quote, not
+# a different home. `note` is absent on purpose: it is a short human-channel
+# rationale, not the ledger's own content (same reasoning as `request`'s
+# `note` in #916).
+_DESTINATION_BY_FIELD = {
+    "evidence": (
+        " — evidence is one contiguous verbatim span from the transcript, "
+        "not a summary; the amendment can only carry the span that proves "
+        "the change, never more of the surrounding context."
+    ),
+}
+
+
+def _refusal_message(prefix: str, exc: amendments.AmendmentError) -> str:
+    return _cap_refusal.format_cap_refusal(
+        prefix, exc, amendments.AmendmentTooLong, _DESTINATION_BY_FIELD)
 
 
 def _amend_channel(args) -> str:
@@ -66,7 +88,7 @@ def _cmd_amend_propose(args) -> int:
             project_dir=project)
     except amendments.AmendmentError as exc:
         _cli._note_usage("amend:refused")
-        print(f"amendment not recorded: {exc}")
+        print(_refusal_message("amendment not recorded", exc))
         return 1
     record = amendments.get(a_id, project_dir=project)
     state = record["state"] if record else "candidate"
@@ -101,7 +123,7 @@ def _cmd_amend_verdict(args) -> int:
                               project_dir=project)
     except amendments.AmendmentError as exc:
         _cli._note_usage(f"amend:{verb}:refused")
-        print(f"amendment {verb} refused: {exc}")
+        print(_refusal_message(f"amendment {verb} refused", exc))
         return 1
     _cli._note_usage(f"amend:{verb}")
     record = amendments.get(args.amendment_id, project_dir=project)

--- a/plugin/daimon_briefing/cli/refute.py
+++ b/plugin/daimon_briefing/cli/refute.py
@@ -12,6 +12,7 @@ import daimon_briefing.cli as _cli
 from .. import refutations, render
 from ._ledger import (
     _print_refutation,
+    _refusal_message,
     _refutation_json,
     _report_vanished_write,
     _refutation_lines,
@@ -31,7 +32,7 @@ def _cmd_refute_add(args) -> int:
             revisit_when=args.revisit_when or "", ratified=args.ratify,
             project_dir=project)
     except refutations.RefutationError as exc:
-        print(f"refutation not recorded: {exc}")
+        print(_refusal_message("refutation not recorded", exc))
         return 1
     record = refutations.get(ref_id, project_dir=project)
     _cli._note_usage("refute:add")
@@ -67,7 +68,7 @@ def _cmd_refute_ratify(args) -> int:
         refutations.ratify(args.refutation_id, channel=_refute_channel(args),
                            note=args.note or "", project_dir=project)
     except refutations.RefutationError as exc:
-        print(f"refutation not ratified: {exc}")
+        print(_refusal_message("refutation not ratified", exc))
         return 1
     record = refutations.get(args.refutation_id, project_dir=project)
     _cli._note_usage("refute:ratify")
@@ -94,7 +95,7 @@ def _cmd_refute_revise(args) -> int:
             anchors=anchors, revisit_when=args.revisit_when,
             ratified=args.ratify, project_dir=project)
     except refutations.RefutationError as exc:
-        print(f"refutation not revised: {exc}")
+        print(_refusal_message("refutation not revised", exc))
         return 1
     record = refutations.get(args.refutation_id, project_dir=project)
     _cli._note_usage("refute:revise")
@@ -124,7 +125,7 @@ def _cmd_refute_overturn(args) -> int:
             evidence=args.evidence,
             note=args.note or "", project_dir=project)
     except refutations.RefutationError as exc:
-        print(f"refutation not overturned: {exc}")
+        print(_refusal_message("refutation not overturned", exc))
         return 1
     record = refutations.get(args.refutation_id, project_dir=project)
     _cli._note_usage("refute:overturn")
@@ -178,7 +179,7 @@ def _cmd_refute_search(args) -> int:
             " ".join(args.query), project_dir=project,
             states=set(args.state or refutations.STATES))
     except refutations.RefutationError as exc:
-        print(f"refutation search refused: {exc}")
+        print(_refusal_message("refutation search refused", exc))
         return 1
     _cli._note_usage("refute:search")
     if args.json:
@@ -206,7 +207,7 @@ def _cmd_refute_guard(args) -> int:
             " ".join(args.query), anchors=args.anchor,
             project_dir=project)
     except refutations.RefutationError as exc:
-        print(f"refutation guard refused: {exc}")
+        print(_refusal_message("refutation guard refused", exc))
         return 1
     # #581: split by outcome and rail, the way `resolve` splits its tags. One
     # aggregate count cannot separate a hit from a miss, so the false-veto rate

--- a/plugin/daimon_briefing/cli/ruling.py
+++ b/plugin/daimon_briefing/cli/ruling.py
@@ -14,6 +14,7 @@ import daimon_briefing.cli as _cli
 from .. import config, normalize, refutations, render
 from ._ledger import (
     _print_ruling,
+    _refusal_message,
     _refutation_json,
     _report_vanished_write,
     _refute_channel,
@@ -31,7 +32,7 @@ def _cmd_ruling_propose(args) -> int:
             revisit_when=args.revisit_when or "", ratified=args.ratify,
             project_dir=project)
     except refutations.RefutationError as exc:
-        print(f"ruling not recorded: {exc}")
+        print(_refusal_message("ruling not recorded", exc))
         return 1
     record = refutations.get(ruling_id, project_dir=project)
     _cli._note_usage("ruling:propose")
@@ -61,7 +62,7 @@ def _cmd_ruling_ratify(args) -> int:
     try:
         channel = _refute_channel(args)
     except refutations.RefutationError as exc:
-        print(f"ruling not ratified: {exc}")
+        print(_refusal_message("ruling not ratified", exc))
         return 1
     record = refutations.get(args.ruling_id, project_dir=project)
     if record is None:
@@ -97,7 +98,7 @@ def _cmd_ruling_ratify(args) -> int:
                            note=args.note or "", verdict_key=displayed_key,
                            project_dir=project)
     except refutations.RefutationError as exc:
-        print(f"ruling not ratified: {exc}")
+        print(_refusal_message("ruling not ratified", exc))
         return 1
     record = refutations.get(args.ruling_id, project_dir=project)
     _cli._note_usage("ruling:ratify")
@@ -134,7 +135,7 @@ def _cmd_ruling_revise(args) -> int:
     try:
         channel = _refute_channel(args)
     except refutations.RefutationError as exc:
-        print(f"ruling not revised: {exc}")
+        print(_refusal_message("ruling not revised", exc))
         return 1
     if (record["state"] == "active" and channel == "cli-tty"
             and (args.verdict is not None or args.subject is not None)):
@@ -161,7 +162,7 @@ def _cmd_ruling_revise(args) -> int:
             anchors=anchors, revisit_when=args.revisit_when,
             ratified=False, project_dir=project)
     except refutations.RefutationError as exc:
-        print(f"ruling not revised: {exc}")
+        print(_refusal_message("ruling not revised", exc))
         return 1
     record = refutations.get(args.ruling_id, project_dir=project)
     _cli._note_usage("ruling:revise")
@@ -193,7 +194,7 @@ def _cmd_ruling_retire(args) -> int:
             evidence=args.evidence or (),
             note=args.note or "", project_dir=project)
     except refutations.RefutationError as exc:
-        print(f"ruling not retired: {exc}")
+        print(_refusal_message("ruling not retired", exc))
         return 1
     record = refutations.get(args.ruling_id, project_dir=project)
     _cli._note_usage("ruling:retire")

--- a/plugin/daimon_briefing/refutations.py
+++ b/plugin/daimon_briefing/refutations.py
@@ -149,6 +149,20 @@ class RefutationError(ValueError):
     """A requested ledger transition is invalid or cannot be persisted."""
 
 
+class RefutationTooLong(RefutationError):
+    """The over-cap branch of `_text`, and ONLY that branch — a required-but-
+    empty field stays a plain `RefutationError`. Carries `field` and `limit`
+    so the CLI boundary can name a field-appropriate destination (#920,
+    mirrors the #916 request-ledger fix) without re-parsing the message
+    string. A caller matching on `RefutationError` still catches this by
+    construction."""
+
+    def __init__(self, message: str, *, field: str, limit: int):
+        super().__init__(message)
+        self.field = field
+        self.limit = limit
+
+
 def _path(project_dir=None):
     slug = store.project_slug(project_dir)
     if not slug:
@@ -161,8 +175,9 @@ def _text(name: str, value, *, required: bool = True) -> str:
     if required and not out:
         raise RefutationError(f"{name} is required")
     if len(out) > _MAX_TEXT:
-        raise RefutationError(
-            f"{name} is too long ({len(out)} > {_MAX_TEXT} characters)")
+        raise RefutationTooLong(
+            f"{name} is too long ({len(out)} > {_MAX_TEXT} characters)",
+            field=name, limit=_MAX_TEXT)
     return out
 
 

--- a/plugin/tests/test_amendments.py
+++ b/plugin/tests/test_amendments.py
@@ -97,6 +97,25 @@ def test_evidence_required_and_capped(project):
         _propose(project, evidence="x" * 2001)
 
 
+def test_over_cap_evidence_raises_the_subclass_with_field_and_limit(project):
+    """#920: the CLI names a destination by inspecting which field tripped
+    the cap, so the exception must carry that field rather than the caller
+    re-parsing the message string — the same shape #916 gave `requests`."""
+    with pytest.raises(amendments.AmendmentTooLong) as exc_info:
+        _propose(project, evidence="x" * 2001)
+    assert exc_info.value.field == "evidence"
+    assert exc_info.value.limit == amendments._MAX_TEXT
+
+
+def test_required_but_empty_evidence_stays_the_plain_error(project):
+    """A required-but-empty field is a different failure than over-cap — it
+    must not carry a `field`/`limit` pair or trip the CLI's destination
+    text, which is over-cap-only."""
+    with pytest.raises(amendments.AmendmentError) as exc_info:
+        _propose(project, evidence="")
+    assert not isinstance(exc_info.value, amendments.AmendmentTooLong)
+
+
 def test_note_refused_on_agent_channel(project):
     # Free-form agent prose never enters the ledger: `note` is a human-channel
     # field, the render side's only unbounded text besides the quote itself.
@@ -409,6 +428,42 @@ def test_cli_amend_agent_propose_records_candidate(project, capsys):
     assert records[0]["state"] == "candidate"
     out = capsys.readouterr().out
     assert "candidate" in out
+
+
+def test_cli_amend_refusal_over_cap_evidence_names_the_quote_destination(
+        project, capsys):
+    """#920: an over-cap `evidence` on `amend propose` names the verbatim-span
+    destination — never an artifact pointer, since the amendment's evidence
+    IS the byte-checked quote, not a pointer to it — plus the checkpoint
+    hint, and never `daimon log`."""
+    from daimon_briefing import cli, store
+    store.write_checkpoint("S-1", _checkpoint_with_item(), project_dir=project)
+    long_evidence = "x" * (amendments._MAX_TEXT + 1)
+    rc = cli.main(["amend", ITEM, "--change", "progressed",
+                   "--evidence", long_evidence, "--by", "agent",
+                   "--project", project])
+    assert rc == 1
+    assert not amendments.records(project_dir=project)
+    out = capsys.readouterr().out
+    assert "is too long" in out
+    assert "contiguous" in out
+    assert "write-checkpoint" in out
+    assert "daimon log" not in out
+
+
+def test_cli_amend_normal_length_records_with_no_destination_text(
+        project, capsys):
+    """The negative case: a normal-length amendment still records cleanly,
+    with no destination text on stdout — the sentence is over-cap-only."""
+    from daimon_briefing import cli, store
+    store.write_checkpoint("S-1", _checkpoint_with_item(), project_dir=project)
+    rc = cli.main(["amend", ITEM, "--change", "progressed",
+                   "--evidence", "the PR merged", "--by", "agent",
+                   "--project", project])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "contiguous" not in out
+    assert "write-checkpoint" not in out
 
 
 def test_cli_amend_unknown_item_refused(project, capsys):

--- a/plugin/tests/test_refutations.py
+++ b/plugin/tests/test_refutations.py
@@ -79,6 +79,25 @@ def test_untyped_evidence_is_refused(tmp_checkpoint_dir):
     assert refutations.records(project_dir=PROJECT) == {}
 
 
+def test_over_cap_raises_the_subclass_with_field_and_limit(tmp_checkpoint_dir):
+    """#920: the CLI names a destination by inspecting which field tripped
+    the cap, so the exception must carry that field rather than the caller
+    re-parsing the message string — the same shape #916 gave `requests`."""
+    with pytest.raises(refutations.RefutationTooLong) as exc_info:
+        _assert(verdict="x" * (refutations._MAX_TEXT + 1))
+    assert exc_info.value.field == "verdict"
+    assert exc_info.value.limit == refutations._MAX_TEXT
+
+
+def test_non_length_failures_still_raise_plain_refutation_error(tmp_checkpoint_dir):
+    """A required-but-empty field is a different failure than over-cap — it
+    must not carry a `field`/`limit` pair or trip the CLI's destination
+    text, which is over-cap-only."""
+    with pytest.raises(refutations.RefutationError) as exc_info:
+        _assert(verdict="")
+    assert not isinstance(exc_info.value, refutations.RefutationTooLong)
+
+
 def test_revision_resets_active_record_until_reratified(tmp_checkpoint_dir):
     ref_id = _assert(channel="cli-tty", ratified=True)
     refutations.revise(
@@ -269,6 +288,79 @@ def test_cli_refute_rejects_agent_self_ratification(
     ])
     assert rc == 1
     assert "requires a human channel" in capsys.readouterr().out
+
+
+def test_cli_refute_add_refusal_over_cap_verdict_names_the_artifact_destination(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    """#920: an over-cap `verdict` on `refute add` names an artifact pointer
+    and the checkpoint, mirroring the #916 request-ledger refusal — but
+    never `daimon log` (nothing reads a ref-less note back)."""
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    long_verdict = "x" * (refutations._MAX_TEXT + 1)
+    rc = cli.main([
+        "refute", "add", "--subject", "bad gate", "--verdict", long_verdict,
+        "--scope", "current replay", "--evidence", "measurement:run-1",
+        "--by", "agent",
+    ])
+    assert rc == 1
+    assert refutations.records(project_dir=PROJECT) == {}
+    out = capsys.readouterr().out
+    assert "is too long" in out
+    assert "pointer" in out
+    assert "write-checkpoint" in out
+    assert "daimon-end" in out
+    assert "daimon log" not in out
+
+
+def test_cli_refute_add_refusal_over_cap_evidence_names_the_proof_destination(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    long_evidence = "measurement:" + "x" * refutations._MAX_TEXT
+    rc = cli.main([
+        "refute", "add", "--subject", "bad gate", "--verdict", "does not work",
+        "--scope", "current replay", "--evidence", long_evidence,
+        "--by", "agent",
+    ])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "is too long" in out
+    assert "pointer" in out
+    assert "write-checkpoint" in out
+    assert "daimon log" not in out
+
+
+def test_cli_refute_add_refusal_over_cap_anchor_names_no_destination(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    """`anchor` is an identifier, not authored prose — its over-cap refusal
+    stays exactly the plain #916-shaped message, with no destination."""
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    long_anchor = "x" * (refutations._MAX_TEXT + 1)
+    rc = cli.main([
+        "refute", "add", "--subject", "bad gate", "--verdict", "does not work",
+        "--scope", "current replay", "--evidence", "measurement:run-1",
+        "--anchor", long_anchor, "--by", "agent",
+    ])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "is too long" in out
+    assert "pointer" not in out
+    assert "write-checkpoint" not in out
+
+
+def test_cli_refute_add_normal_length_records_with_no_destination_text(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    """The negative case: a normal-length refutation still records cleanly,
+    with no destination text on stdout — the sentence is over-cap-only."""
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    rc = cli.main([
+        "refute", "add", "--subject", "bad gate", "--verdict", "does not work",
+        "--scope", "current replay", "--evidence", "measurement:run-1",
+        "--by", "agent",
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "pointer" not in out
+    assert "write-checkpoint" not in out
 
 
 def test_disabled_refutation_write_fails_visibly(

--- a/plugin/tests/test_rulings.py
+++ b/plugin/tests/test_rulings.py
@@ -296,6 +296,48 @@ def test_cli_propose_records_a_candidate_without_escalation_hint(
     assert "ruling ratify" not in out
 
 
+def test_cli_propose_refusal_over_cap_scope_names_the_artifact_destination(
+        tmp_checkpoint_dir, capsys):
+    """#920: an over-cap `scope` on `ruling propose` names an artifact
+    pointer and the checkpoint, the same shape #916 gave `request open` —
+    but never `daimon log` (nothing reads a ref-less note back).
+
+    `scope` is the field to exercise here, not `subject`/`verdict`: a
+    ruling's subject and verdict are ALSO bound by `_guard_ruling_text`'s
+    280-char `_MAX_RULING_TEXT` (#693, "a standing rule that long is a
+    document, not a ruling"), which is stricter than and fires before the
+    general 2000-char `_text` cap this fix targets — so the over-cap
+    `RefutationTooLong` branch is unreachable for those two fields on a
+    RULING specifically (it is still reachable for a plain refutation via
+    `refute add`, which has no such guard; see test_refutations.py)."""
+    long_scope = "x" * (refutations._MAX_TEXT + 1)
+    rc = cli.main([
+        "ruling", "propose", "--subject", "public posts",
+        "--verdict", "internal numbers never appear in public posts",
+        "--scope", long_scope,
+        "--evidence", "issue:693", "--by", "agent", "--project", PROJECT])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "is too long" in out
+    assert "pointer" in out
+    assert "write-checkpoint" in out
+    assert "daimon-end" in out
+    assert "daimon log" not in out
+
+
+def test_cli_propose_normal_length_records_with_no_destination_text(
+        tmp_checkpoint_dir, capsys):
+    rc = cli.main([
+        "ruling", "propose", "--subject", "public posts",
+        "--verdict", "internal numbers never appear in public posts",
+        "--scope", "publishing", "--evidence", "issue:693",
+        "--by", "agent", "--project", PROJECT])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "pointer" not in out
+    assert "write-checkpoint" not in out
+
+
 def test_cli_ratify_prints_text_discloses_render_and_confirms(
         tmp_checkpoint_dir, _tty, monkeypatch, capsys):
     ruling_id = _rule()


### PR DESCRIPTION
Closes #920

## What

The refutation and amendment ledgers now refuse over-cap text the way the request ledger does after #916. Each ledger gains a `TooLong` subclass of its own error type, raised only on the length branch of its `_text` scrubber and carrying the field name and limit. Every CLI catch site for those errors, six each in `cli/refute.py` and `cli/ruling.py` and two in `cli/amend.py`, formats the refusal through a new format-only helper, `cli/_cap_refusal.py`, which imports no ledger and so couples none of them to each other.

Destinations by field. A refutation or ruling `subject`, `scope`, or text that runs long belongs in the artifact it governs (the issue, the design record, the file), with the record carrying the one-paragraph rule and a pointer. Refutation `evidence` is a pointer to the proof, not the proof. Amendment `evidence` gets its own wording: it is the verbatim transcript span that gets byte-checked at session end, so redirecting it to a file would make the check meaningless, and the refusal says the fix is a shorter contiguous span, never more context. `anchor`, `revisit_when`, and `note` name no destination: identifiers and short annotations, not authored prose. Every over-cap refusal adds that durable facts learned while composing belong in a checkpoint. `daimon log` is never named. Exit codes and every non-length refusal are unchanged.

One boundary found while testing: a ruling's `subject` and text already hit the 280-character ruling guard from #693 before the general cap, so the new refusal is reachable on a ruling only through `scope` and `evidence`; plain refutations reach it on every field. The tests exercise the reachable cases.

## Why

#916 fixed this shape on requests and named the two siblings as a follow-up. An agent holding a long refutation reason, a long ruling scope, or a long amendment quote hit the same wall with no word on where the content belongs, and the nearest-store failure followed: the text lands in the harness's own memory file, where daimon never sees it.

## Tests

Twelve new tests across `tests/test_refutations.py`, `tests/test_rulings.py`, and `tests/test_amendments.py`: per ledger, over cap raises the subclass with `field` and `limit` set while required-but-empty raises the plain error; `refute add` over cap on text and on evidence names the artifact and proof destinations respectively; `refute add` over cap on `anchor` names no destination; `ruling propose` over cap on `scope` names the artifact destination; `amend` over cap on `evidence` names the contiguous-span wording; and a normal-length record on each ledger writes with no destination text.

Full suite from `plugin/` with `uv run --extra dev --extra pretty pytest -q`: 4914 passed, 2 skipped. ruff and mypy clean. Manual over-cap runs of `ruling propose --scope` and `amend --evidence` print the refusal followed by the destination sentences, exit nonzero.
