### PR TITLE
feat(requests): accept a per-act author on the in-process ui writer path

### DIFF
--- a/.scars/candidates/prestamped-row-bypasses-the-stamp-chokepoint.md
+++ b/.scars/candidates/prestamped-row-bypasses-the-stamp-chokepoint.md
@@ -1,0 +1,43 @@
+---
+id: 0
+type: landmine
+title: "A gate added to requests._stamp does NOT protect accept's agent path, which writes a pre-stamped row"
+severity: high
+confidence: 0.9
+created: 2026-09-12
+authors: ["claude-code"]
+anchors:
+  - path: plugin/daimon_briefing/requests.py
+  - pattern: "_write_verdict_row\("
+evidence:
+  - commit: 71890b7
+  - note: "#1026: the accept gate was mutation-tested. Removing it made an agent accept carrying author=\"alice\" land a row with no act_author, exit code 0, no refusal."
+expires:
+  condition: "_write_verdict_row stops accepting a caller-built `row`, or the dry-run in accept is re-expressed so the row it writes is stamped by _stamp"
+  review_after: 2027-03-12
+status: candidate
+---
+
+`requests._stamp` looks like the one chokepoint every row on this module's
+write path goes through, and for `open_request`, `revise`, `done`,
+`suppress` and `_verdict` it is. It is not for `accept`.
+
+`accept`'s agent ruling-coverage branch (#961 slice 4 review round 2, H2)
+stamps a SYNTHETIC row, dry-runs the fold's own coverage predicate against
+that exact row's `order`, and then hands the SAME already-stamped row to
+`_write_verdict_row(row=synthetic)`. That parameter exists precisely so the
+row that lands is not re-stamped, which means `_stamp` is never called on
+that path at all. Any validation you add to `_stamp` is silently absent
+there.
+
+#1026 hit this adding a per-act `author` keyword. With the gate only in
+`_stamp`, `accept(channel="cli-agent", author="alice")` did not refuse: it
+took the agent branch, never reached `_stamp`, and appended a verdict row
+that dropped the name and recorded the process identity instead. No error,
+no log line, and the fold happily rendered a verdict attributed to the
+wrong identity. The fix is a second explicit call at the top of `accept`.
+
+Before adding any check to `_stamp`, ask whether it must also hold for a
+caller-supplied `row`, and if so put it in `accept` too. A green suite will
+not tell you: the agent path has its own tests, and none of them pass the
+argument your new check inspects.

--- a/plugin/daimon_briefing/requests.py
+++ b/plugin/daimon_briefing/requests.py
@@ -109,6 +109,14 @@ _STATE_BY_EVENT = {
 }
 # Verdicts and suppression: the human-only half of the verb table (D8).
 _HUMAN_ONLY = frozenset({"needs_info", "accepted", "rejected", "suppressed"})
+# #1026. Channels whose author is DERIVED from the environment this process
+# runs in (`config.author()`: DAIMON_AUTHOR, then git user.name, then the OS
+# user), so naming a different person per act is meaningless there — one
+# terminal, one person. The per-act author is refused on these, which is what
+# stops a shell-out from signing an act as somebody else: `cli-tty` carries
+# human authority and is still refused, so the split here is not authority,
+# it is whether the channel has an environment identity to derive from at all.
+_CLI_CHANNELS = frozenset({"cli-agent", "cli-tty"})
 # States a sender-side event may still move. Everything else is settled by a
 # human verdict or by a completion claim, and re-opening it from the sender
 # side would be exactly the assertion the wedge principle forbids.
@@ -174,7 +182,19 @@ _ROLE_MAX = 64
 # matching a tombstone against it would let one forgotten value delete every
 # record a given author ever wrote. `to` is absent for the same reason in
 # reverse — it is a filesystem-derived slug, not authored prose.
-_PLAINTEXT_FIELDS = ("ask", "why", "note", "evidence", "from_label")
+#
+# #1026: `act_author` IS here, and the difference from `author` above is the
+# reason, not an oversight. `author` is this process's own derived identity,
+# the same value on every row it writes, so a tombstone matching it would
+# empty the ledger of the one person who owns the machine. `act_author` is
+# free prose a multi-person host supplies per act, never derived here — it is
+# the one field on this surface that names a person who is NOT the operator,
+# so the audit must hash it, and reaching every act somebody signed is what a
+# forget aimed at that name is FOR on a surface that exists to serve several
+# people. `pending._strip_plaintext` reads this same declaration, so a
+# foreign bucket's names stop at the read boundary for free (scar 0055).
+_PLAINTEXT_FIELDS = ("ask", "why", "note", "evidence", "from_label",
+                     "act_author")
 
 
 class RequestError(ValueError):
