### PR TITLE
fix(skill): install ships daimon-end to every directory-form host

### DIFF
--- a/plugin/daimon_briefing/_skills/daimon-end/SKILL.md
+++ b/plugin/daimon_briefing/_skills/daimon-end/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: daimon-end
+description: In-session self-serialization — write a Daimon cognitive checkpoint NOW from what the live session still holds, before exiting. Use when ending a session and you want the next session's briefing to be fresh immediately (no wait for the automatic SessionEnd reconstruction), e.g. you plan to restart soon. Write-only; does not exit.
+---
+
+# Daimon — End-of-session self-serialization (`/daimon-end`)
+
+The automatic SessionEnd hook reconstructs a checkpoint from the full transcript
+*after* exit — accurate and verbatim-capable, but it lands 4–25 min later. If you
+restart inside that window, the next session briefs from the **previous** session's
+stale checkpoint.
+
+This skill closes that window: the **live** session writes its own checkpoint now,
+from state it still holds. It is provisional and **never replaces** the automatic
+path — the reconstruction still runs, supersedes this checkpoint, and keeps it as
+a `prev` pointer. So it does not need to be perfect to be useful.
+
+## What to do when invoked
+
+1. **Close what this session moved, FIRST.** Every store daimon reads back
+   has its own close verb, and a store you moved but never closed rides into
+   the next briefing as work. Walk `daimon loops` and `daimon request inbox`
+   and record each close before writing the checkpoint:
+
+   ```bash
+   # a briefed loop this session closed
+   daimon resolve <id> --by agent --evidence "<exact contiguous transcript quote>"
+   # a briefed item that moved but did not close
+   daimon amend <id> --change progressed|blocked|changed --evidence "<quote>" --by agent
+   # an accepted inbound request this session satisfied (a shipped fix, a merged PR)
+   daimon request done <id> --evidence "<quote>" --by agent
+   # a carried item this session re-checked against the world and found still true
+   daimon reverify <id> --evidence "<what you checked>"
+   ```
+
+   (See the daimon-briefing skill's "Closing loops" section for the full
+   quote-discipline rule.) The CLI answers `claim recorded ... pending
+   verification at session end` — that is the expected output, not a failure:
+   each claim is provisional, byte-checked against the transcript when the
+   session ends. A `request done` on an ask another project sent prints
+   `no matching request in this bucket`; that is the read-time join, not a
+   miss. Skipping this step never errors: the checkpoint validates, the
+   briefing renders, and the satisfied request stays `[✓ accepted]` until
+   someone notices.
+
+2. **Decide whether to hand off.** The baton is a different instrument from the
+   checkpoint: the checkpoint captures full state, the baton is the ONE
+   deliberate message that leads the next briefing. If the next session should
+   start somewhere specific — a reply to check, a play whose timing matters, a
+   decision waiting on the human — write it now:
+
+   ```bash
+   daimon handoff "<where the next session should start, and why>"
+   ```
+
+   Skipping is a valid decision when the checkpoint alone suffices; a baton
+   that merely restates the checkpoint is noise. But make the decision
+   consciously — a session that captures everything and hands off nothing
+   leaves the next session to infer its own starting point.
+
+3. **Emit a checkpoint JSON** from your in-context knowledge of THIS session,
+   conforming exactly to the schema:
+
+   ```json
+   {
+     "session_id": "introspection-<short-unique-id>",
+     "working_context": {
+       "active_topic": {"text": "<one line, or empty>", "trust": "inferred"},
+       "open_questions": [
+         {"text": "<unresolved loop>", "trust": "verbatim", "quote": "<exact transcript quote>", "external_state": true}
+       ],
+       "recent_decisions": [
+         {"text": "<decision or assistant-side fix>", "trust": "inferred"}
+       ]
+     },
+     "epistemic_snapshot": {
+       "strong_beliefs": [{"text": "<belief>", "trust": "inferred"}],
+       "uncertainties": [{"text": "<open uncertainty>", "trust": "inferred"}]
+     }
+   }
+   ```
+
+   `session_id` above is a placeholder only. Step 5's `--session` flag, when
+   your host can supply one, replaces it with this session's real id; when it
+   cannot, the CLI itself replaces the placeholder with a fresh generated id
+   rather than ever writing the literal text above. Leave it exactly as shown
+   — do not spend effort inventing a better one, and never invent a
+   `session_id` here as a substitute for `--session`.
+
+   Every item needs `text` + `trust`. `external_state: true` marks items whose
+   state may have changed *outside* the AI session (a PR you'll merge, a deploy) —
+   these surface first in the briefing.
+
+   Volume: 5–10 items per list; prefer the ones a fresh session would get wrong.
+
+4. **HONESTY RULE (load-bearing).** Quote only what you can reproduce exactly —
+   an honest quote helps the later merge with the automatic reconstruction, and
+   this path has no transcript to check against, so the CLI records every item
+   as `inferred` either way (#511). Anything from an earlier,
+   **compacted/summarized** part of the session you can no longer quote verbatim →
+   `trust: "inferred"`, no `quote`. Do not fabricate quotes.
+
+5. **Write it** via the CLI (reads JSON on stdin, validates the schema, routes to
+   this project + global + a per-session file, atomically, with rotation). Write
+   the JSON to a temp file, then check whether your host exposes the live
+   session's own id (Claude Code does, as the `CLAUDE_CODE_SESSION_ID`
+   environment variable) and pass it with `--session` when it does:
+
+   ```bash
+   if [ -n "$CLAUDE_CODE_SESSION_ID" ]; then
+     daimon write-checkpoint --project "$PWD" --session "$CLAUDE_CODE_SESSION_ID" < /tmp/daimon-end.json
+   else
+     daimon write-checkpoint --project "$PWD" < /tmp/daimon-end.json
+   fi
+   ```
+
+   `--session` is what lets the later SessionEnd reconstruction recognize this
+   checkpoint as its OWN earlier state rather than a distinct witness — without
+   it, this checkpoint and its own reconstruction could misread as two
+   independent sessions agreeing with each other (#983). On a host with no live
+   session id to give it, the CLI still writes the checkpoint (falling back to
+   its own generated id, never a placeholder), but this provisional cannot be
+   linked to its own reconstruction — accept that any item born here will
+   never accrue a corroboration badge, on that host, and move on; that is a
+   known and permanent limit of a host with no live session id, not a bug to
+   work around.
+
+   It prints `wrote checkpoint: <path> (source: introspection)`. If it reports a
+   schema-validation error, fix the JSON and retry — do not store garbage.
+
+6. **Confirm** to the user with the printed checkpoint path.
+
+## Where things go
+
+Seven stores, each read by a different surface. Route by what the next
+session must see, and never by which command is nearest. The harness's own
+memory file (MEMORY.md, AGENTS.md, GEMINI.md) is not one of these: daimon
+never reads it, so a fact placed there is lost to every other host.
+
+| What you hold | Where it goes | Who reads it back |
+| --- | --- | --- |
+| Facts, decisions, beliefs, open loops from THIS session | the checkpoint, step 3 above (`daimon write-checkpoint`) | the next briefing, `daimon recall`, carry |
+| The ONE thing the next session should do first | `daimon handoff "<do X first, beware Y>"` (2000 chars max) | the top of the next briefing |
+| A briefed loop this session closed | `daimon resolve <id> --by agent --evidence "<quote>"` | the briefing withholds it once byte-checked |
+| An accepted inbound request this session satisfied | `daimon request done <id> --evidence "<quote>" --by agent` | the sender's brief and `daimon request inbox`, as a claim until byte-checked |
+| A rule that must never decay (a threshold, a boundary, a standing constraint) | `daimon ruling propose --subject ... --verdict ... --scope ... --evidence ... --by agent` | every briefing, once a human ratifies; 7 active per project by default |
+| An approach that was tried and failed | `daimon refute add ... --by agent` | `daimon refute guard` before anyone revives it |
+| A briefed item that moved but did not close | `daimon amend <id> --change progressed|blocked|changed --evidence "<quote>" --by agent` | the briefing, as an unconfirmed claim until a human settles it |
+| A timeline fact worth an audit line and nothing more | `daimon log --text "..."` | nothing reads it back into a briefing or recall; it is an audit trail only |
+
+If `daimon handoff` refuses a baton as too long, the trimmed content is not
+homeless: facts go in the checkpoint, rules go to `ruling propose`. Do not
+move it to the harness memory file.
+
+## Rules
+
+- **Write-only.** Do NOT exit/quit the session — that is the user's action.
+- **Do not remove or disable the automatic hook.** The reconstruction's verbatim
+  fidelity is the authoritative source once it lands.
+- Routing/validation/atomic-write live in the CLI (`write-checkpoint`) — never
+  hand-write checkpoint files or duplicate store logic.

--- a/plugin/daimon_briefing/skill_install.py
+++ b/plugin/daimon_briefing/skill_install.py
@@ -77,6 +77,20 @@ HOSTS: dict[str, dict[str, tuple[str, str, str] | None]] = {
     },
 }
 
+# #1000. Skills daimon ships WHOLE, as their own directory, alongside the
+# generated `daimon` skill. `daimon-end` was packaged from the day it was
+# written and installed by nothing: Claude Code's plugin loader discovers it at
+# the plugin root, so a maintainer running from the checkout always had it,
+# while everyone who installed the wheel and ran `daimon skill install` got the
+# `daimon` skill alone and no way to learn `/daimon-end` exists.
+#
+# The wheel carries `daimon_briefing/` and nothing else, so the plugin-root
+# `skills/` tree cannot be the source here. `_skills/` is a byte-identical
+# mirror kept in scripts/sync_hooks.py's manifest and guarded in
+# tests/test_packaging.py.
+BUNDLED_SKILLS: tuple[str, ...] = ("daimon-end",)
+_BUNDLED_DIR = Path(__file__).resolve().parent / "_skills"
+
 # Per-host read caps, in BYTES. Codex documents project_doc_max_bytes and
 # stops reading past it, so a file over the cap is silently half-applied.
 # Absent host means no known cap, which is why the warning below tests the
@@ -169,6 +183,56 @@ def _replace_block(text: str, block: str) -> str:
         "manually, daimon will not guess at the boundary")
 
 
