### PR TITLE
chore(scars): promote scars 0077 to 0084 from the 983, 984 and 961 slice 3 and 4 reviews

### DIFF
--- a/.scars/0077-carried_from-is-never-stamped-on-a-twin-pair.fence.md
+++ b/.scars/0077-carried_from-is-never-stamped-on-a-twin-pair.fence.md
@@ -1,0 +1,39 @@
+---
+id: 77
+type: fence
+title: carry.merge stamps carried_from only on the plain-carry path, never on a twin (corroborating) pair
+severity: medium
+confidence: 0.85
+created: 2026-09-08
+authors: ["claude-code"]
+promoted_by: Kibukx
+promoted_by_source: explicit
+anchors:
+  - path: plugin/daimon_briefing/carry.py
+  - pattern: "carried_from"
+evidence:
+  - note: #983 investigation: designing a read-time exclusion for already-written corroboration ledger rows (project the item's origin_session forward from the OBSERVER's own checkpoint) required a field linking the observer's stored item back to the checkpoint it was merged from. carried_from looked like that field. Reading carry.py's merge() top to bottom: the plain-carry branch (an item with no native twin) does `kept.setdefault(\"carried_from\", prev_sid)` before appending to `carried`. The twin branch (a native item that MATCHES a prev item — the exact shape a corroboration observation fires on) `continue`s out earlier, after inheriting only origin_session/origin_author onto the twin — never carried_from. So the one case this field would have been useful for (auditing which prev checkpoint a corroborating item came from) is exactly the case it is never stamped in.
+expires:
+  condition: "carry.merge starts stamping carried_from (or an equivalent pointer) on the twin/corroboration branch too"
+  review_after: 2027-03-08
+status: active
+---
+
+Do not reach for `carried_from` to reconstruct which checkpoint a corroborating
+(twin-matched) item was merged from — it is unset on that path by design (see
+carry.py's twin branch, ~line 470-513: only `origin_session`/`origin_author`
+are inherited there, via `setdefault`). `carried_from` is stamped exclusively
+on the plain-carry branch (~line 535, an item with no native match this
+session), because the docstring's own reasoning is that a twin is NOT a copy
+— re-stamping `carried_from` on a reworded restatement would misname the
+session that actually wrote the words.
+
+If a future change needs to answer "which checkpoint did this corroborating
+item's LAST merge read as prev," it has to add a new field for that — probing
+`carried_from` will silently read as absent on every twin, which looks like
+"never carried" rather than "carried via the twin rail, field not tracked
+here." This is why #983's change 3 (read-time exclusion of pre-fix
+self-corroboration ledger rows) was deferred: there is no on-disk pointer from
+a corroboration ledger row back to the origin checkpoint it was measured
+against, and reconstructing one from `carried_from` does not work for exactly
+this reason.

