### PR TITLE
fix(team): the Teammates section withholds what the reader resolved, before the cap

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -603,19 +603,44 @@ def _cmd_anchor(args) -> int:
     return 0
 
 
-def _team_briefings(project) -> list:
+def _team_briefings(project, withheld: list | None = None) -> list:
     """Per-teammate briefing sections for `brief --team`, EXCLUDING the current
     author. Returns [(author, sections), ...] newest-first, or [] when the team dir
     is empty (nothing was ever mirrored). Reuses briefing.build so the #77 decision
     cap applies to teammates identically. Self is matched by slug — the same dir
-    identity read_team fans in on."""
+    identity read_team fans in on.
+
+    #981: each teammate checkpoint is folded through `briefing.withhold` BEFORE
+    it is built, so a resolved item neither prints under Teammates nor takes a
+    capped slot — the same fold every other briefing surface applies. The
+    ledger that governs is the READER's own (`store.resolutions(project)`):
+    what the reader resolved is what the reader stops seeing, on every
+    surface including this one; a teammate's own ledger is theirs and is not
+    read here. Fail-open like the main path: an unreadable ledger withholds
+    nothing rather than dropping the section. `withheld` is an optional
+    out-list the caller can hand in to fold the count into its note.
+    """
     # project_slug munging, matching _dual_write_team's dir identity — _safe_name
     # would re-introduce the "a/b" == "a_b" collision on the self-match.
     self_slug = store.project_slug(config.author())
+    # Read once, before the fan-in: one ledger read for every teammate, and
+    # a failure here is this function's own to swallow (the fan-in's own
+    # tombstone read of the same ledger keeps its own contract).
+    try:
+        resolutions = store.resolutions(project_dir=project)
+    except Exception:
+        resolutions = {}
     out = []
     for author, checkpoint in store.read_team(project_dir=project):
         if store.project_slug(author) == self_slug:
             continue  # never surface your own state as a teammate
+        try:
+            checkpoint, dropped, _candidates = briefing.withhold(
+                checkpoint, resolutions)
+        except Exception:
+            dropped = []
+        if withheld is not None:
+            withheld.extend(dropped)
         b = briefing.build(checkpoint)
         if b is None:
             continue  # nothing worth surfacing for this teammate
@@ -624,7 +649,7 @@ def _team_briefings(project) -> list:
 
 
 def _render_briefing_body(checkpoint, route, *, drift_project, teammates,
-                          worldcheck_project=None) -> int:
+                          worldcheck_project=None, team_withheld=()) -> int:
     """Shared tail of `brief` and `brief --slug`: withhold, worldcheck, drift,
     render, footnotes. `route` is whatever the events ledger should be keyed
     by — a project dir on the normal path, a bare slug on the --slug path (the
@@ -755,10 +780,14 @@ def _render_briefing_body(checkpoint, route, *, drift_project, teammates,
                         row["request_id"], project_dir=worldcheck_project)
         except Exception:
             pass
-    if withheld:
-        render.render_brief_note([
-            f"{len(withheld)} resolved item(s) withheld — "
-            "`daimon status --suppressed` to list"])
+    if withheld or team_withheld:
+        # #981: the count covers the Teammates section too, and says how
+        # many were a teammate's, since `status --suppressed` lists only the
+        # reader's own checkpoint.
+        note = f"{len(withheld) + len(team_withheld)} resolved item(s) withheld"
+        if team_withheld:
+            note += f" ({len(team_withheld)} a teammate's)"
+        render.render_brief_note([note + " — `daimon status --suppressed` to list"])
     # Staleness budget (#215): reuses the SAME resolutions fold `withhold`
     # already did above — no re-read of events.jsonl. Fail-open, same shape
     # as the withhold try/except; a broken stale_carried must never take the
@@ -856,7 +885,12 @@ def _cmd_brief(args) -> int:
         # (no new armor here); empty team -> render_teammates no-ops, so a
         # team-less machine's output stays byte-identical to today.
         if getattr(args, "team", False):
-            render.render_teammates(_team_briefings(project))
+            team_withheld: list = []
+            render.render_teammates(_team_briefings(project, team_withheld))
+            if team_withheld:
+                render.render_brief_note([
+                    f"{len(team_withheld)} resolved item(s) withheld "
+                    "(a teammate's)"])
         return 0
     # Label the global-pointer fallback (#29): status calls the same situation
     # "global checkpoint (fallback)"; brief must not present another project's
@@ -876,14 +910,16 @@ def _cmd_brief(args) -> int:
             "behind; re-run `daimon brief` in a few minutes for the fresh one."])
     # --team (#111): fan in teammates for THIS project. Empty team → None → the
     # renderer emits no Teammates section, byte-identical to a non-team briefing.