+def _bundled_root(rel: str, variant: str) -> Path | None:
+    """The host's skills directory for a directory-form row, or None.
+
+    `full` is the DIRECTORY-FORM contract, not a density: the host scans
+    `<root>/skills/<name>/SKILL.md` and loads a body only when the skill is
+    invoked. `compact` rows are single rules files concatenated into every
+    prompt — they have no directory to scan, so a second skill there is
+    content no host would ever load. test_skill_install.py pins the shape
+    these two lines derive the root from.
+    """
+    if variant != "full":
+        return None
+    return Path(rel).parent.parent
+
+
+def _install_bundled(root: Path) -> list[str]:
+    lines = []
+    for name in BUNDLED_SKILLS:
+        src = _BUNDLED_DIR / name / "SKILL.md"
+        try:
+            body = src.read_text(encoding="utf-8")
+        except OSError as exc:  # a build that lost its package data
+            raise SkillInstallError(
+                f"packaged skill '{name}' is missing from this install "
+                f"({src}) — reinstall daimon-briefing") from exc
+        dest = root / name / "SKILL.md"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(body, encoding="utf-8")
+        lines.append(f"installed daimon skill ({name}) -> {dest}")
+    return lines
+
+
+def _uninstall_bundled(root: Path) -> list[str]:
+    lines = []
+    for name in BUNDLED_SKILLS:
+        dest = root / name / "SKILL.md"
+        if not dest.exists():
+            continue
+        dest.unlink()
+        # daimon created this directory, so it takes it back — but only while
+        # it holds nothing else. Anything the user put beside the skill stays,
+        # and so does the directory holding it.
+        try:
+            dest.parent.rmdir()
+        except OSError:
+            pass
+        lines.append(f"removed {dest}")
+    return lines
+
+
 def install(host: str, *, project: bool, home: Path, cwd: Path) -> list[str]:
     spec, (rel, kind, variant) = _spec(host, project)
     dest = (cwd if project else home) / rel
