### PR TITLE
fix(requests): keep a done request done under a duplicate verdict row

### DIFF
--- a/plugin/daimon_briefing/requests.py
+++ b/plugin/daimon_briefing/requests.py
@@ -721,6 +721,28 @@ def fold(rows: list[dict], policies=frozenset()) -> dict[str, dict]:
             # record citing `supersedes`, so the rejected verdict stays on
             # the record instead of being overwritten by the next ask.
             continue
+        if event in ("accepted", "rejected") and current["state"] == "done":
+            # #1021: `done` is terminal for a VERDICT row, the same shape the
+            # rule above gives `rejected` — a finished record stays finished.
+            # Duplicate verdict rows are ordinary (a decide surface replayed
+            # after a host restart, a second press), and without this the
+            # second `accepted` finds `done_pending` already cleared, falls
+            # through to the generic landing and puts the record back on the
+            # recipient's owed list. Worse, it also discards the session-end
+            # byte-check: `done_verified` below requires `done` or a pending
+            # claim, so a record knocked off `done` renders claimed and
+            # unverified for good.
+            #
+            # Only the two verdict events, and deliberately NOT the whole of
+            # `_STATE_BY_EVENT`. `needs_info` on a `done` record is a person
+            # asking for more, the one deliberate reopen this contract has,
+            # and `revised` (handled above, gated on `_SENDER_MOVABLE`) is
+            # the sender's own reopen the wedge principle names. Counted in
+            # history because the row is real, but `updated_at` stays put for
+            # the same reason `surfaced` leaves it alone: a duplicate must
+            # not make a settled record sort as freshly updated.
+            current["history_count"] += 1
+            continue
         if event == "surfaced":
             # Attention rows never move the record's rendered age: a brief
             # that merely showed the card must not make an untouched ask

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -1663,6 +1663,93 @@ def test_needs_info_after_a_pending_claim_keeps_the_claim_pending(project):
     assert record["done_evidence"] == "shipped in abc123"
 
 