@@ -254,8 +274,46 @@ def _ts(order: int) -> str:
         "%Y-%m-%dT%H:%M:%SZ")
 
 
+def _act_author(channel: str, author) -> str:
+    """#1026: the scrubbed per-act author, or "" when nobody was named.
+
+    The gate, not a formatter — it refuses before any row is built, so a
+    caller that names someone on a channel with no per-act identity gets a
+    refusal instead of a row that silently records the process instead of
+    the person. `None` short-circuits untouched: every existing caller
+    passes nothing, and the channel check must not start failing calls that
+    never mentioned an author (an unknown channel still reaches `_stamp`'s
+    own channel error, which names the right mistake).
+
+    Called from `_stamp`, which every writer on this module's public path
+    goes through, and from exactly one other place: `accept`, whose agent
+    branch writes a pre-stamped row and so never reaches `_stamp` at all.
+    Duplicating it into the other verbs buys nothing a test can tell apart
+    and is one more copy to drift.
+
+    Blank after scrubbing is the same as absent, so the caller cannot write
+    an empty `act_author` key: in an append-only stream the ABSENCE of a key
+    is data (scar 0042), and `""` on the row would be indistinguishable from
+    a row that lost the value.
+    """
+    if author is None:
+        return ""
+    value = _scrub("act_author", author, required=False, limit=_LABEL_MAX)
+    if not value:
+        return ""
+    if CHANNEL_AUTHORITY.get(channel) != "human" or channel in _CLI_CHANNELS:
+        raise RequestError(
+            "a per-act author names the person behind THIS act, and this "
+            "channel derives its author from the environment instead — one "
+            "terminal, one person; name the author only from an in-process "
+            f"human writer, or leave it unset: this call arrived through "
+            f"{channel!r}")
+    return value
+
+
 def _stamp(event: str, request_id: str, channel: str,
-           *, now_ns: int | None = None, event_id: str | None = None) -> dict:
+           *, now_ns: int | None = None, event_id: str | None = None,
+           author: str | None = None) -> dict:
     if event not in EVENTS:
         raise RequestError(f"unknown request event: {event}")
     if not _REQUEST_ID_RE.fullmatch(str(request_id or "")):