@@ -195,23 +259,30 @@ def install(host: str, *, project: bool, home: Path, cwd: Path) -> list[str]:
         cleaned = _clean_windsurf_legacy(home)
         if cleaned:
             lines.append(cleaned)
+    bundled_root = _bundled_root(rel, variant)
+    if bundled_root is not None:
+        lines.extend(_install_bundled((cwd if project else home) / bundled_root))
     lines.insert(0, f"installed daimon skill ({variant}) -> {dest}")
     return lines
 
 
 def uninstall(host: str, *, project: bool, home: Path, cwd: Path) -> list[str]:
-    _spec_dict, (rel, kind, _variant) = _spec(host, project)
-    dest = (cwd if project else home) / rel
-    legacy_lines = []
+    _spec_dict, (rel, kind, variant) = _spec(host, project)
+    base = cwd if project else home
+    dest = base / rel
+    extra_lines = []
     if host == "windsurf" and not project:
         cleaned = _clean_windsurf_legacy(home)
         if cleaned:
-            legacy_lines.append(cleaned)
+            extra_lines.append(cleaned)
+    bundled_root = _bundled_root(rel, variant)
+    if bundled_root is not None:
+        extra_lines.extend(_uninstall_bundled(base / bundled_root))
     if not dest.exists():
-        return legacy_lines + [f"nothing installed at {dest}"]
+        return extra_lines + [f"nothing installed at {dest}"]
     if kind == "owned":
         dest.unlink()
