### PR TITLE
feat(hosts): Kimi Code adapter, briefing through UserPromptSubmit, Stop and SessionEnd capture, wire.jsonl transcripts (#988)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ npx skills add Daily-Nerd/daimon
 
 Adds `daimon-briefing` and `daimon-end` to whichever agent it detects. Use `--skill daimon-briefing` for one of them. Claude Code users who installed the plugin above already have both, so there is no need to run this as well.
 
-**Other hosts** (Windsurf, Codex, Gemini CLI): per-host guides at [daily-nerd.github.io/daimon/docs/hosts](https://daily-nerd.github.io/daimon/docs/hosts/).
+**Other hosts** (Windsurf, Codex, Kimi Code, Gemini CLI): per-host guides at [daily-nerd.github.io/daimon/docs/hosts](https://daily-nerd.github.io/daimon/docs/hosts/).
 
 That's it. End a session → a checkpoint is written; start the next → the briefing appears. Check state anytime with `daimon status` — it reports capture health honestly, including failures, skips, and crashes; a failed capture self-heals on the next start.
 
@@ -93,7 +93,7 @@ That's it. End a session → a checkpoint is written; start the next → the bri
 
 - **Trust-classed, quote-pinned memory:** every briefing item is marked verbatim (exact quote, immutable everywhere) or inferred (allowed to evolve), with provenance and supersession tracked extractively. No embeddings, no graph database, and no required daemon: per-project JSON plus a derived SQLite FTS5 index, stdlib-first and offline-first.
 - **The briefing UX** — memory that arrives as a session-*start* artifact you can skim in 30 seconds, ordered by what to verify first.
-- **Host-agnostic hooks** — Claude Code (live-validated daily), Windsurf (live-validated), Codex (live-validated capture since 2026-08-06); other hosts are reachable via the same thin adapter shape.
+- **Host-agnostic hooks** — Claude Code (live-validated daily), Windsurf (live-validated), Codex (live-validated capture since 2026-08-06), Kimi Code (briefing and capture; the briefing arrives with the first prompt, since that host has no session-start injection channel); other hosts are reachable via the same thin adapter shape.
 
 ## An independent reading
 
@@ -111,6 +111,7 @@ It is not praise alone. The same summary names the weak half: "The retrieval hal
 | CLI (`brief`, `status`, `recall`, `why`, `projects`, `heal`, `anchor`, `forget`, `configure`, `hooks`, `skill`) | stable, on PyPI |
 | Windsurf adapter | live-validated |
 | Codex adapter | live-validated capture (real sessions serialized since 2026-08-06) |
+| Kimi Code adapter | briefing and capture, probe-measured; no ruling checks yet |
 | Gemini host hooks | blocked upstream (`gemini-cli#14715`) |
 | Team memory | shipped, opt-in, early |
 

--- a/docs/hosts/kimi.md
+++ b/docs/hosts/kimi.md
@@ -1,0 +1,5 @@
+# Kimi Code
+
+The maintained guide lives on the site: https://daily-nerd.github.io/daimon/docs/hosts/kimi
+
+Spanish: https://daily-nerd.github.io/daimon/es/docs/hosts/kimi

--- a/hook/_daimon_hook_lib.py
+++ b/hook/_daimon_hook_lib.py
@@ -368,10 +368,12 @@ def kimi_transcript(session_id, home=None, env=None):
     The payload's `session_id` IS the session directory name; the workspace
     directory above it carries a hash daimon cannot predict, hence the glob.
 
-    The id lands in a filesystem path, so it is checked before use. Nothing in
-    the measured payloads suggests a hostile id, and that is exactly the
-    assumption worth enforcing rather than trusting: a single path segment,
-    no separators, no traversal.
+    The id lands in a filesystem path AND inside a glob pattern, so it is
+    checked for both before use. Nothing in the measured payloads suggests a
+    hostile id, and that is exactly the assumption worth enforcing rather than
+    trusting: a single path segment, no separators, no traversal, and no glob
+    metacharacters, since an id of `*` would otherwise resolve whichever real
+    session sorts first and serialize a stranger's transcript under it.
 
     Subagents get sibling `agents/<id>/` directories. This resolves `main`
     only; merging a subagent's own reasoning into the parent's checkpoint is a
@@ -379,7 +381,7 @@ def kimi_transcript(session_id, home=None, env=None):
     transcript.py note).
     """
     sid = str(session_id or "").strip()
-    if not sid or sid in (".", "..") or any(c in sid for c in "/\\"):
+    if not sid or sid in (".", "..") or any(c in sid for c in "/\\*?[]"):
         return None
     root = kimi_home(home, env)
     try:

--- a/hook/_daimon_hook_lib.py
+++ b/hook/_daimon_hook_lib.py
@@ -318,14 +318,92 @@ def _in_flight_stems() -> set:
     return stems
 
 
-def _serialize_in_flight(transcript_path) -> bool:
+def _serialize_in_flight(transcript_path, session_id=None) -> bool:
     """True when a LIVE serialize is already running for this transcript
     (#813). Fails OPEN — an unreadable heartbeat dir must never block a
-    genuine capture, which is the same direction `_in_flight_stems` takes."""
+    genuine capture, which is the same direction `_in_flight_stems` takes.
+
+    `session_id` overrides the stem for a host whose transcripts are not named
+    for their session (#988: every Kimi Code transcript on the machine is
+    called `wire.jsonl`, so the stem is a CONSTANT and this guard would report
+    every Kimi session as in flight while any one of them was running). It is
+    correct only because the same id rides the spawn as `--session`, so the
+    heartbeat the guard reads is stamped with exactly this string. Passing an
+    id here WITHOUT passing it to the CLI would rebuild the no-op that scar
+    0061 records."""
     try:
-        return Path(transcript_path).stem in _in_flight_stems()
+        key = str(session_id).strip() if session_id else Path(transcript_path).stem
+        return key in _in_flight_stems()
     except Exception:  # noqa: BLE001 — a broken guard must not cost a capture
         return False
+
+
+# ---- #988: Kimi Code ----
+#
+# Kimi is the first adapted host that hands a hook a session id and NO
+# transcript path, and exposes no session id in the environment either. The
+# payload is the only source, and the path has to be resolved from it.
+
+
+def kimi_home(home=None, env=None) -> Path:
+    """Kimi's config directory: `KIMI_CODE_HOME` when set, else `~/.kimi-code`.
+
+    Kept in sync with daimon_briefing.kimi_hooks.config_home — the hooks are
+    standalone and cannot import the package. `home` is the base for the
+    default, injectable so a test never reaches a real `~/.kimi-code`; the env
+    override still wins over it, exactly as it does in the installer.
+    """
+    source = os.environ if env is None else env
+    override = str(source.get("KIMI_CODE_HOME") or "").strip()
+    if override:
+        return Path(override).expanduser()
+    return (Path(home) if home is not None else Path.home()) / ".kimi-code"
+
+
+def kimi_transcript(session_id, home=None, env=None):
+    """The `wire.jsonl` for `session_id`, or None when nothing resolves.
+
+    Measured layout (0.42.0, 2026-09-09):
+        <kimi home>/sessions/wd_<dirname>_<12hex>/<session_id>/agents/main/wire.jsonl
+    The payload's `session_id` IS the session directory name; the workspace
+    directory above it carries a hash daimon cannot predict, hence the glob.
+
+    The id lands in a filesystem path, so it is checked before use. Nothing in
+    the measured payloads suggests a hostile id, and that is exactly the
+    assumption worth enforcing rather than trusting: a single path segment,
+    no separators, no traversal.
+
+    Subagents get sibling `agents/<id>/` directories. This resolves `main`
+    only; merging a subagent's own reasoning into the parent's checkpoint is a
+    question for a real multi-agent session, not an assumption (see the
+    transcript.py note).
+    """
+    sid = str(session_id or "").strip()
+    if not sid or sid in (".", "..") or any(c in sid for c in "/\\"):
+        return None
+    root = kimi_home(home, env)
+    try:
+        matches = sorted(root.glob(f"sessions/*/{sid}/agents/main/wire.jsonl"))
+    except OSError:
+        return None
+    return matches[0] if matches else None
+
+
+def kimi_prompt_text(prompt) -> str:
+    """Kimi's `prompt` payload field flattened to plain text.
+
+    Every other host sends a string; Kimi sends a LIST of content parts. Handed
+    to `recall-inject` unflattened it would arrive as a Python repr and every
+    match would be against punctuation. A bare string is passed through so a
+    later host version that simplifies the field keeps working.
+    """
+    if isinstance(prompt, str):
+        return prompt
+    if not isinstance(prompt, list):
+        return ""
+    parts = [p.get("text", "") for p in prompt
+             if isinstance(p, dict) and p.get("type") == "text"]
+    return "\n".join(t for t in parts if t)
 
 
 
@@ -559,10 +637,16 @@ def trim_crash_log(path) -> None:
         pass
 
 
-def spawn_serialize(cli, transcript_path, env):
+def spawn_serialize(cli, transcript_path, env, session_id=None):
     """Spawn `daimon serialize <transcript>` DETACHED so the hook returns
     immediately (serialization is a 30s+ LLM call). Raises OSError on spawn
     failure so the caller can log its own host-tagged diagnostic.
+
+    `session_id` (#988) forwards the host's real session id as `--session`,
+    for a host whose transcript filename does not name its session. It is
+    keyword-only in practice: no existing caller passes it, which matters
+    because the suite replaces this function in roughly sixteen places with
+    three-argument fakes (see scar 0062).
 
     Returns False when the spawn was SKIPPED because a serialize for this same
     transcript is already in flight (#813); any other return means it spawned.
@@ -597,14 +681,24 @@ def spawn_serialize(cli, transcript_path, env):
     hung-after ceiling. The observed race is minutes wide; this narrows it to
     seconds, and `heal` remains the answer for the rest.
     """
-    if _serialize_in_flight(transcript_path):
+    # Called with ONE argument unless there is a session id to widen it with.
+    # The suite monkeypatches this seam with fixed-arity lambdas (`lambda _p:
+    # False`), so an unconditional second argument raises TypeError inside the
+    # spawn path in every one of them — the same fixed-arity fake trap scar
+    # 0062 records one function up.
+    in_flight = (_serialize_in_flight(transcript_path, session_id) if session_id
+                 else _serialize_in_flight(transcript_path))
+    if in_flight:
         return False
     crash = crash_log_path()
     crash.parent.mkdir(parents=True, exist_ok=True)
     trim_crash_log(crash)
+    argv = [cli, "serialize", transcript_path]
+    if session_id:
+        argv += ["--session", str(session_id)]
     with crash.open("a", encoding="utf-8") as crashf:
         subprocess.Popen(
-            [cli, "serialize", transcript_path],
+            argv,
             stdin=subprocess.DEVNULL,
             # #939: a container host's only observable surface is the stream
             # its runtime captures, so a result line in serialize.log alone is

--- a/hook/checks_host.py
+++ b/hook/checks_host.py
@@ -167,6 +167,33 @@ PROFILES = {
         matcher="",
         install_timeout=10,
     ),
+    # #988: there is deliberately NO `kimi` row here yet, and the Kimi adapter
+    # ships its briefing and capture hooks without one.
+    #
+    # What a live probe of Kimi Code 0.42.0 (2026-09-09) DID measure:
+    #   - `PreToolUse` fires with `tool_name: "Bash"` and the command at
+    #     `tool_input.command`, so `command_path` and `matcher` would copy the
+    #     claude-code row unchanged.
+    #   - `cwd` is on the payload, resolved on macOS (`/private/tmp`).
+    #   - `PreToolUse` exit-0 stdout is DROPPED, not appended to context. Only
+    #     `UserPromptSubmit` stdout reaches the model. So the warn channel is
+    #     measured ABSENT, and `warn` would have to cap at `record-only` the
+    #     way the codex row does, rather than be left open.
+    #
+    # What it did NOT measure, and what runbook Part 4 has to prove before a
+    # row lands here: THE DENY CHANNEL. Neither exit code 2 with a reason on
+    # stderr nor the stdout JSON `hookSpecificOutput.permissionDecision: deny`
+    # was ever exercised against a real command. Both strings are present in
+    # the shipped binary and both are documented, and neither of those is a
+    # command observed being blocked.
+    #
+    # A row added on documentation alone would put `enforce` in the
+    # degradation ladder for an enforcement daimon has never watched land,
+    # which is the one direction this ladder must not fail in: a check that
+    # reports enforcing and silently allows is worse than no check, because it
+    # is byte-identical to a clean allow (scar 0072). The windsurf row above
+    # is the precedent, and it caps the whole column at `unsupported` for
+    # exactly this reason.
 }
 
 

--- a/hook/daimon-kimi-session-end.py
+++ b/hook/daimon-kimi-session-end.py
@@ -4,11 +4,15 @@
 Measured on Kimi Code 0.42.0 (2026-09-09): this fires on an interactive exit
 with `reason: "exit"`, and NEVER on `kimi -p` print mode (measured twice; a
 print session ends with "To resume this session" and stays resumable, so it
-never closes). `Stop` is what captures print mode, which makes double capture
-a real shape here rather than a theoretical one: a session captured by Stop
-and then closed interactively arrives at this hook already checkpointed. It
-shares the Stop hook's marker for exactly that reason, and the CLI's own
-identical-bytes guard is the second line of defence.
+never closes). `Stop` is what captures print mode, so an interactive session
+that ran turns and then exited reaches this hook with a Stop capture already
+behind it. This hook is deliberately NOT throttled against that capture, the
+same call Codex makes: Stop's throttle window is the interval between the last
+spawned Stop and `/exit`, so honouring its marker here would drop every turn
+inside that window, the session's tail, which is the part an end-of-session
+checkpoint exists to keep. The repeat is cheap instead: `daimon serialize`
+compares the transcript's sha against the last checkpoint before any LLM work,
+so bytes Stop already captured cost one file read, not a second model call.
 
 Unlike every host adapted before it, the payload carries NO transcript path
 and no environment variable holds one. The path is resolved from the session
@@ -23,7 +27,6 @@ Diagnostics land in ~/.daimon/logs/serialize.log.
 import json
 import os
 import sys
-import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -61,56 +64,6 @@ def _enabled() -> bool:
     return val not in ("0", "false", "no", "off")
 
 
-def _safe_name(session_id: str) -> str:
-    return session_id.replace("/", "_").replace("\\", "_").replace("..", "_")
-
-
-def _marker_path(session_id: str) -> Path:
-    return STATE_DIR / f"{_safe_name(session_id)}.last-stop"
-
-
-def _already_captured(session_id: str) -> bool:
-    """True when the Stop hook already serialized this session inside its
-    throttle window.
-
-    On Codex this hook is deliberately unthrottled, because SessionEnd there is
-    the real end and Stop is only insurance. Here Stop is a genuine capture
-    path for print mode, so an interactive session that ran turns and then
-    exited reaches this hook seconds after a Stop already spawned. Repeating it
-    would burn a second full LLM call on the same bytes.
-    """
-    interval = _interval_seconds()
-    if interval <= 0:
-        return False
-    try:
-        marker = _marker_path(session_id)
-        return (marker.exists()
-                and time.time() - marker.stat().st_mtime < interval)
-    except OSError:
-        return False
-
-
-def _interval_seconds() -> int:
-    """Shared with the Stop hook so the two agree on what "just captured"
-    means. Reading it here rather than hard-coding a window is what keeps a
-    person who set the interval to 0 (serialize every turn) from also
-    silencing this hook."""
-    raw = os.environ.get("DAIMON_KIMI_MIN_SERIALIZE_INTERVAL", "300").strip()
-    try:
-        return max(0, int(raw))
-    except ValueError:
-        return 300
-
-
-def _mark_spawned(session_id: str) -> None:
-    try:
-        STATE_DIR.mkdir(parents=True, exist_ok=True)
-        _marker_path(session_id).write_text(str(int(time.time())),
-                                            encoding="utf-8")
-    except OSError:
-        pass
-
-
 def main() -> int:
     if lib is None:
         _fallback_log(f"{TAG}: hook library missing (_daimon_hook_lib.py) - skipped")
@@ -142,11 +95,6 @@ def main() -> int:
                 f"(searched {lib.kimi_home()}/sessions) - skipped")
         return 0
 
-    if _already_captured(session_id):
-        lib.log(f"{TAG}: skipped serialize for {session_id} "
-                f"(already captured by the Stop hook)")
-        return 0
-
     cli = lib.resolve_cli()
     if cli is None:
         lib.log(f"{TAG}: `daimon` CLI not found - checkpoint skipped")
@@ -166,7 +114,6 @@ def main() -> int:
             lib.log(f"{TAG}: skipped serialize for {session_id} "
                     f"(already in flight) (transcript: {transcript_path})")
             return 0
-        _mark_spawned(session_id)
         lib.log(f"{TAG}: spawned serialize for {session_id} "
                 f"(project: {cwd or '?'}) (transcript: {transcript_path})")
     except OSError as exc:

--- a/hook/daimon-kimi-session-end.py
+++ b/hook/daimon-kimi-session-end.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Kimi Code SessionEnd hook: checkpoint the session that just closed.
+
+Measured on Kimi Code 0.42.0 (2026-09-09): this fires on an interactive exit
+with `reason: "exit"`, and NEVER on `kimi -p` print mode (measured twice; a
+print session ends with "To resume this session" and stays resumable, so it
+never closes). `Stop` is what captures print mode, which makes double capture
+a real shape here rather than a theoretical one: a session captured by Stop
+and then closed interactively arrives at this hook already checkpointed. It
+shares the Stop hook's marker for exactly that reason, and the CLI's own
+identical-bytes guard is the second line of defence.
+
+Unlike every host adapted before it, the payload carries NO transcript path
+and no environment variable holds one. The path is resolved from the session
+id against Kimi's own storage (lib.kimi_transcript), so "no transcript
+resolved" is a routine outcome worth a legible log line rather than silence.
+
+Set DAIMON_KIMI_SERIALIZE_ON_SESSION_END=0 to disable. The LLM work runs
+detached via `daimon serialize`, so the hook returns immediately.
+Diagnostics land in ~/.daimon/logs/serialize.log.
+"""
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Shared helpers live in a same-dir sibling module (see _daimon_hook_lib.py).
+# A stale/partial install may lack it: fail open with a logged one-liner rather
+# than crash. _fallback_log below mirrors lib.log for exactly that window.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    import _daimon_hook_lib as lib
+except Exception:  # noqa: BLE001 — missing/corrupt lib must never crash the hook
+    lib = None
+
+STATE_DIR = Path.home() / ".daimon" / "kimi"
+TAG = "kimi-session-end"
+
+
+def _fallback_log(line: str) -> None:
+    """Best-effort serialize.log write when the shared lib is unavailable
+    (stale/partial install). Mirrors lib.log so a broken install still leaves a
+    breadcrumb instead of a crash. Never raises."""
+    try:
+        log_dir = Path.home() / ".daimon" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with (log_dir / "serialize.log").open("a", encoding="utf-8") as f:
+            f.write(f"{stamp} {line}\n")
+    except OSError:
+        pass
+
+
+def _enabled() -> bool:
+    if lib.disabled():
+        return False
+    val = os.environ.get("DAIMON_KIMI_SERIALIZE_ON_SESSION_END", "1").strip().lower()
+    return val not in ("0", "false", "no", "off")
+
+
+def _safe_name(session_id: str) -> str:
+    return session_id.replace("/", "_").replace("\\", "_").replace("..", "_")
+
+
+def _marker_path(session_id: str) -> Path:
+    return STATE_DIR / f"{_safe_name(session_id)}.last-stop"
+
+
+def _already_captured(session_id: str) -> bool:
+    """True when the Stop hook already serialized this session inside its
+    throttle window.
+
+    On Codex this hook is deliberately unthrottled, because SessionEnd there is
+    the real end and Stop is only insurance. Here Stop is a genuine capture
+    path for print mode, so an interactive session that ran turns and then
+    exited reaches this hook seconds after a Stop already spawned. Repeating it
+    would burn a second full LLM call on the same bytes.
+    """
+    interval = _interval_seconds()
+    if interval <= 0:
+        return False
+    try:
+        marker = _marker_path(session_id)
+        return (marker.exists()
+                and time.time() - marker.stat().st_mtime < interval)
+    except OSError:
+        return False
+
+
+def _interval_seconds() -> int:
+    """Shared with the Stop hook so the two agree on what "just captured"
+    means. Reading it here rather than hard-coding a window is what keeps a
+    person who set the interval to 0 (serialize every turn) from also
+    silencing this hook."""
+    raw = os.environ.get("DAIMON_KIMI_MIN_SERIALIZE_INTERVAL", "300").strip()
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return 300
+
+
+def _mark_spawned(session_id: str) -> None:
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        _marker_path(session_id).write_text(str(int(time.time())),
+                                            encoding="utf-8")
+    except OSError:
+        pass
+
+
+def main() -> int:
+    if lib is None:
+        _fallback_log(f"{TAG}: hook library missing (_daimon_hook_lib.py) - skipped")
+        return 0
+    if not _enabled():
+        return 0
+
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        lib.log(f"{TAG}: unparseable stdin payload - skipped")
+        return 0
+    if not isinstance(payload, dict):
+        lib.log(f"{TAG}: stdin payload was not an object - skipped")
+        return 0
+
+    session_id = str(payload.get("session_id") or "").strip()
+    if not session_id:
+        lib.log(f"{TAG}: payload carried no session_id - skipped")
+        return 0
+
+    transcript_path = lib.kimi_transcript(session_id)
+    if transcript_path is None:
+        # Routine on this host, not a corruption: the payload has no path, so
+        # a lookup that finds nothing means the storage moved, KIMI_CODE_HOME
+        # differs from the session's, or the id is a shape the resolver
+        # refuses. Naming the id and the root is what makes it diagnosable.
+        lib.log(f"{TAG}: transcript not found for {session_id} "
+                f"(searched {lib.kimi_home()}/sessions) - skipped")
+        return 0
+
+    if _already_captured(session_id):
+        lib.log(f"{TAG}: skipped serialize for {session_id} "
+                f"(already captured by the Stop hook)")
+        return 0
+
+    cli = lib.resolve_cli()
+    if cli is None:
+        lib.log(f"{TAG}: `daimon` CLI not found - checkpoint skipped")
+        return 0
+
+    cwd = str(payload.get("cwd") or "").strip()
+    child_env = lib.project_env(cwd, "kimi")
+    try:
+        # `--session` is not optional here: every Kimi transcript is named
+        # `wire.jsonl`, so without it the CLI would derive the id "wire" for
+        # every session on the machine (#988).
+        if lib.spawn_serialize(cli, str(transcript_path), child_env,
+                               session_id=session_id) is False:
+            # `is False` (not falsy) on purpose — see scar 0062: the suite's
+            # spawn fakes return None, and a truthiness check would flip every
+            # one of them into this skip branch.
+            lib.log(f"{TAG}: skipped serialize for {session_id} "
+                    f"(already in flight) (transcript: {transcript_path})")
+            return 0
+        _mark_spawned(session_id)
+        lib.log(f"{TAG}: spawned serialize for {session_id} "
+                f"(project: {cwd or '?'}) (transcript: {transcript_path})")
+    except OSError as exc:
+        lib.log(f"{TAG}: spawn failed ({type(exc).__name__}: {exc})")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:
+        if lib is not None:
+            lib.log(f"{TAG}: hook error ({type(exc).__name__}: {exc})")
+        else:
+            _fallback_log(f"{TAG}: hook error ({type(exc).__name__}: {exc})")
+        sys.exit(0)

--- a/hook/daimon-kimi-stop.py
+++ b/hook/daimon-kimi-stop.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Kimi Code Stop hook: checkpoint the current transcript opportunistically.
+
+On Codex the equivalent hook is pure crash insurance. Here it is a capture
+path in its own right, because `kimi -p` print mode never fires `SessionEnd`
+(measured twice on 0.42.0, 2026-09-09: a print session ends resumable, so it
+never closes and the `exit|archive` matcher never sees it). Without this hook
+every print-mode session on the machine would go uncaptured.
+
+`Stop` fires per turn, so serializing on every one would be expensive. It is
+throttled by DAIMON_KIMI_MIN_SERIALIZE_INTERVAL (default 300 seconds per
+session). Set it to 0 to serialize on every Stop, or
+DAIMON_KIMI_SERIALIZE_ON_STOP=0 to disable this hook while keeping the
+UserPromptSubmit briefing.
+
+The payload carries a session id and no transcript path, so the path is
+resolved from the id (lib.kimi_transcript). The LLM work runs detached via
+`daimon serialize`; diagnostics land in ~/.daimon/logs/serialize.log.
+"""
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Shared helpers live in a same-dir sibling module (see _daimon_hook_lib.py).
+# A stale/partial install may lack it: fail open with a logged one-liner rather
+# than crash. _fallback_log below mirrors lib.log for exactly that window.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    import _daimon_hook_lib as lib
+except Exception:  # noqa: BLE001 — missing/corrupt lib must never crash the hook
+    lib = None
+
+STATE_DIR = Path.home() / ".daimon" / "kimi"
+TAG = "kimi-stop"
+
+
+def _fallback_log(line: str) -> None:
+    """Best-effort serialize.log write when the shared lib is unavailable
+    (stale/partial install). Mirrors lib.log so a broken install still leaves a
+    breadcrumb instead of a crash. Never raises."""
+    try:
+        log_dir = Path.home() / ".daimon" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with (log_dir / "serialize.log").open("a", encoding="utf-8") as f:
+            f.write(f"{stamp} {line}\n")
+    except OSError:
+        pass
+
+
+def _enabled() -> bool:
+    if lib.disabled():
+        return False
+    val = os.environ.get("DAIMON_KIMI_SERIALIZE_ON_STOP", "1").strip().lower()
+    return val not in ("0", "false", "no", "off")
+
+
+def _interval_seconds() -> int:
+    raw = os.environ.get("DAIMON_KIMI_MIN_SERIALIZE_INTERVAL", "300").strip()
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return 300
+
+
+def _safe_name(session_id: str) -> str:
+    return session_id.replace("/", "_").replace("\\", "_").replace("..", "_")
+
+
+def _marker_path(session_id: str) -> Path:
+    return STATE_DIR / f"{_safe_name(session_id)}.last-stop"
+
+
+def _should_spawn(session_id: str) -> bool:
+    interval = _interval_seconds()
+    if interval <= 0:
+        return True
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        marker = _marker_path(session_id)
+        if marker.exists() and time.time() - marker.stat().st_mtime < interval:
+            return False
+        return True
+    except OSError:
+        return True
+
+
+def _mark_spawned(session_id: str) -> None:
+    if _interval_seconds() <= 0:
+        return
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        _marker_path(session_id).write_text(str(int(time.time())),
+                                            encoding="utf-8")
+    except OSError:
+        pass
+
+
+def main() -> int:
+    if lib is None:
+        _fallback_log(f"{TAG}: hook library missing (_daimon_hook_lib.py) - skipped")
+        return 0
+    if not _enabled():
+        return 0
+
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        lib.log(f"{TAG}: unparseable stdin payload - skipped")
+        return 0
+    if not isinstance(payload, dict):
+        lib.log(f"{TAG}: stdin payload was not an object - skipped")
+        return 0
+
+    session_id = str(payload.get("session_id") or "").strip()
+    if not session_id:
+        lib.log(f"{TAG}: payload carried no session_id - skipped")
+        return 0
+
+    # Throttle BEFORE resolving the path: this hook fires after every turn, and
+    # the resolver globs the host's session storage. Inside the window there is
+    # nothing to do with the answer.
+    if not _should_spawn(session_id):
+        lib.log(f"{TAG}: skipped serialize for {session_id} (throttled)")
+        return 0
+
+    transcript_path = lib.kimi_transcript(session_id)
+    if transcript_path is None:
+        lib.log(f"{TAG}: transcript not found for {session_id} "
+                f"(searched {lib.kimi_home()}/sessions) - skipped")
+        return 0
+
+    cli = lib.resolve_cli()
+    if cli is None:
+        lib.log(f"{TAG}: `daimon` CLI not found - checkpoint skipped")
+        return 0
+
+    cwd = str(payload.get("cwd") or "").strip()
+    child_env = lib.project_env(cwd, "kimi")
+    try:
+        # `--session` is not optional here: every Kimi transcript is named
+        # `wire.jsonl` (#988).
+        if lib.spawn_serialize(cli, str(transcript_path), child_env,
+                               session_id=session_id) is False:
+            # `is False` (not falsy) on purpose — see scar 0062.
+            lib.log(f"{TAG}: skipped serialize for {session_id} "
+                    f"(already in flight) (transcript: {transcript_path})")
+            return 0
+        _mark_spawned(session_id)
+        lib.log(f"{TAG}: spawned serialize for {session_id} "
+                f"(project: {cwd or '?'}) (transcript: {transcript_path})")
+    except OSError as exc:
+        lib.log(f"{TAG}: spawn failed ({type(exc).__name__}: {exc})")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:
+        if lib is not None:
+            lib.log(f"{TAG}: hook error ({type(exc).__name__}: {exc})")
+        else:
+            _fallback_log(f"{TAG}: hook error ({type(exc).__name__}: {exc})")
+        sys.exit(0)

--- a/hook/daimon-kimi-user-prompt-submit.py
+++ b/hook/daimon-kimi-user-prompt-submit.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Kimi Code UserPromptSubmit hook: the ONLY channel into the model.
+
+Measured on 0.42.0 (2026-09-09): of every event that fires, only this one's
+stdout reaches the session, arriving as a user message wrapped in
+`<hook_result hook_event="UserPromptSubmit">`. `SessionStart` fires and its
+stdout is dropped. So this hook carries both jobs the other hosts split
+between two events:
+
+1. The briefing, on the FIRST prompt of a session. Kimi offers no usable
+   session-start event, so "first" is kept here as a per-session marker rather
+   than inferred from an event. The consequence a person sees is that the
+   briefing arrives with their first message instead of before it, and the
+   host page says so.
+2. The per-prompt recall injection, on every prompt after that, shelling out
+   to `daimon recall-inject` exactly as the Claude Code prompt hook does.
+
+Noise contract, copied deliberately from daimon-prompt-recall.py: this fires
+on EVERY prompt, so failures are SILENT (exit 0, no output). A diagnostic per
+prompt would be spam. Unlike on Claude Code there is no SessionStart hook to
+surface install problems once a session, so a broken install here is quiet by
+design; `daimon hooks status` is the surface that reports it.
+
+Exit code discipline matters more here than on the capture hooks.
+`UserPromptSubmit` is BLOCKABLE on this host: a non-zero exit is how a hook
+refuses the person's prompt. Every path returns 0.
+"""
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    import _daimon_hook_lib as lib
+except Exception:  # noqa: BLE001 — missing/corrupt lib: silent no-op (see above)
+    lib = None
+
+STATE_DIR = Path.home() / ".daimon" / "kimi"
+BRIEF_TIMEOUT = 8   # the host's registered timeout is 10
+RECALL_TIMEOUT = 4
+DELIVERY_TIMEOUT = 1.5
+
+
+def _safe_name(session_id: str) -> str:
+    return session_id.replace("/", "_").replace("\\", "_").replace("..", "_")
+
+
+def _claim_first_prompt(session_id: str) -> bool:
+    """True exactly once per session: the prompt that gets the briefing.
+
+    Uses `open(..., "x")`, which is atomic on every platform daimon runs on, so
+    two prompts racing in the same session cannot both win and inject the
+    briefing twice. A marker that cannot be written at all yields False rather
+    than True: repeating a briefing on every prompt would be worse than never
+    showing it, because it would push the real conversation out of context.
+    """
+    if not session_id:
+        return False
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        with (STATE_DIR / f"{_safe_name(session_id)}.briefed").open("x") as f:
+            f.write(str(int(time.time())))
+        return True
+    except FileExistsError:
+        return False
+    except OSError:
+        return False
+
+
+def _brief(cli, cwd: str) -> str:
+    """The rendered briefing, or "" when there is nothing to say.
+
+    Shells out to `daimon brief` so the renderer stays single-source-of-truth,
+    matching the Claude Code and Codex hook paths. Plain text, no JSON
+    envelope: this host appends what the hook prints and wraps it itself.
+    """
+    slug = lib.slug(cwd)
+    ckpt_dir = lib.checkpoint_dir()
+    latest = ckpt_dir / slug / "latest.json" if slug else None
+    fallback = False
+    if latest is None or not latest.exists():
+        fallback = latest is not None
+        latest = ckpt_dir / "latest.json"
+    if not latest.exists() or cli is None:
+        return ""
+    try:
+        proc = subprocess.run([cli, "brief"], capture_output=True, text=True,
+                              timeout=BRIEF_TIMEOUT, env=lib.project_env(cwd))
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+    text = proc.stdout.strip()
+    if proc.returncode != 0 or not text or text.startswith("No checkpoint yet"):
+        return ""
+    suffix = (" (global fallback - checkpoint may be from another project)"
+              if fallback else "")
+    return f"DAIMON BRIEFING {lib.age_line(latest)}{suffix}\n{text}"
+
+
+def _deliver(cli, cwd: str, session: str) -> None:
+    """Any undecided ask addressed to this project that this session has not
+    been shown (#756). Silent on every failure, like everything on this path."""
+    if not session:
+        return  # the session id is half the delivery write-once key
+    cmd = [cli, "request-inject", "--session", session]
+    if cwd:
+        cmd += ["--project", cwd]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True,
+                              timeout=DELIVERY_TIMEOUT, env=lib.project_env(cwd))
+    except (subprocess.TimeoutExpired, OSError):
+        return
+    if proc.returncode == 0 and proc.stdout.strip():
+        print(proc.stdout.strip())
+
+
+def _recall(cli, cwd: str, session: str, prompt: str) -> None:
+    # Slash commands are host directives, not work statements — never match.
+    if not prompt.strip() or prompt.lstrip().startswith("/"):
+        return
+    cmd = [cli, "recall-inject"]
+    if cwd:
+        cmd += ["--project", cwd]
+    if session:
+        cmd += ["--session", session]
+    try:
+        proc = subprocess.run(cmd, input=prompt, capture_output=True, text=True,
+                              timeout=RECALL_TIMEOUT, env=lib.project_env(cwd))
+    except (subprocess.TimeoutExpired, OSError):
+        return
+    if proc.returncode == 0 and proc.stdout.strip():
+        print(proc.stdout.strip())
+
+
+def main() -> int:
+    if lib is None or lib.disabled():
+        return 0
+    data = lib.payload()
+    cwd = str(data.get("cwd") or "").strip()
+    session = str(data.get("session_id") or "").strip()
+    # Kimi sends `prompt` as a LIST of content parts, where every other host
+    # sends a string. Unflattened it would reach recall-inject as a repr.
+    prompt = lib.kimi_prompt_text(data.get("prompt"))
+    cli = lib.resolve_cli()
+    if cli is None:
+        return 0
+
+    if _claim_first_prompt(session):
+        text = _brief(cwd=cwd, cli=cli)
+        if text:
+            print(text)
+        # The briefing already answers "where were we", so recall on the same
+        # prompt would restate it. Delivery still runs: an undecided ask is
+        # owed regardless of what the person typed.
+        if (lib._config_get("DAIMON_LIVE_DELIVERY") or "").strip() in (
+                "1", "true", "yes", "on"):
+            _deliver(cli, cwd, session)
+        # Opportunistic self-heal of a previously FAILED serialize (#26). This
+        # is the closest thing to a session start this host offers, and a
+        # failed serialize leaves no checkpoint, which is exactly the case
+        # where heal matters. Runs last: it can never affect what was printed.
+        lib.spawn_heal(cli, cwd)
+        return 0
+
+    if (lib._config_get("DAIMON_LIVE_DELIVERY") or "").strip() in (
+            "1", "true", "yes", "on"):
+        _deliver(cli, cwd, session)
+    _recall(cli, cwd, session, prompt)
+    return 0
+
+
+if __name__ == "__main__":
+    # Exit 0 on ANY error: a non-zero exit from this event refuses the
+    # person's prompt on this host.
+    try:
+        sys.exit(main())
+    except Exception:  # noqa: BLE001
+        sys.exit(0)

--- a/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
+++ b/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
@@ -368,10 +368,12 @@ def kimi_transcript(session_id, home=None, env=None):
     The payload's `session_id` IS the session directory name; the workspace
     directory above it carries a hash daimon cannot predict, hence the glob.
 
-    The id lands in a filesystem path, so it is checked before use. Nothing in
-    the measured payloads suggests a hostile id, and that is exactly the
-    assumption worth enforcing rather than trusting: a single path segment,
-    no separators, no traversal.
+    The id lands in a filesystem path AND inside a glob pattern, so it is
+    checked for both before use. Nothing in the measured payloads suggests a
+    hostile id, and that is exactly the assumption worth enforcing rather than
+    trusting: a single path segment, no separators, no traversal, and no glob
+    metacharacters, since an id of `*` would otherwise resolve whichever real
+    session sorts first and serialize a stranger's transcript under it.
 
     Subagents get sibling `agents/<id>/` directories. This resolves `main`
     only; merging a subagent's own reasoning into the parent's checkpoint is a
@@ -379,7 +381,7 @@ def kimi_transcript(session_id, home=None, env=None):
     transcript.py note).
     """
     sid = str(session_id or "").strip()
-    if not sid or sid in (".", "..") or any(c in sid for c in "/\\"):
+    if not sid or sid in (".", "..") or any(c in sid for c in "/\\*?[]"):
         return None
     root = kimi_home(home, env)
     try:

--- a/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
+++ b/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
@@ -318,14 +318,92 @@ def _in_flight_stems() -> set:
     return stems
 
 
-def _serialize_in_flight(transcript_path) -> bool:
+def _serialize_in_flight(transcript_path, session_id=None) -> bool:
     """True when a LIVE serialize is already running for this transcript
     (#813). Fails OPEN — an unreadable heartbeat dir must never block a
-    genuine capture, which is the same direction `_in_flight_stems` takes."""
+    genuine capture, which is the same direction `_in_flight_stems` takes.
+
+    `session_id` overrides the stem for a host whose transcripts are not named
+    for their session (#988: every Kimi Code transcript on the machine is
+    called `wire.jsonl`, so the stem is a CONSTANT and this guard would report
+    every Kimi session as in flight while any one of them was running). It is
+    correct only because the same id rides the spawn as `--session`, so the
+    heartbeat the guard reads is stamped with exactly this string. Passing an
+    id here WITHOUT passing it to the CLI would rebuild the no-op that scar
+    0061 records."""
     try:
-        return Path(transcript_path).stem in _in_flight_stems()
+        key = str(session_id).strip() if session_id else Path(transcript_path).stem
+        return key in _in_flight_stems()
     except Exception:  # noqa: BLE001 — a broken guard must not cost a capture
         return False
+
+
+# ---- #988: Kimi Code ----
+#
+# Kimi is the first adapted host that hands a hook a session id and NO
+# transcript path, and exposes no session id in the environment either. The
+# payload is the only source, and the path has to be resolved from it.
+
+
+def kimi_home(home=None, env=None) -> Path:
+    """Kimi's config directory: `KIMI_CODE_HOME` when set, else `~/.kimi-code`.
+
+    Kept in sync with daimon_briefing.kimi_hooks.config_home — the hooks are
+    standalone and cannot import the package. `home` is the base for the
+    default, injectable so a test never reaches a real `~/.kimi-code`; the env
+    override still wins over it, exactly as it does in the installer.
+    """
+    source = os.environ if env is None else env
+    override = str(source.get("KIMI_CODE_HOME") or "").strip()
+    if override:
+        return Path(override).expanduser()
+    return (Path(home) if home is not None else Path.home()) / ".kimi-code"
+
+
+def kimi_transcript(session_id, home=None, env=None):
+    """The `wire.jsonl` for `session_id`, or None when nothing resolves.
+
+    Measured layout (0.42.0, 2026-09-09):
+        <kimi home>/sessions/wd_<dirname>_<12hex>/<session_id>/agents/main/wire.jsonl
+    The payload's `session_id` IS the session directory name; the workspace
+    directory above it carries a hash daimon cannot predict, hence the glob.
+
+    The id lands in a filesystem path, so it is checked before use. Nothing in
+    the measured payloads suggests a hostile id, and that is exactly the
+    assumption worth enforcing rather than trusting: a single path segment,
+    no separators, no traversal.
+
+    Subagents get sibling `agents/<id>/` directories. This resolves `main`
+    only; merging a subagent's own reasoning into the parent's checkpoint is a
+    question for a real multi-agent session, not an assumption (see the
+    transcript.py note).
+    """
+    sid = str(session_id or "").strip()
+    if not sid or sid in (".", "..") or any(c in sid for c in "/\\"):
+        return None
+    root = kimi_home(home, env)
+    try:
+        matches = sorted(root.glob(f"sessions/*/{sid}/agents/main/wire.jsonl"))
+    except OSError:
+        return None
+    return matches[0] if matches else None
+
+
+def kimi_prompt_text(prompt) -> str:
+    """Kimi's `prompt` payload field flattened to plain text.
+
+    Every other host sends a string; Kimi sends a LIST of content parts. Handed
+    to `recall-inject` unflattened it would arrive as a Python repr and every
+    match would be against punctuation. A bare string is passed through so a
+    later host version that simplifies the field keeps working.
+    """
+    if isinstance(prompt, str):
+        return prompt
+    if not isinstance(prompt, list):
+        return ""
+    parts = [p.get("text", "") for p in prompt
+             if isinstance(p, dict) and p.get("type") == "text"]
+    return "\n".join(t for t in parts if t)
 
 
 
@@ -559,10 +637,16 @@ def trim_crash_log(path) -> None:
         pass
 
 
-def spawn_serialize(cli, transcript_path, env):
+def spawn_serialize(cli, transcript_path, env, session_id=None):
     """Spawn `daimon serialize <transcript>` DETACHED so the hook returns
     immediately (serialization is a 30s+ LLM call). Raises OSError on spawn
     failure so the caller can log its own host-tagged diagnostic.
+
+    `session_id` (#988) forwards the host's real session id as `--session`,
+    for a host whose transcript filename does not name its session. It is
+    keyword-only in practice: no existing caller passes it, which matters
+    because the suite replaces this function in roughly sixteen places with
+    three-argument fakes (see scar 0062).
 
     Returns False when the spawn was SKIPPED because a serialize for this same
     transcript is already in flight (#813); any other return means it spawned.
@@ -597,14 +681,24 @@ def spawn_serialize(cli, transcript_path, env):
     hung-after ceiling. The observed race is minutes wide; this narrows it to
     seconds, and `heal` remains the answer for the rest.
     """
-    if _serialize_in_flight(transcript_path):
+    # Called with ONE argument unless there is a session id to widen it with.
+    # The suite monkeypatches this seam with fixed-arity lambdas (`lambda _p:
+    # False`), so an unconditional second argument raises TypeError inside the
+    # spawn path in every one of them — the same fixed-arity fake trap scar
+    # 0062 records one function up.
+    in_flight = (_serialize_in_flight(transcript_path, session_id) if session_id
+                 else _serialize_in_flight(transcript_path))
+    if in_flight:
         return False
     crash = crash_log_path()
     crash.parent.mkdir(parents=True, exist_ok=True)
     trim_crash_log(crash)
+    argv = [cli, "serialize", transcript_path]
+    if session_id:
+        argv += ["--session", str(session_id)]
     with crash.open("a", encoding="utf-8") as crashf:
         subprocess.Popen(
-            [cli, "serialize", transcript_path],
+            argv,
             stdin=subprocess.DEVNULL,
             # #939: a container host's only observable surface is the stream
             # its runtime captures, so a result line in serialize.log alone is

--- a/plugin/daimon_briefing/_hooks/checks_host.py
+++ b/plugin/daimon_briefing/_hooks/checks_host.py
@@ -167,6 +167,33 @@ PROFILES = {
         matcher="",
         install_timeout=10,
     ),
+    # #988: there is deliberately NO `kimi` row here yet, and the Kimi adapter
+    # ships its briefing and capture hooks without one.
+    #
+    # What a live probe of Kimi Code 0.42.0 (2026-09-09) DID measure:
+    #   - `PreToolUse` fires with `tool_name: "Bash"` and the command at
+    #     `tool_input.command`, so `command_path` and `matcher` would copy the
+    #     claude-code row unchanged.
+    #   - `cwd` is on the payload, resolved on macOS (`/private/tmp`).
+    #   - `PreToolUse` exit-0 stdout is DROPPED, not appended to context. Only
+    #     `UserPromptSubmit` stdout reaches the model. So the warn channel is
+    #     measured ABSENT, and `warn` would have to cap at `record-only` the
+    #     way the codex row does, rather than be left open.
+    #
+    # What it did NOT measure, and what runbook Part 4 has to prove before a
+    # row lands here: THE DENY CHANNEL. Neither exit code 2 with a reason on
+    # stderr nor the stdout JSON `hookSpecificOutput.permissionDecision: deny`
+    # was ever exercised against a real command. Both strings are present in
+    # the shipped binary and both are documented, and neither of those is a
+    # command observed being blocked.
+    #
+    # A row added on documentation alone would put `enforce` in the
+    # degradation ladder for an enforcement daimon has never watched land,
+    # which is the one direction this ladder must not fail in: a check that
+    # reports enforcing and silently allows is worse than no check, because it
+    # is byte-identical to a clean allow (scar 0072). The windsurf row above
+    # is the precedent, and it caps the whole column at `unsupported` for
+    # exactly this reason.
 }
 
 

--- a/plugin/daimon_briefing/_hooks/daimon-kimi-session-end.py
+++ b/plugin/daimon_briefing/_hooks/daimon-kimi-session-end.py
@@ -4,11 +4,15 @@
 Measured on Kimi Code 0.42.0 (2026-09-09): this fires on an interactive exit
 with `reason: "exit"`, and NEVER on `kimi -p` print mode (measured twice; a
 print session ends with "To resume this session" and stays resumable, so it
-never closes). `Stop` is what captures print mode, which makes double capture
-a real shape here rather than a theoretical one: a session captured by Stop
-and then closed interactively arrives at this hook already checkpointed. It
-shares the Stop hook's marker for exactly that reason, and the CLI's own
-identical-bytes guard is the second line of defence.
+never closes). `Stop` is what captures print mode, so an interactive session
+that ran turns and then exited reaches this hook with a Stop capture already
+behind it. This hook is deliberately NOT throttled against that capture, the
+same call Codex makes: Stop's throttle window is the interval between the last
+spawned Stop and `/exit`, so honouring its marker here would drop every turn
+inside that window, the session's tail, which is the part an end-of-session
+checkpoint exists to keep. The repeat is cheap instead: `daimon serialize`
+compares the transcript's sha against the last checkpoint before any LLM work,
+so bytes Stop already captured cost one file read, not a second model call.
 
 Unlike every host adapted before it, the payload carries NO transcript path
 and no environment variable holds one. The path is resolved from the session
