### PR TITLE
feat(requests): render the approval-requirement kind on every request surface

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -977,9 +977,15 @@ def request_panel_lines(project_dir=None) -> list[str]:
         return []
     lines = [_REQUEST_PANEL_HEADER]
     for row in rows:
+        # #961 slice 2: marked only for `info` — `work` is the default and
+        # the legacy reading, so marking it too would be noise on every
+        # line. Read from the folded row only (THE ONE RULE): `row` here is
+        # already a `requests.inbox_renderable` record, never a raw event.
+        kind_marker = "  [info]" if row.get("kind") == "info" else ""
         marker = "  [blocking]" if row.get("blocking") else ""
         lines.append(f"→ {row['request_id']}  "
-                     f"{_truncate_request_ask(row.get('ask', ''))}{marker}")
+                     f"{_truncate_request_ask(row.get('ask', ''))}"
+                     f"{kind_marker}{marker}")
         lines.append(f"  From: {row.get('from_label') or 'an unnamed project'}")
     overflow = entry.get("overflow") or 0
     if overflow:
@@ -1018,9 +1024,12 @@ def owed_panel_lines(project_dir=None) -> list[str]:
         return []
     lines = [_OWED_PANEL_HEADER]
     for row in rows:
+        # #961 slice 2: same marker, same posture as `request_panel_lines`.
+        kind_marker = "  [info]" if row.get("kind") == "info" else ""
         marker = "  [blocking]" if row.get("blocking") else ""
         lines.append(f"✓ {row['request_id']}  "
-                     f"{_truncate_request_ask(row.get('ask', ''))}{marker}")
+                     f"{_truncate_request_ask(row.get('ask', ''))}"
+                     f"{kind_marker}{marker}")
         lines.append(f"  From: {row.get('from_label') or 'an unnamed project'}")
     overflow = entry.get("overflow") or 0
     if overflow:
@@ -1046,7 +1055,13 @@ def verdict_panel_lines(project_dir=None) -> list[str]:
     sent has been decided yet, or `project_dir` is None). Same posture as
     `request_panel_lines`: fail-open, skeleton furniture, never silently
     truncated over RENDER_CAP. `project_dir` is the CLI's
-    `worldcheck_project` — same D2 CLI-only gate, same caller contract."""
+    `worldcheck_project` — same D2 CLI-only gate, same caller contract.
+
+    #961 slice 2: deliberately carries no `kind` marker. This panel reports
+    the OUTCOME of a request this project itself sent, and it already chose
+    the kind at open time — unlike the two panels above, nothing here is
+    deciding how much scrutiny an ask deserves. Mirrors the same call made
+    for `cli/request.py`'s `_verdict_inject_lines`."""
     if project_dir is None:
         return []
     try:

--- a/plugin/daimon_briefing/cli/lifecycle.py
+++ b/plugin/daimon_briefing/cli/lifecycle.py
@@ -896,9 +896,21 @@ def _decide_cards(rows: list) -> list:
         tag = row["kind"] + (f" · {age}" if age else "")
         blocking = " [blocking: the sender says it is waiting]" if row.get(
             "blocking") else ""
+        # #961 slice 2: `row["approval"]` is the request lane's
+        # approval-requirement kind (info/work) from the folded record — a
+        # DIFFERENT axis from `row["kind"]` above, which is the queue LANE
+        # this card's tag already names. THE LANDMINE this file's own
+        # queue-row builder warns about: overloading `kind` here would make
+        # a request-lane row that happens to be `info` say `[info]` in the
+        # tag instead of `[request]`, silently hiding which lane it is.
+        # Marked only for `info`, same reasoning as the panels: `work` is
+        # the default and the legacy reading.
+        info_marker = (" [info]" if row.get("kind") == "request"
+                       and row.get("approval") == "info" else "")
         # Two spaces after the id: `render._LEDGER_HEADER_RE` reads that shape
         # to give the id its own span, because it is what a human copies.
-        card = [f"[{tag}] {row['id']}  {row['headline']}{blocking}"]
+        card = [f"[{tag}] {row['id']}  {row['headline']}{info_marker}"
+               f"{blocking}"]
         if row.get("context"):
             card.append(f"  {row['context']}")
         card += [f"    {label}: {command}"

--- a/plugin/daimon_briefing/cli/request.py
+++ b/plugin/daimon_briefing/cli/request.py
@@ -121,6 +121,12 @@ def _request_lines(record: dict, project_dir=None) -> list:
     to = record.get("to", "")
     lines.append(f"  To: {to}" + (" (for a human)" if record.get("to_human")
                                   else ""))
+    # #961 slice 2: the approval requirement, always printed on the detail
+    # card — this is a record view, not the compact one-liners below, which
+    # mark `info` only to keep the common `work` case quiet. Read from the
+    # FOLDED record only (THE ONE RULE): `record.get("kind")` here is
+    # whatever `requests.fold`'s `_kind_of` already decided, never a raw row.
+    lines.append(f"  Kind: {record.get('kind') or requests.DEFAULT_KIND}")
     if record.get("from_label"):
         lines.append(f"  From: {record['from_label']}")
     lines.append(f"  Why: {record.get('why', '')}")
@@ -155,6 +161,9 @@ def _inbox_lines(record: dict, project_dir=None) -> list:
              f"{record['request_id']}  {record.get('ask', '')}"]
     lines.append(f"  From: {record.get('from_label') or '?'}"
                  + (" (for a human)" if record.get("to_human") else ""))
+    # #961 slice 2: same posture as `_request_lines` — always printed, read
+    # from the folded record only.
+    lines.append(f"  Kind: {record.get('kind') or requests.DEFAULT_KIND}")
     lines.append(f"  Why: {record.get('why', '')}")
     if record.get("evidence"):
         lines.append(f"  Evidence: {record['evidence']}")
@@ -197,6 +206,10 @@ def _inject_lines(record: dict) -> list[str]:
     lines = [f"daimon request: {record['request_id']} from "
              f"{record.get('from_label') or '?'}"
              + (" (for a human)" if record.get("to_human") else "")
+             # #961 slice 2: marked only for `info`, since `work` is the
+             # default and the legacy reading — printing it on every line
+             # would be noise on a surface built to be thin.
+             + (" [info]" if record.get("kind") == "info" else "")
              + (" [blocking: the sender is waiting]"
                 if record.get("blocking") else "")]
     lines.append(f"  Ask: {record.get('ask', '')}")