-        return legacy_lines + [f"removed {dest}"]
+        return extra_lines + [f"removed {dest}"]
     text = dest.read_text(encoding="utf-8")
     if not _BLOCK_RE.search(text):
         return [f"no daimon:skill block in {dest} — left untouched"]

--- a/plugin/tests/test_packaging.py
+++ b/plugin/tests/test_packaging.py
@@ -108,3 +108,31 @@ def test_the_briefing_skill_closing_loops_names_the_request_close():
     closing = text.split("## Closing loops")[1].split("\n## ")[0]
     assert "daimon request done" in closing
     assert "daimon request inbox" in closing
+
+
+def test_every_sync_pair_is_byte_identical():
+    """`scripts/sync_hooks.py` is the one manifest of deliberately duplicated
+    files, but only the `_hooks/` slice of it had a guard — a mirror added
+    anywhere else drifted with nothing watching. Run
+    `uv run python scripts/sync_hooks.py` to repair."""
+    import sys
+
+    scripts = str(_REPO_ROOT / "scripts")
+    if scripts not in sys.path:
+        sys.path.insert(0, scripts)
+    from sync_hooks import SYNC_PAIRS
+
+    for src, dst in SYNC_PAIRS:
+        source = _REPO_ROOT / src
+        copy = _REPO_ROOT / dst
+        assert copy.exists(), f"{dst} is missing; sync_hooks.py never ran"
+        assert copy.read_bytes() == source.read_bytes(), (
+            f"{dst} drifted from {src}")
+
+
+def test_the_end_skill_ships_inside_the_wheel():
+    """#1000: the wheel carries `daimon_briefing/` alone, so the plugin-root
+    `skills/` tree reaches nobody who installed from PyPI. `daimon skill
+    install` can only write a skill the package itself holds."""
+    packaged = _PLUGIN / "daimon_briefing" / "_skills" / "daimon-end" / "SKILL.md"
+    assert packaged.is_file()

--- a/plugin/tests/test_skill_install.py
+++ b/plugin/tests/test_skill_install.py
@@ -154,6 +154,27 @@ def test_windsurf_global_uninstall_cleans_legacy_block_too(tmp_path):
     assert (mem / "global_rules.md").read_text(encoding="utf-8") == user
 
 
+def test_uninstall_cleans_a_legacy_block_when_nothing_was_installed(tmp_path):
+    """The pre-#88 block outlives the install that would have stripped it: a
+    person who upgraded and never re-installed still has skill content sitting
+    in their MEMORIES file, and `uninstall` is the verb they reach for. It has
+    to clean that even though it finds no skill of its own to remove.
+
+    The existing migrate/uninstall pair never reached this branch, because
+    installing first strips the block, so uninstall then saw a clean file."""
+    home = tmp_path / "home"
+    mem = home / ".codeium" / "windsurf" / "memories"
+    mem.mkdir(parents=True)
+    user = "# my real memories\n"
+    (mem / "global_rules.md").write_text(
+        f"{user}\n<!-- daimon:skill v0.7.0 start -->\nold\n"
+        "<!-- daimon:skill v0.7.0 end -->\n", encoding="utf-8")
+    lines = uninstall("windsurf", project=False, home=home, cwd=tmp_path)
+    assert (mem / "global_rules.md").read_text(encoding="utf-8") == user
+    assert any("legacy daimon:skill block" in line for line in lines)
+    assert any("nothing installed" in line for line in lines)
+
+
 # ---- uninstall ----
 
 def test_uninstall_owned_removes_file(tmp_path):

