### PR TITLE
chore(scars): promote 0073 to 0076, the raw kind comparison, the repointed mock, the double ledger read and the worktree guard

### DIFF
--- a/.scars/0010-judge-grades-wrong-dimension.landmine.md
+++ b/.scars/0010-judge-grades-wrong-dimension.landmine.md
@@ -8,7 +8,7 @@ created: 2026-06-12
 authors: ["claude-code", "Kibukx"]
 anchors:
   - path: research/experiments/track-a/
-  - pattern: "stale|staleness|adversarial.{0,40}verif|overturn"
+  - pattern: "judge.{0,60}(stale|staleness|overturn)|(stale|staleness|overturn).{0,60}judge|adversarial.{0,40}verif"
 evidence:
   - note: H1 holdout judging 2026-06-12, LOGBOOK.md entry; runs/H1/haiku-judge/*-holdout.json hand_review blocks (local)
   - note: v2 revalidation 2026-06-12: staleness judge flagged 5 more (H2 gt9, H4 gt4/5/7/10) — all 5 wrong-dimension errors again; 10/10 false flags across v1+v2. Recall verifier: 3 of 8 overturn claims rejected in hand review (wrong-item evidence, partial-component evidence). runs/H*/haiku-judge/ hand_review blocks (local)

--- a/.scars/0019-scar-pattern-anchors-are-a-three-layer-escape-trap.landmine.md
+++ b/.scars/0019-scar-pattern-anchors-are-a-three-layer-escape-trap.landmine.md
@@ -13,6 +13,7 @@ evidence:
   - note: 2026-07-02, promote refusal: \"briefing\\\\.build\\\\(\" (reflexive YAML double-backslash) reaches the regex engine RAW — '\\\\(' = literal backslash + bare group-open: 'missing ), unterminated subpattern'. scar promote refused.
   - note: 2026-07-02, rot round-trip on scar #16: double-backslash form reported dead (raw '\\\\.' never matches a plain dot); single-QUOTED form kept the quotes as pattern chars (echoed /'briefing\\.build\\b'/) — still dead; double-quoted single-backslash \"briefing\\.build\\b\" went live. Parser strips double quotes only, processes NO escapes.
   - note: 2026-07-02, scar #9 false rot: its pattern matches cli.py:538, but liveness reads only READ_HEAD_BYTES (8KB) per file (scar/orphan.py) — deep matches report as dead anchors.
+  - note: "firing-review 2026-09-08: 14 fires since the last revision, all from editing .scars/candidates and active .scars/*.md files; path .scars/ is the correct and complete risk surface for this quoting/escaping trap, left unchanged"
 expires:
   condition: "scar lint parses patterns with documented quoting/escaping semantics matching the injector AND liveness scans full file contents (or distinguishes 'beyond scan head' from dead)"
   review_after: 2027-01-02

--- a/.scars/0021-single-quoted-violation-field-is-silently-dead.landmine.md
+++ b/.scars/0021-single-quoted-violation-field-is-silently-dead.landmine.md
@@ -10,6 +10,7 @@ anchors:
   - path: .scars/
 evidence:
   - note: 2026-07-06: armed a violation tripwire as violation: 'len\\(\\w+\\)\\s*==\\s*\\d' (single quotes); guilty-diff `scar check --diff` returned violations: [] and `scar lint` reported 0 errors — dead tripwire, green gauge. Same regex in double quotes fired correctly. Mechanism: scar-cli 0.16.1 model.py:150 parses the field with .strip('\"') — double quotes stripped, single quotes kept as literal characters inside the regex, which then never matches
+  - note: "firing-review 2026-09-08: 37 fires since the last revision, all from editing .scars/candidates and active .scars/*.md files during ongoing scar authoring; path .scars/ is the correct and complete risk surface for this quoting trap, left unchanged"
 expires:
   condition: "scar-cli parser also strips single quotes, or scar lint flags a violation value wrapped in single quotes"
   review_after: 2027-07-06