@@ -266,8 +324,11 @@ def _stamp(event: str, request_id: str, channel: str,
     # Derived, never accepted: no way to name one channel and claim another's
     # authority.
     authority = CHANNEL_AUTHORITY[channel]
+    # #1026: gated BEFORE the row exists, so a refusal leaves nothing for a
+    # caller to append by accident.
+    act_author = _act_author(channel, author)
     order = time.time_ns() if now_ns is None else int(now_ns)
-    return {
+    row = {
         "version": VERSION,
         "ts": _ts(order),
         "order": order,
@@ -276,8 +337,13 @@ def _stamp(event: str, request_id: str, channel: str,
         "request_id": request_id,
         "channel": channel,
         "authority": authority,
+        # The PROCESS identity, unchanged by #1026: the row records both, so
+        # a reader can tell a host-attributed name from a derived one.
         "author": config.author(),
     }
+    if act_author:
+        row["act_author"] = act_author
+    return row
 
 
 def _is_torn(path) -> bool:
@@ -301,7 +367,7 @@ def append(row: dict, project_dir=None) -> bool:
         return False
     admitted = policy.admit_row(
         row, redact_fields=("ask", "why", "note", "evidence", "from_label",
-                            "author"))
+                            "author", "act_author"))
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as handle:
@@ -579,9 +645,21 @@ def fold(rows: list[dict], policies=frozenset()) -> dict[str, dict]:
                 "opened_by": authority,
                 "opened_channel": row.get("channel"),
                 "opened_author": row.get("author"),
+                # #1026: the person a multi-person host named for THIS act,
+                # or None for every row the CLI wrote and every row minted
+                # before the field existed. Read exactly as plainly as
+                # `opened_author` beside it, and for the same reason — both
+                # are attribution a forged row could equally claim, so
+                # gating one and not the other would only look like proof.
+                "opened_act_author": row.get("act_author"),
                 "verdict_by": None,
                 "verdict_label": None,
                 "verdict_at": None,
+                # #1026: who decided, when a host named them. Set beside
+                # `verdict_by` in the verdict landing below, so the #1021
+                # `done` guard and the sticky-`rejected` guard keep an inert
+                # duplicate from re-signing a verdict somebody else made.
+                "verdict_act_author": None,
                 # #961 slice 3: who landed the CURRENT `accepted` state,
                 # "human" or "agent" — never written to disk, recomputed on
                 # every fold pass from the authority of the row that landed
@@ -602,6 +680,9 @@ def fold(rows: list[dict], policies=frozenset()) -> dict[str, dict]:
                 # the same terms as `accepted_by` above.
                 "accepted_under": None,
                 "done_by": None,
+                # #1026: who reported it done, when a host named them. Set
+                # beside `done_by` in the `done` landing below.
+                "done_act_author": None,
                 "done_claimed": False,
                 "done_evidence": "",
                 # #978: a completion CLAIMED by a non-human channel on a
@@ -915,6 +996,7 @@ def fold(rows: list[dict], policies=frozenset()) -> dict[str, dict]:
         current["suppressed"] = False
         if event == "done":
             current["done_by"] = authority
+            current["done_act_author"] = row.get("act_author")
             # An agent's completion claim renders as claimed-and-unverified
             # until the session-end byte-check confirms the quote (PR 3).
             current["done_claimed"] = authority != "human"
@@ -922,6 +1004,7 @@ def fold(rows: list[dict], policies=frozenset()) -> dict[str, dict]:
             current["done_pending"] = False
         else:
             current["verdict_by"] = authority
+            current["verdict_act_author"] = row.get("act_author")
             current["verdict_label"] = CHANNEL_LABEL.get(
                 str(row.get("channel") or ""))
             current["verdict_at"] = row.get("ts")
@@ -1023,7 +1106,8 @@ def renderable(project_dir=None) -> dict:
 def open_request(*, to: str, ask: str, why: str, channel: str,
                  blocking: bool = False, to_human: bool = False,
                  evidence: str = "", supersedes: str = "",
-                 kind: str = DEFAULT_KIND, project_dir=None) -> str:
+                 kind: str = DEFAULT_KIND, author: str | None = None,
+                 project_dir=None) -> str:
     """Open a request addressed to another project's slug.
 
     Slug SHAPE is validated here; whether it names a bucket that exists is
@@ -1038,6 +1122,11 @@ def open_request(*, to: str, ask: str, why: str, channel: str,
     caller could otherwise route around. `--to-human` is audience, not
     approval requirement, and can never be paired with `info`: a person is
     always the one who reads it.
+
+    #1026: `author` names the person behind THIS act, for an in-process
+    writer serving several people through one channel. Refused on a channel
+    that derives its author from the environment (`_act_author`), so a
+    shell-out can never sign an ask as somebody else.
     """
     project_dir = config.resolve_project_dir(project_dir)
     if not _SLUG_RE.fullmatch(str(to or "")):