-    teammates = _team_briefings(project) if getattr(args, "team", False) else None
+    team_withheld: list = []
+    teammates = (_team_briefings(project, team_withheld)
+                 if getattr(args, "team", False) else None)
     # #365: never worldcheck a fallback body — the global pointer may belong
     # to ANOTHER project, and probing this cwd's repo against that
     # checkpoint's claims answers for the wrong repo.
     return _render_briefing_body(checkpoint, project,
                                  drift_project=project, teammates=teammates,
                                  worldcheck_project=None if fallback_used
-                                 else project)
+                                 else project, team_withheld=team_withheld)
 
 
 # ---- recall: FTS search over local + team checkpoint history (#112) ----

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -910,7 +910,7 @@ def _cmd_brief(args) -> int:
             "behind; re-run `daimon brief` in a few minutes for the fresh one."])
     # --team (#111): fan in teammates for THIS project. Empty team → None → the
     # renderer emits no Teammates section, byte-identical to a non-team briefing.
-    team_withheld: list = []
+    team_withheld = []
     teammates = (_team_briefings(project, team_withheld)
                  if getattr(args, "team", False) else None)
     # #365: never worldcheck a fallback body — the global pointer may belong

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -1,4 +1,5 @@
 import inspect
+import copy
 import json
 import logging
 import os
