### PR TITLE
test: assert failure mocks are invoked

### DIFF
--- a/plugin/tests/test_cli_brief_owed.py
+++ b/plugin/tests/test_cli_brief_owed.py
@@ -92,10 +92,14 @@ def test_owed_panel_lines_are_empty_without_a_project(tmp_checkpoint_dir):
 
 def test_owed_panel_lines_fail_open(tmp_checkpoint_dir, monkeypatch):
     """ANY composer error costs the panel, never the briefing."""
+    calls = []
+
     def _boom(*a, **k):
+        calls.append(1)
         raise RuntimeError("ledger unreadable")
     monkeypatch.setattr(requests, "owed_renderable", _boom)
     assert briefing.owed_panel_lines("/p/cbo-boom") == []
+    assert calls, "the failure simulation never fired"
 
 
 def test_owed_panel_names_the_verb_that_closes_it(

--- a/plugin/tests/test_corroboration.py
+++ b/plugin/tests/test_corroboration.py
@@ -446,13 +446,16 @@ def test_emits_nothing_when_the_corroboration_fold_cannot_be_read(
     # read: unable to prove this is not a duplicate -> write nothing. A missed
     # boost costs a count; a double-counted witness costs the axis.
     item_id = _seed_origin()
+    calls = []
 
     def _boom(*args, **kwargs):
+        calls.append(1)
         raise RuntimeError("ledger unreadable")
 
     monkeypatch.setattr(store, "corroborations", _boom)
     assert _emit([(item_id, ORIGIN, "ada")]) == 0
     assert _rows(tmp_checkpoint_dir) == []
+    assert calls, "the failure simulation never fired"
 
 
 # ---------------------------------------------------------------------------

--- a/plugin/tests/test_request_briefing.py
+++ b/plugin/tests/test_request_briefing.py
@@ -194,12 +194,16 @@ def test_panel_fails_open_on_a_broken_composer(tmp_checkpoint_dir, monkeypatch):
     `inbox_renderable` (that one still backs `request inbox` and the CLI's
     own `surfaced`-stamping loop) — the failure fence has to target the
     function this panel actually calls, or it stops proving anything."""
+    calls = []
+
     def boom(project_dir=None):
+        calls.append(1)
         raise RuntimeError("boom")
     monkeypatch.setattr(requests, "decision_renderable", boom)
     sender = _seed_sender()
     _ask(sender)
     assert briefing.request_panel_lines(RECIPIENT) == []
+    assert calls, "the failure simulation never fired"
 
 
 def test_panel_survives_budget_pressure(tmp_checkpoint_dir, sample_checkpoint,

--- a/plugin/tests/test_ruling_briefing.py
+++ b/plugin/tests/test_ruling_briefing.py
@@ -98,19 +98,24 @@ def test_renderer_backstops_count_and_text(tmp_checkpoint_dir, monkeypatch):
 def test_ruling_lines_fail_open_on_cap_read_error(tmp_checkpoint_dir,
                                                   monkeypatch):
     _rule("cap failure hides me safely")
+    calls = []
 
     def boom():
+        calls.append(1)
         raise ValueError("corrupt env")
 
     monkeypatch.setattr(briefing.config, "ruling_cap", boom)
     assert briefing.ruling_lines(PROJECT) == []
+    assert calls, "the failure simulation never fired"
 
 
 def test_ruling_loader_fails_open(tmp_checkpoint_dir, sample_checkpoint,
                                   monkeypatch):
     _rule("this ruling will not load")
+    calls = []
 
     def boom(*args, **kwargs):
+        calls.append(1)
         raise OSError("ledger unreadable")
 
     # #962: active_rulings now reads through briefing.rulings_read, which
@@ -120,6 +125,7 @@ def test_ruling_loader_fails_open(tmp_checkpoint_dir, sample_checkpoint,
     out = briefing.render(sample_checkpoint, project_dir=PROJECT)
     assert out  # the briefing still renders
     assert "Standing rulings" not in out
+    assert calls, "the failure simulation never fired"
 
 
 def test_ruling_loader_fails_open_on_an_unreadable_ledger(
@@ -141,14 +147,17 @@ def test_ruling_loader_fails_open_when_path_resolution_itself_raises(
     `UnicodeDecodeError`, not an `OSError`). That seam must fail open too,
     not just the read/fold path below it."""
     _rule("this ruling will not load for a third reason")
+    calls = []
 
     def boom(*args, **kwargs):
+        calls.append(1)
         raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "bad byte")
 
     monkeypatch.setattr(briefing.refutations, "_path", boom)
     out = briefing.render(sample_checkpoint, project_dir=PROJECT)
     assert out  # the briefing still renders, never a raised exception
     assert "Standing rulings" not in out
+    assert calls, "the failure simulation never fired"
 
 
 def test_no_rulings_render_is_byte_identical_to_legacy(tmp_checkpoint_dir,

--- a/plugin/tests/test_ruling_echo.py
+++ b/plugin/tests/test_ruling_echo.py
@@ -211,8 +211,10 @@ def test_status_surfaces_echo_drops_when_nonzero(tmp_checkpoint_dir,
 def test_filter_fails_open_on_ledger_read_error(tmp_checkpoint_dir,
                                                 monkeypatch):
     _active_ruling()
+    calls = []
 
     def boom(**kwargs):
+        calls.append(1)
         raise OSError("ledger unreadable")
 
     monkeypatch.setattr(refutations, "listing", boom)
@@ -220,6 +222,7 @@ def test_filter_fails_open_on_ledger_read_error(tmp_checkpoint_dir,
                                  project_dir=PROJECT, admit=True)
     assert out is not None
     assert VERDICT in _beliefs(out)  # fail-open: the write goes through whole
+    assert calls, "the failure simulation never fired"
 
 
 def test_capture_path_admits(tmp_checkpoint_dir, monkeypatch):

--- a/plugin/tests/test_verdict_briefing.py
+++ b/plugin/tests/test_verdict_briefing.py
@@ -97,12 +97,16 @@ def test_panel_empty_with_nothing_decided(tmp_checkpoint_dir):
 
 
 def test_panel_fails_open_on_a_broken_composer(tmp_checkpoint_dir, monkeypatch):
+    calls = []
+
     def boom(project_dir=None):
+        calls.append(1)
         raise RuntimeError("boom")
     monkeypatch.setattr(requests, "verdict_renderable", boom)
     q_id = _ask()
     requests.accept(q_id, channel="cli-tty", project_dir=RECIPIENT)
     assert briefing.verdict_panel_lines(SENDER) == []
+    assert calls, "the failure simulation never fired"
 
 
 def test_panel_and_incoming_panel_coexist(tmp_checkpoint_dir):


### PR DESCRIPTION
Closes #968

## Summary

- Assert that fail-open exception mocks in the ruling, request, verdict, owed-panel, ruling-echo, and corroboration tests were actually invoked.
- Keep the existing real unreadable-ledger coverage alongside the mock-based checks.
- Make a call-graph regression fail loudly instead of leaving a green but inert test.

## Verification

- 177 passed across the six affected test modules
- Ruff passed
- Hook mirror drift check passed
