### PR TITLE
fix(refutations): a malformed anchors or evidence row is skipped, and ruling list reports an unresolved ledger instead of a traceback

### DIFF
--- a/plugin/daimon_briefing/cli/ruling.py
+++ b/plugin/daimon_briefing/cli/ruling.py
@@ -302,6 +302,30 @@ def _cmd_ruling_retire(args) -> int:
 
 def _cmd_ruling_list(args) -> int:
     project = _cli._resolve_project(args.project)
+    # #969: ask the shared reader for its STATE before asking `listing` for
+    # rows. `listing` reaches `_path` through `records` and `fold` with no
+    # guard of its own, so on a config fault (a bad byte in ~/.daimon/env,
+    # an unexpandable DAIMON_CHECKPOINT_DIR) it raised several statements
+    # before the `unresolved` branch below could name the fault. The library
+    # keeps raising for in-process callers, who have `rulings_read` for the
+    # honest answer; the CLI, which shares the reader's vocabulary, consults
+    # it first. One probe, reused by every branch below. `unresolved` returns
+    # HERE, before the usage counter or anything else that reads config: the
+    # fault is in config itself (a corrupt env file raises on every read), so
+    # every later config touch would die the same way. stdout keeps its
+    # empty-ledger shape, the way `no-bucket` and `unreadable` keep theirs.
+    read = briefing.rulings_read(project)
+    if read.state == "unresolved":
+        # No `path` to name — resolution never got that far, so this line
+        # never interpolates one.
+        print(f"cannot resolve a ledger path for {project}: check "
+              f"DAIMON_CHECKPOINT_DIR and ~/.daimon/env for a bad value",
+              file=sys.stderr)
+        if args.json:
+            print(_refutation_json([]))
+        else:
+            render.render_ledger_lines(["no rulings for this project"])
+        return 1
     rows = refutations.listing(states=set(args.state or refutations.STATES),
                                polarity="ruling", project_dir=project)
     _cli._note_usage("ruling:list")
@@ -322,15 +346,7 @@ def _cmd_ruling_list(args) -> int:
     # shape a TOCTOU takes).
     rc = 0
     if not rows:
-        read = briefing.rulings_read(project)
-        if read.state == "unresolved":
-            # No `path` to name — resolution never got that far, so this
-            # line never interpolates one.
-            print(f"cannot resolve a ledger path for {project}: check "
-                  f"DAIMON_CHECKPOINT_DIR and ~/.daimon/env for a bad value",
-                  file=sys.stderr)
-            rc = 1
-        elif read.state == "unreadable":
+        if read.state == "unreadable":
             print(f"cannot read the ledger for {store.project_slug(project)} "
                   f"(resolved {project}): {read.path} exists but could not "
                   f"be read", file=sys.stderr)

--- a/plugin/daimon_briefing/refutations.py
+++ b/plugin/daimon_briefing/refutations.py
@@ -794,6 +794,17 @@ def events(project_dir=None, *, strict: bool = False) -> list[dict]:
                 or row.get("event") not in EVENTS
                 or not _REF_ID_RE.fullmatch(str(row.get("refutation_id") or ""))):
             continue
+        # #970: `fold` does `list(row.get("anchors") or [])` and the same for
+        # `evidence`; a hand-edited scalar there raised inside the fold and
+        # `rulings_read` reported the whole ledger as UNREADABLE, the one
+        # state a host is meant to refuse enforcement on, about a file it
+        # read fine. A malformed list field is a malformed ROW, dropped here
+        # like a bad `event` or `refutation_id`, so the read succeeds and the
+        # remaining rows are returned. Absent and null stay allowed: the fold
+        # reads both as an empty list.
+        if any(row.get(key) is not None and not isinstance(row.get(key), list)
+               for key in ("anchors", "evidence")):
+            continue
         copy = dict(row)
         copy["_line"] = index
         rows.append(copy)