--- a/.scars/0023-tmp-symlink-breaks-project-slug-match.landmine.md
+++ b/.scars/0023-tmp-symlink-breaks-project-slug-match.landmine.md
@@ -11,6 +11,7 @@ anchors:
   - pattern: "project_slug"
 evidence:
   - note: 2026-07-15: two agents independently lost time to this while manually exercising `daimon resolve` (#303/#304 verification). Both saw 'no checkpoint for this project yet — nothing to resolve' and assumed a code fault; the checkpoint existed, under a different slug.
+  - note: "firing-review 2026-09-08: 63 fires since the last revision, concentrated on store.py, recall.py and cli/ plus other files that reference project_slug; anchors reviewed and confirmed on-target, hazard still live"
 expires:
   condition: "project_slug resolves symlinks (or the CLI reports a slug mismatch instead of 'no checkpoint')"
   review_after: 2027-01-15

--- a/.scars/0024-docusaurus-i18n-md-links-break-across-locales.landmine.md
+++ b/.scars/0024-docusaurus-i18n-md-links-break-across-locales.landmine.md
@@ -11,6 +11,7 @@ anchors:
   - path: website/i18n/
 evidence:
   - pr: 334 (runs 29661022607 and 29661156116 — two failures, one from each direction, same evening)
+  - note: "firing-review 2026-09-08: 21 fires since the last revision, concentrated on website/docs/reference/cli.md and website/docs/hosts/claude-code.md plus their es mirrors under website/i18n/; the whole docs/i18n tree is the correct risk surface for this locale-fallback hazard, left unchanged"
 expires:
   condition: "the site moves off .md-relative doc links entirely (URL-style everywhere), or i18n gains a build-time guarantee that no locale can fall back. NOTE: 100% es coverage does NOT retire this scar — coverage was already 15/15 when it was promoted, and the hazard returns the moment one untranslated page is added."
   review_after: 2026-10-01

--- a/.scars/0025-append-event-any-kind-resolves-the-item.landmine.md
+++ b/.scars/0025-append-event-any-kind-resolves-the-item.landmine.md
@@ -12,7 +12,6 @@ anchors:
   - path: plugin/daimon_briefing/cli/
   - path: plugin/daimon_briefing/recall.py
   - path: plugin/daimon_briefing/briefing.py
-  - path: plugin/tests/
   - pattern: "append_event[(][^)]{0,200}kind="
 violation: "append_event\([^)]{0,200}kind=(?!["'](tombstone|corroboration|handoff)["']|args\.kind)"
 evidence:

--- a/.scars/0026-bare-uv-sync-strips-extras-suite-fails-misleadingly.landmine.md
+++ b/.scars/0026-bare-uv-sync-strips-extras-suite-fails-misleadingly.landmine.md
@@ -18,6 +18,7 @@ evidence:
   - pr: 424
   - pr: 425
   - note: 2026-07-30: recurred TWICE independently — the #418 and #419 fix agents each hit the identical 31-failure test_render shape in fresh git worktrees (`uv sync --extra dev` alone); both recovered only via `uv sync --all-extras`. Two later agents avoided it solely because their prompts pre-warned them. Three independent hits in two days.
+  - note: "firing-review 2026-09-08: 10 fires since the last revision, on .github/workflows/ci.yml, plugin/pyproject.toml and docs/ pages that reference uv sync; anchors reviewed and confirmed on-target, hazard still live"
 expires:
   condition: "dev/pretty move from [project.optional-dependencies] to default dependency-groups, or a sync wrapper/Makefile target becomes the documented path"
   review_after: 2026-10-29

--- a/.scars/0032-gateway-alias-is-not-model-provenance.landmine.md
+++ b/.scars/0032-gateway-alias-is-not-model-provenance.landmine.md
@@ -12,6 +12,7 @@ anchors:
 evidence:
   - note: 2026-07-30 live probe: a request naming claude-haiku-4-5-via-meridian was served by unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF (response.model field; local fallback lane). The operator's gateway defines silent fallback chains ending in a local model — resilience by design, active since 2026-06-25, so any alias-labeled call may have been served by a different model with no error.
   - note: benchmark/results/longmemeval-s-baseline.json stamps model: claude-haiku-4-5-via-meridian for 192 serialize calls (2026-07-12); the fallback chain was live that day, so per-call model purity is unprovable post-hoc. A no-fallback bench lane was added gateway-side 2026-07-17 for exactly this reason.
