### PR TITLE
fix(cli): require human terminal for lifecycle verdicts

### DIFF
--- a/plugin/daimon_briefing/cli/lifecycle.py
+++ b/plugin/daimon_briefing/cli/lifecycle.py
@@ -28,6 +28,22 @@ from .. import (
 from ._ledger import _check_sync_warning
 
 
+def _human_cli_channel(verb: str, *, agent_path: bool = False) -> str | None:
+    """Return the observed human channel, or refuse an unattended write."""
+    if not sys.stdin.isatty():
+        _cli._note_usage(f"{verb}:noninteractive")
+        recovery = (
+            "pass --by agent --evidence \"<verbatim transcript quote>\""
+            if agent_path else "run it from a terminal"
+        )
+        print(
+            f"{verb} is a human verdict and requires an interactive terminal; "
+            f"{recovery}"
+        )
+        return None
+    return "cli-tty"
+
+
 def _cmd_resolve(args) -> int:
     """Append a resolution event for ONE checkpoint item (#102). Exact id
     first; else a fuzzy query that must match uniquely — an ambiguous bind
@@ -72,6 +88,13 @@ def _cmd_resolve(args) -> int:
         print("--by agent requires --evidence \"<verbatim transcript quote>\" "
               "— refused, nothing written")
         return 1
+    if by_agent:
+        event_source = "agent"
+    else:
+        human_channel = _human_cli_channel("resolve", agent_path=True)
+        if human_channel is None:
+            return 1
+        event_source = human_channel
     project = _cli._resolve_project(args.project)
     checkpoint = store.read_latest_body(project_dir=project, route=store.Route.OWN,
                                         admit=store.Admit.ANY)
@@ -105,8 +128,8 @@ def _cmd_resolve(args) -> int:
             print("resolve by exact id: daimon resolve <id>")
             return 1
     # #480 slice 2: the agent path writes a candidate status, credited to
-    # source="agent" — NOT args.status/"cli", which stay exactly what the
-    # human path has always written (byte-identical human behavior).
+    # source="agent" — NOT args.status/"cli". Human writes carry the observed
+    # "cli-tty" source; legacy "cli" rows remain human when folded.
     effective_status = "resolving-candidate" if by_agent else args.status
     if getattr(args, "dry_run", False):
         # A distinct tag, not "resolve": nothing was written, so folding this
@@ -121,7 +144,7 @@ def _cmd_resolve(args) -> int:
     ok = store.append_event(
         target["id"], effective_status,
         note=(evidence if by_agent else (args.note or "")),
-        source=("agent" if by_agent else "cli"),
+        source=event_source,
         project_dir=project, item_text=str(target.get("text") or ""))
     if not ok:
         print("event not written (daimon disabled or project unknown)")
@@ -728,6 +751,9 @@ def _cmd_reverify(args) -> int:
     (a machine guess that has never withheld anything), reopen is allowed
     with no evidence — rejecting a suggestion is not vouching for a claim.
     The reopened event is a human verdict, so re-detection stays silent."""
+    human_channel = _human_cli_channel("reverify")
+    if human_channel is None:
+        return 1
     project = _cli._resolve_project(args.project)
     checkpoint = store.read_latest_body(project_dir=project, route=store.Route.OWN,
                                         admit=store.Admit.ANY)
@@ -764,6 +790,7 @@ def _cmd_reverify(args) -> int:
               "verified — supply --evidence, or fix the anchored code and retry")
         return 1
     ok = store.append_event(item["id"], "reopened", note=note,
+                            source=human_channel,
                             item_text=item.get("text", ""), project_dir=project)
     if not ok:
         print("event not written (daimon disabled or project unknown)")