--- a/plugin/tests/test_skill_install.py
+++ b/plugin/tests/test_skill_install.py
@@ -175,3 +175,105 @@ def test_uninstall_block_removes_only_block(tmp_path):
 def test_unknown_host_refuses(tmp_path):
     with pytest.raises(SkillInstallError, match="unknown host"):
         _run("emacs", tmp_path)
+
+
+# ---- bundled directory-form skills (#1000) ----
+
+def _full_rows():
+    from daimon_briefing.skill_install import HOSTS
+
+    for host, scopes in sorted(HOSTS.items()):
+        for scope, entry in sorted(scopes.items()):
+            if entry is not None and entry[2] == "full":
+                yield host, scope, entry[0]
+
+
+def test_every_full_row_is_directory_form():
+    """`full` is not a density label, it is the DIRECTORY-FORM contract:
+    a lazily-loaded `<root>/skills/<name>/SKILL.md` the host scans by
+    directory. The bundled-skill writer derives its destination root from
+    that shape, so a `full` row that stops ending in `skills/daimon/SKILL.md`
+    would silently send `daimon-end` somewhere no host reads."""
+    rows = list(_full_rows())
+    assert rows
+    for host, scope, rel in rows:
+        assert rel.endswith("skills/daimon/SKILL.md"), f"{host}/{scope}: {rel}"
+
+
+def test_full_hosts_receive_the_bundled_end_skill(tmp_path):
+    """#1000: `daimon-end` was packaged but never installed outside the Claude
+    plugin layout, so a kimi (or plain-CLI claude, or windsurf global) user had
+    no `/daimon-end` and no way to learn it exists."""
+    from daimon_briefing.skill_install import BUNDLED_SKILLS
+
+    for host, scope, rel in _full_rows():
+        home = tmp_path / f"{host}-{scope}-home"
+        cwd = tmp_path / f"{host}-{scope}-repo"
+        home.mkdir()
+        cwd.mkdir()
+        project = scope == "project"
+        install(host, project=project, home=home, cwd=cwd)
+        root = (cwd if project else home) / rel
+        for name in BUNDLED_SKILLS:
+            dest = root.parent.parent / name / "SKILL.md"
+            text = dest.read_text(encoding="utf-8")
+            # Directory form: the host skips a skill whose frontmatter `name`
+            # does not equal its directory name.
+            assert text.startswith("---\n"), f"{host}/{scope}/{name}"
+            assert f"\nname: {name}\n" in text, f"{host}/{scope}/{name}"
+            assert "description:" in text
+
+
+def test_install_reports_every_file_it_wrote(tmp_path):
+    lines, home, _ = _run("kimi", tmp_path)
+    joined = "\n".join(lines)
+    assert str(home / ".kimi-code" / "skills" / "daimon" / "SKILL.md") in joined
+    assert str(home / ".kimi-code" / "skills" / "daimon-end" / "SKILL.md") in joined
+
+
+def test_compact_hosts_get_no_bundled_skill(tmp_path):
+    """The rules-file hosts concatenate one file into every prompt; they have
+    no directory to scan, so a second skill there is content nobody loads."""
+    _, _home, cwd = _run("cursor", tmp_path, project=True)
+    assert not list(cwd.rglob("daimon-end"))
+
+
+def test_uninstall_removes_the_bundled_skill(tmp_path):
+    _, home, _ = _run("kimi", tmp_path)
+    skills = home / ".kimi-code" / "skills"
+    assert (skills / "daimon-end" / "SKILL.md").exists()
+    uninstall("kimi", project=False, home=home, cwd=home)
+    assert not (skills / "daimon" / "SKILL.md").exists()
+    assert not (skills / "daimon-end" / "SKILL.md").exists()
+    # Owned-file semantics: daimon created the directory, daimon takes it back,
+    # but only while it holds nothing else.
+    assert not (skills / "daimon-end").exists()
+
+
+def test_uninstall_keeps_a_bundled_directory_holding_user_files(tmp_path):
+    _, home, _ = _run("kimi", tmp_path)
+    stray = home / ".kimi-code" / "skills" / "daimon-end" / "notes.md"
+    stray.write_text("mine\n", encoding="utf-8")
+    uninstall("kimi", project=False, home=home, cwd=home)
+    assert stray.read_text(encoding="utf-8") == "mine\n"
+
+
+def test_uninstall_without_an_install_does_not_raise(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    lines = uninstall("kimi", project=False, home=home, cwd=home)
+    assert any("nothing installed" in line for line in lines)
+
+
+def test_a_build_missing_its_packaged_skill_refuses_loudly(tmp_path, monkeypatch):
+    """Package data absent is a BUILD fault, not a user condition. Writing the
+    `daimon` skill and silently skipping the rest would reproduce #1000 with
+    the installer reporting success."""
+    from daimon_briefing import skill_install
+
+    monkeypatch.setattr(skill_install, "_BUNDLED_DIR", tmp_path / "gone")
+    home = tmp_path / "home"
+    home.mkdir()
+    with pytest.raises(SkillInstallError) as exc:
+        install("kimi", project=False, home=home, cwd=home)
+    assert "daimon-end" in str(exc.value)

--- a/scripts/sync_hooks.py
+++ b/scripts/sync_hooks.py
@@ -49,6 +49,14 @@ SYNC_PAIRS = (
     ("hook/daimon-kimi-stop.py",
      "plugin/daimon_briefing/_hooks/daimon-kimi-stop.py"),
     ("hook/_daimon_hook_lib.py", "plugin/daimon_briefing/_hooks/_daimon_hook_lib.py"),
+    # #1000: the plugin-root skills/ tree is discoverable only from a source
+    # checkout — the wheel ships daimon_briefing/ alone. `daimon skill install`
+    # writes directory-form skills into the host's own skills dir, so it can
+    # only deliver what the PACKAGE holds. skills/ stays canonical (it is where
+    # the skill is authored and what Claude Code's plugin loader reads); the
+    # packaged copy is the derivative.
+    ("skills/daimon-end/SKILL.md",
+     "plugin/daimon_briefing/_skills/daimon-end/SKILL.md"),
 )
 
 

--- a/website/docs/hosts/claude-code.md
+++ b/website/docs/hosts/claude-code.md
@@ -136,6 +136,8 @@ injections, two serialize LLM calls). See the install sections above.
 daimon skill install claude      # ~/.claude/skills/daimon/SKILL.md
 ```
 
+Install delivers two skills: `daimon` (the protocol) and `daimon-end`, the in-session `/daimon-end` checkpoint flow, written next to it as `~/.claude/skills/daimon-end/SKILL.md`.
+
 `daimon skill show` prints the skill content; `daimon skill list` shows which
 scopes each host supports. Re-run install after upgrading `daimon` to refresh
 the content.

--- a/website/docs/hosts/kimi.md
+++ b/website/docs/hosts/kimi.md
@@ -99,6 +99,8 @@ daimon skill install kimi              # ~/.kimi-code/skills/daimon/SKILL.md
 daimon skill install kimi --project    # <repo>/.kimi-code/skills/daimon/SKILL.md
 ```
 
