### PR TITLE
feat(recall): measure delivered match scores

### DIFF
--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -33,7 +33,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TypedDict
 
-from .. import amendments, anchor, briefing, buckets, capture, carry, config, configure, harvest, inspector, ledger, llm, normalize, privacy, provenance, recall, receipts, redact, refutations, relations, render, requests, schema, serializer, store, teamsync, transcript, worldcheck  # noqa: F401 — several are re-exported for compat only (#708): `cli.<name>` is a stable seam
+from .. import amendments, anchor, briefing, buckets, capture, carry, config, configure, harvest, inspector, ledger, llm, normalize, privacy, provenance, recall, recall_telemetry, receipts, redact, refutations, relations, render, requests, schema, serializer, store, teamsync, transcript, worldcheck  # noqa: F401 — several are re-exported for compat only (#708): `cli.<name>` is a stable seam
 from .. import __version__
 
 # The serialize.log ledger subsystem lives in ledger.py (#147 + #162, pure
@@ -992,6 +992,11 @@ def _cmd_recall(args) -> int:
     except recall.RecallError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
+    recall_telemetry.record(
+        results,
+        query_terms=recall.salient_terms(query),
+        surface="recall-search",
+    )
     if args.json:
         print(json.dumps(results, indent=2, ensure_ascii=False))
         return 0
@@ -1975,6 +1980,12 @@ def _cmd_recall_inject(args) -> int:
         for m in chosen:
             print(_suggest_line(m, terms, now,
                                 own_slug=store.project_slug(project)))
+        recall_telemetry.record(
+            chosen,
+            query_terms=terms,
+            surface="recall-inject",
+            now=datetime.fromtimestamp(now, tz=timezone.utc),
+        )
         if seen_file:
             # #500: count what each origin supplied instead of retiring it
             # outright, so a later, stronger row from the same session stays
@@ -3395,6 +3406,7 @@ def _cmd_stats(args) -> int:
             "verification": _stats_verification(project),
             "resolutions": _stats_resolutions(project, usage),
             "receipts": _stats_receipts(project, usage),
+            "recall": recall_telemetry.stats(),
             # #475 part 2: current-configuration posture, rendered next to
             # (never merged into) the historical fallback counts above.
             "rescue_posture": llm.rescue_posture(),

--- a/plugin/daimon_briefing/config.py
+++ b/plugin/daimon_briefing/config.py
@@ -526,6 +526,17 @@ def log_dir() -> Path:
     return Path.home() / ".daimon" / "logs"
 
 
+def recall_delivery_log() -> Path:
+    """The local structured ledger for items actually delivered by recall.
+
+    It is separate from ``usage.log`` because that file's stable contract is
+    one timestamp plus one counter name per line. Recall measurements need a
+    payload per delivered item and must not make the existing stats fold
+    ambiguous.
+    """
+    return log_dir() / "recall-delivery.jsonl"
+
+
 def project_dir() -> str | None:
     """Working directory of the session being briefed/serialized (per-project
     checkpoint routing). Hooks pass the host payload's cwd through this var;

--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -1029,7 +1029,8 @@ def _scope_clause(scopes: list[str], column: str = "i.project_slug") -> str:
 def search(query: str, project_dir=None, all_projects: bool = False,
            limit: int = 20, slug: str | None = None) -> list[dict]:
     """FTS5 MATCH over the (auto-refreshed) index. Live items first, then by
