### PR TITLE
test(gates): a gate constant must be proven able to fire and to stay silent

### DIFF
--- a/plugin/tests/test_gate_controls.py
+++ b/plugin/tests/test_gate_controls.py
@@ -1,0 +1,118 @@
+"""#944, rescoped: a gate constant must be proven able to BOTH fire and stay silent.
+
+The original shape was a registry of deterministic gate METRICS. The inventory
+killed it: daimon has exactly two such metrics and both already carry
+disagreeing controls, so the registry would have refused nothing and reported
+a clean sweep, which is the defect it existed to prevent.
+
+The population that actually failed is different. Of six one-directional-health
+failures on 2026-09-05, the one living in this repo was a test that asserted no
+residue using the same enumeration the code under test walks, so it could not
+fail for a missing case no matter how many were missing (#620, fixed in #945).
+
+So the rule is aimed at the tests, not at a runtime registry: every threshold
+that gates a rendered warning must be named here, with a control that produces
+a DIFFERENT outcome on each side of it. A control that only ever shows the
+firing case passes against a gate wired to fire always; one that only ever
+shows silence passes against a gate wired to fire never. Only the pair
+separates a live gate from either dead one.
+
+The discovery half is what gives this teeth: the constants are found by
+scanning the source, so adding a new `_*_GATE_*` without a control fails here
+rather than shipping unproven.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+from daimon_briefing import render
+
+_SRC = Path(__file__).parent.parent / "daimon_briefing"
+
+# A threshold whose whole job is to gate a rendered warning. Deliberately
+# narrow: `GATE` in the name is the declaration that something is judged
+# against it. Widening this pattern widens the obligation below, which is the
+# intended direction if more gates appear.
+_GATE_CONST_RE = re.compile(r"^(_[A-Z0-9_]*GATE[A-Z0-9_]*)\s*=", re.M)
+
+
+def _declared_gate_constants() -> set[str]:
+    found: set[str] = set()
+    for path in sorted(_SRC.glob("*.py")):
+        found |= set(_GATE_CONST_RE.findall(path.read_text(encoding="utf-8")))
+    return found
+
+
+def _window(**over) -> dict:
+    base = {"days": 14, "success": 10, "skipped": 0, "errors": 0,
+            "fallback_attempts": 0, "fallback_serializes": 0, "starved": 0,
+            "error_rate_pct": 0.0}
+    base.update(over)
+    return base
+
+
+def _fired(marker: str, w: dict) -> bool:
+    # NOTE: the renderer takes the STATS dict and reads ["window"] out of it,
+    # returning [] for anything without that key. Passing the bare window here
+    # made every "must stay silent" case pass for the wrong reason: no lines
+    # because the shape was wrong, not because the gate held. The disagreement
+    # assertion below is what surfaced it. Keep the wrapper.
+    return any(marker in ln
+               for ln in render._capture_window_lines({"window": w}))
+
+
+# metric name -> (marker, window that MUST fire, window that MUST stay silent)
+CONTROLS: dict = {
+    "_CAPTURE_ERROR_GATE_PCT": (
+        "capture error rate",
+        _window(errors=5, success=5, error_rate_pct=50.0),
+        _window(errors=0, success=10, error_rate_pct=0.0),
+    ),
+    "_RESCUE_GATE_PCT": (
+        "rescue succeeded",
+        _window(fallback_attempts=3, fallback_serializes=1),
+        _window(fallback_attempts=2, fallback_serializes=1),
+    ),
+}
+
+
+def test_every_gate_constant_is_named_by_a_control():
+    """The teeth. A new `_*_GATE_*` constant fails here until someone proves
+    it can both fire and stay silent, rather than shipping unproven."""
+    missing = _declared_gate_constants() - set(CONTROLS)
+    assert not missing, (
+        f"gate constant(s) with no disagreeing control: {sorted(missing)}. "
+        "Add an entry to CONTROLS showing one input that fires it and one "
+        "that does not.")
+
+
+def test_the_scan_finds_the_constants_we_know_exist():
+    """Negative control on the DISCOVERY half. If the regex silently stopped
+    matching, the obligation above would pass by finding nothing, which is
+    the failure mode this whole file is about."""
+    found = _declared_gate_constants()
+    assert "_CAPTURE_ERROR_GATE_PCT" in found
+    assert "_RESCUE_GATE_PCT" in found
+    assert "_DECAY_FLOOR" not in found, "the pattern must stay narrow"
+
+
+@pytest.mark.parametrize("name", sorted(CONTROLS))
+def test_each_gate_actually_fires_on_its_firing_case(name):
+    marker, firing, _ = CONTROLS[name]
+    assert _fired(marker, firing), f"{name} never fires; a gate wired off"
+
+
+@pytest.mark.parametrize("name", sorted(CONTROLS))
+def test_each_gate_actually_stays_silent_on_its_silent_case(name):
+    marker, _, silent = CONTROLS[name]
+    assert not _fired(marker, silent), f"{name} always fires; a gate wired on"
+
+
+@pytest.mark.parametrize("name", sorted(CONTROLS))
+def test_the_two_cases_disagree(name):
+    """States the point directly: a control whose two sides agree proves
+    nothing, however many cases it lists."""
+    marker, firing, silent = CONTROLS[name]
+    assert _fired(marker, firing) != _fired(marker, silent), \
+        f"{name}'s control does not disagree with itself"


### PR DESCRIPTION
Refs #944

Uses `Refs`, not `Closes`: the margin-reporting convention and the quote-check exemption audit from that issue are still unbuilt.

## What

Every threshold matching `_*_GATE_*` in `daimon_briefing/*.py` must be named by a control proving it BOTH fires and stays silent. Constants are discovered by scanning the source, so a new one fails the suite until someone proves it.

| File | Change |
|------|--------|
| `plugin/tests/test_gate_controls.py` | new, 8 tests, no production change |

## Why this and not what the issue originally asked for

The issue asked for the inventory first. I did it, and it came back against the issue's own premise.

daimon has **two** deterministic gate metrics: `_CAPTURE_ERROR_GATE_PCT` (`ledger.py:569`) and `_RESCUE_GATE_PCT` (`ledger.py:571`). Both already carry disagreeing controls; the rescue gate already has the exact pair the issue proposed, in `test_render.py`.

So a registry built to the original spec would have refused nothing and reported a clean sweep, which is the defect it exists to prevent. Full reasoning and the coverage statement are in a comment on #944.

The population that actually fails is tests that pin a gate. The one in-repo failure behind this issue was a residue assertion using the same enumeration the code under test walks, so it could not fail for a missing case however many were missing (#620, fixed in #945).

## Why a pair rather than a case

A control that only shows the firing case passes against a gate wired to fire always. One that only shows silence passes against a gate wired to fire never. Only the pair separates a live gate from either dead one.

## The discovery half has its own control

```python
def test_the_scan_finds_the_constants_we_know_exist():
    assert "_CAPTURE_ERROR_GATE_PCT" in found
    assert "_RESCUE_GATE_PCT" in found
    assert "_DECAY_FLOOR" not in found, "the pattern must stay narrow"
```

Without it, the obligation could pass by finding nothing, which is the same failure wearing a different hat.

## Verified by mutation, not asserted

Appending `_EXPERIMENT_GATE_PCT = 99` to `ledger.py`:

```
AssertionError: gate constant(s) with no disagreeing control:
['_EXPERIMENT_GATE_PCT']. Add an entry to CONTROLS showing one input
that fires it and one that does not.
```

Removing it restores green. `ledger.py` verified unchanged afterwards.

## Found while writing it

The first draft passed its silence assertions for the wrong reason. `render._capture_window_lines` takes the stats dict and reads `["window"]` out of it, returning `[]` for anything else, so a bare window produced no lines because the shape was wrong rather than because the gate held.

The disagreement assertion is what surfaced it, on first use, against its own author. There is now a comment on that helper so the wrapper does not get "simplified" away.

## Tests

8 tests, 4 red before the fix above. `1415 passed` across the render, ledger, gate and cli suites. Ruff clean. No production code touched.