@@ -213,7 +226,14 @@ def _verdict_inject_lines(record: dict) -> list[str]:
     """One delivered verdict, compressed to what the sender acts on. Same
     posture as `_inject_lines`: this lands mid-session on the agent's context
     budget. The note is the recipient's answer to THIS project's own ask, so
-    it is this project's mail rather than a foreign record being rendered."""
+    it is this project's mail rather than a foreign record being rendered.
+
+    #961 slice 2: deliberately carries no `kind` marker. This is the sender
+    reading the OUTCOME of a request it opened itself, and it already chose
+    the kind at open time — the render surfaces that need the marker are the
+    ones where a reader is deciding how much scrutiny an ask deserves, and
+    that decision is already behind this one. Mirrors the same call made for
+    `briefing.verdict_panel_lines`."""
     state = str(record.get("state") or "")
     mark = _INJECT_VERDICT_MARKS.get(state, "?")
     lines = [f"daimon verdict: {mark} {state}  {record['request_id']} "
@@ -236,6 +256,8 @@ def _owed_inject_lines(record: dict) -> list[str]:
     reading this can actually close it."""
     lines = [f"daimon owed: {record['request_id']} to "
              f"{record.get('from_label') or '?'}"
+             # #961 slice 2: same marker, same posture as `_inject_lines`.
+             + (" [info]" if record.get("kind") == "info" else "")
              + (" [blocking: the sender is waiting]"
                 if record.get("blocking") else "")]
     lines.append(f"  Ask: {record.get('ask', '')}")

--- a/plugin/daimon_briefing/pending.py
+++ b/plugin/daimon_briefing/pending.py
@@ -53,7 +53,7 @@ _KIND_RANK = {"request": 0, "amendment": 1, "ruling": 2, "refutation": 2}
 
 
 def _row(*, kind, record_id, slug, headline, waiting_since,
-         commands, context="", blocking=False) -> dict:
+         commands, context="", blocking=False, approval=None) -> dict:
     return {
         "kind": kind,
         "id": record_id,
@@ -66,6 +66,12 @@ def _row(*, kind, record_id, slug, headline, waiting_since,
         "waiting_since": waiting_since,
         "blocking": blocking,
         "commands": commands,
+        # #961 slice 2: the request lane's approval-requirement kind
+        # (info/work), from the FOLDED record — a DIFFERENT axis from
+        # `kind` above, which is the queue LANE (request/amendment/ruling/
+        # refutation). None for every lane but `request`, which never
+        # assigns one.
+        "approval": approval,
     }
 
 
@@ -124,6 +130,9 @@ def _request_rows(project_dir, slug) -> tuple[list, int]:
                      if record.get("from_label") else ""),
             waiting_since=record.get("created_at") or "",
             blocking=bool(record.get("blocking")),