@@ -1079,7 +1168,7 @@ def open_request(*, to: str, ask: str, why: str, channel: str,
         raise RequestError(
             f"{q_id} already exists — this exact ask was opened in the same "
             "second; revise it or wait a moment to open a second one")
-    row = _stamp("opened", q_id, channel, now_ns=order)
+    row = _stamp("opened", q_id, channel, now_ns=order, author=author)
     row.update({
         "to": to,
         "to_human": bool(to_human),
@@ -1102,7 +1191,7 @@ def open_request(*, to: str, ask: str, why: str, channel: str,
 
 def revise(request_id: str, *, channel: str, ask: str | None = None,
            why: str | None = None, evidence: str | None = None,
-           project_dir=None) -> None:
+           author: str | None = None, project_dir=None) -> None:
     """Answer a needs-info, or sharpen an open ask. Capped at MAX_REVISIONS."""
     current = _require(request_id, project_dir)
     if current["state"] not in _SENDER_MOVABLE:
@@ -1114,7 +1203,7 @@ def revise(request_id: str, *, channel: str, ask: str | None = None,
             f"{request_id} has used all {MAX_REVISIONS} revisions; open a "
             f"new request with `--supersedes {request_id}` so the lineage "
             "stays visible")
-    row = _stamp("revised", request_id, channel)
+    row = _stamp("revised", request_id, channel, author=author)
     # Scar 0042: only the keys the caller SET. `None` means unchanged, and
     # the fold reads key presence as intent — forging a key here would clear
     # the field the caller never mentioned.
@@ -1158,7 +1247,8 @@ def _require(request_id: str, project_dir) -> dict:
 
 
 def _write_verdict_row(event: str, request_id: str, channel: str, note: str,
-                       project_dir, row: dict | None = None, **stamp) -> None:
+                       project_dir, row: dict | None = None,
+                       author: str | None = None, **stamp) -> None:
     """`stamp` (#961 slice 4) carries `under_ruling`/`policy_sha256` for a
     ruling-covered agent accept — a truthy extra becomes a row field, an
     absent or falsy one is never written at all, the same "only what the
@@ -1171,8 +1261,14 @@ def _write_verdict_row(event: str, request_id: str, channel: str, note: str,
     that lands carries the identical `order` the dry run checked coverage
     against — never a second `_stamp()` call minting a fresh order after
     the decision was already made on a different one. `None` (every other
-    caller) stamps fresh here, unchanged."""
-    row = dict(row) if row is not None else _stamp(event, request_id, channel)
+    caller) stamps fresh here, unchanged.
+
+    `author` (#1026) reaches the fresh stamp only. The one caller that hands
+    in a `row` is the agent ruling-coverage path in `accept`, whose channel
+    can never carry a per-act author in the first place — `_act_author`
+    refuses it there before `accept` does anything at all."""
+    row = dict(row) if row is not None else _stamp(event, request_id, channel,
+                                                   author=author)
     note = _text("note", note, required=False)
     if note:
         row["note"] = note
@@ -1184,7 +1280,7 @@ def _write_verdict_row(event: str, request_id: str, channel: str, note: str,
 
 
 def _verdict(event: str, request_id: str, *, channel: str, note: str = "",
-             project_dir=None) -> None:
+             author: str | None = None, project_dir=None) -> None:
     if CHANNEL_AUTHORITY.get(channel) != "human":
         state = _STATE_BY_EVENT.get(event, event)
         article = "an" if state[:1] in "aeiou" else "a"
@@ -1197,7 +1293,8 @@ def _verdict(event: str, request_id: str, *, channel: str, note: str = "",
             f"{request_id} was rejected, and a rejection is final for that "
             "record; the sender can open a new request with "
             f"`--supersedes {request_id}`")
-    _write_verdict_row(event, request_id, channel, note, project_dir)
+    _write_verdict_row(event, request_id, channel, note, project_dir,
+                       author=author)
 
 
 def _resolve_covering_ruling(sender: str, project_dir):
@@ -1220,7 +1317,7 @@ def _resolve_covering_ruling(sender: str, project_dir):
 
 
 def accept(request_id: str, *, channel: str, note: str = "",
-           project_dir=None) -> None:
+           author: str | None = None, project_dir=None) -> None:
     """Land the addressed request as accepted.
 
     Human-only for a `work` ask nothing covers, as every verdict verb has
@@ -1258,7 +1355,20 @@ def accept(request_id: str, *, channel: str, note: str = "",
     falls before the interval's `active_from`. The row that finally lands
     is the SAME stamped row the dry run checked — never re-stamped with a
     fresh order after the decision, which would reopen the identical gap.
+
+    #1026: `author` is gated HERE, and this is the ONE verb that needs its
+    own gate. Every other writer reaches `_stamp`, which refuses a per-act
+    author on a channel that derives one — but the agent path below writes
+    through `_write_verdict_row(row=synthetic)`, which by construction never
+    stamps, so `_stamp` is not on that path at all. Without this line an
+    agent caller naming a person would land a row that silently drops the
+    name and records the process instead: no refusal, no error, a verdict
+    attributed to the wrong identity. Gated before the joins and the ruling
+    resolution too, so the refusal costs none of that work.
     """
+    # The gate, not the value: the human path hands `author` on to
+    # `_verdict` -> `_stamp`, which is what actually writes it.
+    _act_author(channel, author)
     authority = CHANNEL_AUTHORITY.get(channel)
     if authority != "human":
         # #961 slice 3 review item 6: `authority == "agent"` explicitly,
@@ -1324,23 +1434,23 @@ def accept(request_id: str, *, channel: str, note: str = "",
                            project_dir, row=synthetic, **stamp)
         return
     _verdict("accepted", request_id, channel=channel, note=note,
-             project_dir=project_dir)
+             author=author, project_dir=project_dir)
 
 
 def reject(request_id: str, *, channel: str, note: str = "",
-           project_dir=None) -> None:
+           author: str | None = None, project_dir=None) -> None:
     _verdict("rejected", request_id, channel=channel, note=note,
-             project_dir=project_dir)
+             author=author, project_dir=project_dir)
 
 
 def needs_info(request_id: str, *, channel: str, note: str = "",
-               project_dir=None) -> None:
+               author: str | None = None, project_dir=None) -> None:
     _verdict("needs_info", request_id, channel=channel, note=note,
-             project_dir=project_dir)
+             author=author, project_dir=project_dir)
 
 
 def suppress(request_id: str, *, channel: str, note: str = "",
-             project_dir=None) -> None:
+             author: str | None = None, project_dir=None) -> None:
     """Drop a record out of the briefing panel — human-only, panel-only.
 
     Not a verdict and not a state: the record stays in `request list`, and
@@ -1353,7 +1463,7 @@ def suppress(request_id: str, *, channel: str, note: str = "",
             "suppressing an addressed request requires a human channel; this "
             f"call arrived through {channel!r}")
     _answering(request_id, project_dir)
-    row = _stamp("suppressed", request_id, channel)
+    row = _stamp("suppressed", request_id, channel, author=author)
     note = _text("note", note, required=False)
     if note:
         row["note"] = note
@@ -1362,16 +1472,21 @@ def suppress(request_id: str, *, channel: str, note: str = "",
 
 
 def done(request_id: str, *, channel: str, evidence: str,
-         project_dir=None) -> None:
+         author: str | None = None, project_dir=None) -> None:
     """Report the ask as satisfied. Either channel, evidence required — an
     agent's claim renders as claimed-and-unverified until the session-end
-    byte-check confirms the quote (PR 3)."""
+    byte-check confirms the quote (PR 3).
+
+    #1026: `author` names the person who reported it, and only a channel
+    with a per-act identity may carry one — an agent's claim is signed by
+    the process that made it, as it always was. Refused by `_stamp` below,
+    which is the one chokepoint every row on this path passes through."""
     current = _answering(request_id, project_dir)
     if current is not None and current["state"] == "rejected":
         raise RequestError(
             f"{request_id} was rejected; a rejected request cannot be "
             "completed")
-    row = _stamp("done", request_id, channel)
+    row = _stamp("done", request_id, channel, author=author)
     row["evidence"] = _scrub("evidence", evidence)
     if not append(row, project_dir=project_dir):
         raise RequestError("completion not written")

--- a/plugin/tests/test_requests.py
+++ b/plugin/tests/test_requests.py
@@ -333,6 +333,211 @@ def test_a_non_human_duplicate_opened_row_cannot_downgrade_an_info_ask(
     assert requests.get(q_id, project_dir=project)["kind"] == "info"
 
 
+# ---- #1026: a per-act author on the in-process writer path ----------------
+
+
+def test_open_records_the_per_act_author_beside_the_process_identity(
+        project, monkeypatch):
+    """#1026: a host serving several people through the `ui` channel names
+    WHO acted, without losing the process identity the row has always
+    carried. DAIMON_AUTHOR is set to something the per-act name cannot be
+    confused with, so the two fields are proved distinct rather than
+    coincidentally equal."""
+    monkeypatch.setenv("DAIMON_AUTHOR", "the-host-process")
+    q_id = _open(project, channel="ui", author="alice")
+    record = requests.get(q_id, project_dir=project)
+    assert record["opened_act_author"] == "alice"
+    assert record["opened_author"] == "the-host-process"
+    assert record["verdict_act_author"] is None
+    assert record["done_act_author"] is None
+
+
+def test_open_without_a_per_act_author_leaves_every_act_field_none(project):
+    """The CLI path is unchanged: no author named, no act fields on the
+    record, and the process identity still lands as it always did."""
+    q_id = _open(project, channel="cli-tty")
+    record = requests.get(q_id, project_dir=project)
+    assert record["opened_act_author"] is None
+    assert record["verdict_act_author"] is None
+    assert record["done_act_author"] is None
+    assert record["opened_author"] == config.author()
+
+
+def test_a_cli_channel_naming_a_per_act_author_writes_nothing(project):
+    """A shell-out must never be able to name someone else: `cli-tty` is a
+    human channel, but it derives its author from the environment, so the
+    keyword is refused there and the ledger stays empty."""
+    with pytest.raises(requests.RequestError) as exc_info:
+        _open(project, channel="cli-tty", author="alice")
+    assert "cli-tty" in str(exc_info.value)
+    assert _rows_or_empty(project) == []
+
+
+def test_an_agent_accept_naming_a_per_act_author_writes_nothing(project):
+    """The refusal fires BEFORE `accept`'s own side effects. This accept
+    would otherwise land: an agent channel may accept an addressed `info`
+    ask that is still open (#961 slice 3), so the only thing stopping it
+    here is the author gate."""
+    q_id = _open(project, channel="cli-tty", kind="info")
+    before = _rows(project)
+    with pytest.raises(requests.RequestError) as exc_info:
+        requests.accept(q_id, channel="cli-agent", author="alice",
+                        project_dir=project)
+    assert "cli-agent" in str(exc_info.value)
+    assert _rows(project) == before
+
+
+def test_a_cli_done_naming_a_per_act_author_writes_nothing(project):
+    q_id = _open(project)
+    before = _rows(project)
+    with pytest.raises(requests.RequestError) as exc_info:
+        requests.done(q_id, channel="cli-tty", author="alice",
+                      evidence="shipped in abc123", project_dir=project)
+    assert "cli-tty" in str(exc_info.value)
+    assert _rows(project) == before
+
+
+@pytest.mark.parametrize("verb,kwargs", [
+    ("reject", {"note": "no"}),
+    ("needs_info", {"note": "which release?"}),
+    ("suppress", {}),
+    ("revise", {"ask": "review it again, with the new numbers"}),
+], ids=["reject", "needs-info", "suppress", "revise"])
+def test_every_other_verb_refuses_a_per_act_author_from_a_cli_channel(
+        project, verb, kwargs):
+    """The gate sits in each verb ahead of its own checks, so every one of
+    them refuses rather than silently signing the act as the process. The
+    same call without an author succeeds, which is what makes this a test of
+    the author gate and not of the verb."""
+    q_id = _open(project, channel="cli-tty")
+    before = _rows(project)
+    with pytest.raises(requests.RequestError) as exc_info:
+        getattr(requests, verb)(q_id, channel="cli-tty", author="alice",
+                                project_dir=project, **kwargs)
+    assert "cli-tty" in str(exc_info.value)
+    assert _rows(project) == before
+    getattr(requests, verb)(q_id, channel="cli-tty", project_dir=project,
+                            **kwargs)
+    assert len(_rows(project)) == len(before) + 1
+
+
+def test_accept_lands_the_per_act_author_on_the_verdict(project):
+    q_id = _open(project, channel="ui", author="alice")
+    requests.accept(q_id, channel="ui", author="bob", note="go ahead",
+                    project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["verdict_act_author"] == "bob"
+    assert record["verdict_by"] == "human"
+    assert record["accepted_by"] == "human"
+    # The ask's own author is untouched by the verdict's.
+    assert record["opened_act_author"] == "alice"
+
+
+@pytest.mark.parametrize("verb,state", [
+    ("reject", "rejected"),
+    ("needs_info", "needs-info"),
+], ids=["reject", "needs-info"])
+def test_every_verdict_verb_lands_the_per_act_author(project, verb, state):
+    q_id = _open(project, channel="ui", author="alice")
+    getattr(requests, verb)(q_id, channel="ui", author="bob",
+                            note="a human note", project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["state"] == state
+    assert record["verdict_act_author"] == "bob"
+    assert record["verdict_by"] == "human"
+
+
+def test_suppress_carries_the_per_act_author_on_its_row(project):
+    """Suppression is a marker, not a verdict: the fold sets `suppressed`
+    and lands no verdict field at all, so the raw row is where the per-act
+    author has to be proved."""
+    q_id = _open(project, channel="ui", author="alice")
+    requests.suppress(q_id, channel="ui", author="bob", project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["suppressed"] is True
+    assert record["verdict_act_author"] is None
+    row = _rows(project)[-1]
+    assert row["event"] == "suppressed"
+    assert row["act_author"] == "bob"
+
+
+def test_done_lands_the_per_act_author(project):
+    q_id = _open(project, channel="ui", author="alice")
+    requests.done(q_id, channel="ui", author="carol",
+                  evidence="shipped in abc123", project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["state"] == "done"
+    assert record["done_act_author"] == "carol"
+    assert record["done_by"] == "human"
+    assert record["done_claimed"] is False
+
+
+def test_revise_carries_the_per_act_author_on_its_row(project):
+    """`revise` writes no fold field for its author (the record has no
+    `revised_by` counterpart to sit beside), so the raw row carries it."""
+    q_id = _open(project, channel="ui", author="alice")
+    requests.revise(q_id, channel="ui", author="dana",
+                    ask="review it again, with the new numbers",
+                    project_dir=project)
+    row = _rows(project)[-1]
+    assert row["event"] == "revised"
+    assert row["act_author"] == "dana"
+
+
+def test_a_duplicate_verdict_on_a_done_record_keeps_the_first_act_author(
+        project):
+    """#1021's guard and #1026 together: the duplicate accept is inert, so
+    the person who actually decided the record stays named. Without the
+    guard reaching this field too, a replayed decide would re-sign somebody
+    else's verdict."""
+    q_id = _open(project)
+    requests.done(q_id, channel="cli-agent", evidence="shipped in abc123",
+                  project_dir=project)
+    requests.accept(q_id, channel="ui", author="dora", project_dir=project)
+    requests.accept(q_id, channel="ui", author="eve", project_dir=project)
+    record = requests.get(q_id, project_dir=project)
+    assert record["state"] == "done"
+    assert record["verdict_act_author"] == "dora"
+
+
+def test_a_legacy_row_with_no_act_author_folds_to_none(project):
+    """Every row minted before this field existed. Appended through
+    `requests.append` with a stamp that names no author, so the key is
+    genuinely absent rather than present-and-empty."""
+    row = requests._stamp("opened", "q-0123456789ab", "ui")
+    row.update({"to": RECIPIENT, "ask": ASK, "why": WHY})
+    assert "act_author" not in row
+    assert requests.append(row, project_dir=project)
+    record = requests.get("q-0123456789ab", project_dir=project)
+    assert record["opened_act_author"] is None
+    assert record["verdict_act_author"] is None
+    assert record["done_act_author"] is None
+
+
+def test_the_per_act_author_is_redacted_on_the_way_to_disk(project):
+    """`append`'s own redaction tuple, not `_scrub`'s: a row built by hand
+    and appended directly never passes the writer's scrub, and a host
+    pasting a secret into a name field must not persist it."""
+    row = requests._stamp("opened", "q-0123456789ab", "ui")
+    row.update({"to": RECIPIENT, "ask": ASK, "why": WHY,
+                "act_author": "token=abcdefghijkl"})
+    assert requests.append(row, project_dir=project)
+    assert "abcdefghijkl" not in json.dumps(_rows(project))
+
+
+def test_the_per_act_author_is_a_plaintext_surface(project):
+    """#645 discipline: a host-supplied name is authored prose this project
+    never derived, so forget must reach it by value and the audit must hash
+    it. The process identity beside it stays out of the pool, for the reason
+    `_PLAINTEXT_FIELDS` already states."""
+    q_id = _open(project, channel="ui", author="alice")
+    row = next(r for r in requests.events(project_dir=project)
+               if r["request_id"] == q_id)
+    assert "alice" in requests.plaintext_values(row)
+    assert normalize.content_key("alice") in requests.row_content_keys(row)
+    assert row["author"] not in requests.plaintext_values(row)
+
+
 def test_a_later_duplicate_opened_row_cannot_revoke_the_kind_an_earlier_agent_accept_relied_on(
         project):
     """#961 slice 3 review item 3: the exact three-row attack. Row 1 (a
@@ -3221,6 +3426,52 @@ def test_stamp_refuses_a_malformed_id_and_an_unknown_channel(project):
     with pytest.raises(requests.RequestError):
         requests._stamp("opened", "q-0123456789ab", "cli-ui")
     assert not _rows_or_empty(project)
+
+
+def test_stamp_carries_a_per_act_author_beside_the_process_identity(
+        project, monkeypatch):
+    """#1026: two fields, never one. `author` stays exactly what it was so a
+    reader can tell a host-attributed name from an environment-derived one,
+    which is the whole point of recording both."""
+    monkeypatch.setenv("DAIMON_AUTHOR", "the-host-process")
+    row = requests._stamp("opened", "q-0123456789ab", "ui", author="alice")
+    assert row["act_author"] == "alice"
+    assert row["author"] == config.author() == "the-host-process"
+
+
+@pytest.mark.parametrize("author", [None, "", "   "],
+                         ids=["absent", "empty", "whitespace"])
+def test_stamp_omits_the_act_author_key_when_nobody_is_named(project, author):
+    """Scar 0042's contract, applied to this field too: in an append-only
+    stream the ABSENCE of a key is data. An empty string or a null on the
+    row would be indistinguishable from a row that lost the value."""
+    row = requests._stamp("opened", "q-0123456789ab", "ui", author=author)
+    assert "act_author" not in row
+
+
+@pytest.mark.parametrize("channel", ["cli-tty", "cli-agent", "mechanical"],
+                         ids=["cli-tty", "cli-agent", "mechanical"])
+def test_stamp_refuses_a_per_act_author_on_a_derived_author_channel(
+        project, channel):
+    """`cli-tty` carries human authority and is still refused: the split is
+    not authority alone, it is whether the channel derives its author from
+    the environment. The message names the channel the call arrived through
+    so a caller learns which seam it hit."""
+    with pytest.raises(requests.RequestError) as exc_info:
+        requests._stamp("opened", "q-0123456789ab", channel, author="alice")
+    assert channel in str(exc_info.value)
+    assert not _rows_or_empty(project)
+
+
+def test_stamp_caps_the_per_act_author_like_every_other_label(project):
+    """The shared `_scrub` helper at `_LABEL_MAX`, the same bound
+    `from_label` already takes — over-cap raises the length subclass
+    carrying its own field, never a silent truncation."""
+    with pytest.raises(requests.RequestTooLong) as exc_info:
+        requests._stamp("opened", "q-0123456789ab", "ui",
+                        author="x" * (requests._LABEL_MAX + 1))
+    assert exc_info.value.field == "act_author"
+    assert exc_info.value.limit == requests._LABEL_MAX
 
 
 def _rows_or_empty(project):


### PR DESCRIPTION
Closes #1026

## What

An optional `author` keyword on the in-process writer path: `open_request`,
`revise`, `accept`, `reject`, `needs_info`, `suppress` and `done`. It reaches
`_stamp`, which writes it as a separate `act_author` field on the row. The
existing `author` field keeps the process identity exactly as today, so a
reader can tell a host-attributed name from an environment-derived one.

The keyword is refused, before any row exists, on `cli-agent`, `cli-tty` and
`mechanical`. Those channels derive their author from the environment, meaning
`DAIMON_AUTHOR`, then git user.name, then the OS user, so naming a
different person per act is meaningless there, and refusing it is what stops
a shell-out from signing an act as somebody else. In practice `ui` and
`signed` accept it. Absent or blank means no key on the row at all, the same
"only what the caller set" contract `revise` already holds.

The fold reads it through as `opened_act_author`, `verdict_act_author` and
`done_act_author`, None for every CLI row and every row minted before the
field existed. The #1021 guard and the sticky `rejected` guard keep an inert
duplicate from re-signing a verdict somebody else made.

`act_author` joins `_PLAINTEXT_FIELDS` and the redaction tuple in `append`,
so the privacy audit hashes it, forget can reach it, and a foreign bucket's
names stop at the read boundary. The comment beside the tuple says why this
field belongs there when `author` deliberately does not: `author` is the one
value on every row this process writes, and a tombstone matching it would
empty the ledger of the operator; `act_author` is host-supplied prose naming
a person who is not the operator.

No CLI flag. Nothing under `plugin/daimon_briefing/cli/` changes.

The gate lives in exactly two places. `_stamp` covers every writer except
one: `accept`'s agent ruling-coverage branch writes a pre-stamped row through
`_write_verdict_row(row=synthetic)` and never reaches `_stamp` at all. With
the gate only in `_stamp`, an agent accept carrying an author landed a row
that silently dropped the name and recorded the process instead, exit 0, no
refusal. `accept` now runs the same gate first, and a scar candidate records
the trap for the next check anyone adds to `_stamp`.

## Why

Every request row was stamped with one author, read once per process. Right
for the CLI, where one person sits at one terminal. Wrong for an in-process
writer serving several people through the `ui` channel: every `opened_author`
and every verdict was signed as the host's own identity, so the ledger
recorded that a person opened or decided something without saying which one.
Mutating `os.environ` between acts is a race, not a design.

## Tests

Twenty-three tests in `plugin/tests/test_requests.py` written before any
implementation, all red (`_stamp() got an unexpected keyword argument
'author'`, `KeyError: 'opened_act_author'`, the redaction assertion). Four
refusal-branch tests added after green and mutation-checked: removing the
`accept` gate makes `test_an_agent_accept_naming_a_per_act_author_writes_nothing`
fail. All fixtures go through the shipping writers; the one legacy-row test
appends a row stamped without the keyword to prove old ledgers fold to None.

Covered: the row carries both identities; blank and absent write no key;
every CLI channel refuses and appends nothing; each verdict verb, `done`,
`suppress` and `revise` land the name on `ui`; a duplicate verdict on a
`done` record keeps the first author; redaction on the way to disk; the
plaintext surfaces; the `_LABEL_MAX` cap shared with every other label.

Full suite: 6591 passed, 2 skipped. `requests.py` at 100 percent line
coverage, every added line hit. `ruff`, `mypy` and `scar lint` clean.
