### PR TITLE
feat(serializer): demote a stitched quote from verbatim and report the stitching rate

### DIFF
--- a/.scars/candidates/stats-json-tail-assertion-forbids-its-own-contract.md
+++ b/.scars/candidates/stats-json-tail-assertion-forbids-its-own-contract.md
@@ -1,0 +1,41 @@
+---
+id: 0
+type: landmine
+title: Appending a stats --json section breaks a tail assertion in test_checks_surfaces.py, a file about rulings
+severity: medium
+confidence: 0.9
+created: 2026-09-12
+authors: ["claude-code"]
+anchors:
+  - path: plugin/daimon_briefing/cli/__init__.py
+  - path: plugin/tests/test_checks_surfaces.py
+evidence:
+  - note: "#974 step 1 — adding the `stitching` section, exactly as the in-code comment instructs, failed test_stats_json_carries_checks_at_the_tail"
+expires:
+  condition: "the tail assertion is rewritten to pin the appended ORDER of all sections rather than whichever one happens to be last"
+  review_after: 2027-03-01
+status: candidate
+---
+
+`_cmd_stats` carries a comment saying `stats --json` key order is a contract
+and a new fact is APPENDED at the tail. Following that instruction breaks
+`test_stats_json_carries_checks_at_the_tail`, which asserts
+`list(payload)[-1] == "checks"`. The assertion does not pin the append-at-tail
+rule, it pins one particular section as permanently last, so it fires against
+the very change the contract asks for.
+
+The trap is where it lives. The failure surfaces in
+`plugin/tests/test_checks_surfaces.py`, a file about armed rulings and check
+firings, with nothing in its name or module docstring connecting it to the
+stats payload. Someone adding a stats section reads `_cmd_stats`, follows the
+comment, runs their own new test file green, and only discovers the breakage
+in a full-suite run. The same shape sits in `tests/test_cli.py`, where
+`list(cap)[-1] == "gates"` pins the tail of the `capture` sub-block.
+
+What to do instead: keep appending at the tail, and when this fires, widen the
+assertion to the pair rather than weakening it to a membership check. `#974`
+changed it to `list(payload)[-2:] == ["checks", "stitching"]`, which is the
+form `test_checks_surfaces.py` already uses for `status --json`
+(`list(payload)[-2:] == ["checks", "identity"]`). Never delete the assertion:
+it is the only thing keeping a new section from being inserted into the middle
+of the documented order.

--- a/docs/checkpoint-schema.json
+++ b/docs/checkpoint-schema.json
@@ -620,7 +620,7 @@
       "constraints": {
         "stripped_at_serialize": true
       },
-      "notes": "verify_quotes verdict (#125): true on a byte-verified quote, false only where a verbatim claim was downgraded. Inferred items carry neither this nor last_verified."
+      "notes": "verify_quotes verdict (#125): true on a byte-verified quote, false only where a verbatim claim was downgraded. An item extracted as inferred carries neither this nor last_verified; one DEMOTED to inferred does keep them, because the verdict is about the bytes and outlives the trust class (#359 grounding, #974 stitching)."
     },
     {
       "field": "last_verified",
@@ -652,7 +652,7 @@
           "outcome: enum[verified, not-verified]",
           "checked_at: string (ISO-8601 UTC, %Y-%m-%dT%H:%M:%SZ)",
           "binding: object {mode: enum[message-ids, transcript-scan], message_ids: array of string}",
-          "stitching?: object {cross_message: boolean, cross_role: boolean} — exists since format_version D-019 (#829); verified receipts only, when per-message attribution was possible; true means NO single message (or single role) can account for all matched quote fragments, i.e. the quote was stitched across turns or speakers; absent = unknown (pre-D-019 receipts, transcript-less captures)"
+          "stitching?: object {cross_message: boolean, cross_role: boolean} — exists since format_version D-019 (#829); verified receipts only, when per-message attribution was possible; true means NO single message (or single role) can account for all matched quote fragments, i.e. the quote was stitched across turns or speakers; absent = unknown (pre-D-019 receipts, transcript-less captures). Since #974 either flag being true DEMOTES the item to trust=inferred at verification: outcome, quote_verified and binding are untouched, so a verified receipt on an inferred item is the expected shape of a stitched quote, not a contradiction"
         ]
       },
       "notes": "Durable per-item evidence receipt (#594, provenance.quote_receipt). verifier is an OBJECT {id, version}: consumers normalizing it as a string rendered every verified claim's verifier as absent."

--- a/plugin/daimon_briefing/cli/__init__.py
+++ b/plugin/daimon_briefing/cli/__init__.py
@@ -3213,6 +3213,84 @@ def _stats_verification(project_dir) -> dict:
     return {"total": sum(by_check.values()), "by_check": by_check}
 
 