@@ -3904,6 +3905,192 @@ def test_cli_brief_team_respects_decision_cap(tmp_checkpoint_dir, sample_checkpo
     assert rc == 0
     out = capsys.readouterr().out
     assert "earlier decision" in out  # overflow marker: cap dropped 1 of grace's 2
+
+
+# --- #981: the Teammates section folds the READER's resolution ledger, the
+# same fold every other briefing surface applies, with the same fail-open. ---
+
+def _teammate_decision_ids(proj):
+    from daimon_briefing import store
+
+    cp = dict(store.read_team(project_dir=proj))["grace"]
+    decisions = cp["working_context"]["recent_decisions"]
+    assert all(d.get("id") for d in decisions), "the mirrored copy must carry ids"
+    return {d["text"]: d["id"] for d in decisions}
+
+
+def test_cli_brief_team_withholds_a_teammate_item_the_reader_resolved(
+        tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch, tmp_path):
+    """The reader's OWN ledger governs what the reader sees of a teammate:
+    a decision the reader resolved is withheld from the Teammates section,
+    the way every other surface withholds it. Both authors share one project
+    bucket here, so the reader's own body is grace's checkpoint too and the
+    same content-derived id resolves in both places."""
+    from daimon_briefing import store
+
+    proj = str((tmp_path / "proj").resolve())
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "grace")
+    store.write_checkpoint("g-1", sample_checkpoint, project_dir=proj)
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    ids = _teammate_decision_ids(proj)
+    store.append_event(ids["Single-pass for Slice 1, chunking is Slice 2"], "resolved",
+                       project_dir=proj)
+
+    assert cli.main(["brief", "--team", "--project", proj]) == 0
+    out = capsys.readouterr().out
+    assert "Teammates" in out
+    assert "Adopt the D-007 prompt" in out, "the live teammate decision still renders"
+    assert "Single-pass for Slice 1, chunking is Slice 2" not in out
+    assert "2 resolved item(s) withheld (1 a teammate's)" in out
+
+
+def test_cli_brief_team_header_only_path_withholds_and_says_so(
+        tmp_checkpoint_dir, capsys, monkeypatch, tmp_path):
+    """The reader has NO checkpoint of their own (the new-teammate case that
+    #223 kept --team alive for): the Teammates section still folds the
+    reader's ledger, and a note names the withheld count on this path too."""
+    import json as _json
+
+    from daimon_briefing import config, store
+
+    proj = str((tmp_path / "proj").resolve())
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    # Another project's checkpoint makes the global pointer point elsewhere:
+    # that is the branch that prints "No briefing for this project yet" and
+    # keeps --team alive (#223), as opposed to a machine with no checkpoint.
+    store.write_checkpoint("e-1", {
+        "session_id": "e-1", "working_context": {
+            "active_topic": {"text": "elsewhere", "trust": "inferred"},
+            "open_questions": [], "recent_decisions": []},
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": [],
+                               "contradictions_flagged": []}},
+        project_dir=str((tmp_path / "elsewhere").resolve()))
+    monkeypatch.setenv("DAIMON_TEAM_PROJECT", "core/x")
+    remote = config.team_dir() / "team-a"
+    (remote / ".git").mkdir(parents=True, exist_ok=True)
+    d = remote / "projects" / "core" / "x" / "authors" / "grace"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "S-g.json").write_text(_json.dumps({
+        "session_id": "S-g", "author": "grace", "team_project": "core/x",
+        "working_context": {
+            "active_topic": {"text": "Hardening the ingest gate", "trust": "inferred"},
+            "open_questions": [],
+            "recent_decisions": [
+                {"text": "Keep the ingest gate", "trust": "inferred",
+                 "id": "r-0000000000aa"},
+                {"text": "Ship the ingest gate tomorrow", "trust": "inferred",
+                 "id": "r-0000000000bb"},
+            ],
+        },
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []},
+    }), encoding="utf-8")
+    store.append_event("r-0000000000bb", "resolved", project_dir=proj)
+
+    assert cli.main(["brief", "--team", "--project", proj]) == 0
+    out = capsys.readouterr().out
+    assert "No briefing for this project yet" in out
+    assert "[grace]" in out
+    assert "Keep the ingest gate" in out
+    assert "Ship the ingest gate tomorrow" not in out
+    assert "1 resolved item(s) withheld (a teammate's)" in out
+
+
+def test_team_briefings_fail_open_when_the_ledger_or_the_fold_raises(
+        tmp_checkpoint_dir, sample_checkpoint, monkeypatch, tmp_path):
+    """Same posture as the main path: an unreadable resolution ledger, or a
+    fold that raises, withholds nothing rather than dropping the section.
+    Exercised on the team builder itself, since the main brief path has
+    readers of its own for the same ledger."""
+    from daimon_briefing import briefing, store
+
+    proj = str((tmp_path / "proj").resolve())
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "grace")
+    store.write_checkpoint("g-1", sample_checkpoint, project_dir=proj)
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    ids = _teammate_decision_ids(proj)
+    store.append_event(ids["Single-pass for Slice 1, chunking is Slice 2"], "resolved",
+                       project_dir=proj)
+
+    def failing_once(real):
+        # The team builder reads the ledger FIRST, before the fan-in, whose
+        # own tombstone reader calls the same function and is not this
+        # test's subject: raise on that first call only, then behave.
+        calls = [0]
+
+        def wrapper(*a, **k):
+            calls[0] += 1
+            if calls[0] == 1:
+                raise RuntimeError("hand-edited ledger")
+            return real(*a, **k)
+        return wrapper
+
+    for target, name in ((store, "resolutions"), (briefing, "withhold")):
+        with monkeypatch.context() as m:
+            m.setattr(target, name, failing_once(getattr(target, name)))
+            withheld: list = []
+            sections = cli._team_briefings(proj, withheld)
+        assert [a for a, _ in sections] == ["grace"], name
+        texts = [d["text"] for d in sections[0][1]["decisions"]]
+        assert "Single-pass for Slice 1, chunking is Slice 2" in texts, (
+            f"{name} raising must fail open to showing the item")
+        assert withheld == [], name
+
+
+def test_cli_brief_team_withheld_note_counts_the_teammates_item(
+        tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch, tmp_path):
+    """Full path: the reader has a checkpoint too. The note that already
+    names the reader's withheld items covers the teammate's, and says so,
+    since `status --suppressed` lists only the reader's own."""
+    from daimon_briefing import store
+
+    proj = str((tmp_path / "proj").resolve())
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    # Two fresh dicts: write_checkpoint stamps `author` INTO the checkpoint
+    # it is handed, and read_team reports that stamp rather than the
+    # directory, so a fixture object written twice mirrors the second file
+    # under the first author's name and the teammate renders twice.
+    monkeypatch.setenv("DAIMON_AUTHOR", "grace")
+    store.write_checkpoint("g-1", copy.deepcopy(sample_checkpoint), project_dir=proj)
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("a-1", copy.deepcopy(sample_checkpoint), project_dir=proj)
+    ids = _teammate_decision_ids(proj)
+    store.append_event(ids["Single-pass for Slice 1, chunking is Slice 2"], "resolved",
+                       project_dir=proj)
+
+    assert cli.main(["brief", "--team", "--project", proj]) == 0
+    out = capsys.readouterr().out
+    assert out.count("[grace]") == 1
+    team = out.split("Teammates")[1]
+    assert "Single-pass for Slice 1, chunking is Slice 2" not in team
+    # Two, not one: item ids are content-derived, so the reader's own copy
+    # of the same decision carries the same id and resolves with it.
+    assert "2 resolved item(s) withheld (1 a teammate's)" in out
+
+
+def test_cli_brief_team_resolved_item_does_not_take_a_capped_slot(
+        tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch, tmp_path):
+    """With the cap at 1, the resolved (newer) decision must not occupy the
+    slot and push the live (older) one into the overflow count."""
+    from daimon_briefing import store
+
+    proj = str((tmp_path / "proj").resolve())
+    monkeypatch.setenv("DAIMON_TEAM", "1")
+    monkeypatch.setenv("DAIMON_MAX_BRIEFING_DECISIONS", "1")
+    monkeypatch.setenv("DAIMON_AUTHOR", "grace")
+    store.write_checkpoint("g-1", sample_checkpoint, project_dir=proj)
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    ids = _teammate_decision_ids(proj)
+    store.append_event(ids["Single-pass for Slice 1, chunking is Slice 2"], "resolved",
+                       project_dir=proj)
+
+    assert cli.main(["brief", "--team", "--project", proj]) == 0
+    out = capsys.readouterr().out
+    assert "Adopt the D-007 prompt" in out
+    assert "Single-pass for Slice 1, chunking is Slice 2" not in out
+    assert "earlier decision" not in out, (
+        "a withheld item must not count against the cap")
 
 
 def test_cli_brief_team_labels_foreign_verbatim_claim(tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch, tmp_path):