@@ -1053,8 +1080,8 @@ def register(sub, fmt) -> None:
     p_forget.set_defaults(func=_cli._cmd_forget)
 
     p_reverify = sub.add_parser(
-        "reverify", help="evidence-gated reopen of a resolved item (#103) — "
-        "refuses without proof, so a claim can't get re-verified for free",
+        "reverify", help="evidence-gated human reopen of a resolved item (#103) — "
+        "requires an interactive terminal and refuses without proof",
         epilog="Examples:\n"
                "  daimon reverify o-3f8a2c --evidence \"checked release page\"\n"
                "  daimon reverify o-3f8a2c   # reopens only if the anchor still checks live\n"

--- a/plugin/daimon_briefing/store.py
+++ b/plugin/daimon_briefing/store.py
@@ -2227,8 +2227,10 @@ def forget_hit_stats(project_dir=None) -> dict:
 # "a person decided this" instead of each hardcoding a literal — the same
 # single-declaration shape surfaces.py uses for delete strategies.
 #
-# `ui` is a peer of `cli`, not a replacement: the ledger is append-only and
-# every row already written says `cli`, so the set widens and never renames.
+# `ui` and `cli-tty` are peers of `cli`, not replacements: the ledger is
+# append-only and every row already written says `cli`, so the set widens and
+# never renames. `cli-tty` is the observed interactive CLI channel; `cli` is
+# retained as the legacy human source.
 # It matches refutations.CHANNEL_AUTHORITY["ui"] == "human", which is the
 # same claim in the refutation ledger's own vocabulary. The two vocabularies
 # stay separate on purpose — that ledger's channels distinguish `cli-tty`
@@ -2237,7 +2239,7 @@ def forget_hit_stats(project_dir=None) -> dict:
 # Widening this set widens WHO counts, never WHAT counts: callers must still
 # filter on `kind` themselves (scar 0025 — kind never isolates a fold on its
 # own), or forget's tombstones and log's freeform rows ride in as decisions.
-HUMAN_EVENT_SOURCES = frozenset({"cli", "ui"})
+HUMAN_EVENT_SOURCES = frozenset({"cli", "cli-tty", "ui"})
 
 
 def append_event(item_ref: str, status: str, note: str = "",

--- a/plugin/tests/test_agent_resolution_verification.py
+++ b/plugin/tests/test_agent_resolution_verification.py
@@ -20,8 +20,15 @@ Three properties matter most here, each pinned by its own test:
 
 import json
 
+import pytest
+
 from daimon_briefing import capture, cli, store
 from tests.conftest import make_messages
+
+
+@pytest.fixture(autouse=True)
+def _interactive_human_cli(monkeypatch):
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True, raising=False)
 
 
 def _new_session_json(session_id="S-new", quote=""):

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -15,6 +15,16 @@ from daimon_briefing import cli
 from tests.conftest import FIXTURES
 
 
+@pytest.fixture(autouse=True)
+def _interactive_human_cli(monkeypatch):
+    """CLI lifecycle tests model a person at a terminal by default.
+
+    Tests for unattended behavior override this explicitly, matching the
+    observed-channel contract in the command implementation.
+    """
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True, raising=False)
+
+
 def _valid_json(session_id="sample_transcript"):
     return json.dumps(
         {
@@ -9039,10 +9049,9 @@ def test_resolve_by_agent_candidate_never_withholds_human_resolve_still_does(
     assert human_item["text"] not in out  # human resolve: withheld as always
 
 
-def test_resolve_human_path_unchanged_source_status_and_message(
+def test_resolve_human_path_records_observed_tty_source_and_status(
         tmp_checkpoint_dir, capsys, monkeypatch):
-    # Regression: the human path must remain byte-identical after the #480
-    # slice 2 agent branch is added.
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
     from daimon_briefing import store
     monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
     cp = _write_cp_with_ids(store)
@@ -9053,9 +9062,25 @@ def test_resolve_human_path_unchanged_source_status_and_message(
     text = cp["working_context"]["open_questions"][0]["text"]
     assert out == f"resolved {iid}: {text} [resolved]\n"
     evt = store.resolutions(project_dir="/p/A")[iid]
-    assert evt["source"] == "cli"
+    assert evt["source"] == "cli-tty"
     assert evt["status"] == "resolved"
     assert store.is_resolved(evt)
+
+
+def test_resolve_human_path_refuses_without_interactive_terminal(
+        tmp_checkpoint_dir, tmp_log_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False)
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    assert cli.main(["resolve", iid]) == 1
+    out = capsys.readouterr().out
+    assert "interactive terminal" in out
+    assert "--by agent --evidence" in out
+    assert store.resolutions(project_dir="/p/A") == {}
+    assert "resolve:noninteractive" in tmp_log_dir.joinpath(
+        "usage.log").read_text()
 
 
 def test_resolve_evidence_without_by_agent_is_rejected(
@@ -9243,6 +9268,28 @@ def test_reverify_not_found_exits_1(tmp_checkpoint_dir, capsys, monkeypatch):
     _write_cp_with_ids(store)
     assert cli.main(["reverify", "no-such-id"]) == 1
     assert store.resolutions(project_dir="/p/A") == {}
+
+
+def test_reverify_refuses_without_interactive_terminal(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False)
+    _write_cp_with_ids(store)
+    assert cli.main(["reverify", "no-such-id"]) == 1
+    assert "interactive terminal" in capsys.readouterr().out
+
+
+def test_reverify_human_path_records_observed_tty_source(
+        tmp_checkpoint_dir, capsys, monkeypatch):
+    from daimon_briefing import store
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", "/p/A")
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    cp = _write_cp_with_ids(store)
+    iid = cp["working_context"]["open_questions"][0]["id"]
+    store.append_event(iid, "resolved", project_dir="/p/A")
+    assert cli.main(["reverify", iid, "--evidence", "checked release page"]) == 0
+    assert store.resolutions(project_dir="/p/A")[iid]["source"] == "cli-tty"
 
 
 def test_reverify_refuses_without_evidence_when_no_anchor(tmp_checkpoint_dir, capsys, monkeypatch):

--- a/plugin/tests/test_write_audit_guard.py
+++ b/plugin/tests/test_write_audit_guard.py
@@ -1046,6 +1046,7 @@ def test_guard_trips_when_admit_row_is_stubbed_out(
     # The mutation: ledger rows stop passing through the admission seam.
     monkeypatch.setattr(policy, "admit_row",
                         lambda row, redact_fields=(), redact_fn=None: row)
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True, raising=False)
     write_audit.command = "resolve"
     assert cli.main(["resolve", item_id, "--note", "done"]) == 0
 


### PR DESCRIPTION
Closes #987

## Summary

- Require an interactive terminal for unlabeled resolve and reverify writes.
- Preserve resolve --by agent --evidence as the explicit agent path.
- Record interactive CLI verdicts as source=cli-tty.
- Continue treating legacy source=cli events as human decisions.
- Record refused noninteractive attempts in usage telemetry.

## Verification

- 679 passed in tests/test_cli.py
- 199 passed in tests/test_store.py
- 17 passed in verification and write-audit tests
- mypy passed for the changed production modules
- Ruff passed

The full repository run reached 6318 passed, but sandbox restrictions prevented tests that invoke ps and bind local sockets from completing.
