### PR TITLE
fix: kimi hooks no longer inject the briefing into print-mode runs

### DIFF
--- a/hook/_daimon_hook_lib.py
+++ b/hook/_daimon_hook_lib.py
@@ -408,6 +408,66 @@ def kimi_prompt_text(prompt) -> str:
     return "\n".join(t for t in parts if t)
 
 
+def _parent_argv(pid) -> list:
+    """argv of `pid` as best the platform exposes it, [] when unreadable.
+
+    Linux keeps the real argv bytes in /proc; every other platform daimon
+    ships on falls back to `ps`, which renders argv as one space-joined
+    string. Joining only ever SPLITS a value that contains spaces, so it can
+    invent tokens but can never hide one: an exact-flag check stays sound."""
+    proc = Path(f"/proc/{pid}/cmdline")
+    try:
+        if proc.exists():
+            raw = proc.read_bytes()
+            return [t.decode("utf-8", "replace") for t in raw.split(b"\0") if t]
+    except OSError:
+        pass
+    try:
+        out = subprocess.run(["ps", "-ww", "-o", "command=", "-p", str(pid)],
+                             capture_output=True, text=True, timeout=2)
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+    line = out.stdout.strip()
+    return line.split() if line else []
+
+
+def kimi_print_mode(argv=None) -> bool:
+    """True when the host process runs a print-mode invocation (`kimi -p`).
+
+    Measured on 0.42.0: UserPromptSubmit fires in print mode too, and the host
+    both injects whatever the hook prints into the one-shot call's context and
+    echoes it to stdout — so the full briefing lands inside a one-shot CLI
+    answer, and daimon's own serializer backend (which shells out to `kimi -p`)
+    reads the dump as part of the response (#999). The capture hooks still run
+    there (Stop is the ONLY capture path in print mode, since SessionEnd never
+    fires), so suppressing this event loses nothing.
+
+    Two guards keep this from misfiring. First, the parent argv must name the
+    host binary: `-p` is a common flag on other tools (pytest's
+    `-p no:cacheprovider` is the measured case — running the hook under a
+    test runner would otherwise silence the briefing), so a bare flag match
+    is not enough. Any argv token may be the name, because a `#!` script
+    parent shows its INTERPRETER as argv[0] under `ps`, pushing the script
+    path into a later token; only the basename is compared, so the flag's
+    own value cannot impersonate the binary unless it IS the binary.
+    Second, only exact flag tokens count: `ps` output is space-joined, and
+    an inexact match would fire on an unrelated argument. An unreadable
+    parent argv, or a parent that never names the host binary, yields False:
+    this hook is the ONLY channel into the model on this host, so a
+    detection miss must not silently disable the briefing — the failure
+    being fixed is noise, not silence.
+    """
+    if argv is None:
+        argv = _parent_argv(os.getppid())
+    if not argv:
+        return False
+    if not any(Path(str(t)).name.lower().removesuffix(".exe") == "kimi"
+               for t in argv):
+        return False
+    return any(t in ("-p", "--prompt") or t.startswith("--prompt=")
+               for t in argv)
+
+
 
 def _failed_session_stems() -> set:
     """Transcript stems (session ids) whose LATEST serialize.log outcome is a

--- a/hook/daimon-kimi-user-prompt-submit.py
+++ b/hook/daimon-kimi-user-prompt-submit.py
@@ -15,6 +15,13 @@ between two events:
 2. The per-prompt recall injection, on every prompt after that, shelling out
    to `daimon recall-inject` exactly as the Claude Code prompt hook does.
 
+Print mode (`kimi -p`) fires this event too, and the host injects whatever
+the hook prints into the one-shot call's context AND echoes it to stdout.
+There is no interactive session to brief, so the hook detects print mode
+from the parent argv and exits before printing anything (#999). Capture is
+untouched: Stop is the only capture path in print mode, since SessionEnd
+never fires there.
+
 Noise contract, copied deliberately from daimon-prompt-recall.py: this fires
 on EVERY prompt, so failures are SILENT (exit 0, no output). A diagnostic per
 prompt would be spam. Unlike on Claude Code there is no SessionStart hook to
@@ -135,6 +142,11 @@ def _recall(cli, cwd: str, session: str, prompt: str) -> None:
 
 def main() -> int:
     if lib is None or lib.disabled():
+        return 0
+    # Print mode has no session worth briefing and the host feeds hook output
+    # straight into the one-shot answer (#999). Everything after this point
+    # prints, so the guard runs before any of it.
+    if lib.kimi_print_mode():
         return 0
     data = lib.payload()
     cwd = str(data.get("cwd") or "").strip()

--- a/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
+++ b/plugin/daimon_briefing/_hooks/_daimon_hook_lib.py
@@ -408,6 +408,66 @@ def kimi_prompt_text(prompt) -> str:
     return "\n".join(t for t in parts if t)
 
 
+def _parent_argv(pid) -> list:
+    """argv of `pid` as best the platform exposes it, [] when unreadable.
+
+    Linux keeps the real argv bytes in /proc; every other platform daimon
+    ships on falls back to `ps`, which renders argv as one space-joined
+    string. Joining only ever SPLITS a value that contains spaces, so it can
+    invent tokens but can never hide one: an exact-flag check stays sound."""
+    proc = Path(f"/proc/{pid}/cmdline")
+    try:
+        if proc.exists():
+            raw = proc.read_bytes()
+            return [t.decode("utf-8", "replace") for t in raw.split(b"\0") if t]
+    except OSError:
+        pass
+    try:
+        out = subprocess.run(["ps", "-ww", "-o", "command=", "-p", str(pid)],
+                             capture_output=True, text=True, timeout=2)
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+    line = out.stdout.strip()
+    return line.split() if line else []
+
+
+def kimi_print_mode(argv=None) -> bool:
+    """True when the host process runs a print-mode invocation (`kimi -p`).
+
+    Measured on 0.42.0: UserPromptSubmit fires in print mode too, and the host
+    both injects whatever the hook prints into the one-shot call's context and
+    echoes it to stdout — so the full briefing lands inside a one-shot CLI
+    answer, and daimon's own serializer backend (which shells out to `kimi -p`)
+    reads the dump as part of the response (#999). The capture hooks still run
+    there (Stop is the ONLY capture path in print mode, since SessionEnd never
+    fires), so suppressing this event loses nothing.
+
+    Two guards keep this from misfiring. First, the parent argv must name the
+    host binary: `-p` is a common flag on other tools (pytest's
+    `-p no:cacheprovider` is the measured case — running the hook under a
+    test runner would otherwise silence the briefing), so a bare flag match
+    is not enough. Any argv token may be the name, because a `#!` script
+    parent shows its INTERPRETER as argv[0] under `ps`, pushing the script
+    path into a later token; only the basename is compared, so the flag's
+    own value cannot impersonate the binary unless it IS the binary.
+    Second, only exact flag tokens count: `ps` output is space-joined, and
+    an inexact match would fire on an unrelated argument. An unreadable
+    parent argv, or a parent that never names the host binary, yields False:
+    this hook is the ONLY channel into the model on this host, so a
+    detection miss must not silently disable the briefing — the failure
+    being fixed is noise, not silence.
+    """
+    if argv is None:
+        argv = _parent_argv(os.getppid())
+    if not argv:
+        return False
+    if not any(Path(str(t)).name.lower().removesuffix(".exe") == "kimi"
+               for t in argv):
+        return False
+    return any(t in ("-p", "--prompt") or t.startswith("--prompt=")
+               for t in argv)
+
+
 
 def _failed_session_stems() -> set:
     """Transcript stems (session ids) whose LATEST serialize.log outcome is a

--- a/plugin/daimon_briefing/_hooks/daimon-kimi-user-prompt-submit.py
+++ b/plugin/daimon_briefing/_hooks/daimon-kimi-user-prompt-submit.py
@@ -15,6 +15,13 @@ between two events:
 2. The per-prompt recall injection, on every prompt after that, shelling out
    to `daimon recall-inject` exactly as the Claude Code prompt hook does.
 
+Print mode (`kimi -p`) fires this event too, and the host injects whatever
+the hook prints into the one-shot call's context AND echoes it to stdout.
+There is no interactive session to brief, so the hook detects print mode
+from the parent argv and exits before printing anything (#999). Capture is
+untouched: Stop is the only capture path in print mode, since SessionEnd
+never fires there.
+
 Noise contract, copied deliberately from daimon-prompt-recall.py: this fires
 on EVERY prompt, so failures are SILENT (exit 0, no output). A diagnostic per
 prompt would be spam. Unlike on Claude Code there is no SessionStart hook to
@@ -135,6 +142,11 @@ def _recall(cli, cwd: str, session: str, prompt: str) -> None:
 
 def main() -> int:
     if lib is None or lib.disabled():
+        return 0
+    # Print mode has no session worth briefing and the host feeds hook output
+    # straight into the one-shot answer (#999). Everything after this point
+    # prints, so the guard runs before any of it.
+    if lib.kimi_print_mode():
         return 0
     data = lib.payload()
     cwd = str(data.get("cwd") or "").strip()

--- a/plugin/tests/test_kimi_hook_scripts.py
+++ b/plugin/tests/test_kimi_hook_scripts.py
@@ -412,6 +412,114 @@ def test_recall_runs_on_a_later_prompt_and_not_on_a_slash_command(home):
     assert capture.read_text(encoding="utf-8").count("recall-inject") == before
 
 
+# ---- print mode: no briefing, no recall, no delivery (#999) ----
+#
+# `kimi -p` fires this event too, and the host injects hook stdout into the
+# one-shot call's context and echoes it to stdout. The guard reads the parent
+# process argv, so the tests below stand in for kimi with a shell wrapper
+# whose OWN argv carries (or omits) the flag. The wrapper must NOT exec the
+# hook: after exec the parent's argv is the interpreter's, and the flag that
+# the guard looks for would be gone.
+
+def _kimi_wrapper(home: Path) -> Path:
+    """A fake kimi parent: runs the hook named by env as a CHILD, keeping its
+    own argv (which is what the guard reads) intact for the child's lifetime.
+    The name matters: the guard requires the parent program to be the host
+    binary, so the wrapper is named exactly `kimi`."""
+    wrapper = home / "kimi"
+    wrapper.write_text('#!/bin/sh\npython3 "$KIMI_HOOK_UNDER_TEST"\n',
+                       encoding="utf-8")
+    wrapper.chmod(0o755)
+    return wrapper
+
+
+def _run_under_wrapper(home, wrapper, argv_tail, payload, extra_env=None):
+    env = {
+        **os.environ,
+        "PATH": f"{home / 'fakebin'}{os.pathsep}{os.environ.get('PATH', '')}",
+        "HOME": str(home),
+        "KIMI_HOOK_UNDER_TEST": str(PROMPT_HOOK),
+    }
+    env.pop("KIMI_CODE_HOME", None)
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run([str(wrapper), *argv_tail],
+                          input=json.dumps(payload), capture_output=True,
+                          text=True, env=env, timeout=30)
+
+
+def test_print_mode_is_detected_from_exact_parent_argv_tokens(home):
+    """The token table. `ps` space-joins argv, so only exact flag tokens may
+    match: an inexact check would fire on an unrelated argument, and an
+    unreadable argv must fail toward the interactive case (silently losing
+    the only channel into the model is the worse miss). The parent program
+    must also BE the host binary: `-p` is a common flag elsewhere (pytest's
+    `-p no:cacheprovider` is the measured case), and a bare flag match
+    would silence the briefing under any test runner."""
+    lib = _load_lib()
+    flag = ["kimi", "-p", "Reply with exactly: OK"]
+    assert lib.kimi_print_mode(flag)
+    assert lib.kimi_print_mode(["/usr/local/bin/kimi", "-p", "input"])
+    assert lib.kimi_print_mode(["kimi", "-m", "alias", "-p", "input"])
+    assert lib.kimi_print_mode(["kimi", "--prompt", "hi"])
+    assert lib.kimi_print_mode(["kimi", "--prompt=hi"])
+    joined = " ".join(flag)  # the `ps` fallback shape
+    assert lib.kimi_print_mode(joined.split())
+    assert not lib.kimi_print_mode(["kimi"])
+    assert not lib.kimi_print_mode(["kimi", "-m", "kimi-code/kimi-for-coding"])
+    assert not lib.kimi_print_mode(["kimi", "--print-mode-ish", "x"])
+    assert not lib.kimi_print_mode(["kimi", "path/that-mentions--prompt"])
+    assert not lib.kimi_print_mode([])
+    # A `-p` flag on a parent that never names the host binary is somebody
+    # else's flag (pytest, perl, ...); the briefing must still fire. A `#!`
+    # script parent shows its interpreter as argv[0] under `ps`, so the name
+    # may sit in any token.
+    assert not lib.kimi_print_mode(
+        ["pytest", "-p", "no:cacheprovider", "tests"])
+    assert not lib.kimi_print_mode(["python", "-m", "pytest", "-p", "x"])
+    assert not lib.kimi_print_mode(["/x/fake-kimi", "-p", "input"])
+    assert not lib.kimi_print_mode(["kimi2", "-p", "input"])
+    assert lib.kimi_print_mode(["/bin/sh", "/x/kimi", "-p", "input"])
+
+
+def test_print_mode_suppresses_the_briefing_and_every_cli_call(
+        home, tmp_checkpoint_dir, sample_checkpoint):
+    """The #999 repro end to end. The parent argv carries `-p`, so nothing may
+    reach stdout: the host would inject it into the model context and echo it,
+    and daimon's serializer backend would read the dump as part of the answer."""
+    _checkpoint(sample_checkpoint)
+    _fake_cli(home)  # a guard miss would record the `brief` call here
+    wrapper = _kimi_wrapper(home)
+    capture = home / "invocations.txt"
+    proc = _run_under_wrapper(
+        home, wrapper, ["-p", "Reply with exactly: OK"],
+        {"hook_event_name": "UserPromptSubmit", "session_id": SESSION,
+         "cwd": PROJECT, "client_type": "kimi_code_cli",
+         "prompt": [{"type": "text", "text": "Reply with exactly: OK"}],
+         "is_steer": False})
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+    _quiet(capture)
+
+
+def test_the_same_wrapper_without_the_flag_still_briefs(
+        home, tmp_checkpoint_dir, sample_checkpoint):
+    """The other direction: detection must not misfire on an interactive
+    parent. Same wrapper, same payload, no `-p` in argv — the briefing has
+    to arrive, or the guard has silently disabled the only channel into the
+    model on this host."""
+    _checkpoint(sample_checkpoint)
+    wrapper = _kimi_wrapper(home)
+    proc = _run_under_wrapper(
+        home, wrapper, [],
+        {"hook_event_name": "UserPromptSubmit", "session_id": SESSION,
+         "cwd": PROJECT, "client_type": "kimi_code_cli",
+         "prompt": [{"type": "text", "text": "where were we"}],
+         "is_steer": False})
+    assert proc.returncode == 0
+    assert "DAIMON BRIEFING" in proc.stdout
+
+
 # ---- every Kimi transcript is named wire.jsonl ----
 #
 # `_run_serialize` derives the session id as `path.stem`, which is true of


### PR DESCRIPTION
fix: kimi hooks no longer inject the briefing into print-mode runs

Closes #999

## What

The Kimi UserPromptSubmit hook now detects a print-mode host invocation and exits silently before printing anything. Detection is `kimi_print_mode` in `_daimon_hook_lib`: the parent process argv is read from `/proc/<pid>/cmdline` on Linux and `ps -ww -o command= -p <pid>` elsewhere, and print mode holds only when an argv token names the host binary (`kimi`) AND the argv carries an exact flag (`-p`, `--prompt`, or `--prompt=...`). Anything unreadable, or any parent that never names the host binary, counts as interactive.

Capture is untouched: Stop remains the only capture path in print mode (SessionEnd never fires there), so a print session still serializes.

## Why

Measured on kimi 0.42.0: `kimi -p "Reply with exactly: OK"` returned stdout containing the entire briefing block followed by the answer, and the injection also reached the model context. Daimon's own command serializer backend shells out to `kimi -p`, so every serializer call through that path paid a multi-thousand-token briefing injection and read the hook dump as part of the response.

The two-part match exists because a bare flag match misfires: `-p` is a common flag on other tools, and running the hook under a test runner (`pytest -p no:cacheprovider`) would otherwise silence the briefing on every prompt.

## Tests

- `tests/test_kimi_hook_scripts.py`: a token-table unit test for the exact-flag, host-binary, and unreadable-argv semantics; an end-to-end test running the hook under a wrapper parent whose argv carries `-p`, asserting empty stdout and zero CLI invocations; and the control test with the same wrapper minus the flag, asserting the briefing still arrives.
- The suppression test goes red when the guard call is removed.
- Full plugin suite: 6294 passed, 2 skipped; the only 2 failures are render color tests that fail identically on main (environment-dependent, pre-existing).
- mypy clean on the touched hook files; `ruff check` clean; `scripts/sync_hooks.py` re-run so the packaged `_hooks` copies stay byte-identical.