+def _stats_stitching(project_dir) -> dict:
+    """Quote-stitching rate over this project's stored receipts (#974).
+
+    #829 records, per VERIFIED receipt, whether the matched fragments could
+    have come from one message / one role
+    (`quote_provenance.stitching.{cross_message, cross_role}`). Nothing read
+    it back, so rule 17's no-stitching doctrine had a measurement nobody
+    could see. This is that read.
+
+    Three decisions, each of which changes what the number means:
+
+    * DENOMINATOR = receipts that CARRY a stitching verdict, never all
+      verified receipts. A pre-D-019 receipt, or one stamped by a
+      transcript-less capture, is absent-means-unknown — folding it in as a
+      clean verdict would report `0%` where the honest answer is "daimon
+      cannot tell you". The unknowns are counted as `unmeasured` and
+      reported beside the rate, the #477 two-populations rule.
+
+    * ONE ITEM COUNTS ONCE, keyed on the stable item id. A carried item
+      rides into every later checkpoint with the same id and the same frozen
+      receipt, so counting occurrences would let a single stitched quote
+      inflate the rate once per session it survived (#562's epoch-artifact
+      class). An item with no id — `active_topic` never carries one — counts
+      as its own occurrence, which is the conservative reading: it cannot be
+      proven to be a duplicate of anything.
+
+    * ITS OWN WALK, not a rider on `_stats_store`'s. That block is
+      machine-wide by contract and this number is per project (audit.py's
+      `project_slug` filter, reused). Stats is a diagnostic verb run by
+      hand; a second pass over the checkpoint dir is cheaper than a
+      per-project count living inside a machine-wide section.
+
+    Never raises: an unreadable checkpoint is skipped, the same posture the
+    other stats folds take."""
+    want_slug = store.project_slug(project_dir)
+    out: dict = {"verified": 0, "measured": 0, "stitched": 0,
+                 "cross_message": 0, "cross_role": 0, "unmeasured": 0,
+                 "rate_pct": None}
+    try:
+        files = store._session_files(config.checkpoint_dir())
+    except OSError:
+        return out
+    seen: set = set()
+    for f in sorted(files):
+        try:
+            cp = json.loads(f.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(cp, dict):
+            continue
+        if want_slug is not None and cp.get("project_slug") != want_slug:
+            continue
+        for item in serializer.iter_items(cp):
+            receipt = item.get("quote_provenance")
+            if (not isinstance(receipt, dict)
+                    or receipt.get("outcome") != "verified"):
+                continue
+            item_id = item.get("id")
+            if isinstance(item_id, str) and item_id:
+                if item_id in seen:
+                    continue
+                seen.add(item_id)
+            out["verified"] += 1
+            stitching = receipt.get("stitching")
+            if not isinstance(stitching, dict):
+                out["unmeasured"] += 1
+                continue
+            out["measured"] += 1
+            cross_message = stitching.get("cross_message") is True
+            cross_role = stitching.get("cross_role") is True
+            out["cross_message"] += int(cross_message)
+            out["cross_role"] += int(cross_role)
+            out["stitched"] += int(cross_message or cross_role)
+    if out["measured"]:
+        out["rate_pct"] = round(100.0 * out["stitched"] / out["measured"], 1)
+    return out
+
+
 def _earlier(current: str | None, ts: str) -> str | None:
     """Earliest of two event stamps, ignoring empties. Stamps are written by
     one helper in a single UTC format, so lexicographic order is chronological
@@ -3421,7 +3499,9 @@ def _cmd_stats(args) -> int:
             "rescue_posture": llm.rescue_posture(),
             # #943 slice 5: appended at the tail — `stats --json` key order is
             # the same contract `status --json` documents.
-            "checks": _stats_checks(project)}
+            "checks": _stats_checks(project),
+            # #974 step 1: same rule, same tail.
+            "stitching": _stats_stitching(project)}
     if args.json:
         print(json.dumps(data, indent=2))
         return 0

--- a/plugin/daimon_briefing/field_table.py
+++ b/plugin/daimon_briefing/field_table.py
@@ -197,8 +197,10 @@ ITEM_RULES: tuple[FieldRule, ...] = (
         "item", "quote_verified", "boolean", True, False, "code", "strip",
         _c(stripped_at_serialize=True),
         "verify_quotes verdict (#125): true on a byte-verified quote, false "
-        "only where a verbatim claim was downgraded. Inferred items carry "
-        "neither this nor last_verified."),
+        "only where a verbatim claim was downgraded. An item extracted as "
+        "inferred carries neither this nor last_verified; one DEMOTED to "
+        "inferred does keep them, because the verdict is about the bytes and "
+        "outlives the trust class (#359 grounding, #974 stitching)."),
     FieldRule(
         "item", "last_verified", "string", True, False, "code", "strip",
         _c(format=_TIMESTAMP, stripped_at_serialize=True),
@@ -228,7 +230,11 @@ ITEM_RULES: tuple[FieldRule, ...] = (
                   "role) can account for all matched quote fragments, i.e. "
                   "the quote was stitched across turns or speakers; absent "
                   "= unknown (pre-D-019 receipts, transcript-less "
-                  "captures)")),
+                  "captures). Since #974 either flag being true DEMOTES the "
+                  "item to trust=inferred at verification: outcome, "
+                  "quote_verified and binding are untouched, so a verified "
+                  "receipt on an inferred item is the expected shape of a "
+                  "stitched quote, not a contradiction")),
         "Durable per-item evidence receipt (#594, provenance.quote_receipt). "
         "verifier is an OBJECT {id, version}: consumers normalizing it as a "
         "string rendered every verified claim's verifier as absent."),

--- a/plugin/daimon_briefing/render.py
+++ b/plugin/daimon_briefing/render.py
@@ -1935,6 +1935,29 @@ def _checks_line(c: dict) -> str:
             f"{c['denied']} denied")
 
 
+def _stitching_line(s: dict) -> str:
+    """#974 step 1: the one quote-stitching line, shared by the plain and rich
+    renderers, in the three states the measurement has to tell apart.
+
+    Nothing verified yet is not zero percent. A corpus whose receipts all
+    predate D-019 is not zero percent either — absent stitching means
+    unknown, and a confident `0.0%` over unknowns is the exact reading rule
+    17's doctrine must never be given. Only the third state prints a rate,
+    and it names the unmeasured remainder beside it rather than folding the
+    two populations into one number (#477)."""
+    if not s.get("verified"):
+        return "quote stitching: no verified quotes yet"
+    if not s.get("measured"):
+        return (f"quote stitching: none of {s['verified']} verified quotes "
+                "carry a stitching verdict (pre-D-019 or transcript-less)")
+    line = (f"quote stitching: {s['stitched']} of {s['measured']} measured "
+            f"verified quotes stitched ({s['rate_pct']}%) — cross-message "
+            f"{s['cross_message']}, cross-role {s['cross_role']}")
+    if s.get("unmeasured"):
+        line += f"; {s['unmeasured']} unmeasured"
+    return line
+
+
 def _plain_stats(data: dict) -> None:
     u, c, s = data["usage"], data["capture"], data["store"]
     print("usage (local, never transmitted):")
@@ -2029,6 +2052,13 @@ def _plain_stats(data: dict) -> None:
         # the exact ambiguity the line exists to remove.
         print("checks (this project):")
         print(f"  {_checks_line(chk)}")
+    stitch = data.get("stitching")
+    if stitch:
+        # #974: always shown, same rule again — "no verified quotes yet" and
+        # "no receipt carries a verdict" are each an answer, and a rule with
+        # no visible measurement is how #829's record sat unread.
+        print("stitching (this project):")
+        print(f"  {_stitching_line(stitch)}")
     res = data.get("resolutions")
     if res:
         # #480 slice 5: the credit block — who is closing loops. Always shown
@@ -2225,6 +2255,17 @@ def _rich_stats(data: dict) -> None:
         chk_table.add_column("value")
         chk_table.add_row("status", _checks_line(chk))
         console.print(chk_table)
+
+    stitch = data.get("stitching")
+    if stitch:
+        # #974: mirrors the plain renderer, same always-shown rule.
+        stitch_table = Table(title="stitching (this project)",
+                             title_justify="left", show_header=True,
+                             header_style="bold")
+        stitch_table.add_column("metric")
+        stitch_table.add_column("value")
+        stitch_table.add_row("status", _stitching_line(stitch))
+        console.print(stitch_table)
 
     res = data.get("resolutions")
     if res:

--- a/plugin/daimon_briefing/serializer.py
+++ b/plugin/daimon_briefing/serializer.py
@@ -56,6 +56,10 @@ log = logging.getLogger(__name__)
 # shape per format_version, so two different receipt shapes must never
 # share the name D-018. Recording only; EXTRACTION_VERSION stays at 3 —
 # what a chunk pass extracts is unchanged, only what verification records.)
+# #974 acts on that record: a stitched verdict now DEMOTES the item's trust
+# class to "inferred". No bump — the persisted SHAPE is unchanged, and the
+# trust field has always been one verify_quotes may downgrade. Only the value
+# a stitched item stores moves, which is a behavior change, not a format one.
 # Checkpoints are only comparable across runs sharing this version (scar
 # landmine #4); pre-bump checkpoints firing the #93 format_version mismatch
 # warning is desired, not a bug.
@@ -1236,7 +1240,9 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
     already trust="inferred" are left untouched — no stamp, either field.
     Runs ONCE at serialize, PRE-redaction, so the quote is still the raw text
     (a quote whose secret redaction will later mask still verifies here
-    against the raw rendered text). Returns the downgrade count.
+    against the raw rendered text). Returns the count of quotes that FAILED
+    the byte check — never the #974 stitching demotions, which passed it (see
+    stamp_receipt) and are logged on their own line.
 
     #358: when `messages` is given, an item bound to source message id(s) is
     checked against JUST those messages first — resolve id, compare bytes. A
