### PR TITLE
feat(cli): unify rich rendering for hooks and skill lifecycle commands

### DIFF
--- a/plugin/daimon_briefing/cli/hooks.py
+++ b/plugin/daimon_briefing/cli/hooks.py
@@ -65,7 +65,8 @@ def _install_one(host: str) -> int:
         from .. import codex_hooks
 
         lines = codex_hooks.install(pkg, Path.home())
-        render.render_hooks_install(lines + ["", _checks_line()])
+        render.render_install_summary(lines + ["", _checks_line()],
+                                      title=f"daimon hooks install {host}")
         return 0
     if spec.get("register") == "kimi":
         # #988. Same self-registering shape as Codex, into TOML rather than
@@ -80,7 +81,8 @@ def _install_one(host: str) -> int:
             print(f"error: {kimi_hooks.config_path(Path.home())} could not be "
                   f"read safely, so nothing was written: {exc}", file=sys.stderr)
             return 1
-        render.render_hooks_install(lines + ["", _checks_line()])
+        render.render_install_summary(lines + ["", _checks_line()],
+                                      title=f"daimon hooks install {host}")
         return 0
     target = _cli._hooks_target_dir()
     target.mkdir(parents=True, exist_ok=True)
@@ -103,7 +105,7 @@ def _install_one(host: str) -> int:
     lines.append("Re-run `daimon hooks install " + host +
                  "` after every `uv tool upgrade daimon-briefing`.")
     lines += ["", _checks_line()]
-    render.render_hooks_install(lines)
+    render.render_install_summary(lines, title=f"daimon hooks install {host}")
     return 0
 
 def _cmd_hooks_install(args) -> int:

--- a/plugin/daimon_briefing/cli/skill.py
+++ b/plugin/daimon_briefing/cli/skill.py
@@ -44,10 +44,12 @@ def _install_one(host: str, *, project: bool, cwd: Path) -> int:
     except skill_install.SkillInstallError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    render.render_skill_lines(lines, footer=(
-        f"Re-run `daimon skill install {host}` after every "
-        "`uv tool upgrade daimon-briefing` to refresh the content.",
-    ))
+    render.render_install_summary(
+        lines, title=f"daimon skill install {host}",
+        footer=(
+            f"Re-run `daimon skill install {host}` after every "
+            "`uv tool upgrade daimon-briefing` to refresh the content.",
+        ))
     return 0
 
 

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -1266,12 +1266,15 @@ def render_hooks_install(lines) -> None:
 
 
 # State styles shared by the hooks and skill audits (#1012): green for
-# CURRENT/REGISTERED/healthy, dim for NOT INSTALLED, yellow for partial or
-# attention states, red for STALE/MISSING/BROKEN/drifted. Anything a map does
-# not name is drift by definition, so the fallback is always red.
+# CURRENT/REGISTERED/PLUGIN/healthy, dim for NOT INSTALLED, yellow for
+# partial or attention states, red for STALE/MISSING/BROKEN/drifted.
+# Anything a map does not name is drift by definition, so the fallback is
+# always red - PLUGIN is a healthy plugin-channel state (skill_install) and
+# must stay green, never the drift fallback.
 _STATE_STYLE = {
     "CURRENT": "green",
     "REGISTERED": "green",
+    "PLUGIN": "green",
     "NOT INSTALLED": "dim",
     "PARTIAL": "yellow",
 }

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -1252,7 +1252,7 @@ def render_recall_lines(lines) -> None:
     _render_lines(lines)
 
 
-# ---- hooks: `daimon hooks list|install` (#68) -------------------------------
+# ---- hooks: `daimon hooks list|install|status` (#68) ------------------------
 
 
 def render_hooks_list(lines) -> None:
@@ -1260,18 +1260,120 @@ def render_hooks_list(lines) -> None:
 
 
 def render_hooks_install(lines) -> None:
+    """`hooks remove` result lines (install itself renders through
+    render_install_summary since #1012)."""
     _render_lines(lines)
 
 
