### PR TITLE
feat(briefing): render a stale carried item as unverified, not its stored tag

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,7 +128,7 @@ Deterministic cross-session carry-over of unresolved items.
 | `DAIMON_BRIEF_MAX_TOKENS` | `3000` | Token budget for the injected briefing, estimated at `len(text)//4` (no tokenizer dependency). `0` = unbounded. |
 | `DAIMON_MAX_BRIEFING_DECISIONS` | `10` | Cap on decisions shown in the briefing (render-time view only — the checkpoint keeps all of them). `0` = unbounded. |
 | `DAIMON_BRIEF_GLOBAL_FALLBACK` | header-only | Controls the cross-project global-pointer fallback when a project has no checkpoint of its own. Default shows a header only; set to `full` (or `1`) to inject the full foreign body. |
-| `DAIMON_STALE_DAYS` | `7.0` | Age threshold (days) past which a carried item's effective last-verified stamp (its `last_verified`, else the latest resolutions.jsonl event, else `first_seen`) is stale enough for `brief` to warn about it. `0` warns on every carried item. |
+| `DAIMON_STALE_DAYS` | `7.0` | Age threshold (days) past which a carried item's effective last-verified stamp (its `last_verified`, else the latest resolutions.jsonl event, else `first_seen`) is stale enough for `brief` to warn about it. `0` warns on every carried item. Past the threshold, the item itself renders as `[? unverified]` with its stored tag and age in a trailing suffix, instead of the stored trust tag (render-time only; `daimon reverify` restores the tag on the next brief). |
 | `DAIMON_PLAIN` | off | When truthy (case-insensitive), forces plain-text output — disables the rich tables/panels in `status`, `brief`, and `--help`. |
 | `NO_COLOR` | unset | Presence-based, per the [NO_COLOR convention](https://no-color.org/): if the variable is set to *any* value (even empty), rich output is disabled. |
 

--- a/plugin/daimon_briefing/briefing.py
+++ b/plugin/daimon_briefing/briefing.py
@@ -35,6 +35,13 @@ log = logging.getLogger("daimon.briefing")
 _VERBATIM_MARK = "✓ verbatim"
 _INFERRED_MARK = "~ inferred"
 _UNTAGGED_MARK = "? untagged"
+# #977: a carried item whose EFFECTIVE last-verified age exceeds the
+# staleness budget (#215) renders as unverified INSTEAD of its stored trust
+# tag; the tag and age ride in a trailing suffix. Render-time only: the
+# stored trust value is never rewritten, and `daimon reverify` restores the
+# tag on the next brief via the resolutions fold (a fresh event ts is the
+# newest age candidate, same rule stale_carried already applies).
+_STALE_CARRIED_MARK = "? unverified"
 # #204: when a receipt-era checkpoint's provenance can't be locally confirmed at
 # brief time, a `verbatim` label has NOT earned its checkmark — the stored bytes
 # may have been edited. Degrade it visibly rather than assert integrity we can't
@@ -69,6 +76,18 @@ def _mark(item, degraded: bool = False) -> str:
     if trust:
         return _INFERRED_MARK
     return _UNTAGGED_MARK
+
+
+def _trust_label(item) -> str:
+    # #977: the stored trust class as a plain word ("verbatim" / "inferred" /
+    # "untagged"), the same three-way vocabulary _mark and render._trust_key
+    # already agree on, without the mark glyphs. Used by the stale-carried
+    # suffix ("was verbatim") so the rendered line names what the tag was
+    # before the render-time substitution.
+    trust = item.get("trust")
+    if trust == "verbatim":
+        return "verbatim"
+    return "inferred" if trust else "untagged"
 
 
 # #268: how many independent sightings a claim needs before the render says
@@ -167,7 +186,17 @@ def _line(item, degraded: bool = False, briefable: bool = False) -> str:
     # (store.py, carry.py) — tolerant of null, same as iter_items' stance.
     text = str(item.get("text") or "").strip()
     quote = str(item.get("quote") or "").strip()
-    base = f'- [{_mark(item, degraded)}] {text}'
+    mark = _mark(item, degraded)
+    stale_days = item.get("_stale_carried_days")
+    was_label = None
+    if isinstance(stale_days, (int, float)) and not isinstance(stale_days, bool):
+        # #977: past the staleness budget, the stored tag must not read as
+        # fresh evidence: render unverified, name the stored tag and the
+        # age in a trailing suffix. The stamp is transient (stamp_stale_carried),
+        # so this never rewrites the stored trust value.
+        was_label = _trust_label(item)
+        mark = _STALE_CARRIED_MARK
+    base = f'- [{mark}] {text}'
     if item.get("carried_from"):
         # Epistemic honesty, same philosophy as trust marks: a loop carried
         # from an older session must not read as fresh context (#33 Phase 2).
@@ -192,6 +221,8 @@ def _line(item, degraded: bool = False, briefable: bool = False) -> str:
     if quote:
         base += f'  — "{quote}"'
     base += _handle_suffix(item, briefable)
+    if was_label is not None:
+        base += f" (was {was_label}, carried {stale_days:.0f}d)"
     candidate = item.get("_supersede_candidate")
     if candidate:
         # #14: a machine-suggested (unconfirmed) supersession — never
@@ -625,6 +656,33 @@ def mark_corroborated(checkpoint, corroborations: dict):
 # ---- #215: staleness budget — carried items nobody has world-checked ----
 
 
+def _carried_age_days(item, resolutions, now):
+    """#977: the EFFECTIVE last-verified age in days for a CARRIED item, or
+    None when the item is not carried or has no parseable stamp at all
+    (fail-open, same house rule as stale_carried). Single source for the
+    newest-of-candidates rule so the classification (stale_carried) and the
+    render stamp (stamp_stale_carried) can never disagree about an age.
+
+    `resolutions` is store.resolutions()'s {item_ref: latest_event} shape."""
+    if not isinstance(item, dict) or not item.get("carried_from"):
+        return None
+    candidates = []
+    lv = store._created_epoch(item.get("last_verified"))
+    if lv is not None:
+        candidates.append(lv)
+    evt = resolutions.get(item.get("id"))
+    if isinstance(evt, dict):
+        evt_ts = store._created_epoch(evt.get("ts"))
+        if evt_ts is not None:
+            candidates.append(evt_ts)
+    fs = store._created_epoch(item.get("first_seen"))
+    if fs is not None:
+        candidates.append(fs)
+    if not candidates:
+        return None  # no parseable stamp at all: fail open, not stale
+    return (now - max(candidates)) / 86400.0
+
+
 def stale_carried(checkpoint, resolutions: dict, now, threshold_days=None) -> list:
     """Carried items whose EFFECTIVE last-verified age exceeds
     `threshold_days`, or [] if none. Pure — `now` is injected (mirrors
@@ -665,26 +723,50 @@ def stale_carried(checkpoint, resolutions: dict, now, threshold_days=None) -> li
     resolutions = resolutions if isinstance(resolutions, dict) else {}
     stale = []
     for item in serializer.iter_items(checkpoint):
-        if not isinstance(item, dict) or not item.get("carried_from"):
-            continue
-        candidates = []
-        lv = store._created_epoch(item.get("last_verified"))
-        if lv is not None:
-            candidates.append(lv)
-        evt = resolutions.get(item.get("id"))
-        if isinstance(evt, dict):
-            evt_ts = store._created_epoch(evt.get("ts"))
-            if evt_ts is not None:
-                candidates.append(evt_ts)
-        fs = store._created_epoch(item.get("first_seen"))
-        if fs is not None:
-            candidates.append(fs)
-        if not candidates:
-            continue  # no parseable stamp at all — fail open, not stale
-        age_days = (now - max(candidates)) / 86400.0
-        if age_days > threshold_days:
+        age_days = _carried_age_days(item, resolutions, now)
+        if age_days is not None and age_days > threshold_days:
             stale.append(item)
     return stale
+
+
+def stamp_stale_carried(checkpoint, resolutions: dict, now, threshold_days=None):
+    """#977: the render-time half of the staleness budget. Returns
+    (checkpoint, stale_items) where every carried item past the threshold
+    carries a transient `_stale_carried_days` stamp (its effective age in
+    days) that `_line` / render._rich_brief turn into the `[? unverified]`
+    mark plus the `(was <tag>, carried Nd)` suffix.
+
+    Same classification as stale_carried (one shared `_carried_age_days`, so
+    the two can never disagree): callers that render should prefer this over
+    stale_carried plus a second pass. Transient like mark_corroborated's count:
+    the stamp rides the IN-MEMORY item only, deep-copied when something is
+    stamped and returned UNCHANGED otherwise, so the stored trust value is
+    never rewritten and a no-stale brief costs nothing."""
+    if threshold_days is None:
+        threshold_days = config.stale_days()
+    if not isinstance(checkpoint, dict):
+        return checkpoint, []
+    resolutions = resolutions if isinstance(resolutions, dict) else {}
+    to_stamp = []  # [(section, key, index, age_days)]
+    for section, key in store._ITEM_LISTS:
+        items = (checkpoint.get(section) or {}).get(key)
+        if not isinstance(items, list):
+            continue
+        for idx, item in enumerate(items):
+            if not isinstance(item, dict):
+                continue
+            age_days = _carried_age_days(item, resolutions, now)
+            if age_days is not None and age_days > threshold_days:
+                to_stamp.append((section, key, idx, age_days))
+    if not to_stamp:
+        return checkpoint, []
+    out = copy.deepcopy(checkpoint)
+    stale = []
+    for section, key, idx, age_days in to_stamp:
+        item = out[section][key][idx]
+        item["_stale_carried_days"] = age_days
+        stale.append(item)
+    return out, stale
 
 
 # ---- #79: token budget — section-preserving truncation ----

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -667,6 +667,7 @@ def _render_briefing_body(checkpoint, route, *, drift_project, teammates,
     the wrong repo context for those claims."""
     withheld: list = []
     events: dict = {}
+    stale_items: list = []
     if checkpoint:
         # Withhold (#103): render-time derivation, fail-open — a briefing
         # must never die over suppression machinery. #14: candidates ride
@@ -688,14 +689,27 @@ def _render_briefing_body(checkpoint, route, *, drift_project, teammates,
         # Corroboration (#268): a SEPARATE axis from the trust class — how many
         # independent sessions have witnessed the claim, never what kind of
         # evidence it is. Its own try: a failure here must cost the badge
-        # only, not the withheld list `events` still owes to stale_carried
-        # below. Transient stamps on the in-memory checkpoint, same posture as
+        # only, not the withheld list `events` still owes to the
+        # stamp_stale_carried pass below. Transient stamps on the in-memory checkpoint, same posture as
         # the candidate flags above and the worldcheck flags below.
         try:
             checkpoint = briefing.mark_corroborated(
                 checkpoint, store.corroborations(project_dir=route))
         except Exception:
             pass
+        # #977: a carried item past the staleness budget (#215) renders as
+        # [? unverified] with its age, not as its stored trust tag. The stamp
+        # must land BEFORE render_brief below; it is transient (in-memory
+        # only, like the corroboration count above), so the stored trust
+        # value is never rewritten. Same resolutions fold as withhold, same
+        # fail-open try as stale_carried had: a broken classification must
+        # never take the briefing down. The warning note after the render
+        # reuses THIS list, so the age computation runs once.
+        try:
+            checkpoint, stale_items = briefing.stamp_stale_carried(
+                checkpoint, events, time.time())
+        except Exception:
+            stale_items = []
     # Worldcheck (#365/#397/#439): opt-in, budget-bounded, read-only
     # spot-check of carried claims — repo state via `gh`, on-disk state via
     # the filesystem, and the origin checkpoint's signed receipt via the vitni
@@ -791,21 +805,16 @@ def _render_briefing_body(checkpoint, route, *, drift_project, teammates,
         if team_withheld:
             note += f" ({len(team_withheld)} a teammate's)"
         render.render_brief_note([note + " — `daimon status --suppressed` to list"])
-    # Staleness budget (#215): reuses the SAME resolutions fold `withhold`
-    # already did above — no re-read of events.jsonl. Fail-open, same shape
-    # as the withhold try/except; a broken stale_carried must never take the
-    # briefing down with it. House rule: zero stale items -> NO line at all,
-    # never a false alarm.
-    if checkpoint:
-        try:
-            stale_items = briefing.stale_carried(checkpoint, events, time.time())
-        except Exception:
-            stale_items = []
-        if stale_items:
-            render.render_brief_note([
-                f"⚠ {len(stale_items)} carried item(s) unverified for "
-                f">{config.stale_days():g} days — world-check before "
-                "repeating as true"])
+    # Staleness budget (#215): the classification already ran before the
+    # render (#977 stamps the stale items with their ages); this standing
+    # warning stays: the per-item substitution above is what makes it
+    # actionable, but the count orients the brief. House rule: zero stale
+    # items -> NO line at all, never a false alarm.
+    if stale_items:
+        render.render_brief_note([
+            f"⚠ {len(stale_items)} carried item(s) unverified for "
+            f">{config.stale_days():g} days — world-check before "
+            "repeating as true"])
     return 0
 
 

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -334,16 +334,30 @@ def _rich_brief(b: dict, degraded: bool = False, rulings=(),
         briefable = key in briefing.BRIEFABLE_SECTIONS
         for i in items:
             trust = _trust_key(i)
-            # Degrade a verbatim item's confident green — its integrity is
-            # unverified (#204). Inferred/untagged never claimed it, so untouched.
-            item_style = "bold red" if (degraded and trust == "verbatim") \
-                else _TRUST_STYLE[trust]
-            # #268: the corroboration badge rides the text line here, the same
-            # position it holds on the plain path (after the annotations,
-            # before the quote) — one shared literal, so the two renders state
-            # the witness count in identical bytes.
-            body.append(f"• {i.get('text', '').strip()}"
-                        f"{briefing.corroboration_badge(i)}", style=item_style)
+            stale_days = i.get("_stale_carried_days")
+            if isinstance(stale_days, (int, float)) \
+                    and not isinstance(stale_days, bool):
+                # #977: parity with briefing._line: a carried item past the
+                # staleness budget renders as unverified instead of its
+                # stored trust color; yellow states "needs a world-check"
+                # without borrowing the verbatim green (the stored tag is
+                # named in the suffix instead).
+                body.append(f"• [? unverified] {i.get('text', '').strip()}"
+                            f"{briefing.corroboration_badge(i)}"
+                            f" (was {trust}, carried {stale_days:.0f}d)",
+                            style="yellow")
+                item_style = "yellow"
+            else:
+                # Degrade a verbatim item's confident green: its integrity is
+                # unverified (#204). Inferred/untagged never claimed it, so untouched.
+                item_style = "bold red" if (degraded and trust == "verbatim") \
+                    else _TRUST_STYLE[trust]
+                # #268: the corroboration badge rides the text line here, the same
+                # position it holds on the plain path (after the annotations,
+                # before the quote): one shared literal, so the two renders state
+                # the witness count in identical bytes.
+                body.append(f"• {i.get('text', '').strip()}"
+                            f"{briefing.corroboration_badge(i)}", style=item_style)
             # #480 slice 1: the id handle, dim like the quote below — it is
             # a supplementary resolve target, not part of the claim itself.
             handle = briefing._handle_suffix(i, briefable)

--- a/plugin/tests/test_briefing.py
+++ b/plugin/tests/test_briefing.py
@@ -1172,6 +1172,75 @@ def test_stale_carried_default_threshold_reads_config():
     assert len(stale) == 1  # default 7.0 days < 10 days old
 
 
+# ---- #977: a stale carried item renders as unverified, not as its stored tag ----
+#
+# stamp_stale_carried is the render-time half of the #215 budget: it stamps a
+# transient `_stale_carried_days` (the SAME effective-age number stale_carried
+# classifies on, one shared helper) on the in-memory item, and _line turns the
+# stamp into the `[? unverified]` mark plus the `(was <tag>, carried Nd)`
+# suffix. The stored trust value is never rewritten; a recent resolutions
+# event (the `daimon reverify` read path) makes the next brief render the
+# stored tag again with no extra machinery.
+
+
+def test_line_renders_stale_carried_as_unverified_with_suffix():
+    cp = _cp215([{"text": "old carried loop", "id": "o-old9",
+                  "trust": "verbatim", "carried_from": "S-prev",
+                  "first_seen": _ts215(10)}])
+    stamped, stale = briefing.stamp_stale_carried(
+        cp, {}, _NOW215, threshold_days=7.0)
+    assert len(stale) == 1
+    item = stamped["working_context"]["open_questions"][0]
+    line = briefing._line(item)
+    assert line.startswith("- [? unverified] old carried loop")
+    assert "(was verbatim, carried 10d)" in line
+    # Render-time rule only: the stored trust value is NOT rewritten, and the
+    # ORIGINAL checkpoint item never carries the transient stamp.
+    assert item["trust"] == "verbatim"
+    assert "_stale_carried_days" not in cp["working_context"]["open_questions"][0]
+
+
+def test_line_renders_fresh_carried_item_with_stored_tag():
+    cp = _cp215([{"text": "fresh carried loop", "id": "o-fresh9",
+                  "trust": "verbatim", "carried_from": "S-prev",
+                  "first_seen": _ts215(2)}])
+    stamped, stale = briefing.stamp_stale_carried(
+        cp, {}, _NOW215, threshold_days=7.0)
+    assert stale == []
+    assert stamped is cp  # nothing to stamp: returned UNCHANGED, no deep copy
+    line = briefing._line(stamped["working_context"]["open_questions"][0])
+    assert line.startswith("- [✓ verbatim] fresh carried loop")
+    assert "unverified" not in line
+
+
+def test_line_leaves_stale_native_item_untouched():
+    # Native (this-session) items were just re-extracted; the budget only
+    # questions carried claims, so an old native item keeps its stored tag.
+    cp = _cp215([{"text": "old native loop", "id": "o-native9",
+                  "trust": "verbatim", "first_seen": _ts215(30)}])
+    stamped, stale = briefing.stamp_stale_carried(
+        cp, {}, _NOW215, threshold_days=7.0)
+    assert stale == []
+    line = briefing._line(stamped["working_context"]["open_questions"][0])
+    assert line.startswith("- [✓ verbatim] old native loop")
+
+
+def test_reverify_event_restores_stored_tag_on_next_brief():
+    # `daimon reverify <id>` writes a resolutions event; the newest-candidate
+    # rule counts that event ts as the effective last-verified, so the item
+    # drops out of the stale set and the next brief renders the stored tag
+    # again. This is the existing #215 fold doing the work: no new machinery.
+    cp = _cp215([{"text": "old carried loop", "id": "o-rev9",
+                  "trust": "verbatim", "carried_from": "S-prev",
+                  "first_seen": _ts215(30)}])
+    resolutions = {"o-rev9": {"ts": _ts215(1), "status": "reopened"}}
+    stamped, stale = briefing.stamp_stale_carried(
+        cp, resolutions, _NOW215, threshold_days=7.0)
+    assert stale == []
+    line = briefing._line(stamped["working_context"]["open_questions"][0])
+    assert line.startswith("- [✓ verbatim] old carried loop")
+
+
 def test_render_never_prints_scene():
     # #317: scenes exist for retrieval, not display — the briefing must not
     # leak them into the rendered text

--- a/plugin/tests/test_briefing.py
+++ b/plugin/tests/test_briefing.py
@@ -1241,6 +1241,25 @@ def test_reverify_event_restores_stored_tag_on_next_brief():
     assert line.startswith("- [✓ verbatim] old carried loop")
 
 
+def test_stamp_stale_carried_tolerates_torn_shapes():
+    # Defensive seams in the stamp pass mirror iter_items' stance (#977): a
+    # non-dict checkpoint, and a list slot holding a non-dict row, must
+    # neither raise nor stamp. The torn checkpoint comes back unchanged; the
+    # torn row is skipped while its well-formed sibling still stamps.
+    out, stale = briefing.stamp_stale_carried("not a checkpoint", {}, _NOW215)
+    assert out == "not a checkpoint"
+    assert stale == []
+    cp = _cp215([{"text": "old carried loop", "id": "o-torn-sib",
+                  "trust": "verbatim", "carried_from": "S-prev",
+                  "first_seen": _ts215(10)}, "torn row"])
+    stamped, stale = briefing.stamp_stale_carried(
+        cp, {}, _NOW215, threshold_days=7.0)
+    assert len(stale) == 1
+    assert stamped["working_context"]["open_questions"][1] == "torn row"
+    line = briefing._line(stamped["working_context"]["open_questions"][0])
+    assert line.startswith("- [? unverified]")
+
+
 def test_render_never_prints_scene():
     # #317: scenes exist for retrieval, not display — the briefing must not
     # leak them into the rendered text

--- a/plugin/tests/test_cli.py
+++ b/plugin/tests/test_cli.py
@@ -5791,6 +5791,8 @@ def test_brief_warns_on_stale_carried_item(
     # staleness budget gets a visible warning line — agreement between two
     # agent-written sources (the carried item + the fresh checkpoint restating
     # it) is not corroboration.
+    # #977: the item itself now renders as [? unverified] with the stored tag
+    # and age in a trailing suffix, instead of its stored trust tag.
     from daimon_briefing import store
     import time as _time
     monkeypatch.setenv("DAIMON_STALE_DAYS", "7")
@@ -5809,6 +5811,46 @@ def test_brief_warns_on_stale_carried_item(
     out = capsys.readouterr().out
     assert "carried item(s) unverified for >7 days" in out
     assert "world-check before repeating as true" in out
+    assert "[? unverified] an old carried loop nobody rechecked" in out
+    assert "(was inferred, carried 10d)" in out
+    # The render-time substitution never rewrites the stored trust value.
+    written = store.read_latest_body(project_dir="/repo/x",
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
+    assert written["working_context"]["open_questions"][0]["trust"] == "inferred"
+
+
+def test_brief_reverify_restores_stored_tag_on_stale_carried_item(
+        tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
+    # #977: `daimon reverify <id>` writes a resolutions event (status
+    # "reopened", the real verb's shape); the next brief counts that event ts
+    # as the effective last-verified (#215's fold, no new machinery), so the
+    # item renders with its stored tag again and the staleness warning
+    # disappears.
+    from daimon_briefing import store
+    import time as _time
+    monkeypatch.setenv("DAIMON_STALE_DAYS", "7")
+    stale_iso = _time.strftime(
+        "%Y-%m-%dT%H:%M:%SZ", _time.gmtime(_time.time() - 10 * 86400))
+    cp = dict(sample_checkpoint)
+    cp["working_context"] = dict(cp["working_context"])
+    cp["working_context"]["open_questions"] = [{
+        "text": "an old carried loop nobody rechecked",
+        "trust": "inferred", "carried_from": "S-prev",
+        "first_seen": stale_iso,
+    }]
+    store.write_checkpoint("S-mine", cp, project_dir="/repo/x")
+    written = store.read_latest_body(project_dir="/repo/x",
+                                     route=store.Route.OWN_ELSE_GLOBAL,
+                                     admit=store.Admit.ANY)
+    item_id = written["working_context"]["open_questions"][0]["id"]
+    store.append_event(item_id, "reopened", project_dir="/repo/x")
+    rc = cli.main(["brief", "--project", "/repo/x"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "[~ inferred] an old carried loop nobody rechecked" in out
+    assert "[? unverified]" not in out
+    assert "carried item(s) unverified for" not in out
 
 
 def test_brief_no_stale_note_when_nothing_stale(
@@ -5826,16 +5868,16 @@ def test_brief_no_stale_note_when_nothing_stale(
 
 def test_brief_fails_open_when_stale_carried_raises(
         tmp_checkpoint_dir, sample_checkpoint, capsys, monkeypatch):
-    # #215 fail-open: a broken stale_carried must never take the briefing
-    # down with it — the brief still renders and exits clean, just without
-    # the budget line.
+    # #215/#977 fail-open: a broken staleness classification must never take
+    # the briefing down with it: the brief still renders and exits clean,
+    # just without the budget line or the per-item unverified stamp.
     from daimon_briefing import briefing, store
     store.write_checkpoint("S-mine", sample_checkpoint, project_dir="/repo/x")
 
     def _boom(*_args, **_kwargs):
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(briefing, "stale_carried", _boom)
+    monkeypatch.setattr(briefing, "stamp_stale_carried", _boom)
     rc = cli.main(["brief", "--project", "/repo/x"])
     assert rc == 0
     out = capsys.readouterr().out

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -74,6 +74,41 @@ def test_render_brief_rich_smoke(monkeypatch, sample_checkpoint, capsys):
     assert "PR #6" in out
 
 
+def test_render_brief_rich_stale_carried_renders_unverified(monkeypatch, capsys):
+    # #977: the rich path mirrors briefing._line's substitution: a carried
+    # item past the staleness budget shows [? unverified] plus the
+    # (was <tag>, carried Nd) suffix instead of its stored trust styling.
+    # The CLI stamps the checkpoint via briefing.stamp_stale_carried before
+    # render_brief; this test drives the same seam directly.
+    import time as _time
+    from daimon_briefing import briefing
+
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    now = 1_900_000_000  # whole seconds, round-trips through the ISO stamp format
+    stale_iso = _time.strftime("%Y-%m-%dT%H:%M:%SZ",
+                               _time.gmtime(now - 10 * 86400))
+    cp = {
+        "session_id": "S-cur",
+        "working_context": {
+            "active_topic": {"text": "wiring", "trust": "inferred"},
+            "open_questions": [
+                {"text": "old carried loop", "trust": "verbatim",
+                 "carried_from": "S-prev", "first_seen": stale_iso},
+            ],
+            "recent_decisions": [],
+        },
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": [],
+                               "contradictions_flagged": []},
+    }
+    stamped, stale = briefing.stamp_stale_carried(
+        cp, {}, now, threshold_days=7.0)
+    assert len(stale) == 1
+    render.render_brief(stamped)
+    out = capsys.readouterr().out
+    assert "[? unverified]" in out
+    assert "(was verbatim, carried 10d)" in out
+
+
 def test_render_brief_rich_handoff_is_a_panel(monkeypatch, sample_checkpoint, capsys):
     # #566: the baton is the highest-priority block; on the rich path it must
     # render as a bordered panel like every ambient section, not bare stdout.


### PR DESCRIPTION
Closes #977

## What

A carried item whose effective last-verified age exceeds `DAIMON_STALE_DAYS` now renders as `[? unverified]` with a `(was <tag>, carried Nd)` suffix on both the plain and rich briefing paths, instead of its stored trust tag.

The substitution is render-time only. `briefing.stamp_stale_carried` stamps a transient `_stale_carried_days` value on the in-memory item (deep-copied when something is stale, returned unchanged otherwise), the stored trust value is never rewritten, and `daimon reverify` restores the stored tag on the next brief through the existing newest-candidate age fold (#215). One shared `_carried_age_days` helper backs both the classification and the stamp, so the two cannot disagree. The CLI stamps before render and reuses the same stale list for the standing warning line, so the age computation runs once. `docs/configuration.md` records the behavior on the `DAIMON_STALE_DAYS` row.

## Why

A carried claim nobody has world-checked must not read as fresh evidence wearing a trust tag it earned sessions ago. The briefing already warns about the stale count (#215); this makes the per-item mark say the same thing.

## Tests

- `tests/test_briefing.py`: stale renders unverified with the suffix; fresh keeps the stored tag and the checkpoint object comes back unchanged; a stale native item is untouched; a recent resolutions event restores the tag.
- `tests/test_cli.py`: end-to-end brief renders the substitution without rewriting stored trust; reverify restores the tag and drops the warning; fail-open when the classification raises.
- `tests/test_render.py`: rich path renders the same mark and suffix.
- Each new test fails against the pre-change source (verified on a clean-HEAD worktree). Focused run: 47 passed. Ruff and mypy clean. Full suite: 6448 passed, 2 skipped; the 2 failures are `render_ledger_lines` escape-assertion tests that fail identically on clean HEAD `d68e5f2`.
