### PR TITLE
feat(hooks): a matching shell action runs its armed checks before it executes

### DIFF
--- a/.scars/candidates/stale-hook-copy-fails-open-as-clean-allow.md
+++ b/.scars/candidates/stale-hook-copy-fails-open-as-clean-allow.md
@@ -1,0 +1,37 @@
+---
+id: 0
+type: landmine
+title: A stale hook copy fails open and is byte-identical to a clean allow
+severity: high
+confidence: 0.9
+created: 2026-09-06
+authors: ["claude-code"]
+anchors:
+  - path: plugin/daimon_briefing/checks_host.py
+  - path: hook/
+  - pattern: "spec_from_file_location"
+evidence:
+  - note: "#943 slice 3, one debugging cycle lost to it"
+status: candidate
+expires:
+  condition: "the end-to-end hook tests load the canonical file, or the sync runs automatically before pytest"
+  review_after: 2027-03-06
+---
+
+The pre-action hook loads `checks_host.py` from its own directory by file
+location, so `hook/checks_host.py` is what the end-to-end tests actually
+execute. Edit the canonical `plugin/daimon_briefing/checks_host.py` and run
+those tests without `scripts/sync_hooks.py` first, and the script loads the
+stale copy, a missing attribute raises, and the top-level guard swallows it.
+The result is exit 0, empty stdout, and no firing row.
+
+That is byte-identical to a clean allow. Every assertion about the host
+contract passes, and the test that should have caught the new behavior simply
+does not see it. The pre-commit drift check catches this before a commit but
+not before a test run, which is where the time goes.
+
+Run the sync before any end-to-end hook run, and point unit tests at the
+canonical file (`test_checks_host.py` loads it by path for exactly this
+reason). The fail-open guard is correct and must stay: it is what keeps a
+broken hook from blocking a session. It just means a missed sync looks like a
+decision instead of a failure.

--- a/hook/checks_host.py
+++ b/hook/checks_host.py
@@ -26,6 +26,7 @@ proceeds and nothing anywhere says why.
 """
 
 import importlib.util
+import json
 from pathlib import Path
 from typing import NamedTuple
 
@@ -71,6 +72,13 @@ INTENTS = ("enforce", "warn", "record-only")
 
 # The decision encoders a profile may name.
 ENCODERS = ("json-permission", "exit2-stderr")
+
+# What the hook actually tells the host, and therefore what reaches the
+# firing log's `decision_emitted`. A record-only mode still emits `allow`:
+# nothing was written to the host, and the `mode` column is where "this only
+# went to the log" is already said. Claiming a fourth word here would report
+# a channel the host was never given.
+DECISIONS = ("allow", "warn", "deny")
 
 
 class Profile(NamedTuple):
@@ -170,3 +178,84 @@ def mode_for(profile, intent) -> str:
     asked = intent if intent in INTENTS else "record-only"
     mode = caps.get(asked, "unsupported")
     return mode if mode in MODES else "unsupported"
+
+
+# ---- encoders (spec section 4) -------------------------------------------
+
+
+class Emission(NamedTuple):
+    """What the hook writes and what it exits with.
+
+    Three channels because the hosts do not agree on one. Claude Code and
+    Codex read a JSON object on stdout and treat a non-zero exit as a hook
+    error; Windsurf documents exit 2 with the reason on stderr. Carrying all
+    three keeps the Windsurf row a row rather than a special case, and the
+    tests pin stderr empty and the exit code 0 on every path of the two
+    hosts that actually ship a script."""
+
+    stdout: str
+    stderr: str
+    exit_code: int
+
+
+_SILENT = Emission("", "", 0)
+
+
+def _encode_json_permission(profile, decision, text) -> Emission:
+    """The measured path on Claude Code and Codex: one JSON object, exit 0.
+
+    The key names are the host's contract, so they are pinned byte for byte
+    by a literal comparison in the tests. A rename here is a deny that
+    silently becomes an allow, and a parsed-dict assertion would not see it.
+
+    A silent allow writes NOTHING rather than an object saying `allow`: the
+    hosts treat absent output as no opinion, and an object claiming a
+    decision is a decision daimon did not make."""
+    event = str(getattr(profile, "event", "") or "")
+    if decision == "deny":
+        return Emission(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": event,
+                "permissionDecision": "deny",
+                "permissionDecisionReason": text,
+            },
+        }, sort_keys=True), "", 0)
+    if decision == "warn" and text:
+        return Emission(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": event,
+                "permissionDecision": "allow",
+            },
+            "systemMessage": text,
+        }, sort_keys=True), "", 0)
+    return _SILENT
+
+
+def _encode_exit2_stderr(profile, decision, text) -> Emission:
+    """Windsurf's documented channel, unmeasured. Reachable only once a
+    Windsurf profile has a mode above `unsupported`, which is after a live
+    probe; until then this exists so the row is complete and its shape is
+    pinned by a test rather than discovered on someone's machine."""
+    if decision not in ("deny", "warn") or not text:
+        return _SILENT
+    return Emission("", text + "\n", 2 if decision == "deny" else 0)
+
+
+_ENCODERS = {
+    "json-permission": _encode_json_permission,
+    "exit2-stderr": _encode_exit2_stderr,
+}
+
+
+def encode(profile, decision, text) -> Emission:
+    """Render one decision the way this host reads it.
+
+    An unknown decision word or an unknown encoder name is a silent allow,
+    never a deny: a value this build does not recognise must not become the
+    strongest thing the host can be asked to do."""
+    if decision not in DECISIONS:
+        return _SILENT
+    fn = _ENCODERS.get(str(getattr(profile, "encoder", "")))
+    if fn is None:
+        return _SILENT
+    return fn(profile, decision, str(text or ""))

--- a/hook/checks_host.py
+++ b/hook/checks_host.py
@@ -28,6 +28,8 @@ proceeds and nothing anywhere says why.
 import importlib.util
 import json
 import os
+import re
+import shlex
 import sys
 import time
 from pathlib import Path
@@ -375,6 +377,44 @@ def _failure_line(entry, outcome) -> str:
     return f"{ruling_id}: {reason}"
 
 
+def _command_text(raw):
+    """The action's command string, or None when there is no command, or the
+    Unresolved cause when there is one daimon cannot read.
+
+    Some hosts send the shell tool's command as an argv array. Read as "no
+    command", every armed check on such a host goes silently inert while the
+    liveness surface reads "armed, never fired", which is the phrase reserved
+    for a wired install that nothing has matched yet. It is joined with shell
+    quoting rather than with a space, because an argument holding a space
+    would otherwise become two arguments in the subject and the check would
+    be judging a command nobody ran."""
+    if isinstance(raw, str):
+        return raw or None
+    if isinstance(raw, list):
+        if raw and all(isinstance(part, str) for part in raw):
+            return shlex.join(raw)
+        return ("arg-form-unparsed",
+                "the host sent a command daimon could not read as text")
+    return None
+
+
+def _match_state(rt, entry, command) -> str:
+    """`hit`, `miss`, or `broken` for one entry's pattern.
+
+    `rt.matches` folds an uncompilable pattern into False, which is right for
+    it and wrong here: "a regex that cannot compile" and "a regex that did
+    not match" are different facts and only one of them was countable.
+    `refutations` compiles the pattern at propose time, so a broken one
+    reaches this point only through a hand-edited manifest."""
+    pattern = entry.get("match")
+    if isinstance(pattern, str) and pattern:
+        try:
+            re.compile(pattern)
+        except (re.error, RecursionError):
+            return "broken"
+    return "hit" if rt.matches(entry, command) else "miss"
+
+
 def decide(profile, payload, *, manifest=None, timeout=None,
            now=None) -> Decision:
     """Run this action's armed checks and say what the host should be told.
@@ -408,8 +448,18 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         payload = {}
     if not _accepts(profile, payload):
         return Decision("", "", 0, rows)
-    command = _dig(payload, getattr(profile, "command_path", ()))
-    if not isinstance(command, str) or not command:
+    command = _command_text(_dig(payload, getattr(profile, "command_path",
+                                                  ())))
+    stamp = _stamp(now)
+    if isinstance(command, tuple):
+        # A command that is present and unreadable, which is not the same as
+        # absent. It gets a row so the state is countable; the action is
+        # allowed because nothing was armed against anything yet.
+        cause, _ = command
+        rows.append(_row(profile, stamp, cause=cause, outcome="unresolved",
+                         decision="allow"))
+        return Decision("", "", 0, rows)
+    if command is None:
         # Not a row: nothing ran and nothing declined to run. A row for every
         # payload without a command would make the firing log a transcript of
         # the session rather than a record of checks.
@@ -421,7 +471,6 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # host launched stands in the action's directory anyway, and arming
         # nothing would disarm every check for that action in silence.
         cwd = os.getcwd()
-    stamp = _stamp(now)
 
     loaded = rt.load_manifest() if manifest is None else manifest
     reason = getattr(loaded, "reason", "")
@@ -433,12 +482,25 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         rows.append(_row(profile, stamp, cause=reason, decision="allow"))
         return Decision("", "", 0, rows)
 
+    try:
+        os.path.realpath(cwd)
+    except (OSError, ValueError):
+        # `armed_for` folds this into an empty list, which would come out as
+        # `no-match`. That cause says every armed check was compared and none
+        # applied; here nothing was compared at all.
+        rows.append(_row(profile, stamp, cause="file-unreadable",
+                         outcome="unresolved", decision="allow"))
+        return Decision("", "", 0, rows)
+
     entries = rt.armed_for(cwd, loaded)
     if not entries:
         rows.append(_row(profile, stamp, cause="no-match", decision="allow"))
         return Decision("", "", 0, rows)
 
-    matching = [entry for entry in entries if rt.matches(entry, command)]
+    matching = [(entry, _match_state(rt, entry, command))
+                for entry in entries]
+    matching = [(entry, state) for entry, state in matching
+                if state != "miss"]
     if not matching:
         # The prefilter is what makes a hook on every shell action
         # affordable, and spec 3.1 names only the two project-level causes.
@@ -450,14 +512,26 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
 
     # Once, for every matching check. The subject cannot change between two
     # entries of the same action, and reading every file argument again would
-    # spend a budget the host will not extend.
-    subject = rt.resolve(command, cwd)
+    # spend a budget the host will not extend. Skipped entirely when every
+    # matching entry carries a pattern that will not compile: there is
+    # nothing to run against them, and the resolve is the expensive half.
+    subject = (rt.resolve(command, cwd)
+               if any(state == "hit" for _, state in matching) else None)
     results = []
     try:
-        for entry in matching:
+        for entry, state in matching:
             mode = mode_for(profile, entry.get("intent"))
             left = deadline - time.monotonic()
-            if isinstance(subject, rt.Unresolved):
+            if state == "broken":
+                # The manifest names a pattern daimon cannot compile, so this
+                # check cannot be applied at all. `unresolved`, which under
+                # `enforce` denies: a rule nobody can evaluate is not a rule
+                # that passed.
+                outcome = rt.Outcome(
+                    "unresolved", "check-crashed",
+                    "this ruling's match pattern could not be compiled; run "
+                    "`daimon check sync`", -1, 0)
+            elif isinstance(subject, rt.Unresolved):
                 outcome = rt.Outcome("unresolved", subject.cause,
                                      subject.reason, -1, 0)
             elif left <= 0:
@@ -474,14 +548,26 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
             else:
                 outcome = rt.run(entry, subject, cwd=cwd,
                                  timeout=min(per_check, left))
-            results.append((entry, mode, outcome))
+            # Appended as it is decided, not after the loop. `rt.run` is
+            # documented never to raise, and this is the case where the
+            # record matters most if it ever does: an earlier check's
+            # violation is the only evidence of what happened. The row is
+            # stamped `allow` and corrected below for the ones that failed,
+            # so a row that escapes through an exception says what the host
+            # actually got, which is nothing.
+            row = _row(profile, stamp, ruling_id=entry.get("ruling_id"),
+                       mode=mode, outcome=outcome.outcome,
+                       cause=outcome.cause, decision="allow",
+                       duration_ms=outcome.duration_ms)
+            rows.append(row)
+            results.append((entry, mode, outcome, row))
     finally:
         # The subject holds the command and every file it named. A `finally`
         # is the only placement that survives an exception nobody predicted.
         rt.discard(subject)
 
-    failing = [(index, entry, mode, outcome)
-               for index, (entry, mode, outcome) in enumerate(results)
+    failing = [(entry, mode, outcome, row)
+               for entry, mode, outcome, row in results
                if outcome.outcome in ("violation", "unresolved")]
     decision, text = "allow", ""
     if failing:
@@ -489,7 +575,7 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # An enforce check that passed has nothing to say about a warn check
         # that did not, and reading it the other way blocks actions nobody
         # armed to block.
-        deciding = max((mode for _, _, mode, _ in failing), key=MODES.index)
+        deciding = max((mode for _, mode, _, _ in failing), key=MODES.index)
         # Only the failures AT OR ABOVE the deciding mode are spoken aloud. A
         # `record-only` check asked for the log and nothing else, and a
         # neighbour that failed at a stronger mode must not carry its reason
@@ -499,7 +585,7 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # would otherwise defeat it.
         floor = MODES.index(deciding)
         text = "\n".join(_failure_line(entry, outcome)
-                         for _, entry, mode, outcome in failing
+                         for entry, mode, outcome, _ in failing
                          if MODES.index(mode) >= floor)
         if deciding == "enforce":
             decision = "deny"
@@ -507,20 +593,14 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
             decision = "warn"
 
     emission = encode(profile, decision, text)
-    failed = {index for index, _, _, _ in failing}
-    for index, (entry, mode, outcome) in enumerate(results):
-        # One action produces one decision, but the log row is per CHECK, so
-        # the row records what THIS check contributed. A check that passed
-        # records `allow`: it did not deny anything, and a clean row stamped
-        # `deny` satisfies the "only a deny under enforce proves it was
-        # honored" filter while proving nothing of the kind. The stats
-        # surface counts these rows.
-        rows.append(_row(profile, stamp, ruling_id=entry.get("ruling_id"),
-                         mode=mode, outcome=outcome.outcome,
-                         cause=outcome.cause,
-                         decision=decision if index in failed
-                         else "allow",
-                         duration_ms=outcome.duration_ms))
+    # One action produces one decision, but the log row is per CHECK, so the
+    # row records what THIS check contributed. A check that passed keeps the
+    # `allow` it was written with: it denied nothing, and a clean row stamped
+    # `deny` satisfies the "only a deny under enforce proves it was honored"
+    # filter while proving nothing of the kind. The stats surface counts
+    # these rows.
+    for _entry, _mode, _outcome, row in failing:
+        row["decision_emitted"] = decision
     return Decision(emission.stdout, emission.stderr, emission.exit_code, rows)
 
 

--- a/hook/checks_host.py
+++ b/hook/checks_host.py
@@ -509,7 +509,14 @@ def main(host, stdin=None, stdout=None, stderr=None) -> int:
             return 0
         decision = decide(profile, _read_payload(stdin))
         for row in decision.rows:
-            rt.log_firing(row)
+            try:
+                rt.log_firing(row)
+            except Exception:  # noqa: BLE001
+                # `log_firing` promises not to raise, and this guard is what
+                # keeps that promise from being load-bearing. The row is
+                # bookkeeping; the deny is the thing the operator armed, and
+                # losing the decision over the record is the wrong trade.
+                pass
         out.write(decision.stdout)
         err.write(decision.stderr)
         return decision.exit_code

--- a/hook/checks_host.py
+++ b/hook/checks_host.py
@@ -570,6 +570,9 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
                for entry, mode, outcome, row in results
                if outcome.outcome in ("violation", "unresolved")]
     decision, text = "allow", ""
+    # Above every real mode until a failure sets it, so that with nothing
+    # failing no row qualifies for the stamp below.
+    floor = len(MODES)
     if failing:
         # The strongest FAILING mode decides, not the strongest mode present.
         # An enforce check that passed has nothing to say about a warn check
@@ -594,13 +597,17 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
 
     emission = encode(profile, decision, text)
     # One action produces one decision, but the log row is per CHECK, so the
-    # row records what THIS check contributed. A check that passed keeps the
-    # `allow` it was written with: it denied nothing, and a clean row stamped
-    # `deny` satisfies the "only a deny under enforce proves it was honored"
-    # filter while proving nothing of the kind. The stats surface counts
-    # these rows.
-    for _entry, _mode, _outcome, row in failing:
-        row["decision_emitted"] = decision
+    # row records what THIS check contributed. Two kinds of row keep the
+    # `allow` they were written with. A check that passed denied nothing, and
+    # a clean row stamped `deny` satisfies the "only a deny under enforce
+    # proves it was honored" filter while proving nothing of the kind. And a
+    # check that failed BELOW the deciding floor had its reason withheld from
+    # the host by its own mode, so it was never heard: stamping the decision
+    # on it claims a contribution to a block it was not allowed to speak in.
+    # The stats surface counts these rows.
+    for _entry, mode, _outcome, row in failing:
+        if MODES.index(mode) >= floor:
+            row["decision_emitted"] = decision
     return Decision(emission.stdout, emission.stderr, emission.exit_code, rows)
 
 

--- a/hook/checks_host.py
+++ b/hook/checks_host.py
@@ -28,6 +28,7 @@ proceeds and nothing anywhere says why.
 import importlib.util
 import json
 import os
+import sys
 import time
 from pathlib import Path
 from typing import NamedTuple
@@ -454,3 +455,72 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
                          cause=outcome.cause, decision=decision,
                          duration_ms=outcome.duration_ms))
     return Decision(emission.stdout, emission.stderr, emission.exit_code, rows)
+
+
+# ---- what the thin per-host scripts call ---------------------------------
+
+# Said on a host that renders a message channel, and only there. A host with
+# no channel for it would be told nothing either way, and the firing log is
+# the honest surface for that fact except that there is no runtime to write
+# it with, which is the state being reported.
+RUNTIME_MISSING = "daimon: check runtime missing, nothing enforced"
+
+
+def _read_payload(stream) -> dict:
+    """The host's payload, or an empty one. Unparseable stdin, a closed pipe
+    and a payload that is not an object are all the same fact here: this
+    process cannot see the action, so it has nothing to say about it."""
+    try:
+        raw = (stream if stream is not None else sys.stdin).read()
+    except Exception:  # noqa: BLE001
+        return {}
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def main(host, stdin=None, stdout=None, stderr=None) -> int:
+    """Run this host's pre-action check and write the decision.
+
+    The whole per-host script is a call to this with a profile name. Reads
+    the payload, decides, records every row, writes the encoded decision
+    once at the end, and returns the exit code the encoder chose, which is 0
+    for every host that ships a script today.
+
+    Writing stdout LAST and once is deliberate: a partial object on a host
+    that parses stdout is worse than no object, and an exception after a
+    first write could leave one."""
+    out = stdout if stdout is not None else sys.stdout
+    err = stderr if stderr is not None else sys.stderr
+    profile = PROFILES.get(host)
+    if profile is None:
+        return 0
+    rt = runtime()
+    try:
+        if rt is None:
+            # Nothing to check with and nothing to write a row with. Say so
+            # where the host has a channel for it; a warn that degrades below
+            # `warn` on this host has nowhere to go, so it goes nowhere.
+            if mode_for(profile, "warn") == "warn":
+                emission = encode(profile, "warn", RUNTIME_MISSING)
+                out.write(emission.stdout)
+            return 0
+        decision = decide(profile, _read_payload(stdin))
+        for row in decision.rows:
+            rt.log_firing(row)
+        out.write(decision.stdout)
+        err.write(decision.stderr)
+        return decision.exit_code
+    except Exception:  # noqa: BLE001 — the action must not die with the hook
+        # Nothing written, so the host sees no opinion and proceeds. The row
+        # is the only record that anything happened, and it is worth one more
+        # attempt that itself cannot raise.
+        if rt is not None:
+            try:
+                rt.log_firing(_row(profile, _stamp(None),
+                                   cause="check-crashed", decision="allow"))
+            except Exception:  # noqa: BLE001
+                pass
+        return 0

--- a/hook/checks_host.py
+++ b/hook/checks_host.py
@@ -27,6 +27,8 @@ proceeds and nothing anywhere says why.
 
 import importlib.util
 import json
+import os
+import time
 from pathlib import Path
 from typing import NamedTuple
 
@@ -259,3 +261,196 @@ def encode(profile, decision, text) -> Emission:
     if fn is None:
         return _SILENT
     return fn(profile, decision, str(text or ""))
+
+
+# ---- the pipeline (spec sections 3.1, 3.4 and 5) -------------------------
+
+# Where a host names the tool it is about to run. Both hosts that filter by
+# tool name spell it this way. A host that spells it differently declares an
+# empty `tool_names` and is selected by its `command_path` alone, which is
+# what the Windsurf row does.
+TOOL_NAME_KEY = "tool_name"
+
+
+class Decision(NamedTuple):
+    """What one action's checks came to.
+
+    `rows` are firing-log rows, built to `FIRING_KEYS` and not yet written:
+    `decide` decides, `main` records. Keeping the write out of here is what
+    lets the whole matrix be tested without a log on disk, and what keeps a
+    failed write from costing the decision."""
+
+    stdout: str
+    stderr: str
+    exit_code: int
+    rows: list
+
+
+def _dig(payload, path):
+    """Walk a path into a payload, or None. A host payload field is a CLAIM
+    (scar 0068): any step may be missing or may not be a mapping at all, and
+    each of those is an action daimon cannot see rather than a crash."""
+    current = payload
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _accepts(profile, payload) -> bool:
+    """Whether this payload names a shell action on this host. An empty
+    `tool_names` accepts anything, because the host already selected by
+    event."""
+    names: frozenset = getattr(profile, "tool_names", frozenset())
+    if not names:
+        return True
+    return _dig(payload, (TOOL_NAME_KEY,)) in names
+
+
+def _row(profile, ts, *, ruling_id="", mode="", outcome="", cause="",
+         decision="allow", duration_ms=0) -> dict:
+    """One firing-log row, in the declared shape. `log_firing` PROJECTS onto
+    FIRING_KEYS, so a row built with a stray field loses it in silence;
+    building to the shape here keeps the two ends one declaration."""
+    return {
+        "ts": ts,
+        "ruling_id": str(ruling_id or ""),
+        "host": str(getattr(profile, "host", "") or ""),
+        "mode": mode,
+        "outcome": outcome,
+        "cause": cause,
+        "decision_emitted": decision,
+        "duration_ms": int(duration_ms or 0),
+    }
+
+
+def _stamp(now) -> str:
+    if isinstance(now, str) and now:
+        return now
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _failure_line(entry, outcome) -> str:
+    """`<ruling_id>: <reason>`, with the cause in front when daimon could not
+    read what the action sends. The cause is what tells a human whether to
+    fix the command or fix the check."""
+    ruling_id = str(entry.get("ruling_id") or "")
+    reason = outcome.reason or "the check reported a violation and gave no reason"
+    if outcome.outcome == "unresolved" and outcome.cause:
+        reason = f"{outcome.cause}: {reason}"
+    return f"{ruling_id}: {reason}"
+
+
+def decide(profile, payload, *, manifest=None, timeout=None,
+           now=None) -> Decision:
+    """Run this action's armed checks and say what the host should be told.
+
+    Never raises. It fires before every shell action, and on the hosts
+    measured so far a hook that crashes is fail-open: the action proceeds and
+    nothing anywhere says why. An exception on the way through still returns
+    an allow, with the rows already gathered plus one saying the machinery
+    was what failed."""
+    rows: list = []
+    try:
+        return _decide(profile, payload, manifest, timeout, now, rows)
+    except Exception:  # noqa: BLE001 — a decision is mandatory
+        rows.append(_row(profile, _stamp(now), cause="check-crashed",
+                         decision="allow"))
+        return Decision("", "", 0, rows)
+
+
+def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
+    rt = runtime()
+    if rt is None:
+        # Nothing to check WITH, and nothing to write a row with either. The
+        # caller owns the diagnostic; see `main`.
+        return Decision("", "", 0, rows)
+    if not isinstance(payload, dict):
+        payload = {}
+    if not _accepts(profile, payload):
+        return Decision("", "", 0, rows)
+    command = _dig(payload, getattr(profile, "command_path", ()))
+    if not isinstance(command, str) or not command:
+        # Not a row: nothing ran and nothing declined to run. A row for every
+        # payload without a command would make the firing log a transcript of
+        # the session rather than a record of checks.
+        return Decision("", "", 0, rows)
+
+    cwd = payload.get(getattr(profile, "cwd_key", ""))
+    if not isinstance(cwd, str) or not cwd:
+        # The host is supposed to send it. When it does not, the process the
+        # host launched stands in the action's directory anyway, and arming
+        # nothing would disarm every check for that action in silence.
+        cwd = os.getcwd()
+    stamp = _stamp(now)
+
+    loaded = rt.load_manifest() if manifest is None else manifest
+    reason = getattr(loaded, "reason", "")
+    if reason:
+        # Spec 3.1: "nothing is armed here" has to be countable, so the stats
+        # surface can say "armed, never fired" instead of "clean". An install
+        # that armed nothing and a manifest daimon can no longer parse are
+        # different facts and keep different causes.
+        rows.append(_row(profile, stamp, cause=reason, decision="allow"))
+        return Decision("", "", 0, rows)
+
+    entries = rt.armed_for(cwd, loaded)
+    if not entries:
+        rows.append(_row(profile, stamp, cause="no-match", decision="allow"))
+        return Decision("", "", 0, rows)
+
+    matching = [entry for entry in entries if rt.matches(entry, command)]
+    if not matching:
+        # The prefilter is what makes a hook on every shell action
+        # affordable, and spec 3.1 names only the two project-level causes.
+        return Decision("", "", 0, rows)
+
+    budget = (float(timeout) if isinstance(timeout, (int, float))
+              and timeout > 0 else rt.check_timeout())
+
+    # Once, for every matching check. The subject cannot change between two
+    # entries of the same action, and reading every file argument again would
+    # spend a budget the host will not extend.
+    subject = rt.resolve(command, cwd)
+    results = []
+    try:
+        for entry in matching:
+            mode = mode_for(profile, entry.get("intent"))
+            if isinstance(subject, rt.Unresolved):
+                outcome = rt.Outcome("unresolved", subject.cause,
+                                     subject.reason, -1, 0)
+            else:
+                outcome = rt.run(entry, subject, cwd=cwd, timeout=budget)
+            results.append((entry, mode, outcome))
+    finally:
+        # The subject holds the command and every file it named. A `finally`
+        # is the only placement that survives an exception nobody predicted.
+        rt.discard(subject)
+
+    failing = [(entry, mode, outcome) for entry, mode, outcome in results
+               if outcome.outcome in ("violation", "unresolved")]
+    decision, text = "allow", ""
+    if failing:
+        # The strongest FAILING mode decides, not the strongest mode present.
+        # An enforce check that passed has nothing to say about a warn check
+        # that did not, and reading it the other way blocks actions nobody
+        # armed to block.
+        deciding = max((mode for _, mode, _ in failing), key=MODES.index)
+        text = "\n".join(_failure_line(entry, outcome)
+                         for entry, _, outcome in failing)
+        if deciding == "enforce":
+            decision = "deny"
+        elif deciding == "warn":
+            decision = "warn"
+
+    emission = encode(profile, decision, text)
+    for entry, mode, outcome in results:
+        # `mode` is this entry's; `decision_emitted` is the ACTION's. One
+        # action produces one decision, and the row that claimed otherwise
+        # would report a deny the host never received.
+        rows.append(_row(profile, stamp, ruling_id=entry.get("ruling_id"),
+                         mode=mode, outcome=outcome.outcome,
+                         cause=outcome.cause, decision=decision,
+                         duration_ms=outcome.duration_ms))
+    return Decision(emission.stdout, emission.stderr, emission.exit_code, rows)

--- a/hook/checks_host.py
+++ b/hook/checks_host.py
@@ -480,7 +480,8 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # is the only placement that survives an exception nobody predicted.
         rt.discard(subject)
 
-    failing = [(entry, mode, outcome) for entry, mode, outcome in results
+    failing = [(index, entry, mode, outcome)
+               for index, (entry, mode, outcome) in enumerate(results)
                if outcome.outcome in ("violation", "unresolved")]
     decision, text = "allow", ""
     if failing:
@@ -488,7 +489,7 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # An enforce check that passed has nothing to say about a warn check
         # that did not, and reading it the other way blocks actions nobody
         # armed to block.
-        deciding = max((mode for _, mode, _ in failing), key=MODES.index)
+        deciding = max((mode for _, _, mode, _ in failing), key=MODES.index)
         # Only the failures AT OR ABOVE the deciding mode are spoken aloud. A
         # `record-only` check asked for the log and nothing else, and a
         # neighbour that failed at a stronger mode must not carry its reason
@@ -498,7 +499,7 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # would otherwise defeat it.
         floor = MODES.index(deciding)
         text = "\n".join(_failure_line(entry, outcome)
-                         for entry, mode, outcome in failing
+                         for _, entry, mode, outcome in failing
                          if MODES.index(mode) >= floor)
         if deciding == "enforce":
             decision = "deny"
@@ -506,13 +507,19 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
             decision = "warn"
 
     emission = encode(profile, decision, text)
-    for entry, mode, outcome in results:
-        # `mode` is this entry's; `decision_emitted` is the ACTION's. One
-        # action produces one decision, and the row that claimed otherwise
-        # would report a deny the host never received.
+    failed = {index for index, _, _, _ in failing}
+    for index, (entry, mode, outcome) in enumerate(results):
+        # One action produces one decision, but the log row is per CHECK, so
+        # the row records what THIS check contributed. A check that passed
+        # records `allow`: it did not deny anything, and a clean row stamped
+        # `deny` satisfies the "only a deny under enforce proves it was
+        # honored" filter while proving nothing of the kind. The stats
+        # surface counts these rows.
         rows.append(_row(profile, stamp, ruling_id=entry.get("ruling_id"),
                          mode=mode, outcome=outcome.outcome,
-                         cause=outcome.cause, decision=decision,
+                         cause=outcome.cause,
+                         decision=decision if index in failed
+                         else "allow",
                          duration_ms=outcome.duration_ms))
     return Decision(emission.stdout, emission.stderr, emission.exit_code, rows)
 

--- a/hook/checks_host.py
+++ b/hook/checks_host.py
@@ -1,0 +1,172 @@
+"""The #943 host adapter core — one pipeline, one row per host.
+
+A host that runs a pre-action hook is a PROFILE ROW here, not a second
+pipeline. The row says what the host calls its event, which tool names it
+uses for a shell action, where the command string sits in its payload, how it
+wants a decision encoded, and which modes it can actually deliver. Everything
+downstream of the row is shared: the same manifest read, the same runner, the
+same firing log. Adding a host is adding a row and a six-line script.
+
+Same two rules as `checks_runtime` and for the same reason (scar 0049):
+
+  * stdlib ONLY. This file is loaded by a script running in whatever
+    interpreter the host launched, with no venv and no `daimon_briefing` on
+    `sys.path`. A package import here breaks every host at once and passes
+    every local test.
+  * the canonical file is THIS one; `hook/` and `_hooks/` hold derivatives.
+    Edit here, then run `scripts/sync_hooks.py`.
+
+`checks_runtime` is loaded from THIS file's own directory by file location,
+never by name: by name it would depend on `sys.path` state and could bind an
+unrelated top-level module.
+
+Nothing here raises. It fires before every shell action on the host, and on
+the hosts measured so far a hook that crashes is fail-open: the action
+proceeds and nothing anywhere says why.
+"""
+
+import importlib.util
+from pathlib import Path
+from typing import NamedTuple
+
+# ---- the runtime, by file location (the `_load_redact` shape) -------------
+
+
+def _load_runtime():
+    """Load `checks_runtime.py` from beside this file, or None.
+
+    None is the stale-install shape: this module shipped, its sibling did
+    not. The caller turns that into an allow that says so, because a hook
+    with no runtime has nothing to check and must not pretend otherwise."""
+    path = Path(__file__).resolve().parent / "checks_runtime.py"
+    if not path.exists():
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_daimon_checks_runtime", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    except Exception:  # noqa: BLE001 — a broken sibling must not crash a hook
+        return None
+
+
+_RUNTIME = _load_runtime()
+
+
+def runtime():
+    """The loaded runtime, or None when the sibling is missing or broken."""
+    return _RUNTIME
+
+
+# ---- modes (spec section 5) ----------------------------------------------
+
+# Weakest to strongest. Every cap and every aggregation reads this order, so
+# "weaker" and "stronger" are spelled once and cannot disagree.
+MODES = ("unsupported", "record-only", "warn", "enforce")
+
+# What an author may ask for, strongest first — the vocabulary
+# `refutations.CHECK_INTENTS` validates on the way in.
+INTENTS = ("enforce", "warn", "record-only")
+
+# The decision encoders a profile may name.
+ENCODERS = ("json-permission", "exit2-stderr")
+
+
+class Profile(NamedTuple):
+    """One host, as a row.
+
+    `host` is the label written to the firing log, so it is what a reader
+    attributes liveness to; two rows sharing one would make the per-host
+    column unmeasurable.
+
+    `tool_names` is the set of tool names that mean "a shell action"; empty
+    means any name is accepted. `command_path` is the path into the payload
+    where the command string sits, and it differs per host in NAME as well as
+    in nesting. `cwd_key` is the top-level key holding the action's working
+    directory.
+
+    `mode_caps` maps each intent to what this host can actually deliver, from
+    spec section 5. It is the whole per-host degradation story: a host that
+    documents no warn channel caps warn at record-only rather than emitting
+    something the operator never sees.
+
+    `matcher` and `install_timeout` are what the registration writes."""
+
+    host: str
+    event: str
+    tool_names: frozenset
+    command_path: tuple
+    cwd_key: str
+    encoder: str
+    mode_caps: dict
+    matcher: str
+    install_timeout: int
+
+
+PROFILES = {
+    "claude-code": Profile(
+        host="claude-code",
+        event="PreToolUse",
+        tool_names=frozenset({"Bash"}),
+        command_path=("tool_input", "command"),
+        cwd_key="cwd",
+        encoder="json-permission",
+        # Both the deny and the warn channel are documented; the deny is
+        # measured. Nothing is capped.
+        mode_caps={"enforce": "enforce", "warn": "warn",
+                   "record-only": "record-only"},
+        matcher="Bash",
+        install_timeout=10,
+    ),
+    "codex": Profile(
+        host="codex",
+        event="PreToolUse",
+        # Codex names the shell tool both ways depending on the build, and
+        # the matcher it registers is the alternation of the two.
+        tool_names=frozenset({"Bash", "shell"}),
+        command_path=("tool_input", "command"),
+        cwd_key="cwd",
+        encoder="json-permission",
+        # Codex documents the same JSON deny and NO warn channel. A warn with
+        # nowhere to go is not a warn, so it degrades to record-only: the run
+        # is still logged and nothing is silently claimed to have been shown.
+        mode_caps={"enforce": "enforce", "warn": "record-only",
+                   "record-only": "record-only"},
+        matcher="Bash|shell",
+        install_timeout=10,
+    ),
+    "windsurf": Profile(
+        host="windsurf",
+        event="pre_run_command",
+        tool_names=frozenset(),
+        # Not tool_input.command. Windsurf carries the shell action under a
+        # different key at a different name, and a copied path would read
+        # None on every action and allow in silence.
+        command_path=("tool_info", "command_line"),
+        cwd_key="cwd",
+        encoder="exit2-stderr",
+        # Documented, unmeasured. Until a live probe the whole column reads
+        # unsupported, so an enforce intent shows unsupported here rather
+        # than claiming an enforcement daimon has never seen delivered.
+        mode_caps={"enforce": "unsupported", "warn": "unsupported",
+                   "record-only": "unsupported"},
+        matcher="",
+        install_timeout=10,
+    ),
+}
+
+
+def mode_for(profile, intent) -> str:
+    """The mode this host actually delivers for that intent.
+
+    The weaker of the two, read off the profile's own cap table. An intent
+    this build never heard of reads as the weakest real intent rather than
+    the strongest: a manifest is a file on disk, and a word nobody
+    recognises must not become an enforcement."""
+    caps = getattr(profile, "mode_caps", None)
+    if not isinstance(caps, dict):
+        return "unsupported"
+    asked = intent if intent in INTENTS else "record-only"
+    mode = caps.get(asked, "unsupported")
+    return mode if mode in MODES else "unsupported"

--- a/hook/checks_host.py
+++ b/hook/checks_host.py
@@ -286,6 +286,18 @@ def encode(profile, decision, text) -> Emission:
 
 # ---- the pipeline (spec sections 3.1, 3.4 and 5) -------------------------
 
+# One deadline for the whole action, in seconds, against a host hook timeout
+# of ten. The two seconds left over pay for the manifest read, the resolve,
+# and the kill-and-drain after a check that had to be stopped.
+#
+# `DAIMON_CHECK_TIMEOUT` still caps ONE check; this caps their sum. Without
+# it the budget was per check, so two checks that both reached the runner's
+# own timeout took past ten seconds, and a hook that reaches the HOST's
+# timeout does not block: the action proceeds, nothing is emitted, and
+# nothing is logged. That silence is byte-identical to a clean allow, which
+# is the one outcome this whole slice exists to make impossible.
+ACTION_BUDGET = 8.0
+
 # Where a host names the tool it is about to run. Both hosts that filter by
 # tool name spell it this way. A host that spells it differently declares an
 # empty `tool_names` and is selected by its `command_path` alone, which is
@@ -432,8 +444,9 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # affordable, and spec 3.1 names only the two project-level causes.
         return Decision("", "", 0, rows)
 
-    budget = (float(timeout) if isinstance(timeout, (int, float))
-              and timeout > 0 else rt.check_timeout())
+    per_check = (float(timeout) if isinstance(timeout, (int, float))
+                 and timeout > 0 else rt.check_timeout())
+    deadline = time.monotonic() + ACTION_BUDGET
 
     # Once, for every matching check. The subject cannot change between two
     # entries of the same action, and reading every file argument again would
@@ -443,11 +456,24 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
     try:
         for entry in matching:
             mode = mode_for(profile, entry.get("intent"))
+            left = deadline - time.monotonic()
             if isinstance(subject, rt.Unresolved):
                 outcome = rt.Outcome("unresolved", subject.cause,
                                      subject.reason, -1, 0)
+            elif left <= 0:
+                # The action's budget is already spent, so this check never
+                # runs. `unresolved`, not clean: daimon proved nothing about
+                # the subject, and letting it through because time ran out is
+                # exactly the fail-open the deadline exists to prevent. Under
+                # `enforce` it still denies. The row is what keeps a starved
+                # check countable instead of invisible.
+                outcome = rt.Outcome(
+                    "unresolved", "check-timeout",
+                    "the action's check budget was spent before this check "
+                    "could run", -1, 0)
             else:
-                outcome = rt.run(entry, subject, cwd=cwd, timeout=budget)
+                outcome = rt.run(entry, subject, cwd=cwd,
+                                 timeout=min(per_check, left))
             results.append((entry, mode, outcome))
     finally:
         # The subject holds the command and every file it named. A `finally`

--- a/hook/checks_host.py
+++ b/hook/checks_host.py
@@ -168,6 +168,26 @@ PROFILES = {
 }
 
 
+def disabled() -> bool:
+    """The `DAIMON_DISABLE` kill switch, read the way every other daimon hook
+    reads it: `1`, `true`, `yes` or `on`, stripped, case-sensitive.
+
+    Copied line for line from `_daimon_hook_lib.disabled()` rather than
+    reinterpreted, quirks included. A switch that turns off three hooks and
+    leaves the fourth armed is worse than one that is strict everywhere, and
+    this is the fourth hook: the one that can block a command, and therefore
+    the one an operator most needs a way out of. An over-broad `enforce`
+    check denies the very shell action that would retire the ruling.
+
+    PROCESS ENVIRONMENT ONLY. Unlike the path accessors above it does NOT
+    fall back to `~/.daimon/env` (scar 0043 does not reach here). Those
+    mirror a location a writer and a deleter have to agree on; this is a
+    switch someone flips for one session, and a copy left on disk would keep
+    every later session disarmed with nothing on screen to say so."""
+    return os.environ.get("DAIMON_DISABLE", "").strip() in (
+        "1", "true", "yes", "on")
+
+
 def mode_for(profile, intent) -> str:
     """The mode this host actually delivers for that intent.
 