+Install delivers two skills: `daimon` (the protocol) and `daimon-end`, the in-session `/daimon-end` checkpoint flow, written next to it as `~/.kimi-code/skills/daimon-end/SKILL.md`.
+
 Kimi scans both locations for skills. The probe measured where it looks,
 not how it ranks the two when both hold a daimon skill, so install to one
 scope. Re-run install after upgrading `daimon` to refresh the content.

--- a/website/docs/hosts/windsurf.md
+++ b/website/docs/hosts/windsurf.md
@@ -90,6 +90,9 @@ daimon skill install windsurf             # ~/.codeium/windsurf/skills/daimon/SK
 daimon skill install windsurf --project   # .windsurf/rules/daimon.md
 ```
 
+Install delivers two skills: `daimon` (the protocol) and `daimon-end`, the in-session `/daimon-end` checkpoint flow, written next to it as `~/.codeium/windsurf/skills/daimon-end/SKILL.md`.
+The project scope is a single rules file, so it carries the protocol alone.
+
 On Windsurf the skill is not just protocol etiquette — it is the briefing
 delivery path. Because Cascade has no session-start event to inject into,
 the skill instructs the agent to run `daimon brief --team` in the terminal

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/claude-code.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/claude-code.md
@@ -144,6 +144,8 @@ Mira las secciones de instalación de arriba.
 daimon skill install claude      # ~/.claude/skills/daimon/SKILL.md
 ```
 