-    bm25 rank, newest checkpoint first within equal rank. Scope: project_dir's
+    descending ``match_score`` (the sign-normalized bm25 rank), newest
+    checkpoint first within equal score. Scope: project_dir's
     slug unless all_projects (or the project is unknown — no filter then,
     matching read_team's semantics). An explicit `slug` IS the scope (#243):
     it addresses a bucket by its stored identity — the slug is lossy, so this
@@ -1060,7 +1061,7 @@ def search(query: str, project_dir=None, all_projects: bool = False,
         " i.session_id, i.created, i.superseded_by, i.superseded_source,"
         " i.invalidated_by, i.cured_by,"
         " i.importance, i.first_seen, i.item_id, i.frontier,"
-        " bm25(items_fts) AS rank"
+        " -bm25(items_fts) AS match_score"
         " FROM items_fts JOIN items i ON i.id = items_fts.rowid"
         " WHERE items_fts MATCH ?"
     )
@@ -1080,7 +1081,7 @@ def search(query: str, project_dir=None, all_projects: bool = False,
     sql += (" ORDER BY (i.invalidated_by IS NOT NULL) ASC,"
             " CASE WHEN i.superseded_by IS NULL THEN 0"
             " WHEN i.superseded_source = 'resolution' THEN 2"
-            " ELSE 1 END ASC, rank ASC,"
+            " ELSE 1 END ASC, match_score DESC,"
             " i.frontier DESC, i.created DESC LIMIT ?")
 
     want_n = max(1, int(limit))
@@ -1410,7 +1411,7 @@ _INVALIDATED_WEIGHT = 0.4
 
 
 def _suggest_weight(row, item_type: str, now: float) -> float:
-    """One row's suggest() rank weight: #78 effective_weight, then the
+    """One row's suggest() weight: #78 effective_weight, then the
     interval-slot demotions. Extracted so the penalties are testable at the
     weight level rather than only through a rigged end-to-end fixture."""
     weight = scoring.effective_weight(
@@ -1507,13 +1508,13 @@ def suggest(prompt: str, project_dir=None, current_session=None,
         # pinned rides out for the #452 age gate (standing rules are
         # age-independent); it is NOT a rank input here.
         " i.pinned,"
-        " bm25(items_fts) AS rank"
+        " -bm25(items_fts) AS match_score"
         " FROM items_fts JOIN items i ON i.id = items_fts.rowid"
         # Best-ranked candidates first (#31 item 4): without ORDER BY the LIMIT
         # window is arbitrary — on a busy project (>N matching rows) the
         # strongest rows could be truncated away, silencing prior work.
         " WHERE items_fts MATCH ?" + _scope_clause(scopes) +
-        " ORDER BY rank ASC LIMIT 256"
+        " ORDER BY match_score DESC LIMIT 256"
     )
     try:
         conn = sqlite3.connect(str(config.recall_db()))
@@ -1557,7 +1558,7 @@ def suggest(prompt: str, project_dir=None, current_session=None,
         # a stronger match from stale items; nothing here ranks on it beyond
         # the existing len(hit) tiebreak below.
         r["term_hits"] = len(hit)
-        relevance = max(0.0, -float(r["rank"]))  # FTS5 bm25(): smaller = better
+        relevance = max(0.0, float(r["match_score"]))
         weight = _suggest_weight(
             r, _KIND_TO_TYPE.get(r["kind"], "recent_decision"), now)
         scored.append((relevance * weight, len(hit), r))

--- a/plugin/daimon_briefing/recall_telemetry.py
+++ b/plugin/daimon_briefing/recall_telemetry.py
@@ -1,0 +1,124 @@
+"""Local telemetry for recall items that were actually delivered.
+
+The recall index is disposable and its scores change when the corpus changes.
+This append-only ledger records the score at the moment a row crossed a
+delivery surface, so later measurement does not re-run history against today's
+index. It contains no item text or query text, only the number of retrieval
+terms used for that delivery.
+"""
+
+import json
+import statistics
+from datetime import datetime, timedelta, timezone
+
+from . import config
+
+WINDOW_DAYS = 7
+
+
+def _stamp(now=None) -> str:
+    value = now or datetime.now(timezone.utc)
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def record(rows, *, query_terms, surface, now=None) -> None:
+    """Append one bounded record for every row actually delivered.
+
+    Telemetry is best-effort. A read or prompt path must never fail because a
+    local measurement file is unavailable or malformed.
+    """
+    entries = []
+    stamp = _stamp(now)
+    term_count = sum(1 for term in query_terms if str(term).strip())
+    for row in rows:
+        score = row.get("match_score")
+        try:
+            score = float(score)
+        except (TypeError, ValueError):
+            score = None
+        hits = row.get("term_hits")
+        if not isinstance(hits, int) or isinstance(hits, bool):
+            hits = None
+        entries.append(json.dumps({
+            "at": stamp,
+            "surface": str(surface),
+            "item_id": row.get("item_id"),
+            "session_id": row.get("session_id"),
+            "project_slug": row.get("project_slug"),
+            "match_score": score,
+            "term_hits": hits,
+            "query_term_count": term_count,
+        }, ensure_ascii=False, separators=(",", ":")))
+    if not entries:
+        return
+    try:
+        path = config.recall_delivery_log()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as stream:
+            stream.write("\n".join(entries) + "\n")
+    except OSError:
+        pass
+
+
+def _parse_stamp(value):
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc)
+    except (TypeError, ValueError):
+        return None
+
+
+def _summary(rows: list[dict]) -> dict:
+    scores = [r["match_score"] for r in rows
+              if isinstance(r.get("match_score"), (int, float))]
+    hits = [r["term_hits"] for r in rows
+            if isinstance(r.get("term_hits"), int)
+            and not isinstance(r.get("term_hits"), bool)]
+    surfaces = sorted({r.get("surface") for r in rows if r.get("surface")})
+    return {
+        "deliveries": len(rows),
+        "scored": len(scores),
+        "match_score": {
+            "min": min(scores) if scores else None,
+            "median": statistics.median(scores) if scores else None,
+            "max": max(scores) if scores else None,
+        },
+        "term_hits": {
+            "min": min(hits) if hits else None,
+            "median": statistics.median(hits) if hits else None,
+            "max": max(hits) if hits else None,
+        },
+        "by_surface": {
+            surface: sum(1 for r in rows if r.get("surface") == surface)
+            for surface in surfaces
+        },
+    }
+
+
+def stats(*, now=None) -> dict:
+    """Read lifetime and recent delivery distributions without rebuilding recall."""
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=WINDOW_DAYS)
+    lifetime, recent = [], []
+    try:
+        lines = config.recall_delivery_log().read_text(encoding="utf-8").splitlines()
+    except OSError:
+        lines = []
+    for line in lines:
+        try:
+            row = json.loads(line)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if not isinstance(row, dict):
+            continue
+        lifetime.append(row)
+        stamp = _parse_stamp(row.get("at"))
+        if stamp is not None and stamp >= cutoff:
+            recent.append(row)
+    return {
+        "window_days": WINDOW_DAYS,
+        "lifetime": _summary(lifetime),
+        "window": _summary(recent),
+    }

--- a/plugin/daimon_briefing/recall_telemetry.py
+++ b/plugin/daimon_briefing/recall_telemetry.py
@@ -76,7 +76,12 @@ def _summary(rows: list[dict]) -> dict:
     hits = [r["term_hits"] for r in rows
             if isinstance(r.get("term_hits"), int)
             and not isinstance(r.get("term_hits"), bool)]
-    surfaces = sorted({r.get("surface") for r in rows if r.get("surface")})
+    surface_names: set[str] = set()
+    for row in rows:
+        surface = row.get("surface")
+        if isinstance(surface, str) and surface:
+            surface_names.add(surface)
+    surfaces = sorted(surface_names)
     return {
         "deliveries": len(rows),
         "scored": len(scores),

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -1791,6 +1791,17 @@ def _plain_stats(data: dict) -> None:
     if c["success"]:
         print(f"  serialize seconds: max {c['max_serialize_seconds']}, "
               f"avg {c['total_serialize_seconds'] // c['success']}")
+    recall_data = data.get("recall")
+    if recall_data:
+        window = recall_data["window"]
+        score = window["match_score"]
+        print(f"recall delivery (last {recall_data['window_days']}d):")
+        print(f"  items: {window['deliveries']}  scored: {window['scored']}  "
+              f"match score min {score['min']}  median {score['median']}  "
+              f"max {score['max']}")
+        print("  surfaces: " + (", ".join(
+            f"{k} {v}" for k, v in window["by_surface"].items())
+            or "none"))
     speaker_line = _speaker_lines_line(c)
     if speaker_line:
         print(f"  {speaker_line}")
@@ -1935,6 +1946,27 @@ def _rich_stats(data: dict) -> None:
         label, _, values = speaker_line.partition(": ")
         capture_table.add_row(label, values)
     console.print(capture_table)
+    recall_data = data.get("recall")
+    if recall_data:
+        window = recall_data["window"]
+        score = window["match_score"]
+        recall_table = Table(
+            title=f"recall delivery (last {recall_data['window_days']}d)",
+            title_justify="left", show_header=True, header_style="bold")
+        recall_table.add_column("metric")
+        recall_table.add_column("value")
+        recall_table.add_row("items delivered", str(window["deliveries"]))
+        recall_table.add_row("items scored", str(window["scored"]))
+        recall_table.add_row(
+            "match score",
+            f"min {score['min']}  median {score['median']}  max {score['max']}",
+        )
+        recall_table.add_row(
+            "surfaces",
+            ", ".join(f"{k} {v}" for k, v in window["by_surface"].items())
+            or "none",
+        )
+        console.print(recall_table)
     # The #364/#742 gate warnings when tripped, and #944's margin line when
     # not. Only a warning is coloured: a margin printed in yellow reads as a
     # problem, which is the opposite of what it says.

--- a/plugin/daimon_briefing/surfaces.py
+++ b/plugin/daimon_briefing/surfaces.py
@@ -319,6 +319,11 @@ SURFACES: tuple[Surface, ...] = (
     #    left rather than calling its counts lifetime. --
     Surface("logs/checks.jsonl", "checks_runtime.log_firing",
             False, "exempt-no-plaintext", "none"),
+    # Recall delivery telemetry carries ids, scores, counts and a fixed
+    # surface label only. Query text is deliberately not persisted, so this
+    # is an auditable machine-local measurement surface without item prose.
+    Surface("logs/recall-delivery.jsonl", "recall_telemetry.record",
+            False, "exempt-no-plaintext", "none"),
     # #616 restored the glob's claim instead of widening it: serializer's
     # downgrade lines — the one writer that put item text under this shape —
     # now log a content hash (normalize.content_key, the same key a forget

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -4548,6 +4548,34 @@ def test_recall_inject_surfaces_prior_work(tmp_checkpoint_dir, capsys, monkeypat
     assert "daimon recall" in out  # points at the deep-dive command
 
 
+def test_recall_inject_records_delivery_score(
+        tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    _seed_recall_history()
+    rc, out = _inject(monkeypatch, capsys,
+                      "debugging the litellm gateway cache pinning again")
+    assert rc == 0 and out
+    rows = [json.loads(line) for line in
+            (tmp_log_dir / "recall-delivery.jsonl").read_text().splitlines()]
+    assert rows and rows[0]["surface"] == "recall-inject"
+    assert rows[0]["match_score"] >= 0
+    assert rows[0]["term_hits"] == 3
+
+
+def test_stats_reports_recall_delivery_distribution(
+        tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    _seed_recall_history()
+    rc, out = _inject(monkeypatch, capsys,
+                      "debugging the litellm gateway cache pinning again")
+    assert rc == 0 and out
+    capsys.readouterr()
+    assert cli.main(["stats", "--json"]) == 0
+    data = json.loads(capsys.readouterr().out)
+    window = data["recall"]["window"]
+    assert window["deliveries"] == 1
+    assert window["scored"] == 1
+    assert window["by_surface"] == {"recall-inject": 1}
+
+
 def test_recall_inject_excludes_latest_briefed_session(tmp_checkpoint_dir, capsys, monkeypatch):
     _seed_recall_history()
     # Prompt matching only the LATEST checkpoint's content: briefing covered it.

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -498,6 +498,18 @@ def test_empty_query_returns_empty(tmp_checkpoint_dir):
     assert recall.search("", all_projects=True) == []
 
 
+def test_search_names_and_normalizes_match_score(tmp_checkpoint_dir, monkeypatch):
+    monkeypatch.setenv("DAIMON_AUTHOR", "ada")
+    store.write_checkpoint("S1", _cp("S1", decisions=[
+        {"text": "osprey harrier combined rework", "trust": "inferred"}]),
+        project_dir="/repo/x")
+    hits = recall.search("osprey harrier", all_projects=True)
+    assert hits
+    assert "rank" not in hits[0]
+    assert isinstance(hits[0]["match_score"], (int, float))
+    assert hits[0]["match_score"] >= 0
+
+
 # ---- #25: AND-then-OR fallback — a richer cue must never zero out recall ----
 
 
@@ -783,6 +795,8 @@ def test_suggest_surfaces_prior_work(tmp_checkpoint_dir, monkeypatch):
                          project_dir="/repo/x", current_session="S-now")
     assert out and out[0]["session_id"] == "S-old"
     assert "cache" in out[0]["text"]
+    assert isinstance(out[0]["match_score"], (int, float))
+    assert out[0]["match_score"] >= 0
 
 
 def test_suggest_excludes_current_session(tmp_checkpoint_dir, monkeypatch):

--- a/plugin/tests/test_recall_telemetry.py
+++ b/plugin/tests/test_recall_telemetry.py
@@ -22,6 +22,42 @@ def test_record_writes_one_structured_row_per_delivery(tmp_path, monkeypatch):
     assert payload["query_term_count"] == 2
 
 
+def test_record_normalizes_invalid_values_and_accepts_naive_time(
+        tmp_path, monkeypatch):
+    log = tmp_path / "logs"
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(log))
+    recall_telemetry.record(
+        [{"item_id": "o-invalid", "match_score": "not-a-score",
+          "term_hits": True}],
+        query_terms=["  ", "gateway"],
+        surface="recall-search",
+        now=datetime(2026, 9, 11),
+    )
+    payload = json.loads((log / "recall-delivery.jsonl").read_text())
+    assert payload["at"] == "2026-09-11T00:00:00Z"
+    assert payload["match_score"] is None
+    assert payload["term_hits"] is None
+    assert payload["query_term_count"] == 1
+
+
+def test_record_skips_empty_delivery_and_ignores_write_errors(
+        tmp_path, monkeypatch):
+    recall_telemetry.record([], query_terms=[], surface="recall-search")
+
+    blocked_parent = tmp_path / "blocked"
+    blocked_parent.write_text("not a directory", encoding="utf-8")
+    monkeypatch.setattr(
+        recall_telemetry.config,
+        "recall_delivery_log",
+        lambda: blocked_parent / "recall-delivery.jsonl",
+    )
+    recall_telemetry.record(
+        [{"item_id": "o-write-error"}],
+        query_terms=[],
+        surface="recall-search",
+    )
+
+
 def test_stats_ignores_malformed_rows_and_splits_recent_window(tmp_path, monkeypatch):
     log = tmp_path / "logs"
     monkeypatch.setenv("DAIMON_LOG_DIR", str(log))
@@ -31,6 +67,7 @@ def test_stats_ignores_malformed_rows_and_splits_recent_window(tmp_path, monkeyp
     fresh = now.strftime("%Y-%m-%dT%H:%M:%SZ")
     (log / "recall-delivery.jsonl").write_text(
         "not json\n"
+        "[]\n"
         + json.dumps({"at": old, "surface": "recall-inject",
                       "match_score": 0.1, "term_hits": 2}) + "\n"
         + json.dumps({"at": fresh, "surface": "recall-search",
@@ -42,3 +79,21 @@ def test_stats_ignores_malformed_rows_and_splits_recent_window(tmp_path, monkeyp
     assert out["window"]["deliveries"] == 1
     assert out["window"]["by_surface"] == {"recall-search": 1}
     assert out["window"]["match_score"]["median"] == 0.8
+
+
+def test_stats_handles_invalid_timestamp_and_missing_log(tmp_path, monkeypatch):
+    log = tmp_path / "logs"
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(log))
+    log.mkdir()
+    (log / "recall-delivery.jsonl").write_text(
+        json.dumps({"at": "not-a-timestamp", "surface": "recall-search"})
+        + "\n",
+        encoding="utf-8",
+    )
+    out = recall_telemetry.stats(now=datetime(2026, 9, 11, tzinfo=timezone.utc))
+    assert out["lifetime"]["deliveries"] == 1
+    assert out["window"]["deliveries"] == 0
+
+    (log / "recall-delivery.jsonl").unlink()
+    out = recall_telemetry.stats()
+    assert out["lifetime"]["deliveries"] == 0

--- a/plugin/tests/test_recall_telemetry.py
+++ b/plugin/tests/test_recall_telemetry.py
@@ -1,0 +1,44 @@
+import json
+from datetime import datetime, timedelta, timezone
+
+from daimon_briefing import recall_telemetry
+
+
+def test_record_writes_one_structured_row_per_delivery(tmp_path, monkeypatch):
+    log = tmp_path / "logs"
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(log))
+    rows = [{"item_id": "o-abc123", "session_id": "S-1",
+             "project_slug": "-repo", "match_score": 0.42,
+             "term_hits": 3}]
+    recall_telemetry.record(
+        rows, query_terms=["gateway", "api_key=secretvalue"],
+        surface="recall-inject",
+        now=datetime(2026, 9, 11, tzinfo=timezone.utc),
+    )
+    payload = json.loads((log / "recall-delivery.jsonl").read_text())
+    assert payload["item_id"] == "o-abc123"
+    assert payload["match_score"] == 0.42
+    assert payload["term_hits"] == 3
+    assert payload["query_term_count"] == 2
+
+
+def test_stats_ignores_malformed_rows_and_splits_recent_window(tmp_path, monkeypatch):
+    log = tmp_path / "logs"
+    monkeypatch.setenv("DAIMON_LOG_DIR", str(log))
+    log.mkdir()
+    now = datetime(2026, 9, 11, tzinfo=timezone.utc)
+    old = (now - timedelta(days=8)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    fresh = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    (log / "recall-delivery.jsonl").write_text(
+        "not json\n"
+        + json.dumps({"at": old, "surface": "recall-inject",
+                      "match_score": 0.1, "term_hits": 2}) + "\n"
+        + json.dumps({"at": fresh, "surface": "recall-search",
+                      "match_score": 0.8, "term_hits": None}) + "\n",
+        encoding="utf-8",
+    )
+    out = recall_telemetry.stats(now=now)
+    assert out["lifetime"]["deliveries"] == 2
+    assert out["window"]["deliveries"] == 1
+    assert out["window"]["by_surface"] == {"recall-search": 1}
+    assert out["window"]["match_score"]["median"] == 0.8


### PR DESCRIPTION
Refs #989

## What

- Rename the raw FTS rank in recall results to `match_score` and normalize its direction so higher means a stronger match.
- Keep `term_hits` on proactive recall suggestions.
- Record delivered recall rows in a local structured ledger with item identity, score, term-hit count, surface, and query-term count.
- Report lifetime and seven-day recall delivery distributions through `daimon stats` and `--json`.
- Keep query text out of persistent telemetry.

## Why

The retrieval index changes over time, so re-running a query cannot reconstruct the score that caused an item to be delivered. This stage records the measurement at delivery time without choosing a weak-match threshold before data exists.

The structured ledger stays separate from `usage.log`, whose contract is one timestamp and one counter name per line.

## Tests

- `plugin/.venv/bin/pytest plugin/tests/test_recall.py plugin/tests/test_recall_telemetry.py plugin/tests/test_cli.py -q -k 'recall_inject or recall_telemetry or score or search_names'`
- `plugin/.venv/bin/pytest plugin/tests/test_render.py -q -k stats`
- `plugin/.venv/bin/ruff check ...`
- Commit hooks: Ruff and hook mirror drift checks passed.