@@ -362,6 +382,11 @@ def decide(profile, payload, *, manifest=None, timeout=None,
 
 
 def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
+    if disabled():
+        # Before the manifest read, before the payload is even looked at: a
+        # disabled hook costs one environment read and leaves no trace. No
+        # row either, because nothing ran and nothing declined to run.
+        return Decision("", "", 0, rows)
     rt = runtime()
     if rt is None:
         # Nothing to check WITH, and nothing to write a row with either. The
@@ -499,6 +524,11 @@ def main(host, stdin=None, stdout=None, stderr=None) -> int:
         return 0
     rt = runtime()
     try:
+        if disabled():
+            # `decide` checks this too. Here as well because the missing-
+            # runtime diagnostic below never reaches it, and a hook the
+            # operator turned off must not still be talking to the host.
+            return 0
         if rt is None:
             # Nothing to check with and nothing to write a row with. Say so
             # where the host has a channel for it; a warn that degrades below

--- a/hook/checks_host.py
+++ b/hook/checks_host.py
@@ -489,8 +489,17 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # that did not, and reading it the other way blocks actions nobody
         # armed to block.
         deciding = max((mode for _, mode, _ in failing), key=MODES.index)
+        # Only the failures AT OR ABOVE the deciding mode are spoken aloud. A
+        # `record-only` check asked for the log and nothing else, and a
+        # neighbour that failed at a stronger mode must not carry its reason
+        # out on its behalf. On Codex that is the whole point of the cap:
+        # `warn` degrades to `record-only` there so nothing is shown that the
+        # host never rendered, and a second check the author did not control
+        # would otherwise defeat it.
+        floor = MODES.index(deciding)
         text = "\n".join(_failure_line(entry, outcome)
-                         for entry, _, outcome in failing)
+                         for entry, mode, outcome in failing
+                         if MODES.index(mode) >= floor)
         if deciding == "enforce":
             decision = "deny"
         elif deciding == "warn":

--- a/hook/checks_runtime.py
+++ b/hook/checks_runtime.py
@@ -187,6 +187,26 @@ def log_dir() -> Path:
     return Path.home() / ".daimon" / "logs"
 
 
+def check_timeout() -> float:
+    """Mirror of config.check_timeout(): the runner's own budget in seconds.
+
+    The hook is the caller that most needs it. A budget configured for the
+    CLI and ignored by the hook means the operator who lowered it to fit a
+    slow machine still loses the action to the HOST's timeout, which is
+    fail-open, and nothing anywhere says why.
+
+    Quirk-faithful per scar 0043, including the parts that read like bugs: a
+    present-but-unparseable value falls back to the default instead of
+    raising, and the floor keeps the smallest configured budget an actual
+    budget rather than an unconditional timeout. DEFAULT_TIMEOUT below is
+    this same number for the path where no configuration is consulted at
+    all."""
+    try:
+        return max(0.5, float(_config_get("DAIMON_CHECK_TIMEOUT") or "5"))
+    except ValueError:
+        return 5.0
+
+
 # ---- manifest -------------------------------------------------------------
 
 

--- a/hook/codex-hooks.py
+++ b/hook/codex-hooks.py
@@ -24,6 +24,10 @@ HOOKS_JSON = CODEX_DIR / "hooks.json"
 # Shared helper module the hook scripts import by same-dir lookup. Copied
 # alongside them on install; removed on uninstall once no daimon hook remains.
 LIB = "_daimon_hook_lib.py"
+# #943: the pre-action hook loads checks_host.py from its own directory and
+# that loads checks_runtime.py the same way. A script installed without them
+# is a hook that finds nothing and allows in silence.
+MODULES = (LIB, "checks_runtime.py", "checks_host.py")
 
 HOOKS = [
     {
@@ -66,6 +70,24 @@ HOOKS = [
             }],
         },
     },
+    {
+        # #943: the pre-action check. `matcher` keeps it to shell actions,
+        # which Codex names both ways depending on the build. No
+        # statusMessage: the other three fire once a session, this one fires
+        # before every command. Timeout 10 against a runner budget of 5, so
+        # the runner decides before Codex gives up and lets the action
+        # through.
+        "script": "daimon-codex-pre-action.py",
+        "event": "PreToolUse",
+        "entry": {
+            "matcher": "Bash|shell",
+            "hooks": [{
+                "type": "command",
+                "command": "python3 ~/.codex/hooks/daimon-codex-pre-action.py",
+                "timeout": 10,
+            }],
+        },
+    },
 ]
 
 
@@ -93,29 +115,31 @@ def is_ours(group, script):
 
 
 def install_lib(dry):
-    src, dst = SRC_DIR / LIB, HOOKS_DIR / LIB
-    same = dst.exists() and src.read_bytes() == dst.read_bytes()
-    action = "up-to-date" if same else ("update" if dst.exists() else "copy")
-    print(f"[{LIB}] library: {action}")
-    if not same and not dry:
-        shutil.copy2(src, dst)
+    for name in MODULES:
+        src, dst = SRC_DIR / name, HOOKS_DIR / name
+        same = dst.exists() and src.read_bytes() == dst.read_bytes()
+        action = "up-to-date" if same else ("update" if dst.exists() else "copy")
+        print(f"[{name}] library: {action}")
+        if not same and not dry:
+            shutil.copy2(src, dst)
 
 
 def uninstall_lib(dry):
-    # Remove the shared library only once no daimon hook script remains in the
+    # Remove the shared modules only once no daimon hook script remains in the
     # dir. `remaining` excludes THIS manager's scripts (removed above), so it
     # counts only foreign daimon-*.py — correct under --dry-run too.
-    dst = HOOKS_DIR / LIB
-    if not dst.exists():
-        return
     ours = {spec["script"] for spec in HOOKS}
     remaining = [p.name for p in HOOKS_DIR.glob("daimon-*.py") if p.name not in ours]
-    if remaining:
-        print(f"[{LIB}] library: kept ({len(remaining)} other daimon hook(s) present)")
-        return
-    print(f"[{LIB}] library: remove {dst}")
-    if not dry:
-        dst.unlink()
+    for name in MODULES:
+        dst = HOOKS_DIR / name
+        if not dst.exists():
+            continue
+        if remaining:
+            print(f"[{name}] library: kept ({len(remaining)} other daimon hook(s) present)")
+            continue
+        print(f"[{name}] library: remove {dst}")
+        if not dry:
+            dst.unlink()
 
 
 def install(dry):

--- a/hook/daimon-codex-pre-action.py
+++ b/hook/daimon-codex-pre-action.py
@@ -47,6 +47,12 @@ def _load_core():
 def main() -> int:
     core = _load_core()
     if core is None:
+        # Silent, and that is the profile rather than an oversight: Codex
+        # documents no message channel, so a diagnostic addressed to one
+        # would be text on a stream the operator never sees, on a host that
+        # parses that stream. The Claude Code sibling of this script does
+        # emit one. The firing log would be the honest surface here, and
+        # there is no runtime loaded to write it with.
         return 0
     return core.main("codex")
 

--- a/hook/daimon-codex-pre-action.py
+++ b/hook/daimon-codex-pre-action.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Daimon pre-action check hook for Codex (#943), PreToolUse on a shell action.
+
+THIS IS THE FIRST DAIMON HOOK THAT CAN FAIL A HOST ACTION. Every other hook
+in this directory observes a session and cannot change it. This one runs
+before a shell action and, when a ruling a human ratified carries a check
+armed to enforce and that check finds a violation, it returns the host's
+structured deny and the action does not run.
+
+Everything it decides lives in `checks_host.py`, loaded from THIS file's own
+directory by file location, never by name off `sys.path`. A host is a profile
+row there; this script is the row's name and nothing else. If you are looking
+for the decision logic, the mode table or the JSON shapes, they are there.
+
+Output contract: stdout is empty or exactly one JSON object, stderr is empty,
+and the exit code is always 0. Codex documents exit 2 as an
+unconditional block, so an escaping exception that happened to exit non-zero
+would block an action no check ever judged. The deny is the deliberate path.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_core():
+    """The shared adapter core from beside this file, or None.
+
+    File-location import (never `import checks_host`) so it never depends on
+    `sys.path` state and never collides with an unrelated top-level module.
+    None is a partial install: the hook then says nothing at all, because
+    there is nothing to check with and a traceback before every shell action
+    is worse than the missing check it would be reporting."""
+    path = Path(__file__).resolve().parent / "checks_host.py"
+    if not path.exists():
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_daimon_checks_host", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    except Exception:  # noqa: BLE001 — a broken module must never crash a hook
+        return None
+
+
+def main() -> int:
+    core = _load_core()
+    if core is None:
+        return 0
+    return core.main("codex")
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:  # noqa: BLE001 — fail open, and silently: stdout is
+        # parsed as JSON by the host, so a diagnostic printed there is a
+        # decision it cannot read.
+        sys.exit(0)

--- a/hook/daimon-hooks.py
+++ b/hook/daimon-hooks.py
@@ -4,6 +4,7 @@
 Manages the daimon hooks in ~/.claude/ (Claude Code):
   - daimon-session-brief.py  SessionStart  inject the latest checkpoint briefing
   - daimon-session-end.py    SessionEnd    serialize the ending session (detached)
+  - daimon-pre-action.py     PreToolUse    run armed checks before a shell action
 
 Same shape as SCAR's scar-hooks.py: idempotent install (skips/updates existing
 entries), uninstall removes only daimon-owned entries (matched by script
@@ -28,9 +29,15 @@ CLAUDE_DIR = Path.home() / ".claude"
 HOOKS_DIR = CLAUDE_DIR / "hooks"
 SETTINGS = CLAUDE_DIR / "settings.json"
 
-# Shared helper module the hook scripts import by same-dir lookup. Copied
-# alongside them on install; removed on uninstall once no daimon hook remains.
+# Shared modules the hook scripts import by same-dir lookup. Copied alongside
+# them on install; removed on uninstall once no daimon hook remains.
+#
+# #943 added the second and third: the pre-action hook loads checks_host.py
+# from its own directory, and that loads checks_runtime.py the same way. A
+# script installed without them is a hook that finds nothing and allows in
+# silence, which is the shape this list exists to prevent.
 LIB = "_daimon_hook_lib.py"
+MODULES = (LIB, "checks_runtime.py", "checks_host.py")
 
 HOOKS = [
     {
@@ -54,6 +61,26 @@ HOOKS = [
                 "command": "python3 ~/.claude/hooks/daimon-session-end.py",
                 "timeout": 10,
                 "statusMessage": "Writing daimon checkpoint...",
+            }],
+        },
+    },
+    {
+        # #943: the pre-action check. This path is the hand install, and it
+        # gets the gate too — a gate that exists on the marketplace path and
+        # not this one is a machine that believes it is guarded.
+        #
+        # `matcher` keeps it to shell actions: without it the hook fires
+        # before every tool call and pays a manifest read for each. No
+        # statusMessage, because the other two fire once a session and this
+        # one fires before every command.
+        "script": "daimon-pre-action.py",
+        "event": "PreToolUse",
+        "entry": {
+            "matcher": "Bash",
+            "hooks": [{
+                "type": "command",
+                "command": "python3 ~/.claude/hooks/daimon-pre-action.py",
+                "timeout": 10,
             }],
         },
     },
@@ -88,29 +115,31 @@ def is_ours(group, script):
 
 
 def install_lib(dry):
-    src, dst = SRC_DIR / LIB, HOOKS_DIR / LIB
-    same = dst.exists() and src.read_bytes() == dst.read_bytes()
-    action = "up-to-date" if same else ("update" if dst.exists() else "copy")
-    print(f"[{LIB}] library: {action}")
-    if not same and not dry:
-        shutil.copy2(src, dst)
+    for name in MODULES:
+        src, dst = SRC_DIR / name, HOOKS_DIR / name
+        same = dst.exists() and src.read_bytes() == dst.read_bytes()
+        action = "up-to-date" if same else ("update" if dst.exists() else "copy")
+        print(f"[{name}] library: {action}")
+        if not same and not dry:
+            shutil.copy2(src, dst)
 
 
 def uninstall_lib(dry):
-    # Remove the shared library only once no daimon hook script remains in the
+    # Remove the shared modules only once no daimon hook script remains in the
     # dir. `remaining` excludes THIS manager's scripts (removed above), so it
     # counts only foreign daimon-*.py — correct under --dry-run too.
-    dst = HOOKS_DIR / LIB
-    if not dst.exists():
-        return
     ours = {spec["script"] for spec in HOOKS}
     remaining = [p.name for p in HOOKS_DIR.glob("daimon-*.py") if p.name not in ours]
-    if remaining:
-        print(f"[{LIB}] library: kept ({len(remaining)} other daimon hook(s) present)")
-        return
-    print(f"[{LIB}] library: remove {dst}")
-    if not dry:
-        dst.unlink()
+    for name in MODULES:
+        dst = HOOKS_DIR / name
+        if not dst.exists():
+            continue
+        if remaining:
+            print(f"[{name}] library: kept ({len(remaining)} other daimon hook(s) present)")
+            continue
+        print(f"[{name}] library: remove {dst}")
+        if not dry:
+            dst.unlink()
 
 
 def install(dry):

--- a/hook/daimon-pre-action.py
+++ b/hook/daimon-pre-action.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Daimon pre-action check hook for Claude Code (#943), PreToolUse on Bash.
+
+THIS IS THE FIRST DAIMON HOOK THAT CAN FAIL A HOST ACTION. Every other hook
+in this directory observes a session and cannot change it. This one runs
+before a shell action and, when a ruling a human ratified carries a check
+armed to enforce and that check finds a violation, it returns the host's
+structured deny and the action does not run.
+
+Everything it decides lives in `checks_host.py`, loaded from THIS file's own
+directory by file location, never by name off `sys.path`. A host is a profile
+row there; this script is the row's name and nothing else. If you are looking
+for the decision logic, the mode table or the JSON shapes, they are there.
+
+Output contract: stdout is empty or exactly one JSON object, stderr is empty,
+and the exit code is always 0. Claude Code documents exit 2 as an
+unconditional block, so an escaping exception that happened to exit non-zero
+would block an action no check ever judged. The deny is the deliberate path.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_core():
+    """The shared adapter core from beside this file, or None.
+
+    File-location import (never `import checks_host`) so it never depends on
+    `sys.path` state and never collides with an unrelated top-level module.
+    None is a partial install: the hook then says nothing at all, because
+    there is nothing to check with and a traceback before every shell action
+    is worse than the missing check it would be reporting."""
+    path = Path(__file__).resolve().parent / "checks_host.py"
+    if not path.exists():
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_daimon_checks_host", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    except Exception:  # noqa: BLE001 — a broken module must never crash a hook
+        return None
+
+
+def main() -> int:
+    core = _load_core()
+    if core is None:
+        return 0
+    return core.main("claude-code")
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:  # noqa: BLE001 — fail open, and silently: stdout is
+        # parsed as JSON by the host, so a diagnostic printed there is a
+        # decision it cannot read.
+        sys.exit(0)

--- a/hook/daimon-pre-action.py
+++ b/hook/daimon-pre-action.py
@@ -19,6 +19,7 @@ would block an action no check ever judged. The deny is the deliberate path.
 """
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -44,9 +45,28 @@ def _load_core():
         return None
 
 
+# The one thing this script can say without the core, and the only thing it
+# ever says on its own: an allow reporting that it could not load the core.
+# A missing runtime already announced itself this way; a missing CORE said
+# nothing at all, and both are the same fact, a partial or half-upgraded
+# install. Silence there is byte-identical to a clean allow.
+CORE_MISSING = "daimon: check core missing, nothing enforced"
+
+
 def main() -> int:
     core = _load_core()
     if core is None:
+        # Built here rather than read off a profile, because the profile
+        # lives in the file that is missing. Claude Code renders
+        # systemMessage; the Codex sibling of this script stays silent
+        # instead, because Codex documents no channel for one.
+        sys.stdout.write(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "allow",
+            },
+            "systemMessage": CORE_MISSING,
+        }, sort_keys=True))
         return 0
     return core.main("claude-code")
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -34,6 +34,18 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}\"/hook/daimon-pre-action.py",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugin/daimon_briefing/_hooks/checks_host.py
+++ b/plugin/daimon_briefing/_hooks/checks_host.py
@@ -26,6 +26,7 @@ proceeds and nothing anywhere says why.
 """
 
 import importlib.util
+import json
 from pathlib import Path
 from typing import NamedTuple
 
@@ -71,6 +72,13 @@ INTENTS = ("enforce", "warn", "record-only")
 
 # The decision encoders a profile may name.
 ENCODERS = ("json-permission", "exit2-stderr")
+
+# What the hook actually tells the host, and therefore what reaches the
+# firing log's `decision_emitted`. A record-only mode still emits `allow`:
+# nothing was written to the host, and the `mode` column is where "this only
+# went to the log" is already said. Claiming a fourth word here would report
+# a channel the host was never given.
+DECISIONS = ("allow", "warn", "deny")
 
 
 class Profile(NamedTuple):
@@ -170,3 +178,84 @@ def mode_for(profile, intent) -> str:
     asked = intent if intent in INTENTS else "record-only"
     mode = caps.get(asked, "unsupported")
     return mode if mode in MODES else "unsupported"
+
+
+# ---- encoders (spec section 4) -------------------------------------------
+
+
+class Emission(NamedTuple):
+    """What the hook writes and what it exits with.
+
+    Three channels because the hosts do not agree on one. Claude Code and
+    Codex read a JSON object on stdout and treat a non-zero exit as a hook
+    error; Windsurf documents exit 2 with the reason on stderr. Carrying all
+    three keeps the Windsurf row a row rather than a special case, and the
+    tests pin stderr empty and the exit code 0 on every path of the two
+    hosts that actually ship a script."""
+
+    stdout: str
+    stderr: str
+    exit_code: int
+
+
+_SILENT = Emission("", "", 0)
+
+
+def _encode_json_permission(profile, decision, text) -> Emission:
+    """The measured path on Claude Code and Codex: one JSON object, exit 0.
+
+    The key names are the host's contract, so they are pinned byte for byte
+    by a literal comparison in the tests. A rename here is a deny that
+    silently becomes an allow, and a parsed-dict assertion would not see it.
+
+    A silent allow writes NOTHING rather than an object saying `allow`: the
+    hosts treat absent output as no opinion, and an object claiming a
+    decision is a decision daimon did not make."""
+    event = str(getattr(profile, "event", "") or "")
+    if decision == "deny":
+        return Emission(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": event,
+                "permissionDecision": "deny",
+                "permissionDecisionReason": text,
+            },
+        }, sort_keys=True), "", 0)
+    if decision == "warn" and text:
+        return Emission(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": event,
+                "permissionDecision": "allow",
+            },
+            "systemMessage": text,
+        }, sort_keys=True), "", 0)
+    return _SILENT
+
+
+def _encode_exit2_stderr(profile, decision, text) -> Emission:
+    """Windsurf's documented channel, unmeasured. Reachable only once a
+    Windsurf profile has a mode above `unsupported`, which is after a live
+    probe; until then this exists so the row is complete and its shape is
+    pinned by a test rather than discovered on someone's machine."""
+    if decision not in ("deny", "warn") or not text:
+        return _SILENT
+    return Emission("", text + "\n", 2 if decision == "deny" else 0)
+
+
+_ENCODERS = {
+    "json-permission": _encode_json_permission,
+    "exit2-stderr": _encode_exit2_stderr,
+}
+
+
+def encode(profile, decision, text) -> Emission:
+    """Render one decision the way this host reads it.
+
+    An unknown decision word or an unknown encoder name is a silent allow,
+    never a deny: a value this build does not recognise must not become the
+    strongest thing the host can be asked to do."""
+    if decision not in DECISIONS:
+        return _SILENT
+    fn = _ENCODERS.get(str(getattr(profile, "encoder", "")))
+    if fn is None:
+        return _SILENT
+    return fn(profile, decision, str(text or ""))

--- a/plugin/daimon_briefing/_hooks/checks_host.py
+++ b/plugin/daimon_briefing/_hooks/checks_host.py
@@ -28,6 +28,8 @@ proceeds and nothing anywhere says why.
 import importlib.util
 import json
 import os
+import re
+import shlex
 import sys
 import time
 from pathlib import Path
@@ -375,6 +377,44 @@ def _failure_line(entry, outcome) -> str:
     return f"{ruling_id}: {reason}"
 
 