@@ -23,7 +27,6 @@ Diagnostics land in ~/.daimon/logs/serialize.log.
 import json
 import os
 import sys
-import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -61,56 +64,6 @@ def _enabled() -> bool:
     return val not in ("0", "false", "no", "off")
 
 
-def _safe_name(session_id: str) -> str:
-    return session_id.replace("/", "_").replace("\\", "_").replace("..", "_")
-
-
-def _marker_path(session_id: str) -> Path:
-    return STATE_DIR / f"{_safe_name(session_id)}.last-stop"
-
-
-def _already_captured(session_id: str) -> bool:
-    """True when the Stop hook already serialized this session inside its
-    throttle window.
-
-    On Codex this hook is deliberately unthrottled, because SessionEnd there is
-    the real end and Stop is only insurance. Here Stop is a genuine capture
-    path for print mode, so an interactive session that ran turns and then
-    exited reaches this hook seconds after a Stop already spawned. Repeating it
-    would burn a second full LLM call on the same bytes.
-    """
-    interval = _interval_seconds()
-    if interval <= 0:
-        return False
-    try:
-        marker = _marker_path(session_id)
-        return (marker.exists()
-                and time.time() - marker.stat().st_mtime < interval)
-    except OSError:
-        return False
-
-
-def _interval_seconds() -> int:
-    """Shared with the Stop hook so the two agree on what "just captured"
-    means. Reading it here rather than hard-coding a window is what keeps a
-    person who set the interval to 0 (serialize every turn) from also
-    silencing this hook."""
-    raw = os.environ.get("DAIMON_KIMI_MIN_SERIALIZE_INTERVAL", "300").strip()
-    try:
-        return max(0, int(raw))
-    except ValueError:
-        return 300
-
-
-def _mark_spawned(session_id: str) -> None:
-    try:
-        STATE_DIR.mkdir(parents=True, exist_ok=True)
-        _marker_path(session_id).write_text(str(int(time.time())),
-                                            encoding="utf-8")
-    except OSError:
-        pass
-
-
 def main() -> int:
     if lib is None:
         _fallback_log(f"{TAG}: hook library missing (_daimon_hook_lib.py) - skipped")
@@ -142,11 +95,6 @@ def main() -> int:
                 f"(searched {lib.kimi_home()}/sessions) - skipped")
         return 0
 
-    if _already_captured(session_id):
-        lib.log(f"{TAG}: skipped serialize for {session_id} "
-                f"(already captured by the Stop hook)")
-        return 0
-
     cli = lib.resolve_cli()
     if cli is None:
         lib.log(f"{TAG}: `daimon` CLI not found - checkpoint skipped")
@@ -166,7 +114,6 @@ def main() -> int:
             lib.log(f"{TAG}: skipped serialize for {session_id} "
                     f"(already in flight) (transcript: {transcript_path})")
             return 0
-        _mark_spawned(session_id)
         lib.log(f"{TAG}: spawned serialize for {session_id} "
                 f"(project: {cwd or '?'}) (transcript: {transcript_path})")
     except OSError as exc:

--- a/plugin/daimon_briefing/_hooks/daimon-kimi-session-end.py
+++ b/plugin/daimon_briefing/_hooks/daimon-kimi-session-end.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Kimi Code SessionEnd hook: checkpoint the session that just closed.
+
+Measured on Kimi Code 0.42.0 (2026-09-09): this fires on an interactive exit
+with `reason: "exit"`, and NEVER on `kimi -p` print mode (measured twice; a
+print session ends with "To resume this session" and stays resumable, so it
+never closes). `Stop` is what captures print mode, which makes double capture
+a real shape here rather than a theoretical one: a session captured by Stop
+and then closed interactively arrives at this hook already checkpointed. It
+shares the Stop hook's marker for exactly that reason, and the CLI's own
+identical-bytes guard is the second line of defence.
+
+Unlike every host adapted before it, the payload carries NO transcript path
+and no environment variable holds one. The path is resolved from the session
+id against Kimi's own storage (lib.kimi_transcript), so "no transcript
+resolved" is a routine outcome worth a legible log line rather than silence.
+
+Set DAIMON_KIMI_SERIALIZE_ON_SESSION_END=0 to disable. The LLM work runs
+detached via `daimon serialize`, so the hook returns immediately.
+Diagnostics land in ~/.daimon/logs/serialize.log.
+"""
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Shared helpers live in a same-dir sibling module (see _daimon_hook_lib.py).
+# A stale/partial install may lack it: fail open with a logged one-liner rather
+# than crash. _fallback_log below mirrors lib.log for exactly that window.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    import _daimon_hook_lib as lib
+except Exception:  # noqa: BLE001 — missing/corrupt lib must never crash the hook
+    lib = None
+
+STATE_DIR = Path.home() / ".daimon" / "kimi"
+TAG = "kimi-session-end"
+
+
+def _fallback_log(line: str) -> None:
+    """Best-effort serialize.log write when the shared lib is unavailable
+    (stale/partial install). Mirrors lib.log so a broken install still leaves a
+    breadcrumb instead of a crash. Never raises."""
+    try:
+        log_dir = Path.home() / ".daimon" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with (log_dir / "serialize.log").open("a", encoding="utf-8") as f:
+            f.write(f"{stamp} {line}\n")
+    except OSError:
+        pass
+
+
+def _enabled() -> bool:
+    if lib.disabled():
+        return False
+    val = os.environ.get("DAIMON_KIMI_SERIALIZE_ON_SESSION_END", "1").strip().lower()
+    return val not in ("0", "false", "no", "off")
+
+
+def _safe_name(session_id: str) -> str:
+    return session_id.replace("/", "_").replace("\\", "_").replace("..", "_")
+
+
+def _marker_path(session_id: str) -> Path:
+    return STATE_DIR / f"{_safe_name(session_id)}.last-stop"
+
+
+def _already_captured(session_id: str) -> bool:
+    """True when the Stop hook already serialized this session inside its
+    throttle window.
+
+    On Codex this hook is deliberately unthrottled, because SessionEnd there is
+    the real end and Stop is only insurance. Here Stop is a genuine capture
+    path for print mode, so an interactive session that ran turns and then
+    exited reaches this hook seconds after a Stop already spawned. Repeating it
+    would burn a second full LLM call on the same bytes.
+    """
+    interval = _interval_seconds()
+    if interval <= 0:
+        return False
+    try:
+        marker = _marker_path(session_id)
+        return (marker.exists()
+                and time.time() - marker.stat().st_mtime < interval)
+    except OSError:
+        return False
+
+
+def _interval_seconds() -> int:
+    """Shared with the Stop hook so the two agree on what "just captured"
+    means. Reading it here rather than hard-coding a window is what keeps a
+    person who set the interval to 0 (serialize every turn) from also
+    silencing this hook."""
+    raw = os.environ.get("DAIMON_KIMI_MIN_SERIALIZE_INTERVAL", "300").strip()
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return 300
+
+
+def _mark_spawned(session_id: str) -> None:
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        _marker_path(session_id).write_text(str(int(time.time())),
+                                            encoding="utf-8")
+    except OSError:
+        pass
+
+
+def main() -> int:
+    if lib is None:
+        _fallback_log(f"{TAG}: hook library missing (_daimon_hook_lib.py) - skipped")
+        return 0
+    if not _enabled():
+        return 0
+
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        lib.log(f"{TAG}: unparseable stdin payload - skipped")
+        return 0
+    if not isinstance(payload, dict):
+        lib.log(f"{TAG}: stdin payload was not an object - skipped")
+        return 0
+
+    session_id = str(payload.get("session_id") or "").strip()
+    if not session_id:
+        lib.log(f"{TAG}: payload carried no session_id - skipped")
+        return 0
+
+    transcript_path = lib.kimi_transcript(session_id)
+    if transcript_path is None:
+        # Routine on this host, not a corruption: the payload has no path, so
+        # a lookup that finds nothing means the storage moved, KIMI_CODE_HOME
+        # differs from the session's, or the id is a shape the resolver
+        # refuses. Naming the id and the root is what makes it diagnosable.
+        lib.log(f"{TAG}: transcript not found for {session_id} "
+                f"(searched {lib.kimi_home()}/sessions) - skipped")
+        return 0
+
+    if _already_captured(session_id):
+        lib.log(f"{TAG}: skipped serialize for {session_id} "
+                f"(already captured by the Stop hook)")
+        return 0
+
+    cli = lib.resolve_cli()
+    if cli is None:
+        lib.log(f"{TAG}: `daimon` CLI not found - checkpoint skipped")
+        return 0
+
+    cwd = str(payload.get("cwd") or "").strip()
+    child_env = lib.project_env(cwd, "kimi")
+    try:
+        # `--session` is not optional here: every Kimi transcript is named
+        # `wire.jsonl`, so without it the CLI would derive the id "wire" for
+        # every session on the machine (#988).
+        if lib.spawn_serialize(cli, str(transcript_path), child_env,
+                               session_id=session_id) is False:
+            # `is False` (not falsy) on purpose — see scar 0062: the suite's
+            # spawn fakes return None, and a truthiness check would flip every
+            # one of them into this skip branch.
+            lib.log(f"{TAG}: skipped serialize for {session_id} "
+                    f"(already in flight) (transcript: {transcript_path})")
+            return 0
+        _mark_spawned(session_id)
+        lib.log(f"{TAG}: spawned serialize for {session_id} "
+                f"(project: {cwd or '?'}) (transcript: {transcript_path})")
+    except OSError as exc:
+        lib.log(f"{TAG}: spawn failed ({type(exc).__name__}: {exc})")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:
+        if lib is not None:
+            lib.log(f"{TAG}: hook error ({type(exc).__name__}: {exc})")
+        else:
+            _fallback_log(f"{TAG}: hook error ({type(exc).__name__}: {exc})")
+        sys.exit(0)

--- a/plugin/daimon_briefing/_hooks/daimon-kimi-stop.py
+++ b/plugin/daimon_briefing/_hooks/daimon-kimi-stop.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Kimi Code Stop hook: checkpoint the current transcript opportunistically.
+
+On Codex the equivalent hook is pure crash insurance. Here it is a capture
+path in its own right, because `kimi -p` print mode never fires `SessionEnd`
+(measured twice on 0.42.0, 2026-09-09: a print session ends resumable, so it
+never closes and the `exit|archive` matcher never sees it). Without this hook
+every print-mode session on the machine would go uncaptured.
+
+`Stop` fires per turn, so serializing on every one would be expensive. It is
+throttled by DAIMON_KIMI_MIN_SERIALIZE_INTERVAL (default 300 seconds per
+session). Set it to 0 to serialize on every Stop, or
+DAIMON_KIMI_SERIALIZE_ON_STOP=0 to disable this hook while keeping the
+UserPromptSubmit briefing.
+
+The payload carries a session id and no transcript path, so the path is
+resolved from the id (lib.kimi_transcript). The LLM work runs detached via
+`daimon serialize`; diagnostics land in ~/.daimon/logs/serialize.log.
+"""
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Shared helpers live in a same-dir sibling module (see _daimon_hook_lib.py).
+# A stale/partial install may lack it: fail open with a logged one-liner rather
+# than crash. _fallback_log below mirrors lib.log for exactly that window.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    import _daimon_hook_lib as lib
+except Exception:  # noqa: BLE001 — missing/corrupt lib must never crash the hook
+    lib = None
+
+STATE_DIR = Path.home() / ".daimon" / "kimi"
+TAG = "kimi-stop"
+
+
+def _fallback_log(line: str) -> None:
+    """Best-effort serialize.log write when the shared lib is unavailable
+    (stale/partial install). Mirrors lib.log so a broken install still leaves a
+    breadcrumb instead of a crash. Never raises."""
+    try:
+        log_dir = Path.home() / ".daimon" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with (log_dir / "serialize.log").open("a", encoding="utf-8") as f:
+            f.write(f"{stamp} {line}\n")
+    except OSError:
+        pass
+
+
+def _enabled() -> bool:
+    if lib.disabled():
+        return False
+    val = os.environ.get("DAIMON_KIMI_SERIALIZE_ON_STOP", "1").strip().lower()
+    return val not in ("0", "false", "no", "off")
+
+
+def _interval_seconds() -> int:
+    raw = os.environ.get("DAIMON_KIMI_MIN_SERIALIZE_INTERVAL", "300").strip()
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return 300
+
+
+def _safe_name(session_id: str) -> str:
+    return session_id.replace("/", "_").replace("\\", "_").replace("..", "_")
+
+
+def _marker_path(session_id: str) -> Path:
+    return STATE_DIR / f"{_safe_name(session_id)}.last-stop"
+
+
+def _should_spawn(session_id: str) -> bool:
+    interval = _interval_seconds()
+    if interval <= 0:
+        return True
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        marker = _marker_path(session_id)
+        if marker.exists() and time.time() - marker.stat().st_mtime < interval:
+            return False
+        return True
+    except OSError:
+        return True
+
+
+def _mark_spawned(session_id: str) -> None:
+    if _interval_seconds() <= 0:
+        return
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        _marker_path(session_id).write_text(str(int(time.time())),
+                                            encoding="utf-8")
+    except OSError:
+        pass
+
+
+def main() -> int:
+    if lib is None:
+        _fallback_log(f"{TAG}: hook library missing (_daimon_hook_lib.py) - skipped")
+        return 0
+    if not _enabled():
+        return 0
+
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        lib.log(f"{TAG}: unparseable stdin payload - skipped")
+        return 0
+    if not isinstance(payload, dict):
+        lib.log(f"{TAG}: stdin payload was not an object - skipped")
+        return 0
+
+    session_id = str(payload.get("session_id") or "").strip()
+    if not session_id:
+        lib.log(f"{TAG}: payload carried no session_id - skipped")
+        return 0
+
+    # Throttle BEFORE resolving the path: this hook fires after every turn, and
+    # the resolver globs the host's session storage. Inside the window there is
+    # nothing to do with the answer.
+    if not _should_spawn(session_id):
+        lib.log(f"{TAG}: skipped serialize for {session_id} (throttled)")
+        return 0
+
+    transcript_path = lib.kimi_transcript(session_id)
+    if transcript_path is None:
+        lib.log(f"{TAG}: transcript not found for {session_id} "
+                f"(searched {lib.kimi_home()}/sessions) - skipped")
+        return 0
+
+    cli = lib.resolve_cli()
+    if cli is None:
+        lib.log(f"{TAG}: `daimon` CLI not found - checkpoint skipped")
+        return 0
+
+    cwd = str(payload.get("cwd") or "").strip()
+    child_env = lib.project_env(cwd, "kimi")
+    try:
+        # `--session` is not optional here: every Kimi transcript is named
+        # `wire.jsonl` (#988).
+        if lib.spawn_serialize(cli, str(transcript_path), child_env,
+                               session_id=session_id) is False:
+            # `is False` (not falsy) on purpose — see scar 0062.
+            lib.log(f"{TAG}: skipped serialize for {session_id} "
+                    f"(already in flight) (transcript: {transcript_path})")
+            return 0
+        _mark_spawned(session_id)
+        lib.log(f"{TAG}: spawned serialize for {session_id} "
+                f"(project: {cwd or '?'}) (transcript: {transcript_path})")
+    except OSError as exc:
+        lib.log(f"{TAG}: spawn failed ({type(exc).__name__}: {exc})")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:
+        if lib is not None:
+            lib.log(f"{TAG}: hook error ({type(exc).__name__}: {exc})")
+        else:
+            _fallback_log(f"{TAG}: hook error ({type(exc).__name__}: {exc})")
+        sys.exit(0)

--- a/plugin/daimon_briefing/_hooks/daimon-kimi-user-prompt-submit.py
+++ b/plugin/daimon_briefing/_hooks/daimon-kimi-user-prompt-submit.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Kimi Code UserPromptSubmit hook: the ONLY channel into the model.
+
+Measured on 0.42.0 (2026-09-09): of every event that fires, only this one's
+stdout reaches the session, arriving as a user message wrapped in
+`<hook_result hook_event="UserPromptSubmit">`. `SessionStart` fires and its
+stdout is dropped. So this hook carries both jobs the other hosts split
+between two events:
+
+1. The briefing, on the FIRST prompt of a session. Kimi offers no usable
+   session-start event, so "first" is kept here as a per-session marker rather
+   than inferred from an event. The consequence a person sees is that the
+   briefing arrives with their first message instead of before it, and the
+   host page says so.
+2. The per-prompt recall injection, on every prompt after that, shelling out
+   to `daimon recall-inject` exactly as the Claude Code prompt hook does.
+
+Noise contract, copied deliberately from daimon-prompt-recall.py: this fires
+on EVERY prompt, so failures are SILENT (exit 0, no output). A diagnostic per
+prompt would be spam. Unlike on Claude Code there is no SessionStart hook to
+surface install problems once a session, so a broken install here is quiet by
+design; `daimon hooks status` is the surface that reports it.
+
+Exit code discipline matters more here than on the capture hooks.
+`UserPromptSubmit` is BLOCKABLE on this host: a non-zero exit is how a hook
+refuses the person's prompt. Every path returns 0.
+"""
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    import _daimon_hook_lib as lib
+except Exception:  # noqa: BLE001 — missing/corrupt lib: silent no-op (see above)
+    lib = None
+
+STATE_DIR = Path.home() / ".daimon" / "kimi"
+BRIEF_TIMEOUT = 8   # the host's registered timeout is 10
+RECALL_TIMEOUT = 4
+DELIVERY_TIMEOUT = 1.5
+
+
+def _safe_name(session_id: str) -> str:
+    return session_id.replace("/", "_").replace("\\", "_").replace("..", "_")
+
+
+def _claim_first_prompt(session_id: str) -> bool:
+    """True exactly once per session: the prompt that gets the briefing.
+
+    Uses `open(..., "x")`, which is atomic on every platform daimon runs on, so
+    two prompts racing in the same session cannot both win and inject the
+    briefing twice. A marker that cannot be written at all yields False rather
+    than True: repeating a briefing on every prompt would be worse than never
+    showing it, because it would push the real conversation out of context.
+    """
+    if not session_id:
+        return False
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        with (STATE_DIR / f"{_safe_name(session_id)}.briefed").open("x") as f:
+            f.write(str(int(time.time())))
+        return True
+    except FileExistsError:
+        return False
+    except OSError:
+        return False
+
+
+def _brief(cli, cwd: str) -> str:
+    """The rendered briefing, or "" when there is nothing to say.
+
+    Shells out to `daimon brief` so the renderer stays single-source-of-truth,
+    matching the Claude Code and Codex hook paths. Plain text, no JSON
+    envelope: this host appends what the hook prints and wraps it itself.
+    """
+    slug = lib.slug(cwd)
+    ckpt_dir = lib.checkpoint_dir()
+    latest = ckpt_dir / slug / "latest.json" if slug else None
+    fallback = False
+    if latest is None or not latest.exists():
+        fallback = latest is not None
+        latest = ckpt_dir / "latest.json"
+    if not latest.exists() or cli is None:
+        return ""
+    try:
+        proc = subprocess.run([cli, "brief"], capture_output=True, text=True,
+                              timeout=BRIEF_TIMEOUT, env=lib.project_env(cwd))
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+    text = proc.stdout.strip()
+    if proc.returncode != 0 or not text or text.startswith("No checkpoint yet"):
+        return ""
+    suffix = (" (global fallback - checkpoint may be from another project)"
+              if fallback else "")
+    return f"DAIMON BRIEFING {lib.age_line(latest)}{suffix}\n{text}"
+
+
+def _deliver(cli, cwd: str, session: str) -> None:
+    """Any undecided ask addressed to this project that this session has not
+    been shown (#756). Silent on every failure, like everything on this path."""
+    if not session:
+        return  # the session id is half the delivery write-once key
+    cmd = [cli, "request-inject", "--session", session]
+    if cwd:
+        cmd += ["--project", cwd]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True,
+                              timeout=DELIVERY_TIMEOUT, env=lib.project_env(cwd))
+    except (subprocess.TimeoutExpired, OSError):
+        return
+    if proc.returncode == 0 and proc.stdout.strip():
+        print(proc.stdout.strip())
+
+
+def _recall(cli, cwd: str, session: str, prompt: str) -> None:
+    # Slash commands are host directives, not work statements — never match.
+    if not prompt.strip() or prompt.lstrip().startswith("/"):
+        return
+    cmd = [cli, "recall-inject"]
+    if cwd:
+        cmd += ["--project", cwd]
+    if session:
+        cmd += ["--session", session]
+    try:
+        proc = subprocess.run(cmd, input=prompt, capture_output=True, text=True,
+                              timeout=RECALL_TIMEOUT, env=lib.project_env(cwd))
+    except (subprocess.TimeoutExpired, OSError):
+        return
+    if proc.returncode == 0 and proc.stdout.strip():
+        print(proc.stdout.strip())
+
+
+def main() -> int:
+    if lib is None or lib.disabled():
+        return 0
+    data = lib.payload()
+    cwd = str(data.get("cwd") or "").strip()
+    session = str(data.get("session_id") or "").strip()
+    # Kimi sends `prompt` as a LIST of content parts, where every other host
+    # sends a string. Unflattened it would reach recall-inject as a repr.
+    prompt = lib.kimi_prompt_text(data.get("prompt"))
+    cli = lib.resolve_cli()
+    if cli is None:
+        return 0
+
+    if _claim_first_prompt(session):
+        text = _brief(cwd=cwd, cli=cli)
+        if text:
+            print(text)
+        # The briefing already answers "where were we", so recall on the same
+        # prompt would restate it. Delivery still runs: an undecided ask is
+        # owed regardless of what the person typed.
+        if (lib._config_get("DAIMON_LIVE_DELIVERY") or "").strip() in (
+                "1", "true", "yes", "on"):
+            _deliver(cli, cwd, session)
+        # Opportunistic self-heal of a previously FAILED serialize (#26). This
+        # is the closest thing to a session start this host offers, and a
+        # failed serialize leaves no checkpoint, which is exactly the case
+        # where heal matters. Runs last: it can never affect what was printed.
+        lib.spawn_heal(cli, cwd)
+        return 0
+
+    if (lib._config_get("DAIMON_LIVE_DELIVERY") or "").strip() in (
+            "1", "true", "yes", "on"):
+        _deliver(cli, cwd, session)
+    _recall(cli, cwd, session, prompt)
+    return 0
+
+
+if __name__ == "__main__":
+    # Exit 0 on ANY error: a non-zero exit from this event refuses the
+    # person's prompt on this host.
+    try:
+        sys.exit(main())
+    except Exception:  # noqa: BLE001
+        sys.exit(0)

--- a/plugin/daimon_briefing/checks_host.py
+++ b/plugin/daimon_briefing/checks_host.py
@@ -167,6 +167,33 @@ PROFILES = {
         matcher="",
         install_timeout=10,
     ),
+    # #988: there is deliberately NO `kimi` row here yet, and the Kimi adapter
+    # ships its briefing and capture hooks without one.
+    #
+    # What a live probe of Kimi Code 0.42.0 (2026-09-09) DID measure:
+    #   - `PreToolUse` fires with `tool_name: "Bash"` and the command at
+    #     `tool_input.command`, so `command_path` and `matcher` would copy the
+    #     claude-code row unchanged.
+    #   - `cwd` is on the payload, resolved on macOS (`/private/tmp`).
+    #   - `PreToolUse` exit-0 stdout is DROPPED, not appended to context. Only
+    #     `UserPromptSubmit` stdout reaches the model. So the warn channel is
+    #     measured ABSENT, and `warn` would have to cap at `record-only` the
+    #     way the codex row does, rather than be left open.
+    #
+    # What it did NOT measure, and what runbook Part 4 has to prove before a
+    # row lands here: THE DENY CHANNEL. Neither exit code 2 with a reason on
+    # stderr nor the stdout JSON `hookSpecificOutput.permissionDecision: deny`
+    # was ever exercised against a real command. Both strings are present in
+    # the shipped binary and both are documented, and neither of those is a
+    # command observed being blocked.
+    #
+    # A row added on documentation alone would put `enforce` in the
+    # degradation ladder for an enforcement daimon has never watched land,
+    # which is the one direction this ladder must not fail in: a check that
+    # reports enforcing and silently allows is worse than no check, because it
+    # is byte-identical to a clean allow (scar 0072). The windsurf row above
+    # is the precedent, and it caps the whole column at `unsupported` for
+    # exactly this reason.
 }
 
 

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -274,7 +274,7 @@ def _print_error(msg: str) -> None:
 
 
 def _run_serialize(transcript_path: Path, project: str | None,
-                   escalate: bool = False) -> int:
+                   escalate: bool = False, session: str | None = None) -> int:
     """Serialize one transcript to a checkpoint routed to `project` (used AS-IS;
     None => global pointer only, NO cwd fallback). The caller decides routing —
     this never calls _resolve_project, so `heal` can route to the FAILED
@@ -299,7 +299,16 @@ def _run_serialize(transcript_path: Path, project: str | None,
     # the checkpoint can bind to its exact source content. None when unreadable —
     # stamped only when present; readers tolerate its absence (old checkpoints).
     transcript_sha = transcript.file_sha256(path)
-    session_id = path.stem
+    # #988: the filename names the session on every host adapted before Kimi
+    # Code, and on Kimi it does not — the session id is a DIRECTORY and the
+    # file inside it is always `wire.jsonl`. Without the override every Kimi
+    # session on the machine would serialize under the id "wire": one
+    # per-session checkpoint overwritten by each new session, and a heartbeat
+    # under a constant name that makes any live serialize look like every
+    # other session's (scar 0061). Same rule #983 set for `write-checkpoint`:
+    # when the host can supply a real session id, that id wins over an
+    # inferred one.
+    session_id = (session or "").strip() or path.stem
 
     # Identical-bytes guard (#185): a `claude --resume` fork leaves the ORIGINAL
     # session's transcript on disk unchanged, but a SessionEnd can still fire for
@@ -421,7 +430,8 @@ _session_end_stamp = capture._session_end_stamp
 
 
 def _cmd_serialize(args) -> int:
-    return _run_serialize(Path(args.transcript), _resolve_project(args.project))
+    return _run_serialize(Path(args.transcript), _resolve_project(args.project),
+                          session=getattr(args, "session", None))
 
 
 def _cmd_write_checkpoint(args) -> int:
@@ -3392,6 +3402,23 @@ _HOOK_HOSTS: dict[str, _HookHostSpec] = {
         "events": ("SessionStart", "Stop", "SessionEnd", "PreToolUse"),
         "register": "codex",
     },
+    # #988. Like Codex, Kimi Code needs several scripts under several events
+    # and a real registration written for it, so it carries `register: "kimi"`
+    # and the install command delegates to kimi_hooks.install. Unlike every
+    # other host, that registration is TOML in a file the host's own login
+    # flow owns, which is why the installer edits text blocks rather than
+    # re-serializing (see kimi_hooks).
+    #
+    # No SessionStart: measured, its stdout is dropped by the host, so the
+    # briefing rides UserPromptSubmit instead. No PreToolUse: the deny channel
+    # is unmeasured, so no check profile ships (see checks_host.PROFILES).
+    "kimi": {
+        "files": ("daimon-kimi-user-prompt-submit.py",
+                  "daimon-kimi-session-end.py", "daimon-kimi-stop.py",
+                  "_daimon_hook_lib.py"),
+        "events": ("UserPromptSubmit", "SessionEnd", "Stop"),
+        "register": "kimi",
+    },
 }
 
 
@@ -3416,11 +3443,16 @@ def _host_scripts(spec) -> str:
 
 
 def _host_install_dir(spec, home: Path) -> Path:
-    """Where a host's hook files live. Codex owns ~/.codex/hooks/ (it registers
-    the scripts there itself); everyone else shares the stable ~/.daimon/hooks/
-    that `hooks install` writes to."""
+    """Where a host's hook files live. A host that registers its own scripts
+    keeps them inside its own config tree (Codex: ~/.codex/hooks/; Kimi Code:
+    ~/.kimi-code/hooks/, or under KIMI_CODE_HOME); everyone else shares the
+    stable ~/.daimon/hooks/ that `hooks install` writes to."""
     if spec.get("register") == "codex":
         return home / ".codex" / "hooks"
+    if spec.get("register") == "kimi":
+        from .. import kimi_hooks
+
+        return kimi_hooks.hooks_dir(home)
     return home / ".daimon" / "hooks"
 
 
@@ -3460,13 +3492,30 @@ def _codex_registration_status(home: Path) -> str:
     return "REGISTERED" if found == len(codex_hooks.HOOKS) else "PARTIAL"
 
 
+def _registration_status(spec, home: Path) -> str | None:
+    """REGISTERED / PARTIAL / UNREGISTERED for a host that writes its own
+    registration, or None for one that only prints a snippet.
+
+    Each host's verdict comes from that host's own installer module, so it can
+    never drift from what `hooks install` actually writes."""
+    kind = spec.get("register")
+    if kind == "codex":
+        return _codex_registration_status(home)
+    if kind == "kimi":
+        from .. import kimi_hooks
+
+        return kimi_hooks.registration_status(home)
+    return None
+
+
 def _host_status_entry(host: str, spec, pkg, home: Path) -> dict:
     install_dir = _host_install_dir(spec, home)
-    reg = _codex_registration_status(home) if spec.get("register") == "codex" else None
+    reg = _registration_status(spec, home)
     installed = any((install_dir / n).exists() for n in spec["files"])
-    if spec.get("register") == "codex":
-        # Codex counts as installed if its hooks dir OR any of our registration
-        # entries exist — either alone is a setup we must audit, not ignore.
+    if reg is not None:
+        # A self-registering host counts as installed if its hooks dir OR any
+        # of our registration entries exist — either alone is a setup we must
+        # audit, not ignore.
         installed = installed or install_dir.exists() or reg != "UNREGISTERED"
     entry: dict = {"host": host, "dir": str(install_dir),
                    "installed": installed, "registration": reg,
@@ -3641,6 +3690,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--project",
         help="project directory to route the checkpoint to "
         "(default: DAIMON_PROJECT_DIR, then cwd)",
+    )
+    p_ser.add_argument(
+        "--session",
+        help="session id for this transcript, overriding the filename (#988: "
+             "a host whose transcript is not named for its session, such as "
+             "Kimi Code, where every file is `wire.jsonl`)",
     )
     p_ser.set_defaults(func=_cmd_serialize)
 

--- a/plugin/daimon_briefing/cli/hooks.py
+++ b/plugin/daimon_briefing/cli/hooks.py
@@ -67,6 +67,21 @@ def _cmd_hooks_install(args) -> int:
         lines = codex_hooks.install(pkg, Path.home())
         render.render_hooks_install(lines + ["", _checks_line()])
         return 0
+    if spec.get("register") == "kimi":
+        # #988. Same self-registering shape as Codex, into TOML rather than
+        # JSON. The ConfigError is caught here and reported: that file holds
+        # the person's provider credentials, and a traceback out of an install
+        # verb reads as "daimon broke my config" when nothing was written.
+        from .. import kimi_hooks
+
+        try:
+            lines = kimi_hooks.install(pkg, Path.home())
+        except kimi_hooks.ConfigError as exc:
+            print(f"error: {kimi_hooks.config_path(Path.home())} could not be "
+                  f"read safely, so nothing was written: {exc}", file=sys.stderr)
+            return 1
+        render.render_hooks_install(lines + ["", _checks_line()])
+        return 0
     target = _cli._hooks_target_dir()
     target.mkdir(parents=True, exist_ok=True)
     for name in spec["files"]:
@@ -90,6 +105,42 @@ def _cmd_hooks_install(args) -> int:
     lines += ["", _checks_line()]
     render.render_hooks_install(lines)
     return 0
+
+def _cmd_hooks_remove(args) -> int:
+    """Unregister a self-registering host's hook entries (#988).
+
+    Only hosts that daimon REGISTERED can be unregistered: for everyone else
+    the registration is a snippet the person pasted into their own config, and
+    daimon has no idea where it landed. Saying so is better than a verb that
+    reports success having touched nothing.
+
+    The installed scripts stay. They are inert once unregistered, and deleting
+    them would break any other registration pointing at the same files.
+    """
+    spec = _cli._HOOK_HOSTS.get(args.host)
+    if spec is None:
+        known = ", ".join(sorted(_cli._HOOK_HOSTS))
+        print(f"error: unknown host '{args.host}' (known: {known})", file=sys.stderr)
+        return 2
+    if spec.get("register") != "kimi":
+        removable = sorted(h for h, s in _cli._HOOK_HOSTS.items()
+                           if s.get("register") == "kimi")
+        print(f"error: daimon does not own the hook registration for "
+              f"'{args.host}', so it cannot remove it. Edit that host's hooks "
+              f"config by hand. Removable: {', '.join(removable)}",
+              file=sys.stderr)
+        return 2
+    from .. import kimi_hooks
+
+    try:
+        lines = kimi_hooks.remove(Path.home())
+    except kimi_hooks.ConfigError as exc:
+        print(f"error: {kimi_hooks.config_path(Path.home())} could not be read "
+              f"safely, so nothing was written: {exc}", file=sys.stderr)
+        return 1
+    render.render_hooks_install(lines)
+    return 0
+
 
 def _cmd_hooks_status(args) -> int:
     """#943 slice 5: the scripts audit, plus the file those scripts READ.
@@ -173,3 +224,11 @@ def register(sub, fmt) -> None:
     )
     ph_install.add_argument("host", help="host to install (see `daimon hooks list`)")
     ph_install.set_defaults(func=_cli._cmd_hooks_install)
+    ph_remove = hooks_sub.add_parser(
+        "remove",
+        help="unregister daimon's hook entries from a host whose registration "
+             "daimon wrote (kimi). The installed scripts are left in place; "
+             "they are inert once unregistered",
+    )
+    ph_remove.add_argument("host", help="host to unregister")
+    ph_remove.set_defaults(func=_cmd_hooks_remove)

--- a/plugin/daimon_briefing/kimi_hooks.py
+++ b/plugin/daimon_briefing/kimi_hooks.py
@@ -196,17 +196,32 @@ def _is_ours(block: Block) -> bool:
     return any(spec.script in command for spec in HOOKS)
 
 
-def _render(spec, hooks_target: Path) -> str:
+def _newline(text: str) -> str:
+    """The file's own line ending, so the lines daimon appends match the lines
+    already there. A config that passed through a Windows editor is CRLF
+    throughout; appending LF blocks to it would leave a mixed file, and
+    reading it with universal newlines would rewrite every line the installer
+    does not own on the way back out."""
+    return "\r\n" if "\r\n" in text else "\n"
+
+
+def _read(path: Path) -> str:
+    """Bytes, decoded, no newline translation: `read_text` folds CRLF to LF
+    and the round trip would then write LF back over a CRLF file."""
+    return path.read_bytes().decode("utf-8")
+
+
+def _render(spec, hooks_target: Path, nl: str = "\n") -> str:
     """One `[[hooks]]` entry as text. Exactly four fields, in the host's own
     documented order. `timeout` is written bare: it is an integer, and quoting
     it would make the host reject the entry's type."""
     command = f"python3 {hooks_target / spec.script}"
-    return (f"{MARKER}\n"
-            "[[hooks]]\n"
-            f'event = "{spec.event}"\n'
-            f'matcher = "{spec.matcher}"\n'
-            f'command = "{command}"\n'
-            f"timeout = {spec.timeout}\n")
+    return (f"{MARKER}{nl}"
+            f"[[hooks]]{nl}"
+            f'event = "{spec.event}"{nl}'
+            f'matcher = "{spec.matcher}"{nl}'
+            f'command = "{command}"{nl}'
+            f"timeout = {spec.timeout}{nl}")
 
 
 def _strip_ours(lines, blocks):
@@ -237,7 +252,7 @@ def _save(path: Path, text: str) -> str | None:
         backup = path.with_name(f"config.toml.daimon-backup-{int(time.time())}")
         shutil.copy2(path, backup)
         note = backup.name