### PR DESCRIPTION
Closes #981

## What

The Teammates section of `daimon brief --team` now folds the resolution ledger before it is built, on both `--team` paths (the normal body and the header-only case where this project has no checkpoint of its own). A teammate item the reader resolved is withheld the way every other briefing surface withholds it, and because the fold runs before `briefing.build`, a withheld item no longer occupies a capped decision slot or pushes a live item into the overflow count.

The ledger that governs is the reader's own, read once before the fan-in: what the reader resolved is what the reader stops seeing, on every surface including this one. A teammate's own ledger is theirs and is not read here. The comment on the team builder and the tests say so explicitly.

The withheld note counts teammate items and says how many were a teammate's, since `daimon status --suppressed` lists only the reader's own checkpoint. On the header-only path, which had no note, one is printed when something was withheld.

Fail-open matches the main path: an unreadable ledger or a fold that raises withholds nothing rather than dropping the section.

## Why

`_team_briefings` built each teammate's sections straight from the stored checkpoint. Its comment reasoned about parity on the decision cap and missed the fold, so one run could print "1 resolved item(s) withheld" for the reader's body and the same item in full under Teammates. No doc stated a contract for suppression on the team path; this was an oversight, not a decision.

## Tests

- Six new tests, each red on the unfixed code. Through the CLI: a resolved teammate decision is withheld while the live one renders; the note counts it and names it as a teammate's; with the decision cap at 1 the resolved newer decision does not take the slot and the live older one renders with no overflow marker; the header-only path withholds and prints its own note. On the team builder directly: a ledger read that raises and a fold that raises both fail open with nothing withheld.
- One fixture trap surfaced while writing them, worth knowing: `store.write_checkpoint` stamps `author` into the dict it is handed, and `read_team` reports that stamp rather than the directory, so a fixture object written twice under two authors mirrors the second file under the first author's name and the teammate renders twice. The tests deep-copy per write and assert the teammate renders once.
- Item ids are content-derived, so when the reader's own checkpoint holds the same decision text as the teammate's, one resolution withholds both; the note test pins that count rather than a naive one.
- Full suite count is in the commit message. Every line of the diff runs under the brief tests.
