### PR TITLE
fix(carry): a session's own provisional checkpoint never corroborates its reconstruction

### DIFF
--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -605,7 +605,11 @@ def mark_corroborated(checkpoint, corroborations: dict):
             entry = corroborations.get(item.get("id"))
             if not isinstance(entry, dict):
                 continue
-            n = 1 + len(entry.get("origins") or ())
+            # #983 change 3: an item whose first writer was a provisional
+            # never accrues the badge, even against a ledger row that
+            # predates this fix — store.corroboration_origins_for reads the
+            # item's own origin_session, already in hand here, no extra I/O.
+            n = 1 + len(store.corroboration_origins_for(item, entry))
             if n >= CORROBORATION_MIN:
                 to_stamp.append((section, key, idx, n))
 

--- a/plugin/daimon_briefing/capture.py
+++ b/plugin/daimon_briefing/capture.py
@@ -245,9 +245,27 @@ def _origin_on_disk(origin_session: str, project) -> bool:
 
     Absent, unreadable, torn, GC'd, or foreign all answer the same way — no.
     store.read_checkpoint is total (it swallows the bad-path/torn-file cases
-    itself), so there is nothing here to catch."""
+    itself), so there is nothing here to catch.
+
+    #983 containment: a provisional (`/daimon-end`'s introspection
+    checkpoint) is never a valid origin, full stop — same predicate
+    (`source == "introspection"`) store.sessions_since_count already uses to
+    exclude provisionals from baton/session counting, reused rather than
+    invented a second time. This is the second line of defense behind the
+    write-time fix (write-checkpoint now stamps the live session's REAL id,
+    #983 change 1, so carry.py's G2 same-session guard fires directly): even
+    if a stale skill install still invents a session id, or a future bug
+    reopens the gap G2 closes, a provisional origin can never mint a
+    corroboration. Blunter than strictly necessary — it also refuses the rare
+    case where the origin session crashed before its own SessionEnd
+    reconstruction ran and a genuinely DIFFERENT, later session independently
+    agreed with the provisional's claim (accepted loss, tested) — but it
+    refuses in the direction carry's own doctrine asks for: a missed
+    observation costs one boost, a forged one costs the axis."""
     cp = store.read_checkpoint(origin_session)
     if not isinstance(cp, dict):
+        return False
+    if cp.get("source") == "introspection":
         return False
     return cp.get("project_slug") == store.project_slug(project)
 

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -28,6 +28,7 @@ import os
 import sys
 import time
 import traceback
+import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TypedDict
@@ -451,6 +452,27 @@ def _cmd_write_checkpoint(args) -> int:
     session_override = str(getattr(args, "session", "") or "").strip()
     if isinstance(checkpoint, dict) and session_override:
         checkpoint["session_id"] = session_override
+    elif isinstance(checkpoint, dict):
+        # #983 B1: no --session (a host with no live-session-id concept at
+        # all, e.g. Codex or Windsurf) leaves this branch as the ONLY guard
+        # against a PLACEHOLDER-shaped session_id ever reaching disk. The
+        # skill's own JSON template still shows "session_id":
+        # "introspection-<short-unique-id>" so a model can see the shape —
+        # but a model that pipes that literal text through unfilled (or
+        # leaves session_id blank/absent) writes a CONSTANT id, verified
+        # with the real CLI: it lands at .../introspection-<short-unique-
+        # id>.json, and every subsequent /daimon-end on that host — any
+        # project — overwrites that SAME file. That is strictly worse than
+        # the pre-#983 behavior (a model-invented, at least locally unique,
+        # id): it does not merely fail to link a provisional to its own
+        # reconstruction, it destroys the previous provisional outright.
+        # A body id that is present, non-blank, and free of angle brackets
+        # is left untouched — this only replaces something that could never
+        # have been a usable id.
+        body_sid = str(checkpoint.get("session_id") or "").strip()
+        if not body_sid or "<" in body_sid or ">" in body_sid:
+            checkpoint["session_id"] = (
+                f"{store.ORIGIN_SESSION_INTROSPECTION_PREFIX}{uuid.uuid4().hex}")
     if not isinstance(checkpoint, dict) or not str(checkpoint.get("session_id", "")).strip():
         print("error: checkpoint must be a JSON object with a non-empty session_id", file=sys.stderr)
         return 1

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -438,6 +438,19 @@ def _cmd_write_checkpoint(args) -> int:
     except json.JSONDecodeError as exc:
         print(f"error: invalid checkpoint JSON on stdin: {exc}", file=sys.stderr)
         return 1
+    # #983: the live session's REAL id, when the host can supply one, always
+    # wins over whatever the model put in the JSON body — never trust a
+    # model-authored session_id for identity, the same discipline
+    # strip_code_owned_keys applies a few lines down to format_version/author/
+    # created. Before this flag existed, the daimon-end skill instructed the
+    # model to INVENT one (`introspection-<short-unique-id>`), so a
+    # provisional and the SessionEnd reconstruction of the very same session
+    # carried two different ids — the one thing that let carry.py's G2
+    # same-session guard (origin_session == observing session) miss every
+    # self-corroboration, since the guard never saw the two halves as one.
+    session_override = str(getattr(args, "session", "") or "").strip()
+    if isinstance(checkpoint, dict) and session_override:
+        checkpoint["session_id"] = session_override
     if not isinstance(checkpoint, dict) or not str(checkpoint.get("session_id", "")).strip():
         print("error: checkpoint must be a JSON object with a non-empty session_id", file=sys.stderr)
         return 1
@@ -3612,6 +3625,16 @@ def build_parser() -> argparse.ArgumentParser:
     p_wc.add_argument(
         "--source", default="introspection",
         help="provenance stamp for the checkpoint (default: introspection)",
+    )
+    p_wc.add_argument(
+        "--session",
+        help="the live session's REAL id (e.g. $CLAUDE_CODE_SESSION_ID), "
+        "stamped onto the checkpoint in place of whatever session_id the "
+        "JSON body carries (#983). This is what lets carry.py's same-session "
+        "guard recognize a later reconstruction of THIS session as its own "
+        "predecessor instead of an independent witness, so a provisional "
+        "can never corroborate itself. Omit only when the host has no way "
+        "to tell the live session its own id.",
     )
     p_wc.set_defaults(func=_cmd_write_checkpoint)
 