--- a/.scars/0078-narrowing-a-composer-strands-an-earlier-slices-real-pipeline-test.fence.md
+++ b/.scars/0078-narrowing-a-composer-strands-an-earlier-slices-real-pipeline-test.fence.md
@@ -1,0 +1,53 @@
+---
+id: 78
+type: fence
+title: Narrowing a shared composer strands an earlier slice's "built through the real pipeline" test — rewrite it against a synthetic row, don't weaken the assertion
+severity: medium
+confidence: 0.8
+created: 2026-09-08
+authors: ["claude-code"]
+promoted_by: Kibukx
+promoted_by_source: explicit
+anchors:
+  - path: plugin/daimon_briefing/pending.py
+  - path: plugin/tests/test_cli_decide.py
+  - path: plugin/tests/test_pending.py
+evidence:
+  - note: #961 slice 3, feat/961-slice3-agent-accept-info
+expires:
+  condition: "pending.py's request lane and lifecycle._decide_cards are merged into one function, or the queue-row shape stops carrying a synthesizable dict"
+  review_after: 2027-03-01
+status: active
+---
+
+#961 slice 2 shipped three tests whose docstrings explicitly argue a synthetic
+row is the WEAKER proof and insist on driving `kind="info"` through the real
+`pending.queue` -> `lifecycle._decide_cards` pipeline
+(`test_decide_card_shows_the_info_marker_for_an_info_request`,
+`test_decide_card_lane_tag_is_never_overloaded_by_the_approval_kind`,
+`test_decide_card_with_the_info_marker_still_gets_ledger_header_spans`).
+Slice 3 added one line to `pending._request_rows` excluding
+`kind == "info"` from the request lane entirely. That line made all three
+tests fail outright (not silently — `pending.queue` no longer returns the
+row at all), because the scenario their own docstrings argued for is no
+longer reachable through the shipped pipeline.
+
+The fix was not to delete the coverage: `_decide_cards` itself is unchanged,
+generic code that still has to render the marker/lane-tag/header-span shape
+correctly if handed a row with `approval == "info"` — the file's own
+`test_decide_cards_lane_guard_is_load_bearing_not_dead_code` already
+established the "hand `_decide_cards` a synthetic row" pattern for exactly
+this reason (a future bug elsewhere leaking `approval` onto a non-request
+lane), so the other three tests were rewritten to use it too, with a
+docstring note on why the real pipeline no longer applies. Full record in
+that commit's diff to `plugin/tests/test_cli_decide.py`.
+
+A future editor narrowing what a shared composer (`pending.queue`,
+`requests.recipient_join`, `requests.inbox_renderable`, …) returns must grep
+the CONSUMERS of that composer for tests whose docstrings claim "built
+through the real pipeline, not hand-typed" — those are the ones a narrowing
+change silently invalidates, and running the full suite is what catches it
+(it did here: 3 failures on the first full run after the pending.py change).
+Rewrite them against a synthetic row shaped like the composer's own row
+builder, matching the pattern this file already established — never just
+delete the assertion or loosen it to pass again.

--- a/.scars/0079-provisional-origin-check-is-time-sensitive-after-983.fence.md
+++ b/.scars/0079-provisional-origin-check-is-time-sensitive-after-983.fence.md
@@ -1,0 +1,38 @@
+---
+id: 79
+type: fence
+title: after #983, a provisional's per-session file only reads as a provisional until its OWN reconstruction lands
+severity: low
+confidence: 0.8
+created: 2026-09-08
+authors: ["claude-code"]
+promoted_by: Kibukx
+promoted_by_source: explicit
+anchors:
+  - path: plugin/daimon_briefing/capture.py
+  - pattern: "_origin_on_disk"
+evidence:
+  - pr: 983
+  - note: #983 fix: write-checkpoint --session now stamps the SAME real session id on a /daimon-end provisional and its later SessionEnd reconstruction, so store.write_checkpoint's path = _contained_path(d, session_id) makes the reconstruction overwrite the provisional's own per-session file in place. capture._origin_on_disk reads that same file to decide whether an origin is a provisional (source == \"introspection\"). Before the session's own reconstruction runs, the file answers 'yes, provisional' (refuses); the instant the reconstruction writes, the same path answers 'no' (source is unset), because it is a different checkpoint occupying the same filename. Verified in test_a_provisional_and_its_own_reconstruction_never_corroborate: a THIRD session's later corroboration of the same claim succeeds only because, by the time it runs, the origin session's reconstruction has already overwritten the file.
+expires:
+  condition: "the per-session file gains a durable 'this session was ever provisional' marker that survives being overwritten by its own reconstruction"
+  review_after: 2027-03-08
+status: active
+---
+
+Do not assume `capture._origin_on_disk`'s provisional check (source ==
+"introspection") is a permanent property of a session id — after #983, it is
+a property of whichever checkpoint currently occupies that session's
+per-session file, and that file gets overwritten in place the moment the
+session's own SessionEnd reconstruction runs (same session id, same
+`_contained_path`). A corroboration emitted in the narrow window between a
+provisional write and its own reconstruction sees "provisional, refuse"; the
+identical origin, checked moments later after the reconstruction lands, sees
+"not a provisional, allow." This is intentional (a session that actually
+finished should be able to back a corroboration once its real transcript
+lands) but it means a test or a future reader reasoning about "was session S
+ever provisional" from `read_checkpoint(S)` alone gets a TIME-DEPENDENT
+answer, not a fact about S's history. If a durable answer is ever needed
+(e.g. an audit trail), it has to come from somewhere other than the
+overwritable per-session file — the reconstruction has no field today that
+records "this session was provisional at some point."