--- a/plugin/tests/test_rulings.py
+++ b/plugin/tests/test_rulings.py
@@ -2264,3 +2264,87 @@ def test_clearing_a_request_policy_on_a_refutation_is_refused(
         refutations.revise(ref_id, channel="cli-agent",
                            evidence=["measurement:again"],
                            clear_request_policy=True, project_dir=PROJECT)
+
+
+# ---- #970: a hand-edited anchors/evidence scalar is a malformed ROW, not an
+# unreadable LEDGER; #969: `ruling list` shares the reader's four-state
+# vocabulary instead of dying on the config fault the reader already names.
+
+def _hand_edit_first_row(field, value):
+    path = refutations._path(PROJECT)
+    lines = path.read_text(encoding="utf-8").splitlines()
+    row = json.loads(lines[0])
+    row[field] = value
+    lines[0] = json.dumps(row)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+@pytest.mark.parametrize("field", ["anchors", "evidence"])
+def test_a_row_with_a_scalar_anchors_or_evidence_is_skipped_not_fatal(
+        tmp_checkpoint_dir, field):
+    """`events` already drops rows that fail its `event`/`refutation_id`
+    checks without sinking the read; these two list fields are no
+    different. The other ruling survives and the reader reports `read`."""
+    from daimon_briefing import briefing
+
+    _rule(subject="first", verdict="first verdict", channel="cli-tty",
+          ratified=True)
+    kept = _rule(subject="second", verdict="second verdict", channel="cli-tty",
+                 ratified=True)
+    _hand_edit_first_row(field, 1)
+    rows = refutations.events(PROJECT, strict=True)
+    assert [r["refutation_id"] for r in rows] == [kept]
+    read = briefing.rulings_read(PROJECT)
+    assert read.state == "read"
+    assert [r["refutation_id"] for r in read.rows] == [kept]
+
+
+def test_ruling_list_survives_a_hand_edited_anchors_field(tmp_checkpoint_dir,
+                                                          capsys):
+    _rule(subject="first", verdict="first verdict", channel="cli-tty",
+          ratified=True)
+    _rule(subject="second", verdict="second verdict", channel="cli-tty",
+          ratified=True)
+    _hand_edit_first_row("anchors", 1)
+    assert cli.main(["ruling", "list", "--project", PROJECT]) == 0
+    out = capsys.readouterr().out
+    assert "second verdict" in out
+    assert "first verdict" not in out
+
+
+@pytest.fixture(params=["corrupt-env-file", "unexpandable-checkpoint-dir"])
+def _config_fault(request, monkeypatch, tmp_path):
+    """The two faults #969 names, both raised by `refutations._path` through
+    `config.checkpoint_dir()`. With the checkpoint dir unset, the corrupt env
+    file raises on the FIRST config read, before any store path exists to
+    touch; the tilde variant raises out of `expanduser` and touches nothing."""
+    if request.param == "corrupt-env-file":
+        bad = tmp_path / "env"
+        bad.write_bytes(b"DAIMON_NOTE=caf\xe9\n")
+        monkeypatch.setenv("DAIMON_ENV_FILE", str(bad))
+        monkeypatch.delenv("DAIMON_CHECKPOINT_DIR")
+    else:
+        monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", "~no-such-user-xyz/daimon")
+    return request.param
+
+
+def test_ruling_list_reports_an_unresolved_ledger_instead_of_a_traceback(
+        tmp_checkpoint_dir, _config_fault, capsys):
+    """The #969 shape: the fault `rulings_read` already reports as
+    `unresolved`. The CLI has to ask the reader BEFORE it asks `listing` for
+    rows, or it dies several statements before its own unresolved branch."""
+    rc = cli.main(["ruling", "list", "--project", PROJECT])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "cannot resolve a ledger path" in captured.err
+    assert "DAIMON_CHECKPOINT_DIR" in captured.err
+    assert "no rulings for this project" in captured.out
+
+
+def test_ruling_list_json_keeps_its_shape_on_an_unresolved_ledger(
+        tmp_checkpoint_dir, _config_fault, capsys):
+    rc = cli.main(["ruling", "list", "--project", PROJECT, "--json"])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert json.loads(captured.out) == []
+    assert "cannot resolve a ledger path" in captured.err


### PR DESCRIPTION
Closes #969
Closes #970

## What

Two faults on the same path, `daimon ruling list` over a ledger the reader cannot use, fixed together because one reproduction reaches both.

**#970.** `refutations.events` now drops a row whose `anchors` or `evidence` is present and not a list, the way it already drops a row with a bad `event` or `refutation_id`. The read succeeds and the remaining rows are returned. `briefing.rulings_read` reports `read` for such a ledger instead of `unreadable`, and `ruling list` renders the surviving rulings instead of dying on a `TypeError` inside the fold. Absent and null stay allowed; the fold reads both as an empty list.

**#969.** `_cmd_ruling_list` asks `briefing.rulings_read` for its state before it asks `refutations.listing` for rows, one probe reused by every branch. On `unresolved` it prints the stderr line that branch already carried, keeps stdout's empty-ledger shape (`[]` under `--json`, "no rulings for this project" otherwise), and exits 1 before the usage counter or anything else that reads config, because the fault is in config itself and every later read would die the same way.

The narrower question the issue raised is answered as the smaller option: the library keeps raising for in-process callers, who have `rulings_read` for the honest answer; the CLI, which shares the reader's vocabulary, consults it first.

## Why

Both are pre-existing and both were made visible by #962, which gave the reader a state to report while the CLI that shares its vocabulary still reached `fold` and `_path` unguarded. The `unreadable` mislabel is the more consequential one: a host that refuses enforcement on that state was refusing about a file it read fine.

## Tests

- #970: for each of `anchors` and `evidence`, a ledger with two rulings and one hand-edited scalar reads one row under `strict=True`, the reader reports `read` with the surviving ruling, and `ruling list` prints it. Red before the guard.
- #969: both faults the issue names, a corrupt env file with the checkpoint dir unset and an unexpandable tilde path in `DAIMON_CHECKPOINT_DIR`, through the CLI, plain and `--json`. Red before the gate, on the exact traceback the issue quotes. The corrupt-file variant raises on the first config read, before any store path exists to touch.
- Disclosed, not fixed here: with the checkpoint dir set, a corrupt env file still raises on the next config read that falls through to the file (the usage counter is the first). That is every command, not this one, and belongs to its own issue if wanted.
- Full suite from an empty store: 6282 passed, 2 skipped. mypy: no issues in 72 source files. Every line of the diff runs under the ruling test files.
