### PR TITLE
fix(stats): the receipt probe reports what it did instead of leaving no trace

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -130,6 +130,48 @@ def _note_usage(command: str) -> None:
         pass
 
 
+# #919: usage.log key prefix for the per-project receipt-probe counters
+# `daimon stats` renders. usage.log is otherwise a per-MACHINE log (#54's own
+# design, and #477's own lesson about conflating populations) — every other
+# worldcheck counter here rides it unscoped. These four fold the project
+# slug into the command name itself so `_stats_receipts` can filter to just
+# THIS project, the one place worldcheck's stats need to be per-project
+# rather than per-machine (the issue this constant answers: a receipt probe
+# fires and leaves zero trace ANYWHERE, #919's diagnosis).
+_RECEIPT_PROBE_USAGE_PREFIX = "worldcheck:receipt-probe:"
+
+
+def _note_receipt_probe_usage(project_dir, wc_stats: dict) -> None:
+    """Fold this run's receipt-probe telemetry into usage.log, project-scoped
+    (#919). `attempted`/`eligible` come from `worldcheck.last_receipt_probe()`
+    — a module-level record, NOT a key in `wc_stats`, because that dict is
+    asserted by exact equality across dozens of worldcheck tests and this is
+    a run-level population fact, not a per-item outcome. `confirmed`/
+    `contradicted`/`skipped` are read straight off `wc_stats`'s existing
+    receipt-validity:<outcome> keys (already correct, just unscoped by
+    project). `skipped` matters as much as the other two: it is the SILENT
+    case #919 exists to expose — a probe that fired and answered nothing (no
+    CLI, no pubkey, a killed deadline, garbage output), which used to read
+    identically to "0 confirmed, 0 contradicted" and therefore identically to
+    "did nothing". A count of zero writes nothing — `_note_usage` in a
+    zero-length range is simply never called, so a disabled or silent run
+    leaves the log untouched, same as every other counter here."""
+    slug = store.project_slug(project_dir)
+    if not slug:
+        return
+    probe = worldcheck.last_receipt_probe()
+    counts = {
+        "attempted": probe["attempted"],
+        "eligible": probe["eligible"],
+        "confirmed": wc_stats.get(f"{worldcheck.RECEIPT_VALIDITY}:confirmed", 0),
+        "contradicted": wc_stats.get(f"{worldcheck.RECEIPT_VALIDITY}:contradicted", 0),
+        "skipped": wc_stats.get(f"{worldcheck.RECEIPT_VALIDITY}:skipped", 0),
+    }
+    for label, count in counts.items():
+        for _ in range(int(count)):
+            _note_usage(f"{_RECEIPT_PROBE_USAGE_PREFIX}{label}:{slug}")
+
+
 def _preflight_error(path: Path) -> str | None:
     """Credential pre-flight, mirroring llm.chat's routing (#52): an API key
     and model are required only when the resolved transport is llm-bound.
@@ -583,6 +625,10 @@ def _render_briefing_body(checkpoint, route, *, drift_project, teammates,
             for counter, count in sorted(wc_stats.items()):
                 for _ in range(int(count)):
                     _note_usage(f"worldcheck:{counter}")
+            # #919: the receipt-probe axis, project-scoped (see the helper's
+            # own docstring for why this one axis needs project scope where
+            # the loop above deliberately stays machine-wide).
+            _note_receipt_probe_usage(worldcheck_project, wc_stats)
             # A POINTER and a REASON CODE, never the item's text (#376) — the
             # same second stream capture writes, for the same reason: folded
             # into events.jsonl a rejection would HIDE the item it describes.
@@ -2757,6 +2803,43 @@ def _earlier(current: str | None, ts: str) -> str | None:
     return ts if current is None or ts < current else current
 
 
+def _stats_receipts(project_dir, usage: dict) -> dict:
+    """Receipt-probe telemetry (this project, #919). `attempted`/`eligible`/
+    `confirmed`/`contradicted`/`skipped` are lifetime usage.log counts scoped
+    to this project's slug via `_RECEIPT_PROBE_USAGE_PREFIX` — the population
+    size the confirmed/contradicted/skipped rates are measured against is
+    `eligible`, not the checkpoint's whole item count, since only carried
+    items with an `origin_session` naming an in-project origin ever enter the
+    pool. `skipped` is the silent case #919 exists to expose: a probe that
+    fired and answered nothing (no CLI, no cached pubkey, a killed deadline,
+    garbage output) used to read identically to "0 confirmed, 0
+    contradicted" — indistinguishable from a probe that never ran at all.
+
+    `cured` is NOT a usage.log counter: it is read live off the rejection
+    ledger's latest-verdict fold (`store.latest_receipt_verdicts`), because a
+    cure changes an EXISTING item's standing rather than adding a new
+    occurrence — `store.append_receipt_cure`'s own docstring is why a
+    lifetime tally would double- or under-count depending on how many times
+    a cured item happened to get re-probed.
+
+    `enabled` is CURRENT config, not history: an install can flip
+    DAIMON_RECEIPTS off after accumulating counts, and the render needs to
+    tell "no receipts configured" apart from "configured, nothing has fired
+    yet" — the exact ambiguity #919 diagnosed in the first place."""
+    slug = store.project_slug(project_dir)
+    attempted = usage.get(f"{_RECEIPT_PROBE_USAGE_PREFIX}attempted:{slug}", 0) if slug else 0
+    eligible = usage.get(f"{_RECEIPT_PROBE_USAGE_PREFIX}eligible:{slug}", 0) if slug else 0
+    confirmed = usage.get(f"{_RECEIPT_PROBE_USAGE_PREFIX}confirmed:{slug}", 0) if slug else 0
+    contradicted = usage.get(
+        f"{_RECEIPT_PROBE_USAGE_PREFIX}contradicted:{slug}", 0) if slug else 0
+    skipped = usage.get(f"{_RECEIPT_PROBE_USAGE_PREFIX}skipped:{slug}", 0) if slug else 0
+    cured = sum(1 for row in store.latest_receipt_verdicts(project_dir=project_dir).values()
+               if row.get("verdict") == "confirmed")
+    return {"enabled": config.receipts_enabled(), "attempted": attempted,
+            "eligible": eligible, "confirmed": confirmed,
+            "contradicted": contradicted, "skipped": skipped, "cured": cured}
+
+
 def _stats_resolutions(project_dir, usage: dict) -> dict:
     """Resolution credit, by source (#480 slice 5) — who is closing loops,
     and whether their receipts hold. Two populations, kept honestly apart
@@ -2860,6 +2943,7 @@ def _cmd_stats(args) -> int:
             "events": _stats_events(project),
             "verification": _stats_verification(project),
             "resolutions": _stats_resolutions(project, usage),
+            "receipts": _stats_receipts(project, usage),
             # #475 part 2: current-configuration posture, rendered next to
             # (never merged into) the historical fallback counts above.
             "rescue_posture": llm.rescue_posture()}

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -1481,6 +1481,21 @@ def _generation_lines(s: dict) -> list[str]:
     return lines
 
 
+def _receipts_line(r: dict) -> str:
+    """#919: the one receipt-probe status line, shared by the plain and rich
+    renderers, in the three wording states the issue's diagnosis needed told
+    apart — disabled, enabled-but-nothing-fired, and enabled-with-counts.
+    Plain wording only, no court vocabulary."""
+    if not r.get("enabled"):
+        return "receipt probes: off (DAIMON_RECEIPTS unset)"
+    if not r.get("attempted"):
+        return "receipt probes: on, none attempted yet"
+    return (f"receipt probes (lifetime): {r['attempted']} attempted "
+            f"of {r['eligible']} eligible, {r['confirmed']} confirmed, "
+            f"{r['contradicted']} contradicted, {r['skipped']} skipped, "
+            f"{r['cured']} cured")
+
+
 def _plain_stats(data: dict) -> None:
     u, c, s = data["usage"], data["capture"], data["store"]
     print("usage (local, never transmitted):")
@@ -1548,6 +1563,12 @@ def _plain_stats(data: dict) -> None:
         print("verification (this project):")
         print(f"  rejections: {v['total']}  " + ", ".join(
             f"{k} {n}" for k, n in sorted(v["by_check"].items())))
+    rcpt = data.get("receipts")
+    if rcpt:
+        # #919: always shown, like resolutions below — "off" and "on, none
+        # attempted yet" are themselves the answer, not noise to gate on.
+        print("receipts (this project):")
+        print(f"  {_receipts_line(rcpt)}")
     res = data.get("resolutions")
     if res:
         # #480 slice 5: the credit block — who is closing loops. Always shown
@@ -1695,6 +1716,17 @@ def _rich_stats(data: dict) -> None:
             ver_table.add_row(check, str(n))
         ver_table.add_row("total", str(v["total"]))
         console.print(ver_table)
+
+    rcpt = data.get("receipts")
+    if rcpt:
+        # #919: mirrors the plain renderer — always shown (off / silent /
+        # counts are each an answer, not noise to gate on).
+        rcpt_table = Table(title="receipts (this project)", title_justify="left",
+                           show_header=True, header_style="bold")
+        rcpt_table.add_column("metric")
+        rcpt_table.add_column("value")
+        rcpt_table.add_row("status", _receipts_line(rcpt))
+        console.print(rcpt_table)
 
     res = data.get("resolutions")
     if res:

--- a/plugin/daimon_briefing/worldcheck.py
+++ b/plugin/daimon_briefing/worldcheck.py
@@ -350,8 +350,12 @@ def _day_bucket() -> int:
     return int(time.time() // 86400)
 
 
-def _receipt_targets(carried, project, deadline) -> set:
-    """The origin session(s) whose signed receipt THIS brief verifies (#439).
+def _receipt_eligible(carried, project, deadline) -> list:
+    """The origin sessions eligible for a receipt probe THIS brief, in
+    checkpoint order, BEFORE the day-bucket rotation samples from them (#919).
+    Kept separate from `_sample_receipt_targets` so a caller can learn the
+    population size the sampler drew from — the sampled `set` holds at most
+    MAX_RECEIPT_PROBES targets, which already collapses that fact away.
 
     Eligibility mirrors `capture._origin_on_disk`: an origin whose checkpoint
     is absent, unreadable, GC'd or belongs to another project is not a witness
@@ -360,21 +364,14 @@ def _receipt_targets(carried, project, deadline) -> set:
     store keeps a BOUNDED number of per-session files, so an old origin being
     gone says nothing about the claim it once carried.
 
-    Sampling is a day-bucket ROTATION over the eligible list, not a
-    hash-modulo gate. A `sha1(origin) % N` scheme is stable, which is exactly
-    what makes it wrong here: the origins it excludes are excluded FOREVER —
-    permanent blind spots, and a tampered checkpoint sitting in one would
-    never be probed on any day. Rotation reaches every origin over
-    consecutive days instead, at the same one-probe-per-brief cost.
-
     Reads one small checkpoint per DISTINCT origin, which is why it takes the
     shared deadline: collection work the budget does not cover is work the
     briefing can still be blocked by."""
     if not config.receipts_enabled():
-        return set()
+        return []
     slug = store.project_slug(project)
     if not slug:
-        return set()
+        return []
     eligible, seen = [], set()
     for item in carried:
         origin = item.get("origin_session")
@@ -386,11 +383,44 @@ def _receipt_targets(carried, project, deadline) -> set:
         cp = store.read_checkpoint(origin)  # total — swallows torn/bad paths
         if isinstance(cp, dict) and cp.get("project_slug") == slug:
             eligible.append(origin)
+    return eligible
+
+
+def _sample_receipt_targets(eligible: list) -> set:
+    """Day-bucket ROTATION over an already-computed eligible list (#439),
+    picking at most MAX_RECEIPT_PROBES of them. Not a hash-modulo gate: a
+    `sha1(origin) % N` scheme is stable, which is exactly what makes it wrong
+    here — the origins it excludes are excluded FOREVER, permanent blind
+    spots, and a tampered checkpoint sitting in one would never be probed on
+    any day. Rotation reaches every origin over consecutive days instead, at
+    the same one-probe-per-brief cost."""
     if not eligible:
         return set()
     start = _day_bucket() % len(eligible)
     return {eligible[(start + i) % len(eligible)]
             for i in range(min(MAX_RECEIPT_PROBES, len(eligible)))}
+
+
+
+# #919: last-run receipt-probe POPULATION, read by the CLI right after
+# check() returns and folded into usage.log there (the same per-project
+# counter convention the outcome counters below already use). Deliberately
+# NOT a key in check()'s own return dict: that dict is asserted by exact
+# equality across dozens of existing tests in this module, and "how many
+# origins were eligible/attempted this run" is a run-level population fact,
+# not a per-item outcome the {class}:{outcome} rollup was built to carry.
+# Reset unconditionally at the top of every check() call (even the early-
+# return paths) so a checkpoint with nothing carried never inherits a stale
+# nonzero reading left behind by a different project's brief earlier in the
+# same process.
+_last_receipt_probe = {"attempted": 0, "eligible": 0}
+
+
+def last_receipt_probe() -> dict:
+    """{"attempted": n, "eligible": m} from the most recent check() call in
+    this process — n the origins `_sample_receipt_targets` picked (probes
+    fired), m the origins `_receipt_eligible` found before that sampling."""
+    return dict(_last_receipt_probe)
 
 
 def _gh_path():
@@ -780,6 +810,12 @@ def check(checkpoint, project_dir) -> dict:
     their own. A caller that iterates the dict blindly must pop it first."""
     # dict, not dict[str, int]: LEDGER_KEY carries list rows (#439).
     stats: dict = {"confirmed": 0, "contradicted": 0, "skipped": 0}
+    # #919: reset the last-run receipt-probe telemetry FIRST, before either
+    # early return below — a checkpoint with nothing carried (or no project)
+    # must read as "0 attempted, 0 eligible" this run, never as whatever a
+    # different project's brief left behind earlier in this same process.
+    _last_receipt_probe["attempted"] = 0
+    _last_receipt_probe["eligible"] = 0
     if not isinstance(checkpoint, dict) or not project_dir:
         return stats
     # Native items were just re-extracted — not in question, for any class.
@@ -794,7 +830,10 @@ def check(checkpoint, project_dir) -> dict:
     # reads origin checkpoints off disk, and collection work the budget does
     # not cover is work the briefing can still be blocked by.
     deadline = time.monotonic() + BUDGET_SECONDS
-    origins = _receipt_targets(carried, project_dir, deadline)
+    eligible = _receipt_eligible(carried, project_dir, deadline)
+    origins = _sample_receipt_targets(eligible)
+    _last_receipt_probe["attempted"] = len(origins)
+    _last_receipt_probe["eligible"] = len(eligible)
     claims = []
     for item in carried:
         found = claim_for(item.get("text"))

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2094,6 +2094,232 @@ def test_worldcheck_ledger_rows_route_cures_through_the_gate(
         == ["receipt", "receipt-ok"]
 
 
+def test_note_receipt_probe_usage_writes_nothing_without_a_project(monkeypatch):
+    # #919: the counters are scoped by project slug, so a missing project has
+    # nowhere to fold into; the helper returns before touching the log.
+    calls = []
+    monkeypatch.setattr(cli, "_note_usage", lambda name: calls.append(name))
+    monkeypatch.setattr(cli.worldcheck, "last_receipt_probe",
+                        lambda: {"attempted": 3, "eligible": 3})
+    assert cli._note_receipt_probe_usage(None, {"receipt-validity:confirmed": 3}) is None
+    assert calls == []
+
+
+# #919: reuses test_worldcheck's receipt-validity fixtures (a signed origin on
+# disk, a cached pubkey dir) — these tests drive one real `daimon brief` end
+# to end, never worldcheck.check() directly, so the CLI's usage.log +
+# rendering wiring is what's under test.
+from tests.test_worldcheck import _signed_origin, _pubkey_dir  # noqa: E402
+
+
+@pytest.fixture
+def receipt_proj(tmp_path):
+    """A real, existing directory — the receipt-validity probe's vitni
+    subprocess runs with `cwd=project_dir` (Popen(cwd=...) needs it to
+    exist), same shape as test_worldcheck.py's own `proj` fixture. Given its
+    own name rather than reusing that one: `proj` is this file's own common
+    local variable name in dozens of unrelated tests, and importing it as a
+    module-level fixture collides with every one of them (ruff F811)."""
+    d = tmp_path / "receipt-projroot"
+    d.mkdir()
+    return str(d)
+
+
+def _one_receipt_item_checkpoint():
+    return {"session_id": "S-mine", "working_context": {"open_questions": [
+        {"text": "note", "trust": "inferred", "carried_from": "S-prev",
+         "origin_session": "S-origin"},
+    ]}, "epistemic_snapshot": {}}
+
+
+def test_stats_receipt_probe_confirms_without_a_ledger_row(
+        tmp_checkpoint_dir, tmp_log_dir, tmp_path, fake_cli, receipt_proj,
+        monkeypatch, capsys):
+    from daimon_briefing import store, worldcheck
+
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", receipt_proj)
+    monkeypatch.setenv("DAIMON_WORLDCHECK", "1")
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    _pubkey_dir(tmp_path, monkeypatch)
+    _signed_origin("S-origin", receipt_proj)
+    store.write_checkpoint("S-mine", _one_receipt_item_checkpoint(),
+                           project_dir=receipt_proj)
+
+    assert cli.main(["brief"]) == 0
+    capsys.readouterr()
+    assert store.verification_rows(project_dir=receipt_proj) == []
+
+    assert cli.main(["stats", "--json"]) == 0
+    r = json.loads(capsys.readouterr().out)["receipts"]
+    assert r == {"enabled": True, "attempted": 1, "eligible": 1,
+                 "confirmed": 1, "contradicted": 0, "skipped": 0, "cured": 0}
+
+
+def test_stats_receipt_probe_tampered_then_repaired_cures(
+        tmp_checkpoint_dir, tmp_log_dir, tmp_path, fake_cli, receipt_proj,
+        monkeypatch, capsys):
+    from daimon_briefing import store, worldcheck
+
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", receipt_proj)
+    monkeypatch.setenv("DAIMON_WORLDCHECK", "1")
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    _pubkey_dir(tmp_path, monkeypatch)
+    _signed_origin("S-origin", receipt_proj, tamper=True)
+    store.write_checkpoint("S-mine", _one_receipt_item_checkpoint(),
+                           project_dir=receipt_proj)
+
+    assert cli.main(["brief"]) == 0
+    capsys.readouterr()
+    assert [row["check"] for row in
+            store.verification_rows(project_dir=receipt_proj)] == ["receipt"]
+    assert cli.main(["stats", "--json"]) == 0
+    r = json.loads(capsys.readouterr().out)["receipts"]
+    assert r["attempted"] == 1
+    assert r["contradicted"] == 1
+    assert r["skipped"] == 0
+    assert r["cured"] == 0
+
+    # Repair: re-sign over the real (untampered) bytes and re-brief.
+    _signed_origin("S-origin", receipt_proj, tamper=False)
+    assert cli.main(["brief"]) == 0
+    capsys.readouterr()
+    assert [row["check"] for row in
+            store.verification_rows(project_dir=receipt_proj)] == \
+        ["receipt", "receipt-ok"]
+    assert cli.main(["stats", "--json"]) == 0
+    r2 = json.loads(capsys.readouterr().out)["receipts"]
+    assert r2["attempted"] == 2       # two briefs, one probe each
+    assert r2["confirmed"] == 1       # the repaired brief
+    assert r2["contradicted"] == 1    # the tampered brief, still counted
+    assert r2["skipped"] == 0
+    assert r2["cured"] == 1           # read live off the latest verdict fold
+
+
+def test_stats_receipt_probe_skipped_when_origin_predates_receipts(
+        tmp_checkpoint_dir, tmp_log_dir, tmp_path, fake_cli, receipt_proj,
+        monkeypatch, capsys):
+    """#919: a probe that fires and finds nothing to verify — an origin
+    written before receipts existed — is the SILENT case this counter exists
+    to expose. It must count as `skipped`, never read as "0 confirmed, 0
+    contradicted" (indistinguishable from a probe that never ran at all)."""
+    from daimon_briefing import store, worldcheck
+
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", receipt_proj)
+    monkeypatch.setenv("DAIMON_WORLDCHECK", "1")
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    _pubkey_dir(tmp_path, monkeypatch)
+    _signed_origin("S-origin", receipt_proj, sidecar=False, receipts_era=False)
+    store.write_checkpoint("S-mine", _one_receipt_item_checkpoint(),
+                           project_dir=receipt_proj)
+
+    assert cli.main(["brief"]) == 0
+    capsys.readouterr()
+    assert store.verification_rows(project_dir=receipt_proj) == []
+
+    assert cli.main(["stats", "--json"]) == 0
+    r = json.loads(capsys.readouterr().out)["receipts"]
+    assert r == {"enabled": True, "attempted": 1, "eligible": 1,
+                 "confirmed": 0, "contradicted": 0, "skipped": 1, "cured": 0}
+
+    assert cli.main(["stats"]) == 0
+    out = capsys.readouterr().out
+    assert ("receipt probes (lifetime): 1 attempted of 1 eligible, "
+            "0 confirmed, 0 contradicted, 1 skipped, 0 cured") in out
+
+
+def test_stats_receipts_line_disabled_says_off(tmp_checkpoint_dir, capsys, monkeypatch):
+    monkeypatch.delenv("DAIMON_RECEIPTS", raising=False)
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/repo/x919disabled")
+    assert cli.main(["stats"]) == 0
+    out = capsys.readouterr().out
+    assert "receipt probes: off (DAIMON_RECEIPTS unset)" in out
+
+
+def test_stats_receipts_line_enabled_none_attempted_yet(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/repo/x919silent")
+    assert cli.main(["stats"]) == 0
+    out = capsys.readouterr().out
+    assert "receipt probes: on, none attempted yet" in out
+
+
+def test_stats_receipts_line_renders_full_counts(
+        tmp_checkpoint_dir, tmp_log_dir, tmp_path, fake_cli, receipt_proj,
+        monkeypatch, capsys):
+    from daimon_briefing import store, worldcheck
+
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", receipt_proj)
+    monkeypatch.setenv("DAIMON_WORLDCHECK", "1")
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    _pubkey_dir(tmp_path, monkeypatch)
+    _signed_origin("S-origin", receipt_proj)
+    store.write_checkpoint("S-mine", _one_receipt_item_checkpoint(),
+                           project_dir=receipt_proj)
+
+    assert cli.main(["brief"]) == 0
+    capsys.readouterr()
+    assert cli.main(["stats"]) == 0
+    out = capsys.readouterr().out
+    assert ("receipt probes (lifetime): 1 attempted of 1 eligible, "
+            "1 confirmed, 0 contradicted, 0 skipped, 0 cured") in out
+
+
+def test_stats_rich_renders_receipts_section(
+        tmp_checkpoint_dir, tmp_log_dir, tmp_path, fake_cli, receipt_proj,
+        monkeypatch, capsys):
+    from daimon_briefing import store, worldcheck
+
+    monkeypatch.setattr("daimon_briefing.render.supports_rich", lambda: True)
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", receipt_proj)
+    monkeypatch.setenv("DAIMON_WORLDCHECK", "1")
+    monkeypatch.setenv("DAIMON_RECEIPTS", "1")
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    _pubkey_dir(tmp_path, monkeypatch)
+    _signed_origin("S-origin", receipt_proj)
+    store.write_checkpoint("S-mine", _one_receipt_item_checkpoint(),
+                           project_dir=receipt_proj)
+
+    assert cli.main(["brief"]) == 0
+    capsys.readouterr()
+    assert cli.main(["stats"]) == 0
+    out = capsys.readouterr().out
+    assert "receipts (this project)" in out
+    assert "1 attempted" in out
+    assert "1 confirmed" in out
+    assert "0 skipped" in out
+
+
+def test_stats_receipts_disabled_counters_untouched_and_line_says_off(
+        tmp_checkpoint_dir, tmp_log_dir, tmp_path, fake_cli, receipt_proj,
+        monkeypatch, capsys):
+    from daimon_briefing import store, worldcheck
+
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", receipt_proj)
+    monkeypatch.setenv("DAIMON_WORLDCHECK", "1")
+    monkeypatch.delenv("DAIMON_RECEIPTS", raising=False)
+    monkeypatch.setattr(worldcheck, "_gh_path", lambda: None)
+    _pubkey_dir(tmp_path, monkeypatch)
+    _signed_origin("S-origin", receipt_proj)  # present on disk, receipts OFF
+    store.write_checkpoint("S-mine", _one_receipt_item_checkpoint(),
+                           project_dir=receipt_proj)
+
+    assert cli.main(["brief"]) == 0
+    capsys.readouterr()
+    assert cli.main(["stats", "--json"]) == 0
+    r = json.loads(capsys.readouterr().out)["receipts"]
+    assert r == {"enabled": False, "attempted": 0, "eligible": 0,
+                 "confirmed": 0, "contradicted": 0, "skipped": 0, "cured": 0}
+
+    assert cli.main(["stats"]) == 0
+    out = capsys.readouterr().out
+    assert "receipt probes: off (DAIMON_RECEIPTS unset)" in out
+
+
 def test_suggest_line_collapses_multiline_item_text():
     # #512: the injection line's echo strip is line-scoped (`[^\n]*`), so item
     # text carrying a newline would leave its tail in the verification

--- a/plugin/tests/test_worldcheck.py
+++ b/plugin/tests/test_worldcheck.py
@@ -1545,6 +1545,54 @@ def test_receipt_check_writes_nothing_to_disk(receipts_on, proj, monkeypatch):
     assert stats["receipt-validity:contradicted"] == 1
 
 
+# ---- #919: last-run receipt-probe telemetry ----------------------------------
+#
+# check()'s own return dict is asserted by exact equality all over this file,
+# so the population facts #919 needs (how many origins were eligible, how many
+# were actually sampled) ride a SEPARATE module-level record instead, read by
+# the CLI right after check() returns. These tests pin that record directly.
+
+
+def test_last_receipt_probe_counts_eligible_before_sampling_caps_it(
+        receipts_on, proj, monkeypatch):
+    # Two eligible origins, MAX_RECEIPT_PROBES caps the sample at one: the
+    # whole point of exposing `eligible` separately from `attempted`.
+    _signed_origin("S-a", proj)
+    _signed_origin("S-b", proj)
+    monkeypatch.setattr(worldcheck, "_day_bucket", lambda: 0)
+    worldcheck.check(_cp_origins(["S-a", "S-b"]), proj)
+    assert worldcheck.last_receipt_probe() == {"attempted": 1, "eligible": 2}
+
+
+def test_last_receipt_probe_zero_when_nothing_eligible(receipts_on, proj):
+    # No signed origin on disk at all -> nothing eligible, nothing attempted.
+    stats = worldcheck.check(_cp_origins(["S-ghost"]), proj)
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 0}
+    assert worldcheck.last_receipt_probe() == {"attempted": 0, "eligible": 0}
+
+
+def test_last_receipt_probe_resets_on_a_checkpoint_with_nothing_carried(
+        receipts_on, proj):
+    # A prior brief left a nonzero reading; a later checkpoint with nothing
+    # carried at all (e.g. a different, quieter project in the same process)
+    # must never inherit it.
+    _signed_origin("S-origin", proj)
+    worldcheck.check(_cp_origins(["S-origin"]), proj)
+    assert worldcheck.last_receipt_probe()["attempted"] == 1
+    empty_cp = {"session_id": "S-now", "working_context": {}, "epistemic_snapshot": {}}
+    stats = worldcheck.check(empty_cp, proj)
+    assert stats == {"confirmed": 0, "contradicted": 0, "skipped": 0}
+    assert worldcheck.last_receipt_probe() == {"attempted": 0, "eligible": 0}
+
+
+def test_last_receipt_probe_zero_when_receipts_disabled(
+        receipts_on, proj, monkeypatch):
+    monkeypatch.delenv("DAIMON_RECEIPTS", raising=False)
+    _signed_origin("S-origin", proj)
+    worldcheck.check(_cp_origins(["S-origin"]), proj)
+    assert worldcheck.last_receipt_probe() == {"attempted": 0, "eligible": 0}
+
+
 # ---- #439 fail-open branches ------------------------------------------------
 #
 # Every branch below is a SILENT SKIP by contract, which is exactly why each

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -104,7 +104,7 @@ request write verb is reachable over MCP.
 | command | what it does |
 | --- | --- |
 | `daimon status` | Checkpoint presence and age, last serialize outcome, health warnings. `--suppressed` lists withheld resolved items. |
-| `daimon stats` | Local usage and capture aggregates — nothing is transmitted; sharing the output is a deliberate paste. `--json` for machines. |
+| `daimon stats` | Local usage and capture aggregates — nothing is transmitted; sharing the output is a deliberate paste. Includes a receipt-probe line with lifetime totals (attempted, eligible, confirmed, contradicted, skipped, cured) when receipts are configured. `--json` for machines. |
 | `daimon log --text "…"` | Append a freeform timeline event to the project's event log — zero-LLM, audit-trail only. |
 | `daimon loops` | List open, addressable loop items with their ids — the read counterpart to `resolve`'s write path. |
 | `daimon decide` | List what is waiting on YOU, each with the one command that closes it — the human-side mirror of `loops`. Reads records that already exist and writes nothing at all, so opening it never changes what the agent is shown. Scoped to this project; other projects arrive as counts. `--all-projects` adds every other project's queue as text, composed per project, each command routed with `--slug=<slug>` so it runs from here. The ten human-only verbs (`request accept`, `reject`, `needs-info`, `suppress`; `amend ratify`, `reject`; `ruling ratify`, `retire`; `refute ratify`, `overturn`) take that flag as routing only. Both are refused while `DAIMON_TENANT_SCOPED` is set. The briefing already carries this count on a single line, pointing back to this command. |

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -109,7 +109,7 @@ alcanzable por MCP.
 | comando | qué hace |
 | --- | --- |
 | `daimon status` | Presencia y edad del checkpoint, resultado del último serialize, avisos de salud. `--suppressed` lista los ítems resueltos retenidos. |
-| `daimon stats` | Agregados locales de uso y captura — nada se transmite; compartir la salida es un pegado deliberado. `--json` para máquinas. |
+| `daimon stats` | Agregados locales de uso y captura — nada se transmite; compartir la salida es un pegado deliberado. Incluye una línea de sondeos de recibo con totales acumulados (intentados, elegibles, confirmados, contradichos, omitidos, curados) cuando los recibos están configurados. `--json` para máquinas. |
 | `daimon log --text "…"` | Agrega un evento libre a la línea de tiempo del proyecto — cero LLM, solo rastro de auditoría. |
 | `daimon loops` | Lista los loops abiertos direccionables con sus ids — la contraparte de lectura del camino de escritura de `resolve`. |
 | `daimon decide` | Lista lo que está esperando por VOS, cada cosa con el único comando que la cierra — el espejo del lado humano de `loops`. Lee registros que ya existen y no escribe nada, así que abrirlo nunca cambia lo que el agente ve. Acotado a este proyecto; los demás proyectos llegan como conteos. `--all-projects` agrega la cola de cada otro proyecto como texto, compuesta por proyecto, con cada comando enrutado con `--slug=<slug>` para que corra desde acá. Los diez verbos solo para humanos (`request accept`, `reject`, `needs-info`, `suppress`; `amend ratify`, `reject`; `ruling ratify`, `retire`; `refute ratify`, `overturn`) toman esa bandera solo como ruteo. Ambos se rechazan mientras `DAIMON_TENANT_SCOPED` esté activo. El briefing ya muestra ese conteo en una sola línea, que apunta de vuelta a este comando. |


### PR DESCRIPTION
Closes #919

## What

`daimon stats` gains one receipt line per project, in three states:

```
receipt probes: off (DAIMON_RECEIPTS unset)
receipt probes: on, none attempted yet
receipt probes (lifetime): 12 attempted of 40 eligible, 11 confirmed, 0 contradicted, 1 skipped, 0 cured
```

`attempted` is probes fired, `eligible` the origins the day-bucket sampler drew from, and `confirmed`, `contradicted`, `skipped` the probe's own outcomes. All five are lifetime usage counters scoped by project slug, folded at the point the probe's ledger rows are already routed. `skipped` is on the line on purpose: a probe that fired and answered nothing (no verifier on the path, a spent deadline, an origin that predates receipts) used to read exactly like a probe that never ran. `cured` is read live off the latest receipt results rather than counted, because a cure changes an existing item's standing rather than adding an occurrence. The `--json` payload carries the same six figures plus `enabled`.

Inside worldcheck, the eligibility scan is split from the day-bucket sampler, and a module-level last-probe record exposes the two population sizes for the most recent check. The check's own return dict is unchanged; dozens of tests assert it by exact equality. Nothing is written to the verification ledger, and the cure gate is untouched.

## Why

The diagnosis on the issue found every gate in the probe chain holding and three confirmations per brief being generated, then dropped by design: a confirmation of an item nothing contradicted changes nothing, and writing it anyway would turn a ledger of problems found into a ledger of work done. That is correct, and it leaves a healthy probe with no trace anywhere. `verification_counts` excluded the receipt axis, so `stats` could not tell enabled from disabled, never-eligible from healthy. Silence was the only signal. This makes the axis legible without changing what the ledger means.

## Tests

Eleven new tests. In `tests/test_worldcheck.py`, the last-probe record counts eligible before sampling caps it, is zero with nothing eligible, resets on a checkpoint with nothing carried, and is zero when receipts are disabled. In `tests/test_cli.py`, each driving a real `daimon brief` then `daimon stats`: a valid receipt increments `attempted` and `confirmed` while the ledger gains no row; a tampered receipt lands a `receipt` row and increments `contradicted`, then a repaired one lands the cure row and `cured` reads 1; an origin that predates receipts increments `skipped`; the off, none-attempted, and full-count wordings are pinned by exact string; the rich renderer carries the section; disabled receipts leave the counters untouched.

Full suite from `plugin/` with `uv run --extra dev --extra pretty pytest -q`: 4925 passed, 2 skipped, and one failure in `test_field_table_corpus` that reads this machine's real checkpoints and fails identically on `main`; it is a local store artifact, not this change. ruff and mypy clean. Docs: the `daimon stats` row in the CLI reference, EN and ES.