+def _command_text(raw):
+    """The action's command string, or None when there is no command, or the
+    Unresolved cause when there is one daimon cannot read.
+
+    Some hosts send the shell tool's command as an argv array. Read as "no
+    command", every armed check on such a host goes silently inert while the
+    liveness surface reads "armed, never fired", which is the phrase reserved
+    for a wired install that nothing has matched yet. It is joined with shell
+    quoting rather than with a space, because an argument holding a space
+    would otherwise become two arguments in the subject and the check would
+    be judging a command nobody ran."""
+    if isinstance(raw, str):
+        return raw or None
+    if isinstance(raw, list):
+        if raw and all(isinstance(part, str) for part in raw):
+            return shlex.join(raw)
+        return ("arg-form-unparsed",
+                "the host sent a command daimon could not read as text")
+    return None
+
+
+def _match_state(rt, entry, command) -> str:
+    """`hit`, `miss`, or `broken` for one entry's pattern.
+
+    `rt.matches` folds an uncompilable pattern into False, which is right for
+    it and wrong here: "a regex that cannot compile" and "a regex that did
+    not match" are different facts and only one of them was countable.
+    `refutations` compiles the pattern at propose time, so a broken one
+    reaches this point only through a hand-edited manifest."""
+    pattern = entry.get("match")
+    if isinstance(pattern, str) and pattern:
+        try:
+            re.compile(pattern)
+        except (re.error, RecursionError):
+            return "broken"
+    return "hit" if rt.matches(entry, command) else "miss"
+
+
 def decide(profile, payload, *, manifest=None, timeout=None,
            now=None) -> Decision:
     """Run this action's armed checks and say what the host should be told.
@@ -408,8 +448,18 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         payload = {}
     if not _accepts(profile, payload):
         return Decision("", "", 0, rows)
-    command = _dig(payload, getattr(profile, "command_path", ()))
-    if not isinstance(command, str) or not command:
+    command = _command_text(_dig(payload, getattr(profile, "command_path",
+                                                  ())))
+    stamp = _stamp(now)
+    if isinstance(command, tuple):
+        # A command that is present and unreadable, which is not the same as
+        # absent. It gets a row so the state is countable; the action is
+        # allowed because nothing was armed against anything yet.
+        cause, _ = command
+        rows.append(_row(profile, stamp, cause=cause, outcome="unresolved",
+                         decision="allow"))
+        return Decision("", "", 0, rows)
+    if command is None:
         # Not a row: nothing ran and nothing declined to run. A row for every
         # payload without a command would make the firing log a transcript of
         # the session rather than a record of checks.
@@ -421,7 +471,6 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # host launched stands in the action's directory anyway, and arming
         # nothing would disarm every check for that action in silence.
         cwd = os.getcwd()
-    stamp = _stamp(now)
 
     loaded = rt.load_manifest() if manifest is None else manifest
     reason = getattr(loaded, "reason", "")
@@ -433,12 +482,25 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         rows.append(_row(profile, stamp, cause=reason, decision="allow"))
         return Decision("", "", 0, rows)
 
+    try:
+        os.path.realpath(cwd)
+    except (OSError, ValueError):
+        # `armed_for` folds this into an empty list, which would come out as
+        # `no-match`. That cause says every armed check was compared and none
+        # applied; here nothing was compared at all.
+        rows.append(_row(profile, stamp, cause="file-unreadable",
+                         outcome="unresolved", decision="allow"))
+        return Decision("", "", 0, rows)
+
     entries = rt.armed_for(cwd, loaded)
     if not entries:
         rows.append(_row(profile, stamp, cause="no-match", decision="allow"))
         return Decision("", "", 0, rows)
 
-    matching = [entry for entry in entries if rt.matches(entry, command)]
+    matching = [(entry, _match_state(rt, entry, command))
+                for entry in entries]
+    matching = [(entry, state) for entry, state in matching
+                if state != "miss"]
     if not matching:
         # The prefilter is what makes a hook on every shell action
         # affordable, and spec 3.1 names only the two project-level causes.
@@ -450,14 +512,26 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
 
     # Once, for every matching check. The subject cannot change between two
     # entries of the same action, and reading every file argument again would
-    # spend a budget the host will not extend.
-    subject = rt.resolve(command, cwd)
+    # spend a budget the host will not extend. Skipped entirely when every
+    # matching entry carries a pattern that will not compile: there is
+    # nothing to run against them, and the resolve is the expensive half.
+    subject = (rt.resolve(command, cwd)
+               if any(state == "hit" for _, state in matching) else None)
     results = []
     try:
-        for entry in matching:
+        for entry, state in matching:
             mode = mode_for(profile, entry.get("intent"))
             left = deadline - time.monotonic()
-            if isinstance(subject, rt.Unresolved):
+            if state == "broken":
+                # The manifest names a pattern daimon cannot compile, so this
+                # check cannot be applied at all. `unresolved`, which under
+                # `enforce` denies: a rule nobody can evaluate is not a rule
+                # that passed.
+                outcome = rt.Outcome(
+                    "unresolved", "check-crashed",
+                    "this ruling's match pattern could not be compiled; run "
+                    "`daimon check sync`", -1, 0)
+            elif isinstance(subject, rt.Unresolved):
                 outcome = rt.Outcome("unresolved", subject.cause,
                                      subject.reason, -1, 0)
             elif left <= 0:
@@ -474,14 +548,26 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
             else:
                 outcome = rt.run(entry, subject, cwd=cwd,
                                  timeout=min(per_check, left))
-            results.append((entry, mode, outcome))
+            # Appended as it is decided, not after the loop. `rt.run` is
+            # documented never to raise, and this is the case where the
+            # record matters most if it ever does: an earlier check's
+            # violation is the only evidence of what happened. The row is
+            # stamped `allow` and corrected below for the ones that failed,
+            # so a row that escapes through an exception says what the host
+            # actually got, which is nothing.
+            row = _row(profile, stamp, ruling_id=entry.get("ruling_id"),
+                       mode=mode, outcome=outcome.outcome,
+                       cause=outcome.cause, decision="allow",
+                       duration_ms=outcome.duration_ms)
+            rows.append(row)
+            results.append((entry, mode, outcome, row))
     finally:
         # The subject holds the command and every file it named. A `finally`
         # is the only placement that survives an exception nobody predicted.
         rt.discard(subject)
 
-    failing = [(index, entry, mode, outcome)
-               for index, (entry, mode, outcome) in enumerate(results)
+    failing = [(entry, mode, outcome, row)
+               for entry, mode, outcome, row in results
                if outcome.outcome in ("violation", "unresolved")]
     decision, text = "allow", ""
     if failing:
@@ -489,7 +575,7 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # An enforce check that passed has nothing to say about a warn check
         # that did not, and reading it the other way blocks actions nobody
         # armed to block.
-        deciding = max((mode for _, _, mode, _ in failing), key=MODES.index)
+        deciding = max((mode for _, mode, _, _ in failing), key=MODES.index)
         # Only the failures AT OR ABOVE the deciding mode are spoken aloud. A
         # `record-only` check asked for the log and nothing else, and a
         # neighbour that failed at a stronger mode must not carry its reason
@@ -499,7 +585,7 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # would otherwise defeat it.
         floor = MODES.index(deciding)
         text = "\n".join(_failure_line(entry, outcome)
-                         for _, entry, mode, outcome in failing
+                         for entry, mode, outcome, _ in failing
                          if MODES.index(mode) >= floor)
         if deciding == "enforce":
             decision = "deny"
@@ -507,20 +593,14 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
             decision = "warn"
 
     emission = encode(profile, decision, text)
-    failed = {index for index, _, _, _ in failing}
-    for index, (entry, mode, outcome) in enumerate(results):
-        # One action produces one decision, but the log row is per CHECK, so
-        # the row records what THIS check contributed. A check that passed
-        # records `allow`: it did not deny anything, and a clean row stamped
-        # `deny` satisfies the "only a deny under enforce proves it was
-        # honored" filter while proving nothing of the kind. The stats
-        # surface counts these rows.
-        rows.append(_row(profile, stamp, ruling_id=entry.get("ruling_id"),
-                         mode=mode, outcome=outcome.outcome,
-                         cause=outcome.cause,
-                         decision=decision if index in failed
-                         else "allow",
-                         duration_ms=outcome.duration_ms))
+    # One action produces one decision, but the log row is per CHECK, so the
+    # row records what THIS check contributed. A check that passed keeps the
+    # `allow` it was written with: it denied nothing, and a clean row stamped
+    # `deny` satisfies the "only a deny under enforce proves it was honored"
+    # filter while proving nothing of the kind. The stats surface counts
+    # these rows.
+    for _entry, _mode, _outcome, row in failing:
+        row["decision_emitted"] = decision
     return Decision(emission.stdout, emission.stderr, emission.exit_code, rows)
 
 

--- a/plugin/daimon_briefing/_hooks/checks_host.py
+++ b/plugin/daimon_briefing/_hooks/checks_host.py
@@ -509,7 +509,14 @@ def main(host, stdin=None, stdout=None, stderr=None) -> int:
             return 0
         decision = decide(profile, _read_payload(stdin))
         for row in decision.rows:
-            rt.log_firing(row)
+            try:
+                rt.log_firing(row)
+            except Exception:  # noqa: BLE001
+                # `log_firing` promises not to raise, and this guard is what
+                # keeps that promise from being load-bearing. The row is
+                # bookkeeping; the deny is the thing the operator armed, and
+                # losing the decision over the record is the wrong trade.
+                pass
         out.write(decision.stdout)
         err.write(decision.stderr)
         return decision.exit_code

--- a/plugin/daimon_briefing/_hooks/checks_host.py
+++ b/plugin/daimon_briefing/_hooks/checks_host.py
@@ -570,6 +570,9 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
                for entry, mode, outcome, row in results
                if outcome.outcome in ("violation", "unresolved")]
     decision, text = "allow", ""
+    # Above every real mode until a failure sets it, so that with nothing
+    # failing no row qualifies for the stamp below.
+    floor = len(MODES)
     if failing:
         # The strongest FAILING mode decides, not the strongest mode present.
         # An enforce check that passed has nothing to say about a warn check
@@ -594,13 +597,17 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
 
     emission = encode(profile, decision, text)
     # One action produces one decision, but the log row is per CHECK, so the
-    # row records what THIS check contributed. A check that passed keeps the
-    # `allow` it was written with: it denied nothing, and a clean row stamped
-    # `deny` satisfies the "only a deny under enforce proves it was honored"
-    # filter while proving nothing of the kind. The stats surface counts
-    # these rows.
-    for _entry, _mode, _outcome, row in failing:
-        row["decision_emitted"] = decision
+    # row records what THIS check contributed. Two kinds of row keep the
+    # `allow` they were written with. A check that passed denied nothing, and
+    # a clean row stamped `deny` satisfies the "only a deny under enforce
+    # proves it was honored" filter while proving nothing of the kind. And a
+    # check that failed BELOW the deciding floor had its reason withheld from
+    # the host by its own mode, so it was never heard: stamping the decision
+    # on it claims a contribution to a block it was not allowed to speak in.
+    # The stats surface counts these rows.
+    for _entry, mode, _outcome, row in failing:
+        if MODES.index(mode) >= floor:
+            row["decision_emitted"] = decision
     return Decision(emission.stdout, emission.stderr, emission.exit_code, rows)
 
 

--- a/plugin/daimon_briefing/_hooks/checks_host.py
+++ b/plugin/daimon_briefing/_hooks/checks_host.py
@@ -28,6 +28,7 @@ proceeds and nothing anywhere says why.
 import importlib.util
 import json
 import os
+import sys
 import time
 from pathlib import Path
 from typing import NamedTuple
@@ -454,3 +455,72 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
                          cause=outcome.cause, decision=decision,
                          duration_ms=outcome.duration_ms))
     return Decision(emission.stdout, emission.stderr, emission.exit_code, rows)
+
+
+# ---- what the thin per-host scripts call ---------------------------------
+
+# Said on a host that renders a message channel, and only there. A host with
+# no channel for it would be told nothing either way, and the firing log is
+# the honest surface for that fact except that there is no runtime to write
+# it with, which is the state being reported.
+RUNTIME_MISSING = "daimon: check runtime missing, nothing enforced"
+
+
+def _read_payload(stream) -> dict:
+    """The host's payload, or an empty one. Unparseable stdin, a closed pipe
+    and a payload that is not an object are all the same fact here: this
+    process cannot see the action, so it has nothing to say about it."""
+    try:
+        raw = (stream if stream is not None else sys.stdin).read()
+    except Exception:  # noqa: BLE001
+        return {}
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def main(host, stdin=None, stdout=None, stderr=None) -> int:
+    """Run this host's pre-action check and write the decision.
+
+    The whole per-host script is a call to this with a profile name. Reads
+    the payload, decides, records every row, writes the encoded decision
+    once at the end, and returns the exit code the encoder chose, which is 0
+    for every host that ships a script today.
+
+    Writing stdout LAST and once is deliberate: a partial object on a host
+    that parses stdout is worse than no object, and an exception after a
+    first write could leave one."""
+    out = stdout if stdout is not None else sys.stdout
+    err = stderr if stderr is not None else sys.stderr
+    profile = PROFILES.get(host)
+    if profile is None:
+        return 0
+    rt = runtime()
+    try:
+        if rt is None:
+            # Nothing to check with and nothing to write a row with. Say so
+            # where the host has a channel for it; a warn that degrades below
+            # `warn` on this host has nowhere to go, so it goes nowhere.
+            if mode_for(profile, "warn") == "warn":
+                emission = encode(profile, "warn", RUNTIME_MISSING)
+                out.write(emission.stdout)
+            return 0
+        decision = decide(profile, _read_payload(stdin))
+        for row in decision.rows:
+            rt.log_firing(row)
+        out.write(decision.stdout)
+        err.write(decision.stderr)
+        return decision.exit_code
+    except Exception:  # noqa: BLE001 — the action must not die with the hook
+        # Nothing written, so the host sees no opinion and proceeds. The row
+        # is the only record that anything happened, and it is worth one more
+        # attempt that itself cannot raise.
+        if rt is not None:
+            try:
+                rt.log_firing(_row(profile, _stamp(None),
+                                   cause="check-crashed", decision="allow"))
+            except Exception:  # noqa: BLE001
+                pass
+        return 0

--- a/plugin/daimon_briefing/_hooks/checks_host.py
+++ b/plugin/daimon_briefing/_hooks/checks_host.py
@@ -27,6 +27,8 @@ proceeds and nothing anywhere says why.
 
 import importlib.util
 import json
+import os
+import time
 from pathlib import Path
 from typing import NamedTuple
 
@@ -259,3 +261,196 @@ def encode(profile, decision, text) -> Emission:
     if fn is None:
         return _SILENT
     return fn(profile, decision, str(text or ""))
+
+
+# ---- the pipeline (spec sections 3.1, 3.4 and 5) -------------------------
+
+# Where a host names the tool it is about to run. Both hosts that filter by
+# tool name spell it this way. A host that spells it differently declares an
+# empty `tool_names` and is selected by its `command_path` alone, which is
+# what the Windsurf row does.
+TOOL_NAME_KEY = "tool_name"
+
+
+class Decision(NamedTuple):
+    """What one action's checks came to.
+
+    `rows` are firing-log rows, built to `FIRING_KEYS` and not yet written:
+    `decide` decides, `main` records. Keeping the write out of here is what
+    lets the whole matrix be tested without a log on disk, and what keeps a
+    failed write from costing the decision."""
+
+    stdout: str
+    stderr: str
+    exit_code: int
+    rows: list
+
+
+def _dig(payload, path):
+    """Walk a path into a payload, or None. A host payload field is a CLAIM
+    (scar 0068): any step may be missing or may not be a mapping at all, and
+    each of those is an action daimon cannot see rather than a crash."""
+    current = payload
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _accepts(profile, payload) -> bool:
+    """Whether this payload names a shell action on this host. An empty
+    `tool_names` accepts anything, because the host already selected by
+    event."""
+    names: frozenset = getattr(profile, "tool_names", frozenset())
+    if not names:
+        return True
+    return _dig(payload, (TOOL_NAME_KEY,)) in names
+
+
+def _row(profile, ts, *, ruling_id="", mode="", outcome="", cause="",
+         decision="allow", duration_ms=0) -> dict:
+    """One firing-log row, in the declared shape. `log_firing` PROJECTS onto
+    FIRING_KEYS, so a row built with a stray field loses it in silence;
+    building to the shape here keeps the two ends one declaration."""
+    return {
+        "ts": ts,
+        "ruling_id": str(ruling_id or ""),
+        "host": str(getattr(profile, "host", "") or ""),
+        "mode": mode,
+        "outcome": outcome,
+        "cause": cause,
+        "decision_emitted": decision,
+        "duration_ms": int(duration_ms or 0),
+    }
+
+
+def _stamp(now) -> str:
+    if isinstance(now, str) and now:
+        return now
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _failure_line(entry, outcome) -> str:
+    """`<ruling_id>: <reason>`, with the cause in front when daimon could not
+    read what the action sends. The cause is what tells a human whether to
+    fix the command or fix the check."""
+    ruling_id = str(entry.get("ruling_id") or "")
+    reason = outcome.reason or "the check reported a violation and gave no reason"
+    if outcome.outcome == "unresolved" and outcome.cause:
+        reason = f"{outcome.cause}: {reason}"
+    return f"{ruling_id}: {reason}"
+
+
+def decide(profile, payload, *, manifest=None, timeout=None,
+           now=None) -> Decision:
+    """Run this action's armed checks and say what the host should be told.
+
+    Never raises. It fires before every shell action, and on the hosts
+    measured so far a hook that crashes is fail-open: the action proceeds and
+    nothing anywhere says why. An exception on the way through still returns
+    an allow, with the rows already gathered plus one saying the machinery
+    was what failed."""
+    rows: list = []
+    try:
+        return _decide(profile, payload, manifest, timeout, now, rows)
+    except Exception:  # noqa: BLE001 — a decision is mandatory
+        rows.append(_row(profile, _stamp(now), cause="check-crashed",
+                         decision="allow"))
+        return Decision("", "", 0, rows)
+
+
+def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
+    rt = runtime()
+    if rt is None:
+        # Nothing to check WITH, and nothing to write a row with either. The
+        # caller owns the diagnostic; see `main`.
+        return Decision("", "", 0, rows)
+    if not isinstance(payload, dict):
+        payload = {}
+    if not _accepts(profile, payload):
+        return Decision("", "", 0, rows)
+    command = _dig(payload, getattr(profile, "command_path", ()))
+    if not isinstance(command, str) or not command:
+        # Not a row: nothing ran and nothing declined to run. A row for every
+        # payload without a command would make the firing log a transcript of
+        # the session rather than a record of checks.
+        return Decision("", "", 0, rows)
+
+    cwd = payload.get(getattr(profile, "cwd_key", ""))
+    if not isinstance(cwd, str) or not cwd:
+        # The host is supposed to send it. When it does not, the process the
+        # host launched stands in the action's directory anyway, and arming
+        # nothing would disarm every check for that action in silence.
+        cwd = os.getcwd()
+    stamp = _stamp(now)
+
+    loaded = rt.load_manifest() if manifest is None else manifest
+    reason = getattr(loaded, "reason", "")
+    if reason:
+        # Spec 3.1: "nothing is armed here" has to be countable, so the stats
+        # surface can say "armed, never fired" instead of "clean". An install
+        # that armed nothing and a manifest daimon can no longer parse are
+        # different facts and keep different causes.
+        rows.append(_row(profile, stamp, cause=reason, decision="allow"))
+        return Decision("", "", 0, rows)
+
+    entries = rt.armed_for(cwd, loaded)
+    if not entries:
+        rows.append(_row(profile, stamp, cause="no-match", decision="allow"))
+        return Decision("", "", 0, rows)
+
+    matching = [entry for entry in entries if rt.matches(entry, command)]
+    if not matching:
+        # The prefilter is what makes a hook on every shell action
+        # affordable, and spec 3.1 names only the two project-level causes.
+        return Decision("", "", 0, rows)
+
+    budget = (float(timeout) if isinstance(timeout, (int, float))
+              and timeout > 0 else rt.check_timeout())
+
+    # Once, for every matching check. The subject cannot change between two
+    # entries of the same action, and reading every file argument again would
+    # spend a budget the host will not extend.
+    subject = rt.resolve(command, cwd)
+    results = []
+    try:
+        for entry in matching:
+            mode = mode_for(profile, entry.get("intent"))
+            if isinstance(subject, rt.Unresolved):
+                outcome = rt.Outcome("unresolved", subject.cause,
+                                     subject.reason, -1, 0)
+            else:
+                outcome = rt.run(entry, subject, cwd=cwd, timeout=budget)
+            results.append((entry, mode, outcome))
+    finally:
+        # The subject holds the command and every file it named. A `finally`
+        # is the only placement that survives an exception nobody predicted.
+        rt.discard(subject)
+
+    failing = [(entry, mode, outcome) for entry, mode, outcome in results
+               if outcome.outcome in ("violation", "unresolved")]
+    decision, text = "allow", ""
+    if failing:
+        # The strongest FAILING mode decides, not the strongest mode present.
+        # An enforce check that passed has nothing to say about a warn check
+        # that did not, and reading it the other way blocks actions nobody
+        # armed to block.
+        deciding = max((mode for _, mode, _ in failing), key=MODES.index)
+        text = "\n".join(_failure_line(entry, outcome)
+                         for entry, _, outcome in failing)
+        if deciding == "enforce":
+            decision = "deny"
+        elif deciding == "warn":
+            decision = "warn"
+
+    emission = encode(profile, decision, text)
+    for entry, mode, outcome in results:
+        # `mode` is this entry's; `decision_emitted` is the ACTION's. One
+        # action produces one decision, and the row that claimed otherwise
+        # would report a deny the host never received.
+        rows.append(_row(profile, stamp, ruling_id=entry.get("ruling_id"),
+                         mode=mode, outcome=outcome.outcome,
+                         cause=outcome.cause, decision=decision,
+                         duration_ms=outcome.duration_ms))
+    return Decision(emission.stdout, emission.stderr, emission.exit_code, rows)

--- a/plugin/daimon_briefing/_hooks/checks_host.py
+++ b/plugin/daimon_briefing/_hooks/checks_host.py
@@ -480,7 +480,8 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # is the only placement that survives an exception nobody predicted.
         rt.discard(subject)
 
-    failing = [(entry, mode, outcome) for entry, mode, outcome in results
+    failing = [(index, entry, mode, outcome)
+               for index, (entry, mode, outcome) in enumerate(results)
                if outcome.outcome in ("violation", "unresolved")]
     decision, text = "allow", ""
     if failing:
@@ -488,7 +489,7 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # An enforce check that passed has nothing to say about a warn check
         # that did not, and reading it the other way blocks actions nobody
         # armed to block.
-        deciding = max((mode for _, mode, _ in failing), key=MODES.index)
+        deciding = max((mode for _, _, mode, _ in failing), key=MODES.index)
         # Only the failures AT OR ABOVE the deciding mode are spoken aloud. A
         # `record-only` check asked for the log and nothing else, and a
         # neighbour that failed at a stronger mode must not carry its reason
@@ -498,7 +499,7 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # would otherwise defeat it.
         floor = MODES.index(deciding)
         text = "\n".join(_failure_line(entry, outcome)
-                         for entry, mode, outcome in failing
+                         for _, entry, mode, outcome in failing
                          if MODES.index(mode) >= floor)
         if deciding == "enforce":
             decision = "deny"
@@ -506,13 +507,19 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
             decision = "warn"
 
     emission = encode(profile, decision, text)
-    for entry, mode, outcome in results:
-        # `mode` is this entry's; `decision_emitted` is the ACTION's. One
-        # action produces one decision, and the row that claimed otherwise
-        # would report a deny the host never received.
+    failed = {index for index, _, _, _ in failing}
+    for index, (entry, mode, outcome) in enumerate(results):
+        # One action produces one decision, but the log row is per CHECK, so
+        # the row records what THIS check contributed. A check that passed
+        # records `allow`: it did not deny anything, and a clean row stamped
+        # `deny` satisfies the "only a deny under enforce proves it was
+        # honored" filter while proving nothing of the kind. The stats
+        # surface counts these rows.
         rows.append(_row(profile, stamp, ruling_id=entry.get("ruling_id"),
                          mode=mode, outcome=outcome.outcome,
-                         cause=outcome.cause, decision=decision,
+                         cause=outcome.cause,
+                         decision=decision if index in failed
+                         else "allow",
                          duration_ms=outcome.duration_ms))
     return Decision(emission.stdout, emission.stderr, emission.exit_code, rows)
 

--- a/plugin/daimon_briefing/_hooks/checks_host.py
+++ b/plugin/daimon_briefing/_hooks/checks_host.py
@@ -1,0 +1,172 @@
+"""The #943 host adapter core — one pipeline, one row per host.
+
+A host that runs a pre-action hook is a PROFILE ROW here, not a second
+pipeline. The row says what the host calls its event, which tool names it
+uses for a shell action, where the command string sits in its payload, how it
+wants a decision encoded, and which modes it can actually deliver. Everything
+downstream of the row is shared: the same manifest read, the same runner, the
+same firing log. Adding a host is adding a row and a six-line script.
+
+Same two rules as `checks_runtime` and for the same reason (scar 0049):
+
+  * stdlib ONLY. This file is loaded by a script running in whatever
+    interpreter the host launched, with no venv and no `daimon_briefing` on
+    `sys.path`. A package import here breaks every host at once and passes
+    every local test.
+  * the canonical file is THIS one; `hook/` and `_hooks/` hold derivatives.
+    Edit here, then run `scripts/sync_hooks.py`.
+
+`checks_runtime` is loaded from THIS file's own directory by file location,
+never by name: by name it would depend on `sys.path` state and could bind an
+unrelated top-level module.
+
+Nothing here raises. It fires before every shell action on the host, and on
+the hosts measured so far a hook that crashes is fail-open: the action
+proceeds and nothing anywhere says why.
+"""
+
+import importlib.util
+from pathlib import Path
+from typing import NamedTuple
+
+# ---- the runtime, by file location (the `_load_redact` shape) -------------
+
+
+def _load_runtime():
+    """Load `checks_runtime.py` from beside this file, or None.
+
+    None is the stale-install shape: this module shipped, its sibling did
+    not. The caller turns that into an allow that says so, because a hook
+    with no runtime has nothing to check and must not pretend otherwise."""
+    path = Path(__file__).resolve().parent / "checks_runtime.py"
+    if not path.exists():
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_daimon_checks_runtime", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    except Exception:  # noqa: BLE001 — a broken sibling must not crash a hook
+        return None
+
+
+_RUNTIME = _load_runtime()
+
+
+def runtime():
+    """The loaded runtime, or None when the sibling is missing or broken."""
+    return _RUNTIME
+
+
+# ---- modes (spec section 5) ----------------------------------------------
+
+# Weakest to strongest. Every cap and every aggregation reads this order, so
+# "weaker" and "stronger" are spelled once and cannot disagree.
+MODES = ("unsupported", "record-only", "warn", "enforce")
+
+# What an author may ask for, strongest first — the vocabulary
+# `refutations.CHECK_INTENTS` validates on the way in.
+INTENTS = ("enforce", "warn", "record-only")
+
+# The decision encoders a profile may name.
+ENCODERS = ("json-permission", "exit2-stderr")
+
+
+class Profile(NamedTuple):
+    """One host, as a row.
+
+    `host` is the label written to the firing log, so it is what a reader
+    attributes liveness to; two rows sharing one would make the per-host
+    column unmeasurable.
+
+    `tool_names` is the set of tool names that mean "a shell action"; empty
+    means any name is accepted. `command_path` is the path into the payload
+    where the command string sits, and it differs per host in NAME as well as
+    in nesting. `cwd_key` is the top-level key holding the action's working
+    directory.
+
+    `mode_caps` maps each intent to what this host can actually deliver, from
+    spec section 5. It is the whole per-host degradation story: a host that
+    documents no warn channel caps warn at record-only rather than emitting
+    something the operator never sees.
+
+    `matcher` and `install_timeout` are what the registration writes."""
+
+    host: str
+    event: str
+    tool_names: frozenset
+    command_path: tuple
+    cwd_key: str
+    encoder: str
+    mode_caps: dict
+    matcher: str
+    install_timeout: int
+
+
+PROFILES = {
+    "claude-code": Profile(
+        host="claude-code",
+        event="PreToolUse",
+        tool_names=frozenset({"Bash"}),
+        command_path=("tool_input", "command"),
+        cwd_key="cwd",
+        encoder="json-permission",
+        # Both the deny and the warn channel are documented; the deny is
+        # measured. Nothing is capped.
+        mode_caps={"enforce": "enforce", "warn": "warn",
+                   "record-only": "record-only"},
+        matcher="Bash",
+        install_timeout=10,
+    ),
+    "codex": Profile(
+        host="codex",
+        event="PreToolUse",
+        # Codex names the shell tool both ways depending on the build, and
+        # the matcher it registers is the alternation of the two.
+        tool_names=frozenset({"Bash", "shell"}),
+        command_path=("tool_input", "command"),
+        cwd_key="cwd",
+        encoder="json-permission",
+        # Codex documents the same JSON deny and NO warn channel. A warn with
+        # nowhere to go is not a warn, so it degrades to record-only: the run
+        # is still logged and nothing is silently claimed to have been shown.
+        mode_caps={"enforce": "enforce", "warn": "record-only",
+                   "record-only": "record-only"},
+        matcher="Bash|shell",
+        install_timeout=10,
+    ),
+    "windsurf": Profile(
+        host="windsurf",
+        event="pre_run_command",
+        tool_names=frozenset(),
+        # Not tool_input.command. Windsurf carries the shell action under a
+        # different key at a different name, and a copied path would read
+        # None on every action and allow in silence.
+        command_path=("tool_info", "command_line"),
+        cwd_key="cwd",
+        encoder="exit2-stderr",
+        # Documented, unmeasured. Until a live probe the whole column reads
+        # unsupported, so an enforce intent shows unsupported here rather
+        # than claiming an enforcement daimon has never seen delivered.
+        mode_caps={"enforce": "unsupported", "warn": "unsupported",
+                   "record-only": "unsupported"},
+        matcher="",
+        install_timeout=10,
+    ),
+}
+
+
+def mode_for(profile, intent) -> str:
+    """The mode this host actually delivers for that intent.
+
+    The weaker of the two, read off the profile's own cap table. An intent
+    this build never heard of reads as the weakest real intent rather than
+    the strongest: a manifest is a file on disk, and a word nobody
+    recognises must not become an enforcement."""
+    caps = getattr(profile, "mode_caps", None)
+    if not isinstance(caps, dict):
+        return "unsupported"
+    asked = intent if intent in INTENTS else "record-only"
+    mode = caps.get(asked, "unsupported")
+    return mode if mode in MODES else "unsupported"

--- a/plugin/daimon_briefing/_hooks/checks_host.py
+++ b/plugin/daimon_briefing/_hooks/checks_host.py
@@ -286,6 +286,18 @@ def encode(profile, decision, text) -> Emission:
 
 # ---- the pipeline (spec sections 3.1, 3.4 and 5) -------------------------
 
+# One deadline for the whole action, in seconds, against a host hook timeout
+# of ten. The two seconds left over pay for the manifest read, the resolve,
+# and the kill-and-drain after a check that had to be stopped.
+#
+# `DAIMON_CHECK_TIMEOUT` still caps ONE check; this caps their sum. Without
+# it the budget was per check, so two checks that both reached the runner's
+# own timeout took past ten seconds, and a hook that reaches the HOST's
+# timeout does not block: the action proceeds, nothing is emitted, and
+# nothing is logged. That silence is byte-identical to a clean allow, which
+# is the one outcome this whole slice exists to make impossible.
+ACTION_BUDGET = 8.0
+
 # Where a host names the tool it is about to run. Both hosts that filter by
 # tool name spell it this way. A host that spells it differently declares an
 # empty `tool_names` and is selected by its `command_path` alone, which is
@@ -432,8 +444,9 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # affordable, and spec 3.1 names only the two project-level causes.
         return Decision("", "", 0, rows)
 
-    budget = (float(timeout) if isinstance(timeout, (int, float))
-              and timeout > 0 else rt.check_timeout())
+    per_check = (float(timeout) if isinstance(timeout, (int, float))
+                 and timeout > 0 else rt.check_timeout())
+    deadline = time.monotonic() + ACTION_BUDGET
 
     # Once, for every matching check. The subject cannot change between two
     # entries of the same action, and reading every file argument again would
@@ -443,11 +456,24 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
     try:
         for entry in matching:
             mode = mode_for(profile, entry.get("intent"))
+            left = deadline - time.monotonic()
             if isinstance(subject, rt.Unresolved):
                 outcome = rt.Outcome("unresolved", subject.cause,
                                      subject.reason, -1, 0)
+            elif left <= 0:
+                # The action's budget is already spent, so this check never
+                # runs. `unresolved`, not clean: daimon proved nothing about
+                # the subject, and letting it through because time ran out is
+                # exactly the fail-open the deadline exists to prevent. Under
+                # `enforce` it still denies. The row is what keeps a starved
+                # check countable instead of invisible.
+                outcome = rt.Outcome(
+                    "unresolved", "check-timeout",
+                    "the action's check budget was spent before this check "
+                    "could run", -1, 0)
             else:
-                outcome = rt.run(entry, subject, cwd=cwd, timeout=budget)
+                outcome = rt.run(entry, subject, cwd=cwd,
+                                 timeout=min(per_check, left))
             results.append((entry, mode, outcome))
     finally:
         # The subject holds the command and every file it named. A `finally`

--- a/plugin/daimon_briefing/_hooks/checks_host.py
+++ b/plugin/daimon_briefing/_hooks/checks_host.py
@@ -168,6 +168,26 @@ PROFILES = {
 }
 
 
+def disabled() -> bool:
+    """The `DAIMON_DISABLE` kill switch, read the way every other daimon hook
+    reads it: `1`, `true`, `yes` or `on`, stripped, case-sensitive.
+
+    Copied line for line from `_daimon_hook_lib.disabled()` rather than
+    reinterpreted, quirks included. A switch that turns off three hooks and
+    leaves the fourth armed is worse than one that is strict everywhere, and
+    this is the fourth hook: the one that can block a command, and therefore
+    the one an operator most needs a way out of. An over-broad `enforce`
+    check denies the very shell action that would retire the ruling.
+
+    PROCESS ENVIRONMENT ONLY. Unlike the path accessors above it does NOT
+    fall back to `~/.daimon/env` (scar 0043 does not reach here). Those
+    mirror a location a writer and a deleter have to agree on; this is a
+    switch someone flips for one session, and a copy left on disk would keep
+    every later session disarmed with nothing on screen to say so."""
+    return os.environ.get("DAIMON_DISABLE", "").strip() in (
+        "1", "true", "yes", "on")
+
+
 def mode_for(profile, intent) -> str:
     """The mode this host actually delivers for that intent.
 
@@ -362,6 +382,11 @@ def decide(profile, payload, *, manifest=None, timeout=None,
 
 
 def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
+    if disabled():
+        # Before the manifest read, before the payload is even looked at: a
+        # disabled hook costs one environment read and leaves no trace. No
+        # row either, because nothing ran and nothing declined to run.
+        return Decision("", "", 0, rows)
     rt = runtime()
     if rt is None:
         # Nothing to check WITH, and nothing to write a row with either. The
@@ -499,6 +524,11 @@ def main(host, stdin=None, stdout=None, stderr=None) -> int:
         return 0
     rt = runtime()
     try:
+        if disabled():
+            # `decide` checks this too. Here as well because the missing-
+            # runtime diagnostic below never reaches it, and a hook the
+            # operator turned off must not still be talking to the host.
+            return 0
         if rt is None:
             # Nothing to check with and nothing to write a row with. Say so
             # where the host has a channel for it; a warn that degrades below

--- a/plugin/daimon_briefing/_hooks/checks_host.py
+++ b/plugin/daimon_briefing/_hooks/checks_host.py
@@ -489,8 +489,17 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # that did not, and reading it the other way blocks actions nobody
         # armed to block.
         deciding = max((mode for _, mode, _ in failing), key=MODES.index)
+        # Only the failures AT OR ABOVE the deciding mode are spoken aloud. A
+        # `record-only` check asked for the log and nothing else, and a
+        # neighbour that failed at a stronger mode must not carry its reason
+        # out on its behalf. On Codex that is the whole point of the cap:
+        # `warn` degrades to `record-only` there so nothing is shown that the
+        # host never rendered, and a second check the author did not control
+        # would otherwise defeat it.
+        floor = MODES.index(deciding)
         text = "\n".join(_failure_line(entry, outcome)
-                         for entry, _, outcome in failing)
+                         for entry, mode, outcome in failing
+                         if MODES.index(mode) >= floor)
         if deciding == "enforce":
             decision = "deny"
         elif deciding == "warn":

--- a/plugin/daimon_briefing/_hooks/checks_runtime.py
+++ b/plugin/daimon_briefing/_hooks/checks_runtime.py
@@ -187,6 +187,26 @@ def log_dir() -> Path:
     return Path.home() / ".daimon" / "logs"
 
 
+def check_timeout() -> float:
+    """Mirror of config.check_timeout(): the runner's own budget in seconds.
+
+    The hook is the caller that most needs it. A budget configured for the
+    CLI and ignored by the hook means the operator who lowered it to fit a
+    slow machine still loses the action to the HOST's timeout, which is
+    fail-open, and nothing anywhere says why.
+
+    Quirk-faithful per scar 0043, including the parts that read like bugs: a
+    present-but-unparseable value falls back to the default instead of
+    raising, and the floor keeps the smallest configured budget an actual
+    budget rather than an unconditional timeout. DEFAULT_TIMEOUT below is
+    this same number for the path where no configuration is consulted at
+    all."""
+    try:
+        return max(0.5, float(_config_get("DAIMON_CHECK_TIMEOUT") or "5"))
+    except ValueError:
+        return 5.0
+
+
 # ---- manifest -------------------------------------------------------------
 
 

--- a/plugin/daimon_briefing/_hooks/daimon-codex-pre-action.py
+++ b/plugin/daimon_briefing/_hooks/daimon-codex-pre-action.py
@@ -47,6 +47,12 @@ def _load_core():
 def main() -> int:
     core = _load_core()
     if core is None:
+        # Silent, and that is the profile rather than an oversight: Codex
+        # documents no message channel, so a diagnostic addressed to one
+        # would be text on a stream the operator never sees, on a host that
+        # parses that stream. The Claude Code sibling of this script does
+        # emit one. The firing log would be the honest surface here, and
+        # there is no runtime loaded to write it with.
         return 0
     return core.main("codex")
 