@@ -1269,9 +1275,15 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
     #829: every verified receipt additionally records a `stitching` verdict —
     whether the matched fragments could have come from one message / one role
     (_stitching_flags' necessity semantics) — when `messages` provides a
-    per-message view. Recording only, never an outcome change: rule 17's
-    no-stitching doctrine (SERIALIZE_SYS) gains a measurement, not an
-    enforcement; the follow-up enforcement is gated on the measured rate."""
+    per-message view.
+
+    #974 is the enforcement that record was gated on. A verified quote whose
+    verdict carries either flag is DEMOTED to trust="inferred": rule 17's
+    no-stitching doctrine (SERIALIZE_SYS) now binds the tag. The outcome is
+    untouched — the receipt still says `verified`, `quote_verified` stays
+    True, the quote and its binding survive — because the bytes WERE
+    witnessed and only the one-contiguous-span claim was not. An absent
+    verdict is unknown and never demotes."""
     # #440: the RAW pair survives alongside the stripped haystacks, read on
     # the failure path only — to tell an echoed quote from an absent one.
     # #512: daimon-output tool rows are blanked in the STRIPPED map (their
@@ -1289,7 +1301,7 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
     # quote-source claims — they never scope the quote check, and a scoped
     # MISS must not execute them for the quote-id's crime.
     signals = signal_message_ids(messages) if messages else set()
-    downgraded = echoed = 0
+    downgraded = echoed = stitched = 0
     digest = provenance.source_digest(transcript_hash, transcript_text)
     # #604: ONE stamp for the whole pass, threaded from the caller's clock —
     # the session-end stamp `created` also uses. Reading the wall clock per
@@ -1334,6 +1346,7 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
         # denominator by forgetting an argument. The re-parse is a few regex
         # splits on one short quote, once per verified receipt; the costly
         # haystack normalization is what the attribution caches hold.
+        nonlocal stitched
         stitching = None
         if outcome == "verified" and messages:
             fragments = _quote_fragments(item.get("quote") or "")
@@ -1347,6 +1360,34 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
             stitching=stitching)
         if receipt is not None:
             item["quote_provenance"] = receipt
+        # #974: rule 17 says a verbatim quote is ONE contiguous span of ONE
+        # message. #829 measured the violation and left the tag alone; this
+        # is where the tag finally answers to the rule.
+        #
+        # Demote, never drop: the text, the quote, the binding and the
+        # receipt are all left exactly as recorded, and `quote_verified`
+        # stays True — the BYTES were witnessed, and only the contiguity
+        # claim `verbatim` carries was not. Flipping quote_verified would
+        # file this under `quote-not-in-transcript` in the rejection ledger
+        # (verification_rejections), a fabrication reason code a witnessed
+        # quote does not belong to. Same shape as ground_outcomes' downgrade,
+        # which also keeps the quote and moves only the class.
+        #
+        # Keyed on the VERDICT, not on the stored receipt: a source_ref
+        # quote_receipt refuses leaves the stitching fact just as true, and
+        # keeping `verbatim` there would mint the false tag this exists to
+        # stop. Absent stitching (pre-D-019, transcript-less, attribution
+        # impossible) is UNKNOWN and never demotes.
+        if stitching and (stitching["cross_message"]
+                          or stitching["cross_role"]):
+            item["trust"] = "inferred"
+            stitched += 1
+            # Content hash, never the text (#616): this line lands in
+            # serialize.log, which is declared exempt-no-plaintext.
+            log.warning("quote verification: downgraded verbatim->inferred "
+                        "(stitched across %s) (content hash %s)",
+                        "speakers" if stitching["cross_role"] else "turns",
+                        normalize.content_key(item.get("text") or ""))
     # The model never gets a vote on the echo verdict (#292 discipline, same
     # as `grounded`/`pinned`): any model-emitted value is dropped before the
     # checker re-derives it.
