### PR TITLE
docs(rulings): say where a change to the pinned host surface becomes visible

### DIFF
--- a/plugin/tests/test_rulings.py
+++ b/plugin/tests/test_rulings.py
@@ -1021,3 +1021,57 @@ def test_active_rulings_carries_the_anchors_a_host_matches_on(tmp_checkpoint_dir
     assert row["refutation_id"] == rid
     assert row["anchors"] == ["chat:user:123", "chat:channel:9"]
     assert row["verdict"] == "internal numbers never appear in public posts"
+
+
+# ---- #940: what a host may rely on, and where a change becomes visible ----
+
+# The keys the CLI reference promises a host process can read. The doc says
+# them in PROSE, because the reader-facing vocabulary gate is line-level and
+# rejects one of these names outright (scar 0069). So this list is the
+# machine-checkable half of that promise: rename or drop a key here and the
+# published contract is broken, whatever the page still says.
+DOCUMENTED_HOST_KEYS = frozenset({
+    "refutation_id", "state", "subject", "scope", "anchors",
+    "activation", "activation_channel", "evidence", "verdict",
+})
+
+
+def test_listing_carries_every_key_the_reference_promises(tmp_checkpoint_dir):
+    rid = _rule(anchors=["chat:user:123"])
+    refutations.ratify(rid, channel="signed", project_dir=PROJECT)
+    (row,) = refutations.listing(states={"active"}, polarity="ruling",
+                                 project_dir=PROJECT)
+    assert DOCUMENTED_HOST_KEYS <= row.keys(), \
+        DOCUMENTED_HOST_KEYS - row.keys()
+
+
+def test_active_rulings_carries_them_too(tmp_checkpoint_dir):
+    """The reference tells a host these two readers agree. If they diverge, a
+    host that switched readers on our advice would silently read fewer fields
+    rather than fail."""
+    from daimon_briefing import briefing
+    rid = _rule()
+    refutations.ratify(rid, channel="signed", project_dir=PROJECT)
+    (row,) = briefing.active_rulings(PROJECT)
+    assert DOCUMENTED_HOST_KEYS <= row.keys(), \
+        DOCUMENTED_HOST_KEYS - row.keys()
+
+
+def test_the_reference_states_where_a_change_to_this_surface_shows_up(
+        tmp_checkpoint_dir):
+    """daimon is pre-1.0 with bump-minor-pre-major, so a break ships as a
+    MINOR release and the version number alone will not warn anyone. The
+    promise we can keep is that the change is VISIBLE, so the page must keep
+    saying where. Both language mirrors, because a host reading the Spanish
+    page is owed the same warning."""
+    from pathlib import Path
+    root = Path(__file__).parent.parent.parent
+    pages = [
+        root / "website/docs/reference/cli.md",
+        root / ("website/i18n/es/docusaurus-plugin-content-docs"
+                "/current/reference/cli.md"),
+    ]
+    for page in pages:
+        text = page.read_text(encoding="utf-8")
+        assert "CHANGELOG.md" in text, f"{page} stopped naming the changelog"
+        assert "1.0" in text, f"{page} stopped saying daimon is pre-1.0"

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -68,6 +68,18 @@ The CLI mints two channels only: `cli-tty` (an interactive terminal) and `cli-ag
 
 The record renders as `ratified (signed)` or `ratified (ui)`, never as human-ratified without the tier. Nothing local is unforgeable: a caller with machine access can drive a UI or allocate a terminal. What the channel earns is provenance, not proof; forgery costs deliberate impersonation instead of one word, and the channel stays auditable afterwards.
 
+#### What a host can rely on
+
+daimon is pre-1.0. A release that breaks something described here arrives as a **minor** version bump, not a major one, so the version number alone will not warn you. Read that sentence twice if you are used to the usual meaning of a minor release.
+
+Stability is not the promise we can keep at this stage. Visibility is. Any change to the calls above, to the accepted channel names, to the rendered activation strings, or to the row fields listed below ships as a breaking commit, which means it appears under `### ⚠ BREAKING CHANGES` in `CHANGELOG.md` with prose saying what moved and what to do about it.
+
+So: pin an exact version, and read that section of `CHANGELOG.md` before you move to a new one.
+
+The row fields a host reads are the record id, its state, subject, scope, anchors, the rendered activation and the channel it arrived through, the evidence list, and the rule text. Both readers above return the same set.
+
+Deliberately not covered: the order rows come back in, the wording of diagnostics and log lines, the message text of a raised error (match on the exception type instead), and anything not named on this page. Importable is not the same as documented.
+
 ## Forget
 
 | command | what it does |

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -69,6 +69,18 @@ La CLI emite solo dos canales: `cli-tty` (una terminal interactiva) y `cli-agent
 
 El registro se muestra como `ratified (signed)` o `ratified (ui)`, nunca como ratificado por humano sin el nivel. Nada local es infalsificable: quien tiene acceso a la máquina puede manejar una UI o abrir una terminal. Lo que el canal gana es procedencia, no prueba; falsificar cuesta una suplantación deliberada en vez de una palabra, y el canal queda auditable después.
 
+#### Con qué puede contar un host
+
+daimon está antes de la 1.0. Una versión que rompa algo de lo descrito acá llega como un salto de versión **menor**, no mayor, así que el número de versión por sí solo no te va a avisar. Leé esa frase dos veces si estás acostumbrado al significado habitual de una versión menor.
+
+La estabilidad no es la promesa que podemos sostener en esta etapa. La visibilidad sí. Cualquier cambio en las llamadas de arriba, en los nombres de canal aceptados, en los textos de activación que se muestran, o en los campos de fila que se listan abajo, sale como un commit que rompe compatibilidad, y por lo tanto aparece bajo `### ⚠ BREAKING CHANGES` en `CHANGELOG.md`, con prosa que dice qué se movió y qué hacer al respecto.
+
+Entonces: fijá una versión exacta y leé esa sección de `CHANGELOG.md` antes de pasar a otra.
+
+Los campos de fila que lee un host son el id del registro, su estado, asunto, alcance, anclas, la activación que se muestra y el canal por el que llegó, la lista de evidencia, y el texto de la regla. Los dos lectores de arriba devuelven el mismo conjunto.
+
+Deliberadamente fuera de la promesa: el orden en que vuelven las filas, la redacción de diagnósticos y líneas de log, el texto del mensaje de un error lanzado (usá el tipo de excepción en su lugar), y todo lo que no esté nombrado en esta página. Que se pueda importar no es lo mismo que que esté documentado.
+
 ## Olvidar
 
 | comando | qué hace |


### PR DESCRIPTION
Closes #940

## What

#927 pinned the in-process `ratify` and `listing` calls as a host surface, shipped the doc block and the library-caller tests, but never stated what a caller may rely on. This adds that statement, on both language mirrors, plus tests that hold it to the code.

| File | Change |
|------|--------|
| `website/docs/reference/cli.md` | new "What a host can rely on" subsection |
| `website/i18n/es/.../reference/cli.md` | Spanish mirror |
| `plugin/tests/test_rulings.py` | three tests pinning the promise |

Note for the reviewer: this PR is docs plus tests and is not itself a compatibility break. The body below deliberately avoids the two-word phrase the marker gate greps for, because a page *about* that subject trips a filter that cannot tell description from instance. Same shape as scar 0069.

## Why

The obvious wording, "stable across minor releases", would have been wrong here and quietly so.

`bump-minor-pre-major` is on, so at `0.x` an incompatible change ships as a MINOR bump. This repo already has one: the PATH-consent change landed in `v0.24.0` to `v0.25.0` under the `⚠` heading in the changelog, and #551 had to correct a release that first shipped it as a patch. A caller applying the usual meaning of a minor release would have been broken with nothing raised.

Stability is not a promise this project can keep before 1.0. Visibility is. So the page says daimon is pre-1.0, says the version number alone will not warn you, and guarantees instead that a change to the calls, the accepted channel names, the rendered activation strings, or the listed row fields ships as an incompatible commit and therefore appears under the `⚠` heading in `CHANGELOG.md`. Pin an exact version and read that section before moving.

Row order is explicitly named as NOT covered, along with diagnostic wording, raised-error message text, and anything the page does not list. That was the open question on the issue; the answer is that it stays free, and the page now says so rather than leaving a caller to assume.

## Tests

- `test_listing_carries_every_key_the_reference_promises` and `test_active_rulings_carries_them_too` pin the documented row fields against both readers, so renaming or dropping one fails the build rather than only making the page wrong.
- `test_the_reference_states_where_a_change_to_this_surface_shows_up` asserts both mirrors keep naming `CHANGELOG.md` and the pre-1.0 status. It failed before this change. A promise about visibility is worthless the moment the pointer to it is deleted, and that deletion would otherwise be invisible.
- The field list lives in the test rather than being grepped out of the page, because the reader-facing vocabulary gate is line-level and rejects one of those field names in prose (scar 0069). The page says them in words; the test says them exactly.
- `279 passed` across the rulings, refutation, docs and vocabulary suites. Ruff clean.