+# ---- #1021: `done` is terminal for a verdict row --------------------------
+
+
+def test_a_duplicate_human_accept_on_a_done_record_keeps_it_done(project):
+    """#1021: a replayed decide (host restart, a second press) must not put
+    the work back on the owed list. The duplicate row is counted in history
+    and nothing else moves."""
+    q_id = _open(project)
+    requests.done(q_id, channel="cli-agent", evidence="shipped in abc123",
+                 project_dir=project)
+    requests.accept(q_id, channel="cli-tty", note="looks right",
+                    project_dir=project)
+    landed = requests.get(q_id, project_dir=project)
+    assert landed["state"] == "done"
+    requests.accept(q_id, channel="cli-tty", note="looks right",
+                    project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["state"] == "done"
+    assert record["done_pending"] is False
+    assert record["done_claimed"] is True
+    assert record["done_evidence"] == "shipped in abc123"
+    assert record["done_by"] == "agent"
+    assert record["verdict_by"] == "human"
+    assert record["history_count"] == landed["history_count"] + 1
+    assert record["updated_at"] == landed["updated_at"]
+
+
+def test_done_verified_still_lands_after_a_duplicate_accept(project):
+    """#1021: the session-end byte-check is thrown away today, because the
+    duplicate accept moved the record off `done` and the `done_verified`
+    guard requires `done` or a pending claim."""
+    q_id = _open(project)
+    requests.done(q_id, channel="cli-agent", evidence="shipped in abc123",
+                 project_dir=project)
+    requests.accept(q_id, channel="cli-tty", project_dir=project)
+    requests.accept(q_id, channel="cli-tty", project_dir=project)
+    assert requests.verify_done(q_id, role="assistant", project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["state"] == "done"
+    assert record["done_claimed"] is False
+    assert record["done_verified_at"]
+
+
+def test_a_human_reject_on_a_done_record_is_inert(project):
+    """#1021: the same rule for the other verdict. A reject arriving after
+    the record settled must not overwrite the accept's own verdict fields."""
+    q_id = _open(project)
+    requests.done(q_id, channel="cli-agent", evidence="shipped in abc123",
+                 project_dir=project)
+    requests.accept(q_id, channel="cli-tty", note="accepted note",
+                    project_dir=project)
+    landed = requests.get(q_id, project_dir=project)
+    requests.reject(q_id, channel="cli-tty", note="rejected note",
+                    project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["state"] == "done"
+    assert record["verdict_by"] == "human"
+    assert record["note"] == "accepted note"
+    assert record["history_count"] == landed["history_count"] + 1
+
+
+def test_needs_info_on_a_done_record_still_reopens_it(project):
+    """Pins today's behavior so #1021's guard is not widened: a person
+    asking for more on a finished record is a deliberate reopen."""
+    q_id = _open(project)
+    requests.done(q_id, channel="cli-agent", evidence="shipped in abc123",
+                 project_dir=project)
+    requests.accept(q_id, channel="cli-tty", project_dir=project)
+    requests.needs_info(q_id, channel="cli-tty", note="which environment?",
+                        project_dir=project)
+    assert requests.get(q_id, project_dir=project)["state"] == "needs-info"
+
+
+def test_a_human_done_then_duplicate_accept_stays_done(project):
+    """#1021, the non-claim path of the same guard: a human completion is
+    never `done_claimed`, and a duplicate accept over it is just as inert."""
+    q_id = _open(project)
+    requests.accept(q_id, channel="cli-tty", project_dir=project)
+    requests.done(q_id, channel="cli-tty", evidence="shipped in abc123",
+                 project_dir=project)
+    requests.accept(q_id, channel="cli-tty", project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["state"] == "done"
+    assert record["done_by"] == "human"
+    assert record["done_claimed"] is False
+
+
 def test_a_revise_of_the_ask_after_a_pending_claim_clears_the_claim(project):
     """REVISED from `test_a_revise_after_a_pending_claim_keeps_it_pending`
     (#978 review round 1, F1): the claim answers the ask that was live when


### PR DESCRIPTION
Closes #1021

## What

One guard in `fold()`, placed right after the existing `rejected` terminal
guard so the two read as one rule: an `accepted` or `rejected` row landing on
a record already in `done` bumps `history_count` and moves nothing else. The
state stays `done`, the verdict fields from the accept that settled it stay
put, and `updated_at` does not move, so a settled record never sorts as
freshly updated because of a replayed row.

Only the two verdict events are caught. `needs_info` on a `done` record still
reopens it, since a person asking for more is the one deliberate reopen this
contract has, and `revised` stays the sender's own reopen. Both are pinned by
tests so the guard is not widened later by accident.

The write boundary is unchanged. A duplicate accept still appends its row and
stays visible in the audit; the fold is what decides it means nothing.

## Why

A duplicate human accept is ordinary: a decide surface replayed after a host
restart, a second press. Today it costs two things at once. The second row
finds `done_pending` already cleared, falls through to the generic landing and
puts the work back on the recipient's owed list. Then the session-end
`done_verified` row arrives, its guard requires `done` or a pending claim,
neither holds, and the byte-check result is discarded. The record renders as
claimed and unverified for good.

The fold had exactly one terminal state. `done` needed to be terminal for
verdicts too, on the same terms.

The `done_verified` guard needed no change: once the record holds at `done`
its existing condition qualifies on its own.

## Tests

Five new tests in `plugin/tests/test_requests.py`, all built through the
shipping writers. Four failed before the fix with `'accepted' == 'done'` or
`'rejected' == 'done'`; the fifth is the `needs_info` pin and passed already,
which is its point.

- duplicate accept on a `done` record keeps it `done`, history grows by one,
  `updated_at` unchanged
- `done_verified` still lands after a duplicate accept
- a reject on a `done` record is inert and does not overwrite the accept's
  note or verdict fields
- `needs_info` on a `done` record still reopens it
- a human `done` followed by a duplicate accept stays `done` (the non-claim
  path of the same guard)

Full suite: 6564 passed, 2 skipped. Every added line in `requests.py` is
covered. `ruff` and `mypy` clean.