+            # #961 slice 2: read from THIS folded record only — `record` is
+            # already `requests.recipient_join`'s output, never a raw row.
+            approval=record.get("kind"),
             commands=[
                 ("accept", f"daimon request accept {rid}"),
                 ("reject", f"daimon request reject {rid} --note \"<why>\""),

--- a/plugin/tests/test_cli_brief_owed.py
+++ b/plugin/tests/test_cli_brief_owed.py
@@ -181,6 +181,8 @@ def test_owed_panel_legacy_row_renders_without_a_kind_marker(
     path.write_text("\n".join(json.dumps(r) for r in rows) + "\n",
                     encoding="utf-8")
     lines = briefing.owed_panel_lines(recipient)
+    # Positive anchor: an empty line list would also satisfy "no marker".
+    assert any(q_id in ln for ln in lines)
     assert not any("[info]" in ln for ln in lines)
 
 
@@ -199,4 +201,5 @@ def test_owed_panel_never_reads_kind_off_a_raw_row(tmp_checkpoint_dir):
     requests.accept("q-0123456789ab", channel="cli-tty",
                     project_dir=recipient)
     lines = briefing.owed_panel_lines(recipient)
+    assert any("q-0123456789ab" in ln for ln in lines)
     assert not any("[info]" in ln for ln in lines)

--- a/plugin/tests/test_cli_brief_owed.py
+++ b/plugin/tests/test_cli_brief_owed.py
@@ -10,7 +10,9 @@ Mirrors test_cli_brief_requests.py and test_cli_brief_verdicts.py: same D2
 same-project gate, same post-print stamp timing.
 """
 
-from daimon_briefing import briefing, cli, requests, store
+import json
+
+from daimon_briefing import briefing, cli, config, requests, store
 
 
 def _seed_checkpoint(project_dir, session):
@@ -23,14 +25,14 @@ def _seed_checkpoint(project_dir, session):
 
 
 def _owed_ask(recipient_dir, ask="port the corroboration model",
-              sender_dir="/p/cbo-sender"):
+              sender_dir="/p/cbo-sender", channel="cli-agent", **kw):
     """An ask addressed to `recipient_dir` and accepted by it — the state in
     which the recipient owes work and nothing surfaced it."""
     _seed_checkpoint(recipient_dir, "S-cbo-recipient")
     sender_slug = _seed_checkpoint(sender_dir, "S-cbo-sender")
     q_id = requests.open_request(to=store.project_slug(recipient_dir), ask=ask,
-                                 why="because", channel="cli-agent",
-                                 project_dir=sender_slug)
+                                 why="because", channel=channel,
+                                 project_dir=sender_slug, **kw)
     requests.accept(q_id, channel="cli-tty", project_dir=recipient_dir)
     return q_id
 
@@ -144,3 +146,57 @@ def test_cli_rich_brief_carries_the_owed_panel(
     out = capsys.readouterr().out
     assert "rich brief carries this" in out
     assert "Requests you accepted" in out
+
+
+def test_owed_panel_marks_an_info_ask(tmp_checkpoint_dir):
+    recipient = "/p/cbo-recipient-info"
+    _owed_ask(recipient, sender_dir="/p/cbo-sender-info",
+              channel="cli-tty", kind="info")
+    lines = briefing.owed_panel_lines(recipient)
+    assert any("[info]" in ln for ln in lines)
+
+
+def test_owed_panel_no_marker_for_a_work_ask(tmp_checkpoint_dir):
+    recipient = "/p/cbo-recipient-work"
+    _owed_ask(recipient, sender_dir="/p/cbo-sender-work")
+    lines = briefing.owed_panel_lines(recipient)
+    assert not any("[info]" in ln for ln in lines)
+
+
+def test_owed_panel_legacy_row_renders_without_a_kind_marker(
+        tmp_checkpoint_dir):
+    """A record minted before #961 carries no `kind` field at all; the owed
+    panel must render it exactly like an ordinary `work` ask."""
+    recipient = "/p/cbo-recipient-legacy"
+    sender = "/p/cbo-sender-legacy"
+    q_id = _owed_ask(recipient, sender_dir=sender, channel="cli-tty",
+                     kind="info")
+    path = (config.checkpoint_dir() / store.project_slug(sender)
+            / "requests.jsonl")
+    rows = [json.loads(ln) for ln in
+            path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    for row in rows:
+        if row.get("request_id") == q_id and row.get("event") == "opened":
+            del row["kind"]
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n",
+                    encoding="utf-8")
+    lines = briefing.owed_panel_lines(recipient)
+    assert not any("[info]" in ln for ln in lines)
+
+
+def test_owed_panel_never_reads_kind_off_a_raw_row(tmp_checkpoint_dir):
+    """THE FOLD RULE THROUGH THE SURFACE: a raw `opened` row appended on a
+    non-human channel with `kind="info"` folds to `work`, and the owed panel
+    must show exactly what the fold says."""
+    recipient = "/p/cbo-recipient-forged"
+    sender = "/p/cbo-sender-forged"
+    _seed_checkpoint(recipient, "S-cbo-recipient-forged")
+    sender_slug = _seed_checkpoint(sender, "S-cbo-sender-forged")
+    row = requests._stamp("opened", "q-0123456789ab", "cli-agent")
+    row.update({"to": store.project_slug(recipient), "ask": "port it",
+               "why": "because", "kind": "info"})
+    assert requests.append(row, project_dir=sender_slug)
+    requests.accept("q-0123456789ab", channel="cli-tty",
+                    project_dir=recipient)
+    lines = briefing.owed_panel_lines(recipient)
+    assert not any("[info]" in ln for ln in lines)

--- a/plugin/tests/test_cli_brief_verdicts.py
+++ b/plugin/tests/test_cli_brief_verdicts.py
@@ -179,3 +179,21 @@ def test_cli_brief_shows_both_panels_together(tmp_checkpoint_dir,
     assert "the sent ask" in out
     assert "the incoming ask" in out
     assert sent_id  # keeps the linter from flagging an unused id
+
+
+def test_verdict_panel_never_shows_a_kind_marker(tmp_checkpoint_dir):
+    """Decision (#961 slice 2): the verdict panel reports the OUTCOME of a
+    request this project itself opened, and it already assigned the kind at
+    open time — re-surfacing it here tells the sender something about its
+    own record it already knows. No marker is added to this surface, the
+    same call made for cli/request.py's `_verdict_inject_lines`."""
+    from daimon_briefing import briefing
+    sender = "/p/cbv-sender-kind"
+    recipient_dir = "/p/cbv-recipient-kind"
+    _seed_checkpoint(recipient_dir, "S-cbv-recipient-kind")
+    q_id = requests.open_request(
+        to=store.project_slug(recipient_dir), ask="publish the schema",
+        why="because", channel="cli-tty", kind="info", project_dir=sender)
+    requests.accept(q_id, channel="cli-tty", project_dir=recipient_dir)
+    lines = briefing.verdict_panel_lines(sender)
+    assert not any("[info]" in ln for ln in lines)

--- a/plugin/tests/test_cli_decide.py
+++ b/plugin/tests/test_cli_decide.py
@@ -146,6 +146,31 @@ def test_decide_card_a_ruling_row_never_shows_an_info_marker(project, capsys):
     assert "[info]" not in out
 
 
+def test_decide_cards_lane_guard_is_load_bearing_not_dead_code():
+    """No REAL composer ever produces a non-request row with `approval`
+    set: `pending._request_rows` is the only caller that passes anything but
+    the default `None`. That makes the `row.get("kind") == "request"` half
+    of `_decide_cards`'s guard unreachable through the shipped pipeline, so a
+    test that only ever drives real rows through `pending.queue` can pass
+    whether or not that half of the guard exists. This test hands
+    `_decide_cards` a synthetic row directly, shaped the way a future bug
+    elsewhere in `pending.py` could actually produce one (a non-request lane
+    that leaks an `approval` value it was never supposed to carry), and
+    checks the guard catches it anyway."""
+    from daimon_briefing.cli import lifecycle
+    row = {
+        "kind": "ruling", "id": "r-0123456789ab", "slug": "-p-x",
+        "headline": "never bump to 1.0 without a human call",
+        "context": "", "waiting_since": "", "blocking": False,
+        "commands": [("ratify", "daimon ruling ratify r-0123456789ab")],
+        "approval": "info",
+    }
+
+    card = lifecycle._decide_cards([row])[0]
+
+    assert "[info]" not in card[0]
+
+
 def test_decide_card_never_reads_the_approval_off_a_raw_row(
         project, capsys):
     """THE FOLD RULE THROUGH THE SURFACE: a raw `opened` row appended on a
@@ -159,6 +184,8 @@ def test_decide_card_never_reads_the_approval_off_a_raw_row(
 
     assert cli.main(["decide"]) == 0
     out = capsys.readouterr().out
+    # Positive anchor: empty output would also satisfy "no marker".
+    assert "q-0123456789ab" in out
     assert "[info]" not in out
 
 
@@ -166,12 +193,22 @@ def test_decide_card_with_the_info_marker_still_gets_ledger_header_spans(
         project):
     """The marker is inserted between the headline and the blocking suffix,
     so the two-space-after-id contract `render._ledger_header_spans` relies
-    on must still hold."""
-    spans = render._ledger_header_spans(
-        "[request] q-0f1e2d3c4b5a  an info-only ask [info]")
+    on must still hold. Built through the REAL pipeline (`pending.queue` ->
+    `lifecycle._decide_cards`), not a hand-typed header string: a hand-typed
+    string proves the regex can parse a shape like this, never that
+    `_decide_cards` actually produces that shape."""
+    from daimon_briefing.cli import lifecycle
+    q_id = requests.open_request(
+        to=store.project_slug(project), ask="an info-only ask",
+        why="why", channel="cli-tty", kind="info", project_dir=project)
+    rows = pending.queue(project_dir=project)["rows"]
+    card = lifecycle._decide_cards(rows)[0]
+
+    spans = render._ledger_header_spans(card[0])
 
     assert spans is not None
-    assert spans[1] == "q-0f1e2d3c4b5a"
+    assert spans[1] == q_id
+    assert "[info]" in card[0]
 
 
 def test_a_verified_amendment_reaches_the_queue(project, capsys):

--- a/plugin/tests/test_cli_decide.py
+++ b/plugin/tests/test_cli_decide.py
@@ -100,6 +100,80 @@ def test_an_amendment_id_gets_the_ledger_header_treatment(project):
     assert spans[1] == "a-0f1e2d3c4b5a"
 
 
+def test_decide_card_shows_the_info_marker_for_an_info_request(
+        project, capsys):
+    requests.open_request(
+        to=store.project_slug(project), ask="an info-only ask",
+        why="the recipient can read this from its own artifacts",
+        channel="cli-tty", kind="info", project_dir=project)
+
+    assert cli.main(["decide"]) == 0
+    out = capsys.readouterr().out
+    assert "[info]" in out
+
+
+def test_decide_card_shows_no_marker_for_a_work_request(project, capsys):
+    requests.open_request(
+        to=store.project_slug(project), ask="bump before the docs change",
+        why="the tag is referenced", channel="cli-agent", project_dir=project)
+
+    assert cli.main(["decide"]) == 0
+    out = capsys.readouterr().out
+    assert "[info]" not in out
+
+
+def test_decide_card_lane_tag_is_never_overloaded_by_the_approval_kind(
+        project, capsys):
+    """THE LANDMINE: `pending._row`'s `kind` key is the queue LANE, never
+    the approval requirement — a request-lane row that happens to be `info`
+    must still say `[request` in the tag, not `[info`."""
+    requests.open_request(
+        to=store.project_slug(project), ask="an info-only ask",
+        why="why", channel="cli-tty", kind="info", project_dir=project)
+
+    assert cli.main(["decide"]) == 0
+    out = capsys.readouterr().out
+    assert "[request" in out
+
+
+def test_decide_card_a_ruling_row_never_shows_an_info_marker(project, capsys):
+    """A non-request lane never carries an approval kind at all, so it must
+    never render the marker even incidentally."""
+    _ruling(project)
+
+    assert cli.main(["decide"]) == 0
+    out = capsys.readouterr().out
+    assert "[info]" not in out
+
+
+def test_decide_card_never_reads_the_approval_off_a_raw_row(
+        project, capsys):
+    """THE FOLD RULE THROUGH THE SURFACE: a raw `opened` row appended on a
+    non-human channel with `kind="info"` folds to `work`, and the decide
+    card must show exactly what the fold says. Appended directly because
+    `open_request` refuses this combination at the write boundary."""
+    row = requests._stamp("opened", "q-0123456789ab", "cli-agent")
+    row.update({"to": store.project_slug(project), "ask": "an ask",
+               "why": "why", "kind": "info"})
+    assert requests.append(row, project_dir=project)
+
+    assert cli.main(["decide"]) == 0
+    out = capsys.readouterr().out
+    assert "[info]" not in out
+
+
+def test_decide_card_with_the_info_marker_still_gets_ledger_header_spans(
+        project):
+    """The marker is inserted between the headline and the blocking suffix,
+    so the two-space-after-id contract `render._ledger_header_spans` relies
+    on must still hold."""
+    spans = render._ledger_header_spans(
+        "[request] q-0f1e2d3c4b5a  an info-only ask [info]")
+
+    assert spans is not None
+    assert spans[1] == "q-0f1e2d3c4b5a"
+
+
 def test_a_verified_amendment_reaches_the_queue(project, capsys):
     a_id = amendments.propose(
         item_id="o-1234567890ab", change="progressed",

--- a/plugin/tests/test_pending.py
+++ b/plugin/tests/test_pending.py
@@ -12,9 +12,18 @@ anchor drives `is_stale`, so a stamping reader would make the person reading
 their own queue the mechanism that ages their asks out of the agent's panel.
 """
 
+import json
+
 import pytest
 
-from daimon_briefing import amendments, pending, refutations, requests, store
+from daimon_briefing import (
+    amendments,
+    config,
+    pending,
+    refutations,
+    requests,
+    store,
+)
 
 
 @pytest.fixture
@@ -125,6 +134,86 @@ def test_a_decided_request_is_not_owed(project):
     requests.accept(q_id, channel="cli-tty", project_dir=project)
 
     assert pending.queue(project_dir=project)["rows"] == []
+
+
+def test_a_request_row_carries_its_approval_kind_from_the_fold(project):
+    """#961 slice 2: `approval` on the queue row comes from the FOLDED
+    record's `kind` — pending.py's own `kind` key on this same row is the
+    queue LANE (request/amendment/ruling/refutation), a different axis
+    entirely, and must stay untouched by this."""
+    q_id = requests.open_request(
+        to=store.project_slug(project), ask="an info-only ask",
+        why="the recipient can read this from its own artifacts",
+        channel="cli-tty", kind="info", project_dir=project)
+
+    row = pending.queue(project_dir=project)["rows"][0]
+
+    assert row["id"] == q_id
+    assert row["kind"] == "request"      # the LANE, untouched by this
+    assert row["approval"] == "info"     # the approval requirement
+
+
+def test_a_work_request_row_carries_approval_work(project):
+    q_id = requests.open_request(
+        to=store.project_slug(project), ask="bump before the docs change",
+        why="the tag is referenced", channel="cli-agent", project_dir=project)
+
+    row = pending.queue(project_dir=project)["rows"][0]
+
+    assert row["id"] == q_id
+    assert row["approval"] == "work"
+
+
+def test_a_non_request_row_carries_no_approval(project):
+    """The ruling/refutation/amendment lanes never assign an approval kind:
+    `approval` stays absent for them, and the render surface reads that as
+    no marker."""
+    refutations.assert_ruling(
+        subject="release", verdict="never bump to 1.0 without a human call",
+        scope="repo", evidence=["issue:766"], channel="cli-agent",
+        project_dir=project)
+
+    row = pending.queue(project_dir=project)["rows"][0]
+
+    assert row["kind"] == "ruling"
+    assert row.get("approval") is None
+
+
+def test_a_legacy_request_row_carries_approval_work(project):
+    """A record minted before #961 has no `kind` field at all; the fold
+    already defaults it to `work` (#961 slice 1), and this queue row must
+    carry that default, never blank or a crash."""
+    q_id = requests.open_request(
+        to=store.project_slug(project), ask="an info-only ask",
+        why="why", channel="cli-tty", kind="info", project_dir=project)
+    path = (config.checkpoint_dir() / store.project_slug(project)
+            / "requests.jsonl")
+    rows = [json.loads(ln) for ln in
+            path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    del rows[0]["kind"]
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n",
+                    encoding="utf-8")
+
+    row = pending.queue(project_dir=project)["rows"][0]
+
+    assert row["id"] == q_id
+    assert row["approval"] == "work"
+
+
+def test_a_request_row_never_reads_approval_off_a_raw_row(project):
+    """THE FOLD RULE THROUGH THE SURFACE: a raw `opened` row appended on a
+    non-human channel with `kind="info"` folds to `work`, and the queue row
+    must carry exactly that, never the forged raw value. Appended directly
+    because `open_request` refuses this combination at the write
+    boundary."""
+    row = requests._stamp("opened", "q-0123456789ab", "cli-agent")
+    row.update({"to": store.project_slug(project), "ask": "an ask",
+               "why": "why", "kind": "info"})
+    assert requests.append(row, project_dir=project)
+
+    result_row = pending.queue(project_dir=project)["rows"][0]
+
+    assert result_row["approval"] == "work"
 
 
 def test_a_foreign_addressed_request_is_owed_but_our_own_outgoing_ask_is_not(

--- a/plugin/tests/test_request_briefing.py
+++ b/plugin/tests/test_request_briefing.py
@@ -69,7 +69,7 @@ def test_panel_legacy_row_renders_without_a_kind_marker(tmp_checkpoint_dir):
     must render it exactly like an ordinary `work` ask — no marker, no
     crash."""
     sender = _seed_sender()
-    _ask(sender, channel="cli-tty", kind="info")
+    q_id = _ask(sender, channel="cli-tty", kind="info")
     path = (config.checkpoint_dir() / store.project_slug(sender)
             / "requests.jsonl")
     rows = [json.loads(ln) for ln in
@@ -78,6 +78,9 @@ def test_panel_legacy_row_renders_without_a_kind_marker(tmp_checkpoint_dir):
     path.write_text("\n".join(json.dumps(r) for r in rows) + "\n",
                     encoding="utf-8")
     lines = briefing.request_panel_lines(RECIPIENT)
+    # Positive anchor: the record is actually rendered here, not just absent
+    # from a panel that happens to have nothing in it.
+    assert any(q_id in ln for ln in lines)
     assert not any("[info]" in ln for ln in lines)
 
 
@@ -94,6 +97,8 @@ def test_panel_never_reads_kind_off_a_raw_row(tmp_checkpoint_dir):
                "kind": "info"})
     assert requests.append(row, project_dir=sender)
     lines = briefing.request_panel_lines(RECIPIENT)
+    # Positive anchor: an empty line list would also satisfy "no marker".
+    assert any("q-0123456789ab" in ln for ln in lines)
     assert not any("[info]" in ln for ln in lines)
 
 

--- a/plugin/tests/test_request_briefing.py
+++ b/plugin/tests/test_request_briefing.py
@@ -5,7 +5,9 @@ shape: fail-open, always present, never budget-dropped. The CLI-only gate
 this file drives briefing.request_panel_lines/render directly.
 """
 
-from daimon_briefing import briefing, requests, store
+import json
+
+from daimon_briefing import briefing, config, requests, store
 
 RECIPIENT = "/p/req-brief-recipient"
 SENDER = "/p/req-brief-sender"
@@ -20,10 +22,10 @@ def _seed_sender(session="S-req-sender"):
     return store.project_slug(SENDER)
 
 
-def _ask(sender_slug, ask="publish the schema", **kw):
+def _ask(sender_slug, ask="publish the schema", channel="cli-agent", **kw):
     return requests.open_request(
         to=store.project_slug(RECIPIENT), ask=ask,
-        why="the client needs it", channel="cli-agent",
+        why="the client needs it", channel=channel,
         project_dir=sender_slug, **kw)
 
 
@@ -46,6 +48,53 @@ def test_panel_marks_blocking(tmp_checkpoint_dir):
     _ask(sender, blocking=True)
     lines = briefing.request_panel_lines(RECIPIENT)
     assert any("blocking" in ln.lower() for ln in lines)
+
+
+def test_panel_marks_an_info_ask(tmp_checkpoint_dir):
+    sender = _seed_sender()
+    _ask(sender, channel="cli-tty", kind="info")
+    lines = briefing.request_panel_lines(RECIPIENT)
+    assert any("[info]" in ln for ln in lines)
+
+
+def test_panel_no_marker_for_a_work_ask(tmp_checkpoint_dir):
+    sender = _seed_sender()
+    _ask(sender)
+    lines = briefing.request_panel_lines(RECIPIENT)
+    assert not any("[info]" in ln for ln in lines)
+
+
+def test_panel_legacy_row_renders_without_a_kind_marker(tmp_checkpoint_dir):
+    """A record minted before #961 carries no `kind` field at all; the panel
+    must render it exactly like an ordinary `work` ask — no marker, no
+    crash."""
+    sender = _seed_sender()
+    _ask(sender, channel="cli-tty", kind="info")
+    path = (config.checkpoint_dir() / store.project_slug(sender)
+            / "requests.jsonl")
+    rows = [json.loads(ln) for ln in
+            path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    del rows[0]["kind"]
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n",
+                    encoding="utf-8")
+    lines = briefing.request_panel_lines(RECIPIENT)
+    assert not any("[info]" in ln for ln in lines)
+
+
+def test_panel_never_reads_kind_off_a_raw_row(tmp_checkpoint_dir):
+    """THE FOLD RULE THROUGH THE SURFACE: a raw `opened` row appended on a
+    non-human channel with `kind="info"` folds to `work`, and the panel must
+    show exactly what the fold says, never the forged raw value. Appended
+    directly because `open_request` refuses this combination at the write
+    boundary."""
+    sender = _seed_sender()
+    row = requests._stamp("opened", "q-0123456789ab", "cli-agent")
+    row.update({"to": store.project_slug(RECIPIENT),
+               "ask": "publish the schema", "why": "the client needs it",
+               "kind": "info"})
+    assert requests.append(row, project_dir=sender)
+    lines = briefing.request_panel_lines(RECIPIENT)
+    assert not any("[info]" in ln for ln in lines)
 
 
 def test_panel_never_silently_truncates_over_cap(tmp_checkpoint_dir):

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -1113,11 +1113,20 @@ def test_cli_request_list_never_reads_kind_off_a_raw_row(project, capsys):
     assert "Kind: info" not in out
 
 
-def test_cli_request_list_json_carries_kind_from_the_fold(
-        project, recipient, capsys):
+def test_cli_request_list_json_reads_kind_from_the_fold_not_the_raw_row(
+        project, capsys):
+    """A stored `work` value and its folded value are the same string, so
+    asserting `kind == "work"` off a plain `--by agent` open (the stored
+    value) proves nothing about which one `--json` actually reads. Forge a
+    row where the two disagree instead: `kind: "info"` on a non-human
+    channel folds to `work` (#961 slice 1's own authority gate), so a
+    payload reading `work` here can only have come from the fold. Appended
+    directly because `open_request` refuses this combination at the write
+    boundary."""
     from daimon_briefing import cli
-    assert _cli_open(project, recipient) == 0
-    capsys.readouterr()
+    row = requests._stamp("opened", "q-0123456789ab", "cli-agent")
+    row.update({"to": RECIPIENT, "ask": ASK, "why": WHY, "kind": "info"})
+    assert requests.append(row, project_dir=project)
     assert cli.main(["request", "list", "--project", project,
                      "--json"]) == 0
     payload = json.loads(capsys.readouterr().out)
@@ -1187,18 +1196,24 @@ def test_cli_request_inbox_never_reads_kind_off_a_raw_row(
     assert "Kind: info" not in out
 
 
-def test_cli_request_inbox_json_carries_kind_from_the_fold(
+def test_cli_request_inbox_json_reads_kind_from_the_fold_not_the_raw_row(
         tmp_checkpoint_dir, capsys):
+    """Same fold-vs-raw distinction as the `list` variant above, for the
+    cross-bucket `inbox` composer. A legitimate `info` ask would make the
+    stored and folded values agree and prove nothing; forging `kind: "info"`
+    on a non-human channel is the one case where they diverge, so a payload
+    reading `work` can only have come from the fold."""
     from daimon_briefing import cli
     recipient_dir = "/p/inbox-961-json-recipient"
     sender_dir = "/p/inbox-961-json-sender"
-    requests.open_request(
-        to=store.project_slug(recipient_dir), ask=ASK, why=WHY,
-        channel="cli-tty", kind="info", project_dir=sender_dir)
+    row = requests._stamp("opened", "q-0123456789ab", "cli-agent")
+    row.update({"to": store.project_slug(recipient_dir), "ask": ASK,
+               "why": WHY, "kind": "info"})
+    assert requests.append(row, project_dir=sender_dir)
     assert cli.main(["request", "inbox", "--project", recipient_dir,
                      "--json"]) == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload[0]["kind"] == "info"
+    assert payload[0]["kind"] == "work"
 
 
 def test_inject_lines_marks_an_info_ask(project):

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -1048,6 +1048,206 @@ def test_cli_open_rejects_an_unknown_kind_choice(project, recipient, capsys):
     assert exc_info.value.code == 2
 
 
+# ---- #961 slice 2: render surfaces -----------------------------------------
+#
+# THE ONE RULE: every surface renders `kind` from the FOLDED record, never a
+# raw ledger row. `test_..._never_reads_kind_off_a_raw_row` below is the
+# fence for that rule on each surface: a raw `opened` row appended on a
+# non-human channel with `kind="info"` folds to `work` (`_kind_of`'s own
+# authority gate — #961 slice 1), and the render must show exactly what the
+# fold says. Appended directly with `requests.append` because `open_request`
+# already refuses this combination at the write boundary.
+
+
+def test_cli_request_list_detail_card_prints_kind_info(
+        project, recipient, monkeypatch, capsys):
+    from daimon_briefing import cli
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    rc = cli.main(["request", "open", "--to", OTHER, "--ask", ASK,
+                   "--why", WHY, "--kind", "info", "--project", project])
+    assert rc == 0
+    capsys.readouterr()
+    assert cli.main(["request", "list", "--project", project]) == 0
+    out = capsys.readouterr().out
+    assert "Kind: info" in out
+
+
+def test_cli_request_list_detail_card_prints_kind_work_by_default(
+        project, recipient, capsys):
+    from daimon_briefing import cli
+    assert _cli_open(project, recipient) == 0
+    capsys.readouterr()
+    assert cli.main(["request", "list", "--project", project]) == 0
+    out = capsys.readouterr().out
+    assert "Kind: work" in out
+    assert "Kind: info" not in out
+
+
+def test_cli_request_list_legacy_row_renders_kind_work(
+        project, recipient, capsys):
+    """A record minted before #961 carries no `kind` key at all; the render
+    surface must show it as `work`, the ledger's own default, never blank or
+    a crash."""
+    from daimon_briefing import cli
+    assert _cli_open(project, recipient) == 0
+    capsys.readouterr()
+    rows = _rows(project)
+    del rows[0]["kind"]
+    path = (config.checkpoint_dir() / store.project_slug(project)
+            / "requests.jsonl")
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n",
+                    encoding="utf-8")
+    assert cli.main(["request", "list", "--project", project]) == 0
+    out = capsys.readouterr().out
+    assert "Kind: work" in out
+
+
+def test_cli_request_list_never_reads_kind_off_a_raw_row(project, capsys):
+    from daimon_briefing import cli
+    row = requests._stamp("opened", "q-0123456789ab", "cli-agent")
+    row.update({"to": RECIPIENT, "ask": ASK, "why": WHY, "kind": "info"})
+    assert requests.append(row, project_dir=project)
+    assert cli.main(["request", "list", "--project", project]) == 0
+    out = capsys.readouterr().out
+    assert "Kind: work" in out
+    assert "Kind: info" not in out
+
+
+def test_cli_request_list_json_carries_kind_from_the_fold(
+        project, recipient, capsys):
+    from daimon_briefing import cli
+    assert _cli_open(project, recipient) == 0
+    capsys.readouterr()
+    assert cli.main(["request", "list", "--project", project,
+                     "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["kind"] == "work"
+
+
+def test_cli_request_inbox_detail_card_prints_kind_info(
+        tmp_checkpoint_dir, capsys):
+    from daimon_briefing import cli
+    recipient_dir = "/p/inbox-961-recipient-a"
+    sender_dir = "/p/inbox-961-sender-a"
+    q_id = requests.open_request(
+        to=store.project_slug(recipient_dir), ask=ASK, why=WHY,
+        channel="cli-tty", kind="info", project_dir=sender_dir)
+    assert cli.main(["request", "inbox", "--project", recipient_dir]) == 0
+    out = capsys.readouterr().out
+    assert q_id in out
+    assert "Kind: info" in out
+
+
+def test_cli_request_inbox_detail_card_prints_kind_work_by_default(
+        tmp_checkpoint_dir, capsys):
+    from daimon_briefing import cli
+    recipient_dir = "/p/inbox-961-recipient-b"
+    sender_dir = "/p/inbox-961-sender-b"
+    requests.open_request(
+        to=store.project_slug(recipient_dir), ask=ASK, why=WHY,
+        channel="cli-agent", project_dir=sender_dir)
+    assert cli.main(["request", "inbox", "--project", recipient_dir]) == 0
+    out = capsys.readouterr().out
+    assert "Kind: work" in out
+    assert "Kind: info" not in out
+
+
+def test_cli_request_inbox_legacy_row_renders_kind_work(
+        tmp_checkpoint_dir, capsys):
+    from daimon_briefing import cli
+    recipient_dir = "/p/inbox-961-recipient-c"
+    sender_dir = "/p/inbox-961-sender-c"
+    requests.open_request(
+        to=store.project_slug(recipient_dir), ask=ASK, why=WHY,
+        channel="cli-tty", kind="info", project_dir=sender_dir)
+    path = (config.checkpoint_dir() / store.project_slug(sender_dir)
+            / "requests.jsonl")
+    rows = [json.loads(ln) for ln in
+            path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    del rows[0]["kind"]
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n",
+                    encoding="utf-8")
+    assert cli.main(["request", "inbox", "--project", recipient_dir]) == 0
+    out = capsys.readouterr().out
+    assert "Kind: work" in out
+
+
+def test_cli_request_inbox_never_reads_kind_off_a_raw_row(
+        tmp_checkpoint_dir, capsys):
+    from daimon_briefing import cli
+    recipient_dir = "/p/inbox-961-recipient-d"
+    sender_dir = "/p/inbox-961-sender-d"
+    row = requests._stamp("opened", "q-0123456789ab", "cli-agent")
+    row.update({"to": store.project_slug(recipient_dir), "ask": ASK,
+               "why": WHY, "kind": "info"})
+    assert requests.append(row, project_dir=sender_dir)
+    assert cli.main(["request", "inbox", "--project", recipient_dir]) == 0
+    out = capsys.readouterr().out
+    assert "Kind: work" in out
+    assert "Kind: info" not in out
+
+
+def test_cli_request_inbox_json_carries_kind_from_the_fold(
+        tmp_checkpoint_dir, capsys):
+    from daimon_briefing import cli
+    recipient_dir = "/p/inbox-961-json-recipient"
+    sender_dir = "/p/inbox-961-json-sender"
+    requests.open_request(
+        to=store.project_slug(recipient_dir), ask=ASK, why=WHY,
+        channel="cli-tty", kind="info", project_dir=sender_dir)
+    assert cli.main(["request", "inbox", "--project", recipient_dir,
+                     "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["kind"] == "info"
+
+
+def test_inject_lines_marks_an_info_ask(project):
+    from daimon_briefing.cli import request as cli_request
+    q_id = requests.open_request(
+        to=store.project_slug(project), ask=ASK, why=WHY,
+        channel="cli-tty", kind="info", project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    lines = cli_request._inject_lines(record)
+    assert "[info]" in lines[0]
+
+
+def test_inject_lines_no_marker_for_a_work_ask(project):
+    from daimon_briefing.cli import request as cli_request
+    q_id = requests.open_request(
+        to=store.project_slug(project), ask=ASK, why=WHY,
+        channel="cli-agent", project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    lines = cli_request._inject_lines(record)
+    assert "[info]" not in lines[0]
+
+
+def test_owed_inject_lines_marks_an_info_ask(project):
+    from daimon_briefing.cli import request as cli_request
+    q_id = requests.open_request(
+        to=store.project_slug(project), ask=ASK, why=WHY,
+        channel="cli-tty", kind="info", project_dir=project)
+    requests.accept(q_id, channel="cli-tty", project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    lines = cli_request._owed_inject_lines(record)
+    assert "[info]" in lines[0]
+
+
+def test_verdict_inject_lines_never_shows_a_kind_marker(project):
+    """Decision (#961 slice 2): the sender-side verdict notification reports
+    the OUTCOME of a request this project itself opened, and it already
+    assigned the kind at open time — re-surfacing it here tells the sender
+    something it already knows. Mirrors the same call made for
+    `briefing.verdict_panel_lines`. No marker is added to this surface."""
+    from daimon_briefing.cli import request as cli_request
+    q_id = requests.open_request(
+        to=store.project_slug(project), ask=ASK, why=WHY,
+        channel="cli-tty", kind="info", project_dir=project)
+    requests.accept(q_id, channel="cli-tty", project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    lines = cli_request._verdict_inject_lines(record)
+    assert "[info]" not in "\n".join(lines)
+
+
 def test_cli_open_human_path_requires_a_terminal(project, recipient,
                                                  monkeypatch, capsys):
     from daimon_briefing import cli

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -176,7 +176,7 @@ nobody ever writes into another project's ledger.
 
 | command | what it does |
 | --- | --- |
-| `daimon request open --to <dir> --ask "…" --why "…"` | Ask another project for something. `--to` takes the recipient's project **directory**, not its slug (a real slug starts with `-`, which argparse reads as an option — `--to=<slug>` also works). Validated against `daimon projects`, with near-match suggestions on a typo; `--anyway` records the ask against a project that has never serialized on this machine. `--blocking` and `--to-human` are flags on the record. Either channel. |
+| `daimon request open --to <dir> --ask "…" --why "…"` | Ask another project for something. `--to` takes the recipient's project **directory**, not its slug (a real slug starts with `-`, which argparse reads as an option — `--to=<slug>` also works). Validated against `daimon projects`, with near-match suggestions on a typo; `--anyway` records the ask against a project that has never serialized on this machine. `--blocking` and `--to-human` are flags on the record. `--kind work\|info` sets the approval requirement: `work` (the default) waits on a person, `info` is answerable from the recipient's own artifacts and owes no accept. Only a human channel may open one as `info`. Either channel otherwise. |
 | `daimon request revise <id> [--ask] [--why] [--evidence]` | Answer a needs-info, or sharpen an open ask. Either channel; capped at 3 revisions per record lifetime — past the cap, open a new request with `--supersedes <id>` to keep the lineage visible. |
 | `daimon request accept\|reject\|needs-info <id> [--note]` | Land a decision. Human-only — requires an interactive terminal. `reject` is final for that record; the sender supersedes with a new request rather than asking again. |
 | `daimon request suppress <id> [--note]` | Drop a request out of the recipient's own briefing panel. Human-only; the record stays in `list`/`inbox`, and any later decision reverses it. |
@@ -194,6 +194,11 @@ undecided". An unanswered request renders `stale` after 3 recipient
 sessions pass with no decision; a decided one leaves the sender's panel
 after 2 sender sessions. Attention decays — records never delete, and both
 stay fully visible in `list`/`inbox`.
+
+A request opened with `--kind info` carries an `[info]` marker on the
+recipient's panels above, on the `daimon decide` card, and on the
+live-delivery line that injects it mid session. A `work` request, the
+default, carries no marker on any of those surfaces.
 
 `daimon status` adds a one-line summary, `requests: N open sent, M
 awaiting you`, silent when both are zero.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/reference/cli.md
@@ -178,7 +178,7 @@ proyecto.
 
 | comando | qué hace |
 | --- | --- |
-| `daimon request open --to <dir> --ask "…" --why "…"` | Pide algo a otro proyecto. `--to` toma el **directorio** del proyecto destinatario, no su slug (un slug real empieza con `-`, que argparse lee como una opción — `--to=<slug>` también funciona). Se valida contra `daimon projects`, con sugerencias por parecido ante un typo; `--anyway` registra el pedido igual contra un proyecto que nunca serializó en esta máquina. `--blocking` y `--to-human` son flags del registro. Cualquier canal. |
+| `daimon request open --to <dir> --ask "…" --why "…"` | Pide algo a otro proyecto. `--to` toma el **directorio** del proyecto destinatario, no su slug (un slug real empieza con `-`, que argparse lee como una opción — `--to=<slug>` también funciona). Se valida contra `daimon projects`, con sugerencias por parecido ante un typo; `--anyway` registra el pedido igual contra un proyecto que nunca serializó en esta máquina. `--blocking` y `--to-human` son flags del registro. `--kind work\|info` fija el requisito de aprobación: `work` (el default) espera una decisión de una persona, `info` se puede responder con los propios artefactos del destinatario y no debe un accept. Solo un canal humano puede abrirla como `info`. El resto, cualquier canal. |
 | `daimon request revise <id> [--ask] [--why] [--evidence]` | Responde un needs-info, o afina una solicitud abierta. Cualquier canal; tope de 3 revisiones por registro — superado el tope, se abre una nueva solicitud con `--supersedes <id>` para mantener visible el linaje. |
 | `daimon request accept\|reject\|needs-info <id> [--note]` | Registra una decisión. Solo humano — requiere una terminal interactiva. `reject` es definitivo para ese registro; el remitente reemplaza con una nueva solicitud en vez de volver a pedir. |
 | `daimon request suppress <id> [--note]` | Saca una solicitud del panel de briefing propio del destinatario. Solo humano; el registro sigue en `list`/`inbox`, y cualquier decisión posterior lo revierte. |
@@ -198,6 +198,11 @@ sesiones del destinatario sin decisión; una ya decidida sale del panel del
 remitente después de 2 sesiones del remitente. La atención decae — los
 registros nunca se eliminan, y ambos siguen totalmente visibles en
 `list`/`inbox`.
+
+Una solicitud abierta con `--kind info` lleva una marca `[info]` en los
+paneles del destinatario de arriba, en la tarjeta de `daimon decide`, y en
+la línea de entrega en vivo que la inyecta a mitad de sesión. Una solicitud
+`work`, el default, no lleva marca en ninguna de esas superficies.
 
 `daimon status` agrega un resumen de una línea, `requests: N open sent, M
 awaiting you`, silencioso cuando los dos son cero.


### PR DESCRIPTION
Refs #961

Second of four slices. Merging this must not close the issue.

## What

Renders the approval-requirement `kind` that #961 slice 1 added to every
request record. Nothing about which asks reach a decision, or what accepting
one requires, changes in this slice: it is render only.

`daimon request list` and `daimon request inbox` print an explicit `Kind:
work` or `Kind: info` line on every record card, always, since these are
detail views. The compact one-line notices that live-delivery prints mid
session (`daimon request-inject`'s undecided and owed lines) add a `[info]`
marker only when the kind is `info`, since `work` is both the default and the
legacy reading, and marking it on every line would be noise on a surface built
to stay thin. The recipient's briefing panels (the undecided-asks panel and
the accepted-and-owed panel) get the same `[info]` marker next to the
existing `[blocking]` one. `daimon decide` gets the marker too, on its own
key: the queue row already carried a `kind` field naming the LANE (request,
amendment, ruling, refutation), so the approval requirement rides a new
`approval` field instead of overloading that one.

Two sender-side surfaces are left unmarked on purpose: the verdict panel in
the briefing, and the verdict notice live delivery prints. Both report the
outcome of a request this project itself opened, and the sender already
chose the kind when it opened the ask. Marking those would repeat something
the reader already decided rather than help a reader decide how much
scrutiny an ask deserves, which is what the marker is for everywhere else.

Every surface reads `kind` from the folded record `requests.fold` (or one of
its composers) already produces, never from a raw ledger row.

## Why

Slice 1 gave every request an approval requirement but nowhere to see it.
A person weighing an inbox full of asks cannot tell an informational one from
a work one without opening each record, which defeats the point: the whole
proposal is that an `info` ask should read as lighter than a `work` one at a
glance.

The one rule worth stating plainly, because both slice 1 defects were exactly
this rule enforced at one boundary and skipped at another: a render must
never call the fold's own authority check itself, and must never read `kind`
off an event row directly. It reads whatever the fold already decided, from
the composer the surface already calls. A raw `opened` row forged on a
non-human channel with `kind: info` still renders as `work` everywhere,
because the fold already turned it into `work` before any of this code sees
it.

The queue-row `kind`/`approval` split exists because `daimon decide` already
used `kind` for something else. Reusing the name for the approval requirement
would have made a request-lane row that happens to be `info` print `[info]`
in its lane tag instead of `[request]`, silently hiding which lane it is in.
A mutation test confirmed the failure mode before the split: folding
`approval` into the lane key does make the guard test fail, so the guard is
checking something real.

## Tests

Full suite run twice on the final tree, both times 5976 passed, 2 skipped,
exit 0, with the checkpoint store, recall database and log directory pointed
at empty temporary directories. Baseline on main under the same conditions is
5941 passed, 2 skipped; this branch adds 35 tests. On a machine with no local
checkpoint store (CI's runner) eight corpus tests skip instead of running, so
CI reports 5967 passed, 10 skipped against a main baseline of 5933 and 10:
same delta, different skip count. ruff and mypy are clean under the commands
CI runs (`ruff check daimon_briefing tests ../scripts`, `mypy
daimon_briefing`).

A blind review of the first three commits found no production defect and
five test and docs gaps, all fixed in the last two commits: the decide-card
span test now drives a real queue row through the card builder instead of a
hand-typed header; both `--json` fold tests now forge a disagreeing raw row
rather than asserting a value the raw read would also have produced; the
lane guard in the decide card has a direct unit test; five absence-only
assertions carry a positive anchor on the request id; and `--kind` plus the
`[info]` marker are documented in the CLI reference, English and Spanish.

Coverage per surface: a legitimate `info` ask opened on a human channel
renders its marker or field; a `work` ask (the default) renders none; a
record minted before this field existed renders as `work`; and a raw
`opened` row forged on a non-human channel with `kind: info` renders as
`work` on every surface, never as `info`, because the render reads the fold's
own decision and not the row. The `daimon decide` lane-tag/approval split is
covered by a dedicated test, plus a mutation check that confirms the test
actually fails if the two are folded back together.

Every new test was checked by disabling the production line it claims to
cover and confirming it goes red, then restoring the line. Two tests
(the sender-side no-marker checks) pin an absence rather than a line, so
there is nothing to disable for them; both were reasoned through instead.
