### PR TITLE
fix(status): a running heal repair reads as in flight, not as retry-exhausted

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -1858,12 +1858,15 @@ def _status_health(proj, glob, outstanding, siblings, *, now,
                 f"schema changed; briefing may render partially (re-serialize to refresh)"
             )
 
-    if outstanding:
-        n = len(outstanding)
+    # #936: a repair in flight is listed in the outstanding block but is not
+    # a failure; counting it would warn about the thing heal is fixing.
+    failed = [f for f in outstanding if f.get("kind") != "in-flight"]
+    if failed:
+        n = len(failed)
         msg = f"{n} session{'s' if n != 1 else ''} failed to serialize"
         # Only point at heal when it can actually repair something (#29) —
         # "run 'daimon heal'" followed by "nothing to heal" is a contradiction.
-        if any(f.get("class") == "healable" for f in outstanding):
+        if any(f.get("class") == "healable" for f in failed):
             msg += " — run 'daimon heal'"
         else:
             msg += " (not auto-repairable)"

--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -209,6 +209,11 @@ def _session_ledger(text: str, now: float) -> dict:
         if m:
             e = _entry(m.group(2))
             e["spawned"] = True
+            # #936: a spawn line after a result opens a NEW attempt. The
+            # previous result belongs to the previous attempt; keeping it
+            # made a running heal retry inherit the failure it was fixing.
+            e["result_kind"] = None
+            e["result_line"] = None
             try:
                 ts = datetime.strptime(m.group(1), "%Y-%m-%dT%H:%M:%SZ")
                 e["spawn_ts"] = ts.replace(tzinfo=timezone.utc).timestamp()
@@ -280,6 +285,18 @@ def checkpoint_covers(sid: str, transcript_path) -> bool:
     return created >= last
 
 
+def _repair_in_flight(age, ceiling, heartbeat_age, sid) -> bool:
+    """A retry attempt counts as running while its heartbeat is fresh, or
+    while it is younger than the hung ceiling and has not stamped a heartbeat
+    yet (the child stamps after its own preflight). Past the ceiling with a
+    stale or absent heartbeat, the hung rule below decides as before."""
+    if heartbeat_age is not None:
+        hb = heartbeat_age(sid)
+        if hb is not None:
+            return hb <= ceiling
+    return age is not None and age <= ceiling
+
+
 def _outstanding_failures(ledger, now, has_checkpoint, ceiling, transcript_exists,
                           force=False, heartbeat_age=None,
                           checkpoint_covers=None) -> list:
@@ -318,6 +335,16 @@ def _outstanding_failures(ledger, now, has_checkpoint, ceiling, transcript_exist
                         "age_str": _format_age(age) if age is not None else "unknown",
                         "transcript": e["transcript"], "project": e["project"],
                         "spawned": e["spawned"], "line": e["result_line"]})
+        elif (e["result_kind"] is None and e["spawned"] and e["retried"]
+              and _repair_in_flight(age, ceiling, heartbeat_age, sid)):
+            # #936: a heal retry that is still running. Visible, not
+            # outstanding-as-failure: status renders it, heal refuses to
+            # start a second one, and the failures warning does not count it.
+            hb = heartbeat_age(sid) if heartbeat_age is not None else None
+            out.append({"sid": sid, "kind": "in-flight", "class": "repairing",
+                        "age": age, "age_str": _format_age(age) if age is not None else "unknown",
+                        "heartbeat_age": hb, "transcript": e["transcript"],
+                        "project": e["project"], "spawned": True, "line": None})
         elif e["result_kind"] is None and e["spawned"] and age is not None and age > ceiling:
             # #342: liveness beats wall-clock. A heartbeat fresher than the
             # ceiling means the serialize is ALIVE — not outstanding, so
@@ -393,6 +420,10 @@ def _heal_plan(text, now, force=False) -> dict:
             continue
         if f["class"] == "healable":
             reason = "newer failure took this run — re-run 'daimon heal' to reach it"
+        elif f["class"] == "repairing":
+            hb = f.get("heartbeat_age")
+            reason = ("repair already running "
+                      + (f"(heartbeat {int(hb)}s ago)" if hb is not None else "(starting)"))
         else:
             reason = _HEAL_SKIP_REASON.get(f["class"], "not auto-repairable")
         skipped.append({"sid": f["sid"], "age_str": f["age_str"], "reason": reason})

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -714,6 +714,14 @@ def _outstanding_lines(outstanding) -> list:
     lines = []
     for f in outstanding:
         age = f["age_str"]
+        if f["kind"] == "in-flight":
+            # #936: a heal retry still running. Say so, and say what NOT to
+            # do: the old wording pointed at --force while the repair ran.
+            hb = f.get("heartbeat_age")
+            beat = f"heartbeat {int(hb)}s ago" if hb is not None else "starting"
+            lines.append(f"  - {f['sid']}  repairing ({beat}) — heal is running, "
+                         "do not force a second one")
+            continue
         if f["kind"] == "hung":
             # #28: a hung spawn whose transcript survived is healable now.
             if f["class"] == "healable":