--- a/plugin/daimon_briefing/_hooks/daimon-codex-pre-action.py
+++ b/plugin/daimon_briefing/_hooks/daimon-codex-pre-action.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Daimon pre-action check hook for Codex (#943), PreToolUse on a shell action.
+
+THIS IS THE FIRST DAIMON HOOK THAT CAN FAIL A HOST ACTION. Every other hook
+in this directory observes a session and cannot change it. This one runs
+before a shell action and, when a ruling a human ratified carries a check
+armed to enforce and that check finds a violation, it returns the host's
+structured deny and the action does not run.
+
+Everything it decides lives in `checks_host.py`, loaded from THIS file's own
+directory by file location, never by name off `sys.path`. A host is a profile
+row there; this script is the row's name and nothing else. If you are looking
+for the decision logic, the mode table or the JSON shapes, they are there.
+
+Output contract: stdout is empty or exactly one JSON object, stderr is empty,
+and the exit code is always 0. Codex documents exit 2 as an
+unconditional block, so an escaping exception that happened to exit non-zero
+would block an action no check ever judged. The deny is the deliberate path.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_core():
+    """The shared adapter core from beside this file, or None.
+
+    File-location import (never `import checks_host`) so it never depends on
+    `sys.path` state and never collides with an unrelated top-level module.
+    None is a partial install: the hook then says nothing at all, because
+    there is nothing to check with and a traceback before every shell action
+    is worse than the missing check it would be reporting."""
+    path = Path(__file__).resolve().parent / "checks_host.py"
+    if not path.exists():
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_daimon_checks_host", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    except Exception:  # noqa: BLE001 — a broken module must never crash a hook
+        return None
+
+
+def main() -> int:
+    core = _load_core()
+    if core is None:
+        return 0
+    return core.main("codex")
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:  # noqa: BLE001 — fail open, and silently: stdout is
+        # parsed as JSON by the host, so a diagnostic printed there is a
+        # decision it cannot read.
+        sys.exit(0)

--- a/plugin/daimon_briefing/checks_host.py
+++ b/plugin/daimon_briefing/checks_host.py
@@ -26,6 +26,7 @@ proceeds and nothing anywhere says why.
 """
 
 import importlib.util
+import json
 from pathlib import Path
 from typing import NamedTuple
 
@@ -71,6 +72,13 @@ INTENTS = ("enforce", "warn", "record-only")
 
 # The decision encoders a profile may name.
 ENCODERS = ("json-permission", "exit2-stderr")
+
+# What the hook actually tells the host, and therefore what reaches the
+# firing log's `decision_emitted`. A record-only mode still emits `allow`:
+# nothing was written to the host, and the `mode` column is where "this only
+# went to the log" is already said. Claiming a fourth word here would report
+# a channel the host was never given.
+DECISIONS = ("allow", "warn", "deny")
 
 
 class Profile(NamedTuple):
@@ -170,3 +178,84 @@ def mode_for(profile, intent) -> str:
     asked = intent if intent in INTENTS else "record-only"
     mode = caps.get(asked, "unsupported")
     return mode if mode in MODES else "unsupported"
+
+
+# ---- encoders (spec section 4) -------------------------------------------
+
+
+class Emission(NamedTuple):
+    """What the hook writes and what it exits with.
+
+    Three channels because the hosts do not agree on one. Claude Code and
+    Codex read a JSON object on stdout and treat a non-zero exit as a hook
+    error; Windsurf documents exit 2 with the reason on stderr. Carrying all
+    three keeps the Windsurf row a row rather than a special case, and the
+    tests pin stderr empty and the exit code 0 on every path of the two
+    hosts that actually ship a script."""
+
+    stdout: str
+    stderr: str
+    exit_code: int
+
+
+_SILENT = Emission("", "", 0)
+
+
+def _encode_json_permission(profile, decision, text) -> Emission:
+    """The measured path on Claude Code and Codex: one JSON object, exit 0.
+
+    The key names are the host's contract, so they are pinned byte for byte
+    by a literal comparison in the tests. A rename here is a deny that
+    silently becomes an allow, and a parsed-dict assertion would not see it.
+
+    A silent allow writes NOTHING rather than an object saying `allow`: the
+    hosts treat absent output as no opinion, and an object claiming a
+    decision is a decision daimon did not make."""
+    event = str(getattr(profile, "event", "") or "")
+    if decision == "deny":
+        return Emission(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": event,
+                "permissionDecision": "deny",
+                "permissionDecisionReason": text,
+            },
+        }, sort_keys=True), "", 0)
+    if decision == "warn" and text:
+        return Emission(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": event,
+                "permissionDecision": "allow",
+            },
+            "systemMessage": text,
+        }, sort_keys=True), "", 0)
+    return _SILENT
+
+
+def _encode_exit2_stderr(profile, decision, text) -> Emission:
+    """Windsurf's documented channel, unmeasured. Reachable only once a
+    Windsurf profile has a mode above `unsupported`, which is after a live
+    probe; until then this exists so the row is complete and its shape is
+    pinned by a test rather than discovered on someone's machine."""
+    if decision not in ("deny", "warn") or not text:
+        return _SILENT
+    return Emission("", text + "\n", 2 if decision == "deny" else 0)
+
+
+_ENCODERS = {
+    "json-permission": _encode_json_permission,
+    "exit2-stderr": _encode_exit2_stderr,
+}
+
+
+def encode(profile, decision, text) -> Emission:
+    """Render one decision the way this host reads it.
+
+    An unknown decision word or an unknown encoder name is a silent allow,
+    never a deny: a value this build does not recognise must not become the
+    strongest thing the host can be asked to do."""
+    if decision not in DECISIONS:
+        return _SILENT
+    fn = _ENCODERS.get(str(getattr(profile, "encoder", "")))
+    if fn is None:
+        return _SILENT
+    return fn(profile, decision, str(text or ""))

--- a/plugin/daimon_briefing/checks_host.py
+++ b/plugin/daimon_briefing/checks_host.py
@@ -28,6 +28,8 @@ proceeds and nothing anywhere says why.
 import importlib.util
 import json
 import os
+import re
+import shlex
 import sys
 import time
 from pathlib import Path
@@ -375,6 +377,44 @@ def _failure_line(entry, outcome) -> str:
     return f"{ruling_id}: {reason}"
 
 
+def _command_text(raw):
+    """The action's command string, or None when there is no command, or the
+    Unresolved cause when there is one daimon cannot read.
+
+    Some hosts send the shell tool's command as an argv array. Read as "no
+    command", every armed check on such a host goes silently inert while the
+    liveness surface reads "armed, never fired", which is the phrase reserved
+    for a wired install that nothing has matched yet. It is joined with shell
+    quoting rather than with a space, because an argument holding a space
+    would otherwise become two arguments in the subject and the check would
+    be judging a command nobody ran."""
+    if isinstance(raw, str):
+        return raw or None
+    if isinstance(raw, list):
+        if raw and all(isinstance(part, str) for part in raw):
+            return shlex.join(raw)
+        return ("arg-form-unparsed",
+                "the host sent a command daimon could not read as text")
+    return None
+
+
+def _match_state(rt, entry, command) -> str:
+    """`hit`, `miss`, or `broken` for one entry's pattern.
+
+    `rt.matches` folds an uncompilable pattern into False, which is right for
+    it and wrong here: "a regex that cannot compile" and "a regex that did
+    not match" are different facts and only one of them was countable.
+    `refutations` compiles the pattern at propose time, so a broken one
+    reaches this point only through a hand-edited manifest."""
+    pattern = entry.get("match")
+    if isinstance(pattern, str) and pattern:
+        try:
+            re.compile(pattern)
+        except (re.error, RecursionError):
+            return "broken"
+    return "hit" if rt.matches(entry, command) else "miss"
+
+
 def decide(profile, payload, *, manifest=None, timeout=None,
            now=None) -> Decision:
     """Run this action's armed checks and say what the host should be told.
@@ -408,8 +448,18 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         payload = {}
     if not _accepts(profile, payload):
         return Decision("", "", 0, rows)
-    command = _dig(payload, getattr(profile, "command_path", ()))
-    if not isinstance(command, str) or not command:
+    command = _command_text(_dig(payload, getattr(profile, "command_path",
+                                                  ())))
+    stamp = _stamp(now)
+    if isinstance(command, tuple):
+        # A command that is present and unreadable, which is not the same as
+        # absent. It gets a row so the state is countable; the action is
+        # allowed because nothing was armed against anything yet.
+        cause, _ = command
+        rows.append(_row(profile, stamp, cause=cause, outcome="unresolved",
+                         decision="allow"))
+        return Decision("", "", 0, rows)
+    if command is None:
         # Not a row: nothing ran and nothing declined to run. A row for every
         # payload without a command would make the firing log a transcript of
         # the session rather than a record of checks.
@@ -421,7 +471,6 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # host launched stands in the action's directory anyway, and arming
         # nothing would disarm every check for that action in silence.
         cwd = os.getcwd()
-    stamp = _stamp(now)
 
     loaded = rt.load_manifest() if manifest is None else manifest
     reason = getattr(loaded, "reason", "")
@@ -433,12 +482,25 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         rows.append(_row(profile, stamp, cause=reason, decision="allow"))
         return Decision("", "", 0, rows)
 
+    try:
+        os.path.realpath(cwd)
+    except (OSError, ValueError):
+        # `armed_for` folds this into an empty list, which would come out as
+        # `no-match`. That cause says every armed check was compared and none
+        # applied; here nothing was compared at all.
+        rows.append(_row(profile, stamp, cause="file-unreadable",
+                         outcome="unresolved", decision="allow"))
+        return Decision("", "", 0, rows)
+
     entries = rt.armed_for(cwd, loaded)
     if not entries:
         rows.append(_row(profile, stamp, cause="no-match", decision="allow"))
         return Decision("", "", 0, rows)
 
-    matching = [entry for entry in entries if rt.matches(entry, command)]
+    matching = [(entry, _match_state(rt, entry, command))
+                for entry in entries]
+    matching = [(entry, state) for entry, state in matching
+                if state != "miss"]
     if not matching:
         # The prefilter is what makes a hook on every shell action
         # affordable, and spec 3.1 names only the two project-level causes.
@@ -450,14 +512,26 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
 
     # Once, for every matching check. The subject cannot change between two
     # entries of the same action, and reading every file argument again would
-    # spend a budget the host will not extend.
-    subject = rt.resolve(command, cwd)
+    # spend a budget the host will not extend. Skipped entirely when every
+    # matching entry carries a pattern that will not compile: there is
+    # nothing to run against them, and the resolve is the expensive half.
+    subject = (rt.resolve(command, cwd)
+               if any(state == "hit" for _, state in matching) else None)
     results = []
     try:
-        for entry in matching:
+        for entry, state in matching:
             mode = mode_for(profile, entry.get("intent"))
             left = deadline - time.monotonic()
-            if isinstance(subject, rt.Unresolved):
+            if state == "broken":
+                # The manifest names a pattern daimon cannot compile, so this
+                # check cannot be applied at all. `unresolved`, which under
+                # `enforce` denies: a rule nobody can evaluate is not a rule
+                # that passed.
+                outcome = rt.Outcome(
+                    "unresolved", "check-crashed",
+                    "this ruling's match pattern could not be compiled; run "
+                    "`daimon check sync`", -1, 0)
+            elif isinstance(subject, rt.Unresolved):
                 outcome = rt.Outcome("unresolved", subject.cause,
                                      subject.reason, -1, 0)
             elif left <= 0:
@@ -474,14 +548,26 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
             else:
                 outcome = rt.run(entry, subject, cwd=cwd,
                                  timeout=min(per_check, left))
-            results.append((entry, mode, outcome))
+            # Appended as it is decided, not after the loop. `rt.run` is
+            # documented never to raise, and this is the case where the
+            # record matters most if it ever does: an earlier check's
+            # violation is the only evidence of what happened. The row is
+            # stamped `allow` and corrected below for the ones that failed,
+            # so a row that escapes through an exception says what the host
+            # actually got, which is nothing.
+            row = _row(profile, stamp, ruling_id=entry.get("ruling_id"),
+                       mode=mode, outcome=outcome.outcome,
+                       cause=outcome.cause, decision="allow",
+                       duration_ms=outcome.duration_ms)
+            rows.append(row)
+            results.append((entry, mode, outcome, row))
     finally:
         # The subject holds the command and every file it named. A `finally`
         # is the only placement that survives an exception nobody predicted.
         rt.discard(subject)
 
-    failing = [(index, entry, mode, outcome)
-               for index, (entry, mode, outcome) in enumerate(results)
+    failing = [(entry, mode, outcome, row)
+               for entry, mode, outcome, row in results
                if outcome.outcome in ("violation", "unresolved")]
     decision, text = "allow", ""
     if failing:
@@ -489,7 +575,7 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # An enforce check that passed has nothing to say about a warn check
         # that did not, and reading it the other way blocks actions nobody
         # armed to block.
-        deciding = max((mode for _, _, mode, _ in failing), key=MODES.index)
+        deciding = max((mode for _, mode, _, _ in failing), key=MODES.index)
         # Only the failures AT OR ABOVE the deciding mode are spoken aloud. A
         # `record-only` check asked for the log and nothing else, and a
         # neighbour that failed at a stronger mode must not carry its reason
@@ -499,7 +585,7 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # would otherwise defeat it.
         floor = MODES.index(deciding)
         text = "\n".join(_failure_line(entry, outcome)
-                         for _, entry, mode, outcome in failing
+                         for entry, mode, outcome, _ in failing
                          if MODES.index(mode) >= floor)
         if deciding == "enforce":
             decision = "deny"
@@ -507,20 +593,14 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
             decision = "warn"
 
     emission = encode(profile, decision, text)
-    failed = {index for index, _, _, _ in failing}
-    for index, (entry, mode, outcome) in enumerate(results):
-        # One action produces one decision, but the log row is per CHECK, so
-        # the row records what THIS check contributed. A check that passed
-        # records `allow`: it did not deny anything, and a clean row stamped
-        # `deny` satisfies the "only a deny under enforce proves it was
-        # honored" filter while proving nothing of the kind. The stats
-        # surface counts these rows.
-        rows.append(_row(profile, stamp, ruling_id=entry.get("ruling_id"),
-                         mode=mode, outcome=outcome.outcome,
-                         cause=outcome.cause,
-                         decision=decision if index in failed
-                         else "allow",
-                         duration_ms=outcome.duration_ms))
+    # One action produces one decision, but the log row is per CHECK, so the
+    # row records what THIS check contributed. A check that passed keeps the
+    # `allow` it was written with: it denied nothing, and a clean row stamped
+    # `deny` satisfies the "only a deny under enforce proves it was honored"
+    # filter while proving nothing of the kind. The stats surface counts
+    # these rows.
+    for _entry, _mode, _outcome, row in failing:
+        row["decision_emitted"] = decision
     return Decision(emission.stdout, emission.stderr, emission.exit_code, rows)
 
 

--- a/plugin/daimon_briefing/checks_host.py
+++ b/plugin/daimon_briefing/checks_host.py
@@ -509,7 +509,14 @@ def main(host, stdin=None, stdout=None, stderr=None) -> int:
             return 0
         decision = decide(profile, _read_payload(stdin))
         for row in decision.rows:
-            rt.log_firing(row)
+            try:
+                rt.log_firing(row)
+            except Exception:  # noqa: BLE001
+                # `log_firing` promises not to raise, and this guard is what
+                # keeps that promise from being load-bearing. The row is
+                # bookkeeping; the deny is the thing the operator armed, and
+                # losing the decision over the record is the wrong trade.
+                pass
         out.write(decision.stdout)
         err.write(decision.stderr)
         return decision.exit_code

--- a/plugin/daimon_briefing/checks_host.py
+++ b/plugin/daimon_briefing/checks_host.py
@@ -570,6 +570,9 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
                for entry, mode, outcome, row in results
                if outcome.outcome in ("violation", "unresolved")]
     decision, text = "allow", ""
+    # Above every real mode until a failure sets it, so that with nothing
+    # failing no row qualifies for the stamp below.
+    floor = len(MODES)
     if failing:
         # The strongest FAILING mode decides, not the strongest mode present.
         # An enforce check that passed has nothing to say about a warn check
@@ -594,13 +597,17 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
 
     emission = encode(profile, decision, text)
     # One action produces one decision, but the log row is per CHECK, so the
-    # row records what THIS check contributed. A check that passed keeps the
-    # `allow` it was written with: it denied nothing, and a clean row stamped
-    # `deny` satisfies the "only a deny under enforce proves it was honored"
-    # filter while proving nothing of the kind. The stats surface counts
-    # these rows.
-    for _entry, _mode, _outcome, row in failing:
-        row["decision_emitted"] = decision
+    # row records what THIS check contributed. Two kinds of row keep the
+    # `allow` they were written with. A check that passed denied nothing, and
+    # a clean row stamped `deny` satisfies the "only a deny under enforce
+    # proves it was honored" filter while proving nothing of the kind. And a
+    # check that failed BELOW the deciding floor had its reason withheld from
+    # the host by its own mode, so it was never heard: stamping the decision
+    # on it claims a contribution to a block it was not allowed to speak in.
+    # The stats surface counts these rows.
+    for _entry, mode, _outcome, row in failing:
+        if MODES.index(mode) >= floor:
+            row["decision_emitted"] = decision
     return Decision(emission.stdout, emission.stderr, emission.exit_code, rows)
 
 

--- a/plugin/daimon_briefing/checks_host.py
+++ b/plugin/daimon_briefing/checks_host.py
@@ -28,6 +28,7 @@ proceeds and nothing anywhere says why.
 import importlib.util
 import json
 import os
+import sys
 import time
 from pathlib import Path
 from typing import NamedTuple
@@ -454,3 +455,72 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
                          cause=outcome.cause, decision=decision,
                          duration_ms=outcome.duration_ms))
     return Decision(emission.stdout, emission.stderr, emission.exit_code, rows)
+
+
+# ---- what the thin per-host scripts call ---------------------------------
+
+# Said on a host that renders a message channel, and only there. A host with
+# no channel for it would be told nothing either way, and the firing log is
+# the honest surface for that fact except that there is no runtime to write
+# it with, which is the state being reported.
+RUNTIME_MISSING = "daimon: check runtime missing, nothing enforced"
+
+
+def _read_payload(stream) -> dict:
+    """The host's payload, or an empty one. Unparseable stdin, a closed pipe
+    and a payload that is not an object are all the same fact here: this
+    process cannot see the action, so it has nothing to say about it."""
+    try:
+        raw = (stream if stream is not None else sys.stdin).read()
+    except Exception:  # noqa: BLE001
+        return {}
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def main(host, stdin=None, stdout=None, stderr=None) -> int:
+    """Run this host's pre-action check and write the decision.
+
+    The whole per-host script is a call to this with a profile name. Reads
+    the payload, decides, records every row, writes the encoded decision
+    once at the end, and returns the exit code the encoder chose, which is 0
+    for every host that ships a script today.
+
+    Writing stdout LAST and once is deliberate: a partial object on a host
+    that parses stdout is worse than no object, and an exception after a
+    first write could leave one."""
+    out = stdout if stdout is not None else sys.stdout
+    err = stderr if stderr is not None else sys.stderr
+    profile = PROFILES.get(host)
+    if profile is None:
+        return 0
+    rt = runtime()
+    try:
+        if rt is None:
+            # Nothing to check with and nothing to write a row with. Say so
+            # where the host has a channel for it; a warn that degrades below
+            # `warn` on this host has nowhere to go, so it goes nowhere.
+            if mode_for(profile, "warn") == "warn":
+                emission = encode(profile, "warn", RUNTIME_MISSING)
+                out.write(emission.stdout)
+            return 0
+        decision = decide(profile, _read_payload(stdin))
+        for row in decision.rows:
+            rt.log_firing(row)
+        out.write(decision.stdout)
+        err.write(decision.stderr)
+        return decision.exit_code
+    except Exception:  # noqa: BLE001 — the action must not die with the hook
+        # Nothing written, so the host sees no opinion and proceeds. The row
+        # is the only record that anything happened, and it is worth one more
+        # attempt that itself cannot raise.
+        if rt is not None:
+            try:
+                rt.log_firing(_row(profile, _stamp(None),
+                                   cause="check-crashed", decision="allow"))
+            except Exception:  # noqa: BLE001
+                pass
+        return 0

--- a/plugin/daimon_briefing/checks_host.py
+++ b/plugin/daimon_briefing/checks_host.py
@@ -27,6 +27,8 @@ proceeds and nothing anywhere says why.
 
 import importlib.util
 import json
+import os
+import time
 from pathlib import Path
 from typing import NamedTuple
 
@@ -259,3 +261,196 @@ def encode(profile, decision, text) -> Emission:
     if fn is None:
         return _SILENT
     return fn(profile, decision, str(text or ""))
+
+
+# ---- the pipeline (spec sections 3.1, 3.4 and 5) -------------------------
+
+# Where a host names the tool it is about to run. Both hosts that filter by
+# tool name spell it this way. A host that spells it differently declares an
+# empty `tool_names` and is selected by its `command_path` alone, which is
+# what the Windsurf row does.
+TOOL_NAME_KEY = "tool_name"
+
+
+class Decision(NamedTuple):
+    """What one action's checks came to.
+
+    `rows` are firing-log rows, built to `FIRING_KEYS` and not yet written:
+    `decide` decides, `main` records. Keeping the write out of here is what
+    lets the whole matrix be tested without a log on disk, and what keeps a
+    failed write from costing the decision."""
+
+    stdout: str
+    stderr: str
+    exit_code: int
+    rows: list
+
+
+def _dig(payload, path):
+    """Walk a path into a payload, or None. A host payload field is a CLAIM
+    (scar 0068): any step may be missing or may not be a mapping at all, and
+    each of those is an action daimon cannot see rather than a crash."""
+    current = payload
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _accepts(profile, payload) -> bool:
+    """Whether this payload names a shell action on this host. An empty
+    `tool_names` accepts anything, because the host already selected by
+    event."""
+    names: frozenset = getattr(profile, "tool_names", frozenset())
+    if not names:
+        return True
+    return _dig(payload, (TOOL_NAME_KEY,)) in names
+
+
+def _row(profile, ts, *, ruling_id="", mode="", outcome="", cause="",
+         decision="allow", duration_ms=0) -> dict:
+    """One firing-log row, in the declared shape. `log_firing` PROJECTS onto
+    FIRING_KEYS, so a row built with a stray field loses it in silence;
+    building to the shape here keeps the two ends one declaration."""
+    return {
+        "ts": ts,
+        "ruling_id": str(ruling_id or ""),
+        "host": str(getattr(profile, "host", "") or ""),
+        "mode": mode,
+        "outcome": outcome,
+        "cause": cause,
+        "decision_emitted": decision,
+        "duration_ms": int(duration_ms or 0),
+    }
+
+
+def _stamp(now) -> str:
+    if isinstance(now, str) and now:
+        return now
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _failure_line(entry, outcome) -> str:
+    """`<ruling_id>: <reason>`, with the cause in front when daimon could not
+    read what the action sends. The cause is what tells a human whether to
+    fix the command or fix the check."""
+    ruling_id = str(entry.get("ruling_id") or "")
+    reason = outcome.reason or "the check reported a violation and gave no reason"
+    if outcome.outcome == "unresolved" and outcome.cause:
+        reason = f"{outcome.cause}: {reason}"
+    return f"{ruling_id}: {reason}"
+
+
+def decide(profile, payload, *, manifest=None, timeout=None,
+           now=None) -> Decision:
+    """Run this action's armed checks and say what the host should be told.
+
+    Never raises. It fires before every shell action, and on the hosts
+    measured so far a hook that crashes is fail-open: the action proceeds and
+    nothing anywhere says why. An exception on the way through still returns
+    an allow, with the rows already gathered plus one saying the machinery
+    was what failed."""
+    rows: list = []
+    try:
+        return _decide(profile, payload, manifest, timeout, now, rows)
+    except Exception:  # noqa: BLE001 — a decision is mandatory
+        rows.append(_row(profile, _stamp(now), cause="check-crashed",
+                         decision="allow"))
+        return Decision("", "", 0, rows)
+
+
+def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
+    rt = runtime()
+    if rt is None:
+        # Nothing to check WITH, and nothing to write a row with either. The
+        # caller owns the diagnostic; see `main`.
+        return Decision("", "", 0, rows)
+    if not isinstance(payload, dict):
+        payload = {}
+    if not _accepts(profile, payload):
+        return Decision("", "", 0, rows)
+    command = _dig(payload, getattr(profile, "command_path", ()))
+    if not isinstance(command, str) or not command:
+        # Not a row: nothing ran and nothing declined to run. A row for every
+        # payload without a command would make the firing log a transcript of
+        # the session rather than a record of checks.
+        return Decision("", "", 0, rows)
+
+    cwd = payload.get(getattr(profile, "cwd_key", ""))
+    if not isinstance(cwd, str) or not cwd:
+        # The host is supposed to send it. When it does not, the process the
+        # host launched stands in the action's directory anyway, and arming
+        # nothing would disarm every check for that action in silence.
+        cwd = os.getcwd()
+    stamp = _stamp(now)
+
+    loaded = rt.load_manifest() if manifest is None else manifest
+    reason = getattr(loaded, "reason", "")
+    if reason:
+        # Spec 3.1: "nothing is armed here" has to be countable, so the stats
+        # surface can say "armed, never fired" instead of "clean". An install
+        # that armed nothing and a manifest daimon can no longer parse are
+        # different facts and keep different causes.
+        rows.append(_row(profile, stamp, cause=reason, decision="allow"))
+        return Decision("", "", 0, rows)
+
+    entries = rt.armed_for(cwd, loaded)
+    if not entries:
+        rows.append(_row(profile, stamp, cause="no-match", decision="allow"))
+        return Decision("", "", 0, rows)
+
+    matching = [entry for entry in entries if rt.matches(entry, command)]
+    if not matching:
+        # The prefilter is what makes a hook on every shell action
+        # affordable, and spec 3.1 names only the two project-level causes.
+        return Decision("", "", 0, rows)
+
+    budget = (float(timeout) if isinstance(timeout, (int, float))
+              and timeout > 0 else rt.check_timeout())
+
+    # Once, for every matching check. The subject cannot change between two
+    # entries of the same action, and reading every file argument again would
+    # spend a budget the host will not extend.
+    subject = rt.resolve(command, cwd)
+    results = []
+    try:
+        for entry in matching:
+            mode = mode_for(profile, entry.get("intent"))
+            if isinstance(subject, rt.Unresolved):
+                outcome = rt.Outcome("unresolved", subject.cause,
+                                     subject.reason, -1, 0)
+            else:
+                outcome = rt.run(entry, subject, cwd=cwd, timeout=budget)
+            results.append((entry, mode, outcome))
+    finally:
+        # The subject holds the command and every file it named. A `finally`
+        # is the only placement that survives an exception nobody predicted.
+        rt.discard(subject)
+
+    failing = [(entry, mode, outcome) for entry, mode, outcome in results
+               if outcome.outcome in ("violation", "unresolved")]
+    decision, text = "allow", ""
+    if failing:
+        # The strongest FAILING mode decides, not the strongest mode present.
+        # An enforce check that passed has nothing to say about a warn check
+        # that did not, and reading it the other way blocks actions nobody
+        # armed to block.
+        deciding = max((mode for _, mode, _ in failing), key=MODES.index)
+        text = "\n".join(_failure_line(entry, outcome)
+                         for entry, _, outcome in failing)
+        if deciding == "enforce":
+            decision = "deny"
+        elif deciding == "warn":
+            decision = "warn"
+
+    emission = encode(profile, decision, text)
+    for entry, mode, outcome in results:
+        # `mode` is this entry's; `decision_emitted` is the ACTION's. One
+        # action produces one decision, and the row that claimed otherwise
+        # would report a deny the host never received.
+        rows.append(_row(profile, stamp, ruling_id=entry.get("ruling_id"),
+                         mode=mode, outcome=outcome.outcome,
+                         cause=outcome.cause, decision=decision,
+                         duration_ms=outcome.duration_ms))
+    return Decision(emission.stdout, emission.stderr, emission.exit_code, rows)

--- a/plugin/daimon_briefing/checks_host.py
+++ b/plugin/daimon_briefing/checks_host.py
@@ -480,7 +480,8 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # is the only placement that survives an exception nobody predicted.
         rt.discard(subject)
 
-    failing = [(entry, mode, outcome) for entry, mode, outcome in results
+    failing = [(index, entry, mode, outcome)
+               for index, (entry, mode, outcome) in enumerate(results)
                if outcome.outcome in ("violation", "unresolved")]
     decision, text = "allow", ""
     if failing:
@@ -488,7 +489,7 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # An enforce check that passed has nothing to say about a warn check
         # that did not, and reading it the other way blocks actions nobody
         # armed to block.
-        deciding = max((mode for _, mode, _ in failing), key=MODES.index)
+        deciding = max((mode for _, _, mode, _ in failing), key=MODES.index)
         # Only the failures AT OR ABOVE the deciding mode are spoken aloud. A
         # `record-only` check asked for the log and nothing else, and a
         # neighbour that failed at a stronger mode must not carry its reason
@@ -498,7 +499,7 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # would otherwise defeat it.
         floor = MODES.index(deciding)
         text = "\n".join(_failure_line(entry, outcome)
-                         for entry, mode, outcome in failing
+                         for _, entry, mode, outcome in failing
                          if MODES.index(mode) >= floor)
         if deciding == "enforce":
             decision = "deny"
@@ -506,13 +507,19 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
             decision = "warn"
 
     emission = encode(profile, decision, text)
-    for entry, mode, outcome in results:
-        # `mode` is this entry's; `decision_emitted` is the ACTION's. One
-        # action produces one decision, and the row that claimed otherwise
-        # would report a deny the host never received.
+    failed = {index for index, _, _, _ in failing}
+    for index, (entry, mode, outcome) in enumerate(results):
+        # One action produces one decision, but the log row is per CHECK, so
+        # the row records what THIS check contributed. A check that passed
+        # records `allow`: it did not deny anything, and a clean row stamped
+        # `deny` satisfies the "only a deny under enforce proves it was
+        # honored" filter while proving nothing of the kind. The stats
+        # surface counts these rows.
         rows.append(_row(profile, stamp, ruling_id=entry.get("ruling_id"),
                          mode=mode, outcome=outcome.outcome,
-                         cause=outcome.cause, decision=decision,
+                         cause=outcome.cause,
+                         decision=decision if index in failed
+                         else "allow",
                          duration_ms=outcome.duration_ms))
     return Decision(emission.stdout, emission.stderr, emission.exit_code, rows)
 

--- a/plugin/daimon_briefing/checks_host.py
+++ b/plugin/daimon_briefing/checks_host.py
@@ -1,0 +1,172 @@
+"""The #943 host adapter core — one pipeline, one row per host.
+
+A host that runs a pre-action hook is a PROFILE ROW here, not a second
+pipeline. The row says what the host calls its event, which tool names it
+uses for a shell action, where the command string sits in its payload, how it
+wants a decision encoded, and which modes it can actually deliver. Everything
+downstream of the row is shared: the same manifest read, the same runner, the
+same firing log. Adding a host is adding a row and a six-line script.
+
+Same two rules as `checks_runtime` and for the same reason (scar 0049):
+
+  * stdlib ONLY. This file is loaded by a script running in whatever
+    interpreter the host launched, with no venv and no `daimon_briefing` on
+    `sys.path`. A package import here breaks every host at once and passes
+    every local test.
+  * the canonical file is THIS one; `hook/` and `_hooks/` hold derivatives.
+    Edit here, then run `scripts/sync_hooks.py`.
+
+`checks_runtime` is loaded from THIS file's own directory by file location,
+never by name: by name it would depend on `sys.path` state and could bind an
+unrelated top-level module.
+
+Nothing here raises. It fires before every shell action on the host, and on
+the hosts measured so far a hook that crashes is fail-open: the action
+proceeds and nothing anywhere says why.
+"""
+
+import importlib.util
+from pathlib import Path
+from typing import NamedTuple
+
+# ---- the runtime, by file location (the `_load_redact` shape) -------------
+
+
+def _load_runtime():
+    """Load `checks_runtime.py` from beside this file, or None.
+
+    None is the stale-install shape: this module shipped, its sibling did
+    not. The caller turns that into an allow that says so, because a hook
+    with no runtime has nothing to check and must not pretend otherwise."""
+    path = Path(__file__).resolve().parent / "checks_runtime.py"
+    if not path.exists():
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_daimon_checks_runtime", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    except Exception:  # noqa: BLE001 — a broken sibling must not crash a hook
+        return None
+
+
+_RUNTIME = _load_runtime()
+
+
+def runtime():
+    """The loaded runtime, or None when the sibling is missing or broken."""
+    return _RUNTIME
+
+
+# ---- modes (spec section 5) ----------------------------------------------
+
+# Weakest to strongest. Every cap and every aggregation reads this order, so
+# "weaker" and "stronger" are spelled once and cannot disagree.
+MODES = ("unsupported", "record-only", "warn", "enforce")
+
+# What an author may ask for, strongest first — the vocabulary
+# `refutations.CHECK_INTENTS` validates on the way in.
+INTENTS = ("enforce", "warn", "record-only")
+
+# The decision encoders a profile may name.
+ENCODERS = ("json-permission", "exit2-stderr")
+
+
+class Profile(NamedTuple):
+    """One host, as a row.
+
+    `host` is the label written to the firing log, so it is what a reader
+    attributes liveness to; two rows sharing one would make the per-host
+    column unmeasurable.
+
+    `tool_names` is the set of tool names that mean "a shell action"; empty
+    means any name is accepted. `command_path` is the path into the payload
+    where the command string sits, and it differs per host in NAME as well as
+    in nesting. `cwd_key` is the top-level key holding the action's working
+    directory.
+
+    `mode_caps` maps each intent to what this host can actually deliver, from
+    spec section 5. It is the whole per-host degradation story: a host that
+    documents no warn channel caps warn at record-only rather than emitting
+    something the operator never sees.
+
+    `matcher` and `install_timeout` are what the registration writes."""
+
+    host: str
+    event: str
+    tool_names: frozenset
+    command_path: tuple
+    cwd_key: str
+    encoder: str
+    mode_caps: dict
+    matcher: str
+    install_timeout: int
+
+
+PROFILES = {
+    "claude-code": Profile(
+        host="claude-code",
+        event="PreToolUse",
+        tool_names=frozenset({"Bash"}),
+        command_path=("tool_input", "command"),
+        cwd_key="cwd",
+        encoder="json-permission",
+        # Both the deny and the warn channel are documented; the deny is
+        # measured. Nothing is capped.
+        mode_caps={"enforce": "enforce", "warn": "warn",
+                   "record-only": "record-only"},
+        matcher="Bash",
+        install_timeout=10,
+    ),
+    "codex": Profile(
+        host="codex",
+        event="PreToolUse",
+        # Codex names the shell tool both ways depending on the build, and
+        # the matcher it registers is the alternation of the two.
+        tool_names=frozenset({"Bash", "shell"}),
+        command_path=("tool_input", "command"),
+        cwd_key="cwd",
+        encoder="json-permission",
+        # Codex documents the same JSON deny and NO warn channel. A warn with
+        # nowhere to go is not a warn, so it degrades to record-only: the run
+        # is still logged and nothing is silently claimed to have been shown.
+        mode_caps={"enforce": "enforce", "warn": "record-only",
+                   "record-only": "record-only"},
+        matcher="Bash|shell",
+        install_timeout=10,
+    ),
+    "windsurf": Profile(
+        host="windsurf",
+        event="pre_run_command",
+        tool_names=frozenset(),
+        # Not tool_input.command. Windsurf carries the shell action under a
+        # different key at a different name, and a copied path would read
+        # None on every action and allow in silence.
+        command_path=("tool_info", "command_line"),
+        cwd_key="cwd",
+        encoder="exit2-stderr",
+        # Documented, unmeasured. Until a live probe the whole column reads
+        # unsupported, so an enforce intent shows unsupported here rather
+        # than claiming an enforcement daimon has never seen delivered.
+        mode_caps={"enforce": "unsupported", "warn": "unsupported",
+                   "record-only": "unsupported"},
+        matcher="",
+        install_timeout=10,
+    ),
+}
+
+
+def mode_for(profile, intent) -> str:
+    """The mode this host actually delivers for that intent.
+
+    The weaker of the two, read off the profile's own cap table. An intent
+    this build never heard of reads as the weakest real intent rather than
+    the strongest: a manifest is a file on disk, and a word nobody
+    recognises must not become an enforcement."""
+    caps = getattr(profile, "mode_caps", None)
+    if not isinstance(caps, dict):
+        return "unsupported"
+    asked = intent if intent in INTENTS else "record-only"
+    mode = caps.get(asked, "unsupported")
+    return mode if mode in MODES else "unsupported"

--- a/plugin/daimon_briefing/checks_host.py
+++ b/plugin/daimon_briefing/checks_host.py
@@ -286,6 +286,18 @@ def encode(profile, decision, text) -> Emission:
 
 # ---- the pipeline (spec sections 3.1, 3.4 and 5) -------------------------
 
+# One deadline for the whole action, in seconds, against a host hook timeout
+# of ten. The two seconds left over pay for the manifest read, the resolve,
+# and the kill-and-drain after a check that had to be stopped.
+#
+# `DAIMON_CHECK_TIMEOUT` still caps ONE check; this caps their sum. Without
+# it the budget was per check, so two checks that both reached the runner's
+# own timeout took past ten seconds, and a hook that reaches the HOST's
+# timeout does not block: the action proceeds, nothing is emitted, and
+# nothing is logged. That silence is byte-identical to a clean allow, which
+# is the one outcome this whole slice exists to make impossible.
+ACTION_BUDGET = 8.0
+
 # Where a host names the tool it is about to run. Both hosts that filter by
 # tool name spell it this way. A host that spells it differently declares an
 # empty `tool_names` and is selected by its `command_path` alone, which is
@@ -432,8 +444,9 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # affordable, and spec 3.1 names only the two project-level causes.
         return Decision("", "", 0, rows)
 
-    budget = (float(timeout) if isinstance(timeout, (int, float))
-              and timeout > 0 else rt.check_timeout())
+    per_check = (float(timeout) if isinstance(timeout, (int, float))
+                 and timeout > 0 else rt.check_timeout())
+    deadline = time.monotonic() + ACTION_BUDGET
 
     # Once, for every matching check. The subject cannot change between two
     # entries of the same action, and reading every file argument again would
@@ -443,11 +456,24 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
     try:
         for entry in matching:
             mode = mode_for(profile, entry.get("intent"))
+            left = deadline - time.monotonic()
             if isinstance(subject, rt.Unresolved):
                 outcome = rt.Outcome("unresolved", subject.cause,
                                      subject.reason, -1, 0)
+            elif left <= 0:
+                # The action's budget is already spent, so this check never
+                # runs. `unresolved`, not clean: daimon proved nothing about
+                # the subject, and letting it through because time ran out is
+                # exactly the fail-open the deadline exists to prevent. Under
+                # `enforce` it still denies. The row is what keeps a starved
+                # check countable instead of invisible.
+                outcome = rt.Outcome(
+                    "unresolved", "check-timeout",
+                    "the action's check budget was spent before this check "
+                    "could run", -1, 0)
             else:
-                outcome = rt.run(entry, subject, cwd=cwd, timeout=budget)
+                outcome = rt.run(entry, subject, cwd=cwd,
+                                 timeout=min(per_check, left))
             results.append((entry, mode, outcome))
     finally:
         # The subject holds the command and every file it named. A `finally`

--- a/plugin/daimon_briefing/checks_host.py
+++ b/plugin/daimon_briefing/checks_host.py
@@ -168,6 +168,26 @@ PROFILES = {
 }
 
 
+def disabled() -> bool:
+    """The `DAIMON_DISABLE` kill switch, read the way every other daimon hook
+    reads it: `1`, `true`, `yes` or `on`, stripped, case-sensitive.
+
+    Copied line for line from `_daimon_hook_lib.disabled()` rather than
+    reinterpreted, quirks included. A switch that turns off three hooks and
+    leaves the fourth armed is worse than one that is strict everywhere, and
+    this is the fourth hook: the one that can block a command, and therefore
+    the one an operator most needs a way out of. An over-broad `enforce`
+    check denies the very shell action that would retire the ruling.
+
+    PROCESS ENVIRONMENT ONLY. Unlike the path accessors above it does NOT
+    fall back to `~/.daimon/env` (scar 0043 does not reach here). Those
+    mirror a location a writer and a deleter have to agree on; this is a
+    switch someone flips for one session, and a copy left on disk would keep
+    every later session disarmed with nothing on screen to say so."""
+    return os.environ.get("DAIMON_DISABLE", "").strip() in (
+        "1", "true", "yes", "on")
+
+
 def mode_for(profile, intent) -> str:
     """The mode this host actually delivers for that intent.
 
@@ -362,6 +382,11 @@ def decide(profile, payload, *, manifest=None, timeout=None,
 
 
 def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
+    if disabled():
+        # Before the manifest read, before the payload is even looked at: a
+        # disabled hook costs one environment read and leaves no trace. No
+        # row either, because nothing ran and nothing declined to run.
+        return Decision("", "", 0, rows)
     rt = runtime()
     if rt is None:
         # Nothing to check WITH, and nothing to write a row with either. The
@@ -499,6 +524,11 @@ def main(host, stdin=None, stdout=None, stderr=None) -> int:
         return 0
     rt = runtime()
     try:
+        if disabled():
+            # `decide` checks this too. Here as well because the missing-
+            # runtime diagnostic below never reaches it, and a hook the
+            # operator turned off must not still be talking to the host.
+            return 0
         if rt is None:
             # Nothing to check with and nothing to write a row with. Say so
             # where the host has a channel for it; a warn that degrades below

--- a/plugin/daimon_briefing/checks_host.py
+++ b/plugin/daimon_briefing/checks_host.py
@@ -489,8 +489,17 @@ def _decide(profile, payload, manifest, timeout, now, rows) -> Decision:
         # that did not, and reading it the other way blocks actions nobody
         # armed to block.
         deciding = max((mode for _, mode, _ in failing), key=MODES.index)
+        # Only the failures AT OR ABOVE the deciding mode are spoken aloud. A
+        # `record-only` check asked for the log and nothing else, and a
+        # neighbour that failed at a stronger mode must not carry its reason
+        # out on its behalf. On Codex that is the whole point of the cap:
+        # `warn` degrades to `record-only` there so nothing is shown that the
+        # host never rendered, and a second check the author did not control
+        # would otherwise defeat it.
+        floor = MODES.index(deciding)
         text = "\n".join(_failure_line(entry, outcome)
-                         for entry, _, outcome in failing)
+                         for entry, mode, outcome in failing
+                         if MODES.index(mode) >= floor)
         if deciding == "enforce":
             decision = "deny"
         elif deciding == "warn":

--- a/plugin/daimon_briefing/checks_runtime.py
+++ b/plugin/daimon_briefing/checks_runtime.py
@@ -187,6 +187,26 @@ def log_dir() -> Path:
     return Path.home() / ".daimon" / "logs"
 
 
+def check_timeout() -> float:
+    """Mirror of config.check_timeout(): the runner's own budget in seconds.
+
+    The hook is the caller that most needs it. A budget configured for the
+    CLI and ignored by the hook means the operator who lowered it to fit a
+    slow machine still loses the action to the HOST's timeout, which is
+    fail-open, and nothing anywhere says why.
+
+    Quirk-faithful per scar 0043, including the parts that read like bugs: a
+    present-but-unparseable value falls back to the default instead of
+    raising, and the floor keeps the smallest configured budget an actual
+    budget rather than an unconditional timeout. DEFAULT_TIMEOUT below is
+    this same number for the path where no configuration is consulted at
+    all."""
+    try:
+        return max(0.5, float(_config_get("DAIMON_CHECK_TIMEOUT") or "5"))
+    except ValueError:
+        return 5.0
+
+
 # ---- manifest -------------------------------------------------------------
 
 

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -3025,10 +3025,15 @@ _HOOK_HOSTS: dict[str, _HookHostSpec] = {
     # registration, so it carries `register: "codex"` and the install command
     # delegates the whole flow to codex_hooks.install (#262). `files`/`events`
     # here drive `hooks list` only; codex_hooks owns the copy + registration.
+    # #943 added daimon-codex-pre-action.py and the two modules it loads by
+    # same-dir lookup. `files` is what the status audit walks, so a file the
+    # install writes and this list omits goes stale invisibly.
     "codex": {
         "files": ("daimon-codex-session-start.py", "daimon-codex-stop.py",
-                  "_daimon_hook_lib.py"),
-        "events": ("SessionStart", "Stop"),
+                  "daimon-codex-session-end.py", "daimon-codex-pre-action.py",
+                  "_daimon_hook_lib.py", "checks_runtime.py",
+                  "checks_host.py"),
+        "events": ("SessionStart", "Stop", "SessionEnd", "PreToolUse"),
         "register": "codex",
     },
 }

--- a/plugin/daimon_briefing/cli/hooks.py
+++ b/plugin/daimon_briefing/cli/hooks.py
@@ -20,6 +20,32 @@ def _cmd_hooks_list(args) -> int:
     render.render_hooks_list(lines)
     return 0
 