@@ -1443,6 +1484,12 @@ def verify_quotes(checkpoint, transcript_text: str, messages=None, *,
     if downgraded:
         log.info("quote verification: %d verbatim item(s) downgraded to inferred"
                  " (%d echo-only)", downgraded, echoed)
+    if stitched:
+        # #974: counted and reported APART from the line above. Those items
+        # failed the byte check; these passed it and failed rule 17, and one
+        # summed number would make the echo-only breakdown stop adding up.
+        log.info("quote verification: %d verified item(s) downgraded to "
+                 "inferred (stitched across turns or speakers)", stitched)
     return downgraded
 
 

--- a/plugin/tests/test_checks_surfaces.py
+++ b/plugin/tests/test_checks_surfaces.py
@@ -919,7 +919,10 @@ def test_stats_json_carries_checks_at_the_tail(tmp_path, monkeypatch, capsys):
     _arm(tmp_path)
     assert _stats(tmp_path, "--json") == 0
     payload = json.loads(capsys.readouterr().out)
-    assert list(payload)[-1] == "checks"
+    # #974 appended `stitching` behind it under the same rule; `checks` is
+    # still the tail as of #943, so pin the pair rather than weakening this
+    # to a membership check.
+    assert list(payload)[-2:] == ["checks", "stitching"]
     assert payload["checks"] == {"armed": 1, "proposed": 0, "fired": 0,
                                  "clean": 0, "violation": 0, "unresolved": 0,
                                  "denied": 0, "log_state": "absent",

--- a/plugin/tests/test_quote_stitching.py
+++ b/plugin/tests/test_quote_stitching.py
@@ -2,10 +2,15 @@
 
 SERIALIZE_SYS rule 17 forbids stitching a quote from different speakers or
 turns, but quote_matches scans one flattened haystack, so a stitched quote
-verifies and earns trust=verbatim. This slice is recording only, additive and
-behavior-preserving: the receipt says whether the matched fragments could have
-come from one message / one role, verification outcomes stay untouched, and
-the violation rate becomes measurable before any semantics change.
+verifies and earns trust=verbatim. The #829 slice was recording only: the
+receipt says whether the matched fragments could have come from one message /
+one role, and the violation rate became measurable before any semantics
+change.
+
+#974 acts on that record. A stitched quote is demoted from verbatim to
+inferred; the text, the quote, the binding and the receipt are all left
+exactly as recorded, and only the trust tag moves. The demotion tests live in
+the last section of this file.
 
 Necessity semantics (pinned here): a flag is True only when NO single message
 (or no single role's messages, joined in transcript order) can account for
@@ -93,9 +98,8 @@ def test_cross_message_same_role_stitch_is_recorded():
             "quote": "first constraint half ... second constraint half"}
     _verify(item, messages)
 
-    # Behavior preserved: the stitched quote still verifies (rule 17 stays
-    # doctrine; enforcement is the measured follow-up, not this slice).
-    assert item["trust"] == "verbatim"
+    # The quote's BYTES are still witnessed (#974 demotes the tag, never the
+    # verdict) — the recorded verdict is what the demotion section asserts on.
     assert item["quote_verified"] is True
     assert item["quote_provenance"]["stitching"] == {
         "cross_message": True, "cross_role": False}
@@ -372,3 +376,213 @@ def test_field_table_documents_the_stitching_shape():
     assert "stitching" in shape
     assert "cross_message" in shape
     assert "cross_role" in shape
+
+
+# ---- #974: a stitched quote is demoted from verbatim ----------------------
+#
+# Rule 17 says a verbatim quote is one contiguous span of one message. #829
+# made the violation measurable; this is where the product finally holds the
+# tag to the rule. Demote, never drop: the text and the receipt stay exactly
+# as recorded, and only `trust` moves.
+
+
+def test_cross_message_stitch_alone_demotes_to_inferred():
+    """Same role, two turns. `cross_message` on its own is a rule-17
+    violation, so it demotes without waiting for a speaker change."""
+    messages = [
+        {"role": "user", "content": "the first constraint half lives here",
+         "id": "u-1"},
+        {"role": "assistant", "content": "acknowledged, moving on", "id": "a-2"},
+        {"role": "user", "content": "the second constraint half arrives now",
+         "id": "u-3"},
+    ]
+    item = {"text": "claim", "trust": "verbatim",
+            "quote": "first constraint half ... second constraint half"}
+    _verify(item, messages)
+
+    assert item["quote_provenance"]["stitching"] == {
+        "cross_message": True, "cross_role": False}
+    assert item["trust"] == "inferred"
+
+
+def test_cross_role_stitch_demotes_to_inferred():
+    messages = [
+        {"role": "user", "content": "the alpha premise stands firm", "id": "u-1"},
+        {"role": "assistant", "content": "the omega conclusion follows cleanly",
+         "id": "a-2"},
+    ]
+    item = {"text": "claim", "trust": "verbatim",
+            "quote": "alpha premise stands ... omega conclusion follows"}
+    _verify(item, messages)
+
+    assert item["quote_provenance"]["stitching"]["cross_role"] is True
+    assert item["trust"] == "inferred"
+
+
+def test_an_unstitched_verified_quote_keeps_verbatim():
+    """The negative control. A demotion that fired on every verified quote
+    would satisfy both assertions above and destroy the trust class."""
+    messages = [
+        {"role": "user", "content": "the durable sentence we agreed on", "id": "u-1"},
+        {"role": "assistant", "content": "unrelated follow-up prose", "id": "a-2"},
+    ]
+    item = {"text": "claim", "trust": "verbatim",
+            "quote": "the durable sentence we agreed on"}
+    _verify(item, messages)
+
+    assert item["quote_provenance"]["stitching"] == {
+        "cross_message": False, "cross_role": False}
+    assert item["trust"] == "verbatim"
+
+
+def test_a_receipt_with_no_stitching_member_never_demotes():
+    """Absent means UNKNOWN, and unknown never demotes. The legacy two-arg
+    call is the shipping path that produces this receipt: no `messages`, no
+    per-message view, no verdict."""
+    item = {"text": "claim", "trust": "verbatim",
+            "quote": "the durable sentence we agreed on"}
+    cp = _checkpoint(item)
+    serializer.verify_quotes(
+        cp, "user: the durable sentence we agreed on",
+        source_ref=_source(), transcript_hash=_HASH)
+
+    assert "stitching" not in item["quote_provenance"]
+    assert item["trust"] == "verbatim"
+
+
+def test_the_demotion_leaves_the_text_the_quote_and_the_receipt_intact():
+    """Demote rather than drop. Everything the receipt recorded is still
+    there afterwards, including the binding, and it still validates."""
+    messages = [
+        {"role": "user", "content": "the alpha premise stands firm", "id": "u-1"},
+        {"role": "assistant", "content": "the omega conclusion follows cleanly",
+         "id": "a-2"},
+    ]
+    quote = "alpha premise stands ... omega conclusion follows"
+    item = {"text": "claim", "trust": "verbatim", "quote": quote,
+            "source_message_ids": ["u-1", "a-2"]}
+    _verify(item, messages)
+
+    assert item["trust"] == "inferred"
+    assert item["text"] == "claim"
+    assert item["quote"] == quote
+    assert item["source_message_ids"] == ["u-1", "a-2"]
+    receipt = item["quote_provenance"]
+    assert receipt["outcome"] == "verified"
+    assert receipt["binding"] == {"mode": "message-ids",
+                                  "message_ids": ["u-1", "a-2"]}
+    assert provenance.valid_quote_receipt(receipt)
+
+
+def test_a_stitched_demotion_is_not_a_quote_rejection():
+    """`quote_verified: False` means the BYTES were not witnessed, and it is
+    what verification_rejections ledgers as `quote-not-in-transcript`. A
+    stitched quote's bytes WERE witnessed, so flipping that flag would file
+    the item under a reason code it does not belong to (#376/#440)."""
+    messages = [
+        {"role": "user", "content": "the alpha premise stands firm", "id": "u-1"},
+        {"role": "assistant", "content": "the omega conclusion follows cleanly",
+         "id": "a-2"},
+    ]
+    item = {"text": "claim", "trust": "verbatim", "id": "q-abc123",
+            "quote": "alpha premise stands ... omega conclusion follows"}
+    cp = _checkpoint(item)
+    serializer.verify_quotes(
+        cp, serializer._render_transcript(messages), messages,
+        source_ref=_source(), transcript_hash=_HASH)
+
+    assert item["trust"] == "inferred"
+    assert item["quote_verified"] is True
+    assert item["last_verified"]
+    assert serializer.verification_rejections(cp) == []
+
+
+def test_the_demotion_does_not_move_the_quote_miss_downgrade_count():
+    """`verify_quotes` returns the number of quotes that FAILED the byte
+    check. A stitched quote passed it, so folding it into that return would
+    make the echo-only breakdown logged beside it stop adding up."""
+    messages = [
+        {"role": "user", "content": "the alpha premise stands firm", "id": "u-1"},
+        {"role": "assistant", "content": "the omega conclusion follows cleanly",
+         "id": "a-2"},
+    ]
+    item = {"text": "claim", "trust": "verbatim",
+            "quote": "alpha premise stands ... omega conclusion follows"}
+    cp = _checkpoint(item)
+    assert serializer.verify_quotes(
+        cp, serializer._render_transcript(messages), messages,
+        source_ref=_source(), transcript_hash=_HASH) == 0
+    assert item["trust"] == "inferred"
+
+
+def test_the_demotion_survives_a_receipt_that_could_not_be_built():
+    """The verdict, not the stored receipt, is what the demotion rests on. A
+    source_ref daimon cannot build a receipt from leaves the stitching fact
+    just as true, and keeping `verbatim` there would mint exactly the false
+    tag this change exists to stop."""
+    messages = [
+        {"role": "user", "content": "the alpha premise stands firm", "id": "u-1"},
+        {"role": "assistant", "content": "the omega conclusion follows cleanly",
+         "id": "a-2"},
+    ]
+    item = {"text": "claim", "trust": "verbatim",
+            "quote": "alpha premise stands ... omega conclusion follows"}
+    cp = _checkpoint(item)
+    serializer.verify_quotes(
+        cp, serializer._render_transcript(messages), messages,
+        source_ref={"version": 1, "host": "nope"}, transcript_hash=_HASH)
+
+    assert "quote_provenance" not in item
+    assert item["trust"] == "inferred"
+
+
+def test_the_demotion_logs_the_content_hash_and_never_the_text(caplog):
+    """serialize.log is declared exempt-no-plaintext, so the diagnostic handle
+    is the content hash (#616), exactly as the quote-miss downgrade does it."""
+    import logging
+
+    from daimon_briefing import normalize
+
+    messages = [
+        {"role": "user", "content": "the alpha premise stands firm", "id": "u-1"},
+        {"role": "assistant", "content": "the omega conclusion follows cleanly",
+         "id": "a-2"},
+    ]
+    item = {"text": "a secret-bearing claim", "trust": "verbatim",
+            "quote": "alpha premise stands ... omega conclusion follows"}
+    with caplog.at_level(logging.INFO, logger="daimon_briefing.serializer"):
+        _verify(item, messages)
+
+    text = caplog.text
+    assert normalize.content_key("a secret-bearing claim") in text
+    assert "a secret-bearing claim" not in text
+    assert "alpha premise stands" not in text
+    assert "stitched" in text
+
+
+def test_the_briefing_renders_a_demoted_quote_as_inferred():
+    """The consumer that matters: a stitched quote must stop wearing the
+    checkmark. `_mark` reads the STORED tag, so the demotion is what moves
+    it and no render-time rule is needed."""
+    from daimon_briefing import briefing
+
+    messages = [
+        {"role": "user", "content": "the alpha premise stands firm", "id": "u-1"},
+        {"role": "assistant", "content": "the omega conclusion follows cleanly",
+         "id": "a-2"},
+    ]
+    item = {"text": "claim", "trust": "verbatim",
+            "quote": "alpha premise stands ... omega conclusion follows"}
+    _verify(item, messages)
+
+    assert briefing._mark(item) == "~ inferred"
+
+
+def test_the_field_table_documents_the_demotion():
+    """#827: the published contract is what an external consumer normalizes
+    against. A flag that now moves the trust class while the contract still
+    calls it a recording would leave every such consumer wrong."""
+    shape = " ".join(dict(
+        field_table.rule("item", "quote_provenance").constraints)["shape"])
+    assert "demote" in shape.lower()
+    assert "trust=inferred" in shape

--- a/plugin/tests/test_stats_stitching.py
+++ b/plugin/tests/test_stats_stitching.py
@@ -1,0 +1,258 @@
+"""#974 step 1: `daimon stats` reports the quote-stitching rate.
+
+#829 made stitching a RECORD on the receipt (`quote_provenance.stitching`).
+Nothing read it back, so the rate a demotion has to be judged against was
+unmeasurable on the one surface an operator actually runs. This file pins the
+measurement: the population, the scoping, the zero-denominator wording, and
+the dedup that keeps one carried item from counting once per session it rode
+through.
+
+Fixtures are built with the SHIPPING writers — serializer.verify_quotes stamps
+the receipts, policy.stamp_item_ids stamps the ids, store.write_checkpoint
+persists and stamps the project slug — so no hand-shaped receipt can hide a
+shape the real pipeline would have written differently.
+"""
+import json
+
+import pytest
+
+from daimon_briefing import cli, policy, provenance, serializer, store
+
+_HASH = "a" * 64
+
+# One clean single-message quote and one stitched cross-role quote, both
+# verified against the same two-message transcript.
+_MESSAGES = [
+    {"role": "user", "content": "the alpha premise stands firm", "id": "u-1"},
+    {"role": "assistant", "content": "the omega conclusion follows cleanly",
+     "id": "a-2"},
+]
+_CLEAN_QUOTE = "the alpha premise stands firm"
+_STITCHED_QUOTE = "alpha premise stands ... omega conclusion follows"
+
+
+def _source(session):
+    return {
+        "version": provenance.SOURCE_REF_VERSION,
+        "host": "claude-code",
+        "session_id": session,
+        "locator": "managed",
+        "author": "alice",
+    }
+
+
+def _checkpoint(session, items):
+    return {
+        "session_id": session,
+        "working_context": {
+            "active_topic": {"text": "topic", "trust": "inferred"},
+            "open_questions": list(items),
+            "recent_decisions": [],
+        },
+        "epistemic_snapshot": {"strong_beliefs": [], "uncertainties": []},
+    }
+
+
+def _item(text, quote):
+    return {"text": text, "trust": "verbatim", "quote": quote}
+
+
+def _write(session, items, project_dir, messages=_MESSAGES):
+    """Verify, stamp ids, persist — the same order serialize_strict runs in."""
+    cp = _checkpoint(session, items)
+    serializer.verify_quotes(
+        cp, serializer._render_transcript(messages), messages,
+        source_ref=_source(session), transcript_hash=_HASH)
+    policy.stamp_item_ids(cp)
+    assert store.write_checkpoint(session, cp, project_dir=project_dir)
+    return cp
+
+
+def _stats_json(capsys):
+    assert cli.main(["stats", "--json"]) == 0
+    return json.loads(capsys.readouterr().out)
+
+
+def _stats_text(capsys):
+    assert cli.main(["stats"]) == 0
+    return capsys.readouterr().out
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    d = tmp_path / "proj"
+    d.mkdir()
+    monkeypatch.setenv("DAIMON_PROJECT_DIR", str(d))
+    return d
+
+
+# ---- the rate itself ------------------------------------------------------
+
+
+def test_stats_reports_the_stitching_rate_over_measured_receipts(project,
+                                                                 capsys):
+    _write("S1", [_item("clean claim", _CLEAN_QUOTE),
+                  _item("stitched claim", _STITCHED_QUOTE)], project)
+
+    s = _stats_json(capsys)["stitching"]
+    assert s["verified"] == 2
+    assert s["measured"] == 2
+    assert s["stitched"] == 1
+    assert s["cross_message"] == 1
+    assert s["cross_role"] == 1
+    assert s["unmeasured"] == 0
+    assert s["rate_pct"] == 50.0
+
+
+def test_the_plain_render_names_the_rate_and_the_two_flags(project, capsys):
+    _write("S1", [_item("clean claim", _CLEAN_QUOTE),
+                  _item("stitched claim", _STITCHED_QUOTE)], project)
+
+    out = _stats_text(capsys)
+    assert "stitching (this project)" in out
+    assert ("quote stitching: 1 of 2 measured verified quotes stitched "
+            "(50.0%)" in out)
+    assert "cross-message 1, cross-role 1" in out
+
+
+def test_the_rich_render_carries_the_same_wording(project, capsys,
+                                                  monkeypatch):
+    monkeypatch.setattr("daimon_briefing.render.supports_rich", lambda: True)
+    monkeypatch.setenv("COLUMNS", "240")
+    _write("S1", [_item("clean claim", _CLEAN_QUOTE),
+                  _item("stitched claim", _STITCHED_QUOTE)], project)
+
+    out = _stats_text(capsys)
+    assert "stitching (this project)" in out
+    assert "1 of 2 measured verified quotes stitched" in out
+
+
+# ---- the zero denominator, in the two shapes it comes in ------------------
+
+
+def test_no_verified_quotes_renders_a_line_rather_than_dividing_by_zero(
+        project, capsys):
+    s = _stats_json(capsys)["stitching"]
+    assert s == {"verified": 0, "measured": 0, "stitched": 0,
+                 "cross_message": 0, "cross_role": 0, "unmeasured": 0,
+                 "rate_pct": None}
+    assert "quote stitching: no verified quotes yet" in _stats_text(capsys)
+
+
+def test_a_corpus_of_only_legacy_receipts_says_so_instead_of_reporting_zero(
+        project, capsys):
+    """A receipt with no `stitching` member is UNKNOWN, never a clean verdict.
+    `0.0%` over a denominator of legacy receipts would read as "nothing is
+    stitched here" when the honest answer is "daimon cannot tell you"."""
+    # The legacy shape, reached through the shipping writer: without
+    # `messages` there is no per-message view, so verify_quotes stamps a
+    # stitching-less receipt exactly as every pre-D-019 capture did.
+    cp = _checkpoint("S1", [_item("legacy claim", _CLEAN_QUOTE)])
+    serializer.verify_quotes(
+        cp, serializer._render_transcript(_MESSAGES),
+        source_ref=_source("S1"), transcript_hash=_HASH)
+    policy.stamp_item_ids(cp)
+    assert store.write_checkpoint("S1", cp, project_dir=project)
+
+    s = _stats_json(capsys)["stitching"]
+    assert s["verified"] == 1
+    assert s["measured"] == 0
+    assert s["unmeasured"] == 1
+    assert s["rate_pct"] is None
+    assert ("quote stitching: none of 1 verified quotes carry a stitching "
+            "verdict" in _stats_text(capsys))
+
+
+def test_a_legacy_receipt_stays_out_of_the_denominator(project, capsys):
+    """Measured and unmeasured are two populations, kept apart: the rate is
+    over receipts that CARRY a verdict, and the rest is reported beside it."""
+    _write("S1", [_item("stitched claim", _STITCHED_QUOTE)], project)
+    legacy = _checkpoint("S2", [_item("legacy claim", _CLEAN_QUOTE)])
+    serializer.verify_quotes(
+        legacy, serializer._render_transcript(_MESSAGES),
+        source_ref=_source("S2"), transcript_hash=_HASH)
+    policy.stamp_item_ids(legacy)
+    assert store.write_checkpoint("S2", legacy, project_dir=project)
+
+    s = _stats_json(capsys)["stitching"]
+    assert s["verified"] == 2
+    assert s["measured"] == 1
+    assert s["stitched"] == 1
+    assert s["unmeasured"] == 1
+    assert s["rate_pct"] == 100.0
+    assert "; 1 unmeasured" in _stats_text(capsys)
+
+
+# ---- populations that must not leak in -----------------------------------
+
+
+def test_another_projects_receipts_never_reach_this_projects_rate(project,
+                                                                  tmp_path,
+                                                                  capsys):
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    _write("S-other", [_item("stitched claim", _STITCHED_QUOTE)], other)
+    _write("S-mine", [_item("clean claim", _CLEAN_QUOTE)], project)
+
+    s = _stats_json(capsys)["stitching"]
+    assert s["measured"] == 1
+    assert s["stitched"] == 0
+    assert s["rate_pct"] == 0.0
+
+
+def test_a_not_verified_receipt_is_not_a_verified_quote(project, capsys):
+    """The denominator is VERIFIED quotes. A downgraded item carries a
+    receipt too, and counting it would dilute the rate with claims that never
+    earned a stitching verdict in the first place."""
+    _write("S1", [_item("absent claim", "a sentence the transcript never said"),
+                  _item("stitched claim", _STITCHED_QUOTE)], project)
+
+    s = _stats_json(capsys)["stitching"]
+    assert s["verified"] == 1
+    assert s["measured"] == 1
+    assert s["stitched"] == 1
+
+
+def test_one_item_carried_across_sessions_counts_once(project, capsys):
+    """A carried item rides into every later checkpoint with the same id and
+    the same frozen receipt. Counting occurrences would let a single stitched
+    quote inflate the rate once per session it survived — the same
+    epoch-artifact class #562 caught in the resolution split."""
+    first = _write("S1", [_item("stitched claim", _STITCHED_QUOTE)], project)
+    carried = json.loads(json.dumps(
+        first["working_context"]["open_questions"][0]))
+    second = _checkpoint("S2", [carried])
+    assert store.write_checkpoint("S2", second, project_dir=project)
+
+    s = _stats_json(capsys)["stitching"]
+    assert s["verified"] == 1
+    assert s["measured"] == 1
+    assert s["stitched"] == 1
+    assert s["rate_pct"] == 100.0
+
+
+# ---- the --json contract --------------------------------------------------
+
+
+def test_stats_json_carries_stitching_at_the_tail(project, capsys):
+    """Key order is part of the --json contract, so a new fact is appended."""
+    payload = _stats_json(capsys)
+    assert list(payload)[-2:] == ["checks", "stitching"]
+    assert list(payload["stitching"]) == [
+        "verified", "measured", "stitched", "cross_message", "cross_role",
+        "unmeasured", "rate_pct"]
+
+
+@pytest.mark.parametrize("junk", ["{not json", "[1, 2, 3]"])
+def test_an_unreadable_checkpoint_never_takes_stats_down(junk, project,
+                                                         capsys):
+    """Two ways a `.json` file in the store is not a checkpoint: it does not
+    parse at all, and it parses into something that is not an object. Both
+    are skipped, and the rate over the real checkpoints is unaffected."""
+    _write("S1", [_item("stitched claim", _STITCHED_QUOTE)], project)
+    from daimon_briefing import config
+
+    (config.checkpoint_dir() / "junk.json").write_text(junk, encoding="utf-8")
+    s = _stats_json(capsys)["stitching"]
+    assert s["measured"] == 1
+    assert s["stitched"] == 1

--- a/plugin/tests/test_stats_stitching.py
+++ b/plugin/tests/test_stats_stitching.py
@@ -104,6 +104,22 @@ def test_stats_reports_the_stitching_rate_over_measured_receipts(project,
     assert s["rate_pct"] == 50.0
 
 
+def test_the_rate_survives_the_demotion_it_is_measured_to_justify(project,
+                                                                  capsys):
+    """#974 step 2 demotes a stitched quote to `inferred`. The rate reads the
+    RECEIPT, never the trust tag, so it keeps measuring after the demotion
+    lands. Keying it on `trust == "verbatim"` would have made the rate fall
+    to zero the moment enforcement shipped, and read as a fixed problem."""
+    cp = _write("S1", [_item("clean claim", _CLEAN_QUOTE),
+                       _item("stitched claim", _STITCHED_QUOTE)], project)
+    stitched = cp["working_context"]["open_questions"][1]
+    assert stitched["trust"] == "inferred"
+
+    s = _stats_json(capsys)["stitching"]
+    assert s["measured"] == 2
+    assert s["stitched"] == 1
+
+
 def test_the_plain_render_names_the_rate_and_the_two_flags(project, capsys):
     _write("S1", [_item("clean claim", _CLEAN_QUOTE),
                   _item("stitched claim", _STITCHED_QUOTE)], project)


### PR DESCRIPTION
Closes #974

## What

Two commits, in the order the issue asks for.

1. `daimon stats` grows a `stitching` section, appended at the tail of the
   `--json` payload under the same key-order contract `checks` follows. It
   reports, for this project: verified quotes, how many of their receipts
   carry a stitching verdict, how many of those are stitched, the
   cross-message and cross-role counts, the unmeasured remainder, and the
   rate.
2. At `stamp_receipt`, a verified quote whose verdict carries
   `cross_message` or `cross_role` now stores `trust: inferred` instead of
   `verbatim`.

Three decisions inside the measurement, each of which changes what the number
means:

- The denominator is receipts that CARRY a verdict, never all verified
  receipts. A pre-D-019 receipt, or one from a transcript-less capture, is
  absent-means-unknown; folding it in would print 0% where the honest answer
  is that daimon cannot tell you. The unknowns are counted as `unmeasured`
  and reported beside the rate.
- One item counts once, keyed on its stable id. A carried item rides into
  every later checkpoint with the same id and the same frozen receipt, so
  counting occurrences would let a single stitched quote inflate the rate
  once per session it survived.
- The rate reads the RECEIPT, never the trust tag, so it keeps measuring
  after the demotion lands. Keying it on `trust == "verbatim"` would have
  made the rate fall to zero the moment enforcement shipped and read as a
  fixed problem.

The demotion keeps everything else: the text, the quote, the source binding
and the receipt are left exactly as recorded, and `quote_verified` stays
true. Receipt version stays 1 and the format version stays D-019.

## Why

Rule 17 says a verbatim quote is one contiguous span of one message. #829
recorded on every verified receipt whether the matched fragments could have
come from one message and one role, then deliberately left the tag alone so
the violation rate could be measured first. Nothing ever read that record
back. A quote assembled from two turns or two speakers still rendered as a
checkmarked verbatim item, and no command printed how often that happened, so
the rule the serializer prompt states was a rule the product did not hold
anything to.

`quote_verified` stays true on a demoted item on purpose. It means the BYTES
were witnessed, and they were; only the contiguity claim `verbatim` carries
was not. Flipping it would file the item under `quote-not-in-transcript` in
the rejection ledger, a fabrication reason code a witnessed quote does not
belong to, and would break the echo-only breakdown that sits beside it. This
is the same shape `ground_outcomes` already uses when it demotes an
ungrounded outcome claim and keeps the quote.

The demotion keys on the verdict, not on the stored receipt. A `source_ref`
that cannot produce a receipt leaves the stitching fact just as true, and
keeping `verbatim` there would mint the false tag the change exists to stop.
An absent verdict never demotes.

## Tests

Red first on every behavior, both commits.

Step 1 adds `plugin/tests/test_stats_stitching.py`, 13 tests, all of which
failed with `KeyError: 'stitching'` before the implementation: the rate over
measured receipts, the plain and rich renderings, the two zero-denominator
states told apart (nothing verified yet, versus a corpus whose receipts all
predate D-019), a legacy receipt staying out of the denominator, another
project's receipts never reaching this project's rate, a not-verified receipt
not counting as a verified quote, one carried item counting once, the
`--json` tail contract, and two junk files in the store that must not take
`stats` down.

Step 2 adds a demotion section to `plugin/tests/test_quote_stitching.py`,
failing with `assert 'verbatim' == 'inferred'` before the change:
`cross_message` alone demotes, `cross_role` demotes, an unstitched verified
quote keeps `verbatim` (the negative control), a receipt with no stitching
member never demotes, the text and quote and binding and receipt all survive,
the demotion produces no rejection-ledger row, it does not move the quote-miss
downgrade count, it still fires when no receipt could be built, it logs the
content hash and never the text, the briefing renders the demoted item as
`~ inferred`, and the published field table documents the new consequence.
The two #829 assertions that pinned "recording only" are updated where the
behavior they pinned is what this issue changes.

Fixtures are built with the shipping writers throughout: `verify_quotes`
stamps the receipts, `policy.stamp_item_ids` stamps the ids,
`store.write_checkpoint` persists and stamps the project slug.

Full suite from `plugin/`: 6513 passed, 2 skipped. `ruff check
daimon_briefing tests ../scripts` clean, `mypy daimon_briefing` clean.
Patch coverage measured per added line over the four touched modules: zero
uncovered new executable lines.

`docs/checkpoint-schema.json` is regenerated, because the published notes for
`quote_verified` and for the stitching member were both left saying things
that are no longer true.
