### PR TITLE
fix(heal): a session with an older checkpoint whose re-capture failed is visible to heal and status

### DIFF
--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -20,7 +20,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from . import config, store
+from . import config, store, transcript
 
 
 def _append_serialize_log(line: str) -> None:
@@ -249,8 +249,41 @@ def _session_ledger(text: str, now: float) -> dict:
     return sessions
 
 
+def checkpoint_covers(sid: str, transcript_path) -> bool:
+    """Does this session's checkpoint reach the end of its transcript? (#929)
+
+    "Lost" used to mean "no checkpoint at all", so a session that was captured
+    once, resumed for hours, and whose re-capture then FAILED read as captured
+    on every surface: `heal` dropped the failure because a checkpoint existed,
+    `status` printed fresh, and the session-start sweep deferred to heal. This
+    is the sweep's own rule applied here: a checkpoint counts only when its
+    `created` stamp is at or after the transcript's last conversation row.
+    Content, never file mtime: hosts append cost rows after the end hook.
+
+    Ambiguous is not lost (#54): no transcript path, an unreadable transcript,
+    a stamp-free transcript, a legacy checkpoint with no `created`, or a
+    checkpoint the bare id cannot address (Codex rollout names, #634) all
+    answer True, so the fold stays exactly as quiet as before for them."""
+    if not transcript_path:
+        return True
+    cp = store.read_checkpoint(sid)
+    if cp is None:
+        return True
+    created = store._created_epoch(cp.get("created"))
+    if created is None:
+        return True
+    try:
+        last = store._created_epoch(transcript.last_timestamp(transcript_path))
+    except Exception:  # noqa: BLE001 — a torn transcript must not break status
+        return True
+    if last is None:
+        return True
+    return created >= last
+
+
 def _outstanding_failures(ledger, now, has_checkpoint, ceiling, transcript_exists,
-                          force=False, heartbeat_age=None) -> list:
+                          force=False, heartbeat_age=None,
+                          checkpoint_covers=None) -> list:
     """Sessions still LOST — no checkpoint AND latest state != success.
     `has_checkpoint(sid)` and `transcript_exists(path)` are injected so this
     stays pure/testable. error+spawn+transcript-on-disk+not-retried -> healable
@@ -268,7 +301,11 @@ def _outstanding_failures(ledger, now, has_checkpoint, ceiling, transcript_exist
     for sid, e in ledger.items():
         if e["result_kind"] in ("success", "skipped"):
             continue
-        if has_checkpoint(sid):
+        # #929: a checkpoint clears the session only when it covers the
+        # transcript; callers that inject no `checkpoint_covers` keep the
+        # pre-#929 "any checkpoint" reading.
+        if has_checkpoint(sid) and (checkpoint_covers is None
+                                    or checkpoint_covers(sid, e["transcript"])):
             continue
         age = e["spawn_age"]
         if e["result_kind"] == "error":
@@ -324,6 +361,7 @@ def _compute_outstanding(text: str, now: float, force: bool = False) -> list:
         # #342: module-level heartbeat_age resolves via the global, not the
         # classifier's same-named parameter.
         heartbeat_age=lambda sid: heartbeat_age(sid, now),
+        checkpoint_covers=checkpoint_covers,
     )
 
 

--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -272,10 +272,9 @@ def checkpoint_covers(sid: str, transcript_path) -> bool:
     created = store._created_epoch(cp.get("created"))
     if created is None:
         return True
-    try:
-        last = store._created_epoch(transcript.last_timestamp(transcript_path))
-    except Exception:  # noqa: BLE001 — a torn transcript must not break status
-        return True
+    # last_timestamp answers None for an unreadable, non-jsonl, or stamp-free
+    # transcript by contract; it never raises, so no guard here.
+    last = store._created_epoch(transcript.last_timestamp(transcript_path))
     if last is None:
         return True
     return created >= last

--- a/plugin/tests/test_lost_behind_transcript.py
+++ b/plugin/tests/test_lost_behind_transcript.py
@@ -1,0 +1,94 @@
+"""#929: a session with an OLDER checkpoint whose re-capture failed is lost
+too. Lost means "no checkpoint at or after the transcript's last conversation
+row", the sweep's rule, not "no checkpoint at all"."""
+
+import json
+
+from daimon_briefing import ledger, store
+
+
+def _ledger_error(sid, transcript):
+    return {sid: {"spawned": True, "spawn_ts": 0.0, "spawn_age": 10, "project": "/p",
+                  "result_kind": "error", "result_line": "error: timed out",
+                  "transcript": transcript, "retried": False}}
+
+
+def test_fold_keeps_a_failure_whose_checkpoint_predates_the_transcript():
+    out = ledger._outstanding_failures(
+        _ledger_error("S1", "/t/S1.jsonl"), 100.0, lambda sid: True, 1800,
+        lambda p: True, checkpoint_covers=lambda sid, t: False)
+    assert [(f["sid"], f["class"]) for f in out] == [("S1", "healable")]
+
+
+def test_fold_drops_a_failure_whose_checkpoint_covers_the_transcript():
+    out = ledger._outstanding_failures(
+        _ledger_error("S1", "/t/S1.jsonl"), 100.0, lambda sid: True, 1800,
+        lambda p: True, checkpoint_covers=lambda sid, t: True)
+    assert out == []
+
+
+def test_fold_without_the_new_predicate_behaves_as_before():
+    out = ledger._outstanding_failures(
+        _ledger_error("S1", "/t/S1.jsonl"), 100.0, lambda sid: True, 1800,
+        lambda p: True)
+    assert out == []
+
+
+def _write_transcript(path, last_stamp):
+    rows = [{"type": "user", "uuid": "u1", "timestamp": "2026-09-01T00:00:00.000Z",
+             "message": {"role": "user", "content": "hi"}},
+            {"type": "assistant", "uuid": "a1", "timestamp": last_stamp,
+             "message": {"role": "assistant", "content": "later"}}]
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+
+def _write_checkpoint(sid, created, sample_checkpoint):
+    cp = dict(sample_checkpoint)
+    cp["session_id"] = sid
+    cp["created"] = created
+    store.write_checkpoint(sid, cp)
+
+
+def test_checkpoint_covers_is_false_when_conversation_continues_after_it(
+        tmp_checkpoint_dir, tmp_path, sample_checkpoint):
+    t = tmp_path / "S1.jsonl"
+    _write_transcript(t, "2026-09-01T06:00:00.000Z")
+    _write_checkpoint("S1", "2026-09-01T01:00:00Z", sample_checkpoint)
+    assert ledger.checkpoint_covers("S1", str(t)) is False
+
+
+def test_checkpoint_covers_is_true_when_the_checkpoint_is_at_or_after_the_last_row(
+        tmp_checkpoint_dir, tmp_path, sample_checkpoint):
+    t = tmp_path / "S1.jsonl"
+    _write_transcript(t, "2026-09-01T00:30:00.000Z")
+    _write_checkpoint("S1", "2026-09-01T01:00:00Z", sample_checkpoint)
+    assert ledger.checkpoint_covers("S1", str(t)) is True
+
+
+def test_checkpoint_covers_is_true_when_it_cannot_judge(
+        tmp_checkpoint_dir, tmp_path, sample_checkpoint):
+    # Missing transcript, or a legacy checkpoint with no created stamp:
+    # ambiguous is not lost (#54), so the fold stays quiet.
+    _write_checkpoint("S1", "2026-09-01T01:00:00Z", sample_checkpoint)
+    assert ledger.checkpoint_covers("S1", str(tmp_path / "gone.jsonl")) is True
+    assert ledger.checkpoint_covers("S1", None) is True
+    t = tmp_path / "S2.jsonl"
+    _write_transcript(t, "2026-09-01T06:00:00.000Z")
+    cp = dict(sample_checkpoint)
+    cp["session_id"] = "S2"
+    cp.pop("created", None)
+    store.write_checkpoint("S2", cp)
+    assert ledger.checkpoint_covers("S2", str(t)) is True
+
+
+def test_compute_outstanding_surfaces_the_stale_failed_session(
+        tmp_checkpoint_dir, tmp_path, sample_checkpoint):
+    t = tmp_path / "S1.jsonl"
+    _write_transcript(t, "2026-09-01T06:00:00.000Z")
+    _write_checkpoint("S1", "2026-09-01T01:00:00Z", sample_checkpoint)
+    text = (f"2026-09-01T05:00:00Z session-start: spawned serialize for S1 "
+            f"(reason: catch-up-orphan, project: /p) (transcript: {t})\n"
+            f"error: LLM call failed on merge level 2, group 1 of 1: ChatError: "
+            f"command backend timed out (transcript: {t}) after 900s\n")
+    out = ledger._compute_outstanding(text, 1_800_000_000.0)
+    assert [(f["sid"], f["kind"], f["class"]) for f in out] == [("S1", "error", "healable")]