+def _checks_line() -> str:
+    """What this project has armed, after materializing it (#943).
+
+    Installing the hook and writing what the hook reads are one step. Left
+    apart, the supported install ends with a gate in place and an empty
+    checks directory, and every surface then reads that as "armed, never
+    fired" rather than "never wired".
+
+    Never a failure. The scripts and the registration already landed; a
+    bookkeeping refusal reported as a failed install sends the operator
+    looking for a problem in the half that worked. The report's own words go
+    out unrewritten, because the reason a sync refused is more specific than
+    anything this line could say for it.
+
+    No `--slug`: that flag reaches ten human-only decision verbs and is
+    refused outright on a tenant-scoped home, and widening it to a verb that
+    materializes executables would hand bucket-choosing power past the check
+    that gates it (#899, #948)."""
+    from .. import checks
+
+    report = checks.sync(_cli._resolve_project(None))
+    if report.ok:
+        return f"checks: {report.armed} armed for {report.slug}"
+    return f"checks: {report.reason}"
+
+
 def _cmd_hooks_install(args) -> int:
     """Copy the host's packaged hook script(s) to ~/.daimon/hooks/ — a STABLE
     path the host's hooks config points at once. Idempotent: re-running after
@@ -38,7 +64,8 @@ def _cmd_hooks_install(args) -> int:
         # events straight into ~/.codex/hooks.json (#262), not a printed snippet.
         from .. import codex_hooks
 
-        render.render_hooks_install(codex_hooks.install(pkg, Path.home()))
+        lines = codex_hooks.install(pkg, Path.home())
+        render.render_hooks_install(lines + ["", _checks_line()])
         return 0
     target = _cli._hooks_target_dir()
     target.mkdir(parents=True, exist_ok=True)
@@ -60,6 +87,7 @@ def _cmd_hooks_install(args) -> int:
     lines.append("")
     lines.append("Re-run `daimon hooks install " + args.host +
                  "` after every `uv tool upgrade daimon-briefing`.")
+    lines += ["", _checks_line()]
     render.render_hooks_install(lines)
     return 0
 

--- a/plugin/daimon_briefing/codex_hooks.py
+++ b/plugin/daimon_briefing/codex_hooks.py
@@ -2,11 +2,12 @@
 path (#262).
 
 Codex is unlike the other packaged hosts: instead of a single entry script that
-the user registers by hand, it runs two distinct scripts under two events
-(SessionStart briefing injection, Stop opportunistic capture) and discovers them
-from ``~/.codex/hooks.json``. So this installer BOTH copies the scripts into
-``~/.codex/hooks/`` AND writes the registration itself, merging idempotently and
-preserving any unrelated entries already in ``hooks.json``.
+the user registers by hand, it runs several scripts under several events
+(SessionStart briefing injection, SessionEnd and Stop capture, PreToolUse check
+enforcement) and discovers them from ``~/.codex/hooks.json``. So this installer
+BOTH copies the scripts into ``~/.codex/hooks/`` AND writes the registration
+itself, merging idempotently and preserving any unrelated entries already in
+``hooks.json``.
 
 This adapts the standalone ``hook/codex-hooks.py`` lifecycle manager (which only
 runs from a repo clone) into the package. The registration shapes below are kept
@@ -66,13 +67,37 @@ HOOKS = (
             }],
         },
     },
+    {
+        # #943: the pre-action check. `matcher` keeps it to shell actions,
+        # which Codex names both ways depending on the build. No
+        # statusMessage: the other three fire once a session, this one fires
+        # before every command. Timeout 10 against a runner budget of 5, so
+        # the runner decides before Codex gives up and lets the action
+        # through.
+        "script": "daimon-codex-pre-action.py",
+        "event": "PreToolUse",
+        "entry": {
+            "matcher": "Bash|shell",
+            "hooks": [{
+                "type": "command",
+                "command": "python3 ~/.codex/hooks/daimon-codex-pre-action.py",
+                "timeout": 10,
+            }],
+        },
+    },
 )
 
-# Everything installed into ~/.codex/hooks/: the two scripts plus the shared
-# stdlib-only helper module they import by same-dir lookup. No redact.py — the
+# Everything installed into ~/.codex/hooks/: the scripts plus the shared
+# stdlib-only modules they import by same-dir lookup. No redact.py — the
 # Codex hooks spawn `daimon serialize` (the CLI redacts) and never scrub at
 # their own write sites, so the redaction module they'd load is dead weight.
-FILES = tuple(spec["script"] for spec in HOOKS) + (LIB,)
+#
+# #943 added the last two. The pre-action hook loads checks_host.py from its
+# own directory and that loads checks_runtime.py the same way, so a script
+# installed without them is a hook that finds nothing and allows in silence.
+# They are imported and never executed, which is why the +x below skips them.
+MODULES = (LIB, "checks_runtime.py", "checks_host.py")
+FILES = tuple(spec["script"] for spec in HOOKS) + MODULES
 
 
 def _is_ours(group, script):
@@ -120,7 +145,7 @@ def install(pkg, home):
     for name in FILES:
         dest = hooks_dir / name
         dest.write_bytes((pkg / name).read_bytes())
-        if name != LIB:  # the lib is imported, not executed
+        if name not in MODULES:  # imported, never executed
             dest.chmod(dest.stat().st_mode | 0o100)  # u+x — Codex runs the scripts
 
     settings = _load(hooks_json)

--- a/plugin/tests/test_checks_host.py
+++ b/plugin/tests/test_checks_host.py
@@ -184,3 +184,119 @@ def test_mode_for_survives_a_profile_that_is_not_one():
     shell action earns its own answer rather than relying on the net."""
     assert ch.mode_for(None, "enforce") == "unsupported"
     assert ch.mode_for(object(), "warn") == "unsupported"
+
+
+# ---- encoders (spec section 4), byte for byte ----------------------------
+
+REASON = "voice gate: no em-dash in a public body"
+
+
+def test_the_json_deny_is_byte_exact():
+    """A literal, not a parsed dict. The host reads these key names and a
+    rename is a deny that silently becomes an allow: a parsed comparison
+    would pass on a dict that spelled every key differently."""
+    out = ch.encode(ch.PROFILES["claude-code"], "deny", REASON)
+    assert out.stdout == (
+        '{"hookSpecificOutput": {"hookEventName": "PreToolUse", '
+        '"permissionDecision": "deny", "permissionDecisionReason": '
+        '"voice gate: no em-dash in a public body"}}')
+    assert out.stderr == ""
+    assert out.exit_code == 0
+
+
+def test_the_json_warn_is_an_allow_carrying_a_message():
+    """Byte-exact for the same reason. A warn that came out as a deny is an
+    action blocked by a check nobody armed to block."""
+    out = ch.encode(ch.PROFILES["claude-code"], "warn", REASON)
+    assert out.stdout == (
+        '{"hookSpecificOutput": {"hookEventName": "PreToolUse", '
+        '"permissionDecision": "allow"}, "systemMessage": '
+        '"voice gate: no em-dash in a public body"}')
+    assert out.stderr == ""
+    assert out.exit_code == 0
+
+
+def test_a_silent_allow_writes_nothing_at_all():
+    """Not an empty JSON object: the hosts treat absent output as no opinion,
+    and an object claiming a decision is a decision daimon did not make."""
+    for host in ("claude-code", "codex"):
+        out = ch.encode(ch.PROFILES[host], "allow", REASON)
+        assert out.stdout == ""
+        assert out.stderr == ""
+        assert out.exit_code == 0
+
+
+def test_a_warn_with_nothing_to_say_is_a_silent_allow():
+    out = ch.encode(ch.PROFILES["claude-code"], "warn", "")
+    assert out.stdout == ""
+
+
+def test_the_event_name_comes_from_the_profile_not_a_literal():
+    """The proof that the encoder is shared rather than copied per host: two
+    profiles, one function, and the event name is read off the row."""
+    import json as _json
+    for host in ("claude-code", "codex"):
+        data = _json.loads(ch.encode(ch.PROFILES[host], "deny", REASON).stdout)
+        assert (data["hookSpecificOutput"]["hookEventName"]
+                == ch.PROFILES[host].event)
+
+
+@pytest.mark.parametrize("host", ["claude-code", "codex"])
+@pytest.mark.parametrize("decision", ["deny", "warn", "allow"])
+def test_the_json_encoder_writes_one_line_and_exits_zero(host, decision):
+    """One JSON object or nothing, on one line, with no trailing text. The
+    hosts parse stdout, so a second line or a stray newline is a decision
+    they cannot read."""
+    out = ch.encode(ch.PROFILES[host], decision, REASON)
+    assert out.exit_code == 0
+    assert out.stderr == ""
+    assert "\n" not in out.stdout
+    if out.stdout:
+        import json as _json
+        _json.loads(out.stdout)
+
+
+def test_a_non_ascii_reason_survives_as_escaped_ascii():
+    """A check's stderr is arbitrary text. Escaping keeps the payload
+    readable on a host whose pipe is not UTF-8 without losing the reason."""
+    import json as _json
+    out = ch.encode(ch.PROFILES["claude-code"], "deny", "café ✅")
+    assert out.stdout.isascii()
+    data = _json.loads(out.stdout)
+    assert (data["hookSpecificOutput"]["permissionDecisionReason"]
+            == "café ✅")
+
+
+def test_the_windsurf_encoder_uses_the_documented_exit_two_channel():
+    """The row is complete so the profile is a row and not a special case.
+    With every mode unsupported nothing in the pipeline reaches a deny here,
+    which is why the shape is pinned by a test rather than by a live host."""
+    out = ch.encode(ch.PROFILES["windsurf"], "deny", REASON)
+    assert out.stdout == ""
+    assert out.stderr == REASON + "\n"
+    assert out.exit_code == 2
+
+    warn = ch.encode(ch.PROFILES["windsurf"], "warn", REASON)
+    assert warn.exit_code == 0
+    assert warn.stderr == REASON + "\n"
+
+    allow = ch.encode(ch.PROFILES["windsurf"], "allow", REASON)
+    assert (allow.stdout, allow.stderr, allow.exit_code) == ("", "", 0)
+
+
+def test_an_unknown_decision_word_is_a_silent_allow():
+    """Never a raise and never a deny. A word this build does not know must
+    not become the strongest thing the host can do."""
+    for host in ch.PROFILES:
+        out = ch.encode(ch.PROFILES[host], "block", REASON)
+        assert (out.stdout, out.stderr, out.exit_code) == ("", "", 0)
+
+
+def test_an_unknown_encoder_name_is_a_silent_allow():
+    broken = ch.PROFILES["claude-code"]._replace(encoder="telepathy")
+    out = ch.encode(broken, "deny", REASON)
+    assert (out.stdout, out.stderr, out.exit_code) == ("", "", 0)
+
+
+def test_the_decision_vocabulary_is_what_the_firing_log_records():
+    assert ch.DECISIONS == ("allow", "warn", "deny")

--- a/plugin/tests/test_checks_host.py
+++ b/plugin/tests/test_checks_host.py
@@ -535,8 +535,9 @@ def test_a_check_that_crashes_is_unresolved_and_not_a_violation(tmp_path):
 
 
 def test_two_matching_checks_aggregate_to_the_strongest_failing_mode(tmp_path):
-    """The deny lists both, because the human fixing this needs the whole
-    picture in the one message the host will show."""
+    """The strongest failing mode decides the action. The message names the
+    checks that decided it; the `warn` check that failed alongside is in the
+    log, which is where its own mode said to put it."""
     hard = _arm(tmp_path, intent="enforce", subject="public posts",
                 scope="publishing")
     soft = _arm(tmp_path, intent="warn", subject="release notes",
@@ -544,9 +545,8 @@ def test_two_matching_checks_aggregate_to_the_strongest_failing_mode(tmp_path):
     d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
     reason = json.loads(d.stdout)["hookSpecificOutput"][
         "permissionDecisionReason"]
-    assert sorted(reason.splitlines()) == sorted([
-        f"{hard}: no em-dash in a public body",
-        f"{soft}: no em-dash in a public body"])
+    assert reason == f"{hard}: no em-dash in a public body"
+    assert soft not in reason
     assert {r["mode"] for r in d.rows} == {"enforce", "warn"}
     # One action, one decision: every row records the decision the hook
     # actually emitted, not the one its own mode would have produced alone.
@@ -954,3 +954,63 @@ def test_every_matching_check_gets_a_row_even_the_ones_that_got_no_time(
     d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
     assert len(d.rows) == 3
     assert {r["cause"] for r in d.rows} == {"check-timeout"}
+
+
+# ---- the message carries only what its mode earned ------------------------
+
+
+def test_a_record_only_reason_never_reaches_the_operator(tmp_path):
+    """`record-only` means the log and nothing else. A neighbour that failed
+    at a stronger mode must not carry the quiet check's reason out with it,
+    or the author who asked for silence gets none."""
+    quiet = _arm(tmp_path, intent="record-only", subject="a",
+                 scope="publishing")
+    loud = _arm(tmp_path, intent="warn", subject="b", scope="publishing")
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    message = json.loads(d.stdout)["systemMessage"]
+    assert message == f"{loud}: no em-dash in a public body"
+    assert quiet not in message
+    # It still ran, and the log still says so.
+    assert {r["ruling_id"] for r in d.rows} == {quiet, loud}
+
+
+def test_a_warn_reason_never_reaches_a_deny_below_it(tmp_path):
+    """Same rule one step up. The deny names the checks that denied; a warn
+    that failed alongside is in the log, where its mode said to put it."""
+    soft = _arm(tmp_path, intent="warn", subject="a", scope="publishing")
+    hard = _arm(tmp_path, intent="enforce", subject="b", scope="publishing")
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    reason = json.loads(d.stdout)["hookSpecificOutput"][
+        "permissionDecisionReason"]
+    assert reason == f"{hard}: no em-dash in a public body"
+    assert soft not in reason
+
+
+def test_the_codex_cap_is_not_defeated_by_a_second_check(tmp_path):
+    """The sharp case. `warn` caps to `record-only` on Codex precisely so
+    nothing is shown that the host never rendered. A second check the author
+    did not control must not carry the capped one's reason out inside a
+    deny."""
+    capped = _arm(tmp_path, intent="warn", subject="a", scope="publishing")
+    hard = _arm(tmp_path, intent="enforce", subject="b", scope="publishing")
+    d = ch.decide(ch.PROFILES["codex"],
+                  _payload(MATCH, tmp_path, tool="shell"))
+    reason = json.loads(d.stdout)["hookSpecificOutput"][
+        "permissionDecisionReason"]
+    assert reason == f"{hard}: no em-dash in a public body"
+    assert capped not in reason
+    assert {r["mode"] for r in d.rows} == {"record-only", "enforce"}
+
+
+def test_two_failures_at_the_deciding_mode_are_both_named(tmp_path):
+    """The narrowing is by mode, not to one line. A human fixing a blocked
+    command needs every check that blocked it in the one message the host
+    will show."""
+    first = _arm(tmp_path, intent="enforce", subject="a", scope="publishing")
+    second = _arm(tmp_path, intent="enforce", subject="b", scope="publishing")
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    reason = json.loads(d.stdout)["hookSpecificOutput"][
+        "permissionDecisionReason"]
+    assert sorted(reason.splitlines()) == sorted([
+        f"{first}: no em-dash in a public body",
+        f"{second}: no em-dash in a public body"])

--- a/plugin/tests/test_checks_host.py
+++ b/plugin/tests/test_checks_host.py
@@ -548,9 +548,10 @@ def test_two_matching_checks_aggregate_to_the_strongest_failing_mode(tmp_path):
     assert reason == f"{hard}: no em-dash in a public body"
     assert soft not in reason
     assert {r["mode"] for r in d.rows} == {"enforce", "warn"}
-    # One action, one decision: every row records the decision the hook
-    # actually emitted, not the one its own mode would have produced alone.
-    assert {r["decision_emitted"] for r in d.rows} == {"deny"}
+    # The `warn` check failed below the deciding floor, so it was never
+    # heard, and its row does not claim to have denied anything.
+    assert {r["ruling_id"]: r["decision_emitted"] for r in d.rows} == \
+        {hard: "deny", soft: "allow"}
 
 
 def test_a_clean_enforce_check_does_not_deny_for_a_warn_neighbour(tmp_path):
@@ -1035,16 +1036,41 @@ def test_a_clean_row_never_claims_the_decision_a_neighbour_caused(tmp_path):
         "permissionDecision"] == "deny"
 
 
-def test_a_failing_row_below_the_deciding_mode_records_the_action(tmp_path):
-    """It contributed a failure, so it carries what the action emitted. What
-    it does NOT carry is a claim that it alone would have denied, which is
-    what the `mode` column beside it is for."""
+def test_a_failing_row_below_the_deciding_floor_keeps_its_allow(tmp_path):
+    """It failed, but its reason was withheld from the host because its own
+    mode said to withhold it. Stamping `deny` on that row claims a check
+    contributed to a block that it was never allowed to speak in, and the
+    stats surface counts these rows."""
     quiet = _arm(tmp_path, intent="record-only", subject="a",
                  scope="publishing")
     hard = _arm(tmp_path, intent="enforce", subject="b", scope="publishing")
     d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
     emitted = {r["ruling_id"]: r["decision_emitted"] for r in d.rows}
-    assert emitted == {quiet: "deny", hard: "deny"}
+    assert emitted == {quiet: "allow", hard: "deny"}
+    # Both still ran, and both still say what they found.
+    assert {r["outcome"] for r in d.rows} == {"violation"}
+
+
+def test_two_failures_at_the_floor_both_record_the_decision(tmp_path):
+    """The narrowing is by mode, not to one row. Every check that was heard
+    records what the host was told."""
+    first = _arm(tmp_path, intent="enforce", subject="a", scope="publishing")
+    second = _arm(tmp_path, intent="enforce", subject="b", scope="publishing")
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    emitted = {r["ruling_id"]: r["decision_emitted"] for r in d.rows}
+    assert emitted == {first: "deny", second: "deny"}
+
+
+def test_a_capped_codex_failure_keeps_its_allow_beside_a_deny(tmp_path):
+    """The Codex cap, one column further. A `warn` check degraded to
+    `record-only` there did not reach the operator, so its row does not claim
+    to have denied anything either."""
+    capped = _arm(tmp_path, intent="warn", subject="a", scope="publishing")
+    hard = _arm(tmp_path, intent="enforce", subject="b", scope="publishing")
+    d = ch.decide(ch.PROFILES["codex"],
+                  _payload(MATCH, tmp_path, tool="shell"))
+    emitted = {r["ruling_id"]: r["decision_emitted"] for r in d.rows}
+    assert emitted == {capped: "allow", hard: "deny"}
 
 
 def test_every_row_of_a_clean_action_records_an_allow(tmp_path):

--- a/plugin/tests/test_checks_host.py
+++ b/plugin/tests/test_checks_host.py
@@ -1,0 +1,186 @@
+"""#943 slice 3: the shared host-adapter core.
+
+`checks_host.py` is what the per-host pre-action scripts call. It runs in
+whatever interpreter the host launched, so this file loads it the way a hook
+will: by FILE LOCATION, under its own module name, from the canonical package
+copy. A relative import or a `daimon_briefing` import in it fails here rather
+than on someone's machine.
+
+The point of the module is that a host is a ROW, not a pipeline. Every test
+below that names a host names it through `PROFILES`, so adding one is adding
+a row and these tests are what say whether the row is complete.
+"""
+
+import ast
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+CANONICAL = (Path(__file__).parents[1] / "daimon_briefing" / "checks_host.py")
+
+
+def _host():
+    spec = importlib.util.spec_from_file_location(
+        "_checks_host_under_test", CANONICAL)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ch = _host()
+
+
+# ---- stdlib only, and the runtime by file location (scar 0049) ------------
+
+
+def test_the_host_core_imports_nothing_from_the_package():
+    """Scar 0049. This module ships into `hook/` and `_hooks/` and is loaded
+    by a script with no venv and no `daimon_briefing` on sys.path, so a
+    package import breaks every host at once and passes every local test."""
+    tree = ast.parse(CANONICAL.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            assert node.level == 0, f"relative import: {ast.dump(node)}"
+            assert not str(node.module or "").startswith("daimon_briefing"), \
+                f"package import: {node.module}"
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert not alias.name.startswith("daimon_briefing"), \
+                    f"package import: {alias.name}"
+                assert alias.name != "checks_runtime", (
+                    "the runtime must load by file location from this file's "
+                    "own directory, never by name off sys.path")
+
+
+def test_the_runtime_loads_from_this_files_own_directory():
+    """Same-directory, file-location load — the `_load_redact` shape. By name
+    it would depend on sys.path state and could bind an unrelated top-level
+    module of the same name."""
+    assert ch.runtime() is not None
+    assert ch.runtime().MANIFEST_NAME == "manifest.json"
+
+
+def test_a_missing_runtime_sibling_is_none_and_never_a_raise(monkeypatch,
+                                                             tmp_path):
+    """The stale-install shape: checks_host.py present, checks_runtime.py not.
+    A raise here fires before every shell action on the host."""
+    stray = tmp_path / "stray"
+    stray.mkdir()
+    (stray / "checks_host.py").write_bytes(CANONICAL.read_bytes())
+    spec = importlib.util.spec_from_file_location(
+        "_checks_host_no_runtime", stray / "checks_host.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    assert mod.runtime() is None
+
+
+# ---- profiles: a host is a row --------------------------------------------
+
+
+def test_every_declared_host_has_a_profile():
+    assert set(ch.PROFILES) == {"claude-code", "codex", "windsurf"}
+
+
+@pytest.mark.parametrize("host", ["claude-code", "codex", "windsurf"])
+def test_a_profile_row_is_complete(host):
+    """Every field the pipeline reads, present on every row. A row missing
+    one is a host that half-works: the adapter reads the payload, finds
+    nothing, and allows in silence."""
+    p = ch.PROFILES[host]
+    assert p.host == host
+    assert isinstance(p.event, str) and p.event
+    assert isinstance(p.tool_names, frozenset)
+    assert isinstance(p.command_path, tuple) and p.command_path
+    assert all(isinstance(k, str) and k for k in p.command_path)
+    assert isinstance(p.cwd_key, str) and p.cwd_key
+    assert p.encoder in ch.ENCODERS
+    assert set(p.mode_caps) == set(ch.INTENTS)
+    assert isinstance(p.matcher, str)
+    assert isinstance(p.install_timeout, int) and p.install_timeout > 0
+
+
+def test_the_payload_shapes_are_the_measured_ones():
+    """Spec section 4. Claude Code and Codex read `tool_input.command` under
+    `PreToolUse`; Windsurf reads `tool_info.command_line` under
+    `pre_run_command`, which is a different field name and not a typo."""
+    assert ch.PROFILES["claude-code"].event == "PreToolUse"
+    assert ch.PROFILES["claude-code"].command_path == ("tool_input", "command")
+    assert ch.PROFILES["claude-code"].tool_names == frozenset({"Bash"})
+    assert ch.PROFILES["claude-code"].matcher == "Bash"
+
+    assert ch.PROFILES["codex"].event == "PreToolUse"
+    assert ch.PROFILES["codex"].command_path == ("tool_input", "command")
+    assert ch.PROFILES["codex"].tool_names == frozenset({"Bash", "shell"})
+    assert ch.PROFILES["codex"].matcher == "Bash|shell"
+
+    assert ch.PROFILES["windsurf"].event == "pre_run_command"
+    assert ch.PROFILES["windsurf"].command_path == ("tool_info",
+                                                    "command_line")
+
+
+def test_the_host_label_is_what_reaches_the_firing_log():
+    """`host` on the row is the value `log_firing` records, so a reader can
+    attribute liveness per host. Two rows sharing a label would make the
+    per-host column unmeasurable, which is the thing this field exists for."""
+    labels = [p.host for p in ch.PROFILES.values()]
+    assert len(labels) == len(set(labels))
+    assert set(labels) == set(ch.PROFILES)
+
+
+# ---- the mode table (spec section 5), cell by cell ------------------------
+
+
+@pytest.mark.parametrize("host,intent,mode", [
+    ("claude-code", "enforce", "enforce"),
+    ("claude-code", "warn", "warn"),
+    ("claude-code", "record-only", "record-only"),
+    ("codex", "enforce", "enforce"),
+    # Codex documents no warn channel. Degrading to record-only is the whole
+    # point of the cap: a warn that silently vanishes reads as a check that
+    # never fired.
+    ("codex", "warn", "record-only"),
+    ("codex", "record-only", "record-only"),
+    # The whole Windsurf column stays unsupported until a live probe. An
+    # enforce intent shows unsupported there, never registered.
+    ("windsurf", "enforce", "unsupported"),
+    ("windsurf", "warn", "unsupported"),
+    ("windsurf", "record-only", "unsupported"),
+])
+def test_the_mode_table_cell_by_cell(host, intent, mode):
+    assert ch.mode_for(ch.PROFILES[host], intent) == mode
+
+
+@pytest.mark.parametrize("host", ["claude-code", "codex", "windsurf"])
+@pytest.mark.parametrize("intent", ["enforce", "warn", "record-only"])
+def test_a_mode_is_never_stronger_than_the_intent_that_asked(host, intent):
+    """The property behind the table: actual mode is the WEAKER of what the
+    author asked for and what the host can deliver. A cell that came out
+    stronger would have daimon enforcing something nobody armed."""
+    rank = ch.MODES.index
+    assert rank(ch.mode_for(ch.PROFILES[host], intent)) <= rank(intent)
+
+
+@pytest.mark.parametrize("intent", ["", "ENFORCE", "block", None, 7, "deny"])
+def test_an_unknown_intent_is_never_stronger_than_record_only(intent):
+    """A manifest is a file on disk and can carry an intent this build never
+    heard of. Reading it as the weakest real mode keeps an unknown word from
+    becoming an enforcement, and keeps it from crashing the hook."""
+    for host in ch.PROFILES:
+        mode = ch.mode_for(ch.PROFILES[host], intent)
+        assert mode in ch.MODES
+        assert ch.MODES.index(mode) <= ch.MODES.index("record-only")
+
+
+def test_modes_run_weakest_to_strongest():
+    """The order every aggregation and cap reads. Written down once so a
+    comparison cannot be spelled two ways."""
+    assert ch.MODES == ("unsupported", "record-only", "warn", "enforce")
+    assert ch.INTENTS == ("enforce", "warn", "record-only")
+
+
+def test_mode_for_survives_a_profile_that_is_not_one():
+    """`main` catches everything, but a function that fires before every
+    shell action earns its own answer rather than relying on the net."""
+    assert ch.mode_for(None, "enforce") == "unsupported"
+    assert ch.mode_for(object(), "warn") == "unsupported"

--- a/plugin/tests/test_checks_host.py
+++ b/plugin/tests/test_checks_host.py
@@ -1014,3 +1014,40 @@ def test_two_failures_at_the_deciding_mode_are_both_named(tmp_path):
     assert sorted(reason.splitlines()) == sorted([
         f"{first}: no em-dash in a public body",
         f"{second}: no em-dash in a public body"])
+
+
+# ---- a row records what that check contributed ----------------------------
+
+
+def test_a_clean_row_never_claims_the_decision_a_neighbour_caused(tmp_path):
+    """The docs this PR adds say a `deny` under `enforce` is what closes the
+    gap between a check that ran and a check that was honored. A clean row
+    carrying `deny` satisfies that filter while proving nothing of the kind,
+    and the stats surface counts these rows."""
+    passed = _arm(tmp_path, body=CLEAN, intent="enforce", subject="a",
+                  scope="publishing")
+    failed = _arm(tmp_path, intent="enforce", subject="b", scope="publishing")
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    emitted = {r["ruling_id"]: r["decision_emitted"] for r in d.rows}
+    assert emitted == {passed: "allow", failed: "deny"}
+    # The action itself still denied.
+    assert json.loads(d.stdout)["hookSpecificOutput"][
+        "permissionDecision"] == "deny"
+
+
+def test_a_failing_row_below_the_deciding_mode_records_the_action(tmp_path):
+    """It contributed a failure, so it carries what the action emitted. What
+    it does NOT carry is a claim that it alone would have denied, which is
+    what the `mode` column beside it is for."""
+    quiet = _arm(tmp_path, intent="record-only", subject="a",
+                 scope="publishing")
+    hard = _arm(tmp_path, intent="enforce", subject="b", scope="publishing")
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    emitted = {r["ruling_id"]: r["decision_emitted"] for r in d.rows}
+    assert emitted == {quiet: "deny", hard: "deny"}
+
+
+def test_every_row_of_a_clean_action_records_an_allow(tmp_path):
+    _arm(tmp_path, body=CLEAN, intent="enforce")
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert [r["decision_emitted"] for r in d.rows] == ["allow"]

--- a/plugin/tests/test_checks_host.py
+++ b/plugin/tests/test_checks_host.py
@@ -814,3 +814,72 @@ def test_main_survives_a_crash_it_cannot_even_record(tmp_path, monkeypatch):
     monkeypatch.setattr(ch, "decide", boom)
     monkeypatch.setattr(ch.runtime(), "log_firing", boom)
     assert _main(CC, _payload(MATCH, tmp_path)) == (0, "", "")
+
+
+# ---- the kill switch ------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", " 1 ", "yes\n"])
+def test_the_kill_switch_stops_the_check_before_anything_is_read(
+        value, tmp_path, monkeypatch):
+    """Every other daimon hook returns 0 in silence when `DAIMON_DISABLE` is
+    set, and this one has the most to answer for: it is the hook that can
+    block a command, so it is the hook an operator most needs a way out of.
+    Checked before the manifest, so a disabled hook costs one env read."""
+    _arm(tmp_path, intent="enforce")
+    monkeypatch.setenv("DAIMON_DISABLE", value)
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert (d.stdout, d.stderr, d.exit_code, d.rows) == ("", "", 0, [])
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "maybe",
+                                   "TRUE", "Yes"])
+def test_a_value_that_is_not_the_kill_switch_leaves_the_check_armed(
+        value, tmp_path, monkeypatch):
+    """`DAIMON_DISABLE=0` is the shape someone writes meaning "leave it on".
+    Reading any non-empty value as true would disarm a gate the operator
+    believes is armed.
+
+    `TRUE` is in this list on purpose: the existing hooks compare
+    case-sensitively, and a switch that disables three hooks and not the
+    fourth is worse than one that is strict everywhere."""
+    _arm(tmp_path, intent="enforce")
+    monkeypatch.setenv("DAIMON_DISABLE", value)
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert json.loads(d.stdout)["hookSpecificOutput"][
+        "permissionDecision"] == "deny"
+
+
+def test_the_kill_switch_is_read_from_the_process_environment_only(
+        tmp_path, monkeypatch):
+    """Unlike the path accessors (scar 0043) this does NOT fall back to
+    `~/.daimon/env`. The paths mirror a config value a writer and a deleter
+    must agree on; this is a switch someone flips for one session, and a copy
+    left in a file on disk would keep every later session disarmed with
+    nothing on screen to say so."""
+    _arm(tmp_path, intent="enforce")
+    monkeypatch.delenv("DAIMON_DISABLE", raising=False)
+    env_file = Path(os.environ["DAIMON_ENV_FILE"])
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    env_file.write_text("DAIMON_DISABLE=1\n", encoding="utf-8")
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert json.loads(d.stdout)["hookSpecificOutput"][
+        "permissionDecision"] == "deny"
+
+
+def test_main_writes_nothing_when_the_kill_switch_is_set(tmp_path,
+                                                         monkeypatch):
+    _arm(tmp_path, intent="enforce")
+    monkeypatch.setenv("DAIMON_DISABLE", "1")
+    assert _main(CC, _payload(MATCH, tmp_path)) == (0, "", "")
+    assert not (ch.runtime().log_dir() / "checks.jsonl").exists()
+
+
+def test_the_kill_switch_silences_the_missing_runtime_message_too(
+        tmp_path, monkeypatch):
+    """The diagnostic never reaches `decide`, so `main` checks the switch on
+    its own. A hook the operator turned off must not still be talking to the
+    host about its own install."""
+    monkeypatch.setattr(ch, "_RUNTIME", None)
+    monkeypatch.setenv("DAIMON_DISABLE", "1")
+    assert _main(CC, _payload(MATCH, tmp_path)) == (0, "", "")

--- a/plugin/tests/test_checks_host.py
+++ b/plugin/tests/test_checks_host.py
@@ -300,3 +300,380 @@ def test_an_unknown_encoder_name_is_a_silent_allow():
 
 def test_the_decision_vocabulary_is_what_the_firing_log_records():
     assert ch.DECISIONS == ("allow", "warn", "deny")
+
+
+# ---- decide: one pipeline, driven by a manifest the ledger wrote ----------
+#
+# Every manifest below is written by `checks.sync` from a ruling ratified
+# through `refutations` on a human channel. A hand-written manifest would
+# test the adapter against a shape nobody produces, and the seam this slice
+# adds is exactly the one between what the ledger writes and what the hook
+# reads.
+
+import hashlib  # noqa: E402
+import json  # noqa: E402
+import os  # noqa: E402
+
+from daimon_briefing import refutations  # noqa: E402
+
+CLEAN = "#!/bin/sh\nexit 0\n"
+VIOLATION = "#!/bin/sh\necho 'no em-dash in a public body' >&2\nexit 1\n"
+CRASHES = "#!/bin/sh\nexit 3\n"
+MATCH = "gh pr create"
+
+
+def _sha(body):
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def _arm(project, *, body=VIOLATION, match=MATCH, intent="warn",
+         subject="public posts", scope="publishing"):
+    """Arm one check the way a human does: an agent proposes, a human
+    ratifies through an in-process human channel, and the ratify syncs."""
+    ruling_id = refutations.assert_ruling(
+        subject=subject, verdict=f"the rule for {subject} in {scope}",
+        scope=scope, evidence=["issue:943"], channel="cli-agent",
+        check={"match": match, "body": body, "intent": intent},
+        project_dir=str(project))
+    refutations.ratify(ruling_id, channel="ui", check_sha256=_sha(body),
+                       project_dir=str(project))
+    return ruling_id
+
+
+def _payload(command, cwd, tool="Bash"):
+    return {"tool_name": tool, "tool_input": {"command": command},
+            "cwd": str(cwd)}
+
+
+CC = "claude-code"
+
+
+def test_a_tool_that_is_not_a_shell_action_is_a_silent_allow(tmp_path):
+    """No row either: nothing ran and nothing declined to run. A row here
+    would report a firing on every file edit in the session."""
+    _arm(tmp_path, intent="enforce")
+    d = ch.decide(ch.PROFILES[CC],
+                  {"tool_name": "Edit", "tool_input": {"command": MATCH},
+                   "cwd": str(tmp_path)})
+    assert (d.stdout, d.stderr, d.exit_code, d.rows) == ("", "", 0, [])
+
+
+@pytest.mark.parametrize("payload", [
+    {},
+    {"tool_name": "Bash", "cwd": "."},
+    {"tool_name": "Bash", "tool_input": {}, "cwd": "."},
+    {"tool_name": "Bash", "tool_input": {"command": None}, "cwd": "."},
+    {"tool_name": "Bash", "tool_input": {"command": 7}, "cwd": "."},
+    {"tool_name": "Bash", "tool_input": "gh pr create", "cwd": "."},
+    {"tool_name": "Bash", "tool_input": {"command": ""}, "cwd": "."},
+])
+def test_a_payload_without_a_command_is_a_silent_allow_and_no_row(payload,
+                                                                  tmp_path):
+    """Scar 0068 generalised: a host payload field is a CLAIM. A missing or
+    non-string command is an action daimon cannot see, which is an allow with
+    nothing to record, never a crash."""
+    _arm(tmp_path, intent="enforce")
+    payload = dict(payload)
+    if "cwd" in payload:
+        payload["cwd"] = str(tmp_path)
+    d = ch.decide(ch.PROFILES[CC], payload)
+    assert (d.stdout, d.exit_code, d.rows) == ("", 0, [])
+
+
+def test_no_manifest_allows_and_records_one_row_saying_so(tmp_path):
+    """Spec 3.1: the manifest is the wired signal, and "nothing is armed
+    here" has to be countable so the stats surface can say "armed, never
+    fired" instead of "clean"."""
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert d.stdout == ""
+    assert len(d.rows) == 1
+    row = d.rows[0]
+    assert row["cause"] == "no-manifest"
+    assert row["decision_emitted"] == "allow"
+    assert row["host"] == "claude-code"
+    assert row["ruling_id"] == ""
+    assert row["outcome"] == ""
+
+
+def test_an_unreadable_manifest_is_its_own_cause(tmp_path):
+    """An install that armed nothing and a manifest daimon wrote and can no
+    longer parse are different facts; folding them reports the first as the
+    second."""
+    from daimon_briefing import config
+    base = config.checks_dir()
+    base.mkdir(parents=True, exist_ok=True)
+    (base / "manifest.json").write_text("{not json", encoding="utf-8")
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert d.stdout == ""
+    assert [r["cause"] for r in d.rows] == ["manifest-unreadable"]
+
+
+def test_a_manifest_that_arms_another_project_is_no_match(tmp_path):
+    """The prefix test is the tenancy boundary. A ruling made for one project
+    must not govern the next directory over, and the row says the action was
+    seen and nothing here was armed for it."""
+    other = tmp_path / "other"
+    here = tmp_path / "here"
+    other.mkdir()
+    here.mkdir()
+    _arm(other, intent="enforce")
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, here))
+    assert d.stdout == ""
+    assert [r["cause"] for r in d.rows] == ["no-match"]
+    assert d.rows[0]["decision_emitted"] == "allow"
+
+
+def test_an_armed_check_whose_pattern_misses_records_nothing(tmp_path):
+    """The prefilter is the whole reason a hook on every Bash call is
+    affordable. A row per non-matching command would make the firing log a
+    transcript of the session, and spec 3.1 names only the two project-level
+    causes."""
+    _arm(tmp_path, intent="enforce")
+    d = ch.decide(ch.PROFILES[CC], _payload("ls -la", tmp_path))
+    assert (d.stdout, d.rows) == ("", [])
+
+
+def test_a_clean_check_is_a_silent_allow_with_a_row(tmp_path):
+    ruling_id = _arm(tmp_path, body=CLEAN, intent="enforce")
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert (d.stdout, d.stderr, d.exit_code) == ("", "", 0)
+    assert len(d.rows) == 1
+    row = d.rows[0]
+    assert row["ruling_id"] == ruling_id
+    assert row["outcome"] == "clean"
+    assert row["cause"] == ""
+    assert row["mode"] == "enforce"
+    assert row["decision_emitted"] == "allow"
+    assert row["duration_ms"] >= 0
+
+
+def test_a_violation_under_enforce_denies_and_names_the_ruling(tmp_path):
+    ruling_id = _arm(tmp_path, intent="enforce")
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    data = json.loads(d.stdout)
+    out = data["hookSpecificOutput"]
+    assert out["permissionDecision"] == "deny"
+    assert out["permissionDecisionReason"] == \
+        f"{ruling_id}: no em-dash in a public body"
+    assert d.exit_code == 0
+    assert d.rows[0]["mode"] == "enforce"
+    assert d.rows[0]["outcome"] == "violation"
+    assert d.rows[0]["decision_emitted"] == "deny"
+
+
+def test_the_same_violation_under_warn_allows_and_says_so(tmp_path):
+    ruling_id = _arm(tmp_path, intent="warn")
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    data = json.loads(d.stdout)
+    assert data["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert data["systemMessage"] == f"{ruling_id}: no em-dash in a public body"
+    assert d.rows[0]["mode"] == "warn"
+    assert d.rows[0]["decision_emitted"] == "warn"
+
+
+def test_the_same_violation_under_record_only_is_silent(tmp_path):
+    """The run still happened and the log still says so. Record-only is the
+    mode where the operator learns from the log rather than from the host."""
+    _arm(tmp_path, intent="record-only")
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert d.stdout == ""
+    assert d.rows[0]["outcome"] == "violation"
+    assert d.rows[0]["mode"] == "record-only"
+    assert d.rows[0]["decision_emitted"] == "allow"
+
+
+def test_the_codex_cap_turns_the_same_warn_into_a_silent_record(tmp_path):
+    """One ruling, one manifest, two hosts. The only thing that differs is
+    the row, which is the claim this slice makes: Codex documents no warn
+    channel, so a warn there is recorded and not shown."""
+    _arm(tmp_path, intent="warn")
+    payload = _payload(MATCH, tmp_path, tool="shell")
+    cc = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    cx = ch.decide(ch.PROFILES["codex"], payload)
+    assert cc.rows[0]["mode"] == "warn" and cc.stdout != ""
+    assert cx.rows[0]["mode"] == "record-only" and cx.stdout == ""
+    assert cx.rows[0]["host"] == "codex"
+    assert cx.rows[0]["decision_emitted"] == "allow"
+
+
+def test_an_enforce_check_on_windsurf_records_and_never_denies(tmp_path):
+    """The unsupported column, end to end. An enforce intent shows up as a
+    logged run and no decision at all, which is the honest reading of a host
+    whose block path has never been measured."""
+    _arm(tmp_path, intent="enforce")
+    d = ch.decide(ch.PROFILES["windsurf"],
+                  {"tool_info": {"command_line": MATCH}, "cwd": str(tmp_path)})
+    assert (d.stdout, d.stderr, d.exit_code) == ("", "", 0)
+    assert d.rows[0]["mode"] == "unsupported"
+    assert d.rows[0]["outcome"] == "violation"
+    assert d.rows[0]["decision_emitted"] == "allow"
+
+
+def test_an_unresolved_subject_denies_under_enforce_and_names_the_cause(
+        tmp_path):
+    """Spec 2.3 and the 2026-09-05 decision: unresolved is never rendered as
+    clean. daimon could not read what the action sends, so under enforce it
+    cannot let it through."""
+    ruling_id = _arm(tmp_path, body=CLEAN, intent="enforce")
+    command = f"{MATCH} --body-file missing.md"
+    d = ch.decide(ch.PROFILES[CC], _payload(command, tmp_path))
+    reason = json.loads(d.stdout)["hookSpecificOutput"][
+        "permissionDecisionReason"]
+    assert reason.startswith(f"{ruling_id}: file-missing: ")
+    assert "missing.md" in reason
+    assert d.rows[0]["outcome"] == "unresolved"
+    assert d.rows[0]["cause"] == "file-missing"
+
+
+def test_a_check_that_crashes_is_unresolved_and_not_a_violation(tmp_path):
+    _arm(tmp_path, body=CRASHES, intent="enforce")
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert d.rows[0]["outcome"] == "unresolved"
+    assert d.rows[0]["cause"] == "check-crashed"
+    assert json.loads(d.stdout)["hookSpecificOutput"][
+        "permissionDecision"] == "deny"
+
+
+def test_two_matching_checks_aggregate_to_the_strongest_failing_mode(tmp_path):
+    """The deny lists both, because the human fixing this needs the whole
+    picture in the one message the host will show."""
+    hard = _arm(tmp_path, intent="enforce", subject="public posts",
+                scope="publishing")
+    soft = _arm(tmp_path, intent="warn", subject="release notes",
+                scope="publishing")
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    reason = json.loads(d.stdout)["hookSpecificOutput"][
+        "permissionDecisionReason"]
+    assert sorted(reason.splitlines()) == sorted([
+        f"{hard}: no em-dash in a public body",
+        f"{soft}: no em-dash in a public body"])
+    assert {r["mode"] for r in d.rows} == {"enforce", "warn"}
+    # One action, one decision: every row records the decision the hook
+    # actually emitted, not the one its own mode would have produced alone.
+    assert {r["decision_emitted"] for r in d.rows} == {"deny"}
+
+
+def test_a_clean_enforce_check_does_not_deny_for_a_warn_neighbour(tmp_path):
+    """The strongest FAILING mode decides, not the strongest mode present. An
+    enforce check that passed has nothing to say about a warn check that
+    did not, and reading it the other way blocks actions nobody armed."""
+    _arm(tmp_path, body=CLEAN, intent="enforce", subject="public posts",
+         scope="publishing")
+    soft = _arm(tmp_path, intent="warn", subject="release notes",
+                scope="publishing")
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    data = json.loads(d.stdout)
+    assert data["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert data["systemMessage"] == f"{soft}: no em-dash in a public body"
+
+
+def test_the_subject_is_resolved_once_for_every_matching_check(tmp_path,
+                                                              monkeypatch):
+    """Resolving reads every file argument off disk. Doing it per entry pays
+    that cost again for a subject that cannot have changed, inside a budget
+    the host will not extend."""
+    _arm(tmp_path, body=CLEAN, intent="warn", subject="a", scope="publishing")
+    _arm(tmp_path, body=CLEAN, intent="warn", subject="b", scope="publishing")
+    rt_mod = ch.runtime()
+    calls = []
+    real = rt_mod.resolve
+    monkeypatch.setattr(rt_mod, "resolve",
+                        lambda *a, **k: (calls.append(a), real(*a, **k))[1])
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert len(d.rows) == 2
+    assert len(calls) == 1
+
+
+def test_the_subject_file_is_discarded_even_when_the_runner_explodes(
+        tmp_path, monkeypatch):
+    """The temp subject holds the command and every file it named. A run that
+    raises must not leave it behind, and `finally` is the only placement that
+    survives an exception nobody predicted."""
+    _arm(tmp_path, body=CLEAN, intent="warn")
+    rt_mod = ch.runtime()
+    seen = []
+    monkeypatch.setattr(rt_mod, "run",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("x")))
+    real_discard = rt_mod.discard
+    monkeypatch.setattr(rt_mod, "discard",
+                        lambda s: (seen.append(getattr(s, "path", "")),
+                                   real_discard(s))[1])
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert seen and seen[0]
+    assert not os.path.exists(seen[0])
+    assert d.stdout == ""
+
+
+@pytest.mark.parametrize("name", ["load_manifest", "armed_for", "matches",
+                                  "resolve", "run", "discard"])
+def test_decide_never_raises_whatever_the_runtime_does(tmp_path, monkeypatch,
+                                                       name):
+    """The one promise this module makes. It fires before every shell action,
+    and on the hosts measured so far a hook that crashes is fail-open: the
+    action proceeds and nothing anywhere says why."""
+    _arm(tmp_path, body=CLEAN, intent="enforce")
+    rt_mod = ch.runtime()
+    monkeypatch.setattr(rt_mod, name,
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError(name)))
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert d.exit_code == 0
+    assert d.stdout == "" or json.loads(d.stdout)
+    assert isinstance(d.rows, list)
+
+
+def test_a_payload_with_no_cwd_falls_back_to_the_process_directory(tmp_path,
+                                                                   monkeypatch):
+    """The host is supposed to send it. When it does not, the process the
+    host launched is standing in the action's directory anyway, and guessing
+    nothing would disarm every check for that action in silence."""
+    _arm(tmp_path, body=CLEAN, intent="enforce")
+    monkeypatch.chdir(tmp_path)
+    d = ch.decide(ch.PROFILES[CC],
+                  {"tool_name": "Bash", "tool_input": {"command": MATCH}})
+    assert [r["outcome"] for r in d.rows] == ["clean"]
+
+
+def test_every_row_of_one_action_shares_one_timestamp(tmp_path):
+    _arm(tmp_path, body=CLEAN, intent="warn", subject="a", scope="publishing")
+    _arm(tmp_path, body=CLEAN, intent="warn", subject="b", scope="publishing")
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path),
+                  now="2026-09-06T00:00:00Z")
+    assert {r["ts"] for r in d.rows} == {"2026-09-06T00:00:00Z"}
+
+
+def test_every_row_carries_exactly_the_declared_firing_keys(tmp_path):
+    """`log_firing` projects onto FIRING_KEYS, so a row with a stray field
+    loses it silently. Building the row to the declared shape here is what
+    keeps the two ends one declaration."""
+    _arm(tmp_path, body=CLEAN, intent="warn")
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    for row in d.rows:
+        assert set(row) == set(ch.runtime().FIRING_KEYS)
+        assert row["cause"] in ch.runtime().LOG_CAUSES or row["cause"] == ""
+
+
+def test_the_runner_budget_comes_from_the_configured_timeout(tmp_path,
+                                                             monkeypatch):
+    """The mirror added for this slice, actually reached. A hook running on
+    the runtime's bare default would ignore an operator who lowered the
+    budget to fit a slow machine."""
+    _arm(tmp_path, body=CLEAN, intent="warn")
+    rt_mod = ch.runtime()
+    seen = {}
+    real = rt_mod.run
+    monkeypatch.setattr(rt_mod, "run",
+                        lambda *a, **k: (seen.update(k), real(*a, **k))[1])
+    monkeypatch.setenv("DAIMON_CHECK_TIMEOUT", "1.5")
+    ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert seen["timeout"] == 1.5
+    ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path), timeout=0.75)
+    assert seen["timeout"] == 0.75
+
+
+def test_a_missing_runtime_decides_nothing_and_says_nothing(tmp_path,
+                                                            monkeypatch):
+    """A stale install: this module shipped, its sibling did not. There is
+    nothing to write a row WITH, so the caller owns the diagnostic."""
+    monkeypatch.setattr(ch, "_RUNTIME", None)
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert (d.stdout, d.stderr, d.exit_code, d.rows) == ("", "", 0, [])