+Install entrega dos skills: `daimon` (el protocolo) y `daimon-end`, el flujo de checkpoint en sesión `/daimon-end`, escrita al lado como `~/.claude/skills/daimon-end/SKILL.md`.
+
 `daimon skill show` imprime el contenido de la skill; `daimon skill list`
 muestra qué alcances soporta cada host. Re-ejecuta install después de
 actualizar `daimon` para refrescar el contenido.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/kimi.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/kimi.md
@@ -104,6 +104,8 @@ daimon skill install kimi              # ~/.kimi-code/skills/daimon/SKILL.md
 daimon skill install kimi --project    # <repo>/.kimi-code/skills/daimon/SKILL.md
 ```
 
+Install entrega dos skills: `daimon` (el protocolo) y `daimon-end`, el flujo de checkpoint en sesión `/daimon-end`, escrita al lado como `~/.kimi-code/skills/daimon-end/SKILL.md`.
+
 Kimi escanea las dos ubicaciones en busca de skills. La prueba midió dónde
 busca, no cómo prioriza entre las dos cuando ambas tienen una skill de
 daimon, así que instalá en un solo alcance. Volvé a correr install después

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/windsurf.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/hosts/windsurf.md
@@ -99,6 +99,9 @@ daimon skill install windsurf             # ~/.codeium/windsurf/skills/daimon/SK
 daimon skill install windsurf --project   # .windsurf/rules/daimon.md
 ```
 
+Install entrega dos skills: `daimon` (el protocolo) y `daimon-end`, el flujo de checkpoint en sesión `/daimon-end`, escrita al lado como `~/.codeium/windsurf/skills/daimon-end/SKILL.md`.
+El alcance de proyecto es un único archivo de reglas, así que lleva solo el protocolo.
+
 En Windsurf la skill no es solo etiqueta de protocolo — es la vía de entrega
 del briefing. Como Cascade no tiene evento de inicio de sesión donde
 inyectar, la skill instruye al agente a ejecutar `daimon brief --team` en la


### PR DESCRIPTION
Closes #1000

## What

`daimon skill install` now delivers the `daimon-end` skill alongside `daimon`
on every host whose skill contract is directory form, and `daimon skill
uninstall` takes both back.

- `skill_install.BUNDLED_SKILLS` names the skills daimon ships whole, as their
  own directory. Today that is `daimon-end`.
- The destination is derived from the row already in `HOSTS`, not from a second
  table: a `full` row IS the directory-form contract
  (`<root>/skills/<name>/SKILL.md`, scanned by directory, body loaded on
  invocation), while a `compact` row is a single rules file concatenated into
  every prompt and has no directory to scan. So claude global and project,
  windsurf global, and kimi global and project gain the second skill; codex,
  gemini, cursor and windsurf project are unchanged.
- The wheel ships `daimon_briefing/` and nothing else, so the plugin-root
  `skills/` tree cannot be the install source. `daimon_briefing/_skills/daimon-end/SKILL.md`
  is a byte-identical mirror, added to the one manifest in
  `scripts/sync_hooks.py`. A build that lost its package data refuses instead of
  reporting a partial install as success.
- Uninstall removes the file and the directory it created, but only while that
  directory holds nothing else.

## Why

`daimon-end` has been packaged since it was written and installed by nothing.
Claude Code's plugin loader discovers it at the plugin root, so a maintainer
running from the checkout always had it, while everyone who installed the wheel
and ran `daimon skill install` got the `daimon` skill alone and no way to learn
that `/daimon-end` exists. Verified on a live kimi install: only
`~/.kimi-code/skills/daimon/` was present.

## Tests

`plugin/tests/test_skill_install.py` gains the bundled-skill family: every
`full` row receives `daimon-end` with frontmatter whose `name` equals its
directory (the host skips it otherwise), compact hosts receive nothing, the
install report names every file it wrote, uninstall removes both skills, a
directory holding a user's own file survives, and a build missing its package
data raises rather than half-installing. `test_every_full_row_is_directory_form`
pins the path shape the destination is derived from.

`plugin/tests/test_packaging.py` gains a generic drift guard over every
`SYNC_PAIRS` entry. Only the `_hooks/` slice had one, so a mirror added
anywhere else drifted with nothing watching.

Four of the new tests failed before the change. Full suite green, mypy and ruff
clean on `daimon_briefing`.