--- a/plugin/tests/test_lost_behind_transcript.py
+++ b/plugin/tests/test_lost_behind_transcript.py
@@ -74,10 +74,14 @@ def test_checkpoint_covers_is_true_when_it_cannot_judge(
     assert ledger.checkpoint_covers("S1", None) is True
     t = tmp_path / "S2.jsonl"
     _write_transcript(t, "2026-09-01T06:00:00.000Z")
-    cp = dict(sample_checkpoint)
-    cp["session_id"] = "S2"
-    cp.pop("created", None)
-    store.write_checkpoint("S2", cp)
+    # The store stamps `created` on every write, so a legacy file without one
+    # has to be written directly to reach that branch.
+    from daimon_briefing import config
+    legacy = dict(sample_checkpoint)
+    legacy["session_id"] = "S2"
+    legacy.pop("created", None)
+    (config.checkpoint_dir() / "S2.json").write_text(json.dumps(legacy), encoding="utf-8")
+    assert store.read_checkpoint("S2") is not None
     assert ledger.checkpoint_covers("S2", str(t)) is True
 
 
@@ -92,3 +96,13 @@ def test_compute_outstanding_surfaces_the_stale_failed_session(
             f"command backend timed out (transcript: {t}) after 900s\n")
     out = ledger._compute_outstanding(text, 1_800_000_000.0)
     assert [(f["sid"], f["kind"], f["class"]) for f in out] == [("S1", "error", "healable")]
+
+
+def test_checkpoint_covers_is_true_for_a_checkpoint_the_bare_id_cannot_address(
+        tmp_checkpoint_dir, tmp_path):
+    # Codex-shaped: has_checkpoint found a rollout-named file the bare id
+    # cannot read back (#634). Cannot judge, so covered.
+    t = tmp_path / "S9.jsonl"
+    _write_transcript(t, "2026-09-01T06:00:00.000Z")
+    assert store.read_checkpoint("S9") is None
+    assert ledger.checkpoint_covers("S9", str(t)) is True


### PR DESCRIPTION
Closes #929

## What

`ledger.checkpoint_covers(sid, transcript_path)` says whether a session's checkpoint reaches the end of its transcript: the checkpoint's `created` stamp must be at or after the transcript's last conversation row (content, never file mtime). `_outstanding_failures` takes it as an optional injected predicate, and `_compute_outstanding` wires it, so a failed re-capture behind an older checkpoint now classifies as `healable` instead of vanishing. Status and heal share that fold, so status stops printing fresh for it and heal lists it. The session-start sweep keeps its exclusion.

Ambiguous stays quiet: no transcript path, an unreadable or stamp-free transcript, a legacy checkpoint with no `created`, or a checkpoint the bare id cannot address all count as covered, so nothing that was silent before starts warning without evidence.

## Why

Lost meant "no checkpoint at all". A session captured once, resumed for hours, and whose catch-up serialize then timed out read as captured on every surface, and both recovery paths deferred to the other. Measured over 60 days on one machine with daimon's own message floor and the content rule: 95 eligible transcripts, one such session. The rule is quiet and the one it finds is real.

## Tests

`tests/test_lost_behind_transcript.py`: the fold keeps a failure whose checkpoint predates the transcript and drops one whose checkpoint covers it; the fold without the new predicate behaves as before; `checkpoint_covers` is false when conversation continues after the checkpoint, true when the checkpoint is at or after the last row, and true whenever it cannot judge; `_compute_outstanding` surfaces the stale failed session end to end against a real checkpoint directory. Six were red before the change; the pre-change behavior test was green before and after by design. Full suite from `plugin/`, ruff, and mypy pass.
