### PR TITLE
chore(scars): promote 0069, the reader-facing vocabulary gate does not exempt code spans

### DIFF
--- a/.scars/0069-reader-vocabulary-gate-ignores-code-spans.landmine.md
+++ b/.scars/0069-reader-vocabulary-gate-ignores-code-spans.landmine.md
@@ -1,24 +1,26 @@
 ---
-id: 0
+id: 69
 type: landmine
 title: The reader-facing vocabulary gate is line-level and does not exempt code spans; a backticked ledger key fails CI on website prose
 severity: medium
 confidence: 0.9
 created: 2026-09-05
 authors: ["claude-code"]
+promoted_by: Kibukx
+promoted_by_source: git-config-interactive
 anchors:
   - path: README.md
   - path: website/docs/
   - path: website/blog/
   - path: website/i18n/
-violation: "\b(trials?|verdicts?|judge[sd]?|judgement|judgment|jury|testimon\w*|hearsay|prosecutes?|guilty|innocent|veredictos?|juicios?|jurado|testimonios?|culpable|inocente)\b"
 evidence:
   - pr: 931
-  - note: "2026-09-05: a new CLI-reference section listed a ruling row's keys, one of them backticked. Local ruff, mypy and the two touched test files were green; CI failed on tests/test_reader_facing_vocabulary.py on both Python versions. The fix was to describe the field in words on both language mirrors."
+  - note: 2026-09-05: a new CLI-reference section listed a ruling row's keys, one of them backticked. Local ruff, mypy and the two touched test files were green; CI failed on tests/test_reader_facing_vocabulary.py on both Python versions. The fix was to describe the field in words on both language mirrors.
 expires:
   condition: "tests/test_reader_facing_vocabulary.py strips inline code spans or fenced blocks before matching, or the gate is removed"
   review_after: 2027-03-05
-status: candidate
+violation: "\b(trials?|verdicts?|judge[sd]?|judgement|judgment|jury|testimon\w*|hearsay|prosecutes?|guilty|innocent|veredictos?|juicios?|jurado|testimonios?|culpable|inocente)\b"
+status: active
 ---
 
 `plugin/tests/test_reader_facing_vocabulary.py` keeps a short list of courtroom


### PR DESCRIPTION
Scars-only change; no issue linkage per the PR template's scars-only exemption.

## What

Promotes the candidate written on #934 to active scar 0069. Reviewer recorded by scar at promotion.

## Why

The reader-facing vocabulary gate on website prose is line-level and does not exempt code spans; a backticked ledger key failed CI on #931 today. The scar fires on edits to README, website docs, blog, and the Spanish mirror, with the gate's own term list as its tripwire.

## Tests

scar lint: 71 files, 0 errors, 0 partial-rot.