### PR TITLE
fix(carry): a resolved item inherits its identity onto a native twin only on a strong restatement

### DIFF
--- a/docs/checkpoint-schema.json
+++ b/docs/checkpoint-schema.json
@@ -599,6 +599,18 @@
       "notes": "Session id of the LAST carry hop (#33); absent on native items. Model-emitted values are stripped (#725)."
     },
     {
+      "field": "restated_after_resolve",
+      "type": "boolean",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "stripped_at_serialize": true
+      },
+      "notes": "#980: carry handed this native item a RESOLVED prev item's id on a strong restatement match (>=4 shared salient terms, or >=0.75 of the shorter list); the item keeps its own wording and `status --suppressed` names the inheritance. Model-emitted values are stripped."
+    },
+    {
       "field": "quote_verified",
       "type": "boolean",
       "optional": true,

--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -27,6 +27,13 @@ _CARRIED_KINDS = schema.CARRIED_KINDS
 
 _MIN_SHARED = 3     # shared salient terms for same-item
 _MIN_RATIO = 0.6    # or this fraction of the shorter term list
+# #980: the bar for a native twin to INHERIT A RESOLVED prev item's identity.
+# Higher than the twin bar on purpose: that bar is tuned for rewording and
+# admits two different statements about one subject at its floor (the
+# issue's pair shares 3 of 5 terms), and on a closed item a false twin does
+# not cost a duplicate, it withholds a live memory under a closed id.
+_INHERIT_SHARED = 4
+_INHERIT_RATIO = 0.75
 # Which rail a same-item match came in on (#268). Dedup treats them alike;
 # corroboration does not — see _match_path and _record_corroboration's G4.
 _MATCH_EXACT = "exact"
@@ -167,6 +174,22 @@ def _match_path(a_text: str, b_text: str, generic=frozenset()) -> str:
     if shared / min(len(a), len(b)) >= _MIN_RATIO:
         return _MATCH_RATIO
     return ""
+
+
+def _restates(a_text: str, b_text: str, generic=frozenset()) -> bool:
+    """#980: is `b_text` a RESTATEMENT of `a_text`, strongly enough to inherit
+    a closed item's identity? Same term algebra as `_match_path`, higher
+    thresholds (`_INHERIT_SHARED`, `_INHERIT_RATIO`). Only consulted after
+    `_same_item` already matched on the SAME `generic`, so the quantity-
+    conflict guard has run and both filtered sets hold at least two terms
+    (that floor lives in `_match_path`; repeating it here would be dead
+    code). A threshold shift, not a proof: a pair at five shared terms and a
+    low ratio still passes, which is why the caller also stamps the record."""
+    a = set(recall.salient_terms(a_text)) - generic
+    b = set(recall.salient_terms(b_text)) - generic
+    shared = len(a & b)
+    return (shared >= _INHERIT_SHARED
+            or shared / min(len(a), len(b)) >= _INHERIT_RATIO)
 
 
 def _same_item(a_text: str, b_text: str, generic=frozenset()) -> bool:
@@ -389,6 +412,19 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                          and not _is_reversal_of(n, text, item.get("id"),
                                                  generic)),
                         None)
+            # #980: a RESOLVED prev item inherits its identity onto a twin only
+            # on a strong restatement. On the twin floor two different claims
+            # about one subject match; for a live prev item that costs one
+            # merged wording, but for a closed one it withholds the live item
+            # under the closed id, in the same words a real resolution
+            # produces. Below the bar the pair is not a twin here: the prev
+            # item is closed, so it falls through to the resolved check and is
+            # not carried, and the native keeps its own identity and text.
+            closed = item.get("id") in resolved
+            if (twin is not None and closed
+                    and not _restates(text, str(twin.get("text") or ""),
+                                      generic)):
+                twin = None
             if twin is not None:
                 # #268: the corroboration verdict runs FIRST — BEFORE the
                 # freeze below, which overwrites the native twin's trust and
@@ -416,7 +452,12 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                 #     to reconsolidate; that is correct).
                 # AGE never resets either way (run-01: 8-12 resets/20 cycles
                 # killed the #128 overdue boost) — keep the older birth stamp.
-                if item.get("trust") == "verbatim":
+                # #980: on a closed prev item the freeze is skipped. Its text
+                # renders nowhere but the suppressed listing, and there the
+                # honest wording is the one this session actually produced;
+                # a reopen (`reverify`) then surfaces what the session said,
+                # under the session's own trust class, not a closed pin.
+                if item.get("trust") == "verbatim" and not closed:
                     twin["text"] = item["text"]
                     # F4 (#527): `because` explains ITS text. The freeze
                     # restores prev's wording, so prev's reasoning rides