+  - note: "firing-review 2026-09-08: 26 fires since the last revision, all on serializer.py; anchors reviewed and confirmed on-target, hazard still live"
 expires:
   condition: "provenance stamping records the served model from the response (response.model) alongside the requested alias, and surfaces a mismatch"
   review_after: 2026-10-30

--- a/.scars/0036-config-env-file-shadows-cleared-process-env.landmine.md
+++ b/.scars/0036-config-env-file-shadows-cleared-process-env.landmine.md
@@ -11,6 +11,7 @@ anchors:
   - pattern: "os\.environ\.pop|monkeypatch\.delenv"
 evidence:
   - note: daimon#475 part 2 review. An exhaustive parity harness compared the old inline rescue_gap formula against rescue_posture() across 40 backend/key/fallback/command combinations. Every 'no API key' row was produced with os.environ.pop('DAIMON_LLM_API_KEY') + pop('LITELLM_API_KEY'). The harness reported rows where config.llm_api_key() was truthy despite the pops, and the first run's conclusions were wrong in BOTH directions: it hid the real defect (2 rows) and invented 2 fake ones. Caught only because a row was internally inconsistent (OLD=True is impossible when the formula requires a truthy key). Re-run with the accessors patched directly, the true answer was 3 changed rows, one of which was a genuine design defect.
+  - note: "firing-review 2026-09-08: 10 fires since the last revision, on config.py plus test files that pop or delenv env vars; anchors reviewed and confirmed on-target, hazard still live"
 expires:
   condition: "config._get stops falling back to the env file, or an official test helper lands that neutralises both sources at once"
   review_after: 2027-01-31

--- a/.scars/0038-sd-multiline-mutation-silently-noops.deadend.md
+++ b/.scars/0038-sd-multiline-mutation-silently-noops.deadend.md
@@ -7,7 +7,7 @@ confidence: 0.9
 created: 2026-08-01
 authors: ["claude-code", "Kibukx"]
 anchors:
-  - path: plugin/
+  - path: plugin/daimon_briefing/
 violation: "sd '[^']*\\n"
 evidence:
   - note: 2026-08-01 session, twice in one day. (1) #475 review: sd pattern spanning 'backend = resolve_backend()...' lines did not match; the 'restored' file still held the mutant and the full suite ran 2 failures that were misread as new-test signal. (2) #480 slice-2 review: sd multiline pattern on _tie_rank did not match, tie-break test 'passed' against UNMUTATED code and the pass was nearly reported as mutation-proof. Both caught only by re-grepping for the MUTANT marker / the expected changed line before trusting the run.

--- a/.scars/0040-fallback-used-flag-gates-the-chunk-cache.landmine.md
+++ b/.scars/0040-fallback-used-flag-gates-the-chunk-cache.landmine.md
@@ -14,6 +14,7 @@ evidence:
   - note: serializer.py:1652 refuses every chunk-cache write once fallback_used() is true, citing the #28/#343 poisoning lesson inline.
   - note: serializer.py:1577 builds the cache key from configure.resolved_backend() — the CONFIGURED backend, which is not the backend that served the call when a fallback fired.
   - commit: 856cc9c
+  - note: "firing-review 2026-09-08: 27 fires since the last revision, 25 of them on serializer.py directly; anchors reviewed and confirmed on-target, hazard still live"
 expires:
   condition: "_chunk_cache_key stamps the backend that actually SERVED the call (e.g. from llm.served_models()) instead of the configured one, making the key self-distinguishing"
   review_after: 2027-02-04

--- a/.scars/0042-append-forged-key-reads-as-fold-intent.landmine.md
+++ b/.scars/0042-append-forged-key-reads-as-fold-intent.landmine.md
@@ -12,6 +12,7 @@ anchors:
 evidence:
   - pr: 575
   - note: 2026-08-05 review of #575: `refute revise` without --anchor cleared every anchor, so guard() stopped matching while `refute show` still rendered [active . human-ratified]. Reproduced independently by two reviewers in isolated DAIMON_CHECKPOINT_DIR dirs; the repo's own suite drove the failing sequence and passed.