--- a/plugin/daimon_briefing/inspector.py
+++ b/plugin/daimon_briefing/inspector.py
@@ -335,7 +335,11 @@ def inspect_item(project_dir, item_id: str, *, include_source: bool = False,
         verifier = "same-version" if recorded == current else "different-version"
 
     corroboration = store.corroborations(project_dir=project_dir).get(item_id, {})
-    references = sorted(corroboration.get("origins") or ())
+    # #983 change 3: `why` must show the SAME effective count the briefing
+    # badge does — an item whose first writer was a provisional never
+    # corroborates, ledger row or not (store.corroboration_origins_for reads
+    # `item["origin_session"]`, already loaded above).
+    references = sorted(store.corroboration_origins_for(item, corroboration))
     result = {
         "schema_version": SCHEMA_VERSION,
         "item": {

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -2598,6 +2598,50 @@ def corroborations(project_dir=None) -> dict:
     return out
 
 
+# #983 change 3: `write-checkpoint` stamps this EXACT prefix on a provisional
+# checkpoint's session_id — the pre-#983 skill's own invented labels, and the
+# CLI's fallback (cli._cmd_write_checkpoint, #983 B1) whenever neither the
+# host nor the model can name the live session — so it survives forever on an
+# item's `origin_session` field (policy.bind_origin's setdefault, never
+# re-bound by a later carry). This is a DIFFERENT signal from
+# sessions_since_count's `source == "introspection"` check: that reads a
+# CHECKPOINT's own provenance stamp, live only while the checkpoint's
+# per-session file has not yet been overwritten by its own reconstruction
+# (see the #983 scar candidate on that). This reads an ITEM's permanent,
+# never-overwritten claim about who first wrote it — durable exactly where
+# the checkpoint-level check is not.
+ORIGIN_SESSION_INTROSPECTION_PREFIX = "introspection-"
+
+
+def corroboration_origins_for(item: dict, entry: dict | None) -> set:
+    """#983 change 3: the EFFECTIVE corroboration origins for `item`, given
+    its `corroborations()` fold `entry` — read-time exclusion of an item
+    whose first writer was a provisional, with NO extra I/O and NO ledger
+    scan: the exclusion reads only `item["origin_session"]`, a field already
+    in hand at every call site (the checkpoint being rendered, or the item
+    `inspector.inspect_item` already loaded).
+
+    A provisional never accrues a badge, PERIOD — not "until its origin
+    session's real reconstruction lands" (that nuance lives at the WRITE
+    boundary, capture._origin_on_disk, and is time-sensitive by construction,
+    see the #983 scar candidate). This is a stronger, permanent read-time
+    rule: once an item's `origin_session` is stamped with the introspection
+    prefix, it keeps that stamp forever (setdefault, never re-bound), so ANY
+    row ever recorded against it — before or after this fix shipped, from any
+    observing session — is discounted. Accepted loss, same doctrine as change
+    2: a missed observation costs one boost, a forged one costs the axis.
+
+    Absent/non-dict `entry` (no corroboration row at all) -> empty set, the
+    same as the caller would get from `entry.get("origins")` directly."""
+    if not isinstance(entry, dict):
+        return set()
+    origin_session = str(item.get("origin_session") or "") if isinstance(
+        item, dict) else ""
+    if origin_session.startswith(ORIGIN_SESSION_INTROSPECTION_PREFIX):
+        return set()
+    return set(entry.get("origins") or ())
+
+
 # ---- #402: value-keyed forget suppression ----
 
 # `forgotten:` status prefix -> canonical content key. The forget command

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2027,26 +2027,25 @@ def test_cli_write_checkpoint_literal_placeholder_body_gets_a_fresh_unique_id(
 
 
 def test_cli_write_checkpoint_two_placeholder_bodies_get_different_ids(
-        tmp_checkpoint_dir, monkeypatch):
+        tmp_checkpoint_dir, monkeypatch, capsys):
     # The fallback must be unique per call, or two /daimon-end writes on a
     # host without a live id would collide on the SAME per-session file —
     # exactly the failure this fix exists to prevent, just with a different
-    # constant.
-    from daimon_briefing import store
+    # constant. Both calls target the SAME project on purpose: two DIFFERENT
+    # projects would each get their own per-session file regardless of
+    # whether the fallback id is unique, so that shape never exercises the
+    # collision at all. Asserting on the PRINTED checkpoint path (not just
+    # the stored session_id) pins the thing that actually collided before
+    # this fix: the on-disk per-session FILE.
+    _stdin(monkeypatch, _valid_json("introspection-<short-unique-id>"))
+    assert cli.main(["write-checkpoint", "--project", "/p/A"]) == 0
+    first_path = capsys.readouterr().out.strip().split("wrote checkpoint: ", 1)[1].split(" (source:", 1)[0]
 
     _stdin(monkeypatch, _valid_json("introspection-<short-unique-id>"))
     assert cli.main(["write-checkpoint", "--project", "/p/A"]) == 0
-    first = store.read_latest_body(
-        project_dir="/p/A", route=store.Route.OWN_ELSE_GLOBAL,
-        admit=store.Admit.ANY)["session_id"]
+    second_path = capsys.readouterr().out.strip().split("wrote checkpoint: ", 1)[1].split(" (source:", 1)[0]
 
-    _stdin(monkeypatch, _valid_json("introspection-<short-unique-id>"))
-    assert cli.main(["write-checkpoint", "--project", "/p/B"]) == 0
-    second = store.read_latest_body(
-        project_dir="/p/B", route=store.Route.OWN_ELSE_GLOBAL,
-        admit=store.Admit.ANY)["session_id"]
-
-    assert first != second
+    assert first_path != second_path
 
 
 def test_cli_write_checkpoint_blank_body_session_id_gets_a_fresh_unique_id(

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -2003,6 +2003,82 @@ def test_cli_write_checkpoint_blank_session_flag_keeps_the_json_body(
     assert ck["session_id"] == "S-from-json"
 
 
+def test_cli_write_checkpoint_literal_placeholder_body_gets_a_fresh_unique_id(
+        tmp_checkpoint_dir, monkeypatch):
+    # #983 B1 (blocker): a host with no live-session-id concept at all (no
+    # --session) combined with a model that pipes the skill's OWN JSON
+    # template through unfilled — the literal
+    # "introspection-<short-unique-id>" placeholder text, angle brackets and
+    # all — must never reach disk as a CONSTANT id. Before this fix it did:
+    # verified with the real CLI, it wrote
+    # .../introspection-<short-unique-id>.json, and every subsequent
+    # /daimon-end anywhere overwrote that same file.
+    from daimon_briefing import store
+
+    _stdin(monkeypatch, _valid_json("introspection-<short-unique-id>"))
+    rc = cli.main(["write-checkpoint", "--project", "/p/A"])
+    assert rc == 0
+    ck = store.read_latest_body(project_dir="/p/A", route=store.Route.OWN_ELSE_GLOBAL,
+                                admit=store.Admit.ANY)
+    sid = ck["session_id"]
+    assert sid != "introspection-<short-unique-id>"
+    assert "<" not in sid and ">" not in sid
+    assert sid.startswith(store.ORIGIN_SESSION_INTROSPECTION_PREFIX)
+
+
+def test_cli_write_checkpoint_two_placeholder_bodies_get_different_ids(
+        tmp_checkpoint_dir, monkeypatch):
+    # The fallback must be unique per call, or two /daimon-end writes on a
+    # host without a live id would collide on the SAME per-session file —
+    # exactly the failure this fix exists to prevent, just with a different
+    # constant.
+    from daimon_briefing import store
+
+    _stdin(monkeypatch, _valid_json("introspection-<short-unique-id>"))
+    assert cli.main(["write-checkpoint", "--project", "/p/A"]) == 0
+    first = store.read_latest_body(
+        project_dir="/p/A", route=store.Route.OWN_ELSE_GLOBAL,
+        admit=store.Admit.ANY)["session_id"]
+
+    _stdin(monkeypatch, _valid_json("introspection-<short-unique-id>"))
+    assert cli.main(["write-checkpoint", "--project", "/p/B"]) == 0
+    second = store.read_latest_body(
+        project_dir="/p/B", route=store.Route.OWN_ELSE_GLOBAL,
+        admit=store.Admit.ANY)["session_id"]
+
+    assert first != second
+
+
+def test_cli_write_checkpoint_blank_body_session_id_gets_a_fresh_unique_id(
+        tmp_checkpoint_dir, monkeypatch):
+    # Same fallback, the other trigger: an empty session_id in the body (no
+    # --session either) is exactly as unusable as the literal placeholder.
+    from daimon_briefing import store
+
+    _stdin(monkeypatch, _valid_json(""))
+    rc = cli.main(["write-checkpoint", "--project", "/p/A"])
+    assert rc == 0
+    ck = store.read_latest_body(project_dir="/p/A", route=store.Route.OWN_ELSE_GLOBAL,
+                                admit=store.Admit.ANY)
+    assert ck["session_id"].startswith(store.ORIGIN_SESSION_INTROSPECTION_PREFIX)
+    assert ck["session_id"] != store.ORIGIN_SESSION_INTROSPECTION_PREFIX  # a hex suffix was appended
+
+
+def test_cli_write_checkpoint_real_session_flag_wins_over_a_placeholder_body(
+        tmp_checkpoint_dir, monkeypatch):
+    # --session still takes priority over the B1 fallback: when the host CAN
+    # supply a real id, it is used even if the body is the unfilled template.
+    from daimon_briefing import store
+
+    _stdin(monkeypatch, _valid_json("introspection-<short-unique-id>"))
+    rc = cli.main(["write-checkpoint", "--project", "/p/A",
+                   "--session", "S-real-983"])
+    assert rc == 0
+    ck = store.read_latest_body(project_dir="/p/A", route=store.Route.OWN_ELSE_GLOBAL,
+                                admit=store.Admit.ANY)
+    assert ck["session_id"] == "S-real-983"
+
+
 def test_cli_write_checkpoint_invalid_json(tmp_checkpoint_dir, monkeypatch, capsys):
     _stdin(monkeypatch, "not json at all")
     rc = cli.main(["write-checkpoint"])

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1958,6 +1958,51 @@ def test_cli_write_checkpoint_source_override(tmp_checkpoint_dir, monkeypatch):
                                   admit=store.Admit.ANY)["source"] == "reconstruction"
 
 
+def test_cli_write_checkpoint_session_flag_overrides_the_json_body(
+        tmp_checkpoint_dir, monkeypatch):
+    # #983 change 1: the live session's REAL id, when the host can supply
+    # one, wins over whatever session_id the model invented in the JSON body
+    # — this is what lets a later reconstruction of the SAME session
+    # recognize this checkpoint as its own predecessor (carry.py's G2).
+    from daimon_briefing import store
+
+    _stdin(monkeypatch, _valid_json("introspection-invented-label"))
+    rc = cli.main(["write-checkpoint", "--project", "/p/A",
+                   "--session", "S-real-983"])
+    assert rc == 0
+    ck = store.read_latest_body(project_dir="/p/A", route=store.Route.OWN_ELSE_GLOBAL,
+                                admit=store.Admit.ANY)
+    assert ck["session_id"] == "S-real-983"
+
+
+def test_cli_write_checkpoint_without_session_flag_keeps_the_json_body(
+        tmp_checkpoint_dir, monkeypatch):
+    # Back-compat: a host that cannot tell the live session its own id omits
+    # --session, and write-checkpoint behaves exactly as before.
+    from daimon_briefing import store
+
+    _stdin(monkeypatch, _valid_json("introspection-invented-label"))
+    rc = cli.main(["write-checkpoint", "--project", "/p/A"])
+    assert rc == 0
+    ck = store.read_latest_body(project_dir="/p/A", route=store.Route.OWN_ELSE_GLOBAL,
+                                admit=store.Admit.ANY)
+    assert ck["session_id"] == "introspection-invented-label"
+
+
+def test_cli_write_checkpoint_blank_session_flag_keeps_the_json_body(
+        tmp_checkpoint_dir, monkeypatch):
+    # An empty/whitespace --session is the same as omitting it — never stamp
+    # an unnameable id over a real one the JSON body already carries.
+    from daimon_briefing import store
+
+    _stdin(monkeypatch, _valid_json("S-from-json"))
+    rc = cli.main(["write-checkpoint", "--project", "/p/A", "--session", "   "])
+    assert rc == 0
+    ck = store.read_latest_body(project_dir="/p/A", route=store.Route.OWN_ELSE_GLOBAL,
+                                admit=store.Admit.ANY)
+    assert ck["session_id"] == "S-from-json"
+
+
 def test_cli_write_checkpoint_invalid_json(tmp_checkpoint_dir, monkeypatch, capsys):
     _stdin(monkeypatch, "not json at all")
     rc = cli.main(["write-checkpoint"])

--- a/plugin/tests/test_corroboration.py
+++ b/plugin/tests/test_corroboration.py
@@ -1093,6 +1093,22 @@ def test_a_real_origin_session_with_the_same_row_still_shows_the_badge():
     assert BADGE_2 in out
 
 
+def test_corroboration_origins_for_is_total_over_a_missing_entry_and_a_non_dict_item():
+    # #983 change 3: the read-time exclusion is called from the render path
+    # and from `daimon why`, both fail-open surfaces. It must be total over
+    # the shapes those callers can hand it: no ledger entry at all (None),
+    # an entry that is not a dict (a torn fold), and an item that is not a
+    # dict. Every such call answers the empty set, never raises, and the
+    # happy path still returns the fold's origins unchanged.
+    assert store.corroboration_origins_for({"origin_session": "S"}, None) == set()
+    assert store.corroboration_origins_for({"origin_session": "S"}, "torn") == set()
+    assert store.corroboration_origins_for("not-a-dict", {"origins": {"O"}}) == {"O"}
+    assert store.corroboration_origins_for({"origin_session": "S"},
+                                           {"origins": {"O"}}) == {"O"}
+    assert store.corroboration_origins_for(
+        {"origin_session": "introspection-x"}, {"origins": {"O"}}) == set()
+
+
 def test_the_stamp_is_transient_and_never_reaches_disk(tmp_checkpoint_dir):
     # The badge is derived at render time from events.jsonl, exactly like
     # withhold's candidate stamps. A `_corroborated` key on a stored

--- a/plugin/tests/test_corroboration.py
+++ b/plugin/tests/test_corroboration.py
@@ -1072,6 +1072,27 @@ def test_a_worldcheck_contradiction_suppresses_the_badge():
     assert "state changed since capture: #60 merged" in out
 
 
+def test_a_provisional_born_item_never_shows_the_badge():
+    # #983 change 3: read-time exclusion. The item's OWN origin_session
+    # carries the introspection- prefix forever (bind_origin's setdefault,
+    # never re-bound) — this is what pre-#983 rows AND #983 B1's fallback ids
+    # both leave behind, so a ledger row recorded before this fix shipped is
+    # discounted exactly like a fresh one would be.
+    out = _rendered(
+        _render_checkpoint(origin_session="introspection-preexisting-abc123"),
+        {ITEM: _entry({OBSERVER})})
+    assert "corroborated" not in out
+
+
+def test_a_real_origin_session_with_the_same_row_still_shows_the_badge():
+    # Control: an item whose first writer was a REAL session (not a
+    # provisional) corroborates normally against the identical ledger row —
+    # change 3 must not blanket-suppress every badge.
+    out = _rendered(_render_checkpoint(origin_session="S-real-983"),
+                    {ITEM: _entry({OBSERVER})})
+    assert BADGE_2 in out
+
+
 def test_the_stamp_is_transient_and_never_reaches_disk(tmp_checkpoint_dir):
     # The badge is derived at render time from events.jsonl, exactly like
     # withhold's candidate stamps. A `_corroborated` key on a stored

--- a/plugin/tests/test_corroboration.py
+++ b/plugin/tests/test_corroboration.py
@@ -30,6 +30,7 @@ import ast
 import json
 import os
 import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -366,6 +367,54 @@ def test_an_origin_from_another_project_emits_nothing(tmp_checkpoint_dir):
     item_id = _seed_origin()
     _seed_origin(project="/p/elsewhere", session="S-foreign")
     assert _emit([(item_id, "S-foreign", "ada")]) == 0
+    assert _rows(tmp_checkpoint_dir) == []
+
+
+def _seed_provisional_origin(project=PROJECT, session=ORIGIN, text=_TEXT):
+    """Same shipping writer as _seed_origin, except the origin checkpoint is
+    a provisional (a `/daimon-end` introspection checkpoint) that was never
+    superseded — e.g. the session crashed before its own SessionEnd
+    reconstruction ran. #983 G7 addition."""
+    store.write_checkpoint(session, {
+        "session_id": session,
+        "source": "introspection",
+        "working_context": {
+            "active_topic": {"text": "seed", "trust": "inferred"},
+            "open_questions": [{"text": text, "trust": "inferred"}],
+            "recent_decisions": [],
+        },
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []},
+    }, project_dir=project)
+    stored = store.read_latest_body(project_dir=project, route=store.Route.OWN,
+                                    admit=store.Admit.ANY)
+    return stored["working_context"]["open_questions"][0]["id"]
+
+
+def test_an_origin_that_is_still_a_provisional_emits_nothing(tmp_checkpoint_dir):
+    # #983 change 2 (containment): a provisional is never a valid origin,
+    # full stop — reuses store.sessions_since_count's exact predicate
+    # (source == "introspection"), never a second detector. This is the
+    # SELF-corroboration case: the introspection checkpoint's own author is
+    # doing the observing (as it would be moments later, once #983 change 1
+    # stamps the SAME real session id on both halves — but this guard does
+    # not need that fix to fire, since it never inspects the observer at all).
+    item_id = _seed_provisional_origin()
+    assert _emit([(item_id, ORIGIN, "ada")]) == 0
+    assert _rows(tmp_checkpoint_dir) == []
+
+
+def test_an_origin_that_is_still_a_provisional_of_a_DIFFERENT_session_also_emits_nothing(
+        tmp_checkpoint_dir):
+    # ACCEPTED LOSS (documented in the #983 issue and _origin_on_disk's
+    # docstring): the origin session here crashed before its own SessionEnd
+    # reconstruction ran, so its per-session file is still the provisional.
+    # A genuinely DIFFERENT, later session's real agreement is discounted
+    # anyway — the guard cannot distinguish "this provisional is still
+    # standing in for its own crashed session" from "this provisional is
+    # itself corroborating", so it refuses both. A missed observation costs
+    # one boost; a forged one costs the axis (carry's own doctrine).
+    item_id = _seed_provisional_origin()
+    assert _emit([(item_id, ORIGIN, "ada")], observer="S-genuinely-later") == 0
     assert _rows(tmp_checkpoint_dir) == []
 
 
@@ -710,6 +759,206 @@ def test_carry_merge_still_runs_when_corroboration_emission_explodes(
     assert written["session_id"] == session
     texts = [q["text"] for q in written["working_context"]["open_questions"]]
     assert "an unrelated prior loop about zephyr batching" in texts
+
+
+# ---------------------------------------------------------------------------
+# #983: a session never corroborates itself, even across the /daimon-end
+# provisional / SessionEnd-reconstruction split.
+#
+# Before this fix, `/daimon-end` (skills/daimon-end/SKILL.md) told the model
+# to INVENT a session id (`introspection-<short-unique-id>`) for its
+# provisional checkpoint. Seconds to minutes later the SAME session's
+# SessionEnd hook reconstructs it under its REAL id, restating the same
+# claim as its own verified verbatim. The two ids differed, so carry.py's G2
+# same-session guard (origin_session == observing session) never fired, and
+# the reconstruction was recorded as an independent witness of its own
+# provisional — a session corroborating itself.
+#
+# Two independent fixes close this, both exercised through the SHIPPING
+# writers (the `write-checkpoint` CLI path for the provisional, `daimon
+# serialize` for the reconstruction — never a hand-shaped checkpoint):
+#
+#   1. Root cause: `write-checkpoint --session <real id>` stamps the live
+#      session's REAL id onto the provisional, so G2 sees both halves as one
+#      session and refuses directly.
+#   2. Containment: `capture._origin_on_disk` refuses ANY provisional
+#      (source == "introspection") as an origin, so even an unpatched skill
+#      install (still inventing an id) or a future bug in G2 cannot mint a
+#      self-corroboration.
+# ---------------------------------------------------------------------------
+
+_REAL_SESSION = "S-real-983"
+_LATER_SESSION = "S-later-983-witness"
+
+
+def _future_transcript(tmp_path, session, quote_text, start):
+    """Same 3-row alternating shape as `_transcript_for`, but stamped
+    strictly AFTER `start` (a datetime) rather than a hardcoded past date —
+    the provisional this session writes first gets `created` = REAL wall-clock
+    time (store.write_checkpoint's setdefault-now; the introspection path has
+    no transcript to backdate it from), so the reconstruction's own `created`
+    (derived from the transcript's last timestamp) must be provably later or
+    store's pointer-regress guard silently no-ops the latest-pointer write
+    (see store._pointer_regresses). Returns (path, the last row's timestamp)."""
+    rows = []
+    for i, (body, offset) in enumerate([
+            (quote_text, 0), ("noted, that matches what we saw", 1),
+            ("same failure again", 2)]):
+        role = "user" if i % 2 == 0 else "assistant"
+        ts = (start + timedelta(minutes=offset)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        rows.append({"type": role, "message": {"role": role, "content": body},
+                     "timestamp": ts})
+    p = tmp_path / f"{session}.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in rows), encoding="utf-8")
+    return p, rows[-1]["timestamp"]
+
+
+def _write_provisional(monkeypatch, project, real_session, text,
+                       invented_label=None, source="introspection"):
+    """The #23 introspection path's OWN shipping writer (cli write-checkpoint),
+    exactly as `/daimon-end` runs it: a JSON body on stdin, `source` defaulted
+    to "introspection", and — the #983 fix — `--session` naming the live
+    session's real id. `invented_label` reproduces the PRE-#983 skill
+    behavior (a placeholder session_id in the JSON body) so the ablation
+    tests below can turn `--session` on and off independently of the JSON
+    body's own claim."""
+    import io
+
+    cp = {
+        "session_id": invented_label or real_session,
+        "working_context": {
+            "active_topic": {"text": "seed", "trust": "inferred"},
+            "open_questions": [{"text": text, "trust": "inferred"}],
+            "recent_decisions": [],
+        },
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []},
+    }
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO(json.dumps(cp)))
+    args = ["write-checkpoint", "--project", project, "--source", source]
+    if real_session:
+        args += ["--session", real_session]
+    assert cli.main(args) == 0
+
+
+def test_a_provisional_and_its_own_reconstruction_never_corroborate(
+        tmp_path, fake_chat_factory, monkeypatch):
+    """The exact #983 field scenario, both changes active. Act 1: the live
+    session writes its own provisional via `/daimon-end`. Act 2: SessionEnd
+    reconstructs the SAME session and independently restates the identical
+    claim as its own verified verbatim — the self-corroboration pattern.
+    Act 3: a genuinely DIFFERENT, later session also restates it — this MUST
+    still corroborate, proving change 2's containment does not outlive the
+    provisional it was refusing (the reconstruction overwrote that
+    session's per-session file, so it no longer reads as a provisional)."""
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", E2E_PROJECT)
+    now = datetime.now(timezone.utc)
+
+    # Act 1: the provisional. The JSON body carries the PRE-#983 invented
+    # placeholder, exactly as an unpatched skill would author it — --session
+    # is what corrects it to the real id, which is the whole point of change
+    # 1: without it this reproduces the bug precondition exactly.
+    _write_provisional(monkeypatch, E2E_PROJECT, _REAL_SESSION, _PREV_TEXT,
+                       invented_label="introspection-preexisting-label")
+    provisional = store.read_checkpoint(_REAL_SESSION)
+    assert provisional["source"] == "introspection"
+    assert provisional["session_id"] == _REAL_SESSION
+
+    # Act 2: the SAME session's SessionEnd reconstruction, independently
+    # restating the identical claim as verified verbatim.
+    recon_start = now + timedelta(minutes=5)
+    tpath, recon_ts = _future_transcript(tmp_path, _REAL_SESSION, _QUOTE,
+                                         recon_start)
+    monkeypatch.setattr(cli, "_chat",
+                        fake_chat_factory(_extraction(_REAL_SESSION, _PREV_TEXT)))
+    assert cli.main(["serialize", str(tpath)]) == 0
+
+    home = tmp_path / ".daimon"
+    assert _corroboration_rows(home) == [], (
+        "a session's own provisional corroborated its own reconstruction")
+    reconstructed = store.read_checkpoint(_REAL_SESSION)
+    assert reconstructed.get("source") != "introspection"  # overwritten
+    item_id = reconstructed["working_context"]["open_questions"][0]["id"]
+    fold = store.corroborations(project_dir=E2E_PROJECT)
+    assert item_id not in fold or fold[item_id]["origins"] == set()
+
+    # Act 3: control — a genuinely different, LATER session restates the
+    # same claim. This is real, independent agreement and must still count,
+    # proving the fix does not blanket-refuse the item forever.
+    later_start = datetime.strptime(recon_ts, "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=timezone.utc) + timedelta(minutes=5)
+    tpath2, _ = _future_transcript(tmp_path, _LATER_SESSION, _QUOTE, later_start)
+    monkeypatch.setattr(
+        cli, "_chat",
+        fake_chat_factory(_extraction(_LATER_SESSION, _PREV_TEXT)))
+    assert cli.main(["serialize", str(tpath2)]) == 0
+
+    rows = _corroboration_rows(home)
+    assert len(rows) == 1, f"expected exactly one genuine witness, got {rows}"
+    assert rows[0]["status"] == f"corroborated-by:{_LATER_SESSION}"
+    fold = store.corroborations(project_dir=E2E_PROJECT)
+    assert fold[item_id]["origins"] == {_LATER_SESSION}
+
+
+def test_self_corroboration_is_blocked_by_change_1_alone(
+        tmp_path, fake_chat_factory, monkeypatch):
+    """Ablation: with change 2's containment DISABLED (monkeypatched back to
+    the pre-#983 project-slug-only check), change 1 alone (the --session
+    override, which lets G2 fire directly) is still enough to block the
+    self-corroboration. The JSON body still carries the pre-#983 invented
+    placeholder — only --session names the real session — so this actually
+    exercises the override rather than a body that already happened to
+    agree with it."""
+
+    def _pre_983_origin_on_disk(origin_session, project):
+        cp = store.read_checkpoint(origin_session)
+        if not isinstance(cp, dict):
+            return False
+        return cp.get("project_slug") == store.project_slug(project)
+
+    monkeypatch.setattr(capture, "_origin_on_disk", _pre_983_origin_on_disk)
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", E2E_PROJECT)
+    now = datetime.now(timezone.utc)
+
+    _write_provisional(monkeypatch, E2E_PROJECT, _REAL_SESSION, _PREV_TEXT,
+                       invented_label="introspection-preexisting-label")  # --session corrects it
+    tpath, _ = _future_transcript(tmp_path, _REAL_SESSION, _QUOTE,
+                                  now + timedelta(minutes=5))
+    monkeypatch.setattr(cli, "_chat",
+                        fake_chat_factory(_extraction(_REAL_SESSION, _PREV_TEXT)))
+    assert cli.main(["serialize", str(tpath)]) == 0
+
+    assert _corroboration_rows(tmp_path / ".daimon") == []
+
+
+def test_self_corroboration_is_blocked_by_change_2_alone(
+        tmp_path, fake_chat_factory, monkeypatch):
+    """Ablation: with change 1 DISABLED (the provisional keeps the pre-#983
+    invented session_id — no `--session` passed, exactly what an unpatched
+    `/daimon-end` skill install still does), change 2's containment alone
+    (any provisional origin is refused) is still enough to block the
+    self-corroboration, even though G2 cannot fire (the two halves carry
+    different ids)."""
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "3")
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", E2E_PROJECT)
+    now = datetime.now(timezone.utc)
+
+    # Change 1 disabled: no real_session passed to --session (None), the
+    # JSON body keeps the old invented placeholder.
+    _write_provisional(monkeypatch, E2E_PROJECT, real_session=None,
+                       text=_PREV_TEXT,
+                       invented_label="introspection-preexisting-label")
+    provisional = store.read_checkpoint("introspection-preexisting-label")
+    assert provisional["source"] == "introspection"
+
+    tpath, _ = _future_transcript(tmp_path, _REAL_SESSION, _QUOTE,
+                                  now + timedelta(minutes=5))
+    monkeypatch.setattr(cli, "_chat",
+                        fake_chat_factory(_extraction(_REAL_SESSION, _PREV_TEXT)))
+    assert cli.main(["serialize", str(tpath)]) == 0
+
+    assert _corroboration_rows(tmp_path / ".daimon") == []
 
 
 # ---------------------------------------------------------------------------

--- a/plugin/tests/test_inspector.py
+++ b/plugin/tests/test_inspector.py
@@ -410,6 +410,31 @@ def test_lifecycle_and_corroboration_fold_without_mutating_evidence(
     }
 
 
+def test_why_never_shows_corroboration_for_a_provisional_born_item(
+    tmp_checkpoint_dir, monkeypatch
+):
+    # #983 change 3: `why` must read the same effective count the briefing
+    # badge does. The item's own origin_session carries the introspection-
+    # prefix forever, so a ledger row recorded before this fix shipped is
+    # discounted here too, not only in the briefing.
+    monkeypatch.setenv("DAIMON_AUTHOR", "alice")
+    _write_checkpoint("S-containing", [
+        _item(receipt=_receipt(_source(), "a" * 64),
+             origin_session="introspection-preexisting-abc123"),
+    ])
+    slug = store.project_slug(_PROJECT)
+    events = tmp_checkpoint_dir / slug / "events.jsonl"
+    events.write_text(json.dumps(
+        {"ts": "2026-08-05T10:01:00Z", "kind": "resolution",
+         "item_ref": store.corroboration_ref(_ITEM_ID),
+         "status": "corroborated-by:S-witness-1", "source": "capture"},
+    ) + "\n", encoding="utf-8")
+
+    result = inspector.inspect_item(_PROJECT, _ITEM_ID)
+
+    assert result["corroboration"] == {"count": 0, "references": []}
+
+
 @pytest.mark.parametrize("status, expected", [
     ("resolved", "resolved"),
     ("superseded-by:o-fedcba", "superseded"),

--- a/skills/daimon-end/SKILL.md
+++ b/skills/daimon-end/SKILL.md
@@ -80,6 +80,10 @@ a `prev` pointer. So it does not need to be perfect to be useful.
    }
    ```
 
+   `session_id` above is a placeholder only — step 5's `--session` flag is what
+   actually names this session, and it overrides whatever goes here. Leave it
+   as shown; do not spend effort inventing a better one.
+
    Every item needs `text` + `trust`. `external_state: true` marks items whose
    state may have changed *outside* the AI session (a PR you'll merge, a deploy) —
    these surface first in the briefing.
@@ -95,11 +99,21 @@ a `prev` pointer. So it does not need to be perfect to be useful.
 
 5. **Write it** via the CLI (reads JSON on stdin, validates the schema, routes to
    this project + global + a per-session file, atomically, with rotation). Write
-   the JSON to a temp file and pipe it:
+   the JSON to a temp file and pipe it, passing THIS session's real id with
+   `--session` (Claude Code exposes it as the `CLAUDE_CODE_SESSION_ID`
+   environment variable — the same id the SessionEnd hook will use to
+   reconstruct this session later):
 
    ```bash
-   daimon write-checkpoint --project "$PWD" < /tmp/daimon-end.json
+   daimon write-checkpoint --project "$PWD" --session "$CLAUDE_CODE_SESSION_ID" < /tmp/daimon-end.json
    ```
+
+   `--session` is what lets the later reconstruction recognize this checkpoint
+   as its OWN earlier state rather than a distinct witness — without it, this
+   checkpoint and its own reconstruction can misread as two independent
+   sessions agreeing with each other (#983). If your host cannot tell you the
+   live session's own id, omit `--session` — the checkpoint still writes, it
+   just loses that recognition.
 
    It prints `wrote checkpoint: <path> (source: introspection)`. If it reports a
    schema-validation error, fix the JSON and retry — do not store garbage.

--- a/skills/daimon-end/SKILL.md
+++ b/skills/daimon-end/SKILL.md
@@ -80,9 +80,12 @@ a `prev` pointer. So it does not need to be perfect to be useful.
    }
    ```
 
-   `session_id` above is a placeholder only — step 5's `--session` flag is what
-   actually names this session, and it overrides whatever goes here. Leave it
-   as shown; do not spend effort inventing a better one.
+   `session_id` above is a placeholder only. Step 5's `--session` flag, when
+   your host can supply one, replaces it with this session's real id; when it
+   cannot, the CLI itself replaces the placeholder with a fresh generated id
+   rather than ever writing the literal text above. Leave it exactly as shown
+   — do not spend effort inventing a better one, and never invent a
+   `session_id` here as a substitute for `--session`.
 
    Every item needs `text` + `trust`. `external_state: true` marks items whose
    state may have changed *outside* the AI session (a PR you'll merge, a deploy) —
@@ -99,21 +102,28 @@ a `prev` pointer. So it does not need to be perfect to be useful.
 
 5. **Write it** via the CLI (reads JSON on stdin, validates the schema, routes to
    this project + global + a per-session file, atomically, with rotation). Write
-   the JSON to a temp file and pipe it, passing THIS session's real id with
-   `--session` (Claude Code exposes it as the `CLAUDE_CODE_SESSION_ID`
-   environment variable — the same id the SessionEnd hook will use to
-   reconstruct this session later):
+   the JSON to a temp file, then check whether your host exposes the live
+   session's own id (Claude Code does, as the `CLAUDE_CODE_SESSION_ID`
+   environment variable) and pass it with `--session` when it does:
 
    ```bash
-   daimon write-checkpoint --project "$PWD" --session "$CLAUDE_CODE_SESSION_ID" < /tmp/daimon-end.json
+   if [ -n "$CLAUDE_CODE_SESSION_ID" ]; then
+     daimon write-checkpoint --project "$PWD" --session "$CLAUDE_CODE_SESSION_ID" < /tmp/daimon-end.json
+   else
+     daimon write-checkpoint --project "$PWD" < /tmp/daimon-end.json
+   fi
    ```
 
-   `--session` is what lets the later reconstruction recognize this checkpoint
-   as its OWN earlier state rather than a distinct witness — without it, this
-   checkpoint and its own reconstruction can misread as two independent
-   sessions agreeing with each other (#983). If your host cannot tell you the
-   live session's own id, omit `--session` — the checkpoint still writes, it
-   just loses that recognition.
+   `--session` is what lets the later SessionEnd reconstruction recognize this
+   checkpoint as its OWN earlier state rather than a distinct witness — without
+   it, this checkpoint and its own reconstruction could misread as two
+   independent sessions agreeing with each other (#983). On a host with no live
+   session id to give it, the CLI still writes the checkpoint (falling back to
+   its own generated id, never a placeholder), but this provisional cannot be
+   linked to its own reconstruction — accept that any item born here will
+   never accrue a corroboration badge, on that host, and move on; that is a
+   known and permanent limit of a host with no live session id, not a bug to
+   work around.
 
    It prints `wrote checkpoint: <path> (source: introspection)`. If it reports a
    schema-validation error, fix the JSON and retry — do not store garbage.

--- a/website/docs/concepts/trust-classes.md
+++ b/website/docs/concepts/trust-classes.md
@@ -109,7 +109,9 @@ What earns the badge:
   *that* session's transcript.
 - The claim's **first writer is provably someone else** — every item records
   the session that originally wrote it, and a session cannot corroborate
-  itself.
+  itself. A `/daimon-end` checkpoint and the automatic reconstruction of that
+  same session count as one session, not two, so restating a provisional
+  checkpoint's own claim never earns the badge.
 - The total reaches **two** — the origin of record plus at least one
   independent witness.
 

--- a/website/docs/concepts/trust-classes.md
+++ b/website/docs/concepts/trust-classes.md
@@ -109,9 +109,14 @@ What earns the badge:
   *that* session's transcript.
 - The claim's **first writer is provably someone else** — every item records
   the session that originally wrote it, and a session cannot corroborate
-  itself. A `/daimon-end` checkpoint and the automatic reconstruction of that
-  same session count as one session, not two, so restating a provisional
-  checkpoint's own claim never earns the badge.
+  itself. A `/daimon-end` provisional checkpoint's own automatic
+  reconstruction can never earn the badge on that claim. On a host that can
+  tell the live session its own id, that is the only loss: once the
+  reconstruction lands, a genuinely later session can still corroborate the
+  claim normally. On a host that cannot, the loss is permanent: every item
+  the provisional wrote never earns the badge, from any session, ever —
+  daimon has no way to tell "this session agreed with its own earlier
+  provisional" apart from "a different session agreed."
 - The total reaches **two** — the origin of record plus at least one
   independent witness.
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/trust-classes.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/trust-classes.md
@@ -119,7 +119,10 @@ Qué gana la insignia:
   cita verbatim verificada contra el transcript de *esa* sesión.
 - El primer autor de la afirmación es **demostrablemente otro** — cada ítem
   registra la sesión que lo escribió originalmente, y una sesión no puede
-  corroborarse a sí misma.
+  corroborarse a sí misma. Un checkpoint de `/daimon-end` y la reconstrucción
+  automática de esa misma sesión cuentan como una sola sesión, no dos, así que
+  reafirmar la propia afirmación de un checkpoint provisional nunca gana la
+  insignia.
 - El total llega a **dos** — el origen registrado más al menos un testigo
   independiente.
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/trust-classes.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/trust-classes.md
@@ -119,10 +119,15 @@ Qué gana la insignia:
   cita verbatim verificada contra el transcript de *esa* sesión.
 - El primer autor de la afirmación es **demostrablemente otro** — cada ítem
   registra la sesión que lo escribió originalmente, y una sesión no puede
-  corroborarse a sí misma. Un checkpoint de `/daimon-end` y la reconstrucción
-  automática de esa misma sesión cuentan como una sola sesión, no dos, así que
-  reafirmar la propia afirmación de un checkpoint provisional nunca gana la
-  insignia.
+  corroborarse a sí misma. La reconstrucción automática de un checkpoint
+  provisional de `/daimon-end` nunca puede ganar la insignia sobre esa misma
+  afirmación. En un host que puede indicarle a la sesión viva su propio id,
+  esa es la única pérdida: una vez que la reconstrucción se asienta, una
+  sesión genuinamente posterior sigue pudiendo corroborar la afirmación con
+  normalidad. En un host que no puede, la pérdida es permanente: todo ítem
+  que el provisional escribió nunca gana la insignia, de ninguna sesión,
+  nunca — daimon no tiene forma de distinguir "esta sesión coincidió con su
+  propio provisional anterior" de "una sesión distinta coincidió".
 - El total llega a **dos** — el origen registrado más al menos un testigo
   independiente.
 


### PR DESCRIPTION
Closes #983

## What

A `/daimon-end` provisional checkpoint and the SessionEnd hook's own
reconstruction of that same session used to carry two different session
ids: the skill told the model to invent one
(`introspection-<short-unique-id>`) for the provisional, and the
reconstruction later ran under the real one. Since carry.py's G2 guard
refuses a corroboration only when the origin session equals the observing
session, the two halves of one session never matched, and the
reconstruction was recorded as an independent witness of its own
provisional.

Three changes, all exercised end to end through the shipping writers (the
`write-checkpoint` CLI path for the provisional, `daimon serialize` for the
reconstruction, never a hand-shaped checkpoint):

1. `daimon write-checkpoint` accepts a new `--session <id>` flag that stamps
   the live session's real id onto the checkpoint in place of whatever
   `session_id` the JSON body carries. `skills/daimon-end/SKILL.md` no
   longer instructs the model to invent one; it branches on whether the
   host exposes a live session id (`$CLAUDE_CODE_SESSION_ID` on Claude
   Code) and passes `--session` only when it does. With this in place, G2
   sees both halves of the session as one and refuses the self-corroboration
   directly.

   A host with no live-session-id concept at all (no `--session`) combined
   with a model that pipes the skill's own JSON template through unfilled
   would otherwise write the literal placeholder text
   `introspection-<short-unique-id>` as a CONSTANT id, verified with the
   real CLI: every `/daimon-end` on that host, any project, overwrote the
   same file. `write-checkpoint` now detects a blank, missing, or
   angle-bracket-shaped `session_id` (with no `--session` override) and
   substitutes a fresh, unique `introspection-<uuid hex>` id instead, so the
   CLI never persists a placeholder-shaped id regardless of host or model
   behavior.

2. `capture._origin_on_disk` refuses any origin checkpoint whose `source`
   is `introspection`, reusing the exact predicate
   `store.sessions_since_count` already uses to exclude provisionals from
   session counting, rather than inventing a second detector. This is a
   write-time, second line of defense: even an unpatched skill install that
   still invents a session id, or a future bug in G2, cannot mint a
   self-corroboration this way.

3. A new read-time exclusion, `store.corroboration_origins_for`, used by
   both the briefing badge (`briefing.mark_corroborated`) and `daimon why`
   (`inspector.inspect_item`): an item whose `origin_session` starts with
   the literal `introspection-` prefix never counts a corroboration origin,
   no matter when the ledger row was written or which session wrote it.
   This closes the gap changes 1 and 2 leave open for the field data
   already on disk (rows written before this fix, from every host) and for
   any host where change 1's `--session` was never available. No extra I/O:
   the exclusion reads only a field already loaded at every call site.

## Accepted loss, stated precisely

On a host that can supply a live session id to `--session` (Claude Code
today), the loss is narrow: change 3 never fires for items born there,
because their `origin_session` is the real session id, not an
`introspection-` one. The only case discounted is a session that crashed
before its own reconstruction ran, so a later, genuinely different session's
agreement with that stranded provisional is refused (change 2's
containment), a missed observation rather than a wrong one.

On a host with no live session id at all, the loss is total and permanent:
every item a provisional there ever writes carries an `introspection-`
`origin_session` forever, so change 3 discounts it against every future
ledger row, from every session, forever. `skills/daimon-end/SKILL.md` says
this plainly and does not try to soften it: there is nothing daimon can do
about it without a live id to bind to.

On-disk facts verified while building this: the provisional is never lost
data even where its corroboration is discounted. `store.write_checkpoint`
rotates the previous `latest.json` into `prev-1.json` as a full blob, not a
diff, so the provisional's content survives at least
`DAIMON_CHECKPOINT_HISTORY` generations regardless of what supersedes it.
And the SessionEnd reconstruction is never accidentally skipped because a
provisional happens to occupy the same per-session file first: the
identical-bytes guard (`store.transcript_unchanged`, #185) only short-
circuits when the existing checkpoint at that session id carries a
`transcript_hash`, and the introspection path never stamps one.

Read-time exclusion of already-written rows was the one change deferred in
an earlier round of this fix, on the belief that no field linked a
corroboration row back to its origin. Review found the field that does
exist: the `introspection-` prefix itself, permanently stamped on the
item's own `origin_session` (change 3 above).

## Why

The corroboration badge exists to measure independent agreement across
sessions. A session's own provisional and its own reconstruction are the
same session's writing restated to itself, not agreement, and the field
data was unambiguous about how often this fired: on the two real stores
this issue measured, the large majority of every corroboration row whose
origin still existed was exactly this pattern, not a genuine second
session.

## Tests

Full suite run twice on the final tree, rebased onto main, both times 6025
passed, 2 skipped, with the checkpoint store, recall database and log
directory pointed at empty temporary directories. Baseline on main at the
rebased branch point was 6010 passed, 2 skipped; this branch adds 16
tests, the last a unit test added after the patch-coverage report for the
read-time exclusion's guard on a missing or torn ledger entry, run alone
and fenced. ruff and mypy are clean under the commands CI runs.

Coverage: a session's own provisional and its own reconstruction restating
the identical claim as verified verbatim produce no corroboration row,
driven through the real `write-checkpoint` and `serialize` CLI paths. A
genuinely different, later session restating the same claim afterward still
corroborates normally, once the origin session's own reconstruction has
landed. A provisional origin from a different, still-provisional session
(one that never got reconstructed) is refused too, with the accepted-loss
tradeoff stated in the test. A literal unfilled placeholder body with no
`--session`, and a blank body `session_id` with no `--session`, both get a
fresh unique id rather than a constant one; two such calls in the SAME
project write to two different on-disk checkpoint paths, which is the
exact collision this fix exists to prevent. A pre-fix-shaped item (an
`introspection-` origin) with a
ledger row already on it renders no badge and `why` reports zero, both
before and after the row was written; a normal item with the identical row
still renders and reports normally.

Every new production change was fenced individually: disabling it and
confirming the test that covers it goes red, then restoring it. For the
core write-time self-corroboration scenario specifically, changes 1 and 2
were also fenced against EACH OTHER: with only change 2 active (no
`--session`, the pre-fix invented placeholder in the body) the scenario
still blocks; with only change 1 active (change 2 reverted to its
pre-#983 shape) it still blocks too, each is independently sufficient
there. Change 3 covers a scenario neither 1 nor 2 reaches at all (a ledger
row already on disk, or a host with no live id ever available), and was
fenced on its own: removing only its prefix check reproduces a visible
badge and a nonzero `why` count on a pre-fix-shaped item while changes 1
and 2 stay in place, confirming it is not redundant with either.
