### PR TITLE
feat(inspector): retain preceding tool context

### DIFF
--- a/docs/checkpoint-schema.json
+++ b/docs/checkpoint-schema.json
@@ -658,6 +658,18 @@
       "notes": "Durable per-item evidence receipt (#594, provenance.quote_receipt). verifier is an OBJECT {id, version}: consumers normalizing it as a string rendered every verified claim's verifier as absent."
     },
     {
+      "field": "preceding_tool_context",
+      "type": "object",
+      "optional": true,
+      "nullable": false,
+      "owner": "code",
+      "disposition": "strip",
+      "constraints": {
+        "stripped_at_serialize": true
+      },
+      "notes": "#1010 code-derived temporal audit metadata. Stores bounded tool-row ids and original source provenance only; it never proves reading, use, understanding or human authorship."
+    },
+    {
       "field": "grounded",
       "type": "boolean",
       "optional": true,

--- a/docs/trust-inspector.md
+++ b/docs/trust-inspector.md
@@ -33,6 +33,15 @@ The inspector reports independent axes because they can legitimately disagree:
 Corroboration is shown separately as a count and source-session references. It
 does not modify any evidence axis.
 
+`preceding_tool_context` is a separate audit section. Its `observed` state
+maps each verified assistant quote source to up to 20 preceding tool-result
+row IDs, ending at a recognized host user-input boundary. `unavailable` names
+why the host capture could not establish that window, and `not_recorded` is
+used for older checkpoints. An empty result list under `observed` means the
+bounded window contained no tool results. These IDs describe recorded order
+only and never prove that the model read or used a result; tool output and
+arguments are never stored.
+
 For example, these facts can coexist:
 
 ```text

--- a/plugin/daimon_briefing/capture.py
+++ b/plugin/daimon_briefing/capture.py
@@ -40,7 +40,7 @@ log = logging.getLogger(__name__)
 
 def run(session_id: str, messages, *, project, chat, deadline,
         transcript_path=None, transcript_sha=None,
-        escalate: bool = False, capture_host=None) -> Path | None:
+        escalate: bool = False, capture_host=None, coverage=None) -> Path | None:
     """Serialize `messages` into a checkpoint routed to `project` (used AS-IS;
     None => global pointer only — the caller decides routing, same contract
     as the old cli._run_serialize).
@@ -64,7 +64,7 @@ def run(session_id: str, messages, *, project, chat, deadline,
     checkpoint = serializer.serialize_strict(
         session_id, messages, chat=chat, deadline=deadline, escalate=escalate,
         source_ref=source_ref, transcript_hash=transcript_sha,
-        now=session_end)
+        now=session_end, coverage=coverage)
     # `created` = when the SESSION ended, not when this write happens (#123).
     # Stamped here — not left to store's setdefault-now — so a heal/re-serialize
     # of an old transcript carries its true age and store's pointer guard can

--- a/plugin/daimon_briefing/carry.py
+++ b/plugin/daimon_briefing/carry.py
@@ -489,6 +489,15 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                                 item["source_message_ids"])
                         else:
                             twin.pop("source_message_ids", None)
+                        # #1010: temporal context is atomic with the quote and
+                        # receipt. A native twin's context describes its old
+                        # wording, so only a valid previous quote's context
+                        # may travel with the frozen quote.
+                        if item.get("preceding_tool_context"):
+                            twin["preceding_tool_context"] = copy.deepcopy(
+                                item["preceding_tool_context"])
+                        else:
+                            twin.pop("preceding_tool_context", None)
                         # quote_verified travels WITH the quote (#167): the
                         # native's verdict attested its own (now replaced)
                         # quote — keeping it would stamp "verified" on a quote
@@ -512,6 +521,7 @@ def merge(new_cp: dict, prev_cp: dict | None, now: float,
                         twin.pop("quote_provenance", None)
                         twin.pop("source_message_ids", None)
                         twin.pop("quote_verified", None)
+                        twin.pop("preceding_tool_context", None)
                     twin["trust"] = "verbatim"
                 if item.get("first_seen") and not twin.get("first_seen"):
                     twin["first_seen"] = item["first_seen"]

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -324,7 +324,9 @@ def _run_serialize(transcript_path: Path, project: str | None,
         return 0
 
     try:
-        messages = transcript.from_file(path)
+        detailed = transcript.from_file_detailed(path)
+        messages = detailed["messages"]
+        coverage = detailed["coverage"]
     except FileNotFoundError:
         msg = f"error: transcript not found: {path}"
         _print_error(msg)
@@ -367,7 +369,8 @@ def _run_serialize(transcript_path: Path, project: str | None,
         # Error POSTURE stays here: capture raises, this door prints/exits.
         out = capture.run(session_id, messages, project=project, chat=_chat,
                           deadline=deadline, transcript_path=path,
-                          transcript_sha=transcript_sha, escalate=escalate)
+                          transcript_sha=transcript_sha, escalate=escalate,
+                          coverage=coverage)
     except serializer.TooShortError as exc:
         msg = f"skipped serialize for {session_id}: {exc}"
         print(msg)

--- a/plugin/daimon_briefing/field_table.py
+++ b/plugin/daimon_briefing/field_table.py
@@ -233,6 +233,12 @@ ITEM_RULES: tuple[FieldRule, ...] = (
         "verifier is an OBJECT {id, version}: consumers normalizing it as a "
         "string rendered every verified claim's verifier as absent."),
     FieldRule(
+        "item", "preceding_tool_context", "object", True, False, "code", "strip",
+        _c(stripped_at_serialize=True),
+        "#1010 code-derived temporal audit metadata. Stores bounded tool-row "
+        "ids and original source provenance only; it never proves reading, "
+        "use, understanding or human authorship."),
+    FieldRule(
         "item", "grounded", "boolean", True, False, "code", "pass",
         _c(),
         "#359 outcome-grounding verdict, re-derived every serialize: any "

--- a/plugin/daimon_briefing/hooks.py
+++ b/plugin/daimon_briefing/hooks.py
@@ -90,7 +90,30 @@ def on_session_end(session_id, completed=None, interrupted=None, model=None, pla
                     session_id,
                 )
                 return
-        messages = transcript.from_session(session_id)
+        coverage = None
+        session_messages = transcript.from_session(session_id)
+        if transcript_path:
+            try:
+                detailed = transcript.from_file_detailed(transcript_path)
+            except (OSError, UnicodeError, ValueError):
+                detailed = None
+            if detailed is None:
+                messages = session_messages
+            else:
+                file_messages = detailed["messages"]
+                if session_messages and file_messages == session_messages:
+                    messages = file_messages
+                    coverage = detailed["coverage"]
+                elif session_messages:
+                    # The path can be an auxiliary host artifact while the
+                    # host's authoritative transcript is SessionDB. Do not
+                    # attach metadata from a different message snapshot.
+                    messages = session_messages
+                else:
+                    messages = file_messages
+                    coverage = detailed["coverage"]
+        else:
+            messages = session_messages
         if not messages:
             # scar 0045: 0 parsed messages is the host-format-drift signature,
             # never a short session — the official skip line would legitimize
@@ -128,6 +151,7 @@ def on_session_end(session_id, completed=None, interrupted=None, model=None, pla
                 session_id, messages, project=root, chat=_chat,
                 deadline=deadline, transcript_path=transcript_path,
                 transcript_sha=transcript_sha, capture_host=platform,
+                coverage=coverage,
             )
         except serializer.TooShortError:
             # Unreachable while both doors share conversation_message_count

--- a/plugin/daimon_briefing/inspector.py
+++ b/plugin/daimon_briefing/inspector.py
@@ -16,7 +16,7 @@ import time
 from pathlib import Path
 
 from . import (config, provenance, recall, redact, schema, scoring,
-               serializer, store, transcript)
+               serializer, store, tool_context, transcript)
 
 
 SCHEMA_VERSION = 1
@@ -187,6 +187,79 @@ def _message_by_id(messages: list[dict]) -> dict[str, dict]:
     return out
 
 
+def _preceding_tool_context(item: dict) -> dict:
+    """Validate stored #1010 metadata before exposing it to an inspector."""
+    raw = item.get("preceding_tool_context")
+    if raw is None:
+        return {"status": "not_recorded", "reason": "not_recorded"}
+    if not isinstance(raw, dict):
+        return {"status": "unavailable", "reason": "invalid_metadata"}
+    if raw.get("policy") != tool_context.POLICY:
+        return {"status": "unavailable", "reason": "unsupported_policy"}
+    if raw.get("version") != tool_context.VERSION or raw.get("message_limit") != tool_context.MESSAGE_LIMIT:
+        return {"status": "unavailable", "reason": "invalid_metadata"}
+    status = raw.get("status")
+    if status == "unavailable":
+        reason = raw.get("reason")
+        if not isinstance(reason, str) or reason not in tool_context._REASONS:
+            return {"status": "unavailable", "reason": "invalid_metadata"}
+        result = {"status": status, "version": raw["version"], "reason": reason,
+                  "policy": raw["policy"], "message_limit": raw["message_limit"]}
+    elif status == "observed":
+        contexts = raw.get("contexts")
+        if not isinstance(contexts, list):
+            return {"status": "unavailable", "reason": "invalid_metadata"}
+        receipt = item.get("quote_provenance")
+        binding = receipt.get("binding") if isinstance(receipt, dict) else None
+        bound_ids = (binding.get("message_ids")
+                     if isinstance(binding, dict)
+                     and binding.get("mode") == "message-ids" else None)
+        if (not isinstance(bound_ids, list)
+                or not all(isinstance(value, str) and value for value in bound_ids)):
+            return {"status": "unavailable", "reason": "invalid_metadata"}
+        safe_contexts = []
+        context_sources = []
+        for context in contexts:
+            if not isinstance(context, dict):
+                return {"status": "unavailable", "reason": "invalid_metadata"}
+            source_id = context.get("source_message_id")
+            result_ids = context.get("preceding_tool_result_ids")
+            boundary = context.get("boundary")
+            examined = context.get("messages_examined")
+            if (not isinstance(source_id, str) or not source_id
+                    or not isinstance(result_ids, list)
+                    or not all(isinstance(value, str) and value for value in result_ids)
+                    or len(result_ids) > tool_context.MESSAGE_LIMIT
+                    or len(set(result_ids)) != len(result_ids)
+                    or boundary not in ("host_user_input", "message_limit")
+                    or isinstance(examined, bool)
+                    or not isinstance(examined, int)
+                    or not 0 <= examined <= tool_context.MESSAGE_LIMIT):
+                return {"status": "unavailable", "reason": "invalid_metadata"}
+            if source_id not in bound_ids or source_id in context_sources:
+                return {"status": "unavailable", "reason": "invalid_metadata"}
+            context_sources.append(source_id)
+            safe_contexts.append({
+                "source_message_id": source_id,
+                "preceding_tool_result_ids": list(result_ids),
+                "boundary": boundary,
+                "messages_examined": examined,
+            })
+        if set(context_sources) != set(bound_ids):
+            return {"status": "unavailable", "reason": "invalid_metadata"}
+        result = {"status": status, "version": raw["version"], "policy": raw["policy"],
+                  "message_limit": raw["message_limit"],
+                  "contexts": safe_contexts}
+    else:
+        return {"status": "unavailable", "reason": "invalid_metadata"}
+    source = raw.get("source")
+    if source is not None:
+        if not provenance.valid_source_ref(source):
+            return {"status": "unavailable", "reason": "invalid_metadata"}
+        result["source"] = source
+    return result
+
+
 def _cap_disclosed_source(value: str) -> tuple[str, bool]:
     """Cap display text without splitting a final-boundary redaction marker."""
     if len(value) <= _SOURCE_CHAR_LIMIT:
@@ -354,6 +427,7 @@ def inspect_item(project_dir, item_id: str, *, include_source: bool = False,
             "origin_session": item.get("origin_session"),
             "occurrences": len(occurrences),
         },
+        "preceding_tool_context": _preceding_tool_context(item),
         "axes": {
             "capture": capture,
             "provenance": provenance_axis,
@@ -462,6 +536,18 @@ def human_lines(result: dict) -> list[str]:
     lines.append(
         f"Corroboration: {corroboration['count']}"
         + (f" ({refs})" if refs else ""))
+    temporal = result.get("preceding_tool_context")
+    if isinstance(temporal, dict):
+        status = temporal.get("status")
+        if status == "observed":
+            lines.append(
+                f"Preceding tool results: observed ({len(temporal.get('contexts', []))} source window(s)); "
+                "order does not prove use")
+        elif status == "not_recorded":
+            lines.append("Preceding tool results: not recorded")
+        else:
+            lines.append(
+                f"Preceding tool results: unavailable ({temporal.get('reason', 'unknown')})")
     source = result.get("source")
     if isinstance(source, dict):
         lines.append(

--- a/plugin/daimon_briefing/policy.py
+++ b/plugin/daimon_briefing/policy.py
@@ -163,7 +163,7 @@ def scrub_forgotten_payload(checkpoint: dict,
 # trusts the receipt over the flat flag), and `trust=verbatim` with no quote
 # fails serializer revalidation ("trust=verbatim item has no quote").
 _QUOTE_CLAIM_KEYS = ("quote_provenance", "quote_verified", "last_verified",
-                     "source_message_ids")
+                     "source_message_ids", "preceding_tool_context")
 
 
 def scrub_forgotten_fields(item: dict, forgotten_keys: set) -> bool:

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -22,7 +22,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 
 from . import (config, configure, field_table, ledger, llm, normalize,
-               provenance, schema)
+               provenance, schema, tool_context)
 
 # No handlers/basicConfig here — the library stays silent unless the caller
 # configures logging. Multi-hour serialize runs need this heartbeat to be killable.
@@ -2267,6 +2267,7 @@ _CODE_OWNED_ITEM_KEYS = ("origin_session", "origin_author",
                          "quote_verified", "last_verified",
                          "quote_provenance", "pinned", "id",
                          "carried_from", "restated_after_resolve", "first_seen",
+                         "preceding_tool_context",
                          # #890: a model naming who said something is an agent
                          # asserting an identity it cannot verify, and the
                          # field would carry more authority than any other
@@ -2434,7 +2435,7 @@ def conversation_message_count(messages) -> int:
 
 def serialize_strict(session_id: str, messages, chat=None, deadline=None,
                      escalate=False, source_ref=None, transcript_hash=None,
-                     now=None) -> dict:
+                     now=None, coverage=None) -> dict:
     """Transcript -> validated checkpoint, or a named SerializeError.
 
     `chat` is an injectable callable (messages, **kwargs) -> str; defaults to the
@@ -2690,6 +2691,12 @@ def serialize_strict(session_id: str, messages, chat=None, deadline=None,
     # signal pointer are marked grounded; unwitnessed verbatim outcome
     # claims in a signal-bearing session store as inferred.
     ground_outcomes(checkpoint, sig_ids)
+    # #1010: this audit field is derived only after quote verification and
+    # grounding. It is code-owned and never enters extraction or merge prompts.
+    for item in iter_items(checkpoint):
+        item.pop("preceding_tool_context", None)
+        item["preceding_tool_context"] = tool_context.derive(
+            item, messages, coverage, source=source_ref)
     # #230: stamp provenance last, immediately before hand-off to store/write —
     # after validation/verification so it can never influence either, and
     # last so nothing downstream re-derives or clobbers it.

--- a/plugin/daimon_briefing/tool_context.py
+++ b/plugin/daimon_briefing/tool_context.py
@@ -1,0 +1,171 @@
+"""Code-derived temporal context for bound assistant quotes (#1010).
+
+This module deliberately contains no transcript or checkpoint I/O.  It turns
+validated parser metadata and validated quote bindings into a bounded audit
+observation.  The result says where tool-result rows occurred in the recorded
+transcript; it never says that a model read or used them.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, cast
+
+
+POLICY = "preceding-tools-v1"
+VERSION = 1
+MESSAGE_LIMIT = 20
+
+_REASONS = {
+    "unsupported_adapter", "coverage_unknown", "coverage_incomplete",
+    "source_binding_unavailable", "source_unresolved", "source_not_assistant",
+    "boundary_unknown", "invalid_metadata", "unsupported_policy",
+    "not_recorded",
+}
+
+
+def unavailable(reason: str, *, source=None) -> dict:
+    """Build the persisted unavailable shape without a misleading empty list."""
+    if reason not in _REASONS:
+        reason = "coverage_unknown"
+    result = {
+        "version": VERSION,
+        "policy": POLICY,
+        "message_limit": MESSAGE_LIMIT,
+        "status": "unavailable",
+        "reason": reason,
+    }
+    if isinstance(source, dict):
+        result["source"] = deepcopy(source)
+    return result
+
+
+def _valid_coverage(coverage) -> bool:
+    return (
+        isinstance(coverage, dict)
+        and coverage.get("version") == VERSION
+        and coverage.get("adapter") == "claude-code"
+        and coverage.get("available") is True
+        and isinstance(coverage.get("rows"), list)
+    )
+
+
+def _valid_source_ids(ids) -> bool:
+    return (
+        isinstance(ids, list)
+        and all(isinstance(value, str) and value for value in ids)
+        and len(ids) == len(set(ids))
+    )
+
+
+def _find_bound_sources(item: dict, surviving_ids: set[str]) -> tuple[list[str], str | None]:
+    """Find source ids from the item's own verified receipts.
+
+    The serializer calls this after quote verification, so the small amount of
+    structural validation here is intentional defense in depth for malformed
+    or legacy records.
+    """
+    sources: list[str] = []
+    saw_candidate = False
+    if not isinstance(item, dict) or item.get("trust") != "verbatim":
+        return [], "source_binding_unavailable"
+    receipt = item.get("quote_provenance")
+    binding = receipt.get("binding") if isinstance(receipt, dict) else None
+    if isinstance(binding, dict) and item.get("quote") and binding.get("mode") == "message-ids":
+        saw_candidate = True
+        ids = binding.get("message_ids")
+        if not _valid_source_ids(ids):
+            return [], "source_binding_unavailable"
+        for value in cast(list[str], ids):
+            if value not in surviving_ids:
+                return [], "source_unresolved"
+            if value not in sources:
+                sources.append(value)
+    if not saw_candidate:
+        return [], "source_binding_unavailable"
+    return sources, None
+
+
+def derive(item: dict, messages: list[dict], coverage: dict | None,
+           *, source=None) -> dict:
+    """Derive one item-wide observation from the surviving quote bindings.
+
+    ``item`` is handled independently so multiple quote sources retain their
+    per-item relationship and never become a flattened checkpoint-wide union.
+    """
+    receipt = item.get("quote_provenance") if isinstance(item, dict) else None
+    original_source = (receipt.get("source") if isinstance(receipt, dict)
+                       else source)
+    if not _valid_coverage(coverage):
+        return unavailable(
+            coverage.get("reason", "coverage_unknown")
+            if isinstance(coverage, dict) else "coverage_unknown",
+            source=original_source,
+        )
+    validated_coverage = cast(dict[str, Any], coverage)
+    rows = cast(list[dict[str, Any]], validated_coverage["rows"])
+    if len(rows) != len(messages):
+        return unavailable("coverage_incomplete", source=original_source)
+    if any(
+        not isinstance(row, dict)
+        or not isinstance(row.get("id"), str)
+        or not row.get("id")
+        or not isinstance(row.get("tool_result"), bool)
+        or not isinstance(row.get("host_user_input"), bool)
+        for row in rows
+    ):
+        return unavailable("coverage_incomplete", source=original_source)
+    by_id = {cast(str, row["id"]) for row in rows}
+    if len(by_id) != len(rows):
+        return unavailable("coverage_incomplete", source=original_source)
+    sources, reason = _find_bound_sources(item, by_id)
+    if reason:
+        return unavailable(reason, source=original_source)
+    positions = {row["id"]: index for index, row in enumerate(rows)}
+    sources.sort(key=positions.__getitem__)
+
+    contexts = []
+    for source_id in sources:
+        index = next((i for i, row in enumerate(rows)
+                      if row.get("id") == source_id), None)
+        if index is None:
+            return unavailable("source_unresolved", source=original_source)
+        if rows[index].get("role") != "assistant" or rows[index].get("tool_result"):
+            return unavailable("source_not_assistant", source=original_source)
+        examined: list[dict[str, Any]] = []
+        boundary = None
+        cursor = index - 1
+        while cursor >= 0 and len(examined) < MESSAGE_LIMIT:
+            row = rows[cursor]
+            if row.get("host_user_input") is True:
+                boundary = "host_user_input"
+                break
+            examined.append(row)
+            cursor -= 1
+        if len(examined) == MESSAGE_LIMIT:
+            # A boundary immediately beyond the cap wins without becoming a
+            # 21st examined message.
+            boundary = ("host_user_input" if cursor >= 0
+                        and rows[cursor].get("host_user_input") is True
+                        else "message_limit")
+        elif boundary is None and cursor < 0:
+            # A prefix with no known boundary may be a truncated capture.
+            return unavailable("boundary_unknown", source=original_source)
+        tool_ids = [row["id"] for row in reversed(examined)
+                    if row.get("tool_result") is True]
+        contexts.append({
+            "source_message_id": source_id,
+            "preceding_tool_result_ids": tool_ids,
+            "boundary": boundary,
+            "messages_examined": len(examined),
+        })
+    result = {
+        "version": VERSION,
+        "policy": POLICY,
+        "message_limit": MESSAGE_LIMIT,
+        "status": "observed",
+        "contexts": contexts,
+    }
+    if isinstance(original_source, dict):
+        result["source"] = deepcopy(original_source)
+    return result

--- a/plugin/daimon_briefing/tool_context.py
+++ b/plugin/daimon_briefing/tool_context.py
@@ -116,8 +116,6 @@ def derive(item: dict, messages: list[dict], coverage: dict | None,
     ):
         return unavailable("coverage_incomplete", source=original_source)
     by_id = {cast(str, row["id"]) for row in rows}
-    if len(by_id) != len(rows):
-        return unavailable("coverage_incomplete", source=original_source)
     sources, reason = _find_bound_sources(item, by_id)
     if reason:
         return unavailable(reason, source=original_source)
@@ -126,10 +124,8 @@ def derive(item: dict, messages: list[dict], coverage: dict | None,
 
     contexts = []
     for source_id in sources:
-        index = next((i for i, row in enumerate(rows)
-                      if row.get("id") == source_id), None)
-        if index is None:
-            return unavailable("source_unresolved", source=original_source)
+        index = next(i for i, row in enumerate(rows)
+                     if row.get("id") == source_id)
         if rows[index].get("role") != "assistant" or rows[index].get("tool_result"):
             return unavailable("source_not_assistant", source=original_source)
         examined: list[dict[str, Any]] = []

--- a/plugin/daimon_briefing/transcript.py
+++ b/plugin/daimon_briefing/transcript.py
@@ -793,6 +793,12 @@ def from_file(path) -> list[dict]:
         raise FileNotFoundError(p)
     text = p.read_text(encoding="utf-8")
 
+    return _from_file_text(p, text)
+
+
+def _from_file_text(p: Path, text: str) -> list[dict]:
+    """Parse one already-read file snapshot."""
+
     if p.suffix == ".jsonl":
         return _from_jsonl(text, kimi=_is_kimi_wire_path(p))
 
@@ -821,3 +827,78 @@ def from_file(path) -> list[dict]:
         if blob:
             messages.append({"role": "user", "content": blob})
     return messages
+
+
+def _claude_coverage(text: str, messages: list[dict]) -> dict:
+    """Return conservative parser metadata for the validated Claude shape."""
+    objects = _objects_of(text)
+    nonempty_lines = [line for line in text.splitlines() if line.strip()]
+    malformed = len(objects) != len(nonempty_lines)
+    if not any(obj.get("type") in ("user", "assistant") for obj in objects):
+        return {"version": 1, "adapter": "claude-code", "available": False,
+                "reason": "unsupported_adapter", "rows": []}
+    rows = []
+    seen = set()
+    for obj in objects:
+        if obj.get("isSidechain") or obj.get("isMeta"):
+            continue
+        role = obj.get("type")
+        if role not in ("user", "assistant"):
+            continue
+        raw_uuid = obj.get("uuid")
+        message_id = raw_uuid.strip() if isinstance(raw_uuid, str) else ""
+        msg = obj.get("message")
+        content = msg.get("content") if isinstance(msg, dict) else None
+        tool = _tool_result_of(obj)
+        has_text = bool(_text_of(content))
+        if not message_id or message_id in seen or not isinstance(content, (str, list)):
+            return {"version": 1, "adapter": "claude-code", "available": False,
+                    "reason": "coverage_incomplete", "rows": []}
+        if tool is not None and has_text:
+            return {"version": 1, "adapter": "claude-code", "available": False,
+                    "reason": "coverage_incomplete", "rows": []}
+        # Claude emits assistant rows containing only tool_use blocks. The
+        # normalized parser intentionally drops those rows, so they do not
+        # consume a temporal position or make the sidecar disagree with it.
+        if role == "assistant" and isinstance(content, list) and not has_text and tool is None:
+            continue
+        if isinstance(msg, dict) and msg.get("role") not in (None, role):
+            return {"version": 1, "adapter": "claude-code", "available": False,
+                    "reason": "coverage_incomplete", "rows": []}
+        seen.add(message_id)
+        rows.append({"id": message_id, "role": role,
+                     "tool_result": tool is not None,
+                     "host_user_input": role == "user" and tool is None})
+    if malformed or len(rows) != len(messages):
+        return {"version": 1, "adapter": "claude-code", "available": False,
+                "reason": "coverage_incomplete", "rows": []}
+    return {"version": 1, "adapter": "claude-code", "available": True,
+            "reason": None, "rows": rows}
+
+
+def from_file_detailed(path) -> dict:
+    """Read messages and same-snapshot coverage metadata for capture."""
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(p)
+    text = p.read_text(encoding="utf-8")
+    messages = _from_file_text(p, text)
+    if p.suffix != ".jsonl":
+        coverage = {"version": 1, "adapter": "generic", "available": False,
+                    "reason": "unsupported_adapter", "rows": []}
+    else:
+        objects = _objects_of(text)
+        if _is_kimi_wire(objects) or _is_kimi_wire_path(p):
+            reason = "source_binding_unavailable"
+            coverage = {"version": 1, "adapter": "kimi", "available": False,
+                        "reason": reason, "rows": []}
+        elif any(obj.get("type") == "event_msg" for obj in objects):
+            coverage = {"version": 1, "adapter": "codex", "available": False,
+                        "reason": "unsupported_adapter", "rows": []}
+        elif any(obj.get("status") is not None and obj.get("type") in
+                 ("user_input", "planner_response") for obj in objects):
+            coverage = {"version": 1, "adapter": "windsurf", "available": False,
+                        "reason": "unsupported_adapter", "rows": []}
+        else:
+            coverage = _claude_coverage(text, messages)
+    return {"messages": messages, "coverage": coverage}

--- a/plugin/tests/golden/why_bound.json
+++ b/plugin/tests/golden/why_bound.json
@@ -21,6 +21,10 @@
     "verifier_comparison": "same-version",
     "lifecycle": "active"
   },
+  "preceding_tool_context": {
+    "status": "not_recorded",
+    "reason": "not_recorded"
+  },
   "corroboration": {
     "count": 0,
     "references": []

--- a/plugin/tests/test_hooks.py
+++ b/plugin/tests/test_hooks.py
@@ -78,6 +78,20 @@ def test_pre_llm_call_never_raises(tmp_checkpoint_dir, monkeypatch):
     assert out is None
 
 
+def test_pre_llm_call_returns_none_when_briefing_is_empty(
+    tmp_checkpoint_dir, sample_checkpoint, monkeypatch
+):
+    from daimon_briefing import store
+
+    store.write_checkpoint("S-prev", sample_checkpoint)
+    monkeypatch.setattr(hooks.briefing, "render", lambda *args, **kwargs: "")
+    out = hooks.pre_llm_call(
+        session_id="S2", user_message="hi", conversation_history=[], is_first_turn=True,
+        model="m", platform="cli",
+    )
+    assert out is None
+
+
 # ---- on_session_end gating + safety ----
 
 
@@ -336,6 +350,52 @@ def test_on_session_end_proceeds_when_no_transcript_path_given(
 
     hooks.on_session_end(
         session_id="S-end", completed=True, interrupted=False, model="m", platform="cli"
+    )
+    assert len(chat.calls) == 1
+
+
+def test_on_session_end_uses_detailed_coverage_for_matching_transcript(
+    tmp_checkpoint_dir, fake_chat_factory, monkeypatch, tmp_path
+):
+    from daimon_briefing import transcript as transcript_mod
+
+    tpath = tmp_path / "S-end.jsonl"
+    tpath.write_text(
+        '{"type":"user","uuid":"u1","message":{"role":"user","content":"hi"}}\n'
+        '{"type":"assistant","uuid":"a1","message":{"role":"assistant","content":"done"}}\n',
+        encoding="utf-8",
+    )
+    messages = transcript_mod.from_file(tpath)
+    chat = fake_chat_factory(_valid_json("S-end"))
+    monkeypatch.setattr(transcript_mod, "from_session", lambda sid: messages)
+    monkeypatch.setattr(hooks, "_chat", chat)
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "1")
+
+    hooks.on_session_end(
+        session_id="S-end", completed=True, interrupted=False, model="m", platform="cli",
+        transcript_path=str(tpath),
+    )
+    assert len(chat.calls) == 1
+
+
+def test_on_session_end_uses_file_messages_when_session_has_none(
+    tmp_checkpoint_dir, fake_chat_factory, monkeypatch, tmp_path
+):
+    from daimon_briefing import transcript as transcript_mod
+
+    tpath = tmp_path / "S-end.jsonl"
+    tpath.write_text(
+        '{"type":"user","uuid":"u1","message":{"role":"user","content":"hi"}}\n',
+        encoding="utf-8",
+    )
+    chat = fake_chat_factory(_valid_json("S-end"))
+    monkeypatch.setattr(transcript_mod, "from_session", lambda sid: [])
+    monkeypatch.setattr(hooks, "_chat", chat)
+    monkeypatch.setenv("DAIMON_MIN_MESSAGES", "1")
+
+    hooks.on_session_end(
+        session_id="S-end", completed=True, interrupted=False, model="m", platform="cli",
+        transcript_path=str(tpath),
     )
     assert len(chat.calls) == 1
 

--- a/plugin/tests/test_inspector.py
+++ b/plugin/tests/test_inspector.py
@@ -824,6 +824,40 @@ def test_why_does_not_trust_malformed_preceding_tool_context(bad, reason):
         "status": "unavailable", "reason": reason}
 
 
+def test_preceding_context_validation_rejects_each_malformed_shape():
+    receipt = _receipt(_source(), "a" * 64)
+    item = _item(receipt=receipt)
+    valid = {
+        "version": 1, "policy": "preceding-tools-v1", "message_limit": 20,
+        "status": "observed", "contexts": [{
+            "source_message_id": "u-1", "preceding_tool_result_ids": [],
+            "boundary": "host_user_input", "messages_examined": 0,
+        }],
+    }
+    cases = [
+        ({**valid, "version": 2}),
+        ({**valid, "status": "unavailable", "contexts": [], "reason": "bad"}),
+        ({**valid, "contexts": "bad"}),
+        ({**valid, "contexts": [{"source_message_id": "wrong",
+                                  "preceding_tool_result_ids": [],
+                                  "boundary": "host_user_input",
+                                  "messages_examined": 0}]}),
+        ({**valid, "contexts": [{"source_message_id": "u-1",
+                                  "preceding_tool_result_ids": ["t-1", "t-1"],
+                                  "boundary": "host_user_input",
+                                  "messages_examined": 0}]}),
+        ({**valid, "contexts": [{"source_message_id": "u-1",
+                                  "preceding_tool_result_ids": [],
+                                  "boundary": "bad", "messages_examined": 0}]}),
+        ({**valid, "source": {"version": 1}}),
+        ({**valid, "status": "unknown"}),
+    ]
+    for raw in cases:
+        checked = {**item, "preceding_tool_context": raw}
+        assert inspector._preceding_tool_context(checked) == {
+            "status": "unavailable", "reason": "invalid_metadata"}
+
+
 def test_forgotten_team_only_item_is_not_resurrected(
     tmp_checkpoint_dir, monkeypatch
 ):

--- a/plugin/tests/test_inspector.py
+++ b/plugin/tests/test_inspector.py
@@ -781,7 +781,47 @@ def test_why_still_refuses_an_id_in_neither_surfaces_nor_index(
 
     assert inspector.inspect_item(_PROJECT, _ITEM_ID) is None
     assert cli.main(["why", _ITEM_ID, "--project", _PROJECT]) == 1
-    assert "no item" in capsys.readouterr().err
+
+
+def test_why_reports_observed_preceding_tool_context_without_source_read(
+        tmp_checkpoint_dir):
+    context = {
+        "version": 1,
+        "policy": "preceding-tools-v1",
+        "message_limit": 20,
+        "status": "observed",
+        "contexts": [{
+            "source_message_id": "u-1",
+            "preceding_tool_result_ids": ["t-1"],
+            "boundary": "host_user_input",
+            "messages_examined": 1,
+        }],
+    }
+    _write_checkpoint(_ITEM_ID, [
+        _item(receipt=_receipt(_source(), "a" * 64),
+              preceding_tool_context=context),
+    ])
+
+    result = inspector.inspect_item(_PROJECT, _ITEM_ID)
+
+    assert result["preceding_tool_context"] == context
+
+
+@pytest.mark.parametrize("bad, reason", [
+    ("not-an-object", "invalid_metadata"),
+    ({"version": 1, "policy": "old", "message_limit": 20,
+      "status": "observed", "contexts": []}, "unsupported_policy"),
+])
+def test_why_does_not_trust_malformed_preceding_tool_context(bad, reason):
+    _write_checkpoint(_ITEM_ID, [
+        _item(receipt=_receipt(_source(), "a" * 64),
+              preceding_tool_context=bad),
+    ])
+
+    result = inspector.inspect_item(_PROJECT, _ITEM_ID)
+
+    assert result["preceding_tool_context"] == {
+        "status": "unavailable", "reason": reason}
 
 
 def test_forgotten_team_only_item_is_not_resurrected(

--- a/plugin/tests/test_inspector.py
+++ b/plugin/tests/test_inspector.py
@@ -807,6 +807,17 @@ def test_why_reports_observed_preceding_tool_context_without_source_read(
     assert result["preceding_tool_context"] == context
 
 
+def test_preceding_context_preserves_valid_source_reference():
+    receipt = _receipt(_source(), "a" * 64)
+    context = {
+        "version": 1, "policy": "preceding-tools-v1", "message_limit": 20,
+        "status": "unavailable", "reason": "coverage_incomplete",
+        "source": _source(),
+    }
+    checked = _item(receipt=receipt, preceding_tool_context=context)
+    assert inspector._preceding_tool_context(checked)["source"] == _source()
+
+
 @pytest.mark.parametrize("bad, reason", [
     ("not-an-object", "invalid_metadata"),
     ({"version": 1, "policy": "old", "message_limit": 20,
@@ -838,6 +849,7 @@ def test_preceding_context_validation_rejects_each_malformed_shape():
         ({**valid, "version": 2}),
         ({**valid, "status": "unavailable", "contexts": [], "reason": "bad"}),
         ({**valid, "contexts": "bad"}),
+        ({**valid, "contexts": ["bad"]}),
         ({**valid, "contexts": [{"source_message_id": "wrong",
                                   "preceding_tool_result_ids": [],
                                   "boundary": "host_user_input",
@@ -849,6 +861,7 @@ def test_preceding_context_validation_rejects_each_malformed_shape():
         ({**valid, "contexts": [{"source_message_id": "u-1",
                                   "preceding_tool_result_ids": [],
                                   "boundary": "bad", "messages_examined": 0}]}),
+        ({**valid, "contexts": []}),
         ({**valid, "source": {"version": 1}}),
         ({**valid, "status": "unknown"}),
     ]
@@ -856,6 +869,60 @@ def test_preceding_context_validation_rejects_each_malformed_shape():
         checked = {**item, "preceding_tool_context": raw}
         assert inspector._preceding_tool_context(checked) == {
             "status": "unavailable", "reason": "invalid_metadata"}
+
+    unavailable = {**valid, "status": "unavailable", "contexts": [],
+                   "reason": "coverage_incomplete"}
+    assert inspector._preceding_tool_context({
+        **item, "preceding_tool_context": unavailable,
+    }) == {
+        "status": "unavailable", "version": 1,
+        "reason": "coverage_incomplete", "policy": "preceding-tools-v1",
+        "message_limit": 20,
+    }
+
+    bad_receipt = {**receipt, "binding": {
+        "mode": "transcript-scan", "message_ids": []}}
+    assert inspector._preceding_tool_context({
+        **item, "quote_provenance": bad_receipt,
+        "preceding_tool_context": valid,
+    }) == {"status": "unavailable", "reason": "invalid_metadata"}
+
+
+def test_human_why_rendering_mentions_observed_temporal_context():
+    result = {
+        "item": {"item_id": "o-abcdef", "kind": "decision",
+                  "text": "claim"},
+        "axes": {"capture": "verified", "bytes": "unknown",
+                  "current_support": "not-checked", "provenance": "bound",
+                  "locator": "absent-local", "verifier_comparison": "same-version",
+                  "lifecycle": "active"},
+        "ranking": {"effective_weight": 0.1, "rules": "recent_decision",
+                    "inputs": {"importance": 5, "importance_source": "default",
+                               "age_days": None, "trust": "verbatim",
+                               "trust_ceiling": 3.0},},
+        "corroboration": {"count": 0, "references": []},
+        "preceding_tool_context": {"status": "observed", "contexts": [{}]},
+    }
+    assert any("Preceding tool results: observed" in line
+               for line in inspector.human_lines(result))
+
+
+def test_human_why_rendering_mentions_unavailable_temporal_context():
+    result = {
+        "item": {"item_id": "o-abcdef", "kind": "decision", "text": "claim"},
+        "axes": {"capture": "verified", "bytes": "unknown",
+                  "current_support": "not-checked", "provenance": "bound",
+                  "locator": "absent-local", "verifier_comparison": "same-version",
+                  "lifecycle": "active"},
+        "ranking": {"effective_weight": 0.1, "rules": "recent_decision",
+                    "inputs": {"importance": 5, "importance_source": "default",
+                               "age_days": None, "trust": "verbatim",
+                               "trust_ceiling": 3.0},},
+        "corroboration": {"count": 0, "references": []},
+        "preceding_tool_context": {"status": "unavailable", "reason": "coverage_incomplete"},
+    }
+    assert any("Preceding tool results: unavailable" in line
+               for line in inspector.human_lines(result))
 
 
 def test_forgotten_team_only_item_is_not_resurrected(

--- a/plugin/tests/test_tool_context.py
+++ b/plugin/tests/test_tool_context.py
@@ -45,6 +45,44 @@ def test_detailed_loader_keeps_messages_and_records_claude_rows(tmp_path):
     assert detailed["coverage"]["rows"][0]["host_user_input"] is True
 
 
+def test_detailed_loader_marks_malformed_and_other_adapters_unavailable(tmp_path):
+    malformed = tmp_path / "bad.jsonl"
+    malformed.write_text('{"type":"user","uuid":"u1","message":{"role":"user","content":"x"}}\n{bad\n')
+    assert transcript.from_file_detailed(malformed)["coverage"]["reason"] == "coverage_incomplete"
+
+    codex = tmp_path / "codex.jsonl"
+    codex.write_text(json.dumps({"type": "event_msg", "payload": {}}) + "\n")
+    assert transcript.from_file_detailed(codex)["coverage"]["reason"] == "unsupported_adapter"
+
+    windsurf = tmp_path / "windsurf.jsonl"
+    windsurf.write_text(json.dumps({"type": "user_input", "status": "done"}) + "\n")
+    assert transcript.from_file_detailed(windsurf)["coverage"]["reason"] == "unsupported_adapter"
+
+    markdown = tmp_path / "notes.md"
+    markdown.write_text("**user**: hello\n")
+    assert transcript.from_file_detailed(markdown)["coverage"]["reason"] == "unsupported_adapter"
+
+
+def test_detailed_loader_ignores_meta_and_tool_call_only_rows(tmp_path):
+    path = tmp_path / "S1.jsonl"
+    rows = [
+        {"type": "user", "uuid": "meta", "isMeta": True,
+         "message": {"role": "user", "content": "synthetic"}},
+        {"type": "user", "uuid": "u1",
+         "message": {"role": "user", "content": "prompt"}},
+        {"type": "assistant", "uuid": "call", "message": {"role": "assistant",
+         "content": [{"type": "tool_use", "id": "call-1"}]}},
+        {"type": "assistant", "uuid": "a1", "message": {"role": "assistant",
+         "content": [{"type": "text", "text": "answer"}]}},
+    ]
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n")
+
+    detailed = transcript.from_file_detailed(path)
+
+    assert detailed["coverage"]["available"] is True
+    assert [row["id"] for row in detailed["coverage"]["rows"]] == ["u1", "a1"]
+
+
 def test_observed_context_is_bounded_and_ordered():
     messages = [
         {"role": "user", "id": "u1", "content": "prompt"},
@@ -120,3 +158,47 @@ def test_model_supplied_context_is_stripped_before_admission():
     serializer.strip_code_owned_keys(checkpoint)
 
     assert "preceding_tool_context" not in checkpoint["working_context"]["active_topic"]
+
+
+def test_invalid_sidecar_shapes_fail_closed():
+    item = _item()
+    messages = [{"role": "assistant", "id": "a-source", "content": "claim"}]
+    base = {"version": 1, "adapter": "claude-code", "available": True,
+            "rows": [{"id": "a-source", "role": "assistant",
+                      "tool_result": False, "host_user_input": False}]}
+    cases = [
+        ({**base, "rows": []}, "coverage_incomplete"),
+        ({**base, "rows": [{"id": "a-source", "tool_result": False,
+                            "host_user_input": False}]}, "source_not_assistant"),
+        ({**base, "rows": [{"id": "a-source", "role": "assistant",
+                            "tool_result": "no", "host_user_input": False}]},
+         "coverage_incomplete"),
+    ]
+    for coverage, reason in cases:
+        assert tool_context.derive(item, messages, coverage)["reason"] == reason
+
+
+def test_invalid_binding_and_unknown_reason_fail_closed():
+    messages = [{"role": "assistant", "id": "a-source", "content": "claim"}]
+    coverage = _coverage([{"id": "a-source", "role": "assistant",
+                           "tool_result": False, "host_user_input": False}])
+    malformed = {**_item(), "quote_provenance": {
+        "binding": {"mode": "message-ids", "message_ids": [""]}}}
+    assert tool_context.derive(malformed, messages, coverage)["reason"] == "source_binding_unavailable"
+    assert tool_context.unavailable("made-up")["reason"] == "coverage_unknown"
+
+
+def test_boundary_after_twenty_rows_takes_precedence():
+    messages = [{"role": "user", "id": "u2", "content": "previous"}]
+    messages += [{"role": "tool", "id": f"t-{i}", "content": "x",
+                  "tool_result": True} for i in range(20)]
+    messages += [{"role": "assistant", "id": "a-source", "content": "claim"}]
+    rows = [{"id": "u2", "role": "user", "tool_result": False,
+             "host_user_input": True}]
+    rows += [{"id": f"t-{i}", "role": "user", "tool_result": True,
+              "host_user_input": False} for i in range(20)]
+    rows += [{"id": "a-source", "role": "assistant", "tool_result": False,
+              "host_user_input": False}]
+    got = tool_context.derive(_item(), messages, _coverage(rows))
+    assert got["contexts"][0]["boundary"] == "host_user_input"
+    assert got["contexts"][0]["messages_examined"] == 20

--- a/plugin/tests/test_tool_context.py
+++ b/plugin/tests/test_tool_context.py
@@ -187,6 +187,20 @@ def test_invalid_binding_and_unknown_reason_fail_closed():
     assert tool_context.derive(malformed, messages, coverage)["reason"] == "source_binding_unavailable"
     assert tool_context.unavailable("made-up")["reason"] == "coverage_unknown"
 
+    inferred = {"text": "claim", "trust": "inferred"}
+    assert tool_context.derive(inferred, messages, coverage)["reason"] == "source_binding_unavailable"
+    scan_bound = {**_item(), "quote_provenance": {
+        "binding": {"mode": "transcript-scan", "message_ids": []}}}
+    assert tool_context.derive(scan_bound, messages, coverage)["reason"] == "source_binding_unavailable"
+
+
+def test_binding_to_missing_message_is_unavailable():
+    messages = [{"role": "assistant", "id": "a-source", "content": "claim"}]
+    coverage = _coverage([{"id": "a-source", "role": "assistant",
+                           "tool_result": False, "host_user_input": False}])
+    missing = _item("missing")
+    assert tool_context.derive(missing, messages, coverage)["reason"] == "source_unresolved"
+
 
 def test_boundary_after_twenty_rows_takes_precedence():
     messages = [{"role": "user", "id": "u2", "content": "previous"}]

--- a/plugin/tests/test_tool_context.py
+++ b/plugin/tests/test_tool_context.py
@@ -1,0 +1,122 @@
+import json
+
+from daimon_briefing import provenance, serializer, tool_context, transcript
+
+
+def _receipt(source_id="a-source"):
+    source = {
+        "version": provenance.SOURCE_REF_VERSION,
+        "host": "claude-code",
+        "session_id": "S1",
+        "locator": "managed",
+    }
+    return provenance.quote_receipt(
+        source, {"algorithm": "sha256", "scope": "raw-file", "value": "a" * 64},
+        outcome="verified", checked_at="2026-09-10T00:00:00Z",
+        binding_mode="message-ids", message_ids=(source_id,),
+    )
+
+
+def _coverage(rows):
+    return {"version": 1, "adapter": "claude-code", "available": True,
+            "rows": rows}
+
+
+def _item(source_id="a-source"):
+    return {"text": "claim", "trust": "verbatim", "quote": "claim",
+            "quote_provenance": _receipt(source_id)}
+
+
+def test_detailed_loader_keeps_messages_and_records_claude_rows(tmp_path):
+    path = tmp_path / "S1.jsonl"
+    rows = [
+        {"type": "user", "uuid": "u1", "message": {"role": "user", "content": "prompt"}},
+        {"type": "assistant", "uuid": "a1", "message": {"role": "assistant", "content": "answer"}},
+    ]
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n")
+
+    detailed = transcript.from_file_detailed(path)
+
+    assert detailed["messages"] == [
+        {"role": "user", "content": "prompt", "id": "u1"},
+        {"role": "assistant", "content": "answer", "id": "a1"},
+    ]
+    assert detailed["coverage"]["available"] is True
+    assert detailed["coverage"]["rows"][0]["host_user_input"] is True
+
+
+def test_observed_context_is_bounded_and_ordered():
+    messages = [
+        {"role": "user", "id": "u1", "content": "prompt"},
+        {"role": "tool", "id": "t1", "content": "error", "tool_result": True},
+        {"role": "assistant", "id": "a-source", "content": "claim"},
+    ]
+    coverage = _coverage([
+        {"id": "u1", "role": "user", "tool_result": False, "host_user_input": True},
+        {"id": "t1", "role": "user", "tool_result": True, "host_user_input": False},
+        {"id": "a-source", "role": "assistant", "tool_result": False, "host_user_input": False},
+    ])
+
+    got = tool_context.derive(_item(), messages, coverage)
+
+    assert got["status"] == "observed"
+    assert got["contexts"] == [{
+        "source_message_id": "a-source",
+        "preceding_tool_result_ids": ["t1"],
+        "boundary": "host_user_input",
+        "messages_examined": 1,
+    }]
+
+
+def test_unsupported_or_incomplete_capture_is_explicitly_unavailable():
+    item = _item()
+    assert tool_context.derive(item, [], None)["reason"] == "coverage_unknown"
+    coverage = {"version": 1, "adapter": "claude-code", "available": False,
+                "reason": "coverage_incomplete", "rows": []}
+    assert tool_context.derive(item, [], coverage)["reason"] == "coverage_incomplete"
+
+
+def test_signal_only_source_is_not_an_assistant_anchor():
+    item = _item("tool-id")
+    messages = [{"role": "tool", "id": "tool-id", "content": "output",
+                 "tool_result": True}]
+    coverage = _coverage([{"id": "tool-id", "role": "user", "tool_result": True,
+                           "host_user_input": False}])
+    assert tool_context.derive(item, messages, coverage)["reason"] == "source_not_assistant"
+
+
+def test_boundary_immediately_before_source_produces_observed_empty_window():
+    messages = [
+        {"role": "user", "id": "u1", "content": "prompt"},
+        {"role": "assistant", "id": "a-source", "content": "claim"},
+    ]
+    coverage = _coverage([
+        {"id": "u1", "role": "user", "tool_result": False, "host_user_input": True},
+        {"id": "a-source", "role": "assistant", "tool_result": False, "host_user_input": False},
+    ])
+
+    got = tool_context.derive(_item(), messages, coverage)
+
+    assert got["status"] == "observed"
+    assert got["contexts"][0]["preceding_tool_result_ids"] == []
+    assert got["contexts"][0]["messages_examined"] == 0
+
+
+def test_short_prefix_without_boundary_is_unavailable():
+    messages = [{"role": "assistant", "id": "a-source", "content": "claim"}]
+    coverage = _coverage([{"id": "a-source", "role": "assistant",
+                           "tool_result": False, "host_user_input": False}])
+
+    assert tool_context.derive(_item(), messages, coverage)["reason"] == "boundary_unknown"
+
+
+def test_model_supplied_context_is_stripped_before_admission():
+    checkpoint = {"working_context": {
+        "active_topic": {"text": "topic", "trust": "inferred",
+                          "preceding_tool_context": {"status": "observed"}},
+        "open_questions": [], "recent_decisions": [],
+    }, "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []}}
+
+    serializer.strip_code_owned_keys(checkpoint)
+
+    assert "preceding_tool_context" not in checkpoint["working_context"]["active_topic"]

--- a/plugin/tests/test_transcript.py
+++ b/plugin/tests/test_transcript.py
@@ -297,6 +297,50 @@ def test_from_file_claude_jsonl_binds_message_uuid_as_id(tmp_path):
     ]
 
 
+def test_detailed_loader_marks_mixed_and_mismatched_claude_rows_unavailable(tmp_path):
+    mixed = _write_jsonl(tmp_path / "mixed.jsonl", [{
+        "type": "user", "uuid": "u1", "message": {"role": "user", "content": [
+            {"type": "text", "text": "prompt"},
+            {"type": "tool_result", "content": "output"},
+        ]},
+    }])
+    assert transcript.from_file_detailed(mixed)["coverage"]["reason"] == "coverage_incomplete"
+
+    mismatched = _write_jsonl(tmp_path / "mismatched.jsonl", [{
+        "type": "user", "uuid": "u1", "message": {"role": "assistant", "content": "prompt"},
+    }])
+    assert transcript.from_file_detailed(mismatched)["coverage"]["reason"] == "coverage_incomplete"
+
+    irrelevant = _write_jsonl(tmp_path / "irrelevant.jsonl", [{"type": "system", "content": "noise"}])
+    assert transcript.from_file_detailed(irrelevant)["coverage"]["reason"] == "unsupported_adapter"
+
+
+def test_detailed_loader_rejects_unknown_role_and_invalid_uuid(tmp_path):
+    unknown_role = _write_jsonl(tmp_path / "unknown-role.jsonl", [
+        {"type": "system", "uuid": "s1",
+         "message": {"role": "system", "content": "noise"}},
+        {"type": "user", "uuid": "u1",
+         "message": {"role": "user", "content": "prompt"}},
+    ])
+    assert transcript.from_file_detailed(unknown_role)["coverage"]["available"] is True
+
+    invalid_uuid = _write_jsonl(tmp_path / "invalid-uuid.jsonl", [{
+        "type": "user", "uuid": " ",
+        "message": {"role": "user", "content": "prompt"},
+    }])
+    assert transcript.from_file_detailed(invalid_uuid)["coverage"]["reason"] == "coverage_incomplete"
+
+
+def test_detailed_loader_marks_kimi_wire_unavailable(tmp_path):
+    path = _write_jsonl(tmp_path / "wire.jsonl", [{
+        "type": "metadata", "protocol_version": 1,
+    }])
+    assert transcript.from_file_detailed(path)["coverage"] == {
+        "version": 1, "adapter": "kimi", "available": False,
+        "reason": "source_binding_unavailable", "rows": [],
+    }
+
+
 def test_from_file_rows_without_usable_uuid_get_no_id_key(tmp_path):
     # Hosts without a stable per-message id — and malformed uuid values — keep
     # today's exact {"role", "content"} shape: no id key, so downstream falls


### PR DESCRIPTION
## What

Adds code-derived preceding tool-result context to verified quote items. The metadata records up to 20 preceding message IDs per source, the host user-input boundary, the original source descriptor, and explicit availability status. It is shown only by the trust inspector.

## Why

When a transcript is no longer available, a quote can retain its source message ID but lose the recorded relationship to immediately preceding tool results. This preserves that temporal relationship without storing tool output or arguments and without implying that a model read or used a result.

## Tests

- `uv run --all-extras pytest -q tests/test_tool_context.py tests/test_inspector.py tests/test_hooks.py tests/test_capture_parity.py`
- `uv run --all-extras ruff check daimon_briefing tests ../scripts`
- `uv run --all-extras mypy daimon_briefing`
- `uv run --all-extras scar lint`

All focused tests pass. The full suite reached 6410 passing tests and 2 skips; two unrelated Rich color assertions remain environment dependent.

Closes #1010
