### PR TITLE
fix(hooks): the session-end hook follows a continued-in pointer to the child transcript

### DIFF
--- a/.scars/candidates/session-end-payload-names-the-parent.md
+++ b/.scars/candidates/session-end-payload-names-the-parent.md
@@ -1,0 +1,32 @@
+---
+id: 0
+type: landmine
+title: A Claude Code SessionEnd payload can name the PARENT of a continued session; serialize what the transcript tail points to, not what the host says
+severity: high
+confidence: 0.85
+created: 2026-09-03
+authors: ["claude-code"]
+anchors:
+  - path: hook/daimon-session-end.py
+evidence:
+  - note: #923 (2026-09-03): a session continued into a new id via a background continuation ran 21h and 4900 lines; at exit the host fired SessionEnd with the parent id and the parent transcript path (358 lines). The hook re-serialized the stub for 223s and wrote nothing for the child. heal saw no failure because every spawn had succeeded. Only the #185 session-start sweep could recover it, one candidate per start, after the next briefing had already rendered without that day
+expires:
+  condition: "the host reports the child session id and transcript path at SessionEnd for a continued session, or the serializer follows continuations itself"
+  review_after: 2027-03-03
+status: candidate
+---
+
+The SessionEnd payload's `session_id` and `transcript_path` are not the session
+the work happened in when the transcript was continued. Claude Code writes a
+`{"type":"continued-in","continuedInSessionId":"<child>"}` line near the tail of
+the PARENT transcript, keeps appending cost lines after it, and at exit reports
+the parent. Trusting the payload literally means: the stub is serialized again
+(its bytes changed, so the identical-bytes guard does not fire), the child gets
+no checkpoint, `daimon status` reads fresh, and `heal` has nothing to heal (#923).
+
+`_follow_continuation` in this file walks those pointers (bounded tail read,
+hop cap, cycle guard) and the spawn line names the CHILD's stem and path, which is
+what the ledger pairs a result line with (#28). Do not "simplify" the hook back to
+`payload["transcript_path"]`, and do not key the in-flight guard or the spawn
+line on the payload's `session_id`. If a host adds another continuation shape,
+extend `_continued_into`, not the sweep: the sweep is the safety net, not the path.

--- a/hook/daimon-session-end.py
+++ b/hook/daimon-session-end.py
@@ -45,6 +45,62 @@ def _fallback_log(line: str) -> None:
         pass
 
 
+# #923: a Claude Code session that is continued into a NEW session id (a
+# background continuation from a slash command, a bridge pickup) leaves the
+# host's pointer near the tail of the PARENT transcript, and SessionEnd then
+# reports the parent, not the child where the work happened. Bounded tail read:
+# transcripts run to tens of MB, the pointer sits in the last few lines.
+_CONTINUED_TAIL_BYTES = 64 * 1024
+_CONTINUED_MAX_HOPS = 8
+
+
+def _continued_into(transcript: Path) -> Path | None:
+    """The transcript a `continued-in` pointer in `transcript`'s tail names, or
+    None when there is no pointer in the tail window. Never raises."""
+    try:
+        size = transcript.stat().st_size
+        with transcript.open("rb") as fh:
+            fh.seek(max(0, size - _CONTINUED_TAIL_BYTES))
+            tail = fh.read().decode("utf-8", errors="replace")
+        for line in reversed(tail.splitlines()):
+            if '"continued-in"' not in line:
+                continue
+            try:
+                entry = json.loads(line)
+            except ValueError:
+                continue
+            if entry.get("type") != "continued-in":
+                continue
+            target = str(entry.get("continuedInSessionId") or "").strip()
+            if target and Path(target).name == target:
+                return transcript.parent / f"{target}.jsonl"
+            return None
+    except OSError:
+        return None
+    return None
+
+
+def _follow_continuation(transcript_path: str) -> tuple[str, list[str]]:
+    """Walk `continued-in` pointers from the reported transcript to the last
+    transcript that exists on disk. Returns (path to serialize, hop log lines).
+    A pointer to a missing file, a cycle, or the hop cap ends the walk at the
+    last transcript that resolved."""
+    current = Path(transcript_path)
+    seen = {current.resolve()}
+    hops: list[str] = []
+    for _ in range(_CONTINUED_MAX_HOPS):
+        nxt = _continued_into(current)
+        if nxt is None or not nxt.exists():
+            break
+        key = nxt.resolve()
+        if key in seen:
+            break
+        hops.append(f"session-end: continued-in {current.stem} -> {nxt.stem}")
+        seen.add(key)
+        current = nxt
+    return str(current), hops
+
+
 def main() -> int:
     if lib is None:
         _fallback_log("session-end: hook library missing (_daimon_hook_lib.py) — skipped")
@@ -70,6 +126,14 @@ def main() -> int:
 
     reason = payload.get("reason", "?")
     session_id = payload.get("session_id", "?")
+    # #923: serialize the transcript the work is in, not the parent stub the
+    # host named. The spawn line below then carries the child's stem and path,
+    # which is what the ledger pairs a result line with (#28).
+    transcript_path, hops = _follow_continuation(transcript_path)
+    if hops:
+        for hop in hops:
+            lib.log(hop)
+        session_id = Path(transcript_path).stem
     # Per-project routing: hand the session's working directory to the child so
     # the serializer writes this project's latest pointer (plus the global one).
     # No cwd in the payload -> child env untouched -> pre-routing behavior.

--- a/plugin/tests/test_claude_hooks.py
+++ b/plugin/tests/test_claude_hooks.py
@@ -439,6 +439,92 @@ def test_session_end_no_cwd_keeps_project_unset_but_passes_host(
     assert "DAIMON_CAPTURE_HOST=claude-code" in captured
 
 
+# ---- daimon-session-end.py: continued-in redirect (#923) ----
+
+
+def _continued(parent: Path, child: Path) -> None:
+    """Write a parent transcript whose LAST line is the host's continuation
+    pointer, the shape Claude Code leaves when a session is continued into a
+    new session id (the parent keeps the bridge, the child does the work)."""
+    parent.write_text(
+        '{"type":"user","message":{"role":"user","content":"hi"}}\n'
+        '{"type":"cost-state","totalCostUSD":1.0}\n'
+        f'{{"type":"continued-in","sessionId":"{parent.stem}",'
+        f'"continuedInSessionId":"{child.stem}"}}\n'
+    )
+
+
+def _end_payload(transcript: Path) -> dict:
+    return {
+        "session_id": transcript.stem,
+        "transcript_path": str(transcript),
+        "cwd": "/Users/x/projA",
+        "reason": "other",
+    }
+
+
+def test_session_end_follows_continued_in_to_the_child(tmp_path, tmp_checkpoint_dir):
+    # #923: the host reports the PARENT at SessionEnd; the work is in the child.
+    fake_bin, capture = _fake_cli(tmp_path)
+    parent = tmp_path / "P-parent.jsonl"
+    child = tmp_path / "C-child.jsonl"
+    child.write_text('{"type":"user","message":{"role":"user","content":"work"}}\n')
+    _continued(parent, child)
+    proc = _run(END_HOOK, _end_payload(parent), tmp_path, extra_env={"PATH": str(fake_bin)})
+    assert proc.returncode == 0
+    captured = _wait_for(capture)
+    assert str(child) in captured
+    assert str(parent) not in captured
+    log = (tmp_path / ".daimon" / "logs" / "serialize.log").read_text()
+    # Ledger-shaped spawn line names the CHILD, so status/heal pair its result.
+    assert "session-end: spawned serialize for C-child" in log
+    assert f"(transcript: {child})" in log
+    # And a breadcrumb explains why the payload's session is not the one spawned.
+    assert "session-end: continued-in P-parent -> C-child" in log
+
+
+def test_session_end_keeps_the_parent_when_the_child_is_missing(tmp_path, tmp_checkpoint_dir):
+    fake_bin, capture = _fake_cli(tmp_path)
+    parent = tmp_path / "P-parent.jsonl"
+    child = tmp_path / "C-gone.jsonl"  # never written
+    _continued(parent, child)
+    proc = _run(END_HOOK, _end_payload(parent), tmp_path, extra_env={"PATH": str(fake_bin)})
+    assert proc.returncode == 0
+    captured = _wait_for(capture)
+    assert str(parent) in captured
+    log = (tmp_path / ".daimon" / "logs" / "serialize.log").read_text()
+    assert "session-end: spawned serialize for P-parent" in log
+
+
+def test_session_end_follows_a_continuation_chain_to_its_end(tmp_path, tmp_checkpoint_dir):
+    fake_bin, capture = _fake_cli(tmp_path)
+    parent = tmp_path / "P-parent.jsonl"
+    middle = tmp_path / "M-middle.jsonl"
+    leaf = tmp_path / "L-leaf.jsonl"
+    leaf.write_text('{"type":"user","message":{"role":"user","content":"work"}}\n')
+    _continued(middle, leaf)
+    _continued(parent, middle)
+    proc = _run(END_HOOK, _end_payload(parent), tmp_path, extra_env={"PATH": str(fake_bin)})
+    assert proc.returncode == 0
+    captured = _wait_for(capture)
+    assert str(leaf) in captured
+    assert str(middle) not in captured
+
+
+def test_session_end_stops_on_a_continuation_cycle(tmp_path, tmp_checkpoint_dir):
+    fake_bin, capture = _fake_cli(tmp_path)
+    parent = tmp_path / "P-parent.jsonl"
+    child = tmp_path / "C-child.jsonl"
+    _continued(parent, child)
+    _continued(child, parent)  # child points back at the parent
+    proc = _run(END_HOOK, _end_payload(parent), tmp_path, extra_env={"PATH": str(fake_bin)})
+    assert proc.returncode == 0
+    captured = _wait_for(capture)
+    # Followed once, then the already-seen parent ends the walk: the child spawns.
+    assert str(child) in captured
+    assert str(parent) not in captured
+
+
 # ---- sweep_orphans (#185): session-start catch-up sweep, unit-level ----
 
 


### PR DESCRIPTION
Closes #923

## What

The Claude Code SessionEnd hook now follows a `continued-in` pointer in the reported transcript's tail and serializes the transcript the work happened in. The spawn line names the child's stem and path, so status and heal pair its result as before. A pointer to a missing file, a cycle, or the hop cap ends the walk at the last transcript that resolved. No pointer means the hook behaves exactly as it did.

## Why

When a session is continued into a new session id, the host reports the parent at SessionEnd. Trusting that payload serialized the short parent stub again and wrote nothing for the child, and heal saw nothing to heal because every spawn had succeeded. The parent stub was already captured at continuation time by the session-start sweep, so redirecting costs one spawn, not two.

A scar candidate anchored on the hook file records the trap.

## Tests

Four subprocess-level tests in `tests/test_claude_hooks.py`: the redirect to the child, the fallback to the parent when the child file is missing, a two-hop chain, and a cycle. Three were red before the change; the fallback test guards the path the redirect must keep. Full suite from `plugin/` with the dev and pretty extras, ruff on the hook file, and `scar lint` all pass.