--- a/plugin/tests/test_heal_in_flight.py
+++ b/plugin/tests/test_heal_in_flight.py
@@ -1,0 +1,90 @@
+"""#936: a heal repair that is still running must read as in flight, not as
+an exhausted failure. A later spawn line opens a new attempt; a pending attempt
+with a fresh heartbeat is `repairing`; status shows it and heal says so."""
+
+import time
+
+from daimon_briefing import ledger, render
+
+
+def _stamp(now, ago):
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now - ago))
+
+
+def _text(now):
+    return (f"{_stamp(now, 600)} session-end: spawned serialize for S1 "
+            f"(reason: other, project: /p) (transcript: /t/S1.jsonl)\n"
+            "error: LLM call failed on merge level 1, group 1 of 1: ChatError: "
+            "command backend timed out (transcript: /t/S1.jsonl) after 900s\n"
+            f"{_stamp(now, 30)} session-start: retry serialize for S1 (prior: error)\n")
+
+
+def test_a_later_spawn_line_opens_a_new_attempt():
+    now = 1_800_000_000.0
+    e = ledger._session_ledger(_text(now), now)["S1"]
+    assert e["spawned"] is True
+    assert e["retried"] is True
+    assert e["result_kind"] is None
+    assert e["result_line"] is None
+    assert e["spawn_age"] == 30
+
+
+def test_a_pending_retry_with_a_fresh_heartbeat_is_repairing():
+    now = 1_800_000_000.0
+    led = ledger._session_ledger(_text(now), now)
+    out = ledger._outstanding_failures(
+        led, now, lambda s: False, 1800, lambda p: True,
+        heartbeat_age=lambda s: 5)
+    assert [(f["sid"], f["kind"], f["class"], f["heartbeat_age"]) for f in out] == [
+        ("S1", "in-flight", "repairing", 5)]
+
+
+def test_a_pending_retry_with_a_stale_heartbeat_falls_through_to_the_hung_rule():
+    now = 1_800_000_000.0
+    led = ledger._session_ledger(_text(now), now)
+    led["S1"]["spawn_age"] = 4000
+    out = ledger._outstanding_failures(
+        led, now, lambda s: False, 1800, lambda p: True,
+        heartbeat_age=lambda s: 3900)
+    assert [(f["sid"], f["kind"], f["class"]) for f in out] == [("S1", "hung", "hung")]
+
+
+def test_a_first_attempt_in_flight_stays_silent_as_before():
+    now = 1_800_000_000.0
+    text = (f"{_stamp(now, 30)} session-end: spawned serialize for S2 "
+            f"(reason: other, project: /p) (transcript: /t/S2.jsonl)\n")
+    led = ledger._session_ledger(text, now)
+    out = ledger._outstanding_failures(
+        led, now, lambda s: False, 1800, lambda p: True,
+        heartbeat_age=lambda s: 5)
+    assert out == []
+
+
+def test_status_renders_the_repair_in_flight():
+    lines = render._outstanding_lines([{
+        "sid": "S1", "kind": "in-flight", "class": "repairing", "age": 30,
+        "age_str": "30s", "heartbeat_age": 5, "transcript": "/t/S1.jsonl",
+        "project": "/p", "spawned": True, "line": None}])
+    assert lines == ["  - S1  repairing (heartbeat 5s ago) — heal is running, do not force a second one"]
+
+
+def test_heal_reports_a_running_repair_instead_of_skipping_silently(monkeypatch):
+    now = 1_800_000_000.0
+    monkeypatch.setattr(ledger, "heartbeat_age", lambda sid, now=None: 5)
+    monkeypatch.setattr(ledger, "_has_checkpoint", lambda sid: False)
+    plan = ledger._heal_plan(_text(now), now)
+    assert plan["target"] is None
+    assert [(s["sid"], s["reason"]) for s in plan["skipped"]] == [
+        ("S1", "repair already running (heartbeat 5s ago)")]
+
+
+def test_status_health_does_not_count_a_running_repair_as_a_failure():
+    from daimon_briefing import cli
+    proj = {"exists": True, "age_seconds": 10, "session_id": "P", "path": "/x"}
+    glob = {"exists": True, "session_id": "P", "same_session_as_project": True}
+    repairing = [{"sid": "S1", "kind": "in-flight", "class": "repairing", "age": 30,
+                  "age_str": "30s", "heartbeat_age": 5, "transcript": "/t", "project": "/p",
+                  "spawned": True, "line": None}]
+    h = cli._status_health(proj, glob, repairing, [], now=1000.0)
+    assert not any("failed to serialize" in w for w in h["warnings"])
+    assert h["ok"] is True


### PR DESCRIPTION
Closes #936

## What

A spawn line after a result now opens a new attempt in the ledger fold: the previous `error` belongs to the previous attempt and is cleared. A pending retry (`retried` set by heal's marker) whose heartbeat is fresh, or which is younger than the hung ceiling and has not stamped one yet, classifies as `repairing` under a new `in-flight` kind. `daimon status` prints it on both renderers as a `repairing (heartbeat Ns ago)` line that says heal is running and not to force a second one, the health verdict does not count it as a failure, and `daimon heal` lists it as "repair already running (heartbeat Ns ago)" instead of skipping silently. A first attempt in flight stays silent as before; a stale heartbeat past the ceiling falls through to the hung rule as before.

## Why

Running `daimon heal` and then reading `daimon status` in another terminal showed the old failure relabeled `retry-exhausted` with advice to re-run with `--force` while the repair was still running. The fold kept the previous result across the new spawn, and the heartbeat was only consulted on the "no result, past the ceiling" path, so a 30-second-old retry never reached it. Forcing at that moment would start the double serialize #545 and #813 close on the hook paths.

## Tests

`tests/test_heal_in_flight.py`: a later spawn resets the result; a pending retry with a fresh heartbeat is repairing; a stale heartbeat past the ceiling is hung as before; a first attempt in flight stays silent; the outstanding line renders the repair; heal reports it as already running; the status verdict does not count it as a failure. Five were red before the change; the silent-first-attempt guard was green before and after by design. Full suite from `plugin/`, ruff, and mypy pass.
