### PR TITLE
chore(scars): promote 0070, 0071 and 0072, the stderr mirror, the slug-shaped --project bypass and the stale hook copy

### DIFF
--- a/.scars/0070-serialize-outcomes-must-not-mirror-to-stderr.deadend.md
+++ b/.scars/0070-serialize-outcomes-must-not-mirror-to-stderr.deadend.md
@@ -1,22 +1,24 @@
 ---
-id: 0
+id: 70
 type: deadend
 title: Serialize outcomes reach a container host through inherited stdout, never through stderr; stderr already means crash here
 severity: medium
 confidence: 0.85
 created: 2026-09-05
 authors: ["claude-code"]
+promoted_by: Kibukx
+promoted_by_source: explicit
 anchors:
   - path: plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
   - path: plugin/daimon_briefing/cli/__init__.py
-  - pattern: "stderr\\s*=\\s*(crashf|subprocess\\.DEVNULL)"
+  - pattern: "stderr=crashf"
 evidence:
   - pr: 194
-  - note: "2026-09-05: a downstream consumer running daimon in a long-lived container asked for an opt-in stderr mirror of serialize outcomes, because a file under ~/.daimon/logs is invisible to a container runtime. Implemented literally, it lands in serialize-crash.log, another file on the same volume, and ships nothing."
+  - note: 2026-09-05: a downstream consumer running daimon in a long-lived container asked for an opt-in stderr mirror of serialize outcomes, because a file under ~/.daimon/logs is invisible to a container runtime. Implemented literally, it lands in serialize-crash.log, another file on the same volume, and ships nothing.
 expires:
   condition: "spawn_serialize stops routing child stderr to crash_log_path(), or #194's separation of diagnostics from crash output is retired"
   review_after: 2027-03-05
-status: candidate
+status: active
 ---
 
 Making a serialize outcome visible to a container host looks like a stderr job, and

--- a/.scars/0071-slug-shaped-project-arg-bypasses-tenant-refusal.deadend.md
+++ b/.scars/0071-slug-shaped-project-arg-bypasses-tenant-refusal.deadend.md
@@ -1,0 +1,40 @@
+---
+id: 71
+type: deadend
+title: Letting --project pass a slug-shaped value through to the bucket bypasses the tenant refusal
+severity: high
+confidence: 0.9
+created: 2026-09-06
+authors: ["claude-code"]
+promoted_by: Kibukx
+promoted_by_source: explicit
+anchors:
+  - path: plugin/daimon_briefing/config.py
+  - path: plugin/daimon_briefing/cli/__init__.py
+violation: "allow_slug=True"
+evidence:
+  - pr: 951
+  - note: review on #951 measured it: DAIMON_TENANT_SCOPED=1, `ruling list --project=<foreign slug>` printed the foreign ruling at rc 0 and `ruling propose --project=<foreign slug>` wrote into that bucket
+expires:
+  condition: "_refuses_caller_scope guards every path a bucket name can enter a verb, not only --slug and --all-projects"
+  review_after: 2027-03-06
+status: active
+---
+
+`config.resolve_project_dir` passes a value with no path separator that names no
+existing directory through untouched, because `_slug_route`, `brief --slug` and
+the bucket-iterating readers in `pending` hand bucket SLUGS in as `project_dir`.
+That passthrough was first applied to the CLI's `--project` handler too. It
+looked harmless: on main the same value absolutized against the cwd and could
+never reach a foreign bucket, and no test asserted that.
+
+Under a tenant-scoped home it was a full bypass. `_refuses_caller_scope` guards
+`--slug` and `--all-projects` only, since before this change `--project` could
+not name a bucket. With the passthrough, `ruling list --project=-Users-x-secret`
+read the foreign bucket at rc 0 and `ruling propose --project=<slug>` wrote into
+it, on every verb, including the ten `_slug_route` deliberately restricts.
+
+The fix is `allow_slug=False` on the CLI path so a `--project` value is ALWAYS
+absolutized. The rule to keep: any NEW way to hand a bucket name into a verb is
+a routing primitive and must meet the tenant refusal; test it under
+`DAIMON_TENANT_SCOPED=1` with a foreign bucket planted before shipping.

--- a/.scars/0072-stale-hook-copy-fails-open-as-clean-allow.landmine.md
+++ b/.scars/0072-stale-hook-copy-fails-open-as-clean-allow.landmine.md
@@ -1,21 +1,23 @@
 ---
-id: 0
+id: 72
 type: landmine
 title: A stale hook copy fails open and is byte-identical to a clean allow
 severity: high
 confidence: 0.9
 created: 2026-09-06
 authors: ["claude-code"]
+promoted_by: Kibukx
+promoted_by_source: explicit
 anchors:
   - path: plugin/daimon_briefing/checks_host.py
   - path: hook/
   - pattern: "spec_from_file_location"
 evidence:
-  - note: "#943 slice 3, one debugging cycle lost to it"
-status: candidate
+  - note: #943 slice 3, one debugging cycle lost to it
 expires:
   condition: "the end-to-end hook tests load the canonical file, or the sync runs automatically before pytest"
   review_after: 2027-03-06
+status: active
 ---
 
 The pre-action hook loads `checks_host.py` from its own directory by file


### PR DESCRIPTION
Scars-only change; no issue linkage per the PR template's scars-only exemption.

## What

Promotes three candidates to active scars. Reviewer recorded by scar at promotion.

- 0070 (deadend): a serialize outcome reaches a container host through inherited stdout, never through stderr, which already means crash. Anchored on the hook lib and the CLI spawn.
- 0071 (deadend): a slug-shaped value passed through `--project` bypasses the tenant refusal. Anchored on the resolver and the CLI, with a violation regex on `allow_slug=True`.
- 0072 (landmine): a stale `hook/checks_host.py` copy fails open with exit 0, empty stdout, and no firing row, byte-identical to a clean allow. Anchored on the hook loader.

Two anchors were repaired after promotion, frontmatter only. 0070 had the double-backslash pattern from scar 0019 and never matched; it now anchors on the literal spawn line. 0071 anchored on a construct that is healthy when absent, so the pattern moved to `violation:`.

## Why

Each one cost a cycle. 0070 came from a field request for a stderr mirror that would have landed in the crash log and shipped nothing. 0071 was measured in review on #951: under a tenant-scoped home, `ruling list --project=<foreign slug>` read a foreign bucket at rc 0 and `ruling propose` wrote into it. 0072 ate a debugging cycle on #943 slice 3 when an end-to-end hook test passed against the stale copy.

## Tests

scar lint: 74 files, 0 errors, 0 orphans, 0 partial-rot. The 0071 violation regex was proven both ways with `scar check --diff`: a diff restoring `allow_slug=True` on the CLI path reports VIOLATION, the same line with `allow_slug=False` reports nothing.