--- a/plugin/tests/test_checks_host.py
+++ b/plugin/tests/test_checks_host.py
@@ -677,3 +677,140 @@ def test_a_missing_runtime_decides_nothing_and_says_nothing(tmp_path,
     monkeypatch.setattr(ch, "_RUNTIME", None)
     d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
     assert (d.stdout, d.stderr, d.exit_code, d.rows) == ("", "", 0, [])
+
+
+# ---- main: what the thin scripts call, driven in process -----------------
+#
+# The end-to-end coverage lives in test_pre_action_hook.py, which spawns the
+# real scripts. These drive the same entry point with substitute streams so
+# the branches a subprocess cannot reach from inside this process are still
+# proved rather than assumed.
+
+import io  # noqa: E402
+
+
+def _main(host, payload, **kw):
+    stdin = io.StringIO(payload if isinstance(payload, str)
+                        else json.dumps(payload))
+    out, err = io.StringIO(), io.StringIO()
+    code = ch.main(host, stdin=stdin, stdout=out, stderr=err, **kw)
+    return code, out.getvalue(), err.getvalue()
+
+
+def test_main_writes_the_decision_and_records_every_row(tmp_path):
+    ruling_id = _arm(tmp_path, intent="enforce")
+    code, out, err = _main(CC, _payload(MATCH, tmp_path))
+    assert (code, err) == (0, "")
+    assert json.loads(out)["hookSpecificOutput"]["permissionDecision"] == "deny"
+    rows = [json.loads(line) for line in
+            (ch.runtime().log_dir() / "checks.jsonl").read_text(
+                encoding="utf-8").splitlines()]
+    assert [r["ruling_id"] for r in rows] == [ruling_id]
+    assert rows[0]["decision_emitted"] == "deny"
+
+
+def test_main_on_a_host_with_no_profile_does_nothing(tmp_path):
+    """A script naming a host this build does not carry. Silent, and never a
+    KeyError before every shell action."""
+    _arm(tmp_path, intent="enforce")
+    assert _main("emacs", _payload(MATCH, tmp_path)) == (0, "", "")
+
+
+def test_main_says_the_runtime_is_missing_where_the_host_will_show_it(
+        tmp_path, monkeypatch):
+    monkeypatch.setattr(ch, "_RUNTIME", None)
+    code, out, err = _main(CC, _payload(MATCH, tmp_path))
+    assert (code, err) == (0, "")
+    assert json.loads(out)["systemMessage"] == ch.RUNTIME_MISSING
+    assert json.loads(out)["hookSpecificOutput"][
+        "permissionDecision"] == "allow"
+
+
+@pytest.mark.parametrize("host", ["codex", "windsurf"])
+def test_main_stays_quiet_about_a_missing_runtime_where_it_cannot_be_shown(
+        host, tmp_path, monkeypatch):
+    """The message channel is a `warn`, and on a host that caps warn below
+    warn it has nowhere to go. Emitting it anyway would put text on a stream
+    the operator never sees, on a host that parses that stream."""
+    monkeypatch.setattr(ch, "_RUNTIME", None)
+    assert _main(host, _payload(MATCH, tmp_path)) == (0, "", "")
+
+
+def test_main_writes_nothing_when_the_decision_itself_explodes(tmp_path,
+                                                               monkeypatch):
+    """Belt and braces over `decide`'s own guard. Nothing written means the
+    host sees no opinion and proceeds, and the row is the only record that
+    anything happened, so it gets one more attempt that cannot itself
+    raise."""
+    _arm(tmp_path, body=CLEAN, intent="enforce")
+    monkeypatch.setattr(ch, "decide",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("x")))
+    assert _main(CC, _payload(MATCH, tmp_path)) == (0, "", "")
+    rows = [json.loads(line) for line in
+            (ch.runtime().log_dir() / "checks.jsonl").read_text(
+                encoding="utf-8").splitlines()]
+    assert [r["cause"] for r in rows] == ["check-crashed"]
+    assert rows[0]["decision_emitted"] == "allow"
+
+
+def test_main_survives_a_log_that_cannot_be_written(tmp_path, monkeypatch):
+    """Losing the decision over the record would be the wrong trade. The row
+    is bookkeeping; the deny is the thing the operator armed."""
+    _arm(tmp_path, intent="enforce")
+    monkeypatch.setattr(ch.runtime(), "log_firing",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("full")))
+    code, out, _ = _main(CC, _payload(MATCH, tmp_path))
+    assert code == 0
+    assert json.loads(out)["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+@pytest.mark.parametrize("raw", ["", "not json", "[]", "null", "3"])
+def test_a_payload_that_is_not_an_object_reads_as_an_empty_one(raw):
+    assert ch._read_payload(io.StringIO(raw)) == {}
+
+
+def test_a_stdin_that_cannot_be_read_reads_as_an_empty_payload():
+    """A closed or broken pipe. The host is gone or was never there, and a
+    traceback would be the same allow with a worse record."""
+    class Broken:
+        def read(self):
+            raise OSError("closed")
+
+    assert ch._read_payload(Broken()) == {}
+
+
+# ---- the loader's own failure modes ---------------------------------------
+
+
+def test_the_loader_returns_none_when_the_sibling_is_absent(tmp_path,
+                                                            monkeypatch):
+    monkeypatch.setattr(ch, "__file__", str(tmp_path / "checks_host.py"))
+    assert ch._load_runtime() is None
+
+
+def test_the_loader_returns_none_when_the_sibling_is_broken(tmp_path,
+                                                            monkeypatch):
+    """A truncated or half-written copy from an interrupted install. It must
+    read as absent, not as an import error before every shell action."""
+    (tmp_path / "checks_runtime.py").write_text("def (\n", encoding="utf-8")
+    monkeypatch.setattr(ch, "__file__", str(tmp_path / "checks_host.py"))
+    assert ch._load_runtime() is None
+
+
+def test_decide_treats_a_payload_that_is_not_a_mapping_as_an_empty_one():
+    """`main` only ever hands it a dict, but `decide` is the module's public
+    entry point and a caller is not a guarantee."""
+    for payload in ("nonsense", None, 7, ["tool_input"]):
+        d = ch.decide(ch.PROFILES[CC], payload)
+        assert (d.stdout, d.rows) == ("", [])
+
+
+def test_main_survives_a_crash_it_cannot_even_record(tmp_path, monkeypatch):
+    """The last line of the net: the decision failed AND the log failed. The
+    action still proceeds, silently, rather than the hook taking the session
+    down with it."""
+    _arm(tmp_path, body=CLEAN, intent="enforce")
+    boom = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("x"))  # noqa: E731
+    monkeypatch.setattr(ch, "decide", boom)
+    monkeypatch.setattr(ch.runtime(), "log_firing", boom)
+    assert _main(CC, _payload(MATCH, tmp_path)) == (0, "", "")

