### PR TITLE
feat(requests): assign an approval-requirement kind at request open

### DIFF
--- a/plugin/daimon_briefing/cli/request.py
+++ b/plugin/daimon_briefing/cli/request.py
@@ -351,7 +351,7 @@ def _cmd_request_open(args) -> int:
             to=to, ask=args.ask, why=args.why, channel=_request_channel(args),
             blocking=bool(args.blocking), to_human=bool(args.to_human),
             evidence=args.evidence or "", supersedes=args.supersedes or "",
-            project_dir=project)
+            kind=args.kind, project_dir=project)
     except requests.RequestError as exc:
         _cli._note_usage("request:open:refused")
         print(_refusal_message("request not recorded", exc))
@@ -501,6 +501,11 @@ def register(sub, fmt) -> None:
     rq_open.add_argument(
         "--to-human", action="store_true",
         help="the ask is for that project's human, not its agent")
+    rq_open.add_argument(
+        "--kind", choices=sorted(requests.KINDS), default=requests.DEFAULT_KIND,
+        help="approval requirement: work (default) waits on a person, info "
+             "is answerable from the recipient's own artifacts and owes no "
+             "accept; only a human channel may open one as info")
     rq_open.add_argument(
         "--blocking", action="store_true",
         help="mark the sender as blocked on it; a flag on the record, never "

--- a/plugin/daimon_briefing/requests.py
+++ b/plugin/daimon_briefing/requests.py
@@ -414,19 +414,32 @@ def fold(rows: list[dict]) -> dict[str, dict]:
             if current is not None:
                 # #961: a duplicate `opened` for an id that already has a
                 # founder is still first-writer-wins for every other field,
-                # but if the two rows DISAGREE about the approval
-                # requirement, that disagreement is free evidence that one
-                # of them is lying about it — the genuine row is still on
-                # disk right beside the forgery, this branch never deletes
-                # either. The authority gate in `_kind_of` already closes
-                # every case where the forger does not also claim a human
-                # channel; a forgery that claims `cli-tty` outright is the
-                # pre-existing forgery boundary this project has already
-                # reasoned about and accepted (see CHANNEL_AUTHORITY's own
-                # comment), and this is the cheap second layer for exactly
-                # that residual case: fail toward MORE scrutiny rather than
-                # trust whichever `opened` row happened to sort first.
-                if _kind_of(row) != current["kind"]:
+                # but if a row carrying HUMAN authority disagrees with the
+                # founder about the approval requirement, that disagreement
+                # is free evidence that one of them is lying about it — the
+                # genuine row is still on disk right beside the forgery,
+                # this branch never deletes either. Gated on `authority ==
+                # "human"`, not on the row's raw `kind` or on `_kind_of(row)`
+                # alone: `_kind_of` of ANY non-human row is already the
+                # constant `DEFAULT_KIND` after its own authority gate, so
+                # comparing it unconditionally would make every non-human
+                # duplicate "disagree" with an `info` founder BY
+                # CONSTRUCTION — an agent could then downgrade any `info`
+                # ask to `work` with one ordinary appended row, no forgery
+                # needed, which is a person's decision being overridden by a
+                # machine just as much as an upgrade would be (review pass 2
+                # finding). Restricting to human duplicates closes that
+                # without reopening anything: the authority gate in
+                # `_kind_of` already handles every case where the forger
+                # does not ALSO claim a human channel; a forgery that claims
+                # `cli-tty` outright is the pre-existing forgery boundary
+                # this project has already reasoned about and accepted (see
+                # CHANNEL_AUTHORITY's own comment), and this is the cheap
+                # second layer for exactly that residual case: a human-
+                # authority duplicate that disagrees fails toward MORE
+                # scrutiny rather than trusting whichever `opened` row
+                # happened to sort first.
+                if authority == "human" and _kind_of(row) != current["kind"]:
                     current["kind"] = DEFAULT_KIND
                 continue  # duplicate logical open, first writer wins otherwise
             # Read-boundary shape check (the write boundary is not the

--- a/plugin/daimon_briefing/requests.py
+++ b/plugin/daimon_briefing/requests.py
@@ -339,18 +339,44 @@ def events(project_dir=None) -> list[dict]:
 
 
 def _kind_of(row: dict) -> str:
-    """The approval-requirement kind an `opened` row carries (#961), folding
-    the legacy default and the `--to-human` invariant into one place.
+    """The approval-requirement kind an `opened` row carries (#961).
 
-    A row minted before this field existed carries no `kind` key at all and
-    reads as `work` — nothing is reclassified by the field's absence. A
-    `to_human` ask reads as `work` regardless of what is stored: the write
-    boundary in `open_request` already refuses the combination, but the
-    invariant belongs here too, so a future reader (a ruling's widened
-    default among them) can never see the two disagree."""
+    Read from a row in exactly one place, this branch of `fold` — no other
+    event re-folds `kind` — so gating it here gates the field for the
+    record's entire lifetime, not one snapshot of it. Three rules, kept in
+    one place because a caller wanting to lower this ask's approval bar has
+    three doors to try, and closing two of them would just relabel the hole:
+
+    1. A row minted before this field existed, or one that otherwise carries
+       no readable member of `KINDS`, reads as `work` — nothing is
+       reclassified by absence, and the unreadable case defaults toward MORE
+       scrutiny, never less. `isinstance(value, str)` guards a non-scalar
+       `kind` (a list, a dict) from raising inside `value in KINDS` — every
+       other expression in this branch is total over arbitrary JSON, and
+       this one must be too, or one poisoned line in one bucket takes down
+       every read surface for that bucket (records, listing, renderable,
+       status_counts, and both `--json` surfaces cross-bucket).
+    2. A `to_human` ask reads as `work` regardless of what is stored.
+    3. `kind == "info"` requires the OPENER's channel to carry human
+       authority — the same `CHANNEL_AUTHORITY` lookup the `_HUMAN_ONLY`
+       re-check below uses for verdict/suppression events. `open_request`
+       already refuses a non-human channel and the `to_human` combination at
+       the WRITE boundary, but `requests.append` is public, takes an
+       arbitrary dict, and validates no payload field — so a caller that
+       skips `open_request` (or a back-dated duplicate `opened` row for an
+       id that already exists) could otherwise mint or reclassify an `info`
+       ask with no person ever touching it. Rules 2 and 3 belong at THIS
+       boundary, not only the write one, for exactly that reason. `ui` and
+       `signed` both map to `"human"`, so the legitimate in-process human
+       writer pays nothing for this check.
+    """
     value = row.get("kind")
-    kind = value if value in KINDS else DEFAULT_KIND
-    return DEFAULT_KIND if row.get("to_human") is True else kind
+    kind = value if isinstance(value, str) and value in KINDS else DEFAULT_KIND
+    if row.get("to_human") is True:
+        return DEFAULT_KIND
+    if CHANNEL_AUTHORITY.get(str(row.get("channel") or "")) != "human":
+        return DEFAULT_KIND
+    return kind
 
 
 def fold(rows: list[dict]) -> dict[str, dict]:
@@ -386,7 +412,23 @@ def fold(rows: list[dict]) -> dict[str, dict]:
         current = out.get(q_id)
         if event == "opened":
             if current is not None:
-                continue  # duplicate logical open, first writer wins
+                # #961: a duplicate `opened` for an id that already has a
+                # founder is still first-writer-wins for every other field,
+                # but if the two rows DISAGREE about the approval
+                # requirement, that disagreement is free evidence that one
+                # of them is lying about it — the genuine row is still on
+                # disk right beside the forgery, this branch never deletes
+                # either. The authority gate in `_kind_of` already closes
+                # every case where the forger does not also claim a human
+                # channel; a forgery that claims `cli-tty` outright is the
+                # pre-existing forgery boundary this project has already
+                # reasoned about and accepted (see CHANNEL_AUTHORITY's own
+                # comment), and this is the cheap second layer for exactly
+                # that residual case: fail toward MORE scrutiny rather than
+                # trust whichever `opened` row happened to sort first.
+                if _kind_of(row) != current["kind"]:
+                    current["kind"] = DEFAULT_KIND
+                continue  # duplicate logical open, first writer wins otherwise
             # Read-boundary shape check (the write boundary is not the
             # boundary that matters — events() is deliberately tolerant, and
             # a row edited on disk must not ride into the render).
@@ -645,6 +687,14 @@ def open_request(*, to: str, ask: str, why: str, channel: str,
     supersedes = str(supersedes or "").strip()
     if supersedes and not _REQUEST_ID_RE.fullmatch(supersedes):
         raise RequestError(f"invalid superseded request id: {supersedes!r}")
+    # #961 review finding 5: an unknown channel is a channel-shaped problem,
+    # not a kind-shaped one. `_stamp` re-checks this too (the row is not
+    # written until it runs), but that happens after every check below, so a
+    # caller with a bogus channel and `kind="info"` would otherwise be told
+    # about `info`'s human-only rule rather than about the typo.
+    if channel not in CHANNEL_AUTHORITY:
+        raise RequestError(
+            f"channel must be one of: {', '.join(sorted(CHANNEL_AUTHORITY))}")
     if kind not in KINDS:
         raise RequestError(f"kind must be one of: {', '.join(sorted(KINDS))}")
     if to_human and kind == "info":

--- a/plugin/daimon_briefing/requests.py
+++ b/plugin/daimon_briefing/requests.py
@@ -54,6 +54,17 @@ from . import buckets, config, normalize, policy, redact, store
 from .refutations import CHANNEL_AUTHORITY, CHANNEL_LABEL
 
 VERSION = 1
+# #961: the approval-requirement a request carries. `info` is answerable from
+# the recipient's own artifacts and owes no accept; `work` asks the recipient
+# to change something or spend effort and waits on a person. Two values,
+# never a free string — the same discrete-enum posture CHANNEL_AUTHORITY and
+# EVENTS already hold this module to.
+KINDS = frozenset({"info", "work"})
+# The fold's fallback for a row that carries no readable `kind` at all — every
+# request minted before this field existed, and any other unreadable value.
+# Nothing is reclassified by the field's absence (the amendment's own words),
+# and the unreadable case defaults toward MORE scrutiny, never less.
+DEFAULT_KIND = "work"
 # The closed event vocabulary, frozen in PR 1 so the format cannot drift as
 # the arc lands: `surfaced` (the recipient's brief stamped this ask) and
 # `verdict_surfaced` (the sender's brief stamped the answer) are written by
@@ -327,6 +338,21 @@ def events(project_dir=None) -> list[dict]:
     return rows
 
 
+def _kind_of(row: dict) -> str:
+    """The approval-requirement kind an `opened` row carries (#961), folding
+    the legacy default and the `--to-human` invariant into one place.
+
+    A row minted before this field existed carries no `kind` key at all and
+    reads as `work` — nothing is reclassified by the field's absence. A
+    `to_human` ask reads as `work` regardless of what is stored: the write
+    boundary in `open_request` already refuses the combination, but the
+    invariant belongs here too, so a future reader (a ruling's widened
+    default among them) can never see the two disagree."""
+    value = row.get("kind")
+    kind = value if value in KINDS else DEFAULT_KIND
+    return DEFAULT_KIND if row.get("to_human") is True else kind
+
+
 def fold(rows: list[dict]) -> dict[str, dict]:
     """Fold this bucket's rows into current records, deterministic under
     reorder.
@@ -374,6 +400,7 @@ def fold(rows: list[dict]) -> dict[str, dict]:
                 "to": str(row.get("to") or ""),
                 "to_human": row.get("to_human") is True,
                 "blocking": row.get("blocking") is True,
+                "kind": _kind_of(row),
                 "ask": str(row.get("ask") or ""),
                 "why": str(row.get("why") or ""),
                 "evidence": str(row.get("evidence") or ""),
@@ -596,13 +623,21 @@ def renderable(project_dir=None) -> dict:
 def open_request(*, to: str, ask: str, why: str, channel: str,
                  blocking: bool = False, to_human: bool = False,
                  evidence: str = "", supersedes: str = "",
-                 project_dir=None) -> str:
+                 kind: str = DEFAULT_KIND, project_dir=None) -> str:
     """Open a request addressed to another project's slug.
 
     Slug SHAPE is validated here; whether it names a bucket that exists is
     the CLI's check — a project that has not serialized yet has no bucket,
     and refusing to record the ask at the module seam would make the ledger
     unusable exactly when a team is onboarding.
+
+    #961: `kind` is the approval requirement, assigned once, here, by the
+    SENDER. Only a person may assign `info` — an agent lowering its own
+    ask's approval bar is exactly the assertion the wedge principle forbids
+    — so this is enforced at this library boundary, not only in the CLI a
+    caller could otherwise route around. `--to-human` is audience, not
+    approval requirement, and can never be paired with `info`: a person is
+    always the one who reads it.
     """
     project_dir = config.resolve_project_dir(project_dir)
     if not _SLUG_RE.fullmatch(str(to or "")):
@@ -610,6 +645,19 @@ def open_request(*, to: str, ask: str, why: str, channel: str,
     supersedes = str(supersedes or "").strip()
     if supersedes and not _REQUEST_ID_RE.fullmatch(supersedes):
         raise RequestError(f"invalid superseded request id: {supersedes!r}")
+    if kind not in KINDS:
+        raise RequestError(f"kind must be one of: {', '.join(sorted(KINDS))}")
+    if to_human and kind == "info":
+        raise RequestError(
+            "--to-human addresses that project's person, which is always "
+            "the work approval requirement; it cannot be opened as kind "
+            "info")
+    if kind == "info" and CHANNEL_AUTHORITY.get(channel) != "human":
+        raise RequestError(
+            "kind info lowers this request's own approval requirement, and "
+            "only the sender's human channel may assign it; open it as kind "
+            f"work (the default), or run this from a human channel — this "
+            f"call arrived through {channel!r}")
     slug = store.project_slug(project_dir)
     if not slug:
         raise RequestError("project unknown; requests are recorded in the "
@@ -628,6 +676,7 @@ def open_request(*, to: str, ask: str, why: str, channel: str,
         "to": to,
         "to_human": bool(to_human),
         "blocking": bool(blocking),
+        "kind": kind,
         "ask": ask,
         "why": why,
         "from_label": _sender_label(project_dir),

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -143,6 +143,89 @@ def test_non_length_failures_still_raise_plain_request_error(project):
     assert not isinstance(exc_info.value, requests.RequestTooLong)
 
 
+def test_open_kind_defaults_to_work(project):
+    q_id = _open(project)
+    assert requests.get(q_id, project_dir=project)["kind"] == "work"
+
+
+def test_open_accepts_kind_work_explicitly(project):
+    q_id = _open(project, channel="cli-tty", kind="work")
+    assert requests.get(q_id, project_dir=project)["kind"] == "work"
+
+
+def test_open_accepts_kind_info_from_a_human_channel(project):
+    q_id = _open(project, channel="cli-tty", kind="info")
+    assert requests.get(q_id, project_dir=project)["kind"] == "info"
+
+
+def test_open_refuses_an_invalid_kind(project):
+    with pytest.raises(requests.RequestError):
+        _open(project, channel="cli-tty", kind="urgent")
+
+
+def test_a_legacy_record_with_no_kind_field_reads_as_work(project):
+    """#961 amendment: nothing is reclassified by the field's absence. Write
+    a real record through the shipping writer, then strip the `kind` key the
+    way a pre-ship record would lack it, and confirm the read lands on
+    `work` — the ledger's own default, not an artifact of the test."""
+    q_id = _open(project, channel="cli-tty", kind="info")
+    rows = _rows(project)
+    assert rows[0]["kind"] == "info"
+    del rows[0]["kind"]
+    path = (config.checkpoint_dir() / store.project_slug(project)
+            / "requests.jsonl")
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n",
+                    encoding="utf-8")
+    record = requests.get(q_id, project_dir=project)
+    assert record["kind"] == "work"
+
+
+def test_to_human_with_no_kind_yields_work(project):
+    q_id = _open(project, channel="cli-tty", to_human=True)
+    assert requests.get(q_id, project_dir=project)["kind"] == "work"
+
+
+def test_to_human_combined_with_kind_info_is_refused(project):
+    with pytest.raises(requests.RequestError) as exc_info:
+        _open(project, channel="cli-tty", to_human=True, kind="info")
+    assert "human" in str(exc_info.value)
+    assert not requests.records(project_dir=project)
+
+
+def test_an_agent_channel_cannot_open_a_request_as_kind_info(project):
+    with pytest.raises(requests.RequestError) as exc_info:
+        _open(project, channel="cli-agent", kind="info")
+    assert "human channel" in str(exc_info.value)
+    assert not requests.records(project_dir=project)
+
+
+def test_an_agent_channel_opening_kind_work_is_unaffected(project):
+    """Explicit `--kind work` from an agent is the default, not a
+    bar-lowering move, so it must still succeed."""
+    q_id = _open(project, channel="cli-agent", kind="work")
+    assert requests.get(q_id, project_dir=project)["kind"] == "work"
+
+
+def test_revise_never_changes_an_existing_records_kind(project):
+    """Kind is assigned once, at open, by a person. `revise` carries no
+    `kind` parameter at all, so an agent channel revising the ask has no way
+    to touch it — the record's kind must survive every revision unchanged."""
+    q_id = _open(project, channel="cli-tty", kind="info")
+    requests.revise(q_id, channel="cli-agent", ask="a sharper ask",
+                    project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["kind"] == "info"
+    assert record["ask"] == "a sharper ask"
+
+
+def test_kind_round_trips_through_the_ledger(project):
+    q_id = _open(project, channel="cli-tty", kind="info")
+    row = _rows(project)[0]
+    assert row["kind"] == "info"
+    record = requests.get(q_id, project_dir=project)
+    assert record["kind"] == "info"
+
+
 def test_unresolvable_project_writes_nothing(project):
     assert requests._path(None) is None
     assert requests.append({"event": "opened"}, project_dir=None) is False
@@ -765,6 +848,57 @@ def test_cli_open_anyway_records_it_with_a_loud_warning(project, recipient,
     assert "warning:" in out and "never surfaced" in out
 
 
+def test_cli_open_defaults_kind_to_work(project, recipient, capsys):
+    assert _cli_open(project, recipient) == 0
+    q_id = next(iter(requests.records(project_dir=project)))
+    assert requests.get(q_id, project_dir=project)["kind"] == "work"
+
+
+def test_cli_open_accepts_the_kind_flag_from_a_human_channel(
+        project, recipient, monkeypatch, capsys):
+    from daimon_briefing import cli
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    rc = cli.main(["request", "open", "--to", OTHER, "--ask", ASK,
+                   "--why", WHY, "--kind", "info", "--project", project])
+    assert rc == 0
+    q_id = next(iter(requests.records(project_dir=project)))
+    assert requests.get(q_id, project_dir=project)["kind"] == "info"
+
+
+def test_cli_open_refuses_kind_info_from_the_agent_channel(project, recipient,
+                                                            capsys):
+    from daimon_briefing import cli
+    rc = cli.main(["request", "open", "--to", OTHER, "--ask", ASK,
+                   "--why", WHY, "--kind", "info", "--by", "agent",
+                   "--project", project])
+    assert rc == 1
+    assert not requests.records(project_dir=project)
+    out = capsys.readouterr().out
+    assert "human channel" in out
+
+
+def test_cli_open_refuses_to_human_with_kind_info(project, recipient,
+                                                   monkeypatch, capsys):
+    from daimon_briefing import cli
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    rc = cli.main(["request", "open", "--to", OTHER, "--ask", ASK,
+                   "--why", WHY, "--to-human", "--kind", "info",
+                   "--project", project])
+    assert rc == 1
+    assert not requests.records(project_dir=project)
+    out = capsys.readouterr().out
+    assert "human" in out
+
+
+def test_cli_open_rejects_an_unknown_kind_choice(project, recipient, capsys):
+    from daimon_briefing import cli
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["request", "open", "--to", OTHER, "--ask", ASK,
+                 "--why", WHY, "--kind", "urgent", "--by", "agent",
+                 "--project", project])
+    assert exc_info.value.code == 2
+
+
 def test_cli_open_human_path_requires_a_terminal(project, recipient,
                                                  monkeypatch, capsys):
     from daimon_briefing import cli
@@ -936,6 +1070,40 @@ def test_cli_list_renders_records_and_json(project, recipient, monkeypatch,
     payload = json.loads(capsys.readouterr().out)
     assert [r["request_id"] for r in payload] == [q_id]
     assert payload[0]["state"] == "open"
+
+
+def test_request_json_payload_carries_kind_including_the_legacy_default(
+        project, recipient, monkeypatch, capsys):
+    """#961: the `--json` payload is a parsing contract (#948 and #963 both
+    held its shape deliberately unchanged while moving signals to stderr and
+    exit codes instead). `kind` is a DELIBERATE addition to that contract,
+    not an accidental one, and this pins it — without this test, slice 2
+    could rename or drop the key with nothing going red."""
+    from daimon_briefing import cli
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    info_id = requests.open_request(
+        to=store.project_slug(OTHER), ask=ASK, why=WHY, channel="cli-tty",
+        kind="info", project_dir=project)
+    legacy_id = requests.open_request(
+        to=store.project_slug(OTHER), ask="a second, older-shaped ask",
+        why=WHY, channel="cli-tty", project_dir=project)
+    # Simulate a record written before `kind` existed: strip the key from
+    # its raw `opened` row the way a pre-ship line would never have carried
+    # it, never a hand-shaped fixture (#963's own lesson).
+    path = (config.checkpoint_dir() / store.project_slug(project)
+            / "requests.jsonl")
+    rows = [json.loads(ln) for ln in
+            path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    for row in rows:
+        if row.get("request_id") == legacy_id:
+            del row["kind"]
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n",
+                    encoding="utf-8")
+    assert cli.main(["request", "list", "--json", "--project", project]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    by_id = {row["request_id"]: row for row in payload}
+    assert by_id[info_id]["kind"] == "info"
+    assert by_id[legacy_id]["kind"] == "work"
 
 
 def test_cli_list_keeps_suppressed_records_visible(project, recipient,

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -301,6 +301,37 @@ def test_a_backdated_duplicate_claiming_a_human_channel_still_forced_to_work(
     assert requests.get(q_id, project_dir=project)["kind"] == "work"
 
 
+@pytest.mark.parametrize("channel,extra", [
+    ("cli-agent", {"kind": "work"}),
+    ("cli-agent", {"kind": "info"}),
+    ("cli-agent", {}),
+    ("mechanical", {"kind": "info"}),
+], ids=["agent-dup-kind-work", "agent-dup-kind-info", "agent-dup-no-kind-key",
+        "mechanical-dup-kind-info"])
+def test_a_non_human_duplicate_opened_row_cannot_downgrade_an_info_ask(
+        project, channel, extra):
+    """#961 review pass 2 (MEDIUM). The disagreement rule must fire ONLY on
+    a duplicate carrying HUMAN authority. Gated on `_kind_of(row)` alone (or
+    on the row's raw stored `kind`), it would fire on every non-human
+    duplicate no matter what, because `_kind_of` of any non-human row is
+    already the constant `work` after its OWN authority gate — an agent
+    could then downgrade any `info` ask back to `work` with one ordinary
+    appended row, no forgery and no back-dating needed, which overrides a
+    person's decision just as much as an upgrade would (the amendment does
+    not say "only a person raises the bar", it says only a person changes
+    it). None of these four ordinary duplicates — an agent copying the
+    founder's own `work`, an agent copying `info` verbatim, an agent
+    omitting `kind` entirely, or a mechanical row claiming `info` — may
+    move a human-opened `info` ask off `info`. Duplicate row appended
+    directly: a legitimate second `opened` for an id that already has a
+    founder is not something `open_request` produces."""
+    q_id = _open(project, channel="cli-tty", kind="info")
+    dup = requests._stamp("opened", q_id, channel)
+    dup.update({"to": RECIPIENT, "ask": ASK, "why": WHY, **extra})
+    assert requests.append(dup, project_dir=project)
+    assert requests.get(q_id, project_dir=project)["kind"] == "info"
+
+
 @pytest.mark.parametrize("bad_kind", [["info"], {"k": "info"}, 7, None,
                                       "informational"],
                          ids=["list", "dict", "int", "none", "bad-string"])

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -180,9 +180,30 @@ def test_a_legacy_record_with_no_kind_field_reads_as_work(project):
     assert record["kind"] == "work"
 
 
-def test_to_human_with_no_kind_yields_work(project):
+def test_to_human_with_no_kind_argument_reaches_work_via_the_legacy_default(
+        project):
+    """This reaches `work` through the LEGACY DEFAULT (no `kind` was ever
+    given), not through the `to_human` invariant in `_kind_of` — it would
+    pass identically if that invariant were deleted. The invariant itself is
+    covered separately, by a row that forces the two to disagree."""
     q_id = _open(project, channel="cli-tty", to_human=True)
     assert requests.get(q_id, project_dir=project)["kind"] == "work"
+
+
+def test_to_human_true_with_kind_info_forged_on_disk_still_reads_as_work(
+        project):
+    """#961 review finding 3: `open_request` refuses `to_human=True` paired
+    with `kind="info"` at the write boundary, so the only way to exercise
+    the read-time invariant in `_kind_of` is a row the writer would never
+    produce. Appended directly, not through `open_request`, for exactly
+    that reason — this is the actual regression fence for the `to_human`
+    branch of `_kind_of`, which the prior test above never covered."""
+    row = requests._stamp("opened", "q-0123456789ab", "cli-tty")
+    row.update({"to": RECIPIENT, "ask": ASK, "why": WHY,
+                "to_human": True, "kind": "info"})
+    assert requests.append(row, project_dir=project)
+    record = requests.get("q-0123456789ab", project_dir=project)
+    assert record["kind"] == "work"
 
 
 def test_to_human_combined_with_kind_info_is_refused(project):
@@ -204,6 +225,103 @@ def test_an_agent_channel_opening_kind_work_is_unaffected(project):
     bar-lowering move, so it must still succeed."""
     q_id = _open(project, channel="cli-agent", kind="work")
     assert requests.get(q_id, project_dir=project)["kind"] == "work"
+
+
+def test_open_refuses_an_unknown_channel_with_the_channel_shaped_message(
+        project):
+    """#961 review finding 5: an unknown channel is a channel problem, not a
+    kind problem. Before the fix, a bogus channel plus `kind="info"` was
+    refused with the human-only-kind message rather than the channel one,
+    which tells the caller about the wrong mistake."""
+    with pytest.raises(requests.RequestError) as exc_info:
+        _open(project, channel="bogus-channel", kind="info")
+    assert "channel must be one of" in str(exc_info.value)
+    assert not requests.records(project_dir=project)
+
+
+def test_requests_append_cannot_mint_kind_info_by_bypassing_open_request(
+        project):
+    """#961 review finding 1 (CRITICAL). `open_request` refuses `kind=info`
+    from a non-human channel at the write boundary, but `requests.append`
+    is public, takes an arbitrary dict, and validates no payload field —
+    so the authority gate belongs in the fold too (`_kind_of`), not only in
+    `open_request`. Row appended directly, never through `open_request`,
+    because the write boundary would refuse exactly this."""
+    row = requests._stamp("opened", "q-0123456789ab", "cli-agent")
+    row.update({"to": RECIPIENT, "ask": ASK, "why": WHY, "kind": "info"})
+    assert requests.append(row, project_dir=project)
+    record = requests.get("q-0123456789ab", project_dir=project)
+    assert record["kind"] == "work"
+    assert record["opened_by"] == "agent"  # the row is otherwise honored
+
+
+def test_a_backdated_duplicate_opened_row_cannot_reclassify_a_human_ask(
+        project):
+    """#961 review finding 1 (CRITICAL), the concrete attack: a genuine
+    human `work` ask is already on the ledger; a second, back-dated
+    `opened` row for the SAME id, claiming the agent channel and
+    `kind=info`, sorts BEFORE it by `order` and would otherwise be taken as
+    the founding row (first-writer-wins is resolved by `order`, not file
+    position). The authority gate in `_kind_of` must close this even
+    though the forgery becomes the record's founder. Row appended
+    directly: `open_request` refuses `kind=info` from this channel, which
+    is exactly the boundary a caller bypassing it is trying to route
+    around."""
+    q_id = _open(project, channel="cli-tty", kind="work")
+    genuine = next(r for r in requests.events(project_dir=project)
+                   if r["event"] == "opened")
+    forged = requests._stamp("opened", q_id, "cli-agent",
+                             now_ns=genuine["order"] - 1_000_000_000)
+    forged.update({"to": genuine["to"], "ask": genuine["ask"],
+                   "why": genuine["why"], "kind": "info"})
+    assert requests.append(forged, project_dir=project)
+    assert requests.get(q_id, project_dir=project)["kind"] == "work"
+
+
+def test_a_backdated_duplicate_claiming_a_human_channel_still_forced_to_work(
+        project):
+    """#961 review finding 1's residual case, closed by the OPTIONAL
+    disagreement rule (review section (b), step 2). The authority gate
+    alone does not stop a forgery that outright claims `cli-tty` — that
+    channel forgery is the pre-existing boundary this project already
+    accepts (refutations.py's own reasoning: forgery costs impersonation,
+    not proof). But the genuine row is still on disk disagreeing with the
+    forgery about `kind`, and that disagreement is free evidence: two
+    `opened` rows for one id that disagree about the approval requirement
+    means somebody is lying, so the fold fails toward MORE scrutiny rather
+    than trusting whichever one sorts first."""
+    q_id = _open(project, channel="cli-tty", kind="work")
+    genuine = next(r for r in requests.events(project_dir=project)
+                   if r["event"] == "opened")
+    forged = requests._stamp("opened", q_id, "cli-tty",
+                             now_ns=genuine["order"] - 1_000_000_000)
+    forged.update({"to": genuine["to"], "ask": genuine["ask"],
+                   "why": genuine["why"], "kind": "info"})
+    assert requests.append(forged, project_dir=project)
+    assert requests.get(q_id, project_dir=project)["kind"] == "work"
+
+
+@pytest.mark.parametrize("bad_kind", [["info"], {"k": "info"}, 7, None,
+                                      "informational"],
+                         ids=["list", "dict", "int", "none", "bad-string"])
+def test_an_unreadable_kind_value_never_crashes_a_read_surface(project,
+                                                                bad_kind):
+    """#961 review finding 2 (HIGH). `value in KINDS` against a frozenset
+    raises `TypeError` for a non-scalar value, and every read surface built
+    on `fold` (records, listing, renderable, status_counts, both `--json`
+    surfaces) inherited the crash from one poisoned line. Every other
+    expression in the `opened` branch is total over arbitrary JSON; this one
+    must be too, or a fail-open caller upstream (the briefing panel, status)
+    silently drops every addressed ask instead of erroring loudly. Row
+    appended directly: the writer never puts a non-string here."""
+    row = requests._stamp("opened", "q-0123456789ab", "cli-tty")
+    row.update({"to": RECIPIENT, "ask": ASK, "why": WHY, "kind": bad_kind})
+    assert requests.append(row, project_dir=project)
+    record = requests.records(project_dir=project)["q-0123456789ab"]
+    assert record["kind"] == "work"
+    assert requests.listing(project_dir=project)
+    assert requests.renderable(project_dir=project)["rows"]
+    assert requests.status_counts(project_dir=project)["open_sent"] == 1
 
 
 def test_revise_never_changes_an_existing_records_kind(project):
@@ -2041,6 +2159,41 @@ def test_cli_request_inbox_json_matches_inbox_listing(project, recipient,
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload == requests.inbox_listing(project_dir=OTHER)
+
+
+def test_request_inbox_json_payload_carries_kind_including_the_legacy_default(
+        project, recipient, monkeypatch, capsys):
+    """#961 review finding 4. `list --json` was pinned in the prior commit,
+    but `inbox --json` is the RECIPIENT-side payload — the one a future
+    `accept --by agent` gate reads, and the one a downstream consumer
+    parses to decide what it owes. Both `--json` surfaces are the same raw
+    fold record and both gained `kind` in this slice; this pins the other
+    one the same way, for a fresh info request and for a record simulating
+    the legacy default."""
+    from daimon_briefing import cli
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    info_id = requests.open_request(
+        to=store.project_slug(OTHER), ask=ASK, why=WHY, channel="cli-tty",
+        kind="info", project_dir=project)
+    legacy_id = requests.open_request(
+        to=store.project_slug(OTHER), ask="a second, older-shaped ask",
+        why=WHY, channel="cli-tty", project_dir=project)
+    path = (config.checkpoint_dir() / store.project_slug(project)
+            / "requests.jsonl")
+    rows = [json.loads(ln) for ln in
+            path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    for row in rows:
+        if row.get("request_id") == legacy_id:
+            del row["kind"]
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n",
+                    encoding="utf-8")
+    capsys.readouterr()
+    rc = cli.main(["request", "inbox", "--json", "--project", OTHER])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    by_id = {row["request_id"]: row for row in payload}
+    assert by_id[info_id]["kind"] == "info"
+    assert by_id[legacy_id]["kind"] == "work"
 
 
 def test_cli_request_inbox_empty_says_so(recipient, capsys):


### PR DESCRIPTION
Refs #961

First of four slices. Merging this must not close the issue.

## What

Every cross-project request lands in the recipient's human decision queue, whether it asks that project to do work or only asks how to consume it. A person who approves dozens of informational asks stops reading them, which is the failure the queue exists to prevent.

Adds `kind` to the request record, exactly `info` or `work`, as the approval requirement. `request open` takes `--kind`, defaulting to `work`. Every request written before this ships reads as `work`; nothing is reclassified by the absence of a field. `--to-human` is audience rather than approval requirement, so it implies `work`, and opening it as `info` is refused rather than silently coerced.

Only a person assigns the kind. An agent channel opening `info` is refused, and the same rule is enforced again in the fold, because the write boundary can be bypassed by appending to the ledger directly. `kind` is not accepted by `revise` and has exactly one writer, so it cannot be changed after the record exists.

Out of scope, in later slices: the render surfaces, `accept --by agent` gated on kind, the ruling hook, and the `revise --kind info --by agent` proposal ceremony.

## Why

The contract follows the amendment on the issue, which reverses one clause of the proposal body: the recipient's agent never reclassifies. It may propose, and a person ratifies.

`kind` is the first approval-bearing field on the `opened` row, which is why it needed a fold-level check that the row's other fields do not. Review found that guarding only the write boundary let an agent both mint `info` on its own request and reclassify a human's `work` ask, by appending a back-dated duplicate. The module's own comment calls the fold the boundary that matters, precisely because the write boundary is not.

It is not part of `_HUMAN_ONLY`. That set makes whole events inert, and an agent opening a `work` ask is the normal documented path. The gap is one dimension finer: gating one field on an otherwise-admissible event.

A duplicate `opened` row whose kind disagrees with the founder forces `work`, since two rows disagreeing about an approval requirement means one is lying and the evidence sits in the ledger. That rule fires only for a duplicate carrying human authority. An earlier form fired unconditionally and compared post-gate values, which let any agent downgrade a human `info` ask with one ordinary row: `_kind_of` of a non-human row is always `work`, so it disagreed by construction. Narrowing it loses nothing. Across 50 combinations of founder kind, duplicate channel and duplicate kind shape, the two forms differ on 10, and all 10 are the defect.

## Tests

Full suite 5933 passed, 10 skipped, run independently twice. Baseline on main is 5901, so +32. ruff and mypy clean.

Coverage pins both directions: an agent cannot mint or reclassify `info` through `open_request`, `append`, a hand-edited row, a back-dated duplicate, or a foreign bucket read cross-project; and no non-human duplicate can downgrade a human `info` ask. A legitimate `info` ask from `cli-tty`, `ui` or `signed` still reads `info`. An unreadable `kind` value no longer raises inside the fold, which previously took down every request read surface and made the fail-open callers above it silently drop an addressed ask.

Every new test was checked by deleting the line it claims to cover and confirming it goes red. One earlier test passed with its subject removed, because it reached its expected value through the legacy default rather than the invariant it was named for; it has been renamed and a real fence added. That check follows #968.

Rows the shipping writer refuses are appended directly, and each such test says in its docstring why the writer could not produce it.
