### PR TITLE
fix(recall): persist item_id in recall-inject delivery telemetry

### DIFF
--- a/plugin/daimon_briefing/recall.py
+++ b/plugin/daimon_briefing/recall.py
@@ -1467,7 +1467,10 @@ def suggest(prompt: str, project_dir=None, current_session=None,
 
     Each returned row also carries `term_hits` (its own distinct-term match
     count) and `pinned` (the #369 standing-rule flag) — inputs to the cli
-    age gate (#452), not rank inputs here.
+    age gate (#452), not rank inputs here. It also carries `item_id`, the
+    minted id the delivery telemetry (#989) persists with the row: without it
+    a delivered row cannot be joined back to its ledger item, resolution or
+    superseded chain from stored state.
     """
     # #899: the auto-inject path fans across own + host-allowlisted scopes
     # too; a shared scope reached by `recall` but not here would exist when
@@ -1497,6 +1500,10 @@ def suggest(prompt: str, project_dir=None, current_session=None,
         "SELECT i.text, i.quote, i.trust, i.kind, i.author, i.stated_by,"
         " i.project_slug,"
         " i.session_id, i.created, i.importance, i.first_seen, i.superseded_by,"
+        # i.item_id rides out for the #989 delivery telemetry: the recall-
+        # inject surface persists it per delivered row, and a null means a
+        # delivered row can never be joined back to its ledger identity.
+        " i.item_id,"
         # #907: same rule for the writer column — without it every human
         # resolution reaches _suggest_weight as an unattributed row and
         # demotes at the model-link rate, on this same surface.

--- a/plugin/tests/test_inspector.py
+++ b/plugin/tests/test_inspector.py
@@ -722,13 +722,18 @@ def test_recall_exposes_item_id_in_json_and_human_output(
 
     assert cli.main(["recall", "quorint", "--project", _PROJECT]) == 0
     assert f"[{_ITEM_ID}]" in capsys.readouterr().out
-    # The proactive backend has its own SELECT/output contract; adding ids to
-    # deliberate recall must not leak them into injected suggestion rows.
+    # #597 kept ids out of proactive INJECTION; #1017 gives the suggestion ROW
+    # an item_id for delivery telemetry. The presentation contract belongs to
+    # the injected line, not the row dict: _suggest_line never renders the id,
+    # so what crosses into the prompt is unchanged.
     suggestions = recall.suggest(
         "review the quorint trust inspector decision again",
         project_dir=_PROJECT, current_session="S-now")
     assert suggestions
-    assert all("item_id" not in row for row in suggestions)
+    assert all(isinstance(row.get("item_id"), str) and row["item_id"]
+               for row in suggestions)
+    for row in suggestions:
+        assert row["item_id"] not in cli._suggest_line(row, [], 0.0)
 
 
 # ---- #674: why falls back to the recall index when its own walk misses ----

--- a/plugin/tests/test_recall.py
+++ b/plugin/tests/test_recall.py
@@ -799,6 +799,20 @@ def test_suggest_surfaces_prior_work(tmp_checkpoint_dir, monkeypatch):
     assert out[0]["match_score"] >= 0
 
 
+def test_suggest_rows_carry_item_id_for_delivery_telemetry(
+        tmp_checkpoint_dir, monkeypatch):
+    # #1017: the recall-inject surface persists row["item_id"] per delivery,
+    # but the SELECT behind suggest() omitted i.item_id, so every recall-inject
+    # ledger row landed as null while recall-search rows carried a real id.
+    # This is the producer-side contract, exercised end to end: the telemetry
+    # writer tests feed hand-built dicts and could never catch a missing
+    # column here.
+    _seed_history()
+    out = recall.suggest("debugging the litellm gateway cache pinning again",
+                         project_dir="/repo/x", current_session="S-now")
+    assert out and isinstance(out[0]["item_id"], str) and out[0]["item_id"]
+
+
 def test_suggest_excludes_current_session(tmp_checkpoint_dir, monkeypatch):
     _seed_history()
     out = recall.suggest("debugging the litellm gateway cache pinning again",


### PR DESCRIPTION
Fixes #1017

## What

Adds `i.item_id` to the `recall.suggest()` SELECT so every row delivered on the `recall-inject` surface carries the minted item id, and `recall_telemetry.record()` stops persisting null `item_id` values in `logs/recall-delivery.jsonl`. Two tests pin the reconciled contract:

- `test_suggest_rows_carry_item_id_for_delivery_telemetry` exercises `suggest()` end to end and asserts the row carries `item_id`. The existing telemetry tests only fed hand-built dicts into `record()`, which is why the missing column shipped green.
- The #597 inspector test asserted `item_id` was absent from suggestion rows. That contract is reframed at the right layer: #597's intent was that proactive injection stays id-free in the PROMPT. `_suggest_line()` never renders `item_id`, so the injected line is byte-identical; the test now asserts the row carries the id and the rendered line does not.

## Why

#989's ledger contract names `item_id` as one of the persisted fields, and the surfaces.py comment says the ledger carries ids, but every recall-inject row written since #1013 merged has `"item_id": null`. Without it, a delivered row cannot be joined back to its ledger item, its resolution, or its superseded chain, which is exactly the join the weak-match threshold decision and later recall-lifecycle work need from stored state. The measurement week already in flight is accumulating rows that are less actionable than the issue promised.

## Tests

- `pytest tests/test_recall.py` — 172 passed, including the new producer-side regression test.
- `pytest tests/test_inspector.py tests/test_recall_telemetry.py` — 53 passed.
- `pytest tests/test_cli.py -k "recall_inject or suggest"` — 44 passed.
- Full suite: 6441 passed, 2 skipped. The only failures were `test_render_ledger_lines_paints_the_warning_register` and `test_render_ledger_lines_spans_a_request_id_like_a_ruling_id`, which fail identically on pristine `main` in this shell (Rich color detection under a non-color environment); unrelated to this change.