+  - note: "firing-review 2026-09-08: this id (42) is shared with 0042-coverage-test-walking-the-scrubbers-own-surface-set.landmine.md, a pre-existing duplicate-id defect flagged separately for a human to renumber, which means the firing log cannot attribute counts between the two by id alone; the fires that land on refutations.py match this scar's own anchors and the hazard is still live, so anchors are left unchanged"
 expires:
   condition: "no ledger fold distinguishes replace-from-unchanged by key presence (e.g. every partial update carries an explicit clear flag)"
   review_after: 2027-02-05

--- a/.scars/0042-coverage-test-walking-the-scrubbers-own-surface-set.landmine.md
+++ b/.scars/0042-coverage-test-walking-the-scrubbers-own-surface-set.landmine.md
@@ -13,6 +13,7 @@ anchors:
 evidence:
   - note: test_opt_in_scrubs_local_copies asserted no residue by iterating store.project_surfaces(PROJECT) — the exact set scrub_content_key walks. apply_foreign_tombstones reaches only that set, so the chunk cache, crash log, adapter transcripts, events.jsonl and own team-mirror copies all kept the plaintext while the test passed and the CLI printed success. Found in the #600 slice B design review, 2026-08-07; filed as #620.
   - note: Second instance of the class. The first shipped a forget bug to main because a passing test asserted the residue it was meant to catch (see forget-plaintext-surfaces).
+  - note: "firing-review 2026-09-08: this id (42) is shared with 0042-append-forged-key-reads-as-fold-intent.landmine.md, a pre-existing duplicate-id defect flagged separately for a human to renumber, which means the firing log cannot attribute counts between the two by id alone; the fires that land on store.py match this scar's own anchors and the hazard is still live, so anchors are left unchanged"
 expires:
   condition: "residue assertions enumerate surfaces from surfaces.SURFACES (plaintext=True) rather than from the walk under test"
   review_after: 2027-02-07

--- a/.scars/0049-redact-py-is-package-owned-and-import-free.landmine.md
+++ b/.scars/0049-redact-py-is-package-owned-and-import-free.landmine.md
@@ -14,6 +14,7 @@ evidence:
   - commit: a5f3a64
   - pr: 661
   - note: "2026-08-10, #660/#661 — added `from . import normalize` to redact.py; it is copied verbatim next to the standalone Windsurf hook scripts, which run with a sys.path insert and cannot resolve the package"
+  - note: "firing-review 2026-09-08: 39 fires since the last revision, mostly test_cli.py and other test files edited alongside the field_table/mcp_tools/requests work; anchors reviewed and confirmed on-target, hazard still live"
 expires:
   condition: "redact.py stops being shipped standalone beside the hook scripts, or the hook copies become real imports of the installed package"
   review_after: 2027-02-01

--- a/.scars/0054-source-text-assertions-are-satisfied-by-comments.landmine.md
+++ b/.scars/0054-source-text-assertions-are-satisfied-by-comments.landmine.md
@@ -7,7 +7,6 @@ confidence: 0.9
 created: 2026-08-15
 authors: ["claude-code", "Kibukx"]
 anchors:
-  - path: plugin/tests/
   - pattern: "inspect\.getsource"
 evidence:
   - pr: 693 PR 2 review round 1: both blind reviewers independently proved the mutation survives