+# State styles shared by the hooks and skill audits (#1012): green for
+# CURRENT/REGISTERED/healthy, dim for NOT INSTALLED, yellow for partial or
+# attention states, red for STALE/MISSING/BROKEN/drifted. Anything a map does
+# not name is drift by definition, so the fallback is always red.
+_STATE_STYLE = {
+    "CURRENT": "green",
+    "REGISTERED": "green",
+    "NOT INSTALLED": "dim",
+    "PARTIAL": "yellow",
+}
+
+
+def _rich_drift_summary(total: int, drifted: int, unit: str) -> None:
+    """The compact summary line under a status table (#1012): the audited
+    count plus the drift count, the drift number red when nonzero and green
+    when clean. Hooks counts hosts; skills counts rows - each names its own
+    table's unit."""
+    from rich.console import Console
+    from rich.text import Text
+
+    line = Text(f"{total} {unit}, ")
+    line.append(f"{drifted} drifted", style="red" if drifted else "green")
+    Console().print(line)
+
+
+def _checks_trailing_style(ln: str, first: bool) -> str | None:
+    """#1012: the manifest block keeps the shared wording `check sync --check`
+    prints (one source of truth, never rewritten here) and gains state colour
+    on the rich path. Only the header line carries a state; detail and fix
+    lines stay unstyled, same as the plain path."""
+    if not first:
+        return None
+    if "drifted" in ln or "could not be read" in ln:
+        return "red"
+    if "no manifest" in ln:
+        return "dim"
+    return "green"
+
+
+def _rich_hooks_status(report, trailing) -> None:
+    """The #1012 rich presentation of the hooks audit: one row per host
+    (host+dir, per-file verdicts, registration state), a drift summary, the
+    fix lines below the table, then the #943 manifest block. Same facts as
+    the plain lines; the layout mirrors render_skill_status so the two
+    lifecycle audits read as one product."""
+    from rich.console import Console
+    from rich.table import Table
+    from rich.text import Text
+
+    console = Console()
+    if not report:
+        console.print(Text("no packaged hook hosts", style="dim"))
+    else:
+        table = Table(show_header=True, header_style="bold")
+        for col in ("host", "files", "registration"):
+            table.add_column(col)
+        for h in report:
+            host_cell = Text()
+            host_cell.append(h["host"],
+                             style="dim" if not h["installed"] else "bold")
+            host_cell.append(f"\n{h['dir']}", style="dim")
+            if not h["installed"]:
+                files_cell = Text("NOT INSTALLED", style="dim")
+                reg_cell = Text("n/a", style="dim")
+            else:
+                files_cell = Text()
+                for i, f in enumerate(h["files"]):
+                    if i:
+                        files_cell.append("\n")
+                    files_cell.append(
+                        f"{f['status']:<8} {f['name']}",
+                        style=_STATE_STYLE.get(f["status"], "red"))
+                reg = h["registration"]
+                reg_cell = (Text("manual", style="dim") if reg is None
+                            else Text(reg,
+                                      style=_STATE_STYLE.get(reg, "red")))
+            if h["drift"]:
+                host_cell.append("\n⚠ drifted", style="yellow")
+            table.add_row(host_cell, files_cell, reg_cell)
+        console.print(table)
+        _rich_drift_summary(len(report),
+                            sum(1 for h in report if h["drift"]), "hosts")
+    repairs = sorted({h["host"] for h in report if h["drift"]})
+    if repairs:
+        print("")
+        for host in repairs:
+            print(f"fix: daimon hooks install {host}")
+    for i, ln in enumerate(trailing):
+        console.print(ln, style=_checks_trailing_style(ln, i == 0),
+                      markup=False)
+
+
 def render_hooks_status(report, trailing=()) -> None:
-    """Per-host, per-file drift audit (#266). NOT INSTALLED hosts get one line;
-    installed hosts list each file's verdict, the registration state where the
-    host uses one, and a single fix hint when anything drifted.
+    """Per-host, per-file drift audit (#266; rich table #1012). NOT INSTALLED
+    hosts get one line; installed hosts list each file's verdict, the
+    registration state where the host uses one, and a single fix hint when
+    anything drifted.
 
     `trailing` is the #943 manifest block: the file the installed scripts
     READ, audited against this project's ledger. It follows the per-host
     lines rather than joining them because it is not per host, and it is
-    empty on a machine where the audit could not run."""
+    empty on a machine where the audit could not run.
+
+    Rich renders a table plus summary and moves the fix hints below it;
+    plain stays the pre-#1012 line format, byte for byte - pipes and hooks
+    read that surface."""
+    if supports_rich():
+        _rich_hooks_status(report, trailing)
+        return
     lines: list[str] = []
     for h in report:
         if not h["installed"]:
@@ -1288,6 +1390,76 @@ def render_hooks_status(report, trailing=()) -> None:
         lines.append("no packaged hook hosts")
     lines.extend(trailing)
     _render_lines(lines)
+
+
+# ---- install summaries: `hooks install` / `skill install` (#1012) ------------
+
+
+_INSTALL_GROUP_HEADERS = (
+    ("installed", "Installed"),
+    ("registration", "Registration"),
+    ("attention", "Attention"),
+    ("next steps", "Next steps"),
+)
+
+
+def _install_group(ln: str) -> str:
+    """#1012 bucket for one install-output line, keying off the stable
+    prefixes and wordings the installers print (never rewriting them): the
+    artifact confirmations, the self-registering hosts' registration
+    verdicts, warnings, and everything a person must still do by hand."""
+    if ln.startswith("installed "):
+        return "installed"
+    if ln.startswith(("warning:", "⚠")):
+        return "attention"
+    if ("registered" in ln or ln.startswith("updated ")
+            or "already up to date" in ln):
+        return "registration"
+    return "next steps"
+
+
+def render_install_summary(lines, *, footer=None, title=None) -> None:
+    """Success summary for `hooks install` and `skill install` (#1012): the
+    same pre-formatted lines the plain path always printed, grouped under
+    Installed / Registration / Attention / Next steps in one panel on the
+    rich path. Manual-registration snippets and the re-run-after-upgrade
+    reminder stay in Next steps, unrewritten - an install report a person
+    acts on must not drift from the words the installers own. Plain path is
+    the bare print loop, byte-identical to the pre-#1012 output."""
+    if not supports_rich():
+        for ln in lines:
+            print(ln)
+        if footer:
+            print("")
+            for ln in footer:
+                print(ln)
+        return
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.text import Text
+
+    grouped: dict[str, list[str]] = {
+        key: [] for key, _ in _INSTALL_GROUP_HEADERS}
+    for ln in lines:
+        if ln.strip():
+            grouped[_install_group(ln)].append(ln)
+    if footer:
+        grouped["next steps"].extend(footer)
+    entries: list[tuple[str, str | None]] = []
+    for key, header in _INSTALL_GROUP_HEADERS:
+        rows = grouped[key]
+        if not rows:
+            continue
+        entries.append((header, "bold yellow" if key == "attention" else "bold"))
+        entries.extend((f"  {ln}", "yellow" if key == "attention" else None)
+                       for ln in rows)
+    body = Text()
+    for i, (chunk, style) in enumerate(entries):
+        if i:
+            body.append("\n")
+        body.append(chunk, style=style)
+    Console().print(Panel(body, title=title, border_style="green",
+                          title_align="left"))
 
 
 # ---- team: `daimon team init|sync|status` (#68) -----------------------------
@@ -2265,7 +2437,7 @@ def render_skill_status(report) -> None:
 
     An audit names its own repair, or the reader is left with a verdict and
     nowhere to go. The fix line only appears when something actually drifted;
-    a clean machine gets the table alone.
+    a clean machine gets the table and the #1012 summary line alone.
     """
     # A leftover under a channel daimon does not write repairs by REMOVAL
     # (#1008): the installer declines to serve a plugin-served host, so
@@ -2289,11 +2461,12 @@ def render_skill_status(report) -> None:
         for col in ("host/scope", "skill", "state", "version", "path"):
             table.add_column(col)
         for scope, skill, state, version, path in rows:
-            style = {"CURRENT": "green", "PLUGIN": "green",
-                     "NOT INSTALLED": "dim"}.get(state, "red")
+            style = _STATE_STYLE.get(state, "red")
             table.add_row(scope, skill, f"[{style}]{state}[/{style}]",
                           version, path)
         console.print(table)
+        _rich_drift_summary(len(rows),
+                            sum(1 for r in report if r["drift"]), "rows")
     if repairs:
         print("")
         for host, verb in repairs:

--- a/plugin/tests/test_hooks_install.py
+++ b/plugin/tests/test_hooks_install.py
@@ -366,3 +366,58 @@ def test_hooks_install_grows_no_slug_flag(capsys):
     #948)."""
     with pytest.raises(SystemExit):
         cli.main(["hooks", "install", "codex", "--slug", "somewhere"])
+
+
+# ---- #1012: the rich install summary -----------------------------------------
+#
+# Plain install output is pinned byte-for-byte by the tests above; rich
+# groups the same lines under Installed / Registration / Next steps so the
+# two lifecycle installs read as one product.
+
+
+def test_hooks_install_rich_groups_a_manual_registration_host(
+        tmp_path, monkeypatch, capsys):
+    from daimon_briefing import render
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    assert cli.main(["hooks", "install", "windsurf"]) == 0
+    out = capsys.readouterr().out
+    assert "daimon hooks install windsurf" in out
+    assert "Installed" in out
+    assert "Next steps" in out
+    # the manual registration snippet is content, not rewritten (#1012);
+    # assert the short anchors - the tmp paths fold under the 80-col test
+    # console, and the plain test above pins them byte for byte
+    assert "command: python3" in out
+    assert "pre_user_prompt" in out and "post_cascade_response" in out
+    assert "checks: " in out
+
+
+def test_hooks_install_rich_groups_a_self_registering_host(
+        tmp_path, monkeypatch, capsys):
+    from daimon_briefing import render
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    out = capsys.readouterr().out
+    assert "daimon hooks install codex" in out
+    assert "Installed" in out
+    assert "Registration" in out
+    assert "SessionStart: registered" in out
+    assert "trust" in out.lower()
+    assert "checks: " in out
+
+
+def test_hooks_install_plain_output_is_unchanged_by_the_summary(
+        tmp_path, monkeypatch, capsys):
+    """The grouping is rich-only: a pipe still reads the exact pre-#1012
+    lines, group headers included in nothing."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    capsys.readouterr()
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    out = capsys.readouterr().out
+    assert "installed" in out and "registered" in out
+    assert "Installed" not in out and "Registration" not in out
+    assert "Next steps" not in out

--- a/plugin/tests/test_hooks_status.py
+++ b/plugin/tests/test_hooks_status.py
@@ -296,6 +296,144 @@ def test_render_hooks_status_empty_report(capsys):
     assert "no packaged hook hosts" in capsys.readouterr().out
 
 
+# ---- #1012: the rich table presentation -------------------------------------
+#
+# Rich is a separate branch from the plain lines: it must carry the same
+# facts (hosts, file verdicts, registration, manifest block, fix commands)
+# or the audit speaks only to pipes.
+
+
+def _drift_windsurf(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "windsurf"]) == 0
+    target = tmp_path.joinpath(*_WINDSURF_DIR)
+    (target / "daimon-windsurf-hooks.py").write_text("# drifted copy")
+
+
+def test_status_rich_renders_table_summary_and_fix(tmp_path, monkeypatch,
+                                                   capsys):
+    _drift_windsurf(tmp_path, monkeypatch)
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    capsys.readouterr()
+    rc = cli.main(["hooks", "status"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "windsurf" in out and "codex" in out and "kimi" in out
+    assert "STALE" in out and "CURRENT" in out
+    assert f"{len(cli._HOOK_HOSTS)} hosts, 1 drifted" in out
+    # repair commands stay visible below the table
+    assert "fix: daimon hooks install windsurf" in out
+
+
+def test_status_rich_clean_machine_says_zero_drift(tmp_path, monkeypatch,
+                                                   capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "windsurf"]) == 0
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    capsys.readouterr()
+    rc = cli.main(["hooks", "status"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert f"{len(cli._HOOK_HOSTS)} hosts, 0 drifted" in out
+
+
+def test_status_rich_marks_a_never_installed_host(tmp_path, monkeypatch,
+                                                  capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "windsurf"]) == 0
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    capsys.readouterr()
+    assert cli.main(["hooks", "status"]) == 0
+    out = capsys.readouterr().out
+    # the installed snippet host has no registration state to audit
+    assert "manual" in out
+    assert "NOT INSTALLED" in out
+
+
+def test_status_rich_carries_the_self_registration_verdict(tmp_path,
+                                                           monkeypatch,
+                                                           capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cli.main(["hooks", "install", "codex"]) == 0
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    capsys.readouterr()
+    assert cli.main(["hooks", "status"]) == 0
+    out = capsys.readouterr().out
+    assert "REGISTERED" in out
+
+
+def test_status_rich_keeps_the_manifest_block(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", str(tmp_path))
+    _arm_a_check(tmp_path)
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    capsys.readouterr()
+    assert cli.main(["hooks", "status"]) == 0
+    out = capsys.readouterr().out
+    assert "checks manifest (this project): in step, 1 armed" in out
+    assert "fix:" not in out, "an in-step manifest names no repair"
+
+
+def test_status_rich_reports_manifest_drift(tmp_path, monkeypatch, capsys):
+    from daimon_briefing import checks, config
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", str(tmp_path))
+    _arm_a_check(tmp_path)
+    checks.sync(str(tmp_path))
+    (config.checks_dir() / "manifest.json").write_text("[]\n",
+                                                       encoding="utf-8")
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    capsys.readouterr()
+    rc = cli.main(["hooks", "status"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "checks manifest (this project): drifted" in out
+    assert "fix: daimon check sync" in out
+
+
+def test_status_rich_reports_an_unreadable_manifest(tmp_path, monkeypatch,
+                                                    capsys):
+    from daimon_briefing import config
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", str(tmp_path))
+    base = config.checks_dir()
+    base.mkdir(parents=True, exist_ok=True)
+    (base / "manifest.json").write_text("{not json", encoding="utf-8")
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    capsys.readouterr()
+    rc = cli.main(["hooks", "status"])
+    out = capsys.readouterr().out
+    # an unreadable manifest is drift, the way checks.audit folds it
+    assert rc == 1
+    assert "checks manifest (this project): could not be read" in out
+    assert "fix: daimon check sync" in out
+
+
+def test_status_rich_says_no_manifest_when_absent(tmp_path, monkeypatch,
+                                                  capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    assert cli.main(["hooks", "status"]) == 0
+    out = capsys.readouterr().out
+    assert "checks manifest (this project): no manifest" in out
+
+
+def test_status_plain_output_has_no_summary_line(tmp_path, monkeypatch,
+                                                 capsys):
+    """#1012 pins the plain surface byte-for-byte: the summary and the table
+    are rich-only, so pipes keep reading exactly the pre-#1012 lines."""
+    _drift_windsurf(tmp_path, monkeypatch)
+    capsys.readouterr()
+    rc = cli.main(["hooks", "status"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "hosts," not in out
+    assert "┌" not in out and "│" not in out
+
+
 # ---- #943 slice 5: the manifest the hooks read is audited here too ---------
 #
 # The scripts landing is half of "the gate is in place". The other half is

--- a/plugin/tests/test_render.py
+++ b/plugin/tests/test_render.py
@@ -1360,6 +1360,95 @@ def test_render_hooks_install_rich_smoke(monkeypatch, capsys):
     assert "installed" in out
 
 
+# ---- #1012: shared lifecycle presentation ------------------------------------
+
+
+def _hooks_report_sample():
+    return [
+        {"host": "codex", "dir": "/h/.codex/hooks", "installed": True,
+         "registration": "REGISTERED", "drift": False,
+         "files": [{"name": "daimon-codex-stop.py", "status": "CURRENT"}]},
+        {"host": "windsurf", "dir": "/h/.daimon/hooks", "installed": True,
+         "registration": None, "drift": True,
+         "files": [{"name": "redact.py", "status": "CURRENT"},
+                   {"name": "daimon-windsurf-hooks.py", "status": "STALE"}]},
+        {"host": "kimi", "dir": "/h/.kimi-code/hooks", "installed": False,
+         "registration": "UNREGISTERED", "drift": False, "files": []},
+    ]
+
+
+def test_render_hooks_status_rich_table_smoke(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_hooks_status(_hooks_report_sample())
+    out = capsys.readouterr().out
+    assert "codex" in out and "windsurf" in out and "kimi" in out
+    assert "CURRENT" in out and "STALE" in out and "NOT INSTALLED" in out
+    assert "REGISTERED" in out and "manual" in out
+    assert "3 hosts, 1 drifted" in out
+    assert "fix: daimon hooks install windsurf" in out
+
+
+def test_render_hooks_status_rich_empty_report(monkeypatch, capsys):
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_hooks_status([])
+    out = capsys.readouterr().out
+    assert "no packaged hook hosts" in out
+
+
+def test_render_hooks_status_rich_keeps_the_manifest_block(monkeypatch, capsys):
+    """Trailing lines are the shared manifest block; the rich path prints
+    them after the fixes, same position the plain lines hold."""
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_hooks_status(
+        _hooks_report_sample(),
+        trailing=["checks manifest (this project): in step, 1 armed"])
+    out = capsys.readouterr().out
+    assert "checks manifest (this project): in step, 1 armed" in out
+
+
+def test_render_install_summary_plain_exact_format(capsys):
+    render.render_install_summary(
+        ["installed 1 file(s) to /h/.daimon/hooks"],
+        footer=("Re-run `daimon hooks install windsurf`",))
+    out = capsys.readouterr().out
+    assert out == ("installed 1 file(s) to /h/.daimon/hooks\n"
+                   "\n"
+                   "Re-run `daimon hooks install windsurf`\n")
+
+
+def test_render_install_summary_rich_groups_every_line(monkeypatch, capsys):
+    """Every non-blank line lands in exactly one group and the panel keeps
+    the installers' own words."""
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    render.render_install_summary(
+        ["installed 2 file(s) to /h/.daimon/hooks",
+         "",
+         "  SessionStart: registered daimon-codex-session-start.py",
+         "updated /h/.codex/hooks.json",
+         "/h/.codex/hooks.json already up to date",
+         "warning: /d is 9,000 bytes, host truncates this file",
+         "Register this command for the events below:",
+         "  command: python3 /h/.daimon/hooks/entry.py",
+         "checks: 0 armed for slug"],
+        footer=("Re-run `daimon hooks install codex`",),
+        title="daimon hooks install codex")
+    out = capsys.readouterr().out
+    assert "Installed" in out
+    assert "installed 2 file(s) to /h/.daimon/hooks" in out
+    assert "Registration" in out
+    assert "SessionStart: registered daimon-codex-session-start.py" in out
+    assert "updated /h/.codex/hooks.json" in out
+    assert "/h/.codex/hooks.json already up to date" in out
+    assert "Attention" in out
+    assert "warning: /d is 9,000 bytes, host truncates this file" in out
+    assert "Next steps" in out
+    assert "Register this command for the events below:" in out
+    assert "command: python3 /h/.daimon/hooks/entry.py" in out
+    assert "checks: 0 armed for slug" in out
+    assert "Re-run `daimon hooks install codex`" in out
+    assert "daimon hooks install codex" in out
+
+
 # ---- team: `daimon team init|sync|status` (#68 rich parity) ----------------
 
 

--- a/plugin/tests/test_skill_cli.py
+++ b/plugin/tests/test_skill_cli.py
@@ -61,3 +61,34 @@ def test_skill_install_project_no_git_falls_back_to_cwd(tmp_path, monkeypatch, c
     monkeypatch.chdir(no_git_dir)
     assert cli.main(["skill", "install", "cursor", "--project"]) == 0
     assert (no_git_dir / ".cursor" / "rules" / "daimon.mdc").exists()
+
+
+# ---- #1012: the rich install summary -----------------------------------------
+#
+# Same grouping contract as `hooks install`: Installed / Next steps in one
+# panel on the rich path; plain keeps the exact pre-#1012 lines.
+
+
+def test_skill_install_rich_groups_the_summary(tmp_path, monkeypatch, capsys):
+    from daimon_briefing import render
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    assert cli.main(["skill", "install", "kimi"]) == 0
+    out = capsys.readouterr().out
+    assert "daimon skill install kimi" in out
+    assert "Installed" in out
+    assert "installed daimon skill" in out
+    # the upgrade reminder is a next step, not an artifact line
+    assert "Next steps" in out
+    assert "Re-run `daimon skill install kimi`" in out
+
+
+def test_skill_install_plain_output_is_unchanged_by_the_summary(
+        tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    capsys.readouterr()
+    assert cli.main(["skill", "install", "kimi"]) == 0
+    out = capsys.readouterr().out
+    assert "installed daimon skill" in out
+    assert "Installed" not in out and "Next steps" not in out

--- a/plugin/tests/test_skill_status.py
+++ b/plugin/tests/test_skill_status.py
@@ -439,6 +439,27 @@ def test_a_plugin_served_host_with_no_file_is_not_missing(tmp_path):
     assert row["channel"] == "plugin"
 
 
+def test_a_plugin_served_row_renders_green_in_the_rich_table(
+        tmp_path, monkeypatch, capsys):
+    """#1012 follow-up: the shared style map dropped PLUGIN, and a healthy
+    plugin-channel machine rendered red - the drift fallback. FORCE_COLOR
+    makes rich emit the escapes so the colour is asserted, not implied;
+    NO_COLOR and TERM=dumb are cleared because the outer shell may set them
+    (the environment quirk behind the two known render-test failures)."""
+    from daimon_briefing import render
+
+    home = _home(tmp_path)
+    _plugin_registry(home)
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    monkeypatch.setenv("TERM", "xterm-256color")
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    render.render_skill_status(skill_install.audit(home=home, cwd=tmp_path))
+    out = capsys.readouterr().out
+    assert "\x1b[32mPLUGIN\x1b[0m" in out
+    assert "\x1b[31mPLUGIN\x1b[0m" not in out
+
+
 def test_a_leftover_under_the_plugin_is_named_as_a_leftover(tmp_path):
     """The regression this issue was filed for. An older CLI install leaves a
     skill file behind, the plugin now serves the same skill, and the audit

--- a/plugin/tests/test_skill_status.py
+++ b/plugin/tests/test_skill_status.py
@@ -338,6 +338,56 @@ def test_the_rich_table_carries_every_row_and_the_repair(tmp_path, monkeypatch,
     out = capsys.readouterr().out
     assert "kimi" in out
     assert "STALE" in out
+    assert "1 drifted" in out
+    assert "fix: daimon skill install kimi" in out
+
+
+def test_the_rich_summary_counts_rows_not_just_drift(tmp_path, monkeypatch,
+                                                     capsys):
+    """#1012: the same compact summary shape the hooks table prints, naming
+    the table's own unit - one row per host/scope/skill."""
+    from daimon_briefing import render
+
+    home = _home(tmp_path)
+    skill_install.install("kimi", project=False, home=home, cwd=tmp_path)
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    capsys.readouterr()
+    render.render_skill_status(skill_install.audit(home=home, cwd=tmp_path))
+    out = capsys.readouterr().out
+    report = skill_install.audit(home=home, cwd=tmp_path)
+    assert f"{len(report)} rows, 0 drifted" in out
+
+
+def test_the_plain_path_has_no_summary_line(tmp_path, capsys):
+    """The summary is a rich-path addition; plain output stays the
+    pre-#1012 contract pipes read."""
+    from daimon_briefing import render
+
+    home = _home(tmp_path)
+    skill_install.install("kimi", project=False, home=home, cwd=tmp_path)
+    capsys.readouterr()
+    render.render_skill_status(skill_install.audit(home=home, cwd=tmp_path))
+    out = capsys.readouterr().out
+    assert "kimi" in out
+    assert "rows," not in out
+
+
+def test_skill_status_cli_rich_summary(tmp_path, monkeypatch, capsys):
+    import daimon_briefing.cli as cli
+    from daimon_briefing import render
+
+    home = _home(tmp_path)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("DAIMON_CHECKPOINT_DIR", str(tmp_path / "store"))
+    monkeypatch.setenv("PATH", "")
+    assert cli.main(["skill", "install", "kimi"]) == 0
+    (home / ".kimi-code" / "skills" / "daimon" / "SKILL.md").write_text(
+        "drifted\n", encoding="utf-8")
+    monkeypatch.setattr(render, "supports_rich", lambda: True)
+    capsys.readouterr()
+    assert cli.main(["skill", "status"]) == 1
+    out = capsys.readouterr().out
+    assert "1 drifted" in out
     assert "fix: daimon skill install kimi" in out
 
 


### PR DESCRIPTION
Closes #1012

## What

Give the hooks and skill lifecycle commands one shared visual language.

- `daimon hooks status` now renders a Rich table when interactive: one row
  per host with the install dir, per-file verdicts, and the registration
  state, followed by a compact summary line with host and drift counts and
  the repair commands below the table. The checks manifest block keeps its
  shared wording and follows the fixes as before.
- `daimon skill status` gains the same summary line under its existing
  table, so both audits end the same way.
- Both status commands keep one state style map: green for CURRENT,
  REGISTERED and healthy states, dim for NOT INSTALLED, yellow for partial
  or attention states, red for STALE, MISSING, BROKEN and drifted states.
- `daimon hooks install` and `daimon skill install` render a grouped Rich
  summary on success: Installed artifacts, Registration state, Attention
  warnings when present, and Next steps. Manual registration snippets and
  the re-run-after-upgrade reminder stay in the installers' own words.
- Plain output for non-TTY and DAIMON_PLAIN modes is byte-identical to
  before, and both `--json` contracts, exit codes, and repair commands are
  unchanged. The two audits keep their distinct schemas.

## Why

The two audits exposed related installation state but looked like different
products: skill status had a structured table while hooks status printed
manually formatted lines, and install output was mostly plain confirmation
text. The issue asks for consistent interaction and visual hierarchy
without forcing both audits into one wide table.

## Tests

- `.venv/bin/python -m pytest tests/ -q` from `plugin/`: 6471 passed,
  2 skipped, with only the two pre-existing rich-color-detection failures
  in test_render.py that already fail on main.
- New Rich-path tests monkeypatch `render.supports_rich` to True and cover
  the hooks status table, summary, registration column, manifest block
  states, and the grouped install panels for both families; new plain-path
  tests pin the pre-#1012 byte output and the absence of the summary line.
- `.venv/bin/ruff check daimon_briefing/ tests/` and
  `.venv/bin/mypy daimon_briefing/` both pass.