-    path.write_text(text, encoding="utf-8")
+    path.write_bytes(text.encode("utf-8"))  # no newline translation, see _read
     return note
 
 
@@ -258,16 +273,19 @@ def install(pkg, home, env=None):
             dest.chmod(dest.stat().st_mode | 0o100)  # u+x
 
     path = config_path(home, env)
-    original = path.read_text(encoding="utf-8") if path.exists() else ""
+    original = _read(path) if path.exists() else ""
     blocks = _hook_blocks(original)  # raises ConfigError before anything is written
     ours = [b for b in blocks if _is_ours(b)]
 
     lines = [f"installed {len(FILES)} file(s) to {target}"]
+    nl = _newline(original)
     kept = _strip_ours(original.splitlines(keepends=True), ours)
     body = "".join(kept)
     if body and not body.endswith("\n"):
-        body += "\n"
-    additions = "".join(f"\n{_render(spec, target)}" for spec in HOOKS)
+        # The one byte the round trip does not give back: remove cannot tell
+        # this newline from one the person wrote. The host page says so.
+        body += nl
+    additions = "".join(f"{nl}{_render(spec, target, nl)}" for spec in HOOKS)
     updated = body + additions
 
     if updated == original:
@@ -303,7 +321,7 @@ def remove(home, env=None):
     path = config_path(home, env)
     if not path.exists():
         return [f"{path} does not exist - nothing to remove"]
-    original = path.read_text(encoding="utf-8")
+    original = _read(path)
     ours = [b for b in _hook_blocks(original) if _is_ours(b)]
     if not ours:
         return [f"{path}: no daimon entries found"]
@@ -325,8 +343,8 @@ def registration_status(home, env=None) -> str:
     if not path.exists():
         return "UNREGISTERED"
     try:
-        blocks = _hook_blocks(path.read_text(encoding="utf-8"))
-    except (OSError, ConfigError):
+        blocks = _hook_blocks(_read(path))
+    except (OSError, UnicodeDecodeError, ConfigError):
         return "UNREGISTERED"
     found = sum(1 for spec in HOOKS
                 if any(spec.script in str(b.fields.get("command") or "")

--- a/plugin/daimon_briefing/kimi_hooks.py
+++ b/plugin/daimon_briefing/kimi_hooks.py
@@ -1,0 +1,336 @@
+"""Packaged Kimi Code hook installer — `daimon hooks install kimi` (#988).
+
+Kimi Code is the first host whose hooks config is TOML rather than JSON, and
+that difference is not cosmetic. `~/.kimi-code/config.toml` is written by the
+host's own login flow and holds provider credentials and model tables; a
+`[[hooks]]` entry in it accepts EXACTLY four fields (`event`, `matcher`,
+`command`, `timeout`), and a fifth fails the WHOLE config load rather than
+that one entry. So a `statusMessage` copied across from the Codex manager
+would not degrade a hook, it would unhook the host and lock the person out of
+their own config until they found it.
+
+Two rules follow, and both are load-bearing:
+
+1. **Never re-serialize.** There is no TOML writer in the stdlib, and the
+   kernel floor is 3.10 so there is no `tomllib` READER either. Rather than
+   take a dependency (the kernel is stdlib forever) or reimplement TOML, this
+   module treats the file as TEXT and edits BLOCKS of it. Everything it did
+   not write comes back byte-identical: comments, key order, spacing. The
+   `_hook_blocks` scanner below is deliberately small, and it is a locator,
+   not a parser: it finds where daimon's own entries begin and end and reads
+   the handful of scalar fields those entries carry. It does not attempt
+   arrays, inline tables, or multi-line strings, because daimon never writes
+   them and never needs to read one to find its own blocks.
+2. **Exactly four fields, always.**
+
+Ownership keys on the daimon script filename inside `command`, the same rule
+the Codex installer uses, so a hand-edited entry pointing at one of our
+scripts is still recognised as ours and refreshed rather than duplicated.
+
+Host facts this encodes, all measured on a live Kimi Code 0.42.0 session on
+2026-09-09 (see the probe runbook):
+
+- Only `UserPromptSubmit` stdout reaches the model, as a user message wrapped
+  in `<hook_result hook_event="UserPromptSubmit">`. `SessionStart` stdout is
+  dropped, so registering it would spawn an interpreter per session to write
+  into a closed pipe.
+- `SessionEnd` fires on interactive exit and NEVER on `kimi -p` print mode
+  (measured twice: a print session ends resumable, so it never closes). `Stop`
+  fires per turn in both, which is why the throttled Stop capture is not
+  optional here the way it is a pure backstop on Codex.
+- No `PreToolUse` entry: the deny channel is unmeasured, so no check profile
+  ships (see `checks_host.PROFILES`).
+- Hooks load at session start only. A person who installs mid-session has to
+  start a new one, and the install output says so.
+"""
+
+import os
+import re
+import shutil
+import time
+from pathlib import Path
+from typing import NamedTuple
+
+LIB = "_daimon_hook_lib.py"
+
+# The shared stdlib-only module the scripts load by same-dir lookup. No
+# redact.py: like the Codex hooks, these spawn `daimon serialize` and the CLI
+# does the redacting, so a redaction module here would be dead weight. No
+# checks_*.py either, because no pre-action check ships for this host yet.
+MODULES = (LIB,)
+
+
+class HookSpec(NamedTuple):
+    """One registration. The field set is the host's whole vocabulary for a
+    `[[hooks]]` entry, so this type IS the four-field rule: there is nowhere to
+    put a fifth field even by accident."""
+
+    script: str
+    event: str
+    matcher: str
+    timeout: int
+
+
+# `matcher` is a regex the host applies to the event's subject; `.*` on all
+# three because none of them is tool-scoped.
+HOOKS: tuple[HookSpec, ...] = (
+    # The only channel into the model. Carries the briefing on a session's
+    # first prompt and the per-prompt recall injection after that.
+    HookSpec("daimon-kimi-user-prompt-submit.py", "UserPromptSubmit", ".*", 10),
+    HookSpec("daimon-kimi-session-end.py", "SessionEnd", ".*", 10),
+    HookSpec("daimon-kimi-stop.py", "Stop", ".*", 10),
+)
+
+FILES = tuple(spec.script for spec in HOOKS) + MODULES
+
+# Written above each block so a person reading their own config knows what put
+# it there and what will take it away. Removal does NOT key on this line (a
+# hand-edited config may have lost it); it keys on the command. It is carried
+# along on removal only when it sits directly above a block we own.
+MARKER = ("# daimon (issue #988): written by `daimon hooks install kimi`. "
+          "Remove with `daimon hooks remove kimi`.")
+
+_ARRAY_HEADER_RE = re.compile(r"^\s*\[\[\s*hooks\s*\]\]\s*(?:#.*)?$")
+_ANY_HEADER_RE = re.compile(r"^\s*\[")
+# One scalar assignment. Values daimon writes are a quoted string or a bare
+# integer, which is the whole vocabulary a `[[hooks]]` entry has.
+_KV_RE = re.compile(r"""^\s*([A-Za-z_][A-Za-z0-9_-]*)\s*=\s*
+                        (?:"((?:[^"\\]|\\.)*)"|'([^']*)'|([^\s#]+))
+                        \s*(?:\#.*)?$""", re.VERBOSE)
+
+
+class ConfigError(Exception):
+    """The config could not be read well enough to edit it safely.
+
+    Raised rather than repaired. This file holds the person's provider
+    credentials, and a writer that guesses at a shape it does not understand
+    is one append away from losing them. A refusal leaves them with a working
+    host and a message that names the file.
+    """
+
+
+class Block(NamedTuple):
+    """One `[[hooks]]` entry located in the file.
+
+    `start`/`end` are line indices into `splitlines(keepends=True)`, half-open,
+    covering the header line through the last line that belongs to the entry.
+    `fields` holds its scalar assignments as strings.
+    """
+
+    start: int
+    end: int
+    fields: dict
+
+
+def _env(env):
+    return os.environ if env is None else env
+
+
+def config_home(home, env=None) -> Path:
+    """Kimi's config directory: `KIMI_CODE_HOME` when set, else `~/.kimi-code`.
+
+    The host documents that variable for its own user scope (skills, mcp.json),
+    so honouring it is what the host itself would do. It is also the override
+    that keeps every test in this repo away from a real `~/.kimi-code`.
+    """
+    override = str(_env(env).get("KIMI_CODE_HOME") or "").strip()
+    return Path(override).expanduser() if override else Path(home) / ".kimi-code"
+
+
+def hooks_dir(home, env=None) -> Path:
+    return config_home(home, env) / "hooks"
+
+
+def config_path(home, env=None) -> Path:
+    return config_home(home, env) / "config.toml"
+
+
+def _hook_blocks(text: str):
+    """Every `[[hooks]]` entry in `text`, in file order.
+
+    A block runs from its `[[hooks]]` header to the line before the next table
+    header of any kind, or to end of file. Blank lines and comments inside it
+    belong to it; a trailing run of blank lines does not, so removing a block
+    cannot eat the separation between its neighbours.
+    """
+    lines = text.splitlines(keepends=True)
+    blocks = []
+    index = 0
+    while index < len(lines):
+        if not _ARRAY_HEADER_RE.match(lines[index]):
+            index += 1
+            continue
+        start = index
+        fields: dict = {}
+        last_content = index
+        cursor = index + 1
+        while cursor < len(lines) and not _ANY_HEADER_RE.match(lines[cursor]):
+            stripped = lines[cursor].strip()
+            if stripped and not stripped.startswith("#"):
+                match = _KV_RE.match(lines[cursor])
+                if match is None:
+                    raise ConfigError(
+                        f"line {cursor + 1}: cannot read this line inside a "
+                        f"[[hooks]] entry: {stripped!r}")
+                key = match.group(1)
+                value = next(g for g in match.groups()[1:] if g is not None)
+                fields[key] = value
+                last_content = cursor
+            elif stripped.startswith("#"):
+                last_content = cursor
+            cursor += 1
+        blocks.append(Block(start=start, end=last_content + 1, fields=fields))
+        index = cursor
+    return blocks
+
+
+def _is_ours(block: Block) -> bool:
+    """True when a block's command runs one of daimon's Kimi hook scripts.
+
+    Keyed on the exact script filenames rather than the substring "daimon", so
+    an unrelated tool with daimon in its path is never removed by us, and a
+    daimon script registered by hand at some other path is still recognised as
+    ours and refreshed rather than duplicated.
+    """
+    command = str(block.fields.get("command") or "")
+    return any(spec.script in command for spec in HOOKS)
+
+
+def _render(spec, hooks_target: Path) -> str:
+    """One `[[hooks]]` entry as text. Exactly four fields, in the host's own
+    documented order. `timeout` is written bare: it is an integer, and quoting
+    it would make the host reject the entry's type."""
+    command = f"python3 {hooks_target / spec.script}"
+    return (f"{MARKER}\n"
+            "[[hooks]]\n"
+            f'event = "{spec.event}"\n'
+            f'matcher = "{spec.matcher}"\n'
+            f'command = "{command}"\n'
+            f"timeout = {spec.timeout}\n")
+
+
+def _strip_ours(lines, blocks):
+    """`lines` minus every block we own, plus the marker line directly above
+    one and the blank line we inserted before it.
+
+    Deletions run back to front so earlier indices stay valid. Taking the
+    marker and the separating blank line back is what makes install/remove a
+    true round trip instead of a cycle that grows the file each time.
+    """
+    out = list(lines)
+    for block in sorted(blocks, key=lambda b: b.start, reverse=True):
+        start, end = block.start, block.end
+        if start > 0 and out[start - 1].strip() == MARKER:
+            start -= 1
+        if start > 0 and out[start - 1].strip() == "":
+            start -= 1
+        del out[start:end]
+    return out
+
+
+def _save(path: Path, text: str) -> str | None:
+    """Write `text`, backing up any existing file first. Returns the backup
+    name, or None when there was nothing to back up (a fresh install)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    note = None
+    if path.exists():
+        backup = path.with_name(f"config.toml.daimon-backup-{int(time.time())}")
+        shutil.copy2(path, backup)
+        note = backup.name
+    path.write_text(text, encoding="utf-8")
+    return note
+
+
+def install(pkg, home, env=None):
+    """Install/refresh the Kimi Code hook integration; return output lines.
+
+    `pkg` is a traversable for `daimon_briefing._hooks`; `home` is the home
+    directory, passed in so tests install into a temp HOME. Idempotent:
+    re-running refreshes the scripts to match the installed CLI, and rewrites
+    a stale registration in place rather than appending a second one.
+    """
+    target = hooks_dir(home, env)
+    target.mkdir(parents=True, exist_ok=True)
+    for name in FILES:
+        dest = target / name
+        dest.write_bytes((pkg / name).read_bytes())
+        if name not in MODULES:  # imported by same-dir lookup, never executed
+            dest.chmod(dest.stat().st_mode | 0o100)  # u+x
+
+    path = config_path(home, env)
+    original = path.read_text(encoding="utf-8") if path.exists() else ""
+    blocks = _hook_blocks(original)  # raises ConfigError before anything is written
+    ours = [b for b in blocks if _is_ours(b)]
+
+    lines = [f"installed {len(FILES)} file(s) to {target}"]
+    kept = _strip_ours(original.splitlines(keepends=True), ours)
+    body = "".join(kept)
+    if body and not body.endswith("\n"):
+        body += "\n"
+    additions = "".join(f"\n{_render(spec, target)}" for spec in HOOKS)
+    updated = body + additions
+
+    if updated == original:
+        for spec in HOOKS:
+            lines.append(f"  {spec.event}: already registered ({spec.script})")
+        lines.append(f"{path} already up to date")
+    else:
+        verb = "re-registered" if ours else "registered"
+        for spec in HOOKS:
+            lines.append(f"  {spec.event}: {verb} {spec.script}")
+        backup = _save(path, updated)
+        lines.append(f"updated {path}" + (f" (backup: {backup})" if backup
+                                          else " (new file)"))
+
+    lines += [
+        "",
+        "Kimi Code loads hooks at session start. Start a NEW session for these "
+        "to take effect; a running one will not pick them up.",
+        "",
+        "Re-run `daimon hooks install kimi` after every "
+        "`uv tool upgrade daimon-briefing`.",
+    ]
+    return lines
+
+
+def remove(home, env=None):
+    """Remove daimon's `[[hooks]]` entries; return output lines.
+
+    Leaves the installed scripts in place. They are inert once unregistered,
+    and deleting them would break any OTHER registration a person wrote by
+    hand pointing at the same files.
+    """
+    path = config_path(home, env)
+    if not path.exists():
+        return [f"{path} does not exist - nothing to remove"]
+    original = path.read_text(encoding="utf-8")
+    ours = [b for b in _hook_blocks(original) if _is_ours(b)]
+    if not ours:
+        return [f"{path}: no daimon entries found"]
+    updated = "".join(_strip_ours(original.splitlines(keepends=True), ours))
+    backup = _save(path, updated)
+    return [f"removed {len(ours)} daimon entr(y/ies) from {path}"
+            + (f" (backup: {backup})" if backup else "")]
+
+
+def registration_status(home, env=None) -> str:
+    """REGISTERED / PARTIAL / UNREGISTERED for the config.toml entries.
+
+    An unreadable config reads UNREGISTERED rather than raising: this runs
+    inside `daimon hooks status`, whose job is to report, and a status verb
+    that crashes on the state it exists to describe is worse than one that
+    reports the state it can prove.
+    """
+    path = config_path(home, env)
+    if not path.exists():
+        return "UNREGISTERED"
+    try:
+        blocks = _hook_blocks(path.read_text(encoding="utf-8"))
+    except (OSError, ConfigError):
+        return "UNREGISTERED"
+    found = sum(1 for spec in HOOKS
+                if any(spec.script in str(b.fields.get("command") or "")
+                       for b in blocks))
+    if found == 0:
+        return "UNREGISTERED"
+    return "REGISTERED" if found == len(HOOKS) else "PARTIAL"

--- a/plugin/daimon_briefing/ledger.py
+++ b/plugin/daimon_briefing/ledger.py
@@ -69,7 +69,8 @@ def _append_retry_log(session_id: str, prior: str) -> None:
 # host and the verb are alternations. A new host adapter MUST add its prefix
 # here or its serializes are invisible to status/hung detection/heal.
 _SPAWN_RE = re.compile(
-    r"^(\S+) (?:gemini-session-end|codex-session-end|session-end|codex-stop|"
+    r"^(\S+) (?:gemini-session-end|codex-session-end|kimi-session-end|"
+    r"session-end|codex-stop|kimi-stop|"
     r"windsurf-cascade|"
     r"windsurf-finalizer|session-start): "
     r"(?:spawned|retry) serialize for (\S+)"
@@ -546,7 +547,8 @@ def serialize_in_flight(project_slug: str, now: float | None = None) -> bool:
 # Host prefix on a spawn line, for per-host capture counts. Deliberately the
 # same alternation as _SPAWN_RE (a new host adapter updates both).
 _STATS_HOST_RE = re.compile(
-    r"^\S+ (gemini-session-end|codex-session-end|session-end|codex-stop|"
+    r"^\S+ (gemini-session-end|codex-session-end|kimi-session-end|"
+    r"session-end|codex-stop|kimi-stop|"
     r"windsurf-cascade|"
     r"windsurf-finalizer): "
     r"spawned serialize for "

--- a/plugin/daimon_briefing/skill_content.py
+++ b/plugin/daimon_briefing/skill_content.py
@@ -1,7 +1,7 @@
 """Canonical agent-skill content, two densities (#66).
 
 FULL renders the lazily-loaded SKILL.md (Claude Code; Windsurf global since
-#88) — description-gated, so the frontmatter description carries triggering
+#88; Kimi Code since #988) — description-gated, so the frontmatter description carries triggering
 conditions ONLY (a workflow summary there makes agents skip the body).
 COMPACT renders the always-injected rules block for Codex/Gemini/Cursor and
 Windsurf --project — those hosts concatenate the whole file into every

--- a/plugin/daimon_briefing/skill_install.py
+++ b/plugin/daimon_briefing/skill_install.py
@@ -62,6 +62,19 @@ HOSTS: dict[str, dict[str, tuple[str, str, str] | None]] = {
         "global": (".gemini/GEMINI.md", "block", "compact"),
         "project": ("GEMINI.md", "block", "compact"),
     },
+    # #988. Kimi Code's skill contract is Claude's, not the rules-file shape:
+    # a directory-form `<scope>/skills/<name>/SKILL.md` whose frontmatter
+    # `name` MUST equal the directory name, scanned from `~/.kimi-code/skills/`
+    # (user) and `<repo>/.kimi-code/skills/` (project). At session start the
+    # host injects only the LISTING (name plus description) and loads the body
+    # when the skill is invoked, so this is description-gated like Claude and
+    # takes `full` rather than the always-injected compact block. Project scope
+    # is the same relative path under the repo root, which is why both rows
+    # read the same and only the base directory differs.
+    "kimi": {
+        "global": (".kimi-code/skills/daimon/SKILL.md", "owned", "full"),
+        "project": (".kimi-code/skills/daimon/SKILL.md", "owned", "full"),
+    },
 }
 
 # Per-host read caps, in BYTES. Codex documents project_doc_max_bytes and

--- a/plugin/daimon_briefing/transcript.py
+++ b/plugin/daimon_briefing/transcript.py
@@ -4,7 +4,8 @@
    import is guarded (hermes only available in-hermes); unavailable -> [] not raise.
 2. from_file(path) — CLI/dogfood fallback. `.jsonl` parses as an agent session
    transcript; anything else as plain text/markdown. Includes a dedicated
-   branch for Windsurf Cascade's native transcript (#70).
+   branch for Windsurf Cascade's native transcript (#70) and one for Kimi
+   Code's `wire.jsonl` event log (#988).
 
 All messages normalize to OpenAI-format dicts: {"role": str, "content": str},
 plus an optional "id" (#358) when the host row carries a stable per-message
@@ -270,15 +271,209 @@ def _split_speaker_line(content: str, delim: str) -> tuple[str | None, str, bool
     return who, rest, True
 
 
-def _from_jsonl(text: str, speaker_line: str | None = None) -> list[dict]:
-    """Parse a JSONL agent transcript into conversation messages.
+# ---- #988: Kimi Code `wire.jsonl` ----
+#
+# Kimi Code does not persist a message list. It appends an EVENT log per agent
+# at ~/.kimi-code/sessions/<workspace>/<session>/agents/<agent>/wire.jsonl and
+# folds it into messages when it reads it back. Two consequences shape this
+# branch, both measured on live 0.42.0 sessions (2026-09-09):
+#
+# 1. ONE prompt is written THREE times. `prompt.accepted`, `turn.prompt` and
+#    `context.append_message` carry byte-identical text for the same prompt
+#    (hash-compared across three real sessions, every prompt, no exceptions).
+#    `context.append_message` is the canonical record — it is literally the
+#    event that appends to context — so the other two are treated as mirrors
+#    and suppressed. They are not simply ignored: a log cut off mid-turn keeps
+#    the mirrors and loses the append, and losing the last prompt of a crashed
+#    session is the opposite of what a crash-insurance capture is for.
+#
+# 2. ONE assistant turn arrives as a run of fragments. `content.part` events
+#    carry `{"type": "text", "text": ...}` or `{"type": "think", "think": ...}`;
+#    consecutive text fragments are one message, and thinking is dropped for
+#    the same reason `_text_of` drops Claude Code's thinking blocks.
+#
+# Shapes relied on, redacted from real events:
+#   {"type":"context.append_message","agentId":"main","message":{"role":"user",
+#    "content":[{"type":"text","text":"..."}],"toolCalls":[],
+#    "origin":{"kind":"user"}},"time":1788971099794}
+#   {"type":"turn.prompt","agentId":"main","input":[{"type":"text","text":"..."}],
+#    "origin":{"kind":"user"},"promptId":"...","time":...}
+#   {"type":"context.append_loop_event","agentId":"main","event":{
+#    "type":"tool.call","toolCallId":"...","name":"Bash",
+#    "args":{"command":"..."},"display":{...}},"time":...}
+#   {"type":"context.append_loop_event","agentId":"main","event":{
+#    "type":"tool.result","parentUuid":"...","toolCallId":"...",
+#    "result":{"output":"...","isError":true}},"time":...}
+#
+# Subagent logs (`agents/<other>/wire.jsonl`) are NOT merged in this slice. A
+# parent's log holds only the Agent call and the returned result, so a
+# subagent's own reasoning is absent from the main transcript; whether that is
+# worth merging is a question for a real multi-agent session, not an
+# assumption. Handed a subagent file directly, this branch folds it normally.
+#
+# `time` is epoch MILLISECONDS (verified: 1788971099794 -> 2026-09-09T16:24:59Z).
 
-    Claude Code exposes stable-enough user/assistant rows today. Codex also
-    exposes a `transcript_path` to hooks, but its docs explicitly say the format
-    is not stable, so this parser accepts a small set of role/content shapes and
-    ignores everything else. A noise-only file returns [] — never the raw-blob
-    fallback.
-    """
+# Kimi's own scaffolding, appended to context by the host rather than by a
+# person: a date-change notice, a permission-mode notice. The direct analogue
+# of Claude Code's `isMeta` rows, which this parser has always dropped.
+_KIMI_NOISE_ORIGINS = ("injection",)
+
+# Lifecycle events that mirror a prompt already recorded by
+# `context.append_message`. See note 1 above.
+_KIMI_MIRROR_TYPES = ("prompt.accepted", "turn.prompt", "turn.steer")
+
+
+def _is_kimi_wire(objects: list[dict]) -> bool:
+    """True when the first object is a Kimi wire header. Keyed on the header
+    that opens every log Kimi writes, not on a key count, so a
+    protocol-widened header still selects the branch."""
+    for obj in objects:
+        return (obj.get("type") == "metadata"
+                and "protocol_version" in obj)
+    return False
+
+
+def _is_kimi_wire_path(path: Path) -> bool:
+    """True for `.../agents/<agentId>/wire.jsonl`. The header check above is
+    the primary signal; this covers a log whose head was rotated or truncated
+    away, which would otherwise fall through to the generic reader."""
+    return (path.name == "wire.jsonl"
+            and path.parent.parent.name == "agents")
+
+
+def _kimi_text(parts) -> str:
+    """Flatten a Kimi content-part list to plain text. Only `text` parts —
+    `think` parts are the model's reasoning, noise for the serializer."""
+    if not isinstance(parts, list):
+        return ""
+    out = [p.get("text", "") for p in parts
+           if isinstance(p, dict) and p.get("type") == "text"]
+    return "\n".join(t for t in out if t).strip()
+
+
+def _kimi_appended_texts(objects: list[dict]) -> dict[str, int]:
+    """Prepass: how many times each user text was recorded by the canonical
+    `context.append_message`. A mirror whose text is in here is a duplicate;
+    a mirror whose text is NOT is the only surviving copy of that prompt."""
+    counts: dict[str, int] = {}
+    for obj in objects:
+        if obj.get("type") != "context.append_message":
+            continue
+        msg = obj.get("message")
+        if not isinstance(msg, dict):
+            continue
+        text = _kimi_text(msg.get("content"))
+        if text:
+            counts[text] = counts.get(text, 0) + 1
+    return counts
+
+
+def _kimi_tool_message(event: dict, daimon_calls: set[str]) -> dict | None:
+    """A `tool.result` event as a #359 tool message, or None when it carries
+    no usable id. Grounding is pointer-based ([mN] marker -> host id), so an
+    id-less row cannot be cited and is dropped rather than half-kept. Kimi's
+    `toolCallId` is that id: it is stable, and it is what pairs the result
+    with the call that produced it."""
+    result = event.get("result")
+    if not isinstance(result, dict):
+        return None
+    call_id = str(event.get("toolCallId") or "").strip()
+    if not call_id:
+        return None
+    output = result.get("output")
+    text = (output.strip() if isinstance(output, str) else "")
+    msg: dict = {"role": "tool",
+                 "content": text[:_TOOL_RESULT_MAX_CHARS] or "(no output)",
+                 "id": call_id, "tool_result": True}
+    if result.get("isError"):
+        msg["tool_error"] = True
+    # #512, same provenance rule as the Claude Code branch: a result born from
+    # a daimon invocation is daimon's own output echoed back, never a witness.
+    if call_id in daimon_calls:
+        msg["daimon_output"] = True
+    return msg
+
+
+def _from_kimi_wire(objects: list[dict]) -> list[dict]:
+    """Fold a Kimi Code wire event log into conversation messages.
+
+    Total for this format: an unrecognized event type contributes nothing and
+    never raises, so a Kimi release that adds events keeps parsing. A log with
+    no message-bearing events yields [] — never the raw-blob fallback."""
+    messages: list[dict] = []
+    appended = _kimi_appended_texts(objects)
+    daimon_calls: set[str] = set()
+    mirrored: set[str] = set()
+    buf: list[str] = []
+
+    def flush() -> None:
+        text = "\n".join(buf).strip()
+        buf.clear()
+        if text:
+            messages.append({"role": "assistant", "content": text})
+
+    for obj in objects:
+        typ = obj.get("type")
+        if typ == "context.append_message":
+            msg = obj.get("message")
+            if not isinstance(msg, dict):
+                continue
+            origin = msg.get("origin")
+            kind = origin.get("kind") if isinstance(origin, dict) else None
+            if kind in _KIMI_NOISE_ORIGINS:
+                continue
+            role = str(msg.get("role") or "").lower()
+            if role not in ("user", "assistant"):
+                continue
+            text = _kimi_text(msg.get("content"))
+            if not text:
+                continue
+            flush()
+            messages.append({"role": role, "content": text})
+        elif typ in _KIMI_MIRROR_TYPES:
+            text = _kimi_text(obj.get("input") if "input" in obj
+                              else obj.get("content"))
+            if not text or appended.get(text):
+                continue
+            # `prompt.accepted` and `turn.prompt` mirror EACH OTHER too, so the
+            # fallback keys on the prompt id both carry (text alone would drop
+            # a prompt the user genuinely typed twice).
+            key = str(obj.get("promptId") or text)
+            if key in mirrored:
+                continue
+            mirrored.add(key)
+            flush()
+            messages.append({"role": "user", "content": text})
+        elif typ == "context.append_loop_event":
+            event = obj.get("event")
+            if not isinstance(event, dict):
+                continue
+            etype = event.get("type")
+            if etype == "content.part":
+                part = event.get("part")
+                if isinstance(part, dict) and part.get("type") == "text":
+                    text = str(part.get("text") or "").strip()
+                    if text:
+                        buf.append(text)
+            elif etype == "tool.call":
+                if _is_daimon_tool_use({"name": event.get("name"),
+                                        "input": event.get("args")}):
+                    call_id = str(event.get("toolCallId") or "").strip()
+                    if call_id:
+                        daimon_calls.add(call_id)
+            elif etype == "tool.result":
+                flush()
+                tool_msg = _kimi_tool_message(event, daimon_calls)
+                if tool_msg is not None:
+                    messages.append(tool_msg)
+    flush()
+    return messages
+
+
+def _objects_of(text: str) -> list[dict]:
+    """Every parseable JSON object in a JSONL blob, in file order. A malformed
+    line is skipped, never fatal: a log truncated mid-write by a crashed host
+    is exactly the transcript most worth reading."""
     objects: list[dict] = []
     for line in text.splitlines():
         line = line.strip()
@@ -291,6 +486,29 @@ def _from_jsonl(text: str, speaker_line: str | None = None) -> list[dict]:
         if not isinstance(obj, dict):
             continue
         objects.append(obj)
+    return objects
+
+
+def _from_jsonl(text: str, speaker_line: str | None = None,
+                kimi: bool = False) -> list[dict]:
+    """Parse a JSONL agent transcript into conversation messages.
+
+    Claude Code exposes stable-enough user/assistant rows today. Codex also
+    exposes a `transcript_path` to hooks, but its docs explicitly say the format
+    is not stable, so this parser accepts a small set of role/content shapes and
+    ignores everything else. A noise-only file returns [] — never the raw-blob
+    fallback.
+
+    `kimi` forces the Kimi Code branch for a file whose PATH says it is a wire
+    log even though its header is gone (see `_is_kimi_wire_path`).
+    """
+    objects = _objects_of(text)
+
+    # #988: Kimi Code writes an event log, not a message list, so its branch
+    # runs first and is total — a wire log must never fall through to the
+    # generic reader below, which would read its `type` keys as roles.
+    if kimi or _is_kimi_wire(objects):
+        return _from_kimi_wire(objects)
 
     # Current Codex rollouts emit each visible turn twice: once as an
     # `event_msg` and once as a nested `response_item`. Prefer the event stream
@@ -506,6 +724,16 @@ def _stamp_epoch(stamp) -> float | None:
     return dt.timestamp()
 
 
+def _kimi_epoch(stamp) -> float | None:
+    """Epoch seconds for a Kimi wire event's `time`, which is epoch
+    MILLISECONDS. None for anything that is not a number, and for a boolean:
+    `bool` is an `int` in Python, and a stray flag read as a 1970 timestamp
+    would silently win the max against every real stamp."""
+    if isinstance(stamp, bool) or not isinstance(stamp, (int, float)):
+        return None
+    return stamp / 1000.0
+
+
 def last_timestamp(path) -> str | None:
     """Session-end stamp for a `.jsonl` transcript: the max top-level `timestamp`
     across rows, normalized to the checkpoint `created` format (#123). The max —
@@ -519,18 +747,15 @@ def last_timestamp(path) -> str | None:
         text = p.read_text(encoding="utf-8")
     except OSError:
         return None
+    objects = _objects_of(text)
+    # #988: Kimi stamps every event with `time` in epoch MILLISECONDS and has
+    # no `timestamp` key at all, so without this branch every Kimi capture
+    # reports no session-end stamp and the ledger falls back to file mtime.
+    kimi = _is_kimi_wire(objects) or _is_kimi_wire_path(p)
     best = None
-    for line in text.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            obj = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(obj, dict):
-            continue
-        epoch = _stamp_epoch(obj.get("timestamp"))
+    for obj in objects:
+        epoch = (_kimi_epoch(obj.get("time")) if kimi
+                 else _stamp_epoch(obj.get("timestamp")))
         if epoch is not None and (best is None or epoch > best):
             best = epoch
     if best is None:
@@ -567,7 +792,7 @@ def from_file(path) -> list[dict]:
     text = p.read_text(encoding="utf-8")
 
     if p.suffix == ".jsonl":
-        return _from_jsonl(text)
+        return _from_jsonl(text, kimi=_is_kimi_wire_path(p))
 
     messages: list[dict] = []
     current_role = None

--- a/plugin/daimon_briefing/transcript.py
+++ b/plugin/daimon_briefing/transcript.py
@@ -727,8 +727,10 @@ def _stamp_epoch(stamp) -> float | None:
 def _kimi_epoch(stamp) -> float | None:
     """Epoch seconds for a Kimi wire event's `time`, which is epoch
     MILLISECONDS. None for anything that is not a number, and for a boolean:
-    `bool` is an `int` in Python, and a stray flag read as a 1970 timestamp
-    would silently win the max against every real stamp."""
+    `bool` is an `int` in Python, so `True / 1000` reads as 0.001 seconds past
+    the epoch. It never wins the max against a real stamp, but in a log whose
+    only numeric `time` is a stray flag it is the only candidate, and the
+    capture would report a 1970 end instead of falling back to the mtime."""
     if isinstance(stamp, bool) or not isinstance(stamp, (int, float)):
         return None
     return stamp / 1000.0

--- a/plugin/tests/test_docs_hosts_stubs.py
+++ b/plugin/tests/test_docs_hosts_stubs.py
@@ -53,6 +53,7 @@ PAGES = {
     "codex.md": "codex.md",
     "gemini.md": "gemini.md",
     "windsurf.md": "windsurf.md",
+    "kimi.md": "kimi.md",
 }
 
 MAIN_LINK = re.compile(r"https://daily-nerd\.github\.io/daimon/docs/hosts/")

--- a/plugin/tests/test_kimi_hook_scripts.py
+++ b/plugin/tests/test_kimi_hook_scripts.py
@@ -153,6 +153,20 @@ def test_a_session_id_carrying_a_separator_is_refused(home):
     assert lib.kimi_transcript("", home=home, env={}) is None
 
 
+def test_the_resolver_refuses_glob_metacharacters_in_the_session_id(home):
+    """The id is interpolated into `root.glob(...)`, so to the resolver `*`
+    is not a name, it is a wildcard: an id of `*` resolves whichever real
+    session sorts first, and the hook would then serialize a stranger's
+    transcript under the attacker-supplied id. Traversal was already refused;
+    this is the other class the same interpolation admits, and the one the
+    guard's own docstring claimed to close."""
+    lib = _load_lib()
+    real = _wire(home)
+    assert lib.kimi_transcript(SESSION, home=home, env={}) == real
+    for hostile in ("*", "?", "session_*", f"[{SESSION[0]}]{SESSION[1:]}"):
+        assert lib.kimi_transcript(hostile, home=home, env={}) is None, hostile
+
+
 def test_the_resolver_honours_kimi_code_home(home, tmp_path):
     lib = _load_lib()
     relocated = tmp_path / "relocated"
@@ -208,10 +222,14 @@ def test_session_end_records_a_reason_when_no_transcript_resolves(home):
     assert SESSION in log
 
 
-def test_session_end_does_not_serialize_a_session_stop_just_captured(home):
-    """Print mode never fires SessionEnd, so a session captured by Stop and
-    then closed interactively is the double-capture case. The Stop marker is
-    shared on purpose, which is what makes the second write a no-op."""
+def test_session_end_serializes_even_when_stop_just_captured(home):
+    """The Stop throttle window is the interval between the LAST spawned Stop
+    and `/exit`, so a SessionEnd that honoured Stop's marker would drop up to
+    a whole window of the session tail: every turn after that Stop. Codex
+    leaves SessionEnd unthrottled for the same reason. The repeat is cheap:
+    the CLI compares the transcript's sha against the last checkpoint before
+    any LLM work, so bytes already captured cost one file read, not a second
+    model call."""
     _wire(home)
     bin_dir, capture = _fake_cli(home)
     env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"}
@@ -219,13 +237,15 @@ def test_session_end_does_not_serialize_a_session_stop_just_captured(home):
                "cwd": "/private/tmp/proj", "stop_hook_active": False}
     _run(STOP_HOOK, payload, home, env)
     _wait_for(capture, "serialize")
-    first = _spawns(capture)
-    assert first == 1
+    assert _spawns(capture) == 1
     _run(SESSION_END_HOOK, {**payload, "hook_event_name": "SessionEnd",
                             "reason": "exit"}, home, env)
-    time.sleep(1.0)  # long enough for a spawn to have landed, had one happened
-    assert _spawns(capture) == first
-    assert "already captured" in _log(home)
+    deadline = time.monotonic() + 10.0
+    while _spawns(capture) < 2 and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert _spawns(capture) == 2, _log(home)
+    assert "already captured" not in _log(home)
+    assert "kimi-session-end: spawned serialize" in _log(home)
 
 
 def test_session_end_can_be_disabled(home):

--- a/plugin/tests/test_kimi_hook_scripts.py
+++ b/plugin/tests/test_kimi_hook_scripts.py
@@ -1,0 +1,523 @@
+"""Subprocess-level tests for the standalone Kimi Code hook scripts (#988).
+
+Kimi differs from every host daimon already adapts in one way that shapes all
+three scripts: the hook payload carries a `session_id` and NO transcript path,
+and no environment variable carries one either. The path has to be resolved
+from the id against the host's own session storage, so "transcript not found"
+is a first-class outcome here rather than a corrupted-payload edge case, and
+each script has to say so in the log instead of failing silently.
+
+The other shaping fact: `kimi -p` print mode never fires `SessionEnd`
+(measured twice), so `Stop` is the only capture path for it. That makes the
+throttled Stop hook load-bearing rather than pure crash insurance, and it
+makes double-capture a real risk worth a test.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+HOOK_DIR = Path(__file__).resolve().parents[2] / "hook"
+PROMPT_HOOK = HOOK_DIR / "daimon-kimi-user-prompt-submit.py"
+SESSION_END_HOOK = HOOK_DIR / "daimon-kimi-session-end.py"
+STOP_HOOK = HOOK_DIR / "daimon-kimi-stop.py"
+VENV_BIN = Path(sys.executable).parent
+
+SESSION = "session_8a1593d9-376b-43d3-abc9-5796eb848fa3"
+
+
+def _run(script: Path, payload, home, extra_env=None):
+    env = {
+        **os.environ,
+        "PATH": f"{VENV_BIN}{os.pathsep}{os.environ.get('PATH', '')}",
+        "HOME": str(home),
+    }
+    env.pop("KIMI_CODE_HOME", None)
+    if extra_env:
+        env.update(extra_env)
+    stdin = json.dumps(payload) if isinstance(payload, dict) else (payload or "")
+    return subprocess.run([sys.executable, str(script)], input=stdin,
+                          capture_output=True, text=True, env=env, timeout=30)
+
+
+def _wire(home: Path, session=SESSION, workspace="wd_proj_0123456789ab") -> Path:
+    """A minimal but real wire.jsonl at the measured storage path."""
+    path = (home / ".kimi-code" / "sessions" / workspace / session
+            / "agents" / "main" / "wire.jsonl")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"type": "metadata", "protocol_version": "1.5",
+                    "created_at": 1788971099783}) + "\n",
+        encoding="utf-8")
+    return path
+
+
+def _fake_cli(home: Path):
+    """A `daimon` on PATH that appends its argv to a file and exits 0."""
+    bin_dir = home / "fakebin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    capture = home / "invocations.txt"
+    script = bin_dir / "daimon"
+    script.write_text(
+        "#!/bin/sh\n"
+        f'printf "%s\\n" "$*" >> "{capture}"\n'
+        "exit 0\n", encoding="utf-8")
+    script.chmod(0o755)
+    return bin_dir, capture
+
+
+def _wait_for(path: Path, needle="", timeout=10.0) -> str:
+    """The serialize spawn is DETACHED, so the hook returns before the child
+    has run. Poll rather than sleep a fixed slice."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            text = path.read_text(encoding="utf-8")
+            if needle in text:
+                return text
+        time.sleep(0.05)
+    raise AssertionError(f"never saw {needle!r} in {path}")
+
+
+def _spawns(path: Path) -> int:
+    """How many times the fake CLI was invoked.
+
+    Counts LINES, never occurrences of the word "serialize": pytest's own tmp
+    directory names are derived from the test name, so a test about serializing
+    puts that word inside every captured path and doubles its own count.
+    """
+    if not path.exists():
+        return 0
+    return len([ln for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()])
+
+
+def _quiet(path: Path, seconds=1.0) -> None:
+    """Assert a detached child never appears. There is nothing to poll FOR, so
+    this waits out the window a real spawn would have needed."""
+    time.sleep(seconds)
+    assert not path.exists(), f"expected no spawn, got: {path.read_text()}"
+
+
+def _log(home: Path) -> str:
+    path = home / ".daimon" / "logs" / "serialize.log"
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+@pytest.fixture()
+def home(tmp_path):
+    h = tmp_path / "home"
+    (h / ".kimi-code").mkdir(parents=True)
+    return h
+
+
+# ---- resolving a transcript from a session id ----
+
+def test_the_library_resolves_a_transcript_from_the_session_id(home):
+    """The payload names the session and nothing else. Measured: the payload's
+    `session_id` IS the session directory name, one level below a workspace
+    directory whose name daimon cannot predict, hence the glob."""
+    lib = _load_lib()
+    wire = _wire(home)
+    found = lib.kimi_transcript(SESSION, home=home, env={})
+    assert found == wire
+
+
+def test_an_unknown_session_resolves_to_nothing(home):
+    lib = _load_lib()
+    _wire(home)
+    assert lib.kimi_transcript("session_does-not-exist", home=home, env={}) is None
+
+
+def test_a_session_id_carrying_a_separator_is_refused(home):
+    """The id is host-supplied and lands straight in a glob pattern. This
+    plants a REAL file the pattern would otherwise reach: without the guard,
+    `sessions/*/a/b/agents/main/wire.jsonl` matches it and an id that is not a
+    single path segment silently selects a transcript one level deeper than
+    the layout allows. Nothing in the measured payloads suggests a hostile id,
+    which is exactly why the assumption is pinned rather than trusted."""
+    lib = _load_lib()
+    nested = (home / ".kimi-code" / "sessions" / "wd_proj_1" / "a" / "b"
+              / "agents" / "main" / "wire.jsonl")
+    nested.parent.mkdir(parents=True)
+    nested.write_text("{}\n", encoding="utf-8")
+    assert nested.exists()
+    assert lib.kimi_transcript("a/b", home=home, env={}) is None
+    assert lib.kimi_transcript("a\\b", home=home, env={}) is None
+    assert lib.kimi_transcript("..", home=home, env={}) is None
+    assert lib.kimi_transcript("", home=home, env={}) is None
+
+
+def test_the_resolver_honours_kimi_code_home(home, tmp_path):
+    lib = _load_lib()
+    relocated = tmp_path / "relocated"
+    path = (relocated / "sessions" / "wd_x_1" / SESSION / "agents" / "main"
+            / "wire.jsonl")
+    path.parent.mkdir(parents=True)
+    path.write_text("{}\n", encoding="utf-8")
+    assert lib.kimi_transcript(
+        SESSION, home=home, env={"KIMI_CODE_HOME": str(relocated)}) == path
+
+
+def _load_lib():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "kimi_hook_lib_under_test", HOOK_DIR / "_daimon_hook_lib.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---- SessionEnd ----
+
+def test_session_end_spawns_serialize_for_the_resolved_transcript(home):
+    wire = _wire(home)
+    bin_dir, capture = _fake_cli(home)
+    proc = _run(SESSION_END_HOOK,
+                {"hook_event_name": "SessionEnd", "session_id": SESSION,
+                 "cwd": "/private/tmp/proj", "client_type": "kimi_code_cli",
+                 "reason": "exit", "session_title": "t"},
+                home, {"PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"})
+    assert proc.returncode == 0
+    invoked = _wait_for(capture, "serialize")
+    assert str(wire) in invoked
+    assert f"--session {SESSION}" in invoked, (
+        "without --session the CLI would name every Kimi checkpoint 'wire'")
+    assert "kimi-session-end: spawned serialize" in _log(home)
+
+
+def test_session_end_records_a_reason_when_no_transcript_resolves(home):
+    """Kimi is the only host where this is routine rather than broken: the
+    payload has no path, so a lookup that finds nothing is the normal shape of
+    "storage moved" and has to be legible in the log, not silent."""
+    bin_dir, _ = _fake_cli(home)
+    proc = _run(SESSION_END_HOOK,
+                {"hook_event_name": "SessionEnd", "session_id": SESSION,
+                 "cwd": "/private/tmp/proj", "reason": "exit"},
+                home, {"PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"})
+    assert proc.returncode == 0
+    log = _log(home)
+    assert "kimi-session-end" in log
+    assert "transcript not found" in log
+    assert SESSION in log
+
+
+def test_session_end_does_not_serialize_a_session_stop_just_captured(home):
+    """Print mode never fires SessionEnd, so a session captured by Stop and
+    then closed interactively is the double-capture case. The Stop marker is
+    shared on purpose, which is what makes the second write a no-op."""
+    _wire(home)
+    bin_dir, capture = _fake_cli(home)
+    env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"}
+    payload = {"hook_event_name": "Stop", "session_id": SESSION,
+               "cwd": "/private/tmp/proj", "stop_hook_active": False}
+    _run(STOP_HOOK, payload, home, env)
+    _wait_for(capture, "serialize")
+    first = _spawns(capture)
+    assert first == 1
+    _run(SESSION_END_HOOK, {**payload, "hook_event_name": "SessionEnd",
+                            "reason": "exit"}, home, env)
+    time.sleep(1.0)  # long enough for a spawn to have landed, had one happened
+    assert _spawns(capture) == first
+    assert "already captured" in _log(home)
+
+
+def test_session_end_can_be_disabled(home):
+    _wire(home)
+    bin_dir, capture = _fake_cli(home)
+    _run(SESSION_END_HOOK,
+         {"hook_event_name": "SessionEnd", "session_id": SESSION,
+          "cwd": "/p", "reason": "exit"}, home,
+         {"PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+          "DAIMON_KIMI_SERIALIZE_ON_SESSION_END": "0"})
+    _quiet(capture)
+
+
+# ---- Stop ----
+
+def test_stop_captures_a_print_mode_session(home):
+    """The reason this hook is not optional on Kimi. `kimi -p` never fires
+    SessionEnd, so without Stop a print session is never captured at all."""
+    wire = _wire(home)
+    bin_dir, capture = _fake_cli(home)
+    proc = _run(STOP_HOOK,
+                {"hook_event_name": "Stop", "session_id": SESSION,
+                 "cwd": "/private/tmp/proj", "stop_hook_active": False},
+                home, {"PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"})
+    assert proc.returncode == 0
+    invoked = _wait_for(capture, "serialize")
+    assert str(wire) in invoked
+    assert f"--session {SESSION}" in invoked
+    assert "kimi-stop: spawned serialize" in _log(home)
+
+
+def test_stop_is_throttled_within_the_interval(home):
+    _wire(home)
+    bin_dir, capture = _fake_cli(home)
+    env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"}
+    payload = {"hook_event_name": "Stop", "session_id": SESSION, "cwd": "/p"}
+    _run(STOP_HOOK, payload, home, env)
+    _wait_for(capture, "serialize")
+    _run(STOP_HOOK, payload, home, env)
+    time.sleep(1.0)
+    assert _spawns(capture) == 1
+    assert "throttled" in _log(home)
+
+
+def test_a_zero_interval_serializes_on_every_stop(home):
+    _wire(home)
+    bin_dir, capture = _fake_cli(home)
+    env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+           "DAIMON_KIMI_MIN_SERIALIZE_INTERVAL": "0"}
+    payload = {"hook_event_name": "Stop", "session_id": SESSION, "cwd": "/p"}
+    _run(STOP_HOOK, payload, home, env)
+    _wait_for(capture, "serialize")
+    _run(STOP_HOOK, payload, home, env)
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline and _spawns(capture) < 2:
+        time.sleep(0.05)
+    assert _spawns(capture) == 2
+
+
+def test_stop_can_be_disabled(home):
+    _wire(home)
+    bin_dir, capture = _fake_cli(home)
+    _run(STOP_HOOK, {"hook_event_name": "Stop", "session_id": SESSION,
+                     "cwd": "/p"}, home,
+         {"PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+          "DAIMON_KIMI_SERIALIZE_ON_STOP": "0"})
+    _quiet(capture)
+
+
+# ---- UserPromptSubmit: the only channel into the model ----
+
+PROJECT = "/private/tmp/kimi-proj"
+
+
+def _checkpoint(sample_checkpoint):
+    """Give this project a checkpoint for `daimon brief` to render."""
+    from daimon_briefing import store
+
+    mine = json.loads(json.dumps(sample_checkpoint))
+    mine["session_id"] = "S-kimi"
+    store.write_checkpoint("S-kimi", mine, project_dir=PROJECT)
+
+
+def _prompt(home, text="where were we", session=SESSION):
+    """Run the prompt hook with the REAL CLI on PATH, which is what renders
+    the briefing."""
+    return _run(PROMPT_HOOK,
+                {"hook_event_name": "UserPromptSubmit", "session_id": session,
+                 "cwd": PROJECT, "client_type": "kimi_code_cli",
+                 "prompt": [{"type": "text", "text": text}],
+                 "is_steer": False}, home)
+
+
+def test_the_briefing_is_emitted_on_the_first_prompt_of_a_session(
+        home, tmp_checkpoint_dir, sample_checkpoint):
+    """Kimi has no usable SessionStart, so the briefing rides the first prompt.
+    Plain stdout, no JSON envelope: the host appends what the hook prints,
+    wrapped in a `hook_result` tag of its own."""
+    _checkpoint(sample_checkpoint)
+    proc = _prompt(home)
+    assert proc.returncode == 0
+    assert "DAIMON BRIEFING" in proc.stdout
+    assert "checkpoint: S-kimi" in proc.stdout
+
+
+def test_the_briefing_is_emitted_only_once_per_session(
+        home, tmp_checkpoint_dir, sample_checkpoint):
+    """The second prompt of a session must not repeat it. The host gives no
+    session-start event to hang "first" on, so the hook keeps its own marker."""
+    _checkpoint(sample_checkpoint)
+    first = _prompt(home)
+    second = _prompt(home)
+    assert "DAIMON BRIEFING" in first.stdout
+    assert "DAIMON BRIEFING" not in second.stdout
+
+
+def test_a_different_session_gets_its_own_briefing(
+        home, tmp_checkpoint_dir, sample_checkpoint):
+    _checkpoint(sample_checkpoint)
+    _prompt(home)
+    other = _prompt(home, session="session_other")
+    assert "DAIMON BRIEFING" in other.stdout
+
+
+def test_no_checkpoint_means_no_output_at_all(home, tmp_checkpoint_dir):
+    """This hook fires on EVERY prompt. A diagnostic line per prompt would be
+    spam, so silence is the contract when there is nothing to say."""
+    proc = _prompt(home)
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_the_prompt_part_list_is_flattened_for_recall(home):
+    """Kimi's `prompt` is a LIST of parts, where every other host sends a
+    string. Handed to `recall-inject` unflattened it would arrive as a Python
+    repr, and every match would be against punctuation."""
+    lib = _load_lib()
+    assert lib.kimi_prompt_text(
+        [{"type": "text", "text": "first"}, {"type": "text", "text": "second"}]
+    ) == "first\nsecond"
+    # A host that later sends a bare string must keep working.
+    assert lib.kimi_prompt_text("plain") == "plain"
+    assert lib.kimi_prompt_text(None) == ""
+    assert lib.kimi_prompt_text([{"type": "image", "url": "x"}]) == ""
+
+
+def test_recall_runs_on_a_later_prompt_and_not_on_a_slash_command(home):
+    """Same noise gate as the Claude Code prompt hook: a slash command is a
+    host directive, not somebody asking about prior work."""
+    bin_dir, capture = _fake_cli(home)
+    env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"}
+    base = {"hook_event_name": "UserPromptSubmit", "session_id": SESSION,
+            "cwd": PROJECT}
+    _run(PROMPT_HOOK, {**base, "prompt": [{"type": "text", "text": "hi"}]},
+         home, env)  # first prompt of the session
+    _run(PROMPT_HOOK,
+         {**base, "prompt": [{"type": "text", "text": "what about the parser"}]},
+         home, env)
+    text = capture.read_text(encoding="utf-8")
+    assert "recall-inject" in text
+    before = text.count("recall-inject")
+    _run(PROMPT_HOOK, {**base, "prompt": [{"type": "text", "text": "/help"}]},
+         home, env)
+    assert capture.read_text(encoding="utf-8").count("recall-inject") == before
+
+
+# ---- every Kimi transcript is named wire.jsonl ----
+#
+# `_run_serialize` derives the session id as `path.stem`, which is true of
+# every host adapted so far because each names the transcript for its session.
+# Kimi does not: the session id is a DIRECTORY, and the file inside it is
+# always `wire.jsonl`. Left alone, every Kimi session on the machine would
+# serialize under the id "wire", overwrite the previous one's per-session
+# checkpoint, and make the in-flight guard treat two unrelated sessions as the
+# same work. So `serialize` gained `--session`, following the same rule #983
+# set for `write-checkpoint`: when the host can supply a real session id, that
+# id wins over anything inferred.
+
+def _serialize_session_id(tmp_path, monkeypatch, session=None):
+    """The session id `_run_serialize` actually adopts for a transcript.
+
+    Captured at the first place the id is USED (the identical-bytes guard)
+    rather than asserted from a checkpoint on disk: without an LLM backend the
+    run fails long before it writes one, so an on-disk assertion would pass
+    whether the flag worked or not."""
+    from daimon_briefing import cli as cli_mod
+
+    seen = []
+    monkeypatch.setattr(cli_mod.store, "transcript_unchanged",
+                        lambda sid, sha: seen.append(sid) or True)
+    wire = tmp_path / "agents" / "main" / "wire.jsonl"
+    wire.parent.mkdir(parents=True, exist_ok=True)
+    wire.write_text(
+        json.dumps({"type": "metadata", "protocol_version": "1.5"}) + "\n",
+        encoding="utf-8")
+    cli_mod._run_serialize(wire, PROJECT, session=session)
+    assert seen, "the session id was never used"
+    return seen[0]
+
+
+def test_serialize_takes_the_session_id_from_the_flag_not_the_filename(
+        tmp_path, tmp_checkpoint_dir, monkeypatch):
+    assert _serialize_session_id(tmp_path, monkeypatch, session=SESSION) == SESSION
+
+
+def test_without_the_flag_the_filename_still_wins_as_it_always_has(
+        tmp_path, tmp_checkpoint_dir, monkeypatch):
+    """The other half: every host adapted before Kimi passes no `--session`,
+    and their behavior has to be unchanged. On Kimi the stem is the constant
+    "wire", which is the whole reason the flag exists."""
+    assert _serialize_session_id(tmp_path, monkeypatch) == "wire"
+
+
+def test_the_serialize_flag_is_reachable_from_the_command_line(tmp_path):
+    """The parser half. A flag `_run_serialize` honours and the argument
+    parser never defines is a flag no hook can actually pass."""
+    proc = subprocess.run(
+        [sys.executable, "-m", "daimon_briefing.cli", "serialize", "--help"],
+        capture_output=True, text=True, timeout=60, env=os.environ)
+    # Word-bounded: a plain substring check also matches `--sessionX`, so a
+    # renamed flag would pass a test written to catch a MISSING one.
+    assert re.search(r"--session\b", proc.stdout), proc.stdout
+
+
+def test_two_kimi_sessions_do_not_collapse_into_one_checkpoint(home):
+    """The failure this flag exists to prevent, stated as behavior rather than
+    as an argument about filenames."""
+    lib = _load_lib()
+    calls = []
+
+    class _Fake:
+        def __init__(self, cmd, **kw):
+            calls.append(cmd)
+
+    import subprocess as sp
+    real = sp.Popen
+    sp.Popen = _Fake
+    try:
+        lib.spawn_serialize("daimon", "/s/a/agents/main/wire.jsonl", {},
+                            session_id="session_a")
+        lib.spawn_serialize("daimon", "/s/b/agents/main/wire.jsonl", {},
+                            session_id="session_b")
+    finally:
+        sp.Popen = real
+    ids = [cmd[cmd.index("--session") + 1] for cmd in calls]
+    assert ids == ["session_a", "session_b"]
+
+
+def test_the_in_flight_guard_keys_on_the_supplied_session_id(home, monkeypatch):
+    """Without the override the guard keys on the stem, so a live serialize of
+    ANY Kimi session would report every other Kimi session as in flight and
+    silently drop its capture."""
+    lib = _load_lib()
+    monkeypatch.setattr(lib, "_in_flight_stems", lambda: {"session_a"})
+    assert lib._serialize_in_flight("/s/a/agents/main/wire.jsonl",
+                                    session_id="session_a") is True
+    assert lib._serialize_in_flight("/s/b/agents/main/wire.jsonl",
+                                    session_id="session_b") is False
+
+
+# ---- fail-open, on every script ----
+
+@pytest.mark.parametrize("script", [PROMPT_HOOK, SESSION_END_HOOK, STOP_HOOK])
+@pytest.mark.parametrize("payload", ["", "not json", "[]", "{}"])
+def test_no_script_crashes_the_host_on_a_bad_payload(script, payload, home):
+    """Kimi is fail-open by design, but a non-zero exit from a BLOCKABLE event
+    is how a hook denies. `UserPromptSubmit` is blockable, so a crashing hook
+    here would not merely be noisy, it would refuse the person's prompt."""
+    proc = _run(script, payload, home)
+    assert proc.returncode == 0, proc.stderr
+
+
+@pytest.mark.parametrize("script", [PROMPT_HOOK, SESSION_END_HOOK, STOP_HOOK])
+def test_a_partial_install_missing_the_library_still_exits_clean(script, home,
+                                                                 tmp_path):
+    stray = tmp_path / "stray"
+    stray.mkdir()
+    copy = stray / script.name
+    copy.write_text(script.read_text(encoding="utf-8"), encoding="utf-8")
+    proc = _run(copy, {"session_id": SESSION, "cwd": "/p",
+                       "prompt": [{"type": "text", "text": "hi"}]}, home)
+    assert proc.returncode == 0, proc.stderr
+
+
+@pytest.mark.parametrize("script", [PROMPT_HOOK, SESSION_END_HOOK, STOP_HOOK])
+def test_the_global_disable_silences_every_script(script, home):
+    _wire(home)
+    bin_dir, capture = _fake_cli(home)
+    proc = _run(script, {"session_id": SESSION, "cwd": "/p",
+                         "prompt": [{"type": "text", "text": "hi"}]}, home,
+                {"PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+                 "DAIMON_DISABLE": "1"})
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+    _quiet(capture)

--- a/plugin/tests/test_kimi_hooks_install.py
+++ b/plugin/tests/test_kimi_hooks_install.py
@@ -1,0 +1,472 @@
+"""`daimon hooks install kimi` — the TOML registration path (#988).
+
+Every shipped host manager so far writes JSON and can re-serialize the whole
+file safely. Kimi Code reads a TOML `config.toml` that its own login flow
+populates with provider credentials and model tables, and it has a trap the
+JSON hosts do not: a `[[hooks]]` entry with a FIFTH field fails the WHOLE
+config load, not just that entry. Two rules follow, and these tests are what
+holds them.
+
+1. Never re-serialize. The installer appends and removes TEXT BLOCKS, so
+   everything it did not write comes back byte-identical, comments and key
+   order included. A round trip (install then remove) is the assertion.
+2. Exactly four fields per entry, always.
+
+Measured against Kimi Code 0.42.0 on 2026-09-09; the probe notes carry the
+payloads and the config shape.
+"""
+
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from daimon_briefing import kimi_hooks
+
+REPO = Path(__file__).resolve().parents[2]
+PKG_HOOKS = REPO / "plugin" / "daimon_briefing" / "_hooks"
+
+# A config.toml shaped like the one Kimi's login flow writes: provider tables,
+# an OAuth sub-table, a comment, and no hooks at all. Nothing daimon owns.
+BASE_CONFIG = """\
+# Kimi Code configuration.
+model = "kimi-code/kimi-for-coding"
+
+[services.moonshot]
+api_key = "REDACTED"
+
+[services.moonshot_fetch.oauth]
+storage = "file"
+key = "oauth/kimi-code"
+"""
+
+
+def _home(tmp_path) -> Path:
+    home = tmp_path / "home"
+    (home / ".kimi-code").mkdir(parents=True)
+    return home
+
+
+def _write_config(home: Path, text: str) -> Path:
+    path = home / ".kimi-code" / "config.toml"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _install(home: Path, env=None):
+    return kimi_hooks.install(PKG_HOOKS, home, env=env if env is not None else {})
+
+
+# ---- where things go ----
+
+def test_the_config_home_defaults_to_the_dot_directory(tmp_path):
+    home = _home(tmp_path)
+    assert kimi_hooks.config_home(home, env={}) == home / ".kimi-code"
+
+
+def test_kimi_code_home_overrides_the_default(tmp_path):
+    """Kimi documents `KIMI_CODE_HOME` for its user scope. Honouring it is what
+    lets a test, and a person with a relocated config, install somewhere that
+    is not the real `~/.kimi-code`."""
+    elsewhere = tmp_path / "relocated"
+    home = _home(tmp_path)
+    env = {"KIMI_CODE_HOME": str(elsewhere)}
+    assert kimi_hooks.config_home(home, env=env) == elsewhere
+    assert kimi_hooks.config_path(home, env=env) == elsewhere / "config.toml"
+
+
+def test_install_copies_every_file_and_marks_the_scripts_executable(tmp_path):
+    home = _home(tmp_path)
+    _write_config(home, BASE_CONFIG)
+    _install(home)
+    hooks_dir = kimi_hooks.hooks_dir(home, env={})
+    for name in kimi_hooks.FILES:
+        dest = hooks_dir / name
+        assert dest.exists(), f"{name} was not installed"
+        assert dest.read_bytes() == (PKG_HOOKS / name).read_bytes()
+        executable = bool(dest.stat().st_mode & stat.S_IXUSR)
+        # The shared modules are imported by same-dir lookup, never executed.
+        assert executable is (name not in kimi_hooks.MODULES), name
+
+
+# ---- the four-field rule ----
+
+def test_every_written_entry_carries_exactly_the_four_allowed_fields(tmp_path):
+    """The trap this whole module is shaped around. A fifth field does not
+    degrade the entry, it fails the entire config load, so a `statusMessage`
+    copied over from the Codex manager would silently unhook the host."""
+    home = _home(tmp_path)
+    _write_config(home, BASE_CONFIG)
+    _install(home)
+    blocks = kimi_hooks._hook_blocks(kimi_hooks.config_path(home, env={})
+                                     .read_text(encoding="utf-8"))
+    assert len(blocks) == len(kimi_hooks.HOOKS)
+    for block in blocks:
+        assert set(block.fields) == {"event", "matcher", "command", "timeout"}
+
+
+def test_the_timeout_written_is_inside_the_hosts_accepted_range(tmp_path):
+    home = _home(tmp_path)
+    _write_config(home, BASE_CONFIG)
+    _install(home)
+    for block in kimi_hooks._hook_blocks(
+            kimi_hooks.config_path(home, env={}).read_text(encoding="utf-8")):
+        assert 1 <= int(block.fields["timeout"]) <= 600
+
+
+def test_the_three_measured_events_are_registered(tmp_path):
+    """No `SessionStart`: its stdout is dropped by the host, so registering it
+    would spawn an interpreter per session to write to a closed pipe. No
+    `PreToolUse`: the deny channel is unmeasured, so no check profile ships."""
+    home = _home(tmp_path)
+    _write_config(home, BASE_CONFIG)
+    _install(home)
+    events = {b.fields["event"] for b in kimi_hooks._hook_blocks(
+        kimi_hooks.config_path(home, env={}).read_text(encoding="utf-8"))}
+    assert events == {"UserPromptSubmit", "SessionEnd", "Stop"}
+
+
+def test_each_command_points_at_the_installed_script_by_absolute_path(tmp_path):
+    """Kimi runs the command as given, from the session's cwd. A relative path
+    would resolve against the project the person happens to be in."""
+    home = _home(tmp_path)
+    _write_config(home, BASE_CONFIG)
+    _install(home)
+    hooks_dir = kimi_hooks.hooks_dir(home, env={})
+    commands = {b.fields["command"] for b in kimi_hooks._hook_blocks(
+        kimi_hooks.config_path(home, env={}).read_text(encoding="utf-8"))}
+    assert len(commands) == len(kimi_hooks.HOOKS)
+    for command in commands:
+        assert str(hooks_dir) in command
+        script = command.split()[-1]
+        assert Path(script).is_absolute()
+        assert Path(script).exists()
+
+
+# ---- never disturb what we do not own ----
+
+def test_everything_above_our_blocks_survives_byte_for_byte(tmp_path):
+    home = _home(tmp_path)
+    path = _write_config(home, BASE_CONFIG)
+    _install(home)
+    after = path.read_text(encoding="utf-8")
+    assert after.startswith(BASE_CONFIG), (
+        "the installer rewrote content it does not own")
+
+
+def test_install_then_remove_restores_the_file_byte_for_byte(tmp_path):
+    """The round trip is the real guard. It catches a re-serializing writer,
+    a dropped comment, a reordered key, and blank lines accumulating across
+    repeated install/remove cycles, none of which a field-level assertion
+    would notice."""
+    home = _home(tmp_path)
+    path = _write_config(home, BASE_CONFIG)
+    for _ in range(3):
+        _install(home)
+        kimi_hooks.remove(home, env={})
+        assert path.read_text(encoding="utf-8") == BASE_CONFIG
+
+
+def test_a_foreign_hooks_entry_is_never_touched(tmp_path):
+    """Someone else's `[[hooks]]` block is the case where "remove our entries"
+    and "remove the hooks array" differ, and only one of them is correct."""
+    foreign = BASE_CONFIG + """
+[[hooks]]
+event = "PreToolUse"
+matcher = "Bash"
+command = "python3 /home/someone/my-own-linter.py"
+timeout = 5
+"""
+    home = _home(tmp_path)
+    path = _write_config(home, foreign)
+    _install(home)
+    kimi_hooks.remove(home, env={})
+    assert path.read_text(encoding="utf-8") == foreign
+
+
+def test_install_is_idempotent(tmp_path):
+    home = _home(tmp_path)
+    path = _write_config(home, BASE_CONFIG)
+    _install(home)
+    once = path.read_text(encoding="utf-8")
+    lines = _install(home)
+    assert path.read_text(encoding="utf-8") == once
+    assert any("already registered" in line for line in lines)
+
+
+def test_a_stale_registration_is_refreshed_rather_than_duplicated(tmp_path):
+    """A person who installed under an older path, or moved KIMI_CODE_HOME,
+    has a daimon block pointing at a script that is no longer there. It must
+    end up corrected, not doubled: two `UserPromptSubmit` entries mean two
+    briefings in one prompt."""
+    stale = BASE_CONFIG + """
+[[hooks]]
+event = "UserPromptSubmit"
+matcher = ".*"
+command = "python3 /old/path/daimon-kimi-user-prompt-submit.py"
+timeout = 10
+"""
+    home = _home(tmp_path)
+    path = _write_config(home, stale)
+    _install(home)
+    text = path.read_text(encoding="utf-8")
+    blocks = [b for b in kimi_hooks._hook_blocks(text)
+              if b.fields.get("event") == "UserPromptSubmit"]
+    assert len(blocks) == 1
+    assert "/old/path/" not in text
+
+
+def test_the_existing_file_is_backed_up_before_the_first_write(tmp_path):
+    home = _home(tmp_path)
+    _write_config(home, BASE_CONFIG)
+    _install(home)
+    backups = list((home / ".kimi-code").glob("config.toml.daimon-backup-*"))
+    assert len(backups) == 1
+    assert backups[0].read_text(encoding="utf-8") == BASE_CONFIG
+
+
+def test_a_missing_config_is_created_rather_than_refused(tmp_path):
+    """`hooks install` before the first `kimi` login. Nothing to preserve, so
+    nothing to back up, and the file we write is ours alone."""
+    home = _home(tmp_path)
+    lines = _install(home)
+    path = kimi_hooks.config_path(home, env={})
+    assert path.exists()
+    assert len(kimi_hooks._hook_blocks(path.read_text(encoding="utf-8"))) == 3
+    assert not list((home / ".kimi-code").glob("config.toml.daimon-backup-*"))
+    assert any("registered" in line for line in lines)
+
+
+def test_remove_on_a_config_with_no_daimon_blocks_writes_nothing(tmp_path):
+    home = _home(tmp_path)
+    path = _write_config(home, BASE_CONFIG)
+    before = path.stat().st_mtime_ns
+    kimi_hooks.remove(home, env={})
+    assert path.read_text(encoding="utf-8") == BASE_CONFIG
+    assert path.stat().st_mtime_ns == before, "a no-op still rewrote the file"
+
+
+def test_remove_without_a_config_file_is_not_an_error(tmp_path):
+    home = _home(tmp_path)
+    lines = kimi_hooks.remove(home, env={})
+    assert lines and not kimi_hooks.config_path(home, env={}).exists()
+
+
+# ---- the block parser itself ----
+
+def test_a_block_ends_at_the_next_table_header(tmp_path):
+    text = """\
+[[hooks]]
+event = "Stop"
+command = "python3 /x/daimon-kimi-stop.py"
+
+[services.other]
+key = "value"
+"""
+    blocks = kimi_hooks._hook_blocks(text)
+    assert len(blocks) == 1
+    assert "services.other" not in "\n".join(
+        text.splitlines()[blocks[0].start:blocks[0].end])
+
+
+def test_the_parser_reads_indented_and_commented_entries(tmp_path):
+    """Not a shape daimon writes, but one a person can hand-edit into the file.
+    A parser that misses it would leave a duplicate behind on the next
+    install."""
+    text = """\
+  [[hooks]]
+  event = "Stop"   # fires per turn
+  matcher = ".*"
+  command = "python3 /x/hooks/daimon-kimi-stop.py"
+  timeout = 10
+"""
+    blocks = kimi_hooks._hook_blocks(text)
+    assert len(blocks) == 1
+    assert blocks[0].fields["event"] == "Stop"
+    assert blocks[0].fields["command"].endswith("daimon-kimi-stop.py")
+    assert kimi_hooks._is_ours(blocks[0])
+
+
+def test_a_command_naming_no_daimon_script_is_not_ours():
+    text = """\
+[[hooks]]
+event = "Stop"
+matcher = ".*"
+command = "python3 /x/daimon-ish-but-not-ours.py"
+timeout = 10
+"""
+    assert not kimi_hooks._is_ours(kimi_hooks._hook_blocks(text)[0])
+
+
+def test_an_unreadable_hooks_entry_refuses_rather_than_clobbers(tmp_path):
+    """The case that matters: a `[[hooks]]` entry holding a line this parser
+    cannot read. It cannot tell where that block ends or whether daimon owns
+    it, so removing or replacing it would be a guess, and the file it would be
+    guessing inside holds the person's provider credentials. Refusing leaves
+    them with a working host and a message."""
+    home = _home(tmp_path)
+    path = _write_config(home, BASE_CONFIG + """
+[[hooks]]
+event = "Stop"
+command = [ "python3", "/x/y.py" ]
+""")
+    before = path.read_text(encoding="utf-8")
+    with pytest.raises(kimi_hooks.ConfigError):
+        _install(home)
+    assert path.read_text(encoding="utf-8") == before
+
+
+def test_a_file_that_is_not_toml_at_all_is_still_appended_to(tmp_path):
+    """The deliberate limit of the refusal above, stated so it is a decision
+    rather than an oversight. This module is not a TOML validator, and it does
+    not need to be: a file the HOST cannot parse is already not loading, the
+    append preserves every existing byte, and once the person fixes their typo
+    their hooks are there. Refusing here would block a repair, not protect
+    anything."""
+    home = _home(tmp_path)
+    broken = "[[hooks]\nevent = broken\n"
+    path = _write_config(home, broken)
+    _install(home)
+    assert path.read_text(encoding="utf-8").startswith(broken)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="tomllib is 3.11+")
+def test_what_the_installer_writes_is_valid_toml(tmp_path):
+    """The kernel floor is 3.10, so the installer cannot depend on `tomllib`
+    and hand-rolls its block parser. The TEST is free to use it, and this is
+    the assertion that the hand-rolled writer produces something the real
+    parser accepts."""
+    import tomllib
+
+    home = _home(tmp_path)
+    path = _write_config(home, BASE_CONFIG)
+    _install(home)
+    parsed = tomllib.loads(path.read_text(encoding="utf-8"))
+    assert parsed["services"]["moonshot"]["api_key"] == "REDACTED"
+    assert len(parsed["hooks"]) == 3
+    for entry in parsed["hooks"]:
+        assert set(entry) == {"event", "matcher", "command", "timeout"}
+        assert isinstance(entry["timeout"], int)
+
+
+# ---- registration status, the audit `daimon hooks status` reads ----
+
+def test_registration_status_reports_the_three_states(tmp_path):
+    home = _home(tmp_path)
+    _write_config(home, BASE_CONFIG)
+    assert kimi_hooks.registration_status(home, env={}) == "UNREGISTERED"
+    _install(home)
+    assert kimi_hooks.registration_status(home, env={}) == "REGISTERED"
+    kimi_hooks.remove(home, env={})
+    assert kimi_hooks.registration_status(home, env={}) == "UNREGISTERED"
+
+
+def test_a_partial_registration_is_reported_as_partial(tmp_path):
+    """The shape a half-finished hand edit leaves behind. Reporting it as
+    REGISTERED would tell someone their sessions are being captured when one
+    of the two capture events is gone."""
+    home = _home(tmp_path)
+    path = _write_config(home, BASE_CONFIG)
+    _install(home)
+    text = path.read_text(encoding="utf-8")
+    blocks = [b for b in kimi_hooks._hook_blocks(text)
+              if b.fields["event"] == "Stop"]
+    lines = text.splitlines(keepends=True)
+    del lines[blocks[0].start:blocks[0].end]
+    path.write_text("".join(lines), encoding="utf-8")
+    assert kimi_hooks.registration_status(home, env={}) == "PARTIAL"
+
+
+def test_an_unreadable_config_reports_unregistered_not_a_crash(tmp_path):
+    home = _home(tmp_path)
+    _write_config(home, "[[hooks]\nbroken")
+    assert kimi_hooks.registration_status(home, env={}) == "UNREGISTERED"
+
+
+# ---- wiring into the shipped CLI ----
+
+def test_kimi_is_a_known_hooks_host():
+    from daimon_briefing import cli
+
+    spec = cli._HOOK_HOSTS.get("kimi")
+    assert spec is not None, "`daimon hooks install kimi` has no host entry"
+    assert spec["register"] == "kimi"
+    assert set(spec["files"]) == set(kimi_hooks.FILES), (
+        "the status audit walks `files`; a file the install writes and this "
+        "list omits goes stale invisibly")
+    assert set(spec["events"]) == {"UserPromptSubmit", "SessionEnd", "Stop"}
+
+
+def test_the_status_audit_looks_inside_the_kimi_config_directory(tmp_path):
+    from daimon_briefing import cli
+
+    home = _home(tmp_path)
+    spec = cli._HOOK_HOSTS["kimi"]
+    assert cli._host_install_dir(spec, home) == home / ".kimi-code" / "hooks"
+
+
+def test_the_ledger_can_attribute_both_new_capture_tags():
+    """A host adapter whose spawn lines the ledger cannot parse is invisible to
+    `daimon status`, to hung detection, and to `heal`."""
+    from daimon_briefing import ledger
+
+    ts = "2026-09-09T17:05:49Z"
+    for tag in ("kimi-session-end", "kimi-stop"):
+        line = f"{ts} {tag}: spawned serialize for session_abc (transcript: /t.jsonl)"
+        assert ledger._SPAWN_RE.match(line), f"{tag} spawns are invisible"
+        assert ledger._SPAWN_RE.match(line).group(2) == "session_abc"
+        assert ledger._STATS_HOST_RE.match(line).group(1) == tag
+
+
+def test_the_new_scripts_are_in_the_sync_manifest():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "sync_hooks_kimi", REPO / "scripts" / "sync_hooks.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    sources = {src for src, _dst in mod.SYNC_PAIRS}
+    for script in (h.script for h in kimi_hooks.HOOKS):
+        assert f"hook/{script}" in sources, (
+            f"{script} is hand-copied outside SYNC_PAIRS and drifts silently")
+
+
+def test_no_check_profile_ships_for_kimi_yet():
+    """Deliberate, and asserted so it cannot be added by reflex. Kimi's deny
+    channel (exit 2, and the JSON permission decision) has never been seen to
+    block a command on a live session. A profile would put `enforce` in the
+    ladder for an enforcement daimon has not watched land."""
+    from daimon_briefing import checks_host
+
+    assert "kimi" not in checks_host.PROFILES
+
+
+# ---- the agent skill (`daimon skill install kimi`) ----
+
+def test_kimi_is_a_known_skill_host(tmp_path):
+    """Kimi's skill contract is Claude's, measured against 0.42.0: a directory
+    form `<scope>/skills/<name>/SKILL.md` with `name` and `description`
+    frontmatter, scanned from `~/.kimi-code/skills/` and the project's
+    `.kimi-code/skills/`, with a LISTING injected at session start and the
+    body loaded only on invocation. So it takes the `owned`/`full` shape, not
+    the always-injected compact block the rules-file hosts need."""
+    from daimon_briefing import skill_install
+
+    spec = skill_install.HOSTS.get("kimi")
+    assert spec is not None
+    assert spec["global"] == (".kimi-code/skills/daimon/SKILL.md", "owned", "full")
+    assert spec["project"] == (".kimi-code/skills/daimon/SKILL.md", "owned", "full")
+
+
+def test_installing_the_skill_for_kimi_writes_a_usable_skill_file(tmp_path):
+    from daimon_briefing import skill_install
+
+    skill_install.install("kimi", project=False, home=tmp_path, cwd=tmp_path)
+    path = tmp_path / ".kimi-code" / "skills" / "daimon" / "SKILL.md"
+    text = path.read_text(encoding="utf-8")
+    # The host requires both frontmatter fields in directory form, and skips a
+    # skill whose `name` does not match its directory.
+    assert text.startswith("---")
+    assert "name: daimon" in text
+    assert "description:" in text

--- a/plugin/tests/test_kimi_hooks_install.py
+++ b/plugin/tests/test_kimi_hooks_install.py
@@ -168,6 +168,38 @@ def test_install_then_remove_restores_the_file_byte_for_byte(tmp_path):
         assert path.read_text(encoding="utf-8") == BASE_CONFIG
 
 
+def test_a_crlf_config_keeps_its_line_endings_across_install_and_remove(tmp_path):
+    """A config.toml that passed through a Windows editor ends every line in
+    CRLF. Reading it with universal newlines and writing LF back would rewrite
+    every line the installer does not own, which is the exact thing "never
+    re-serialize" exists to prevent. The installer's own lines follow the
+    file's convention so the result is not a mixed-ending file either."""
+    home = _home(tmp_path)
+    path = home / ".kimi-code" / "config.toml"
+    crlf = BASE_CONFIG.replace("\n", "\r\n").encode("utf-8")
+    path.write_bytes(crlf)
+    _install(home)
+    after = path.read_bytes()
+    assert after.startswith(crlf)
+    assert b"\n" not in after.replace(b"\r\n", b""), (
+        "the installer's own lines must match the file's line endings")
+    kimi_hooks.remove(home, env={})
+    assert path.read_bytes() == crlf
+
+
+def test_a_config_without_a_trailing_newline_gains_exactly_one(tmp_path):
+    """The one byte the round trip does not restore, pinned so the docs can
+    say exactly that instead of "byte for byte". A last line with no newline
+    needs one before a block can be appended, and remove has no way to tell
+    that newline from one the person wrote."""
+    home = _home(tmp_path)
+    bare = BASE_CONFIG.rstrip("\n")
+    path = _write_config(home, bare)
+    _install(home)
+    kimi_hooks.remove(home, env={})
+    assert path.read_text(encoding="utf-8") == bare + "\n"
+
+
 def test_a_foreign_hooks_entry_is_never_touched(tmp_path):
     """Someone else's `[[hooks]]` block is the case where "remove our entries"
     and "remove the hooks array" differ, and only one of them is correct."""

--- a/plugin/tests/test_kimi_hooks_install.py
+++ b/plugin/tests/test_kimi_hooks_install.py
@@ -416,7 +416,112 @@ def test_an_unreadable_config_reports_unregistered_not_a_crash(tmp_path):
     assert kimi_hooks.registration_status(home, env={}) == "UNREGISTERED"
 
 
+# A `[[hooks]]` entry daimon's locator cannot read: the line inside the block
+# is neither a comment nor `key = value`. `_hook_blocks` raises ConfigError on
+# it, which is the case every verb below has to survive without writing.
+BROKEN_CONFIG = BASE_CONFIG + "\n[[hooks]]\nthis line is not an assignment\n"
+
+
+def test_a_config_the_locator_cannot_read_reports_unregistered(tmp_path):
+    """Distinct from a config that merely holds no `[[hooks]]`: this one makes
+    the locator RAISE, and status has to swallow that into UNREGISTERED the
+    same way it swallows an unreadable file."""
+    home = _home(tmp_path)
+    _write_config(home, BROKEN_CONFIG)
+    with pytest.raises(kimi_hooks.ConfigError):
+        kimi_hooks._hook_blocks(BROKEN_CONFIG)
+    assert kimi_hooks.registration_status(home, env={}) == "UNREGISTERED"
+
+
 # ---- wiring into the shipped CLI ----
+
+def _cli_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("KIMI_CODE_HOME", raising=False)
+    (tmp_path / ".kimi-code").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def test_cli_install_kimi_registers_and_reports(tmp_path, monkeypatch, capsys):
+    from daimon_briefing import cli
+
+    home = _cli_home(tmp_path, monkeypatch)
+    assert cli.main(["hooks", "install", "kimi"]) == 0
+    assert kimi_hooks.registration_status(home, env={}) == "REGISTERED"
+    out = capsys.readouterr().out
+    assert "registered daimon-kimi-user-prompt-submit.py" in out
+    assert "Start a NEW session" in out
+
+
+def test_cli_install_kimi_refuses_a_config_it_cannot_read(tmp_path, monkeypatch,
+                                                         capsys):
+    """The one place a traceback would read as "daimon broke my config": the
+    verb reports the file by name and exit 1, and writes nothing, not even a
+    backup, because there was nothing safe to write."""
+    from daimon_briefing import cli
+
+    home = _cli_home(tmp_path, monkeypatch)
+    path = _write_config(home, BROKEN_CONFIG)
+    before = path.read_bytes()
+    assert cli.main(["hooks", "install", "kimi"]) == 1
+    err = capsys.readouterr().err
+    assert "could not be read safely, so nothing was written" in err
+    assert str(path) in err
+    assert path.read_bytes() == before
+    assert not list(path.parent.glob("config.toml.daimon-backup-*"))
+
+
+def test_cli_remove_kimi_unregisters_and_leaves_the_scripts(tmp_path, monkeypatch,
+                                                            capsys):
+    from daimon_briefing import cli
+
+    home = _cli_home(tmp_path, monkeypatch)
+    assert cli.main(["hooks", "install", "kimi"]) == 0
+    capsys.readouterr()
+    assert cli.main(["hooks", "remove", "kimi"]) == 0
+    assert "removed 3 daimon entr" in capsys.readouterr().out
+    assert kimi_hooks.registration_status(home, env={}) == "UNREGISTERED"
+    for name in kimi_hooks.FILES:
+        assert (kimi_hooks.hooks_dir(home, env={}) / name).exists()
+
+
+def test_cli_remove_kimi_refuses_a_config_it_cannot_read(tmp_path, monkeypatch,
+                                                        capsys):
+    from daimon_briefing import cli
+
+    home = _cli_home(tmp_path, monkeypatch)
+    path = _write_config(home, BROKEN_CONFIG)
+    before = path.read_bytes()
+    assert cli.main(["hooks", "remove", "kimi"]) == 1
+    assert "could not be read safely" in capsys.readouterr().err
+    assert path.read_bytes() == before
+
+
+def test_cli_remove_refuses_a_host_daimon_did_not_register(tmp_path, monkeypatch,
+                                                          capsys):
+    """Codex is self-registering too, but through its own manager; Windsurf is
+    a pasted snippet. Neither is removable through this verb, and the error
+    names what is, so the person does not go looking for a flag."""
+    from daimon_briefing import cli
+
+    _cli_home(tmp_path, monkeypatch)
+    for host in ("codex", "windsurf"):
+        assert cli.main(["hooks", "remove", host]) == 2
+        err = capsys.readouterr().err
+        assert f"does not own the hook registration for '{host}'" in err
+        assert "Removable: kimi" in err
+
+
+def test_cli_remove_names_an_unknown_host(tmp_path, monkeypatch, capsys):
+    from daimon_briefing import cli
+
+    _cli_home(tmp_path, monkeypatch)
+    assert cli.main(["hooks", "remove", "nosuchhost"]) == 2
+    err = capsys.readouterr().err
+    assert "unknown host 'nosuchhost'" in err
+    assert "kimi" in err
+
+
 
 def test_kimi_is_a_known_hooks_host():
     from daimon_briefing import cli

--- a/plugin/tests/test_kimi_transcript.py
+++ b/plugin/tests/test_kimi_transcript.py
@@ -391,3 +391,19 @@ def test_a_claude_code_iso_stamp_still_wins_its_own_branch(tmp_path):
         {"type": "user", "uuid": "u1", "timestamp": "2026-07-01T10:05:30.500Z",
          "message": {"role": "user", "content": "hi"}}) + "\n")
     assert transcript.last_timestamp(path) == "2026-07-01T10:05:30Z"
+
+
+def test_a_boolean_time_is_not_a_1970_stamp(tmp_path):
+    """`bool` is an `int` in Python. `True / 1000` is 0.001 seconds past the
+    epoch: it never WINS the max against a real stamp, but in a log whose only
+    numeric `time` is a stray flag it is the only candidate, and the capture
+    would report a session that ended in 1970 instead of falling back to the
+    file's mtime."""
+    assert transcript._kimi_epoch(True) is None
+    assert transcript._kimi_epoch(False) is None
+    assert transcript._kimi_epoch(MS) == MS / 1000.0
+    path = tmp_path / "agents" / "main" / "wire.jsonl"
+    path.parent.mkdir(parents=True)
+    rows = [_metadata(), {**_append_message("hi"), "time": True}]
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+    assert transcript.last_timestamp(path) is None

--- a/plugin/tests/test_kimi_transcript.py
+++ b/plugin/tests/test_kimi_transcript.py
@@ -407,3 +407,42 @@ def test_a_boolean_time_is_not_a_1970_stamp(tmp_path):
     rows = [_metadata(), {**_append_message("hi"), "time": True}]
     path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
     assert transcript.last_timestamp(path) is None
+
+
+# ---- shapes a truncated or hand-edited log can present ----
+
+def test_an_empty_wire_log_at_the_wire_path_folds_to_nothing(tmp_path):
+    """No header to key on and no rows: the path still selects the branch,
+    and the header check itself answers False rather than raising on an
+    empty object list."""
+    assert transcript._is_kimi_wire([]) is False
+    path = _write(tmp_path, [])
+    assert transcript.from_file(path) == []
+
+
+def test_malformed_events_contribute_nothing_and_never_raise(tmp_path):
+    """One of each shape the fold has to step over: a message that is not an
+    object, a role that is neither user nor assistant, content that is not a
+    part list, an empty part list, a loop event that is not an object, a tool
+    result whose `result` is not an object, and one with no call id. The one
+    well-formed prompt beside them is the whole output."""
+    system = _append_message("host notice")
+    system["message"]["role"] = "system"
+    string_content = _append_message("ignored")
+    string_content["message"]["content"] = "a bare string, not a part list"
+    objs = [
+        _metadata(),
+        {"type": "context.append_message", "message": "not an object", "time": MS},
+        system,
+        string_content,
+        _append_message(""),
+        {"type": "context.append_loop_event", "event": "not an object", "time": MS},
+        {"type": "context.append_loop_event", "time": MS,
+         "event": {"type": "tool.result", "toolCallId": "call-1",
+                   "result": "not an object"}},
+        {"type": "context.append_loop_event", "time": MS,
+         "event": {"type": "tool.result", "result": {"output": "orphan"}}},
+        _append_message("the real prompt"),
+    ]
+    path = _write(tmp_path, objs)
+    assert _roles(transcript.from_file(path)) == [("user", "the real prompt")]

--- a/plugin/tests/test_kimi_transcript.py
+++ b/plugin/tests/test_kimi_transcript.py
@@ -1,0 +1,393 @@
+"""Kimi Code `wire.jsonl` folds into the same message list every other host
+produces (#988).
+
+Kimi does not write a message list. It writes an append-only EVENT log and
+folds it into messages at read time, so the same user prompt appears in up to
+three events (`prompt.accepted`, `turn.prompt`, `context.append_message`) and
+one assistant turn arrives as a run of `content.part` fragments. A branch that
+took every text-carrying event at face value would triple every prompt and
+shatter every answer.
+
+Every fixture here is SYNTHETIC, written by the helper below in the shapes
+measured on a live 0.42.0 session. The real sample logs carry the
+maintainer's session text and are never copied into this repo.
+"""
+import json
+
+import pytest
+
+from daimon_briefing import serializer, transcript
+
+MS = 1788971099794  # epoch milliseconds, the unit Kimi stamps `time` in
+
+
+def _metadata(ms=MS):
+    return {"type": "metadata", "protocol_version": "1.0", "created_at": ms}
+
+
+def _append_message(text, role="user", origin=None, ms=MS):
+    return {
+        "type": "context.append_message",
+        "agentId": "main",
+        "message": {
+            "role": role,
+            "content": [{"type": "text", "text": text}],
+            "toolCalls": [],
+            "origin": origin if origin is not None else {"kind": "user"},
+        },
+        "time": ms,
+    }
+
+
+def _turn_prompt(text, prompt_id="p-1", ms=MS):
+    return {"type": "turn.prompt", "agentId": "main",
+            "input": [{"type": "text", "text": text}],
+            "origin": {"kind": "user"}, "promptId": prompt_id, "time": ms}
+
+
+def _prompt_accepted(text, prompt_id="p-1", ms=MS):
+    return {"type": "prompt.accepted", "agentId": "main",
+            "promptId": prompt_id,
+            "content": [{"type": "text", "text": text}], "time": ms}
+
+
+def _part(kind, text, step_uuid="s-1", ms=MS):
+    """A `content.part` loop event. `kind` is "text" (assistant prose) or
+    "think" (the model's reasoning, which is noise for the serializer)."""
+    return {"type": "context.append_loop_event", "agentId": "main",
+            "event": {"type": "content.part", "uuid": "u-part",
+                      "turnId": "1", "step": 1, "stepUuid": step_uuid,
+                      "part": {"type": kind, kind: text}},
+            "time": ms}
+
+
+def _tool_call(name, args, call_id="call-1", ms=MS):
+    return {"type": "context.append_loop_event", "agentId": "main",
+            "event": {"type": "tool.call", "uuid": "u-call", "turnId": "1",
+                      "step": 1, "stepUuid": "s-1", "toolCallId": call_id,
+                      "name": name, "args": args,
+                      "display": {"kind": "command"}},
+            "time": ms}
+
+
+def _tool_result(output, call_id="call-1", is_error=None, ms=MS):
+    result = {"output": output}
+    if is_error is not None:
+        result["isError"] = is_error
+    return {"type": "context.append_loop_event", "agentId": "main",
+            "event": {"type": "tool.result", "parentUuid": "u-call",
+                      "toolCallId": call_id, "result": result},
+            "time": ms}
+
+
+def _write(tmp_path, objs, name="wire.jsonl", agent="main"):
+    """Write a wire log at the real on-disk shape:
+    <sessions>/wd_<dir>_<hex>/session_<uuid>/agents/<agent>/wire.jsonl"""
+    d = (tmp_path / "sessions" / "wd_proj_0123456789ab"
+         / "session_abc" / "agents" / agent)
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / name
+    path.write_text("\n".join(json.dumps(o) for o in objs) + "\n",
+                    encoding="utf-8")
+    return path
+
+
+def _roles(msgs):
+    return [(m["role"], m["content"]) for m in msgs]
+
+
+# ---- detection ----
+
+def test_metadata_first_line_selects_the_kimi_branch(tmp_path):
+    path = _write(tmp_path, [_metadata(), _append_message("hello there")])
+    assert _roles(transcript.from_file(path)) == [("user", "hello there")]
+
+
+def test_wire_path_selects_the_branch_without_a_metadata_header(tmp_path):
+    """A log rotated or truncated past its header is still a Kimi log: the
+    path says so. Without this the file falls through to the generic branch,
+    which reads `type` keys it was never meant to see."""
+    path = _write(tmp_path, [_append_message("hello there")])
+    assert _roles(transcript.from_file(path)) == [("user", "hello there")]
+
+
+def test_a_claude_code_row_is_not_mistaken_for_kimi(tmp_path):
+    path = tmp_path / "cc.jsonl"
+    path.write_text(json.dumps(
+        {"type": "user", "uuid": "u1",
+         "message": {"role": "user", "content": "plain claude row"}}) + "\n")
+    msgs = transcript.from_file(path)
+    assert _roles(msgs) == [("user", "plain claude row")]
+    assert msgs[0]["id"] == "u1"
+
+
+# ---- the mirror problem ----
+
+def test_one_prompt_carried_by_three_events_yields_one_message(tmp_path):
+    """Measured on three live sessions: `prompt.accepted`, `turn.prompt` and
+    `context.append_message` carry byte-identical text for the same prompt."""
+    text = "run the suite and tell me what broke"
+    path = _write(tmp_path, [
+        _metadata(),
+        _prompt_accepted(text),
+        _turn_prompt(text),
+        _append_message(text),
+    ])
+    assert _roles(transcript.from_file(path)) == [("user", text)]
+
+
+def test_a_prompt_with_no_appended_message_is_still_captured_once(tmp_path):
+    """A log cut off mid-turn keeps the lifecycle events and loses the
+    canonical append. The prompt must survive, and survive exactly once."""
+    text = "the prompt whose append never landed"
+    path = _write(tmp_path, [
+        _metadata(), _prompt_accepted(text), _turn_prompt(text)])
+    assert _roles(transcript.from_file(path)) == [("user", text)]
+
+
+def test_the_same_prompt_typed_twice_yields_two_messages(tmp_path):
+    path = _write(tmp_path, [
+        _metadata(),
+        _turn_prompt("one last one", "p-1"),
+        _append_message("one last one"),
+        _turn_prompt("one last one", "p-2"),
+        _append_message("one last one"),
+    ])
+    assert _roles(transcript.from_file(path)) == [
+        ("user", "one last one"), ("user", "one last one")]
+
+
+# ---- assistant text and thinking ----
+
+def test_text_parts_of_one_step_merge_into_one_assistant_message(tmp_path):
+    path = _write(tmp_path, [
+        _metadata(),
+        _append_message("question"),
+        _part("text", "First half."),
+        _part("text", "Second half."),
+    ])
+    assert _roles(transcript.from_file(path)) == [
+        ("user", "question"), ("assistant", "First half.\nSecond half.")]
+
+
+def test_thinking_parts_never_reach_the_message_list(tmp_path):
+    path = _write(tmp_path, [
+        _metadata(),
+        _part("think", "the model's private reasoning"),
+        _part("text", "the answer"),
+    ])
+    assert _roles(transcript.from_file(path)) == [("assistant", "the answer")]
+
+
+def test_a_tool_call_between_two_text_runs_splits_them(tmp_path):
+    path = _write(tmp_path, [
+        _metadata(),
+        _part("text", "Let me look."),
+        _tool_call("Bash", {"command": "ls"}),
+        _tool_result("a\nb"),
+        _part("text", "Two files."),
+    ])
+    assert [m["role"] for m in transcript.from_file(path)] == [
+        "assistant", "tool", "assistant"]
+
+
+# ---- tool results ----
+
+def test_tool_result_becomes_a_tool_message_keyed_on_the_call_id(tmp_path):
+    path = _write(tmp_path, [
+        _metadata(),
+        _tool_call("Bash", {"command": "pytest -q"}, "call-9"),
+        _tool_result("6059 passed", "call-9"),
+    ])
+    msg = transcript.from_file(path)[0]
+    assert msg["role"] == "tool"
+    assert msg["content"] == "6059 passed"
+    assert msg["id"] == "call-9"
+    assert msg["tool_result"] is True
+    assert "tool_error" not in msg
+
+
+def test_a_failed_tool_result_carries_tool_error(tmp_path):
+    path = _write(tmp_path, [
+        _metadata(),
+        _tool_call("Bash", {"command": "false"}),
+        _tool_result("exit 1", is_error=True),
+    ])
+    assert transcript.from_file(path)[0]["tool_error"] is True
+
+
+def test_tool_output_is_capped_at_parse_time(tmp_path):
+    path = _write(tmp_path, [
+        _metadata(),
+        _tool_call("Read", {"path": "big.txt"}),
+        _tool_result("x" * 5000),
+    ])
+    content = transcript.from_file(path)[0]["content"]
+    assert len(content) == transcript._TOOL_RESULT_MAX_CHARS
+
+
+def test_empty_tool_output_still_reports_that_it_ran(tmp_path):
+    path = _write(tmp_path, [
+        _metadata(), _tool_call("Bash", {"command": "true"}), _tool_result("")])
+    assert transcript.from_file(path)[0]["content"] == "(no output)"
+
+
+def test_a_daimon_shell_call_marks_its_result_as_daimon_output(tmp_path):
+    path = _write(tmp_path, [
+        _metadata(),
+        _tool_call("Bash", {"command": "daimon brief"}, "call-d"),
+        _tool_result("DAIMON BRIEFING (checkpoint: S1)", "call-d"),
+    ])
+    assert transcript.from_file(path)[0]["daimon_output"] is True
+
+
+def test_an_ordinary_shell_call_is_not_marked_daimon_output(tmp_path):
+    path = _write(tmp_path, [
+        _metadata(),
+        _tool_call("Bash", {"command": "rg daimon plugin/"}, "call-r"),
+        _tool_result("plugin/cli.py:1", "call-r"),
+    ])
+    assert "daimon_output" not in transcript.from_file(path)[0]
+
+
+def test_a_daimon_mcp_tool_marks_its_result_as_daimon_output(tmp_path):
+    path = _write(tmp_path, [
+        _metadata(),
+        _tool_call("mcp__daimon__daimon_recall", {"query": "x"}, "call-m"),
+        _tool_result("prior work", "call-m"),
+    ])
+    assert transcript.from_file(path)[0]["daimon_output"] is True
+
+
+# ---- host scaffolding ----
+
+def test_host_injected_reminders_are_dropped(tmp_path):
+    """`origin.kind == "injection"` is Kimi's own scaffolding (a date change,
+    a permission-mode notice). It is the direct analogue of Claude Code's
+    `isMeta` rows, which this parser has always dropped."""
+    path = _write(tmp_path, [
+        _metadata(),
+        _append_message("<system-reminder>\nToday's date is 2026-09-09.\n"
+                        "</system-reminder>",
+                        origin={"kind": "injection", "variant": "date_change"}),
+        _append_message("real question"),
+    ])
+    assert _roles(transcript.from_file(path)) == [("user", "real question")]
+
+
+def test_a_hook_result_message_survives_parsing(tmp_path):
+    """Hook output is context the model actually read, so it stays in the
+    message list. What it must never do is pass as a WITNESS."""
+    briefing = ('<hook_result hook_event="UserPromptSubmit">\n'
+                "DAIMON BRIEFING (checkpoint: S1, written 2m ago)\n"
+                "we decided to keep the resolver\n</hook_result>")
+    path = _write(tmp_path, [
+        _metadata(),
+        _append_message(briefing,
+                        origin={"kind": "hook_result",
+                                "event": "UserPromptSubmit"}),
+        _append_message("and now my actual question"),
+    ])
+    msgs = transcript.from_file(path)
+    assert [m["role"] for m in msgs] == ["user", "user"]
+    assert "DAIMON BRIEFING" in msgs[0]["content"]
+
+
+def test_the_injected_briefing_is_stripped_from_the_verification_haystack(
+        tmp_path):
+    """The reuse that matters: daimon's own briefing rides into a Kimi
+    session inside a `hook_result` message of its own, so the existing
+    message-scoped strip blanks it whole. A quote lifted from a PRIOR
+    session's briefing must not verify as witnessed in THIS one (#440)."""
+    briefing = ('<hook_result hook_event="UserPromptSubmit">\n'
+                "DAIMON BRIEFING (checkpoint: S1, written 2m ago)\n"
+                "we decided to keep the resolver\n</hook_result>")
+    path = _write(tmp_path, [_metadata(), _append_message(
+        briefing, origin={"kind": "hook_result", "event": "UserPromptSubmit"})])
+    body = transcript.from_file(path)[0]["content"]
+    assert "we decided to keep the resolver" not in serializer.strip_injected(body)
+
+
+def test_a_skill_activation_prompt_is_kept_as_user_context(tmp_path):
+    path = _write(tmp_path, [
+        _metadata(),
+        _append_message("Skill instructions: read the docs first",
+                        origin={"kind": "skill_activation",
+                                "skillName": "check-docs"}),
+    ])
+    assert _roles(transcript.from_file(path)) == [
+        ("user", "Skill instructions: read the docs first")]
+
+
+# ---- robustness ----
+
+@pytest.mark.parametrize("noise", [
+    {"type": "llm.request", "model": "k2", "time": MS},
+    {"type": "usage.record", "usage": {"output": 12}, "time": MS},
+    {"type": "token_counting.measured", "tokens": 4, "time": MS},
+    {"type": "permission.set_mode", "mode": "auto", "time": MS},
+    {"type": "file_history.tracked", "path": "/x/y.py", "time": MS},
+    {"type": "interaction.request", "request": {"toolName": "Bash"},
+     "time": MS},
+    {"type": "interaction.resolved", "response": {"decision": "approved"},
+     "time": MS},
+    {"type": "profile.bind", "systemPrompt": "a very long system prompt",
+     "time": MS},
+    {"type": "llm.tools_snapshot", "tools": [{"name": "Bash"}], "time": MS},
+    {"type": "turn.ended", "reason": "completed", "time": MS},
+    {"type": "an.event.type.that.does.not.exist.yet", "time": MS},
+])
+def test_noise_events_contribute_nothing_and_never_raise(tmp_path, noise):
+    path = _write(tmp_path, [_metadata(), noise, _append_message("the ask")])
+    assert _roles(transcript.from_file(path)) == [("user", "the ask")]
+
+
+def test_a_malformed_line_is_skipped_not_fatal(tmp_path):
+    path = _write(tmp_path, [_metadata(), _append_message("survivor")])
+    path.write_text(path.read_text(encoding="utf-8") + "{not json\n",
+                    encoding="utf-8")
+    assert _roles(transcript.from_file(path)) == [("user", "survivor")]
+
+
+def test_a_header_only_log_yields_no_messages(tmp_path):
+    """Never the raw-blob fallback: an empty session is empty, not one giant
+    user message holding the whole event log."""
+    path = _write(tmp_path, [_metadata(),
+                             {"type": "runtime.set_binding", "time": MS}])
+    assert transcript.from_file(path) == []
+
+
+def test_a_subagent_log_parses_on_its_own_terms(tmp_path):
+    """Subagent files are not merged into the main log in this slice. Handed
+    one directly, the branch still folds it rather than refusing."""
+    path = _write(tmp_path, [_metadata(), _append_message("subagent task")],
+                  agent="sub-1")
+    assert _roles(transcript.from_file(path)) == [("user", "subagent task")]
+
+
+# ---- timestamps ----
+
+def test_last_timestamp_reads_kimi_millisecond_stamps(tmp_path):
+    path = _write(tmp_path, [
+        _metadata(ms=MS),
+        _append_message("first", ms=MS),
+        _append_message("last", ms=MS + 15297),
+    ])
+    assert transcript.last_timestamp(path) == "2026-09-09T16:25:15Z"
+
+
+def test_last_timestamp_takes_the_max_not_the_last_row(tmp_path):
+    path = _write(tmp_path, [
+        _metadata(ms=MS),
+        _append_message("late", ms=MS + 60000),
+        _append_message("early", ms=MS),
+    ])
+    assert transcript.last_timestamp(path) == "2026-09-09T16:25:59Z"
+
+
+def test_a_claude_code_iso_stamp_still_wins_its_own_branch(tmp_path):
+    path = tmp_path / "cc.jsonl"
+    path.write_text(json.dumps(
+        {"type": "user", "uuid": "u1", "timestamp": "2026-07-01T10:05:30.500Z",
+         "message": {"role": "user", "content": "hi"}}) + "\n")
+    assert transcript.last_timestamp(path) == "2026-07-01T10:05:30Z"

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -805,6 +805,13 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
     def r_hooks_install():
         run(["hooks", "install", "windsurf"], 0)  # HOME is tmp-isolated
 
+    def r_hooks_remove():
+        # #988: exercised against a HOME with no Kimi config at all, which is
+        # the no-op branch. It still has to be under the guard: the branch
+        # that DOES write backs up and rewrites config.toml, and this recipe
+        # is what proves the verb declares its write shape either way.
+        run(["hooks", "remove", "kimi"], 0)  # HOME is tmp-isolated
+
     def r_hooks_status():
         run(["hooks", "status"], 0)
 
@@ -890,6 +897,7 @@ def _drive_all(audit, tmp_path, monkeypatch, proj):
         ("check", "sync"): r_check_sync,
         ("hooks", "list"): r_hooks_list,
         ("hooks", "install"): r_hooks_install,
+        ("hooks", "remove"): r_hooks_remove,
         ("hooks", "status"): r_hooks_status,
         ("skill", "list"): r_skill_list,
         ("skill", "show"): r_skill_show,

--- a/scripts/sync_hooks.py
+++ b/scripts/sync_hooks.py
@@ -40,6 +40,14 @@ SYNC_PAIRS = (
     ("hook/daimon-codex-stop.py", "plugin/daimon_briefing/_hooks/daimon-codex-stop.py"),
     ("hook/daimon-codex-session-end.py", "plugin/daimon_briefing/_hooks/daimon-codex-session-end.py"),
     ("hook/daimon-codex-pre-action.py", "plugin/daimon_briefing/_hooks/daimon-codex-pre-action.py"),
+    # #988: the Kimi Code adapter. Same direction as the Codex scripts —
+    # hook/ is canonical, the packaged copy is the derivative.
+    ("hook/daimon-kimi-user-prompt-submit.py",
+     "plugin/daimon_briefing/_hooks/daimon-kimi-user-prompt-submit.py"),
+    ("hook/daimon-kimi-session-end.py",
+     "plugin/daimon_briefing/_hooks/daimon-kimi-session-end.py"),
+    ("hook/daimon-kimi-stop.py",
+     "plugin/daimon_briefing/_hooks/daimon-kimi-stop.py"),
     ("hook/_daimon_hook_lib.py", "plugin/daimon_briefing/_hooks/_daimon_hook_lib.py"),
 )
 

--- a/website/docs/hosts/index.md
+++ b/website/docs/hosts/index.md
@@ -15,6 +15,7 @@ hook events each host actually exposes.
 | [Codex](./codex.md) | `daimon hooks install codex` | `SessionEnd` hook serializes on graceful end; throttled `Stop` hook covers everything else | `SessionStart` hook injects via `additionalContext` | live-validated capture (since 2026-08-06) |
 | [Gemini CLI](./gemini.md) | Manual `hook/gemini-hooks.py install` (from a clone) | Blocked upstream (`gemini-cli#14715` — `transcript_path` is an empty stub) | `SessionStart` hook injects via `additionalContext` | blocked upstream (`gemini-cli#14715`) |
 | [Windsurf (Cascade)](./windsurf.md) | `daimon hooks install windsurf` | Throttled serialize on `pre_user_prompt` / `post_cascade_response(_with_transcript)` | None — Cascade has no session-start-equivalent event; the skill instructs the agent to run `daimon brief --team` in the terminal at session start | live-validated |
+| [Kimi Code](./kimi.md) | `daimon hooks install kimi` | `SessionEnd` hook serializes on interactive exit; throttled `Stop` hook is the only path in print mode | `UserPromptSubmit` hook injects with your first prompt (no session-start channel) | measured on one live session (2026-09-09) |
 
 ## Three moving parts
 
@@ -23,7 +24,7 @@ Every host setup combines up to three pieces, installed independently:
 - **Hooks** capture your sessions and (where the host supports it) inject the
   briefing as context. Claude Code gets a packaged plugin; other hosts install
   standalone hook scripts via `daimon hooks install <host>` (Windsurf,
-  Codex) or the manual lifecycle scripts under `hook/` (Gemini, and
+  Codex, Kimi Code) or the manual lifecycle scripts under `hook/` (Gemini, and
   Claude Code without the plugin).
 - **The skill** (`daimon skill install <host>`) teaches the agent on the other
   side of the hook how to use what the hooks capture — read the briefing at

--- a/website/docs/hosts/kimi.md
+++ b/website/docs/hosts/kimi.md
@@ -1,0 +1,118 @@
+---
+description: "Set up daimon on Kimi Code. UserPromptSubmit-only briefing, throttled Stop capture as the print-mode path, and the pre-action checks not wired yet."
+---
+
+# Kimi Code
+
+Kimi Code support is measured on one live 0.42.0 session (2026-09-09): the
+install path, the three hook registrations, and the print-mode gap below all
+come from that run, not from a fleet. Ruling pre-action checks are not wired
+for this host yet.
+
+## Install
+
+Adds daimon's capture -> inject loop to Kimi Code from the released package:
+
+```sh
+daimon hooks install kimi
+```
+
+This copies three hook scripts, plus the modules they share, into the Kimi
+config directory, then appends `[[hooks]]` entries to
+`~/.kimi-code/config.toml` (or `$KIMI_CODE_HOME/config.toml` when that
+variable is set). The config file is backed up before daimon writes to it.
+The writer only ever appends or removes daimon's own blocks. It never
+rewrites the provider or model tables.
+
+Re-run `daimon hooks install kimi` after every `uv tool upgrade
+daimon-briefing`, same as every other host, so the installed scripts match
+the CLI version. Hooks load once, at session start: after installing, start
+a new Kimi session. The one already running will not pick up the change.
+
+Requires the `daimon` CLI on `PATH`:
+
+```sh
+uv tool install 'daimon-briefing[pretty]'
+```
+
+## What each script does
+
+- **`daimon-kimi-user-prompt-submit.py`**: `UserPromptSubmit` hook. This is
+  the only channel Kimi gives a hook to put text into the session, so it
+  carries the briefing. Kimi has no session-start injection point (see
+  Limitations below). The model sees the briefing as a user message wrapped
+  in a `hook_result` tag, attached to your first prompt.
+- **`daimon-kimi-session-end.py`**: `SessionEnd` hook. Serializes the
+  finished session when an interactive Kimi session exits. It is
+  idempotent: a session the `Stop` hook already captured is not written a
+  second time.
+- **`daimon-kimi-stop.py`**: `Stop` hook. Runs a throttled capture after
+  each turn. This is crash insurance for an interactive session, and it is
+  the only capture path in print mode, where `SessionEnd` never fires (see
+  Limitations).
+
+## Limitations
+
+- **No briefing at session start.** Kimi's `SessionStart` hook is
+  observation only, its stdout is dropped. The briefing arrives with your
+  first prompt instead, through the `UserPromptSubmit` hook above.
+- **Print mode never closes.** `kimi -p` sessions stay resumable and never
+  fire `SessionEnd`, measured twice on a live session. The `Stop` hook is
+  what captures them, and `SessionEnd`'s serialize stays idempotent, so a
+  session already captured there is not written twice.
+- **No pre-action checks yet.** Kimi's deny channel has not been measured on
+  a live session, so this release ships no check profile for it.
+- **Hooks load at session start only.** Installing does not reach a session
+  already running. Start a new one to pick up the change.
+- **macOS records the resolved path.** Kimi stores the working directory it
+  resolves to, so a session started under `/tmp/x` is recorded as
+  `/private/tmp/x`. Keep that in mind when you look sessions up by
+  directory.
+
+## Transcripts
+
+Kimi writes each session's transcript to
+`~/.kimi-code/sessions/<workspace>/<session id>/agents/main/wire.jsonl`. The
+hook payload carries the session id, not a path, so daimon resolves the
+transcript by globbing for that session id under the sessions directory.
+Subagent transcripts are not merged into the main transcript in this
+release.
+
+## MCP
+
+Kimi needs no daimon-specific MCP adapter. It reads a project-root
+`.mcp.json` in the same format Claude Code uses, so an existing daimon MCP
+entry works unchanged.
+
+## Teach the agent the protocol
+
+```sh
+daimon skill install kimi              # ~/.kimi-code/skills/daimon/SKILL.md
+daimon skill install kimi --project    # <repo>/.kimi-code/skills/daimon/SKILL.md
+```
+
+Kimi scans both locations and injects the skill's name and description at
+session start, loading the body only when the skill is invoked. Project
+scope wins over user scope. Re-run install after upgrading `daimon` to
+refresh the content.
+
+## Remove
+
+```sh
+daimon hooks remove kimi
+```
+
+This takes daimon's `[[hooks]]` entries back out of `config.toml` and leaves
+everything else in the file byte for byte as it was. The installed scripts
+stay where they are, inert once unregistered. Checkpoints under `~/.daimon/`
+are untouched.
+
+## Verify
+
+```sh
+daimon status
+```
+
+`daimon status` reports capture health for Kimi the same as any other host,
+including the print-mode gap above. A capture made through the `Stop`
+throttle counts the same as one made through `SessionEnd`.

--- a/website/docs/hosts/kimi.md
+++ b/website/docs/hosts/kimi.md
@@ -43,9 +43,10 @@ uv tool install 'daimon-briefing[pretty]'
   Limitations below). The model sees the briefing as a user message wrapped
   in a `hook_result` tag, attached to your first prompt.
 - **`daimon-kimi-session-end.py`**: `SessionEnd` hook. Serializes the
-  finished session when an interactive Kimi session exits. It is
-  idempotent: a session the `Stop` hook already captured is not written a
-  second time.
+  finished session when an interactive Kimi session exits, including the
+  turns after the last `Stop` capture. Bytes `Stop` already captured are
+  not re-serialized: the CLI checks the transcript against the last
+  checkpoint before any model call.
 - **`daimon-kimi-stop.py`**: `Stop` hook. Runs a throttled capture after
   each turn. This is crash insurance for an interactive session, and it is
   the only capture path in print mode, where `SessionEnd` never fires (see
@@ -58,8 +59,15 @@ uv tool install 'daimon-briefing[pretty]'
   first prompt instead, through the `UserPromptSubmit` hook above.
 - **Print mode never closes.** `kimi -p` sessions stay resumable and never
   fire `SessionEnd`, measured twice on a live session. The `Stop` hook is
-  what captures them, and `SessionEnd`'s serialize stays idempotent, so a
-  session already captured there is not written twice.
+  what captures them. On an interactive exit `SessionEnd` runs its own
+  capture regardless of a recent `Stop`, so the turns after the last Stop
+  are not lost; the CLI compares the transcript against the last checkpoint
+  first, so bytes Stop already captured cost a file read, not a second
+  model call.
+- **A resumed session is not briefed again.** The briefing marker is keyed
+  on the session id, so `kimi -r` on a session that already received its
+  briefing gets the per-prompt recall injection but no second briefing.
+  Resume itself has not been measured on a live session.
 - **No pre-action checks yet.** Kimi's deny channel has not been measured on
   a live session, so this release ships no check profile for it.
 - **Hooks load at session start only.** Installing does not reach a session
@@ -91,10 +99,9 @@ daimon skill install kimi              # ~/.kimi-code/skills/daimon/SKILL.md
 daimon skill install kimi --project    # <repo>/.kimi-code/skills/daimon/SKILL.md
 ```
 
-Kimi scans both locations and injects the skill's name and description at
-session start, loading the body only when the skill is invoked. Project
-scope wins over user scope. Re-run install after upgrading `daimon` to
-refresh the content.
+Kimi scans both locations for skills. The probe measured where it looks,
+not how it ranks the two when both hold a daimon skill, so install to one
+scope. Re-run install after upgrading `daimon` to refresh the content.
 
 ## Remove
 
@@ -103,7 +110,9 @@ daimon hooks remove kimi
 ```
 
 This takes daimon's `[[hooks]]` entries back out of `config.toml` and leaves
-everything else in the file byte for byte as it was. The installed scripts
+everything else in the file as it was, line endings included. The one
+exception: a file whose last line had no newline gains one, and remove
+cannot tell it from one you wrote. The installed scripts
 stay where they are, inert once unregistered. Checkpoints under `~/.daimon/`
 are untouched.
 
@@ -113,6 +122,6 @@ are untouched.
 daimon status
 ```
 
-`daimon status` reports capture health for Kimi the same as any other host,
-including the print-mode gap above. A capture made through the `Stop`
-throttle counts the same as one made through `SessionEnd`.
+`daimon status` reports capture health for Kimi the same as any other host.
+A capture made through the `Stop` throttle counts the same as one made
+through `SessionEnd`; nothing in the report singles out print-mode sessions.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/index.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/index.md
@@ -15,6 +15,7 @@ profundidad del soporte varía según los eventos de hook que cada host expone.
 | [Codex](./codex.md) | `daimon hooks install codex` | El hook `SessionEnd` serializa al cierre ordenado; el hook `Stop` con throttle cubre el resto | El hook `SessionStart` inyecta vía `additionalContext` | captura validada en uso real (desde 2026-08-06) |
 | [Gemini CLI](./gemini.md) | Manual `hook/gemini-hooks.py install` (desde un clon) | Bloqueado upstream (`gemini-cli#14715` — `transcript_path` es un stub vacío) | El hook `SessionStart` inyecta vía `additionalContext` | bloqueado upstream (`gemini-cli#14715`) |
 | [Windsurf (Cascade)](./windsurf.md) | `daimon hooks install windsurf` | Serialización con throttle en `pre_user_prompt` / `post_cascade_response(_with_transcript)` | Ninguna — Cascade no tiene evento equivalente a inicio de sesión; la skill instruye al agente a ejecutar `daimon brief --team` en la terminal al empezar | validado en uso real |
+| [Kimi Code](./kimi.md) | `daimon hooks install kimi` | El hook `SessionEnd` serializa al cerrar la sesión interactiva; el hook `Stop` con throttle es la única vía en modo print | El hook `UserPromptSubmit` inyecta con tu primer prompt (sin canal de inicio de sesión) | medido en una sola sesión en vivo (2026-09-09) |
 
 ## Tres piezas móviles
 
@@ -24,8 +25,9 @@ independiente:
 - **Los hooks** capturan tus sesiones y (donde el host lo permite) inyectan el
   briefing como contexto. Claude Code tiene un plugin empaquetado; los demás
   hosts instalan scripts de hook independientes vía
-  `daimon hooks install <host>` (Windsurf, Codex) o los scripts manuales
-  de ciclo de vida bajo `hook/` (Gemini, y Claude Code sin el plugin).
+  `daimon hooks install <host>` (Windsurf, Codex, Kimi Code) o los scripts
+  manuales de ciclo de vida bajo `hook/` (Gemini, y Claude Code sin el
+  plugin).
 - **La skill** (`daimon skill install <host>`) le enseña al agente del otro
   lado del hook cómo usar lo que los hooks capturan — leer el briefing al
   inicio de sesión (obteniéndolo con `daimon brief --team` cuando el host no

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/kimi.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/kimi.md
@@ -46,8 +46,10 @@ uv tool install 'daimon-briefing[pretty]'
   como un mensaje de usuario envuelto en una etiqueta `hook_result`,
   adjunto a tu primer prompt.
 - **`daimon-kimi-session-end.py`**: hook `SessionEnd`. Serializa la sesión
-  terminada cuando una sesión interactiva de Kimi se cierra. Es idempotente:
-  una sesión que el hook `Stop` ya capturó no se vuelve a escribir.
+  terminada cuando una sesión interactiva de Kimi se cierra, incluidos los
+  turnos posteriores a la última captura de `Stop`. Los bytes que `Stop` ya
+  capturó no se vuelven a serializar: la CLI compara la transcripción con el
+  último checkpoint antes de cualquier llamada al modelo.
 - **`daimon-kimi-stop.py`**: hook `Stop`. Corre una captura con throttle
   después de cada turno. Es un seguro contra crashes para una sesión
   interactiva, y es la única vía de captura en modo print, donde
@@ -60,9 +62,16 @@ uv tool install 'daimon-briefing[pretty]'
   tu primer prompt, a través del hook `UserPromptSubmit` de arriba.
 - **El modo print nunca cierra.** Las sesiones de `kimi -p` quedan
   resumibles y nunca disparan `SessionEnd`, medido dos veces en una sesión
-  en vivo. El hook `Stop` es lo que las captura, y la serialización de
-  `SessionEnd` sigue siendo idempotente, así que una sesión ya capturada
-  ahí no se escribe dos veces.
+  en vivo. El hook `Stop` es lo que las captura. En una salida interactiva,
+  `SessionEnd` corre su propia captura aunque haya un `Stop` reciente, así
+  que los turnos posteriores al último Stop no se pierden; la CLI compara la
+  transcripción con el último checkpoint antes de nada, así que los bytes que
+  Stop ya capturó cuestan una lectura de archivo, no una segunda llamada al
+  modelo.
+- **Una sesión resumida no recibe el briefing de nuevo.** El marcador del
+  briefing se indexa por id de sesión, así que `kimi -r` sobre una sesión
+  que ya lo recibió obtiene la inyección de recall por prompt pero no un
+  segundo briefing. El resume en sí no se midió en una sesión en vivo.
 - **Todavía sin checks de pre-acción.** El canal de rechazo de Kimi no se
   midió en una sesión en vivo, así que esta versión no trae un perfil de
   checks para este host.
@@ -95,9 +104,9 @@ daimon skill install kimi              # ~/.kimi-code/skills/daimon/SKILL.md
 daimon skill install kimi --project    # <repo>/.kimi-code/skills/daimon/SKILL.md
 ```
 
-Kimi escanea las dos ubicaciones e inyecta el nombre y la descripción de la
-skill al iniciar la sesión, y carga el cuerpo solo cuando se la invoca. El
-alcance de proyecto gana sobre el de usuario. Volvé a correr install después
+Kimi escanea las dos ubicaciones en busca de skills. La prueba midió dónde
+busca, no cómo prioriza entre las dos cuando ambas tienen una skill de
+daimon, así que instalá en un solo alcance. Volvé a correr install después
 de actualizar `daimon` para refrescar el contenido.
 
 ## Desinstalar
@@ -107,7 +116,9 @@ daimon hooks remove kimi
 ```
 
 Saca las entradas `[[hooks]]` de daimon del `config.toml` y deja el resto
-del archivo byte por byte como estaba. Los scripts instalados quedan donde
+del archivo como estaba, finales de línea incluidos. La única excepción: un
+archivo cuya última línea no tenía salto de línea gana uno, y remove no
+puede distinguirlo de uno que escribiste vos. Los scripts instalados quedan donde
 están, inertes una vez desregistrados. Los checkpoints en `~/.daimon/` no se
 tocan.
 
@@ -118,5 +129,5 @@ daimon status
 ```
 
 `daimon status` reporta la salud de captura de Kimi igual que en cualquier
-otro host, incluido el hueco del modo print de arriba. Una captura hecha por
-el throttle de `Stop` cuenta igual que una hecha por `SessionEnd`.
+otro host. Una captura hecha por el throttle de `Stop` cuenta igual que una
+hecha por `SessionEnd`; nada en el reporte distingue las sesiones en modo print.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/kimi.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/kimi.md
@@ -1,0 +1,122 @@
+---
+description: "Configura daimon en Kimi Code. Briefing solo por UserPromptSubmit, captura con Stop throttled como via del modo print, y los checks de pre-accion todavia sin conectar."
+---
+
+# Kimi Code
+
+El soporte de Kimi Code está medido sobre una sola sesión en vivo de 0.42.0
+(2026-09-09): la instalación, los tres registros de hooks y el hueco del
+modo print de más abajo salen de esa corrida, no de una flota. Los checks de
+pre-acción de las rulings todavía no están conectados para este host.
+
+## Instalación
+
+Agrega el ciclo de captura -> inyección de daimon a Kimi Code desde el
+paquete publicado:
+
+```sh
+daimon hooks install kimi
+```
+
+Esto copia tres scripts de hook, más los módulos que comparten, al
+directorio de configuración de Kimi, y luego agrega entradas `[[hooks]]` a
+`~/.kimi-code/config.toml` (o `$KIMI_CODE_HOME/config.toml` cuando esa
+variable está definida). El archivo de configuración se respalda antes de
+que daimon escriba en él. El escritor solo agrega o quita sus propios
+bloques. Nunca reescribe las tablas de proveedor o modelo.
+
+Re-ejecuta `daimon hooks install kimi` después de cada `uv tool upgrade
+daimon-briefing`, igual que en cualquier otro host, para que los scripts
+instalados coincidan con la versión del CLI. Los hooks se cargan una sola
+vez, al inicio de la sesión: después de instalar, iniciá una sesión nueva de
+Kimi. La que ya está corriendo no va a tomar el cambio.
+
+Requiere el CLI `daimon` en el `PATH`:
+
+```sh
+uv tool install 'daimon-briefing[pretty]'
+```
+
+## Qué hace cada script
+
+- **`daimon-kimi-user-prompt-submit.py`**: hook `UserPromptSubmit`. Es el
+  único canal que Kimi le da a un hook para meter texto en la sesión, así
+  que es el que lleva el briefing. Kimi no tiene un punto de inyección al
+  inicio de sesión (mirá Limitaciones más abajo). El modelo ve el briefing
+  como un mensaje de usuario envuelto en una etiqueta `hook_result`,
+  adjunto a tu primer prompt.
+- **`daimon-kimi-session-end.py`**: hook `SessionEnd`. Serializa la sesión
+  terminada cuando una sesión interactiva de Kimi se cierra. Es idempotente:
+  una sesión que el hook `Stop` ya capturó no se vuelve a escribir.
+- **`daimon-kimi-stop.py`**: hook `Stop`. Corre una captura con throttle
+  después de cada turno. Es un seguro contra crashes para una sesión
+  interactiva, y es la única vía de captura en modo print, donde
+  `SessionEnd` nunca se dispara (mirá Limitaciones).
+
+## Limitaciones
+
+- **Sin briefing al inicio de sesión.** El hook `SessionStart` de Kimi es
+  solo de observación, su stdout se descarta. El briefing llega recién con
+  tu primer prompt, a través del hook `UserPromptSubmit` de arriba.
+- **El modo print nunca cierra.** Las sesiones de `kimi -p` quedan
+  resumibles y nunca disparan `SessionEnd`, medido dos veces en una sesión
+  en vivo. El hook `Stop` es lo que las captura, y la serialización de
+  `SessionEnd` sigue siendo idempotente, así que una sesión ya capturada
+  ahí no se escribe dos veces.
+- **Todavía sin checks de pre-acción.** El canal de rechazo de Kimi no se
+  midió en una sesión en vivo, así que esta versión no trae un perfil de
+  checks para este host.
+- **Los hooks se cargan solo al inicio de sesión.** Instalar no llega a una
+  sesión que ya está corriendo. Iniciá una nueva para que tome el cambio.
+- **macOS registra la ruta resuelta.** Kimi guarda el directorio de trabajo
+  al que resuelve, así que una sesión iniciada bajo `/tmp/x` queda
+  registrada como `/private/tmp/x`. Tené esto en cuenta si buscás sesiones
+  por directorio.
+
+## Transcripts
+
+Kimi escribe el transcript de cada sesión en
+`~/.kimi-code/sessions/<workspace>/<session id>/agents/main/wire.jsonl`. El
+payload del hook lleva el id de sesión, no una ruta, así que daimon resuelve
+el transcript buscando ese id de sesión dentro del directorio de sesiones.
+Los transcripts de subagentes no se combinan con el transcript principal en
+esta versión.
+
+## MCP
+
+Kimi no necesita un adaptador MCP propio de daimon. Lee un `.mcp.json` en
+la raíz del proyecto con el mismo formato que usa Claude Code, así que una
+entrada MCP de daimon ya existente funciona sin cambios.
+
+## Enseñale el protocolo al agente
+
+```sh
+daimon skill install kimi              # ~/.kimi-code/skills/daimon/SKILL.md
+daimon skill install kimi --project    # <repo>/.kimi-code/skills/daimon/SKILL.md
+```
+
+Kimi escanea las dos ubicaciones e inyecta el nombre y la descripción de la
+skill al iniciar la sesión, y carga el cuerpo solo cuando se la invoca. El
+alcance de proyecto gana sobre el de usuario. Volvé a correr install después
+de actualizar `daimon` para refrescar el contenido.
+
+## Desinstalar
+
+```sh
+daimon hooks remove kimi
+```
+
+Saca las entradas `[[hooks]]` de daimon del `config.toml` y deja el resto
+del archivo byte por byte como estaba. Los scripts instalados quedan donde
+están, inertes una vez desregistrados. Los checkpoints en `~/.daimon/` no se
+tocan.
+
+## Verificar
+
+```sh
+daimon status
+```
+
+`daimon status` reporta la salud de captura de Kimi igual que en cualquier
+otro host, incluido el hueco del modo print de arriba. Una captura hecha por
+el throttle de `Stop` cuenta igual que una hecha por `SessionEnd`.


### PR DESCRIPTION
Refs #988

Slice one of the Kimi Code adapter: briefing, capture and transcript
parsing. Ruling pre-action checks are deliberately not in this slice, so
merging this must not close the issue.

Every host fact below was measured on a live Kimi Code 0.42.0 session on
2026-09-09, not read off the vendor's docs. Where a documented behavior and
the measured one disagree, the measurement wins and the code says so.

## What

**`daimon hooks install kimi`** copies three hook scripts plus the shared
library into the Kimi config directory (`$KIMI_CODE_HOME`, else
`~/.kimi-code`), then registers them by appending `[[hooks]]` entries to
`config.toml`.

That file is the reason this installer is not a copy of the Codex one.
Every host adapted so far stores its hooks as JSON that daimon can safely
re-serialize whole. Kimi's is TOML written by its own login flow, holding
provider credentials and model tables, and a `[[hooks]]` entry there accepts
exactly four fields. A fifth does not degrade that entry, it fails the whole
config load. So the installer never re-serializes: it locates blocks as text
and appends or removes them, and the four fields are a `NamedTuple` with
nowhere to put a fifth. Install then remove returns the file as it was,
line endings included, which is the test that catches a dropped comment, a
reordered key, a CRLF file rewritten as LF, and blank lines accumulating
across repeated cycles. The one byte it does not give back is pinned by its
own test and named on the host page: a last line with no newline gains one. A `[[hooks]]` entry it cannot read
raises rather than guessing, because the guess would be happening inside a
file that holds someone's credentials. `daimon hooks remove kimi` is the
other half.

**Three registrations, and the events that are missing are the point.**

- `UserPromptSubmit` carries the briefing. It is the only channel that puts
  text into a Kimi session: `SessionStart` fires and its stdout is dropped.
  So the briefing arrives with the first prompt rather than before it, kept
  to once per session by an atomic marker claim, with recall injection on
  every prompt after that.
- `SessionEnd` serializes an interactive exit.
- `Stop` runs a throttled capture per turn. On Codex the equivalent hook is
  pure crash insurance. Here it is the only capture path for `kimi -p`, which
  never fires `SessionEnd` at all (measured twice: a print session ends
  resumable, so it never closes). `SessionEnd` stays unthrottled against
  that Stop capture, the same call Codex makes: the throttle window is the
  interval between the last spawned Stop and `/exit`, so honouring the
  marker would drop the session tail. The repeat is cheap because the CLI
  compares the transcript's sha against the last checkpoint before any LLM
  work.

No `PreToolUse` entry and no check profile. The deny channel, exit 2 and the
JSON permission decision, was never exercised against a real command. Both
are documented and both strings sit in the binary, and neither of those is a
command observed being blocked. A profile added on that evidence would put
`enforce` in the degradation ladder for an enforcement daimon has never
watched land, and a check that reports enforcing while silently allowing is
byte-identical to a clean allow. The exact facts a later probe has to prove
are written into `checks_host.PROFILES` where the row would go.

**Transcript parsing.** Kimi persists an event log, not a message list.
`transcript.py` gains a `wire.jsonl` branch that folds it, selected by the
log's header or by the `agents/<id>/wire.jsonl` path shape when the head has
been truncated away. Two measured shapes drive it. One prompt is written
three times, by `prompt.accepted`, `turn.prompt` and
`context.append_message`, byte-identical across every prompt in three real
sessions, so the mirrors are suppressed against the canonical append rather
than folded three times. A mirror whose text never appears in an append is
kept, because a log cut off mid-turn keeps the mirrors and loses the append,
and losing the last prompt of a crashed session is the opposite of what
crash insurance is for. Assistant turns arrive as runs of fragments and are
joined; thinking parts are dropped, as they are on Claude Code. Unknown
event types contribute nothing and never raise.

## Why a general CLI flag came with a host adapter

`daimon serialize` gained `--session`, and the Kimi hooks pass it on every
spawn. This was not planned, it fell out of the build.

`_run_serialize` derives its session id from the transcript filename, which
is correct on every host adapted before this one, because each names the
transcript for its session. Kimi does not. The session id is a directory and
the file inside it is always `wire.jsonl`. Without the flag, every Kimi
session on a machine would serialize under the id `wire`: each new session
overwriting the previous one's per-session checkpoint, and a heartbeat under
a constant name making any live serialize look like every other session's,
which is scar 0061 arriving from the other direction. The flag follows the
rule #983 already set for `write-checkpoint`: when the host can supply a real
session id, that id wins over an inferred one. Passing it to the CLI and
keying the in-flight guard on it are one change, because doing only the
second would rebuild the no-op that scar records.

## Review round

A blind review of the branch found one high and two medium items, all fixed
here before the PR, each with a test that was red first.

- **High.** `SessionEnd` returned early on the Stop hook's throttle marker,
  so every turn between the last spawned Stop and `/exit` was lost at the
  one moment an end-of-session checkpoint exists for. The marker check is
  gone; the test that pinned the old behaviour now pins the opposite.
- **Medium.** The TOML installer read with universal newlines and wrote LF
  back, rewriting every line of a CRLF config it does not own. It now reads
  and writes bytes and appends its own blocks in the file's line ending.
- **Medium.** The session-id guard in the transcript resolver refused
  traversal but not glob metacharacters, and the id is interpolated into a
  glob: an id of `*` resolved a real, unrelated transcript. `*?[]` are now
  refused, with a test that plants a real transcript the unguarded glob
  reached.
- **Low.** The boolean guard in the Kimi epoch parser had an inverted
  comment and no fence; both fixed. The host page dropped two sentences the
  probe never supported (`daimon status` naming a print-mode gap; project
  skill scope winning over user scope) and gained one the code implies: a
  resumed session with the same id is not briefed a second time.

## Tests

Full suite on the branch before the review fixes, run twice: 6172 passed,
2 skipped, against a baseline of 6059 at the branch point. After the review
fixes, run once against an empty checkpoint store: 6176 passed, 2 skipped
(five tests added, one replaced). codecov then flagged 28 uncovered patch
lines, the `hooks install kimi`/`hooks remove kimi` CLI paths and the wire
fold's defensive branches; nine tests cover them and the suite is 6185
passed, 2 skipped, empty store. `ruff` and `mypy` clean under CI's own
commands; the hook mirror check passes.

Review-round fences: the Stop-marker test was red on the old hook and green
after; the CRLF test was red with the old `read_text`/`write_text` pair and
red again when the newline detector was forced to LF; the glob test was red
with the old guard; the boolean-epoch test went red with the `bool` clause
removed. All restored and green.

Strict TDD throughout. Twenty-two behaviors were fenced by breaking the
production line, confirming the test went red, and restoring. Two of those
tests passed while their behavior was broken and were rewritten: the
`--session` assertion was reading a checkpoint that a backend-less run never
wrote, and the traversal test used an id that found nothing whether the guard
existed or not, so it now plants a real file the unguarded glob would reach.
A third asserted a flag name by substring and accepted `--sessionX`.

Manual smoke without a Kimi session: a synthetic `wire.jsonl` through the
fold, which returns one user message rather than three; the prompt hook fed a
hand-written `UserPromptSubmit` payload on stdin, printing the briefing and
exiting 0; the session-end hook resolving a transcript from a session id
alone, and logging a named reason when it resolves nothing; and an install
against a temp home producing valid four-field TOML and a clean round trip.

Docs: a host page in English and Spanish, the host index in both, and the
README and status table. Subagent transcripts are not merged in this slice
and every surface that could imply otherwise says so.

