### PR TITLE
feat(checks): an armed check runs under a budget and a human can try one first

### DIFF
--- a/hook/checks_runtime.py
+++ b/hook/checks_runtime.py
@@ -1,0 +1,203 @@
+"""The #943 check runtime — stdlib only, loadable by a standalone hook.
+
+A host's pre-action hook runs in whatever interpreter the host launched, with
+no venv and no `daimon_briefing` on `sys.path`. So the part of the check
+machinery that runs INSIDE a hook lives here, and this file ships
+byte-identical into `_hooks/` and `hook/` the way `redact.py` does.
+
+Two rules follow from that, both scars:
+
+  * stdlib ONLY (scar 0049). `from . import config` looks completely ordinary
+    from inside the package, passes every local test, and breaks every host
+    hook. The path accessors below are therefore hand-copied mirrors of
+    `config.checks_dir` / `config.log_dir`, and a probe table in
+    `test_checks_runtime.py` asserts behavioral equality against the config
+    functions rather than against literals.
+  * the canonical file is THIS one and the copies are derivatives (scar 0049
+    again, which reverses scar 0044's direction for the adapter scripts).
+    Edit here, then run `scripts/sync_hooks.py`.
+
+Nothing here raises. The hook that calls it fires before every shell action
+on the host, so an exception is an action that proceeds with no record of
+why. Every function returns a value that says what happened, including when
+what happened is that daimon could not tell.
+"""
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import NamedTuple
+
+MANIFEST_NAME = "manifest.json"
+FIRING_LOG_NAME = "checks.jsonl"
+
+# Scar 0022 applied to the SUBJECT rather than the pattern. `check.match` is
+# caller-supplied and capped at 200 bytes, which bounds its length and says
+# nothing about its backtracking. Bounding the string it runs against is what
+# keeps a pathological pair from outliving the host's hook timeout, and that
+# timeout is fail-open: a hook that reaches it does not block, the tool
+# proceeds. This is the one known bound and it is documented as such.
+MATCH_INPUT_BYTES = 4096
+
+
+class Manifest(NamedTuple):
+    """What `load_manifest` found. `reason` is empty when the manifest was
+    read; otherwise it names the state for the firing log, because "no
+    manifest" and "a manifest daimon can no longer parse" are different
+    facts and folding them would report an unwritten install as a broken
+    one."""
+    entries: list
+    reason: str
+
+
+# ---- config mirrors (scar 0043: copy the QUIRKS, not the intent) ----------
+
+
+def _env_file_path() -> Path:
+    """Mirror of daimon_briefing.config._env_file_path."""
+    raw = os.environ.get("DAIMON_ENV_FILE")
+    return Path(raw).expanduser() if raw else Path.home() / ".daimon" / "env"
+
+
+def _env_file_values() -> dict:
+    """Mirror of daimon_briefing.config._file_values — KEY=VALUE lines, with
+    the `export ` prefix, surrounding quotes, blank lines and `#` comments
+    tolerated. Copied rather than imported because hooks run standalone;
+    config.py is the CANONICAL form and this copy must follow it line-form
+    for line-form."""
+    try:
+        text = _env_file_path().read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return {}
+    values = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
+        key, _, val = line.partition("=")
+        key, val = key.strip(), val.strip()
+        if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+            val = val[1:-1]
+        if key:
+            values[key] = val
+    return values
+
+
+def _config_get(name: str) -> str:
+    """Mirror of daimon_briefing.config._get: process env WINS, env file is
+    the fallback. Present-but-empty in the process env is a value and
+    shadows the file, exactly as on the package side."""
+    val = os.environ.get(name)
+    if val is not None:
+        return val
+    return _env_file_values().get(name) or ""
+
+
+def checks_dir() -> Path:
+    """Where the manifest and the materialized bodies live, resolved the way
+    the WRITER resolves it.
+
+    `checks.sync` writes through config.checks_dir(); this reads. A path
+    resolved any other way here has the hook reading an empty directory
+    while the CLI reports N checks armed, and neither side can see the
+    split — the same writer/reader gap scar 0043 records one directory over.
+    So this reproduces config.checks_dir() exactly, including the parts that
+    look like bugs: no strip (so "   " is a relative directory named three
+    spaces, and the reader must agree), and the env-file fallback, which is
+    the channel a GUI-launched host actually uses."""
+    raw = _config_get("DAIMON_CHECKS_DIR")
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".daimon" / "checks"
+
+
+def log_dir() -> Path:
+    """Mirror of config.log_dir(), same reasoning as checks_dir(): the
+    firing log sits under it and `daimon forget` purges through the config
+    accessor."""
+    raw = _config_get("DAIMON_LOG_DIR")
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".daimon" / "logs"
+
+
+# ---- manifest -------------------------------------------------------------
+
+
+def load_manifest(path=None) -> Manifest:
+    """Read the armed-check manifest. Never raises, never partially fails.
+
+    An absent manifest is the ordinary state of an install that has armed
+    nothing, so it reads as empty with `no-manifest` rather than as an
+    error. A manifest that exists and cannot be parsed is a different fact
+    and gets its own reason: both allow the action, and only one of them
+    means daimon wrote something it can no longer read."""
+    target = Path(path) if path is not None else checks_dir() / MANIFEST_NAME
+    try:
+        raw = target.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return Manifest([], "no-manifest")
+    except (OSError, UnicodeDecodeError):
+        return Manifest([], "manifest-unreadable")
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return Manifest([], "manifest-unreadable")
+    if not isinstance(data, list):
+        return Manifest([], "manifest-unreadable")
+    # A row that is not an object is dropped rather than fatal: one bad row
+    # must not disarm every other project's checks.
+    return Manifest([row for row in data if isinstance(row, dict)], "")
+
+
+def armed_for(cwd, manifest) -> list:
+    """The manifest entries armed for this working directory.
+
+    `project_dir` on an entry is already the resolved physical root (the
+    writer runs it through config.resolve_project_dir, which walks to the
+    git toplevel). Here the cwd is realpath'd to meet it, so a project
+    reached through a symlink still arms, and the prefix test carries an
+    explicit separator so /srv/appliance is not governed by a ruling made
+    for /srv/app."""
+    entries = getattr(manifest, "entries", manifest)
+    if not isinstance(entries, list) or not isinstance(cwd, str) or not cwd:
+        return []
+    try:
+        here = os.path.realpath(cwd)
+    except (OSError, ValueError):
+        return []
+    out = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        root = entry.get("project_dir")
+        if not isinstance(root, str) or not root:
+            continue
+        bounded = root if root.endswith(os.sep) else root + os.sep
+        if here == root or here.startswith(bounded):
+            out.append(entry)
+    return out
+
+
+def matches(entry, command) -> bool:
+    """The cheap prefilter: does this entry's regex hit the command string?
+
+    Unanchored and case-sensitive, per the spec, and read over at most
+    MATCH_INPUT_BYTES bytes of the command. An unusable pattern matches
+    nothing instead of raising: a hand-edited manifest can carry a regex the
+    writer would have refused, and that must not become a traceback on every
+    shell action."""
+    if not isinstance(entry, dict) or not isinstance(command, str):
+        return False
+    pattern = entry.get("match")
+    if not isinstance(pattern, str) or not pattern:
+        return False
+    subject = command.encode("utf-8", "replace")[:MATCH_INPUT_BYTES].decode(
+        "utf-8", "ignore")
+    try:
+        return re.search(pattern, subject) is not None
+    except (re.error, RecursionError):
+        return False

--- a/hook/checks_runtime.py
+++ b/hook/checks_runtime.py
@@ -574,3 +574,56 @@ def _run(entry_or_body, subject, cwd, timeout, started) -> Outcome:
     # passes it.
     return out("unresolved", "check-crashed",
                reason or f"the check exited {code}", code)
+
+
+# ---- firing log (spec 3.4) ------------------------------------------------
+
+# The whole row, and nothing else. Spec 3.4: no command text, no paths, no
+# subject. `decision_emitted` is what the hook actually wrote to the host, so
+# a reader can tell a check that RAN from a check that was honored — only
+# `deny` under `enforce` closes that gap.
+FIRING_KEYS = ("ts", "ruling_id", "host", "mode", "outcome", "cause",
+               "decision_emitted", "duration_ms")
+
+# Every value `cause` may hold. The manifest reasons join the runner's causes
+# because "nothing was armed here" is a firing the stats surface has to be
+# able to count, and it is the difference between "armed, never fired" and
+# "clean".
+LOG_CAUSES = CAUSES | {"no-manifest", "no-match", "manifest-unreadable"}
+
+
+def log_firing(row, path=None) -> bool:
+    """Append one row to the firing log. Returns whether it landed.
+
+    The row is PROJECTED onto FIRING_KEYS rather than filtered, so a caller
+    that hands over the whole outcome record (reason and command included)
+    cannot leak them here. `cause` is the one field where free text could
+    otherwise reach a log declared to hold no plaintext, so a value outside
+    the declared set is recorded as `unknown`: the state is still signalled,
+    it just cannot bring a path along.
+
+    Never raises. A hook that cannot write its log still has an action to
+    allow or deny, and losing the decision over the record would be the
+    wrong trade."""
+    try:
+        source = row if isinstance(row, dict) else {}
+        cause = str(source.get("cause") or "")
+        stamped = {
+            "ts": str(source.get("ts") or "") or time.strftime(
+                "%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "ruling_id": str(source.get("ruling_id") or ""),
+            "host": str(source.get("host") or ""),
+            "mode": str(source.get("mode") or ""),
+            "outcome": str(source.get("outcome") or ""),
+            "cause": cause if cause in LOG_CAUSES else (cause and "unknown"),
+            "decision_emitted": str(source.get("decision_emitted") or ""),
+            "duration_ms": int(source.get("duration_ms") or 0),
+        }
+        target = (Path(path) if path is not None
+                  else log_dir() / FIRING_LOG_NAME)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(stamped, ensure_ascii=False) + "\n")
+        return True
+    except (OSError, ValueError, TypeError):
+        return False

--- a/hook/checks_runtime.py
+++ b/hook/checks_runtime.py
@@ -26,11 +26,28 @@ what happened is that daimon could not tell.
 import json
 import os
 import re
+import shlex
+import tempfile
 from pathlib import Path
 from typing import NamedTuple
 
 MANIFEST_NAME = "manifest.json"
 FIRING_LOG_NAME = "checks.jsonl"
+
+# Spec 2.3. `unresolved` is one outcome with many causes, and the set is
+# closed: a cause outside it means a code path invented a state no surface
+# knows how to render.
+CAUSES = frozenset({
+    "file-missing", "file-unreadable", "file-oversize", "file-binary",
+    "stdin-pipe", "arg-form-unparsed", "check-timeout", "check-crashed",
+    "body-hash-mismatch", "runtime-missing",
+})
+
+# A file argument daimon will read into the subject. Above this it reports
+# file-oversize rather than paying to read it: the point of the cap is that
+# the hook's budget is spent before the host's, not that large files are
+# suspicious.
+MAX_SUBJECT_FILE_BYTES = 1024 * 1024
 
 # Scar 0022 applied to the SUBJECT rather than the pattern. `check.match` is
 # caller-supplied and capped at 200 bytes, which bounds its length and says
@@ -48,6 +65,22 @@ class Manifest(NamedTuple):
     facts and folding them would report an unwritten install as a broken
     one."""
     entries: list
+    reason: str
+
+
+class Subject(NamedTuple):
+    """A materialized subject: the command string plus every file argument
+    daimon could read. `path` is a temp file the CALLER must hand back to
+    `discard` once the check has run."""
+    path: str
+    files: tuple
+
+
+class Unresolved(NamedTuple):
+    """Daimon could not prove the subject clean. Never rendered as clean and
+    never counted as a violation. `reason` is for a human and may name a
+    path; the firing log carries the cause and never the reason."""
+    cause: str
     reason: str
 
 
@@ -201,3 +234,188 @@ def matches(entry, command) -> bool:
         return re.search(pattern, subject) is not None
     except (re.error, RecursionError):
         return False
+
+
+# ---- resolver (spec 3.2) --------------------------------------------------
+
+SUBJECT_SEPARATOR = "--- daimon:subject ---"
+
+# Flags whose value is a path to read. `-F` is gh's short form of
+# --body-file on `pr create` / `issue create` AND its field flag on `api`,
+# so it appears in both tables and the value's shape decides.
+_PATH_FLAGS = ("--body-file", "--notes-file", "-F")
+_FIELD_FLAGS = ("-F", "--field")
+_KNOWN_FLAGS = frozenset(_PATH_FLAGS) | frozenset(_FIELD_FLAGS)
+
+# A heredoc puts the body INSIDE the command string, so `--body-file -` is
+# resolvable after all. The terminator may be quoted (no expansion), and
+# `<<-` allows a tab-indented terminator line.
+#
+# The lazy body is a scan for the terminator, not an ambiguous alternation,
+# so scar 0022's backtracking shape does not apply. The bound that does apply
+# is upstream: this runs only on a command the prefilter already matched.
+_HEREDOC_RE = re.compile(
+    r"<<-?[ \t]*(['\"]?)(\w+)\1[^\n]*\n(.*?)\n[ \t]*\2(?=\s|$)", re.DOTALL)
+
+
+def _split_attached(token):
+    """`--body-file=x` -> ("--body-file", "x", True); anything else is left
+    for the two-token form."""
+    if token.startswith("-") and "=" in token:
+        head, _, tail = token.partition("=")
+        if head in _KNOWN_FLAGS:
+            return head, tail, True
+    return token, "", False
+
+
+def _read_file(raw, base):
+    """The file's text, or the Unresolved cause that stopped it. Relative
+    paths resolve against the action's working directory, because that is
+    what the shell would have done."""
+    path = raw if os.path.isabs(raw) else os.path.join(base, raw)
+    try:
+        size = os.stat(path).st_size
+    except FileNotFoundError:
+        return Unresolved("file-missing", f"{raw} does not exist")
+    except OSError as exc:
+        return Unresolved("file-unreadable", f"{raw}: {exc.strerror or exc}")
+    if size > MAX_SUBJECT_FILE_BYTES:
+        return Unresolved(
+            "file-oversize",
+            f"{raw} is {size} bytes, over the {MAX_SUBJECT_FILE_BYTES} cap")
+    try:
+        with open(path, "rb") as handle:
+            data = handle.read()
+    except OSError as exc:
+        return Unresolved("file-unreadable", f"{raw}: {exc.strerror or exc}")
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return Unresolved("file-binary", f"{raw} is not UTF-8 text")
+
+
+def _subject_text(command, reads) -> str:
+    parts = [command, "\n", SUBJECT_SEPARATOR, "\n"]
+    for flag, source, text in reads:
+        parts.append(f"--- daimon:file {flag} {source} ---\n")
+        parts.append(text)
+        if text and not text.endswith("\n"):
+            parts.append("\n")
+    return "".join(parts)
+
+
+def resolve(command, cwd):
+    """The action's subject, or the cause daimon could not build one.
+
+    Subject = the command string, a separator, then every resolved file's
+    bytes under a header naming the flag it came from. Written to a 0o600
+    file in the SYSTEM temp dir: a file under ~/.daimon would have to be
+    declared in the surface registry and carry a deletion story, and this
+    one lives for the length of one exec.
+
+    Fail-closed and first-failure-wins. One argument daimon cannot read
+    means it cannot prove the subject clean, whatever the others say."""
+    if not isinstance(command, str):
+        return Unresolved("arg-form-unparsed", "the command is not a string")
+    base = cwd if isinstance(cwd, str) and cwd else os.getcwd()
+
+    heredocs: list = []
+
+    def _take(match):
+        heredocs.append(match.group(3))
+        return " "
+
+    try:
+        tokens = shlex.split(_HEREDOC_RE.sub(_take, command), posix=True)
+    except ValueError as exc:
+        return Unresolved("arg-form-unparsed",
+                          f"the command could not be tokenized: {exc}")
+
+    reads: list = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        flag, value, attached = _split_attached(token)
+        if flag not in _KNOWN_FLAGS:
+            # Row 6: a form outside the table is never assumed harmless.
+            if token == "-" and index and tokens[index - 1].startswith("-"):
+                return Unresolved(
+                    "arg-form-unparsed",
+                    f"{tokens[index - 1]} reads standard input in a form "
+                    "daimon does not parse")
+            if token.startswith("@") and len(token) > 1:
+                return Unresolved(
+                    "arg-form-unparsed",
+                    f"{token} names a file in a form daimon does not parse")
+            index += 1
+            continue
+        if not attached:
+            index += 1
+            if index >= len(tokens):
+                return Unresolved("arg-form-unparsed",
+                                  f"{flag} was given no value")
+            value = tokens[index]
+        index += 1
+
+        if value == "-":
+            if not heredocs:
+                return Unresolved(
+                    "stdin-pipe",
+                    f"{flag} reads standard input and the command carries no "
+                    "heredoc, so the bytes come from a process daimon cannot "
+                    "see")
+            reads.append((flag, "<heredoc>", heredocs.pop(0)))
+            continue
+        raw = value
+        if flag in _FIELD_FLAGS and "=" in value:
+            _, _, rhs = value.partition("=")
+            if not rhs.startswith("@"):
+                # A literal field value names no file. Reporting unresolved
+                # here would make every `gh api -F name=x` unprovable for
+                # nothing.
+                continue
+            raw = rhs[1:]
+        elif flag in _FIELD_FLAGS and value.startswith("@"):
+            raw = value[1:]
+        elif flag not in _PATH_FLAGS:
+            continue
+        if not raw:
+            return Unresolved("arg-form-unparsed",
+                              f"{flag} was given an empty path")
+        text = _read_file(raw, base)
+        if isinstance(text, Unresolved):
+            return text
+        reads.append((flag, raw, text))
+
+    handle_fd, path = tempfile.mkstemp(prefix="daimon-check-",
+                                       suffix=".subject")
+    try:
+        with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
+            handle.write(_subject_text(command, reads))
+        # mkstemp is already umask-independent; stated again so the mode is
+        # a property of this file rather than of the stdlib's default.
+        os.chmod(path, 0o600)
+    except OSError as exc:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        # Not a cause the spec's table anticipated: the subject could not be
+        # built because daimon's own temp dir failed. It is unresolved either
+        # way, and `check-crashed` is the cause that says the machinery, not
+        # the argument, is what went wrong.
+        return Unresolved("check-crashed",
+                          f"the subject file could not be written: {exc}")
+    return Subject(path, tuple((flag, source) for flag, source, _ in reads))
+
+
+def discard(subject) -> None:
+    """Remove a materialized subject. Never raises: it runs in a `finally`
+    on a path that already has an outcome to report."""
+    path = getattr(subject, "path", None)
+    if not isinstance(path, str) or not path:
+        return
+    try:
+        os.unlink(path)
+    except OSError:
+        pass

--- a/hook/checks_runtime.py
+++ b/hook/checks_runtime.py
@@ -23,11 +23,15 @@ why. Every function returns a value that says what happened, including when
 what happened is that daimon could not tell.
 """
 
+import hashlib
 import json
 import os
 import re
 import shlex
+import signal
+import subprocess
 import tempfile
+import time
 from pathlib import Path
 from typing import NamedTuple
 
@@ -74,6 +78,18 @@ class Subject(NamedTuple):
     `discard` once the check has run."""
     path: str
     files: tuple
+    command: str = ""
+
+
+class Outcome(NamedTuple):
+    """What one check run produced. `outcome` is one of the three spec 2.3
+    values and never folds: unresolved is not clean and is not a violation.
+    `exit_code` is -1 when no process ran."""
+    outcome: str
+    cause: str
+    reason: str
+    exit_code: int
+    duration_ms: int
 
 
 class Unresolved(NamedTuple):
@@ -406,7 +422,8 @@ def resolve(command, cwd):
         # the argument, is what went wrong.
         return Unresolved("check-crashed",
                           f"the subject file could not be written: {exc}")
-    return Subject(path, tuple((flag, source) for flag, source, _ in reads))
+    return Subject(path, tuple((flag, source) for flag, source, _ in reads),
+                   command)
 
 
 def discard(subject) -> None:
@@ -419,3 +436,141 @@ def discard(subject) -> None:
         os.unlink(path)
     except OSError:
         pass
+
+
+# ---- runner (spec 3.3) ----------------------------------------------------
+
+DEFAULT_TIMEOUT = 5.0
+
+
+def body_name(entry) -> str:
+    """The materialized body's file name: the ruling id and the head of the
+    hash it was ratified with. Two names for one ruling means the pin moved,
+    and the stale one is swept at the next sync."""
+    return f"{entry.get('ruling_id', '')}-{str(entry.get('sha256', ''))[:12]}.sh"
+
+
+def body_path(entry, base=None) -> Path:
+    return (Path(base) if base is not None else checks_dir()) / body_name(entry)
+
+
+def _kill_group(proc) -> None:
+    """start_new_session put the check in its own process group, so a body
+    that backgrounded something is killed WITH it. Killing only the direct
+    child leaves a grandchild holding the pipe, and the read that follows
+    blocks past the host's hook timeout, which is fail-open: the action
+    proceeds and nothing says why."""
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (OSError, AttributeError, ProcessLookupError):
+        try:
+            proc.kill()
+        except OSError:
+            pass
+
+
+def _first_line(text) -> str:
+    for line in (text or "").splitlines():
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+def run(entry_or_body, subject, *, cwd=None, timeout=None) -> Outcome:
+    """Run one check against one subject and say what happened.
+
+    `entry_or_body` is a manifest entry (whose `sha256` is re-checked against
+    the file on disk before exec) or a plain path to a body the caller just
+    materialized. Never raises: every path returns an Outcome, because the
+    hook that calls this fires before every shell action and an exception is
+    an action that proceeds with no record of why."""
+    started = time.monotonic()
+    try:
+        return _run(entry_or_body, subject, cwd, timeout, started)
+    except Exception as exc:  # noqa: BLE001 — an outcome is mandatory
+        return Outcome("unresolved", "check-crashed",
+                       f"the check runner failed: {type(exc).__name__}: {exc}",
+                       -1, int((time.monotonic() - started) * 1000))
+
+
+def _run(entry_or_body, subject, cwd, timeout, started) -> Outcome:
+    def out(outcome, cause, reason, exit_code=-1):
+        return Outcome(outcome, cause, reason, exit_code,
+                       int((time.monotonic() - started) * 1000))
+
+    ruling_id = ""
+    pinned = ""
+    if isinstance(entry_or_body, dict):
+        ruling_id = str(entry_or_body.get("ruling_id") or "")
+        pinned = str(entry_or_body.get("sha256") or "")
+        override = entry_or_body.get("body_path")
+        path = Path(override) if override else body_path(entry_or_body)
+    else:
+        path = Path(entry_or_body)
+
+    try:
+        body = path.read_bytes()
+    except OSError as exc:
+        return out("unresolved", "check-crashed",
+                   f"the check body could not be read: {exc.strerror or exc}")
+    if pinned and hashlib.sha256(body).hexdigest() != pinned:
+        # Someone edited the materialized body. Never a silent skip: an
+        # unresolved outcome is visible, a skip looks like a clean run.
+        return out("unresolved", "body-hash-mismatch",
+                   "the check body on disk is not the one this ruling was "
+                   "ratified with; run `daimon check sync`")
+
+    env = dict(os.environ)
+    env["DAIMON_CHECK_SUBJECT"] = str(getattr(subject, "path", "") or "")
+    env["DAIMON_CHECK_COMMAND"] = str(getattr(subject, "command", "") or "")
+    env["DAIMON_CHECK_RULING"] = ruling_id
+    budget = (float(timeout) if isinstance(timeout, (int, float))
+              and timeout > 0 else DEFAULT_TIMEOUT)
+
+    try:
+        proc = subprocess.Popen(
+            ["sh", str(path)],
+            cwd=str(cwd) if cwd else None,
+            env=env,
+            # Scar 0034: no stdin PIPE, so nothing here can close a pipe and
+            # make the communicate() below raise on a flush. /dev/null is
+            # also what keeps a body that reads stdin from blocking on an
+            # inherited terminal until the budget expires.
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return out("unresolved", "runtime-missing",
+                   "no POSIX sh on PATH, so no check can run on this host")
+    except OSError as exc:
+        return out("unresolved", "check-crashed",
+                   f"the check could not be started: {exc.strerror or exc}")
+
+    try:
+        _, err = proc.communicate(timeout=budget)
+    except subprocess.TimeoutExpired:
+        _kill_group(proc)
+        try:
+            proc.communicate(timeout=1)
+        except Exception:  # noqa: BLE001 — the outcome is already decided
+            pass
+        return out("unresolved", "check-timeout",
+                   f"the check did not finish within {budget:g}s")
+
+    code = proc.returncode
+    reason = _first_line(err)
+    if code == 0:
+        return out("clean", "", "", 0)
+    if code == 1:
+        return out("violation", "",
+                   reason or "the check reported a violation and gave no "
+                             "reason", 1)
+    # 126 and 127 land here with sh's own first stderr line, which is how a
+    # body that reaches outside itself becomes observable: the slice 1 path
+    # refusal catches a bare single-token path, and a one-line `sh /host.sh`
+    # passes it.
+    return out("unresolved", "check-crashed",
+               reason or f"the check exited {code}", code)

--- a/hook/checks_runtime.py
+++ b/hook/checks_runtime.py
@@ -61,6 +61,20 @@ MAX_SUBJECT_FILE_BYTES = 1024 * 1024
 # proceeds. This is the one known bound and it is documented as such.
 MATCH_INPUT_BYTES = 4096
 
+# The same bound at the resolver's door, which is the second way in. The
+# prefilter above reads a slice; the resolver has to TOKENIZE what it was
+# given, and shlex is superlinear in the length of a single argument.
+# Measured, with heredocs already stripped: 0.14s at 64 KiB, 5.3s at 512 KiB,
+# 21s at 1 MiB. The host hook timeout is 10s and it is fail-open, so a
+# resolver that outlives it lets the action through with no record at all.
+#
+# It counts the command AFTER heredoc bodies are removed, because those cost
+# nothing to skip: the expensive input is one long inline argument, a base64
+# blob or an expanded --body. A command above this is unresolved, never
+# allowed, because a command daimon declined to parse is one it can prove
+# nothing about.
+MAX_COMMAND_BYTES = 64 * 1024
+
 
 class Manifest(NamedTuple):
     """What `load_manifest` found. `reason` is empty when the manifest was
@@ -521,6 +535,15 @@ def resolve(command, cwd):
         return f" {_HEREDOC_MARK}{len(heredocs) - 1}\x00 "
 
     text = _HEREDOC_RE.sub(_take, command)
+    # Bounded BEFORE the lexer, which is the expensive part. Above the cap
+    # daimon declines rather than spending the host's whole hook budget on
+    # tokenizing one enormous argument and then being overtaken by a timeout
+    # that lets the action through.
+    if len(text.encode("utf-8", "replace")) > MAX_COMMAND_BYTES:
+        return Unresolved(
+            "arg-form-unparsed",
+            f"the command is too long to resolve within the check budget "
+            f"(over {MAX_COMMAND_BYTES} bytes with heredocs removed)")
     # Every heredoc BODY is gone by now, so a remaining newline separates two
     # commands exactly as a semicolon does. Spelling it as one lets a single
     # lexer pass find every boundary; the lexer folds a bare newline into

--- a/hook/checks_runtime.py
+++ b/hook/checks_runtime.py
@@ -273,6 +273,54 @@ _KNOWN_FLAGS = frozenset(_PATH_FLAGS) | frozenset(_FIELD_FLAGS)
 _HEREDOC_RE = re.compile(
     r"<<-?[ \t]*(['\"]?)(\w+)\1[^\n]*\n(.*?)\n[ \t]*\2(?=\s|$)", re.DOTALL)
 
+# A heredoc is replaced by a marker token rather than by whitespace, so the
+# token stream still says WHERE the redirect stood. NUL is in it because a
+# command string carrying one cannot be executed anyway, which makes a
+# collision with real text impossible rather than unlikely.
+_HEREDOC_MARK = "\x00daimon-heredoc-"
+
+# Tokens that end one simple command and begin the next. `&` is here for the
+# same reason the others are: what follows it is a different command, and a
+# heredoc on one side of it does not feed an argument on the other.
+_SEGMENT_BREAKS = frozenset({"&&", "||", ";", "|", "&"})
+
+
+def _heredoc_index(token):
+    """The heredoc a marker token stands for, or None for a real argument."""
+    if token.startswith(_HEREDOC_MARK) and token.endswith("\x00"):
+        try:
+            return int(token[len(_HEREDOC_MARK):-1])
+        except ValueError:
+            return None
+    return None
+
+
+def _segments(tokens):
+    """The command split into simple commands: (tokens, heredoc indexes, fed
+    by a pipe).
+
+    A heredoc redirect belongs to the command it is attached to, and nothing
+    else in the string can claim it. Without this split, `cat <<EOF ... EOF`
+    followed by a governed command hands the governed command text it never
+    reads — and if that text is clean, the record says the real body was
+    proven safe."""
+    out = []
+    current: list = []
+    marks: list = []
+    piped = False
+    for token in tokens:
+        if token in _SEGMENT_BREAKS:
+            out.append((current, marks, piped))
+            current, marks, piped = [], [], token == "|"
+            continue
+        index = _heredoc_index(token)
+        if index is None:
+            current.append(token)
+        else:
+            marks.append(index)
+    out.append((current, marks, piped))
+    return out
+
 
 def _split_attached(token):
     """`--body-file=x` -> ("--body-file", "x", True); anything else is left
@@ -361,39 +409,17 @@ def _subject_text(command, reads) -> str:
     return "".join(parts)
 
 
-def resolve(command, cwd):
-    """The action's subject, or the cause daimon could not build one.
+def _resolve_segment(tokens, marks, piped, heredocs, base, reads):
+    """Read one simple command's file arguments into `reads`.
 
-    Subject = the command string, a separator, then every resolved file's
-    bytes under a header naming the flag it came from. Written to a 0o600
-    file in the SYSTEM temp dir: a file under ~/.daimon would have to be
-    declared in the surface registry and carry a deletion story, and this
-    one lives for the length of one exec.
-
-    Fail-closed and first-failure-wins. One argument daimon cannot read
-    means it cannot prove the subject clean, whatever the others say."""
-    if not isinstance(command, str):
-        return Unresolved("arg-form-unparsed", "the command is not a string")
-    base = cwd if isinstance(cwd, str) and cwd else os.getcwd()
-
-    heredocs: list = []
-
-    def _take(match):
-        heredocs.append(match.group(3))
-        return " "
-
-    try:
-        tokens = shlex.split(_HEREDOC_RE.sub(_take, command), posix=True)
-    except ValueError as exc:
-        return Unresolved("arg-form-unparsed",
-                          f"the command could not be tokenized: {exc}")
-
-    # Counted before the walk: binding a heredoc is only safe when there is
-    # exactly one candidate on each side.
+    Returns None when the segment is fine, or the Unresolved that stopped it.
+    A heredoc binds only from `marks`, which holds the redirects that stood
+    inside THIS command, so text belonging to a neighbour can never be
+    presented as what the governed command reads."""
+    # Counted per segment: binding is only safe with exactly one candidate on
+    # each side, and the sides are this command's, not the whole string's.
     consumers = sum(1 for flag, value, _ in _walk(tokens)
                     if flag is not None and value == "-")
-
-    reads: list = []
     for flag, value, previous in _walk(tokens):
         if flag is None:
             # Row 6: a form outside the table is never assumed harmless.
@@ -413,32 +439,31 @@ def resolve(command, cwd):
                               f"{flag} was given no value")
 
         if value == "-":
-            if not heredocs:
-                return Unresolved(
-                    "stdin-pipe",
-                    f"{flag} reads standard input and the command carries no "
-                    "heredoc, so the bytes come from a process daimon cannot "
-                    "see")
-            if len(heredocs) != 1 or consumers != 1:
-                # Which heredoc feeds which argument is a question this
-                # tokenizer cannot answer: it keeps neither the order nor the
-                # redirections. Handing over the first one guesses, and a
-                # wrong guess builds the subject from unrelated text and then
-                # reports clean on a body nothing ever read.
-                #
-                # KNOWN RESIDUAL: one heredoc belonging to an EARLIER command
-                # plus one argument reading standard input counts as one and
-                # one, so it still binds the wrong text. Closing that needs
-                # the heredoc's offset in the raw command matched against the
-                # offset of the argument that consumes it, which is thrown
-                # away above. Pinned by a test that says so out loud.
+            if len(marks) == 1 and consumers == 1:
+                reads.append((flag, "<heredoc>", heredocs[marks[0]]))
+                continue
+            if not marks:
+                if piped:
+                    return Unresolved(
+                        "stdin-pipe",
+                        f"{flag} reads standard input and a pipe fills it, so "
+                        "the bytes come from a process daimon cannot see")
+                # A heredoc elsewhere in the string belongs to the command it
+                # is attached to, never to this one. Borrowing it would build
+                # the subject from text this command never reads, and if THAT
+                # text is clean the record says the real body was proven safe.
                 return Unresolved(
                     "arg-form-unparsed",
-                    f"the command carries {len(heredocs)} heredoc(s) and "
-                    f"{consumers} argument(s) reading standard input; daimon "
-                    "binds one to one or not at all")
-            reads.append((flag, "<heredoc>", heredocs[0]))
-            continue
+                    f"{flag} reads standard input and this command carries no "
+                    "heredoc of its own, so daimon cannot see what fills it")
+            # Inside one command the counts still have to be one and one:
+            # which heredoc feeds which argument is not something the token
+            # stream answers, and a guess is the same defect one scope down.
+            return Unresolved(
+                "arg-form-unparsed",
+                f"this command carries {len(marks)} heredoc(s) and "
+                f"{consumers} argument(s) reading standard input; daimon "
+                "binds one to one or not at all")
         raw = value
         if flag in _FIELD_FLAGS and "=" in value:
             _, _, rhs = value.partition("=")
@@ -459,6 +484,55 @@ def resolve(command, cwd):
         if isinstance(text, Unresolved):
             return text
         reads.append((flag, raw, text))
+    return None
+
+
+def resolve(command, cwd):
+    """The action's subject, or the cause daimon could not build one.
+
+    Subject = the command string, a separator, then every resolved file's
+    bytes under a header naming the flag it came from. Written to a 0o600
+    file in the SYSTEM temp dir: a file under ~/.daimon would have to be
+    declared in the surface registry and carry a deletion story, and this
+    one lives for the length of one exec.
+
+    Fail-closed and first-failure-wins. One argument daimon cannot read
+    means it cannot prove the subject clean, whatever the others say."""
+    if not isinstance(command, str):
+        return Unresolved("arg-form-unparsed", "the command is not a string")
+    base = cwd if isinstance(cwd, str) and cwd else os.getcwd()
+
+    heredocs: list = []
+
+    def _take(match):
+        heredocs.append(match.group(3))
+        return f" {_HEREDOC_MARK}{len(heredocs) - 1}\x00 "
+
+    text = _HEREDOC_RE.sub(_take, command)
+    # Every heredoc BODY is gone by now, so a remaining newline separates two
+    # commands exactly as a semicolon does. Spelling it as one lets a single
+    # lexer pass find every boundary; the lexer folds a bare newline into
+    # whitespace and would otherwise run two commands together. A newline
+    # inside a quoted argument is rewritten too, which changes that argument's
+    # text and nothing daimon reads from it.
+    text = text.replace("\r\n", "\n").replace("\n", " ; ")
+    try:
+        # punctuation_chars makes the shell operators their own tokens while
+        # keeping quotes intact, which is what the segment split needs.
+        lexer = shlex.shlex(text, posix=True, punctuation_chars=True)
+        lexer.whitespace_split = True
+        lexer.commenters = ""  # shlex.split's setting: `#` is not a comment
+        tokens = list(lexer)
+    except ValueError as exc:
+        return Unresolved("arg-form-unparsed",
+                          f"the command could not be tokenized: {exc}")
+
+    reads: list = []
+    for seg_tokens, marks, piped in _segments(tokens):
+        outcome = _resolve_segment(seg_tokens, marks, piped, heredocs, base,
+                                   reads)
+        if outcome is not None:
+            return outcome
 
     handle_fd, path = tempfile.mkstemp(prefix="daimon-check-",
                                        suffix=".subject")

--- a/hook/checks_runtime.py
+++ b/hook/checks_runtime.py
@@ -276,12 +276,53 @@ _HEREDOC_RE = re.compile(
 
 def _split_attached(token):
     """`--body-file=x` -> ("--body-file", "x", True); anything else is left
-    for the two-token form."""
+    for the two-token form.
+
+    The single-dash case comes FIRST and does not need an `=`. pflag, the
+    flag library gh uses, accepts a shorthand value attached to its flag, so
+    `-Fbody.md` is the same command as `-F body.md` and `-Fkey=@p` the same
+    as `-F key=@p`. Splitting here rather than at the use sites means the
+    field and the dash rules below apply to both spellings unchanged: an
+    attached form daimon did not split fell through every branch and left
+    the subject holding only the command string, which reports CLEAN for a
+    file that was never opened."""
+    if (token.startswith("-") and not token.startswith("--")
+            and len(token) > 2 and token[:2] in _KNOWN_FLAGS):
+        value = token[2:]
+        # pflag treats a leading `=` after a shorthand as the separator, so
+        # `-F=body.md` names the file body.md and not a field with an empty
+        # name. Following it keeps the two spellings one command.
+        return token[:2], value[1:] if value.startswith("=") else value, True
     if token.startswith("-") and "=" in token:
         head, _, tail = token.partition("=")
         if head in _KNOWN_FLAGS:
             return head, tail, True
     return token, "", False
+
+
+def _walk(tokens):
+    """(flag, value, previous token) for each step of the command.
+
+    `flag` is None for a token that names no known flag, and `value` is None
+    when a known flag ran off the end with nothing after it. One generator,
+    two readers: the dash-consumer count below and the resolver itself, so
+    the two can never disagree about what a token means."""
+    index = 0
+    while index < len(tokens):
+        previous = tokens[index - 1] if index else ""
+        flag, value, attached = _split_attached(tokens[index])
+        if flag not in _KNOWN_FLAGS:
+            index += 1
+            yield None, tokens[index - 1], previous
+            continue
+        if not attached:
+            index += 1
+            if index >= len(tokens):
+                yield flag, None, previous
+                return
+            value = tokens[index]
+        index += 1
+        yield flag, value, previous
 
 
 def _read_file(raw, base):
@@ -348,30 +389,23 @@ def resolve(command, cwd):
                           f"the command could not be tokenized: {exc}")
 
     reads: list = []
-    index = 0
-    while index < len(tokens):
-        token = tokens[index]
-        flag, value, attached = _split_attached(token)
-        if flag not in _KNOWN_FLAGS:
+    for flag, value, previous in _walk(tokens):
+        if flag is None:
             # Row 6: a form outside the table is never assumed harmless.
-            if token == "-" and index and tokens[index - 1].startswith("-"):
+            token = value
+            if token == "-" and previous.startswith("-"):
                 return Unresolved(
                     "arg-form-unparsed",
-                    f"{tokens[index - 1]} reads standard input in a form "
-                    "daimon does not parse")
+                    f"{previous} reads standard input in a form daimon does "
+                    "not parse")
             if token.startswith("@") and len(token) > 1:
                 return Unresolved(
                     "arg-form-unparsed",
                     f"{token} names a file in a form daimon does not parse")
-            index += 1
             continue
-        if not attached:
-            index += 1
-            if index >= len(tokens):
-                return Unresolved("arg-form-unparsed",
-                                  f"{flag} was given no value")
-            value = tokens[index]
-        index += 1
+        if value is None:
+            return Unresolved("arg-form-unparsed",
+                              f"{flag} was given no value")
 
         if value == "-":
             if not heredocs:

--- a/hook/checks_runtime.py
+++ b/hook/checks_runtime.py
@@ -389,6 +389,12 @@ def _read_file(raw, base):
         return Unresolved("file-missing", f"{raw} does not exist")
     except OSError as exc:
         return Unresolved("file-unreadable", f"{raw}: {exc.strerror or exc}")
+    except ValueError as exc:
+        # A NUL in the path: `open` rejects it before the OS ever sees it, and
+        # it raises ValueError rather than OSError, so it walks straight past
+        # the clause above. The command string comes from a host payload and
+        # can carry one.
+        return Unresolved("file-unreadable", f"{raw}: {exc}")
     if len(data) > MAX_SUBJECT_FILE_BYTES:
         return Unresolved(
             "file-oversize",
@@ -416,6 +422,12 @@ def _resolve_segment(tokens, marks, piped, heredocs, base, reads):
     A heredoc binds only from `marks`, which holds the redirects that stood
     inside THIS command, so text belonging to a neighbour can never be
     presented as what the governed command reads."""
+    # A marker token is minted by `_take` and nothing else, but the command
+    # string arrives from a host payload and can spell one out. An index no
+    # heredoc answers to is simply not a heredoc; without this the bind below
+    # reads past the end of the list and the resolver raises, which is the
+    # one thing this module promises never to do.
+    marks = [index for index in marks if 0 <= index < len(heredocs)]
     # Counted per segment: binding is only safe with exactly one candidate on
     # each side, and the sides are this command's, not the whole string's.
     consumers = sum(1 for flag, value, _ in _walk(tokens)
@@ -534,9 +546,13 @@ def resolve(command, cwd):
         if outcome is not None:
             return outcome
 
-    handle_fd, path = tempfile.mkstemp(prefix="daimon-check-",
-                                       suffix=".subject")
+    # mkstemp inside the try, not before it: a temp dir that is full or
+    # read-only fails HERE, and a raise from this function is an action that
+    # proceeds with no record of why.
+    path = ""
     try:
+        handle_fd, path = tempfile.mkstemp(prefix="daimon-check-",
+                                           suffix=".subject")
         with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
             handle.write(_subject_text(command, reads))
         # mkstemp is already umask-independent; stated again so the mode is
@@ -544,7 +560,8 @@ def resolve(command, cwd):
         os.chmod(path, 0o600)
     except OSError as exc:
         try:
-            os.unlink(path)
+            if path:
+                os.unlink(path)
         except OSError:
             pass
         # Not a cause the spec's table anticipated: the subject could not be

--- a/hook/checks_runtime.py
+++ b/hook/checks_runtime.py
@@ -388,6 +388,11 @@ def resolve(command, cwd):
         return Unresolved("arg-form-unparsed",
                           f"the command could not be tokenized: {exc}")
 
+    # Counted before the walk: binding a heredoc is only safe when there is
+    # exactly one candidate on each side.
+    consumers = sum(1 for flag, value, _ in _walk(tokens)
+                    if flag is not None and value == "-")
+
     reads: list = []
     for flag, value, previous in _walk(tokens):
         if flag is None:
@@ -414,7 +419,25 @@ def resolve(command, cwd):
                     f"{flag} reads standard input and the command carries no "
                     "heredoc, so the bytes come from a process daimon cannot "
                     "see")
-            reads.append((flag, "<heredoc>", heredocs.pop(0)))
+            if len(heredocs) != 1 or consumers != 1:
+                # Which heredoc feeds which argument is a question this
+                # tokenizer cannot answer: it keeps neither the order nor the
+                # redirections. Handing over the first one guesses, and a
+                # wrong guess builds the subject from unrelated text and then
+                # reports clean on a body nothing ever read.
+                #
+                # KNOWN RESIDUAL: one heredoc belonging to an EARLIER command
+                # plus one argument reading standard input counts as one and
+                # one, so it still binds the wrong text. Closing that needs
+                # the heredoc's offset in the raw command matched against the
+                # offset of the argument that consumes it, which is thrown
+                # away above. Pinned by a test that says so out loud.
+                return Unresolved(
+                    "arg-form-unparsed",
+                    f"the command carries {len(heredocs)} heredoc(s) and "
+                    f"{consumers} argument(s) reading standard input; daimon "
+                    "binds one to one or not at all")
+            reads.append((flag, "<heredoc>", heredocs[0]))
             continue
         raw = value
         if flag in _FIELD_FLAGS and "=" in value:

--- a/hook/checks_runtime.py
+++ b/hook/checks_runtime.py
@@ -330,21 +330,21 @@ def _read_file(raw, base):
     paths resolve against the action's working directory, because that is
     what the shell would have done."""
     path = raw if os.path.isabs(raw) else os.path.join(base, raw)
+    # One answer about one file. A stat that decides the cap and an open that
+    # happens afterwards are two answers, and they disagree whenever the file
+    # changes in between; reading one byte past the cap and judging THAT
+    # cannot disagree with itself, and it never holds more than the cap.
     try:
-        size = os.stat(path).st_size
+        with open(path, "rb") as handle:
+            data = handle.read(MAX_SUBJECT_FILE_BYTES + 1)
     except FileNotFoundError:
         return Unresolved("file-missing", f"{raw} does not exist")
     except OSError as exc:
         return Unresolved("file-unreadable", f"{raw}: {exc.strerror or exc}")
-    if size > MAX_SUBJECT_FILE_BYTES:
+    if len(data) > MAX_SUBJECT_FILE_BYTES:
         return Unresolved(
             "file-oversize",
-            f"{raw} is {size} bytes, over the {MAX_SUBJECT_FILE_BYTES} cap")
-    try:
-        with open(path, "rb") as handle:
-            data = handle.read()
-    except OSError as exc:
-        return Unresolved("file-unreadable", f"{raw}: {exc.strerror or exc}")
+            f"{raw} is over the {MAX_SUBJECT_FILE_BYTES} byte cap")
     try:
         return data.decode("utf-8")
     except UnicodeDecodeError:
@@ -499,6 +499,15 @@ def discard(subject) -> None:
 
 DEFAULT_TIMEOUT = 5.0
 
+# What a check body inherits, plus every LC_* and the three DAIMON_CHECK_*
+# variables the runner sets. A ratified body is human-armed and runs as the
+# user, so this is not a sandbox and does not pretend to be one. It is a blast
+# radius: the body's job is to read one subject file, and handing it every
+# token in the host session widens what a mistake in someone else's script can
+# reach, for nothing. PATH and HOME stay because a body that cannot find its
+# own tools reports check-crashed and looks like a defect in the check.
+_ENV_KEEP = frozenset({"PATH", "HOME", "LANG", "TMPDIR"})
+
 
 def body_name(entry) -> str:
     """The materialized body's file name: the ruling id and the head of the
@@ -577,7 +586,8 @@ def _run(entry_or_body, subject, cwd, timeout, started) -> Outcome:
                    "the check body on disk is not the one this ruling was "
                    "ratified with; run `daimon check sync`")
 
-    env = dict(os.environ)
+    env = {name: value for name, value in os.environ.items()
+           if name in _ENV_KEEP or name.startswith("LC_")}
     env["DAIMON_CHECK_SUBJECT"] = str(getattr(subject, "path", "") or "")
     env["DAIMON_CHECK_COMMAND"] = str(getattr(subject, "command", "") or "")
     env["DAIMON_CHECK_RULING"] = ruling_id

--- a/plugin/daimon_briefing/_hooks/checks_runtime.py
+++ b/plugin/daimon_briefing/_hooks/checks_runtime.py
@@ -1,0 +1,203 @@
+"""The #943 check runtime — stdlib only, loadable by a standalone hook.
+
+A host's pre-action hook runs in whatever interpreter the host launched, with
+no venv and no `daimon_briefing` on `sys.path`. So the part of the check
+machinery that runs INSIDE a hook lives here, and this file ships
+byte-identical into `_hooks/` and `hook/` the way `redact.py` does.
+
+Two rules follow from that, both scars:
+
+  * stdlib ONLY (scar 0049). `from . import config` looks completely ordinary
+    from inside the package, passes every local test, and breaks every host
+    hook. The path accessors below are therefore hand-copied mirrors of
+    `config.checks_dir` / `config.log_dir`, and a probe table in
+    `test_checks_runtime.py` asserts behavioral equality against the config
+    functions rather than against literals.
+  * the canonical file is THIS one and the copies are derivatives (scar 0049
+    again, which reverses scar 0044's direction for the adapter scripts).
+    Edit here, then run `scripts/sync_hooks.py`.
+
+Nothing here raises. The hook that calls it fires before every shell action
+on the host, so an exception is an action that proceeds with no record of
+why. Every function returns a value that says what happened, including when
+what happened is that daimon could not tell.
+"""
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import NamedTuple
+
+MANIFEST_NAME = "manifest.json"
+FIRING_LOG_NAME = "checks.jsonl"
+
+# Scar 0022 applied to the SUBJECT rather than the pattern. `check.match` is
+# caller-supplied and capped at 200 bytes, which bounds its length and says
+# nothing about its backtracking. Bounding the string it runs against is what
+# keeps a pathological pair from outliving the host's hook timeout, and that
+# timeout is fail-open: a hook that reaches it does not block, the tool
+# proceeds. This is the one known bound and it is documented as such.
+MATCH_INPUT_BYTES = 4096
+
+
+class Manifest(NamedTuple):
+    """What `load_manifest` found. `reason` is empty when the manifest was
+    read; otherwise it names the state for the firing log, because "no
+    manifest" and "a manifest daimon can no longer parse" are different
+    facts and folding them would report an unwritten install as a broken
+    one."""
+    entries: list
+    reason: str
+
+
+# ---- config mirrors (scar 0043: copy the QUIRKS, not the intent) ----------
+
+
+def _env_file_path() -> Path:
+    """Mirror of daimon_briefing.config._env_file_path."""
+    raw = os.environ.get("DAIMON_ENV_FILE")
+    return Path(raw).expanduser() if raw else Path.home() / ".daimon" / "env"
+
+
+def _env_file_values() -> dict:
+    """Mirror of daimon_briefing.config._file_values — KEY=VALUE lines, with
+    the `export ` prefix, surrounding quotes, blank lines and `#` comments
+    tolerated. Copied rather than imported because hooks run standalone;
+    config.py is the CANONICAL form and this copy must follow it line-form
+    for line-form."""
+    try:
+        text = _env_file_path().read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return {}
+    values = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
+        key, _, val = line.partition("=")
+        key, val = key.strip(), val.strip()
+        if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+            val = val[1:-1]
+        if key:
+            values[key] = val
+    return values
+
+
+def _config_get(name: str) -> str:
+    """Mirror of daimon_briefing.config._get: process env WINS, env file is
+    the fallback. Present-but-empty in the process env is a value and
+    shadows the file, exactly as on the package side."""
+    val = os.environ.get(name)
+    if val is not None:
+        return val
+    return _env_file_values().get(name) or ""
+
+
+def checks_dir() -> Path:
+    """Where the manifest and the materialized bodies live, resolved the way
+    the WRITER resolves it.
+
+    `checks.sync` writes through config.checks_dir(); this reads. A path
+    resolved any other way here has the hook reading an empty directory
+    while the CLI reports N checks armed, and neither side can see the
+    split — the same writer/reader gap scar 0043 records one directory over.
+    So this reproduces config.checks_dir() exactly, including the parts that
+    look like bugs: no strip (so "   " is a relative directory named three
+    spaces, and the reader must agree), and the env-file fallback, which is
+    the channel a GUI-launched host actually uses."""
+    raw = _config_get("DAIMON_CHECKS_DIR")
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".daimon" / "checks"
+
+
+def log_dir() -> Path:
+    """Mirror of config.log_dir(), same reasoning as checks_dir(): the
+    firing log sits under it and `daimon forget` purges through the config
+    accessor."""
+    raw = _config_get("DAIMON_LOG_DIR")
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".daimon" / "logs"
+
+
+# ---- manifest -------------------------------------------------------------
+
+
+def load_manifest(path=None) -> Manifest:
+    """Read the armed-check manifest. Never raises, never partially fails.
+
+    An absent manifest is the ordinary state of an install that has armed
+    nothing, so it reads as empty with `no-manifest` rather than as an
+    error. A manifest that exists and cannot be parsed is a different fact
+    and gets its own reason: both allow the action, and only one of them
+    means daimon wrote something it can no longer read."""
+    target = Path(path) if path is not None else checks_dir() / MANIFEST_NAME
+    try:
+        raw = target.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return Manifest([], "no-manifest")
+    except (OSError, UnicodeDecodeError):
+        return Manifest([], "manifest-unreadable")
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return Manifest([], "manifest-unreadable")
+    if not isinstance(data, list):
+        return Manifest([], "manifest-unreadable")
+    # A row that is not an object is dropped rather than fatal: one bad row
+    # must not disarm every other project's checks.
+    return Manifest([row for row in data if isinstance(row, dict)], "")
+
+
+def armed_for(cwd, manifest) -> list:
+    """The manifest entries armed for this working directory.
+
+    `project_dir` on an entry is already the resolved physical root (the
+    writer runs it through config.resolve_project_dir, which walks to the
+    git toplevel). Here the cwd is realpath'd to meet it, so a project
+    reached through a symlink still arms, and the prefix test carries an
+    explicit separator so /srv/appliance is not governed by a ruling made
+    for /srv/app."""
+    entries = getattr(manifest, "entries", manifest)
+    if not isinstance(entries, list) or not isinstance(cwd, str) or not cwd:
+        return []
+    try:
+        here = os.path.realpath(cwd)
+    except (OSError, ValueError):
+        return []
+    out = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        root = entry.get("project_dir")
+        if not isinstance(root, str) or not root:
+            continue
+        bounded = root if root.endswith(os.sep) else root + os.sep
+        if here == root or here.startswith(bounded):
+            out.append(entry)
+    return out
+
+
+def matches(entry, command) -> bool:
+    """The cheap prefilter: does this entry's regex hit the command string?
+
+    Unanchored and case-sensitive, per the spec, and read over at most
+    MATCH_INPUT_BYTES bytes of the command. An unusable pattern matches
+    nothing instead of raising: a hand-edited manifest can carry a regex the
+    writer would have refused, and that must not become a traceback on every
+    shell action."""
+    if not isinstance(entry, dict) or not isinstance(command, str):
+        return False
+    pattern = entry.get("match")
+    if not isinstance(pattern, str) or not pattern:
+        return False
+    subject = command.encode("utf-8", "replace")[:MATCH_INPUT_BYTES].decode(
+        "utf-8", "ignore")
+    try:
+        return re.search(pattern, subject) is not None
+    except (re.error, RecursionError):
+        return False

--- a/plugin/daimon_briefing/_hooks/checks_runtime.py
+++ b/plugin/daimon_briefing/_hooks/checks_runtime.py
@@ -574,3 +574,56 @@ def _run(entry_or_body, subject, cwd, timeout, started) -> Outcome:
     # passes it.
     return out("unresolved", "check-crashed",
                reason or f"the check exited {code}", code)
+
+
+# ---- firing log (spec 3.4) ------------------------------------------------
+
+# The whole row, and nothing else. Spec 3.4: no command text, no paths, no
+# subject. `decision_emitted` is what the hook actually wrote to the host, so
+# a reader can tell a check that RAN from a check that was honored — only
+# `deny` under `enforce` closes that gap.
+FIRING_KEYS = ("ts", "ruling_id", "host", "mode", "outcome", "cause",
+               "decision_emitted", "duration_ms")
+
+# Every value `cause` may hold. The manifest reasons join the runner's causes
+# because "nothing was armed here" is a firing the stats surface has to be
+# able to count, and it is the difference between "armed, never fired" and
+# "clean".
+LOG_CAUSES = CAUSES | {"no-manifest", "no-match", "manifest-unreadable"}
+
+
+def log_firing(row, path=None) -> bool:
+    """Append one row to the firing log. Returns whether it landed.
+
+    The row is PROJECTED onto FIRING_KEYS rather than filtered, so a caller
+    that hands over the whole outcome record (reason and command included)
+    cannot leak them here. `cause` is the one field where free text could
+    otherwise reach a log declared to hold no plaintext, so a value outside
+    the declared set is recorded as `unknown`: the state is still signalled,
+    it just cannot bring a path along.
+
+    Never raises. A hook that cannot write its log still has an action to
+    allow or deny, and losing the decision over the record would be the
+    wrong trade."""
+    try:
+        source = row if isinstance(row, dict) else {}
+        cause = str(source.get("cause") or "")
+        stamped = {
+            "ts": str(source.get("ts") or "") or time.strftime(
+                "%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "ruling_id": str(source.get("ruling_id") or ""),
+            "host": str(source.get("host") or ""),
+            "mode": str(source.get("mode") or ""),
+            "outcome": str(source.get("outcome") or ""),
+            "cause": cause if cause in LOG_CAUSES else (cause and "unknown"),
+            "decision_emitted": str(source.get("decision_emitted") or ""),
+            "duration_ms": int(source.get("duration_ms") or 0),
+        }
+        target = (Path(path) if path is not None
+                  else log_dir() / FIRING_LOG_NAME)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(stamped, ensure_ascii=False) + "\n")
+        return True
+    except (OSError, ValueError, TypeError):
+        return False

--- a/plugin/daimon_briefing/_hooks/checks_runtime.py
+++ b/plugin/daimon_briefing/_hooks/checks_runtime.py
@@ -26,11 +26,28 @@ what happened is that daimon could not tell.
 import json
 import os
 import re
+import shlex
+import tempfile
 from pathlib import Path
 from typing import NamedTuple
 
 MANIFEST_NAME = "manifest.json"
 FIRING_LOG_NAME = "checks.jsonl"
+
+# Spec 2.3. `unresolved` is one outcome with many causes, and the set is
+# closed: a cause outside it means a code path invented a state no surface
+# knows how to render.
+CAUSES = frozenset({
+    "file-missing", "file-unreadable", "file-oversize", "file-binary",
+    "stdin-pipe", "arg-form-unparsed", "check-timeout", "check-crashed",
+    "body-hash-mismatch", "runtime-missing",
+})
+
+# A file argument daimon will read into the subject. Above this it reports
+# file-oversize rather than paying to read it: the point of the cap is that
+# the hook's budget is spent before the host's, not that large files are
+# suspicious.
+MAX_SUBJECT_FILE_BYTES = 1024 * 1024
 
 # Scar 0022 applied to the SUBJECT rather than the pattern. `check.match` is
 # caller-supplied and capped at 200 bytes, which bounds its length and says
@@ -48,6 +65,22 @@ class Manifest(NamedTuple):
     facts and folding them would report an unwritten install as a broken
     one."""
     entries: list
+    reason: str
+
+
+class Subject(NamedTuple):
+    """A materialized subject: the command string plus every file argument
+    daimon could read. `path` is a temp file the CALLER must hand back to
+    `discard` once the check has run."""
+    path: str
+    files: tuple
+
+
+class Unresolved(NamedTuple):
+    """Daimon could not prove the subject clean. Never rendered as clean and
+    never counted as a violation. `reason` is for a human and may name a
+    path; the firing log carries the cause and never the reason."""
+    cause: str
     reason: str
 
 
@@ -201,3 +234,188 @@ def matches(entry, command) -> bool:
         return re.search(pattern, subject) is not None
     except (re.error, RecursionError):
         return False
+
+
+# ---- resolver (spec 3.2) --------------------------------------------------
+
+SUBJECT_SEPARATOR = "--- daimon:subject ---"
+
+# Flags whose value is a path to read. `-F` is gh's short form of
+# --body-file on `pr create` / `issue create` AND its field flag on `api`,
+# so it appears in both tables and the value's shape decides.
+_PATH_FLAGS = ("--body-file", "--notes-file", "-F")
+_FIELD_FLAGS = ("-F", "--field")
+_KNOWN_FLAGS = frozenset(_PATH_FLAGS) | frozenset(_FIELD_FLAGS)
+
+# A heredoc puts the body INSIDE the command string, so `--body-file -` is
+# resolvable after all. The terminator may be quoted (no expansion), and
+# `<<-` allows a tab-indented terminator line.
+#
+# The lazy body is a scan for the terminator, not an ambiguous alternation,
+# so scar 0022's backtracking shape does not apply. The bound that does apply
+# is upstream: this runs only on a command the prefilter already matched.
+_HEREDOC_RE = re.compile(
+    r"<<-?[ \t]*(['\"]?)(\w+)\1[^\n]*\n(.*?)\n[ \t]*\2(?=\s|$)", re.DOTALL)
+
+
+def _split_attached(token):
+    """`--body-file=x` -> ("--body-file", "x", True); anything else is left
+    for the two-token form."""
+    if token.startswith("-") and "=" in token:
+        head, _, tail = token.partition("=")
+        if head in _KNOWN_FLAGS:
+            return head, tail, True
+    return token, "", False
+
+
+def _read_file(raw, base):
+    """The file's text, or the Unresolved cause that stopped it. Relative
+    paths resolve against the action's working directory, because that is
+    what the shell would have done."""
+    path = raw if os.path.isabs(raw) else os.path.join(base, raw)
+    try:
+        size = os.stat(path).st_size
+    except FileNotFoundError:
+        return Unresolved("file-missing", f"{raw} does not exist")
+    except OSError as exc:
+        return Unresolved("file-unreadable", f"{raw}: {exc.strerror or exc}")
+    if size > MAX_SUBJECT_FILE_BYTES:
+        return Unresolved(
+            "file-oversize",
+            f"{raw} is {size} bytes, over the {MAX_SUBJECT_FILE_BYTES} cap")
+    try:
+        with open(path, "rb") as handle:
+            data = handle.read()
+    except OSError as exc:
+        return Unresolved("file-unreadable", f"{raw}: {exc.strerror or exc}")
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return Unresolved("file-binary", f"{raw} is not UTF-8 text")
+
+
+def _subject_text(command, reads) -> str:
+    parts = [command, "\n", SUBJECT_SEPARATOR, "\n"]
+    for flag, source, text in reads:
+        parts.append(f"--- daimon:file {flag} {source} ---\n")
+        parts.append(text)
+        if text and not text.endswith("\n"):
+            parts.append("\n")
+    return "".join(parts)
+
+
+def resolve(command, cwd):
+    """The action's subject, or the cause daimon could not build one.
+
+    Subject = the command string, a separator, then every resolved file's
+    bytes under a header naming the flag it came from. Written to a 0o600
+    file in the SYSTEM temp dir: a file under ~/.daimon would have to be
+    declared in the surface registry and carry a deletion story, and this
+    one lives for the length of one exec.
+
+    Fail-closed and first-failure-wins. One argument daimon cannot read
+    means it cannot prove the subject clean, whatever the others say."""
+    if not isinstance(command, str):
+        return Unresolved("arg-form-unparsed", "the command is not a string")
+    base = cwd if isinstance(cwd, str) and cwd else os.getcwd()
+
+    heredocs: list = []
+
+    def _take(match):
+        heredocs.append(match.group(3))
+        return " "
+
+    try:
+        tokens = shlex.split(_HEREDOC_RE.sub(_take, command), posix=True)
+    except ValueError as exc:
+        return Unresolved("arg-form-unparsed",
+                          f"the command could not be tokenized: {exc}")
+
+    reads: list = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        flag, value, attached = _split_attached(token)
+        if flag not in _KNOWN_FLAGS:
+            # Row 6: a form outside the table is never assumed harmless.
+            if token == "-" and index and tokens[index - 1].startswith("-"):
+                return Unresolved(
+                    "arg-form-unparsed",
+                    f"{tokens[index - 1]} reads standard input in a form "
+                    "daimon does not parse")
+            if token.startswith("@") and len(token) > 1:
+                return Unresolved(
+                    "arg-form-unparsed",
+                    f"{token} names a file in a form daimon does not parse")
+            index += 1
+            continue
+        if not attached:
+            index += 1
+            if index >= len(tokens):
+                return Unresolved("arg-form-unparsed",
+                                  f"{flag} was given no value")
+            value = tokens[index]
+        index += 1
+
+        if value == "-":
+            if not heredocs:
+                return Unresolved(
+                    "stdin-pipe",
+                    f"{flag} reads standard input and the command carries no "
+                    "heredoc, so the bytes come from a process daimon cannot "
+                    "see")
+            reads.append((flag, "<heredoc>", heredocs.pop(0)))
+            continue
+        raw = value
+        if flag in _FIELD_FLAGS and "=" in value:
+            _, _, rhs = value.partition("=")
+            if not rhs.startswith("@"):
+                # A literal field value names no file. Reporting unresolved
+                # here would make every `gh api -F name=x` unprovable for
+                # nothing.
+                continue
+            raw = rhs[1:]
+        elif flag in _FIELD_FLAGS and value.startswith("@"):
+            raw = value[1:]
+        elif flag not in _PATH_FLAGS:
+            continue
+        if not raw:
+            return Unresolved("arg-form-unparsed",
+                              f"{flag} was given an empty path")
+        text = _read_file(raw, base)
+        if isinstance(text, Unresolved):
+            return text
+        reads.append((flag, raw, text))
+
+    handle_fd, path = tempfile.mkstemp(prefix="daimon-check-",
+                                       suffix=".subject")
+    try:
+        with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
+            handle.write(_subject_text(command, reads))
+        # mkstemp is already umask-independent; stated again so the mode is
+        # a property of this file rather than of the stdlib's default.
+        os.chmod(path, 0o600)
+    except OSError as exc:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        # Not a cause the spec's table anticipated: the subject could not be
+        # built because daimon's own temp dir failed. It is unresolved either
+        # way, and `check-crashed` is the cause that says the machinery, not
+        # the argument, is what went wrong.
+        return Unresolved("check-crashed",
+                          f"the subject file could not be written: {exc}")
+    return Subject(path, tuple((flag, source) for flag, source, _ in reads))
+
+
+def discard(subject) -> None:
+    """Remove a materialized subject. Never raises: it runs in a `finally`
+    on a path that already has an outcome to report."""
+    path = getattr(subject, "path", None)
+    if not isinstance(path, str) or not path:
+        return
+    try:
+        os.unlink(path)
+    except OSError:
+        pass

--- a/plugin/daimon_briefing/_hooks/checks_runtime.py
+++ b/plugin/daimon_briefing/_hooks/checks_runtime.py
@@ -23,11 +23,15 @@ why. Every function returns a value that says what happened, including when
 what happened is that daimon could not tell.
 """
 
+import hashlib
 import json
 import os
 import re
 import shlex
+import signal
+import subprocess
 import tempfile
+import time
 from pathlib import Path
 from typing import NamedTuple
 
@@ -74,6 +78,18 @@ class Subject(NamedTuple):
     `discard` once the check has run."""
     path: str
     files: tuple
+    command: str = ""
+
+
+class Outcome(NamedTuple):
+    """What one check run produced. `outcome` is one of the three spec 2.3
+    values and never folds: unresolved is not clean and is not a violation.
+    `exit_code` is -1 when no process ran."""
+    outcome: str
+    cause: str
+    reason: str
+    exit_code: int
+    duration_ms: int
 
 
 class Unresolved(NamedTuple):
@@ -406,7 +422,8 @@ def resolve(command, cwd):
         # the argument, is what went wrong.
         return Unresolved("check-crashed",
                           f"the subject file could not be written: {exc}")
-    return Subject(path, tuple((flag, source) for flag, source, _ in reads))
+    return Subject(path, tuple((flag, source) for flag, source, _ in reads),
+                   command)
 
 
 def discard(subject) -> None:
@@ -419,3 +436,141 @@ def discard(subject) -> None:
         os.unlink(path)
     except OSError:
         pass
+
+
+# ---- runner (spec 3.3) ----------------------------------------------------
+
+DEFAULT_TIMEOUT = 5.0
+
+
+def body_name(entry) -> str:
+    """The materialized body's file name: the ruling id and the head of the
+    hash it was ratified with. Two names for one ruling means the pin moved,
+    and the stale one is swept at the next sync."""
+    return f"{entry.get('ruling_id', '')}-{str(entry.get('sha256', ''))[:12]}.sh"
+
+
+def body_path(entry, base=None) -> Path:
+    return (Path(base) if base is not None else checks_dir()) / body_name(entry)
+
+
+def _kill_group(proc) -> None:
+    """start_new_session put the check in its own process group, so a body
+    that backgrounded something is killed WITH it. Killing only the direct
+    child leaves a grandchild holding the pipe, and the read that follows
+    blocks past the host's hook timeout, which is fail-open: the action
+    proceeds and nothing says why."""
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (OSError, AttributeError, ProcessLookupError):
+        try:
+            proc.kill()
+        except OSError:
+            pass
+
+
+def _first_line(text) -> str:
+    for line in (text or "").splitlines():
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+def run(entry_or_body, subject, *, cwd=None, timeout=None) -> Outcome:
+    """Run one check against one subject and say what happened.
+
+    `entry_or_body` is a manifest entry (whose `sha256` is re-checked against
+    the file on disk before exec) or a plain path to a body the caller just
+    materialized. Never raises: every path returns an Outcome, because the
+    hook that calls this fires before every shell action and an exception is
+    an action that proceeds with no record of why."""
+    started = time.monotonic()
+    try:
+        return _run(entry_or_body, subject, cwd, timeout, started)
+    except Exception as exc:  # noqa: BLE001 — an outcome is mandatory
+        return Outcome("unresolved", "check-crashed",
+                       f"the check runner failed: {type(exc).__name__}: {exc}",
+                       -1, int((time.monotonic() - started) * 1000))
+
+
+def _run(entry_or_body, subject, cwd, timeout, started) -> Outcome:
+    def out(outcome, cause, reason, exit_code=-1):
+        return Outcome(outcome, cause, reason, exit_code,
+                       int((time.monotonic() - started) * 1000))
+
+    ruling_id = ""
+    pinned = ""
+    if isinstance(entry_or_body, dict):
+        ruling_id = str(entry_or_body.get("ruling_id") or "")
+        pinned = str(entry_or_body.get("sha256") or "")
+        override = entry_or_body.get("body_path")
+        path = Path(override) if override else body_path(entry_or_body)
+    else:
+        path = Path(entry_or_body)
+
+    try:
+        body = path.read_bytes()
+    except OSError as exc:
+        return out("unresolved", "check-crashed",
+                   f"the check body could not be read: {exc.strerror or exc}")
+    if pinned and hashlib.sha256(body).hexdigest() != pinned:
+        # Someone edited the materialized body. Never a silent skip: an
+        # unresolved outcome is visible, a skip looks like a clean run.
+        return out("unresolved", "body-hash-mismatch",
+                   "the check body on disk is not the one this ruling was "
+                   "ratified with; run `daimon check sync`")
+
+    env = dict(os.environ)
+    env["DAIMON_CHECK_SUBJECT"] = str(getattr(subject, "path", "") or "")
+    env["DAIMON_CHECK_COMMAND"] = str(getattr(subject, "command", "") or "")
+    env["DAIMON_CHECK_RULING"] = ruling_id
+    budget = (float(timeout) if isinstance(timeout, (int, float))
+              and timeout > 0 else DEFAULT_TIMEOUT)
+
+    try:
+        proc = subprocess.Popen(
+            ["sh", str(path)],
+            cwd=str(cwd) if cwd else None,
+            env=env,
+            # Scar 0034: no stdin PIPE, so nothing here can close a pipe and
+            # make the communicate() below raise on a flush. /dev/null is
+            # also what keeps a body that reads stdin from blocking on an
+            # inherited terminal until the budget expires.
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return out("unresolved", "runtime-missing",
+                   "no POSIX sh on PATH, so no check can run on this host")
+    except OSError as exc:
+        return out("unresolved", "check-crashed",
+                   f"the check could not be started: {exc.strerror or exc}")
+
+    try:
+        _, err = proc.communicate(timeout=budget)
+    except subprocess.TimeoutExpired:
+        _kill_group(proc)
+        try:
+            proc.communicate(timeout=1)
+        except Exception:  # noqa: BLE001 — the outcome is already decided
+            pass
+        return out("unresolved", "check-timeout",
+                   f"the check did not finish within {budget:g}s")
+
+    code = proc.returncode
+    reason = _first_line(err)
+    if code == 0:
+        return out("clean", "", "", 0)
+    if code == 1:
+        return out("violation", "",
+                   reason or "the check reported a violation and gave no "
+                             "reason", 1)
+    # 126 and 127 land here with sh's own first stderr line, which is how a
+    # body that reaches outside itself becomes observable: the slice 1 path
+    # refusal catches a bare single-token path, and a one-line `sh /host.sh`
+    # passes it.
+    return out("unresolved", "check-crashed",
+               reason or f"the check exited {code}", code)

--- a/plugin/daimon_briefing/_hooks/checks_runtime.py
+++ b/plugin/daimon_briefing/_hooks/checks_runtime.py
@@ -61,6 +61,20 @@ MAX_SUBJECT_FILE_BYTES = 1024 * 1024
 # proceeds. This is the one known bound and it is documented as such.
 MATCH_INPUT_BYTES = 4096
 
+# The same bound at the resolver's door, which is the second way in. The
+# prefilter above reads a slice; the resolver has to TOKENIZE what it was
+# given, and shlex is superlinear in the length of a single argument.
+# Measured, with heredocs already stripped: 0.14s at 64 KiB, 5.3s at 512 KiB,
+# 21s at 1 MiB. The host hook timeout is 10s and it is fail-open, so a
+# resolver that outlives it lets the action through with no record at all.
+#
+# It counts the command AFTER heredoc bodies are removed, because those cost
+# nothing to skip: the expensive input is one long inline argument, a base64
+# blob or an expanded --body. A command above this is unresolved, never
+# allowed, because a command daimon declined to parse is one it can prove
+# nothing about.
+MAX_COMMAND_BYTES = 64 * 1024
+
 
 class Manifest(NamedTuple):
     """What `load_manifest` found. `reason` is empty when the manifest was
@@ -521,6 +535,15 @@ def resolve(command, cwd):
         return f" {_HEREDOC_MARK}{len(heredocs) - 1}\x00 "
 
     text = _HEREDOC_RE.sub(_take, command)
+    # Bounded BEFORE the lexer, which is the expensive part. Above the cap
+    # daimon declines rather than spending the host's whole hook budget on
+    # tokenizing one enormous argument and then being overtaken by a timeout
+    # that lets the action through.
+    if len(text.encode("utf-8", "replace")) > MAX_COMMAND_BYTES:
+        return Unresolved(
+            "arg-form-unparsed",
+            f"the command is too long to resolve within the check budget "
+            f"(over {MAX_COMMAND_BYTES} bytes with heredocs removed)")
     # Every heredoc BODY is gone by now, so a remaining newline separates two
     # commands exactly as a semicolon does. Spelling it as one lets a single
     # lexer pass find every boundary; the lexer folds a bare newline into

--- a/plugin/daimon_briefing/_hooks/checks_runtime.py
+++ b/plugin/daimon_briefing/_hooks/checks_runtime.py
@@ -273,6 +273,54 @@ _KNOWN_FLAGS = frozenset(_PATH_FLAGS) | frozenset(_FIELD_FLAGS)
 _HEREDOC_RE = re.compile(
     r"<<-?[ \t]*(['\"]?)(\w+)\1[^\n]*\n(.*?)\n[ \t]*\2(?=\s|$)", re.DOTALL)
 
+# A heredoc is replaced by a marker token rather than by whitespace, so the
+# token stream still says WHERE the redirect stood. NUL is in it because a
+# command string carrying one cannot be executed anyway, which makes a
+# collision with real text impossible rather than unlikely.
+_HEREDOC_MARK = "\x00daimon-heredoc-"
+
+# Tokens that end one simple command and begin the next. `&` is here for the
+# same reason the others are: what follows it is a different command, and a
+# heredoc on one side of it does not feed an argument on the other.
+_SEGMENT_BREAKS = frozenset({"&&", "||", ";", "|", "&"})
+
+
+def _heredoc_index(token):
+    """The heredoc a marker token stands for, or None for a real argument."""
+    if token.startswith(_HEREDOC_MARK) and token.endswith("\x00"):
+        try:
+            return int(token[len(_HEREDOC_MARK):-1])
+        except ValueError:
+            return None
+    return None
+
+
+def _segments(tokens):
+    """The command split into simple commands: (tokens, heredoc indexes, fed
+    by a pipe).
+
+    A heredoc redirect belongs to the command it is attached to, and nothing
+    else in the string can claim it. Without this split, `cat <<EOF ... EOF`
+    followed by a governed command hands the governed command text it never
+    reads — and if that text is clean, the record says the real body was
+    proven safe."""
+    out = []
+    current: list = []
+    marks: list = []
+    piped = False
+    for token in tokens:
+        if token in _SEGMENT_BREAKS:
+            out.append((current, marks, piped))
+            current, marks, piped = [], [], token == "|"
+            continue
+        index = _heredoc_index(token)
+        if index is None:
+            current.append(token)
+        else:
+            marks.append(index)
+    out.append((current, marks, piped))
+    return out
+
 
 def _split_attached(token):
     """`--body-file=x` -> ("--body-file", "x", True); anything else is left
@@ -361,39 +409,17 @@ def _subject_text(command, reads) -> str:
     return "".join(parts)
 
 
-def resolve(command, cwd):
-    """The action's subject, or the cause daimon could not build one.
+def _resolve_segment(tokens, marks, piped, heredocs, base, reads):
+    """Read one simple command's file arguments into `reads`.
 
-    Subject = the command string, a separator, then every resolved file's
-    bytes under a header naming the flag it came from. Written to a 0o600
-    file in the SYSTEM temp dir: a file under ~/.daimon would have to be
-    declared in the surface registry and carry a deletion story, and this
-    one lives for the length of one exec.
-
-    Fail-closed and first-failure-wins. One argument daimon cannot read
-    means it cannot prove the subject clean, whatever the others say."""
-    if not isinstance(command, str):
-        return Unresolved("arg-form-unparsed", "the command is not a string")
-    base = cwd if isinstance(cwd, str) and cwd else os.getcwd()
-
-    heredocs: list = []
-
-    def _take(match):
-        heredocs.append(match.group(3))
-        return " "
-
-    try:
-        tokens = shlex.split(_HEREDOC_RE.sub(_take, command), posix=True)
-    except ValueError as exc:
-        return Unresolved("arg-form-unparsed",
-                          f"the command could not be tokenized: {exc}")
-
-    # Counted before the walk: binding a heredoc is only safe when there is
-    # exactly one candidate on each side.
+    Returns None when the segment is fine, or the Unresolved that stopped it.
+    A heredoc binds only from `marks`, which holds the redirects that stood
+    inside THIS command, so text belonging to a neighbour can never be
+    presented as what the governed command reads."""
+    # Counted per segment: binding is only safe with exactly one candidate on
+    # each side, and the sides are this command's, not the whole string's.
     consumers = sum(1 for flag, value, _ in _walk(tokens)
                     if flag is not None and value == "-")
-
-    reads: list = []
     for flag, value, previous in _walk(tokens):
         if flag is None:
             # Row 6: a form outside the table is never assumed harmless.
@@ -413,32 +439,31 @@ def resolve(command, cwd):
                               f"{flag} was given no value")
 
         if value == "-":
-            if not heredocs:
-                return Unresolved(
-                    "stdin-pipe",
-                    f"{flag} reads standard input and the command carries no "
-                    "heredoc, so the bytes come from a process daimon cannot "
-                    "see")
-            if len(heredocs) != 1 or consumers != 1:
-                # Which heredoc feeds which argument is a question this
-                # tokenizer cannot answer: it keeps neither the order nor the
-                # redirections. Handing over the first one guesses, and a
-                # wrong guess builds the subject from unrelated text and then
-                # reports clean on a body nothing ever read.
-                #
-                # KNOWN RESIDUAL: one heredoc belonging to an EARLIER command
-                # plus one argument reading standard input counts as one and
-                # one, so it still binds the wrong text. Closing that needs
-                # the heredoc's offset in the raw command matched against the
-                # offset of the argument that consumes it, which is thrown
-                # away above. Pinned by a test that says so out loud.
+            if len(marks) == 1 and consumers == 1:
+                reads.append((flag, "<heredoc>", heredocs[marks[0]]))
+                continue
+            if not marks:
+                if piped:
+                    return Unresolved(
+                        "stdin-pipe",
+                        f"{flag} reads standard input and a pipe fills it, so "
+                        "the bytes come from a process daimon cannot see")
+                # A heredoc elsewhere in the string belongs to the command it
+                # is attached to, never to this one. Borrowing it would build
+                # the subject from text this command never reads, and if THAT
+                # text is clean the record says the real body was proven safe.
                 return Unresolved(
                     "arg-form-unparsed",
-                    f"the command carries {len(heredocs)} heredoc(s) and "
-                    f"{consumers} argument(s) reading standard input; daimon "
-                    "binds one to one or not at all")
-            reads.append((flag, "<heredoc>", heredocs[0]))
-            continue
+                    f"{flag} reads standard input and this command carries no "
+                    "heredoc of its own, so daimon cannot see what fills it")
+            # Inside one command the counts still have to be one and one:
+            # which heredoc feeds which argument is not something the token
+            # stream answers, and a guess is the same defect one scope down.
+            return Unresolved(
+                "arg-form-unparsed",
+                f"this command carries {len(marks)} heredoc(s) and "
+                f"{consumers} argument(s) reading standard input; daimon "
+                "binds one to one or not at all")
         raw = value
         if flag in _FIELD_FLAGS and "=" in value:
             _, _, rhs = value.partition("=")
@@ -459,6 +484,55 @@ def resolve(command, cwd):
         if isinstance(text, Unresolved):
             return text
         reads.append((flag, raw, text))
+    return None
+
+
+def resolve(command, cwd):
+    """The action's subject, or the cause daimon could not build one.
+
+    Subject = the command string, a separator, then every resolved file's
+    bytes under a header naming the flag it came from. Written to a 0o600
+    file in the SYSTEM temp dir: a file under ~/.daimon would have to be
+    declared in the surface registry and carry a deletion story, and this
+    one lives for the length of one exec.
+
+    Fail-closed and first-failure-wins. One argument daimon cannot read
+    means it cannot prove the subject clean, whatever the others say."""
+    if not isinstance(command, str):
+        return Unresolved("arg-form-unparsed", "the command is not a string")
+    base = cwd if isinstance(cwd, str) and cwd else os.getcwd()
+
+    heredocs: list = []
+
+    def _take(match):
+        heredocs.append(match.group(3))
+        return f" {_HEREDOC_MARK}{len(heredocs) - 1}\x00 "
+
+    text = _HEREDOC_RE.sub(_take, command)
+    # Every heredoc BODY is gone by now, so a remaining newline separates two
+    # commands exactly as a semicolon does. Spelling it as one lets a single
+    # lexer pass find every boundary; the lexer folds a bare newline into
+    # whitespace and would otherwise run two commands together. A newline
+    # inside a quoted argument is rewritten too, which changes that argument's
+    # text and nothing daimon reads from it.
+    text = text.replace("\r\n", "\n").replace("\n", " ; ")
+    try:
+        # punctuation_chars makes the shell operators their own tokens while
+        # keeping quotes intact, which is what the segment split needs.
+        lexer = shlex.shlex(text, posix=True, punctuation_chars=True)
+        lexer.whitespace_split = True
+        lexer.commenters = ""  # shlex.split's setting: `#` is not a comment
+        tokens = list(lexer)
+    except ValueError as exc:
+        return Unresolved("arg-form-unparsed",
+                          f"the command could not be tokenized: {exc}")
+
+    reads: list = []
+    for seg_tokens, marks, piped in _segments(tokens):
+        outcome = _resolve_segment(seg_tokens, marks, piped, heredocs, base,
+                                   reads)
+        if outcome is not None:
+            return outcome
 
     handle_fd, path = tempfile.mkstemp(prefix="daimon-check-",
                                        suffix=".subject")

--- a/plugin/daimon_briefing/_hooks/checks_runtime.py
+++ b/plugin/daimon_briefing/_hooks/checks_runtime.py
@@ -276,12 +276,53 @@ _HEREDOC_RE = re.compile(
 
 def _split_attached(token):
     """`--body-file=x` -> ("--body-file", "x", True); anything else is left
-    for the two-token form."""
+    for the two-token form.
+
+    The single-dash case comes FIRST and does not need an `=`. pflag, the
+    flag library gh uses, accepts a shorthand value attached to its flag, so
+    `-Fbody.md` is the same command as `-F body.md` and `-Fkey=@p` the same
+    as `-F key=@p`. Splitting here rather than at the use sites means the
+    field and the dash rules below apply to both spellings unchanged: an
+    attached form daimon did not split fell through every branch and left
+    the subject holding only the command string, which reports CLEAN for a
+    file that was never opened."""
+    if (token.startswith("-") and not token.startswith("--")
+            and len(token) > 2 and token[:2] in _KNOWN_FLAGS):
+        value = token[2:]
+        # pflag treats a leading `=` after a shorthand as the separator, so
+        # `-F=body.md` names the file body.md and not a field with an empty
+        # name. Following it keeps the two spellings one command.
+        return token[:2], value[1:] if value.startswith("=") else value, True
     if token.startswith("-") and "=" in token:
         head, _, tail = token.partition("=")
         if head in _KNOWN_FLAGS:
             return head, tail, True
     return token, "", False
+
+
+def _walk(tokens):
+    """(flag, value, previous token) for each step of the command.
+
+    `flag` is None for a token that names no known flag, and `value` is None
+    when a known flag ran off the end with nothing after it. One generator,
+    two readers: the dash-consumer count below and the resolver itself, so
+    the two can never disagree about what a token means."""
+    index = 0
+    while index < len(tokens):
+        previous = tokens[index - 1] if index else ""
+        flag, value, attached = _split_attached(tokens[index])
+        if flag not in _KNOWN_FLAGS:
+            index += 1
+            yield None, tokens[index - 1], previous
+            continue
+        if not attached:
+            index += 1
+            if index >= len(tokens):
+                yield flag, None, previous
+                return
+            value = tokens[index]
+        index += 1
+        yield flag, value, previous
 
 
 def _read_file(raw, base):
@@ -348,30 +389,23 @@ def resolve(command, cwd):
                           f"the command could not be tokenized: {exc}")
 
     reads: list = []
-    index = 0
-    while index < len(tokens):
-        token = tokens[index]
-        flag, value, attached = _split_attached(token)
-        if flag not in _KNOWN_FLAGS:
+    for flag, value, previous in _walk(tokens):
+        if flag is None:
             # Row 6: a form outside the table is never assumed harmless.
-            if token == "-" and index and tokens[index - 1].startswith("-"):
+            token = value
+            if token == "-" and previous.startswith("-"):
                 return Unresolved(
                     "arg-form-unparsed",
-                    f"{tokens[index - 1]} reads standard input in a form "
-                    "daimon does not parse")
+                    f"{previous} reads standard input in a form daimon does "
+                    "not parse")
             if token.startswith("@") and len(token) > 1:
                 return Unresolved(
                     "arg-form-unparsed",
                     f"{token} names a file in a form daimon does not parse")
-            index += 1
             continue
-        if not attached:
-            index += 1
-            if index >= len(tokens):
-                return Unresolved("arg-form-unparsed",
-                                  f"{flag} was given no value")
-            value = tokens[index]
-        index += 1
+        if value is None:
+            return Unresolved("arg-form-unparsed",
+                              f"{flag} was given no value")
 
         if value == "-":
             if not heredocs:

--- a/plugin/daimon_briefing/_hooks/checks_runtime.py
+++ b/plugin/daimon_briefing/_hooks/checks_runtime.py
@@ -389,6 +389,12 @@ def _read_file(raw, base):
         return Unresolved("file-missing", f"{raw} does not exist")
     except OSError as exc:
         return Unresolved("file-unreadable", f"{raw}: {exc.strerror or exc}")
+    except ValueError as exc:
+        # A NUL in the path: `open` rejects it before the OS ever sees it, and
+        # it raises ValueError rather than OSError, so it walks straight past
+        # the clause above. The command string comes from a host payload and
+        # can carry one.
+        return Unresolved("file-unreadable", f"{raw}: {exc}")
     if len(data) > MAX_SUBJECT_FILE_BYTES:
         return Unresolved(
             "file-oversize",
@@ -416,6 +422,12 @@ def _resolve_segment(tokens, marks, piped, heredocs, base, reads):
     A heredoc binds only from `marks`, which holds the redirects that stood
     inside THIS command, so text belonging to a neighbour can never be
     presented as what the governed command reads."""
+    # A marker token is minted by `_take` and nothing else, but the command
+    # string arrives from a host payload and can spell one out. An index no
+    # heredoc answers to is simply not a heredoc; without this the bind below
+    # reads past the end of the list and the resolver raises, which is the
+    # one thing this module promises never to do.
+    marks = [index for index in marks if 0 <= index < len(heredocs)]
     # Counted per segment: binding is only safe with exactly one candidate on
     # each side, and the sides are this command's, not the whole string's.
     consumers = sum(1 for flag, value, _ in _walk(tokens)
@@ -534,9 +546,13 @@ def resolve(command, cwd):
         if outcome is not None:
             return outcome
 
-    handle_fd, path = tempfile.mkstemp(prefix="daimon-check-",
-                                       suffix=".subject")
+    # mkstemp inside the try, not before it: a temp dir that is full or
+    # read-only fails HERE, and a raise from this function is an action that
+    # proceeds with no record of why.
+    path = ""
     try:
+        handle_fd, path = tempfile.mkstemp(prefix="daimon-check-",
+                                           suffix=".subject")
         with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
             handle.write(_subject_text(command, reads))
         # mkstemp is already umask-independent; stated again so the mode is
@@ -544,7 +560,8 @@ def resolve(command, cwd):
         os.chmod(path, 0o600)
     except OSError as exc:
         try:
-            os.unlink(path)
+            if path:
+                os.unlink(path)
         except OSError:
             pass
         # Not a cause the spec's table anticipated: the subject could not be

--- a/plugin/daimon_briefing/_hooks/checks_runtime.py
+++ b/plugin/daimon_briefing/_hooks/checks_runtime.py
@@ -388,6 +388,11 @@ def resolve(command, cwd):
         return Unresolved("arg-form-unparsed",
                           f"the command could not be tokenized: {exc}")
 
+    # Counted before the walk: binding a heredoc is only safe when there is
+    # exactly one candidate on each side.
+    consumers = sum(1 for flag, value, _ in _walk(tokens)
+                    if flag is not None and value == "-")
+
     reads: list = []
     for flag, value, previous in _walk(tokens):
         if flag is None:
@@ -414,7 +419,25 @@ def resolve(command, cwd):
                     f"{flag} reads standard input and the command carries no "
                     "heredoc, so the bytes come from a process daimon cannot "
                     "see")
-            reads.append((flag, "<heredoc>", heredocs.pop(0)))
+            if len(heredocs) != 1 or consumers != 1:
+                # Which heredoc feeds which argument is a question this
+                # tokenizer cannot answer: it keeps neither the order nor the
+                # redirections. Handing over the first one guesses, and a
+                # wrong guess builds the subject from unrelated text and then
+                # reports clean on a body nothing ever read.
+                #
+                # KNOWN RESIDUAL: one heredoc belonging to an EARLIER command
+                # plus one argument reading standard input counts as one and
+                # one, so it still binds the wrong text. Closing that needs
+                # the heredoc's offset in the raw command matched against the
+                # offset of the argument that consumes it, which is thrown
+                # away above. Pinned by a test that says so out loud.
+                return Unresolved(
+                    "arg-form-unparsed",
+                    f"the command carries {len(heredocs)} heredoc(s) and "
+                    f"{consumers} argument(s) reading standard input; daimon "
+                    "binds one to one or not at all")
+            reads.append((flag, "<heredoc>", heredocs[0]))
             continue
         raw = value
         if flag in _FIELD_FLAGS and "=" in value:

--- a/plugin/daimon_briefing/_hooks/checks_runtime.py
+++ b/plugin/daimon_briefing/_hooks/checks_runtime.py
@@ -330,21 +330,21 @@ def _read_file(raw, base):
     paths resolve against the action's working directory, because that is
     what the shell would have done."""
     path = raw if os.path.isabs(raw) else os.path.join(base, raw)
+    # One answer about one file. A stat that decides the cap and an open that
+    # happens afterwards are two answers, and they disagree whenever the file
+    # changes in between; reading one byte past the cap and judging THAT
+    # cannot disagree with itself, and it never holds more than the cap.
     try:
-        size = os.stat(path).st_size
+        with open(path, "rb") as handle:
+            data = handle.read(MAX_SUBJECT_FILE_BYTES + 1)
     except FileNotFoundError:
         return Unresolved("file-missing", f"{raw} does not exist")
     except OSError as exc:
         return Unresolved("file-unreadable", f"{raw}: {exc.strerror or exc}")
-    if size > MAX_SUBJECT_FILE_BYTES:
+    if len(data) > MAX_SUBJECT_FILE_BYTES:
         return Unresolved(
             "file-oversize",
-            f"{raw} is {size} bytes, over the {MAX_SUBJECT_FILE_BYTES} cap")
-    try:
-        with open(path, "rb") as handle:
-            data = handle.read()
-    except OSError as exc:
-        return Unresolved("file-unreadable", f"{raw}: {exc.strerror or exc}")
+            f"{raw} is over the {MAX_SUBJECT_FILE_BYTES} byte cap")
     try:
         return data.decode("utf-8")
     except UnicodeDecodeError:
@@ -499,6 +499,15 @@ def discard(subject) -> None:
 
 DEFAULT_TIMEOUT = 5.0
 
+# What a check body inherits, plus every LC_* and the three DAIMON_CHECK_*
+# variables the runner sets. A ratified body is human-armed and runs as the
+# user, so this is not a sandbox and does not pretend to be one. It is a blast
+# radius: the body's job is to read one subject file, and handing it every
+# token in the host session widens what a mistake in someone else's script can
+# reach, for nothing. PATH and HOME stay because a body that cannot find its
+# own tools reports check-crashed and looks like a defect in the check.
+_ENV_KEEP = frozenset({"PATH", "HOME", "LANG", "TMPDIR"})
+
 
 def body_name(entry) -> str:
     """The materialized body's file name: the ruling id and the head of the
@@ -577,7 +586,8 @@ def _run(entry_or_body, subject, cwd, timeout, started) -> Outcome:
                    "the check body on disk is not the one this ruling was "
                    "ratified with; run `daimon check sync`")
 
-    env = dict(os.environ)
+    env = {name: value for name, value in os.environ.items()
+           if name in _ENV_KEEP or name.startswith("LC_")}
     env["DAIMON_CHECK_SUBJECT"] = str(getattr(subject, "path", "") or "")
     env["DAIMON_CHECK_COMMAND"] = str(getattr(subject, "command", "") or "")
     env["DAIMON_CHECK_RULING"] = ruling_id

--- a/plugin/daimon_briefing/checks.py
+++ b/plugin/daimon_briefing/checks.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
+import tempfile
 from pathlib import Path
 from typing import NamedTuple
 
@@ -135,3 +137,65 @@ def _sync(project_dir) -> SyncReport:
         except OSError:
             pass
     return SyncReport(True, len(entries), slug)
+
+
+def try_run(ruling_id: str, command: str, *, channel: str, cwd=None,
+            project_dir=None, proposed: bool = False):
+    """Run one ruling's check against a command, without arming anything.
+
+    Human-only, and enforced HERE rather than only at the CLI: this is the
+    one verb in the family that EXECUTES a body, and `ui` and `signed` reach
+    it directly. A dry run of a candidate is the whole point of the verb —
+    docs tell an author to try a body before a human arms it — so a body no
+    human has confirmed does run, which is exactly why the caller has to be
+    a human.
+
+    Writes nothing. Not the firing log (a rehearsal counted as a firing
+    makes the liveness surface report a check that never guarded an action),
+    not the manifest, and not a body under ~/.daimon/checks, where the hook
+    could not tell it from an armed one."""
+    if refutations.CHANNEL_AUTHORITY.get(channel) != "human":
+        raise refutations.RefutationError(
+            "a dry run executes the check body, so it requires a human "
+            f"channel; this call arrived through {channel!r}")
+    record = refutations.get(ruling_id, project_dir=project_dir)
+    if record is None:
+        raise refutations.RefutationError(f"unknown ruling: {ruling_id}")
+    if record.get("polarity") != "ruling":
+        raise refutations.RefutationError(
+            f"{ruling_id} is a refutation; only a ruling carries a check")
+    if proposed:
+        check = (record.get("revision_proposed") or {}).get("check")
+        if not isinstance(check, dict):
+            raise refutations.RefutationError(
+                f"{ruling_id} has no proposed check; drop --proposed to run "
+                "the one it carries")
+    else:
+        check = record.get("check")
+        if not isinstance(check, dict):
+            raise refutations.RefutationError(
+                f"{ruling_id} carries no check")
+    body = str(check.get("body") or "")
+
+    workdir = tempfile.mkdtemp(prefix="daimon-check-try-")
+    try:
+        path = Path(workdir) / "check.sh"
+        path.write_text(body, encoding="utf-8")
+        os.chmod(path, 0o500)
+        subject = checks_runtime.resolve(command, cwd or os.getcwd())
+        if isinstance(subject, checks_runtime.Unresolved):
+            return checks_runtime.Outcome(
+                "unresolved", subject.cause, subject.reason, -1, 0)
+        try:
+            # The stored sha256 goes along, so the dry run exercises the same
+            # re-hash the armed path does instead of a shortcut around it.
+            return checks_runtime.run(
+                {"ruling_id": ruling_id,
+                 "sha256": str(check.get("sha256") or ""),
+                 "body_path": str(path)},
+                subject, cwd=cwd or os.getcwd(),
+                timeout=config.check_timeout())
+        finally:
+            checks_runtime.discard(subject)
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)

--- a/plugin/daimon_briefing/checks.py
+++ b/plugin/daimon_briefing/checks.py
@@ -1,0 +1,137 @@
+"""#943: turning armed rulings into something a standalone hook can run.
+
+The package half of the check contract. `checks_runtime` reads a manifest and
+a set of executable bodies without importing daimon; this module is what
+writes them, from the ledger, and it is the only writer of
+`~/.daimon/checks/`.
+
+Sync is called by every ledger writer that can change whether a check is
+armed, and by `daimon check sync`. It is idempotent by construction: a repeat
+run touches neither bytes nor mtimes, because it runs after every ratify in
+the tree and churning the disk each time would be its own defect.
+
+It never raises. It runs AFTER a ledger write that already landed, so turning
+a bookkeeping failure into a failed ratify would be the wrong trade; the
+caller reports the failure and keeps its own exit code.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import NamedTuple
+
+from . import checks_runtime, config, refutations, store
+
+
+class SyncReport(NamedTuple):
+    """What one sync did. `armed` counts THIS project's entries, never the
+    manifest's total: the directory is global and every other project's
+    entries pass through untouched."""
+    ok: bool
+    armed: int
+    slug: str
+    reason: str = ""
+
+
+def _write_body(path: Path, body: str) -> None:
+    """Materialize one check body, atomically, at 0o500.
+
+    Skipped entirely when the bytes on disk already match, which is what
+    makes a repeat sync free. Mode 0500 is read-and-execute for the owner:
+    the runner re-hashes before every exec anyway, so the mode is a statement
+    about intent rather than the thing keeping the body honest."""
+    blob = body.encode("utf-8")
+    try:
+        if path.read_bytes() == blob:
+            return
+    except OSError:
+        pass
+    tmp = path.with_name(path.name + f".{os.getpid()}.tmp")
+    tmp.write_bytes(blob)
+    os.chmod(tmp, 0o500)
+    os.replace(tmp, path)  # atomic on POSIX
+
+
+def sync(project_dir=None) -> SyncReport:
+    """Rebuild this project's armed checks from its ledger. Never raises."""
+    try:
+        return _sync(project_dir)
+    except Exception as exc:  # noqa: BLE001 — a report, never a raise
+        return SyncReport(False, 0, "", f"{type(exc).__name__}: {exc}")
+
+
+def _sync(project_dir) -> SyncReport:
+    resolved = config.resolve_project_dir(project_dir)
+    slug = store.project_slug(resolved)
+    if not slug:
+        return SyncReport(False, 0, "", "that project directory names no "
+                                        "bucket, so there is no ledger to read")
+    root = str(resolved)
+    base = config.checks_dir()
+    manifest_path = base / checks_runtime.MANIFEST_NAME
+
+    loaded = checks_runtime.load_manifest(manifest_path)
+    if loaded.reason == "manifest-unreadable":
+        # Rebuilding from one project's view would drop every other
+        # project's entries, which is a wider action than the failure
+        # justifies. Refuse and say so.
+        return SyncReport(False, 0, slug,
+                          "the existing manifest could not be read; rebuilding "
+                          "from this project alone would disarm the others")
+
+    armed = []
+    for record in refutations.listing(states={"active"}, polarity="ruling",
+                                      project_dir=project_dir):
+        check = record.get("check")
+        # `check_lifecycle` is derived at fold time and is the ONE place that
+        # knows a candidate's check is not a mode. Reading `state` here
+        # instead would be a second answer to the same question.
+        if not isinstance(check, dict) or record.get("check_lifecycle") != "armed":
+            continue
+        sha = str(check.get("sha256") or "")
+        ruling_id = str(record.get("refutation_id") or "")
+        if not sha or not ruling_id:
+            continue
+        armed.append(({
+            "ruling_id": ruling_id,
+            "project_dir": root,
+            "match": str(check.get("match") or ""),
+            "intent": str(check.get("intent") or "warn"),
+            "sha256": sha,
+            "armed_at": str(record.get("activated_at") or ""),
+        }, str(check.get("body") or "")))
+
+    entries = [entry for entry, _ in armed]
+    others = [e for e in loaded.entries if e.get("project_dir") != root]
+    merged = others + entries
+
+    # A ruling id hashes subject and scope, so two projects can name the same
+    # body file. Only names THIS project claimed before, and that nothing in
+    # the merged manifest still wants, are removed.
+    wanted = {checks_runtime.body_name(e) for e in merged}
+    stale = {checks_runtime.body_name(e) for e in loaded.entries
+             if e.get("project_dir") == root} - wanted
+
+    base.mkdir(parents=True, exist_ok=True)
+    for entry, body in armed:
+        _write_body(base / checks_runtime.body_name(entry), body)
+
+    blob = json.dumps(merged, ensure_ascii=False, indent=2) + "\n"
+    try:
+        current = manifest_path.read_text(encoding="utf-8")
+    except OSError:
+        current = ""
+    if current != blob:
+        store._atomic_write(manifest_path, blob)
+
+    # After the manifest, never before: a body removed while the manifest
+    # still names it is a body-hash-mismatch on the next action, and the
+    # order that produces that is the order nobody runs in a test.
+    for name in sorted(stale):
+        try:
+            (base / name).unlink()
+        except OSError:
+            pass
+    return SyncReport(True, len(entries), slug)

--- a/plugin/daimon_briefing/checks_runtime.py
+++ b/plugin/daimon_briefing/checks_runtime.py
@@ -1,0 +1,203 @@
+"""The #943 check runtime — stdlib only, loadable by a standalone hook.
+
+A host's pre-action hook runs in whatever interpreter the host launched, with
+no venv and no `daimon_briefing` on `sys.path`. So the part of the check
+machinery that runs INSIDE a hook lives here, and this file ships
+byte-identical into `_hooks/` and `hook/` the way `redact.py` does.
+
+Two rules follow from that, both scars:
+
+  * stdlib ONLY (scar 0049). `from . import config` looks completely ordinary
+    from inside the package, passes every local test, and breaks every host
+    hook. The path accessors below are therefore hand-copied mirrors of
+    `config.checks_dir` / `config.log_dir`, and a probe table in
+    `test_checks_runtime.py` asserts behavioral equality against the config
+    functions rather than against literals.
+  * the canonical file is THIS one and the copies are derivatives (scar 0049
+    again, which reverses scar 0044's direction for the adapter scripts).
+    Edit here, then run `scripts/sync_hooks.py`.
+
+Nothing here raises. The hook that calls it fires before every shell action
+on the host, so an exception is an action that proceeds with no record of
+why. Every function returns a value that says what happened, including when
+what happened is that daimon could not tell.
+"""
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import NamedTuple
+
+MANIFEST_NAME = "manifest.json"
+FIRING_LOG_NAME = "checks.jsonl"
+
+# Scar 0022 applied to the SUBJECT rather than the pattern. `check.match` is
+# caller-supplied and capped at 200 bytes, which bounds its length and says
+# nothing about its backtracking. Bounding the string it runs against is what
+# keeps a pathological pair from outliving the host's hook timeout, and that
+# timeout is fail-open: a hook that reaches it does not block, the tool
+# proceeds. This is the one known bound and it is documented as such.
+MATCH_INPUT_BYTES = 4096
+
+
+class Manifest(NamedTuple):
+    """What `load_manifest` found. `reason` is empty when the manifest was
+    read; otherwise it names the state for the firing log, because "no
+    manifest" and "a manifest daimon can no longer parse" are different
+    facts and folding them would report an unwritten install as a broken
+    one."""
+    entries: list
+    reason: str
+
+
+# ---- config mirrors (scar 0043: copy the QUIRKS, not the intent) ----------
+
+
+def _env_file_path() -> Path:
+    """Mirror of daimon_briefing.config._env_file_path."""
+    raw = os.environ.get("DAIMON_ENV_FILE")
+    return Path(raw).expanduser() if raw else Path.home() / ".daimon" / "env"
+
+
+def _env_file_values() -> dict:
+    """Mirror of daimon_briefing.config._file_values — KEY=VALUE lines, with
+    the `export ` prefix, surrounding quotes, blank lines and `#` comments
+    tolerated. Copied rather than imported because hooks run standalone;
+    config.py is the CANONICAL form and this copy must follow it line-form
+    for line-form."""
+    try:
+        text = _env_file_path().read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return {}
+    values = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
+        key, _, val = line.partition("=")
+        key, val = key.strip(), val.strip()
+        if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+            val = val[1:-1]
+        if key:
+            values[key] = val
+    return values
+
+
+def _config_get(name: str) -> str:
+    """Mirror of daimon_briefing.config._get: process env WINS, env file is
+    the fallback. Present-but-empty in the process env is a value and
+    shadows the file, exactly as on the package side."""
+    val = os.environ.get(name)
+    if val is not None:
+        return val
+    return _env_file_values().get(name) or ""
+
+
+def checks_dir() -> Path:
+    """Where the manifest and the materialized bodies live, resolved the way
+    the WRITER resolves it.
+
+    `checks.sync` writes through config.checks_dir(); this reads. A path
+    resolved any other way here has the hook reading an empty directory
+    while the CLI reports N checks armed, and neither side can see the
+    split — the same writer/reader gap scar 0043 records one directory over.
+    So this reproduces config.checks_dir() exactly, including the parts that
+    look like bugs: no strip (so "   " is a relative directory named three
+    spaces, and the reader must agree), and the env-file fallback, which is
+    the channel a GUI-launched host actually uses."""
+    raw = _config_get("DAIMON_CHECKS_DIR")
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".daimon" / "checks"
+
+
+def log_dir() -> Path:
+    """Mirror of config.log_dir(), same reasoning as checks_dir(): the
+    firing log sits under it and `daimon forget` purges through the config
+    accessor."""
+    raw = _config_get("DAIMON_LOG_DIR")
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".daimon" / "logs"
+
+
+# ---- manifest -------------------------------------------------------------
+
+
+def load_manifest(path=None) -> Manifest:
+    """Read the armed-check manifest. Never raises, never partially fails.
+
+    An absent manifest is the ordinary state of an install that has armed
+    nothing, so it reads as empty with `no-manifest` rather than as an
+    error. A manifest that exists and cannot be parsed is a different fact
+    and gets its own reason: both allow the action, and only one of them
+    means daimon wrote something it can no longer read."""
+    target = Path(path) if path is not None else checks_dir() / MANIFEST_NAME
+    try:
+        raw = target.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return Manifest([], "no-manifest")
+    except (OSError, UnicodeDecodeError):
+        return Manifest([], "manifest-unreadable")
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return Manifest([], "manifest-unreadable")
+    if not isinstance(data, list):
+        return Manifest([], "manifest-unreadable")
+    # A row that is not an object is dropped rather than fatal: one bad row
+    # must not disarm every other project's checks.
+    return Manifest([row for row in data if isinstance(row, dict)], "")
+
+
+def armed_for(cwd, manifest) -> list:
+    """The manifest entries armed for this working directory.
+
+    `project_dir` on an entry is already the resolved physical root (the
+    writer runs it through config.resolve_project_dir, which walks to the
+    git toplevel). Here the cwd is realpath'd to meet it, so a project
+    reached through a symlink still arms, and the prefix test carries an
+    explicit separator so /srv/appliance is not governed by a ruling made
+    for /srv/app."""
+    entries = getattr(manifest, "entries", manifest)
+    if not isinstance(entries, list) or not isinstance(cwd, str) or not cwd:
+        return []
+    try:
+        here = os.path.realpath(cwd)
+    except (OSError, ValueError):
+        return []
+    out = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        root = entry.get("project_dir")
+        if not isinstance(root, str) or not root:
+            continue
+        bounded = root if root.endswith(os.sep) else root + os.sep
+        if here == root or here.startswith(bounded):
+            out.append(entry)
+    return out
+
+
+def matches(entry, command) -> bool:
+    """The cheap prefilter: does this entry's regex hit the command string?
+
+    Unanchored and case-sensitive, per the spec, and read over at most
+    MATCH_INPUT_BYTES bytes of the command. An unusable pattern matches
+    nothing instead of raising: a hand-edited manifest can carry a regex the
+    writer would have refused, and that must not become a traceback on every
+    shell action."""
+    if not isinstance(entry, dict) or not isinstance(command, str):
+        return False
+    pattern = entry.get("match")
+    if not isinstance(pattern, str) or not pattern:
+        return False
+    subject = command.encode("utf-8", "replace")[:MATCH_INPUT_BYTES].decode(
+        "utf-8", "ignore")
+    try:
+        return re.search(pattern, subject) is not None
+    except (re.error, RecursionError):
+        return False

--- a/plugin/daimon_briefing/checks_runtime.py
+++ b/plugin/daimon_briefing/checks_runtime.py
@@ -574,3 +574,56 @@ def _run(entry_or_body, subject, cwd, timeout, started) -> Outcome:
     # passes it.
     return out("unresolved", "check-crashed",
                reason or f"the check exited {code}", code)
+
+
+# ---- firing log (spec 3.4) ------------------------------------------------
+
+# The whole row, and nothing else. Spec 3.4: no command text, no paths, no
+# subject. `decision_emitted` is what the hook actually wrote to the host, so
+# a reader can tell a check that RAN from a check that was honored — only
+# `deny` under `enforce` closes that gap.
+FIRING_KEYS = ("ts", "ruling_id", "host", "mode", "outcome", "cause",
+               "decision_emitted", "duration_ms")
+
+# Every value `cause` may hold. The manifest reasons join the runner's causes
+# because "nothing was armed here" is a firing the stats surface has to be
+# able to count, and it is the difference between "armed, never fired" and
+# "clean".
+LOG_CAUSES = CAUSES | {"no-manifest", "no-match", "manifest-unreadable"}
+
+
+def log_firing(row, path=None) -> bool:
+    """Append one row to the firing log. Returns whether it landed.
+
+    The row is PROJECTED onto FIRING_KEYS rather than filtered, so a caller
+    that hands over the whole outcome record (reason and command included)
+    cannot leak them here. `cause` is the one field where free text could
+    otherwise reach a log declared to hold no plaintext, so a value outside
+    the declared set is recorded as `unknown`: the state is still signalled,
+    it just cannot bring a path along.
+
+    Never raises. A hook that cannot write its log still has an action to
+    allow or deny, and losing the decision over the record would be the
+    wrong trade."""
+    try:
+        source = row if isinstance(row, dict) else {}
+        cause = str(source.get("cause") or "")
+        stamped = {
+            "ts": str(source.get("ts") or "") or time.strftime(
+                "%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "ruling_id": str(source.get("ruling_id") or ""),
+            "host": str(source.get("host") or ""),
+            "mode": str(source.get("mode") or ""),
+            "outcome": str(source.get("outcome") or ""),
+            "cause": cause if cause in LOG_CAUSES else (cause and "unknown"),
+            "decision_emitted": str(source.get("decision_emitted") or ""),
+            "duration_ms": int(source.get("duration_ms") or 0),
+        }
+        target = (Path(path) if path is not None
+                  else log_dir() / FIRING_LOG_NAME)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(stamped, ensure_ascii=False) + "\n")
+        return True
+    except (OSError, ValueError, TypeError):
+        return False

--- a/plugin/daimon_briefing/checks_runtime.py
+++ b/plugin/daimon_briefing/checks_runtime.py
@@ -26,11 +26,28 @@ what happened is that daimon could not tell.
 import json
 import os
 import re
+import shlex
+import tempfile
 from pathlib import Path
 from typing import NamedTuple
 
 MANIFEST_NAME = "manifest.json"
 FIRING_LOG_NAME = "checks.jsonl"
+
+# Spec 2.3. `unresolved` is one outcome with many causes, and the set is
+# closed: a cause outside it means a code path invented a state no surface
+# knows how to render.
+CAUSES = frozenset({
+    "file-missing", "file-unreadable", "file-oversize", "file-binary",
+    "stdin-pipe", "arg-form-unparsed", "check-timeout", "check-crashed",
+    "body-hash-mismatch", "runtime-missing",
+})
+
+# A file argument daimon will read into the subject. Above this it reports
+# file-oversize rather than paying to read it: the point of the cap is that
+# the hook's budget is spent before the host's, not that large files are
+# suspicious.
+MAX_SUBJECT_FILE_BYTES = 1024 * 1024
 
 # Scar 0022 applied to the SUBJECT rather than the pattern. `check.match` is
 # caller-supplied and capped at 200 bytes, which bounds its length and says
@@ -48,6 +65,22 @@ class Manifest(NamedTuple):
     facts and folding them would report an unwritten install as a broken
     one."""
     entries: list
+    reason: str
+
+
+class Subject(NamedTuple):
+    """A materialized subject: the command string plus every file argument
+    daimon could read. `path` is a temp file the CALLER must hand back to
+    `discard` once the check has run."""
+    path: str
+    files: tuple
+
+
+class Unresolved(NamedTuple):
+    """Daimon could not prove the subject clean. Never rendered as clean and
+    never counted as a violation. `reason` is for a human and may name a
+    path; the firing log carries the cause and never the reason."""
+    cause: str
     reason: str
 
 
@@ -201,3 +234,188 @@ def matches(entry, command) -> bool:
         return re.search(pattern, subject) is not None
     except (re.error, RecursionError):
         return False
+
+
+# ---- resolver (spec 3.2) --------------------------------------------------
+
+SUBJECT_SEPARATOR = "--- daimon:subject ---"
+
+# Flags whose value is a path to read. `-F` is gh's short form of
+# --body-file on `pr create` / `issue create` AND its field flag on `api`,
+# so it appears in both tables and the value's shape decides.
+_PATH_FLAGS = ("--body-file", "--notes-file", "-F")
+_FIELD_FLAGS = ("-F", "--field")
+_KNOWN_FLAGS = frozenset(_PATH_FLAGS) | frozenset(_FIELD_FLAGS)
+
+# A heredoc puts the body INSIDE the command string, so `--body-file -` is
+# resolvable after all. The terminator may be quoted (no expansion), and
+# `<<-` allows a tab-indented terminator line.
+#
+# The lazy body is a scan for the terminator, not an ambiguous alternation,
+# so scar 0022's backtracking shape does not apply. The bound that does apply
+# is upstream: this runs only on a command the prefilter already matched.
+_HEREDOC_RE = re.compile(
+    r"<<-?[ \t]*(['\"]?)(\w+)\1[^\n]*\n(.*?)\n[ \t]*\2(?=\s|$)", re.DOTALL)
+
+
+def _split_attached(token):
+    """`--body-file=x` -> ("--body-file", "x", True); anything else is left
+    for the two-token form."""
+    if token.startswith("-") and "=" in token:
+        head, _, tail = token.partition("=")
+        if head in _KNOWN_FLAGS:
+            return head, tail, True
+    return token, "", False
+
+
+def _read_file(raw, base):
+    """The file's text, or the Unresolved cause that stopped it. Relative
+    paths resolve against the action's working directory, because that is
+    what the shell would have done."""
+    path = raw if os.path.isabs(raw) else os.path.join(base, raw)
+    try:
+        size = os.stat(path).st_size
+    except FileNotFoundError:
+        return Unresolved("file-missing", f"{raw} does not exist")
+    except OSError as exc:
+        return Unresolved("file-unreadable", f"{raw}: {exc.strerror or exc}")
+    if size > MAX_SUBJECT_FILE_BYTES:
+        return Unresolved(
+            "file-oversize",
+            f"{raw} is {size} bytes, over the {MAX_SUBJECT_FILE_BYTES} cap")
+    try:
+        with open(path, "rb") as handle:
+            data = handle.read()
+    except OSError as exc:
+        return Unresolved("file-unreadable", f"{raw}: {exc.strerror or exc}")
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return Unresolved("file-binary", f"{raw} is not UTF-8 text")
+
+
+def _subject_text(command, reads) -> str:
+    parts = [command, "\n", SUBJECT_SEPARATOR, "\n"]
+    for flag, source, text in reads:
+        parts.append(f"--- daimon:file {flag} {source} ---\n")
+        parts.append(text)
+        if text and not text.endswith("\n"):
+            parts.append("\n")
+    return "".join(parts)
+
+
+def resolve(command, cwd):
+    """The action's subject, or the cause daimon could not build one.
+
+    Subject = the command string, a separator, then every resolved file's
+    bytes under a header naming the flag it came from. Written to a 0o600
+    file in the SYSTEM temp dir: a file under ~/.daimon would have to be
+    declared in the surface registry and carry a deletion story, and this
+    one lives for the length of one exec.
+
+    Fail-closed and first-failure-wins. One argument daimon cannot read
+    means it cannot prove the subject clean, whatever the others say."""
+    if not isinstance(command, str):
+        return Unresolved("arg-form-unparsed", "the command is not a string")
+    base = cwd if isinstance(cwd, str) and cwd else os.getcwd()
+
+    heredocs: list = []
+
+    def _take(match):
+        heredocs.append(match.group(3))
+        return " "
+
+    try:
+        tokens = shlex.split(_HEREDOC_RE.sub(_take, command), posix=True)
+    except ValueError as exc:
+        return Unresolved("arg-form-unparsed",
+                          f"the command could not be tokenized: {exc}")
+
+    reads: list = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        flag, value, attached = _split_attached(token)
+        if flag not in _KNOWN_FLAGS:
+            # Row 6: a form outside the table is never assumed harmless.
+            if token == "-" and index and tokens[index - 1].startswith("-"):
+                return Unresolved(
+                    "arg-form-unparsed",
+                    f"{tokens[index - 1]} reads standard input in a form "
+                    "daimon does not parse")
+            if token.startswith("@") and len(token) > 1:
+                return Unresolved(
+                    "arg-form-unparsed",
+                    f"{token} names a file in a form daimon does not parse")
+            index += 1
+            continue
+        if not attached:
+            index += 1
+            if index >= len(tokens):
+                return Unresolved("arg-form-unparsed",
+                                  f"{flag} was given no value")
+            value = tokens[index]
+        index += 1
+
+        if value == "-":
+            if not heredocs:
+                return Unresolved(
+                    "stdin-pipe",
+                    f"{flag} reads standard input and the command carries no "
+                    "heredoc, so the bytes come from a process daimon cannot "
+                    "see")
+            reads.append((flag, "<heredoc>", heredocs.pop(0)))
+            continue
+        raw = value
+        if flag in _FIELD_FLAGS and "=" in value:
+            _, _, rhs = value.partition("=")
+            if not rhs.startswith("@"):
+                # A literal field value names no file. Reporting unresolved
+                # here would make every `gh api -F name=x` unprovable for
+                # nothing.
+                continue
+            raw = rhs[1:]
+        elif flag in _FIELD_FLAGS and value.startswith("@"):
+            raw = value[1:]
+        elif flag not in _PATH_FLAGS:
+            continue
+        if not raw:
+            return Unresolved("arg-form-unparsed",
+                              f"{flag} was given an empty path")
+        text = _read_file(raw, base)
+        if isinstance(text, Unresolved):
+            return text
+        reads.append((flag, raw, text))
+
+    handle_fd, path = tempfile.mkstemp(prefix="daimon-check-",
+                                       suffix=".subject")
+    try:
+        with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
+            handle.write(_subject_text(command, reads))
+        # mkstemp is already umask-independent; stated again so the mode is
+        # a property of this file rather than of the stdlib's default.
+        os.chmod(path, 0o600)
+    except OSError as exc:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        # Not a cause the spec's table anticipated: the subject could not be
+        # built because daimon's own temp dir failed. It is unresolved either
+        # way, and `check-crashed` is the cause that says the machinery, not
+        # the argument, is what went wrong.
+        return Unresolved("check-crashed",
+                          f"the subject file could not be written: {exc}")
+    return Subject(path, tuple((flag, source) for flag, source, _ in reads))
+
+
+def discard(subject) -> None:
+    """Remove a materialized subject. Never raises: it runs in a `finally`
+    on a path that already has an outcome to report."""
+    path = getattr(subject, "path", None)
+    if not isinstance(path, str) or not path:
+        return
+    try:
+        os.unlink(path)
+    except OSError:
+        pass

--- a/plugin/daimon_briefing/checks_runtime.py
+++ b/plugin/daimon_briefing/checks_runtime.py
@@ -23,11 +23,15 @@ why. Every function returns a value that says what happened, including when
 what happened is that daimon could not tell.
 """
 
+import hashlib
 import json
 import os
 import re
 import shlex
+import signal
+import subprocess
 import tempfile
+import time
 from pathlib import Path
 from typing import NamedTuple
 
@@ -74,6 +78,18 @@ class Subject(NamedTuple):
     `discard` once the check has run."""
     path: str
     files: tuple
+    command: str = ""
+
+
+class Outcome(NamedTuple):
+    """What one check run produced. `outcome` is one of the three spec 2.3
+    values and never folds: unresolved is not clean and is not a violation.
+    `exit_code` is -1 when no process ran."""
+    outcome: str
+    cause: str
+    reason: str
+    exit_code: int
+    duration_ms: int
 
 
 class Unresolved(NamedTuple):
@@ -406,7 +422,8 @@ def resolve(command, cwd):
         # the argument, is what went wrong.
         return Unresolved("check-crashed",
                           f"the subject file could not be written: {exc}")
-    return Subject(path, tuple((flag, source) for flag, source, _ in reads))
+    return Subject(path, tuple((flag, source) for flag, source, _ in reads),
+                   command)
 
 
 def discard(subject) -> None:
@@ -419,3 +436,141 @@ def discard(subject) -> None:
         os.unlink(path)
     except OSError:
         pass
+
+
+# ---- runner (spec 3.3) ----------------------------------------------------
+
+DEFAULT_TIMEOUT = 5.0
+
+
+def body_name(entry) -> str:
+    """The materialized body's file name: the ruling id and the head of the
+    hash it was ratified with. Two names for one ruling means the pin moved,
+    and the stale one is swept at the next sync."""
+    return f"{entry.get('ruling_id', '')}-{str(entry.get('sha256', ''))[:12]}.sh"
+
+
+def body_path(entry, base=None) -> Path:
+    return (Path(base) if base is not None else checks_dir()) / body_name(entry)
+
+
+def _kill_group(proc) -> None:
+    """start_new_session put the check in its own process group, so a body
+    that backgrounded something is killed WITH it. Killing only the direct
+    child leaves a grandchild holding the pipe, and the read that follows
+    blocks past the host's hook timeout, which is fail-open: the action
+    proceeds and nothing says why."""
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (OSError, AttributeError, ProcessLookupError):
+        try:
+            proc.kill()
+        except OSError:
+            pass
+
+
+def _first_line(text) -> str:
+    for line in (text or "").splitlines():
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+def run(entry_or_body, subject, *, cwd=None, timeout=None) -> Outcome:
+    """Run one check against one subject and say what happened.
+
+    `entry_or_body` is a manifest entry (whose `sha256` is re-checked against
+    the file on disk before exec) or a plain path to a body the caller just
+    materialized. Never raises: every path returns an Outcome, because the
+    hook that calls this fires before every shell action and an exception is
+    an action that proceeds with no record of why."""
+    started = time.monotonic()
+    try:
+        return _run(entry_or_body, subject, cwd, timeout, started)
+    except Exception as exc:  # noqa: BLE001 — an outcome is mandatory
+        return Outcome("unresolved", "check-crashed",
+                       f"the check runner failed: {type(exc).__name__}: {exc}",
+                       -1, int((time.monotonic() - started) * 1000))
+
+
+def _run(entry_or_body, subject, cwd, timeout, started) -> Outcome:
+    def out(outcome, cause, reason, exit_code=-1):
+        return Outcome(outcome, cause, reason, exit_code,
+                       int((time.monotonic() - started) * 1000))
+
+    ruling_id = ""
+    pinned = ""
+    if isinstance(entry_or_body, dict):
+        ruling_id = str(entry_or_body.get("ruling_id") or "")
+        pinned = str(entry_or_body.get("sha256") or "")
+        override = entry_or_body.get("body_path")
+        path = Path(override) if override else body_path(entry_or_body)
+    else:
+        path = Path(entry_or_body)
+
+    try:
+        body = path.read_bytes()
+    except OSError as exc:
+        return out("unresolved", "check-crashed",
+                   f"the check body could not be read: {exc.strerror or exc}")
+    if pinned and hashlib.sha256(body).hexdigest() != pinned:
+        # Someone edited the materialized body. Never a silent skip: an
+        # unresolved outcome is visible, a skip looks like a clean run.
+        return out("unresolved", "body-hash-mismatch",
+                   "the check body on disk is not the one this ruling was "
+                   "ratified with; run `daimon check sync`")
+
+    env = dict(os.environ)
+    env["DAIMON_CHECK_SUBJECT"] = str(getattr(subject, "path", "") or "")
+    env["DAIMON_CHECK_COMMAND"] = str(getattr(subject, "command", "") or "")
+    env["DAIMON_CHECK_RULING"] = ruling_id
+    budget = (float(timeout) if isinstance(timeout, (int, float))
+              and timeout > 0 else DEFAULT_TIMEOUT)
+
+    try:
+        proc = subprocess.Popen(
+            ["sh", str(path)],
+            cwd=str(cwd) if cwd else None,
+            env=env,
+            # Scar 0034: no stdin PIPE, so nothing here can close a pipe and
+            # make the communicate() below raise on a flush. /dev/null is
+            # also what keeps a body that reads stdin from blocking on an
+            # inherited terminal until the budget expires.
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return out("unresolved", "runtime-missing",
+                   "no POSIX sh on PATH, so no check can run on this host")
+    except OSError as exc:
+        return out("unresolved", "check-crashed",
+                   f"the check could not be started: {exc.strerror or exc}")
+
+    try:
+        _, err = proc.communicate(timeout=budget)
+    except subprocess.TimeoutExpired:
+        _kill_group(proc)
+        try:
+            proc.communicate(timeout=1)
+        except Exception:  # noqa: BLE001 — the outcome is already decided
+            pass
+        return out("unresolved", "check-timeout",
+                   f"the check did not finish within {budget:g}s")
+
+    code = proc.returncode
+    reason = _first_line(err)
+    if code == 0:
+        return out("clean", "", "", 0)
+    if code == 1:
+        return out("violation", "",
+                   reason or "the check reported a violation and gave no "
+                             "reason", 1)
+    # 126 and 127 land here with sh's own first stderr line, which is how a
+    # body that reaches outside itself becomes observable: the slice 1 path
+    # refusal catches a bare single-token path, and a one-line `sh /host.sh`
+    # passes it.
+    return out("unresolved", "check-crashed",
+               reason or f"the check exited {code}", code)

--- a/plugin/daimon_briefing/checks_runtime.py
+++ b/plugin/daimon_briefing/checks_runtime.py
@@ -61,6 +61,20 @@ MAX_SUBJECT_FILE_BYTES = 1024 * 1024
 # proceeds. This is the one known bound and it is documented as such.
 MATCH_INPUT_BYTES = 4096
 
+# The same bound at the resolver's door, which is the second way in. The
+# prefilter above reads a slice; the resolver has to TOKENIZE what it was
+# given, and shlex is superlinear in the length of a single argument.
+# Measured, with heredocs already stripped: 0.14s at 64 KiB, 5.3s at 512 KiB,
+# 21s at 1 MiB. The host hook timeout is 10s and it is fail-open, so a
+# resolver that outlives it lets the action through with no record at all.
+#
+# It counts the command AFTER heredoc bodies are removed, because those cost
+# nothing to skip: the expensive input is one long inline argument, a base64
+# blob or an expanded --body. A command above this is unresolved, never
+# allowed, because a command daimon declined to parse is one it can prove
+# nothing about.
+MAX_COMMAND_BYTES = 64 * 1024
+
 
 class Manifest(NamedTuple):
     """What `load_manifest` found. `reason` is empty when the manifest was
@@ -521,6 +535,15 @@ def resolve(command, cwd):
         return f" {_HEREDOC_MARK}{len(heredocs) - 1}\x00 "
 
     text = _HEREDOC_RE.sub(_take, command)
+    # Bounded BEFORE the lexer, which is the expensive part. Above the cap
+    # daimon declines rather than spending the host's whole hook budget on
+    # tokenizing one enormous argument and then being overtaken by a timeout
+    # that lets the action through.
+    if len(text.encode("utf-8", "replace")) > MAX_COMMAND_BYTES:
+        return Unresolved(
+            "arg-form-unparsed",
+            f"the command is too long to resolve within the check budget "
+            f"(over {MAX_COMMAND_BYTES} bytes with heredocs removed)")
     # Every heredoc BODY is gone by now, so a remaining newline separates two
     # commands exactly as a semicolon does. Spelling it as one lets a single
     # lexer pass find every boundary; the lexer folds a bare newline into

--- a/plugin/daimon_briefing/checks_runtime.py
+++ b/plugin/daimon_briefing/checks_runtime.py
@@ -273,6 +273,54 @@ _KNOWN_FLAGS = frozenset(_PATH_FLAGS) | frozenset(_FIELD_FLAGS)
 _HEREDOC_RE = re.compile(
     r"<<-?[ \t]*(['\"]?)(\w+)\1[^\n]*\n(.*?)\n[ \t]*\2(?=\s|$)", re.DOTALL)
 
+# A heredoc is replaced by a marker token rather than by whitespace, so the
+# token stream still says WHERE the redirect stood. NUL is in it because a
+# command string carrying one cannot be executed anyway, which makes a
+# collision with real text impossible rather than unlikely.
+_HEREDOC_MARK = "\x00daimon-heredoc-"
+
+# Tokens that end one simple command and begin the next. `&` is here for the
+# same reason the others are: what follows it is a different command, and a
+# heredoc on one side of it does not feed an argument on the other.
+_SEGMENT_BREAKS = frozenset({"&&", "||", ";", "|", "&"})
+
+
+def _heredoc_index(token):
+    """The heredoc a marker token stands for, or None for a real argument."""
+    if token.startswith(_HEREDOC_MARK) and token.endswith("\x00"):
+        try:
+            return int(token[len(_HEREDOC_MARK):-1])
+        except ValueError:
+            return None
+    return None
+
+
+def _segments(tokens):
+    """The command split into simple commands: (tokens, heredoc indexes, fed
+    by a pipe).
+
+    A heredoc redirect belongs to the command it is attached to, and nothing
+    else in the string can claim it. Without this split, `cat <<EOF ... EOF`
+    followed by a governed command hands the governed command text it never
+    reads — and if that text is clean, the record says the real body was
+    proven safe."""
+    out = []
+    current: list = []
+    marks: list = []
+    piped = False
+    for token in tokens:
+        if token in _SEGMENT_BREAKS:
+            out.append((current, marks, piped))
+            current, marks, piped = [], [], token == "|"
+            continue
+        index = _heredoc_index(token)
+        if index is None:
+            current.append(token)
+        else:
+            marks.append(index)
+    out.append((current, marks, piped))
+    return out
+
 
 def _split_attached(token):
     """`--body-file=x` -> ("--body-file", "x", True); anything else is left
@@ -361,39 +409,17 @@ def _subject_text(command, reads) -> str:
     return "".join(parts)
 
 
-def resolve(command, cwd):
-    """The action's subject, or the cause daimon could not build one.
+def _resolve_segment(tokens, marks, piped, heredocs, base, reads):
+    """Read one simple command's file arguments into `reads`.
 
-    Subject = the command string, a separator, then every resolved file's
-    bytes under a header naming the flag it came from. Written to a 0o600
-    file in the SYSTEM temp dir: a file under ~/.daimon would have to be
-    declared in the surface registry and carry a deletion story, and this
-    one lives for the length of one exec.
-
-    Fail-closed and first-failure-wins. One argument daimon cannot read
-    means it cannot prove the subject clean, whatever the others say."""
-    if not isinstance(command, str):
-        return Unresolved("arg-form-unparsed", "the command is not a string")
-    base = cwd if isinstance(cwd, str) and cwd else os.getcwd()
-
-    heredocs: list = []
-
-    def _take(match):
-        heredocs.append(match.group(3))
-        return " "
-
-    try:
-        tokens = shlex.split(_HEREDOC_RE.sub(_take, command), posix=True)
-    except ValueError as exc:
-        return Unresolved("arg-form-unparsed",
-                          f"the command could not be tokenized: {exc}")
-
-    # Counted before the walk: binding a heredoc is only safe when there is
-    # exactly one candidate on each side.
+    Returns None when the segment is fine, or the Unresolved that stopped it.
+    A heredoc binds only from `marks`, which holds the redirects that stood
+    inside THIS command, so text belonging to a neighbour can never be
+    presented as what the governed command reads."""
+    # Counted per segment: binding is only safe with exactly one candidate on
+    # each side, and the sides are this command's, not the whole string's.
     consumers = sum(1 for flag, value, _ in _walk(tokens)
                     if flag is not None and value == "-")
-
-    reads: list = []
     for flag, value, previous in _walk(tokens):
         if flag is None:
             # Row 6: a form outside the table is never assumed harmless.
@@ -413,32 +439,31 @@ def resolve(command, cwd):
                               f"{flag} was given no value")
 
         if value == "-":
-            if not heredocs:
-                return Unresolved(
-                    "stdin-pipe",
-                    f"{flag} reads standard input and the command carries no "
-                    "heredoc, so the bytes come from a process daimon cannot "
-                    "see")
-            if len(heredocs) != 1 or consumers != 1:
-                # Which heredoc feeds which argument is a question this
-                # tokenizer cannot answer: it keeps neither the order nor the
-                # redirections. Handing over the first one guesses, and a
-                # wrong guess builds the subject from unrelated text and then
-                # reports clean on a body nothing ever read.
-                #
-                # KNOWN RESIDUAL: one heredoc belonging to an EARLIER command
-                # plus one argument reading standard input counts as one and
-                # one, so it still binds the wrong text. Closing that needs
-                # the heredoc's offset in the raw command matched against the
-                # offset of the argument that consumes it, which is thrown
-                # away above. Pinned by a test that says so out loud.
+            if len(marks) == 1 and consumers == 1:
+                reads.append((flag, "<heredoc>", heredocs[marks[0]]))
+                continue
+            if not marks:
+                if piped:
+                    return Unresolved(
+                        "stdin-pipe",
+                        f"{flag} reads standard input and a pipe fills it, so "
+                        "the bytes come from a process daimon cannot see")
+                # A heredoc elsewhere in the string belongs to the command it
+                # is attached to, never to this one. Borrowing it would build
+                # the subject from text this command never reads, and if THAT
+                # text is clean the record says the real body was proven safe.
                 return Unresolved(
                     "arg-form-unparsed",
-                    f"the command carries {len(heredocs)} heredoc(s) and "
-                    f"{consumers} argument(s) reading standard input; daimon "
-                    "binds one to one or not at all")
-            reads.append((flag, "<heredoc>", heredocs[0]))
-            continue
+                    f"{flag} reads standard input and this command carries no "
+                    "heredoc of its own, so daimon cannot see what fills it")
+            # Inside one command the counts still have to be one and one:
+            # which heredoc feeds which argument is not something the token
+            # stream answers, and a guess is the same defect one scope down.
+            return Unresolved(
+                "arg-form-unparsed",
+                f"this command carries {len(marks)} heredoc(s) and "
+                f"{consumers} argument(s) reading standard input; daimon "
+                "binds one to one or not at all")
         raw = value
         if flag in _FIELD_FLAGS and "=" in value:
             _, _, rhs = value.partition("=")
@@ -459,6 +484,55 @@ def resolve(command, cwd):
         if isinstance(text, Unresolved):
             return text
         reads.append((flag, raw, text))
+    return None
+
+
+def resolve(command, cwd):
+    """The action's subject, or the cause daimon could not build one.
+
+    Subject = the command string, a separator, then every resolved file's
+    bytes under a header naming the flag it came from. Written to a 0o600
+    file in the SYSTEM temp dir: a file under ~/.daimon would have to be
+    declared in the surface registry and carry a deletion story, and this
+    one lives for the length of one exec.
+
+    Fail-closed and first-failure-wins. One argument daimon cannot read
+    means it cannot prove the subject clean, whatever the others say."""
+    if not isinstance(command, str):
+        return Unresolved("arg-form-unparsed", "the command is not a string")
+    base = cwd if isinstance(cwd, str) and cwd else os.getcwd()
+
+    heredocs: list = []
+
+    def _take(match):
+        heredocs.append(match.group(3))
+        return f" {_HEREDOC_MARK}{len(heredocs) - 1}\x00 "
+
+    text = _HEREDOC_RE.sub(_take, command)
+    # Every heredoc BODY is gone by now, so a remaining newline separates two
+    # commands exactly as a semicolon does. Spelling it as one lets a single
+    # lexer pass find every boundary; the lexer folds a bare newline into
+    # whitespace and would otherwise run two commands together. A newline
+    # inside a quoted argument is rewritten too, which changes that argument's
+    # text and nothing daimon reads from it.
+    text = text.replace("\r\n", "\n").replace("\n", " ; ")
+    try:
+        # punctuation_chars makes the shell operators their own tokens while
+        # keeping quotes intact, which is what the segment split needs.
+        lexer = shlex.shlex(text, posix=True, punctuation_chars=True)
+        lexer.whitespace_split = True
+        lexer.commenters = ""  # shlex.split's setting: `#` is not a comment
+        tokens = list(lexer)
+    except ValueError as exc:
+        return Unresolved("arg-form-unparsed",
+                          f"the command could not be tokenized: {exc}")
+
+    reads: list = []
+    for seg_tokens, marks, piped in _segments(tokens):
+        outcome = _resolve_segment(seg_tokens, marks, piped, heredocs, base,
+                                   reads)
+        if outcome is not None:
+            return outcome
 
     handle_fd, path = tempfile.mkstemp(prefix="daimon-check-",
                                        suffix=".subject")

--- a/plugin/daimon_briefing/checks_runtime.py
+++ b/plugin/daimon_briefing/checks_runtime.py
@@ -276,12 +276,53 @@ _HEREDOC_RE = re.compile(
 
 def _split_attached(token):
     """`--body-file=x` -> ("--body-file", "x", True); anything else is left
-    for the two-token form."""
+    for the two-token form.
+
+    The single-dash case comes FIRST and does not need an `=`. pflag, the
+    flag library gh uses, accepts a shorthand value attached to its flag, so
+    `-Fbody.md` is the same command as `-F body.md` and `-Fkey=@p` the same
+    as `-F key=@p`. Splitting here rather than at the use sites means the
+    field and the dash rules below apply to both spellings unchanged: an
+    attached form daimon did not split fell through every branch and left
+    the subject holding only the command string, which reports CLEAN for a
+    file that was never opened."""
+    if (token.startswith("-") and not token.startswith("--")
+            and len(token) > 2 and token[:2] in _KNOWN_FLAGS):
+        value = token[2:]
+        # pflag treats a leading `=` after a shorthand as the separator, so
+        # `-F=body.md` names the file body.md and not a field with an empty
+        # name. Following it keeps the two spellings one command.
+        return token[:2], value[1:] if value.startswith("=") else value, True
     if token.startswith("-") and "=" in token:
         head, _, tail = token.partition("=")
         if head in _KNOWN_FLAGS:
             return head, tail, True
     return token, "", False
+
+
+def _walk(tokens):
+    """(flag, value, previous token) for each step of the command.
+
+    `flag` is None for a token that names no known flag, and `value` is None
+    when a known flag ran off the end with nothing after it. One generator,
+    two readers: the dash-consumer count below and the resolver itself, so
+    the two can never disagree about what a token means."""
+    index = 0
+    while index < len(tokens):
+        previous = tokens[index - 1] if index else ""
+        flag, value, attached = _split_attached(tokens[index])
+        if flag not in _KNOWN_FLAGS:
+            index += 1
+            yield None, tokens[index - 1], previous
+            continue
+        if not attached:
+            index += 1
+            if index >= len(tokens):
+                yield flag, None, previous
+                return
+            value = tokens[index]
+        index += 1
+        yield flag, value, previous
 
 
 def _read_file(raw, base):
@@ -348,30 +389,23 @@ def resolve(command, cwd):
                           f"the command could not be tokenized: {exc}")
 
     reads: list = []
-    index = 0
-    while index < len(tokens):
-        token = tokens[index]
-        flag, value, attached = _split_attached(token)
-        if flag not in _KNOWN_FLAGS:
+    for flag, value, previous in _walk(tokens):
+        if flag is None:
             # Row 6: a form outside the table is never assumed harmless.
-            if token == "-" and index and tokens[index - 1].startswith("-"):
+            token = value
+            if token == "-" and previous.startswith("-"):
                 return Unresolved(
                     "arg-form-unparsed",
-                    f"{tokens[index - 1]} reads standard input in a form "
-                    "daimon does not parse")
+                    f"{previous} reads standard input in a form daimon does "
+                    "not parse")
             if token.startswith("@") and len(token) > 1:
                 return Unresolved(
                     "arg-form-unparsed",
                     f"{token} names a file in a form daimon does not parse")
-            index += 1
             continue
-        if not attached:
-            index += 1
-            if index >= len(tokens):
-                return Unresolved("arg-form-unparsed",
-                                  f"{flag} was given no value")
-            value = tokens[index]
-        index += 1
+        if value is None:
+            return Unresolved("arg-form-unparsed",
+                              f"{flag} was given no value")
 
         if value == "-":
             if not heredocs:

--- a/plugin/daimon_briefing/checks_runtime.py
+++ b/plugin/daimon_briefing/checks_runtime.py
@@ -389,6 +389,12 @@ def _read_file(raw, base):
         return Unresolved("file-missing", f"{raw} does not exist")
     except OSError as exc:
         return Unresolved("file-unreadable", f"{raw}: {exc.strerror or exc}")
+    except ValueError as exc:
+        # A NUL in the path: `open` rejects it before the OS ever sees it, and
+        # it raises ValueError rather than OSError, so it walks straight past
+        # the clause above. The command string comes from a host payload and
+        # can carry one.
+        return Unresolved("file-unreadable", f"{raw}: {exc}")
     if len(data) > MAX_SUBJECT_FILE_BYTES:
         return Unresolved(
             "file-oversize",
@@ -416,6 +422,12 @@ def _resolve_segment(tokens, marks, piped, heredocs, base, reads):
     A heredoc binds only from `marks`, which holds the redirects that stood
     inside THIS command, so text belonging to a neighbour can never be
     presented as what the governed command reads."""
+    # A marker token is minted by `_take` and nothing else, but the command
+    # string arrives from a host payload and can spell one out. An index no
+    # heredoc answers to is simply not a heredoc; without this the bind below
+    # reads past the end of the list and the resolver raises, which is the
+    # one thing this module promises never to do.
+    marks = [index for index in marks if 0 <= index < len(heredocs)]
     # Counted per segment: binding is only safe with exactly one candidate on
     # each side, and the sides are this command's, not the whole string's.
     consumers = sum(1 for flag, value, _ in _walk(tokens)
@@ -534,9 +546,13 @@ def resolve(command, cwd):
         if outcome is not None:
             return outcome
 
-    handle_fd, path = tempfile.mkstemp(prefix="daimon-check-",
-                                       suffix=".subject")
+    # mkstemp inside the try, not before it: a temp dir that is full or
+    # read-only fails HERE, and a raise from this function is an action that
+    # proceeds with no record of why.
+    path = ""
     try:
+        handle_fd, path = tempfile.mkstemp(prefix="daimon-check-",
+                                           suffix=".subject")
         with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
             handle.write(_subject_text(command, reads))
         # mkstemp is already umask-independent; stated again so the mode is
@@ -544,7 +560,8 @@ def resolve(command, cwd):
         os.chmod(path, 0o600)
     except OSError as exc:
         try:
-            os.unlink(path)
+            if path:
+                os.unlink(path)
         except OSError:
             pass
         # Not a cause the spec's table anticipated: the subject could not be

--- a/plugin/daimon_briefing/checks_runtime.py
+++ b/plugin/daimon_briefing/checks_runtime.py
@@ -388,6 +388,11 @@ def resolve(command, cwd):
         return Unresolved("arg-form-unparsed",
                           f"the command could not be tokenized: {exc}")
 
+    # Counted before the walk: binding a heredoc is only safe when there is
+    # exactly one candidate on each side.
+    consumers = sum(1 for flag, value, _ in _walk(tokens)
+                    if flag is not None and value == "-")
+
     reads: list = []
     for flag, value, previous in _walk(tokens):
         if flag is None:
@@ -414,7 +419,25 @@ def resolve(command, cwd):
                     f"{flag} reads standard input and the command carries no "
                     "heredoc, so the bytes come from a process daimon cannot "
                     "see")
-            reads.append((flag, "<heredoc>", heredocs.pop(0)))
+            if len(heredocs) != 1 or consumers != 1:
+                # Which heredoc feeds which argument is a question this
+                # tokenizer cannot answer: it keeps neither the order nor the
+                # redirections. Handing over the first one guesses, and a
+                # wrong guess builds the subject from unrelated text and then
+                # reports clean on a body nothing ever read.
+                #
+                # KNOWN RESIDUAL: one heredoc belonging to an EARLIER command
+                # plus one argument reading standard input counts as one and
+                # one, so it still binds the wrong text. Closing that needs
+                # the heredoc's offset in the raw command matched against the
+                # offset of the argument that consumes it, which is thrown
+                # away above. Pinned by a test that says so out loud.
+                return Unresolved(
+                    "arg-form-unparsed",
+                    f"the command carries {len(heredocs)} heredoc(s) and "
+                    f"{consumers} argument(s) reading standard input; daimon "
+                    "binds one to one or not at all")
+            reads.append((flag, "<heredoc>", heredocs[0]))
             continue
         raw = value
         if flag in _FIELD_FLAGS and "=" in value:

--- a/plugin/daimon_briefing/checks_runtime.py
+++ b/plugin/daimon_briefing/checks_runtime.py
@@ -330,21 +330,21 @@ def _read_file(raw, base):
     paths resolve against the action's working directory, because that is
     what the shell would have done."""
     path = raw if os.path.isabs(raw) else os.path.join(base, raw)
+    # One answer about one file. A stat that decides the cap and an open that
+    # happens afterwards are two answers, and they disagree whenever the file
+    # changes in between; reading one byte past the cap and judging THAT
+    # cannot disagree with itself, and it never holds more than the cap.
     try:
-        size = os.stat(path).st_size
+        with open(path, "rb") as handle:
+            data = handle.read(MAX_SUBJECT_FILE_BYTES + 1)
     except FileNotFoundError:
         return Unresolved("file-missing", f"{raw} does not exist")
     except OSError as exc:
         return Unresolved("file-unreadable", f"{raw}: {exc.strerror or exc}")
-    if size > MAX_SUBJECT_FILE_BYTES:
+    if len(data) > MAX_SUBJECT_FILE_BYTES:
         return Unresolved(
             "file-oversize",
-            f"{raw} is {size} bytes, over the {MAX_SUBJECT_FILE_BYTES} cap")
-    try:
-        with open(path, "rb") as handle:
-            data = handle.read()
-    except OSError as exc:
-        return Unresolved("file-unreadable", f"{raw}: {exc.strerror or exc}")
+            f"{raw} is over the {MAX_SUBJECT_FILE_BYTES} byte cap")
     try:
         return data.decode("utf-8")
     except UnicodeDecodeError:
@@ -499,6 +499,15 @@ def discard(subject) -> None:
 
 DEFAULT_TIMEOUT = 5.0
 
+# What a check body inherits, plus every LC_* and the three DAIMON_CHECK_*
+# variables the runner sets. A ratified body is human-armed and runs as the
+# user, so this is not a sandbox and does not pretend to be one. It is a blast
+# radius: the body's job is to read one subject file, and handing it every
+# token in the host session widens what a mistake in someone else's script can
+# reach, for nothing. PATH and HOME stay because a body that cannot find its
+# own tools reports check-crashed and looks like a defect in the check.
+_ENV_KEEP = frozenset({"PATH", "HOME", "LANG", "TMPDIR"})
+
 
 def body_name(entry) -> str:
     """The materialized body's file name: the ruling id and the head of the
@@ -577,7 +586,8 @@ def _run(entry_or_body, subject, cwd, timeout, started) -> Outcome:
                    "the check body on disk is not the one this ruling was "
                    "ratified with; run `daimon check sync`")
 
-    env = dict(os.environ)
+    env = {name: value for name, value in os.environ.items()
+           if name in _ENV_KEEP or name.startswith("LC_")}
     env["DAIMON_CHECK_SUBJECT"] = str(getattr(subject, "path", "") or "")
     env["DAIMON_CHECK_COMMAND"] = str(getattr(subject, "command", "") or "")
     env["DAIMON_CHECK_RULING"] = ruling_id

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -1200,6 +1200,9 @@ from .team import (  # noqa: E402
     _cmd_team_status,  # noqa: F401 — re-exported for compat
     _cmd_team_sync,  # noqa: F401 — re-exported for compat
 )
+from .check import (  # noqa: E402
+    _cmd_check_sync,  # noqa: F401 — re-exported for compat
+)
 from .hooks import (  # noqa: E402
     _cmd_hooks_install,  # noqa: F401 — re-exported for compat
     _cmd_hooks_list,  # noqa: F401 — re-exported for compat
@@ -1215,6 +1218,7 @@ from .skill import (  # noqa: E402
 from . import (  # noqa: E402
     amend,
     audit,
+    check,
     hooks,
     lifecycle,
     refute,
@@ -1786,11 +1790,15 @@ def _write_worldcheck_ledger(rows, route) -> None:
     the first place that knows where the item currently stands. A cure for an
     item nothing contradicted changes nothing, and writing it anyway would
     turn a ledger of problems found into a ledger of work done."""
-    for item_ref, check, reason in rows:
-        if check == worldcheck.LEDGER_CONFIRM_CHECK:
+    # `check_name`, not `check`: the #943 `daimon check` verb family is
+    # imported into this module under that name, and a loop variable shadowing
+    # it is the kind of collision that is silent until the shadowed name is
+    # needed in the same scope.
+    for item_ref, check_name, reason in rows:
+        if check_name == worldcheck.LEDGER_CONFIRM_CHECK:
             store.append_receipt_cure(item_ref, project_dir=route)
         else:
-            store.append_verification(item_ref, check, reason,
+            store.append_verification(item_ref, check_name, reason,
                                       project_dir=route)
 
 
@@ -3643,6 +3651,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_stats.add_argument("--json", action="store_true", help="machine-readable output")
     p_stats.set_defaults(func=_cmd_stats)
+
+    check.register(sub, fmt)
 
     hooks.register(sub, fmt)
 

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -1154,6 +1154,7 @@ from .refute import (  # noqa: E402
     _cmd_refute_show,  # noqa: F401 — re-exported for compat
 )
 from .ruling import (  # noqa: E402
+    _cmd_ruling_check_try,  # noqa: F401 — re-exported for compat
     _cmd_ruling_list,  # noqa: F401 — re-exported for compat
     _cmd_ruling_propose,  # noqa: F401 — re-exported for compat
     _cmd_ruling_ratify,  # noqa: F401 — re-exported for compat

--- a/plugin/daimon_briefing/cli/_ledger.py
+++ b/plugin/daimon_briefing/cli/_ledger.py
@@ -201,6 +201,31 @@ def _check_args(args) -> dict | None:
     return {"match": match, "body": body, "intent": intent or "warn"}
 
 
+def _check_sync_warning() -> str:
+    """#943: the line to show when a write landed but the armed-check
+    manifest did not, or "" when there is nothing to say.
+
+    The verb succeeded — the ledger is the record and it changed. What did
+    not change is the derived view a host hook reads, so the check the human
+    just armed is not yet armed anywhere. Silence there would leave someone
+    believing a ratified check is running. The exit code stays the verb's:
+    this is bookkeeping, not a failed ratification.
+
+    One wording, two renderers: the ruling verbs print it directly and
+    `forget` folds it into its report list."""
+    report = refutations.last_check_sync()
+    if report is None or report.ok:
+        return ""
+    return (f"warning: check manifest not updated ({report.reason}); "
+            "run daimon check sync")
+
+
+def _warn_check_sync() -> None:
+    line = _check_sync_warning()
+    if line:
+        print(line)
+
+
 def _check_ceremony_lines(check: dict, *, label: str, verb: str) -> list[str]:
     """#943: the two disclosure lines a ceremony prints before a human arms
     a check. One home for the wording, shared by ratify and revise, so the

--- a/plugin/daimon_briefing/cli/check.py
+++ b/plugin/daimon_briefing/cli/check.py
@@ -1,0 +1,51 @@
+"""`daimon check` verbs — the armed-check manifest (#943).
+
+One verb so far. `check sync` rebuilds `~/.daimon/checks/` from the ledger:
+the manifest a host hook reads and one executable body per armed check.
+
+Every ledger writer already calls the same function, so this exists for the
+cases a writer cannot cover — a manifest deleted or corrupted by hand, an
+install whose checks directory moved, a sync that failed and printed its
+warning. Safe to repeat, and `hooks install` will call it in slice 3.
+"""
+
+import daimon_briefing.cli as _cli
+
+from .. import checks, render
+
+
+def _cmd_check_sync(args) -> int:
+    project = _cli._resolve_project(args.project)
+    report = checks.sync(project)
+    if not report.ok:
+        # stdout, like every other refusal in the ledger families: #194
+        # moved diagnostics off stderr, and the warning the ruling verbs
+        # print for the same failure goes here too.
+        print(f"checks: manifest not updated ({report.reason})")
+        return 1
+    # Reported even at zero. A silent success is how a project that armed
+    # nothing and a project whose sync never ran come to look identical.
+    render.render_ledger_lines(
+        [f"checks: {report.armed} armed for {report.slug}"])
+    return 0
+
+
+def register(sub, fmt) -> None:
+    """Register the `check` parser family on the top-level subparsers."""
+    p_check = sub.add_parser(
+        "check",
+        help="armed rulings' checks (#943): rebuild what a host hook reads")
+    check_sub = p_check.add_subparsers(dest="check_cmd", required=True)
+    pc_sync = check_sub.add_parser(
+        "sync",
+        help="rebuild the check manifest and bodies from this project's "
+             "ledger; safe to repeat, and every ratify already does it")
+    pc_sync.add_argument(
+        "--project",
+        help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    # `--slug` is deliberately absent. Slice 2 adds no routing primitive:
+    # that flag reaches ten human-only decision verbs and is refused outright
+    # on a tenant-scoped home, and widening it to a verb that materializes
+    # executables would hand bucket-choosing power past the check that gates
+    # it (#899, #948).
+    pc_sync.set_defaults(func=_cli._cmd_check_sync)

--- a/plugin/daimon_briefing/cli/lifecycle.py
+++ b/plugin/daimon_briefing/cli/lifecycle.py
@@ -25,6 +25,7 @@ from .. import (
     serializer,
     store,
 )
+from ._ledger import _check_sync_warning
 
 
 def _cmd_resolve(args) -> int:
@@ -684,6 +685,14 @@ def _cmd_forget(args) -> int:
         report.append(
             f"scrubbed {scrubbed_lines} legacy downgrade line(s) in "
             "serialize.log (payload replaced; ledger lines kept)")
+    # #943: a forgotten ruling's check has to leave the disk with it, and
+    # the removal happens by re-deriving the manifest from the ledger this
+    # forget just rewrote. When that derivation fails, the body is still
+    # armed and the report must say so rather than claiming a clean sweep.
+    check_warning = _check_sync_warning()
+    if check_warning:
+        report.append(f"{check_warning} — a forgotten ruling's check may "
+                      "still be armed on this host")
     render.render_lifecycle_lines(report)
     return 0
 

--- a/plugin/daimon_briefing/cli/ruling.py
+++ b/plugin/daimon_briefing/cli/ruling.py
@@ -11,7 +11,7 @@ import sys
 
 import daimon_briefing.cli as _cli
 
-from .. import config, normalize, refutations, render, store
+from .. import checks, config, normalize, refutations, render, store
 from ._ledger import (
     _check_args,
     _check_ceremony_lines,
@@ -294,6 +294,45 @@ def _cmd_ruling_show(args) -> int:
     return 0
 
 
+def _cmd_ruling_check_try(args) -> int:
+    """#943: run a ruling's check against a command, arming nothing.
+
+    Exit codes are the auditors' three: 0 clean, 1 violation, 3 could not be
+    proven either way. Unresolved never collapses into 0, which would read as
+    clean, or into 1, which would report a violation the check never found.
+    """
+    project = _cli._resolve_project(args.project)
+    try:
+        channel = _refute_channel(args)
+    except refutations.RefutationError as exc:
+        print(_refusal_message("check not run", exc))
+        return 1
+    if channel != "cli-tty":
+        # Never invoke the runner to harvest its error string, and never
+        # execute a body to discover the caller was not allowed to ask.
+        print("check not run: a dry run executes the check body, so it "
+              f"requires a human channel; this call arrived through {channel!r}")
+        return 1
+    try:
+        outcome = checks.try_run(
+            args.ruling_id, args.command, channel=channel, cwd=args.cwd,
+            project_dir=project, proposed=args.proposed)
+    except refutations.RefutationError as exc:
+        print(_refusal_message("check not run", exc))
+        return 1
+    lines = [f"  outcome: {outcome.outcome}"]
+    if outcome.cause:
+        lines.append(f"  cause: {outcome.cause}")
+    if outcome.reason:
+        lines.append(f"  reason: {outcome.reason}")
+    lines.append(f"  duration: {outcome.duration_ms} ms")
+    lines.append("  Nothing was armed and nothing was logged; this was a "
+                 "rehearsal.")
+    render.render_ledger_lines(lines)
+    _cli._note_usage("ruling:check-try")
+    return {"clean": 0, "violation": 1}.get(outcome.outcome, 3)
+
+
 def register(sub, fmt) -> None:
     """Register the `ruling` parser family on the top-level subparsers."""
     p_ruling = sub.add_parser(
@@ -416,6 +455,30 @@ def register(sub, fmt) -> None:
     rl_retire.add_argument("--slug", metavar="SLUG", help=_cli.SLUG_ROUTE_HELP)
     rl_retire.add_argument("--json", action="store_true", help="machine-readable output")
     rl_retire.set_defaults(func=_cli._cmd_ruling_retire)
+
+    rl_check = ruling_sub.add_parser(
+        "check", help="the check a ruling carries (#943): try it before a "
+                      "human arms it")
+    check_sub = rl_check.add_subparsers(dest="ruling_check_cmd", required=True)
+    rc_try = check_sub.add_parser(
+        "try", help="run this ruling's check against a command and print the "
+                    "outcome; arms nothing, logs nothing")
+    rc_try.add_argument("ruling_id", help="exact r-... id")
+    rc_try.add_argument("--command", required=True, metavar="CMD",
+                        help="the command string to check, as a host would "
+                             "hand it to the hook")
+    rc_try.add_argument("--cwd", metavar="DIR",
+                        help="working directory the command would run in; "
+                             "relative file arguments resolve against it "
+                             "(default: the current directory)")
+    rc_try.add_argument(
+        "--proposed", action="store_true",
+        help="run the pending revision's check instead of the armed one")
+    rc_try.add_argument("--by", choices=["agent"], default=None,
+                        help="declare yourself an agent; a dry run then "
+                             "refuses, because it executes the body")
+    rc_try.add_argument("--project", help="project directory (default: DAIMON_PROJECT_DIR, then cwd)")
+    rc_try.set_defaults(func=_cli._cmd_ruling_check_try)
 
     rl_list = ruling_sub.add_parser("list", help="list project rulings")
     rl_list.add_argument("--state", action="append",

--- a/plugin/daimon_briefing/cli/ruling.py
+++ b/plugin/daimon_briefing/cli/ruling.py
@@ -15,6 +15,7 @@ from .. import config, normalize, refutations, render, store
 from ._ledger import (
     _check_args,
     _check_ceremony_lines,
+    _warn_check_sync,
     _print_ruling,
     _refusal_message,
     _refutation_json,
@@ -111,6 +112,7 @@ def _cmd_ruling_ratify(args) -> int:
     except refutations.RefutationError as exc:
         print(_refusal_message("ruling not ratified", exc))
         return 1
+    _warn_check_sync()
     record = refutations.get(args.ruling_id, project_dir=project)
     _cli._note_usage("ruling:ratify")
     if record is None:
@@ -185,6 +187,7 @@ def _cmd_ruling_revise(args) -> int:
     except refutations.RefutationError as exc:
         print(_refusal_message("ruling not revised", exc))
         return 1
+    _warn_check_sync()
     record = refutations.get(args.ruling_id, project_dir=project)
     _cli._note_usage("ruling:revise")
     if record is None:
@@ -217,6 +220,7 @@ def _cmd_ruling_retire(args) -> int:
     except refutations.RefutationError as exc:
         print(_refusal_message("ruling not retired", exc))
         return 1
+    _warn_check_sync()
     record = refutations.get(args.ruling_id, project_dir=project)
     _cli._note_usage("ruling:retire")
     if record is None:

--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -487,6 +487,35 @@ def keys_dir() -> Path:
     return Path.home() / ".daimon" / "keys"
 
 
+def checks_dir() -> Path:
+    """Where #943 materializes armed checks: manifest.json plus one 0o500
+    script per armed ruling. Default ~/.daimon/checks; DAIMON_CHECKS_DIR
+    overrides (the autouse test fixture points it under tmp, because HOME is
+    not redirected and a fall-through here writes the developer's real home).
+
+    `checks_runtime.py` mirrors this accessor line for line — the hook side
+    reads what this side writes, and a divergence splits the two silently."""
+    raw = _get("DAIMON_CHECKS_DIR")
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".daimon" / "checks"
+
+
+def check_timeout() -> float:
+    """The check runner's own budget in seconds (#943). Default 5, against a
+    host hook timeout of 10.
+
+    The runner has to decide before the HOST gives up: on Claude Code and
+    Codex a hook that reaches the host's timeout does not block and the tool
+    proceeds, so a runner without its own budget converts a hanging check
+    into a silently allowed action. The floor keeps the smallest configured
+    budget an actual budget rather than an unconditional timeout."""
+    try:
+        return max(0.5, float(_get("DAIMON_CHECK_TIMEOUT") or "5"))
+    except ValueError:
+        return 5.0
+
+
 def log_dir() -> Path:
     """Where the session-end hook writes serialize.log. The hook hardcodes
     ~/.daimon/logs; this override exists so the CLI (and tests) can point

--- a/plugin/daimon_briefing/refutations.py
+++ b/plugin/daimon_briefing/refutations.py
@@ -144,6 +144,19 @@ CHECK_INTENTS = frozenset({"enforce", "warn", "record-only"})
 _MAX_CHECK_BODY = 8192
 _MAX_CHECK_MATCH = 200
 _CHECK_PATH_RE = re.compile(r"\s*(?:~|/|\./)[^\s]*\s*")
+# #943 slice 2, widening the rule above from the whole body to each LINE.
+# The bare-path refusal catches `~/.claude/voicegate.sh` as an entire body; a
+# body that merely CALLS one passes it, and then the check travels to another
+# machine as a script whose real content is a file that is not there. The
+# runner does observe that (sh exits 127) but only after the ruling is
+# ratified and every host has started reporting unresolved. Refusing at
+# propose time is the same constraint one step earlier.
+#
+# Roots only, each with its separator, so `/rooted-thing` and a bare `$HOME`
+# comparison do not trip it. A relative path travels with the repo and is
+# deliberately allowed.
+_CHECK_HOST_ROOT_RE = re.compile(r"(?:^|[^\w/])(?:~/|\$HOME/|\$\{HOME\}/|"
+                                 r"/Users/|/home/|/root/)")
 
 # Every field of a ledger row that can hold ITEM plaintext, flat then nested
 # (#645). One declaration, two consumers: `forget_content_key` below decides
@@ -337,6 +350,16 @@ def _check(value) -> dict | None:
         raise RefutationError(
             "check body must be the script itself, not a path to one: a "
             "path is invisible to every other host and machine")
+    # Checked after the bare-path rule so the older, more specific message
+    # wins for a body that IS a path — that one explains what a body is,
+    # which is the more useful thing to hear.
+    for number, line in enumerate(body.splitlines(), start=1):
+        if _CHECK_HOST_ROOT_RE.search(line):
+            raise RefutationError(
+                f"check body line {number} names a host-local path; the "
+                "check travels with the ruling, so anything outside the body "
+                "is missing on every other host and machine, and the ruling "
+                "reports unresolved there forever")
     for field, text in (("match", match), ("body", body)):
         scrubbed, _ = redact.redact_text(text)
         if scrubbed != text:

--- a/plugin/daimon_briefing/refutations.py
+++ b/plugin/daimon_briefing/refutations.py
@@ -32,6 +32,7 @@ import re
 import time
 import uuid
 from datetime import datetime, timezone
+from typing import NamedTuple
 
 from . import config, normalize, policy, redact, store
 
@@ -627,6 +628,11 @@ def forget_content_key(content_key: str, *, project_dir=None) -> list[str]:
         except OSError:
             pass
         return []
+    # A forgotten ruling's check must leave the disk with it. The dropped
+    # records are already gone from the ledger here, so the manifest is
+    # rebuilt unconditionally rather than from a record that no longer
+    # exists to be inspected.
+    _sync_checks(project_dir, force=bool(doomed))
     return sorted(doomed)
 
 
@@ -1061,6 +1067,62 @@ def assert_ruling(*, subject: str, verdict: str, scope: str,
     return ref_id
 
 
+class _CheckSyncFailure(NamedTuple):
+    """Stands in for a `checks.SyncReport` when the writer could not even be
+    reached. Same field names, so the caller reads one shape."""
+    reason: str
+    ok: bool = False
+    armed: int = 0
+    slug: str = ""
+
+
+_last_check_sync = None
+
+
+def last_check_sync():
+    """The report from the most recent writer-triggered manifest sync, or
+    None when the last write carried no check.
+
+    The ledger writers return their own things (an event name, an id,
+    nothing), and a bookkeeping failure must not change any of them. So the
+    report is left here for the caller that just made the write to pick up
+    and render. Every writer that can touch a check assigns it, None
+    included, so a caller reading it straight after its own call cannot see
+    a previous verb's answer."""
+    return _last_check_sync
+
+
+def _load_checks():
+    """Imported at call time, not at module scope: `checks` reads this module
+    to build the manifest, and a top-level import would be a cycle."""
+    from . import checks
+    return checks
+
+
+def _sync_checks(project_dir=None, *, record=None, row=None,
+                 force: bool = False) -> None:
+    """Rebuild the armed-check manifest after a write that could change it.
+
+    Skipped when nothing in sight carries a check. `checks.sync` re-folds the
+    whole ledger, and every refutation ratify in the tree paying for a
+    manifest that cannot have changed is a cost with no reader.
+
+    Never raises. It runs after an append that already landed, so a failure
+    here is bookkeeping, not a failed write, and the caller reports it
+    through `last_check_sync()`."""
+    global _last_check_sync
+    _last_check_sync = None
+    carries = force or any(
+        isinstance(source, dict) and source.get("check") is not None
+        for source in (record, row))
+    if not carries:
+        return
+    try:
+        _last_check_sync = _load_checks().sync(project_dir)
+    except Exception as exc:  # noqa: BLE001 — a report, never a raise
+        _last_check_sync = _CheckSyncFailure(f"{type(exc).__name__}: {exc}")
+
+
 def retire(ruling_id: str, *, channel: str, evidence=(), note: str = "",
            project_dir=None) -> str:
     """#693: end an active ruling. Human channels retire directly; an agent
@@ -1084,6 +1146,7 @@ def retire(ruling_id: str, *, channel: str, evidence=(), note: str = "",
     row["note"] = _text("note", note, required=False)
     if not append(row, project_dir=project_dir):
         raise RefutationError("retirement not written")
+    _sync_checks(project_dir, record=current)
     return event
 
 
@@ -1120,6 +1183,7 @@ def ratify(refutation_id: str, *, channel: str, note: str = "",
         row["check_sha256"] = str(check_sha256)
     if not append(row, project_dir=project_dir):
         raise RefutationError("ratification not written")
+    _sync_checks(project_dir, record=current)
 
 
 def revise(refutation_id: str, *, channel: str, evidence,
@@ -1220,6 +1284,9 @@ def revise(refutation_id: str, *, channel: str, evidence,
         row["ratified"] = True
     if not append(row, project_dir=project_dir):
         raise RefutationError("revision not written")
+    # Either side can carry it: the record may already be armed, and this
+    # row may be what arms it.
+    _sync_checks(project_dir, record=current, row=row)
 
 
 def overturn(refutation_id: str, *, channel: str, evidence, note: str = "",
@@ -1242,6 +1309,10 @@ def overturn(refutation_id: str, *, channel: str, evidence, note: str = "",
     row["note"] = _text("note", note, required=False)
     if not append(row, project_dir=project_dir):
         raise RefutationError("overturn event not written")
+    # Inert by construction today: this function refuses rulings outright,
+    # and only a ruling carries a check. Wired so the seam is one set of
+    # writers rather than four plus an exception.
+    _sync_checks(project_dir, record=current)
     return event
 
 

--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -67,6 +67,13 @@ NOT_AGENT_FACING = {
         "decision about their own memory, not an agent's"
     ),
     "log": "human bookkeeping: a freeform timeline entry, zero-LLM",
+    "check": (
+        "repair verb (#943): the armed-check manifest is a DERIVED view, and "
+        "every ledger writer already rebuilds it, so this exists for a "
+        "manifest damaged out of band and for `hooks install` to call. An "
+        "agent has nothing to decide with it, and running it changes what "
+        "executes before that agent's own shell actions"
+    ),
     "serve": (
         "human-only viewer: opens a local browser UI for a person to read "
         "memory; an agent reads the same engines through brief/recall/why "

--- a/plugin/daimon_briefing/surfaces.py
+++ b/plugin/daimon_briefing/surfaces.py
@@ -266,6 +266,15 @@ SURFACES: tuple[Surface, ...] = (
     #    specific contract wins. --
     Surface("logs/backend-stderr.log", "llm._log_backend_stderr",
             True, "wholesale-purge", "forget"),
+    # -- #943 check firing log: one row per runner invocation, carrying ids,
+    #    outcomes, causes and durations only. No command text, no paths, no
+    #    subject — and that is a property of the WRITER, which projects every
+    #    row onto a fixed key list rather than trusting its callers, so the
+    #    exemption rests on code and not on a convention. Before the *.log
+    #    glob, which would not catch a .jsonl anyway, so the shape sits with
+    #    the other log declarations instead of after the catch-all. --
+    Surface("logs/checks.jsonl", "checks_runtime.log_firing",
+            False, "exempt-no-plaintext", "none"),
     # #616 restored the glob's claim instead of widening it: serializer's
     # downgrade lines — the one writer that put item text under this shape —
     # now log a content hash (normalize.content_key, the same key a forget

--- a/plugin/daimon_briefing/surfaces.py
+++ b/plugin/daimon_briefing/surfaces.py
@@ -314,6 +314,20 @@ SURFACES: tuple[Surface, ...] = (
     # belief bytes (cli._hooks_target_dir).
     Surface("hooks/*", "cli install-hooks", False, "exempt-no-plaintext",
             "none"),
+    # -- #943 armed checks. Both shapes carry AUTHORED text: the manifest
+    #    holds `check.match` and each body IS `check.body`, and refutations
+    #    already declares that pair plaintext (_PLAINTEXT_NESTED) so forget
+    #    reaches it in the ledger. Declaring these exempt would be the same
+    #    claim contradicting itself one directory over.
+    #
+    #    `rewrite` is what checks.sync already does: it rebuilds the manifest
+    #    from the ledger and removes the bodies no active ruling wants, and
+    #    every writer that can disarm a ruling calls it — forget included. So
+    #    deletion reaches here by re-deriving from a ledger the forget
+    #    already rewrote, rather than by a second walk that could disagree
+    #    with the first. --
+    Surface("checks/manifest.json", "checks.sync", True, "rewrite", "forget"),
+    Surface("checks/*.sh", "checks.sync", True, "rewrite", "forget"),
 )
 
 _PLACEHOLDER_RE = re.compile(r"\{[a-z]+\}")

--- a/plugin/tests/conftest.py
+++ b/plugin/tests/conftest.py
@@ -30,6 +30,10 @@ def _isolate_daimon_home(tmp_path, monkeypatch):
     # write the developer's real ~/.daimon/windsurf, and the purge/reap paths
     # DELETE, so an unredirected default would destroy real host state.
     monkeypatch.setenv("DAIMON_WINDSURF_DIR", str(home / "windsurf"))
+    # #943: the check manifest and the materialized 0o500 bodies. HOME is NOT
+    # redirected here, so an unset override resolves to the DEVELOPER'S real
+    # ~/.daimon/checks and a sync test would arm scripts in the live install.
+    monkeypatch.setenv("DAIMON_CHECKS_DIR", str(home / "checks"))
     monkeypatch.delenv("DAIMON_TEAM", raising=False)
     monkeypatch.delenv("DAIMON_AUTHOR", raising=False)
     # #896: and the host-declared per-session speaker — a developer who exports

--- a/plugin/tests/test_checks_runtime.py
+++ b/plugin/tests/test_checks_runtime.py
@@ -502,3 +502,231 @@ def test_resolve_never_raises_on_a_command_that_is_not_a_string(tmp_path):
     got = rt.resolve(None, str(tmp_path))
     assert isinstance(got, rt.Unresolved)
     assert got.cause == "arg-form-unparsed"
+
+
+# ---- runner (spec 3.3) ----------------------------------------------------
+
+
+import hashlib  # noqa: E402
+
+
+def _body(tmp_path, text, name="check.sh"):
+    path = tmp_path / name
+    path.write_text(text, encoding="utf-8")
+    path.chmod(0o500)
+    return path
+
+
+def _subject(tmp_path, command="gh pr create --title x"):
+    got = rt.resolve(command, str(tmp_path))
+    assert isinstance(got, rt.Subject), getattr(got, "cause", "")
+    return got
+
+
+def _armed(tmp_path, body, ruling_id="r-abc123", pin=True):
+    sha = hashlib.sha256(Path(body).read_bytes()).hexdigest()
+    return {"ruling_id": ruling_id, "project_dir": str(tmp_path),
+            "match": "gh pr create", "intent": "warn",
+            "sha256": sha if pin else "f" * 64, "armed_at": "t",
+            "body_path": str(body)}
+
+
+def test_a_check_that_exits_zero_is_clean(tmp_path):
+    subject = _subject(tmp_path)
+    got = rt.run(_body(tmp_path, "exit 0\n"), subject, cwd=str(tmp_path),
+                 timeout=5)
+    assert (got.outcome, got.cause, got.exit_code) == ("clean", "", 0)
+    assert got.duration_ms >= 0
+    rt.discard(subject)
+
+
+def test_a_check_that_exits_one_is_a_violation_carrying_its_first_line(
+        tmp_path):
+    subject = _subject(tmp_path)
+    body = _body(tmp_path, "echo 'the post names a machine' >&2\n"
+                           "echo 'second line' >&2\n"
+                           "exit 1\n")
+    got = rt.run(body, subject, cwd=str(tmp_path), timeout=5)
+    assert (got.outcome, got.cause, got.exit_code) == ("violation", "", 1)
+    assert got.reason == "the post names a machine"
+    rt.discard(subject)
+
+
+def test_a_violation_with_no_stderr_still_says_something(tmp_path):
+    subject = _subject(tmp_path)
+    got = rt.run(_body(tmp_path, "exit 1\n"), subject, cwd=str(tmp_path),
+                 timeout=5)
+    assert got.outcome == "violation"
+    assert got.reason, "a violation with an empty reason renders as blank"
+    rt.discard(subject)
+
+
+def test_any_other_exit_code_is_unresolved_never_a_violation(tmp_path):
+    """Exit 5 is a script that broke, not a subject that failed. Folding it
+    into violation would deny actions on the strength of a typo."""
+    subject = _subject(tmp_path)
+    got = rt.run(_body(tmp_path, "exit 5\n"), subject, cwd=str(tmp_path),
+                 timeout=5)
+    assert (got.outcome, got.cause, got.exit_code) == \
+        ("unresolved", "check-crashed", 5)
+    rt.discard(subject)
+
+
+def test_a_body_that_reaches_outside_itself_is_caught_by_the_runner(tmp_path):
+    """The slice 1 path refusal catches a bare single-token path. A one-line
+    `sh /host/path.sh` body passes that and is observable only here: sh exits
+    127 and its own first stderr line is the reason."""
+    subject = _subject(tmp_path)
+    got = rt.run(_body(tmp_path, "sh /nonexistent/host.sh\n"), subject,
+                 cwd=str(tmp_path), timeout=5)
+    assert (got.outcome, got.cause) == ("unresolved", "check-crashed")
+    assert got.exit_code == 127
+    assert "nonexistent" in got.reason
+
+
+def test_a_body_that_runs_a_non_executable_file_is_check_crashed(tmp_path):
+    subject = _subject(tmp_path)
+    plain = tmp_path / "plain.txt"
+    plain.write_text("not a program\n", encoding="utf-8")
+    plain.chmod(0o644)
+    got = rt.run(_body(tmp_path, f"{plain}\n"), subject, cwd=str(tmp_path),
+                 timeout=5)
+    assert (got.outcome, got.cause) == ("unresolved", "check-crashed")
+    assert got.exit_code == 126
+    rt.discard(subject)
+
+
+def test_a_check_that_overruns_its_budget_is_unresolved_not_clean(tmp_path):
+    subject = _subject(tmp_path)
+    got = rt.run(_body(tmp_path, "sleep 30\n"), subject, cwd=str(tmp_path),
+                 timeout=0.5)
+    assert (got.outcome, got.cause) == ("unresolved", "check-timeout")
+    assert got.duration_ms > 0
+    rt.discard(subject)
+
+
+def test_the_budget_kills_the_whole_process_group(tmp_path):
+    """start_new_session puts the check in its own group, so a body that
+    backgrounded something is killed WITH it. Killing only the direct child
+    leaves a grandchild holding the pipe and the next read blocks past the
+    host timeout, which is fail-open."""
+    subject = _subject(tmp_path)
+    marker = tmp_path / "alive"
+    body = _body(tmp_path, f"(sleep 20; echo yes > {marker}) &\nsleep 20\n")
+    got = rt.run(body, subject, cwd=str(tmp_path), timeout=0.5)
+    assert got.cause == "check-timeout"
+    assert not marker.exists()
+    rt.discard(subject)
+
+
+def test_a_host_without_sh_reports_runtime_missing(tmp_path, monkeypatch):
+    subject = _subject(tmp_path)
+    monkeypatch.setenv("PATH", "")
+    got = rt.run(_body(tmp_path, "exit 0\n"), subject, cwd=str(tmp_path),
+                 timeout=5)
+    assert (got.outcome, got.cause) == ("unresolved", "runtime-missing")
+    rt.discard(subject)
+
+
+def test_a_body_that_no_longer_hashes_to_its_pin_never_runs(tmp_path):
+    """Someone edited the materialized body. Re-hash before exec, and the
+    mismatch is unresolved rather than a silent skip."""
+    subject = _subject(tmp_path)
+    body = _body(tmp_path, "exit 0\n")
+    entry = _armed(tmp_path, body, pin=False)
+    got = rt.run(entry, subject, cwd=str(tmp_path), timeout=5)
+    assert (got.outcome, got.cause) == ("unresolved", "body-hash-mismatch")
+    assert got.exit_code == -1, "the check must not have run at all"
+    rt.discard(subject)
+
+
+def test_a_body_that_matches_its_pin_runs(tmp_path):
+    subject = _subject(tmp_path)
+    entry = _armed(tmp_path, _body(tmp_path, "exit 0\n"))
+    assert rt.run(entry, subject, cwd=str(tmp_path), timeout=5).outcome == \
+        "clean"
+    rt.discard(subject)
+
+
+def test_a_missing_body_file_is_unresolved(tmp_path):
+    subject = _subject(tmp_path)
+    got = rt.run(tmp_path / "gone.sh", subject, cwd=str(tmp_path), timeout=5)
+    assert got.outcome == "unresolved"
+    assert got.cause == "check-crashed"
+    rt.discard(subject)
+
+
+def test_the_check_is_handed_the_subject_the_command_and_the_ruling(tmp_path):
+    subject = _subject(tmp_path, "gh pr create --title 'a title'")
+    out = tmp_path / "seen"
+    entry = _armed(tmp_path, _body(
+        tmp_path,
+        f'printf "%s\\n%s\\n%s\\n" "$DAIMON_CHECK_RULING" '
+        f'"$DAIMON_CHECK_COMMAND" "$(cat "$DAIMON_CHECK_SUBJECT")" > {out}\n'))
+    assert rt.run(entry, subject, cwd=str(tmp_path), timeout=5).outcome == \
+        "clean"
+    seen = out.read_text(encoding="utf-8")
+    assert seen.startswith("r-abc123\n")
+    assert "gh pr create --title 'a title'" in seen
+    rt.discard(subject)
+
+
+def test_the_check_runs_in_the_action_s_working_directory(tmp_path):
+    subject = _subject(tmp_path)
+    work = tmp_path / "work"
+    work.mkdir()
+    out = tmp_path / "pwd"
+    body = _body(tmp_path, f"pwd > {out}\n")
+    assert rt.run(body, subject, cwd=str(work), timeout=5).outcome == "clean"
+    assert Path(out.read_text(encoding="utf-8").strip()).resolve() == \
+        work.resolve()
+    rt.discard(subject)
+
+
+def test_the_check_reads_standard_input_as_empty_and_does_not_hang(tmp_path):
+    """stdin is /dev/null, never an open pipe. A body that reads stdin gets
+    EOF; an inherited terminal would block until the budget expires and
+    report check-timeout for a check that was fine."""
+    subject = _subject(tmp_path)
+    got = rt.run(_body(tmp_path, "cat > /dev/null\nexit 0\n"), subject,
+                 cwd=str(tmp_path), timeout=5)
+    assert got.outcome == "clean"
+    rt.discard(subject)
+
+
+def test_the_runner_never_raises(tmp_path, monkeypatch):
+    """Proven by monkeypatching the failure in. The hook fires before every
+    shell action; an exception here is an action that proceeds with no record
+    of why."""
+    subject = _subject(tmp_path)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("the platform said no")
+
+    monkeypatch.setattr(rt.subprocess, "Popen", boom)
+    got = rt.run(_body(tmp_path, "exit 0\n"), subject, cwd=str(tmp_path),
+                 timeout=5)
+    assert (got.outcome, got.cause) == ("unresolved", "check-crashed")
+    assert "the platform said no" in got.reason
+    rt.discard(subject)
+
+
+def test_every_cause_the_runner_emits_is_a_declared_cause():
+    assert {"check-timeout", "check-crashed", "body-hash-mismatch",
+            "runtime-missing"} <= rt.CAUSES
+
+
+def test_the_body_file_name_is_the_ruling_and_the_head_of_its_hash():
+    entry = {"ruling_id": "r-1a2b3c4d5e6f", "sha256": "ab" * 32}
+    assert rt.body_name(entry) == "r-1a2b3c4d5e6f-abababababab.sh"
+    assert rt.body_path(entry).parent == rt.checks_dir()
+
+
+def test_run_never_leaves_the_subject_behind_for_its_caller(tmp_path):
+    """The runner does not own the subject file: resolve made it and the
+    caller discards it. Pinned so a later change cannot quietly move that
+    responsibility and leave a double unlink."""
+    subject = _subject(tmp_path)
+    rt.run(_body(tmp_path, "exit 0\n"), subject, cwd=str(tmp_path), timeout=5)
+    assert Path(subject.path).exists()
+    rt.discard(subject)

--- a/plugin/tests/test_checks_runtime.py
+++ b/plugin/tests/test_checks_runtime.py
@@ -730,3 +730,107 @@ def test_run_never_leaves_the_subject_behind_for_its_caller(tmp_path):
     rt.run(_body(tmp_path, "exit 0\n"), subject, cwd=str(tmp_path), timeout=5)
     assert Path(subject.path).exists()
     rt.discard(subject)
+
+
+# ---- firing log (spec 3.4) ------------------------------------------------
+
+
+import json  # noqa: E402
+
+
+def _log_lines():
+    path = config.log_dir() / "checks.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in
+            path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_a_firing_row_carries_the_declared_keys_and_nothing_else():
+    assert rt.log_firing({"ruling_id": "r-1", "host": "claude-code",
+                          "mode": "warn", "outcome": "clean", "cause": "",
+                          "decision_emitted": "allow",
+                          "duration_ms": 12}) is True
+    rows = _log_lines()
+    assert len(rows) == 1
+    assert set(rows[0]) == set(rt.FIRING_KEYS)
+
+
+def test_the_log_never_carries_the_command_the_paths_or_the_reason():
+    """Spec 3.4 in its own words: no command text, no paths, no subject. The
+    reason shown to the agent may name a path; the log does not. Enforced by
+    PROJECTION rather than by asking callers to be careful."""
+    secret = "/Users/someone/private/notes.md"
+    rt.log_firing({"ruling_id": "r-1", "outcome": "unresolved",
+                   "cause": "file-missing", "duration_ms": 3,
+                   "reason": f"{secret} does not exist",
+                   "command": f"gh pr create --body-file {secret}",
+                   "subject": "/tmp/daimon-check-xyz.subject"})
+    raw = (config.log_dir() / "checks.jsonl").read_text(encoding="utf-8")
+    assert secret not in raw
+    assert "gh pr create" not in raw
+    assert "daimon-check-xyz" not in raw
+
+
+def test_a_cause_outside_the_declared_set_is_recorded_without_its_text():
+    """The cause field is the one place free text could reach a no-plaintext
+    log. An unknown value still signals that something happened; it just
+    cannot bring a path along with it."""
+    rt.log_firing({"ruling_id": "r-1", "outcome": "unresolved",
+                   "cause": "exploded reading /Users/someone/x", "duration_ms": 1})
+    rows = _log_lines()
+    assert rows[0]["cause"] == "unknown"
+
+
+@pytest.mark.parametrize("cause", sorted(
+    {"file-missing", "no-manifest", "no-match", "manifest-unreadable",
+     "check-timeout", "body-hash-mismatch"}))
+def test_the_causes_a_hook_actually_emits_survive_the_projection(cause):
+    rt.log_firing({"ruling_id": "r-1", "outcome": "unresolved",
+                   "cause": cause, "duration_ms": 1})
+    assert _log_lines()[0]["cause"] == cause
+
+
+def test_a_row_with_no_timestamp_is_stamped_in_utc():
+    rt.log_firing({"ruling_id": "r-1", "outcome": "clean", "duration_ms": 1})
+    ts = _log_lines()[0]["ts"]
+    assert ts.endswith("Z") and ts[4] == "-" and "T" in ts
+
+
+def test_rows_append_rather_than_replace():
+    rt.log_firing({"ruling_id": "r-1", "outcome": "clean", "duration_ms": 1})
+    rt.log_firing({"ruling_id": "r-2", "outcome": "violation", "duration_ms": 2})
+    assert [r["ruling_id"] for r in _log_lines()] == ["r-1", "r-2"]
+
+
+def test_the_log_directory_is_created_on_first_write():
+    assert not (config.log_dir() / "checks.jsonl").exists()
+    assert rt.log_firing({"ruling_id": "r-1", "outcome": "clean"}) is True
+    assert (config.log_dir() / "checks.jsonl").exists()
+
+
+def test_a_log_that_cannot_be_written_reports_false_and_never_raises(
+        monkeypatch, tmp_path):
+    """A hook that cannot write its own log still has an action to allow or
+    deny. The write failing is not a reason to lose the decision."""
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory", encoding="utf-8")
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(blocker))
+    assert rt.log_firing({"ruling_id": "r-1", "outcome": "clean"}) is False
+
+
+def test_the_firing_log_is_declared_in_the_surface_registry():
+    from daimon_briefing import surfaces
+    entry = [s for s in surfaces.SURFACES if s.shape == "logs/checks.jsonl"]
+    assert entry, "a new file under ~/.daimon must be declared"
+    assert entry[0].plaintext is False
+    assert entry[0].delete == "exempt-no-plaintext"
+
+
+def test_the_firing_log_entry_precedes_the_generic_log_glob():
+    """The registry is order-sensitive: `logs/*.log` would not catch a
+    .jsonl, but the specific declaration still has to sit with the other
+    log shapes rather than after the catch-all."""
+    from daimon_briefing import surfaces
+    shapes = [s.shape for s in surfaces.SURFACES]
+    assert shapes.index("logs/checks.jsonl") < shapes.index("logs/*.log")

--- a/plugin/tests/test_checks_runtime.py
+++ b/plugin/tests/test_checks_runtime.py
@@ -727,16 +727,33 @@ def test_any_other_exit_code_is_unresolved_never_a_violation(tmp_path):
     rt.discard(subject)
 
 
+# What `sh` IS differs by platform, and so does what it says when a script
+# operand is missing. Measured on both:
+#
+#   dash (Debian /bin/sh)      exit 2    "cannot open <path>: No such file"
+#   bash and macOS /bin/sh     exit 127  "<path>: No such file or directory"
+#
+# The claim these tests make is that neither number is 0 or 1, which is what
+# puts the run in `check-crashed` rather than in `clean` or `violation`. The
+# number itself is the shell's business. Pinning 127 passed on macOS and
+# failed every Linux lane, so do not re-pin it.
+_SHELL_MISSING_WORDINGS = ("nonexistent", "not found", "can't open",
+                           "cannot open", "no such file")
+
+
 def test_a_body_that_reaches_outside_itself_is_caught_by_the_runner(tmp_path):
     """The slice 1 path refusal catches a bare single-token path. A one-line
-    `sh /host/path.sh` body passes that and is observable only here: sh exits
-    127 and its own first stderr line is the reason."""
+    `sh /host/path.sh` body passes that and is observable only here: sh fails
+    to open the script and its own first stderr line becomes the reason."""
     subject = _subject(tmp_path)
     got = rt.run(_body(tmp_path, "sh /nonexistent/host.sh\n"), subject,
                  cwd=str(tmp_path), timeout=5)
     assert (got.outcome, got.cause) == ("unresolved", "check-crashed")
-    assert got.exit_code == 127
-    assert "nonexistent" in got.reason
+    assert got.exit_code not in (0, 1), \
+        "0 would read as clean and 1 as a violation the check never found"
+    assert any(word in got.reason.casefold()
+               for word in _SHELL_MISSING_WORDINGS), got.reason
+    rt.discard(subject)
 
 
 def test_a_body_that_runs_a_non_executable_file_is_check_crashed(tmp_path):
@@ -747,7 +764,11 @@ def test_a_body_that_runs_a_non_executable_file_is_check_crashed(tmp_path):
     got = rt.run(_body(tmp_path, f"{plain}\n"), subject, cwd=str(tmp_path),
                  timeout=5)
     assert (got.outcome, got.cause) == ("unresolved", "check-crashed")
-    assert got.exit_code == 126
+    # 126 on both shells measured, and still not pinned: what this test is
+    # for is that a body which cannot execute what it names lands outside
+    # clean and violation, not that the shell picked a particular number.
+    assert got.exit_code not in (0, 1)
+    assert got.reason, "sh said why, and the runner must carry it"
     rt.discard(subject)
 
 

--- a/plugin/tests/test_checks_runtime.py
+++ b/plugin/tests/test_checks_runtime.py
@@ -1044,3 +1044,267 @@ def test_the_firing_log_entry_precedes_the_generic_log_glob():
     from daimon_briefing import surfaces
     shapes = [s.shape for s in surfaces.SURFACES]
     assert shapes.index("logs/checks.jsonl") < shapes.index("logs/*.log")
+
+
+# ---- the fallback branches, each exercised rather than excused ------------
+#
+# Every test below drives a path that only runs when something has already
+# gone wrong. They exist because those are exactly the paths that decide
+# whether a hook allows an action with a record saying why, or crashes and
+# lets it through saying nothing.
+
+
+def test_a_manifest_that_is_not_utf8_reads_as_unreadable():
+    path = config.checks_dir() / "manifest.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\xff\xfe\x00 not text")
+    loaded = rt.load_manifest()
+    assert loaded.entries == []
+    assert loaded.reason == "manifest-unreadable"
+
+
+def test_a_manifest_that_cannot_be_opened_at_all_reads_as_unreadable(tmp_path):
+    """A directory where the file should be. Distinct from absent: daimon
+    put something there and can no longer read it."""
+    target = tmp_path / "manifest.json"
+    target.mkdir()
+    assert rt.load_manifest(target).reason == "manifest-unreadable"
+
+
+def test_a_cwd_that_cannot_be_resolved_arms_nothing(tmp_path):
+    """An embedded NUL makes realpath raise rather than return. The hook
+    still has an action in front of it and needs an answer."""
+    root = os.path.realpath(str(tmp_path))
+    assert rt.armed_for("\x00not-a-path", _manifest(root)) == []
+
+
+def test_a_non_object_entry_in_a_hand_built_manifest_is_skipped(tmp_path):
+    """load_manifest filters these, but armed_for is called with whatever a
+    caller holds, and one bad row must not disarm the good ones."""
+    root = os.path.realpath(str(tmp_path))
+    manifest = rt.Manifest(["nope", 7, {"ruling_id": "r-0",
+                                        "project_dir": root, "match": "x"}], "")
+    assert [e["ruling_id"] for e in rt.armed_for(root, manifest)] == ["r-0"]
+
+
+def test_a_command_that_forges_a_heredoc_marker_is_not_read_as_one(tmp_path):
+    """The marker is minted by the substitution and by nothing else, but the
+    command string arrives from a host payload and can spell one out. An
+    index no heredoc answers to is not a heredoc.
+
+    Before the bounds check this raised IndexError out of a module whose
+    whole contract is that it never raises."""
+    forged = f"gh pr create --body-file - {rt._HEREDOC_MARK}0\x00"
+    got = _resolve(forged, tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "arg-form-unparsed"
+
+
+def test_a_forged_marker_with_a_junk_index_is_a_plain_argument(tmp_path):
+    """Not a marker, so it is read as the path it looks like. `open` refuses
+    a NUL before the OS sees it, and it raises ValueError rather than
+    OSError, which walked straight past the clause meant to catch it."""
+    forged = f"gh pr create --body-file {rt._HEREDOC_MARK}not-a-number\x00"
+    got = _resolve(forged, tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "file-unreadable"
+
+
+def test_a_flag_at_the_very_end_with_no_value_is_unparsed(tmp_path):
+    got = _resolve("gh pr create --body-file", tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "arg-form-unparsed"
+    assert "no value" in got.reason
+
+
+def test_a_field_flag_given_a_bare_at_path_reads_it(tmp_path):
+    body = tmp_path / "body.md"
+    body.write_text("the body text\n", encoding="utf-8")
+    got = _resolve(f"gh api repos/x -F @{body}", tmp_path)
+    assert isinstance(got, rt.Subject), getattr(got, "cause", "")
+    assert "the body text" in _text_of(got)
+    rt.discard(got)
+
+
+def test_a_field_only_flag_given_a_plain_word_names_no_file(tmp_path):
+    """`--field` is not a body flag, so a value with neither `=` nor `@`
+    names nothing to read and is not a reason to call the subject
+    unprovable."""
+    got = _resolve("gh api repos/x --field plain", tmp_path)
+    assert isinstance(got, rt.Subject)
+    assert got.files == ()
+    rt.discard(got)
+
+
+def test_a_flag_given_an_empty_path_is_unparsed(tmp_path):
+    got = _resolve("gh pr create --body-file ''", tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "arg-form-unparsed"
+    assert "empty path" in got.reason
+
+
+def test_a_temp_dir_that_refuses_the_subject_is_unresolved_not_a_crash(
+        tmp_path, monkeypatch):
+    """The resolver has read the arguments and has nowhere to put them. It
+    still owes the hook an outcome."""
+    def boom(*args, **kwargs):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(rt.tempfile, "mkstemp", boom)
+    got = _resolve("gh pr create --title x", tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "check-crashed"
+    assert "no space left" in got.reason
+
+
+def test_a_subject_that_cannot_be_written_takes_its_temp_file_with_it(
+        tmp_path, monkeypatch):
+    sink = tmp_path / "sink"
+    sink.mkdir()
+    monkeypatch.setattr(rt.tempfile, "tempdir", str(sink))
+
+    def boom(*args, **kwargs):
+        raise OSError("the disk went away mid-write")
+
+    monkeypatch.setattr(rt.os, "fdopen", boom)
+    got = _resolve("gh pr create --title x", tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "check-crashed"
+    assert list(sink.iterdir()) == [], "a half-written subject was left behind"
+
+
+def test_a_subject_whose_cleanup_also_fails_still_reports(
+        tmp_path, monkeypatch):
+    def boom(*args, **kwargs):
+        raise OSError("write failed")
+
+    def also_boom(*args, **kwargs):
+        raise OSError("and so did the cleanup")
+
+    monkeypatch.setattr(rt.os, "fdopen", boom)
+    monkeypatch.setattr(rt.os, "unlink", also_boom)
+    got = _resolve("gh pr create --title x", tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "check-crashed"
+
+
+@pytest.mark.parametrize("value", [None, "", 7, object()])
+def test_discard_ignores_anything_that_is_not_a_subject(value):
+    rt.discard(value)  # must not raise
+    rt.discard(rt.Subject(value if isinstance(value, str) else "", (), ""))
+
+
+def test_discard_survives_a_file_that_is_already_gone(tmp_path):
+    """It runs in a `finally` on a path that already has an outcome to
+    report, so a second failure there must not replace it."""
+    rt.discard(rt.Subject(str(tmp_path / "never-existed"), (), ""))
+
+
+def test_the_budget_falls_back_to_killing_the_child_alone(tmp_path,
+                                                          monkeypatch):
+    """A platform without process groups, or a group that vanished between
+    the timeout and the kill. The check must still stop."""
+    calls = []
+
+    def no_groups(*args, **kwargs):
+        raise ProcessLookupError("no such process group")
+
+    monkeypatch.setattr(rt.os, "killpg", no_groups)
+    real_popen = rt.subprocess.Popen
+
+    def watched(*args, **kwargs):
+        proc = real_popen(*args, **kwargs)
+        original = proc.kill
+        proc.kill = lambda: (calls.append("kill"), original())[1]
+        return proc
+
+    monkeypatch.setattr(rt.subprocess, "Popen", watched)
+    subject = _subject(tmp_path)
+    got = rt.run(_body(tmp_path, "sleep 30\n"), subject, cwd=str(tmp_path),
+                 timeout=0.5)
+    assert got.cause == "check-timeout"
+    assert calls == ["kill"], "the fallback kill never ran"
+    rt.discard(subject)
+
+
+def test_a_spawn_that_fails_for_any_other_reason_is_check_crashed(
+        tmp_path, monkeypatch):
+    """Not a missing sh: an exec that the platform refused. Different cause,
+    because runtime-missing tells an operator to install a shell."""
+    def boom(*args, **kwargs):
+        raise OSError(12, "Cannot allocate memory")
+
+    monkeypatch.setattr(rt.subprocess, "Popen", boom)
+    subject = _subject(tmp_path)
+    got = rt.run(_body(tmp_path, "exit 0\n"), subject, cwd=str(tmp_path),
+                 timeout=5)
+    assert (got.outcome, got.cause) == ("unresolved", "check-crashed")
+    assert "Cannot allocate memory" in got.reason
+    rt.discard(subject)
+
+
+def test_a_reap_that_fails_after_the_kill_still_reports_the_timeout(
+        tmp_path, monkeypatch):
+    """The outcome is already decided by the time the corpse is collected.
+    A second failure there must not turn a timeout into a traceback."""
+    class Stubborn:
+        pid = -1
+        returncode = None
+
+        def communicate(self, timeout=None):
+            raise rt.subprocess.TimeoutExpired("sh", timeout or 0)
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(rt.subprocess, "Popen",
+                        lambda *a, **k: Stubborn())
+    monkeypatch.setattr(rt.os, "killpg",
+                        lambda *a, **k: None)
+    monkeypatch.setattr(rt.os, "getpgid", lambda pid: pid)
+    subject = _subject(tmp_path)
+    got = rt.run(_body(tmp_path, "exit 0\n"), subject, cwd=str(tmp_path),
+                 timeout=0.01)
+    assert (got.outcome, got.cause) == ("unresolved", "check-timeout")
+    rt.discard(subject)
+
+
+def test_a_log_directory_that_cannot_be_made_reports_false(monkeypatch):
+    def boom(*args, **kwargs):
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(rt.Path, "mkdir", boom)
+    assert rt.log_firing({"ruling_id": "r-1", "outcome": "clean"}) is False
+
+
+def test_a_firing_row_whose_duration_is_not_a_number_reports_false():
+    assert rt.log_firing({"ruling_id": "r-1", "outcome": "clean",
+                          "duration_ms": "soon"}) is False
+
+
+def test_a_child_that_cannot_be_killed_at_all_still_reports_the_timeout(
+        tmp_path, monkeypatch):
+    """Both kills refused: no process group, and the direct kill fails too
+    (the child is already a zombie, or the platform said no). The outcome
+    was decided at the timeout; nothing after it may replace that with a
+    traceback."""
+    class Unkillable:
+        pid = -1
+        returncode = None
+
+        def communicate(self, timeout=None):
+            raise rt.subprocess.TimeoutExpired("sh", timeout or 0)
+
+        def kill(self):
+            raise OSError("no such process")
+
+    def no_groups(*args, **kwargs):
+        raise ProcessLookupError("no such process group")
+
+    monkeypatch.setattr(rt.subprocess, "Popen", lambda *a, **k: Unkillable())
+    monkeypatch.setattr(rt.os, "killpg", no_groups)
+    subject = _subject(tmp_path)
+    got = rt.run(_body(tmp_path, "exit 0\n"), subject, cwd=str(tmp_path),
+                 timeout=0.01)
+    assert (got.outcome, got.cause) == ("unresolved", "check-timeout")
+    rt.discard(subject)

--- a/plugin/tests/test_checks_runtime.py
+++ b/plugin/tests/test_checks_runtime.py
@@ -580,6 +580,33 @@ def test_a_file_exactly_at_the_cap_still_resolves(tmp_path):
     rt.discard(got)
 
 
+def test_the_cap_is_enforced_by_the_read_not_by_a_prior_stat(tmp_path):
+    """Check-then-read is two answers about one file. A stat that decides the
+    cap and an open that happens afterwards disagree whenever the file grows
+    in between, and the read wins. Reading one byte past the cap and judging
+    THAT is one answer."""
+    big = tmp_path / "grows.md"
+    big.write_bytes(b"x" * 16)
+    real_open = rt.open if hasattr(rt, "open") else open
+
+    def growing(path, *args, **kwargs):
+        # Grow it at the moment of opening: a stat taken earlier is now stale.
+        if str(path).endswith("grows.md"):
+            with real_open(path, "wb") as handle:
+                handle.write(b"x" * (rt.MAX_SUBJECT_FILE_BYTES + 1))
+        return real_open(path, *args, **kwargs)
+
+    import builtins
+    original = builtins.open
+    builtins.open = growing
+    try:
+        got = _resolve(f"gh pr create --body-file {big}", tmp_path)
+    finally:
+        builtins.open = original
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "file-oversize"
+
+
 def test_a_file_that_is_not_utf8_is_file_binary(tmp_path):
     blob = tmp_path / "blob.bin"
     blob.write_bytes(b"\xff\xfe\x00\x01")
@@ -805,6 +832,40 @@ def test_the_check_reads_standard_input_as_empty_and_does_not_hang(tmp_path):
     got = rt.run(_body(tmp_path, "cat > /dev/null\nexit 0\n"), subject,
                  cwd=str(tmp_path), timeout=5)
     assert got.outcome == "clean"
+    rt.discard(subject)
+
+
+def test_the_body_does_not_inherit_the_parent_environment(tmp_path,
+                                                          monkeypatch):
+    """A ratified body is human-armed and runs as the user, so this is not a
+    sandbox. It is a blast radius: the body has one job, reading a subject
+    file, and handing it every token in the host session widens what a
+    mistake in someone else's script can reach for no gain."""
+    monkeypatch.setenv("MY_API_TOKEN", "zqx-should-not-travel")
+    subject = _subject(tmp_path)
+    out = tmp_path / "seen-env"
+    got = rt.run(_body(tmp_path, f"env > {out}\nexit 0\n"), subject,
+                 cwd=str(tmp_path), timeout=5)
+    assert got.outcome == "clean", got
+    seen = out.read_text(encoding="utf-8")
+    assert "zqx-should-not-travel" not in seen
+    assert "MY_API_TOKEN" not in seen
+    rt.discard(subject)
+
+
+def test_the_body_still_gets_what_it_needs_to_run(tmp_path):
+    """The other half: a minimal environment that dropped PATH would make
+    every body fail to find its own tools, which reads as check-crashed."""
+    subject = _subject(tmp_path)
+    out = tmp_path / "seen-env"
+    entry = _armed(tmp_path, _body(tmp_path, f"env > {out}\nexit 0\n"))
+    assert rt.run(entry, subject, cwd=str(tmp_path), timeout=5).outcome == \
+        "clean"
+    names = {line.split("=", 1)[0]
+             for line in out.read_text(encoding="utf-8").splitlines()
+             if "=" in line}
+    assert {"PATH", "DAIMON_CHECK_SUBJECT", "DAIMON_CHECK_COMMAND",
+            "DAIMON_CHECK_RULING"} <= names
     rt.discard(subject)
 
 

--- a/plugin/tests/test_checks_runtime.py
+++ b/plugin/tests/test_checks_runtime.py
@@ -1,0 +1,275 @@
+"""#943 slice 2: the standalone check runtime.
+
+`checks_runtime.py` is loaded by host hook scripts that cannot import the
+venv-only package, so every test here loads the SHIPPED copy by file location
+under its own module name — the way a hook will. Byte-identity with the
+canonical module is a separate drift test (test_hooks_install.py); together
+they mean these assertions bind the canonical file too.
+"""
+
+import ast
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+from daimon_briefing import config
+
+CANONICAL = (Path(__file__).parents[1] / "daimon_briefing"
+             / "checks_runtime.py")
+SHIPPED = (Path(__file__).parents[1] / "daimon_briefing" / "_hooks"
+           / "checks_runtime.py")
+
+
+def _runtime():
+    """The shipped runtime, loaded standalone. A relative import or a
+    `daimon_briefing` import in the canonical file fails HERE, which is the
+    only place it can fail before a host hook hits it in production."""
+    spec = importlib.util.spec_from_file_location(
+        "_checks_runtime_under_test", SHIPPED)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+rt = _runtime()
+
+
+# ---- stdlib only (scar 0049) ----------------------------------------------
+
+
+def test_the_runtime_imports_nothing_from_the_package():
+    """Scar 0049 in its own words: `from . import normalize` looks ordinary,
+    passes every local test, and breaks the standalone hooks, which cannot
+    resolve `daimon_briefing`. An AST walk catches it at authoring time
+    rather than on the host."""
+    tree = ast.parse(CANONICAL.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            assert node.level == 0, f"relative import: {ast.dump(node)}"
+            assert not str(node.module or "").startswith("daimon_briefing"), \
+                f"package import: {node.module}"
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert not alias.name.startswith("daimon_briefing"), \
+                    f"package import: {alias.name}"
+
+
+# ---- path mirrors (scar 0043) ---------------------------------------------
+
+
+@pytest.mark.parametrize("name,mirror,canon", [
+    ("DAIMON_CHECKS_DIR", "checks_dir", "checks_dir"),
+    ("DAIMON_LOG_DIR", "log_dir", "log_dir"),
+])
+def test_mirror_and_config_agree_over_the_whole_probe_table(
+        name, mirror, canon, tmp_path, monkeypatch):
+    """Behavioral equality against the config function, never against a
+    literal this test would also have to get right (scar 0043's idiom).
+
+    The strip axis is the one that looks like a bug and is not: config does
+    not strip, so "   " is a RELATIVE directory named three spaces. A mirror
+    that stripped would resolve somewhere the writer never writes, and the
+    hook would read an empty manifest forever with nothing to report."""
+    fn, ref = getattr(rt, mirror), getattr(config, canon)
+    for raw in (None, "", "   ", "  /tmp/dchecks  ", "/tmp/dchecks",
+                "~/dchecks"):
+        monkeypatch.delenv(name, raising=False)
+        if raw is not None:
+            monkeypatch.setenv(name, raw)
+        assert fn() == ref(), repr(raw)
+
+    # The env-file PARSER is a second copy of config._file_values and can
+    # drift line-form by line-form. Each line discriminates one rule:
+    # quoting, the export prefix, whitespace, comments, an empty value.
+    monkeypatch.delenv(name, raising=False)
+    env_file = Path(os.environ["DAIMON_ENV_FILE"])
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    resolved = set()
+    for line in (f"{name}={tmp_path}/plain",
+                 f'{name}="{tmp_path}/quoted"',
+                 f"{name}='{tmp_path}/single'",
+                 f"export {name}={tmp_path}/exported",
+                 f"  export   {name} =  {tmp_path}/spaced  ",
+                 f"# {name}={tmp_path}/commented",
+                 f"{name}=",
+                 f"{name}=~/tilde",
+                 f"NOT_THE_VAR={tmp_path}/other",
+                 f"{name}={tmp_path}/first\n{name}={tmp_path}/last"):
+        env_file.write_text(line + "\n", encoding="utf-8")
+        assert fn() == ref(), line
+        resolved.add(fn())
+    assert len(resolved) > 1, \
+        "every probe resolved alike — the env file was never read at all"
+
+
+# ---- manifest -------------------------------------------------------------
+
+
+def _write_manifest(entries):
+    import json
+    path = config.checks_dir() / "manifest.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(entries), encoding="utf-8")
+    return path
+
+
+def test_no_manifest_reads_as_empty_with_a_reason():
+    """Never an exception: the hook runs on every Bash call and a raise here
+    is an action that proceeds with no record of why. `no-manifest` is the
+    honest signal that lets a stats surface say "armed, never fired" instead
+    of "clean" (scar 0057)."""
+    loaded = rt.load_manifest()
+    assert loaded.entries == []
+    assert loaded.reason == "no-manifest"
+
+
+def test_a_manifest_that_is_not_json_reads_as_empty_with_its_own_reason():
+    """Distinct from no-manifest on purpose. Both allow, but only one of
+    them means daimon wrote something it can no longer read."""
+    path = config.checks_dir() / "manifest.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+    loaded = rt.load_manifest()
+    assert loaded.entries == []
+    assert loaded.reason == "manifest-unreadable"
+
+
+def test_a_manifest_that_is_not_a_list_reads_as_unreadable():
+    _write_manifest({"ruling_id": "r-1"})
+    assert rt.load_manifest().reason == "manifest-unreadable"
+
+
+def test_a_manifest_of_entries_loads_with_no_reason():
+    _write_manifest([{"ruling_id": "r-1", "project_dir": "/p/a",
+                      "match": "gh pr create", "intent": "warn",
+                      "sha256": "a" * 64, "armed_at": "2026-09-06T00:00:00Z"}])
+    loaded = rt.load_manifest()
+    assert loaded.reason == ""
+    assert [e["ruling_id"] for e in loaded.entries] == ["r-1"]
+
+
+def test_non_object_rows_are_dropped_not_fatal():
+    _write_manifest(["nope", 7, {"ruling_id": "r-1", "project_dir": "/p/a",
+                                 "match": "x", "intent": "warn",
+                                 "sha256": "a" * 64, "armed_at": "t"}])
+    loaded = rt.load_manifest()
+    assert loaded.reason == ""
+    assert [e["ruling_id"] for e in loaded.entries] == ["r-1"]
+
+
+# ---- armed_for: the prefix match ------------------------------------------
+
+
+def _manifest(*project_dirs):
+    return rt.Manifest([{"ruling_id": f"r-{i}", "project_dir": p,
+                         "match": "x", "intent": "warn", "sha256": "a" * 64,
+                         "armed_at": "t"}
+                        for i, p in enumerate(project_dirs)], "")
+
+
+def test_the_project_dir_matches_its_own_directory(tmp_path):
+    root = os.path.realpath(str(tmp_path))
+    armed = rt.armed_for(root, _manifest(root))
+    assert [e["ruling_id"] for e in armed] == ["r-0"]
+
+
+def test_a_subdirectory_of_the_project_matches(tmp_path):
+    root = os.path.realpath(str(tmp_path))
+    deep = tmp_path / "src" / "pkg"
+    deep.mkdir(parents=True)
+    assert len(rt.armed_for(str(deep), _manifest(root))) == 1
+
+
+def test_a_sibling_whose_name_merely_starts_the_same_does_not_match(tmp_path):
+    """A separator-less prefix test arms /srv/appliance from an entry for
+    /srv/app. The separator is the whole point."""
+    root = os.path.realpath(str(tmp_path / "app"))
+    (tmp_path / "app").mkdir()
+    (tmp_path / "appliance").mkdir()
+    assert rt.armed_for(str(tmp_path / "appliance"), _manifest(root)) == []
+
+
+def test_a_foreign_project_matches_nothing(tmp_path):
+    other = os.path.realpath(str(tmp_path / "other"))
+    (tmp_path / "other").mkdir()
+    (tmp_path / "here").mkdir()
+    assert rt.armed_for(str(tmp_path / "here"), _manifest(other)) == []
+
+
+def test_a_slug_shaped_cwd_matches_nothing(tmp_path):
+    """A slug is an address daimon mints for a bucket, never a directory.
+    Passing one here must resolve to nothing rather than prefix-matching by
+    accident."""
+    root = os.path.realpath(str(tmp_path))
+    assert rt.armed_for("-Users-someone-code-daimon", _manifest(root)) == []
+
+
+def test_an_entry_without_a_project_dir_is_skipped(tmp_path):
+    manifest = rt.Manifest([{"ruling_id": "r-0", "match": "x"}], "")
+    assert rt.armed_for(str(tmp_path), manifest) == []
+
+
+def test_armed_for_follows_symlinks_on_both_sides(tmp_path):
+    """The writer stores the physical path (git toplevel, realpath'd). A cwd
+    reached through a symlink is the same project and must arm."""
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real)
+    root = os.path.realpath(str(real))
+    assert len(rt.armed_for(str(link), _manifest(root))) == 1
+
+
+def test_armed_for_never_raises_on_a_cwd_that_cannot_be_resolved(tmp_path):
+    root = os.path.realpath(str(tmp_path))
+    assert rt.armed_for("", _manifest(root)) == []
+    assert rt.armed_for(None, _manifest(root)) == []
+
+
+# ---- matches: the regex prefilter -----------------------------------------
+
+
+def _entry(match):
+    return {"ruling_id": "r-0", "project_dir": "/p", "match": match,
+            "intent": "warn", "sha256": "a" * 64, "armed_at": "t"}
+
+
+def test_the_match_is_an_unanchored_case_sensitive_search():
+    assert rt.matches(_entry("gh pr create"), "cd /x && gh pr create --fill")
+    assert not rt.matches(_entry("gh pr create"), "GH PR CREATE")
+
+
+def test_a_command_that_merely_mentions_the_verb_still_matches():
+    """Documented behavior, not a defect: a gate matches its own subject
+    matter. The remedy is rewording the command, never loosening the
+    prefilter."""
+    assert rt.matches(_entry("gh pr create"), "echo 'gh pr create'")
+
+
+def test_the_prefilter_reads_at_most_the_first_4096_bytes():
+    """Scar 0022's bound, applied to the INPUT rather than the pattern. The
+    pattern is caller-supplied and capped at 200 bytes, which bounds its
+    length and not its backtracking; bounding the subject is what keeps a
+    pathological pair from outliving the host timeout, which is fail-open."""
+    assert rt.matches(_entry("NEEDLE"), "NEEDLE" + "x" * 9000)
+    assert not rt.matches(_entry("NEEDLE"), "x" * 5000 + "NEEDLE")
+
+
+def test_the_bound_counts_bytes_not_characters():
+    pad = "é" * 2100  # 4200 bytes, 2100 characters
+    assert not rt.matches(_entry("NEEDLE"), pad + "NEEDLE")
+
+
+def test_an_unusable_pattern_matches_nothing_and_never_raises():
+    """A hand-edited manifest can carry a pattern the writer would have
+    refused. The hook must not turn that into a traceback on every Bash
+    call."""
+    assert rt.matches(_entry("("), "anything") is False
+    assert rt.matches(_entry(""), "anything") is False
+    assert rt.matches({"ruling_id": "r-0"}, "anything") is False
+
+
+def test_matches_tolerates_a_command_that_is_not_a_string():
+    assert rt.matches(_entry("x"), None) is False

--- a/plugin/tests/test_checks_runtime.py
+++ b/plugin/tests/test_checks_runtime.py
@@ -1,10 +1,14 @@
 """#943 slice 2: the standalone check runtime.
 
 `checks_runtime.py` is loaded by host hook scripts that cannot import the
-venv-only package, so every test here loads the SHIPPED copy by file location
-under its own module name — the way a hook will. Byte-identity with the
-canonical module is a separate drift test (test_hooks_install.py); together
-they mean these assertions bind the canonical file too.
+venv-only package, so every test here loads it by FILE LOCATION under its own
+module name, the way a hook will: a relative import or a package import in
+the module fails at that load rather than on someone's host.
+
+It loads the CANONICAL file, not the shipped copy. Byte-identity is a
+separate drift test (test_hooks_install.py), and keeping the two concerns
+apart means an edit that has not been synced yet fails one obvious test
+instead of every test in this file.
 """
 
 import ast
@@ -18,16 +22,14 @@ from daimon_briefing import config
 
 CANONICAL = (Path(__file__).parents[1] / "daimon_briefing"
              / "checks_runtime.py")
-SHIPPED = (Path(__file__).parents[1] / "daimon_briefing" / "_hooks"
-           / "checks_runtime.py")
 
 
 def _runtime():
-    """The shipped runtime, loaded standalone. A relative import or a
-    `daimon_briefing` import in the canonical file fails HERE, which is the
-    only place it can fail before a host hook hits it in production."""
+    """The runtime, loaded standalone. A relative import or a
+    `daimon_briefing` import in it fails HERE, which is the only place it can
+    fail before a host hook hits it in production."""
     spec = importlib.util.spec_from_file_location(
-        "_checks_runtime_under_test", SHIPPED)
+        "_checks_runtime_under_test", CANONICAL)
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
@@ -273,3 +275,230 @@ def test_an_unusable_pattern_matches_nothing_and_never_raises():
 
 def test_matches_tolerates_a_command_that_is_not_a_string():
     assert rt.matches(_entry("x"), None) is False
+
+
+# ---- resolver: spec 3.2, every row both ways ------------------------------
+
+
+def _text_of(subject):
+    return Path(subject.path).read_text(encoding="utf-8")
+
+
+def _resolve(command, cwd):
+    got = rt.resolve(command, str(cwd))
+    return got
+
+
+def test_a_command_with_no_file_argument_still_resolves(tmp_path):
+    """The command string alone is a subject. A check that only inspects the
+    command must not report unresolved for having nothing to read."""
+    got = _resolve("gh pr create --title x", tmp_path)
+    assert isinstance(got, rt.Subject)
+    assert got.files == ()
+    assert "gh pr create --title x" in _text_of(got)
+    rt.discard(got)
+
+
+def test_the_subject_file_is_owner_only_and_outside_the_daimon_home(tmp_path):
+    """0o600, and in the system temp dir on purpose: a file under ~/.daimon
+    would have to be declared in the surface registry and carry a deletion
+    story, and this one exists for the length of one exec."""
+    got = _resolve("gh pr create", tmp_path)
+    path = Path(got.path)
+    assert path.stat().st_mode & 0o777 == 0o600
+    assert config.checks_dir() not in path.parents
+    assert Path.home() not in path.parents
+    rt.discard(got)
+    assert not path.exists()
+
+
+@pytest.mark.parametrize("template", [
+    "gh pr create --body-file {p}",
+    "gh pr create --body-file={p}",
+    "gh issue create -F {p}",
+    "gh release create v1 --notes-file {p}",
+    "gh release create v1 --notes-file={p}",
+    "gh api repos/x -F body=@{p}",
+    "gh api repos/x --field body=@{p}",
+    "gh api repos/x --field=body=@{p}",
+])
+def test_every_resolving_row_reads_the_file(template, tmp_path):
+    body = tmp_path / "body.md"
+    body.write_text("the body text\n", encoding="utf-8")
+    got = _resolve(template.format(p=body), tmp_path)
+    assert isinstance(got, rt.Unresolved) is False, getattr(got, "cause", "")
+    assert "the body text" in _text_of(got)
+    rt.discard(got)
+
+
+def test_a_relative_path_resolves_against_the_working_directory(tmp_path):
+    (tmp_path / "notes").mkdir()
+    (tmp_path / "notes" / "b.md").write_text("relative body", encoding="utf-8")
+    got = _resolve("gh pr create --body-file notes/b.md", tmp_path)
+    assert "relative body" in _text_of(got)
+    rt.discard(got)
+
+
+def test_the_subject_is_the_command_then_a_separator_then_headed_file_bytes(
+        tmp_path):
+    a = tmp_path / "a.md"
+    b = tmp_path / "b.md"
+    a.write_text("AAA", encoding="utf-8")
+    b.write_text("BBB", encoding="utf-8")
+    command = f"gh pr create --body-file {a} --notes-file {b}"
+    got = _resolve(command, tmp_path)
+    text = _text_of(got)
+    assert text.startswith(command)
+    # Each file is announced by the flag it came from, in command order.
+    # Read AFTER the separator: the command itself names both flags, so a
+    # search over the whole subject would find those and prove nothing.
+    body = text.split(rt.SUBJECT_SEPARATOR, 1)[1]
+    assert body.index("--body-file") < body.index("AAA") < \
+        body.index("--notes-file") < body.index("BBB")
+    assert [flag for flag, _ in got.files] == ["--body-file", "--notes-file"]
+    rt.discard(got)
+
+
+def test_a_heredoc_body_is_read_out_of_the_command_string(tmp_path):
+    command = ("gh pr create --body-file - <<'EOF'\n"
+               "the heredoc body\n"
+               "EOF")
+    got = _resolve(command, tmp_path)
+    assert isinstance(got, rt.Subject)
+    assert "the heredoc body" in _text_of(got)
+    rt.discard(got)
+
+
+def test_an_unquoted_heredoc_terminator_resolves_the_same_way(tmp_path):
+    command = "gh pr create --body-file - <<EOF\nunquoted body\nEOF"
+    got = _resolve(command, tmp_path)
+    assert "unquoted body" in _text_of(got)
+    rt.discard(got)
+
+
+def test_a_dash_suppressed_heredoc_resolves(tmp_path):
+    command = "gh pr create --body-file - <<-EOF\n\tindented body\n\tEOF"
+    got = _resolve(command, tmp_path)
+    assert "indented body" in _text_of(got)
+    rt.discard(got)
+
+
+def test_a_dash_fed_by_a_pipe_is_unresolved_as_stdin_pipe(tmp_path):
+    """No heredoc in the command string means the bytes are arriving from a
+    process daimon cannot see. Never clean."""
+    got = _resolve("cat notes.md | gh pr create --body-file -", tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "stdin-pipe"
+
+
+def test_a_dash_after_a_flag_outside_the_table_is_arg_form_unparsed(tmp_path):
+    got = _resolve("gh pr create --input -", tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "arg-form-unparsed"
+
+
+def test_an_at_path_outside_the_table_is_arg_form_unparsed(tmp_path):
+    payload = tmp_path / "payload.json"
+    payload.write_text("{}", encoding="utf-8")
+    got = _resolve(f"curl -d @{payload} https://x", tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "arg-form-unparsed"
+
+
+def test_a_literal_field_value_is_not_a_file_and_resolves(tmp_path):
+    """`-F key=value` with no `@` names no file. Reporting unresolved here
+    would make every gh api call unprovable for no reason."""
+    got = _resolve("gh api repos/x -F name=daimon", tmp_path)
+    assert isinstance(got, rt.Subject)
+    assert got.files == ()
+    rt.discard(got)
+
+
+def test_a_command_that_cannot_be_tokenized_is_arg_form_unparsed(tmp_path):
+    got = _resolve("gh pr create --title 'unbalanced", tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "arg-form-unparsed"
+
+
+# ---- resolver: the file failure causes ------------------------------------
+
+
+def test_a_missing_file_is_file_missing(tmp_path):
+    got = _resolve(f"gh pr create --body-file {tmp_path}/gone.md", tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "file-missing"
+
+
+def test_an_unreadable_file_is_file_unreadable(tmp_path):
+    if os.getuid() == 0:
+        pytest.skip("root reads anything; the mode bit proves nothing")
+    body = tmp_path / "locked.md"
+    body.write_text("secret", encoding="utf-8")
+    body.chmod(0o000)
+    try:
+        got = _resolve(f"gh pr create --body-file {body}", tmp_path)
+        assert isinstance(got, rt.Unresolved)
+        assert got.cause == "file-unreadable"
+    finally:
+        body.chmod(0o600)
+
+
+def test_a_directory_argument_is_file_unreadable(tmp_path):
+    (tmp_path / "adir").mkdir()
+    got = _resolve(f"gh pr create --body-file {tmp_path}/adir", tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "file-unreadable"
+
+
+def test_a_file_over_the_cap_is_file_oversize(tmp_path):
+    big = tmp_path / "big.md"
+    big.write_bytes(b"x" * (rt.MAX_SUBJECT_FILE_BYTES + 1))
+    got = _resolve(f"gh pr create --body-file {big}", tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "file-oversize"
+
+
+def test_a_file_exactly_at_the_cap_still_resolves(tmp_path):
+    at = tmp_path / "at.md"
+    at.write_bytes(b"x" * rt.MAX_SUBJECT_FILE_BYTES)
+    got = _resolve(f"gh pr create --body-file {at}", tmp_path)
+    assert isinstance(got, rt.Subject)
+    rt.discard(got)
+
+
+def test_a_file_that_is_not_utf8_is_file_binary(tmp_path):
+    blob = tmp_path / "blob.bin"
+    blob.write_bytes(b"\xff\xfe\x00\x01")
+    got = _resolve(f"gh pr create --body-file {blob}", tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "file-binary"
+
+
+def test_the_first_failure_wins_and_no_subject_file_is_left_behind(
+        tmp_path, monkeypatch):
+    """Left to right, and fail-closed: one unreadable argument means daimon
+    cannot prove the subject clean, whatever the other arguments say. The
+    temp dir is redirected so the leftover assertion is about THIS call and
+    not about whatever else is in /tmp."""
+    sink = tmp_path / "tmpsink"
+    sink.mkdir()
+    monkeypatch.setattr(rt.tempfile, "tempdir", str(sink))
+    ok = tmp_path / "ok.md"
+    ok.write_text("fine", encoding="utf-8")
+    got = _resolve(
+        f"gh pr create --body-file {tmp_path}/gone.md --notes-file {ok}",
+        tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "file-missing"
+    assert list(sink.iterdir()) == [], "a subject file was left behind"
+
+
+def test_every_cause_the_resolver_emits_is_a_declared_cause():
+    assert {"file-missing", "file-unreadable", "file-oversize", "file-binary",
+            "stdin-pipe", "arg-form-unparsed"} <= rt.CAUSES
+
+
+def test_resolve_never_raises_on_a_command_that_is_not_a_string(tmp_path):
+    got = rt.resolve(None, str(tmp_path))
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "arg-form-unparsed"

--- a/plugin/tests/test_checks_runtime.py
+++ b/plugin/tests/test_checks_runtime.py
@@ -447,12 +447,24 @@ def test_one_heredoc_and_one_reader_bind_to_each_other(tmp_path):
     rt.discard(got)
 
 
-def test_a_second_heredoc_makes_the_binding_a_guess_and_daimon_refuses(
-        tmp_path):
-    """A compound line where an earlier command has its own heredoc. The
-    tokenizer has thrown away the order and the redirections, so handing the
-    first heredoc to the first reader builds the subject from unrelated text
-    and reports clean on a body nothing ever read."""
+def test_a_heredoc_belonging_to_another_command_is_never_borrowed(tmp_path):
+    """A heredoc redirect belongs to the simple command it is attached to.
+    Here it belongs to `cat`, and the governed command reads standard input
+    from somewhere daimon cannot see. Binding it anyway builds the subject
+    from text the governed command never reads, and if THAT text is clean the
+    record says the body was proven safe."""
+    command = ("cat <<'EOF' > note.txt\n"
+               "JUNK\n"
+               "EOF\n"
+               "gh pr create -F -")
+    got = _resolve(command, tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "arg-form-unparsed"
+
+
+def test_a_heredoc_binds_inside_its_own_command_even_beside_another(tmp_path):
+    """Two commands, one heredoc each: neither is ambiguous, so the governed
+    one resolves and it resolves to ITS heredoc."""
     command = ("cat <<'EOF' > note.txt\n"
                "JUNK\n"
                "EOF\n"
@@ -460,14 +472,29 @@ def test_a_second_heredoc_makes_the_binding_a_guess_and_daimon_refuses(
                "the real body\n"
                "BODY")
     got = _resolve(command, tmp_path)
-    assert isinstance(got, rt.Unresolved)
-    assert got.cause == "arg-form-unparsed"
+    assert isinstance(got, rt.Subject), getattr(got, "cause", "")
+    # Past the separator: the subject opens with the whole command string,
+    # which quotes both heredocs, so a search over all of it proves nothing
+    # about which one was READ.
+    body = _text_of(got).split(rt.SUBJECT_SEPARATOR, 1)[1]
+    assert "the real body" in body
+    assert "JUNK" not in body
+    rt.discard(got)
+
+
+def test_a_trailing_command_after_the_heredoc_does_not_break_the_binding(
+        tmp_path):
+    got = _resolve("gh pr create -F - <<EOF\nthe body\nEOF && echo done",
+                   tmp_path)
+    assert isinstance(got, rt.Subject), getattr(got, "cause", "")
+    assert "the body" in _text_of(got)
+    rt.discard(got)
 
 
 def test_two_readers_and_one_heredoc_is_a_guess_too(tmp_path):
-    """The other side of the same count. Two arguments reading standard
-    input and one heredoc: whichever one daimon picks, the other is read
-    from somewhere it cannot see."""
+    """The other side of the same count, now inside one simple command. Two
+    arguments reading standard input and one heredoc: whichever one daimon
+    picks, the other is read from somewhere it cannot see."""
     command = ("gh pr create --body-file - --notes-file - <<'EOF'\n"
                "shared\n"
                "EOF")
@@ -476,25 +503,12 @@ def test_two_readers_and_one_heredoc_is_a_guess_too(tmp_path):
     assert got.cause == "arg-form-unparsed"
 
 
-def test_the_one_to_one_rule_does_not_yet_reach_a_borrowed_heredoc(tmp_path):
-    """KNOWN RESIDUAL, pinned so it stays visible rather than becoming a
-    surprise. One heredoc that belongs to an EARLIER command, and one
-    argument reading standard input: the counts are one and one, so the
-    rule above binds them and the subject is built from the wrong text.
-
-    Closing this needs the heredoc's offset in the raw command matched
-    against the offset of the argument that consumes it, which the current
-    tokenizer discards. Until then this is the resolver's one remaining
-    fail-open shape, and it is narrower than the family the count rule
-    already closed."""
-    command = ("cat <<'EOF' > note.txt\n"
-               "JUNK\n"
-               "EOF\n"
-               "gh pr create --body-file -")
-    got = _resolve(command, tmp_path)
-    assert isinstance(got, rt.Subject), "if this now refuses, delete this test"
-    assert "JUNK" in _text_of(got), "the residual this test documents"
-    rt.discard(got)
+def test_a_pipeline_still_reports_the_pipe_rather_than_the_form(tmp_path):
+    """When a `|` feeds the governed command, daimon knows exactly why it
+    cannot read the bytes, and says that instead of blaming the argument."""
+    got = _resolve("printf x | gh pr create -F -", tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "stdin-pipe"
 
 
 def test_a_dash_fed_by_a_pipe_is_unresolved_as_stdin_pipe(tmp_path):

--- a/plugin/tests/test_checks_runtime.py
+++ b/plugin/tests/test_checks_runtime.py
@@ -1308,3 +1308,59 @@ def test_a_child_that_cannot_be_killed_at_all_still_reports_the_timeout(
                  timeout=0.01)
     assert (got.outcome, got.cause) == ("unresolved", "check-timeout")
     rt.discard(subject)
+
+
+# ---- the resolver's own input bound (scar 0022, second door) --------------
+
+
+def test_a_command_at_the_cap_still_resolves(tmp_path):
+    command = "gh pr create --title " + "A" * (
+        rt.MAX_COMMAND_BYTES - len("gh pr create --title "))
+    assert len(command.encode("utf-8")) == rt.MAX_COMMAND_BYTES
+    got = _resolve(command, tmp_path)
+    assert isinstance(got, rt.Subject), getattr(got, "cause", "")
+    rt.discard(got)
+
+
+def test_a_command_over_the_cap_is_unresolved_never_skipped(tmp_path):
+    """One byte past the cap. Unresolved, not allowed: a command daimon
+    declined to parse is one it cannot prove anything about."""
+    command = "gh pr create --title " + "A" * rt.MAX_COMMAND_BYTES
+    got = _resolve(command, tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "arg-form-unparsed"
+    assert "too long" in got.reason
+
+
+def test_the_cap_counts_bytes_not_characters(tmp_path):
+    command = "gh pr create --title " + "é" * rt.MAX_COMMAND_BYTES
+    got = _resolve(command, tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "arg-form-unparsed"
+
+
+def test_a_large_heredoc_body_is_not_what_the_cap_counts(tmp_path):
+    """The heredoc is stripped before the cap is measured, so a two megabyte
+    PR body still resolves. The cost is in tokenizing a long inline
+    ARGUMENT, and that is what the cap bounds."""
+    body = "x" * (2 * 1024 * 1024)
+    command = f"gh pr create --body-file - <<'EOF'\n{body}\nEOF"
+    got = _resolve(command, tmp_path)
+    assert isinstance(got, rt.Subject), getattr(got, "cause", "")
+    assert body in _text_of(got)
+    rt.discard(got)
+
+
+def test_a_megabyte_of_inline_argument_returns_well_inside_the_budget(
+        tmp_path):
+    """Measured before the cap existed: 5.3s at 512 KiB and 21s at 1 MiB on
+    the author's machine, against a 10s host hook timeout that is fail-open.
+    A hook that outlives it does not block and the action proceeds with no
+    record, so the resolver has to decline long before then."""
+    import time as _time
+    command = "gh pr create --title " + "A" * (1024 * 1024)
+    started = _time.monotonic()
+    got = _resolve(command, tmp_path)
+    elapsed = _time.monotonic() - started
+    assert isinstance(got, rt.Unresolved)
+    assert elapsed < 0.5, f"resolve took {elapsed:.2f}s on a 1 MiB command"

--- a/plugin/tests/test_checks_runtime.py
+++ b/plugin/tests/test_checks_runtime.py
@@ -438,6 +438,65 @@ def test_a_dash_suppressed_heredoc_resolves(tmp_path):
     rt.discard(got)
 
 
+def test_one_heredoc_and_one_reader_bind_to_each_other(tmp_path):
+    """The case daimon can answer without guessing."""
+    got = _resolve("gh pr create --body-file - <<'EOF'\nthe only body\nEOF",
+                   tmp_path)
+    assert isinstance(got, rt.Subject)
+    assert "the only body" in _text_of(got)
+    rt.discard(got)
+
+
+def test_a_second_heredoc_makes_the_binding_a_guess_and_daimon_refuses(
+        tmp_path):
+    """A compound line where an earlier command has its own heredoc. The
+    tokenizer has thrown away the order and the redirections, so handing the
+    first heredoc to the first reader builds the subject from unrelated text
+    and reports clean on a body nothing ever read."""
+    command = ("cat <<'EOF' > note.txt\n"
+               "JUNK\n"
+               "EOF\n"
+               "gh pr create --body-file - <<'BODY'\n"
+               "the real body\n"
+               "BODY")
+    got = _resolve(command, tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "arg-form-unparsed"
+
+
+def test_two_readers_and_one_heredoc_is_a_guess_too(tmp_path):
+    """The other side of the same count. Two arguments reading standard
+    input and one heredoc: whichever one daimon picks, the other is read
+    from somewhere it cannot see."""
+    command = ("gh pr create --body-file - --notes-file - <<'EOF'\n"
+               "shared\n"
+               "EOF")
+    got = _resolve(command, tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "arg-form-unparsed"
+
+
+def test_the_one_to_one_rule_does_not_yet_reach_a_borrowed_heredoc(tmp_path):
+    """KNOWN RESIDUAL, pinned so it stays visible rather than becoming a
+    surprise. One heredoc that belongs to an EARLIER command, and one
+    argument reading standard input: the counts are one and one, so the
+    rule above binds them and the subject is built from the wrong text.
+
+    Closing this needs the heredoc's offset in the raw command matched
+    against the offset of the argument that consumes it, which the current
+    tokenizer discards. Until then this is the resolver's one remaining
+    fail-open shape, and it is narrower than the family the count rule
+    already closed."""
+    command = ("cat <<'EOF' > note.txt\n"
+               "JUNK\n"
+               "EOF\n"
+               "gh pr create --body-file -")
+    got = _resolve(command, tmp_path)
+    assert isinstance(got, rt.Subject), "if this now refuses, delete this test"
+    assert "JUNK" in _text_of(got), "the residual this test documents"
+    rt.discard(got)
+
+
 def test_a_dash_fed_by_a_pipe_is_unresolved_as_stdin_pipe(tmp_path):
     """No heredoc in the command string means the bytes are arriving from a
     process daimon cannot see. Never clean."""

--- a/plugin/tests/test_checks_runtime.py
+++ b/plugin/tests/test_checks_runtime.py
@@ -331,6 +331,61 @@ def test_every_resolving_row_reads_the_file(template, tmp_path):
     rt.discard(got)
 
 
+@pytest.mark.parametrize("template", [
+    "gh pr create -F{p}",
+    "gh api repos/x -Fbody=@{p}",
+    "gh api repos/x -Ffield=@{p}",
+])
+def test_an_attached_short_flag_value_is_read_like_a_detached_one(
+        template, tmp_path):
+    """pflag, which gh uses, accepts a shorthand value attached to its flag,
+    so `-Fbody.md` is the same command as `-F body.md`. A resolver that skips
+    the attached form reports CLEAN for a file it never opened, which is the
+    one outcome that lets the action through carrying a record saying it was
+    proven safe."""
+    body = tmp_path / "body.md"
+    body.write_text("the body text\n", encoding="utf-8")
+    got = _resolve(template.format(p=body), tmp_path)
+    assert isinstance(got, rt.Subject), getattr(got, "cause", "")
+    assert "the body text" in _text_of(got)
+    rt.discard(got)
+
+
+def test_an_attached_short_flag_reading_stdin_is_not_silently_skipped(
+        tmp_path):
+    got = _resolve("cat notes.md | gh pr create -F-", tmp_path)
+    assert isinstance(got, rt.Unresolved)
+    assert got.cause == "stdin-pipe"
+
+
+@pytest.mark.parametrize("command", [
+    "gh pr create -Fbody.md",
+    "gh api repos/x -Fbody=@body.md",
+    "gh pr create -F-",
+    "gh pr create -F=body.md",
+    "gh pr create -Fnotes/body.md",
+])
+def test_no_attached_short_flag_form_ever_resolves_without_reading_it(
+        command, tmp_path):
+    """The general guard. Every form here names a file that does not exist,
+    so the only honest answers are a read that fails or a form daimon says it
+    cannot parse. A Subject carrying no files would mean the resolver decided
+    a command it did not understand was safe."""
+    got = _resolve(command, tmp_path)
+    assert isinstance(got, rt.Unresolved), \
+        f"{command!r} resolved with files {getattr(got, 'files', None)}"
+    assert got.cause in rt.CAUSES
+
+
+def test_an_attached_literal_field_still_names_no_file(tmp_path):
+    """The one attached form that legitimately reads nothing: `-Fname=x` is a
+    value, not a path, exactly as the detached form is."""
+    got = _resolve("gh api repos/x -Fname=daimon", tmp_path)
+    assert isinstance(got, rt.Subject)
+    assert got.files == ()
+    rt.discard(got)
+
+
 def test_a_relative_path_resolves_against_the_working_directory(tmp_path):
     (tmp_path / "notes").mkdir()
     (tmp_path / "notes" / "b.md").write_text("relative body", encoding="utf-8")

--- a/plugin/tests/test_checks_sync.py
+++ b/plugin/tests/test_checks_sync.py
@@ -483,3 +483,55 @@ def test_the_ratify_ceremony_is_quiet_when_the_manifest_updated(
     monkeypatch.setattr("builtins.input", lambda prompt="": "y")
     assert cli.main(["ruling", "ratify", ruling_id, "--project", PROJECT]) == 0
     assert "warning: check manifest" not in capsys.readouterr().out
+
+
+# ---- `daimon check sync` --------------------------------------------------
+
+
+def test_check_sync_reports_what_it_armed(tmp_checkpoint_dir, capsys):
+    from daimon_briefing import cli
+    _arm()
+    (config.checks_dir() / "manifest.json").unlink()
+    rc = cli.main(["check", "sync", "--project", PROJECT])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "checks: 1 armed for -p-checks-sync" in out
+    assert _manifest().entries
+
+
+def test_check_sync_says_zero_rather_than_nothing(tmp_checkpoint_dir, capsys):
+    """A silent success is how a project that armed nothing and a project
+    whose sync never ran look identical."""
+    from daimon_briefing import cli
+    assert cli.main(["check", "sync", "--project", PROJECT]) == 0
+    assert "checks: 0 armed for -p-checks-sync" in capsys.readouterr().out
+
+
+def test_check_sync_is_safe_to_repeat(tmp_checkpoint_dir):
+    from daimon_briefing import cli
+    _arm()
+    before = _snapshot()
+    time.sleep(0.01)
+    assert cli.main(["check", "sync", "--project", PROJECT]) == 0
+    assert _snapshot() == before
+
+
+def test_check_sync_reports_a_failure_and_exits_non_zero(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    from daimon_briefing import cli
+    monkeypatch.setattr(checks, "sync",
+                        lambda *a, **k: checks.SyncReport(
+                            False, 0, "", "the disk said no"))
+    rc = cli.main(["check", "sync", "--project", PROJECT])
+    assert rc == 1
+    assert "the disk said no" in capsys.readouterr().out
+
+
+def test_check_sync_has_no_slug_flag(tmp_checkpoint_dir):
+    """Slice 2 adds no routing primitive. `--slug` reaches ten human-only
+    decision verbs and is refused outright on a tenant-scoped home; widening
+    it here would hand a bucket-choosing power to a verb that writes
+    executables."""
+    from daimon_briefing import cli
+    with pytest.raises(SystemExit):
+        cli.main(["check", "sync", "--slug", "-p-checks-sync"])

--- a/plugin/tests/test_checks_sync.py
+++ b/plugin/tests/test_checks_sync.py
@@ -250,12 +250,13 @@ def test_sync_reports_a_failure_instead_of_raising(
         tmp_checkpoint_dir, monkeypatch):
     """Sync runs after a ledger write that already landed. Raising here
     would turn a bookkeeping failure into a failed ratify."""
-    _arm()
-
     def boom(*args, **kwargs):
         raise OSError("the disk said no")
 
+    # Patched BEFORE the ratify: arming already syncs, so a sync installed
+    # afterwards would find the manifest correct and never write at all.
     monkeypatch.setattr(checks.store, "_atomic_write", boom)
+    _arm()
     report = checks.sync(PROJECT)
     assert report.ok is False
     assert "the disk said no" in report.reason
@@ -316,3 +317,169 @@ def test_the_manifest_is_json_a_reader_outside_python_can_parse(
     raw = (config.checks_dir() / "manifest.json").read_text(encoding="utf-8")
     assert isinstance(json.loads(raw), list)
     assert os.linesep or True
+
+
+# ---- sync at the writers --------------------------------------------------
+
+
+def _snapshot():
+    base = config.checks_dir()
+    if not base.exists():
+        return {}
+    return {p.name: (p.read_bytes(), p.stat().st_mtime_ns)
+            for p in base.iterdir()}
+
+
+def test_ratify_arms_the_check_with_no_explicit_sync(tmp_checkpoint_dir):
+    """The manifest is a derived view of the ledger. A user who ratifies and
+    never learns `check sync` exists still gets an armed check."""
+    ruling_id = _arm()
+    entries = _manifest().entries
+    assert [e["ruling_id"] for e in entries] == [ruling_id]
+    assert len(_bodies()) == 1
+
+
+def test_retire_disarms_it_with_no_explicit_sync(tmp_checkpoint_dir):
+    ruling_id = _arm()
+    refutations.retire(ruling_id, channel="cli-tty", project_dir=PROJECT)
+    assert _manifest().entries == []
+    assert _bodies() == []
+
+
+def test_a_human_revise_arms_the_new_body_with_no_explicit_sync(
+        tmp_checkpoint_dir):
+    ruling_id = _arm()
+    new_body = BODY.replace("FORBIDDEN", "BANNED")
+    refutations.revise(ruling_id, channel="cli-tty", evidence=["issue:943"],
+                       check={"match": MATCH, "body": new_body,
+                              "intent": "warn"},
+                       project_dir=PROJECT)
+    entry = _manifest().entries[0]
+    assert entry["sha256"] == _sha(new_body)
+    assert (config.checks_dir() / checks_runtime.body_name(entry)).read_text(
+        encoding="utf-8") == new_body
+
+
+def test_an_agent_revision_proposal_leaves_the_armed_body_alone(
+        tmp_checkpoint_dir):
+    """Spec 2.2: an agent's pending revision is `proposed`; the host keeps
+    seeing the old body. The write happens, and nothing on disk moves."""
+    ruling_id = _arm()
+    before = _snapshot()
+    time.sleep(0.01)
+    refutations.revise(ruling_id, channel="cli-agent", evidence=["issue:943"],
+                       check={"match": MATCH, "body": BODY.replace(
+                           "FORBIDDEN", "SNEAKY"), "intent": "warn"},
+                       project_dir=PROJECT)
+    assert _snapshot() == before
+
+
+def test_forget_disarms_the_check_with_no_explicit_sync(tmp_checkpoint_dir):
+    _arm()
+    assert len(_bodies()) == 1
+    refutations.forget_content_key(
+        normalize.content_key("the rule for public posts in publishing"),
+        project_dir=PROJECT)
+    assert _manifest().entries == []
+    assert _bodies() == []
+
+
+def test_a_write_that_touches_no_check_touches_no_file(tmp_checkpoint_dir):
+    """Every refutation ratify in the tree would otherwise pay a full ledger
+    re-fold and an mtime bump for a manifest that cannot have changed."""
+    _arm()
+    before = _snapshot()
+    other = refutations.assert_refutation(
+        subject="a losing approach", verdict="it lost", scope="elsewhere",
+        evidence=["issue:943"], channel="cli-agent", project_dir=PROJECT)
+    time.sleep(0.01)
+    refutations.ratify(other, channel="cli-tty", project_dir=PROJECT)
+    assert _snapshot() == before
+    assert refutations.last_check_sync() is None
+
+
+def test_overturning_a_refutation_never_reaches_the_manifest(
+        tmp_checkpoint_dir):
+    """A ruling is retired, never overturned, so this writer can only ever
+    see a record with no check. Wired anyway, and inert by construction."""
+    _arm()
+    before = _snapshot()
+    other = refutations.assert_refutation(
+        subject="a losing approach", verdict="it lost", scope="elsewhere",
+        evidence=["issue:943"], channel="cli-agent", project_dir=PROJECT)
+    time.sleep(0.01)
+    refutations.overturn(other, channel="cli-tty", evidence=["issue:943"],
+                         project_dir=PROJECT)
+    assert _snapshot() == before
+
+
+def test_the_kill_switch_stops_the_write_and_the_manifest_with_it(
+        tmp_checkpoint_dir, monkeypatch):
+    """append is silent under DAIMON_DISABLE, so the writer raises and the
+    manifest must not be rebuilt from a ledger that did not change."""
+    ruling_id = _arm()
+    before = _snapshot()
+    monkeypatch.setenv("DAIMON_DISABLE", "1")
+    time.sleep(0.01)
+    with pytest.raises(refutations.RefutationError):
+        refutations.retire(ruling_id, channel="cli-tty", project_dir=PROJECT)
+    assert _snapshot() == before
+
+
+def test_a_failing_sync_never_fails_the_write(tmp_checkpoint_dir, monkeypatch):
+    """The append already landed. Raising here would report a failed ratify
+    for a ruling the ledger says is active."""
+    ruling_id = _propose()
+    monkeypatch.setattr(checks, "sync",
+                        lambda *a, **k: checks.SyncReport(
+                            False, 0, "-p-checks-sync", "the disk said no"))
+    refutations.ratify(ruling_id, channel="cli-tty", check_sha256=_sha(),
+                       project_dir=PROJECT)
+    assert refutations.get(ruling_id, project_dir=PROJECT)["state"] == "active"
+    report = refutations.last_check_sync()
+    assert report is not None and report.ok is False
+    assert report.reason == "the disk said no"
+
+
+def test_a_check_writer_that_cannot_be_loaded_is_reported_not_raised(
+        tmp_checkpoint_dir, monkeypatch):
+    ruling_id = _propose()
+
+    def boom(*args, **kwargs):
+        raise ImportError("no checks module here")
+
+    monkeypatch.setattr(refutations, "_load_checks", boom)
+    refutations.ratify(ruling_id, channel="cli-tty", check_sha256=_sha(),
+                       project_dir=PROJECT)
+    report = refutations.last_check_sync()
+    assert report is not None and report.ok is False
+    assert "no checks module here" in report.reason
+
+
+# ---- the CLI says so ------------------------------------------------------
+
+
+def test_the_ratify_ceremony_warns_when_the_manifest_did_not_update(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    from daimon_briefing import cli
+    ruling_id = _propose()
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True, raising=False)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+    monkeypatch.setattr(checks, "sync",
+                        lambda *a, **k: checks.SyncReport(
+                            False, 0, "-p-checks-sync", "the disk said no"))
+    rc = cli.main(["ruling", "ratify", ruling_id, "--project", PROJECT])
+    out = capsys.readouterr().out
+    assert rc == 0, "a bookkeeping failure must not change the verb's exit"
+    assert "warning: check manifest not updated (the disk said no)" in out
+    assert "daimon check sync" in out
+
+
+def test_the_ratify_ceremony_is_quiet_when_the_manifest_updated(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    from daimon_briefing import cli
+    ruling_id = _propose()
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True, raising=False)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+    assert cli.main(["ruling", "ratify", ruling_id, "--project", PROJECT]) == 0
+    assert "warning: check manifest" not in capsys.readouterr().out

--- a/plugin/tests/test_checks_sync.py
+++ b/plugin/tests/test_checks_sync.py
@@ -1,0 +1,318 @@
+"""#943 slice 2: materializing armed checks from the ledger.
+
+`checks.sync` is the package half of the runtime contract. It reads the
+ledger and writes what a standalone hook can read without importing daimon:
+a manifest and one executable body per armed check.
+"""
+
+import hashlib
+import json
+import os
+import time
+
+import pytest
+
+from daimon_briefing import checks, checks_runtime, config, normalize, refutations
+
+PROJECT = "/p/checks-sync"
+OTHER = "/p/checks-other"
+BODY = "#!/bin/sh\ngrep -q FORBIDDEN \"$DAIMON_CHECK_SUBJECT\" && exit 1\nexit 0\n"
+MATCH = "gh pr create"
+
+
+def _sha(body=BODY):
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def _propose(project=PROJECT, *, subject="public posts", scope="publishing",
+             body=BODY, match=MATCH, check=True):
+    return refutations.assert_ruling(
+        subject=subject, verdict=f"the rule for {subject} in {scope}",
+        scope=scope, evidence=["issue:943"], channel="cli-agent",
+        check={"match": match, "body": body, "intent": "warn"} if check
+        else None,
+        project_dir=project)
+
+
+def _arm(project=PROJECT, **kwargs):
+    body = kwargs.get("body", BODY)
+    ruling_id = _propose(project, **kwargs)
+    refutations.ratify(ruling_id, channel="cli-tty",
+                       check_sha256=_sha(body) if kwargs.get("check", True)
+                       else "",
+                       project_dir=project)
+    return ruling_id
+
+
+def _manifest():
+    return checks_runtime.load_manifest(
+        config.checks_dir() / "manifest.json")
+
+
+def _bodies():
+    base = config.checks_dir()
+    return sorted(p.name for p in base.glob("*.sh")) if base.exists() else []
+
+
+# ---- what an armed check materializes into --------------------------------
+
+
+def test_an_armed_check_lands_in_the_manifest_with_the_declared_fields(
+        tmp_checkpoint_dir):
+    ruling_id = _arm()
+    report = checks.sync(PROJECT)
+    assert report.ok and report.armed == 1
+    entries = _manifest().entries
+    assert len(entries) == 1
+    assert set(entries[0]) == {"ruling_id", "project_dir", "match", "intent",
+                               "sha256", "armed_at"}
+    assert entries[0]["ruling_id"] == ruling_id
+    assert entries[0]["match"] == MATCH
+    assert entries[0]["intent"] == "warn"
+    assert entries[0]["sha256"] == _sha()
+    assert entries[0]["armed_at"], "an armed check must say when it was armed"
+
+
+def test_the_manifest_records_the_resolved_project_directory(
+        tmp_checkpoint_dir):
+    """The runtime prefix-matches a realpath'd cwd against this value, so it
+    has to be the same resolution the ledger routed the write through."""
+    _arm()
+    checks.sync(PROJECT)
+    assert _manifest().entries[0]["project_dir"] == \
+        config.resolve_project_dir(PROJECT)
+
+
+def test_the_body_is_materialized_executable_and_byte_exact(
+        tmp_checkpoint_dir):
+    _arm()
+    checks.sync(PROJECT)
+    entry = _manifest().entries[0]
+    path = config.checks_dir() / checks_runtime.body_name(entry)
+    assert path.exists()
+    assert path.read_text(encoding="utf-8") == BODY
+    assert path.stat().st_mode & 0o777 == 0o500
+
+
+def test_the_manifest_the_writer_produces_is_one_the_runtime_can_use(
+        tmp_checkpoint_dir, tmp_path):
+    """The two halves are only correct together. This is the seam: sync
+    writes, the runtime reads, and a cwd inside the project finds the entry."""
+    _arm(project=str(tmp_path))
+    checks.sync(str(tmp_path))
+    loaded = _manifest()
+    assert loaded.reason == ""
+    armed = checks_runtime.armed_for(str(tmp_path), loaded)
+    assert len(armed) == 1
+    assert checks_runtime.matches(armed[0], "gh pr create --fill")
+
+
+# ---- what never lands -----------------------------------------------------
+
+
+def test_a_candidate_check_never_lands(tmp_checkpoint_dir):
+    """`proposed` is a lifecycle, not a mode. A candidate's body is code no
+    human ever confirmed, and record-only would still execute it."""
+    _propose()
+    report = checks.sync(PROJECT)
+    assert report.ok and report.armed == 0
+    assert _manifest().entries == []
+    assert _bodies() == []
+
+
+def test_a_ruling_with_no_check_lands_nothing(tmp_checkpoint_dir):
+    _arm(check=False)
+    assert checks.sync(PROJECT).armed == 0
+    assert _manifest().entries == []
+
+
+def test_a_retired_ruling_drops_its_entry_and_its_body(tmp_checkpoint_dir):
+    ruling_id = _arm()
+    checks.sync(PROJECT)
+    assert len(_bodies()) == 1
+    refutations.retire(ruling_id, channel="cli-tty", project_dir=PROJECT)
+    checks.sync(PROJECT)
+    assert _manifest().entries == []
+    assert _bodies() == [], "a disarmed check must not stay on disk"
+
+
+def test_a_forgotten_ruling_drops_its_entry_and_its_body(tmp_checkpoint_dir):
+    _arm()
+    checks.sync(PROJECT)
+    refutations.forget_content_key(
+        normalize.content_key("the rule for public posts in publishing"),
+        project_dir=PROJECT)
+    checks.sync(PROJECT)
+    assert _manifest().entries == []
+    assert _bodies() == []
+
+
+def test_a_revised_body_removes_the_one_it_replaced(tmp_checkpoint_dir):
+    """The file name carries the hash, so a new body is a new file. Leaving
+    the old one behind would keep a script the ruling no longer stands for."""
+    ruling_id = _arm()
+    checks.sync(PROJECT)
+    stale = _bodies()
+    new_body = BODY.replace("FORBIDDEN", "BANNED")
+    refutations.revise(ruling_id, channel="cli-tty", evidence=["issue:943"],
+                       check={"match": MATCH, "body": new_body,
+                              "intent": "warn"},
+                       project_dir=PROJECT)
+    checks.sync(PROJECT)
+    assert _bodies() != stale
+    assert len(_bodies()) == 1
+    entry = _manifest().entries[0]
+    assert (config.checks_dir() / checks_runtime.body_name(entry)).read_text(
+        encoding="utf-8") == new_body
+
+
+# ---- one directory, many projects -----------------------------------------
+
+
+def test_another_project_s_entries_and_bodies_survive(tmp_checkpoint_dir):
+    """The checks directory is global and the sync is per project. A sync
+    here must never disarm a ruling made somewhere else."""
+    _arm(project=OTHER, subject="release notes", scope="publishing")
+    checks.sync(OTHER)
+    theirs = _manifest().entries
+    assert len(theirs) == 1
+
+    _arm(project=PROJECT)
+    report = checks.sync(PROJECT)
+    assert report.armed == 1, "the report counts THIS project only"
+    entries = _manifest().entries
+    assert len(entries) == 2
+    assert theirs[0] in entries
+    assert len(_bodies()) == 2
+
+
+def test_retiring_here_leaves_the_other_project_armed(tmp_checkpoint_dir):
+    ruling_id = _arm(project=PROJECT)
+    _arm(project=OTHER, subject="release notes", scope="publishing")
+    checks.sync(OTHER)
+    checks.sync(PROJECT)
+    assert len(_manifest().entries) == 2
+
+    refutations.retire(ruling_id, channel="cli-tty", project_dir=PROJECT)
+    checks.sync(PROJECT)
+    entries = _manifest().entries
+    assert [e["project_dir"] for e in entries] == \
+        [config.resolve_project_dir(OTHER)]
+    assert len(_bodies()) == 1
+
+
+def test_two_projects_sharing_a_body_keep_it_when_one_disarms(
+        tmp_checkpoint_dir):
+    """Ruling ids hash subject and scope, so two projects can name the same
+    body file. Removing it because THIS project stopped wanting it would
+    disarm the other one silently."""
+    here = _arm(project=PROJECT)
+    _arm(project=OTHER)
+    checks.sync(OTHER)
+    checks.sync(PROJECT)
+    assert len(_bodies()) == 1, "the fixture must actually share a name"
+
+    refutations.retire(here, channel="cli-tty", project_dir=PROJECT)
+    checks.sync(PROJECT)
+    assert len(_manifest().entries) == 1
+    assert len(_bodies()) == 1, "the other project still needs that body"
+
+
+# ---- idempotence ----------------------------------------------------------
+
+
+def test_a_repeat_sync_changes_neither_bytes_nor_mtimes(tmp_checkpoint_dir):
+    """Every ledger writer calls this. A sync that rewrote identical files
+    would churn the disk on every ratify in the tree."""
+    _arm()
+    checks.sync(PROJECT)
+    base = config.checks_dir()
+    before = {p.name: (p.read_bytes(), p.stat().st_mtime_ns)
+              for p in base.iterdir()}
+    time.sleep(0.01)
+    checks.sync(PROJECT)
+    after = {p.name: (p.read_bytes(), p.stat().st_mtime_ns)
+             for p in base.iterdir()}
+    assert after == before
+
+
+def test_the_manifest_is_replaced_atomically_and_leaves_no_temp_file(
+        tmp_checkpoint_dir):
+    _arm()
+    checks.sync(PROJECT)
+    assert [p.name for p in config.checks_dir().glob("*.tmp")] == []
+
+
+# ---- never raises ---------------------------------------------------------
+
+
+def test_sync_reports_a_failure_instead_of_raising(
+        tmp_checkpoint_dir, monkeypatch):
+    """Sync runs after a ledger write that already landed. Raising here
+    would turn a bookkeeping failure into a failed ratify."""
+    _arm()
+
+    def boom(*args, **kwargs):
+        raise OSError("the disk said no")
+
+    monkeypatch.setattr(checks.store, "_atomic_write", boom)
+    report = checks.sync(PROJECT)
+    assert report.ok is False
+    assert "the disk said no" in report.reason
+
+
+def test_sync_reports_a_failure_for_a_project_that_names_no_bucket(
+        tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setattr(checks.store, "project_slug", lambda *a, **k: "")
+    report = checks.sync(PROJECT)
+    assert report.ok is False
+    assert report.reason
+
+
+def test_a_manifest_that_cannot_be_read_does_not_erase_it(
+        tmp_checkpoint_dir):
+    """A corrupt manifest is not permission to drop every other project's
+    entries. Sync refuses rather than rebuilding from what it can see."""
+    _arm(project=OTHER, subject="release notes", scope="publishing")
+    checks.sync(OTHER)
+    path = config.checks_dir() / "manifest.json"
+    path.write_text("{ not json", encoding="utf-8")
+    _arm(project=PROJECT)
+    report = checks.sync(PROJECT)
+    assert report.ok is False
+    assert path.read_text(encoding="utf-8") == "{ not json"
+
+
+# ---- the surfaces the sync owns -------------------------------------------
+
+
+@pytest.mark.parametrize("shape", ["checks/manifest.json", "checks/*.sh"])
+def test_the_sync_s_files_are_declared_in_the_surface_registry(shape):
+    """Both carry authored text: the manifest holds `check.match` and the
+    body IS `check.body`, and refutations already declares that pair
+    plaintext for forget's reach. So the honest declaration is plaintext with
+    a real deletion story, not an exemption."""
+    from daimon_briefing import surfaces
+    entry = [s for s in surfaces.SURFACES if s.shape == shape]
+    assert entry, f"{shape} is a new file under ~/.daimon"
+    assert entry[0].owner == "checks.sync"
+    assert entry[0].plaintext is True
+    assert entry[0].delete == "rewrite"
+
+
+@pytest.mark.parametrize("shape", ["checks/manifest.json", "checks/*.sh"])
+def test_the_sync_s_files_appear_in_the_foreign_apply_gap(shape):
+    """A foreign tombstone apply walks the bucket json and nothing else, so
+    it does not reach these. The gap is registry-derived, and a new plaintext
+    surface widening it on its own is the safe direction (#620)."""
+    from daimon_briefing import surfaces
+    assert shape in surfaces.foreign_apply_gap()
+
+
+def test_the_manifest_is_json_a_reader_outside_python_can_parse(
+        tmp_checkpoint_dir):
+    _arm()
+    checks.sync(PROJECT)
+    raw = (config.checks_dir() / "manifest.json").read_text(encoding="utf-8")
+    assert isinstance(json.loads(raw), list)
+    assert os.linesep or True

--- a/plugin/tests/test_checks_sync.py
+++ b/plugin/tests/test_checks_sync.py
@@ -535,3 +535,77 @@ def test_check_sync_has_no_slug_flag(tmp_checkpoint_dir):
     from daimon_briefing import cli
     with pytest.raises(SystemExit):
         cli.main(["check", "sync", "--slug", "-p-checks-sync"])
+
+
+# ---- the fallback branches ------------------------------------------------
+
+
+def test_a_record_whose_check_lost_its_hash_is_not_armed(
+        tmp_checkpoint_dir, monkeypatch):
+    """The writer always computes the hash, so this shape cannot come from
+    the CLI. It can come from a hand-edited ledger, and arming a body with
+    no pin would give the runner nothing to re-hash against, which is the
+    whole mechanism that catches an edited body."""
+    monkeypatch.setattr(refutations, "listing", lambda **kwargs: [
+        {"refutation_id": "r-nohash", "check_lifecycle": "armed",
+         "check": {"match": MATCH, "body": BODY, "intent": "warn"},
+         "activated_at": "t"},
+        {"refutation_id": "", "check_lifecycle": "armed",
+         "check": {"match": MATCH, "body": BODY, "sha256": _sha()},
+         "activated_at": "t"},
+    ])
+    report = checks.sync(PROJECT)
+    assert report.ok and report.armed == 0
+    assert _manifest().entries == []
+    assert _bodies() == []
+
+
+def test_a_stale_body_that_cannot_be_removed_does_not_sink_the_sync(
+        tmp_checkpoint_dir):
+    """Sync runs after a ledger write that already landed. A body that will
+    not go is worth reporting, never worth turning a retirement into a
+    failure: the manifest no longer names it, so no host will run it."""
+    ruling_id = _arm()
+    entry = _manifest().entries[0]
+    body = config.checks_dir() / checks_runtime.body_name(entry)
+    body.unlink()
+    # A directory in its place: unlink refuses, the way a locked file would.
+    body.mkdir()
+    refutations.retire(ruling_id, channel="cli-tty", project_dir=PROJECT)
+    report = checks.sync(PROJECT)
+    assert report.ok
+    assert _manifest().entries == [], "the manifest must stop naming it"
+    assert body.is_dir(), "the fixture stopped exercising the failure"
+
+
+def test_forget_says_so_when_the_armed_body_may_have_outlived_the_ruling(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    """forget removes a ruling's check by re-deriving the manifest from the
+    ledger it just rewrote. When that derivation fails, the body is still on
+    disk and still armed, and an irreversible operation reporting a clean
+    sweep it did not perform is worse than one that says what it missed."""
+    from daimon_briefing import cli, store
+
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", PROJECT)
+    _arm()
+    store.write_checkpoint("S1", {
+        "session_id": "S1",
+        "working_context": {"recent_decisions": [
+            {"text": "the rule for public posts in publishing",
+             "trust": "inferred"}]},
+    }, project_dir=PROJECT)
+    stored = store.read_latest_body(project_dir=PROJECT, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
+    item_id = stored["working_context"]["recent_decisions"][0]["id"]
+
+    # Removing an ACTIVE ruling is a human decision, so forget wants a
+    # terminal and a confirmation before it will do this at all.
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True, raising=False)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+    monkeypatch.setattr(checks, "sync",
+                        lambda *a, **k: checks.SyncReport(
+                            False, 0, "-p-checks-sync", "the disk said no"))
+    assert cli.main(["forget", item_id, "--project", PROJECT]) == 0
+    out = capsys.readouterr().out
+    assert "check manifest not updated (the disk said no)" in out
+    assert "may still be armed" in out

--- a/plugin/tests/test_config.py
+++ b/plugin/tests/test_config.py
@@ -920,3 +920,56 @@ def test_extra_read_slugs_drops_entries_that_are_not_slugs(monkeypatch):
     widen a read."""
     monkeypatch.setenv("DAIMON_EXTRA_READ_SLUGS", "-p-ok, /etc/x, a b, *, -p-also")
     assert config.extra_read_slugs() == ("-p-ok", "-p-also")
+
+
+# ---- #943 slice 2: the check runtime's two knobs ---------------------------
+
+
+def test_checks_dir_from_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("DAIMON_CHECKS_DIR", str(tmp_path / "ch"))
+    assert config.checks_dir() == tmp_path / "ch"
+
+
+def test_checks_dir_default(monkeypatch):
+    monkeypatch.delenv("DAIMON_CHECKS_DIR", raising=False)
+    d = config.checks_dir()
+    assert d.name == "checks"
+    assert ".daimon" in str(d)
+
+
+def test_checks_dir_expands_a_tilde(monkeypatch):
+    monkeypatch.setenv("DAIMON_CHECKS_DIR", "~/somewhere/checks")
+    assert config.checks_dir() == Path.home() / "somewhere" / "checks"
+
+
+def test_check_timeout_default_and_override(monkeypatch):
+    monkeypatch.delenv("DAIMON_CHECK_TIMEOUT", raising=False)
+    assert config.check_timeout() == 5.0
+    monkeypatch.setenv("DAIMON_CHECK_TIMEOUT", "2.5")
+    assert config.check_timeout() == 2.5
+
+
+def test_check_timeout_garbage_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("DAIMON_CHECK_TIMEOUT", "soon")
+    assert config.check_timeout() == 5.0
+
+
+def test_check_timeout_has_a_floor(monkeypatch):
+    """A budget of zero is not "no budget", it is a runner that reports
+    check-timeout on every check and reads as if every check crashed. The
+    floor keeps the smallest configured budget a budget."""
+    monkeypatch.setenv("DAIMON_CHECK_TIMEOUT", "0")
+    assert config.check_timeout() == 0.5
+    monkeypatch.setenv("DAIMON_CHECK_TIMEOUT", "-9")
+    assert config.check_timeout() == 0.5
+
+
+def test_the_autouse_fixture_isolates_the_checks_dir():
+    """HOME is NOT redirected by the autouse fixture, so a checks dir that
+    fell through to the default would be the DEVELOPER'S real one — the shape
+    of the incident where manual runs wrote scratch buckets into the live
+    store. The fixture must own this path like every other ~/.daimon path."""
+    resolved = config.checks_dir()
+    assert resolved != Path.home() / ".daimon" / "checks"
+    assert not (Path.home() / ".daimon" / "checks").exists() or \
+        Path.home() not in resolved.parents

--- a/plugin/tests/test_hooks_install.py
+++ b/plugin/tests/test_hooks_install.py
@@ -49,6 +49,19 @@ def test_shipped_redact_matches_canonical_module():
     assert shipped == canonical, "hook-shipped redact.py drifted from the canonical module"
 
 
+def test_shipped_checks_runtime_matches_canonical_module():
+    # #943: the pre-action hook runs the check runtime standalone and cannot
+    # import the venv-only package, so a copy ships beside it. Same direction
+    # as redact.py (scar 0049): the PACKAGE module is canonical. Hand-written
+    # for the same reason redact's is — the parametrized test above joins
+    # REPO_HOOK_DIR, which is the wrong end of this pair.
+    canonical = (Path(__file__).parents[1] / "daimon_briefing"
+                 / "checks_runtime.py").read_bytes()
+    shipped = (PKG_HOOKS_DIR / "checks_runtime.py").read_bytes()
+    assert shipped == canonical, \
+        "hook-shipped checks_runtime.py drifted from the canonical module"
+
+
 def test_hooks_install_windsurf_writes_stable_executable_copies(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("HOME", str(tmp_path))
     rc = cli.main(["hooks", "install", "windsurf"])

--- a/plugin/tests/test_ruling_check_try_cli.py
+++ b/plugin/tests/test_ruling_check_try_cli.py
@@ -1,0 +1,283 @@
+"""#943 slice 2: `daimon ruling check try`, the dry run before ratification.
+
+The one verb in this family that EXECUTES a body, so it carries the same
+double check ratification does: a CLI pre-check on the observed channel, and
+a module guard that an in-process caller cannot walk around. It writes
+nothing: not the firing log, not the manifest, and not a body under
+~/.daimon/checks.
+"""
+
+import hashlib
+
+import pytest
+
+from daimon_briefing import checks, cli, config, refutations
+
+PROJECT = "/p/check-try"
+CLEAN = "#!/bin/sh\nexit 0\n"
+DIRTY = ("#!/bin/sh\ngrep -q FORBIDDEN \"$DAIMON_CHECK_SUBJECT\" "
+         "&& { echo 'the subject says FORBIDDEN' >&2; exit 1; }\nexit 0\n")
+BROKEN = "#!/bin/sh\nexit 7\n"
+MATCH = "gh pr create"
+
+
+@pytest.fixture
+def _tty(monkeypatch):
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True, raising=False)
+
+
+def _sha(body):
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def _propose(body=CLEAN, subject="public posts", scope="publishing"):
+    return refutations.assert_ruling(
+        subject=subject, verdict=f"the rule for {subject}", scope=scope,
+        evidence=["issue:943"], channel="cli-agent",
+        check={"match": MATCH, "body": body, "intent": "warn"},
+        project_dir=PROJECT)
+
+
+def _arm(body=CLEAN, **kwargs):
+    ruling_id = _propose(body, **kwargs)
+    refutations.ratify(ruling_id, channel="cli-tty", check_sha256=_sha(body),
+                       project_dir=PROJECT)
+    return ruling_id
+
+
+def _try(ruling_id, command="gh pr create --title x", extra=()):
+    return cli.main(["ruling", "check", "try", ruling_id,
+                     "--command", command, "--project", PROJECT, *extra])
+
+
+# ---- the human-only double check ------------------------------------------
+
+
+def test_an_agent_channel_is_refused_before_the_body_is_read(
+        tmp_checkpoint_dir, _tty, capsys):
+    """The CLI refuses without calling the writer: never invoke a runner to
+    harvest its error string, and never execute the body to find out."""
+    ruling_id = _arm()
+    assert _try(ruling_id, extra=["--by", "agent"]) == 1
+    assert "requires a human channel" in capsys.readouterr().out
+
+
+def test_a_non_interactive_caller_cannot_claim_the_human_channel(
+        tmp_checkpoint_dir, monkeypatch, capsys):
+    ruling_id = _arm()
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False, raising=False)
+    assert _try(ruling_id) == 1
+    assert "no interactive terminal" in capsys.readouterr().out
+
+
+def test_the_module_guard_refuses_an_agent_channel_reaching_it_directly(
+        tmp_checkpoint_dir):
+    """The real guard. `ui` and `signed` reach try_run without passing the
+    CLI at all, so the authority test has to live here too."""
+    ruling_id = _arm()
+    with pytest.raises(refutations.RefutationError, match="human channel"):
+        checks.try_run(ruling_id, "gh pr create", channel="cli-agent",
+                       project_dir=PROJECT)
+
+
+def test_an_in_process_human_channel_is_allowed(tmp_checkpoint_dir):
+    ruling_id = _arm()
+    outcome = checks.try_run(ruling_id, "gh pr create", channel="ui",
+                            project_dir=PROJECT)
+    assert outcome.outcome == "clean"
+
+
+# ---- the three exit codes -------------------------------------------------
+
+
+def test_a_clean_check_exits_zero(tmp_checkpoint_dir, _tty, capsys):
+    assert _try(_arm(CLEAN)) == 0
+    assert "outcome: clean" in capsys.readouterr().out
+
+
+def test_a_violation_exits_one_and_shows_the_check_s_own_reason(
+        tmp_checkpoint_dir, _tty, tmp_path, capsys):
+    body_file = tmp_path / "body.md"
+    body_file.write_text("this text is FORBIDDEN\n", encoding="utf-8")
+    ruling_id = _arm(DIRTY)
+    rc = _try(ruling_id, command=f"gh pr create --body-file {body_file}")
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "outcome: violation" in out
+    assert "the subject says FORBIDDEN" in out
+
+
+def test_an_unresolved_subject_exits_three(tmp_checkpoint_dir, _tty, capsys):
+    """Three, the auditors' convention for "cannot prove". Never folded into
+    zero, which would read as clean, or into one, which would read as a
+    violation the check never found."""
+    ruling_id = _arm(CLEAN)
+    rc = _try(ruling_id, command="gh pr create --body-file /nope/gone.md")
+    out = capsys.readouterr().out
+    assert rc == 3
+    assert "outcome: unresolved" in out
+    assert "cause: file-missing" in out
+
+
+def test_a_crashing_check_exits_three(tmp_checkpoint_dir, _tty, capsys):
+    assert _try(_arm(BROKEN)) == 3
+    assert "cause: check-crashed" in capsys.readouterr().out
+
+
+def test_the_run_reports_how_long_it_took(tmp_checkpoint_dir, _tty, capsys):
+    _try(_arm(CLEAN))
+    assert "duration:" in capsys.readouterr().out
+
+
+# ---- which body it runs ---------------------------------------------------
+
+
+def test_a_candidate_s_proposed_body_can_be_tried_before_ratification(
+        tmp_checkpoint_dir, _tty, capsys):
+    """The whole point of the verb: new checks arm in warn first, and try
+    exists so a body can be tested BEFORE a human arms it."""
+    ruling_id = _propose(CLEAN)
+    assert refutations.get(ruling_id,
+                           project_dir=PROJECT)["state"] == "candidate"
+    assert _try(ruling_id) == 0
+    assert "outcome: clean" in capsys.readouterr().out
+
+
+def test_an_active_ruling_runs_its_armed_body_not_a_pending_proposal(
+        tmp_checkpoint_dir, _tty, tmp_path, capsys):
+    body_file = tmp_path / "body.md"
+    body_file.write_text("this text is FORBIDDEN\n", encoding="utf-8")
+    ruling_id = _arm(CLEAN)
+    refutations.revise(ruling_id, channel="cli-agent", evidence=["issue:943"],
+                       check={"match": MATCH, "body": DIRTY, "intent": "warn"},
+                       project_dir=PROJECT)
+    rc = _try(ruling_id, command=f"gh pr create --body-file {body_file}")
+    assert rc == 0, "the armed body is the clean one; the proposal is not armed"
+
+
+def test_the_pending_proposal_is_reachable_behind_a_flag(
+        tmp_checkpoint_dir, _tty, tmp_path, capsys):
+    body_file = tmp_path / "body.md"
+    body_file.write_text("this text is FORBIDDEN\n", encoding="utf-8")
+    ruling_id = _arm(CLEAN)
+    refutations.revise(ruling_id, channel="cli-agent", evidence=["issue:943"],
+                       check={"match": MATCH, "body": DIRTY, "intent": "warn"},
+                       project_dir=PROJECT)
+    rc = _try(ruling_id, command=f"gh pr create --body-file {body_file}",
+              extra=["--proposed"])
+    assert rc == 1
+    assert "outcome: violation" in capsys.readouterr().out
+
+
+def test_asking_for_a_proposal_that_does_not_exist_is_refused(
+        tmp_checkpoint_dir, _tty, capsys):
+    assert _try(_arm(CLEAN), extra=["--proposed"]) == 1
+    assert "no proposed check" in capsys.readouterr().out
+
+
+def test_a_ruling_with_no_check_is_refused(tmp_checkpoint_dir, _tty, capsys):
+    ruling_id = refutations.assert_ruling(
+        subject="unrelated", verdict="a rule with no check", scope="elsewhere",
+        evidence=["issue:943"], channel="cli-agent", project_dir=PROJECT)
+    assert _try(ruling_id) == 1
+    assert "carries no check" in capsys.readouterr().out
+
+
+def test_an_unknown_id_is_refused(tmp_checkpoint_dir, _tty, capsys):
+    assert _try("r-000000000000") == 1
+    assert "unknown ruling" in capsys.readouterr().out
+
+
+def test_a_refutation_id_is_refused(tmp_checkpoint_dir, _tty, capsys):
+    other = refutations.assert_refutation(
+        subject="a losing approach", verdict="it lost", scope="elsewhere",
+        evidence=["issue:943"], channel="cli-agent", project_dir=PROJECT)
+    assert _try(other) == 1
+    assert "refutation" in capsys.readouterr().out
+
+
+# ---- it writes nothing ----------------------------------------------------
+
+
+def test_a_dry_run_writes_no_firing_log(tmp_checkpoint_dir, _tty):
+    """A try is a rehearsal. Counting it as a firing would make the liveness
+    surface report a check that has never actually guarded an action."""
+    _try(_arm(CLEAN))
+    assert not (config.log_dir() / "checks.jsonl").exists()
+
+
+def test_a_dry_run_of_a_candidate_arms_nothing(tmp_checkpoint_dir, _tty):
+    _try(_propose(CLEAN))
+    base = config.checks_dir()
+    assert not (base / "manifest.json").exists()
+    assert not base.exists() or list(base.glob("*.sh")) == []
+
+
+def test_the_body_is_materialized_outside_the_checks_directory(
+        tmp_checkpoint_dir, _tty, monkeypatch):
+    """A body under ~/.daimon/checks would be indistinguishable from an armed
+    one to the hook that reads that directory."""
+    seen = []
+    real = checks.checks_runtime.run
+
+    def spy(entry_or_body, subject, **kwargs):
+        seen.append(str(entry_or_body.get("body_path")))
+        return real(entry_or_body, subject, **kwargs)
+
+    monkeypatch.setattr(checks.checks_runtime, "run", spy)
+    _try(_arm(CLEAN))
+    assert seen and str(config.checks_dir()) not in seen[0]
+    assert str(config.log_dir()) not in seen[0]
+
+
+def test_the_temporary_body_is_removed_after_the_run(
+        tmp_checkpoint_dir, _tty, monkeypatch):
+    from pathlib import Path
+    seen = []
+    real = checks.checks_runtime.run
+
+    def spy(entry_or_body, subject, **kwargs):
+        seen.append(str(entry_or_body.get("body_path")))
+        return real(entry_or_body, subject, **kwargs)
+
+    monkeypatch.setattr(checks.checks_runtime, "run", spy)
+    _try(_arm(CLEAN))
+    assert seen and not Path(seen[0]).exists()
+
+
+def test_an_armed_ruling_s_try_leaves_the_manifest_byte_identical(
+        tmp_checkpoint_dir, _tty):
+    ruling_id = _arm(CLEAN)
+    manifest = config.checks_dir() / "manifest.json"
+    before = (manifest.read_bytes(), manifest.stat().st_mtime_ns)
+    _try(ruling_id)
+    assert (manifest.read_bytes(), manifest.stat().st_mtime_ns) == before
+
+
+# ---- the flags ------------------------------------------------------------
+
+
+def test_the_command_is_required(tmp_checkpoint_dir, _tty):
+    with pytest.raises(SystemExit):
+        cli.main(["ruling", "check", "try", "r-000000000000",
+                  "--project", PROJECT])
+
+
+def test_the_working_directory_can_be_named(tmp_checkpoint_dir, _tty, tmp_path):
+    """A relative file argument resolves against it, the way the hook payload
+    would supply the action's cwd."""
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "body.md").write_text("this text is FORBIDDEN\n", encoding="utf-8")
+    ruling_id = _arm(DIRTY)
+    rc = _try(ruling_id, command="gh pr create --body-file body.md",
+              extra=["--cwd", str(work)])
+    assert rc == 1
+
+
+def test_without_a_working_directory_a_relative_path_misses(
+        tmp_checkpoint_dir, _tty, capsys):
+    ruling_id = _arm(DIRTY)
+    rc = _try(ruling_id, command="gh pr create --body-file nowhere-at-all.md")
+    assert rc == 3
+    assert "cause: file-missing" in capsys.readouterr().out

--- a/plugin/tests/test_rulings.py
+++ b/plugin/tests/test_rulings.py
@@ -1462,3 +1462,52 @@ def test_stale_check_pin_ratify_does_not_reset_the_proposal_cap(tmp_checkpoint_d
 def test_check_validator_refuses_a_non_object():
     with pytest.raises(refutations.RefutationError, match="must be an object"):
         refutations._check("exit 0")
+
+
+# ---- #943 slice 2: a body that reaches outside itself ---------------------
+#
+# The slice 1 refusal above catches a body that IS a bare path. A multi-line
+# body that merely CALLS one passes it, and the check then travels to another
+# machine as a script whose real content is a file that is not there. The
+# runner sees that as exit 127, which is honest but late: the ruling was
+# already ratified and every host reports unresolved forever.
+
+
+@pytest.mark.parametrize("body", [
+    "#!/bin/sh\nsh ~/.claude/voicegate.sh \"$DAIMON_CHECK_SUBJECT\"\n",
+    "#!/bin/sh\nexec $HOME/gate \"$DAIMON_CHECK_SUBJECT\"\n",
+    "#!/bin/sh\n. /Users/someone/lib/rules.sh\nexit 0\n",
+    "#!/bin/sh\n/home/someone/gate || exit 1\n",
+    "#!/bin/sh\ntest -f /root/allowlist && exit 0\nexit 1\n",
+    "#!/bin/sh\nexit 0  # see ~/notes/why.md\n",
+])
+def test_a_check_body_line_reaching_a_host_local_root_is_refused(body):
+    with pytest.raises(refutations.RefutationError,
+                       match="host-local path"):
+        refutations._check(_check(body=body))
+
+
+@pytest.mark.parametrize("body", [
+    "#!/bin/sh\nsh ./scripts/gate.sh \"$DAIMON_CHECK_SUBJECT\"\nexit 0\n",
+    "#!/bin/sh\ngrep -q FORBIDDEN \"$DAIMON_CHECK_SUBJECT\" && exit 1\nexit 0\n",
+    "#!/bin/sh\ntest -x /usr/bin/grep || exit 0\nexit 0\n",
+    "#!/bin/sh\necho \"$DAIMON_CHECK_COMMAND\" | grep -q gh && exit 1\nexit 0\n",
+    "#!/bin/sh\nmktemp -d /tmp/check.XXXX >/dev/null\nexit 0\n",
+])
+def test_a_body_that_stays_inside_itself_is_accepted(body):
+    assert refutations._check(_check(body=body))["body"] == body
+
+
+def test_the_refusal_names_the_line_it_found(_capture=None):
+    """A body is up to 8192 bytes. "somewhere in here" is not a fix."""
+    body = "#!/bin/sh\nexit 0\nsh ~/gate.sh\n"
+    with pytest.raises(refutations.RefutationError) as excinfo:
+        refutations._check(_check(body=body))
+    assert "line 3" in str(excinfo.value)
+
+
+def test_the_single_token_path_refusal_still_says_what_it_always_said():
+    """The two rules overlap and the older, more specific one must win: a
+    bare path gets the message that explains what a body IS."""
+    with pytest.raises(refutations.RefutationError, match="must be the script"):
+        refutations._check(_check(body="~/.claude/voicegate.sh"))

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -479,6 +479,24 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
     def r_ruling_retire():
         run(["ruling", "retire", ctx["ruling_id"]], 0)
 
+    def r_ruling_check_try():
+        # #943: the one ruling verb that EXECUTES the body, so it needs a
+        # ruling that actually carries one. Proposed rather than ratified —
+        # trying a candidate before a human arms it is the verb's purpose,
+        # and it keeps this recipe off the ruling cap's ratify path.
+        body = tmp_path / "try-gate.sh"
+        body.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        subject = "check-try subject"
+        run([
+            "ruling", "propose", "--subject", subject,
+            "--verdict", "a rule whose check exits clean",
+            "--scope", "publishing", "--evidence", "issue:943", "--by", "agent",
+            "--check-body-file", str(body), "--check-match", "gh pr create",
+        ], 0)
+        run(["ruling", "check", "try",
+             refutations.make_id(subject, "publishing"),
+             "--command", "gh pr create --title x"], 0)
+
     def r_ruling_show():
         run(["ruling", "show", ctx["ruling_id"]], 0)
 
@@ -740,6 +758,7 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
         ("ruling", "revise"): r_ruling_revise,
         ("ruling", "retire"): r_ruling_retire,
         ("ruling", "show"): r_ruling_show,
+        ("ruling", "check", "try"): r_ruling_check_try,
         ("ruling", "list"): r_ruling_list,
         ("amend", "propose"): r_amend_propose,
         ("amend", "ratify"): r_amend_ratify,

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -711,6 +711,13 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
     def r_stats():
         run(["stats"], 0)
 
+    def r_check_sync():
+        # #943: writes under ~/.daimon/checks, outside both audited roots, so
+        # the guard sees no write here. Driven anyway because the registry is
+        # about every leaf verb being exercised, not only the ones that land
+        # inside the checkpoint store.
+        run(["check", "sync"], 0)
+
     def r_hooks_list():
         run(["hooks", "list"], 0)
 
@@ -797,6 +804,7 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
         ("team", "status"): r_team_status,
         ("configure",): r_configure,
         ("stats",): r_stats,
+        ("check", "sync"): r_check_sync,
         ("hooks", "list"): r_hooks_list,
         ("hooks", "install"): r_hooks_install,
         ("hooks", "status"): r_hooks_status,

--- a/scripts/sync_hooks.py
+++ b/scripts/sync_hooks.py
@@ -24,6 +24,12 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SYNC_PAIRS = (
     ("plugin/daimon_briefing/redact.py", "plugin/daimon_briefing/_hooks/redact.py"),
     ("plugin/daimon_briefing/redact.py", "hook/redact.py"),
+    # #943: same direction as redact.py — the PACKAGE file is canonical and
+    # both standalone copies are derivatives. Edit
+    # plugin/daimon_briefing/checks_runtime.py, then run this script.
+    ("plugin/daimon_briefing/checks_runtime.py",
+     "plugin/daimon_briefing/_hooks/checks_runtime.py"),
+    ("plugin/daimon_briefing/checks_runtime.py", "hook/checks_runtime.py"),
     ("hook/daimon-windsurf-hooks.py", "plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py"),
     ("hook/daimon-codex-session-start.py", "plugin/daimon_briefing/_hooks/daimon-codex-session-start.py"),
     ("hook/daimon-codex-stop.py", "plugin/daimon_briefing/_hooks/daimon-codex-stop.py"),

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -84,6 +84,8 @@ A value attached to a short flag is the same command as a detached one, so `-Fbo
 
 A heredoc belongs to the command it is attached to, and to no other. daimon splits the command string at `&&`, `||`, `;`, `|` and newlines, and a heredoc in one of those pieces can only be read for an argument in that same piece. So `cat <<EOF > note.txt ... EOF` followed by `gh pr create -F -` is unresolved rather than checked against the text `cat` was given. Inside one command the counts still have to be one and one: which heredoc feeds which argument is not a question the command string answers, and a wrong guess would build the subject from text the action never sends.
 
+A command over 64 KiB once its heredoc bodies are set aside is `arg-form-unparsed`: tokenizing one enormous inline argument costs more than the whole hook budget, and a resolver overtaken by the host's timeout lets the action through with no record at all. A long heredoc body does not count toward that, so a large PR body still resolves.
+
 Relative paths resolve against the working directory. A file over 1 MiB is `file-oversize`, one that is not UTF-8 text is `file-binary`, and a missing or unreadable one is `file-missing` or `file-unreadable`. One argument daimon cannot read makes the whole subject unresolved, whatever the others say.
 
 Every run ends in exactly one of three outcomes, and they never fold together:

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -14,6 +14,7 @@ Every daimon verb, grouped by what you are trying to do. Each command's
 | `daimon configure` | Detect the resolved LLM backend and fill gaps in `~/.daimon/env`. `--test` runs a live round-trip. |
 | `daimon hooks install <host>` | Ship the host hook scripts (Windsurf, Codex) from the package. `list` / `status` inspect. |
 | `daimon skill install <host>` | Install the daimon agent skill into a host's skill directory. Re-run after upgrades. |
+| `daimon check sync` | Rebuild `~/.daimon/checks` — the manifest of armed checks a host hook reads, and one file per check body — from this project's ledger. Every ratify, revise, retire and forget already does this, so run it only when the manifest was damaged out of band. Safe to repeat: an unchanged manifest is not rewritten. Prints how many checks are armed, zero included. |
 | `daimon heal` | Re-serialize the most recent failed session when it is safe to do so. |
 | `daimon mcp serve` | Serve the daimon tools over MCP (stdio). |
 
@@ -36,6 +37,7 @@ Every daimon verb, grouped by what you are trying to do. Each command's
 | `daimon audit privacy` | Prove the deletion contract: hash every plaintext field on every surface (checkpoints, rotated pointers, the event ledger, the team mirror, the recall index and its orphan snapshots) and report any forgotten value that survived. Read-only. |
 | `daimon refute list\|show\|search\|guard` | Read the negative-knowledge ledger without decay. `guard` emits active exact-anchor/subject matches only; it is advisory and never blocks a command. `search` returns both polarities, labelled; `list` and `guard` stay refutation-only. Add `--json` for deliberation integrations. |
 | `daimon ruling list\|show` | Read the standing rulings: human-ratified positive constraints on the same ledger, never decayed, never re-extracted. `show` includes pending agent proposals. A `list` that finds nothing exits 1 and names the bucket on stderr when the project has never been written from, and exits 0 when the project has a bucket that holds no rulings. |
+| `daimon ruling check try <id> --command "<cmd>"` | Run this ruling's check against a command you name and print the outcome. Arms nothing, logs nothing, and materializes the body outside the checks directory. `--cwd` sets the working directory relative file arguments resolve against; `--proposed` runs a pending agent revision's body instead of the armed one. Human path only, like `ratify`: it executes the body, so an interactive terminal is required and `--by agent` is refused. Same exit contract as the auditors below. |
 | `daimon serve` | Open the [read-only local viewer](viewer.md) on localhost — search as recall, per-entry "why" pages, refutations, diff, check strip, print view. Nothing writes. |
 | `daimon relations list\|show\|confirm\|reject\|retract` | The [typed relation ledger](relations.md): machines propose, only a person confirms, and deciding needs an interactive terminal. Candidates never render on an entry surface. |
 
@@ -57,7 +59,50 @@ The auditors share one exit contract, so a script can act on the answer:
 | `daimon resolve <id or text>` | Mark an item resolved — append-only event; the item stops carrying. `--dry-run` previews the match; `--by agent --evidence "<quote>"` claims a close that is byte-checked at session end. |
 | `daimon anchor <file> <symbol>` | Bind a cognitive item to a code symbol; briefings then warn when the anchored code drifts. |
 | `daimon refute add\|ratify\|revise\|overturn` | Manage scoped negative knowledge in its own append-only ledger. Agent writes remain candidates; only an explicit human ratification activates a guard, and `ratify` requires the human path — an interactive terminal with `--by` omitted. Revisions require a new typed evidence citation, whose shape is checked but never resolved or verified, and reset an active refutation to candidate until it is ratified again. Agent overturns remain proposals. |
-| `daimon ruling propose\|ratify\|revise\|retire` | Manage standing rulings on the same ledger, with a stricter lifecycle: `ratify` shows the full text, discloses that it will render into every future session, and binds the activation to the text it displayed; a human revising an active ruling confirms the change and the ruling stays active; agent revise and retire calls record proposals while the text stands; activation refuses past the cap (`DAIMON_RULING_CAP`, default 7). Retirement needs no evidence citation. `propose` and `revise` may attach a check with `--check-body-file`, `--check-match` and `--check-intent`: a script whose bytes are stored on the ruling (a path is refused), a pattern on the command string that selects the actions it runs before, and what it asks each host for (`warn` by default). A candidate's check reads as proposed, not armed, and no host runs it. `ratify` prints the check and binds the activation to the body it showed, by hash. Running the check is a later release; this release records and renders it. |
+| `daimon ruling propose\|ratify\|revise\|retire` | Manage standing rulings on the same ledger, with a stricter lifecycle: `ratify` shows the full text, discloses that it will render into every future session, and binds the activation to the text it displayed; a human revising an active ruling confirms the change and the ruling stays active; agent revise and retire calls record proposals while the text stands; activation refuses past the cap (`DAIMON_RULING_CAP`, default 7). Retirement needs no evidence citation. `propose` and `revise` may attach a check with `--check-body-file`, `--check-match` and `--check-intent`: a script whose bytes are stored on the ruling (a path is refused), a pattern on the command string that selects the actions it runs before, and what it asks each host for (`warn` by default). A candidate's check reads as proposed, not armed, and no host runs it. `ratify` prints the check and binds the activation to the body it showed, by hash, and materializes it for a host to run. A body that names a host-local path on any line is refused, because the check travels with the ruling and a path outside it is missing on every other machine. See [Checks at runtime](#checks-at-runtime). |
+
+### Checks at runtime
+
+Ratifying a ruling that carries a check writes two things under `~/.daimon/checks`: a manifest naming every armed check and the project directory it belongs to, and one file per check holding the exact body the ruling stores. Every ledger write that can arm or disarm a check rebuilds them; `daimon check sync` rebuilds them on demand. The host adapters that actually run a check on a real action arrive in a later release — what ships here is the machinery underneath and the command to test a body against it.
+
+A check runs against a **subject**: the command string, a separator, then the contents of every file argument daimon could resolve, each under a header naming the flag it came from. The subject goes to a temporary file at mode 600 and is removed after the run. Its path arrives in `DAIMON_CHECK_SUBJECT`, alongside `DAIMON_CHECK_COMMAND` and `DAIMON_CHECK_RULING`; the working directory is the action's own, and standard input is `/dev/null`.
+
+What the resolver reads:
+
+| form in the command | what daimon does |
+| --- | --- |
+| `--body-file <path>`, `--body-file=<path>`, `-F <path>` | reads the file |
+| `--notes-file <path>`, `--notes-file=<path>` | reads the file |
+| `-F key=@<path>`, `--field key=@<path>` | reads the file |
+| `<flag> -` with a heredoc in the same command | reads the heredoc text |
+| `<flag> -` with no heredoc | unresolved, cause `stdin-pipe` |
+| any other `@<path>` or `<flag> -` | unresolved, cause `arg-form-unparsed` |
+
+Relative paths resolve against the working directory. A file over 1 MiB is `file-oversize`, one that is not UTF-8 text is `file-binary`, and a missing or unreadable one is `file-missing` or `file-unreadable`. One argument daimon cannot read makes the whole subject unresolved, whatever the others say.
+
+Every run ends in exactly one of three outcomes, and they never fold together:
+
+| outcome | what it means |
+| --- | --- |
+| `clean` | the check ran on the full subject and exited 0 |
+| `violation` | the check ran on the full subject and exited 1 — its own first stderr line is the reason |
+| `unresolved` | daimon could not prove the subject clean: an argument it could not read, a check that crashed or exceeded its budget, a body that no longer hashes to what the ruling was ratified with, or no `sh` on the host |
+
+`unresolved` is never rendered as clean and never counted as a violation.
+
+The runner carries its own budget, `DAIMON_CHECK_TIMEOUT`, five seconds by default against a host hook timeout of ten. That budget is not optional: on the hosts measured so far, a hook that reaches the host's own timeout does not block and the action proceeds, so a check without a budget of its own turns a hang into a silent allow. Overrunning kills the check and its whole process group and reports `unresolved`.
+
+Each run appends one row to `~/.daimon/logs/checks.jsonl`: ids, outcomes, causes, durations, host and mode. No command text, no paths, no subject. The reason shown to the agent may name a path; the log does not.
+
+Read that log for liveness, not for compliance. A row proves the check RAN. Only `decision_emitted: deny` under `enforce` closes the gap between a check that ran and a check that was honored.
+
+Two conventions worth keeping. Arm a new check with intent `warn` first, so a pattern that matches more than you meant costs a warning rather than a blocked action. And run `daimon ruling check try` before you ratify — that is what it is for.
+
+| variable | default | what it holds |
+| --- | --- | --- |
+| `DAIMON_CHECKS_DIR` | `~/.daimon/checks` | the manifest and the materialized bodies |
+| `DAIMON_CHECK_TIMEOUT` | `5` | the runner's budget in seconds, floored at 0.5 |
+| `DAIMON_LOG_DIR` | `~/.daimon/logs` | holds `checks.jsonl` |
 
 ### Rulings from a host process
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -74,12 +74,15 @@ What the resolver reads:
 | `--body-file <path>`, `--body-file=<path>`, `-F <path>`, `-F<path>` | reads the file |
 | `--notes-file <path>`, `--notes-file=<path>` | reads the file |
 | `-F key=@<path>`, `--field key=@<path>`, `-Fkey=@<path>` | reads the file |
-| `<flag> -` with exactly one heredoc in the command | reads the heredoc text |
-| `<flag> -` with no heredoc | unresolved, cause `stdin-pipe` |
-| more than one heredoc, or more than one argument reading standard input | unresolved, cause `arg-form-unparsed` |
+| `<flag> -` with exactly one heredoc in the SAME command | reads the heredoc text |
+| `<flag> -` fed by a pipe | unresolved, cause `stdin-pipe` |
+| `<flag> -` whose own command carries no heredoc | unresolved, cause `arg-form-unparsed` |
+| a command with more than one heredoc or more than one `<flag> -` | unresolved, cause `arg-form-unparsed` |
 | any other `@<path>` or `<flag> -` | unresolved, cause `arg-form-unparsed` |
 
-A value attached to a short flag is the same command as a detached one, so `-Fbody.md` is read exactly as `-F body.md` is. Where a heredoc could belong to more than one argument, or an argument could be fed by more than one heredoc, daimon refuses rather than guessing: which one feeds which is a question it cannot answer from the command string alone, and a wrong guess would build the subject from text the action never sends.
+A value attached to a short flag is the same command as a detached one, so `-Fbody.md` is read exactly as `-F body.md` is.
+
+A heredoc belongs to the command it is attached to, and to no other. daimon splits the command string at `&&`, `||`, `;`, `|` and newlines, and a heredoc in one of those pieces can only be read for an argument in that same piece. So `cat <<EOF > note.txt ... EOF` followed by `gh pr create -F -` is unresolved rather than checked against the text `cat` was given. Inside one command the counts still have to be one and one: which heredoc feeds which argument is not a question the command string answers, and a wrong guess would build the subject from text the action never sends.
 
 Relative paths resolve against the working directory. A file over 1 MiB is `file-oversize`, one that is not UTF-8 text is `file-binary`, and a missing or unreadable one is `file-missing` or `file-unreadable`. One argument daimon cannot read makes the whole subject unresolved, whatever the others say.
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -71,12 +71,15 @@ What the resolver reads:
 
 | form in the command | what daimon does |
 | --- | --- |
-| `--body-file <path>`, `--body-file=<path>`, `-F <path>` | reads the file |
+| `--body-file <path>`, `--body-file=<path>`, `-F <path>`, `-F<path>` | reads the file |
 | `--notes-file <path>`, `--notes-file=<path>` | reads the file |
-| `-F key=@<path>`, `--field key=@<path>` | reads the file |
-| `<flag> -` with a heredoc in the same command | reads the heredoc text |
+| `-F key=@<path>`, `--field key=@<path>`, `-Fkey=@<path>` | reads the file |
+| `<flag> -` with exactly one heredoc in the command | reads the heredoc text |
 | `<flag> -` with no heredoc | unresolved, cause `stdin-pipe` |
+| more than one heredoc, or more than one argument reading standard input | unresolved, cause `arg-form-unparsed` |
 | any other `@<path>` or `<flag> -` | unresolved, cause `arg-form-unparsed` |
+
+A value attached to a short flag is the same command as a detached one, so `-Fbody.md` is read exactly as `-F body.md` is. Where a heredoc could belong to more than one argument, or an argument could be fed by more than one heredoc, daimon refuses rather than guessing: which one feeds which is a question it cannot answer from the command string alone, and a wrong guess would build the subject from text the action never sends.
 
 Relative paths resolve against the working directory. A file over 1 MiB is `file-oversize`, one that is not UTF-8 text is `file-binary`, and a missing or unreadable one is `file-missing` or `file-unreadable`. One argument daimon cannot read makes the whole subject unresolved, whatever the others say.
 
@@ -89,6 +92,8 @@ Every run ends in exactly one of three outcomes, and they never fold together:
 | `unresolved` | daimon could not prove the subject clean: an argument it could not read, a check that crashed or exceeded its budget, a body that no longer hashes to what the ruling was ratified with, or no `sh` on the host |
 
 `unresolved` is never rendered as clean and never counted as a violation.
+
+The body runs with a minimal environment: `PATH`, `HOME`, `LANG`, the `LC_*` variables and `TMPDIR`, plus the three above. It is not a sandbox — a check you ratified runs as you, and could do anything you could. Trimming the environment only keeps a script whose job is reading one file from being handed every token in the session.
 
 The runner carries its own budget, `DAIMON_CHECK_TIMEOUT`, five seconds by default against a host hook timeout of ten. That budget is not optional: on the hosts measured so far, a hook that reaches the host's own timeout does not block and the action proceeds, so a check without a budget of its own turns a hang into a silent allow. Overrunning kills the check and its whole process group and reports `unresolved`.
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -75,12 +75,15 @@ Qué lee el resolutor:
 | `--body-file <ruta>`, `--body-file=<ruta>`, `-F <ruta>`, `-F<ruta>` | lee el archivo |
 | `--notes-file <ruta>`, `--notes-file=<ruta>` | lee el archivo |
 | `-F clave=@<ruta>`, `--field clave=@<ruta>`, `-Fclave=@<ruta>` | lee el archivo |
-| `<bandera> -` con exactamente un heredoc en el comando | lee el texto del heredoc |
-| `<bandera> -` sin heredoc | sin resolver, causa `stdin-pipe` |
-| más de un heredoc, o más de un argumento que lee entrada estándar | sin resolver, causa `arg-form-unparsed` |
+| `<bandera> -` con exactamente un heredoc en el MISMO comando | lee el texto del heredoc |
+| `<bandera> -` alimentada por un pipe | sin resolver, causa `stdin-pipe` |
+| `<bandera> -` cuyo propio comando no trae heredoc | sin resolver, causa `arg-form-unparsed` |
+| un comando con más de un heredoc o más de una `<bandera> -` | sin resolver, causa `arg-form-unparsed` |
 | cualquier otro `@<ruta>` o `<bandera> -` | sin resolver, causa `arg-form-unparsed` |
 
-Un valor pegado a una bandera corta es el mismo comando que uno separado, así que `-Fbody.md` se lee igual que `-F body.md`. Cuando un heredoc podría pertenecer a más de un argumento, o un argumento podría venir de más de un heredoc, daimon se niega en vez de adivinar: cuál alimenta a cuál es una pregunta que no puede responder solo con la línea de comando, y una respuesta equivocada armaría el sujeto con texto que la acción nunca envía.
+Un valor pegado a una bandera corta es el mismo comando que uno separado, así que `-Fbody.md` se lee igual que `-F body.md`.
+
+Un heredoc pertenece al comando al que está pegado, y a ningún otro. daimon parte la línea en `&&`, `||`, `;`, `|` y saltos de línea, y un heredoc en uno de esos pedazos solo puede leerse para un argumento de ese mismo pedazo. Así que `cat <<EOF > note.txt ... EOF` seguido de `gh pr create -F -` queda sin resolver, en vez de comprobarse contra el texto que recibió `cat`. Dentro de un mismo comando las cuentas siguen teniendo que ser uno a uno: cuál heredoc alimenta a cuál argumento no es algo que la línea de comando responda, y una respuesta equivocada armaría el sujeto con texto que la acción nunca envía.
 
 Las rutas relativas resuelven contra el directorio de trabajo. Un archivo de más de 1 MiB es `file-oversize`, uno que no es texto UTF-8 es `file-binary`, y uno que falta o no se puede leer es `file-missing` o `file-unreadable`. Un solo argumento que daimon no puede leer deja todo el sujeto sin resolver, digan lo que digan los demás.
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -72,12 +72,15 @@ Qué lee el resolutor:
 
 | forma en el comando | qué hace daimon |
 | --- | --- |
-| `--body-file <ruta>`, `--body-file=<ruta>`, `-F <ruta>` | lee el archivo |
+| `--body-file <ruta>`, `--body-file=<ruta>`, `-F <ruta>`, `-F<ruta>` | lee el archivo |
 | `--notes-file <ruta>`, `--notes-file=<ruta>` | lee el archivo |
-| `-F clave=@<ruta>`, `--field clave=@<ruta>` | lee el archivo |
-| `<bandera> -` con un heredoc en el mismo comando | lee el texto del heredoc |
+| `-F clave=@<ruta>`, `--field clave=@<ruta>`, `-Fclave=@<ruta>` | lee el archivo |
+| `<bandera> -` con exactamente un heredoc en el comando | lee el texto del heredoc |
 | `<bandera> -` sin heredoc | sin resolver, causa `stdin-pipe` |
+| más de un heredoc, o más de un argumento que lee entrada estándar | sin resolver, causa `arg-form-unparsed` |
 | cualquier otro `@<ruta>` o `<bandera> -` | sin resolver, causa `arg-form-unparsed` |
+
+Un valor pegado a una bandera corta es el mismo comando que uno separado, así que `-Fbody.md` se lee igual que `-F body.md`. Cuando un heredoc podría pertenecer a más de un argumento, o un argumento podría venir de más de un heredoc, daimon se niega en vez de adivinar: cuál alimenta a cuál es una pregunta que no puede responder solo con la línea de comando, y una respuesta equivocada armaría el sujeto con texto que la acción nunca envía.
 
 Las rutas relativas resuelven contra el directorio de trabajo. Un archivo de más de 1 MiB es `file-oversize`, uno que no es texto UTF-8 es `file-binary`, y uno que falta o no se puede leer es `file-missing` o `file-unreadable`. Un solo argumento que daimon no puede leer deja todo el sujeto sin resolver, digan lo que digan los demás.
 
@@ -90,6 +93,8 @@ Cada corrida termina en exactamente uno de tres resultados, y nunca se mezclan:
 | `unresolved` | daimon no pudo probar que el sujeto estuviera limpio: un argumento que no pudo leer, un check que se rompió o se pasó de presupuesto, un cuerpo que ya no hashea a lo que se ratificó, o un anfitrión sin `sh` |
 
 `unresolved` nunca se muestra como limpio y nunca se cuenta como violación.
+
+El cuerpo corre con un entorno mínimo: `PATH`, `HOME`, `LANG`, las variables `LC_*` y `TMPDIR`, más las tres de arriba. No es un sandbox — un check que ratificaste corre como vos, y podría hacer cualquier cosa que vos puedas. Recortar el entorno solo evita que a un script cuyo trabajo es leer un archivo se le entregue cada token de la sesión.
 
 El runner lleva su propio presupuesto, `DAIMON_CHECK_TIMEOUT`, cinco segundos por defecto contra un timeout de hook del anfitrión de diez. Ese presupuesto no es opcional: en los anfitriones medidos hasta ahora, un hook que llega al timeout del propio anfitrión no bloquea y la acción sigue, así que un check sin presupuesto propio convierte un cuelgue en un permiso silencioso. Pasarse mata el check y todo su grupo de procesos, y reporta `unresolved`.
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -85,6 +85,8 @@ Un valor pegado a una bandera corta es el mismo comando que uno separado, así q
 
 Un heredoc pertenece al comando al que está pegado, y a ningún otro. daimon parte la línea en `&&`, `||`, `;`, `|` y saltos de línea, y un heredoc en uno de esos pedazos solo puede leerse para un argumento de ese mismo pedazo. Así que `cat <<EOF > note.txt ... EOF` seguido de `gh pr create -F -` queda sin resolver, en vez de comprobarse contra el texto que recibió `cat`. Dentro de un mismo comando las cuentas siguen teniendo que ser uno a uno: cuál heredoc alimenta a cuál argumento no es algo que la línea de comando responda, y una respuesta equivocada armaría el sujeto con texto que la acción nunca envía.
 
+Un comando de más de 64 KiB, una vez apartados los cuerpos de sus heredocs, es `arg-form-unparsed`: tokenizar un solo argumento enorme cuesta más que todo el presupuesto del hook, y un resolutor al que se le adelanta el timeout del anfitrión deja pasar la acción sin ningún registro. Un heredoc largo no cuenta para ese límite, así que un cuerpo de PR grande sigue resolviendo.
+
 Las rutas relativas resuelven contra el directorio de trabajo. Un archivo de más de 1 MiB es `file-oversize`, uno que no es texto UTF-8 es `file-binary`, y uno que falta o no se puede leer es `file-missing` o `file-unreadable`. Un solo argumento que daimon no puede leer deja todo el sujeto sin resolver, digan lo que digan los demás.
 
 Cada corrida termina en exactamente uno de tres resultados, y nunca se mezclan:

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -14,6 +14,7 @@ comando trae la superficie completa de flags; esta página es el mapa.
 | `daimon configure` | Detecta el backend LLM resuelto y completa los huecos en `~/.daimon/env`. `--test` corre un round-trip real. |
 | `daimon hooks install <host>` | Instala los hook scripts del host (Windsurf, Codex) desde el paquete. `list` / `status` inspeccionan. |
 | `daimon skill install <host>` | Instala la skill de agente de daimon en el directorio de skills del host. Volvé a correrlo después de cada upgrade. |
+| `daimon check sync` | Reconstruye `~/.daimon/checks` — el manifiesto de checks armados que lee un hook del anfitrión, y un archivo por cada cuerpo de check — desde el ledger de este proyecto. Cada ratify, revise, retire y forget ya lo hace, así que correlo solo cuando el manifiesto se dañó por fuera. Es seguro repetirlo: un manifiesto que no cambió no se reescribe. Imprime cuántos checks quedaron armados, cero incluido. |
 | `daimon heal` | Re-serializa la última sesión fallida cuando es seguro hacerlo. |
 | `daimon mcp serve` | Sirve las herramientas de daimon por MCP (stdio). |
 
@@ -36,6 +37,7 @@ comando trae la superficie completa de flags; esta página es el mapa.
 | `daimon audit privacy` | Prueba el contrato de borrado: hashea cada campo con texto plano en cada superficie (checkpoints, punteros rotados, el registro de eventos, el espejo de equipo, el índice de recall y sus snapshots huérfanos) y reporta todo valor olvidado que haya sobrevivido. Solo lectura. |
 | `daimon refute list\|show\|search\|guard` | Lee el ledger de conocimiento negativo sin decaimiento. `guard` emite solo matches activos por ancla exacta o frase de sujeto; es consultivo y nunca bloquea un comando. `search` devuelve ambas polaridades, etiquetadas; `list` y `guard` quedan solo para refutaciones. Sumá `--json` para integraciones de deliberación. |
 | `daimon ruling list\|show` | Lee las reglas vigentes: restricciones positivas ratificadas por humanos en el mismo ledger, que nunca decaen ni se re-extraen. `show` incluye propuestas de agentes pendientes. Un `list` que no encuentra nada sale con 1 y nombra el bucket en stderr cuando el proyecto nunca fue escrito, y sale con 0 cuando el proyecto tiene un bucket sin reglas. |
+| `daimon ruling check try <id> --command "<cmd>"` | Corre el check de esa regla contra una línea de comando que vos nombrás e imprime el resultado. No arma nada, no registra nada, y materializa el cuerpo fuera del directorio de checks. `--cwd` fija el directorio de trabajo contra el que resuelven las rutas relativas; `--proposed` corre el cuerpo de una revisión de agente pendiente en lugar del armado. Solo vía humana, como `ratify`: ejecuta el cuerpo, así que hace falta una terminal interactiva y `--by agent` se rechaza. Mismo contrato de salida que los auditores de abajo. |
 | `daimon serve` | Abre el [visor local de solo lectura](viewer.md) en localhost — búsqueda como recall, páginas "why" por entrada, refutaciones, diff, check strip, vista de impresión. Nada escribe. |
 | `daimon relations list\|show\|confirm\|reject\|retract` | El [ledger de relaciones tipadas](relations.md): las máquinas proponen, solo una persona confirma, y decidir necesita una terminal interactiva. Los candidatos nunca se renderizan en la superficie de una entrada. |
 
@@ -58,7 +60,50 @@ actuar sobre la respuesta:
 | `daimon resolve <id o texto>` | Marca un ítem como resuelto — evento append-only; el ítem deja de arrastrarse. `--dry-run` previsualiza el match; `--by agent --evidence "<cita>"` reclama un cierre que se verifica byte a byte al final de la sesión. |
 | `daimon anchor <archivo> <símbolo>` | Ancla un ítem cognitivo a un símbolo de código; los briefings avisan cuando el código anclado cambió. |
 | `daimon refute add\|ratify\|revise\|overturn` | Gestiona conocimiento negativo con alcance en su propio ledger append-only. Las escrituras de agentes quedan como candidatas; solo una ratificación humana explícita activa un guard, y `ratify` exige la vía humana: una terminal interactiva y `--by` omitido. Las revisiones exigen una cita de evidencia tipada nueva, cuya forma se valida pero nunca se resuelve ni se verifica, y devuelven una refutación activa a candidata hasta que se vuelva a ratificar. Los overturns de agentes siguen siendo propuestas. |
-| `daimon ruling propose\|ratify\|revise\|retire` | Gestiona reglas vigentes en el mismo ledger, con un ciclo más estricto: `ratify` muestra el texto completo, avisa que va a renderizarse en cada sesión futura y ata la activación al texto mostrado; un humano que revisa una regla activa confirma el cambio y la regla sigue activa; los revise y retire de agentes registran propuestas mientras el texto queda en pie; la activación se rechaza pasado el tope (`DAIMON_RULING_CAP`, por defecto 7). Retirar no exige cita de evidencia. `propose` y `revise` pueden adjuntar un check con `--check-body-file`, `--check-match` y `--check-intent`: un script cuyos bytes quedan guardados en la regla (una ruta se rechaza), un patrón sobre la línea de comando que elige las acciones antes de las cuales corre, y qué le pide a cada anfitrión (`warn` por defecto). El check de una candidata se lee como propuesto, no armado, y ningún anfitrión lo ejecuta. `ratify` muestra el check y ata la activación al cuerpo que mostró, por hash. Ejecutar el check llega en una versión posterior; esta versión lo registra y lo muestra. |
+| `daimon ruling propose\|ratify\|revise\|retire` | Gestiona reglas vigentes en el mismo ledger, con un ciclo más estricto: `ratify` muestra el texto completo, avisa que va a renderizarse en cada sesión futura y ata la activación al texto mostrado; un humano que revisa una regla activa confirma el cambio y la regla sigue activa; los revise y retire de agentes registran propuestas mientras el texto queda en pie; la activación se rechaza pasado el tope (`DAIMON_RULING_CAP`, por defecto 7). Retirar no exige cita de evidencia. `propose` y `revise` pueden adjuntar un check con `--check-body-file`, `--check-match` y `--check-intent`: un script cuyos bytes quedan guardados en la regla (una ruta se rechaza), un patrón sobre la línea de comando que elige las acciones antes de las cuales corre, y qué le pide a cada anfitrión (`warn` por defecto). El check de una candidata se lee como propuesto, no armado, y ningún anfitrión lo ejecuta. `ratify` muestra el check y ata la activación al cuerpo que mostró, por hash, y lo materializa para que un anfitrión pueda correrlo. Un cuerpo que nombra una ruta local del anfitrión en cualquier línea se rechaza, porque el check viaja con la regla y una ruta fuera de él no existe en ninguna otra máquina. Ver [Checks en ejecución](#checks-en-ejecución). |
+
+### Checks en ejecución
+
+Ratificar una regla que lleva un check escribe dos cosas bajo `~/.daimon/checks`: un manifiesto que nombra cada check armado y el directorio de proyecto al que pertenece, y un archivo por check con los bytes exactos que la regla guarda. Cada escritura en el ledger que puede armar o desarmar un check los reconstruye; `daimon check sync` los reconstruye a pedido. Los adaptadores de anfitrión que efectivamente corren un check sobre una acción real llegan en una versión posterior — lo que sale acá es la maquinaria de abajo y el comando para probar un cuerpo contra ella.
+
+Un check corre contra un **sujeto**: la línea de comando, un separador, y después el contenido de cada argumento de archivo que daimon pudo resolver, cada uno bajo un encabezado que nombra la bandera de la que salió. El sujeto va a un archivo temporal con modo 600 y se borra después de la corrida. Su ruta llega en `DAIMON_CHECK_SUBJECT`, junto con `DAIMON_CHECK_COMMAND` y `DAIMON_CHECK_RULING`; el directorio de trabajo es el de la acción, y la entrada estándar es `/dev/null`.
+
+Qué lee el resolutor:
+
+| forma en el comando | qué hace daimon |
+| --- | --- |
+| `--body-file <ruta>`, `--body-file=<ruta>`, `-F <ruta>` | lee el archivo |
+| `--notes-file <ruta>`, `--notes-file=<ruta>` | lee el archivo |
+| `-F clave=@<ruta>`, `--field clave=@<ruta>` | lee el archivo |
+| `<bandera> -` con un heredoc en el mismo comando | lee el texto del heredoc |
+| `<bandera> -` sin heredoc | sin resolver, causa `stdin-pipe` |
+| cualquier otro `@<ruta>` o `<bandera> -` | sin resolver, causa `arg-form-unparsed` |
+
+Las rutas relativas resuelven contra el directorio de trabajo. Un archivo de más de 1 MiB es `file-oversize`, uno que no es texto UTF-8 es `file-binary`, y uno que falta o no se puede leer es `file-missing` o `file-unreadable`. Un solo argumento que daimon no puede leer deja todo el sujeto sin resolver, digan lo que digan los demás.
+
+Cada corrida termina en exactamente uno de tres resultados, y nunca se mezclan:
+
+| resultado | qué significa |
+| --- | --- |
+| `clean` | el check corrió sobre el sujeto completo y salió con 0 |
+| `violation` | el check corrió sobre el sujeto completo y salió con 1 — su propia primera línea de stderr es la razón |
+| `unresolved` | daimon no pudo probar que el sujeto estuviera limpio: un argumento que no pudo leer, un check que se rompió o se pasó de presupuesto, un cuerpo que ya no hashea a lo que se ratificó, o un anfitrión sin `sh` |
+
+`unresolved` nunca se muestra como limpio y nunca se cuenta como violación.
+
+El runner lleva su propio presupuesto, `DAIMON_CHECK_TIMEOUT`, cinco segundos por defecto contra un timeout de hook del anfitrión de diez. Ese presupuesto no es opcional: en los anfitriones medidos hasta ahora, un hook que llega al timeout del propio anfitrión no bloquea y la acción sigue, así que un check sin presupuesto propio convierte un cuelgue en un permiso silencioso. Pasarse mata el check y todo su grupo de procesos, y reporta `unresolved`.
+
+Cada corrida agrega una fila a `~/.daimon/logs/checks.jsonl`: ids, resultados, causas, duraciones, anfitrión y modo. Nada del texto del comando, ninguna ruta, nada del sujeto. La razón que ve el agente puede nombrar una ruta; el log no.
+
+Leé ese log para saber si el check está vivo, no para saber si se cumplió. Una fila prueba que el check CORRIÓ. Solo `decision_emitted: deny` bajo `enforce` cierra la distancia entre un check que corrió y un check que fue respetado.
+
+Dos convenciones que conviene sostener. Armá un check nuevo con intención `warn` primero, así un patrón que agarra más de lo que pensabas cuesta una advertencia y no una acción bloqueada. Y corré `daimon ruling check try` antes de ratificar — para eso está.
+
+| variable | por defecto | qué guarda |
+| --- | --- | --- |
+| `DAIMON_CHECKS_DIR` | `~/.daimon/checks` | el manifiesto y los cuerpos materializados |
+| `DAIMON_CHECK_TIMEOUT` | `5` | el presupuesto del runner en segundos, con piso de 0.5 |
+| `DAIMON_LOG_DIR` | `~/.daimon/logs` | contiene `checks.jsonl` |
 
 ### Reglas desde un proceso anfitrión
 


### PR DESCRIPTION
Refs #943

Slice 2 of #943: the runtime. Slice 1 (#949) let a ruling carry a check that only a human can arm. This slice lets an armed check run. No host adapter yet; that is slice 3.

## What

- `checks_runtime.py`, stdlib only and loadable by a hook script without importing the package, shipped byte-identical to `_hooks/` and `hook/` through the existing sync script and drift test. It reads the manifest, matches the working directory by resolved prefix, runs the regex prefilter on at most the first 4096 bytes of the command, resolves the command's file arguments into a subject, runs the check, and appends one row to the firing log.
- The resolver covers the first table from the spec: `--body-file <p>` and `--body-file=<p>`, `-F <p>`, `--notes-file <p>`, `-F key=@<p>` and `--field key=@<p>`, attached short forms such as `-Fbody.md` and `-Fkey=@body.md`, a `-` argument fed by a heredoc attached to the same simple command, and a `-` fed by a pipe as `stdin-pipe`. A heredoc binds only inside the simple command that reads it (the stream splits at `&&`, `||`, `;`, `|` and `&`), one heredoc to one reader; a `-` whose command has no heredoc and no pipe, and anything else with `@` or `-`, is `arg-form-unparsed`. The resolver never answers `clean` for text it did not read. Files over 1 MiB, non-UTF-8 files, missing and unreadable files each get their own cause. Relative paths resolve against the working directory.
- The runner executes `sh <body>` with a minimal environment (path, home, locale, temp dir, and the subject path, command string and ruling id), stdin from `/dev/null`, its own process group, and a budget from `DAIMON_CHECK_TIMEOUT` (default 5 seconds). Exit 0 is `clean`, exit 1 is `violation` with the check's first stderr line as the reason, everything else is `unresolved` with a cause: timeout, crash (126 and 127 included, which is how a body that calls a host-local path surfaces), body hash mismatch, or a missing `sh`. The body file is re-hashed before every run. The runner never raises.
- The firing log at `logs/checks.jsonl` carries timestamp, ruling id, host, mode, outcome, cause, the decision emitted and the duration. No command text, no paths, no subject.
- `checks.sync(project_dir)` materializes the ledger's armed checks into `checks/manifest.json` plus one `<ruling_id>-<sha12>.sh` body per check at mode 0500, written through a temp file and an atomic replace. A candidate never lands. Other projects' entries survive a sync. Bodies this project no longer wants are removed. Manifest entries key on the same project resolution the CLI uses.
- `ratify`, `revise`, `retire` and `forget` keep the manifest in step after their own write. A sync that fails never changes the verb's result; the CLI prints one warning line pointing at `daimon check sync`.
- A check body may not reference a host-local root (`~/`, `$HOME/`, `/Users/`, `/home/`, `/root/`) on any line. Slice 1 refused only a bare path as the whole body. This is its own commit.
- `daimon ruling check try <id> --command "<cmd>" [--cwd DIR] [--proposed]` runs a candidate's or an armed ruling's check without arming anything and without writing the firing log or the manifest. Human only, with the same two-layer check `ratify` uses. Exit 0 clean, 1 violation, 3 unresolved.
- `daimon check sync [--project]` rebuilds the manifest for one project and reports how many checks are armed.
- Two new environment knobs: `DAIMON_CHECKS_DIR` (default `~/.daimon/checks`) and `DAIMON_CHECK_TIMEOUT`. The runtime resolves them with the same rules as the package, including the env-file fallback, pinned by a probe table.
- Reference docs gained a "Checks at runtime" section in both languages, including the sentence that a log row proves a check ran and only a `deny` decision under `enforce` closes the gap between ran and honored.

## Why

A ruling that only renders into context gets re-derived from memory and reproduced by half. Slice 1 stored the check and pinned it at ratification. Without a runtime the ceremony's promise that the check "will run before matching actions" is prose. This slice makes the promise executable and testable before a host is wired: a human can try a check against a real command, see the outcome and the cause, and only then ratify it.

## Tests

- `tests/test_checks_runtime.py`: every resolver row both ways, heredoc with quoted and unquoted terminators, pipe versus heredoc, compound commands where the heredoc feeds a neighbouring command, attached short flags, a parent-env secret that must not reach the body, oversize boundary, binary, missing, unreadable; runner outcomes for exit 0, 1, 5, 126 and 127, timeout with a background child, hash mismatch, missing `sh`, and a runner that never raises when `Popen` itself fails, when the temp dir is full, when a file argument carries a NUL byte, or when the command string carries a forged heredoc marker; firing log rows carry only the documented keys and never a path; prefix match on a resolved cwd rejects a sibling directory with a shared prefix; the regex bound.
- `tests/test_checks_sync.py`: manifest build, atomic replace, per-project merge, stale body removal, mode 0500, sync after each writer, the warning path when sync fails, the kill switch, and the drift pair for the two synced copies.
- `tests/test_ruling_check_try_cli.py`: `--by agent` refused, non-TTY refused, exit codes, nothing written to the log or the manifest, `--proposed` on a pending revision and refused when none is pending.
- Probe table over process-env and env-file forms proving the runtime's directory resolution matches the package's.
- Registry gates: surfaces registry, write-audit command registry, skill content, sync check.
- Full suite from `plugin/` with the CI extras: 5317 passed, 0 failed, 10 skipped (216 new). Ruff and mypy clean. `scripts/sync_hooks.py --check` in sync. Verified by hand that `hook/checks_runtime.py` loads and runs a check under the system Python with no virtualenv.
