### PR TITLE
fix(team): a foreign tombstone apply names the surfaces it cannot reach

### DIFF
--- a/plugin/daimon_briefing/cli/team.py
+++ b/plugin/daimon_briefing/cli/team.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import daimon_briefing.cli as _cli
 
-from .. import config, recall, render, store, teamsync
+from .. import config, recall, render, store, surfaces, teamsync
 
 
 def _cmd_team_init(args) -> int:
@@ -56,8 +56,21 @@ def _cmd_team_sync(args) -> int:
                   " opt-in, and there is no undo", file=sys.stderr)
         else:
             applied = store.apply_foreign_tombstones(all_projects=True)
+            # #620: this walk reaches the *.json checkpoint shapes and no
+            # others, so an unqualified success line claims a sweep it did
+            # not perform. The operation is irreversible and machine-wide:
+            # the user spends a one-way consent, and being told it worked
+            # when the value survives elsewhere is worse than a refusal.
+            # The gap is derived from the surface registry, so a plaintext
+            # class added later is reported as unreached rather than
+            # silently absorbed into the count.
+            gap = surfaces.foreign_apply_gap()
             print(f"applied teammates' forget tombstones to {len(applied)} "
                   "local surface(s) across all projects")
+            print(f"  not reached ({len(gap)} plaintext surface class(es)): "
+                  + ", ".join(gap))
+            print("  the value may survive there; full coverage lands with"
+                  " the read-through model (#752)")
     # #246: fetched teammate files are fingerprint input — freshen here (the
     # SessionStart hook spawns sync detached, off the prompt path) so the
     # first recall after a fetch doesn't pay the rebuild. Unconditional on

--- a/plugin/daimon_briefing/surfaces.py
+++ b/plugin/daimon_briefing/surfaces.py
@@ -334,6 +334,40 @@ def _parts_match(shape_parts: tuple, parts: tuple) -> bool:
         and _parts_match(rest, parts[1:])
 
 