@@ -498,6 +539,11 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                 # recorded against the old id still binds after re-extraction.
                 if item.get("id"):
                     twin.setdefault("id", item["id"])
+                    if closed:
+                        # #980: the gate is a threshold shift, not a proof;
+                        # the stamp is what lets `status --suppressed` say
+                        # "identity inherited" instead of "resolved".
+                        twin["restated_after_resolve"] = True
                 # Origin (#268) rides that same rail, and the twin path is the
                 # ONLY place it needs a line: plain carry deep-copies the whole
                 # prev item, binding included. A reworded twin is not a copy —

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -2254,6 +2254,13 @@ def _print_suppressed(project) -> int:
             paren = f"{status} {ts}"
             if note:
                 paren += f", {note}"
+            if item.get("restated_after_resolve") is True:
+                # #980: carry matched this session's item to a closed one and
+                # handed it the closed id; the wording shown is this
+                # session's own, so a person can tell a match from a
+                # resolution they recorded.
+                paren += ("; identity inherited from a resolved item, "
+                          "wording is this session's own")
             print(f"  {item_id}  [{key}] {text}  ({paren})")
     if candidates:
         # #14: machine SUGGESTIONS, not resolutions — a separate subsection

--- a/plugin/daimon_briefing/field_table.py
+++ b/plugin/daimon_briefing/field_table.py
@@ -186,6 +186,14 @@ ITEM_RULES: tuple[FieldRule, ...] = (
         "Session id of the LAST carry hop (#33); absent on native items. "
         "Model-emitted values are stripped (#725)."),
     FieldRule(
+        "item", "restated_after_resolve", "boolean", True, False, "code", "strip",
+        _c(stripped_at_serialize=True),
+        "#980: carry handed this native item a RESOLVED prev item's id on a "
+        "strong restatement match (>=4 shared salient terms, or >=0.75 of the "
+        "shorter list); the item keeps its own wording and `status "
+        "--suppressed` names the inheritance. Model-emitted values are "
+        "stripped."),
+    FieldRule(
         "item", "quote_verified", "boolean", True, False, "code", "strip",
         _c(stripped_at_serialize=True),
         "verify_quotes verdict (#125): true on a byte-verified quote, false "

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -2266,7 +2266,7 @@ _CODE_OWNED_KEYS = (
 _CODE_OWNED_ITEM_KEYS = ("origin_session", "origin_author",
                          "quote_verified", "last_verified",
                          "quote_provenance", "pinned", "id",
-                         "carried_from", "first_seen",
+                         "carried_from", "restated_after_resolve", "first_seen",
                          # #890: a model naming who said something is an agent
                          # asserting an identity it cannot verify, and the
                          # field would carry more authority than any other

--- a/plugin/tests/test_carry.py
+++ b/plugin/tests/test_carry.py
@@ -554,6 +554,81 @@ def test_resolved_prev_with_native_twin_still_inherits_id_and_native_survives():
     assert qs[0]["id"] == "o-dead01"
 
 
+# --- #980: a resolved prev item inherits its identity onto a native twin
+# only when the match is STRONG. The twin bar (3 shared terms, or 60%) is
+# tuned for rewording and admits two different statements about one subject
+# at its floor; a closed item must not extinguish a live one on that floor.
+
+# The issue's own pair: 5 salient terms each, 3 shared (exporter, archive,
+# writing), ratio 0.6 — clears today's twin bar, not the inheritance gate.
+_CLOSED_Q = "should the exporter batch rows before writing the archive"
+_LIVE_Q = "should the exporter compress the archive before writing it to disk"
+
+
+def test_a_different_item_on_the_twin_floor_does_not_inherit_a_resolved_identity():
+    prev = _cp("S-prev", 1, questions=[
+        _item(_CLOSED_Q, id="o-dead01", trust="verbatim", quote=_CLOSED_Q)])
+    new = _cp("S-new", 0, questions=[_item(_LIVE_Q, days=0)])
+    out = carry.merge(new, prev, NOW, resolved=frozenset({"o-dead01"}))
+    qs = out["working_context"]["open_questions"]
+    assert len(qs) == 1, "the closed item is not carried and the live one stays"
+    live = qs[0]
+    assert live["text"] == _LIVE_Q
+    assert "id" not in live, "the live item keeps its own identity"
+    assert live["trust"] == "inferred" and "quote" not in live, (
+        "the closed item's frozen text and quote must not overwrite the live one")
+    assert "restated_after_resolve" not in live
+
+
+def test_the_same_pair_still_twins_when_the_prev_item_is_live():
+    """Negative control for the gate: the gate applies to RESOLVED prev items
+    only. A live prev item on the same pair keeps today's behaviour, twin
+    identity and the verbatim freeze included."""
+    prev = _cp("S-prev", 1, questions=[
+        _item(_CLOSED_Q, id="o-live01", trust="verbatim", quote=_CLOSED_Q)])
+    new = _cp("S-new", 0, questions=[_item(_LIVE_Q, days=0)])
+    out = carry.merge(new, prev, NOW)
+    qs = out["working_context"]["open_questions"]
+    assert len(qs) == 1
+    assert qs[0]["id"] == "o-live01"
+    assert qs[0]["text"] == _CLOSED_Q
+    assert "restated_after_resolve" not in qs[0]
+
+
+def test_a_rewording_of_a_resolved_item_inherits_its_identity_and_is_stamped():
+    """The case the inheritance exists for: 4 shared terms, a rewording. The
+    id lands so withhold keeps it closed; the stamp names the inheritance;
+    and the fresh wording survives, since the closed item's text renders
+    nowhere but the suppressed listing, where the live wording is the
+    honest one to show."""
+    prev = _cp("S-prev", 1, questions=[
+        _item("dead loop no longer relevant", id="o-dead01",
+              trust="verbatim", quote="dead loop no longer relevant")])
+    new = _cp("S-new", 0, questions=[
+        _item("dead loop is no longer relevant now", days=0)])
+    out = carry.merge(new, prev, NOW, resolved=frozenset({"o-dead01"}))
+    qs = out["working_context"]["open_questions"]
+    assert len(qs) == 1
+    assert qs[0]["id"] == "o-dead01"
+    assert qs[0]["restated_after_resolve"] is True
+    assert qs[0]["text"] == "dead loop is no longer relevant now"
+    assert "quote" not in qs[0] and qs[0]["trust"] == "inferred"
+
+
+def test_a_resolved_identity_is_inherited_on_the_ratio_rail():
+    """3 shared of 4 is 0.75: a short rewording that cannot reach four
+    shared terms still inherits, on the ratio side of the gate."""
+    prev = _cp("S-prev", 1, questions=[
+        _item("exporter archive writer batching", id="o-dead02")])
+    new = _cp("S-new", 0, questions=[
+        _item("exporter archive writer compression", days=0)])
+    out = carry.merge(new, prev, NOW, resolved=frozenset({"o-dead02"}))
+    qs = out["working_context"]["open_questions"]
+    assert len(qs) == 1
+    assert qs[0]["id"] == "o-dead02"
+    assert qs[0]["restated_after_resolve"] is True
+
+
 def test_merge_without_resolved_kwarg_unchanged():
     prev = _cp("S-prev", 1, questions=[_item("zephyr ledger drop unresolved")])
     new = _cp("S-new")

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -5682,6 +5682,67 @@ def test_status_suppressed_lists_withheld_strong_belief(tmp_checkpoint_dir, samp
     assert item_id in out
 
 
+def _q_checkpoint(sid, text, **item):
+    return {"session_id": sid, "created": "2026-09-09T00:00:00Z",
+            "working_context": {"active_topic": {"text": "exporter", "trust": "inferred"},
+                                "open_questions": [{"text": text, "trust": "inferred",
+                                                    "importance": 7, **item}],
+                                "recent_decisions": []},
+            "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": [],
+                                   "contradictions_flagged": []}}
+
+
+def test_a_live_question_sharing_a_resolved_ones_vocabulary_survives_the_brief(
+        tmp_checkpoint_dir, capsys):
+    """#980 through the shipping path: write, resolve, carry_forward, write,
+    brief. Two different questions sharing three salient terms: the closed
+    one is withheld, the live one is printed, and nothing says withheld."""
+    from daimon_briefing import capture, store
+    P = "/repo/x"
+    closed = "should the exporter batch rows before writing the archive"
+    live = "should the exporter compress the archive before writing it to disk"
+    store.write_checkpoint("S1", _q_checkpoint("S1", closed, quote=closed,
+                                               trust="verbatim"), project_dir=P)
+    first = store.read_latest_body(project_dir=P, route=store.Route.OWN,
+                                   admit=store.Admit.ANY)
+    closed_id = first["working_context"]["open_questions"][0]["id"]
+    store.append_event(closed_id, "resolved", project_dir=P)
+    merged = capture.carry_forward(_q_checkpoint("S2", live), P)
+    store.write_checkpoint("S2", merged, project_dir=P)
+    assert cli.main(["brief", "--project", P]) == 0
+    out = capsys.readouterr().out
+    assert live in out
+    assert closed not in out
+    assert "withheld" not in out
+    assert cli.main(["status", "--suppressed", "--project", P]) == 0
+    assert "no suppressed items" in capsys.readouterr().out
+
+
+def test_status_suppressed_names_an_inherited_identity_with_the_live_wording(
+        tmp_checkpoint_dir, capsys):
+    """#980: when a fresh item DOES inherit a closed identity (a rewording),
+    the suppressed listing shows the fresh wording and says the identity was
+    inherited, so a person can tell a real resolution from a match."""
+    from daimon_briefing import capture, store
+    P = "/repo/x"
+    closed = "dead loop no longer relevant"
+    reworded = "dead loop is no longer relevant now"
+    store.write_checkpoint("S1", _q_checkpoint("S1", closed, quote=closed,
+                                               trust="verbatim"), project_dir=P)
+    first = store.read_latest_body(project_dir=P, route=store.Route.OWN,
+                                   admit=store.Admit.ANY)
+    closed_id = first["working_context"]["open_questions"][0]["id"]
+    store.append_event(closed_id, "resolved", project_dir=P)
+    merged = capture.carry_forward(_q_checkpoint("S2", reworded), P)
+    store.write_checkpoint("S2", merged, project_dir=P)
+    assert cli.main(["status", "--suppressed", "--project", P]) == 0
+    out = capsys.readouterr().out
+    assert closed_id in out
+    assert reworded in out
+    assert closed not in out
+    assert "identity inherited from a resolved item" in out
+
+
 def test_status_suppressed_none_prints_message(tmp_checkpoint_dir, sample_checkpoint, capsys):
     from daimon_briefing import store
     store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")


### PR DESCRIPTION
Closes #980

## What

A resolved previous item now inherits its identity onto a native twin only on a strong restatement: at least four shared salient terms, or a term ratio of at least 0.75 on the shorter list. The twin bar itself (three shared terms, or 0.6) is unchanged for live items. Below the inheritance bar a closed item is not a twin at all: it falls through to the existing resolved check and is not carried, and the native item keeps its own identity, text and trust.

When a closed item does pass the bar, the native item inherits the id, as before, and gains a `restated_after_resolve` stamp. On that path the verbatim freeze is skipped: the closed item's text renders nowhere but the suppressed listing, and there the honest wording is the one this session produced. `daimon status --suppressed` prints the stamp as "identity inherited from a resolved item, wording is this session's own" beside the resolution, so a person can tell a match from a resolution they recorded.

`restated_after_resolve` is a code-owned item field: declared in the field table, stripped from model output at serialize like `carried_from`, and the schema document is regenerated.

## Why

`carry.merge` runs the fuzzy twin match before the resolved check, so a closed previous item still enters the twin block; identity inheritance happens there and the verbatim freeze copies the closed text and quote over the fresh item. The next briefing then withholds the fresh item as though a human had resolved it, and in the verbatim case the suppressed listing shows the closed item's text, so the live item leaves no trace on any surface. The issue's own pair, two different questions about the exporter sharing three of five salient terms, reproduces it through the shipping writers.

Moving the resolved check ahead of the twin match instead breaks the tested rewording case (a reworded closed item would resurface) and trades a silent suppression for a silent resurrection, so the ordering stays and the gate goes inside the twin block. The gate is a threshold shift, not a proof; the stamp is what makes a misfire visible.

## Tests

- Six new tests, each red on the unfixed code and green after. At merge level: the issue's pair keeps the live item's own identity, text and trust; the same pair with a LIVE previous item still twins and freezes, as a negative control; a rewording of a closed item inherits the id, is stamped, and keeps its own wording; a three-of-four pair inherits on the ratio rail.
- Through the shipping path (`store.write_checkpoint`, `store.append_event`, `capture.carry_forward`, `daimon brief`, `daimon status --suppressed`): the live question is printed by the brief with nothing withheld, and an inherited identity is listed with the live wording and the marker.
- Existing carry, withhold and field-table suites unchanged; the published schema artifact test passes against the regenerated document. Every line of the diff runs under the carry, CLI and field-table tests.
- Full suite count is in the last commit's message.
