### PR TITLE
feat(refutations): add a receipt evidence kind

### DIFF
--- a/plugin/daimon_briefing/refutations.py
+++ b/plugin/daimon_briefing/refutations.py
@@ -112,8 +112,12 @@ _EVENT_RANK = {
 }
 _REF_ID_RE = re.compile(r"r-[0-9a-f]{12}")
 _ISSUE_RE = re.compile(r"(?:issue:|#)(\d+)\b", re.IGNORECASE)
+# #928: `receipt` is a signed receipt reference (a ratification or an
+# enforcement action signed out of band). Recorded like every other kind:
+# cited, not verified; resolving pointers is #581's territory.
 _EVIDENCE_KINDS = frozenset({
     "message", "transcript", "artifact", "issue", "measurement", "url",
+    "receipt",
 })
 _SPACE_RE = re.compile(r"\s+")
 _MAX_TEXT = 2000
@@ -232,7 +236,8 @@ def _evidence(values, *, required: bool = True) -> list[str]:
             raise RefutationError(
                 f"invalid evidence source {value!r}; use a typed source such as "
                 "message:<id>, transcript:<session>, artifact:<path>, "
-                "issue:<number>, measurement:<receipt>, or url:<source>")
+                "issue:<number>, measurement:<receipt>, receipt:<id>, or "
+                "url:<source>")
         if value not in seen:
             seen.add(value)
             out.append(value)

--- a/plugin/tests/test_refutations.py
+++ b/plugin/tests/test_refutations.py
@@ -1061,3 +1061,23 @@ def test_cli_refute_write_verbs_survive_the_record_vanishing(
     out = capsys.readouterr().out
     assert "Traceback" not in out
     assert out.strip(), "a vanished record must still report what happened"
+
+
+# ---- #928: a receipt evidence kind ----
+
+
+def test_receipt_evidence_is_accepted_and_stored(tmp_checkpoint_dir):
+    rid = _assert(evidence=["receipt:rcpt-01ABC"])
+    row = refutations.records(project_dir=PROJECT)[rid]
+    assert "receipt:rcpt-01ABC" in row["evidence"]
+
+
+def test_receipt_evidence_with_an_empty_payload_is_refused(tmp_checkpoint_dir):
+    with pytest.raises(refutations.RefutationError, match="typed source"):
+        _assert(evidence=["receipt:"])
+    assert refutations.records(project_dir=PROJECT) == {}
+
+
+def test_evidence_refusal_names_the_receipt_kind(tmp_checkpoint_dir):
+    with pytest.raises(refutations.RefutationError, match="receipt:<id>"):
+        _assert(evidence=["signed by someone"])


### PR DESCRIPTION
Closes #928

## What

`receipt` joins the closed set of evidence kinds on refutations and rulings, validated like every other kind (a non-empty payload after the colon). The refusal text that lists the accepted kinds names it. No row shape change, no migration: evidence is already a list of typed strings.

## Why

A host that signs a ratification or an enforcement action out of band had no kind to cite the receipt under; `measurement:` means a measurement's receipt and `url:` loses the kind on read. Daimon still records the pointer as cited, not verified; resolving pointers stays with #581.

## Tests

`tests/test_refutations.py`: a `receipt:<id>` source is accepted and stored on the record; a bare `receipt:` is refused as an empty payload; the refusal text names `receipt:<id>`. Two were red before the change; the empty-payload case was green before and after as the shared guard. Full suite from `plugin/` with the dev and pretty extras, ruff, and mypy pass.
