### PR TITLE
docs(configuration): document eight undocumented env vars

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@ called out in the "What it does" column.
 | `DAIMON_DISABLE` | off | Kill switch. When truthy, every hook becomes a no-op — no capture, no briefing. |
 | `DAIMON_ENV_FILE` | `~/.daimon/env` | Path to the env file that backs every other variable. Read from the process env only (it names the file, so it can't live inside it). |
 | `DAIMON_PROJECT_DIR` | unset | Working directory of the session being briefed or serialized, used to route per-project checkpoints. Hooks pass the host's cwd through it; unset means the project is unknown and daimon falls back to the global pointer. |
+| `DAIMON_CAPTURE_HOST` | unset | Host-set hint naming which agent produced a capture (`claude-code`, `codex`, `windsurf`, `gemini`, `hermes`, `manual`), forwarded by installed capture hooks (#594). Not something you set by hand — a hook wires it into the environment it hands to the CLI, for the cases a bare transcript path can't resolve on its own. |
 | `DAIMON_SESSION_SPEAKER` | unset | The one person this session belongs to, declared by the host. Fills an item's `stated_by` when the transcript carries no per-message `said_by`, and only for items bound entirely to user messages; anything citing an assistant or tool message stays unattributed. A pure label, never a key, so it does not touch `DAIMON_AUTHOR`'s namespacing. Set it only where one session is one person for its whole life. A host that serves several people through a single session must leave it unset. |
 | `DAIMON_SPEAKER_LINE` | unset | The delimiter a host writes around its own speaker line at the head of each user message, for a host that serves several people through one session but does not author the transcript. Literal character(s) or the `U+E000` spelling. When set, a user row that starts with `<delim>from=<id> name="<name>"...<delim>` gets `said_by` as `name (id)` and the line is cut from the content before anything reads it; only position zero counts, and only user rows. The value is host-declared, the same honesty as a row's own `said_by`. The host must strip the delimiter from user text before prepending its line, or a user can forge one. Unset means content is never read for attribution. |
 | `DAIMON_MIN_MESSAGES` | `10` | Minimum message count before a session is worth serializing. Shorter sessions are skipped. |
@@ -62,6 +63,19 @@ Deterministic cross-session carry-over of unresolved items.
 | `DAIMON_STALE_DAYS` | `7.0` | Age threshold (days) past which a carried item's effective last-verified stamp (its `last_verified`, else the latest resolutions.jsonl event, else `first_seen`) is stale enough for `brief` to warn about it. `0` warns on every carried item. |
 | `DAIMON_PLAIN` | off | When truthy (case-insensitive), forces plain-text output — disables the rich tables/panels in `status`, `brief`, and `--help`. |
 | `NO_COLOR` | unset | Presence-based, per the [NO_COLOR convention](https://no-color.org/): if the variable is set to *any* value (even empty), rich output is disabled. |
+
+## Worldcheck
+
+Opt-in (#365): a brief-time spot-check of carried PR/issue-state claims
+against reality, via read-only `gh` probes. Default off — `daimon brief` runs
+on the SessionStart hook's latency-critical injection path (an 8s subprocess
+budget inside a 10s hook budget), so even budget-bounded network probes there
+must be deliberately opted into. Flag off, the render path never touches the
+worldcheck module at all — output stays byte-identical to a build without it.
+
+| Variable | Default | What it does |
+|---|---|---|
+| `DAIMON_WORLDCHECK` | off | When truthy, spot-check carried PR/issue-state claims against reality via read-only `gh` probes at brief time. |
 
 ## Recall
 
@@ -129,6 +143,7 @@ per-host setup.
 | Variable | Default | What it does |
 |---|---|---|
 | `DAIMON_CODEX_SERIALIZE_ON_STOP` | on | Whether the Codex `Stop` hook serializes at all. On unless set to `0`, `false`, `no`, or `off` (case-insensitive). |
+| `DAIMON_CODEX_SERIALIZE_ON_SESSION_END` | on | Whether the Codex `SessionEnd` hook serializes at all — the real end of a session, fired once on graceful teardown with the complete transcript, deliberately unthrottled. On unless set to `0`, `false`, `no`, or `off` (case-insensitive). Does not replace `Stop`, which stays as crash insurance for a SIGKILL or a closed terminal that never reaches `SessionEnd`. |
 | `DAIMON_CODEX_MIN_SERIALIZE_INTERVAL` | `300` | Minimum seconds between Codex serialize spawns. `0` serializes on every `Stop`. |
 | `DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL` | `300` | Minimum seconds between Windsurf serialize spawns (Windsurf has no session-end event, so capture runs on this throttle). `0` serializes every turn. |
 | `DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS` | `600` | Quiet period after the last Windsurf activity before a debounced finalizer serializes the trajectory's final transcript state — covers sessions whose last turns land inside the throttle window. Fractional values accepted; `0` disables the finalizer. |
@@ -163,6 +178,30 @@ checkpoints, so candidate files are committable.
 |---|---|---|
 | `DAIMON_SCAR_HARVEST` | off | When truthy, draft scar (negative-knowledge) candidates at session end into `.scars/candidates/` — repos with a `.scars/` directory only. |
 
+## Heal escalation
+
+Opt-in (#360): `daimon heal`'s default retry re-runs the same extraction
+shape that already failed. Escalation re-serializes from several distinct
+perspectives instead, merged by the ordinary merge pass — multiplying the LLM
+token cost roughly by the perspective count on your own backend, which is why
+it ships off by default. Gates the heal path only: the session-end default
+serialize never escalates, flag or no flag.
+
+| Variable | Default | What it does |
+|---|---|---|
+| `DAIMON_HEAL_ESCALATION` | off | When truthy, `daimon heal` re-serializes from multiple perspectives instead of retrying the same extraction shape. Heal-path only. |
+
+## Scene traces
+
+Opt-in experiment (#317): the serializer asks for a per-item `scene`, one to
+two sentences of episodic context, alongside the rest of the extraction.
+Gated on the LongMemEval harness clearing it as a net win before it can
+become default.
+
+| Variable | Default | What it does |
+|---|---|---|
+| `DAIMON_SCENE_TRACES` | off | When truthy, ask the serializer to also produce each item's `scene` field. |
+
 ## Ops & diagnostics
 
 | Variable | Default | What it does |
@@ -190,6 +229,7 @@ The URL, key, and model each fall back to a `LITELLM_*` variable if the
 | `DAIMON_LLM_TEMPERATURE` | `0.0` | Sampling temperature for every chat call. `0.0` for deterministic extraction; some upstreams reject anything but a fixed value. |
 | `DAIMON_LLM_FALLBACK` | on | When the primary backend fails, auto-fall-back to the rescue command (`DAIMON_LLM_COMMAND_FALLBACK`). Applies to both a litellm and a `command` primary. Set to `0` to disable. |
 | `DAIMON_FALLBACK_MIN_SECONDS` | `DAIMON_TIMEOUT` | Minimum budget the rescue command is guaranteed on entry. The primary may have drained the shared serialize deadline retrying the very failure the rescue exists to fix, which would kill the rescue on arrival; a healthy remaining budget is never shrunk. |
+| `DAIMON_RESAMPLE_MIN_SECONDS` | `DAIMON_TIMEOUT` | #553: minimum budget the validation resample is guaranteed on entry — the same failure #341 fixed for the command fallback, one path over. The shared deadline can be drained by the attempt whose output just got rejected, which would hand the resample nothing to work with. Defaults to `timeout_seconds()` for the same reason `DAIMON_FALLBACK_MIN_SECONDS` does. |
 | `DAIMON_LLM_STREAM` | on | Stream the litellm response so the socket timeout bounds the inter-frame gap rather than the whole completion. Without it, a long completion trips the timeout and retries from scratch. Set to `0` to disable. |
 | `DAIMON_LLM_NO_CACHE` | off | When truthy, bypass gateway response caching per request — needed when a cached bad response pins a failure or runs must be statistically independent. |
 | `DAIMON_LLM_BRIEFING` | off | When truthy, render the briefing via the LLM instead of the deterministic template. |
@@ -220,3 +260,5 @@ only matter if your sessions routinely run very long.
 | `DAIMON_CHUNK_OVERLAP` | `100` | Lines of overlap between adjacent chunks, so an item straddling a boundary is seen whole by at least one chunk. |
 | `DAIMON_CHUNK_CONCURRENCY` | `4` | Parallel chunk-serialize LLM calls. Minimum 1 (sequential). |
 | `DAIMON_MERGE_GROUP_SIZE` | `3` | Max partial checkpoints merged per hierarchical merge call. Minimum 2. Lower to `2` if merge calls die on a gateway with a server-side request ceiling (reasoning models generating 3-way merges can exceed it; raising `DAIMON_TIMEOUT` won't help — the kill is server-side). |
+| `DAIMON_CHUNK_CACHE` | on | #48: content-addressed cache of chunk-extraction output, keyed on the chunk's own bytes, so a re-run of a heal or retry re-pays a call only when the chunk source actually changed. Kill switch — on unless set to `0`. |
+| `DAIMON_CHUNK_CACHE_DAYS` | `3` | Rotation window for the chunk cache, in days. Cached output is pre-redaction (the #125 quote-verification ordering forces this), so the window is a privacy bound as much as a disk bound — 3 days covers the heal/retry window while keeping exposure short. |

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -31,6 +31,7 @@ called out in the "What it does" column.
 | `DAIMON_DISABLE` | off | Kill switch. When truthy, every hook becomes a no-op — no capture, no briefing. |
 | `DAIMON_ENV_FILE` | `~/.daimon/env` | Path to the env file that backs every other variable. Read from the process env only (it names the file, so it can't live inside it). |
 | `DAIMON_PROJECT_DIR` | unset | Working directory of the session being briefed or serialized, used to route per-project checkpoints. Hooks pass the host's cwd through it; unset means the project is unknown and daimon falls back to the global pointer. |
+| `DAIMON_CAPTURE_HOST` | unset | Host-set hint naming which agent produced a capture (`claude-code`, `codex`, `windsurf`, `gemini`, `hermes`, `manual`), forwarded by installed capture hooks (#594). Not something you set by hand — a hook wires it into the environment it hands to the CLI, for the cases a bare transcript path can't resolve on its own. |
 | `DAIMON_MIN_MESSAGES` | `10` | Minimum message count before a session is worth serializing. Shorter sessions are skipped. |
 | `DAIMON_TIMEOUT` | `420` | Total serialize budget in seconds, shared across retry attempts (per-attempt socket timeouts are capped to the remaining budget). Real serialize/merge calls on gateway and CLI backends run 74s–25min; keep ≥420 or slow calls and retries cannot fit. |
 | `DAIMON_HUNG_AFTER` | `1800` | Seconds past which a serialize spawn that produced no result line is treated as hung/killed rather than still running. Default 30 min sits safely beyond a slow run (production serializes take 4–25 min). |
@@ -64,6 +65,19 @@ Deterministic cross-session carry-over of unresolved items.
 | `DAIMON_STALE_DAYS` | `7.0` | Age threshold (days) past which a carried item's effective last-verified stamp (its `last_verified`, else the latest resolutions.jsonl event, else `first_seen`) is stale enough for `brief` to warn about it. `0` warns on every carried item. |
 | `DAIMON_PLAIN` | off | When truthy (case-insensitive), forces plain-text output — disables the rich tables/panels in `status`, `brief`, and `--help`. |
 | `NO_COLOR` | unset | Presence-based, per the [NO_COLOR convention](https://no-color.org/): if the variable is set to *any* value (even empty), rich output is disabled. |
+
+## Worldcheck
+
+Opt-in (#365): a brief-time spot-check of carried PR/issue-state claims
+against reality, via read-only `gh` probes. Default off — `daimon brief` runs
+on the SessionStart hook's latency-critical injection path (an 8s subprocess
+budget inside a 10s hook budget), so even budget-bounded network probes there
+must be deliberately opted into. Flag off, the render path never touches the
+worldcheck module at all — output stays byte-identical to a build without it.
+
+| Variable | Default | What it does |
+|---|---|---|
+| `DAIMON_WORLDCHECK` | off | When truthy, spot-check carried PR/issue-state claims against reality via read-only `gh` probes at brief time. |
 
 ## Recall
 
@@ -121,11 +135,36 @@ Serialize-throttle knobs for hosts that lack a clean session-end event. See
 | Variable | Default | What it does |
 |---|---|---|
 | `DAIMON_CODEX_SERIALIZE_ON_STOP` | on | Whether the Codex `Stop` hook serializes at all. On unless set to `0`, `false`, `no`, or `off` (case-insensitive). |
+| `DAIMON_CODEX_SERIALIZE_ON_SESSION_END` | on | Whether the Codex `SessionEnd` hook serializes at all — the real end of a session, fired once on graceful teardown with the complete transcript, deliberately unthrottled. On unless set to `0`, `false`, `no`, or `off` (case-insensitive). Does not replace `Stop`, which stays as crash insurance for a SIGKILL or a closed terminal that never reaches `SessionEnd`. |
 | `DAIMON_CODEX_MIN_SERIALIZE_INTERVAL` | `300` | Minimum seconds between Codex serialize spawns. `0` serializes on every `Stop`. |
 | `DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL` | `300` | Minimum seconds between Windsurf serialize spawns (Windsurf has no session-end event, so capture runs on this throttle). `0` serializes every turn. |
 | `DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS` | `600` | Quiet period after the last Windsurf activity before a debounced finalizer serializes the trajectory's final transcript state — covers sessions whose last turns land inside the throttle window. Fractional values accepted; `0` disables the finalizer. |
 | `DAIMON_WINDSURF_DIR` | `~/.daimon/windsurf` | Where the Windsurf adapter keeps the transcripts it accumulates. Read by both the hook that writes them and the `forget`/`heal` paths that delete them — change it in one place only, or the writer and the deleter stop agreeing. |
 | `DAIMON_WINDSURF_STATE_DAYS` | `7` | Age window for daimon-authored Windsurf transcripts and unparsed payload dumps, reaped by `daimon heal`. A privacy bound: a forgotten value cannot be located inside prose, so this limits how long the source conversation lingers between `forget` runs. Clamped to at least 1 — unlike the other Windsurf knobs, `0` does not disable it. |
+
+## Heal escalation
+
+Opt-in (#360): `daimon heal`'s default retry re-runs the same extraction
+shape that already failed. Escalation re-serializes from several distinct
+perspectives instead, merged by the ordinary merge pass — multiplying the LLM
+token cost roughly by the perspective count on your own backend, which is why
+it ships off by default. Gates the heal path only: the session-end default
+serialize never escalates, flag or no flag.
+
+| Variable | Default | What it does |
+|---|---|---|
+| `DAIMON_HEAL_ESCALATION` | off | When truthy, `daimon heal` re-serializes from multiple perspectives instead of retrying the same extraction shape. Heal-path only. |
+
+## Scene traces
+
+Opt-in experiment (#317): the serializer asks for a per-item `scene`, one to
+two sentences of episodic context, alongside the rest of the extraction.
+Gated on the LongMemEval harness clearing it as a net win before it can
+become default.
+
+| Variable | Default | What it does |
+|---|---|---|
+| `DAIMON_SCENE_TRACES` | off | When truthy, ask the serializer to also produce each item's `scene` field. |
 
 ## Ops & diagnostics
 
@@ -155,6 +194,7 @@ endpoint is down.
 | `DAIMON_LLM_TEMPERATURE` | `0.0` | Sampling temperature for every chat call. `0.0` for deterministic extraction; some upstreams reject anything but a fixed value. |
 | `DAIMON_LLM_FALLBACK` | on | When the primary backend fails, auto-fall-back to the rescue command (`DAIMON_LLM_COMMAND_FALLBACK`). Applies to both a litellm and a `command` primary. Set to `0` to disable. |
 | `DAIMON_FALLBACK_MIN_SECONDS` | `DAIMON_TIMEOUT` | Minimum budget the rescue command is guaranteed on entry. The primary may have drained the shared serialize deadline retrying the very failure the rescue exists to fix, which would kill the rescue on arrival; a healthy remaining budget is never shrunk. |
+| `DAIMON_RESAMPLE_MIN_SECONDS` | `DAIMON_TIMEOUT` | #553: minimum budget the validation resample is guaranteed on entry — the same failure #341 fixed for the command fallback, one path over. The shared deadline can be drained by the attempt whose output just got rejected, which would hand the resample nothing to work with. Defaults to `timeout_seconds()` for the same reason `DAIMON_FALLBACK_MIN_SECONDS` does. |
 | `DAIMON_LLM_STREAM` | on | Stream the litellm response so the socket timeout bounds the inter-frame gap rather than the whole completion. Without it, a long completion trips the timeout and retries from scratch. Set to `0` to disable. |
 | `DAIMON_LLM_NO_CACHE` | off | When truthy, bypass gateway response caching per request — needed when a cached bad response pins a failure or runs must be statistically independent. |
 | `DAIMON_LLM_BRIEFING` | off | When truthy, render the briefing via the LLM instead of the deterministic template. |
@@ -185,3 +225,5 @@ only matter if your sessions routinely run very long.
 | `DAIMON_CHUNK_OVERLAP` | `100` | Lines of overlap between adjacent chunks, so an item straddling a boundary is seen whole by at least one chunk. |
 | `DAIMON_CHUNK_CONCURRENCY` | `4` | Parallel chunk-serialize LLM calls. Minimum 1 (sequential). |
 | `DAIMON_MERGE_GROUP_SIZE` | `3` | Max partial checkpoints merged per hierarchical merge call. Minimum 2. Lower to `2` if merge calls die on a gateway with a server-side request ceiling (reasoning models generating 3-way merges can exceed it; raising `DAIMON_TIMEOUT` won't help — the kill is server-side). |
+| `DAIMON_CHUNK_CACHE` | on | #48: content-addressed cache of chunk-extraction output, keyed on the chunk's own bytes, so a re-run of a heal or retry re-pays a call only when the chunk source actually changed. Kill switch — on unless set to `0`. |
+| `DAIMON_CHUNK_CACHE_DAYS` | `3` | Rotation window for the chunk cache, in days. Cached output is pre-redaction (the #125 quote-verification ordering forces this), so the window is a privacy bound as much as a disk bound — 3 days covers the heal/retry window while keeping exposure short. |

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting-started/configuration.md
@@ -37,6 +37,7 @@ medido, no configuración de usuario.
 | `DAIMON_DISABLE` | off | Interruptor de apagado. Cuando es verdadero, cada hook se vuelve un no-op — sin captura, sin briefing. |
 | `DAIMON_ENV_FILE` | `~/.daimon/env` | Ruta del archivo de entorno que respalda a todas las demás variables. Se lee solo del entorno del proceso (nombra al archivo, así que no puede vivir dentro de él). |
 | `DAIMON_PROJECT_DIR` | sin definir | Directorio de trabajo de la sesión que se briefea o serializa, usado para enrutar checkpoints por proyecto. Los hooks pasan el cwd del host a través de ella; sin definir significa proyecto desconocido y daimon cae al puntero global. |
+| `DAIMON_CAPTURE_HOST` | sin definir | Pista puesta por el host indicando qué agente produjo una captura (`claude-code`, `codex`, `windsurf`, `gemini`, `hermes`, `manual`), enviada por los hooks de captura instalados (#594). No es algo que definas a mano — un hook la mete en el entorno que le pasa al CLI, para los casos en que una ruta de transcript sola no alcanza para resolverlo. |
 | `DAIMON_MIN_MESSAGES` | `10` | Conteo mínimo de mensajes para que una sesión valga la pena serializar. Las sesiones más cortas se omiten. |
 | `DAIMON_TIMEOUT` | `420` | Presupuesto total de serialización en segundos, compartido entre reintentos (los timeouts de socket por intento se limitan al presupuesto restante). Las llamadas reales de serialize/merge en backends gateway y CLI corren 74s–25min; mantén ≥420 o las llamadas lentas y los reintentos no caben. |
 | `DAIMON_HUNG_AFTER` | `1800` | Segundos tras los cuales un proceso de serialización sin línea de resultado se trata como colgado/matado en lugar de aún corriendo. El default de 30 min queda con margen sobre una corrida lenta (las serializaciones en producción toman 4–25 min). |
@@ -70,6 +71,21 @@ Arrastre determinista de ítems sin resolver entre sesiones.
 | `DAIMON_STALE_DAYS` | `7.0` | Umbral de edad (días) tras el cual el sello efectivo de última verificación de un ítem arrastrado (su `last_verified`, si no el último evento de resolutions.jsonl, si no `first_seen`) está lo bastante desactualizado para que `brief` lo advierta. `0` advierte en cada ítem arrastrado. |
 | `DAIMON_PLAIN` | off | Cuando es verdadero (sin distinción de mayúsculas), fuerza salida de texto plano — desactiva las tablas/paneles enriquecidos en `status`, `brief` y `--help`. |
 | `NO_COLOR` | sin definir | Por presencia, según la [convención NO_COLOR](https://no-color.org/): si la variable está definida con *cualquier* valor (incluso vacío), la salida enriquecida se desactiva. |
+
+## Worldcheck
+
+Opt-in (#365): un chequeo puntual, al momento del briefing, de las
+afirmaciones de estado de PR/issue arrastradas contra la realidad, vía
+probes de solo-lectura con `gh`. Apagado por defecto — `daimon brief` corre
+en la ruta de inyección crítica en latencia del hook SessionStart (un
+presupuesto de subproceso de 8s dentro de un presupuesto de hook de 10s),
+así que incluso probes de red acotados en presupuesto ahí deben activarse a
+propósito. Con el flag apagado, la ruta de render nunca toca el módulo de
+worldcheck — la salida queda byte-idéntica a una build sin él.
+
+| Variable | Default | Qué hace |
+|---|---|---|
+| `DAIMON_WORLDCHECK` | off | Cuando es verdadero, chequea las afirmaciones de estado de PR/issue arrastradas contra la realidad vía probes de solo-lectura con `gh` al momento del briefing. |
 
 ## Recall
 
@@ -132,11 +148,37 @@ de sesión. Mira [Hosts](../hosts/) para la configuración por host.
 | Variable | Default | Qué hace |
 |---|---|---|
 | `DAIMON_CODEX_SERIALIZE_ON_STOP` | on | Si el hook `Stop` de Codex serializa en absoluto. Activo salvo que valga `0`, `false`, `no` u `off` (sin distinción de mayúsculas). |
+| `DAIMON_CODEX_SERIALIZE_ON_SESSION_END` | on | Si el hook `SessionEnd` de Codex serializa en absoluto — el fin real de una sesión, disparado una sola vez en el cierre ordenado con el transcript completo, deliberadamente sin throttle. Activo salvo que valga `0`, `false`, `no` u `off` (sin distinción de mayúsculas). No reemplaza a `Stop`, que sigue como seguro ante un SIGKILL o una terminal cerrada que nunca llega a `SessionEnd`. |
 | `DAIMON_CODEX_MIN_SERIALIZE_INTERVAL` | `300` | Segundos mínimos entre lanzamientos de serialización de Codex. `0` serializa en cada `Stop`. |
 | `DAIMON_WINDSURF_MIN_SERIALIZE_INTERVAL` | `300` | Segundos mínimos entre lanzamientos de serialización de Windsurf (Windsurf no tiene evento de fin de sesión, así que la captura corre con este throttle). `0` serializa cada turno. |
 | `DAIMON_WINDSURF_FINALIZER_QUIET_SECONDS` | `600` | Periodo de silencio tras la última actividad de Windsurf antes de que un finalizador con debounce serialice el estado final del transcript de la trayectoria — cubre sesiones cuyos últimos turnos caen dentro de la ventana del throttle. Acepta valores fraccionarios; `0` desactiva el finalizador. |
 | `DAIMON_WINDSURF_DIR` | `~/.daimon/windsurf` | Dónde guarda el adaptador de Windsurf los transcripts que acumula. Lo leen tanto el hook que los escribe como las rutas de `forget`/`heal` que los borran — cámbialo en un solo sitio, o el que escribe y el que borra dejan de coincidir. |
 | `DAIMON_WINDSURF_STATE_DAYS` | `7` | Ventana de antigüedad para los transcripts de Windsurf que escribe daimon y los volcados `unparsed`, recogidos por `daimon heal`. Es un límite de privacidad: un valor olvidado no puede localizarse dentro de la prosa, así que esto acota cuánto tiempo permanece la conversación de origen entre ejecuciones de `forget`. Con mínimo 1 — a diferencia de los otros ajustes de Windsurf, `0` no lo desactiva. |
+
+## Escalamiento de heal
+
+Opt-in (#360): el reintento por defecto de `daimon heal` vuelve a correr la
+misma forma de extracción que ya había fallado. El escalamiento serializa de
+nuevo desde varias perspectivas distintas en su lugar, fusionadas por el paso
+de merge de siempre — lo que multiplica el costo de tokens del LLM
+aproximadamente por la cantidad de perspectivas en tu propio backend, razón
+por la cual sale apagado por defecto. Regula solo la ruta de heal: la
+serialización por defecto de fin de sesión nunca escala, con o sin el flag.
+
+| Variable | Default | Qué hace |
+|---|---|---|
+| `DAIMON_HEAL_ESCALATION` | off | Cuando es verdadero, `daimon heal` serializa de nuevo desde varias perspectivas en vez de reintentar la misma forma de extracción. Solo en la ruta de heal. |
+
+## Scene traces
+
+Experimento opt-in (#317): el serializador pide un `scene` por ítem, una o
+dos oraciones de contexto episódico, junto con el resto de la extracción.
+Depende de que el harness de LongMemEval lo confirme como ganancia neta
+antes de poder volverse default.
+
+| Variable | Default | Qué hace |
+|---|---|---|
+| `DAIMON_SCENE_TRACES` | off | Cuando es verdadero, le pide al serializador que también produzca el campo `scene` de cada ítem. |
 
 ## Operación y diagnóstico
 
@@ -166,6 +208,7 @@ significa que la configuración está incompleta, no que el endpoint esté caíd
 | `DAIMON_LLM_TEMPERATURE` | `0.0` | Temperatura de muestreo de cada llamada de chat. `0.0` para extracción determinista; algunos upstreams rechazan cualquier valor que no sea uno fijo. |
 | `DAIMON_LLM_FALLBACK` | on | Cuando el backend primario falla, cae automáticamente al comando de rescate (`DAIMON_LLM_COMMAND_FALLBACK`). Aplica tanto a un primario litellm como a uno `command`. Ponlo en `0` para desactivarlo. |
 | `DAIMON_FALLBACK_MIN_SECONDS` | `DAIMON_TIMEOUT` | Presupuesto mínimo garantizado al comando de rescate al entrar. El primario pudo haber agotado el deadline compartido reintentando la misma falla que el rescate existe para resolver, lo que lo mataría al llegar; un presupuesto restante sano nunca se recorta. |
+| `DAIMON_RESAMPLE_MIN_SECONDS` | `DAIMON_TIMEOUT` | #553: presupuesto mínimo garantizado al remuestreo de validación al entrar — la misma falla que #341 arregló para el fallback de comando, un paso más allá. El deadline compartido puede agotarlo el intento cuya salida acaba de ser rechazada, lo que dejaría al remuestreo sin nada con qué trabajar. Cae a `timeout_seconds()` por la misma razón que `DAIMON_FALLBACK_MIN_SECONDS`. |
 | `DAIMON_LLM_STREAM` | on | Transmite la respuesta de litellm para que el timeout del socket acote el intervalo entre frames y no la longitud total de la respuesta. Sin esto, una respuesta larga dispara el timeout y reintenta desde cero. Ponlo en `0` para desactivarlo. |
 | `DAIMON_LLM_NO_CACHE` | off | Cuando es verdadero, evita el cache de respuestas del gateway por request — necesario cuando una respuesta mala cacheada fija una falla o cuando las corridas deben ser estadísticamente independientes. |
 | `DAIMON_LLM_BRIEFING` | off | Cuando es verdadero, renderiza el briefing vía LLM en lugar de la plantilla determinista. |
@@ -196,3 +239,5 @@ campo; solo importan si tus sesiones son rutinariamente muy largas.
 | `DAIMON_CHUNK_OVERLAP` | `100` | Líneas de solapamiento entre chunks adyacentes, para que un ítem que cruza un borde sea visto entero por al menos un chunk. |
 | `DAIMON_CHUNK_CONCURRENCY` | `4` | Llamadas LLM de serialización de chunks en paralelo. Mínimo 1 (secuencial). |
 | `DAIMON_MERGE_GROUP_SIZE` | `3` | Máximo de checkpoints parciales fusionados por llamada de merge jerárquico. Mínimo 2. Bájalo a `2` si las llamadas de merge mueren en un gateway con techo de request del lado del servidor (los modelos de razonamiento generando merges de 3 vías pueden excederlo; subir `DAIMON_TIMEOUT` no ayuda — el kill es del lado del servidor). |
+| `DAIMON_CHUNK_CACHE` | on | #48: cache de contenido-direccionado de la salida de extracción por chunk, indexada por los bytes del propio chunk, para que un reintento de heal o retry vuelva a pagar una llamada solo cuando el chunk de origen cambió de verdad. Interruptor de apagado — activo salvo que valga `0`. |
+| `DAIMON_CHUNK_CACHE_DAYS` | `3` | Ventana de rotación del cache de chunks, en días. La salida cacheada es previa a la redacción (lo exige el orden de verificación de citas de #125), así que la ventana es tanto un límite de privacidad como de disco — 3 días cubre la ventana de heal/retry manteniendo la exposición corta. |


### PR DESCRIPTION
Documentation-only change; no issue linkage per the PR template's docs-only exemption.

## What

Adds eight environment variables to `docs/configuration.md`, the website configuration page, and its Spanish mirror. Each row follows the table format already used in its section and cites the issue named in the variable's own docstring:

- `DAIMON_CAPTURE_HOST` (Core section, #594)
- `DAIMON_CODEX_SERIALIZE_ON_SESSION_END` (Host hooks section, next to `DAIMON_CODEX_SERIALIZE_ON_STOP`)
- `DAIMON_HEAL_ESCALATION` (new Heal escalation section, #360)
- `DAIMON_SCENE_TRACES` (new Scene traces section, #317)
- `DAIMON_WORLDCHECK` (new Worldcheck section, #365)
- `DAIMON_RESAMPLE_MIN_SECONDS` (LLM backend section, next to `DAIMON_FALLBACK_MIN_SECONDS`)
- `DAIMON_CHUNK_CACHE` and `DAIMON_CHUNK_CACHE_DAYS` (Serializer chunking section, #48)

## Why

The code reads all eight (`config.py` and the Codex hook files) but the configuration reference and the website never named them. Anyone trying to tune heal escalation, the chunk cache, worldcheck, or the Codex session-end serialize had no documented knob to find. Defaults were verified against the reading sites, not copied from memory.

## Tests

- `uv run --extra dev python -m pytest tests/test_reader_facing_vocabulary.py -q` from `plugin/`: 3 passed. The added prose introduces no banned reader-facing term.
- `git diff --stat main` lists only the three docs/website paths, no code or test files.
