### PR TITLE
chore(scars): scar 5 fires on the act, not on every file under plugin/

### DIFF
--- a/.scars/0005-uv-run-daimon-resolves-stale-global-tool.landmine.md
+++ b/.scars/0005-uv-run-daimon-resolves-stale-global-tool.landmine.md
@@ -7,9 +7,9 @@ confidence: 0.95
 created: 2026-07-02
 authors: [claude, Kibukx]
 anchors:
-  - path: plugin/
   - path: README.md
   - path: docs/
+  - command: "uv run daimon"
 violation: "uv run daimon"
 evidence:
   - note: "2026-07-02: live verification of D-011 importance emission ran a 320s chunked serialize that silently produced a D-010 checkpoint — `uv run daimon serialize` from repo root had executed ~/.local/share/uv/tools/daimon-briefing (last `uv tool install` snapshot), not the branch code"

--- a/.scars/0068-session-end-payload-names-the-parent.landmine.md
+++ b/.scars/0068-session-end-payload-names-the-parent.landmine.md
@@ -1,19 +1,21 @@
 ---
-id: 0
+id: 68
 type: landmine
 title: A Claude Code SessionEnd payload can name the PARENT of a continued session; serialize what the transcript tail points to, not what the host says
 severity: high
 confidence: 0.85
 created: 2026-09-03
 authors: ["claude-code"]
+promoted_by: Kibukx
+promoted_by_source: git-config-interactive
 anchors:
   - path: hook/daimon-session-end.py
 evidence:
-  - note: #923 (2026-09-03): a session continued into a new id via a background continuation ran 21h and 4900 lines; at exit the host fired SessionEnd with the parent id and the parent transcript path (358 lines). The hook re-serialized the stub for 223s and wrote nothing for the child. heal saw no failure because every spawn had succeeded. Only the #185 session-start sweep could recover it, one candidate per start, after the next briefing had already rendered without that day
+  - note: #923 (2026-09-03): a session continued into a new id via a background continuation ran 21h and 4900 lines; at exit the host fired SessionEnd with the parent id and the parent transcript path (358 lines). The hook re-serialized the stub for 223s and wrote nothing for the child. heal saw no failure because every spawn had succeeded. Only the
 expires:
   condition: "the host reports the child session id and transcript path at SessionEnd for a continued session, or the serializer follows continuations itself"
   review_after: 2027-03-03
-status: candidate
+status: active
 ---
 
 The SessionEnd payload's `session_id` and `transcript_path` are not the session

--- a/.scars/candidates/reader-vocabulary-gate-ignores-code-spans.md
+++ b/.scars/candidates/reader-vocabulary-gate-ignores-code-spans.md
@@ -1,0 +1,35 @@
+---
+id: 0
+type: landmine
+title: The reader-facing vocabulary gate is line-level and does not exempt code spans; a backticked ledger key fails CI on website prose
+severity: medium
+confidence: 0.9
+created: 2026-09-05
+authors: ["claude-code"]
+anchors:
+  - path: README.md
+  - path: website/docs/
+  - path: website/blog/
+  - path: website/i18n/
+violation: "\b(trials?|verdicts?|judge[sd]?|judgement|judgment|jury|testimon\w*|hearsay|prosecutes?|guilty|innocent|veredictos?|juicios?|jurado|testimonios?|culpable|inocente)\b"
+evidence:
+  - pr: 931
+  - note: "2026-09-05: a new CLI-reference section listed a ruling row's keys, one of them backticked. Local ruff, mypy and the two touched test files were green; CI failed on tests/test_reader_facing_vocabulary.py on both Python versions. The fix was to describe the field in words on both language mirrors."
+expires:
+  condition: "tests/test_reader_facing_vocabulary.py strips inline code spans or fenced blocks before matching, or the gate is removed"
+  review_after: 2027-03-05
+status: candidate
+---
+
+`plugin/tests/test_reader_facing_vocabulary.py` keeps a short list of courtroom
+words out of every reader-facing surface (README, website/docs, website/blog,
+website/i18n). Its docstring says code identifiers are out of scope, but the
+matcher runs `EXCLUDED.finditer(line)` on raw lines: nothing strips backticks
+or fences. A JSON key or CLI flag that happens to be an excluded word fails
+the gate exactly like prose does, on both language mirrors, and only in CI if
+you did not run that one test file locally.
+
+When a governed page has to refer to such a field, describe it ("the rule
+text") instead of naming the key, or add an ALLOWED entry to the test with a
+reason; do not weaken the pattern. The violation regex above is the gate's own
+term list, so this scar trips on the same edit the test would reject.


### PR DESCRIPTION
Scars-only change; no issue linkage per the PR template's scars-only exemption.

## What

Scar #5 (`uv run daimon` from the repo root runs the stale global tool) loses its `path: plugin/` anchor and gains `command: "uv run daimon"`. The `README.md` and `docs/` anchors stay.

## Why

The scar accounts for 971 of 2393 recorded firings on this checkout, 40 percent of everything, because `plugin/` is the whole source tree: every edit anywhere fired it and it crowded better-matched scars out of the injection cap. The act it warns about is a command, and command anchors rank on their own path, so the scar now fires on the act instead of on every file.

The two path anchors are kept on purpose: the `violation` tripwire only evaluates on files an anchor matched, and README and docs are where the wrong incantation would be written into prose. Dropping every path anchor would leave the scar lint-clean and disarmed.

## Tests

`scar lint`: 70 files, 0 errors, 0 partial-rot. `scar check --diff` on a docs edit containing the incantation: fires #5 and reports the violation. `scar check --diff` on a plain `plugin/` edit: #5 silent.