--- a/.scars/0080-revise-clear-must-gate-on-the-claim-writer-not-the-event.landmine.md
+++ b/.scars/0080-revise-clear-must-gate-on-the-claim-writer-not-the-event.landmine.md
@@ -1,0 +1,38 @@
+---
+id: 80
+type: landmine
+title: "Clearing done_* fields on a `revised` row unconditionally erases a settled HUMAN completion reachable through needs-info; gate the clear on done_pending (the AGENT-claim writer), never on the `revised` event alone"
+severity: high
+confidence: 0.9
+created: 2026-09-09
+authors: ["claude-code"]
+promoted_by: Kibukx
+promoted_by_source: explicit
+anchors:
+  - path: plugin/daimon_briefing/requests.py
+  - pattern: "event == .revised."
+evidence:
+  - note: "#978 review round 2 (B1). A first fix (round 1, F1) landed a
+expires:
+  condition: "done_pending stops being the sole write site for an agent completion claim (e.g. a second claim-shaped field is added elsewhere) without updating this gate"
+  review_after: 2027-03-01
+status: active
+---
+
+The `revised` branch in `requests.fold` (requests.py) is the one place a sender
+opens a settled record back up. Any field it clears there must be gated on
+WHO WROTE the field's current value, never on the event name in isolation — a
+`revised` row does not know, and must not assume, that whatever sits in
+`done_*` right now came from an agent claim it is entitled to erase.
+
+`done_pending` is the correct gate specifically because it has exactly one
+writer: the non-human `done` landing on a `work` record no person has
+accepted (requests.py's own #978 branch). It is never True for a human
+`done`, an `info`-kind completion, or a completion on an already-accepted
+record — all three of which the earlier code path already excludes from
+`done_pending` in the first place. So `if current["done_pending"]:` is not an
+extra check bolted on for one bug; it is the field that already answers "is
+there an agent claim here" everywhere else in this same fold. A future editor
+adding a new way to reach `done_*` on a record must either write through
+`done_pending` too, or add its own gate here — clearing on the raw event name
+is the deadend this scar exists to name.

--- a/.scars/0081-skill-json-template-placeholder-can-reach-the-cli-verbatim.landmine.md
+++ b/.scars/0081-skill-json-template-placeholder-can-reach-the-cli-verbatim.landmine.md
@@ -1,0 +1,41 @@
+---
+id: 81
+type: landmine
+title: a skill's example JSON template value can reach the CLI byte-for-byte unfilled, not just wrong
+severity: high
+confidence: 0.85
+created: 2026-09-08
+authors: ["claude-code"]
+promoted_by: Kibukx
+promoted_by_source: explicit
+anchors:
+  - path: skills/
+  - path: plugin/daimon_briefing/cli/__init__.py
+  - pattern: "write-checkpoint"
+evidence:
+  - pr: 983
+  - note: #983 round 1 shipped write-checkpoint --session, assuming a host without a live session id would still get a model-invented, at least locally-unique, session_id in the JSON body (the pre-fix behavior). Round 2 review verified with the real CLI on a host with no --session available: a model that pipes the skill's own example template through with the placeholder field UNFILLED writes the literal text \"introspection-<short-unique-id>\" to disk as a session_id. Because that string is a CONSTANT (not derived from anything per-invocation), every subsequent /daimon-end write on that host, in ANY project, landed at the exact same per-session file path and overwrote the PRIOR provisional outright, worse than the original bug (which at least produced distinct, if wrongly-linked, ids).
+expires:
+  condition: "the skill format gains a templating mechanism the model cannot pipe through unfilled (e.g. the CLI generates and returns the id, rather than asking for one in the request body)"
+  review_after: 2027-03-08
+status: active
+---
+
+Do not assume a model reliably replaces a placeholder shown inside a skill's
+example JSON (`"session_id": "introspection-<short-unique-id>"`) before
+piping that JSON to a CLI. A model can, and in practice does, forward the
+literal example text unchanged, angle brackets and all. If a field like this
+also has to be UNIQUE per invocation for downstream identity logic (as
+`session_id` is for corroboration linking, #983), a literal unfilled
+placeholder is not merely wrong, it is a constant that collides across every
+future invocation, silently overwriting prior state each time.
+
+The fix pattern: the CLI receiving the value must independently validate its
+SHAPE (blank, missing, or containing template markers like `<`/`>`) and
+substitute a freshly generated value when it looks unfilled, rather than
+trusting that a schema-shaped request implies a model actually replaced
+every placeholder in it. Never rely on prose instructions alone ("leave it
+as shown, the CLI replaces it") to guarantee a downstream consumer treats an
+unfilled field correctly; when identity or uniqueness is load-bearing,
+generate it in code, on the receiving end, whenever the caller cannot
+reliably supply the real thing.

--- a/.scars/0082-current-only-policy-snapshot-reverts-a-landed-accept.landmine.md
+++ b/.scars/0082-current-only-policy-snapshot-reverts-a-landed-accept.landmine.md
@@ -1,0 +1,37 @@
+---
+id: 82
+type: landmine
+title: Injecting a CURRENT-STATE ruling snapshot into a fold's re-check of an already-landed decision makes that decision depend on another ledger's later state
+severity: high
+confidence: 0.9
+created: 2026-09-09
+authors: ["claude-code"]
+promoted_by: Kibukx
+promoted_by_source: explicit
+anchors:
+  - path: plugin/daimon_briefing/requests.py
+  - path: plugin/daimon_briefing/refutations.py
+  - pattern: "active_request_policies|request_policy_history"
+evidence:
+  - note: #961 slice 4 build, 2026-09-09: the first implementation injected refutations.active_request_policies (state == active only) into requests.fold's widened accept exception. Two tests failed identically: a ruling retired AFTER an agent accept landed under it, and a ruling revised to a different sender AFTER the same, both reverted the already-accepted record back to open on the very next re-fold, because fold recomputes state from scratch every call from a policy set resolved fresh each time. Fixed by adding refutations.request_policy_history, a MONOTONIC set built by folding every prefix of the ruling ledger and accumulating every snapshot where the grant was active, so a hash that was ever legitimately active stays valid for the fold's re-check forever, even past the ruling's later overturn. The write boundary (accept()) correctly kept using the current-state snapshot, since refusing NEW accepts after overturn is a different question the fold's own re-check must not answer the same way.
+expires:
+  condition: "requests.fold or refutations.active_request_policies changes shape enough that this reasoning no longer applies, or the fold gains genuine memory across calls"
+  review_after: 2027-03-09
+status: active
+---
+
+Whenever a fold-style function re-derives a record's state from scratch on
+every call, and that derivation consults a SECOND ledger's CURRENT state to
+decide whether an already-landed transition still counts, a later change to
+the second ledger silently reverts the first. The bug reads as "the accept
+disappeared" with no error anywhere: `fold` ran cleanly, the policy set was
+resolved cleanly, the membership test just came back false the second time.
+
+The fix is not "cache the old result" (the fold has no state to cache into)
+but to make the injected fact itself monotonic: a set of everything the
+second ledger ever validated, not everything it validates right now. The
+write boundary that MINTS a new dependent fact should still use the
+current-state question; only the re-derivation of a past one needs the
+historical question. Conflating the two in one resolver function is the
+trap — build two, name them for the question each answers, and never let a
+caller reach for the wrong one by habit.

--- a/.scars/0083-monotonic-policy-history-admits-a-post-overturn-forgery.fence.md
+++ b/.scars/0083-monotonic-policy-history-admits-a-post-overturn-forgery.fence.md
@@ -1,0 +1,40 @@
+---
+id: 83
+type: fence
+title: refutations.request_policy_history checks order-aware intervals, not membership; a row that BACKDATES its order into an old window is still indistinguishable from a genuine accept made then
+severity: low
+confidence: 0.85
+created: 2026-09-09
+authors: ["claude-code"]
+promoted_by: Kibukx
+promoted_by_source: explicit
+anchors:
+  - path: plugin/daimon_briefing/refutations.py
+  - path: plugin/daimon_briefing/requests.py
+  - pattern: "request_policy_history|_covered_by_policy"
+evidence:
+  - note: #961 slice 4 build, 2026-09-09: the first implementation of request_policy_history was a MONOTONIC set (every grant ever active, no notion of when), which closed binding decision 3 (a past accept survives an overturn) but left a gap: a request row forged directly via requests.append (bypassing accept() entirely) citing a once-active, since-overturned ruling id/hash landed unconditionally, since a forged row's CURRENT order was never checked against anything. Fixed in the same session, before merge, per review: request_policy_history now returns (sender, kind, verb, by, ruling_id, sha256, active_from, active_until) INTERVALS in `order` units (both refutations._stamp and requests._stamp compute order = time.time_ns(), one clock, verified not assumed), and requests._covered_by_policy requires the accepted row's own order to fall inside the interval. A forged row with a CURRENT order citing an overturned hash is now inert (tests/test_requests.py::test_a_forged_row_with_a_current_order_citing_an_overturned_hash_is_inert). The narrower residual that remains: a row that ALSO backdates its own order (_stamp(..., now_ns=...)) into a window that WAS legitimately open for that exact grant is indistinguishable from a genuine accept made then, since order is the only ordering signal available and the forger controls it. Pinned by tests/test_requests.py::test_disclosed_gap_a_backdated_forged_row_inside_an_old_window_still_lands.
+expires:
+  condition: "the codebase gains a cross-ledger physical ordering primitive independent of the order field a writer supplies (e.g. a monotonic append-position counter neither ledger's caller can set), or accept() gains its own tamper-evident receipt distinct from a raw requests.append row"
+  review_after: 2027-03-09
+status: active
+---
+
+This is now a much narrower gap than the monotonic-set version it replaced.
+Reaching it requires: (1) `requests.append` access, already inside the
+trust boundary every other forged-row scenario in this codebase assumes;
+(2) knowing a specific ruling id and its exact historical policy hash from
+a window that genuinely was open at some point; (3) the ability to set
+`order` on the forged row to a value inside that window rather than the
+current time, which every write path but a direct `requests.append` call
+denies.
+
+Do not try to close this by making `order` unforgeable at the field level
+(a caller with `requests.append` access can already write any well-formed
+row) or by adding a monotonic counter that only `_stamp` increments (a
+forger calling `_stamp` gets a fresh one same as anyone, so it does not
+help unless the counter is bound to something outside the row itself,
+like an append-position the file offset already encodes but nothing reads
+back today). If this is ever worth closing, the shape is a receipt written
+by `accept()` itself into a THIRD location neither ledger's `append`
+reaches, not another field on the row a forger already controls.

--- a/.scars/0084-two-founder-passes-with-unequal-shape-checks-disagree.landmine.md
+++ b/.scars/0084-two-founder-passes-with-unequal-shape-checks-disagree.landmine.md
@@ -1,0 +1,32 @@
+---
+id: 84
+type: landmine
+title: Two independent pre-passes deriving related facts from the same founder row will disagree the moment only one applies the read-boundary shape check
+severity: high
+confidence: 0.9
+created: 2026-09-09
+authors: ["claude-code"]
+promoted_by: Kibukx
+promoted_by_source: explicit
+anchors:
+  - path: plugin/daimon_briefing/requests.py
+  - pattern: "_founder_by_id|_founder_kind_by_id|_founder_origin_by_id"
+evidence:
+  - note: #961 slice 4 review round 2, item C1, 2026-09-09: slice 4 added `_founder_origin_by_id` beside the existing `_founder_kind_by_id`, both walking the same sorted `opened` rows to answer two DIFFERENT questions about the same founder row (its kind, its origin bucket). `_founder_kind_by_id` applied the read-boundary shape check (`_SLUG_RE` on `to`, a non-empty `ask`) before accepting a row as founder — the identical check `fold`'s own founder branch makes. `_founder_origin_by_id` was written fresh and never carried that check over, because origin felt like a different, simpler question. A shape-invalid `opened` row (empty ask) planted in a foreign bucket at an EARLIER order than the genuine founder therefore could not win `kind` (shape-checked pass skipped it) but DID win `origin` (unchecked pass accepted it), so a record's `kind`/`ask`/`to` came from the genuine sender while its `from_slug` — and every policy match keyed on it — came from an entirely different, invalid row a stranger controlled. Fixed by merging both passes into `_founder_by_id`, which resolves `(kind, origin_slug)` from the SAME founder row under the SAME shape check, so the two fields cannot drift apart by construction.
+expires:
+  condition: "the founder-resolution pattern (a pre-pass over opened rows deciding a fold-time fact before the main pass runs) is retired or replaced with a different mechanism entirely"
+  review_after: 2027-03-09
+status: active
+---
+
+When a fold-style reader needs two or more facts about "the row that founded
+this record" (kind, origin, author, whatever), resolve them all from ONE
+pre-pass over ONE sorted list, applying the read-boundary shape check ONCE,
+before returning any of them. Do not write a second pre-pass "for the other
+field" even when it looks like a simpler, independent question — it will
+silently diverge from the first the moment a malformed or forged row can
+satisfy one check and not the other, and the two answers will disagree about
+which row is authoritative with no error anywhere. The fold's own founder
+branch is the one true shape check; every pre-pass computing a founder-derived
+fact must call the identical guard, ideally by construction (one function,
+one return of a tuple/dict) rather than by remembering to copy it.


### PR DESCRIPTION
Scars-only PR. Human sign-off happened at promotion, so no issue link.

## What

Promotes eight reviewed candidates into active scars, 0077 through 0084:

- 0077 (fence) carried_from is never stamped on a twin pair
- 0078 (fence) narrowing a composer strands an earlier slice's real pipeline test
- 0079 (fence) the provisional origin check is time-sensitive after #983
- 0080 (landmine) a revise clear must gate on the claim writer, not the event
- 0081 (landmine) a skill JSON template placeholder can reach the CLI verbatim
- 0082 (landmine) a current-only policy snapshot reverts a landed accept
- 0083 (fence) a monotonic policy history admits a post-overturn forgery
- 0084 (landmine) two founder passes with unequal shape checks disagree

## Why

Each one records a defect or a deliberate oddity that a green suite did not show, found during the #983, #984 and #961 slice 3 and 4 reviews. Shipping them with the code they protect means the next edit to those anchors sees the history before touching it.

## Tests

- `scar lint`: 86 files, 0 errors, 0 orphans, 0 unreachable evidence.
- 0082 to 0084 anchor to the #961 slice 4 code that is still on its branch, so lint reports partial rot on main until that PR lands. Expected, and it clears on its own.