+# #620: what a FOREIGN tombstone apply actually reaches.
+#
+# store.apply_foreign_tombstones calls scrub_content_key and nothing else,
+# and that walk is *.json under the checkpoint dir. These two shapes are the
+# whole of its coverage. A local `daimon forget` reaches far more.
+#
+# Declared here rather than inferred from the walk, deliberately. Inferring
+# it would make the covered set and the walk the same statement, and a test
+# over it could not fail for a class the walk misses -- the tautology already
+# recorded on #620 and generalised as #944. Adding a plaintext surface to
+# SURFACES therefore widens the reported GAP on its own, which is the safe
+# direction: a new class is assumed unreached until someone says otherwise.
+FOREIGN_APPLY_SHAPES: frozenset = frozenset({
+    "checkpoints/{slug}/*.json",
+    "checkpoints/*.json",
+})
+
+
+def foreign_apply_gap() -> tuple[str, ...]:
+    """Plaintext surface shapes a foreign tombstone apply does NOT reach.
+
+    The caller prints these instead of an unqualified success line. An
+    irreversible, machine-wide operation that reports a clean sweep it did
+    not perform is worse than one that refuses: the user spends a one-way,
+    no-undo consent and is told it worked.
+
+    Never empty in practice, and the test says so: an empty return would
+    assert full coverage, which is the claim this exists to prevent anyone
+    making by accident."""
+    return tuple(sorted(
+        s.shape for s in SURFACES
+        if s.plaintext and s.shape not in FOREIGN_APPLY_SHAPES))
+
+
 def match(pattern: str) -> Surface | None:
     """Classify a path (or a write-audit-normalized pattern) against the
     registry. First declaration wins; None means UNDECLARED — the caller's

--- a/plugin/tests/test_foreign_apply_coverage.py
+++ b/plugin/tests/test_foreign_apply_coverage.py
@@ -1,0 +1,105 @@
+"""#620 interim: a foreign tombstone apply must name what it cannot reach.
+
+`store.apply_foreign_tombstones` calls `scrub_content_key` and nothing else,
+so it walks the `*.json` checkpoint shapes only. It printed an unqualified
+success line while eleven other plaintext surface classes kept the value.
+An irreversible, machine-wide operation reporting a clean sweep it did not
+perform is the silent-success shape this issue exists to remove.
+
+The structural fix retires with the copy model (#752). Until then the honest
+report is the whole deliverable: say the coverage, name the gap.
+
+NEGATIVE CONTROL (#944): the existing test for this path asserts no residue
+using the same surface enumeration the scrubber itself walks, so it cannot
+fail for a missing surface class no matter how many are missing. Every
+assertion here derives its expectation from the REGISTRY instead, and the
+disagreeing pair below is the point: one shape must be covered and another
+must not, so a function stuck returning everything (or nothing) fails.
+"""
+from daimon_briefing import surfaces
+
+
+def test_the_covered_shapes_are_all_declared_plaintext_surfaces():
+    """A shape claimed as covered that the registry does not declare is a
+    typo that would silently shrink the reported gap."""
+    declared = {s.shape for s in surfaces.SURFACES if s.plaintext}
+    assert surfaces.FOREIGN_APPLY_SHAPES <= declared, \
+        surfaces.FOREIGN_APPLY_SHAPES - declared
+
+
+def test_the_gap_is_every_other_plaintext_surface():
+    """Derived from the registry, never hardcoded: adding a plaintext surface
+    without adding it to the covered set makes it appear in the gap on its
+    own, rather than being silently absorbed into a clean success line."""
+    expected = {s.shape for s in surfaces.SURFACES
+                if s.plaintext} - surfaces.FOREIGN_APPLY_SHAPES
+    assert set(surfaces.foreign_apply_gap()) == expected
+
+
+def test_the_gap_disagrees_with_itself():
+    """The negative control. A gap function stuck at 'everything' or at
+    'nothing' would satisfy a one-sided test; only a disagreeing pair
+    separates a live answer from either dead one."""
+    gap = set(surfaces.foreign_apply_gap())
+    assert "checkpoints/{slug}/events.jsonl" in gap, "a known-missed class"
+    assert "checkpoints/{slug}/*.json" not in gap, "a known-covered class"
+
+
+def test_the_gap_names_every_class_the_issue_reproduced():
+    """#620 reproduced the value surviving in each of these after an armed
+    apply reported success. If a later change quietly starts claiming one,
+    this fails rather than the success line growing more confident."""
+    gap = set(surfaces.foreign_apply_gap())
+    for shape in ("checkpoints/{slug}/events.jsonl",
+                  "checkpoints/.chunk-cache/*",
+                  "logs/serialize-crash.log",
+                  "windsurf/transcripts/*.md",
+                  "team/{remote}/**/*.json"):
+        assert shape in gap, shape
+
+
+def test_the_gap_is_not_empty_and_is_sorted():
+    """Empty would mean full coverage, which is the claim this issue exists
+    to stop anyone making by accident."""
+    gap = surfaces.foreign_apply_gap()
+    assert gap, "an empty gap asserts a clean sweep that does not happen"
+    assert list(gap) == sorted(gap)
+
+
+# ---- the reported line, which is the user-visible half ----
+
+
+def _run_apply(monkeypatch, capsys, tmp_path, applied):
+    from daimon_briefing import config, store
+    from daimon_briefing.cli import team
+    import argparse
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "ckpt"))
+    monkeypatch.setattr(config, "team_apply_forget", lambda: True)
+    monkeypatch.setattr(store, "apply_foreign_tombstones",
+                        lambda **kw: list(applied))
+    monkeypatch.setattr(team.recall, "warm", lambda *a, **k: None)
+    monkeypatch.setattr(team, "_sync", lambda *a, **k: None, raising=False)
+    args = argparse.Namespace(apply_forget=True)
+    try:
+        team._cmd_team_sync(args)
+    except AttributeError:
+        team.cmd_sync(args)
+    return capsys.readouterr().out
+
+
+def test_the_success_line_names_what_it_did_not_reach(monkeypatch, capsys,
+                                                      tmp_path):
+    """The whole deliverable. Before this, the line read as a clean sweep of
+    every surface holding the value; eleven plaintext classes kept it."""
+    out = _run_apply(monkeypatch, capsys, tmp_path, ["a.json", "b.json"])
+    assert "2" in out
+    assert "not reached" in out.lower() or "did not reach" in out.lower()
+    assert "checkpoints/{slug}/events.jsonl" in out
+
+
+def test_a_zero_surface_apply_still_names_the_gap(monkeypatch, capsys,
+                                                  tmp_path):
+    """Zero rewritten is the case most likely to read as 'nothing to do'.
+    It is not: the value may sit in every class the walk never opens."""
+    out = _run_apply(monkeypatch, capsys, tmp_path, [])
+    assert "checkpoints/{slug}/events.jsonl" in out


### PR DESCRIPTION
Refs #620

Interim slice, not the structural fix. Uses `Refs` rather than `Closes` so merging leaves the issue open for the remaining items listed at the bottom.

## What

`store.apply_foreign_tombstones` calls `scrub_content_key` and nothing else, so it walks the `*.json` checkpoint shapes only. It printed an unqualified success line while fifteen other plaintext surface classes kept the value.

The line now reports its coverage and names the gap:

```
applied teammates' forget tombstones to 2 local surface(s) across all projects
  not reached (15 plaintext surface class(es)): checkpoints/.chunk-cache/*, ...
  the value may survive there; full coverage lands with the read-through model (#752)
```

| File | Change |
|------|--------|
| `plugin/daimon_briefing/surfaces.py` | `FOREIGN_APPLY_SHAPES` and `foreign_apply_gap()` |
| `plugin/daimon_briefing/cli/team.py` | the apply reports coverage and gap |
| `plugin/tests/test_foreign_apply_coverage.py` | new, 7 tests |

The walk itself is unchanged. This slice buys honesty, not coverage.

## Why

An irreversible, machine-wide operation that reports a sweep it did not perform is worse than one that refuses. The user spends a one-way, no-undo consent and is told it worked, while the value survives in the event ledger, the chunk cache, adapter transcripts, the crash log, and this machine's own team-mirror copies.

The structural fix retires with the copy model (#752), per the rescoping note on the issue. Until then the honest report is the whole deliverable.

## The design choice worth reviewing

`FOREIGN_APPLY_SHAPES` **declares** the two covered shapes rather than inferring them from the walk.

Inferring would make the covered set and the walk the same statement, so no test over it could fail for a class the walk misses. That is the tautology already recorded on #620 and generalised as #944.

Declaring it means a plaintext surface added to `SURFACES` later is reported as unreached on its own. A new class is assumed missed until someone says otherwise, which is the safe direction for a privacy surface.

## Tests

Seven, all failing before the change.

The important one is the negative control, applying #944 to its own first customer:

```python
assert "checkpoints/{slug}/events.jsonl" in gap      # a known-missed class
assert "checkpoints/{slug}/*.json" not in gap        # a known-covered class
```

A gap function stuck at "everything" or at "nothing" satisfies a one-sided test. Only a disagreeing pair separates a live answer from either dead one. The existing test on this path is one-sided in exactly that way, which is why it cannot fail for a missing surface class.

The rest derive every expectation from the registry rather than from the scrubber's own walk, assert the zero-rewritten case still names the gap (the case most likely to read as "nothing to do"), and assert the gap is never empty, since empty would assert the clean sweep this PR exists to stop claiming.

Full suite from `plugin/` as CI runs it: `5000 passed, 2 skipped`. Ruff and mypy clean.

## Still open on #620 after this

The local tombstone for durability, whose cost is that it has to answer what reopen means for a key you never forgot. The audit class for suppressed-but-present. The armed state in team status. A distinct exit code on refusal.