--- a/plugin/tests/test_checks_host.py
+++ b/plugin/tests/test_checks_host.py
@@ -883,3 +883,74 @@ def test_the_kill_switch_silences_the_missing_runtime_message_too(
     monkeypatch.setattr(ch, "_RUNTIME", None)
     monkeypatch.setenv("DAIMON_DISABLE", "1")
     assert _main(CC, _payload(MATCH, tmp_path)) == (0, "", "")
+
+
+# ---- one budget for the whole action --------------------------------------
+
+
+def test_the_action_budget_leaves_the_host_room_to_receive_the_decision():
+    """Eight seconds against a host timeout of ten. The two that are left pay
+    for the manifest read, the resolve, and the kill-and-drain after a check
+    that had to be stopped. A hook that reaches the HOST's timeout does not
+    block: the action proceeds, and nothing is written and nothing is
+    logged."""
+    assert ch.ACTION_BUDGET == 8.0
+    assert ch.ACTION_BUDGET < ch.PROFILES[CC].install_timeout
+
+
+def test_a_check_with_no_budget_left_never_spawns_and_is_unresolved(
+        tmp_path, monkeypatch):
+    """The budget belongs to the ACTION, so the last check of a slow action
+    can find it already spent. It is `unresolved`, which under `enforce` is a
+    deny: daimon could not prove the subject clean, and letting it through
+    because time ran out is exactly the fail-open the budget exists to
+    prevent."""
+    _arm(tmp_path, body=CLEAN, intent="enforce")
+    monkeypatch.setattr(ch, "ACTION_BUDGET", 0.0)
+    spawned = []
+    monkeypatch.setattr(ch.runtime(), "run",
+                        lambda *a, **k: spawned.append(a))
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert spawned == []
+    assert d.rows[0]["outcome"] == "unresolved"
+    assert d.rows[0]["cause"] == "check-timeout"
+    assert json.loads(d.stdout)["hookSpecificOutput"][
+        "permissionDecision"] == "deny"
+
+
+def test_each_check_gets_the_lesser_of_its_own_cap_and_what_is_left(
+        tmp_path, monkeypatch):
+    """`DAIMON_CHECK_TIMEOUT` still caps one check. The action deadline caps
+    the sum. Whichever is smaller is what the runner is given, because a
+    per-check cap that outlives the action's own budget is the defect being
+    fixed."""
+    _arm(tmp_path, body=CLEAN, intent="warn", subject="a", scope="publishing")
+    _arm(tmp_path, body=CLEAN, intent="warn", subject="b", scope="publishing")
+    seen = []
+    real = ch.runtime().run
+    monkeypatch.setattr(ch.runtime(), "run",
+                        lambda *a, **k: (seen.append(k["timeout"]),
+                                         real(*a, **k))[1])
+
+    monkeypatch.setenv("DAIMON_CHECK_TIMEOUT", "0.6")
+    ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert seen == [0.6, 0.6], seen  # the per-check cap is the smaller one
+
+    seen.clear()
+    monkeypatch.setattr(ch, "ACTION_BUDGET", 0.4)
+    ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert seen and all(t <= 0.4 for t in seen), seen
+
+
+def test_every_matching_check_gets_a_row_even_the_ones_that_got_no_time(
+        tmp_path, monkeypatch):
+    """The row is how a check that never ran stays countable. Dropping it
+    would leave the liveness surface reading "armed, never fired" for a check
+    that was armed, matched, and starved."""
+    for name in ("a", "b", "c"):
+        _arm(tmp_path, body=CLEAN, intent="warn", subject=name,
+             scope="publishing")
+    monkeypatch.setattr(ch, "ACTION_BUDGET", 0.0)
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert len(d.rows) == 3
+    assert {r["cause"] for r in d.rows} == {"check-timeout"}

--- a/plugin/tests/test_checks_host.py
+++ b/plugin/tests/test_checks_host.py
@@ -1051,3 +1051,139 @@ def test_every_row_of_a_clean_action_records_an_allow(tmp_path):
     _arm(tmp_path, body=CLEAN, intent="enforce")
     d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
     assert [r["decision_emitted"] for r in d.rows] == ["allow"]
+
+
+# ---- a state daimon cannot read stays countable ---------------------------
+
+
+def test_a_command_sent_as_a_list_is_joined_and_checked(tmp_path):
+    """Some Codex builds send the shell tool's command as an argv array. Read
+    as "no command", every armed check on that host goes silently inert and
+    the liveness surface reads "armed, never fired", which the docs describe
+    as the honest signal for a wired-but-quiet install."""
+    ruling_id = _arm(tmp_path, intent="enforce")
+    d = ch.decide(ch.PROFILES["codex"],
+                  {"tool_name": "shell",
+                   "tool_input": {"command": ["gh", "pr", "create", "-t", "x"]},
+                   "cwd": str(tmp_path)})
+    assert json.loads(d.stdout)["hookSpecificOutput"][
+        "permissionDecisionReason"].startswith(ruling_id)
+
+
+def test_a_joined_command_is_quoted_the_way_a_shell_would_read_it(tmp_path):
+    """Joined with shell quoting, not with a space. An argument holding a
+    space would otherwise become two arguments in the subject the check
+    reads, and the check would be judging a command nobody ran."""
+    _arm(tmp_path, body=CLEAN, intent="enforce")
+    seen = []
+    real = ch.runtime().resolve
+    monkeypatch_free = ch.runtime()
+    original = monkeypatch_free.resolve
+    monkeypatch_free.resolve = lambda c, cwd: (seen.append(c), real(c, cwd))[1]
+    try:
+        ch.decide(ch.PROFILES["codex"],
+                  {"tool_name": "shell",
+                   "tool_input": {"command": ["gh", "pr", "create", "--body",
+                                              "a b"]},
+                   "cwd": str(tmp_path)})
+    finally:
+        monkeypatch_free.resolve = original
+    assert seen == ["gh pr create --body 'a b'"]
+
+
+@pytest.mark.parametrize("command", [["gh", 7], [None], [{"a": 1}], [[]]])
+def test_a_list_command_that_is_not_all_strings_is_recorded(command,
+                                                            tmp_path):
+    """Not a rowless allow. daimon could not read what the action sends, and
+    that state has to be countable or the surface reports a quiet install
+    where there was an unreadable one."""
+    _arm(tmp_path, intent="enforce")
+    d = ch.decide(ch.PROFILES["codex"],
+                  {"tool_name": "shell", "tool_input": {"command": command},
+                   "cwd": str(tmp_path)})
+    assert d.stdout == ""
+    assert [(r["cause"], r["outcome"]) for r in d.rows] == \
+        [("arg-form-unparsed", "unresolved")]
+
+
+def test_a_match_that_cannot_compile_is_recorded_and_denies(tmp_path):
+    """`refutations` compiles the pattern at propose time, so this is
+    reachable only by hand-editing the manifest. "A regex that cannot
+    compile" is still a different fact from "a regex that did not match", and
+    only one of them was countable."""
+    ruling_id = _arm(tmp_path, body=CLEAN, intent="enforce")
+    path = ch.runtime().checks_dir() / "manifest.json"
+    entries = json.loads(path.read_text(encoding="utf-8"))
+    entries[0]["match"] = "gh pr create("
+    path.write_text(json.dumps(entries), encoding="utf-8")
+
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert [(r["ruling_id"], r["cause"], r["outcome"]) for r in d.rows] == \
+        [(ruling_id, "check-crashed", "unresolved")]
+    assert json.loads(d.stdout)["hookSpecificOutput"][
+        "permissionDecision"] == "deny"
+
+
+def test_a_broken_pattern_does_not_cost_the_subject_a_resolve(tmp_path):
+    """Nothing to run it against, so nothing is read off disk for it. The
+    resolve is the expensive half and it is bounded by the action budget."""
+    _arm(tmp_path, body=CLEAN, intent="enforce")
+    path = ch.runtime().checks_dir() / "manifest.json"
+    entries = json.loads(path.read_text(encoding="utf-8"))
+    entries[0]["match"] = "gh pr create("
+    path.write_text(json.dumps(entries), encoding="utf-8")
+
+    resolved = []
+    rt_mod = ch.runtime()
+    original = rt_mod.resolve
+    rt_mod.resolve = lambda *a, **k: resolved.append(a)
+    try:
+        ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    finally:
+        rt_mod.resolve = original
+    assert resolved == []
+
+
+def test_a_working_directory_daimon_cannot_read_names_that_cause(tmp_path):
+    """`no-match` says every armed check was compared and none applied. When
+    the working directory itself is unusable, nothing was compared, and the
+    two states must not share a name."""
+    _arm(tmp_path, intent="enforce")
+    d = ch.decide(ch.PROFILES[CC],
+                  _payload(MATCH, str(tmp_path) + "\x00/sub"))
+    assert d.stdout == ""
+    assert [(r["cause"], r["outcome"]) for r in d.rows] == \
+        [("file-unreadable", "unresolved")]
+
+
+def test_rows_already_decided_survive_an_exception_mid_loop(tmp_path,
+                                                            monkeypatch):
+    """`rt.run` is documented never to raise, so this is the theoretical
+    case. It is also the one where the record matters most: the first check's
+    violation is the only evidence of what happened."""
+    armed = {_arm(tmp_path, intent="enforce", subject="a",
+                  scope="publishing"),
+             _arm(tmp_path, intent="enforce", subject="b",
+                  scope="publishing")}
+    rt_mod = ch.runtime()
+    real = rt_mod.run
+    calls = []
+
+    def _run(*a, **k):
+        calls.append(a)
+        if len(calls) > 1:
+            raise RuntimeError("second one explodes")
+        return real(*a, **k)
+
+    monkeypatch.setattr(rt_mod, "run", _run)
+    d = ch.decide(ch.PROFILES[CC], _payload(MATCH, tmp_path))
+    assert d.stdout == ""
+    # The check that finished keeps its row, with the decision the host
+    # actually got, which is nothing.
+    survived = [r for r in d.rows if r["outcome"] == "violation"]
+    assert len(survived) == 1
+    assert survived[0]["ruling_id"] in armed
+    assert survived[0]["decision_emitted"] == "allow"
+    # And the crash itself is recorded rather than swallowed.
+    assert any(r["cause"] == "check-crashed" and r["ruling_id"] == ""
+               for r in d.rows)

--- a/plugin/tests/test_checks_runtime.py
+++ b/plugin/tests/test_checks_runtime.py
@@ -106,6 +106,52 @@ def test_mirror_and_config_agree_over_the_whole_probe_table(
         "every probe resolved alike — the env file was never read at all"
 
 
+def test_the_timeout_mirror_agrees_with_config_over_its_own_probe_table(
+        tmp_path, monkeypatch):
+    """#943 slice 3: the hook needs the budget, not just the paths.
+
+    `DAIMON_CHECK_TIMEOUT` is a number rather than a path, so it cannot share
+    the table above — every probe there is path-shaped and would collapse to
+    the same 5.0 here, which is exactly the shape that passes while measuring
+    nothing. It gets its own table, asserted the same way: against the config
+    function, never against a literal this test would also have to get right.
+
+    The quirks that look like bugs and are not (scar 0043): a present-but-
+    unparseable value is the default rather than an error, a value under the
+    floor is the floor rather than an unconditional timeout, and the env file
+    is read when the process env is silent, because that is the channel a
+    GUI-launched host actually uses."""
+    name = "DAIMON_CHECK_TIMEOUT"
+    resolved = set()
+    for raw in (None, "", "   ", "0", "0.1", "3", "  7  ", "12.5", "abc",
+                "-2", "1e1"):
+        monkeypatch.delenv(name, raising=False)
+        if raw is not None:
+            monkeypatch.setenv(name, raw)
+        assert rt.check_timeout() == config.check_timeout(), repr(raw)
+        resolved.add(rt.check_timeout())
+    assert len(resolved) > 1, "every probe resolved alike"
+
+    monkeypatch.delenv(name, raising=False)
+    env_file = Path(os.environ["DAIMON_ENV_FILE"])
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    from_file = set()
+    for line in (f"{name}=1",
+                 f'{name}="2"',
+                 f"{name}='3'",
+                 f"export {name}=4",
+                 f"  export   {name} =  6  ",
+                 f"# {name}=8",
+                 f"{name}=",
+                 "NOT_THE_VAR=9",
+                 f"{name}=1\n{name}=11"):
+        env_file.write_text(line + "\n", encoding="utf-8")
+        assert rt.check_timeout() == config.check_timeout(), line
+        from_file.add(rt.check_timeout())
+    assert len(from_file) > 1, \
+        "every probe resolved alike — the env file was never read at all"
+
+
 # ---- manifest -------------------------------------------------------------
 
 

--- a/plugin/tests/test_hooks_install.py
+++ b/plugin/tests/test_hooks_install.py
@@ -286,3 +286,83 @@ def test_skill_install_codex_is_not_lifecycle_hooks(tmp_path, monkeypatch):
     assert cli.main(["skill", "install", "codex"]) == 0
     assert (tmp_path / ".codex" / "AGENTS.md").exists()
     assert not (tmp_path / ".codex" / "hooks.json").exists()
+
+
+# ---- #943: installing the hook also materializes what it reads ------------
+
+
+def _arm_a_check(project):
+    """A ruling with a check, armed the way a human arms one."""
+    import hashlib
+
+    from daimon_briefing import refutations
+    body = "#!/bin/sh\nexit 0\n"
+    ruling_id = refutations.assert_ruling(
+        subject="public posts", verdict="the rule for public posts",
+        scope="publishing", evidence=["issue:943"], channel="cli-agent",
+        check={"match": "gh pr create", "body": body, "intent": "warn"},
+        project_dir=str(project))
+    refutations.ratify(
+        ruling_id, channel="ui",
+        check_sha256=hashlib.sha256(body.encode("utf-8")).hexdigest(),
+        project_dir=str(project))
+    return ruling_id
+
+
+@pytest.mark.parametrize("host", ["codex", "windsurf"])
+def test_hooks_install_reports_what_is_armed_for_this_project(
+        host, tmp_path, monkeypatch, capsys):
+    """Installing the hook and materializing what it reads are one step. Left
+    apart, the supported install ends with a hook in place and an empty
+    checks directory, which reads on every surface as "armed, nothing fired"
+    rather than "never wired"."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _arm_a_check(project)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(project)
+    assert cli.main(["hooks", "install", host]) == 0
+    out = capsys.readouterr().out
+    assert "checks: 1 armed for " in out
+
+
+def test_hooks_install_says_zero_when_the_project_arms_nothing(
+        tmp_path, monkeypatch, capsys):
+    """Not silence. "Nothing is armed here" is the ordinary state and it is
+    the one a reader most needs told apart from "the sync did not run"."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(project)
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    assert "checks: 0 armed for " in capsys.readouterr().out
+
+
+def test_a_failed_check_sync_is_information_and_not_a_failed_install(
+        tmp_path, monkeypatch, capsys):
+    """The hook files landed and the registration landed. Returning non-zero
+    would report that as a failed install and send the operator looking for a
+    problem in the half that worked."""
+    from daimon_briefing import config
+    project = tmp_path / "proj"
+    project.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(project)
+    base = config.checks_dir()
+    base.mkdir(parents=True, exist_ok=True)
+    (base / "manifest.json").write_text("{not json", encoding="utf-8")
+
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    out = capsys.readouterr().out
+    assert "checks: " in out
+    assert "disarm" in out  # the refusal's own words, not a rewrite
+    assert (tmp_path / ".codex" / "hooks.json").exists()
+
+
+def test_hooks_install_grows_no_slug_flag(capsys):
+    """`--slug` reaches ten human-only decision verbs and is refused on a
+    tenant-scoped home. Widening it to a verb that materializes executables
+    would hand bucket-choosing power past the check that gates it (#899,
+    #948)."""
+    with pytest.raises(SystemExit):
+        cli.main(["hooks", "install", "codex", "--slug", "somewhere"])

--- a/plugin/tests/test_hooks_install.py
+++ b/plugin/tests/test_hooks_install.py
@@ -62,6 +62,29 @@ def test_shipped_checks_runtime_matches_canonical_module():
         "hook-shipped checks_runtime.py drifted from the canonical module"
 
 
+def test_shipped_checks_host_matches_canonical_module():
+    # #943 slice 3: the adapter core ships beside the runtime, same direction
+    # (scar 0049, the PACKAGE module is canonical). The parametrized guard
+    # above compares hook/ against _hooks/; this one is the third side of the
+    # triangle, and without it both copies could drift together.
+    canonical = (Path(__file__).parents[1] / "daimon_briefing"
+                 / "checks_host.py").read_bytes()
+    shipped = (PKG_HOOKS_DIR / "checks_host.py").read_bytes()
+    assert shipped == canonical, \
+        "hook-shipped checks_host.py drifted from the canonical module"
+
+
+def test_the_adapter_core_ships_to_both_standalone_dirs():
+    # A host script loads checks_host.py as a same-dir sibling. Missing from
+    # either destination is a hook that finds nothing and allows in silence,
+    # on the plugin path or the installed path depending on which copy is
+    # absent, which is the half-broken shape nobody reproduces.
+    dests = {dst for src, dst in SYNC_PAIRS
+             if src == "plugin/daimon_briefing/checks_host.py"}
+    assert dests == {"plugin/daimon_briefing/_hooks/checks_host.py",
+                     "hook/checks_host.py"}
+
+
 def test_hooks_install_windsurf_writes_stable_executable_copies(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("HOME", str(tmp_path))
     rc = cli.main(["hooks", "install", "windsurf"])

--- a/plugin/tests/test_hooks_install.py
+++ b/plugin/tests/test_hooks_install.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from daimon_briefing import cli
+from daimon_briefing import cli, codex_hooks
 
 REPO_HOOK_DIR = Path(__file__).parents[2] / "hook"
 PKG_HOOKS_DIR = Path(__file__).parents[1] / "daimon_briefing" / "_hooks"
@@ -26,8 +26,11 @@ _SHIPPED = tuple(
 )
 
 _WINDSURF_FILES = cli._HOOK_HOSTS["windsurf"]["files"]
-_CODEX_SCRIPTS = ("daimon-codex-session-start.py", "daimon-codex-stop.py")
-_CODEX_FILES = _CODEX_SCRIPTS + ("_daimon_hook_lib.py",)
+# Derived from the installer's own manifest rather than restated here: a
+# second list would let the install ship a file no test looks at. Scripts are
+# what Codex executes; MODULES are imported by same-dir lookup (#943).
+_CODEX_FILES = codex_hooks.FILES
+_CODEX_SCRIPTS = tuple(n for n in _CODEX_FILES if n not in codex_hooks.MODULES)
 
 
 @pytest.mark.parametrize("name", _SHIPPED)
@@ -130,7 +133,7 @@ def test_codex_scripts_are_packaged_and_drift_guarded():
     # The drift guard (test_packaged_hook_matches_repo_copy) parametrizes over
     # _SHIPPED, so proving the codex scripts are in _SHIPPED proves they are
     # both packaged AND covered by the byte-identity drift test.
-    for name in _CODEX_SCRIPTS:
+    for name in _CODEX_FILES:
         assert name in _SHIPPED, f"{name} not shipped via sync_hooks manifest"
 
 
@@ -139,6 +142,25 @@ def test_hooks_list_names_codex_with_events(capsys):
     out = capsys.readouterr().out
     assert "codex" in out
     assert "SessionStart" in out and "Stop" in out
+    assert "PreToolUse" in out
+
+
+def test_the_codex_modules_are_shipped_but_never_registered(tmp_path,
+                                                            monkeypatch):
+    # #943: the modules ride along because the scripts load them by same-dir
+    # lookup. They are imported, never run, and nothing registers them as a
+    # hook — a module in the HOOKS manifest would be a command Codex tries to
+    # execute on an event.
+    assert set(codex_hooks.MODULES) <= set(codex_hooks.FILES)
+    assert not (set(codex_hooks.MODULES)
+                & {spec["script"] for spec in codex_hooks.HOOKS})
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    cfg = json.loads((tmp_path / ".codex" / "hooks.json").read_text())["hooks"]
+    commands = [h["command"] for groups in cfg.values() for g in groups
+                for h in g["hooks"]]
+    for name in codex_hooks.MODULES:
+        assert not any(name in c for c in commands), f"{name} registered"
 
 
 def test_hooks_install_codex_copies_scripts_and_lib_to_codex_dir(tmp_path, monkeypatch):
@@ -154,7 +176,7 @@ def test_hooks_install_codex_copies_scripts_and_lib_to_codex_dir(tmp_path, monke
         assert (hooks_dir / name).stat().st_mode & stat.S_IXUSR, f"{name} not executable"
 
 
-def test_hooks_install_codex_registers_both_events(tmp_path, monkeypatch):
+def test_hooks_install_codex_registers_every_event(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     assert cli.main(["hooks", "install", "codex"]) == 0
     cfg = json.loads((tmp_path / ".codex" / "hooks.json").read_text())["hooks"]
@@ -171,6 +193,15 @@ def test_hooks_install_codex_registers_both_events(tmp_path, monkeypatch):
     assert "daimon-codex-stop.py" in stop_hook["command"]
     assert stop_hook["statusMessage"] == "Writing daimon checkpoint..."
 
+    # #943: the pre-action check, kept to shell actions by its matcher and
+    # carrying no statusMessage — it fires before every command, not once a
+    # session.
+    pre = cfg["PreToolUse"][0]
+    assert pre["matcher"] == "Bash|shell"
+    assert "daimon-codex-pre-action.py" in pre["hooks"][0]["command"]
+    assert pre["hooks"][0]["timeout"] == 10
+    assert "statusMessage" not in pre["hooks"][0]
+
 
 def test_hooks_install_codex_preserves_unrelated_entries(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
@@ -182,7 +213,7 @@ def test_hooks_install_codex_preserves_unrelated_entries(tmp_path, monkeypatch):
             "SessionStart": [
                 {"hooks": [{"type": "command", "command": "python3 /other/thing.py"}]}
             ],
-            # an event daimon never touches
+            # a foreign entry under the event #943 added
             "PreToolUse": [
                 {"hooks": [{"type": "command", "command": "echo hi"}]}
             ],
@@ -194,7 +225,9 @@ def test_hooks_install_codex_preserves_unrelated_entries(tmp_path, monkeypatch):
     ss_cmds = [h["command"] for g in cfg["SessionStart"] for h in g["hooks"]]
     assert "python3 /other/thing.py" in ss_cmds  # foreign entry untouched
     assert any("daimon-codex-session-start.py" in c for c in ss_cmds)  # ours added
-    assert cfg["PreToolUse"][0]["hooks"][0]["command"] == "echo hi"  # unrelated event kept
+    pre_cmds = [h["command"] for g in cfg["PreToolUse"] for h in g["hooks"]]
+    assert "echo hi" in pre_cmds  # foreign entry untouched
+    assert any("daimon-codex-pre-action.py" in c for c in pre_cmds)  # ours added
 
 
 def test_hooks_install_codex_recovers_corrupt_hooks_json(tmp_path, monkeypatch):
@@ -216,8 +249,8 @@ def test_hooks_install_codex_is_idempotent(tmp_path, monkeypatch):
     assert cli.main(["hooks", "install", "codex"]) == 0
     assert cli.main(["hooks", "install", "codex"]) == 0  # re-run must not duplicate
     cfg = json.loads((tmp_path / ".codex" / "hooks.json").read_text())["hooks"]
-    assert len(cfg["SessionStart"]) == 1
-    assert len(cfg["Stop"]) == 1
+    for spec in codex_hooks.HOOKS:
+        assert len(cfg[spec["event"]]) == 1, spec["event"]
 
 
 def test_hooks_install_codex_refreshes_stale_script(tmp_path, monkeypatch):

--- a/plugin/tests/test_pre_action_hook.py
+++ b/plugin/tests/test_pre_action_hook.py
@@ -1,0 +1,310 @@
+"""#943 slice 3: the pre-action hooks, run the way the hosts run them.
+
+These are the first daimon hooks that can fail a host action, so nothing
+here imports them. Each test spawns the script in a fresh interpreter with a
+payload on stdin, exactly as Claude Code and Codex do, and reads back what
+the host would read: stdout, stderr and the exit code.
+
+Two disciplines every test holds to. stdout is empty or ONE JSON object,
+pinned the way the Gemini hooks are (`json.loads(proc.stdout)` or
+`proc.stdout == ""`), because a host that cannot parse the hook's output
+learns nothing from it. And the exit code is 0 on every path: exit 2 is a
+documented unconditional block on both hosts, so an escaping exception that
+happened to exit non-zero would block an action no check ever judged.
+
+The manifest under test is written by `checks.sync` from a ruling ratified
+in process through `refutations` on a human channel. A hand-written manifest
+would exercise a shape nobody produces.
+"""
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from daimon_briefing import config, refutations
+
+HOOK_DIR = Path(__file__).parents[2] / "hook"
+CLAUDE_HOOK = HOOK_DIR / "daimon-pre-action.py"
+CODEX_HOOK = HOOK_DIR / "daimon-codex-pre-action.py"
+CORE = "checks_host.py"
+RUNTIME = "checks_runtime.py"
+
+CLEAN = "#!/bin/sh\nexit 0\n"
+VIOLATION = "#!/bin/sh\necho 'no em-dash in a public body' >&2\nexit 1\n"
+MATCH = "gh pr create"
+
+
+def _sha(body):
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def _arm(project, *, body=VIOLATION, intent="warn", subject="public posts",
+         scope="publishing", match=MATCH):
+    ruling_id = refutations.assert_ruling(
+        subject=subject, verdict=f"the rule for {subject} in {scope}",
+        scope=scope, evidence=["issue:943"], channel="cli-agent",
+        check={"match": match, "body": body, "intent": intent},
+        project_dir=str(project))
+    refutations.ratify(ruling_id, channel="ui", check_sha256=_sha(body),
+                       project_dir=str(project))
+    return ruling_id
+
+
+def _run(script, payload, tmp_path):
+    """Spawn the hook the way the host does: its own interpreter, the payload
+    on stdin, no daimon_briefing anywhere on the path. A non-dict payload is
+    passed through as a raw string, which is how the unparseable-stdin cases
+    are driven."""
+    text = payload if isinstance(payload, str) else json.dumps(payload)
+    return subprocess.run(
+        [sys.executable, str(script)], input=text, capture_output=True,
+        text=True, timeout=60,
+        env={**os.environ, "HOME": str(tmp_path)})
+
+
+def _payload(command, cwd, *, host="claude-code"):
+    return {"tool_name": "Bash" if host == "claude-code" else "shell",
+            "tool_input": {"command": command}, "cwd": str(cwd)}
+
+
+def _assert_host_contract(proc):
+    """Every path, both hosts: exit 0, stderr silent, stdout empty or one
+    parseable JSON object."""
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stderr == ""
+    if proc.stdout:
+        assert json.loads(proc.stdout)
+    return proc.stdout
+
+
+def _log_rows():
+    path = config.log_dir() / "checks.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in
+            path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+HOOKS = [("claude-code", CLAUDE_HOOK), ("codex", CODEX_HOOK)]
+IDS = ["claude-code", "codex"]
+
+
+# ---- the shape of a decision, through the real scripts --------------------
+
+
+@pytest.mark.parametrize("host,script", HOOKS, ids=IDS)
+def test_a_violation_under_enforce_denies_on_both_hosts(host, script,
+                                                        tmp_path):
+    """The one path measured on both hosts: JSON deny, exit 0. The hook never
+    relies on exit 2, which is documented as an unconditional block and would
+    fire on a crash as readily as on a decision."""
+    ruling_id = _arm(tmp_path, intent="enforce")
+    proc = _run(script, _payload(MATCH, tmp_path, host=host), tmp_path)
+    data = json.loads(_assert_host_contract(proc))
+    out = data["hookSpecificOutput"]
+    assert out["hookEventName"] == "PreToolUse"
+    assert out["permissionDecision"] == "deny"
+    assert out["permissionDecisionReason"] == \
+        f"{ruling_id}: no em-dash in a public body"
+
+
+@pytest.mark.parametrize("host,script", HOOKS, ids=IDS)
+def test_a_clean_check_says_nothing_at_all(host, script, tmp_path):
+    _arm(tmp_path, body=CLEAN, intent="enforce")
+    proc = _run(script, _payload(MATCH, tmp_path, host=host), tmp_path)
+    assert _assert_host_contract(proc) == ""
+    assert [r["outcome"] for r in _log_rows()] == ["clean"]
+
+
+def test_a_warn_reaches_claude_code_as_an_allow_with_a_message(tmp_path):
+    ruling_id = _arm(tmp_path, intent="warn")
+    proc = _run(CLAUDE_HOOK, _payload(MATCH, tmp_path), tmp_path)
+    data = json.loads(_assert_host_contract(proc))
+    assert data["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert data["systemMessage"] == f"{ruling_id}: no em-dash in a public body"
+    assert _log_rows()[0]["decision_emitted"] == "warn"
+
+
+def test_the_same_warn_is_recorded_and_not_shown_on_codex(tmp_path):
+    """Codex documents no warn channel. The run still happened and the log
+    still says so, at the mode the host could actually deliver."""
+    _arm(tmp_path, intent="warn")
+    proc = _run(CODEX_HOOK, _payload(MATCH, tmp_path, host="codex"), tmp_path)
+    assert _assert_host_contract(proc) == ""
+    row = _log_rows()[0]
+    assert row["host"] == "codex"
+    assert row["mode"] == "record-only"
+    assert row["outcome"] == "violation"
+    assert row["decision_emitted"] == "allow"
+
+
+@pytest.mark.parametrize("host,script", HOOKS, ids=IDS)
+def test_a_record_only_check_never_reaches_the_host(host, script, tmp_path):
+    _arm(tmp_path, intent="record-only")
+    proc = _run(script, _payload(MATCH, tmp_path, host=host), tmp_path)
+    assert _assert_host_contract(proc) == ""
+    assert _log_rows()[0]["mode"] == "record-only"
+
+
+@pytest.mark.parametrize("host,script", HOOKS, ids=IDS)
+def test_an_unresolved_subject_denies_under_enforce(host, script, tmp_path):
+    """Spec 2.3: unresolved is never rendered as clean. daimon could not read
+    what the action sends, so under enforce it cannot let it through."""
+    ruling_id = _arm(tmp_path, body=CLEAN, intent="enforce")
+    command = f"{MATCH} --body-file missing.md"
+    proc = _run(script, _payload(command, tmp_path, host=host), tmp_path)
+    data = json.loads(_assert_host_contract(proc))
+    reason = data["hookSpecificOutput"]["permissionDecisionReason"]
+    assert reason.startswith(f"{ruling_id}: file-missing: ")
+    row = _log_rows()[0]
+    assert row["outcome"] == "unresolved"
+    assert row["cause"] == "file-missing"
+    assert row["decision_emitted"] == "deny"
+
+
+# ---- nothing armed, and nothing to say ------------------------------------
+
+
+@pytest.mark.parametrize("host,script", HOOKS, ids=IDS)
+def test_no_manifest_allows_and_leaves_a_row_that_says_so(host, script,
+                                                          tmp_path):
+    proc = _run(script, _payload(MATCH, tmp_path, host=host), tmp_path)
+    assert _assert_host_contract(proc) == ""
+    rows = _log_rows()
+    assert [r["cause"] for r in rows] == ["no-manifest"]
+    assert rows[0]["decision_emitted"] == "allow"
+    assert rows[0]["host"] == host
+
+
+@pytest.mark.parametrize("host,script", HOOKS, ids=IDS)
+def test_a_ruling_armed_for_another_project_is_no_match(host, script,
+                                                        tmp_path):
+    other, here = tmp_path / "other", tmp_path / "here"
+    other.mkdir()
+    here.mkdir()
+    _arm(other, intent="enforce")
+    proc = _run(script, _payload(MATCH, here, host=host), tmp_path)
+    assert _assert_host_contract(proc) == ""
+    assert [r["cause"] for r in _log_rows()] == ["no-match"]
+
+
+@pytest.mark.parametrize("host,script", HOOKS, ids=IDS)
+def test_a_tool_that_is_not_a_shell_action_is_ignored_entirely(host, script,
+                                                               tmp_path):
+    """No output and no row. A row on every file edit would turn the firing
+    log into a transcript of the session."""
+    _arm(tmp_path, intent="enforce")
+    proc = _run(script, {"tool_name": "Edit",
+                         "tool_input": {"command": MATCH},
+                         "cwd": str(tmp_path)}, tmp_path)
+    assert _assert_host_contract(proc) == ""
+    assert _log_rows() == []
+
+
+@pytest.mark.parametrize("host,script", HOOKS, ids=IDS)
+@pytest.mark.parametrize("payload", ["", "not json at all", "[]", "null",
+                                     '{"tool_name": "Bash"}'])
+def test_an_unusable_payload_is_a_silent_allow(host, script, payload,
+                                               tmp_path):
+    """Scar 0068 generalised: a host payload field is a claim. Unparseable
+    stdin, a payload that is not an object, and an object with no command all
+    describe an action daimon cannot see, which is an allow and never a
+    crash."""
+    _arm(tmp_path, intent="enforce")
+    proc = _run(script, payload, tmp_path)
+    assert _assert_host_contract(proc) == ""
+    assert _log_rows() == []
+
+
+# ---- partial installs -----------------------------------------------------
+
+
+def _stray(script, tmp_path, *, include=()):
+    """The script in a directory holding only `include` — the shape a partial
+    or half-upgraded install leaves behind."""
+    home = tmp_path / "stray"
+    home.mkdir(exist_ok=True)
+    dest = home / script.name
+    dest.write_bytes(script.read_bytes())
+    for name in include:
+        (home / name).write_bytes((HOOK_DIR / name).read_bytes())
+    return dest
+
+
+@pytest.mark.parametrize("host,script", HOOKS, ids=IDS)
+def test_a_hook_with_no_adapter_core_beside_it_says_nothing(host, script,
+                                                            tmp_path):
+    """Fail open and silent. There is nothing to check with and nothing to
+    write a row with, and a traceback on stderr before every shell action is
+    worse than the missing check it would be reporting."""
+    _arm(tmp_path, intent="enforce")
+    proc = _run(_stray(script, tmp_path), _payload(MATCH, tmp_path, host=host),
+                tmp_path)
+    assert _assert_host_contract(proc) == ""
+    assert _log_rows() == []
+
+
+def test_a_missing_runtime_tells_claude_code_that_nothing_is_enforced(
+        tmp_path):
+    """The half-upgraded install: the core shipped, the runtime did not. On a
+    host with a message channel, saying so is the difference between a check
+    that passed and a check that never ran."""
+    _arm(tmp_path, intent="enforce")
+    proc = _run(_stray(CLAUDE_HOOK, tmp_path, include=(CORE,)),
+                _payload(MATCH, tmp_path), tmp_path)
+    data = json.loads(_assert_host_contract(proc))
+    assert data["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert data["systemMessage"] == \
+        "daimon: check runtime missing, nothing enforced"
+    assert _log_rows() == []
+
+
+def test_the_same_missing_runtime_is_silent_on_codex(tmp_path):
+    """Codex renders no message channel, so a diagnostic addressed to one is
+    noise the operator never sees. The row would be the honest surface, and
+    there is no runtime to write it with."""
+    _arm(tmp_path, intent="enforce")
+    proc = _run(_stray(CODEX_HOOK, tmp_path, include=(CORE,)),
+                _payload(MATCH, tmp_path, host="codex"), tmp_path)
+    assert _assert_host_contract(proc) == ""
+    assert _log_rows() == []
+
+
+def test_the_core_and_the_runtime_together_are_a_working_hook(tmp_path):
+    """The converse of the two above: copied out of the repo entirely, with
+    both siblings, the hook still decides. That is what `hooks install` ships
+    and what proves the file-location load does not depend on this tree."""
+    _arm(tmp_path, intent="enforce")
+    proc = _run(_stray(CODEX_HOOK, tmp_path, include=(CORE, RUNTIME)),
+                _payload(MATCH, tmp_path, host="codex"), tmp_path)
+    data = json.loads(_assert_host_contract(proc))
+    assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+# ---- the file header says what this hook can do ---------------------------
+
+
+@pytest.mark.parametrize("host,script", HOOKS, ids=IDS)
+def test_the_header_says_this_hook_can_fail_a_host_action(host, script):
+    """Every other daimon hook is unable to affect the session it observes.
+    Someone reading this one for the first time has to learn that from the
+    file, not from an incident."""
+    head = script.read_text(encoding="utf-8")[:2000]
+    assert "fail a host action" in head.lower()
+    assert script.read_text(encoding="utf-8").startswith("#!/usr/bin/env python3")
+
+
+@pytest.mark.parametrize("host,script", HOOKS, ids=IDS)
+def test_the_script_names_its_profile_and_nothing_else(host, script):
+    """The thin-script contract: a host is a row plus a name. A script that
+    made its own decisions would be a second pipeline, which is the thing
+    this slice exists to not have."""
+    text = script.read_text(encoding="utf-8")
+    assert f'main("{host}")' in text
+    assert "permissionDecision" not in text
+    assert "hookSpecificOutput" not in text

--- a/plugin/tests/test_pre_action_hook.py
+++ b/plugin/tests/test_pre_action_hook.py
@@ -237,15 +237,16 @@ def _stray(script, tmp_path, *, include=()):
 
 
 @pytest.mark.parametrize("host,script", HOOKS, ids=IDS)
-def test_a_hook_with_no_adapter_core_beside_it_says_nothing(host, script,
-                                                            tmp_path):
-    """Fail open and silent. There is nothing to check with and nothing to
-    write a row with, and a traceback on stderr before every shell action is
-    worse than the missing check it would be reporting."""
+def test_a_hook_with_no_adapter_core_beside_it_fails_open(host, script,
+                                                          tmp_path):
+    """Exit 0, nothing on stderr, no row. There is nothing to check with and
+    nothing to write a row with, and a traceback before every shell action is
+    worse than the missing check it would be reporting. Whether the hook says
+    so on stdout is the host's own question, answered just below."""
     _arm(tmp_path, intent="enforce")
     proc = _run(_stray(script, tmp_path), _payload(MATCH, tmp_path, host=host),
                 tmp_path)
-    assert _assert_host_contract(proc) == ""
+    _assert_host_contract(proc)
     assert _log_rows() == []
 
 
@@ -300,14 +301,16 @@ def test_the_header_says_this_hook_can_fail_a_host_action(host, script):
 
 
 @pytest.mark.parametrize("host,script", HOOKS, ids=IDS)
-def test_the_script_names_its_profile_and_nothing_else(host, script):
+def test_the_script_names_its_profile_and_little_else(host, script):
     """The thin-script contract: a host is a row plus a name. A script that
     made its own decisions would be a second pipeline, which is the thing
-    this slice exists to not have."""
+    this slice exists to not have. The one exception is the shape below,
+    which a script has to carry because the core is what is missing when it
+    is needed."""
     text = script.read_text(encoding="utf-8")
     assert f'main("{host}")' in text
-    assert "permissionDecision" not in text
-    assert "hookSpecificOutput" not in text
+    assert "mode_caps" not in text
+    assert "armed_for" not in text
 
 
 # ---- registration: the event, on both hosts and both install paths --------
@@ -530,3 +533,54 @@ def test_two_hanging_checks_still_decide_inside_the_host_budget(tmp_path):
     assert len(rows) == 2
     assert {r["outcome"] for r in rows} == {"unresolved"}
     assert {r["cause"] for r in rows} == {"check-timeout"}
+
+
+# ---- a missing core is as visible as a missing runtime --------------------
+
+
+def test_a_missing_core_tells_claude_code_that_nothing_is_enforced(tmp_path):
+    """A missing runtime said so and a missing core did not, and they are the
+    same fact: a partial or half-upgraded install. Silence there is
+    byte-identical to a clean allow, which is the shape the scar candidate on
+    this branch is about."""
+    _arm(tmp_path, intent="enforce")
+    proc = _run(_stray(CLAUDE_HOOK, tmp_path), _payload(MATCH, tmp_path),
+                tmp_path)
+    data = json.loads(_assert_host_contract(proc))
+    assert data["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert data["systemMessage"] == \
+        "daimon: check core missing, nothing enforced"
+    assert _log_rows() == []
+
+
+def test_a_broken_core_says_the_same_thing_as_an_absent_one(tmp_path):
+    """A truncated or half-written copy from an interrupted install. The
+    script cannot tell the two apart and does not need to: neither can
+    decide anything."""
+    _arm(tmp_path, intent="enforce")
+    staged = _stray(CLAUDE_HOOK, tmp_path)
+    (staged.parent / CORE).write_text("def (\n", encoding="utf-8")
+    proc = _run(staged, _payload(MATCH, tmp_path), tmp_path)
+    assert json.loads(_assert_host_contract(proc))["systemMessage"] == \
+        "daimon: check core missing, nothing enforced"
+
+
+def test_a_missing_core_stays_silent_on_codex(tmp_path):
+    """Codex renders no message channel, so the diagnostic has nowhere to go.
+    The profile says which hosts have one, and the script that cannot load
+    the profile has to carry that one fact itself."""
+    _arm(tmp_path, intent="enforce")
+    proc = _run(_stray(CODEX_HOOK, tmp_path),
+                _payload(MATCH, tmp_path, host="codex"), tmp_path)
+    assert _assert_host_contract(proc) == ""
+
+
+@pytest.mark.parametrize("host,script", HOOKS, ids=IDS)
+def test_a_script_can_only_ever_emit_an_allow_on_its_own(host, script):
+    """The thin-script contract, restated now that one of them carries a
+    shape. A script decides nothing: the only thing it can say without the
+    core is that it could not load the core, and that is an allow."""
+    text = script.read_text(encoding="utf-8")
+    assert f'main("{host}")' in text
+    assert '"deny"' not in text
+    assert "permissionDecisionReason" not in text

--- a/plugin/tests/test_pre_action_hook.py
+++ b/plugin/tests/test_pre_action_hook.py
@@ -308,3 +308,160 @@ def test_the_script_names_its_profile_and_nothing_else(host, script):
     assert f'main("{host}")' in text
     assert "permissionDecision" not in text
     assert "hookSpecificOutput" not in text
+
+
+# ---- registration: the event, on both hosts and both install paths --------
+
+import importlib.util  # noqa: E402
+
+REPO = Path(__file__).parents[2]
+
+
+def _module(rel, name):
+    spec = importlib.util.spec_from_file_location(name, REPO / rel)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _core():
+    return _module("plugin/daimon_briefing/checks_host.py", "_core_for_reg")
+
+
+def test_the_plugin_registers_the_hook_on_shell_actions_only():
+    """The first `matcher` in this manifest. Without it the hook would fire
+    before every tool call in the session, including the reads and edits the
+    spec puts out of scope, and pay a manifest read for each."""
+    cfg = json.loads((REPO / "hooks" / "hooks.json").read_text(
+        encoding="utf-8"))["hooks"]
+    groups = cfg["PreToolUse"]
+    assert len(groups) == 1
+    assert groups[0]["matcher"] == "Bash"
+    hook = groups[0]["hooks"][0]
+    assert hook["type"] == "command"
+    assert hook["command"] == \
+        'python3 "${CLAUDE_PLUGIN_ROOT}"/hook/daimon-pre-action.py'
+    # Ten against a runner budget of five: the runner has to decide before
+    # the host gives up, because a hook that reaches the host timeout does
+    # not block and the action proceeds.
+    assert hook["timeout"] == 10
+    # No statusMessage. The other three fire once a session; this one fires
+    # before every shell action, and a spinner on each would be noise.
+    assert "statusMessage" not in hook
+
+
+def test_the_registered_matcher_and_timeout_come_from_the_profile_row():
+    """The registration is hand-written JSON on both hosts, so this is where
+    it is held to the row. A matcher that drifted from `tool_names` is a hook
+    that never fires, or one that fires and allows in silence."""
+    core = _core()
+    cfg = json.loads((REPO / "hooks" / "hooks.json").read_text(
+        encoding="utf-8"))["hooks"]
+    cc = core.PROFILES["claude-code"]
+    assert cfg[cc.event][0]["matcher"] == cc.matcher
+    assert cfg[cc.event][0]["hooks"][0]["timeout"] == cc.install_timeout
+
+    cx = core.PROFILES["codex"]
+    codex = {h["event"]: h for h in
+             _module("plugin/daimon_briefing/codex_hooks.py",
+                     "_codex_for_reg").HOOKS}
+    entry = codex[cx.event]["entry"]
+    assert entry["matcher"] == cx.matcher
+    assert entry["hooks"][0]["timeout"] == cx.install_timeout
+
+
+def test_the_manual_claude_code_manager_registers_the_same_event():
+    """`hook/daimon-hooks.py` writes ~/.claude/settings.json for someone who
+    installed by hand rather than through the marketplace. A gate that exists
+    on one path and not the other is a machine that believes it is guarded."""
+    hooks = {h["event"]: h for h in
+             _module("hook/daimon-hooks.py", "_manual_mgr").HOOKS}
+    entry = hooks["PreToolUse"]
+    assert entry["script"] == "daimon-pre-action.py"
+    assert entry["entry"]["matcher"] == "Bash"
+    assert entry["entry"]["hooks"][0]["timeout"] == 10
+
+
+@pytest.mark.parametrize("rel", ["hook/codex-hooks.py",
+                                 "plugin/daimon_briefing/codex_hooks.py"])
+def test_both_codex_manifests_register_the_pre_action_hook(rel):
+    """The standalone manager cannot import the package, so the shape lives
+    in two files by necessity; test_codex_session_end asserts they agree."""
+    hooks = {h["event"]: h for h in
+             _module(rel, f"_codex_{abs(hash(rel))}").HOOKS}
+    entry = hooks["PreToolUse"]
+    assert entry["script"] == "daimon-codex-pre-action.py"
+    assert entry["entry"]["matcher"] == "Bash|shell"
+    assert entry["entry"]["hooks"][0]["timeout"] == 10
+    assert "daimon-codex-pre-action.py" in \
+        entry["entry"]["hooks"][0]["command"]
+
+
+def test_the_codex_install_ships_the_core_and_the_runtime():
+    """`FILES` is scripts plus the shared modules. A script installed without
+    the two siblings it loads is the silent half-install the fail-open tests
+    above describe, arriving through the supported path."""
+    from daimon_briefing import codex_hooks
+    assert "daimon-codex-pre-action.py" in codex_hooks.FILES
+    assert "checks_host.py" in codex_hooks.FILES
+    assert "checks_runtime.py" in codex_hooks.FILES
+
+
+def test_the_status_audit_can_see_every_file_the_install_writes():
+    """`hooks status` reads `spec["files"]`, so a file installed but not
+    listed there is never audited and goes stale invisibly."""
+    from daimon_briefing import cli, codex_hooks
+    spec = cli._HOOK_HOSTS["codex"]
+    assert set(codex_hooks.FILES) <= set(spec["files"])
+    assert "PreToolUse" in spec["events"]
+
+
+def test_the_codex_script_ships_through_the_sync_manifest():
+    sync = _module("scripts/sync_hooks.py", "_sync_for_reg")
+    assert ("hook/daimon-codex-pre-action.py",
+            "plugin/daimon_briefing/_hooks/daimon-codex-pre-action.py") \
+        in sync.SYNC_PAIRS
+
+
+def test_the_claude_code_script_has_no_packaged_copy():
+    """Deliberate, and the same as the other three Claude Code hooks: the
+    plugin runs them straight out of `hook/` through CLAUDE_PLUGIN_ROOT, and
+    a packaged copy nothing installs is a second file to keep in step."""
+    sync = _module("scripts/sync_hooks.py", "_sync_for_reg2")
+    assert not any("daimon-pre-action.py" in dst
+                   for _src, dst in sync.SYNC_PAIRS)
+    assert not (REPO / "plugin" / "daimon_briefing" / "_hooks"
+                / "daimon-pre-action.py").exists()
+
+
+def test_the_manual_manager_installs_the_modules_the_hook_loads(tmp_path):
+    """The hand-install path ships the two siblings too. Registering the
+    script alone would install the silent half-broken shape by hand, on
+    purpose, through the supported command."""
+    proc = subprocess.run(
+        [sys.executable, str(HOOK_DIR / "daimon-hooks.py"), "install"],
+        capture_output=True, text=True, timeout=60,
+        env={**os.environ, "HOME": str(tmp_path)})
+    assert proc.returncode == 0, proc.stderr
+    installed = tmp_path / ".claude" / "hooks"
+    for name in ("daimon-pre-action.py", CORE, RUNTIME):
+        assert (installed / name).is_file(), f"{name} not installed"
+        assert (installed / name).read_bytes() == \
+            (HOOK_DIR / name).read_bytes()
+    cfg = json.loads((tmp_path / ".claude" / "settings.json").read_text(
+        encoding="utf-8"))["hooks"]
+    assert cfg["PreToolUse"][0]["matcher"] == "Bash"
+
+
+def test_the_manual_manager_uninstall_removes_what_it_installed(tmp_path):
+    """A module left behind after uninstall is a file `hooks status` will
+    never mention again and nothing will ever refresh."""
+    env = {**os.environ, "HOME": str(tmp_path)}
+    for verb in ("install", "uninstall"):
+        proc = subprocess.run(
+            [sys.executable, str(HOOK_DIR / "daimon-hooks.py"), verb],
+            capture_output=True, text=True, timeout=60, env=env)
+        assert proc.returncode == 0, proc.stderr
+    installed = tmp_path / ".claude" / "hooks"
+    for name in ("daimon-pre-action.py", CORE, RUNTIME):
+        assert not (installed / name).exists(), f"{name} left behind"

--- a/plugin/tests/test_pre_action_hook.py
+++ b/plugin/tests/test_pre_action_hook.py
@@ -465,3 +465,23 @@ def test_the_manual_manager_uninstall_removes_what_it_installed(tmp_path):
     installed = tmp_path / ".claude" / "hooks"
     for name in ("daimon-pre-action.py", CORE, RUNTIME):
         assert not (installed / name).exists(), f"{name} left behind"
+
+
+# ---- the kill switch, through the real scripts ----------------------------
+
+
+@pytest.mark.parametrize("host,script", HOOKS, ids=IDS)
+def test_the_kill_switch_turns_the_gate_off_on_both_hosts(host, script,
+                                                          tmp_path):
+    """The way out of an over-broad `enforce` check. Setting `DAIMON_DISABLE`
+    in the host's environment turns every daimon hook off, and this is the one
+    that most needs it: the command that would retire the ruling is itself a
+    shell action the check would deny."""
+    _arm(tmp_path, intent="enforce")
+    proc = subprocess.run(
+        [sys.executable, str(script)],
+        input=json.dumps(_payload(MATCH, tmp_path, host=host)),
+        capture_output=True, text=True, timeout=60,
+        env={**os.environ, "HOME": str(tmp_path), "DAIMON_DISABLE": "1"})
+    assert _assert_host_contract(proc) == ""
+    assert _log_rows() == []

--- a/plugin/tests/test_pre_action_hook.py
+++ b/plugin/tests/test_pre_action_hook.py
@@ -485,3 +485,48 @@ def test_the_kill_switch_turns_the_gate_off_on_both_hosts(host, script,
         env={**os.environ, "HOME": str(tmp_path), "DAIMON_DISABLE": "1"})
     assert _assert_host_contract(proc) == ""
     assert _log_rows() == []
+
+
+# ---- the action budget, measured through the real script ------------------
+
+import time  # noqa: E402
+
+SLOW_VIOLATION = "#!/bin/sh\nsleep 4\necho 'slow and wrong' >&2\nexit 1\n"
+HANGS = "#!/bin/sh\nsleep 30\n"
+
+
+def _elapsed(script, payload, tmp_path):
+    started = time.monotonic()
+    proc = _run(script, payload, tmp_path)
+    return time.monotonic() - started, proc
+
+
+def test_three_slow_checks_still_decide_inside_the_host_budget(tmp_path):
+    """The host timeout is 10 s and it is fail-open: a hook that reaches it
+    does not block, the action proceeds, and no row is written. Three checks
+    at 4 s each is 12 s when the budget is per check, which is silence
+    byte-identical to a clean allow."""
+    for name in ("a", "b", "c"):
+        _arm(tmp_path, body=SLOW_VIOLATION, intent="enforce", subject=name,
+             scope="publishing")
+    seconds, proc = _elapsed(CLAUDE_HOOK, _payload(MATCH, tmp_path), tmp_path)
+    data = json.loads(_assert_host_contract(proc))
+    assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert seconds < 9.0, f"{seconds:.2f}s leaves the host no room"
+    assert len(_log_rows()) == 3
+
+
+def test_two_hanging_checks_still_decide_inside_the_host_budget(tmp_path):
+    """Two checks that both reach the runner's own timeout is the ordinary
+    bad case, not a contrived one: per check it is 10 s before the drains."""
+    for name in ("a", "b"):
+        _arm(tmp_path, body=HANGS, intent="enforce", subject=name,
+             scope="publishing")
+    seconds, proc = _elapsed(CLAUDE_HOOK, _payload(MATCH, tmp_path), tmp_path)
+    data = json.loads(_assert_host_contract(proc))
+    assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert seconds < 9.0, f"{seconds:.2f}s leaves the host no room"
+    rows = _log_rows()
+    assert len(rows) == 2
+    assert {r["outcome"] for r in rows} == {"unresolved"}
+    assert {r["cause"] for r in rows} == {"check-timeout"}

--- a/scripts/sync_hooks.py
+++ b/scripts/sync_hooks.py
@@ -39,6 +39,7 @@ SYNC_PAIRS = (
     ("hook/daimon-codex-session-start.py", "plugin/daimon_briefing/_hooks/daimon-codex-session-start.py"),
     ("hook/daimon-codex-stop.py", "plugin/daimon_briefing/_hooks/daimon-codex-stop.py"),
     ("hook/daimon-codex-session-end.py", "plugin/daimon_briefing/_hooks/daimon-codex-session-end.py"),
+    ("hook/daimon-codex-pre-action.py", "plugin/daimon_briefing/_hooks/daimon-codex-pre-action.py"),
     ("hook/_daimon_hook_lib.py", "plugin/daimon_briefing/_hooks/_daimon_hook_lib.py"),
 )
 

--- a/scripts/sync_hooks.py
+++ b/scripts/sync_hooks.py
@@ -30,6 +30,11 @@ SYNC_PAIRS = (
     ("plugin/daimon_briefing/checks_runtime.py",
      "plugin/daimon_briefing/_hooks/checks_runtime.py"),
     ("plugin/daimon_briefing/checks_runtime.py", "hook/checks_runtime.py"),
+    # #943 slice 3: the adapter core, same direction and same reason. The
+    # per-host scripts are thin and load this from their own directory.
+    ("plugin/daimon_briefing/checks_host.py",
+     "plugin/daimon_briefing/_hooks/checks_host.py"),
+    ("plugin/daimon_briefing/checks_host.py", "hook/checks_host.py"),
     ("hook/daimon-windsurf-hooks.py", "plugin/daimon_briefing/_hooks/daimon-windsurf-hooks.py"),
     ("hook/daimon-codex-session-start.py", "plugin/daimon_briefing/_hooks/daimon-codex-session-start.py"),
     ("hook/daimon-codex-stop.py", "plugin/daimon_briefing/_hooks/daimon-codex-stop.py"),

--- a/website/docs/hosts/claude-code.md
+++ b/website/docs/hosts/claude-code.md
@@ -110,6 +110,11 @@ close the capture -> inject loop; the fourth guards shell actions:
   check RAN. Only `decision_emitted: deny` under `enforce` closes the gap
   between a check that ran and a check that was honored.
 
+  `DAIMON_DISABLE=1` in the host's environment turns every daimon hook off,
+  this one included, and is the way out of an `enforce` check whose pattern
+  matches more than you meant: the command that retires the ruling is itself
+  a shell action the check would otherwise deny.
+
 These two capture/inject scripts are wired in one of two mutually exclusive
 ways — pick ONE (both at once double-fires every session: two briefing
 injections, two serialize LLM calls). See the install sections above.

--- a/website/docs/hosts/claude-code.md
+++ b/website/docs/hosts/claude-code.md
@@ -12,8 +12,8 @@ feed back into the code — the evidence trail lives in the
 /plugin install daimon@daimon
 ```
 
-The plugin registers the `SessionStart` / `UserPromptSubmit` / `SessionEnd`
-hooks itself via `.claude-plugin/plugin.json` + `hooks/hooks.json`. Order
+The plugin registers the `SessionStart` / `UserPromptSubmit` / `SessionEnd` /
+`PreToolUse` hooks itself via `.claude-plugin/plugin.json` + `hooks/hooks.json`. Order
 doesn't matter relative to installing the `daimon` CLI: if the hooks land
 before the CLI, sessions start normally and the hook prints a one-line install
 hint instead of a briefing.
@@ -35,7 +35,8 @@ python3 hook/daimon-hooks.py status
 ```
 
 Install copies the hook scripts to `~/.claude/hooks/` and registers them
-under `SessionStart` / `SessionEnd` in `~/.claude/settings.json` (idempotent;
+under `SessionStart` / `SessionEnd` / `PreToolUse` in
+`~/.claude/settings.json` (idempotent;
 settings backed up before every mutation). Requires the `daimon` CLI on PATH —
 `uv tool install 'daimon-briefing[pretty]'`, see the
 [quickstart](../getting-started/quickstart) — and the hooks also accept the
@@ -44,8 +45,8 @@ re-run install so the hook scripts stay in sync.
 
 ## What each script does
 
-Three scripts close the capture -> inject loop, whichever install path
-registers them:
+Four scripts run on this host, whichever install path registers them. Three
+close the capture -> inject loop; the fourth guards shell actions:
 
 - **`daimon-session-brief.py`** — `SessionStart` hook. Reads the payload from
   stdin and shells out to the installed `daimon brief` CLI (single source of
@@ -91,6 +92,23 @@ registers them:
   suggestion. Prompts that are not a person asking for work never match:
   slash commands (host directives) and host-emitted machine blocks —
   background-task notifications, teammate/agent messages, command output.
+
+- **`daimon-pre-action.py`** — `PreToolUse` hook, matcher `Bash`. **This is
+  the first daimon hook that can fail a host action.** Before a shell command
+  runs, it reads the armed-check manifest, keeps the checks armed for the
+  action's working directory, and runs the ones whose pattern matches the
+  command. A check ratified with intent `enforce` that reports a violation, or
+  a subject daimon could not read, comes back as Claude Code's structured deny
+  and the command does not run; `warn` comes back as an allow carrying the
+  reason; `record-only` says nothing to the host at all. Everything it decides
+  lives in `checks_host.py`, loaded from beside the script, and the script
+  itself only names its host. Exits 0 on every path, writes nothing to stderr,
+  and writes either one JSON object or nothing at all. See
+  [Checks at runtime](../reference/cli#checks-at-runtime).
+
+  Every run appends one row to `~/.daimon/logs/checks.jsonl`. A row proves the
+  check RAN. Only `decision_emitted: deny` under `enforce` closes the gap
+  between a check that ran and a check that was honored.
 
 These two capture/inject scripts are wired in one of two mutually exclusive
 ways — pick ONE (both at once double-fires every session: two briefing

--- a/website/docs/hosts/claude-code.md
+++ b/website/docs/hosts/claude-code.md
@@ -115,6 +115,11 @@ close the capture -> inject loop; the fourth guards shell actions:
   matches more than you meant: the command that retires the ruling is itself
   a shell action the check would otherwise deny.
 
+  The budget is shared across the whole action, not given to each check, so
+  on a crowded manifest a later check can find the time already spent and
+  report `unresolved`, which denies under `enforce` and warns under `warn`.
+  Keep a project's armed checks few and their bodies fast.
+
 These two capture/inject scripts are wired in one of two mutually exclusive
 ways — pick ONE (both at once double-fires every session: two briefing
 injections, two serialize LLM calls). See the install sections above.

--- a/website/docs/hosts/codex.md
+++ b/website/docs/hosts/codex.md
@@ -18,9 +18,10 @@ clone needed):
 daimon hooks install codex
 ```
 
-This copies the three hook scripts and their shared helper to `~/.codex/hooks/`
-and registers `SessionStart`, `SessionEnd`, and `Stop` in `~/.codex/hooks.json`, preserving any
-unrelated entries already there. It is idempotent — re-run it after every
+This copies the four hook scripts and the modules they share to
+`~/.codex/hooks/` and registers `SessionStart`, `SessionEnd`, `Stop` and
+`PreToolUse` in `~/.codex/hooks.json`, preserving any unrelated entries
+already there. It is idempotent — re-run it after every
 `uv tool upgrade daimon-briefing` to refresh the scripts to match the installed
 CLI. After installing, open `/hooks` in Codex to review and trust the hook
 definitions — Codex skips untrusted hook definitions until you do.
@@ -62,6 +63,19 @@ python3 hook/codex-hooks.py status
   (default `300` seconds per session). Set it to `0` to serialize every turn,
   or set `DAIMON_CODEX_SERIALIZE_ON_STOP=0` to disable Codex capture while
   leaving briefing injection installed.
+
+- **`daimon-codex-pre-action.py`** — `PreToolUse` hook, matcher `Bash|shell`.
+  **This is the first daimon hook that can fail a host action.** Before a
+  shell command runs, it runs this project's armed checks against it and
+  returns Codex's structured deny when a check ratified with intent `enforce`
+  reports a violation or daimon could not read what the command sends. Codex
+  documents no channel for a warning, so intent `warn` degrades to
+  `record-only` here: the run is logged and nothing is shown. Exits 0 on every
+  path. See [Checks at runtime](../reference/cli#checks-at-runtime).
+
+  Every run appends one row to `~/.daimon/logs/checks.jsonl`. A row proves the
+  check RAN. Only `decision_emitted: deny` under `enforce` closes the gap
+  between a check that ran and a check that was honored.
 
 Codex docs note that `transcript_path` is provided for convenience but its
 format is not a stable interface. Daimon's JSONL parser is intentionally

--- a/website/docs/hosts/codex.md
+++ b/website/docs/hosts/codex.md
@@ -77,6 +77,11 @@ python3 hook/codex-hooks.py status
   check RAN. Only `decision_emitted: deny` under `enforce` closes the gap
   between a check that ran and a check that was honored.
 
+  `DAIMON_DISABLE=1` in the host's environment turns every daimon hook off,
+  this one included, and is the way out of an `enforce` check whose pattern
+  matches more than you meant: the command that retires the ruling is itself
+  a shell action the check would otherwise deny.
+
 Codex docs note that `transcript_path` is provided for convenience but its
 format is not a stable interface. Daimon's JSONL parser is intentionally
 best-effort and ignores unknown rows rather than treating raw JSON as

--- a/website/docs/hosts/codex.md
+++ b/website/docs/hosts/codex.md
@@ -82,6 +82,11 @@ python3 hook/codex-hooks.py status
   matches more than you meant: the command that retires the ruling is itself
   a shell action the check would otherwise deny.
 
+  The budget is shared across the whole action, not given to each check, so
+  on a crowded manifest a later check can find the time already spent and
+  report `unresolved`, which denies under `enforce` and warns under `warn`.
+  Keep a project's armed checks few and their bodies fast.
+
 Codex docs note that `transcript_path` is provided for convenience but its
 format is not a stable interface. Daimon's JSONL parser is intentionally
 best-effort and ignores unknown rows rather than treating raw JSON as

--- a/website/docs/hosts/windsurf.md
+++ b/website/docs/hosts/windsurf.md
@@ -53,6 +53,11 @@ events:
   `~/.daimon/windsurf/unparsed-<event>-<stamp>.json` (at most one dump per
   event name), so the next adapter iteration has real evidence to work from
   instead of another manual probe round.
+- **No pre-action checks:** a ruling's check reads `unsupported` on Windsurf.
+  Cascade documents a `pre_run_command` event, but nothing daimon has measured
+  says what it does with a decision, so the column stays `unsupported` rather
+  than claiming an enforcement nobody has seen delivered. A check armed to
+  `enforce` shows `unsupported` here, not `registered`.
 - **No briefing injection:** Cascade's hook set has no session-start-equivalent
   event, so unlike Claude Code/Codex/Gemini the briefing is not injected as
   context. This is a permanent host constraint, not a bug — the skill closes

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -63,7 +63,25 @@ The auditors share one exit contract, so a script can act on the answer:
 
 ### Checks at runtime
 
-Ratifying a ruling that carries a check writes two things under `~/.daimon/checks`: a manifest naming every armed check and the project directory it belongs to, and one file per check holding the exact body the ruling stores. Every ledger write that can arm or disarm a check rebuilds them; `daimon check sync` rebuilds them on demand. The host adapters that actually run a check on a real action arrive in a later release — what ships here is the machinery underneath and the command to test a body against it.
+Ratifying a ruling that carries a check writes two things under `~/.daimon/checks`: a manifest naming every armed check and the project directory it belongs to, and one file per check holding the exact body the ruling stores. Every ledger write that can arm or disarm a check rebuilds them; `daimon check sync` rebuilds them on demand, and so does `daimon hooks install`, which prints what it found.
+
+On a host with a pre-action hook installed, a matching shell command runs its armed checks before it executes. The hook reads the manifest, keeps the checks whose project directory contains the action's working directory, and runs the ones whose pattern matches the command string. It always exits 0 and writes either one JSON object or nothing: the deny is a decision the hook makes deliberately, never an exit code that a crash could produce by accident.
+
+### What a check gets on each host
+
+What the author asked for is an intent. What a host delivers is a mode, and it is the weaker of the two.
+
+| intent | Claude Code | Codex | Windsurf |
+| --- | --- | --- | --- |
+| `enforce` | `enforce` | `enforce` | `unsupported` |
+| `warn` | `warn` | `record-only` | `unsupported` |
+| `record-only` | `record-only` | `record-only` | `unsupported` |
+
+`enforce` returns the host's structured deny and the command does not run. `warn` allows the command and shows the reason. `record-only` says nothing to the host and leaves the run in the log. `unsupported` is what a host gets when daimon has not measured how it delivers a decision at all: Cascade documents a `pre_run_command` event, but nothing measured says what it does with one, so the whole Windsurf column stays `unsupported` rather than claiming an enforcement nobody has seen delivered.
+
+Codex is the interesting cell. It documents no channel for a warning, so `warn` degrades to `record-only` there: the check still runs and the log still says so, and daimon does not claim to have shown the author something the host never rendered.
+
+When more than one armed check matches a command, the strongest FAILING mode decides. An `enforce` check that passed does not block the command for a `warn` check that did not, and the message names every check that failed.
 
 A check runs against a **subject**: the command string, a separator, then the contents of every file argument daimon could resolve, each under a header naming the flag it came from. The subject goes to a temporary file at mode 600 and is removed after the run. Its path arrives in `DAIMON_CHECK_SUBJECT`, alongside `DAIMON_CHECK_COMMAND` and `DAIMON_CHECK_RULING`; the working directory is the action's own, and standard input is `/dev/null`.
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -81,7 +81,7 @@ What the author asked for is an intent. What a host delivers is a mode, and it i
 
 Codex is the interesting cell. It documents no channel for a warning, so `warn` degrades to `record-only` there: the check still runs and the log still says so, and daimon does not claim to have shown the author something the host never rendered.
 
-When more than one armed check matches a command, the strongest FAILING mode decides. An `enforce` check that passed does not block the command for a `warn` check that did not, and the message names every check that failed.
+When more than one armed check matches a command, the strongest FAILING mode decides. An `enforce` check that passed does not block the command for a `warn` check that did not, and the message names every check that failed at that mode or above. A weaker check's reason stays in the log: `record-only` asked for the log and nothing else, and a neighbour that failed harder does not carry it out on its behalf.
 
 A check runs against a **subject**: the command string, a separator, then the contents of every file argument daimon could resolve, each under a header naming the flag it came from. The subject goes to a temporary file at mode 600 and is removed after the run. Its path arrives in `DAIMON_CHECK_SUBJECT`, alongside `DAIMON_CHECK_COMMAND` and `DAIMON_CHECK_RULING`; the working directory is the action's own, and standard input is `/dev/null`.
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/claude-code.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/claude-code.md
@@ -109,7 +109,7 @@ custodia las acciones de shell:
   se carga desde al lado del script, y el script solo nombra a su anfitrión.
   Sale con 0 en todos los caminos, no escribe nada en stderr y escribe o bien
   un objeto JSON o bien nada. Mira
-  [Checks en ejecución](../reference/cli#checks-at-runtime).
+  [Checks en ejecución](../reference/cli#checks-en-ejecución).
 
   Cada corrida agrega una fila a `~/.daimon/logs/checks.jsonl`. Una fila
   prueba que el check CORRIÓ. Solo `decision_emitted: deny` bajo `enforce`

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/claude-code.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/claude-code.md
@@ -14,7 +14,7 @@ vive en el
 ```
 
 El plugin registra por sí mismo los hooks `SessionStart` / `UserPromptSubmit`
-/ `SessionEnd` vía `.claude-plugin/plugin.json` + `hooks/hooks.json`. El orden
+/ `SessionEnd` / `PreToolUse` vía `.claude-plugin/plugin.json` + `hooks/hooks.json`. El orden
 no importa respecto a instalar el CLI `daimon`: si los hooks llegan antes que
 el CLI, las sesiones arrancan con normalidad y el hook imprime una línea con
 la sugerencia de instalación en lugar de un briefing.
@@ -37,7 +37,7 @@ python3 hook/daimon-hooks.py status
 ```
 
 Install copia los scripts de hook a `~/.claude/hooks/` y los registra bajo
-`SessionStart` / `SessionEnd` en `~/.claude/settings.json` (idempotente; los
+`SessionStart` / `SessionEnd` / `PreToolUse` en `~/.claude/settings.json` (idempotente; los
 settings se respaldan antes de cada mutación). Requiere el CLI `daimon` en el
 PATH — `uv tool install 'daimon-briefing[pretty]'`, mira el
 [inicio rápido](../getting-started/quickstart) — y los hooks también aceptan
@@ -46,8 +46,9 @@ CLI, re-ejecuta install para que los scripts de hook queden sincronizados.
 
 ## Qué hace cada script
 
-Tres scripts cierran el ciclo de captura -> inyección, sea cual sea la ruta de
-instalación que los registre:
+Cuatro scripts corren en este anfitrión, sea cual sea la ruta de instalación
+que los registre. Tres cierran el ciclo de captura -> inyección; el cuarto
+custodia las acciones de shell:
 
 - **`daimon-session-brief.py`** — hook `SessionStart`. Lee el payload de stdin
   y delega en el CLI `daimon brief` instalado (única fuente de verdad para el
@@ -95,6 +96,24 @@ instalación que los registre:
   nunca coinciden: los comandos slash (directivas del host) y los bloques
   emitidos por el host — notificaciones de tareas en segundo plano, mensajes
   de agentes o compañeros de equipo, salida de comandos.
+
+- **`daimon-pre-action.py`** — hook `PreToolUse`, matcher `Bash`. **Este es el
+  primer hook de daimon que puede hacer fallar una acción del anfitrión.**
+  Antes de que corra un comando de shell, lee el manifiesto de checks armados,
+  se queda con los armados para el directorio de trabajo de la acción y corre
+  aquellos cuyo patrón coincide con el comando. Un check ratificado con
+  intención `enforce` que reporta una violación, o un sujeto que daimon no
+  pudo leer, vuelve como el rechazo estructurado de Claude Code y el comando
+  no corre; `warn` vuelve como un permiso que lleva la razón; `record-only` no
+  le dice nada al anfitrión. Todo lo que decide vive en `checks_host.py`, que
+  se carga desde al lado del script, y el script solo nombra a su anfitrión.
+  Sale con 0 en todos los caminos, no escribe nada en stderr y escribe o bien
+  un objeto JSON o bien nada. Mira
+  [Checks en ejecución](../reference/cli#checks-at-runtime).
+
+  Cada corrida agrega una fila a `~/.daimon/logs/checks.jsonl`. Una fila
+  prueba que el check CORRIÓ. Solo `decision_emitted: deny` bajo `enforce`
+  cierra la distancia entre un check que corrió y un check que fue respetado.
 
 Estos dos scripts de captura/inyección se cablean de una de dos maneras
 mutuamente excluyentes — elige UNA (ambas a la vez disparan todo dos veces

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/claude-code.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/claude-code.md
@@ -115,6 +115,11 @@ custodia las acciones de shell:
   prueba que el check CORRIÓ. Solo `decision_emitted: deny` bajo `enforce`
   cierra la distancia entre un check que corrió y un check que fue respetado.
 
+  `DAIMON_DISABLE=1` en el entorno del anfitrión apaga todos los hooks de
+  daimon, este incluido, y es la salida de un check `enforce` cuyo patrón
+  coincide con más de lo que querías: el comando que retira la regla es a su
+  vez una acción de shell que el check rechazaría.
+
 Estos dos scripts de captura/inyección se cablean de una de dos maneras
 mutuamente excluyentes — elige UNA (ambas a la vez disparan todo dos veces
 por sesión: dos inyecciones de briefing, dos llamadas LLM de serialización).

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/claude-code.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/claude-code.md
@@ -120,6 +120,12 @@ custodia las acciones de shell:
   coincide con más de lo que querías: el comando que retira la regla es a su
   vez una acción de shell que el check rechazaría.
 
+  El presupuesto es compartido por toda la acción, no se le da a cada check,
+  así que en un manifiesto cargado un check tardío puede encontrar el tiempo
+  ya gastado y reportar `unresolved`, que rechaza bajo `enforce` y advierte
+  bajo `warn`. Mantené pocos checks armados por proyecto y sus cuerpos
+  rápidos.
+
 Estos dos scripts de captura/inyección se cablean de una de dos maneras
 mutuamente excluyentes — elige UNA (ambas a la vez disparan todo dos veces
 por sesión: dos inyecciones de briefing, dos llamadas LLM de serialización).

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/codex.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/codex.md
@@ -20,8 +20,9 @@ publicado (sin necesidad de clonar el repo):
 daimon hooks install codex
 ```
 
-Esto copia los tres scripts de hook y su helper compartido a `~/.codex/hooks/` y
-registra `SessionStart`, `SessionEnd` y `Stop` en `~/.codex/hooks.json`, preservando
+Esto copia los cuatro scripts de hook y los módulos que comparten a
+`~/.codex/hooks/` y registra `SessionStart`, `SessionEnd`, `Stop` y
+`PreToolUse` en `~/.codex/hooks.json`, preservando
 cualquier entrada no relacionada que ya exista. Es idempotente — re-ejecútalo
 después de cada `uv tool upgrade daimon-briefing` para refrescar los scripts
 y que coincidan con el CLI instalado. Tras instalar, abre `/hooks` en Codex
@@ -67,6 +68,21 @@ python3 hook/codex-hooks.py status
   sesión). Ponlo en `0` para serializar cada turno, o pon
   `DAIMON_CODEX_SERIALIZE_ON_STOP=0` para desactivar la captura de Codex
   dejando instalada la inyección del briefing.
+
+- **`daimon-codex-pre-action.py`** — hook `PreToolUse`, matcher `Bash|shell`.
+  **Este es el primer hook de daimon que puede hacer fallar una acción del
+  anfitrión.** Antes de que corra un comando de shell, corre contra él los
+  checks armados de este proyecto y devuelve el rechazo estructurado de Codex
+  cuando un check ratificado con intención `enforce` reporta una violación o
+  daimon no pudo leer lo que el comando envía. Codex no documenta ningún canal
+  para una advertencia, así que la intención `warn` degrada acá a
+  `record-only`: la corrida queda en el registro y no se muestra nada. Sale
+  con 0 en todos los caminos. Mira
+  [Checks en ejecución](../reference/cli#checks-at-runtime).
+
+  Cada corrida agrega una fila a `~/.daimon/logs/checks.jsonl`. Una fila
+  prueba que el check CORRIÓ. Solo `decision_emitted: deny` bajo `enforce`
+  cierra la distancia entre un check que corrió y un check que fue respetado.
 
 La documentación de Codex señala que `transcript_path` se provee por
 conveniencia pero su formato no es una interfaz estable. El parser JSONL de

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/codex.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/codex.md
@@ -89,6 +89,12 @@ python3 hook/codex-hooks.py status
   coincide con más de lo que querías: el comando que retira la regla es a su
   vez una acción de shell que el check rechazaría.
 
+  El presupuesto es compartido por toda la acción, no se le da a cada check,
+  así que en un manifiesto cargado un check tardío puede encontrar el tiempo
+  ya gastado y reportar `unresolved`, que rechaza bajo `enforce` y advierte
+  bajo `warn`. Mantené pocos checks armados por proyecto y sus cuerpos
+  rápidos.
+
 La documentación de Codex señala que `transcript_path` se provee por
 conveniencia pero su formato no es una interfaz estable. El parser JSONL de
 Daimon es deliberadamente best-effort e ignora filas desconocidas en lugar de

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/codex.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/codex.md
@@ -78,7 +78,7 @@ python3 hook/codex-hooks.py status
   para una advertencia, así que la intención `warn` degrada acá a
   `record-only`: la corrida queda en el registro y no se muestra nada. Sale
   con 0 en todos los caminos. Mira
-  [Checks en ejecución](../reference/cli#checks-at-runtime).
+  [Checks en ejecución](../reference/cli#checks-en-ejecución).
 
   Cada corrida agrega una fila a `~/.daimon/logs/checks.jsonl`. Una fila
   prueba que el check CORRIÓ. Solo `decision_emitted: deny` bajo `enforce`

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/codex.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/codex.md
@@ -84,6 +84,11 @@ python3 hook/codex-hooks.py status
   prueba que el check CORRIÓ. Solo `decision_emitted: deny` bajo `enforce`
   cierra la distancia entre un check que corrió y un check que fue respetado.
 
+  `DAIMON_DISABLE=1` en el entorno del anfitrión apaga todos los hooks de
+  daimon, este incluido, y es la salida de un check `enforce` cuyo patrón
+  coincide con más de lo que querías: el comando que retira la regla es a su
+  vez una acción de shell que el check rechazaría.
+
 La documentación de Codex señala que `transcript_path` se provee por
 conveniencia pero su formato no es una interfaz estable. El parser JSONL de
 Daimon es deliberadamente best-effort e ignora filas desconocidas en lugar de

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/windsurf.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/windsurf.md
@@ -58,6 +58,12 @@ de Cascade:
   (como máximo un volcado por nombre de evento), para que la siguiente
   iteración del adaptador tenga evidencia real en lugar de otra ronda de
   probes manuales.
+- **Sin checks de pre-acción:** el check de una regla lee `unsupported` en
+  Windsurf. Cascade documenta un evento `pre_run_command`, pero nada que
+  daimon haya medido dice qué hace con una decisión, así que la columna queda
+  en `unsupported` en lugar de reclamar una imposición que nadie vio
+  entregada. Un check armado en `enforce` muestra `unsupported` acá, no
+  `registered`.
 - **Sin inyección de briefing:** el conjunto de hooks de Cascade no tiene un
   evento equivalente a inicio de sesión, así que a diferencia de Claude
   Code/Codex/Gemini el briefing no se inyecta como contexto. Es una

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -82,7 +82,7 @@ Lo que pidió el autor es una intención. Lo que entrega un anfitrión es un mod
 
 Codex es la celda interesante. No documenta ningún canal para una advertencia, así que `warn` degrada allí a `record-only`: el check igual corre y el registro igual lo dice, y daimon no dice haberle mostrado al autor algo que el anfitrión nunca mostró.
 
-Cuando más de un check armado coincide con un comando, decide el modo más fuerte de los que FALLARON. Un check `enforce` que pasó no bloquea el comando por un check `warn` que no, y el mensaje nombra cada check que falló.
+Cuando más de un check armado coincide con un comando, decide el modo más fuerte de los que FALLARON. Un check `enforce` que pasó no bloquea el comando por un check `warn` que no, y el mensaje nombra cada check que falló en ese modo o por encima. La razón de un check más débil queda en el registro: `record-only` pidió el registro y nada más, y un vecino que falló más fuerte no la saca en su nombre.
 
 Un check corre contra un **sujeto**: la línea de comando, un separador, y después el contenido de cada argumento de archivo que daimon pudo resolver, cada uno bajo un encabezado que nombra la bandera de la que salió. El sujeto va a un archivo temporal con modo 600 y se borra después de la corrida. Su ruta llega en `DAIMON_CHECK_SUBJECT`, junto con `DAIMON_CHECK_COMMAND` y `DAIMON_CHECK_RULING`; el directorio de trabajo es el de la acción, y la entrada estándar es `/dev/null`.
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -64,7 +64,25 @@ actuar sobre la respuesta:
 
 ### Checks en ejecución
 
-Ratificar una regla que lleva un check escribe dos cosas bajo `~/.daimon/checks`: un manifiesto que nombra cada check armado y el directorio de proyecto al que pertenece, y un archivo por check con los bytes exactos que la regla guarda. Cada escritura en el ledger que puede armar o desarmar un check los reconstruye; `daimon check sync` los reconstruye a pedido. Los adaptadores de anfitrión que efectivamente corren un check sobre una acción real llegan en una versión posterior — lo que sale acá es la maquinaria de abajo y el comando para probar un cuerpo contra ella.
+Ratificar una regla que lleva un check escribe dos cosas bajo `~/.daimon/checks`: un manifiesto que nombra cada check armado y el directorio de proyecto al que pertenece, y un archivo por check con los bytes exactos que la regla guarda. Cada escritura en el ledger que puede armar o desarmar un check los reconstruye; `daimon check sync` los reconstruye a pedido, y también lo hace `daimon hooks install`, que imprime lo que encontró.
+
+En un anfitrión con el hook de pre-acción instalado, un comando de shell que coincide corre sus checks armados antes de ejecutarse. El hook lee el manifiesto, se queda con los checks cuyo directorio de proyecto contiene el directorio de trabajo de la acción, y corre aquellos cuyo patrón coincide con la cadena del comando. Siempre sale con 0 y escribe o bien un objeto JSON o bien nada: el rechazo es una decisión que el hook toma deliberadamente, nunca un código de salida que un crash podría producir por accidente.
+
+### Qué recibe un check en cada anfitrión
+
+Lo que pidió el autor es una intención. Lo que entrega un anfitrión es un modo, y es el más débil de los dos.
+
+| intención | Claude Code | Codex | Windsurf |
+| --- | --- | --- | --- |
+| `enforce` | `enforce` | `enforce` | `unsupported` |
+| `warn` | `warn` | `record-only` | `unsupported` |
+| `record-only` | `record-only` | `record-only` | `unsupported` |
+
+`enforce` devuelve el rechazo estructurado del anfitrión y el comando no corre. `warn` permite el comando y muestra la razón. `record-only` no le dice nada al anfitrión y deja la corrida en el registro. `unsupported` es lo que recibe un anfitrión del que daimon no midió cómo entrega una decisión: Cascade documenta un evento `pre_run_command`, pero nada medido dice qué hace con una, así que toda la columna de Windsurf queda en `unsupported` en lugar de reclamar una imposición que nadie vio entregada.
+
+Codex es la celda interesante. No documenta ningún canal para una advertencia, así que `warn` degrada allí a `record-only`: el check igual corre y el registro igual lo dice, y daimon no dice haberle mostrado al autor algo que el anfitrión nunca mostró.
+
+Cuando más de un check armado coincide con un comando, decide el modo más fuerte de los que FALLARON. Un check `enforce` que pasó no bloquea el comando por un check `warn` que no, y el mensaje nombra cada check que falló.
 
 Un check corre contra un **sujeto**: la línea de comando, un separador, y después el contenido de cada argumento de archivo que daimon pudo resolver, cada uno bajo un encabezado que nombra la bandera de la que salió. El sujeto va a un archivo temporal con modo 600 y se borra después de la corrida. Su ruta llega en `DAIMON_CHECK_SUBJECT`, junto con `DAIMON_CHECK_COMMAND` y `DAIMON_CHECK_RULING`; el directorio de trabajo es el de la acción, y la entrada estándar es `/dev/null`.
 


### PR DESCRIPTION
Refs #943

Slice 3 of #943, with the Codex half of the spec's slice 4 folded in: the host adapters. Slice 2 (#952) built the runtime; this slice wires it to a real action. On Claude Code and Codex, a shell command that matches an armed check now runs that check first and the host receives a structured decision.

## What

- One shared core, `checks_host.py`, stdlib only, loadable by a hook script without importing the package, shipped byte-identical to `_hooks/` and `hook/` through the sync script and drift test. It loads the runtime from its own directory, reads the payload, matches the working directory, runs the armed checks, encodes the decision, and logs one firing row per check.
- A host is a profile row, not a pipeline. A row names the event, the accepted tool names, where the payload keeps the command and the working directory, the decision encoder, the install matcher and timeout, and the mode table: the actual mode a check gets on that host, which is the weaker of what the author asked for and what the host can deliver. Claude Code delivers `enforce`, `warn` and `record-only`. Codex delivers `enforce` and `record-only`, so `warn` degrades to `record-only` until its warn path is measured. Windsurf is a row with every mode `unsupported` and no script until it is measured.
- The per-host scripts are thin. `hook/daimon-pre-action.py` and `hook/daimon-codex-pre-action.py` each load the core and name their profile. A future host that reads the same JSON is one row plus one such script.
- The decision, byte-exact. A deny is `{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": ...}}`. A warning is an allow plus `systemMessage`. A silent allow is empty stdout. Every path exits 0, so a hook that fails never blocks by accident and never allows by crash without a row saying so.
- Aggregation across several checks on one action: the strongest failing mode decides, and the message names only the checks at or above that mode, so a `record-only` reason never leaks into a warning. A clean `enforce` check next to a failing `warn` check warns; it does not deny. Each firing row records what that check contributed: a clean check, or a failing check below the deciding floor, logs `allow` even when a neighbour denied. `unresolved` is never rendered as clean.
- No manifest, an unreadable manifest, or no armed check for this working directory is a silent allow with one firing row naming that state, so a later surface can say "armed, never fired" instead of "clean".
- One deadline per action. The hook has 8 seconds of the host's 10 to decide; each check gets at most `DAIMON_CHECK_TIMEOUT` (default 5) within that, and a check that finds no time left is `unresolved` without being spawned, which under `enforce` still denies. Three checks that each sleep 4 seconds deny in under 9. Without this, two slow checks pushed the hook past the host timeout, and the host treats that as an allow with no record.
- `DAIMON_DISABLE=1` in the host's environment turns this hook off along with every other daimon hook. It is the way out of an over-broad `enforce` check, whose retire command is itself a shell action.
- Registration on both paths for Claude Code: the plugin's `hooks/hooks.json` gains `PreToolUse` with matcher `Bash`, and the manual `settings.json` manager registers the same event. Codex: `PreToolUse` with matcher `Bash|shell` in both hook manifests, the runtime and core shipped alongside the script, install idempotent, foreign entries preserved, backup kept.
- `daimon hooks install` now ends by materializing the current project's armed checks, so the hook has something to read the moment it is registered.
- Docs in both languages: each host page says what a check gets on that host, and that a firing row proves the check ran while only a `deny` under `enforce` proves the action was honoured.
- A candidate scar records the one trap this slice hit: a stale synced copy of the core fails open as a clean allow.

## Why

Slice 1 stored the check and pinned it at ratification. Slice 2 made it runnable and testable by a human before arming. Until this slice the ceremony's promise that the check "will run before matching actions" had no host behind it. Making the adapter a table rather than per-host code is deliberate: two copies of the pipeline would be the drift the sync machinery exists to prevent, and the hosts that matter today already speak the same measured deny.

## Tests

- `tests/test_checks_host.py`: every cell of the mode table, the three encoders byte-exact by literal string comparison, the decide matrix over a manifest that `checks.sync` wrote from a ruling ratified in-process, one row per check with its mode and the emitted decision, the three project-level rows, non-accepted tools, resolve once and discard always, aggregation across mixed modes, and a core that never raises when the manifest read, the resolver or the runner is made to raise.
- `tests/test_pre_action_hook.py`: both scripts run as the host runs them, payload on stdin, for deny, warn, record, clean, unresolved, no manifest, no match, a non-Bash tool, a missing library, a missing runtime, a missing or broken core, an argv-array command, and the kill switch; three checks that each sleep 4 seconds deny in under 9 seconds wall clock, two hanging checks likewise; stdout empty or one JSON object, stderr empty, exit 0 on every path; registration in all four manifests.
- `tests/test_hooks_install.py`: Codex install adds the new event, preserves foreign entries, stays idempotent, keeps its backup, and prints the materialization line.
- Manual end-to-end in a temp store: a real ratified ruling denied a real command with the exact JSON above and wrote the firing row.
- Full suite from `plugin/` with the CI extras: 5531 passed, 0 failed, 10 skipped (209 new). Ruff and mypy clean. `scripts/sync_hooks.py --check` in sync. The core is at 100 percent line coverage.