--- a/.scars/0055-rendering-cross-bucket-content-is-a-write.landmine.md
+++ b/.scars/0055-rendering-cross-bucket-content-is-a-write.landmine.md
@@ -13,6 +13,7 @@ evidence:
   - note: transcript.py:138 _tool_result_of flattens tool_result payloads; transcript.py:302 gives them their own row shape (#359) — so CLI stdout in an agent session is checkpoint input
   - note: recall.py:760-766 already implements the safe pattern and states the doctrine: counts by project, never content, because crossing projects stays user-invoked (#94/#95)
   - note: daimon#766 design review 2026-08-27 — caught before any code was written
+  - note: "firing-review 2026-09-08: 64 fires since the last revision, 92% on the anchored cli/ files (cli/__init__.py, request.py, ruling.py, refute.py, amend.py, lifecycle.py) during active rulings and request work; anchors reviewed and confirmed on-target, hazard still live"
 expires:
   condition: "capture excludes daimon's own CLI output from serialization, OR surfaces.py can map a deletion into checkpoint item text that originated as captured tool output"
   review_after: 2027-02-27

--- a/.scars/0066-docs-tree-lacks-reference-section.deadend.md
+++ b/.scars/0066-docs-tree-lacks-reference-section.deadend.md
@@ -7,7 +7,7 @@ confidence: 0.8
 created: 2026-09-02
 authors: ["claude-code", "Kibukx"]
 promoted_by: Kibukx
-promoted_by_source: git-config
+promoted_by_source: explicit
 anchors:
   - path: docs/
   - path: website/docs/

--- a/.scars/0067-suggest-select-feeds-the-weight.landmine.md
+++ b/.scars/0067-suggest-select-feeds-the-weight.landmine.md
@@ -7,7 +7,7 @@ confidence: 0.9
 created: 2026-09-02
 authors: ["claude-code", "Kibukx"]
 promoted_by: Kibukx
-promoted_by_source: git-config
+promoted_by_source: explicit
 anchors:
   - pattern: "_suggest_weight"
 evidence:

--- a/.scars/0073-raw-kind-comparison-reopens-the-to-human-rule.deadend.md
+++ b/.scars/0073-raw-kind-comparison-reopens-the-to-human-rule.deadend.md
@@ -12,8 +12,8 @@ anchors:
   - path: plugin/daimon_briefing/requests.py
   - pattern: "_kind_of\(row\) != current\[.kind.\]"
 evidence:
-  - commit: f4bdb74
-  - pr: 971
+  - commit: 636a1b7
+  - pr: 972
   - note: #961 slice 1. The shipped disagreement rule fired unconditionally and compared post-gate values, so any non-human duplicate downgraded a human info ask (measured: an agent duplicate copying kind=info verbatim still forced work). Two candidate fixes were built and measured, both 5929 passed / 10 skipped, no existing test separating them.
 expires:
   condition: "the founder's raw kind is retained on the record, so a raw comparison no longer needs side state in fold"

--- a/.scars/0073-raw-kind-comparison-reopens-the-to-human-rule.deadend.md
+++ b/.scars/0073-raw-kind-comparison-reopens-the-to-human-rule.deadend.md
@@ -1,0 +1,43 @@
+---
+id: 73
+type: deadend
+title: "Comparing RAW stored kind values in the duplicate-opened branch reopens _kind_of's to_human rule; compare the post-gate value and gate on the duplicate's own authority instead"
+severity: medium
+confidence: 0.9
+created: 2026-09-08
+authors: ["claude-code"]
+promoted_by: Kibukx
+promoted_by_source: explicit
+anchors:
+  - path: plugin/daimon_briefing/requests.py
+  - pattern: "_kind_of\(row\) != current\[.kind.\]"
+evidence:
+  - commit: f4bdb74
+  - pr: 971
+  - note: #961 slice 1. The shipped disagreement rule fired unconditionally and compared post-gate values, so any non-human duplicate downgraded a human info ask (measured: an agent duplicate copying kind=info verbatim still forced work). Two candidate fixes were built and measured, both 5929 passed / 10 skipped, no existing test separating them.
+expires:
+  condition: "the founder's raw kind is retained on the record, so a raw comparison no longer needs side state in fold"
+  review_after: 2027-03-01
+status: active
+---
+
+Fixing the downgrade needs the `authority == "human"` guard on the duplicate row. It
+does NOT need raw-value comparison, and adding that half is a deadend.
+
+The variant that was tried: gate on the duplicate's authority AND compare the raw
+stored `kind` strings rather than `_kind_of`'s post-gate values. It was implemented
+and the full suite ran green, identical to the alternative. It fails on exactly one
+input: a duplicate claiming `to_human: True` together with `kind: "info"`, the
+combination `open_request` refuses outright. Raw comparison reads `"info" == "info"`,
+calls it agreement, and lets the `to_human` claim fall on the floor. `_kind_of`
+enforces `to_human` implies `work` for the founding row; the raw variant would not
+enforce it for a contesting one. That split enforcement is the same shape as the
+original defect it was fixing, where the write boundary guarded a rule the fold did not.
+
+It also costs new mutable state: the founder's raw `kind` is not retained anywhere, so
+a faithful implementation threads a side table through `fold`, whose docstring promises
+determinism under reorder.
+
+Keep the post-gate comparison. It fires on a superset of what raw fires on, every extra
+firing is toward `work` on a row that contradicts itself, and there is no input where
+raw is safe and post-gate is not.

--- a/.scars/0074-repointed-mock-silently-narrows-coverage.landmine.md
+++ b/.scars/0074-repointed-mock-silently-narrows-coverage.landmine.md
@@ -13,7 +13,7 @@ anchors:
   - path: plugin/daimon_briefing/briefing.py
   - pattern: "monkeypatch\.setattr\([^,]*refutations"
 evidence:
-  - commit: 3b352ff
+  - commit: 8d66b44
   - pr: 971
   - note: #962: test_ruling_loader_fails_open patched refutations.listing, the OUTERMOST call, so its guard covered everything active_rulings touched including config-layer path resolution. The refactor moved active_rulings onto events()+fold(), the patch was repointed to refutations.events, and events sits INSIDE the new try. Path resolution moved outside the guard in the same change. active_rulings began raising UnicodeDecodeError and RuntimeError on config faults and briefing.render went from degrading to crashing, while 5888 tests passed. Caught only by an adversarial pass that ran the repro against both branches.
 expires:

--- a/.scars/0074-repointed-mock-silently-narrows-coverage.landmine.md
+++ b/.scars/0074-repointed-mock-silently-narrows-coverage.landmine.md
@@ -1,0 +1,54 @@
+---
+id: 74
+type: landmine
+title: "Moving a function off a call graph silently shrinks any monkeypatch-based failure test aimed at the old call site; the test keeps passing while covering strictly less"
+severity: high
+confidence: 0.95
+created: 2026-09-07
+authors: ["claude-code"]
+promoted_by: Kibukx
+promoted_by_source: explicit
+anchors:
+  - path: plugin/tests/test_ruling_briefing.py
+  - path: plugin/daimon_briefing/briefing.py
+  - pattern: "monkeypatch\.setattr\([^,]*refutations"
+evidence:
+  - commit: 3b352ff
+  - pr: 971
+  - note: #962: test_ruling_loader_fails_open patched refutations.listing, the OUTERMOST call, so its guard covered everything active_rulings touched including config-layer path resolution. The refactor moved active_rulings onto events()+fold(), the patch was repointed to refutations.events, and events sits INSIDE the new try. Path resolution moved outside the guard in the same change. active_rulings began raising UnicodeDecodeError and RuntimeError on config faults and briefing.render went from degrading to crashing, while 5888 tests passed. Caught only by an adversarial pass that ran the repro against both branches.
+expires:
+  condition: "every failure-simulating monkeypatch in plugin/tests asserts it was actually invoked (issue #968), so a bypassed patch fails loudly instead of narrowing silently"
+  review_after: 2027-03-01
+status: active
+---
+
+A monkeypatch that simulates a failure only tests what the patched function still
+sits upstream of. Move the code onto a different call and the patch goes inert:
+nothing raises, nothing goes red, and the test now proves a strictly smaller
+claim than its name says.
+
+This is not hypothetical. `test_ruling_loader_fails_open` patched
+`refutations.listing`, which was the outermost call `active_rulings` made, so the
+guard it exercised covered the whole body including `_path` and the config layer
+underneath it. #962 rewired `active_rulings` onto `events()` + `fold()`. The
+patch was repointed to `refutations.events` to keep the test running, and
+`events` sits inside the new `try`. In the same change `_path` moved outside that
+`try`. Result: `active_rulings` could raise on a bad byte in `~/.daimon/env`,
+`briefing.render` went from degrading to crashing, and the suite stayed green at
+5888 passing. The mock was repointed to follow the implementation rather than the
+contract, and the coverage narrowed with it.
+
+What a future editor must do instead. When you move a function off a call graph,
+find every `monkeypatch.setattr` aimed at the old call site and ask what the patch
+was standing in for, not merely how to make it run again. If the answer is "any
+failure anywhere below this point", the replacement must sit at least as far out,
+or the contract needs its own local guard. Prefer breaking the real dependency
+over mocking it where that is cheap: `plugin/tests/test_rulings.py` now also
+replaces the ledger with a directory, and that test cannot be bypassed by a
+refactor at all. And make the fake count its own invocations so a bypassed patch
+fails loudly, which is issue #968.
+
+Same family as the hand-shaped fixtures in #963: in both cases a test described
+the code instead of checking it, and a green suite proved nothing. There are 77
+files under `plugin/tests/` using `monkeypatch.setattr`; not all are failure
+simulations, but every one of them is a place this can happen again.

--- a/.scars/0075-ruling-list-still-reads-the-ledger-twice.fence.md
+++ b/.scars/0075-ruling-list-still-reads-the-ledger-twice.fence.md
@@ -1,21 +1,23 @@
 ---
-id: 0
+id: 75
 type: fence
 title: "`daimon ruling list` still reads the ledger twice: `rulings_read` only settles no-bucket/unreadable, `listing()` still does the actual row fetch"
 severity: low
 confidence: 0.8
 created: 2026-09-07
 authors: ["claude-code"]
+promoted_by: Kibukx
+promoted_by_source: explicit
 anchors:
   - path: plugin/daimon_briefing/cli/ruling.py
   - path: plugin/daimon_briefing/briefing.py
   - pattern: "briefing\.rulings_read"
 evidence:
-  - note: "#962: briefing.rulings_read(project_dir) reads standing rulings only (state==\"active\", polarity==\"ruling\"), but `daimon ruling list` supports --state candidate/overturned and is a general listing, so `_cmd_ruling_list` still has to call refutations.listing() separately for `rows`. It calls rulings_read() a second time, only when rows is empty, purely to learn which of the four states (unresolved/no-bucket/unreadable/read) applies."
+  - note: #962: briefing.rulings_read(project_dir) reads standing rulings only (state==\"active\", polarity==\"ruling\"), but `daimon ruling list` supports --state candidate/overturned and is a general listing, so `_cmd_ruling_list` still has to call refutations.listing() separately for `rows`. It calls rulings_read() a second time, only when rows is empty, purely to learn which of the four states (unresolved/no-bucket/unreadable/read) applies.
 expires:
   condition: "listing()/records() gain their own strict= parameter so one call produces both the rows and the read-state, closing the second read"
   review_after: 2027-03-01
-status: candidate
+status: active
 ---
 
 `rulings_read` is scoped to active rulings only, by design (#962's own contract:

--- a/.scars/0076-worktree-guard-blocks-git-not-file-edits.landmine.md
+++ b/.scars/0076-worktree-guard-blocks-git-not-file-edits.landmine.md
@@ -11,7 +11,7 @@ promoted_by_source: explicit
 anchors:
   - path: docs/
   - path: website/docs/
-  - pattern: "cd /Users/[a-z]+/Documents/Daily-Nerd/daimon &&"
+violation: "cd /Users/[a-z]+/Documents/Daily-Nerd/daimon &&"
 evidence:
   - note: #963, fix/963-bucket-migration: five doc files were edited from the shared checkout path while the branch lived in a worktree. git status in the worktree showed no docs change, and the reader-vocabulary and website gates ran green against the worktree's unedited copies.
 expires:

--- a/.scars/0076-worktree-guard-blocks-git-not-file-edits.landmine.md
+++ b/.scars/0076-worktree-guard-blocks-git-not-file-edits.landmine.md
@@ -1,21 +1,23 @@
 ---
-id: 0
+id: 76
 type: landmine
 title: In a worktree the guard blocks git outside it but not file edits, so a docs change lands in the shared checkout and the gates still pass
 severity: medium
 confidence: 0.9
 created: 2026-09-07
 authors: ["claude-code"]
+promoted_by: Kibukx
+promoted_by_source: explicit
 anchors:
   - path: docs/
   - path: website/docs/
   - pattern: "cd /Users/[a-z]+/Documents/Daily-Nerd/daimon &&"
 evidence:
-  - note: "#963, fix/963-bucket-migration: five doc files were edited from the shared checkout path while the branch lived in a worktree. git status in the worktree showed no docs change, and the reader-vocabulary and website gates ran green against the worktree's unedited copies."
+  - note: #963, fix/963-bucket-migration: five doc files were edited from the shared checkout path while the branch lived in a worktree. git status in the worktree showed no docs change, and the reader-vocabulary and website gates ran green against the worktree's unedited copies.
 expires:
   condition: "the worktree isolation guard refuses non-git writes to the shared checkout too"
   review_after: 2027-03-01
-status: candidate
+status: active
 ---
 
 An agent working in `.claude/worktrees/<id>` is stopped by the isolation guard


### PR DESCRIPTION
Scars-only change; no issue linkage per the PR template's scars-only exemption.

## What

Promotes four candidates to active scars and clears every warning the same `scar lint` run raised. Reviewer recorded by scar at promotion.

- 0073 (deadend): in the duplicate-opened branch of the request fold, comparing the raw stored `kind` strings instead of the post-gate value reopens the rule that `to_human` implies `work`. Anchored on the comparison line in `requests.py`.
- 0074 (landmine): moving a function off a call graph silently shrinks any monkeypatch-based failure test aimed at the old call site; the test keeps passing while covering strictly less. Anchored on the rulings loader and its test.
- 0075 (fence): `daimon ruling list` still reads the ledger twice on purpose, because `rulings_read` settles only the no-bucket and unreadable states while `listing()` fetches the rows. Anchored on the CLI and the reader.
- 0076 (landmine): in a worktree the isolation guard blocks git against the shared checkout but not file edits, so a docs change lands outside the branch and the doc gates pass against pristine copies. Anchored on `docs/` and `website/docs/`.

Three frontmatter repairs after promotion. 0073 and 0074 cited branch commits that a squash merge left off history; both now cite the merge commit on main, and 0073 cited the neighbouring PR number by mistake. 0076 anchored on a command shape that is healthy when absent, so the pattern moved to `violation:`.

Lint hygiene on the existing set, all frontmatter, no scar archived:

- Four anchors were too broad and fired on routine edits. 0038 anchored the whole `plugin/` tree (29% of tracked files) and now anchors `plugin/daimon_briefing/`. 0025 and 0054 anchored all of `plugin/tests/` while their pattern anchors already cover any file that contains the risky call; the directory anchors are dropped, the patterns stay. 0010 matched the bare words `stale` and `overturn`, which are ordinary vocabulary in the refute and request code; the pattern now requires `judge` within reach of them.
- Eleven scars over the firing-review threshold were checked file by file against the firing log. Each fires on exactly the files its body names as the hazard, so each keeps its anchors and carries one evidence note recording the review, which is what resets the window.
- 0066 and 0067 record the reviewer explicitly.
- Two scar files share id 42. Lint has no duplicate-id check and the firing log records ids only, so their counts cannot be told apart by the tool. Both files carry a note; renumbering is left for a person because other scars cross-reference by id.

## Why

Each one was measured, not guessed. 0073 was a fix variant that ran green on the full suite and still let a contesting row drop the `to_human` claim on the floor. 0074 is how #962 crashed the briefing while the suite stayed green: the patch followed the implementation instead of the contract. 0075 records that the remaining double read is a scope decision, so the next reader does not file it as a bug. 0076 cost a cycle on #963 when five doc edits landed in the shared checkout and the vocabulary gate reported clean.

## Tests

scar lint: 78 files, 0 errors, 0 orphans, 0 partial-rot, 0 unreachable evidence, 0 breadth warnings, 0 reviewer warnings. The narrowed anchors were replayed against the recorded firing targets: the noise files stop matching, the named hazard files still match. No code changes.
